### PR TITLE
Fix stale import preview pipeline counts

### DIFF
--- a/tests/e2e/test_pipeline.py
+++ b/tests/e2e/test_pipeline.py
@@ -1,3 +1,4 @@
+import json
 import re
 
 from playwright.sync_api import expect
@@ -142,12 +143,56 @@ def test_pipeline_import_plan_waits_for_folder_preview_scope(live_server, page):
     page.goto(f"{url}/pipeline")
     expect(page.locator("#pillClassify")).to_contain_text("Already done")
 
-    page.route("**/api/import/folder-preview", lambda route: None)
+    stale_plan_route = []
+
+    def hold_stale_plan(route):
+        stale_plan_route.append(route)
+
+    page.route("**/api/pipeline/plan", hold_stale_plan)
+    page.evaluate("setTimeout(refreshPipelinePlan, 0)")
+    for _ in range(50):
+        if stale_plan_route:
+            break
+        page.wait_for_timeout(100)
+    assert stale_plan_route
+
+    folder_preview_route = []
+    page.route("**/api/import/folder-preview", lambda route: folder_preview_route.append(route))
     page.fill("#cfgSourceInput", "/Volumes/Photography/Raw Files/USA/2026/2026-05-30")
     page.locator("#card-source button", has_text="Add").click()
+    stale_plan_route[0].fulfill(
+        status=200,
+        content_type="application/json",
+        body=json.dumps({
+            "stages": {
+                "Previews": {"state": "done-prior", "summary": "stale"},
+                "Classify": {"state": "done-prior", "summary": "stale"},
+                "Extract": {"state": "done-prior", "summary": "stale"},
+                "EyeKeypoints": {"state": "done-prior", "summary": "stale"},
+                "Group": {"state": "done-prior", "summary": "stale"},
+            },
+            "scope": {"collection_id": None, "photo_count": None, "new_count": 0, "known_count": 0},
+        }),
+    )
 
     expect(page.locator("[data-testid='pipeline-plan-summary'] .plan-loading")).to_be_visible()
     expect(page.locator("#pillClassify")).not_to_contain_text("Already done")
+    for _ in range(50):
+        if folder_preview_route:
+            break
+        page.wait_for_timeout(100)
+    assert folder_preview_route
+    folder_preview_route[0].fulfill(
+        status=200,
+        content_type="application/json",
+        body=json.dumps({
+            "total_count": 0,
+            "total_size": 0,
+            "type_breakdown": {},
+            "duplicate_count": 0,
+            "files": [],
+        }),
+    )
 
 
 def test_pipeline_reclassify_flips_classify_pill_to_will_run(live_server, page):

--- a/tests/e2e/test_pipeline.py
+++ b/tests/e2e/test_pipeline.py
@@ -137,6 +137,19 @@ def test_pipeline_status_pills_visible_for_processing_stages(live_server, page):
     expect(page.locator("#pillExtract")).to_contain_text("Will run")
 
 
