### PR TITLE
Skip no-op capture time adjustments

### DIFF
--- a/vireo/capture_time.py
+++ b/vireo/capture_time.py
@@ -138,7 +138,7 @@ def _photo_shift_minutes(mode, target_minutes, manual_shift, photo):
 
 
 def _offset_tags_already_target(photo, target_offset):
-    """Return True when every present OffsetTime* tag already matches target."""
+    """Return True when all OffsetTime* tags are present and match target."""
     if not target_offset:
         return True
     exif = _exif_group(photo)
@@ -147,8 +147,7 @@ def _offset_tags_already_target(photo, target_offset):
         exif.get("OffsetTimeOriginal"),
         exif.get("OffsetTimeDigitized"),
     ]
-    present = [str(value).strip() for value in values if value]
-    return bool(present) and all(value == target_offset for value in present)
+    return all(value and str(value).strip() == target_offset for value in values)
 
 
 def _is_noop_adjustment(mode, target_offset, photo_shift, photo):

--- a/vireo/capture_time.py
+++ b/vireo/capture_time.py
@@ -336,7 +336,11 @@ def adjust_capture_time(
                 progress_callback(index, total, photo["filename"])
             continue
 
-        if _is_noop_adjustment(mode, target_offset_str, photo_shift, photo):
+        has_companion = _has_key(photo, "companion_path") and bool(photo["companion_path"])
+        if (
+            not has_companion
+            and _is_noop_adjustment(mode, target_offset_str, photo_shift, photo)
+        ):
             skipped += 1
             shifts_used.append(photo_shift)
             if progress_callback:

--- a/vireo/capture_time.py
+++ b/vireo/capture_time.py
@@ -137,6 +137,28 @@ def _photo_shift_minutes(mode, target_minutes, manual_shift, photo):
     return target_minutes - current_minutes
 
 
+def _offset_tags_already_target(photo, target_offset):
+    """Return True when every present OffsetTime* tag already matches target."""
+    if not target_offset:
+        return True
+    exif = _exif_group(photo)
+    values = [
+        exif.get("OffsetTime"),
+        exif.get("OffsetTimeOriginal"),
+        exif.get("OffsetTimeDigitized"),
+    ]
+    present = [str(value).strip() for value in values if value]
+    return bool(present) and all(value == target_offset for value in present)
+
+
+def _is_noop_adjustment(mode, target_offset, photo_shift, photo):
+    if photo_shift != 0:
+        return False
+    if mode == "manual":
+        return True
+    return _offset_tags_already_target(photo, target_offset)
+
+
 def format_preview_timestamp(dt):
     if dt is None:
         return None
@@ -287,6 +309,7 @@ def adjust_capture_time(
 
     log.info("Starting capture-time adjustment for %d photo(s)", len(photos))
     written = 0
+    skipped = 0
     failed = 0
     failures = []
     total = len(photos)
@@ -309,6 +332,13 @@ def adjust_capture_time(
             failures.append(
                 {"photo_id": photo["id"], "filename": photo["filename"], "error": str(exc)}
             )
+            if progress_callback:
+                progress_callback(index, total, photo["filename"])
+            continue
+
+        if _is_noop_adjustment(mode, target_offset_str, photo_shift, photo):
+            skipped += 1
+            shifts_used.append(photo_shift)
             if progress_callback:
                 progress_callback(index, total, photo["filename"])
             continue
@@ -364,10 +394,16 @@ def adjust_capture_time(
 
     unanimous = bool(shifts_used) and all(s == shifts_used[0] for s in shifts_used)
     summary_shift = shifts_used[0] if unanimous else None
-    log.info("Capture-time adjustment finished: %d updated, %d failed", written, failed)
+    log.info(
+        "Capture-time adjustment finished: %d updated, %d skipped, %d failed",
+        written,
+        skipped,
+        failed,
+    )
 
     return {
         "updated": written,
+        "skipped": skipped,
         "failed": failed,
         "failures": failures[:20],
         "shift_minutes": summary_shift,

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -4570,7 +4570,8 @@ async function startCaptureTimeJob() {
           return;
         }
         var result = done.result || {};
-        showToast('Capture time updated: ' + (result.updated || 0) + ' updated, ' + (result.failed || 0) + ' failed', result.failed ? 'error' : 'success');
+        var skippedText = result.skipped ? ', ' + result.skipped + ' skipped' : '';
+        showToast('Capture time updated: ' + (result.updated || 0) + ' updated' + skippedText + ', ' + (result.failed || 0) + ' failed', result.failed ? 'error' : 'success');
         resetAndLoad();
         loadSummary();
       },

--- a/vireo/tests/test_capture_time_api.py
+++ b/vireo/tests/test_capture_time_api.py
@@ -203,6 +203,81 @@ def test_capture_time_job_skips_already_correct_offset(client_with_photo, monkey
     assert job["result"]["failed"] == 0
 
 
+def test_capture_time_job_writes_missing_offset_tags(client_with_photo, monkeypatch):
+    """A matching OffsetTimeOriginal alone is not enough to skip the file."""
+    import capture_time
+
+    app, db, photo_id = client_with_photo
+    photo = db.get_photo(photo_id)
+    folder = db.conn.execute(
+        "SELECT path FROM folders WHERE id = ?", (photo["folder_id"],)
+    ).fetchone()
+    path = os.path.join(folder["path"], photo["filename"])
+    db.conn.execute(
+        "UPDATE photos SET timestamp = ?, exif_data = ? WHERE id = ?",
+        (
+            "2026-05-22T17:07:23.560000",
+            json.dumps(
+                {
+                    "EXIF": {
+                        "DateTimeOriginal": "2026:05:22 17:07:23",
+                        "SubSecTimeOriginal": "56",
+                        "OffsetTimeOriginal": "-10:00",
+                    }
+                }
+            ),
+            photo_id,
+        ),
+    )
+    db.conn.commit()
+
+    commands = []
+
+    def fake_run(cmd, **_kwargs):
+        commands.append(list(cmd))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    def fake_extract(paths):
+        assert paths == [path]
+        return {
+            path: {
+                "EXIF": {
+                    "DateTimeOriginal": "2026:05:22 17:07:23",
+                    "SubSecTimeOriginal": "56",
+                    "OffsetTimeOriginal": "-10:00",
+                    "OffsetTime": "-10:00",
+                    "OffsetTimeDigitized": "-10:00",
+                }
+            }
+        }
+
+    monkeypatch.setattr(capture_time.shutil, "which", lambda name: "/usr/bin/exiftool")
+    monkeypatch.setattr(capture_time.subprocess, "run", fake_run)
+    monkeypatch.setattr(capture_time, "extract_metadata", fake_extract)
+
+    client = app.test_client()
+    resp = client.post(
+        "/api/jobs/capture-time",
+        json={
+            "photo_ids": [photo_id],
+            "mode": "preserve_instant",
+            "target_offset": "-10:00",
+            "keep_backups": False,
+        },
+    )
+
+    assert resp.status_code == 200
+    job = wait_for_job_via_client(client, resp.get_json()["job_id"])
+    assert job["status"] == "completed"
+    assert job["result"]["updated"] == 1
+    assert job["result"]["skipped"] == 0
+    assert commands
+    assert "-OffsetTime=-10:00" in commands[0]
+    assert "-OffsetTimeOriginal=-10:00" in commands[0]
+    assert "-OffsetTimeDigitized=-10:00" in commands[0]
+    assert not any(arg.startswith("-AllDates") for arg in commands[0])
+
+
 def test_capture_time_job_does_not_skip_companion_pair_from_primary_cache(
     client_with_photo, monkeypatch
 ):

--- a/vireo/tests/test_capture_time_api.py
+++ b/vireo/tests/test_capture_time_api.py
@@ -203,6 +203,90 @@ def test_capture_time_job_skips_already_correct_offset(client_with_photo, monkey
     assert job["result"]["failed"] == 0
 
 
+def test_capture_time_job_does_not_skip_companion_pair_from_primary_cache(
+    client_with_photo, monkeypatch
+):
+    """Companion files must still be rewritten when only primary cached EXIF is known."""
+    import capture_time
+
+    app, db, photo_id = client_with_photo
+    photo = db.get_photo(photo_id)
+    folder = db.conn.execute(
+        "SELECT path FROM folders WHERE id = ?", (photo["folder_id"],)
+    ).fetchone()
+    primary_path = os.path.join(folder["path"], photo["filename"])
+    companion_name = "test.xmp"
+    companion_path = os.path.join(folder["path"], companion_name)
+    with open(companion_path, "w", encoding="utf-8") as handle:
+        handle.write("<xmpmeta></xmpmeta>")
+
+    db.conn.execute(
+        "UPDATE photos SET companion_path = ?, timestamp = ?, exif_data = ? WHERE id = ?",
+        (
+            companion_name,
+            "2026-05-22T17:07:23.560000",
+            json.dumps(
+                {
+                    "EXIF": {
+                        "DateTimeOriginal": "2026:05:22 17:07:23",
+                        "SubSecTimeOriginal": "56",
+                        "OffsetTimeOriginal": "-10:00",
+                        "OffsetTime": "-10:00",
+                        "OffsetTimeDigitized": "-10:00",
+                    }
+                }
+            ),
+            photo_id,
+        ),
+    )
+    db.conn.commit()
+
+    commands = []
+
+    def fake_run(cmd, **_kwargs):
+        commands.append(list(cmd))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    def fake_extract(paths):
+        assert paths == [primary_path]
+        return {
+            primary_path: {
+                "EXIF": {
+                    "DateTimeOriginal": "2026:05:22 17:07:23",
+                    "SubSecTimeOriginal": "56",
+                    "OffsetTimeOriginal": "-10:00",
+                    "OffsetTime": "-10:00",
+                    "OffsetTimeDigitized": "-10:00",
+                }
+            }
+        }
+
+    monkeypatch.setattr(capture_time.shutil, "which", lambda name: "/usr/bin/exiftool")
+    monkeypatch.setattr(capture_time.subprocess, "run", fake_run)
+    monkeypatch.setattr(capture_time, "extract_metadata", fake_extract)
+
+    client = app.test_client()
+    resp = client.post(
+        "/api/jobs/capture-time",
+        json={
+            "photo_ids": [photo_id],
+            "mode": "preserve_instant",
+            "target_offset": "-10:00",
+            "keep_backups": False,
+        },
+    )
+
+    assert resp.status_code == 200
+    job = wait_for_job_via_client(client, resp.get_json()["job_id"])
+    assert job["status"] == "completed"
+    assert job["result"]["updated"] == 1
+    assert job["result"]["skipped"] == 0
+    assert commands
+    assert primary_path in commands[0]
+    assert companion_path in commands[0]
+    assert not any(arg.startswith("-AllDates") for arg in commands[0])
+
+
 def test_capture_time_preview_preserves_instant_uses_per_photo_shifts(app_and_db):
     """preserve_instant must shift each photo by *its own* current offset.
 

--- a/vireo/tests/test_capture_time_api.py
+++ b/vireo/tests/test_capture_time_api.py
@@ -153,6 +153,56 @@ def test_capture_time_job_writes_exiftool_and_refreshes_cache(client_with_photo,
     assert metadata["EXIF"]["OffsetTimeOriginal"] == "-10:00"
 
 
+def test_capture_time_job_skips_already_correct_offset(client_with_photo, monkeypatch):
+    """Already-correct preserve-instant photos should not be rewritten."""
+    import capture_time
+
+    app, db, photo_id = client_with_photo
+    db.conn.execute(
+        "UPDATE photos SET timestamp = ?, exif_data = ? WHERE id = ?",
+        (
+            "2026-05-22T17:07:23.560000",
+            json.dumps(
+                {
+                    "EXIF": {
+                        "DateTimeOriginal": "2026:05:22 17:07:23",
+                        "SubSecTimeOriginal": "56",
+                        "OffsetTimeOriginal": "-10:00",
+                        "OffsetTime": "-10:00",
+                        "OffsetTimeDigitized": "-10:00",
+                    }
+                }
+            ),
+            photo_id,
+        ),
+    )
+    db.conn.commit()
+
+    def fail_run(*_args, **_kwargs):
+        raise AssertionError("ExifTool should not run for a no-op capture-time adjustment")
+
+    monkeypatch.setattr(capture_time.shutil, "which", lambda name: "/usr/bin/exiftool")
+    monkeypatch.setattr(capture_time.subprocess, "run", fail_run)
+
+    client = app.test_client()
+    resp = client.post(
+        "/api/jobs/capture-time",
+        json={
+            "photo_ids": [photo_id],
+            "mode": "preserve_instant",
+            "target_offset": "-10:00",
+            "keep_backups": False,
+        },
+    )
+
+    assert resp.status_code == 200
+    job = wait_for_job_via_client(client, resp.get_json()["job_id"])
+    assert job["status"] == "completed"
+    assert job["result"]["updated"] == 0
+    assert job["result"]["skipped"] == 1
+    assert job["result"]["failed"] == 0
+
+
 def test_capture_time_preview_preserves_instant_uses_per_photo_shifts(app_and_db):
     """preserve_instant must shift each photo by *its own* current offset.
 
@@ -368,11 +418,12 @@ def test_capture_time_job_accepts_large_select_all_payload(client_with_photo, mo
     assert resp.status_code == 200
     job = wait_for_job_via_client(client, resp.get_json()["job_id"])
     assert job["status"] == "completed"
-    assert job["result"]["updated"] == 1
+    assert job["result"]["updated"] == 0
+    assert job["result"]["skipped"] == 1
     assert job["config"]["photo_count"] == 1
     assert job["config"]["photo_ids_sample"] == [photo_id]
     assert "photo_ids" not in job["config"]
-    assert commands[0][-1] == path
+    assert commands == []
 
 
 def test_capture_time_job_applies_per_photo_shifts(client_with_photo, monkeypatch):


### PR DESCRIPTION
## Summary
- Skip capture-time jobs for photos that already require no wall-clock or offset change.
- Report skipped photo counts in the completion toast.
- Add regression coverage proving already-correct `-10:00` photos do not invoke ExifTool.

## Why
Restarting and rerunning a large timezone correction could still touch every already-correct photo because a zero-minute shift still rewrote `OffsetTime*` tags. This makes reruns slow and creates unnecessary file writes/backups.

## Validation
- `pytest vireo/tests/test_capture_time_api.py vireo/tests/test_collections_api.py vireo/tests/test_photos_api.py`
- `ruff check vireo/capture_time.py vireo/tests/test_capture_time_api.py`