### PR TITLE
[codex] Add saved location suggestions

### DIFF
--- a/tests/e2e/test_location_section.py
+++ b/tests/e2e/test_location_section.py
@@ -126,6 +126,41 @@ def test_freetext_enter_creates_location(live_server, page):
     expect(page.locator("#locationEmpty")).to_be_hidden()
 
 
+def test_existing_location_keywords_suggest_while_typing(live_server, page):
+    """The Location input shows saved location keywords separately from Google."""
+    db = live_server["db"]
+    photo_ids = live_server["data"]["photos"][:2]
+    existing_location_id = db.get_or_create_text_location("San Diego Airbnb")
+    db.set_photo_location(photo_ids[1], existing_location_id)
+
+    page.goto(f"{live_server['url']}/browse")
+    page.locator(f".grid-card[data-id='{photo_ids[0]}']").wait_for(state="visible")
+    page.locator(f".grid-card[data-id='{photo_ids[0]}']").click()
+    _wait_for_detail_loaded(page)
+
+    inp = page.locator("#locationInput")
+    inp.wait_for(state="visible")
+    inp.fill("SA")
+
+    suggestions = page.locator("#locationKeywordSuggestions")
+    expect(suggestions).to_be_visible()
+    expect(suggestions).to_contain_text("San Diego Airbnb")
+    expect(suggestions).to_contain_text("Saved location")
+
+    suggestions.locator(".keyword-suggestion-option", has_text="San Diego Airbnb").click()
+
+    expect(page.locator("#locationFilled")).to_be_visible()
+    expect(page.locator("#locationFilled .filled-place")).to_have_text(
+        "San Diego Airbnb"
+    )
+    row = db.conn.execute(
+        "SELECT 1 FROM photo_keywords "
+        "WHERE photo_id = ? AND keyword_id = ?",
+        (photo_ids[0], existing_location_id),
+    ).fetchone()
+    assert row is not None
+
+
 def test_enter_after_place_changed_does_not_submit_freetext(live_server, page):
     """Regression for the keyboard-selected-autocomplete race: when the
     user presses Enter to pick a highlighted Google suggestion, the

--- a/tests/e2e/test_location_section.py
+++ b/tests/e2e/test_location_section.py
@@ -161,6 +161,38 @@ def test_existing_location_keywords_suggest_while_typing(live_server, page):
     assert row is not None
 
 
+def test_saved_location_enter_does_not_steal_google_keyboard_pick(live_server, page):
+    """With a Google key configured, Enter remains available to Google Places."""
+    db = live_server["db"]
+    photo_ids = live_server["data"]["photos"][:2]
+    existing_location_id = db.get_or_create_text_location("San Diego Airbnb")
+    db.set_photo_location(photo_ids[1], existing_location_id)
+    _set_api_key()
+
+    page.goto(f"{live_server['url']}/browse")
+    page.locator(f".grid-card[data-id='{photo_ids[0]}']").wait_for(state="visible")
+    page.locator(f".grid-card[data-id='{photo_ids[0]}']").click()
+    _wait_for_detail_loaded(page)
+
+    inp = page.locator("#locationInput")
+    inp.wait_for(state="visible")
+    inp.fill("San")
+    expect(page.locator("#locationKeywordSuggestions")).to_be_visible()
+
+    # Simulate Google place_changed having just handled the keyboard pick.
+    page.evaluate("window._locationLastPickedAt = Date.now();")
+    inp.press("Enter")
+    page.wait_for_timeout(600)
+
+    row = db.conn.execute(
+        "SELECT 1 FROM photo_keywords "
+        "WHERE photo_id = ? AND keyword_id = ?",
+        (photo_ids[0], existing_location_id),
+    ).fetchone()
+    assert row is None
+    expect(page.locator("#locationEmpty")).to_be_visible()
+
+
 def test_enter_after_place_changed_does_not_submit_freetext(live_server, page):
     """Regression for the keyboard-selected-autocomplete race: when the
     user presses Enter to pick a highlighted Google suggestion, the

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3542,6 +3542,34 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             candidate = body["details"].get("place_id")
         return _coerce_place_id(candidate)
 