+def test_pipeline_import_plan_waits_for_folder_preview_scope(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/pipeline")
+    expect(page.locator("#pillClassify")).to_contain_text("Already done")
+
+    page.route("**/api/import/folder-preview", lambda route: None)
+    page.fill("#cfgSourceInput", "/Volumes/Photography/Raw Files/USA/2026/2026-05-30")
+    page.locator("#card-source button", has_text="Add").click()
+
+    expect(page.locator("[data-testid='pipeline-plan-summary'] .plan-loading")).to_be_visible()
+    expect(page.locator("#pillClassify")).not_to_contain_text("Already done")
+
+
 def test_pipeline_reclassify_flips_classify_pill_to_will_run(live_server, page):
     url = live_server["url"]
     page.goto(f"{url}/pipeline")

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1525,6 +1525,7 @@ function showPreviewLoading() {
   _previewLoading = true;
   _previewData = null;
   _previewSelected = {};
+  _planFetchSeq++;
   _pipelinePlan = null;
   updateSamVariantWarning(null);
   refreshPipelineUI();

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1394,6 +1394,7 @@ var _sourceFolders = [];
 // -- Import preview state --
 var _previewData = null;       // response from /api/import/folder-preview
 var _previewSelected = {};     // { filePath: true/false }
+var _previewLoading = false;   // true while import/new-images preview scope is unresolved
 var _previewAbort = null;      // AbortController for in-flight request
 var _duplicateResults = {};    // path -> true for duplicates (cache)
 var _duplicateCheckAbort = null;  // AbortController for in-flight check
@@ -1510,7 +1511,9 @@ function showPreviewPlaceholder() {
   document.getElementById('previewContent').style.display = 'none';
   document.getElementById('previewLoading').style.display = 'none';
   document.getElementById('previewError').style.display = 'none';
+  _previewLoading = false;
   _previewData = null;
+  _previewSelected = {};
   if (_thumbSchedulerCancel) { _thumbSchedulerCancel(); _thumbSchedulerCancel = null; }
 }
 
@@ -1519,6 +1522,12 @@ function showPreviewLoading() {
   document.getElementById('previewContent').style.display = 'none';
   document.getElementById('previewLoading').style.display = '';
   document.getElementById('previewError').style.display = 'none';
+  _previewLoading = true;
+  _previewData = null;
+  _previewSelected = {};
+  _pipelinePlan = null;
+  updateSamVariantWarning(null);
+  refreshPipelineUI();
   // Cancel any in-flight duplicate check when preview context changes
   if (_duplicateCheckAbort) { _duplicateCheckAbort.abort(); _duplicateCheckAbort = null; }
   if (_thumbSchedulerCancel) { _thumbSchedulerCancel(); _thumbSchedulerCancel = null; }
@@ -1531,6 +1540,9 @@ function showPreviewError(msg) {
   var errEl = document.getElementById('previewError');
   errEl.style.display = '';
   errEl.textContent = msg;
+  _previewLoading = false;
+  _previewData = null;
+  _previewSelected = {};
   if (_thumbSchedulerCancel) { _thumbSchedulerCancel(); _thumbSchedulerCancel = null; }
 }
 
@@ -1539,6 +1551,7 @@ function renderPreview() {
   document.getElementById('previewLoading').style.display = 'none';
   document.getElementById('previewError').style.display = 'none';
   document.getElementById('previewContent').style.display = '';
+  _previewLoading = false;
 
   var data = _previewData;
   if (!data) return;
@@ -4129,11 +4142,28 @@ function _buildPlanBody() {
   return body;
 }
 
+function _planIsWaitingForImportPreview() {
+  if (_sourceMode === 'import') {
+    return _sourceFolders.length > 0 && getIngestFileTypes().length > 0
+      && (_previewLoading || !_previewData);
+  }
+  if (_sourceMode === 'new_images') {
+    return newImagesSnapshotId !== null && (_previewLoading || !_previewData);
+  }
+  return false;
+}
+
 async function refreshPipelinePlan() {
   // Don't fetch a plan while a pipeline is running — live state is
   // authoritative, and the running stages would race the plan response.
   if (_pipelineRunning) return;
   var seq = ++_planFetchSeq;
+  if (_planIsWaitingForImportPreview()) {
+    _pipelinePlan = null;
+    updateSamVariantWarning(null);
+    refreshPipelineUI();
+    return;
+  }
   try {
     var data = await safeFetch('/api/pipeline/plan', {
       method: 'POST',


### PR DESCRIPTION
Fixes the pipeline page showing stale whole-workspace plan counts while a newly selected import folder preview is still loading. The preview state now clears old plan data, tracks unresolved import/new-images preview scope, and skips plan requests until selected file paths are available. Added an e2e regression that holds the folder preview request open and verifies the prior Already done state disappears. Validated with pytest tests/e2e/test_pipeline.py and targeted pipeline plan API tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
* Pipeline import now properly waits for preview data before displaying the plan. The import plan UI will no longer update or show results until the preview scope is fully resolved, preventing stale status indicators and race conditions that could occur when preview and plan requests process out of order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->