### PR TITLE
Select all matching Browse photos

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2626,6 +2626,34 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             }
         )
 
+    @app.route("/api/photos/ids")
+    def api_photo_ids():
+        """Return every photo ID matching the current Browse filters."""
+        db = _get_db()
+        sort = request.args.get("sort", "date")
+        folder_id = request.args.get("folder_id", None, type=int)
+        rating_min = request.args.get("rating_min", None, type=int)
+        date_from = request.args.get("date_from", None)
+        date_to = request.args.get("date_to", None)
+        keyword = request.args.get("keyword", None)
+        color_label = request.args.get("color_label", None)
+        try:
+            flag = _request_flag_filter()
+        except ValueError as e:
+            return json_error(str(e), 400)
+
+        photo_ids = db.get_photo_ids(
+            folder_id=folder_id,
+            sort=sort,
+            rating_min=rating_min,
+            date_from=date_from,
+            date_to=date_to,
+            keyword=keyword,
+            color_label=color_label,
+            flag=flag,
+        )
+        return jsonify({"photo_ids": photo_ids, "total": len(photo_ids)})
+
     @app.route("/api/photos/calendar")
     def api_photos_calendar():
         db = _get_db()
@@ -2788,7 +2816,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("photo_ids must be a list", 400)
         if not raw_ids:
             return json_error("photo_ids required", 400)
-        if len(raw_ids) > 500:
+        if len(raw_ids) > 50000:
             return json_error("too many photo_ids", 400)
 
         photo_ids = []
@@ -4942,6 +4970,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "total": total,
             }
         )
+
+    @app.route("/api/collections/<int:collection_id>/photo-ids")
+    def api_collection_photo_ids(collection_id):
+        """Return every photo ID matching a collection."""
+        db = _get_db()
+        photo_ids = db.get_collection_photo_ids(collection_id)
+        return jsonify({"photo_ids": photo_ids, "total": len(photo_ids)})
 
     # -- Highlights --
 
@@ -11459,7 +11494,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("photo_ids must be a list", 400)
         if not raw_ids:
             return json_error("photo_ids required", 400)
-        if len(raw_ids) > 5000:
+        if len(raw_ids) > 50000:
             return json_error("too many photo_ids", 400)
 
         photo_ids = []

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -14442,6 +14442,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         limit = min(max(1, request.args.get("limit", 50, type=int)), 1000)
         threshold = request.args.get("threshold", 0.15, type=float)
+        ids_only = request.args.get("ids_only", "").lower() in ("1", "true", "yes")
 
         db = _get_db()
 
@@ -14491,7 +14492,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         # Top-N by similarity
         if total_matches > 0:
-            top_indices = np.argsort(filtered_sims)[::-1][:limit]
+            ranked_indices = np.argsort(filtered_sims)[::-1]
+            if ids_only:
+                return jsonify({
+                    "photo_ids": [filtered_ids[idx] for idx in ranked_indices],
+                    "total_matches": total_matches,
+                    "model_used": model_name,
+                })
+            top_indices = ranked_indices[:limit]
             top_pids = [filtered_ids[idx] for idx in top_indices]
             top_sims = [float(filtered_sims[idx]) for idx in top_indices]
             photos_map = db.get_photos_by_ids(top_pids)
@@ -14503,6 +14511,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         "similarity": round(sim, 4),
                     })
         else:
