### PR TITLE
[codex] Fix batch EXIF location accept

### DIFF
--- a/tests/e2e/test_location_section.py
+++ b/tests/e2e/test_location_section.py
@@ -45,6 +45,17 @@ def _seed_exif_photo(live_server, lat=40.785091, lng=-73.968285):
     return photo_id
 
 
+def _seed_exif_photos(live_server, photo_ids, lat=40.785091, lng=-73.968285):
+    """Set lat/lng on the given photos."""
+    db = live_server["db"]
+    with db.conn:
+        for photo_id in photo_ids:
+            db.conn.execute(
+                "UPDATE photos SET latitude = ?, longitude = ? WHERE id = ?",
+                (lat, lng, photo_id),
+            )
+
+
 def _seed_reverse_geocode_cache(live_server, lat, lng, place_id, details):
     """Pre-populate `place_reverse_geocode_cache` so the proxy serves a hit."""
     live_server["db"].reverse_geocode_cache_put(
@@ -344,3 +355,59 @@ def test_exif_accept_button_attaches_location(live_server, page, monkeypatch):
         (photo_id, _CANNED_PLACE_ID),
     ).fetchone()
     assert row is not None
+
+
+def test_exif_accept_batches_selection_and_refreshes_smart_collection(
+    live_server, page, monkeypatch
+):
+    """Accepting an EXIF suggestion applies to the active selection and reloads
+    the GPS-without-location smart collection.
+    """
+    photo_ids = live_server["data"]["photos"][:3]
+    _seed_exif_photos(live_server, photo_ids)
+    _seed_reverse_geocode_cache(
+        live_server, 40.785091, -73.968285, _CANNED_PLACE_ID, _CANNED_DETAILS,
+    )
+    _set_api_key()
+
+    import places
+    monkeypatch.setattr(
+        places, "place_details", lambda pid, key: _CANNED_DETAILS,
+    )
+
+    db = live_server["db"]
+    collection_id = next(
+        c["id"]
+        for c in db.get_collections()
+        if c["name"] == "GPS Without Location Keyword"
+    )
+    assert db.count_collection_photos(collection_id) == 3
+
+    page.goto(f"{live_server['url']}/browse")
+    page.locator(".grid-card").first.wait_for(state="visible")
+    page.evaluate("(collectionId) => filterByCollection(collectionId)", collection_id)
+    page.wait_for_function(
+        "(collectionId) => activeCollectionId === collectionId && photos.length === 3",
+        arg=collection_id,
+    )
+
+    page.locator(f".grid-card[data-id='{photo_ids[0]}']").click()
+    _wait_for_detail_loaded(page)
+    expect(page.locator("#locationExifSuggestion button.accept-btn")).to_be_visible()
+    page.locator(f".grid-card[data-id='{photo_ids[1]}']").click(modifiers=["Meta"])
+    page.locator(f".grid-card[data-id='{photo_ids[2]}']").click(modifiers=["Meta"])
+    page.wait_for_function("() => selectedPhotos.size === 3")
+
+    page.locator("#locationExifSuggestion button.accept-btn").click()
+    page.wait_for_function("() => activeCollectionId !== null && photos.length === 0")
+
+    for photo_id in photo_ids:
+        row = db.conn.execute(
+            "SELECT 1 FROM photo_keywords pk "
+            "JOIN keywords k ON k.id = pk.keyword_id "
+            "WHERE pk.photo_id = ? AND k.type = 'location' AND k.place_id = ?",
+            (photo_id, _CANNED_PLACE_ID),
+        ).fetchone()
+        assert row is not None
+        expect(page.locator(f".grid-card[data-id='{photo_id}']")).to_have_count(0)
+    assert db.count_collection_photos(collection_id) == 0

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3760,6 +3760,81 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         )
         return jsonify({"location": _serialize_photo_location(db, photo_id)})
 