+    def _extract_keyword_id(body):
+        """Return an integer keyword_id from a JSON body, or None."""
+        candidate = body.get("keyword_id")
+        if candidate is None:
+            return None
+        if isinstance(candidate, bool):
+            return None
+        if isinstance(candidate, int):
+            return candidate
+        if isinstance(candidate, str):
+            stripped = candidate.strip()
+            if stripped.isdigit():
+                return int(stripped)
+        return None
+
+    def _location_keyword_edit_error(db, keyword_id):
+        """Return an error response unless ``keyword_id`` is a location keyword."""
+        if keyword_id is None:
+            return json_error("invalid keyword_id", 400)
+        row = db.conn.execute(
+            "SELECT id, type FROM keywords WHERE id = ?", (keyword_id,),
+        ).fetchone()
+        if row is None:
+            return json_error("keyword_not_found", 404)
+        if row["type"] != "location":
+            return json_error("keyword is not a location", 400)
+        return None
+
     def _normalize_client_place_details(body):
         """Normalize a Google Maps JS Place payload from the request body.
 
@@ -3726,8 +3754,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         ``type='location'`` link).
         """
         body = request.get_json(silent=True) or {}
+        keyword_id = _extract_keyword_id(body)
         place_id = _extract_place_id(body)
-        if not place_id:
+        if keyword_id is None and not place_id:
             return json_error("missing place_id", 400)
 
         db = _get_db()
@@ -3737,6 +3766,21 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         edit_error = _photo_location_edit_error(db, photo_id)
         if edit_error is not None:
             return edit_error
+
+        if keyword_id is not None:
+            keyword_error = _location_keyword_edit_error(db, keyword_id)
+            if keyword_error is not None:
+                return keyword_error
+            db.set_photo_location(photo_id, keyword_id)
+            _queue_location_sync_if_enabled(photo_id)
+            location = _serialize_photo_location(db, photo_id)
+            db.record_edit(
+                'location_set',
+                f"set location: {location.get('name', 'unknown') if location else 'unknown'}",
+                str(keyword_id),
+                [{'photo_id': photo_id, 'old_value': '', 'new_value': str(keyword_id)}],
+            )
+            return jsonify({"location": location})
 
         details = _normalize_client_place_details(body)
         if details is None:
@@ -3823,8 +3867,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if len(photo_ids) > 1000:
             return json_error("too many photo_ids", 400)
 
+        keyword_id = _extract_keyword_id(body)
         place_id = _extract_place_id(body)
-        if not place_id:
+        if keyword_id is None and not place_id:
             return json_error("missing place_id", 400)
 
         db = _get_db()
@@ -3832,6 +3877,41 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             edit_error = _photo_location_edit_error(db, pid)
             if edit_error is not None:
                 return edit_error
