### PR TITLE
[codex] Batch free-text location edits

### DIFF
--- a/tests/e2e/test_location_section.py
+++ b/tests/e2e/test_location_section.py
@@ -411,3 +411,49 @@ def test_exif_accept_batches_selection_and_refreshes_smart_collection(
         assert row is not None
         expect(page.locator(f".grid-card[data-id='{photo_id}']")).to_have_count(0)
     assert db.count_collection_photos(collection_id) == 0
+
+
+def test_freetext_location_batches_selection_and_refreshes_smart_collection(
+    live_server, page
+):
+    """Typing a free-text location applies to the active selection."""
+    photo_ids = live_server["data"]["photos"][:3]
+    _seed_exif_photos(live_server, photo_ids)
+
+    db = live_server["db"]
+    collection_id = next(
+        c["id"]
+        for c in db.get_collections()
+        if c["name"] == "GPS Without Location Keyword"
+    )
+    assert db.count_collection_photos(collection_id) == 3
+
+    page.goto(f"{live_server['url']}/browse")
+    page.locator(".grid-card").first.wait_for(state="visible")
+    page.evaluate("(collectionId) => filterByCollection(collectionId)", collection_id)
+    page.wait_for_function(
+        "(collectionId) => activeCollectionId === collectionId && photos.length === 3",
+        arg=collection_id,
+    )
+
+    page.locator(f".grid-card[data-id='{photo_ids[0]}']").click()
+    _wait_for_detail_loaded(page)
+    page.locator(f".grid-card[data-id='{photo_ids[1]}']").click(modifiers=["Meta"])
+    page.locator(f".grid-card[data-id='{photo_ids[2]}']").click(modifiers=["Meta"])
+    page.wait_for_function("() => selectedPhotos.size === 3")
+
+    inp = page.locator("#locationInput")
+    inp.fill("the meadow")
+    inp.press("Enter")
+    page.wait_for_function("() => activeCollectionId !== null && photos.length === 0")
+
+    for photo_id in photo_ids:
+        row = db.conn.execute(
+            "SELECT k.name FROM photo_keywords pk "
+            "JOIN keywords k ON k.id = pk.keyword_id "
+            "WHERE pk.photo_id = ? AND k.type = 'location'",
+            (photo_id,),
+        ).fetchone()
+        assert row["name"] == "the meadow"
+        expect(page.locator(f".grid-card[data-id='{photo_id}']")).to_have_count(0)
+    assert db.count_collection_photos(collection_id) == 0

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3802,6 +3802,69 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         )
         return jsonify({"location": _serialize_photo_location(db, photo_id)})
 
