### PR TITLE
Clarify location smart collections

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1375,6 +1375,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     # because the target name already exists, leaving a duplicate.
     init_db.migrate_default_subject_collection()
     init_db.migrate_default_needs_identification_collection()
+    init_db.migrate_default_location_collections()
     # One-time rewrite of the previous miss-threshold defaults (0.25 / 0.15)
     # to the new defaults (0.20 / 0.12) in both ~/.vireo/config.json and
     # workspace overrides. Gated by a marker so it runs once; re-saved

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -64,6 +64,18 @@ NEEDS_IDENTIFICATION_RULES = [
     {"field": "wildlife_excluded", "op": "equals", "value": 0},
 ]
 
+GPS_WITHOUT_LOCATION_KEYWORD_RULES = [
+    {"field": "location_keyword_missing", "op": "equals", "value": 1},
+]
+
+NO_LOCATION_INFORMATION_RULES = {
+    "mode": "all",
+    "rules": [
+        {"field": "has_gps", "op": "equals", "value": 0},
+        {"field": "has_location_keyword", "op": "equals", "value": 0},
+    ],
+}
+
 ALL_NAV_IDS = frozenset({
     "pipeline", "jobs", "pipeline_review", "pipeline_rapid_review", "review", "cull",
     "misses", "highlights", "browse", "map", "variants",
@@ -9646,6 +9658,13 @@ class Database:
             if field == "has_gps":
                 has = "p.latitude IS NOT NULL AND p.longitude IS NOT NULL"
                 return (has if _truthy(value) else f"NOT ({has})"), []
+            if field == "has_location_keyword":
+                has = (
+                    "EXISTS (SELECT 1 FROM photo_keywords pk "
+                    "JOIN keywords k ON k.id = pk.keyword_id "
+                    "WHERE pk.photo_id = p.id AND k.type = 'location')"
+                )
+                return (has if _truthy(value) else f"NOT {has}"), []
             if field == "location_keyword_missing":
                 gps = "p.latitude IS NOT NULL AND p.longitude IS NOT NULL"
                 no_loc = (
@@ -9869,8 +9888,8 @@ class Database:
                 [{"field": "timestamp", "op": "recent_days", "value": 30}],
             ),
             (
-                "Needs Location",
-                [{"field": "location_keyword_missing", "op": "equals", "value": 1}],
+                "GPS Without Location Keyword",
+                GPS_WITHOUT_LOCATION_KEYWORD_RULES,
             ),
         ]
         for name, rules in defaults:
@@ -9885,6 +9904,63 @@ class Database:
         """Create missing default smart collections in every workspace."""
         for ws in self.get_workspaces():
             self.create_default_collections(workspace_id=ws["id"])
+
+    def migrate_default_location_collections(self):
+        """Clarify default location collection names/rules across workspaces.
+
+        - ``Needs Location`` was the default collection for photos that already
+          have EXIF GPS but lack a structured Vireo location keyword. Rename
+          exact default instances to the more literal
+          ``GPS Without Location Keyword``.
+        - Some workspaces had a hand-built ``No Location`` collection using the
+          inverse of that rule. That actually meant "not GPS-without-keyword",
+          not "has no location". For that exact legacy rule, replace it with a
+          true ``No Location Information`` collection.
+        """
+        updated = 0
+        gps_rule = GPS_WITHOUT_LOCATION_KEYWORD_RULES
+        no_location_inverse_rules = [
+            [{"field": "location_keyword_missing", "op": "equals", "value": 0}],
+            {
+                "mode": "all",
+                "rules": [
+                    {"field": "location_keyword_missing", "op": "equals", "value": 0},
+                ],
+            },
+        ]
+
+        rows = self.conn.execute(
+            "SELECT id, workspace_id, name, rules FROM collections "
+            "WHERE name IN ('Needs Location', 'No Location')"
+        ).fetchall()
+        for row in rows:
+            try:
+                current = json.loads(row["rules"])
+            except (TypeError, ValueError):
+                continue
+
+            if row["name"] == "Needs Location" and current == gps_rule:
+                self.conn.execute(
+                    "UPDATE collections SET name = ? WHERE id = ?",
+                    ("GPS Without Location Keyword", row["id"]),
+                )
+                updated += 1
+                continue
+
+            if row["name"] == "No Location" and current in no_location_inverse_rules:
+                self.conn.execute(
+                    "UPDATE collections SET name = ?, rules = ? WHERE id = ?",
+                    (
+                        "No Location Information",
+                        json.dumps(NO_LOCATION_INFORMATION_RULES),
+                        row["id"],
+                    ),
+                )
+                updated += 1
+
+        if updated:
+            self.conn.commit()
+        return updated
 
     def migrate_default_subject_collection(self):
         """Rename legacy 'Needs Classification' (with rule has_species==0)

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -9918,7 +9918,13 @@ class Database:
           true ``No Location Information`` collection.
         """
         updated = 0
-        gps_rule = GPS_WITHOUT_LOCATION_KEYWORD_RULES
+        gps_rules = [
+            GPS_WITHOUT_LOCATION_KEYWORD_RULES,
+            {
+                "mode": "all",
+                "rules": GPS_WITHOUT_LOCATION_KEYWORD_RULES,
+            },
+        ]
         no_location_inverse_rules = [
             [{"field": "location_keyword_missing", "op": "equals", "value": 0}],
             {
@@ -9939,10 +9945,14 @@ class Database:
             except (TypeError, ValueError):
                 continue
 
-            if row["name"] == "Needs Location" and current == gps_rule:
+            if row["name"] == "Needs Location" and current in gps_rules:
                 self.conn.execute(
-                    "UPDATE collections SET name = ? WHERE id = ?",
-                    ("GPS Without Location Keyword", row["id"]),
+                    "UPDATE collections SET name = ?, rules = ? WHERE id = ?",
+                    (
+                        "GPS Without Location Keyword",
+                        json.dumps(GPS_WITHOUT_LOCATION_KEYWORD_RULES),
+                        row["id"],
+                    ),
                 )
                 updated += 1
                 continue

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2361,6 +2361,7 @@ var FIELD_OPS = {
   has_mask: ['equals'],
   active_mask_variant: ['is', 'is not', 'contains'],
   has_gps: ['equals'],
+  has_location_keyword: ['equals'],
   wildlife_excluded: ['equals'],
   location_keyword_missing: ['equals'],
   inat_submitted: ['equals'],
@@ -2387,6 +2388,7 @@ var FIELD_LABELS = {
   has_mask: 'Has Mask',
   active_mask_variant: 'Mask Variant',
   has_gps: 'Has GPS',
+  has_location_keyword: 'Has Location Keyword',
   wildlife_excluded: 'Not Wildlife',
   location_keyword_missing: 'GPS Without Location Keyword',
   inat_submitted: 'iNaturalist Submitted',
@@ -2426,8 +2428,8 @@ function defaultValueForRule(field, op) {
   if (field === 'active_mask_variant') return 'sam2-large';
   if (field === 'prediction_status') return 'pending';
   if (field === 'wildlife_excluded') return 0;
-  if (['has_mask', 'has_gps', 'location_keyword_missing', 'inat_submitted',
-       'is_duplicate', 'needs_review'].indexOf(field) !== -1) return 1;
+  if (['has_mask', 'has_gps', 'has_location_keyword', 'location_keyword_missing',
+       'inat_submitted', 'is_duplicate', 'needs_review'].indexOf(field) !== -1) return 1;
   return '';
 }
 
@@ -2658,8 +2660,9 @@ function renderRuleValueInput(r, i) {
   if (r.field === 'all') {
     return '<span style="flex:1;color:var(--text-ghost);font-size:12px;">Matches every photo in this workspace</span>';
   }
-  if (['has_mask', 'has_gps', 'wildlife_excluded', 'location_keyword_missing',
-       'inat_submitted', 'is_duplicate', 'needs_review'].indexOf(r.field) !== -1) {
+  if (['has_mask', 'has_gps', 'has_location_keyword', 'wildlife_excluded',
+       'location_keyword_missing', 'inat_submitted', 'is_duplicate',
+       'needs_review'].indexOf(r.field) !== -1) {
     var boolVal = (r.value === true || r.value === 1 || r.value === '1' || r.value === 'true') ? '1' : '0';
     return '<select onchange="updateRule(\'' + p + '\',\'value\',this.value)" style="flex:1;">' +
         '<option value="1"' + (boolVal==='1'?' selected':'') + '>Yes</option>' +
@@ -2817,8 +2820,9 @@ function coerceRuleForSave(node) {
        'noise_estimate', 'crop_complete', 'prediction_confidence'].indexOf(node.field) !== -1) {
     val = parseFloat(val);
     if (isNaN(val)) val = 0;
-  } else if (['has_mask', 'has_gps', 'location_keyword_missing', 'inat_submitted',
-              'is_duplicate', 'needs_review', 'all'].indexOf(node.field) !== -1) {
+  } else if (['has_mask', 'has_gps', 'has_location_keyword',
+              'location_keyword_missing', 'inat_submitted', 'is_duplicate',
+              'needs_review', 'all'].indexOf(node.field) !== -1) {
     val = (val === true || val === 1 || val === '1' || val === 'true') ? 1 : 0;
   } else if (node.field === 'timestamp' && node.op === 'recent_days') {
     val = parseInt(val, 10) || 0;

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -1625,6 +1625,10 @@ def test_migrate_default_location_collections_renames_and_fixes_exact_legacy_rul
     db.set_active_workspace(ws_id)
     db.add_collection("Needs Location", json.dumps(GPS_WITHOUT_LOCATION_KEYWORD_RULES))
     db.add_collection(
+        "Needs Location",
+        json.dumps({"mode": "all", "rules": GPS_WITHOUT_LOCATION_KEYWORD_RULES}),
+    )
+    db.add_collection(
         "No Location",
         json.dumps({
             "mode": "all",
@@ -1647,7 +1651,7 @@ def test_migrate_default_location_collections_renames_and_fixes_exact_legacy_rul
         for c in db.get_collections()
         if c["name"] == "No Location"
     ]
-    assert updated == 2
+    assert updated == 3
     assert rows["GPS Without Location Keyword"] == GPS_WITHOUT_LOCATION_KEYWORD_RULES
     assert rows["No Location Information"] == NO_LOCATION_INFORMATION_RULES
     assert custom == [[{"field": "rating", "op": ">=", "value": 3}]]

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -1320,7 +1320,7 @@ def test_default_collections_created(tmp_path):
     assert 'Untagged' in names
     assert 'Flagged' in names
     assert 'Recent Import' in names
-    assert 'Needs Location' in names
+    assert 'GPS Without Location Keyword' in names
 
 
 def test_default_collections_idempotent(tmp_path):
@@ -1354,7 +1354,7 @@ def test_default_collections_adds_missing(tmp_path):
     assert 'Needs Identification' in names
     assert 'Untagged' in names
     assert 'Recent Import' in names
-    assert 'Needs Location' in names
+    assert 'GPS Without Location Keyword' in names
     assert len(colls) == 6  # no duplicate Flagged
 
 
@@ -1369,7 +1369,7 @@ def test_default_collections_for_all_workspaces_adds_missing_defaults(tmp_path):
 
     # Simulate an upgraded multi-workspace database where only one workspace
     # already had the older default set. The all-workspaces startup pass should
-    # add the new Needs Location default everywhere without duplicating Flagged.
+    # add the new GPS/location-keyword default everywhere without duplicating Flagged.
     db.conn.execute(
         "INSERT INTO collections (workspace_id, name, rules) VALUES (?, ?, ?)",
         (
@@ -1388,7 +1388,7 @@ def test_default_collections_for_all_workspaces_adds_missing_defaults(tmp_path):
             "SELECT name FROM collections WHERE workspace_id = ?", (ws,),
         ).fetchall()
         names = [r["name"] for r in rows]
-        assert "Needs Location" in names
+        assert "GPS Without Location Keyword" in names
         assert names.count("Flagged") == 1
 
 
@@ -1530,13 +1530,13 @@ def test_upgrade_path_no_duplicate_collection(tmp_path):
     # Sanity: default collections include one Needs Identification, not a
     # duplicate alongside the legacy Needs Classification.
     default_names = {"All Photos", "Needs Identification", "Untagged",
-                     "Flagged", "Recent Import", "Needs Location"}
+                     "Flagged", "Recent Import", "GPS Without Location Keyword"}
     assert default_names.issubset(cols.keys())
 
 
-def test_default_needs_location_collection_matches_gps_without_location_keyword(tmp_path):
-    """The default Needs Location collection surfaces geotagged photos that
-    still need Vireo's structured location keyword."""
+def test_default_gps_without_location_keyword_collection_matches_expected_photos(tmp_path):
+    """The default GPS/location-keyword collection surfaces geotagged photos
+    that still need Vireo's structured location keyword."""
     from db import Database
 
     db = Database(str(tmp_path / "test.db"))
@@ -1564,10 +1564,93 @@ def test_default_needs_location_collection_matches_gps_without_location_keyword(
 
     db.create_default_collections()
     cid = next(c["id"] for c in db.get_collections()
-               if c["name"] == "Needs Location")
+               if c["name"] == "GPS Without Location Keyword")
 
     pids = {p["id"] for p in db.get_collection_photos(cid, per_page=999)}
     assert pids == {needs_location}
+
+
+def test_has_location_keyword_rule_and_no_location_information_definition(tmp_path):
+    """No Location Information means no EXIF GPS and no location keyword."""
+    import json
+
+    from db import NO_LOCATION_INFORMATION_RULES, Database
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    fid = db.add_folder('/photos', name='photos')
+    no_location = db.add_photo(
+        folder_id=fid, filename='no-location.jpg',
+        extension='.jpg', file_size=100, file_mtime=1.0,
+    )
+    gps_no_keyword = db.add_photo(
+        folder_id=fid, filename='gps-no-keyword.jpg',
+        extension='.jpg', file_size=100, file_mtime=1.0,
+    )
+    no_gps_with_keyword = db.add_photo(
+        folder_id=fid, filename='keyword-only.jpg',
+        extension='.jpg', file_size=100, file_mtime=1.0,
+    )
+    gps_with_keyword = db.add_photo(
+        folder_id=fid, filename='gps-keyword.jpg',
+        extension='.jpg', file_size=100, file_mtime=1.0,
+    )
+    db.conn.execute(
+        "UPDATE photos SET latitude = 1.0, longitude = 2.0 WHERE id IN (?, ?)",
+        (gps_no_keyword, gps_with_keyword),
+    )
+    loc_kw = db.add_keyword("Yosemite", kw_type="location")
+    db.tag_photo(no_gps_with_keyword, loc_kw)
+    db.tag_photo(gps_with_keyword, loc_kw)
+
+    cid = db.add_collection("No Location Information", json.dumps(NO_LOCATION_INFORMATION_RULES))
+
+    pids = {p["id"] for p in db.get_collection_photos(cid, per_page=999)}
+    assert pids == {no_location}
+
+
+def test_migrate_default_location_collections_renames_and_fixes_exact_legacy_rules(tmp_path):
+    """Clarify old location collection names without touching customized rules."""
+    import json
+
+    from db import (
+        GPS_WITHOUT_LOCATION_KEYWORD_RULES,
+        NO_LOCATION_INFORMATION_RULES,
+        Database,
+    )
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    db.add_collection("Needs Location", json.dumps(GPS_WITHOUT_LOCATION_KEYWORD_RULES))
+    db.add_collection(
+        "No Location",
+        json.dumps({
+            "mode": "all",
+            "rules": [
+                {"field": "location_keyword_missing", "op": "equals", "value": 0},
+            ],
+        }),
+    )
+    db.add_collection("No Location", json.dumps([{"field": "rating", "op": ">=", "value": 3}]))
+
+    updated = db.migrate_default_location_collections()
+
+    rows = {
+        c["name"]: json.loads(c["rules"])
+        for c in db.get_collections()
+        if c["name"] != "No Location"
+    }
+    custom = [
+        json.loads(c["rules"])
+        for c in db.get_collections()
+        if c["name"] == "No Location"
+    ]
+    assert updated == 2
+    assert rows["GPS Without Location Keyword"] == GPS_WITHOUT_LOCATION_KEYWORD_RULES
+    assert rows["No Location Information"] == NO_LOCATION_INFORMATION_RULES
+    assert custom == [[{"field": "rating", "op": ">=", "value": 3}]]
 
 
 def test_default_genre_keywords_inserted(tmp_path):

--- a/vireo/tests/test_workspaces_api.py
+++ b/vireo/tests/test_workspaces_api.py
@@ -102,7 +102,7 @@ def test_create_workspace_seeds_default_collections(app_and_db):
     ).fetchall()
     names = {r["name"] for r in rows}
     assert {"All Photos", "Needs Identification", "Untagged",
-            "Flagged", "Recent Import", "Needs Location"} <= names
+            "Flagged", "Recent Import", "GPS Without Location Keyword"} <= names
 
 
 def test_update_workspace(app_and_db):


### PR DESCRIPTION
Renames the default location smart collection to `GPS Without Location Keyword` so it describes photos that have EXIF GPS but lack a structured Vireo location keyword. Adds a `has_location_keyword` rule and uses it to migrate exact legacy `No Location` inverse-rule collections into a true `No Location Information` collection. The startup migration preserves customized `No Location` collections while updating exact legacy defaults across workspaces. Tests cover the new rule semantics, migration behavior, and workspace default seeding.