### PR TITLE
[codex] Exclude ambient jobs from badges

### DIFF
--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -22,8 +22,14 @@ struct JobInfo {
     status: String,
     started_at: Option<String>,
     progress: Option<JobProgress>,
+    #[serde(default = "default_counts_for_badge")]
+    counts_for_badge: bool,
     #[serde(rename = "type")]
     _job_type: String,
+}
+
+fn default_counts_for_badge() -> bool {
+    true
 }
 
 #[derive(Deserialize)]
@@ -360,7 +366,10 @@ pub fn start_job_polling(app: AppHandle, port: u16, stop: Arc<AtomicBool>) {
         let mut last_dock_progress: Option<DockProgress> = None;
         while !stop.load(Ordering::Relaxed) {
             let jobs = fetch_jobs(port);
-            let running: Vec<&JobInfo> = jobs.iter().filter(|j| j.status == "running").collect();
+            let running: Vec<&JobInfo> = jobs
+                .iter()
+                .filter(|j| j.status == "running" && j.counts_for_badge)
+                .collect();
             let count = running.len();
             let dock_progress = dock_progress_for_jobs(&running);
             let count_changed = last_count != Some(count);

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5957,6 +5957,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "new_images_walk",
                 job_work_fn,
                 ephemeral=True,
+                counts_for_badge=False,
                 workspace_id=ws_id,
                 config={"workspace_name": ws_name},
             )

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -264,6 +264,7 @@ class JobRunner:
                         "workspace_id": ctx["workspace_id"],
                         "steps": [],
                         "ephemeral": False,
+                        "counts_for_badge": True,
                         "runtime_warning": ctx["runtime_warning"],
                     }
                     self._prune_finished_jobs()
@@ -334,6 +335,7 @@ class JobRunner:
             "workspace_id": ctx["workspace_id"],
             "steps": [],
             "ephemeral": False,
+            "counts_for_badge": True,
             "runtime_warning": ctx.get("runtime_warning"),
             "_ended_at": time.time(),
             "_persisted": True,
