### PR TITLE
Add dedicated Best Batch review page

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -447,9 +447,11 @@ def _best_batch_scope(db, seed_photo_id, max_gap_seconds=8.0, max_sequence_gap=2
         start = max(0, end - max_photos)
         return rows[start:end]
 
-    def _time_ok(left, right):
+    def _time_ok(left, right, require_timestamps=False):
         gap = _time_gap_seconds(left["timestamp"], right["timestamp"])
-        return gap is None or gap <= max_gap_seconds
+        if gap is None:
+            return not require_timestamps
+        return gap <= max_gap_seconds
 
     if seed_key:
         prefix, _, width, _ = seed_key
@@ -512,10 +514,16 @@ def _best_batch_scope(db, seed_photo_id, max_gap_seconds=8.0, max_sequence_gap=2
     if seed_idx is None:
         return None, "Photo not found"
     left = seed_idx
-    while left > 0 and _time_ok(rows[left - 1], rows[left]):
+    while (
+        left > 0
+        and _time_ok(rows[left - 1], rows[left], require_timestamps=True)
+    ):
         left -= 1
     right = seed_idx
-    while right < len(rows) - 1 and _time_ok(rows[right], rows[right + 1]):
+    while (
+        right < len(rows) - 1
+        and _time_ok(rows[right], rows[right + 1], require_timestamps=True)
+    ):
         right += 1
     batch = rows[left:right + 1]
     if len(batch) < 2:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -387,6 +387,275 @@ def _chunked(seq, size=_SQL_PARAM_CHUNK):
         yield seq[i:i + size]
 
 
+def _filename_sequence_key(filename):
+    """Return (prefix, number, width, ext) for names like DSC_3069.NEF."""
+    stem, ext = os.path.splitext(filename or "")
+    match = re.match(r"^(.*?)(\d+)$", stem)
+    if not match:
+        return None
+    digits = match.group(2)
+    return (match.group(1), int(digits), len(digits), ext.lower())
+
+
+def _parse_capture_timestamp(value):
+    if value is None or isinstance(value, datetime):
+        return value
+    try:
+        return datetime.fromisoformat(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _time_gap_seconds(a, b):
+    ta = _parse_capture_timestamp(a)
+    tb = _parse_capture_timestamp(b)
+    if ta is None or tb is None:
+        return None
+    try:
+        return abs((ta - tb).total_seconds())
+    except TypeError:
+        return None
+
+
+def _best_batch_scope(db, seed_photo_id, max_gap_seconds=8.0, max_sequence_gap=2, max_photos=120):
+    """Find a likely burst/batch around one seed photo.
+
+    The first pass follows same-folder filename sequence numbers, which matches
+    camera batches such as DSC_3069...DSC_3133. Capture time is used as a
+    boundary when available. If a filename has no trailing number, fall back to
+    neighboring capture-time rows in the folder.
+    """
+    seed = db.get_photo(seed_photo_id, verify_workspace=True)
+    if not seed:
+        return None, "Photo not found"
+
+    folder_id = seed["folder_id"]
+    seed_key = _filename_sequence_key(seed["filename"])
+    seed_ext = (seed["extension"] or os.path.splitext(seed["filename"])[1]).lower()
+    ws = db._ws_id()
+
+    def _limited(rows):
+        if len(rows) <= max_photos:
+            return rows
+        seed_idx = next(
+            (i for i, row in enumerate(rows) if row["id"] == seed_photo_id),
+            len(rows) // 2,
+        )
+        half = max_photos // 2
+        start = max(0, seed_idx - half)
+        end = min(len(rows), start + max_photos)
+        start = max(0, end - max_photos)
+        return rows[start:end]
+
+    def _time_ok(left, right):
+        gap = _time_gap_seconds(left["timestamp"], right["timestamp"])
+        return gap is None or gap <= max_gap_seconds
+
+    if seed_key:
+        prefix, _, width, _ = seed_key
+        rows = db.conn.execute(
+            """SELECT p.id, p.folder_id, p.filename, p.extension, p.timestamp,
+                      p.flag, p.rating, p.quality_score, p.sharpness
+               FROM photos p
+               JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+               JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')
+               WHERE wf.workspace_id = ? AND p.folder_id = ? AND p.filename LIKE ?
+               ORDER BY p.filename ASC, p.id ASC""",
+            (ws, folder_id, f"{prefix}%"),
+        ).fetchall()
+        seq_rows = []
+        for row in rows:
+            key = _filename_sequence_key(row["filename"])
+            row_ext = (row["extension"] or os.path.splitext(row["filename"])[1]).lower()
+            if (
+                key
+                and key[0] == prefix
+                and key[2] == width
+                and row_ext == seed_ext
+            ):
+                seq_rows.append((key[1], row))
+        seq_rows.sort(key=lambda item: (item[0], item[1]["filename"], item[1]["id"]))
+        seed_idx = next(
+            (i for i, (_, row) in enumerate(seq_rows) if row["id"] == seed_photo_id),
+            None,
+        )
+        if seed_idx is not None:
+            left = seed_idx
+            while left > 0:
+                prev_num, prev_row = seq_rows[left - 1]
+                curr_num, curr_row = seq_rows[left]
+                if curr_num - prev_num > max_sequence_gap or not _time_ok(prev_row, curr_row):
+                    break
+                left -= 1
+            right = seed_idx
+            while right < len(seq_rows) - 1:
+                curr_num, curr_row = seq_rows[right]
+                next_num, next_row = seq_rows[right + 1]
+                if next_num - curr_num > max_sequence_gap or not _time_ok(curr_row, next_row):
+                    break
+                right += 1
+            batch = [row for _, row in seq_rows[left:right + 1]]
+            if len(batch) >= 2:
+                return _limited(batch), "filename_sequence"
+
+    rows = db.conn.execute(
+        """SELECT p.id, p.folder_id, p.filename, p.extension, p.timestamp,
+                  p.flag, p.rating, p.quality_score, p.sharpness
+           FROM photos p
+           JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+           JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')
+           WHERE wf.workspace_id = ? AND p.folder_id = ?
+           ORDER BY p.timestamp IS NULL, p.timestamp ASC, p.filename ASC, p.id ASC""",
+        (ws, folder_id),
+    ).fetchall()
+    seed_idx = next((i for i, row in enumerate(rows) if row["id"] == seed_photo_id), None)
+    if seed_idx is None:
+        return None, "Photo not found"
+    left = seed_idx
+    while left > 0 and _time_ok(rows[left - 1], rows[left]):
+        left -= 1
+    right = seed_idx
+    while right < len(rows) - 1 and _time_ok(rows[right], rows[right + 1]):
+        right += 1
+    batch = rows[left:right + 1]
+    if len(batch) < 2:
+        return None, "No neighboring batch photos found"
+    return _limited(batch), "capture_time"
+
+
+def _quality_rank(photos, key, photo_id):
+    values = [
+        (p["id"], p.get(key))
+        for p in photos
+        if p.get(key) is not None
+    ]
+    if not values:
+        return None
+    values.sort(key=lambda item: item[1], reverse=True)
+    for idx, (pid, _) in enumerate(values, start=1):
+        if pid == photo_id:
+            return idx
+    return None
+
+
+def _best_batch_reasons(photo, photos, is_best=False):
+    reasons = []
+    reject_reasons = photo.get("reject_reasons") or []
+    if reject_reasons:
+        return [str(r).replace("_", " ") for r in reject_reasons[:3]]
+
+    q_rank = _quality_rank(photos, "quality_composite", photo["id"])
+    focus_key = "eye_focus_score" if photo.get("eye_focus_score") is not None else "focus_score"
+    focus_rank = _quality_rank(photos, focus_key, photo["id"])
+    exposure_rank = _quality_rank(photos, "exposure_score", photo["id"])
+
+    if q_rank == 1:
+        reasons.append("highest overall quality")
+    elif q_rank is not None and q_rank <= 3:
+        reasons.append(f"quality rank #{q_rank}")
+    if focus_rank == 1:
+        reasons.append("sharpest eye" if focus_key == "eye_focus_score" else "sharpest subject")
+    elif focus_rank is not None and focus_rank <= 3:
+        reasons.append(f"focus rank #{focus_rank}")
+    if exposure_rank == 1 and photo.get("exposure_score", 0) >= 0.7:
+        reasons.append("cleanest exposure")
+    if photo.get("crop_complete") is not None and photo.get("crop_complete") >= 0.9:
+        reasons.append("full subject in frame")
+    if is_best and not reasons:
+        reasons.append("best available score in this batch")
+    if not reasons:
+        reasons.append("usable alternate")
+    return reasons[:4]
+
+
+def _build_best_batch_response(db, seed_photo_id, rows):
+    import config as cfg
+    from pipeline import (
+        load_photo_features,
+        run_selected_batch_review,
+        serialize_results,
+    )
+
+    effective_cfg = db.get_effective_config(cfg.load())
+    photo_ids = [row["id"] for row in rows]
+    loaded = load_photo_features(db, config=effective_cfg, photo_ids=photo_ids)
+    by_id = {p["id"]: p for p in loaded}
+    photos = [by_id[pid] for pid in photo_ids if pid in by_id]
+    if len(photos) < 2:
+        return None, "At least two batch photos with pipeline features are required"
+    if not any(
+        p.get("mask_path")
+        or p.get("subject_tenengrad") is not None
+        or p.get("eye_tenengrad") is not None
+        for p in photos
+    ):
+        return None, "Run the pipeline on these photos before using Best Batch"
+
+    results = serialize_results(run_selected_batch_review(photos, config=effective_cfg))
+    result_photos = results.get("photos", [])
+    if len(result_photos) < 2:
+        return None, "Could not score this batch"
+
+    ranked = sorted(
+        result_photos,
+        key=lambda p: (
+            p.get("label") != "REJECT",
+            p.get("quality_composite") if p.get("quality_composite") is not None else -1,
+            p.get("focus_score") if p.get("focus_score") is not None else -1,
+        ),
+        reverse=True,
+    )
+    best = ranked[0]
+    alternate_ids = [p["id"] for p in ranked[1:5] if p.get("label") != "REJECT"]
+    reject_ids = [p["id"] for p in result_photos if p["id"] != best["id"]]
+    sequence_keys = [_filename_sequence_key(p.get("filename")) for p in result_photos]
+    sequence_nums = [key[1] for key in sequence_keys if key]
+
+    cards = []
+    for idx, photo in enumerate(ranked, start=1):
+        if photo["id"] == best["id"]:
+            role = "best"
+        elif photo["id"] in alternate_ids:
+            role = "alternate"
+        else:
+            role = "reject"
+        cards.append({
+            "id": photo["id"],
+            "filename": photo.get("filename"),
+            "rank": idx,
+            "role": role,
+            "label": photo.get("label"),
+            "quality": photo.get("quality_composite"),
+            "quality_pct": (
+                round(photo["quality_composite"] * 100)
+                if photo.get("quality_composite") is not None else None
+            ),
+            "focus": photo.get("eye_focus_score", photo.get("focus_score")),
+            "sharpness": photo.get("subject_tenengrad"),
+            "exposure": photo.get("exposure_score"),
+            "flag": photo.get("flag") or "none",
+            "rating": photo.get("rating"),
+            "reasons": _best_batch_reasons(photo, result_photos, is_best=photo["id"] == best["id"]),
+        })
+
+    best_reasons = _best_batch_reasons(best, result_photos, is_best=True)
+    return {
+        "seed_photo_id": seed_photo_id,
+        "photo_ids": photo_ids,
+        "count": len(photo_ids),
+        "sequence_range": (
+            [min(sequence_nums), max(sequence_nums)] if sequence_nums else None
+        ),
+        "best_photo_id": best["id"],
+        "best_filename": best.get("filename"),
+        "best_reasons": best_reasons,
+        "summary": results.get("summary", {}),
+        "cards": cards,
+        "alternate_ids": alternate_ids,
+        "suggested_reject_ids": reject_ids,
+    }, None
+
+
 def _has_current_working_copy_failure(
     photo, vireo_dir=None, trust_existing_working_copy=True,
     live_source_path=None, folder_path=None,
@@ -2575,6 +2844,74 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         )
         results["source"] = "browse-selection"
         return jsonify(results)
+
+    @app.route("/api/photos/<int:photo_id>/best-batch")
+    def api_photo_best_batch(photo_id):
+        """Find neighboring burst frames and rank the best photo in that batch."""
+        db = _get_db()
+        max_gap = request.args.get("gap_seconds", 8.0, type=float)
+        max_photos = request.args.get("max_photos", 120, type=int)
+        max_gap = max(0.0, min(max_gap, 120.0))
+        max_photos = max(2, min(max_photos, 500))
+
+        rows, method_or_error = _best_batch_scope(
+            db,
+            photo_id,
+            max_gap_seconds=max_gap,
+            max_photos=max_photos,
+        )
+        if rows is None:
+            return json_error(method_or_error, 404)
+
+        result, error = _build_best_batch_response(db, photo_id, rows)
+        if error:
+            return json_error(error, 404)
+        result["scope_method"] = method_or_error
+        return jsonify(result)
+
+    @app.route("/api/photos/best-batch", methods=["POST"])
+    def api_selected_photos_best_batch():
+        """Rank an explicit selected set as a temporary best-batch group."""
+        db = _get_db()
+        body = request.get_json(silent=True) or {}
+        raw_ids = body.get("photo_ids", [])
+        if not isinstance(raw_ids, list) or not raw_ids:
+            return json_error("photo_ids required")
+        if len(raw_ids) > 500:
+            return json_error("too many photo_ids", 400)
+
+        photo_ids = []
+        seen = set()
+        for raw in raw_ids:
+            if isinstance(raw, bool) or not isinstance(raw, int):
+                return json_error("photo_ids must be integers", 400)
+            if raw in seen:
+                continue
+            seen.add(raw)
+            photo_ids.append(raw)
+        if len(photo_ids) < 2:
+            return json_error("at least two selected photos are required", 400)
+
+        placeholders = ",".join("?" for _ in photo_ids)
+        rows = db.conn.execute(
+            f"""SELECT p.id, p.folder_id, p.filename, p.extension, p.timestamp,
+                      p.flag, p.rating, p.quality_score, p.sharpness
+               FROM photos p
+               JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+               JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')
+               WHERE wf.workspace_id = ? AND p.id IN ({placeholders})""",
+            (db._ws_id(), *photo_ids),
+        ).fetchall()
+        by_id = {row["id"]: row for row in rows}
+        rows = [by_id[pid] for pid in photo_ids if pid in by_id]
+        if len(rows) < 2:
+            return json_error("at least two selected photos are required", 400)
+
+        result, error = _build_best_batch_response(db, photo_ids[0], rows)
+        if error:
+            return json_error(error, 404)
+        result["scope_method"] = "selected_photos"
+        return jsonify(result)
 
     @app.route("/api/photos/geo")
     def api_photos_geo():

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3945,6 +3945,77 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                        flag, items, is_batch=True)
         return jsonify({"ok": True, "updated": len(old_values)})
 
+    @app.route("/api/batch/best-batch-flags", methods=["POST"])
+    def api_batch_best_batch_flags():
+        db = _get_db()
+        body = request.get_json(silent=True) or {}
+        best_photo_id = body.get("best_photo_id")
+        reject_photo_ids = body.get("reject_photo_ids", [])
+        if isinstance(best_photo_id, bool) or not isinstance(best_photo_id, int):
+            return json_error("best_photo_id must be an integer")
+        if not isinstance(reject_photo_ids, list):
+            return json_error("reject_photo_ids must be a list")
+        normalized_reject_ids = []
+        seen_reject_ids = set()
+        for pid in reject_photo_ids:
+            if isinstance(pid, bool) or not isinstance(pid, int):
+                return json_error("reject_photo_ids must contain only integers")
+            if pid == best_photo_id:
+                return json_error("best_photo_id cannot also be rejected")
+            if pid not in seen_reject_ids:
+                normalized_reject_ids.append(pid)
+                seen_reject_ids.add(pid)
+
+        desired_flags = {best_photo_id: "flagged"}
+        desired_flags.update({pid: "rejected" for pid in normalized_reject_ids})
+        photo_ids = list(desired_flags.keys())
+        photos_map = db.get_photos_by_ids(photo_ids)
+        if len(photos_map) != len(photo_ids):
+            return json_error("One or more photos were not found", 404)
+        try:
+            for pid in photo_ids:
+                db._verify_photo_in_workspace(pid)
+        except ValueError as e:
+            return json_error(str(e), 403)
+
+        items = []
+        for pid in photo_ids:
+            new_flag = desired_flags[pid]
+            old_flag = photos_map[pid]["flag"]
+            db.conn.execute(
+                "UPDATE photos SET flag = ? WHERE id = ?",
+                (new_flag, pid),
+            )
+            db.queue_flag_change_if_enabled(pid, new_flag, _commit=False)
+            items.append({
+                "photo_id": pid,
+                "old_value": old_flag,
+                "new_value": new_flag,
+            })
+        reject_count = len(normalized_reject_ids)
+        description = (
+            f"Best Batch: flagged best photo and rejected {reject_count} "
+            f"{'photo' if reject_count == 1 else 'photos'}"
+        )
+        db.record_edit(
+            "flag",
+            description,
+            "best_batch_apply",
+            items,
+            is_batch=True,
+            _commit=False,
+        )
+        db.conn.commit()
+        db._prune_edit_history()
+        return jsonify({
+            "ok": True,
+            "updated": len(items),
+            "photos": {
+                str(pid): {"flag": desired_flags[pid]}
+                for pid in photo_ids
+            },
+        })
+
     @app.route("/api/batch/color_label", methods=["POST"])
     def api_batch_color_label():
         db = _get_db()

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -630,6 +630,8 @@ def _build_best_batch_response(db, seed_photo_id, rows):
         cards.append({
             "id": photo["id"],
             "filename": photo.get("filename"),
+            "width": photo.get("width"),
+            "height": photo.get("height"),
             "rank": idx,
             "role": role,
             "label": photo.get("label"),

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -639,7 +639,12 @@ def _build_best_batch_response(db, seed_photo_id, rows):
                 if photo.get("quality_composite") is not None else None
             ),
             "focus": photo.get("eye_focus_score", photo.get("focus_score")),
+            "focus_basis": "eye" if photo.get("eye_focus_score") is not None else "subject",
             "sharpness": photo.get("subject_tenengrad"),
+            "eye_x": photo.get("eye_x"),
+            "eye_y": photo.get("eye_y"),
+            "eye_conf": photo.get("eye_conf"),
+            "eye_tenengrad": photo.get("eye_tenengrad"),
             "exposure": photo.get("exposure_score"),
             "flag": photo.get("flag") or "none",
             "rating": photo.get("rating"),
@@ -1972,6 +1977,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     @app.route("/browse")
     def browse():
         return render_template("browse.html")
+
+    @app.route("/best-batch")
+    def best_batch_page():
+        return render_template("best_batch.html")
 
     @app.route("/zoom-test")
     def zoom_test_page():

--- a/vireo/templates/best_batch.html
+++ b/vireo/templates/best_batch.html
@@ -115,14 +115,23 @@ body {
   position: relative;
   aspect-ratio: 1;
   background-color: #050505;
-  background-repeat: no-repeat;
+  overflow: hidden;
 }
-.focus-crop.eye {
-  background-size: 780% auto;
+.focus-crop img {
+  display: block;
+  position: absolute;
+  max-width: none;
+  max-height: none;
 }
-.focus-crop.subject {
-  background-size: cover;
-  background-position: center center;
+.focus-crop.eye img {
+  width: 780%;
+  height: auto;
+}
+.focus-crop.subject img {
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 .crosshair {
   position: absolute;
@@ -377,15 +386,25 @@ function scoreText(card) {
   return parts.join(' · ') || 'No score';
 }
 
-function cropStyle(card) {
-  var url = previewUrl(card.id, 1920);
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function focusImageStyle(card) {
   var hasEye = card.focus_basis === 'eye' && card.eye_x != null && card.eye_y != null;
   if (!hasEye) {
-    return "background-image:url('" + url + "');";
+    return '';
   }
-  var x = Math.max(0, Math.min(100, Number(card.eye_x) * 100));
-  var y = Math.max(0, Math.min(100, Number(card.eye_y) * 100));
-  return "background-image:url('" + url + "');background-position:" + x.toFixed(2) + "% " + y.toFixed(2) + "%;";
+  var zoom = 7.8;
+  var width = Number(card.width) || 1;
+  var height = Number(card.height) || width;
+  var imageWidthPct = zoom * 100;
+  var imageHeightPct = imageWidthPct * (height / width);
+  var x = clamp(Number(card.eye_x), 0, 1);
+  var y = clamp(Number(card.eye_y), 0, 1);
+  var left = clamp(50 - x * imageWidthPct, 100 - imageWidthPct, 0);
+  var top = clamp(50 - y * imageHeightPct, 100 - imageHeightPct, 0);
+  return 'left:' + left.toFixed(2) + '%;top:' + top.toFixed(2) + '%;';
 }
 
 function selectedIdsFromStorage() {
@@ -469,7 +488,8 @@ function renderBatch(data) {
   document.getElementById('focusGrid').innerHTML = cards.map(function(card) {
     var hasEye = card.focus_basis === 'eye' && card.eye_x != null && card.eye_y != null;
     return '<div class="focus-card ' + escapeAttr(card.role || '') + '" data-photo-id="' + card.id + '" onclick="inspectPhoto(' + card.id + ')">' +
-      '<div class="focus-crop ' + (hasEye ? 'eye' : 'subject') + '" style="' + escapeAttr(cropStyle(card)) + '">' +
+      '<div class="focus-crop ' + (hasEye ? 'eye' : 'subject') + '">' +
+        '<img src="' + previewUrl(card.id, 1920) + '" alt="' + escapeAttr(card.filename || '') + '" loading="lazy" style="' + escapeAttr(focusImageStyle(card)) + '">' +
         (hasEye ? '<span class="crosshair"></span>' : '') +
       '</div>' +
       '<div class="focus-meta">' +

--- a/vireo/templates/best_batch.html
+++ b/vireo/templates/best_batch.html
@@ -1,0 +1,576 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="icon" type="image/png" href="/favicon.ico">
+<link rel="apple-touch-icon" href="/static/apple-touch-icon.png">
+<link rel="stylesheet" href="/static/vireo-base.css">
+<title>Vireo - Best Batch</title>
+<style>
+body {
+  min-height: 100vh;
+  background: var(--bg-primary);
+}
+.best-page {
+  padding: 16px 18px 28px;
+}
+.best-toolbar {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 16px;
+  align-items: center;
+  margin-bottom: 14px;
+}
+.best-title h1 {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+.best-subtitle {
+  margin-top: 4px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+.best-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+.best-btn {
+  border: 1px solid var(--border-primary);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  border-radius: 4px;
+  padding: 8px 12px;
+  font-size: 13px;
+  cursor: pointer;
+}
+.best-btn:hover {
+  border-color: var(--accent);
+  color: var(--text-primary);
+}
+.best-btn.primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--bg-primary);
+}
+.best-btn.danger {
+  background: var(--danger);
+  border-color: var(--danger);
+  color: white;
+}
+.best-btn:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+.status {
+  border: 1px solid var(--border-primary);
+  background: var(--bg-secondary);
+  border-radius: 8px;
+  padding: 28px;
+  color: var(--text-muted);
+  text-align: center;
+}
+.focus-section {
+  margin-bottom: 14px;
+}
+.section-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: end;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+.section-title {
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.section-note {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+.focus-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 10px;
+}
+.focus-card {
+  border: 1px solid var(--border-primary);
+  background: var(--bg-secondary);
+  border-radius: 7px;
+  overflow: hidden;
+  cursor: pointer;
+}
+.focus-card.best,
+.focus-card.inspecting {
+  border-color: var(--accent);
+}
+.focus-crop {
+  position: relative;
+  aspect-ratio: 1;
+  background-color: #050505;
+  background-repeat: no-repeat;
+}
+.focus-crop.eye {
+  background-size: 780% auto;
+}
+.focus-crop.subject {
+  background-size: cover;
+  background-position: center center;
+}
+.crosshair {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 24px;
+  height: 24px;
+  transform: translate(-50%, -50%);
+  border: 1px solid color-mix(in srgb, var(--accent) 88%, white);
+  border-radius: 50%;
+  box-shadow: 0 0 0 1px rgba(0,0,0,0.7);
+  pointer-events: none;
+}
+.crosshair::before,
+.crosshair::after {
+  content: "";
+  position: absolute;
+  background: color-mix(in srgb, var(--accent) 88%, white);
+  box-shadow: 0 0 0 1px rgba(0,0,0,0.5);
+}
+.crosshair::before {
+  left: 50%;
+  top: -10px;
+  width: 1px;
+  height: 44px;
+}
+.crosshair::after {
+  top: 50%;
+  left: -10px;
+  width: 44px;
+  height: 1px;
+}
+.focus-meta,
+.rank-meta {
+  padding: 8px 9px;
+}
+.role {
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.role.best { color: var(--accent); }
+.role.alternate { color: var(--warning); }
+.role.reject { color: var(--danger); }
+.filename {
+  margin-top: 4px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.score {
+  margin-top: 4px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+.inspect-layout {
+  display: grid;
+  grid-template-columns: minmax(520px, 1.2fr) minmax(320px, 0.8fr);
+  gap: 14px;
+  align-items: start;
+}
+.preview-panel {
+  border: 1px solid var(--border-primary);
+  border-radius: 8px;
+  overflow: hidden;
+  background: #050505;
+}
+.preview-panel img {
+  display: block;
+  width: 100%;
+  height: min(60vh, 760px);
+  object-fit: contain;
+  cursor: zoom-in;
+}
+.preview-meta {
+  border-top: 1px solid var(--border-primary);
+  background: var(--bg-secondary);
+  padding: 10px 12px;
+}
+.preview-name {
+  color: var(--text-primary);
+  font-size: 16px;
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+.preview-score {
+  margin-top: 5px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+.reason-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 9px;
+}
+.reason {
+  border: 1px solid var(--border-primary);
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  border-radius: 999px;
+  padding: 4px 8px;
+  font-size: 11px;
+}
+.rank-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
+  gap: 10px;
+}
+.rank-card {
+  border: 1px solid var(--border-primary);
+  background: var(--bg-secondary);
+  border-radius: 7px;
+  overflow: hidden;
+  cursor: pointer;
+}
+.rank-card.best,
+.rank-card.inspecting {
+  border-color: var(--accent);
+}
+.rank-card.reject {
+  opacity: 0.72;
+}
+.rank-card img {
+  display: block;
+  width: 100%;
+  aspect-ratio: 4/3;
+  object-fit: contain;
+  background: #050505;
+}
+@media (max-width: 980px) {
+  .best-toolbar,
+  .inspect-layout {
+    grid-template-columns: 1fr;
+  }
+  .best-actions {
+    justify-content: flex-start;
+  }
+  .preview-panel img {
+    height: 58vh;
+  }
+}
+@media (max-width: 620px) {
+  .best-page {
+    padding: 12px;
+  }
+  .focus-grid,
+  .rank-list {
+    grid-template-columns: repeat(auto-fit, minmax(145px, 1fr));
+  }
+}
+</style>
+</head>
+<body>
+{% include '_navbar.html' %}
+
+<main class="best-page">
+  <div class="best-toolbar">
+    <div class="best-title">
+      <h1>Best Batch</h1>
+      <div id="bestSubtitle" class="best-subtitle">Loading selected photos...</div>
+    </div>
+    <div class="best-actions">
+      <button class="best-btn" onclick="window.location.href='/browse'">Back to Browse</button>
+      <button class="best-btn" id="reviewBtn" onclick="openReviewBurst()" disabled>Review Burst</button>
+      <button class="best-btn primary" id="flagBtn" onclick="flagBest()" disabled>Flag Best</button>
+      <button class="best-btn danger" id="rejectBtn" onclick="flagBestRejectRest()" disabled>Flag Best + Reject Rest</button>
+    </div>
+  </div>
+
+  <div id="bestStatus" class="status">Loading batch...</div>
+  <div id="bestContent" style="display:none;">
+    <section class="focus-section">
+      <div class="section-head">
+        <div class="section-title">Focus Check</div>
+        <div id="focusNote" class="section-note"></div>
+      </div>
+      <div id="focusGrid" class="focus-grid"></div>
+    </section>
+
+    <section class="inspect-layout">
+      <div class="preview-panel">
+        <img id="inspectImg" alt="" onclick="openInspectedLightbox()" title="Open 1:1 zoom">
+        <div class="preview-meta">
+          <div id="inspectRole" class="role"></div>
+          <div id="inspectName" class="preview-name"></div>
+          <div id="inspectScore" class="preview-score"></div>
+          <div id="inspectReasons" class="reason-row"></div>
+        </div>
+      </div>
+
+      <div>
+        <div class="section-head">
+          <div class="section-title">Ranked Frames</div>
+        </div>
+        <div id="rankList" class="rank-list"></div>
+      </div>
+    </section>
+  </div>
+</main>
+
+<script>
+var bestBatchData = null;
+var inspectedId = null;
+
+function escapeHtml(value) {
+  return String(value == null ? '' : value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function escapeAttr(value) {
+  return escapeHtml(value);
+}
+
+async function fetchJson(url, options) {
+  var resp = await fetch(url, options || {});
+  var data = null;
+  try { data = await resp.json(); } catch (e) {}
+  if (!resp.ok) {
+    throw new Error((data && data.error) || ('Request failed: ' + resp.status));
+  }
+  return data;
+}
+
+function previewUrl(photoId, size) {
+  return '/photos/' + photoId + '/preview?size=' + (size || 1920);
+}
+
+function thumbnailUrl(photoId) {
+  return '/thumbnails/' + photoId + '.jpg';
+}
+
+function roleLabel(role) {
+  if (role === 'best') return 'Best';
+  if (role === 'alternate') return 'Alt';
+  return 'Reject';
+}
+
+function scoreText(card) {
+  var parts = [];
+  if (card.quality_pct != null) parts.push('Q ' + card.quality_pct);
+  if (card.focus != null) parts.push((card.focus_basis === 'eye' ? 'Eye' : 'Subject') + ' ' + Math.round(card.focus * 100));
+  if (card.sharpness != null) parts.push('Subject S ' + Math.round(card.sharpness));
+  return parts.join(' · ') || 'No score';
+}
+
+function cropStyle(card) {
+  var url = previewUrl(card.id, 1920);
+  var hasEye = card.focus_basis === 'eye' && card.eye_x != null && card.eye_y != null;
+  if (!hasEye) {
+    return "background-image:url('" + url + "');";
+  }
+  var x = Math.max(0, Math.min(100, Number(card.eye_x) * 100));
+  var y = Math.max(0, Math.min(100, Number(card.eye_y) * 100));
+  return "background-image:url('" + url + "');background-position:" + x.toFixed(2) + "% " + y.toFixed(2) + "%;";
+}
+
+function selectedIdsFromStorage() {
+  try {
+    var raw = window.sessionStorage.getItem('vireo.bestBatchIds');
+    var ids = raw ? JSON.parse(raw) : [];
+    return Array.isArray(ids) ? ids.filter(function(id) { return Number.isInteger(id); }) : [];
+  } catch (e) {
+    return [];
+  }
+}
+
+function seedIdFromRequest(ids) {
+  var params = new URLSearchParams(window.location.search);
+  var queryId = Number(params.get('photo_id'));
+  if (Number.isInteger(queryId) && queryId > 0) return queryId;
+  try {
+    var stored = Number(window.sessionStorage.getItem('vireo.bestBatchSeedId'));
+    if (Number.isInteger(stored) && stored > 0) return stored;
+  } catch (e) {}
+  return ids.length ? ids[0] : null;
+}
+
+function setStatus(message) {
+  var status = document.getElementById('bestStatus');
+  var content = document.getElementById('bestContent');
+  status.textContent = message;
+  status.style.display = '';
+  content.style.display = 'none';
+}
+
+function inspectPhoto(photoId) {
+  if (!bestBatchData || !bestBatchData.cards) return;
+  var card = bestBatchData.cards.find(function(c) { return c.id === photoId; });
+  if (!card) return;
+  inspectedId = card.id;
+
+  var img = document.getElementById('inspectImg');
+  img.onerror = function() {
+    this.onerror = null;
+    this.src = thumbnailUrl(card.id);
+  };
+  img.src = previewUrl(card.id, 1920);
+  img.alt = card.filename || '';
+
+  var role = document.getElementById('inspectRole');
+  role.className = 'role ' + (card.role || '');
+  role.textContent = '#' + card.rank + ' ' + roleLabel(card.role);
+  document.getElementById('inspectName').textContent = card.filename || '';
+  document.getElementById('inspectScore').textContent = scoreText(card);
+  document.getElementById('inspectReasons').innerHTML = (card.reasons || []).map(function(reason) {
+    return '<span class="reason">' + escapeHtml(reason) + '</span>';
+  }).join('');
+
+  document.querySelectorAll('.focus-card,.rank-card').forEach(function(el) {
+    el.classList.toggle('inspecting', Number(el.dataset.photoId) === photoId);
+  });
+}
+
+function renderBatch(data) {
+  bestBatchData = data;
+  var cards = data.cards || [];
+  var best = cards.find(function(c) { return c.id === data.best_photo_id; }) || cards[0];
+  if (!best) {
+    setStatus('No scored photos found in this batch.');
+    return;
+  }
+
+  document.getElementById('bestStatus').style.display = 'none';
+  document.getElementById('bestContent').style.display = '';
+  document.getElementById('bestSubtitle').textContent =
+    data.count + ' photos' + (data.sequence_range ? ' · #' + data.sequence_range[0] + '-' + data.sequence_range[1] : '');
+
+  var hasAnyEye = cards.some(function(card) {
+    return card.focus_basis === 'eye' && card.eye_x != null && card.eye_y != null;
+  });
+  document.getElementById('focusNote').textContent = hasAnyEye
+    ? 'Eye crops are centered on detected keypoints. Click a crop to inspect the full frame.'
+    : 'No eye keypoints found for this batch; focus evidence falls back to subject/full-frame context.';
+
+  document.getElementById('focusGrid').innerHTML = cards.map(function(card) {
+    var hasEye = card.focus_basis === 'eye' && card.eye_x != null && card.eye_y != null;
+    return '<div class="focus-card ' + escapeAttr(card.role || '') + '" data-photo-id="' + card.id + '" onclick="inspectPhoto(' + card.id + ')">' +
+      '<div class="focus-crop ' + (hasEye ? 'eye' : 'subject') + '" style="' + escapeAttr(cropStyle(card)) + '">' +
+        (hasEye ? '<span class="crosshair"></span>' : '') +
+      '</div>' +
+      '<div class="focus-meta">' +
+        '<div class="role ' + escapeAttr(card.role || '') + '">#' + card.rank + ' ' + roleLabel(card.role) + '</div>' +
+        '<div class="filename" title="' + escapeAttr(card.filename || '') + '">' + escapeHtml(card.filename || '') + '</div>' +
+        '<div class="score">' + escapeHtml(scoreText(card)) + '</div>' +
+      '</div>' +
+    '</div>';
+  }).join('');
+
+  document.getElementById('rankList').innerHTML = cards.map(function(card) {
+    var reasons = (card.reasons || []).slice(0, 2).join(' · ');
+    return '<div class="rank-card ' + escapeAttr(card.role || '') + '" data-photo-id="' + card.id + '" onclick="inspectPhoto(' + card.id + ')">' +
+      '<img src="' + thumbnailUrl(card.id) + '" alt="' + escapeAttr(card.filename || '') + '" loading="lazy">' +
+      '<div class="rank-meta">' +
+        '<div class="role ' + escapeAttr(card.role || '') + '">#' + card.rank + ' ' + roleLabel(card.role) + '</div>' +
+        '<div class="filename" title="' + escapeAttr(card.filename || '') + '">' + escapeHtml(card.filename || '') + '</div>' +
+        '<div class="score">' + escapeHtml(scoreText(card)) + '</div>' +
+        '<div class="score">' + escapeHtml(reasons) + '</div>' +
+      '</div>' +
+    '</div>';
+  }).join('');
+
+  document.getElementById('reviewBtn').disabled = !data.photo_ids || data.photo_ids.length < 2;
+  document.getElementById('flagBtn').disabled = !data.best_photo_id;
+  document.getElementById('rejectBtn').disabled = !data.best_photo_id;
+  inspectPhoto(best.id);
+}
+
+async function loadBatch() {
+  var ids = selectedIdsFromStorage();
+  var seedId = seedIdFromRequest(ids);
+  if (!seedId) {
+    setStatus('Go back to Browse and select at least one photo first.');
+    return;
+  }
+  try {
+    var data;
+    if (ids.length >= 2) {
+      data = await fetchJson('/api/photos/best-batch', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({photo_ids: ids}),
+      });
+      data.scope_method = data.scope_method || 'selected_photos';
+    } else {
+      data = await fetchJson('/api/photos/' + seedId + '/best-batch');
+    }
+    renderBatch(data);
+  } catch (e) {
+    setStatus(e && e.message ? e.message : 'Could not rank this batch.');
+  }
+}
+
+function openInspectedLightbox() {
+  if (!bestBatchData || !window.openLightbox || !inspectedId) return;
+  var cards = bestBatchData.cards || [];
+  var card = cards.find(function(c) { return c.id === inspectedId; }) || cards[0];
+  if (!card) return;
+  openLightbox(card.id, card.filename || '', cards.map(function(c) {
+    return {id: c.id, filename: c.filename || ''};
+  }));
+}
+
+function openReviewBurst() {
+  if (!bestBatchData || !bestBatchData.photo_ids || bestBatchData.photo_ids.length < 2) return;
+  try {
+    window.sessionStorage.setItem('vireo.browseBurstReviewIds', JSON.stringify(bestBatchData.photo_ids));
+  } catch (e) {
+    if (window.showToast) showToast('Could not open burst review for this batch.', 'error');
+    return;
+  }
+  window.location.href = '/pipeline/review?browse_burst=1';
+}
+
+async function flagBest() {
+  if (!bestBatchData || !bestBatchData.best_photo_id) return;
+  await fetchJson('/api/batch/flag', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({photo_ids: [bestBatchData.best_photo_id], flag: 'flagged'}),
+  });
+  if (window.showUndoToast) showUndoToast();
+  if (window.showToast) showToast('Flagged best photo.', 'success');
+}
+
+async function flagBestRejectRest() {
+  if (!bestBatchData || !bestBatchData.best_photo_id) return;
+  await fetchJson('/api/batch/best-batch-flags', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({
+      best_photo_id: bestBatchData.best_photo_id,
+      reject_photo_ids: bestBatchData.suggested_reject_ids || [],
+    }),
+  });
+  if (window.showUndoToast) showUndoToast();
+  if (window.showToast) showToast('Applied best-batch flags.', 'success');
+}
+
+loadBatch();
+</script>
+</body>
+</html>

--- a/vireo/templates/best_batch.html
+++ b/vireo/templates/best_batch.html
@@ -567,27 +567,39 @@ function openReviewBurst() {
 
 async function flagBest() {
   if (!bestBatchData || !bestBatchData.best_photo_id) return;
-  await fetchJson('/api/batch/flag', {
-    method: 'POST',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({photo_ids: [bestBatchData.best_photo_id], flag: 'flagged'}),
-  });
-  if (window.showUndoToast) showUndoToast();
-  if (window.showToast) showToast('Flagged best photo.', 'success');
+  try {
+    await fetchJson('/api/batch/flag', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({photo_ids: [bestBatchData.best_photo_id], flag: 'flagged'}),
+    });
+    if (window.showUndoToast) showUndoToast();
+    if (window.showToast) showToast('Flagged best photo.', 'success');
+  } catch (e) {
+    if (window.showToast) {
+      showToast(e && e.message ? e.message : 'Could not flag best photo.', 'error');
+    }
+  }
 }
 
 async function flagBestRejectRest() {
   if (!bestBatchData || !bestBatchData.best_photo_id) return;
-  await fetchJson('/api/batch/best-batch-flags', {
-    method: 'POST',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({
-      best_photo_id: bestBatchData.best_photo_id,
-      reject_photo_ids: bestBatchData.suggested_reject_ids || [],
-    }),
-  });
-  if (window.showUndoToast) showUndoToast();
-  if (window.showToast) showToast('Applied best-batch flags.', 'success');
+  try {
+    await fetchJson('/api/batch/best-batch-flags', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({
+        best_photo_id: bestBatchData.best_photo_id,
+        reject_photo_ids: bestBatchData.suggested_reject_ids || [],
+      }),
+    });
+    if (window.showUndoToast) showUndoToast();
+    if (window.showToast) showToast('Applied best-batch flags.', 'success');
+  } catch (e) {
+    if (window.showToast) {
+      showToast(e && e.message ? e.message : 'Could not apply best-batch flags.', 'error');
+    }
+  }
 }
 
 loadBatch();

--- a/vireo/templates/best_batch.html
+++ b/vireo/templates/best_batch.html
@@ -526,6 +526,13 @@ async function loadBatch() {
     setStatus('Go back to Browse and select at least one photo first.');
     return;
   }
+  if (ids.length >= 2 && ids.indexOf(seedId) === -1) {
+    ids = [];
+    try {
+      window.sessionStorage.removeItem('vireo.bestBatchIds');
+      window.sessionStorage.removeItem('vireo.bestBatchSeedId');
+    } catch (e) {}
+  }
   try {
     var data;
     if (ids.length >= 2) {

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3799,39 +3799,26 @@ function renderBestBatch(data) {
     '<div class="best-batch-list">' + cards + '</div>';
 }
 
-async function openBestBatch() {
-  var seedId = bestBatchSeedId();
-  var ids = getActiveSelection();
+function openBestBatchForIds(ids, seedId) {
+  ids = Array.isArray(ids) ? ids.filter(function(id) { return id != null; }) : [];
+  seedId = seedId || (ids.length ? ids[0] : bestBatchSeedId());
   if (!seedId) {
     showToast('Select a photo first.', 'error');
     return;
   }
-  bestBatchData = null;
-  var modal = document.getElementById('bestBatchModal');
-  var content = document.getElementById('bestBatchContent');
-  if (content) {
-    content.className = 'best-batch-empty';
-    content.textContent = 'Loading batch...';
-  }
-  if (modal) modal.classList.add('open');
   try {
-    var data;
-    if (ids.length >= 2) {
-      data = await safeFetch('/api/photos/best-batch', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({photo_ids: ids}),
-      }, { toast: false });
-    } else {
-      data = await safeFetch('/api/photos/' + seedId + '/best-batch', {}, { toast: false });
-    }
-    renderBestBatch(data);
+    window.sessionStorage.setItem('vireo.bestBatchIds', JSON.stringify(ids));
+    window.sessionStorage.setItem('vireo.bestBatchSeedId', String(seedId));
   } catch (e) {
-    if (content) {
-      content.className = 'best-batch-empty';
-      content.textContent = e && e.message ? e.message : 'Could not rank this batch.';
-    }
+    showToast('Could not open Best Batch for this selection.', 'error');
+    return;
   }
+  window.location.href = '/best-batch?photo_id=' + encodeURIComponent(seedId);
+}
+
+function openBestBatch() {
+  var ids = getActiveSelection();
+  openBestBatchForIds(ids, bestBatchSeedId());
 }
 
 function openBestBatchInReview() {
@@ -5773,7 +5760,7 @@ function buildPhotoContextMenu(photoIds) {
     { label: 'Compare', disabled: photoIds.length < 2, disabledHint: 'Select at least two photos',
       onClick: function() { openBrowseCompare(); } },
     { label: 'Best Batch',
-      onClick: function() { openBestBatch(); } },
+      onClick: function() { openBestBatchForIds(photoIds, photoIds[0]); } },
     { label: 'Review Burst', disabled: photoIds.length < 2, disabledHint: 'Select at least two photos',
       onClick: function() { openSelectedInBurstReview(); } },
   ].concat(buildOpenInEditorMenuItems(photoIds)).concat([

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3860,18 +3860,11 @@ async function applyBestBatchPickAndReject() {
   var bestId = bestBatchData.best_photo_id;
   var rejectIds = (bestBatchData.suggested_reject_ids || []).filter(function(id) { return id !== bestId; });
   try {
-    await safeFetch('/api/batch/flag', {
+    await safeFetch('/api/batch/best-batch-flags', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({photo_ids: [bestId], flag: 'flagged'}),
+      body: JSON.stringify({best_photo_id: bestId, reject_photo_ids: rejectIds}),
     });
-    if (rejectIds.length) {
-      await safeFetch('/api/batch/flag', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({photo_ids: rejectIds, flag: 'rejected'}),
-      });
-    }
   } catch(e) { return; }
   [bestId].concat(rejectIds).forEach(function(id) {
     var p = photos.find(function(x) { return x.id === id; });

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -416,6 +416,146 @@ body {
 }
 .capture-time-before { color: var(--text-muted); }
 .capture-time-after { color: var(--accent); }
+
+.best-batch-modal {
+  width: min(1120px, calc(100vw - 32px));
+  max-height: calc(100vh - 48px);
+  display: flex;
+  flex-direction: column;
+}
+.best-batch-head {
+  display: grid;
+  grid-template-columns: minmax(260px, 360px) 1fr;
+  gap: 16px;
+  min-height: 240px;
+}
+.best-batch-pick {
+  position: relative;
+  background: var(--bg-primary);
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  overflow: hidden;
+}
+.best-batch-pick img {
+  width: 100%;
+  aspect-ratio: 3/2;
+  object-fit: cover;
+  display: block;
+  background: var(--bg-tertiary);
+}
+.best-batch-pick-meta {
+  padding: 10px 12px;
+}
+.best-batch-eyebrow {
+  font-size: 10px;
+  color: var(--accent);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 4px;
+}
+.best-batch-title {
+  color: var(--text-primary);
+  font-size: 16px;
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+.best-batch-score {
+  margin-top: 6px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+.best-batch-summary {
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.45;
+}
+.best-batch-reasons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 12px;
+}
+.best-batch-reason {
+  border: 1px solid var(--border-primary);
+  border-radius: 999px;
+  padding: 4px 8px;
+  color: var(--text-secondary);
+  font-size: 11px;
+  background: var(--bg-tertiary);
+}
+.best-batch-list {
+  margin-top: 16px;
+  overflow: auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 10px;
+  padding-right: 4px;
+}
+.best-batch-card {
+  border: 1px solid var(--border-primary);
+  border-radius: 6px;
+  overflow: hidden;
+  background: var(--bg-primary);
+}
+.best-batch-card.best { border-color: var(--accent); }
+.best-batch-card.reject { opacity: 0.72; }
+.best-batch-card img {
+  width: 100%;
+  aspect-ratio: 3/2;
+  object-fit: cover;
+  display: block;
+}
+.best-batch-card-body {
+  padding: 7px 8px;
+  min-height: 88px;
+}
+.best-batch-card-name {
+  font-size: 11px;
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.best-batch-card-line {
+  margin-top: 4px;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.best-batch-role {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.best-batch-role.best { color: var(--accent); }
+.best-batch-role.alternate { color: var(--warning); }
+.best-batch-role.reject { color: var(--danger); }
+.best-batch-actions {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 8px;
+  margin-top: 14px;
+}
+.best-batch-empty {
+  padding: 28px;
+  text-align: center;
+  color: var(--text-dim);
+}
+@media (max-width: 760px) {
+  .best-batch-head {
+    grid-template-columns: 1fr;
+    min-height: 0;
+  }
+  .best-batch-actions {
+    flex-wrap: wrap;
+    justify-content: stretch;
+  }
+  .best-batch-actions .modal-btn {
+    flex: 1 1 150px;
+  }
+}
+
 .detail-close {
   float: right;
   background: none;
@@ -1217,6 +1357,7 @@ body {
       <button onclick="addToCollection()" style="background:var(--bg-tertiary);color:var(--info);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">+ Collection</button>
       <button onclick="openCaptureTimeModal()" style="background:var(--bg-tertiary);color:var(--text-secondary);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Adjust Time</button>
       <button id="compareBtn" onclick="openBrowseCompare()" title="Compare two selected photos side by side" style="display:none;background:var(--bg-tertiary);color:var(--accent);border:1px solid var(--accent);border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Compare</button>
+      <button id="bestBatchBtn" onclick="openBestBatch()" title="Find and rank neighboring frames around the selected photo" style="display:none;background:var(--bg-tertiary);color:var(--accent);border:1px solid var(--accent);border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Best Batch</button>
       <button id="burstReviewBtn" onclick="openSelectedInBurstReview()" title="Open selected photos in burst review" style="display:none;background:var(--bg-tertiary);color:var(--accent);border:1px solid var(--accent);border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Review Burst</button>
       <button id="developBtn" onclick="developSelected()" title="Develop selected RAW photos with darktable" style="background:var(--bg-tertiary);color:var(--text-secondary);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Develop</button>
       <button onclick="openInEditorBatch(event)" style="background:var(--bg-tertiary);color:var(--text-secondary);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Open in Editor</button>
@@ -1457,6 +1598,20 @@ body {
   </div>
 </div>
 
+<!-- Best Batch Modal -->
+<div class="modal-overlay" id="bestBatchModal">
+  <div class="modal best-batch-modal">
+    <h3>Best Batch</h3>
+    <div id="bestBatchContent" class="best-batch-empty">Loading batch...</div>
+    <div class="best-batch-actions">
+      <button class="modal-btn modal-btn-cancel" onclick="hideBestBatch()">Close</button>
+      <button class="modal-btn" id="bestBatchReviewBtn" onclick="openBestBatchInReview()" style="background:var(--bg-tertiary);color:var(--text-secondary);">Review Burst</button>
+      <button class="modal-btn modal-btn-primary" id="bestBatchFlagBtn" onclick="applyBestBatchPickOnly()">Flag Best</button>
+      <button class="modal-btn" id="bestBatchRejectBtn" onclick="applyBestBatchPickAndReject()" style="background:var(--danger);color:white;">Flag Best + Reject Rest</button>
+    </div>
+  </div>
+</div>
+
 <!-- Capture Time Modal -->
 <div class="modal-overlay" id="captureTimeModal">
   <div class="modal" style="width:720px;max-width:calc(100vw - 32px);">
@@ -1564,6 +1719,7 @@ var selectedDay = null;
 var calendarData = null;
 var clipSearchActive = false;
 var searchFilterTimer = null;
+var bestBatchData = null;
 var keywordAutocompleteCache = null;
 var keywordAutocompletePromise = null;
 var keywordAutocompleteStates = {};
@@ -3506,6 +3662,14 @@ function updateCompareButton(ids) {
   btn.disabled = !canCompare;
 }
 
+function updateBestBatchButton(ids) {
+  var btn = document.getElementById('bestBatchBtn');
+  if (!btn) return;
+  var canFind = ids.length >= 1;
+  btn.style.display = canFind ? '' : 'none';
+  btn.disabled = !canFind;
+}
+
 function updateBurstReviewButton(ids) {
   var btn = document.getElementById('burstReviewBtn');
   if (!btn) return;
@@ -3529,6 +3693,7 @@ function updateBatchBar() {
     bar.style.display = 'none';
   }
   updateCompareButton(ids);
+  updateBestBatchButton(ids);
   updateBurstReviewButton(ids);
   updateSelectionPanel(ids);
 }
@@ -3550,6 +3715,173 @@ function openSelectedInBurstReview() {
     return;
   }
   window.location.href = '/pipeline/review?browse_burst=1';
+}
+
+function bestBatchSeedId() {
+  if (selectedPhotoId != null) return selectedPhotoId;
+  var ids = getActiveSelection();
+  return ids.length ? ids[0] : null;
+}
+
+function hideBestBatch() {
+  var modal = document.getElementById('bestBatchModal');
+  if (modal) modal.classList.remove('open');
+}
+
+function bestBatchRoleLabel(role) {
+  if (role === 'best') return 'Best';
+  if (role === 'alternate') return 'Alt';
+  return 'Reject';
+}
+
+function bestBatchScoreText(card) {
+  var parts = [];
+  if (card.quality_pct != null) parts.push('Q ' + card.quality_pct);
+  if (card.focus != null) parts.push('F ' + Math.round(card.focus * 100));
+  if (card.sharpness != null) parts.push('S ' + Math.round(card.sharpness));
+  return parts.join(' · ') || 'No score';
+}
+
+function renderBestBatch(data) {
+  bestBatchData = data;
+  var content = document.getElementById('bestBatchContent');
+  if (!content) return;
+  var best = (data.cards || []).find(function(c) { return c.id === data.best_photo_id; }) || (data.cards || [])[0];
+  if (!best) {
+    content.className = 'best-batch-empty';
+    content.textContent = 'No scored photos found in this batch.';
+    return;
+  }
+  var countText = data.count + ' photos';
+  if (data.sequence_range) {
+    countText += ' · #' + data.sequence_range[0] + '–' + data.sequence_range[1];
+  }
+  var reasonHtml = (data.best_reasons || []).map(function(r) {
+    return '<span class="best-batch-reason">' + escapeHtml(r) + '</span>';
+  }).join('');
+  var cards = (data.cards || []).map(function(card) {
+    var reasons = (card.reasons || []).slice(0, 2).map(escapeHtml).join(' · ');
+    return '<div class="best-batch-card ' + escapeAttr(card.role || '') + '" data-photo-id="' + card.id + '">' +
+      '<img src="/thumbnails/' + card.id + '.jpg" alt="' + escapeAttr(card.filename || '') + '" loading="lazy">' +
+      '<div class="best-batch-card-body">' +
+        '<div class="best-batch-role ' + escapeAttr(card.role || '') + '">#' + card.rank + ' ' + bestBatchRoleLabel(card.role) + '</div>' +
+        '<div class="best-batch-card-name" title="' + escapeAttr(card.filename || '') + '">' + escapeHtml(card.filename || '') + '</div>' +
+        '<div class="best-batch-card-line">' + escapeHtml(bestBatchScoreText(card)) + '</div>' +
+        '<div class="best-batch-card-line">' + reasons + '</div>' +
+      '</div>' +
+    '</div>';
+  }).join('');
+  content.className = '';
+  content.innerHTML =
+    '<div class="best-batch-head">' +
+      '<div class="best-batch-pick">' +
+        '<img src="/thumbnails/' + best.id + '.jpg" alt="' + escapeAttr(best.filename || '') + '">' +
+        '<div class="best-batch-pick-meta">' +
+          '<div class="best-batch-eyebrow">Best Pick</div>' +
+          '<div class="best-batch-title">' + escapeHtml(best.filename || '') + '</div>' +
+          '<div class="best-batch-score">' + escapeHtml(bestBatchScoreText(best)) + '</div>' +
+        '</div>' +
+      '</div>' +
+      '<div class="best-batch-summary">' +
+        '<div class="best-batch-eyebrow">' + escapeHtml(countText) + '</div>' +
+        '<div>' + escapeHtml(best.filename || 'This photo') + ' is the top-ranked frame in the detected batch.</div>' +
+        '<div class="best-batch-reasons">' + reasonHtml + '</div>' +
+      '</div>' +
+    '</div>' +
+    '<div class="best-batch-list">' + cards + '</div>';
+}
+
+async function openBestBatch() {
+  var seedId = bestBatchSeedId();
+  var ids = getActiveSelection();
+  if (!seedId) {
+    showToast('Select a photo first.', 'error');
+    return;
+  }
+  bestBatchData = null;
+  var modal = document.getElementById('bestBatchModal');
+  var content = document.getElementById('bestBatchContent');
+  if (content) {
+    content.className = 'best-batch-empty';
+    content.textContent = 'Loading batch...';
+  }
+  if (modal) modal.classList.add('open');
+  try {
+    var data;
+    if (ids.length >= 2) {
+      data = await safeFetch('/api/photos/best-batch', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({photo_ids: ids}),
+      }, { toast: false });
+    } else {
+      data = await safeFetch('/api/photos/' + seedId + '/best-batch', {}, { toast: false });
+    }
+    renderBestBatch(data);
+  } catch (e) {
+    if (content) {
+      content.className = 'best-batch-empty';
+      content.textContent = e && e.message ? e.message : 'Could not rank this batch.';
+    }
+  }
+}
+
+function openBestBatchInReview() {
+  if (!bestBatchData || !bestBatchData.photo_ids || bestBatchData.photo_ids.length < 2) return;
+  try {
+    window.sessionStorage.setItem('vireo.browseBurstReviewIds', JSON.stringify(bestBatchData.photo_ids));
+  } catch (e) {
+    showToast('Could not open burst review for this batch.', 'error');
+    return;
+  }
+  window.location.href = '/pipeline/review?browse_burst=1';
+}
+
+async function applyBestBatchPickOnly() {
+  if (!bestBatchData || !bestBatchData.best_photo_id) return;
+  var bestId = bestBatchData.best_photo_id;
+  try {
+    await safeFetch('/api/batch/flag', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({photo_ids: [bestId], flag: 'flagged'}),
+    });
+  } catch(e) { return; }
+  var p = photos.find(function(x) { return x.id === bestId; });
+  if (p) p.flag = 'flagged';
+  refreshGridCards([bestId]);
+  scheduleCollectionCountsRefresh();
+  showUndoToast();
+  showToast('Flagged best photo.', 'success');
+}
+
+async function applyBestBatchPickAndReject() {
+  if (!bestBatchData || !bestBatchData.best_photo_id) return;
+  var bestId = bestBatchData.best_photo_id;
+  var rejectIds = (bestBatchData.suggested_reject_ids || []).filter(function(id) { return id !== bestId; });
+  try {
+    await safeFetch('/api/batch/flag', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({photo_ids: [bestId], flag: 'flagged'}),
+    });
+    if (rejectIds.length) {
+      await safeFetch('/api/batch/flag', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({photo_ids: rejectIds, flag: 'rejected'}),
+      });
+    }
+  } catch(e) { return; }
+  [bestId].concat(rejectIds).forEach(function(id) {
+    var p = photos.find(function(x) { return x.id === id; });
+    if (p) p.flag = id === bestId ? 'flagged' : 'rejected';
+  });
+  refreshGridCards([bestId].concat(rejectIds));
+  scheduleCollectionCountsRefresh();
+  showUndoToast();
+  showToast('Applied best-batch flags.', 'success');
+  hideBestBatch();
 }
 
 function updateSelectionPanel(ids) {
@@ -5398,6 +5730,8 @@ function buildPhotoContextMenu(photoIds) {
       onClick: function() { if (typeof findSimilar === 'function') findSimilar(photoIds[0]); } },
     { label: 'Compare', disabled: photoIds.length < 2, disabledHint: 'Select at least two photos',
       onClick: function() { openBrowseCompare(); } },
+    { label: 'Best Batch',
+      onClick: function() { openBestBatch(); } },
     { label: 'Review Burst', disabled: photoIds.length < 2, disabledHint: 'Select at least two photos',
       onClick: function() { openSelectedInBurstReview(); } },
   ].concat(buildOpenInEditorMenuItems(photoIds)).concat([

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -176,6 +176,24 @@ def test_api_photos_rejects_unknown_flag_filter(app_and_db):
     assert resp.status_code == 400
 
 
+def _mark_best_batch_quality(db, photo_id, sharpness):
+    db.conn.execute(
+        """UPDATE photos
+           SET mask_path = 'mask.png',
+               subject_tenengrad = ?,
+               bg_tenengrad = 5,
+               crop_complete = 1,
+               bg_separation = 0,
+               subject_clip_high = 0,
+               subject_clip_low = 0,
+               subject_y_median = 115,
+               subject_size = 0.05,
+               noise_estimate = 1
+           WHERE id = ?""",
+        (sharpness, photo_id),
+    )
+
+
 def test_api_photo_best_batch_ranks_filename_sequence(app_and_db):
     """GET /api/photos/<id>/best-batch finds adjacent camera frames and ranks them."""
     app, db = app_and_db
@@ -192,21 +210,7 @@ def test_api_photo_best_batch_ranks_filename_sequence(app_and_db):
             file_mtime=float(idx),
             timestamp=f"2024-03-01T12:00:0{idx - 3069}",
         )
-        db.conn.execute(
-            """UPDATE photos
-               SET mask_path = 'mask.png',
-                   subject_tenengrad = ?,
-                   bg_tenengrad = 5,
-                   crop_complete = 1,
-                   bg_separation = 0,
-                   subject_clip_high = 0,
-                   subject_clip_low = 0,
-                   subject_y_median = 115,
-                   subject_size = 0.05,
-                   noise_estimate = 1
-               WHERE id = ?""",
-            (sharp, pid),
-        )
+        _mark_best_batch_quality(db, pid, sharp)
         pids.append(pid)
     db.conn.commit()
 
@@ -225,6 +229,65 @@ def test_api_photo_best_batch_ranks_filename_sequence(app_and_db):
     selected = client.post("/api/photos/best-batch", json={"photo_ids": pids}).get_json()
     assert selected["scope_method"] == "selected_photos"
     assert selected["best_photo_id"] == pids[1]
+
+
+def test_api_photo_best_batch_capture_time_requires_real_timestamps(app_and_db):
+    """Timestamp fallback should not group unrelated null-timestamp photos."""
+    app, db = app_and_db
+    folder_id = db.conn.execute(
+        "SELECT id FROM folders WHERE path = ?", ('/photos/2024',)
+    ).fetchone()["id"]
+    pids = []
+    for filename in ["alpha.jpg", "beta.jpg", "gamma.jpg"]:
+        pid = db.add_photo(
+            folder_id=folder_id,
+            filename=filename,
+            extension=".jpg",
+            file_size=1000,
+            file_mtime=1.0,
+            timestamp=None,
+        )
+        _mark_best_batch_quality(db, pid, 80)
+        pids.append(pid)
+    db.conn.commit()
+
+    client = app.test_client()
+    resp = client.get(f"/api/photos/{pids[1]}/best-batch")
+
+    assert resp.status_code == 404
+    assert resp.get_json()["error"] == "No neighboring batch photos found"
+
+
+def test_api_photo_best_batch_ranks_capture_time_without_sequence(app_and_db):
+    """Timestamp fallback still works for non-sequence filenames with real times."""
+    app, db = app_and_db
+    folder_id = db.conn.execute(
+        "SELECT id FROM folders WHERE path = ?", ('/photos/2024',)
+    ).fetchone()["id"]
+    pids = []
+    for idx, (filename, sharp) in enumerate(
+        [("alpha.jpg", 10), ("beta.jpg", 90), ("gamma.jpg", 30)]
+    ):
+        pid = db.add_photo(
+            folder_id=folder_id,
+            filename=filename,
+            extension=".jpg",
+            file_size=1000,
+            file_mtime=1.0,
+            timestamp=f"2024-03-01T12:00:0{idx * 3}",
+        )
+        _mark_best_batch_quality(db, pid, sharp)
+        pids.append(pid)
+    db.conn.commit()
+
+    client = app.test_client()
+    resp = client.get(f"/api/photos/{pids[1]}/best-batch")
+
+    assert resp.status_code == 200, resp.get_json()
+    data = resp.get_json()
+    assert data["scope_method"] == "capture_time"
+    assert data["photo_ids"] == pids
+    assert data["best_photo_id"] == pids[1]
 
 
 def test_api_best_batch_flags_records_single_undoable_edit(app_and_db):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -227,6 +227,74 @@ def test_api_photo_best_batch_ranks_filename_sequence(app_and_db):
     assert selected["best_photo_id"] == pids[1]
 
 
+def test_api_best_batch_flags_records_single_undoable_edit(app_and_db):
+    """Best Batch apply updates mixed flags as one atomic undo action."""
+    app, db = app_and_db
+    photos = db.get_photos()
+    photo_ids = [p["id"] for p in photos]
+    best_id, reject_id, keep_reject_id = photo_ids
+    db.update_photo_flag(reject_id, "flagged")
+
+    client = app.test_client()
+    pre_history = db.get_edit_history()
+    resp = client.post(
+        "/api/batch/best-batch-flags",
+        json={
+            "best_photo_id": best_id,
+            "reject_photo_ids": [reject_id, keep_reject_id],
+        },
+    )
+
+    assert resp.status_code == 200, resp.get_json()
+    assert resp.get_json()["updated"] == 3
+    flags = {
+        row["id"]: row["flag"]
+        for row in db.conn.execute(
+            "SELECT id, flag FROM photos WHERE id IN (?, ?, ?)",
+            (best_id, reject_id, keep_reject_id),
+        )
+    }
+    assert flags == {
+        best_id: "flagged",
+        reject_id: "rejected",
+        keep_reject_id: "rejected",
+    }
+    post_history = db.get_edit_history()
+    assert len(post_history) == len(pre_history) + 1
+    assert post_history[0]["action_type"] == "flag"
+    assert post_history[0]["new_value"] == "best_batch_apply"
+    assert post_history[0]["item_count"] == 3
+
+    undo = client.post("/api/undo")
+
+    assert undo.status_code == 200, undo.get_json()
+    flags = {
+        row["id"]: row["flag"]
+        for row in db.conn.execute(
+            "SELECT id, flag FROM photos WHERE id IN (?, ?, ?)",
+            (best_id, reject_id, keep_reject_id),
+        )
+    }
+    assert flags == {
+        best_id: "none",
+        reject_id: "flagged",
+        keep_reject_id: "none",
+    }
+
+
+def test_api_best_batch_flags_rejects_best_photo_in_rejects(app_and_db):
+    app, db = app_and_db
+    best_id = db.get_photos()[0]["id"]
+    client = app.test_client()
+
+    resp = client.post(
+        "/api/batch/best-batch-flags",
+        json={"best_photo_id": best_id, "reject_photo_ids": [best_id]},
+    )
+
+    assert resp.status_code == 400
+
+
 def test_api_set_flag_queues_xmp_when_enabled(app_and_db):
     """POST /api/photos/<id>/flag queues a flag sync when configured."""
     import config as cfg

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -176,6 +176,57 @@ def test_api_photos_rejects_unknown_flag_filter(app_and_db):
     assert resp.status_code == 400
 
 
+def test_api_photo_best_batch_ranks_filename_sequence(app_and_db):
+    """GET /api/photos/<id>/best-batch finds adjacent camera frames and ranks them."""
+    app, db = app_and_db
+    folder_id = db.conn.execute(
+        "SELECT id FROM folders WHERE path = ?", ('/photos/2024',)
+    ).fetchone()["id"]
+    pids = []
+    for idx, sharp in enumerate([10, 80, 30], start=3069):
+        pid = db.add_photo(
+            folder_id=folder_id,
+            filename=f"DSC_{idx}.jpg",
+            extension=".jpg",
+            file_size=1000 + idx,
+            file_mtime=float(idx),
+            timestamp=f"2024-03-01T12:00:0{idx - 3069}",
+        )
+        db.conn.execute(
+            """UPDATE photos
+               SET mask_path = 'mask.png',
+                   subject_tenengrad = ?,
+                   bg_tenengrad = 5,
+                   crop_complete = 1,
+                   bg_separation = 0,
+                   subject_clip_high = 0,
+                   subject_clip_low = 0,
+                   subject_y_median = 115,
+                   subject_size = 0.05,
+                   noise_estimate = 1
+               WHERE id = ?""",
+            (sharp, pid),
+        )
+        pids.append(pid)
+    db.conn.commit()
+
+    client = app.test_client()
+    resp = client.get(f"/api/photos/{pids[1]}/best-batch")
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["scope_method"] == "filename_sequence"
+    assert data["photo_ids"] == pids
+    assert data["best_photo_id"] == pids[1]
+    assert data["best_filename"] == "DSC_3070.jpg"
+    assert data["sequence_range"] == [3069, 3071]
+    assert data["cards"][0]["role"] == "best"
+
+    selected = client.post("/api/photos/best-batch", json={"photo_ids": pids}).get_json()
+    assert selected["scope_method"] == "selected_photos"
+    assert selected["best_photo_id"] == pids[1]
+
+
 def test_api_set_flag_queues_xmp_when_enabled(app_and_db):
     """POST /api/photos/<id>/flag queues a flag sync when configured."""
     import config as cfg


### PR DESCRIPTION
## Summary

Moves Best Batch review out of the cramped Browse modal and into a dedicated `/best-batch` page.

- Adds a Best Batch page with a focus-first comparison workspace.
- Shows eye-centered focus crops when eye keypoints exist, with a clear subject-focus fallback when they do not.
- Keeps a large inspected frame, ranked frame list, Review Burst, Flag Best, and Flag Best + Reject Rest actions on the page.
- Updates Browse's Best Batch button and context-menu action to pass the selected photo ids through sessionStorage and navigate to `/best-batch`.
- Exposes the focus basis and eye-keypoint metadata in the Best Batch API response so the page can render the verification crops.

## Why

The modal made users judge eye sharpness from a small full-frame preview. For birds, the eye is often too small to verify that recommendation confidently. A dedicated page gives enough space for direct focus comparison before applying flags or rejects.

## Validation

- `python -m pytest vireo/tests/test_photos_api.py -k best_batch -q`
- `python -m ruff check vireo/app.py vireo/tests/test_photos_api.py`
- `python -m py_compile vireo/app.py`
- Route smoke check: `/best-batch` returns `200`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a dedicated Best Batch interface page for improved photo selection and ranking workflows
  * Extended best-batch results with detailed focus metadata including eye position and confidence metrics
  * Added inspection panel with ranked frame thumbnails and batch flagging capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->