### PR TITLE
Add assigned location GPS export

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2700,12 +2700,26 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         """Queue GPS sidecar sync for location edits when the setting is enabled."""
         db = _get_db()
         import config as cfg
+        from config import _deep_merge
 
-        enabled = bool(
-            db.get_effective_config(cfg.load()).get(
-                "write_assigned_location_to_xmp", False
-            )
-        )
+        effective_config = cfg.load()
+        if workspace_id is not None:
+            ws = db.get_workspace(workspace_id)
+            if ws and ws["config_overrides"]:
+                try:
+                    overrides = (
+                        json.loads(ws["config_overrides"])
+                        if isinstance(ws["config_overrides"], str)
+                        else ws["config_overrides"]
+                    )
+                    if isinstance(overrides, dict):
+                        effective_config = _deep_merge(effective_config, overrides)
+                except (json.JSONDecodeError, TypeError):
+                    pass
+        else:
+            effective_config = db.get_effective_config(effective_config)
+
+        enabled = bool(effective_config.get("write_assigned_location_to_xmp", False))
         if not enabled:
             return
         db.remove_pending_changes(
@@ -3576,11 +3590,21 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         )
 
         photo_rows = db.conn.execute(
-            "SELECT photo_id FROM photo_keywords WHERE keyword_id = ?",
+            """SELECT DISTINCT pk.photo_id, wf.workspace_id
+               FROM photo_keywords pk
+               JOIN photos p ON p.id = pk.photo_id
+               JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+               WHERE pk.keyword_id = ?""",
             (result["keyword_id"],),
         ).fetchall()
         for row in photo_rows:
-            _queue_location_sync_if_enabled(row["photo_id"])
+            _queue_location_sync_if_enabled(
+                row["photo_id"],
+                workspace_id=row["workspace_id"],
+                _commit=False,
+            )
+        if photo_rows:
+            db.conn.commit()
 
         return jsonify({
             "keyword": _serialize_keyword(db, result["keyword_id"]),

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -8665,6 +8665,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         ).fetchone()
         if not photo:
             return json_error("Photo not found", 404)
+        if not db._photo_in_workspace(photo_id):
+            return json_error(
+                f"Photo {photo_id} does not belong to the active workspace", 403,
+            )
 
         # Use the current-fingerprint helper so a photo with cached
         # predictions from multiple label sets doesn't prefill iNat with
@@ -8757,6 +8761,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         ).fetchone()
         if not photo:
             return json_error("Photo not found", 404)
+        if not db._photo_in_workspace(photo_id):
+            return json_error(
+                f"Photo {photo_id} does not belong to the active workspace", 403,
+            )
 
         photo_path = os.path.join(photo["folder_path"], photo["filename"])
         if not os.path.isfile(photo_path):
@@ -8834,6 +8842,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             ).fetchone()
             if not photo:
                 results.append({"photo_id": photo_id, "error": "Photo not found"})
+                continue
+            if not db._photo_in_workspace(photo_id):
+                results.append({
+                    "photo_id": photo_id,
+                    "error": (
+                        f"Photo {photo_id} does not belong to the active workspace"
+                    ),
+                })
                 continue
 
             photo_path = os.path.join(photo["folder_path"], photo["filename"])

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2697,31 +2697,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             )
 
     def _queue_location_sync_if_enabled(photo_id, workspace_id=None, _commit=True):
-        """Queue GPS sidecar sync for location edits when the setting is enabled."""
+        """Queue GPS sidecar sync or cleanup work for location edits."""
         db = _get_db()
-        import config as cfg
-        from config import _deep_merge
-
-        effective_config = cfg.load()
-        if workspace_id is not None:
-            ws = db.get_workspace(workspace_id)
-            if ws and ws["config_overrides"]:
-                try:
-                    overrides = (
-                        json.loads(ws["config_overrides"])
-                        if isinstance(ws["config_overrides"], str)
-                        else ws["config_overrides"]
-                    )
-                    if isinstance(overrides, dict):
-                        effective_config = _deep_merge(effective_config, overrides)
-                except (json.JSONDecodeError, TypeError):
-                    pass
-        else:
-            effective_config = db.get_effective_config(effective_config)
-
-        enabled = bool(effective_config.get("write_assigned_location_to_xmp", False))
-        if not enabled:
-            return
         if workspace_id is None:
             if not db._photo_in_workspace(photo_id):
                 return
@@ -2732,6 +2709,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             (photo_id, workspace_id),
         ).fetchone() is None:
             return
+        # Queue even when assigned-location writes are disabled so sync can
+        # remove stale Vireo-authored GPS previously written while enabled.
         db.remove_pending_changes(
             photo_id, "location", workspace_id=workspace_id, _commit=_commit,
         )

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2722,6 +2722,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         enabled = bool(effective_config.get("write_assigned_location_to_xmp", False))
         if not enabled:
             return
+        if workspace_id is None:
+            if not db._photo_in_workspace(photo_id):
+                return
+        elif db.conn.execute(
+            """SELECT 1 FROM photos p
+               JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+               WHERE p.id = ? AND wf.workspace_id = ?""",
+            (photo_id, workspace_id),
+        ).fetchone() is None:
+            return
         db.remove_pending_changes(
             photo_id, "location", workspace_id=workspace_id, _commit=_commit,
         )
@@ -2729,6 +2739,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             photo_id, "location", "effective",
             workspace_id=workspace_id, _commit=_commit,
         )
+
+    def _photo_location_edit_error(db, photo_id):
+        """Return an error response when a photo cannot be edited in this workspace."""
+        if db.conn.execute(
+            "SELECT 1 FROM photos WHERE id = ?", (photo_id,)
+        ).fetchone() is None:
+            return json_error("photo_not_found", 404)
+        if not db._photo_in_workspace(photo_id):
+            return json_error(
+                f"Photo {photo_id} does not belong to the active workspace", 403,
+            )
+        return None
 
     # -- Edit API routes --
 
@@ -3345,10 +3367,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # Guard against stale clients (e.g. tab open after photo deleted).
         # Without this, set_photo_location's INSERT into photo_keywords
         # raises a FK IntegrityError that surfaces as a 500.
-        if db.conn.execute(
-            "SELECT 1 FROM photos WHERE id = ?", (photo_id,)
-        ).fetchone() is None:
-            return json_error("photo_not_found", 404)
+        edit_error = _photo_location_edit_error(db, photo_id)
+        if edit_error is not None:
+            return edit_error
 
         details = _normalize_client_place_details(body)
         if details is None:
@@ -3396,10 +3417,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         stripped = name.strip()
 
         db = _get_db()
-        if db.conn.execute(
-            "SELECT 1 FROM photos WHERE id = ?", (photo_id,)
-        ).fetchone() is None:
-            return json_error("photo_not_found", 404)
+        edit_error = _photo_location_edit_error(db, photo_id)
+        if edit_error is not None:
+            return edit_error
         try:
             leaf_id = db.get_or_create_text_location(stripped)
         except ValueError:
@@ -3419,10 +3439,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def api_clear_photo_location(photo_id):
         """Remove all ``type='location'`` keyword links for ``photo_id``."""
         db = _get_db()
-        if db.conn.execute(
-            "SELECT 1 FROM photos WHERE id = ?", (photo_id,)
-        ).fetchone() is None:
-            return json_error("photo_not_found", 404)
+        edit_error = _photo_location_edit_error(db, photo_id)
+        if edit_error is not None:
+            return edit_error
         db.clear_photo_location(photo_id)
         _queue_location_sync_if_enabled(photo_id)
         db.record_edit(

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2696,6 +2696,26 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 workspace_id=workspace_id, _commit=_commit,
             )
 