+    @app.route("/api/batch/location/text", methods=["POST"])
+    def api_batch_set_photo_location_text():
+        """Attach one free-text location keyword to multiple photos."""
+        body = request.get_json(silent=True) or {}
+        raw_ids = body.get("photo_ids", [])
+        if not isinstance(raw_ids, list) or not raw_ids:
+            return json_error("photo_ids required", 400)
+
+        photo_ids = []
+        seen = set()
+        for raw in raw_ids:
+            if isinstance(raw, bool) or not isinstance(raw, int):
+                return json_error("photo_ids must contain only integers", 400)
+            if raw not in seen:
+                photo_ids.append(raw)
+                seen.add(raw)
+        if not photo_ids:
+            return json_error("photo_ids required", 400)
+        if len(photo_ids) > 1000:
+            return json_error("too many photo_ids", 400)
+
+        name = body.get("name") or ""
+        if not name.strip():
+            return json_error("missing name", 400)
+        stripped = name.strip()
+
+        db = _get_db()
+        for pid in photo_ids:
+            edit_error = _photo_location_edit_error(db, pid)
+            if edit_error is not None:
+                return edit_error
+
+        try:
+            leaf_id = db.get_or_create_text_location(stripped)
+        except ValueError:
+            return json_error("missing name", 400)
+
+        items = []
+        for pid in photo_ids:
+            db.set_photo_location(pid, leaf_id)
+            _queue_location_sync_if_enabled(pid, _commit=False)
+            items.append({
+                "photo_id": pid,
+                "old_value": "",
+                "new_value": str(leaf_id),
+            })
+        if items:
+            db.record_edit(
+                "location_set",
+                f"set location: {stripped} on {len(items)} photos",
+                str(leaf_id),
+                items,
+                is_batch=True,
+                _commit=False,
+            )
+        db.conn.commit()
+        db._prune_edit_history()
+        return jsonify({
+            "ok": True,
+            "updated": len(items),
+            "location": _serialize_photo_location(db, photo_ids[0]),
+        })
+
     @app.route("/api/batch/location", methods=["POST"])
     def api_batch_set_photo_location():
         """Attach one Google place location to multiple photos."""

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -5288,15 +5288,23 @@ async function _submitLocationText(name) {
   var photoId = window._detailPhotoId;
   if (!photoId) return;
   _hideLocationError();
+  var ids = _locationApplyPhotoIds();
+  var useBatch = ids.length > 1;
   try {
-    var resp = await safeFetch('/api/photos/' + photoId + '/location/text', {
+    var endpoint = useBatch
+      ? '/api/batch/location/text'
+      : '/api/photos/' + photoId + '/location/text';
+    var body = useBatch
+      ? { name: name, photo_ids: ids }
+      : { name: name };
+    var resp = await safeFetch(endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name: name }),
+      body: JSON.stringify(body),
     });
     if (resp && resp.location) {
       renderLocationFilled(resp.location);
-      await _afterLocationMutation([photoId], photoId);
+      await _afterLocationMutation(useBatch ? ids : [photoId], photoId);
     }
   } catch(e) {
     _showLocationError('Could not save location.');

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -3412,6 +3412,33 @@ def test_batch_photo_location_sets_all_selected_photos(app_and_db, monkeypatch):
     assert entry["item_count"] == len(photo_ids)
 
 
+def test_batch_photo_location_text_sets_all_selected_photos(app_and_db):
+    """Batch free-text location POST stores one location across selected photos."""
+    app, db = app_and_db
+    photo_ids = [p["id"] for p in db.get_photos()[:3]]
+
+    client = app.test_client()
+    resp = client.post(
+        "/api/batch/location/text",
+        json={"photo_ids": photo_ids, "name": "the meadow"},
+    )
+    assert resp.status_code == 200, resp.get_json()
+    assert resp.get_json()["updated"] == len(photo_ids)
+
+    for pid in photo_ids:
+        row = db.conn.execute(
+            "SELECT k.name, k.place_id FROM photo_keywords pk "
+            "JOIN keywords k ON k.id = pk.keyword_id "
+            "WHERE pk.photo_id = ? AND k.type = 'location'",
+            (pid,),
+        ).fetchone()
+        assert dict(row) == {"name": "the meadow", "place_id": None}
+
+    entry = db.get_edit_history()[0]
+    assert entry["action_type"] == "location_set"
+    assert entry["item_count"] == len(photo_ids)
+
+
 def test_delete_photo_location_records_edit(app_and_db):
     """DELETE adds an entry to the audit log even though it doesn't write a sidecar."""
     app, db = app_and_db


### PR DESCRIPTION
## Summary

Follow-up to #947: batch the free-text Browse location path as well as the Google place / EXIF suggestion path.

## Root Cause

The logs for the failed retry showed `POST /api/photos/<id>/location/text`, not `/api/batch/location`. That means the user was applying a typed free-text location while multiple photos were selected. The first fix covered EXIF/Google place accepts, but `_submitLocationText` still posted only the detail photo.

## Changes

- Added `/api/batch/location/text` for assigning one free-text location keyword to multiple selected photos.
- Updated `_submitLocationText` to use the active Browse selection when multiple photos are selected.
- Added API and e2e regressions showing free-text location updates all selected GPS-without-location photos and refreshes the smart collection.

## Validation

- `pytest vireo/tests/test_photos_api.py -q -k "location"`
- `pytest tests/e2e/test_location_section.py -q`