### PR TITLE
Respect checked pending changes in XMP sync

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -11460,6 +11460,35 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def api_job_sync():
         runner = app._job_runner
         active_ws = _get_db()._active_workspace_id
+        body = request.get_json(silent=True)
+        if body is None:
+            body = {}
+        elif not isinstance(body, dict):
+            return json_error("request body must be a JSON object", 400)
+
+        raw_change_ids = body.get("change_ids")
+        change_ids = None
+        if raw_change_ids is not None:
+            if not isinstance(raw_change_ids, list):
+                return json_error("change_ids must be a list", 400)
+            if not raw_change_ids:
+                return json_error("change_ids required", 400)
+            if len(raw_change_ids) > 50000:
+                return json_error("too many change_ids", 400)
+            change_ids = []
+            seen = set()
+            for raw in raw_change_ids:
+                if isinstance(raw, bool):
+                    return json_error("change_ids must be integers", 400)
+                try:
+                    cid = int(raw)
+                except (TypeError, ValueError):
+                    return json_error("change_ids must be integers", 400)
+                if cid <= 0:
+                    return json_error("change_ids must be positive integers", 400)
+                if cid not in seen:
+                    seen.add(cid)
+                    change_ids.append(cid)
 
         def work(job):
             from sync import sync_to_xmp
@@ -11479,9 +11508,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     },
                 )
 
-            return sync_to_xmp(thread_db, progress_callback=progress_cb)
+            return sync_to_xmp(thread_db, progress_callback=progress_cb, change_ids=change_ids)
 
-        job_id = runner.start("sync", work, workspace_id=active_ws)
+        config = {"change_ids": change_ids} if change_ids is not None else {}
+        job_id = runner.start("sync", work, config=config, workspace_id=active_ws)
         return jsonify({"job_id": job_id})
 
     @app.route("/api/jobs/capture-time", methods=["POST"])

--- a/vireo/sync.py
+++ b/vireo/sync.py
@@ -54,17 +54,22 @@ def _write_assigned_location_to_xmp_enabled(db):
         return False
 
 
-def sync_to_xmp(db, progress_callback=None):
+def sync_to_xmp(db, progress_callback=None, change_ids=None):
     """Write pending changes to XMP sidecars.
 
     Args:
         db: Database instance
         progress_callback: optional callable(current, total)
+        change_ids: optional pending_changes ids to sync. When provided, any
+            other queued changes are left pending.
 
     Returns:
         dict with synced, failed, failures counts
     """
     changes = db.get_pending_changes()
+    if change_ids is not None:
+        selected_ids = {int(cid) for cid in change_ids}
+        changes = [c for c in changes if c["id"] in selected_ids]
     if not changes:
         return {"synced": 0, "failed": 0, "failures": []}
 

--- a/vireo/templates/_sync_panel.html
+++ b/vireo/templates/_sync_panel.html
@@ -22,7 +22,7 @@
     <div id="syncPreviewContent">Loading...</div>
     <div style="display:flex;gap:8px;margin-top:16px;justify-content:flex-end;">
       <button onclick="discardAllChanges()" style="background:none;color:var(--danger);border:1px solid var(--danger);border-radius:4px;padding:6px 14px;font-size:12px;cursor:pointer;">Discard All</button>
-      <button onclick="closeSyncPreview(); runSync();" style="background:var(--accent);color:var(--accent-text);border:none;border-radius:4px;padding:6px 14px;font-size:12px;cursor:pointer;font-weight:500;">Sync to XMP</button>
+      <button onclick="runVisibleSync()" style="background:var(--accent);color:var(--accent-text);border:none;border-radius:4px;padding:6px 14px;font-size:12px;cursor:pointer;font-weight:500;">Sync to XMP</button>
     </div>
   </div>
 </div>
@@ -51,11 +51,21 @@ async function checkPendingSync() {
   } catch(e) {}
 }
 