+    def _queue_location_sync_if_enabled(photo_id, workspace_id=None, _commit=True):
+        """Queue GPS sidecar sync for location edits when the setting is enabled."""
+        db = _get_db()
+        import config as cfg
+
+        enabled = bool(
+            db.get_effective_config(cfg.load()).get(
+                "write_assigned_location_to_xmp", False
+            )
+        )
+        if not enabled:
+            return
+        db.remove_pending_changes(
+            photo_id, "location", workspace_id=workspace_id, _commit=_commit,
+        )
+        db.queue_change(
+            photo_id, "location", "effective",
+            workspace_id=workspace_id, _commit=_commit,
+        )
+
     # -- Edit API routes --
 
     @app.route("/api/photos/<int:photo_id>/rating", methods=["POST"])
@@ -3337,6 +3357,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "error_detail": str(err),
             }), 409
         db.set_photo_location(photo_id, leaf_id)
+        _queue_location_sync_if_enabled(photo_id)
         db.record_edit(
             'location_set',
             f"set location: {details.get('name', 'unknown')}",
@@ -3371,6 +3392,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # Defensive: validation above should already catch empty input.
             return json_error("missing name", 400)
         db.set_photo_location(photo_id, leaf_id)
+        _queue_location_sync_if_enabled(photo_id)
         db.record_edit(
             'location_set',
             f"set location: {stripped}",
@@ -3388,6 +3410,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         ).fetchone() is None:
             return json_error("photo_not_found", 404)
         db.clear_photo_location(photo_id)
+        _queue_location_sync_if_enabled(photo_id)
         db.record_edit(
             'location_clear',
             "cleared location",
@@ -3551,6 +3574,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             str(result['keyword_id']),
             [],
         )
+
+        photo_rows = db.conn.execute(
+            "SELECT photo_id FROM photo_keywords WHERE keyword_id = ?",
+            (result["keyword_id"],),
+        ).fetchall()
+        for row in photo_rows:
+            _queue_location_sync_if_enabled(row["photo_id"])
 
         return jsonify({
             "keyword": _serialize_keyword(db, result["keyword_id"]),
@@ -8615,9 +8645,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             params.append("taxon_name=" + species)
         if photo["timestamp"]:
             params.append("observed_on=" + photo["timestamp"][:10])
-        lat = photo["latitude"] if "latitude" in photo.keys() else None
-        lng = photo["longitude"] if "longitude" in photo.keys() else None
-        if lat and lng:
+        loc = db.get_effective_photo_location(photo_id)
+        lat = loc["latitude"] if loc else None
+        lng = loc["longitude"] if loc else None
+        if lat is not None and lng is not None:
             params.append("lat=" + str(lat))
             params.append("lng=" + str(lng))
 
@@ -8703,8 +8734,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         taxon = data.get("taxon_name") or (pred["scientific_name"] if pred else None) or (pred["species"] if pred else None)
         observed_on = data.get("observed_on") or (photo["timestamp"][:10] if photo["timestamp"] else None)
-        photo_lat = photo["latitude"] if "latitude" in photo.keys() else None
-        photo_lng = photo["longitude"] if "longitude" in photo.keys() else None
+        loc = db.get_effective_photo_location(photo_id)
+        photo_lat = loc["latitude"] if loc else None
+        photo_lng = loc["longitude"] if loc else None
         lat = data.get("latitude") if data.get("latitude") is not None else photo_lat
         lng = data.get("longitude") if data.get("longitude") is not None else photo_lng
 
@@ -8775,8 +8807,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
             taxon = sub.get("taxon_name") or (pred["scientific_name"] if pred else None) or (pred["species"] if pred else None)
             observed_on = sub.get("observed_on") or (photo["timestamp"][:10] if photo["timestamp"] else None)
-            photo_lat = photo["latitude"] if "latitude" in photo.keys() else None
-            photo_lng = photo["longitude"] if "longitude" in photo.keys() else None
+            loc = db.get_effective_photo_location(photo_id)
+            photo_lat = loc["latitude"] if loc else None
+            photo_lng = loc["longitude"] if loc else None
             lat = sub.get("latitude") if sub.get("latitude") is not None else photo_lat
             lng = sub.get("longitude") if sub.get("longitude") is not None else photo_lng
 

--- a/vireo/config.py
+++ b/vireo/config.py
@@ -21,6 +21,7 @@ DEFAULTS = {
     "preview_max_size": 1920,
     "keyword_case": "auto",
     "sync_flags_to_xmp": True,
+    "write_assigned_location_to_xmp": False,
     "max_edit_history": 1000,
     "inat_token": "",
     "hf_token": "",

--- a/vireo/config_schema.py
+++ b/vireo/config_schema.py
@@ -123,6 +123,12 @@ SCHEMA = {
         "label": "Sync pick/reject flags to XMP",
         "desc": "Write Vireo pick/reject flags to XMP sidecars using Lightroom-compatible pick metadata.",
     },
+    "write_assigned_location_to_xmp": {
+        "type": "bool",
+        "category": "Metadata", "scope": "both",
+        "label": "Write assigned locations to XMP",
+        "desc": "Write Vireo-assigned location coordinates to XMP sidecars so Lightroom exports can include GPS metadata.",
+    },
     "scan_workers": {
         "type": "int", "min": 0, "max": 64,
         "category": "Behavior", "scope": "global",

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -4638,7 +4638,49 @@ class Database:
         """
         return self.conn.execute(query, species_col_params + params).fetchall()
 
-    def get_effective_photo_location(self, photo_id):
+    def get_assigned_photo_location(self, photo_id, verify_workspace=True):
+        """Return linked location-keyword coordinates for one visible photo."""
+        if verify_workspace:
+            self._verify_photo_in_workspace(photo_id)
+
+        row = self.conn.execute(
+            """
+            SELECT p.id,
+                   kl.latitude AS latitude,
+                   kl.longitude AS longitude,
+                   kl.name AS keyword_location_name,
+                   kl.place_id AS place_id
+            FROM photos p
+            LEFT JOIN (
+                SELECT pk_loc.photo_id, k_loc.name, k_loc.place_id,
+                       k_loc.latitude, k_loc.longitude,
+                       ROW_NUMBER() OVER (
+                         PARTITION BY pk_loc.photo_id
+                         ORDER BY (k_loc.parent_id IS NULL) ASC, k_loc.id DESC
+                       ) AS rn
+                FROM photo_keywords pk_loc
+                JOIN keywords k_loc ON k_loc.id = pk_loc.keyword_id
+                WHERE pk_loc.photo_id = ?
+                  AND k_loc.type = 'location'
+                  AND k_loc.latitude IS NOT NULL
+                  AND k_loc.longitude IS NOT NULL
+            ) kl ON kl.photo_id = p.id AND kl.rn = 1
+            WHERE p.id = ?
+            """,
+            (photo_id, photo_id),
+        ).fetchone()
+        if row is None or row["latitude"] is None or row["longitude"] is None:
+            return None
+        return {
+            "photo_id": row["id"],
+            "latitude": row["latitude"],
+            "longitude": row["longitude"],
+            "source": "keyword",
+            "keyword_location_name": row["keyword_location_name"],
+            "place_id": row["place_id"],
+        }
+
+    def get_effective_photo_location(self, photo_id, verify_workspace=True):
         """Return the coordinates Vireo should use for a single photo.
 
         EXIF GPS is source metadata and wins when both axes are present. If
@@ -4646,6 +4688,9 @@ class Database:
         ``type='location'`` keyword coordinates. Returns ``None`` when neither
         source has a complete coordinate pair.
         """
+        if verify_workspace:
+            self._verify_photo_in_workspace(photo_id)
+
         row = self.conn.execute(
             """
             SELECT p.id,
@@ -4665,13 +4710,14 @@ class Database:
                        ) AS rn
                 FROM photo_keywords pk_loc
                 JOIN keywords k_loc ON k_loc.id = pk_loc.keyword_id
-                WHERE k_loc.type = 'location'
+                WHERE pk_loc.photo_id = ?
+                  AND k_loc.type = 'location'
                   AND k_loc.latitude IS NOT NULL
                   AND k_loc.longitude IS NOT NULL
             ) kl ON kl.photo_id = p.id AND kl.rn = 1
             WHERE p.id = ?
             """,
-            (photo_id,),
+            (photo_id, photo_id),
         ).fetchone()
         if row is None:
             return None

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -4638,6 +4638,66 @@ class Database:
         """
         return self.conn.execute(query, species_col_params + params).fetchall()
 
+    def get_effective_photo_location(self, photo_id):
+        """Return the coordinates Vireo should use for a single photo.
+
+        EXIF GPS is source metadata and wins when both axes are present. If
+        EXIF GPS is absent or partial, fall back as a pair to the linked
+        ``type='location'`` keyword coordinates. Returns ``None`` when neither
+        source has a complete coordinate pair.
+        """
+        row = self.conn.execute(
+            """
+            SELECT p.id,
+                   p.latitude AS photo_latitude,
+                   p.longitude AS photo_longitude,
+                   kl.latitude AS keyword_latitude,
+                   kl.longitude AS keyword_longitude,
+                   kl.name AS keyword_location_name,
+                   kl.place_id AS place_id
+            FROM photos p
+            LEFT JOIN (
+                SELECT pk_loc.photo_id, k_loc.name, k_loc.place_id,
+                       k_loc.latitude, k_loc.longitude,
+                       ROW_NUMBER() OVER (
+                         PARTITION BY pk_loc.photo_id
+                         ORDER BY (k_loc.parent_id IS NULL) ASC, k_loc.id DESC
+                       ) AS rn
+                FROM photo_keywords pk_loc
+                JOIN keywords k_loc ON k_loc.id = pk_loc.keyword_id
+                WHERE k_loc.type = 'location'
+                  AND k_loc.latitude IS NOT NULL
+                  AND k_loc.longitude IS NOT NULL
+            ) kl ON kl.photo_id = p.id AND kl.rn = 1
+            WHERE p.id = ?
+            """,
+            (photo_id,),
+        ).fetchone()
+        if row is None:
+            return None
+
+        if row["photo_latitude"] is not None and row["photo_longitude"] is not None:
+            return {
+                "photo_id": row["id"],
+                "latitude": row["photo_latitude"],
+                "longitude": row["photo_longitude"],
+                "source": "exif",
+                "keyword_location_name": None,
+                "place_id": None,
+            }
+
+        if row["keyword_latitude"] is not None and row["keyword_longitude"] is not None:
+            return {
+                "photo_id": row["id"],
+                "latitude": row["keyword_latitude"],
+                "longitude": row["keyword_longitude"],
+                "source": "keyword",
+                "keyword_location_name": row["keyword_location_name"],
+                "place_id": row["place_id"],
+            }
+
+        return None
+
     def get_accepted_species(self):
         """Return distinct marker species from geolocated photos in the active workspace.
 

--- a/vireo/sync.py
+++ b/vireo/sync.py
@@ -104,6 +104,7 @@ def sync_to_xmp(db, progress_callback=None):
             new_rating = None
             new_flag = None
             sync_location = False
+            cleanup_location = False
             supported_ids = []
             unsupported_changes = []
 
@@ -127,6 +128,8 @@ def sync_to_xmp(db, progress_callback=None):
                     supported_ids.append(c["id"])
                     if sync_locations:
                         sync_location = True
+                    else:
+                        cleanup_location = True
 
             # Write keywords
             if keywords_to_add:
@@ -159,6 +162,8 @@ def sync_to_xmp(db, progress_callback=None):
                     )
                 else:
                     remove_vireo_gps_location(xmp_path)
+            elif cleanup_location:
+                remove_vireo_gps_location(xmp_path)
 
             if supported_ids:
                 synced += 1

--- a/vireo/sync.py
+++ b/vireo/sync.py
@@ -4,7 +4,15 @@ import logging
 import os
 from collections import defaultdict
 
-from xmp import read_keywords, remove_keywords, write_pick_flag, write_rating, write_sidecar
+from xmp import (
+    read_keywords,
+    remove_keywords,
+    remove_vireo_gps_location,
+    write_gps_location,
+    write_pick_flag,
+    write_rating,
+    write_sidecar,
+)
 
 log = logging.getLogger(__name__)
 
@@ -79,6 +87,7 @@ def sync_to_xmp(db, progress_callback=None):
             keywords_to_remove = set()
             new_rating = None
             new_flag = None
+            sync_location = False
             supported_ids = []
             unsupported_changes = []
 
@@ -98,6 +107,9 @@ def sync_to_xmp(db, progress_callback=None):
                         supported_ids.append(c["id"])
                     else:
                         unsupported_changes.append(c)
+                elif c["change_type"] == "location":
+                    sync_location = True
+                    supported_ids.append(c["id"])
 
             # Write keywords
             if keywords_to_add:
@@ -118,6 +130,18 @@ def sync_to_xmp(db, progress_callback=None):
             # Write rating
             if new_rating is not None:
                 write_rating(xmp_path, new_rating)
+
+            if sync_location:
+                loc = db.get_effective_photo_location(photo_id)
+                if loc and loc.get("latitude") is not None and loc.get("longitude") is not None:
+                    write_gps_location(
+                        xmp_path,
+                        loc["latitude"],
+                        loc["longitude"],
+                        source=loc.get("source") or "assigned",
+                    )
+                else:
+                    remove_vireo_gps_location(xmp_path)
 
             if supported_ids:
                 synced += 1

--- a/vireo/sync.py
+++ b/vireo/sync.py
@@ -39,6 +39,21 @@ def _sync_flags_to_xmp_enabled(db):
         return False
 
 
+def _write_assigned_location_to_xmp_enabled(db):
+    """Return whether the active workspace should write assigned GPS to XMP."""
+    try:
+        import config as cfg
+
+        return bool(
+            db.get_effective_config(cfg.load()).get(
+                "write_assigned_location_to_xmp", False
+            )
+        )
+    except Exception:
+        log.warning("Failed to read write_assigned_location_to_xmp config", exc_info=True)
+        return False
+
+
 def sync_to_xmp(db, progress_callback=None):
     """Write pending changes to XMP sidecars.
 
@@ -59,6 +74,7 @@ def sync_to_xmp(db, progress_callback=None):
         by_photo[c["photo_id"]].append(c)
 
     sync_flags = _sync_flags_to_xmp_enabled(db)
+    sync_locations = _write_assigned_location_to_xmp_enabled(db)
     synced = 0
     failed = 0
     failures = []
@@ -108,8 +124,9 @@ def sync_to_xmp(db, progress_callback=None):
                     else:
                         unsupported_changes.append(c)
                 elif c["change_type"] == "location":
-                    sync_location = True
                     supported_ids.append(c["id"])
+                    if sync_locations:
+                        sync_location = True
 
             # Write keywords
             if keywords_to_add:
@@ -132,7 +149,7 @@ def sync_to_xmp(db, progress_callback=None):
                 write_rating(xmp_path, new_rating)
 
             if sync_location:
-                loc = db.get_effective_photo_location(photo_id)
+                loc = db.get_assigned_photo_location(photo_id)
                 if loc and loc.get("latitude") is not None and loc.get("longitude") is not None:
                     write_gps_location(
                         xmp_path,

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -3175,6 +3175,63 @@ def test_get_geolocated_photos_with_partial_exif_uses_keyword_pair(tmp_path):
     assert r['keyword_location_name'] == 'Central Park'
 
 
+def test_get_effective_photo_location_prefers_exif(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder('/photos', name='photos')
+    pid = db.add_photo(folder_id=fid, filename='both.jpg', extension='.jpg',
+                       file_size=100, file_mtime=1.0)
+    db.conn.execute(
+        "UPDATE photos SET latitude=?, longitude=? WHERE id=?",
+        (37.7749, -122.4194, pid),
+    )
+    kid = db.conn.execute(
+        "INSERT INTO keywords (name, type, latitude, longitude) "
+        "VALUES (?, 'location', ?, ?)",
+        ('Paris Airbnb', 48.8566, 2.3522),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (pid, kid),
+    )
+    db.conn.commit()
+
+    loc = db.get_effective_photo_location(pid)
+    assert loc["source"] == "exif"
+    assert loc["latitude"] == 37.7749
+    assert loc["longitude"] == -122.4194
+    assert loc["keyword_location_name"] is None
+
+
+def test_get_effective_photo_location_falls_back_to_keyword_pair(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder('/photos', name='photos')
+    pid = db.add_photo(folder_id=fid, filename='assigned.jpg', extension='.jpg',
+                       file_size=100, file_mtime=1.0)
+    db.conn.execute(
+        "UPDATE photos SET latitude=?, longitude=NULL WHERE id=?",
+        (37.7749, pid),
+    )
+    kid = db.conn.execute(
+        "INSERT INTO keywords (name, type, place_id, latitude, longitude) "
+        "VALUES (?, 'location', ?, ?, ?)",
+        ('Paris Airbnb', 'place_123', 48.8566, 2.3522),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (pid, kid),
+    )
+    db.conn.commit()
+
+    loc = db.get_effective_photo_location(pid)
+    assert loc["source"] == "keyword"
+    assert loc["latitude"] == 48.8566
+    assert loc["longitude"] == 2.3522
+    assert loc["keyword_location_name"] == "Paris Airbnb"
+    assert loc["place_id"] == "place_123"
+
+
 def test_get_accepted_species(tmp_path):
     """get_accepted_species returns distinct marker species from geolocated photos."""
     from db import Database

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -3232,6 +3232,26 @@ def test_get_effective_photo_location_falls_back_to_keyword_pair(tmp_path):
     assert loc["place_id"] == "place_123"
 
 
+def test_get_effective_photo_location_enforces_active_workspace(tmp_path):
+    import pytest
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder('/photos', name='photos')
+    pid = db.add_photo(folder_id=fid, filename='geo.jpg', extension='.jpg',
+                       file_size=100, file_mtime=1.0)
+    db.conn.execute(
+        "UPDATE photos SET latitude=?, longitude=? WHERE id=?",
+        (37.7749, -122.4194, pid),
+    )
+    db.conn.commit()
+
+    other_ws = db.create_workspace("Other")
+    db.set_active_workspace(other_ws)
+
+    with pytest.raises(ValueError, match="active workspace"):
+        db.get_effective_photo_location(pid)
+
+
 def test_get_accepted_species(tmp_path):
     """get_accepted_species returns distinct marker species from geolocated photos."""
     from db import Database

--- a/vireo/tests/test_inat.py
+++ b/vireo/tests/test_inat.py
@@ -209,6 +209,39 @@ def test_api_inat_prepare_uses_assigned_location_coords(app_and_db):
     assert "lng=2.3522" in data["upload_url"]
 
 
+def _add_out_of_workspace_photo(db):
+    active_ws = db._active_workspace_id
+    base_dir = db.conn.execute("SELECT path FROM folders LIMIT 1").fetchone()["path"]
+    other_dir = os.path.join(os.path.dirname(base_dir), "other-photos")
+    os.makedirs(other_dir, exist_ok=True)
+    Image.new('RGB', (100, 100)).save(os.path.join(other_dir, 'outside.jpg'))
+
+    other_ws = db.create_workspace("Other")
+    db.set_active_workspace(other_ws)
+    fid = db.add_folder(other_dir, name="other-photos")
+    pid = db.add_photo(
+        folder_id=fid,
+        filename='outside.jpg',
+        extension='.jpg',
+        file_size=1000,
+        file_mtime=1.0,
+        timestamp='2024-06-02T10:00:00',
+    )
+    db.set_active_workspace(active_ws)
+    return pid
+
+
+def test_api_inat_prepare_rejects_out_of_workspace_photo(app_and_db):
+    app, db, _ = app_and_db
+    pid = _add_out_of_workspace_photo(db)
+
+    client = app.test_client()
+    resp = client.get(f'/api/inat/prepare/{pid}')
+
+    assert resp.status_code == 403
+    assert "active workspace" in resp.get_json()["error"]
+
+
 def test_api_inat_submit_no_token(app_and_db):
     app, db, pid = app_and_db
     client = app.test_client()
@@ -260,6 +293,21 @@ def test_api_inat_submit_uses_assigned_location_coords(app_and_db):
     assert kwargs["longitude"] == 2.3522
 
 
+def test_api_inat_submit_rejects_out_of_workspace_photo(app_and_db):
+    app, db, _ = app_and_db
+    import config as cfg
+    cfg.save({"inat_token": "fake-token"})
+    pid = _add_out_of_workspace_photo(db)
+
+    client = app.test_client()
+    with patch("inat.submit_observation") as mock_submit:
+        resp = client.post('/api/inat/submit', json={'photo_id': pid})
+
+    assert resp.status_code == 403
+    assert "active workspace" in resp.get_json()["error"]
+    mock_submit.assert_not_called()
+
+
 def test_api_inat_submit_batch(app_and_db):
     app, db, pid = app_and_db
     import config as cfg
@@ -273,6 +321,27 @@ def test_api_inat_submit_batch(app_and_db):
     data = resp.get_json()
     assert len(data['results']) == 1
     assert data['results'][0]['observation_id'] == 11111
+
+
+def test_api_inat_submit_batch_rejects_out_of_workspace_photo(app_and_db):
+    app, db, _ = app_and_db
+    import config as cfg
+    cfg.save({"inat_token": "fake-token"})
+    pid = _add_out_of_workspace_photo(db)
+
+    client = app.test_client()
+    with patch("inat.submit_observation") as mock_submit:
+        resp = client.post('/api/inat/submit-batch', json={
+            'submissions': [{'photo_id': pid}]
+        })
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['results'] == [{
+        'photo_id': pid,
+        'error': f"Photo {pid} does not belong to the active workspace",
+    }]
+    mock_submit.assert_not_called()
 
 
 def test_api_inat_submissions_lookup(app_and_db):

--- a/vireo/tests/test_inat.py
+++ b/vireo/tests/test_inat.py
@@ -185,6 +185,29 @@ def test_api_inat_prepare_includes_submission_status(app_and_db):
     assert data['existing_observation_url'] == "https://www.inaturalist.org/observations/999"
 
 
+def test_api_inat_prepare_uses_assigned_location_coords(app_and_db):
+    app, db, pid = app_and_db
+    kid = db.conn.execute(
+        "INSERT INTO keywords (name, type, latitude, longitude) "
+        "VALUES (?, 'location', ?, ?)",
+        ("Paris Airbnb", 48.8566, 2.3522),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (pid, kid),
+    )
+    db.conn.commit()
+
+    client = app.test_client()
+    resp = client.get(f'/api/inat/prepare/{pid}')
+    data = resp.get_json()
+
+    assert data['latitude'] == 48.8566
+    assert data['longitude'] == 2.3522
+    assert "lat=48.8566" in data["upload_url"]
+    assert "lng=2.3522" in data["upload_url"]
+
+
 def test_api_inat_submit_no_token(app_and_db):
     app, db, pid = app_and_db
     client = app.test_client()
@@ -208,6 +231,32 @@ def test_api_inat_submit_success(app_and_db):
     # Verify recorded in DB
     subs = db.get_inat_submissions([pid])
     assert pid in subs
+
+
+def test_api_inat_submit_uses_assigned_location_coords(app_and_db):
+    app, db, pid = app_and_db
+    import config as cfg
+    cfg.save({"inat_token": "fake-token"})
+
+    kid = db.conn.execute(
+        "INSERT INTO keywords (name, type, latitude, longitude) "
+        "VALUES (?, 'location', ?, ?)",
+        ("Paris Airbnb", 48.8566, 2.3522),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (pid, kid),
+    )
+    db.conn.commit()
+
+    client = app.test_client()
+    with patch("inat.submit_observation", return_value=(12345, "https://www.inaturalist.org/observations/12345")) as mock_submit:
+        resp = client.post('/api/inat/submit', json={'photo_id': pid})
+
+    assert resp.status_code == 200
+    kwargs = mock_submit.call_args.kwargs
+    assert kwargs["latitude"] == 48.8566
+    assert kwargs["longitude"] == 2.3522
 
 
 def test_api_inat_submit_batch(app_and_db):

--- a/vireo/tests/test_inat.py
+++ b/vireo/tests/test_inat.py
@@ -200,6 +200,7 @@ def test_api_inat_prepare_uses_assigned_location_coords(app_and_db):
 
     client = app.test_client()
     resp = client.get(f'/api/inat/prepare/{pid}')
+    assert resp.status_code == 200
     data = resp.get_json()
 
     assert data['latitude'] == 48.8566

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -2918,6 +2918,46 @@ def test_post_photo_location_returns_404_on_missing_photo(app_and_db, monkeypatc
     assert resp.get_json()["error"] == "photo_not_found"
 
 
+def _add_out_of_workspace_photo(db):
+    active_ws = db._active_workspace_id
+    other_ws = db.create_workspace("Other")
+    db.set_active_workspace(other_ws)
+    fid = db.add_folder("/photos/other", name="other")
+    pid = db.add_photo(
+        folder_id=fid,
+        filename="outside.jpg",
+        extension=".jpg",
+        file_size=100,
+        file_mtime=1.0,
+    )
+    db.set_active_workspace(active_ws)
+    return pid
+
+
+def test_post_photo_location_rejects_out_of_workspace_photo(app_and_db):
+    """Location edits must not queue sync changes for hidden workspace photos."""
+    app, db = app_and_db
+    pid = _add_out_of_workspace_photo(db)
+
+    client = app.test_client()
+    resp = client.post(
+        f"/api/photos/{pid}/location",
+        json={
+            "place_id": "ChIJ4zGFAZpYwokRGUGph3Mf37k",
+            "place": _central_park_client_place(),
+        },
+    )
+    assert resp.status_code == 403
+    assert "active workspace" in resp.get_json()["error"]
+
+    assert db.conn.execute(
+        "SELECT 1 FROM photo_keywords WHERE photo_id = ?", (pid,),
+    ).fetchone() is None
+    assert db.conn.execute(
+        "SELECT 1 FROM pending_changes WHERE photo_id = ?", (pid,),
+    ).fetchone() is None
+
+
 def test_post_photo_location_text_returns_404_on_missing_photo(app_and_db):
     """Same FK guard for the free-text fallback path."""
     app, _ = app_and_db
@@ -2930,6 +2970,26 @@ def test_post_photo_location_text_returns_404_on_missing_photo(app_and_db):
     assert resp.get_json()["error"] == "photo_not_found"
 
 
+def test_post_photo_location_text_rejects_out_of_workspace_photo(app_and_db):
+    app, db = app_and_db
+    pid = _add_out_of_workspace_photo(db)
+
+    client = app.test_client()
+    resp = client.post(
+        f"/api/photos/{pid}/location/text",
+        json={"name": "the meadow"},
+    )
+    assert resp.status_code == 403
+    assert "active workspace" in resp.get_json()["error"]
+
+    assert db.conn.execute(
+        "SELECT 1 FROM photo_keywords WHERE photo_id = ?", (pid,),
+    ).fetchone() is None
+    assert db.conn.execute(
+        "SELECT 1 FROM pending_changes WHERE photo_id = ?", (pid,),
+    ).fetchone() is None
+
+
 def test_delete_photo_location_returns_404_on_missing_photo(app_and_db):
     """DELETE on a missing photo returns 404 for consistency with the
     POST routes (was previously a silent 200 because the underlying
@@ -2939,6 +2999,36 @@ def test_delete_photo_location_returns_404_on_missing_photo(app_and_db):
     resp = client.delete("/api/photos/999999/location")
     assert resp.status_code == 404
     assert resp.get_json()["error"] == "photo_not_found"
+
+
+def test_delete_photo_location_rejects_out_of_workspace_photo(app_and_db):
+    app, db = app_and_db
+    active_ws = db._active_workspace_id
+    other_ws = db.create_workspace("Other")
+    db.set_active_workspace(other_ws)
+    fid = db.add_folder("/photos/other", name="other")
+    pid = db.add_photo(
+        folder_id=fid,
+        filename="outside.jpg",
+        extension=".jpg",
+        file_size=100,
+        file_mtime=1.0,
+    )
+    leaf_id = db.upsert_place_chain(_central_park_details())
+    db.set_photo_location(pid, leaf_id)
+    db.set_active_workspace(active_ws)
+
+    client = app.test_client()
+    resp = client.delete(f"/api/photos/{pid}/location")
+    assert resp.status_code == 403
+    assert "active workspace" in resp.get_json()["error"]
+
+    assert db.conn.execute(
+        "SELECT 1 FROM photo_keywords WHERE photo_id = ?", (pid,),
+    ).fetchone() is not None
+    assert db.conn.execute(
+        "SELECT 1 FROM pending_changes WHERE photo_id = ?", (pid,),
+    ).fetchone() is None
 
 
 def test_delete_photo_location_clears_links(app_and_db):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -2990,6 +2990,28 @@ def test_post_photo_location_text_rejects_out_of_workspace_photo(app_and_db):
     ).fetchone() is None
 
 
+def test_post_photo_location_text_queues_cleanup_when_xmp_location_disabled(app_and_db):
+    """Disabled assigned-location writes still need a cleanup sync opportunity."""
+    import config as cfg
+    app, db = app_and_db
+    cfg.save({**cfg.load(), "write_assigned_location_to_xmp": False})
+    photo = db.get_photos()[0]
+    pid = photo["id"]
+
+    client = app.test_client()
+    resp = client.post(
+        f"/api/photos/{pid}/location/text",
+        json={"name": "the meadow"},
+    )
+
+    assert resp.status_code == 200, resp.get_json()
+    row = db.conn.execute(
+        "SELECT change_type, value FROM pending_changes WHERE photo_id = ?",
+        (pid,),
+    ).fetchone()
+    assert dict(row) == {"change_type": "location", "value": "effective"}
+
+
 def test_delete_photo_location_returns_404_on_missing_photo(app_and_db):
     """DELETE on a missing photo returns 404 for consistency with the
     POST routes (was previously a silent 200 because the underlying

--- a/vireo/tests/test_sync.py
+++ b/vireo/tests/test_sync.py
@@ -247,3 +247,64 @@ def test_sync_to_xmp_treats_legacy_null_flag_as_none(tmp_path, monkeypatch):
     )
     pick = desc.get('{http://ns.adobe.com/xmp/1.0/DynamicMedia/}pick')
     assert pick == '0'
+
+
+def test_sync_to_xmp_writes_effective_location(tmp_path):
+    """location changes write effective coordinates into the sidecar."""
+    from xml.etree import ElementTree as ET
+
+    from db import Database
+    from sync import sync_to_xmp
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    pid, xmp_path = _setup_photo_with_xmp(tmp_path, db)
+
+    kid = db.conn.execute(
+        "INSERT INTO keywords (name, type, latitude, longitude) "
+        "VALUES (?, 'location', ?, ?)",
+        ("Paris Airbnb", 48.8566, 2.3522),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (pid, kid),
+    )
+    db.conn.commit()
+    db.queue_change(pid, "location", "effective")
+
+    result = sync_to_xmp(db)
+
+    assert result["synced"] == 1
+    assert result["failed"] == 0
+    assert len(db.get_pending_changes()) == 0
+
+    desc = ET.parse(xmp_path).getroot().find(
+        './/{http://www.w3.org/1999/02/22-rdf-syntax-ns#}Description'
+    )
+    assert desc.get('{http://ns.adobe.com/exif/1.0/}GPSLatitude') == '48,51.396000N'
+    assert desc.get('{http://ns.adobe.com/exif/1.0/}GPSLongitude') == '2,21.132000E'
+    assert desc.get('{https://vireo.app/ns/1.0/}gpsSource') == 'keyword'
+
+
+def test_sync_to_xmp_removes_stale_vireo_location_when_effective_location_missing(tmp_path):
+    """Clearing a Vireo-assigned location removes only Vireo-authored GPS."""
+    from db import Database
+    from sync import sync_to_xmp
+    from xmp import write_gps_location
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    pid, xmp_path = _setup_photo_with_xmp(tmp_path, db)
+    write_gps_location(xmp_path, 48.8566, 2.3522, source="keyword")
+    db.queue_change(pid, "location", "effective")
+
+    result = sync_to_xmp(db)
+
+    assert result["synced"] == 1
+    with open(xmp_path) as f:
+        content = f.read()
+    assert "GPSLatitude" not in content
+    assert "GPSLongitude" not in content
+    assert "vireo:gpsSource" not in content

--- a/vireo/tests/test_sync.py
+++ b/vireo/tests/test_sync.py
@@ -249,12 +249,18 @@ def test_sync_to_xmp_treats_legacy_null_flag_as_none(tmp_path, monkeypatch):
     assert pick == '0'
 
 
-def test_sync_to_xmp_writes_effective_location(tmp_path):
+def test_sync_to_xmp_writes_effective_location(tmp_path, monkeypatch):
     """location changes write effective coordinates into the sidecar."""
     from xml.etree import ElementTree as ET
 
+    import config as cfg
     from db import Database
     from sync import sync_to_xmp
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    config = cfg.load()
+    config["write_assigned_location_to_xmp"] = True
+    cfg.save(config)
 
     db = Database(str(tmp_path / "test.db"))
     ws_id = db.ensure_default_workspace()
@@ -287,16 +293,95 @@ def test_sync_to_xmp_writes_effective_location(tmp_path):
     assert desc.get('{https://vireo.app/ns/1.0/}gpsSource') == 'keyword'
 
 
-def test_sync_to_xmp_removes_stale_vireo_location_when_effective_location_missing(tmp_path):
+def test_sync_to_xmp_removes_stale_vireo_location_when_effective_location_missing(tmp_path, monkeypatch):
     """Clearing a Vireo-assigned location removes only Vireo-authored GPS."""
+    import config as cfg
     from db import Database
     from sync import sync_to_xmp
     from xmp import write_gps_location
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    config = cfg.load()
+    config["write_assigned_location_to_xmp"] = True
+    cfg.save(config)
 
     db = Database(str(tmp_path / "test.db"))
     ws_id = db.ensure_default_workspace()
     db.set_active_workspace(ws_id)
     pid, xmp_path = _setup_photo_with_xmp(tmp_path, db)
+    write_gps_location(xmp_path, 48.8566, 2.3522, source="keyword")
+    db.queue_change(pid, "location", "effective")
+
+    result = sync_to_xmp(db)
+
+    assert result["synced"] == 1
+    with open(xmp_path) as f:
+        content = f.read()
+    assert "GPSLatitude" not in content
+    assert "GPSLongitude" not in content
+    assert "vireo:gpsSource" not in content
+
+
+def test_sync_to_xmp_clears_location_change_without_writing_when_disabled(tmp_path, monkeypatch):
+    """Turning the setting off before sync prevents queued GPS writes."""
+    import config as cfg
+    from db import Database
+    from sync import sync_to_xmp
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    config = cfg.load()
+    config["write_assigned_location_to_xmp"] = False
+    cfg.save(config)
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    pid, xmp_path = _setup_photo_with_xmp(tmp_path, db)
+
+    kid = db.conn.execute(
+        "INSERT INTO keywords (name, type, latitude, longitude) "
+        "VALUES (?, 'location', ?, ?)",
+        ("Paris Airbnb", 48.8566, 2.3522),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (pid, kid),
+    )
+    db.conn.commit()
+    db.queue_change(pid, "location", "effective")
+
+    result = sync_to_xmp(db)
+
+    assert result["synced"] == 1
+    assert result["failed"] == 0
+    assert len(db.get_pending_changes()) == 0
+    with open(xmp_path) as f:
+        content = f.read()
+    assert "GPSLatitude" not in content
+    assert "GPSLongitude" not in content
+
+
+def test_sync_to_xmp_location_cleanup_does_not_write_exif_fallback(tmp_path, monkeypatch):
+    """Assigned-location sync cleanup should not preserve Vireo GPS via EXIF fallback."""
+    import config as cfg
+    from db import Database
+    from sync import sync_to_xmp
+    from xmp import write_gps_location
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    config = cfg.load()
+    config["write_assigned_location_to_xmp"] = True
+    cfg.save(config)
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    pid, xmp_path = _setup_photo_with_xmp(tmp_path, db)
+    db.conn.execute(
+        "UPDATE photos SET latitude=?, longitude=? WHERE id=?",
+        (40.7829, -73.9654, pid),
+    )
+    db.conn.commit()
     write_gps_location(xmp_path, 48.8566, 2.3522, source="keyword")
     db.queue_change(pid, "location", "effective")
 

--- a/vireo/tests/test_sync.py
+++ b/vireo/tests/test_sync.py
@@ -361,6 +361,37 @@ def test_sync_to_xmp_clears_location_change_without_writing_when_disabled(tmp_pa
     assert "GPSLongitude" not in content
 
 
+def test_sync_to_xmp_disabled_location_change_removes_stale_vireo_gps(tmp_path, monkeypatch):
+    """Disabling assigned-location writes still cleans up Vireo-authored GPS."""
+    import config as cfg
+    from db import Database
+    from sync import sync_to_xmp
+    from xmp import write_gps_location
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    config = cfg.load()
+    config["write_assigned_location_to_xmp"] = False
+    cfg.save(config)
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    pid, xmp_path = _setup_photo_with_xmp(tmp_path, db)
+    write_gps_location(xmp_path, 48.8566, 2.3522, source="keyword")
+    db.queue_change(pid, "location", "effective")
+
+    result = sync_to_xmp(db)
+
+    assert result["synced"] == 1
+    assert result["failed"] == 0
+    assert len(db.get_pending_changes()) == 0
+    with open(xmp_path) as f:
+        content = f.read()
+    assert "GPSLatitude" not in content
+    assert "GPSLongitude" not in content
+    assert "vireo:gpsSource" not in content
+
+
 def test_sync_to_xmp_location_cleanup_does_not_write_exif_fallback(tmp_path, monkeypatch):
     """Assigned-location sync cleanup should not preserve Vireo GPS via EXIF fallback."""
     import config as cfg

--- a/vireo/tests/test_xmp.py
+++ b/vireo/tests/test_xmp.py
@@ -218,6 +218,13 @@ def test_remove_vireo_gps_location_restores_previous_gps(sample_xmp):
     assert "vireo:gpsSource" not in content
 
 
+def test_write_gps_location_rejects_out_of_range_coords(sample_xmp):
+    with pytest.raises(ValueError, match="latitude"):
+        write_gps_location(sample_xmp, 91.0, 2.3522)
+    with pytest.raises(ValueError, match="longitude"):
+        write_gps_location(sample_xmp, 48.8566, 181.0)
+
+
 # ── remove_keywords ─────────────────────────────────────────────────────
 
 def test_remove_keywords_normal(sample_xmp):

--- a/vireo/tests/test_xmp.py
+++ b/vireo/tests/test_xmp.py
@@ -10,6 +10,8 @@ from xmp import (
     read_hierarchical_keywords,
     read_keywords,
     remove_keywords,
+    remove_vireo_gps_location,
+    write_gps_location,
     write_pick_flag,
     write_rating,
     write_sidecar,
@@ -147,6 +149,73 @@ def test_write_pick_flag_rejected_creates_sidecar(missing_xmp):
     with open(missing_xmp) as f:
         content = f.read()
     assert 'xmpDM:pick="-1"' in content
+
+
+# ── write_gps_location / remove_vireo_gps_location ──────────────────────
+
+def test_write_gps_location_writes_exif_gps(sample_xmp):
+    write_gps_location(sample_xmp, 48.8566, 2.3522)
+
+    with open(sample_xmp) as f:
+        content = f.read()
+    assert 'exif:GPSLatitude="48,51.396000N"' in content
+    assert 'exif:GPSLongitude="2,21.132000E"' in content
+    assert 'exif:GPSMapDatum="WGS-84"' in content
+    assert 'vireo:gpsSource="assigned"' in content
+
+
+def test_remove_vireo_gps_location_only_when_marked(sample_xmp):
+    write_gps_location(sample_xmp, 48.8566, 2.3522)
+
+    assert remove_vireo_gps_location(sample_xmp) is True
+
+    with open(sample_xmp) as f:
+        content = f.read()
+    assert "GPSLatitude" not in content
+    assert "GPSLongitude" not in content
+    assert "vireo:gpsSource" not in content
+
+
+def test_remove_vireo_gps_location_preserves_unmarked_gps(sample_xmp):
+    from xml.etree import ElementTree as ET
+
+    ns_rdf = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    ns_exif = "http://ns.adobe.com/exif/1.0/"
+    tree = ET.parse(sample_xmp)
+    desc = tree.getroot().find(f".//{{{ns_rdf}}}Description")
+    desc.set(f"{{{ns_exif}}}GPSLatitude", "48,51.396000N")
+    desc.set(f"{{{ns_exif}}}GPSLongitude", "2,21.132000E")
+    tree.write(sample_xmp, xml_declaration=True, encoding="unicode")
+
+    assert remove_vireo_gps_location(sample_xmp) is False
+
+    with open(sample_xmp) as f:
+        content = f.read()
+    assert 'exif:GPSLatitude="48,51.396000N"' in content
+    assert 'exif:GPSLongitude="2,21.132000E"' in content
+
+
+def test_remove_vireo_gps_location_restores_previous_gps(sample_xmp):
+    from xml.etree import ElementTree as ET
+
+    ns_rdf = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    ns_exif = "http://ns.adobe.com/exif/1.0/"
+    tree = ET.parse(sample_xmp)
+    desc = tree.getroot().find(f".//{{{ns_rdf}}}Description")
+    desc.set(f"{{{ns_exif}}}GPSLatitude", "40,46.974000N")
+    desc.set(f"{{{ns_exif}}}GPSLongitude", "73,57.924000W")
+    tree.write(sample_xmp, xml_declaration=True, encoding="unicode")
+
+    write_gps_location(sample_xmp, 48.8566, 2.3522)
+    assert remove_vireo_gps_location(sample_xmp) is True
+
+    with open(sample_xmp) as f:
+        content = f.read()
+    assert 'exif:GPSLatitude="40,46.974000N"' in content
+    assert 'exif:GPSLongitude="73,57.924000W"' in content
+    assert "previousGPSLatitude" not in content
+    assert "previousGPSLongitude" not in content
+    assert "vireo:gpsSource" not in content
 
 
 # ── remove_keywords ─────────────────────────────────────────────────────

--- a/vireo/xmp.py
+++ b/vireo/xmp.py
@@ -5,6 +5,7 @@ All XMP namespace constants and helpers live here as the single source of truth.
 """
 
 import logging
+import math
 from pathlib import Path
 from xml.etree import ElementTree as ET
 
@@ -256,6 +257,13 @@ def write_gps_location(xmp_path, latitude, longitude, source="assigned"):
     so ``remove_vireo_gps_location`` can clear stale assigned-location GPS
     without touching unrelated GPS metadata from another application.
     """
+    lat = float(latitude)
+    lon = float(longitude)
+    if not math.isfinite(lat) or not (-90.0 <= lat <= 90.0):
+        raise ValueError("latitude must be between -90 and 90")
+    if not math.isfinite(lon) or not (-180.0 <= lon <= 180.0):
+        raise ValueError("longitude must be between -180 and 180")
+
     root, tree = _load_or_create_xmp(xmp_path)
     desc = _get_or_create_description(root)
     marker = f"{{{NS_VIREO}}}gpsSource"
@@ -274,8 +282,8 @@ def write_gps_location(xmp_path, latitude, longitude, source="assigned"):
             if attr in desc.attrib:
                 desc.set(f"{{{NS_VIREO}}}previous{name}", desc.attrib[attr])
 
-    desc.set(exif_attrs["GPSLatitude"], _format_gps_coordinate(latitude, "N", "S"))
-    desc.set(exif_attrs["GPSLongitude"], _format_gps_coordinate(longitude, "E", "W"))
+    desc.set(exif_attrs["GPSLatitude"], _format_gps_coordinate(lat, "N", "S"))
+    desc.set(exif_attrs["GPSLongitude"], _format_gps_coordinate(lon, "E", "W"))
     desc.set(exif_attrs["GPSMapDatum"], "WGS-84")
     desc.set(exif_attrs["GPSVersionID"], "2.3.0.0")
     desc.set(marker, source or "assigned")

--- a/vireo/xmp.py
+++ b/vireo/xmp.py
@@ -17,6 +17,8 @@ NS_DC = "http://purl.org/dc/elements/1.1/"
 NS_LR = "http://ns.adobe.com/lightroom/1.0/"
 NS_XMP = "http://ns.adobe.com/xap/1.0/"
 NS_XMPDM = "http://ns.adobe.com/xmp/1.0/DynamicMedia/"
+NS_EXIF = "http://ns.adobe.com/exif/1.0/"
+NS_VIREO = "https://vireo.app/ns/1.0/"
 
 # Register namespaces so ET preserves prefixes on output
 ET.register_namespace("x", NS_X)
@@ -27,9 +29,10 @@ ET.register_namespace("xmp", NS_XMP)
 ET.register_namespace("xmpDM", NS_XMPDM)
 ET.register_namespace("crs", "http://ns.adobe.com/camera-raw-settings/1.0/")
 ET.register_namespace("photoshop", "http://ns.adobe.com/photoshop/1.0/")
-ET.register_namespace("exif", "http://ns.adobe.com/exif/1.0/")
+ET.register_namespace("exif", NS_EXIF)
 ET.register_namespace("tiff", "http://ns.adobe.com/tiff/1.0/")
 ET.register_namespace("aux", "http://ns.adobe.com/exif/1.0/aux/")
+ET.register_namespace("vireo", NS_VIREO)
 
 
 # ── Private helpers ─────────────────────────────────────────────────────
@@ -96,6 +99,15 @@ def _get_or_create_description(root):
     if desc is None:
         desc = ET.SubElement(rdf, f"{{{NS_RDF}}}Description")
     return desc
+
+
+def _format_gps_coordinate(value, positive_ref, negative_ref):
+    """Return an XMP GPSCoordinate string such as ``48,51.398N``."""
+    ref = positive_ref if value >= 0 else negative_ref
+    absolute = abs(float(value))
+    degrees = int(absolute)
+    minutes = (absolute - degrees) * 60.0
+    return f"{degrees},{minutes:.6f}{ref}"
 
 
 # ── Public API ──────────────────────────────────────────────────────────
@@ -235,6 +247,77 @@ def write_pick_flag(xmp_path, flag):
     desc.set(f"{{{NS_XMPDM}}}pick", values[flag])
     ET.indent(tree, space="  ")
     tree.write(xmp_path, xml_declaration=True, encoding="unicode")
+
+
+def write_gps_location(xmp_path, latitude, longitude, source="assigned"):
+    """Write Lightroom-compatible GPS coordinates to an XMP sidecar.
+
+    A small Vireo marker records that these GPS fields were written by Vireo,
+    so ``remove_vireo_gps_location`` can clear stale assigned-location GPS
+    without touching unrelated GPS metadata from another application.
+    """
+    root, tree = _load_or_create_xmp(xmp_path)
+    desc = _get_or_create_description(root)
+    marker = f"{{{NS_VIREO}}}gpsSource"
+    exif_attrs = {
+        "GPSLatitude": f"{{{NS_EXIF}}}GPSLatitude",
+        "GPSLongitude": f"{{{NS_EXIF}}}GPSLongitude",
+        "GPSMapDatum": f"{{{NS_EXIF}}}GPSMapDatum",
+        "GPSVersionID": f"{{{NS_EXIF}}}GPSVersionID",
+    }
+
+    # First Vireo write: preserve any GPS another app had already written so
+    # clearing the Vireo-assigned location can restore it. Rewrites of an
+    # existing Vireo GPS keep the original backup.
+    if marker not in desc.attrib:
+        for name, attr in exif_attrs.items():
+            if attr in desc.attrib:
+                desc.set(f"{{{NS_VIREO}}}previous{name}", desc.attrib[attr])
+
+    desc.set(exif_attrs["GPSLatitude"], _format_gps_coordinate(latitude, "N", "S"))
+    desc.set(exif_attrs["GPSLongitude"], _format_gps_coordinate(longitude, "E", "W"))
+    desc.set(exif_attrs["GPSMapDatum"], "WGS-84")
+    desc.set(exif_attrs["GPSVersionID"], "2.3.0.0")
+    desc.set(marker, source or "assigned")
+    ET.indent(tree, space="  ")
+    tree.write(xmp_path, xml_declaration=True, encoding="unicode")
+
+
+def remove_vireo_gps_location(xmp_path):
+    """Remove GPS fields only when Vireo previously wrote them."""
+    result = _parse_xmp(xmp_path)
+    if result is None:
+        return False
+
+    root, tree = result
+    desc = root.find(f".//{{{NS_RDF}}}Description")
+    if desc is None:
+        return False
+
+    marker = f"{{{NS_VIREO}}}gpsSource"
+    if marker not in desc.attrib:
+        return False
+
+    removed = False
+    for name in ("GPSLatitude", "GPSLongitude", "GPSMapDatum", "GPSVersionID"):
+        gps_attr = f"{{{NS_EXIF}}}{name}"
+        previous_attr = f"{{{NS_VIREO}}}previous{name}"
+        if previous_attr in desc.attrib:
+            desc.set(gps_attr, desc.attrib[previous_attr])
+            del desc.attrib[previous_attr]
+            removed = True
+        elif gps_attr in desc.attrib:
+            del desc.attrib[gps_attr]
+            removed = True
+
+    if marker in desc.attrib:
+        del desc.attrib[marker]
+        removed = True
+
+    if removed:
+        ET.indent(tree, space="  ")
+        tree.write(xmp_path, xml_declaration=True, encoding="unicode")
+    return removed
 
 
 def remove_keywords(xmp_path, keywords_to_remove):


### PR DESCRIPTION
Adds an effective photo location resolver that preserves EXIF-vs-assigned provenance while letting Vireo use Google-linked location keyword coordinates when EXIF GPS is missing.

Uses effective location for iNaturalist prepare/submit defaults and adds an opt-in `write_assigned_location_to_xmp` metadata setting.

When enabled, location changes sync Lightroom-compatible EXIF GPS fields into XMP sidecars with Vireo markers so stale Vireo-authored GPS can be removed or prior GPS restored safely.

Validation: `pytest vireo/tests/test_xmp.py vireo/tests/test_sync.py vireo/tests/test_inat.py vireo/tests/test_config_schema.py -q`, `pytest vireo/tests/test_db.py -q -k "geolocated or effective_photo_location or location"`, and `python -m compileall -q vireo/app.py vireo/db.py vireo/sync.py vireo/xmp.py vireo/config.py vireo/config_schema.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New option to write assigned location coordinates into photo sidecars; when enabled, assigned locations are written or removed from XMP.
  * iNaturalist prepare/submit now prefer an effective (EXIF or assigned) location when EXIF is incomplete.

* **Behavior Changes**
  * Setting/clearing locations and keyword reassociation queue per-photo sidecar sync work.

* **Tests**
  * Added unit and integration tests covering effective-location selection and XMP write/remove behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->