+
+        if keyword_id is not None:
+            keyword_error = _location_keyword_edit_error(db, keyword_id)
+            if keyword_error is not None:
+                return keyword_error
+
+            location_name = "unknown"
+            items = []
+            for pid in photo_ids:
+                db.set_photo_location(pid, keyword_id)
+                _queue_location_sync_if_enabled(pid, _commit=False)
+                loc = _serialize_photo_location(db, pid)
+                if loc and location_name == "unknown":
+                    location_name = loc.get("name") or "unknown"
+                items.append({
+                    "photo_id": pid,
+                    "old_value": "",
+                    "new_value": str(keyword_id),
+                })
+            if items:
+                db.record_edit(
+                    "location_set",
+                    f"set location: {location_name} on {len(items)} photos",
+                    str(keyword_id),
+                    items,
+                    is_batch=True,
+                    _commit=False,
+                )
+            db.conn.commit()
+            db._prune_edit_history()
+            return jsonify({
+                "ok": True,
+                "updated": len(items),
+                "location": _serialize_photo_location(db, photo_ids[0]),
+            })
 
         details = _normalize_client_place_details(body)
         if details is None:

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -5570,13 +5570,14 @@ function _onLocationInputInput() {
 function _onLocationInputKeydown(e) {
   var dropdown = document.getElementById('locationKeywordSuggestions');
   var localOpen = dropdown && dropdown.classList.contains('open') && _locationKeywordState.matches.length > 0;
-  if (localOpen && e.key === 'ArrowDown') {
+  var googlePlacesMayHandleKeyboard = !!(window.GOOGLE_MAPS_API_KEY || '').trim();
+  if (localOpen && !googlePlacesMayHandleKeyboard && e.key === 'ArrowDown') {
     e.preventDefault();
     _locationKeywordState.activeIndex = (_locationKeywordState.activeIndex + 1) % _locationKeywordState.matches.length;
     renderLocationKeywordSuggestions();
     return;
   }
-  if (localOpen && e.key === 'ArrowUp') {
+  if (localOpen && !googlePlacesMayHandleKeyboard && e.key === 'ArrowUp') {
     e.preventDefault();
     _locationKeywordState.activeIndex = (_locationKeywordState.activeIndex - 1 + _locationKeywordState.matches.length) % _locationKeywordState.matches.length;
     renderLocationKeywordSuggestions();
@@ -5587,7 +5588,7 @@ function _onLocationInputKeydown(e) {
     return;
   }
   if (e.key !== 'Enter') return;
-  if (localOpen && _locationKeywordState.activeIndex >= 0) {
+  if (localOpen && !googlePlacesMayHandleKeyboard && _locationKeywordState.activeIndex >= 0) {
     e.preventDefault();
     chooseLocationKeywordSuggestion(_locationKeywordState.activeIndex);
     return;

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -728,6 +728,11 @@ body {
   padding: 4px 0;
 }
 .keyword-suggestion-list.open { display: block; }
+.location-keyword-suggestion-list {
+  top: auto;
+  bottom: calc(100% + 2px);
+  z-index: 10001;
+}
 .keyword-suggestion-option {
   display: flex;
   align-items: center;
@@ -1503,7 +1508,10 @@ body {
         <div class="detail-section-title">Location</div>
         <div id="locationFilled" hidden></div>
         <div id="locationEmpty">
-          <input type="text" id="locationInput" class="add-kw-input" placeholder="📍 Add location..." autocomplete="off">
+          <div class="keyword-autocomplete">
+            <input type="text" id="locationInput" class="add-kw-input" placeholder="📍 Add location..." autocomplete="off">
+            <div class="keyword-suggestion-list location-keyword-suggestion-list" id="locationKeywordSuggestions" role="listbox"></div>
+          </div>
           <div id="locationExifSuggestion" class="location-suggestion" hidden></div>
           <div id="locationError" class="location-error" hidden></div>
         </div>
@@ -1755,6 +1763,7 @@ async function loadKeywordAutocompleteOptions(force) {
             id: k.id,
             name: k.name,
             type: k.type || 'general',
+            place_id: k.place_id || null,
             photo_count: k.photo_count || 0,
             search: String(k.name || '').toLowerCase(),
           };
@@ -5151,6 +5160,10 @@ var _locationAutocompleteBound = false;
 // keyboard-selected autocomplete suggestion (where place_changed fires
 // AFTER the keydown event) gets a chance to cancel the text path.
 var _locationPendingTextSubmit = null;
+var _locationKeywordState = {
+  matches: [],
+  activeIndex: -1,
+};
 
 function _showLocationError(msg) {
   var el = document.getElementById('locationError');
@@ -5167,6 +5180,81 @@ function _hideLocationError() {
   if (el) el.hidden = true;
 }
 
+function hideLocationKeywordSuggestions() {
+  var dropdown = document.getElementById('locationKeywordSuggestions');
+  if (dropdown) {
+    dropdown.classList.remove('open');
+    dropdown.innerHTML = '';
+  }
+  _locationKeywordState.matches = [];
+  _locationKeywordState.activeIndex = -1;
+}
+
+function renderLocationKeywordSuggestions() {
+  var input = document.getElementById('locationInput');
+  var dropdown = document.getElementById('locationKeywordSuggestions');
+  if (!input || !dropdown) return;
+  var query = input.value.trim().toLowerCase();
+  if (!query || !keywordAutocompleteCache || !keywordAutocompleteCache.length) {
+    hideLocationKeywordSuggestions();
+    return;
+  }
+
+  _locationKeywordState.matches = keywordAutocompleteCache
+    .filter(function(k) { return k && k.type === 'location'; })
+    .map(function(k) {
+      return { keyword: k, score: keywordMatchScore(k.search, query) };
+    })
+    .filter(function(item) { return item.score < 99; })
+    .sort(function(a, b) {
+      return a.score - b.score || a.keyword.search.localeCompare(b.keyword.search) || a.keyword.id - b.keyword.id;
+    })
+    .slice(0, 6)
+    .map(function(item) { return item.keyword; });
+
+  if (!_locationKeywordState.matches.length) {
+    hideLocationKeywordSuggestions();
+    return;
+  }
+  if (_locationKeywordState.activeIndex < 0 || _locationKeywordState.activeIndex >= _locationKeywordState.matches.length) {
+    _locationKeywordState.activeIndex = 0;
+  }
+
+  dropdown.innerHTML = _locationKeywordState.matches.map(function(k, idx) {
+    var active = idx === _locationKeywordState.activeIndex ? ' active' : '';
+    var count = k.photo_count === 1 ? '1 photo' : k.photo_count + ' photos';
+    var source = k.place_id ? 'Saved Google place' : 'Saved location';
+    return '<div class="keyword-suggestion-option' + active + '" role="option" data-index="' + idx + '">' +
+      '<span class="keyword-suggestion-name">' + escapeHtml(k.name) + '</span>' +
+      '<span class="keyword-suggestion-meta">' + escapeHtml(source + ' · ' + count) + '</span>' +
+      '</div>';
+  }).join('');
+  dropdown.classList.add('open');
+}
+
+function updateLocationKeywordSuggestions() {
+  var input = document.getElementById('locationInput');
+  if (!input || !input.value.trim()) {
+    hideLocationKeywordSuggestions();
+    return;
+  }
+  loadKeywordAutocompleteOptions().then(renderLocationKeywordSuggestions);
+}
+
+function chooseLocationKeywordSuggestion(index) {
+  var keyword = _locationKeywordState.matches[index];
+  if (!keyword) return;
+  var input = document.getElementById('locationInput');
+  if (input) input.value = keyword.name;
+  hideLocationKeywordSuggestions();
+  if (_locationPendingTextSubmit) {
+    clearTimeout(_locationPendingTextSubmit);
+    _locationPendingTextSubmit = null;
+  }
+  _locationLastPickedAt = Date.now();
+  _submitLocationKeyword(keyword);
+}
+
 function _locationApplyPhotoIds() {
   var ids = getActiveSelection();
   if (ids.length > 1) return ids;
@@ -5175,6 +5263,7 @@ function _locationApplyPhotoIds() {
 }
 
 async function _afterLocationMutation(photoIds, detailPhotoId) {
+  invalidateKeywordAutocompleteCache();
   loadKeywords();
   scheduleCollectionCountsRefresh();
   refreshPendingSyncBanner();
@@ -5284,6 +5373,32 @@ async function _submitLocationPlace(placeId, placeDetails) {
   }
 }
 
+async function _submitLocationKeyword(keyword) {
+  var photoId = window._detailPhotoId;
+  if (!photoId || !keyword || !keyword.id) return;
+  _hideLocationError();
+  var ids = _locationApplyPhotoIds();
+  var useBatch = ids.length > 1;
+  var body = { keyword_id: keyword.id };
+  if (useBatch) body.photo_ids = ids;
+  try {
+    var endpoint = useBatch
+      ? '/api/batch/location'
+      : '/api/photos/' + photoId + '/location';
+    var resp = await safeFetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (resp && resp.location) {
+      renderLocationFilled(resp.location);
+    }
+    await _afterLocationMutation(useBatch ? ids : [photoId], photoId);
+  } catch(e) {
+    _showLocationError('Could not save location.');
+  }
+}
+
 async function _submitLocationText(name) {
   var photoId = window._detailPhotoId;
   if (!photoId) return;
@@ -5351,6 +5466,7 @@ function renderLocationEmpty() {
   empty.hidden = false;
   var input = document.getElementById('locationInput');
   if (input) input.value = '';
+  hideLocationKeywordSuggestions();
   // Reset any prior EXIF suggestion. The caller (renderDetail) re-runs
   // maybeShowExifSuggestion(photo) after this, which decides whether to
   // populate the line for the new photo.
@@ -5443,10 +5559,39 @@ async function acceptExifSuggestion(placeId) {
 
 function _onLocationInputFocus() {
   bindLocationAutocomplete();
+  updateLocationKeywordSuggestions();
+}
+
+function _onLocationInputInput() {
+  _locationKeywordState.activeIndex = 0;
+  updateLocationKeywordSuggestions();
 }
 
 function _onLocationInputKeydown(e) {
+  var dropdown = document.getElementById('locationKeywordSuggestions');
+  var localOpen = dropdown && dropdown.classList.contains('open') && _locationKeywordState.matches.length > 0;
+  if (localOpen && e.key === 'ArrowDown') {
+    e.preventDefault();
+    _locationKeywordState.activeIndex = (_locationKeywordState.activeIndex + 1) % _locationKeywordState.matches.length;
+    renderLocationKeywordSuggestions();
+    return;
+  }
+  if (localOpen && e.key === 'ArrowUp') {
+    e.preventDefault();
+    _locationKeywordState.activeIndex = (_locationKeywordState.activeIndex - 1 + _locationKeywordState.matches.length) % _locationKeywordState.matches.length;
+    renderLocationKeywordSuggestions();
+    return;
+  }
+  if (e.key === 'Escape') {
+    hideLocationKeywordSuggestions();
+    return;
+  }
   if (e.key !== 'Enter') return;
+  if (localOpen && _locationKeywordState.activeIndex >= 0) {
+    e.preventDefault();
+    chooseLocationKeywordSuggestion(_locationKeywordState.activeIndex);
+    return;
+  }
   // DO NOT preventDefault — Google's autocomplete listens for Enter to
   // pick the highlighted suggestion. Suppressing the event would block
   // keyboard place selection. The input has no surrounding form, so
@@ -5478,7 +5623,20 @@ document.addEventListener('DOMContentLoaded', function() {
   var input = document.getElementById('locationInput');
   if (input) {
     input.addEventListener('focus', _onLocationInputFocus);
+    input.addEventListener('input', _onLocationInputInput);
     input.addEventListener('keydown', _onLocationInputKeydown);
+    input.addEventListener('blur', function() {
+      setTimeout(hideLocationKeywordSuggestions, 120);
+    });
+  }
+  var locationDropdown = document.getElementById('locationKeywordSuggestions');
+  if (locationDropdown) {
+    locationDropdown.addEventListener('mousedown', function(e) {
+      var option = e.target.closest('.keyword-suggestion-option');
+      if (!option) return;
+      e.preventDefault();
+      chooseLocationKeywordSuggestion(parseInt(option.dataset.index, 10));
+    });
   }
   bindKeywordAutocomplete('addKeywordInput', 'addKeywordSuggestions', addKeyword);
   bindKeywordAutocomplete('batchKeywordInput', 'batchKeywordSuggestions', function() {


### PR DESCRIPTION
## Summary

- Shows existing `location` keywords as Vireo-owned suggestions while typing in the photo Location field.
- Lets the existing photo and batch location endpoints apply a saved location by `keyword_id`, alongside the existing Google `place_id` path.
- Adds E2E coverage for reusing a saved free-text location such as `San Diego Airbnb` from the Location input.

## Validation

- `python -m pytest tests/e2e/test_location_section.py -q`
- `python -m pytest vireo/tests/test_app.py -q`
- `python -m pytest vireo/tests/test_db.py -q`
- `python -m py_compile vireo/app.py`