### PR TITLE
Clarify threshold-hidden classification results

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -14046,6 +14046,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                  ON pr_rev.prediction_id = pr.id AND pr_rev.workspace_id = ?
                WHERE d.photo_id = ?
                  AND d.detector_confidence >= ?
+                 AND d.detector_model != 'full-image'
                  AND pr.labels_fingerprint = (
                     SELECT pr2.labels_fingerprint FROM predictions pr2
                     WHERE pr2.detection_id = pr.detection_id

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -14004,7 +14004,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             min_conf = float(min_conf)
         except (TypeError, ValueError):
             min_conf = 0.2
-        raw_dets = db.get_detections(photo_id, min_conf=0)
+        raw_dets = [
+            d for d in db.get_detections(photo_id, min_conf=0)
+            if d["detector_model"] != "full-image"
+        ]
         dets = [d for d in raw_dets if d["detector_confidence"] >= min_conf]
         result["detections"] = [dict(d) for d in dets]
 
@@ -14060,6 +14063,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                FROM predictions pr
                JOIN detections d ON d.id = pr.detection_id
                WHERE d.photo_id = ?
+                 AND d.detector_model != 'full-image'
                  AND pr.labels_fingerprint = (
                     SELECT pr2.labels_fingerprint FROM predictions pr2
                     WHERE pr2.detection_id = pr.detection_id
@@ -14073,7 +14077,31 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             """SELECT cr.prediction_count, d.detector_confidence
                FROM classifier_runs cr
                JOIN detections d ON d.id = cr.detection_id
-               WHERE d.photo_id = ?""",
+               WHERE d.photo_id = ?
+                 AND d.detector_model != 'full-image'""",
+            (photo_id,),
+        ).fetchall()
+        full_image_pred_rows = db.conn.execute(
+            """SELECT pr.id
+               FROM predictions pr
+               JOIN detections d ON d.id = pr.detection_id
+               WHERE d.photo_id = ?
+                 AND d.detector_model = 'full-image'
+                 AND pr.labels_fingerprint = (
+                    SELECT pr2.labels_fingerprint FROM predictions pr2
+                    WHERE pr2.detection_id = pr.detection_id
+                      AND pr2.classifier_model = pr.classifier_model
+                    ORDER BY pr2.created_at DESC, pr2.id DESC
+                    LIMIT 1
+                 )""",
+            (photo_id,),
+        ).fetchall()
+        full_image_classifier_runs = db.conn.execute(
+            """SELECT cr.prediction_count
+               FROM classifier_runs cr
+               JOIN detections d ON d.id = cr.detection_id
+               WHERE d.photo_id = ?
+                 AND d.detector_model = 'full-image'""",
             (photo_id,),
         ).fetchall()
         max_raw_conf = (
@@ -14094,6 +14122,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 if p["detector_confidence"] < min_conf
             ),
             "classifier_run_count": len(classifier_runs),
+            "full_image_prediction_count": len(full_image_pred_rows),
+            "full_image_classifier_run_count": len(full_image_classifier_runs),
             "hidden_classifier_run_count": sum(
                 1
                 for r in classifier_runs

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -13992,9 +13992,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         result.pop("detection_box", None)
         result.pop("detection_conf", None)
 
-        # Get detections for this photo — threshold resolved at read time
-        # from the workspace-effective config.
-        dets = db.get_detections(photo_id)
+        # Get detections for this photo. The main inspector view honors the
+        # workspace-effective detector threshold, but the diagnostics keep raw
+        # counts so the UI can distinguish "not run" from "hidden by threshold".
+        import config as cfg
+        ws = db._active_workspace_id
+        min_conf = db.get_effective_config(cfg.load()).get(
+            "detector_confidence", 0.2
+        )
+        try:
+            min_conf = float(min_conf)
+        except (TypeError, ValueError):
+            min_conf = 0.2
+        raw_dets = db.get_detections(photo_id, min_conf=0)
+        dets = [d for d in raw_dets if d["detector_confidence"] >= min_conf]
         result["detections"] = [dict(d) for d in dets]
 
         # Primary detection = highest-confidence above threshold.
@@ -14017,11 +14028,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # Also pin to the most recent labels_fingerprint per
         # (detection, classifier_model) so a workspace that rotated label
         # sets doesn't see a debug payload mixing stale and current labels.
-        import config as cfg
-        ws = db._active_workspace_id
-        min_conf = db.get_effective_config(cfg.load()).get(
-            "detector_confidence", 0.2
-        )
         preds = db.conn.execute(
             """SELECT pr.species, pr.confidence, pr.classifier_model AS model,
                       pr.category,
@@ -14048,6 +14054,57 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             (ws, photo_id, min_conf),
         ).fetchall()
         result["predictions"] = [dict(p) for p in preds]
+
+        current_pred_rows = db.conn.execute(
+            """SELECT pr.id, d.detector_confidence
+               FROM predictions pr
+               JOIN detections d ON d.id = pr.detection_id
+               WHERE d.photo_id = ?
+                 AND pr.labels_fingerprint = (
+                    SELECT pr2.labels_fingerprint FROM predictions pr2
+                    WHERE pr2.detection_id = pr.detection_id
+                      AND pr2.classifier_model = pr.classifier_model
+                    ORDER BY pr2.created_at DESC, pr2.id DESC
+                    LIMIT 1
+                 )""",
+            (photo_id,),
+        ).fetchall()
+        classifier_runs = db.conn.execute(
+            """SELECT cr.prediction_count, d.detector_confidence
+               FROM classifier_runs cr
+               JOIN detections d ON d.id = cr.detection_id
+               WHERE d.photo_id = ?""",
+            (photo_id,),
+        ).fetchall()
+        max_raw_conf = (
+            max(d["detector_confidence"] for d in raw_dets)
+            if raw_dets else None
+        )
+        result["classification_diagnostics"] = {
+            "detector_confidence_threshold": min_conf,
+            "raw_detection_count": len(raw_dets),
+            "visible_detection_count": len(dets),
+            "hidden_detection_count": max(0, len(raw_dets) - len(dets)),
+            "max_detector_confidence": max_raw_conf,
+            "current_prediction_count": len(current_pred_rows),
+            "visible_prediction_count": len(preds),
+            "hidden_prediction_count": sum(
+                1
+                for p in current_pred_rows
+                if p["detector_confidence"] < min_conf
+            ),
+            "classifier_run_count": len(classifier_runs),
+            "hidden_classifier_run_count": sum(
+                1
+                for r in classifier_runs
+                if r["detector_confidence"] < min_conf
+            ),
+            "zero_prediction_classifier_run_count": sum(
+                1
+                for r in classifier_runs
+                if r["prediction_count"] == 0
+            ),
+        }
 
         # Get keywords
         keywords = db.get_photo_keywords(photo_id)

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -5076,6 +5076,10 @@ function closePipeline() {
 
 function renderPipeline(data, photoId) {
   var c = document.getElementById('pipelineContent');
+  var diag = data.classification_diagnostics || {};
+  var detectorThreshold = diag.detector_confidence_threshold != null ? diag.detector_confidence_threshold : 0.2;
+  var detectorThresholdPct = Math.round(detectorThreshold * 100);
+  var maxDetectorPct = diag.max_detector_confidence != null ? Math.round(diag.max_detector_confidence * 100) : null;
   var html = '<div class="pipeline-steps">';
 
   // Step 1: Original image
@@ -5106,8 +5110,12 @@ function renderPipeline(data, photoId) {
       '<div class="pipeline-stat">Confidence: <b>' + Math.round(data.detection_conf * 100) + '%</b></div>' +
       '<div class="pipeline-stat">Subject size: <b>' + Math.round((db.w * db.h) * 10000) / 100 + '%</b> of frame</div>' +
     '</div>';
+  } else if ((diag.hidden_detection_count || 0) > 0) {
+    html += '<p style="color:var(--text-dim);font-size:13px;">No subject above the current detector threshold. ' +
+      diag.hidden_detection_count + ' lower-confidence detection' + (diag.hidden_detection_count === 1 ? ' is' : 's are') +
+      ' stored' + (maxDetectorPct != null ? ' (best ' + maxDetectorPct + '%, threshold ' + detectorThresholdPct + '%)' : '') + '.</p>';
   } else {
-    html += '<p style="color:var(--text-dim);font-size:13px;">No subject detected — full image sent to classifier</p>';
+    html += '<p style="color:var(--text-dim);font-size:13px;">No subject detected</p>';
   }
   html += '</div>';
 
@@ -5166,7 +5174,22 @@ function renderPipeline(data, photoId) {
       '</div>';
     }
   } else {
-    html += '<p style="color:var(--text-dim);font-size:13px;">No predictions yet — run classification first</p>';
+    var currentPreds = diag.current_prediction_count || 0;
+    var hiddenPreds = diag.hidden_prediction_count || 0;
+    var classifierRuns = diag.classifier_run_count || 0;
+    if (hiddenPreds > 0) {
+      html += '<p style="color:var(--text-dim);font-size:13px;">Classification ran, but ' +
+        hiddenPreds + ' stored prediction' + (hiddenPreds === 1 ? ' is' : 's are') +
+        ' attached to detection' + (hiddenPreds === 1 ? '' : 's') +
+        ' below the current detector threshold' +
+        (maxDetectorPct != null ? ' (best detection ' + maxDetectorPct + '%, threshold ' + detectorThresholdPct + '%)' : '') + '.</p>';
+    } else if (classifierRuns > 0 && currentPreds === 0) {
+      html += '<p style="color:var(--text-dim);font-size:13px;">Classification ran, but no predictions were stored above the classification threshold.</p>';
+    } else if ((diag.hidden_detection_count || 0) > 0) {
+      html += '<p style="color:var(--text-dim);font-size:13px;">No predictions visible because all stored detections are below the current detector threshold.</p>';
+    } else {
+      html += '<p style="color:var(--text-dim);font-size:13px;">No predictions yet &mdash; run classification first</p>';
+    }
   }
   html += '</div>';
 

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -5177,12 +5177,18 @@ function renderPipeline(data, photoId) {
     var currentPreds = diag.current_prediction_count || 0;
     var hiddenPreds = diag.hidden_prediction_count || 0;
     var classifierRuns = diag.classifier_run_count || 0;
+    var fullImagePreds = diag.full_image_prediction_count || 0;
+    var fullImageRuns = diag.full_image_classifier_run_count || 0;
     if (hiddenPreds > 0) {
       html += '<p style="color:var(--text-dim);font-size:13px;">Classification ran, but ' +
         hiddenPreds + ' stored prediction' + (hiddenPreds === 1 ? ' is' : 's are') +
         ' attached to detection' + (hiddenPreds === 1 ? '' : 's') +
         ' below the current detector threshold' +
         (maxDetectorPct != null ? ' (best detection ' + maxDetectorPct + '%, threshold ' + detectorThresholdPct + '%)' : '') + '.</p>';
+    } else if (fullImagePreds > 0) {
+      html += '<p style="color:var(--text-dim);font-size:13px;">Classification ran using the full image because no detector box was available.</p>';
+    } else if (fullImageRuns > 0) {
+      html += '<p style="color:var(--text-dim);font-size:13px;">Classification ran using the full image, but no predictions were stored above the classification threshold.</p>';
     } else if (classifierRuns > 0 && currentPreds === 0) {
       html += '<p style="color:var(--text-dim);font-size:13px;">Classification ran, but no predictions were stored above the classification threshold.</p>';
     } else if ((diag.hidden_detection_count || 0) > 0) {

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -1738,6 +1738,9 @@ def test_api_photo_pipeline_diagnoses_full_image_predictions(app_and_db):
     """Synthetic full-image anchors are not below-threshold detector boxes."""
     app, db = app_and_db
     pid = db.conn.execute("SELECT id FROM photos LIMIT 1").fetchone()["id"]
+    db.update_workspace(db._active_workspace_id, config_overrides={
+        "detector_confidence": 0.0,
+    })
     det_id = db.save_detections(pid, [
         {"box": {"x": 0, "y": 0, "w": 1, "h": 1},
          "confidence": 0, "category": "animal"},
@@ -1761,6 +1764,7 @@ def test_api_photo_pipeline_diagnoses_full_image_predictions(app_and_db):
     data = resp.get_json()
 
     assert data["detections"] == []
+    assert data["predictions"] == []
     diag = data["classification_diagnostics"]
     assert diag["raw_detection_count"] == 0
     assert diag["hidden_detection_count"] == 0

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -1681,6 +1681,57 @@ def test_api_photo_pipeline_predictions_honor_threshold_and_fingerprint(app_and_
         f"predictions must match detections (one current-fingerprint "
         f"row, no stale, no below-threshold); got {species}"
     )
+    diag = data["classification_diagnostics"]
+    assert diag["raw_detection_count"] == 2
+    assert diag["visible_detection_count"] == 1
+    assert diag["hidden_detection_count"] == 1
+    assert diag["current_prediction_count"] == 2
+    assert diag["visible_prediction_count"] == 1
+    assert diag["hidden_prediction_count"] == 1
+
+
+def test_api_photo_pipeline_diagnoses_threshold_hidden_predictions(app_and_db):
+    """A photo can be classified while the inspector has no visible predictions.
+
+    Low-confidence detections are stored globally and may have predictions from
+    the run that produced them. The visible inspector lists still honor the
+    active detector threshold, but diagnostics must make the hidden state clear.
+    """
+    app, db = app_and_db
+    pid = db.conn.execute("SELECT id FROM photos LIMIT 1").fetchone()["id"]
+    det_id = db.save_detections(pid, [
+        {"box": {"x": 0.6, "y": 0.6, "w": 0.3, "h": 0.3},
+         "confidence": 0.05, "category": "animal"},
+    ], detector_model="MDV6")[0]
+    db.conn.execute(
+        "INSERT INTO predictions (detection_id, classifier_model, "
+        "labels_fingerprint, species, confidence, created_at) "
+        "VALUES (?, 'bioclip-2', 'fp-new', 'Sparrow', 0.9, '2026-04-24')",
+        (det_id,),
+    )
+    db.conn.execute(
+        "INSERT INTO classifier_runs (detection_id, classifier_model, "
+        "labels_fingerprint, prediction_count) VALUES (?, 'bioclip-2', 'fp-new', 1)",
+        (det_id,),
+    )
+    db.conn.commit()
+
+    client = app.test_client()
+    resp = client.get(f"/api/photos/{pid}/pipeline")
+    assert resp.status_code == 200
+    data = resp.get_json()
+
+    assert data["detections"] == []
+    assert data["predictions"] == []
+    diag = data["classification_diagnostics"]
+    assert diag["raw_detection_count"] == 1
+    assert diag["visible_detection_count"] == 0
+    assert diag["hidden_detection_count"] == 1
+    assert diag["current_prediction_count"] == 1
+    assert diag["visible_prediction_count"] == 0
+    assert diag["hidden_prediction_count"] == 1
+    assert diag["classifier_run_count"] == 1
+    assert diag["hidden_classifier_run_count"] == 1
 
 
 def test_compare_predictions_api_requires_collection(app_and_db):

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -1734,6 +1734,43 @@ def test_api_photo_pipeline_diagnoses_threshold_hidden_predictions(app_and_db):
     assert diag["hidden_classifier_run_count"] == 1
 
 
+def test_api_photo_pipeline_diagnoses_full_image_predictions(app_and_db):
+    """Synthetic full-image anchors are not below-threshold detector boxes."""
+    app, db = app_and_db
+    pid = db.conn.execute("SELECT id FROM photos LIMIT 1").fetchone()["id"]
+    det_id = db.save_detections(pid, [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1},
+         "confidence": 0, "category": "animal"},
+    ], detector_model="full-image")[0]
+    db.conn.execute(
+        "INSERT INTO predictions (detection_id, classifier_model, "
+        "labels_fingerprint, species, confidence, created_at) "
+        "VALUES (?, 'bioclip-2', 'fp-new', 'Robin', 0.8, '2026-04-24')",
+        (det_id,),
+    )
+    db.conn.execute(
+        "INSERT INTO classifier_runs (detection_id, classifier_model, "
+        "labels_fingerprint, prediction_count) VALUES (?, 'bioclip-2', 'fp-new', 1)",
+        (det_id,),
+    )
+    db.conn.commit()
+
+    client = app.test_client()
+    resp = client.get(f"/api/photos/{pid}/pipeline")
+    assert resp.status_code == 200
+    data = resp.get_json()
+
+    assert data["detections"] == []
+    diag = data["classification_diagnostics"]
+    assert diag["raw_detection_count"] == 0
+    assert diag["hidden_detection_count"] == 0
+    assert diag["current_prediction_count"] == 0
+    assert diag["hidden_prediction_count"] == 0
+    assert diag["classifier_run_count"] == 0
+    assert diag["full_image_prediction_count"] == 1
+    assert diag["full_image_classifier_run_count"] == 1
+
+
 def test_compare_predictions_api_requires_collection(app_and_db):
     """GET /api/predictions/compare without collection_id returns 400."""
     app, _ = app_and_db


### PR DESCRIPTION
## Summary
Clarifies the Pipeline Inspector when classification has run but predictions are hidden because their detections are below the active detector threshold. The photo pipeline API now includes diagnostics for raw detections, visible detections, hidden predictions, and classifier runs, while the UI uses those diagnostics to avoid saying users need to run classification again. Adds focused API coverage for threshold-hidden prediction states.

## Tests
pytest vireo/tests/test_app.py -k "photo_pipeline"