### PR TITLE
Fix multi-select keyword add

### DIFF
--- a/tests/e2e/test_browse_single_select.py
+++ b/tests/e2e/test_browse_single_select.py
@@ -216,6 +216,54 @@ def test_add_keyword_autocomplete_caches_empty_result(live_server, page):
     assert calls["count"] == 1
 
 
+def test_shift_selected_detail_keyword_add_applies_to_selection(live_server, page):
+    """The visible detail keyword field must honor a shift range selection.
+
+    Regression: after click A -> Shift-click C, the detail pane for A stayed
+    visible. Typing a keyword there posted to /api/photos/<A>/keywords, even
+    though the UI showed three selected photos.
+    """
+    db = live_server["db"]
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    cards = page.locator(".grid-card")
+    cards.nth(2).wait_for(state="visible")
+
+    cards.nth(0).click()
+    cards.nth(2).click(modifiers=["Shift"])
+
+    selected_ids = page.evaluate(
+        "getActiveSelection().slice().sort((a, b) => a - b)"
+    )
+    assert len(selected_ids) == 3
+    expect(page.locator("#batchCount")).to_have_text("3 selected")
+    expect(page.locator("#addKeywordInput")).to_be_visible()
+
+    keyword_name = "Range Keyword Smoke"
+    keyword_input = page.locator("#addKeywordInput")
+    keyword_input.fill(keyword_name)
+
+    with page.expect_response(
+        lambda r: "/api/batch/keyword" in r.url
+        and r.request.method == "POST"
+        and r.status == 200
+    ):
+        keyword_input.press("Enter")
+
+    rows = db.conn.execute(
+        """
+        SELECT pk.photo_id
+        FROM photo_keywords pk
+        JOIN keywords k ON k.id = pk.keyword_id
+        WHERE k.name = ? AND pk.photo_id IN ({})
+        ORDER BY pk.photo_id
+        """.format(",".join("?" for _ in selected_ids)),
+        [keyword_name] + selected_ids,
+    ).fetchall()
+    assert [row["photo_id"] for row in rows] == selected_ids
+
+
 def test_cmd_click_toggles_focus_out_of_set_reconciles(live_server, page):
     """click A, cmd-click B, cmd-click A: the focus must not linger on A.
 

--- a/tests/e2e/test_browse_single_select.py
+++ b/tests/e2e/test_browse_single_select.py
@@ -264,6 +264,50 @@ def test_shift_selected_detail_keyword_add_applies_to_selection(live_server, pag
     assert [row["photo_id"] for row in rows] == selected_ids
 
 
+def test_singleton_multiselect_detail_keyword_add_stays_single_photo(live_server, page):
+    """A one-photo set with a focused detail pane should stay a detail edit."""
+    db = live_server["db"]
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    cards = page.locator(".grid-card")
+    cards.nth(1).wait_for(state="visible")
+
+    a_id = int(cards.nth(0).get_attribute("data-id"))
+    b_id = int(cards.nth(1).get_attribute("data-id"))
+
+    cards.nth(0).click()
+    cards.nth(1).click(modifiers=["Meta"])
+    cards.nth(1).click(modifiers=["Meta"])
+
+    assert page.evaluate("Array.from(selectedPhotos)") == [a_id]
+    assert page.evaluate("selectedPhotoId") == a_id
+    expect(page.locator("#addKeywordInput")).to_be_visible()
+
+    keyword_name = "Singleton Detail Keyword"
+    keyword_input = page.locator("#addKeywordInput")
+    keyword_input.fill(keyword_name)
+
+    with page.expect_response(
+        lambda r: f"/api/photos/{a_id}/keywords" in r.url
+        and r.request.method == "POST"
+        and r.status == 200
+    ):
+        keyword_input.press("Enter")
+
+    rows = db.conn.execute(
+        """
+        SELECT pk.photo_id
+        FROM photo_keywords pk
+        JOIN keywords k ON k.id = pk.keyword_id
+        WHERE k.name = ? AND pk.photo_id IN (?, ?)
+        ORDER BY pk.photo_id
+        """,
+        (keyword_name, a_id, b_id),
+    ).fetchall()
+    assert [row["photo_id"] for row in rows] == [a_id]
+
+
 def test_cmd_click_toggles_focus_out_of_set_reconciles(live_server, page):
     """click A, cmd-click B, cmd-click A: the focus must not linger on A.
 

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -4670,7 +4670,9 @@ function updateDetailColors() {
 }
 
 async function addKeyword(keyword) {
-  if (!selectedPhotoId) return;
+  var ids = getActiveSelection();
+  var useBatch = selectedPhotos.size > 0 && ids.length > 0;
+  if (!selectedPhotoId && !useBatch) return;
   var input = document.getElementById('addKeywordInput');
   var name = input.value.trim();
   if (!name) return;
@@ -4683,8 +4685,12 @@ async function addKeyword(keyword) {
   var payload = selectedKeyword && selectedKeyword.id
     ? { keyword_id: selectedKeyword.id }
     : { name: name };
+  if (useBatch) payload.photo_ids = ids;
   try {
-    await safeFetch('/api/photos/' + selectedPhotoId + '/keywords', {
+    var endpoint = useBatch
+      ? '/api/batch/keyword'
+      : '/api/photos/' + selectedPhotoId + '/keywords';
+    await safeFetch(endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
@@ -4693,7 +4699,11 @@ async function addKeyword(keyword) {
     state.selectedKeyword = null;
     hideKeywordSuggestions('addKeywordInput');
     if (!selectedKeyword) invalidateKeywordAutocompleteCache();
-    loadDetail(selectedPhotoId);
+    if (selectedPhotoId) loadDetail(selectedPhotoId);
+    if (useBatch) {
+      selectionKeywordKey = '';
+      loadSelectionKeywordSuggestions(ids);
+    }
     loadKeywords();
     scheduleCollectionCountsRefresh();
     refreshPendingSyncBanner();

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3493,6 +3493,10 @@ function getActiveSelection() {
   return [];
 }
 
+function selectionIdsKey(ids) {
+  return ids.slice().sort(function(a, b) { return a - b; }).join(',');
+}
+
 function isBrowseCompareOpen() {
   var overlay = document.getElementById('browseCompareOverlay');
   return !!(overlay && overlay.classList.contains('active'));
@@ -3702,7 +3706,7 @@ async function renderBrowseCompare() {
 }
 
 async function loadSelectionKeywordSuggestions(ids) {
-  var key = ids.slice().sort(function(a, b) { return a - b; }).join(',');
+  var key = selectionIdsKey(ids);
   if (key === selectionKeywordKey) return;
   selectionKeywordKey = key;
   var seq = ++selectionKeywordRequestSeq;
@@ -4671,7 +4675,8 @@ function updateDetailColors() {
 
 async function addKeyword(keyword) {
   var ids = getActiveSelection();
-  var useBatch = selectedPhotos.size > 0 && ids.length > 0;
+  var useBatch = ids.length > 1;
+  var batchSelectionKey = selectionIdsKey(ids);
   if (!selectedPhotoId && !useBatch) return;
   var input = document.getElementById('addKeywordInput');
   var name = input.value.trim();
@@ -4700,7 +4705,7 @@ async function addKeyword(keyword) {
     hideKeywordSuggestions('addKeywordInput');
     if (!selectedKeyword) invalidateKeywordAutocompleteCache();
     if (selectedPhotoId) loadDetail(selectedPhotoId);
-    if (useBatch) {
+    if (useBatch && selectionIdsKey(getActiveSelection()) === batchSelectionKey) {
       selectionKeywordKey = '';
       loadSelectionKeywordSuggestions(ids);
     }


### PR DESCRIPTION
## Summary
Fixes Browse keyword entry so a visible multi-selection posts to the batch keyword endpoint instead of labeling only the focused photo. This preserves the normal single-photo detail keyword behavior while refreshing multi-select keyword suggestions after batch writes. Adds an e2e regression for click plus Shift-click range selection followed by typing in the visible keyword field.

## Validation
- pytest tests/e2e/test_browse_single_select.py::test_add_keyword_input_suggests_existing_keyword tests/e2e/test_browse_single_select.py::test_multiselect_offers_partial_keyword_fill tests/e2e/test_browse_single_select.py::test_shift_selected_detail_keyword_add_applies_to_selection -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for bulk keyword management—apply keywords to multiple selected photos simultaneously using shift-click selection in the Browse grid.

* **Tests**
  * Added end-to-end test to verify keyword additions correctly apply to all selected photos in batch operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->