+            if ids_only:
+                return jsonify({
+                    "photo_ids": [],
+                    "total_matches": 0,
+                    "model_used": model_name,
+                })
             results = []
 
         return jsonify({

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1258,9 +1258,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             elapsed = time.time() - request._start_time
             if request.method in ("POST", "DELETE"):
                 # Log user actions with details about what changed
-                body = request.get_json(silent=True) or {}
                 detail = ""
                 path = request.path
+                if path in ("/api/capture-time/preview", "/api/jobs/capture-time"):
+                    body = {}
+                else:
+                    body = request.get_json(silent=True) or {}
                 if "/rating" in path:
                     detail = f" rating={body.get('rating')}"
                 elif "/flag" in path:
@@ -11555,7 +11558,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "capture-time",
             work,
             config={
-                "photo_ids": photo_ids,
+                "photo_count": len(photo_ids),
+                "photo_ids_sample": photo_ids[:20],
                 "mode": mode,
                 "target_offset": target_offset,
                 "shift_minutes": shift_minutes,

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -4289,6 +4289,80 @@ class Database:
         """
         return self.conn.execute(query, params).fetchall()
 
+    def get_photo_ids(
+        self,
+        folder_id=None,
+        sort="date",
+        rating_min=None,
+        date_from=None,
+        date_to=None,
+        keyword=None,
+        color_label=None,
+        flag=None,
+    ):
+        """Return all filtered photo IDs scoped to active workspace."""
+        conditions = ["wf.workspace_id = ?"]
+        where_params = [self._ws_id()]
+        join_params = []
+
+        if folder_id is not None:
+            subtree = self.get_folder_subtree_ids(folder_id)
+            placeholders = ",".join("?" for _ in subtree)
+            conditions.append(f"p.folder_id IN ({placeholders})")
+            where_params.extend(subtree)
+        if rating_min is not None:
+            conditions.append("p.rating >= ?")
+            where_params.append(rating_min)
+        if date_from is not None:
+            conditions.append("p.timestamp >= ?")
+            where_params.append(date_from)
+        if date_to is not None:
+            conditions.append("p.timestamp <= ?")
+            where_params.append(_inclusive_date_to(date_to))
+        if flag is not None:
+            conditions.append("COALESCE(p.flag, 'none') = ?")
+            where_params.append(flag)
+
+        join_clause = ("JOIN workspace_folders wf ON wf.folder_id = p.folder_id"
+                       "\nJOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')")
+        if keyword is not None:
+            join_clause += """
+                LEFT JOIN photo_keywords pk ON pk.photo_id = p.id
+                LEFT JOIN keywords k ON k.id = pk.keyword_id
+            """
+            conditions.append("(k.name LIKE ? OR p.filename LIKE ?)")
+            where_params.append(f"%{keyword}%")
+            where_params.append(f"%{keyword}%")
+
+        if color_label is not None:
+            join_clause += "\nJOIN photo_color_labels pcl ON pcl.photo_id = p.id AND pcl.workspace_id = ?"
+            join_params.append(self._ws_id())
+            conditions.append("pcl.color = ?")
+            where_params.append(color_label)
+
+        params = join_params + where_params
+        where = "WHERE " + " AND ".join(conditions)
+
+        sort_map = {
+            "date": "p.timestamp ASC, p.filename ASC, p.id ASC",
+            "date_desc": "p.timestamp DESC, p.filename ASC, p.id ASC",
+            "name": "p.filename ASC, p.id ASC",
+            "name_desc": "p.filename DESC, p.id ASC",
+            "rating": "p.rating DESC, p.filename ASC, p.id ASC",
+            "sharpness": "p.sharpness DESC, p.filename ASC, p.id ASC",
+            "sharpness_asc": "p.sharpness ASC, p.filename ASC, p.id ASC",
+            "quality": "p.quality_score DESC, p.filename ASC, p.id ASC",
+        }
+        order = sort_map.get(sort, "p.timestamp ASC, p.filename ASC, p.id ASC")
+        distinct = "DISTINCT " if keyword is not None else ""
+        query = f"""
+            SELECT {distinct}p.id FROM photos p
+            {join_clause}
+            {where}
+            ORDER BY {order}
+        """
+        return [row["id"] for row in self.conn.execute(query, params).fetchall()]
+
     def count_filtered_photos(
         self,
         folder_id=None,
@@ -9849,6 +9923,22 @@ class Database:
             LIMIT ? OFFSET ?
         """
         return self.conn.execute(query, params).fetchall()
+
+    def get_collection_photo_ids(self, collection_id):
+        """Return all photo IDs matching a collection in display order."""
+        parts = self._build_collection_query(collection_id)
+        if parts is None:
+            return []
+
+        folder_join, join_clause, where, params = parts
+        query = f"""
+            SELECT DISTINCT p.id FROM photos p
+            {folder_join}
+            {join_clause}
+            {where}
+            ORDER BY p.timestamp ASC, p.filename ASC, p.id ASC
+        """
+        return [row["id"] for row in self.conn.execute(query, params).fetchall()]
 
     def count_collection_photos(self, collection_id):
         """Return total count of photos matching collection rules."""

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3943,7 +3943,17 @@ function updateSelectionPanel(ids) {
   if (summary) summary.classList.add('hidden');
   if (detail) detail.classList.toggle('visible', detailMatchesSelectedPhoto());
   panel.classList.remove('hidden');
-  document.getElementById('selectionCount').textContent = ids.length + ' photos selected';
+  document.getElementById('selectionCount').textContent = ids.length.toLocaleString() + ' photos selected';
+  if (ids.length > 1000) {
+    selectionKeywordKey = selectionIdsKey(ids);
+    selectionKeywordMissingById = {};
+    selectionKeywordRequestSeq++;
+    var list = document.getElementById('selectionKeywordSuggestions');
+    if (list) {
+      list.innerHTML = '<div class="selection-empty">Keyword suggestions are available for selections of 1,000 photos or fewer.</div>';
+    }
+    return;
+  }
   loadSelectionKeywordSuggestions(ids);
 }
 

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3026,6 +3026,11 @@ async function saveCollection() {
 /* ---------- Photo Loading ---------- */
 function resetAndLoad() {
   cancelScheduledSearchFilter();
+  if (clipSearchActive) {
+    clipSearchActive = false;
+    document.getElementById('clipSearchInput').value = '';
+    document.getElementById('clipClearBtn').style.display = 'none';
+  }
   photos = [];
   currentPage = 1;
   allLoaded = false;

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3372,6 +3372,9 @@ async function runClipSearch() {
     return;
   }
 
+  loadEpoch++;
+  selectAllRequestSeq++;
+  var epoch = loadEpoch;
   photos = [];
   allLoaded = true;
   selectedPhotos.clear();
@@ -3390,6 +3393,7 @@ async function runClipSearch() {
     params.set('limit', 100);
     params.set('threshold', 0.15);
     var data = await safeFetch('/api/photos/search?' + params.toString());
+    if (epoch !== loadEpoch) return;
 
     if (data.reason) {
       var msg = {
@@ -3668,10 +3672,24 @@ async function selectAllMatchingPhotos() {
   var requestEpoch = loadEpoch;
 
   if (clipSearchActive) {
-    photos.forEach(function(p) { selectedPhotos.add(p.id); });
-    renderGrid();
-    updateBatchBar();
-    showToast('Selected ' + selectedPhotos.size.toLocaleString() + ' loaded search result' + (selectedPhotos.size === 1 ? '' : 's'));
+    var query = document.getElementById('clipSearchInput').value.trim();
+    if (!query) return;
+    var searchParams = new URLSearchParams();
+    searchParams.set('q', query);
+    searchParams.set('threshold', 0.15);
+    searchParams.set('ids_only', '1');
+    showToast('Selecting all matching search results...');
+    try {
+      var searchData = await safeFetch('/api/photos/search?' + searchParams.toString(), {}, { toast: false });
+      if (requestSeq !== selectAllRequestSeq || requestEpoch !== loadEpoch) return;
+      selectedPhotos.clear();
+      (searchData.photo_ids || []).forEach(function(id) { selectedPhotos.add(id); });
+      renderGrid();
+      updateBatchBar();
+      showToast('Selected ' + selectedPhotos.size.toLocaleString() + ' search result' + (selectedPhotos.size === 1 ? '' : 's'));
+    } catch(e) {
+      showToast('Could not select all search results: ' + (e.message || e), 'error');
+    }
     return;
   }
 

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3045,6 +3045,28 @@ function resetAndLoad() {
   loadPhotos();
 }
 
+function buildCurrentBrowseParams() {
+  var params = new URLSearchParams();
+  params.set('sort', document.getElementById('sortSelect').value);
+
+  if (activeFolderId) params.set('folder_id', activeFolderId);
+  if (filterRating > 0) params.set('rating_min', filterRating);
+  if (flagFilter) params.set('flag', flagFilter);
+
+  var colorFilter = document.getElementById('colorFilter').value;
+  if (colorFilter) params.set('color_label', colorFilter);
+
+  var dateFrom = document.getElementById('dateFrom').value;
+  var dateTo = document.getElementById('dateTo').value;
+  if (dateFrom) params.set('date_from', dateFrom);
+  if (dateTo) params.set('date_to', dateTo);
+
+  var search = document.getElementById('searchInput').value.trim();
+  if (search) params.set('keyword', search);
+  if (activeKeyword) params.set('keyword', activeKeyword);
+  return params;
+}
+
 async function loadPhotos() {
   if (loading || allLoaded) return;
   loading = true;
@@ -3059,26 +3081,9 @@ async function loadPhotos() {
     cparams.set('per_page', perPage);
     url = '/api/collections/' + activeCollectionId + '/photos?' + cparams.toString();
   } else {
-    var params = new URLSearchParams();
+    var params = buildCurrentBrowseParams();
     params.set('page', currentPage);
     params.set('per_page', perPage);
-    params.set('sort', document.getElementById('sortSelect').value);
-
-    if (activeFolderId) params.set('folder_id', activeFolderId);
-    if (filterRating > 0) params.set('rating_min', filterRating);
-    if (flagFilter) params.set('flag', flagFilter);
-
-    var colorFilter = document.getElementById('colorFilter').value;
-    if (colorFilter) params.set('color_label', colorFilter);
-
-    var dateFrom = document.getElementById('dateFrom').value;
-    var dateTo = document.getElementById('dateTo').value;
-    if (dateFrom) params.set('date_from', dateFrom);
-    if (dateTo) params.set('date_to', dateTo);
-
-    var search = document.getElementById('searchInput').value.trim();
-    if (search) params.set('keyword', search);
-    if (activeKeyword) params.set('keyword', activeKeyword);
     url = '/api/photos?' + params.toString();
   }
 
@@ -3653,6 +3658,39 @@ function getActiveSelection() {
   return [];
 }
 
+async function selectAllMatchingPhotos() {
+  anchorRestoreEpoch++;
+  selectedPhotoId = null;
+  selectedIndex = -1;
+
+  if (clipSearchActive) {
+    photos.forEach(function(p) { selectedPhotos.add(p.id); });
+    renderGrid();
+    updateBatchBar();
+    showToast('Selected ' + selectedPhotos.size.toLocaleString() + ' loaded search result' + (selectedPhotos.size === 1 ? '' : 's'));
+    return;
+  }
+
+  var url;
+  if (activeCollectionId) {
+    url = '/api/collections/' + activeCollectionId + '/photo-ids';
+  } else {
+    url = '/api/photos/ids?' + buildCurrentBrowseParams().toString();
+  }
+
+  showToast('Selecting all matching photos...');
+  try {
+    var data = await safeFetch(url, {}, { toast: false });
+    selectedPhotos.clear();
+    (data.photo_ids || []).forEach(function(id) { selectedPhotos.add(id); });
+    renderGrid();
+    updateBatchBar();
+    showToast('Selected ' + selectedPhotos.size.toLocaleString() + ' photo' + (selectedPhotos.size === 1 ? '' : 's'));
+  } catch(e) {
+    showToast('Could not select all photos: ' + (e.message || e), 'error');
+  }
+}
+
 function selectionIdsKey(ids) {
   return ids.slice().sort(function(a, b) { return a - b; }).join(',');
 }
@@ -3696,7 +3734,7 @@ function updateBatchBar() {
   var ids = getActiveSelection();
   if (ids.length >= 1) {
     bar.style.display = 'flex';
-    document.getElementById('batchCount').textContent = ids.length + ' selected';
+    document.getElementById('batchCount').textContent = ids.length.toLocaleString() + ' selected';
   } else {
     bar.style.display = 'none';
   }
@@ -5506,9 +5544,7 @@ document.addEventListener('keydown', function(e) {
   // Select all
   if (matchesShortcut(e, _shortcuts.select_all)) {
     e.preventDefault();
-    photos.forEach(function(p) { selectedPhotos.add(p.id); });
-    renderGrid();
-    updateBatchBar();
+    selectAllMatchingPhotos();
     return;
   }
 

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1708,6 +1708,7 @@ var inatSubmitted = {};  // {photo_id: true}
 var colorLabels = {};    // {photo_id: color_string}
 var colorLabelGen = 0;   // bumped on local edits; guards against stale fetch responses
 var loadEpoch = 0;       // bumped on any grid reset; guards against stale loadPhotos responses
+var selectAllRequestSeq = 0; // bumped to ignore stale async select-all responses
 var filterRating = 0;
 var flagFilter = '';
 var activeFolderId = null;
@@ -3029,6 +3030,7 @@ function resetAndLoad() {
   currentPage = 1;
   allLoaded = false;
   loadEpoch++;
+  selectAllRequestSeq++;
   loading = false;
   // Dataset is about to change; any prior selection (multi-select Set or
   // single-focus id) points at photos that may not exist in the new view.
@@ -3662,6 +3664,8 @@ async function selectAllMatchingPhotos() {
   anchorRestoreEpoch++;
   selectedPhotoId = null;
   selectedIndex = -1;
+  var requestSeq = ++selectAllRequestSeq;
+  var requestEpoch = loadEpoch;
 
   if (clipSearchActive) {
     photos.forEach(function(p) { selectedPhotos.add(p.id); });
@@ -3681,6 +3685,7 @@ async function selectAllMatchingPhotos() {
   showToast('Selecting all matching photos...');
   try {
     var data = await safeFetch(url, {}, { toast: false });
+    if (requestSeq !== selectAllRequestSeq || requestEpoch !== loadEpoch) return;
     selectedPhotos.clear();
     (data.photo_ids || []).forEach(function(id) { selectedPhotos.add(id); });
     renderGrid();

--- a/vireo/tests/test_capture_time_api.py
+++ b/vireo/tests/test_capture_time_api.py
@@ -369,6 +369,9 @@ def test_capture_time_job_accepts_large_select_all_payload(client_with_photo, mo
     job = wait_for_job_via_client(client, resp.get_json()["job_id"])
     assert job["status"] == "completed"
     assert job["result"]["updated"] == 1
+    assert job["config"]["photo_count"] == 1
+    assert job["config"]["photo_ids_sample"] == [photo_id]
+    assert "photo_ids" not in job["config"]
     assert commands[0][-1] == path
 
 

--- a/vireo/tests/test_capture_time_api.py
+++ b/vireo/tests/test_capture_time_api.py
@@ -314,6 +314,64 @@ def test_capture_time_preview_manual_mode_ignores_target_offset(app_and_db):
     assert data["samples"][0]["after_offset"] == "-07:00"
 
 
+def test_capture_time_preview_accepts_large_select_all_payload(app_and_db):
+    """Preview accepts full-result select-all payloads while sampling rows."""
+    app, db = app_and_db
+    photo = db.get_photos()[0]
+
+    client = app.test_client()
+    resp = client.post(
+        "/api/capture-time/preview",
+        json={
+            "photo_ids": [photo["id"]] * 501,
+            "mode": "manual",
+            "shift_minutes": 0,
+        },
+    )
+
+    assert resp.status_code == 200
+    assert resp.get_json()["samples"][0]["photo_id"] == photo["id"]
+
+
+def test_capture_time_job_accepts_large_select_all_payload(client_with_photo, monkeypatch):
+    """Capture-time jobs can run selections above the old 5000-photo UI limit."""
+    import capture_time
+
+    app, db, photo_id = client_with_photo
+    photo = db.get_photo(photo_id)
+    folder = db.conn.execute(
+        "SELECT path FROM folders WHERE id = ?", (photo["folder_id"],)
+    ).fetchone()
+    path = os.path.join(folder["path"], photo["filename"])
+
+    commands = []
+
+    def fake_run(cmd, **_kwargs):
+        commands.append(cmd)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(capture_time.shutil, "which", lambda name: "/usr/bin/exiftool")
+    monkeypatch.setattr(capture_time.subprocess, "run", fake_run)
+    monkeypatch.setattr(capture_time, "extract_metadata", lambda paths: {paths[0]: {"EXIF": {}}})
+
+    client = app.test_client()
+    resp = client.post(
+        "/api/jobs/capture-time",
+        json={
+            "photo_ids": [photo_id] * 5001,
+            "mode": "manual",
+            "shift_minutes": 0,
+            "keep_backups": False,
+        },
+    )
+
+    assert resp.status_code == 200
+    job = wait_for_job_via_client(client, resp.get_json()["job_id"])
+    assert job["status"] == "completed"
+    assert job["result"]["updated"] == 1
+    assert commands[0][-1] == path
+
+
 def test_capture_time_job_applies_per_photo_shifts(client_with_photo, monkeypatch):
     """Each ExifTool invocation must use that photo's own derived shift."""
     import capture_time

--- a/vireo/tests/test_collections_api.py
+++ b/vireo/tests/test_collections_api.py
@@ -118,6 +118,30 @@ def test_browse_init_marks_manual_photo_targets(app_and_db):
     assert by_name["Smart"]["can_add_photos"] is False
 
 
+def test_collection_photo_ids_returns_all_matching_ids(app_and_db):
+    """Collection select-all support returns all matching IDs without pagination."""
+    app, db = app_and_db
+    _clear_default_collections(app, db)
+    client = app.test_client()
+
+    resp = client.post(
+        "/api/collections",
+        json={
+            "name": "Four Stars",
+            "rules": [{"field": "rating", "op": ">=", "value": 4}],
+        },
+    )
+    assert resp.status_code == 200
+    collection_id = resp.get_json()["id"]
+    expected = [p["id"] for p in db.get_collection_photos(collection_id, per_page=999999)]
+
+    resp = client.get(f"/api/collections/{collection_id}/photo-ids")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["photo_ids"] == expected
+    assert data["total"] == len(expected)
+
+
 def test_delete_collection(app_and_db):
     """DELETE /api/collections/<id> removes it."""
     app, db = app_and_db

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -35,6 +35,21 @@ def test_api_photos_filter_folder(app_and_db):
     assert data['photos'][0]['filename'] == 'bird2.jpg'
 
 
+def test_api_photo_ids_matches_browse_filters(app_and_db):
+    """GET /api/photos/ids returns every ID matching the current Browse filters."""
+    app, db = app_and_db
+    folders = db.get_folder_tree()
+    jan = [f for f in folders if f['name'] == 'January'][0]
+    expected = [p["id"] for p in db.get_photos(folder_id=jan["id"], sort="name")]
+
+    client = app.test_client()
+    resp = client.get(f'/api/photos/ids?folder_id={jan["id"]}&sort=name')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["photo_ids"] == expected
+    assert data["total"] == len(expected)
+
+
 def test_api_photos_filter_rating(app_and_db):
     """GET /api/photos?rating_min= filters by minimum rating."""
     app, _ = app_and_db

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1,3 +1,9 @@
+import sys
+import types
+
+import numpy as np
+
+
 def test_api_photos_default(app_and_db):
     """GET /api/photos returns all photos."""
     app, _ = app_and_db
@@ -48,6 +54,47 @@ def test_api_photo_ids_matches_browse_filters(app_and_db):
     data = resp.get_json()
     assert data["photo_ids"] == expected
     assert data["total"] == len(expected)
+
+
+def test_api_photo_search_ids_only_returns_all_matches(app_and_db, monkeypatch):
+    """GET /api/photos/search?ids_only=1 returns all CLIP match IDs, not the page."""
+    app, db = app_and_db
+    photos = db.get_photos(sort="name")
+    by_name = {p["filename"]: p["id"] for p in photos}
+    model_name = "test-clip"
+
+    db.upsert_photo_embedding(
+        by_name["bird1.jpg"], model_name, np.array([0.95, 0.0], dtype=np.float32).tobytes()
+    )
+    db.upsert_photo_embedding(
+        by_name["bird2.jpg"], model_name, np.array([0.8, 0.0], dtype=np.float32).tobytes()
+    )
+    db.upsert_photo_embedding(
+        by_name["bird3.jpg"], model_name, np.array([0.1, 0.0], dtype=np.float32).tobytes()
+    )
+
+    import models
+    monkeypatch.setattr(models, "get_active_model", lambda: {
+        "name": model_name,
+        "model_type": "bioclip",
+        "model_str": "fake",
+        "weights_path": "",
+    })
+    monkeypatch.setitem(
+        sys.modules,
+        "text_encoder",
+        types.SimpleNamespace(
+            encode_text=lambda *_args, **_kwargs: np.array([1.0, 0.0], dtype=np.float32)
+        ),
+    )
+
+    client = app.test_client()
+    resp = client.get('/api/photos/search?q=bird&threshold=0.15&limit=1&ids_only=1')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["photo_ids"] == [by_name["bird1.jpg"], by_name["bird2.jpg"]]
+    assert data["total_matches"] == 2
+    assert "results" not in data
 
 
 def test_api_photos_filter_rating(app_and_db):


### PR DESCRIPTION
Updates Browse so Cmd+A selects every photo matching the current workspace, folder, collection, and active filters instead of only thumbnails already loaded in the grid. Adds IDs-only endpoints for filtered photo queries and collections, then uses them from the Browse selection flow. Raises capture-time preview and job payload limits to support large selections like 6,000-photo timezone corrections. Validated with `pytest vireo/tests/test_capture_time_api.py vireo/tests/test_collections_api.py vireo/tests/test_photos_api.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * "Select All" now selects all matching photos across current browse filters and search results, not just visible ones.
  * Increased batch operation limits: capture-time correction workflows now support up to 50,000 photos per operation.
  * Enhanced filtering for collections and browse endpoints.

* **Tests**
  * Added test coverage for large-selection workflows and collection filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->