-async function runSync() {
+async function runSync(changeIds) {
   var status = document.getElementById('syncStatus');
   status.textContent = 'Syncing...';
   try {
-    var data = await safeFetch('/api/jobs/sync', {method: 'POST'}, { toast: false });
+    var requestOptions = {method: 'POST'};
+    if (Array.isArray(changeIds)) {
+      if (changeIds.length === 0) {
+        status.textContent = 'No checked changes to sync.';
+        status.style.color = 'var(--text-dim)';
+        return;
+      }
+      requestOptions.headers = {'Content-Type': 'application/json'};
+      requestOptions.body = JSON.stringify({change_ids: changeIds});
+    }
+    var data = await safeFetch('/api/jobs/sync', requestOptions, { toast: false });
 
     safeEventSource('/api/jobs/' + data.job_id + '/stream', {
       onProgress: function(p) {
@@ -127,7 +137,7 @@ function renderSyncPreview() {
   }
 
   var html = '<div style="display:flex;gap:12px;align-items:center;margin-bottom:12px;flex-wrap:wrap;">';
-  html += '<span style="font-size:12px;color:var(--text-dim);">Show:</span>';
+  html += '<span style="font-size:12px;color:var(--text-dim);">Include:</span>';
   typeList.forEach(function(t) {
     var label = t.replace(/_/g, ' ');
     var color = t === 'keyword_add' ? 'var(--accent)' : t === 'keyword_remove' ? 'var(--danger)' : 'var(--warning)';
@@ -149,9 +159,9 @@ function renderSyncPreview() {
   });
 
   html += '<div style="display:flex;gap:8px;margin-bottom:12px;">' +
-    '<span style="font-size:12px;color:var(--text-dim);flex:1;">' + visibleCount + ' change(s) across ' + visiblePhotos + ' photo(s)</span>' +
+    '<span style="font-size:12px;color:var(--text-dim);flex:1;">' + visibleCount + ' checked change(s) across ' + visiblePhotos + ' photo(s)</span>' +
     '<button onclick="discardAllChanges()" style="background:none;color:var(--danger);border:1px solid var(--danger);border-radius:4px;padding:4px 12px;font-size:11px;cursor:pointer;">Discard All</button>' +
-    '<button onclick="closeSyncPreview(); runSync();" style="background:var(--accent);color:var(--accent-text);border:none;border-radius:4px;padding:4px 12px;font-size:11px;cursor:pointer;font-weight:500;">Sync All to XMP</button>' +
+    '<button onclick="runVisibleSync()" style="background:var(--accent);color:var(--accent-text);border:none;border-radius:4px;padding:4px 12px;font-size:11px;cursor:pointer;font-weight:500;">Sync to XMP</button>' +
   '</div>';
 
   data.photos.forEach(function(p) {
@@ -213,6 +223,29 @@ function closeSyncPreview() {
   _syncModalOpen = false;
   _syncDestroyLightboxPanel();
   checkPendingSync();
+}
+
+function getVisibleSyncChangeIds() {
+  var ids = [];
+  if (!_syncPreviewData || !_syncPreviewData.photos || !_syncActiveFilters) return ids;
+  _syncPreviewData.photos.forEach(function(p) {
+    p.changes.forEach(function(c) {
+      if (_syncActiveFilters.has(c.type)) ids.push(c.id);
+    });
+  });
+  return ids;
+}
+
+function runVisibleSync() {
+  var changeIds = getVisibleSyncChangeIds();
+  if (changeIds.length === 0) {
+    var status = document.getElementById('syncStatus');
+    status.textContent = 'No checked changes to sync.';
+    status.style.color = 'var(--text-dim)';
+    return;
+  }
+  closeSyncPreview();
+  runSync(changeIds);
 }
 
 function _syncFindPhotoData(photoId) {

--- a/vireo/tests/test_job_submission_api.py
+++ b/vireo/tests/test_job_submission_api.py
@@ -333,3 +333,30 @@ def test_job_sync_returns_job_id(app_and_db):
     data = resp.get_json()
     assert "job_id" in data
     assert data["job_id"].startswith("sync-")
+
+
+def test_job_sync_accepts_selected_change_ids(app_and_db):
+    """POST /api/jobs/sync accepts a checked pending-change subset."""
+    app, db = app_and_db
+    client = app.test_client()
+    pid = db.get_photos()[0]["id"]
+    db.queue_change(pid, "rating", "4")
+    change_id = db.get_pending_changes()[0]["id"]
+
+    resp = client.post("/api/jobs/sync", json={"change_ids": [change_id]})
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "job_id" in data
+    assert data["job_id"].startswith("sync-")
+
+
+def test_job_sync_rejects_empty_selected_change_ids(app_and_db):
+    """An explicitly empty checked subset is a client error."""
+    app, _ = app_and_db
+    client = app.test_client()
+
+    resp = client.post("/api/jobs/sync", json={"change_ids": []})
+
+    assert resp.status_code == 400
+    assert "change_ids" in resp.get_json()["error"]

--- a/vireo/tests/test_sync.py
+++ b/vireo/tests/test_sync.py
@@ -79,6 +79,39 @@ def test_sync_to_xmp_writes_rating(tmp_path):
     assert rating == '4'
 
 
+def test_sync_to_xmp_limits_sync_to_selected_change_ids(tmp_path):
+    """sync_to_xmp can write only the checked pending changes."""
+    from xml.etree import ElementTree as ET
+
+    from db import Database
+    from sync import sync_to_xmp
+    from xmp import read_keywords
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    pid, xmp_path = _setup_photo_with_xmp(tmp_path, db)
+
+    db.queue_change(pid, "keyword_add", "Northern cardinal")
+    db.queue_change(pid, "rating", "4")
+    pending = db.get_pending_changes()
+    ids_by_type = {c["change_type"]: c["id"] for c in pending}
+
+    result = sync_to_xmp(db, change_ids=[ids_by_type["keyword_add"]])
+
+    assert result["synced"] == 1
+    assert result["failed"] == 0
+    assert "Northern cardinal" in read_keywords(xmp_path)
+
+    desc = ET.parse(xmp_path).getroot().find(
+        ".//{http://www.w3.org/1999/02/22-rdf-syntax-ns#}Description"
+    )
+    assert desc.get("{http://ns.adobe.com/xap/1.0/}Rating") is None
+
+    remaining = db.get_pending_changes()
+    assert [(c["change_type"], c["value"]) for c in remaining] == [("rating", "4")]
+
+
 def test_sync_to_xmp_handles_missing_file(tmp_path):
     """sync_to_xmp tracks failures when XMP file path doesn't exist."""
     from db import Database


### PR DESCRIPTION
## Summary
- Updates Review Pending Changes so modal sync buttons say Sync to XMP and submit only the currently checked change types.
- Adds selected change ID support to the sync job endpoint and sync engine so unchecked pending changes remain queued.
- Adds regression coverage for selected sync IDs and endpoint validation.

## Tests
- pytest vireo/tests/test_sync.py
- pytest vireo/tests/test_sync.py::test_sync_to_xmp_limits_sync_to_selected_change_ids vireo/tests/test_job_submission_api.py::test_job_sync_returns_job_id vireo/tests/test_job_submission_api.py::test_job_sync_accepts_selected_change_ids vireo/tests/test_job_submission_api.py::test_job_sync_rejects_empty_selected_change_ids