+    @app.route("/api/batch/location", methods=["POST"])
+    def api_batch_set_photo_location():
+        """Attach one Google place location to multiple photos."""
+        body = request.get_json(silent=True) or {}
+        raw_ids = body.get("photo_ids", [])
+        if not isinstance(raw_ids, list) or not raw_ids:
+            return json_error("photo_ids required", 400)
+
+        photo_ids = []
+        seen = set()
+        for raw in raw_ids:
+            if isinstance(raw, bool) or not isinstance(raw, int):
+                return json_error("photo_ids must contain only integers", 400)
+            if raw not in seen:
+                photo_ids.append(raw)
+                seen.add(raw)
+        if not photo_ids:
+            return json_error("photo_ids required", 400)
+        if len(photo_ids) > 1000:
+            return json_error("too many photo_ids", 400)
+
+        place_id = _extract_place_id(body)
+        if not place_id:
+            return json_error("missing place_id", 400)
+
+        db = _get_db()
+        for pid in photo_ids:
+            edit_error = _photo_location_edit_error(db, pid)
+            if edit_error is not None:
+                return edit_error
+
+        details = _normalize_client_place_details(body)
+        if details is None:
+            import config as cfg
+            key = cfg.load().get("google_maps_api_key", "")
+            if not key:
+                return json_error("no_api_key", 400)
+            details = places.place_details(place_id, key)
+            if details is None:
+                return json_error("place_not_found", 404)
+
+        try:
+            leaf_id = db.upsert_place_chain(details)
+        except RuntimeError as err:
+            return jsonify({
+                "error": "name_conflict",
+                "error_detail": str(err),
+            }), 409
+
+        items = []
+        for pid in photo_ids:
+            db.set_photo_location(pid, leaf_id)
+            _queue_location_sync_if_enabled(pid, _commit=False)
+            items.append({
+                "photo_id": pid,
+                "old_value": "",
+                "new_value": str(leaf_id),
+            })
+        if items:
+            db.record_edit(
+                "location_set",
+                f"set location: {details.get('name', 'unknown')} on {len(items)} photos",
+                str(leaf_id),
+                items,
+                is_batch=True,
+                _commit=False,
+            )
+        db.conn.commit()
+        db._prune_edit_history()
+        return jsonify({
+            "ok": True,
+            "updated": len(items),
+            "location": _serialize_photo_location(db, photo_ids[0]),
+        })
+
     @app.route("/api/photos/<int:photo_id>/location", methods=["DELETE"])
     def api_clear_photo_location(photo_id):
         """Remove all ``type='location'`` keyword links for ``photo_id``."""

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -5104,6 +5104,29 @@ function _hideLocationError() {
   if (el) el.hidden = true;
 }
 