@@ -345,7 +347,7 @@ class JobRunner:
             self._subscribers.setdefault(job_id, [])
 
     def start(self, job_type, work_fn, config=None, workspace_id=None,
-              ephemeral=False, runtime_warning=None):
+              ephemeral=False, runtime_warning=None, counts_for_badge=True):
         """Start a background job.
 
         Args:
@@ -362,6 +364,8 @@ class JobRunner:
                        it to clutter the history list.
             runtime_warning: optional user-facing warning metadata to expose
                        while the job is running.
+            counts_for_badge: if False, the job remains visible in job lists
+                       but does not contribute to app/Dock attention badges.
 
         Returns:
             job_id string
@@ -382,6 +386,7 @@ class JobRunner:
             "workspace_id": workspace_id,
             "steps": [],
             "ephemeral": ephemeral,
+            "counts_for_badge": counts_for_badge,
             "runtime_warning": runtime_warning,
         }
 
@@ -618,6 +623,7 @@ class JobRunner:
             "workspace_id": ctx["workspace_id"],
             "steps": [],
             "ephemeral": False,
+            "counts_for_badge": True,
             "runtime_warning": ctx.get("runtime_warning"),
         }
 

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -5585,6 +5585,14 @@ function isLiveJob(job) {
   );
 }
 
+function countsForBadge(job) {
+  return !job || job.counts_for_badge !== false;
+}
+
+function isAttentionJob(job) {
+  return isLiveJob(job) && countsForBadge(job);
+}
+
 function isWaitingJob(job) {
   return !!job && (job.status === 'queued' || job.status === 'pending');
 }
@@ -5596,7 +5604,7 @@ async function nativeMenuCancelCurrentJob() {
   // the queued path atomically), so the native menu's "cancel current
   // job" should be able to reach them — otherwise a waiting pipeline
   // is stuck if the user closes the pipeline page.
-  var running = list.find(isLiveJob);
+  var running = list.find(isAttentionJob);
   if (!running) {
     nativeMenuInfo('No active job to cancel');
     return;
@@ -6179,10 +6187,9 @@ function formatDuration(seconds) {
       if (lpSource) { lpSource.close(); lpSource = null; }
       // Only warn on actual tab close, not internal navigation
       if (isInternalNav) { isInternalNav = false; return; }
-      // Warn on tab close when ANY live job exists — including queued
-      // or pending jobs. Closing the tab leaves them sitting in the
-      // server-side queue with no UI to manage them from this session.
-      var running = activeJobs.filter(isLiveJob);
+      // Warn on tab close when user-attention work exists, including queued
+      // or pending jobs. Ambient system jobs should not block tab close.
+      var running = activeJobs.filter(isAttentionJob);
       if (running.length > 0) {
         e.preventDefault();
         e.returnValue = '';
@@ -6478,7 +6485,9 @@ function formatDuration(seconds) {
   var _lastDockProgress = { state: null, value: -1 };
   function updateDockProgress() {
     if (!window.__TAURI_INTERNALS__) return;
-    var running = activeJobs.filter(function(j) { return j.status === 'running'; });
+    var running = activeJobs.filter(function(j) {
+      return j.status === 'running' && countsForBadge(j);
+    });
     var state, value;
     if (running.length === 0) {
       state = 'none'; value = null;
@@ -6516,13 +6525,15 @@ function formatDuration(seconds) {
     // pipeline — there'd be no way to find or cancel the queued run
     // from this surface.
     var allRunning = activeJobs.filter(isLiveJob);
+    var attentionJobs = allRunning.filter(countsForBadge);
     var thisWs = allRunning.filter(function(j) { return j.workspace_id === _activeWsId; });
     var otherWs = allRunning.filter(function(j) { return j.workspace_id !== _activeWsId; });
 
-    // Badges count all active jobs across workspaces
-    document.getElementById('jobsBadge').textContent = allRunning.length;
+    // Badges count attention-worthy work across workspaces. Ambient system
+    // jobs stay visible in the panel without asking for attention.
+    document.getElementById('jobsBadge').textContent = attentionJobs.length;
     var navBadge = document.getElementById('navJobBadge');
-    if (navBadge) navBadge.textContent = allRunning.length > 0 ? ' (' + allRunning.length + ')' : '';
+    if (navBadge) navBadge.textContent = attentionJobs.length > 0 ? ' (' + attentionJobs.length + ')' : '';
 
     if (allRunning.length === 0) {
       // "Last run" fallback must exclude live state — running,
@@ -6590,11 +6601,19 @@ function formatDuration(seconds) {
 
   function updateSummary() {
     var summary = document.getElementById('jobSummary');
-    var running = activeJobs.filter(function(j) { return j.status === 'running'; });
-    var waiting = activeJobs.filter(isWaitingJob);
+    var liveJobs = activeJobs.filter(isLiveJob);
+    var attentionJobs = liveJobs.filter(countsForBadge);
+    var running = attentionJobs.filter(function(j) { return j.status === 'running'; });
+    var waiting = attentionJobs.filter(isWaitingJob);
 
     if (running.length === 0 && waiting.length === 0) {
-      summary.textContent = 'No active jobs';
+      if (liveJobs.length > 0) {
+        summary.textContent = liveJobs.length === 1
+          ? 'Background: ' + window.formatJobType(liveJobs[0].type)
+          : liveJobs.length + ' background jobs';
+      } else {
+        summary.textContent = 'No active jobs';
+      }
       summary.classList.add('idle');
       summary.classList.remove('active');
       return;
@@ -6643,9 +6662,9 @@ function formatDuration(seconds) {
   }
 
   function updateActivityDot() {
-    // The dot signals "something live is happening" — waiting work counts
-    // because the user has work the system is on the hook to run.
-    var running = activeJobs.filter(isLiveJob);
+    // The dot signals attention-worthy work; ambient system jobs remain in
+    // the Jobs panel without lighting up the navbar.
+    var running = activeJobs.filter(isAttentionJob);
     var dot = document.getElementById('navActivityDot');
     if (dot) dot.classList.toggle('active', running.length > 0);
   }

--- a/vireo/tests/test_jobs.py
+++ b/vireo/tests/test_jobs.py
@@ -2,6 +2,7 @@
 import logging
 import os
 import sys
+import threading
 import time
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
@@ -320,6 +321,44 @@ def test_ephemeral_job_skips_history_persistence(tmp_path):
         "SELECT * FROM job_history WHERE id = ?", (job_id,)
     ).fetchall()
     assert rows == [], "ephemeral jobs must not be persisted to job_history"
+
+
+def test_jobs_count_for_badge_by_default():
+    """Jobs opt into attention badges unless explicitly marked ambient."""
+    from jobs import JobRunner
+
+    runner = JobRunner()
+    release = threading.Event()
+
+    def work(job):
+        release.wait(timeout=2)
+
+    job_id = runner.start("scan", work)
+    try:
+        job = runner.get(job_id)
+        assert job["counts_for_badge"] is True
+    finally:
+        release.set()
+        wait_for_job_via_runner(runner, job_id)
+
+
+def test_job_can_opt_out_of_badge_counting():
+    """Ambient jobs stay listed but do not contribute to app badges."""
+    from jobs import JobRunner
+
+    runner = JobRunner()
+    release = threading.Event()
+
+    def work(job):
+        release.wait(timeout=2)
+
+    job_id = runner.start("new_images_walk", work, counts_for_badge=False)
+    try:
+        job = runner.get(job_id)
+        assert job["counts_for_badge"] is False
+    finally:
+        release.set()
+        wait_for_job_via_runner(runner, job_id)
 
 
 def test_ephemeral_failed_job_skips_history_persistence(tmp_path):

--- a/vireo/tests/test_new_images_api.py
+++ b/vireo/tests/test_new_images_api.py
@@ -245,6 +245,7 @@ def test_api_new_images_registers_ephemeral_job_on_cache_cold(app_and_db, monkey
         job = walk_jobs[0]
         assert job["status"] == "running"
         assert job["workspace_id"] == ws_id
+        assert job["counts_for_badge"] is False
         # Job is tied to the workspace via config.workspace_name for the UI label.
         assert "workspace_name" in job["config"]
     finally:


### PR DESCRIPTION
## Summary
- Add `counts_for_badge` job metadata, defaulting to true for existing jobs.
- Mark the automatic new-images walk as ambient so it stays visible in jobs UI without incrementing attention badges.
- Update web and native badge/progress/attention paths to ignore ambient jobs.

## Validation
- `python -m pytest vireo/tests/test_jobs.py vireo/tests/test_new_images_api.py -q`
- `git diff --check`
- `cargo check` passed after temporarily creating the expected local sidecar placeholder path, then removing it.

## Note
- `cargo fmt --check` is blocked by pre-existing formatting drift in unrelated Tauri files, so unrelated Rust formatting was left untouched.