+function _locationApplyPhotoIds() {
+  var ids = getActiveSelection();
+  if (ids.length > 1) return ids;
+  var photoId = window._detailPhotoId;
+  return photoId ? [photoId] : [];
+}
+
+async function _afterLocationMutation(photoIds, detailPhotoId) {
+  loadKeywords();
+  scheduleCollectionCountsRefresh();
+  refreshPendingSyncBanner();
+  if (activeCollectionId) {
+    await filterByCollection(activeCollectionId);
+    return;
+  }
+  if (photoIds && photoIds.length) refreshGridCards(photoIds);
+  if (detailPhotoId && selectedPhotoId === detailPhotoId) {
+    loadDetail(detailPhotoId);
+  } else {
+    loadSummary();
+  }
+}
+
 async function bindLocationAutocomplete() {
   if (_locationAutocompleteBound) return;
   // Wait for the /api/config fetch to resolve so window.GOOGLE_MAPS_API_KEY
@@ -5175,19 +5198,24 @@ async function _submitLocationPlace(placeId, placeDetails) {
   var photoId = window._detailPhotoId;
   if (!photoId) return;
   _hideLocationError();
+  var ids = _locationApplyPhotoIds();
+  var useBatch = ids.length > 1;
   var body = { place_id: placeId };
   if (placeDetails) body.place = placeDetails;
+  if (useBatch) body.photo_ids = ids;
   try {
-    var resp = await safeFetch('/api/photos/' + photoId + '/location', {
+    var endpoint = useBatch
+      ? '/api/batch/location'
+      : '/api/photos/' + photoId + '/location';
+    var resp = await safeFetch(endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     });
     if (resp && resp.location) {
       renderLocationFilled(resp.location);
-      // The location keyword may also appear in the Keywords list; refresh.
-      loadDetail(photoId);
     }
+    await _afterLocationMutation(useBatch ? ids : [photoId], photoId);
   } catch(e) {
     _showLocationError('Could not save location.');
   }
@@ -5205,7 +5233,7 @@ async function _submitLocationText(name) {
     });
     if (resp && resp.location) {
       renderLocationFilled(resp.location);
-      loadDetail(photoId);
+      await _afterLocationMutation([photoId], photoId);
     }
   } catch(e) {
     _showLocationError('Could not save location.');
@@ -5219,7 +5247,7 @@ async function clearPhotoLocation() {
   try {
     await safeFetch('/api/photos/' + photoId + '/location', { method: 'DELETE' });
     renderLocationEmpty();
-    loadDetail(photoId);
+    await _afterLocationMutation([photoId], photoId);
   } catch(e) {
     _showLocationError('Could not clear location.');
   }
@@ -5322,21 +5350,29 @@ async function acceptExifSuggestion(placeId) {
   var photoId = window._detailPhotoId;
   if (!photoId || !placeId) return;
   _hideLocationError();
+  var ids = _locationApplyPhotoIds();
+  var useBatch = ids.length > 1;
   try {
-    var resp = await safeFetch('/api/photos/' + photoId + '/location', {
+    var endpoint = useBatch
+      ? '/api/batch/location'
+      : '/api/photos/' + photoId + '/location';
+    var body = useBatch
+      ? { place_id: placeId, photo_ids: ids }
+      : { place_id: placeId };
+    var resp = await safeFetch(endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ place_id: placeId }),
+      body: JSON.stringify(body),
     });
     if (resp && resp.location) {
       renderLocationFilled(resp.location);
-      loadDetail(photoId);
     }
     var sugg = document.getElementById('locationExifSuggestion');
     if (sugg) {
       sugg.hidden = true;
       sugg.innerHTML = '';
     }
+    await _afterLocationMutation(useBatch ? ids : [photoId], photoId);
   } catch(e) {
     _showLocationError('Could not save location.');
   }

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -3304,6 +3304,52 @@ def test_post_photo_location_records_edit(app_and_db, monkeypatch):
     assert "Central Park" in entry["description"]
 
 
+def test_batch_photo_location_sets_all_selected_photos(app_and_db, monkeypatch):
+    """Batch location POST stores one place keyword across selected photos."""
+    import config as cfg
+    import places
+    app, db = app_and_db
+
+    cfg.save({**cfg.load(), "google_maps_api_key": ""})
+
+    def fail_place_details(place_id, key):
+        raise AssertionError("client place details should avoid server lookup")
+
+    monkeypatch.setattr(places, "place_details", fail_place_details)
+
+    photo_ids = [p["id"] for p in db.get_photos()[:3]]
+    client = app.test_client()
+    resp = client.post(
+        "/api/batch/location",
+        json={
+            "photo_ids": photo_ids,
+            "place_id": "ChIJ4zGFAZpYwokRGUGph3Mf37k",
+            "place": _central_park_client_place(),
+        },
+    )
+    assert resp.status_code == 200, resp.get_json()
+    assert resp.get_json()["updated"] == len(photo_ids)
+
+    for pid in photo_ids:
+        row = db.conn.execute(
+            "SELECT k.place_id FROM photo_keywords pk "
+            "JOIN keywords k ON k.id = pk.keyword_id "
+            "WHERE pk.photo_id = ? AND k.type = 'location'",
+            (pid,),
+        ).fetchone()
+        assert row["place_id"] == "ChIJ4zGFAZpYwokRGUGph3Mf37k"
+        queued = db.conn.execute(
+            "SELECT value FROM pending_changes "
+            "WHERE photo_id = ? AND change_type = 'location'",
+            (pid,),
+        ).fetchone()
+        assert queued["value"] == "effective"
+
+    entry = db.get_edit_history()[0]
+    assert entry["action_type"] == "location_set"
+    assert entry["item_count"] == len(photo_ids)
+
+
 def test_delete_photo_location_records_edit(app_and_db):
     """DELETE adds an entry to the audit log even though it doesn't write a sidecar."""
     app, db = app_and_db


### PR DESCRIPTION
## Summary

Fixes the Browse location EXIF suggestion flow so accepting a reverse-geocoded location honors the active multi-selection instead of only updating the detail photo.

## Root Cause

Location keywords use a separate API/UI path from generic keyword assignment because they carry Google place metadata, parent-chain location keywords, replacement semantics, and GPS sidecar sync. The EXIF Accept button still posted only to `/api/photos/<id>/location`, so the existing batch keyword behavior did not apply. The Browse detail refresh also did not reload the active smart collection, leaving fixed photos visible in `GPS Without Location Keyword` until a manual refresh.

## Changes

- Added `/api/batch/location` for assigning one Google place location to multiple photos.
- Routed EXIF Accept and Google place selection through the active Browse selection when multiple photos are selected.
- Refreshed keyword/sidebar/sync state after location edits and reloaded the active smart collection so photos leave `GPS Without Location Keyword` immediately.
- Added API and browser regressions for multi-photo EXIF location accept.

## Validation

- `pytest vireo/tests/test_photos_api.py -q -k "location"`
- `pytest tests/e2e/test_location_section.py -q`