### PR TITLE
Add photo map deep links

### DIFF
--- a/tests/e2e/test_browse_context_menu.py
+++ b/tests/e2e/test_browse_context_menu.py
@@ -19,6 +19,25 @@ def test_right_click_photo_opens_menu(live_server, page):
     expect(menu.locator(".vireo-ctx-item", has_text="Reveal in")).to_be_visible()
     expect(menu.locator(".vireo-ctx-item", has_text="Copy Path")).to_be_visible()
     expect(menu.locator(".vireo-ctx-item", has_text="Delete")).to_be_visible()
+    expect(menu.locator(".vireo-ctx-item", has_text="View on Map")).to_be_visible()
+
+
+def test_view_on_map_context_action_targets_right_clicked_photo(live_server, page):
+    """Browse's right-click View on Map action targets the context photo."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    cards = page.locator(".grid-card")
+    cards.first.wait_for(state="visible")
+    pid = int(cards.nth(1).get_attribute("data-id"))
+
+    page.evaluate("window.viewPhotoOnMap = id => { window.__mapTarget = id; }")
+    cards.nth(1).click(button="right")
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+
+    menu.locator(".vireo-ctx-item", has_text="View on Map").click()
+    assert page.evaluate("window.__mapTarget") == pid
 
 
 def test_browse_selection_opens_burst_review(live_server, page):

--- a/tests/e2e/test_map_deep_link.py
+++ b/tests/e2e/test_map_deep_link.py
@@ -120,3 +120,31 @@ def test_map_photo_id_deep_link_reports_missing_location(live_server, page):
     page.goto(f"{live_server['url']}/map?photo_id={pid}")
 
     expect(page.locator("#mapStatus")).to_contain_text("No map location found for this photo.")
+
+
+def test_map_photo_id_deep_link_is_one_shot_for_later_filters(live_server, page):
+    """Later filter changes should not keep treating the deep-link photo as missing."""
+    linked_pid = live_server["data"]["photos"][0]
+    other_pid = live_server["data"]["photos"][3]
+    live_server["db"].conn.execute(
+        "UPDATE photos SET latitude = ?, longitude = ? WHERE id = ?",
+        (37.7749, -122.4194, linked_pid),
+    )
+    live_server["db"].conn.execute(
+        "UPDATE photos SET latitude = ?, longitude = ? WHERE id = ?",
+        (40.7128, -74.0060, other_pid),
+    )
+    live_server["db"].conn.commit()
+
+    page.route("https://unpkg.com/**", _stub_leaflet)
+    page.goto(f"{live_server['url']}/map?photo_id={linked_pid}")
+    page.wait_for_function(
+        "pid => window.activePhotoId === pid && !!window.__openedPopup",
+        arg=linked_pid,
+        timeout=3000,
+    )
+
+    page.select_option("#filterSpecies", "American Robin")
+
+    expect(page.locator("#mapStatus")).to_contain_text("Showing 1 of 2 geolocated photos")
+    expect(page.locator("#mapStatus")).not_to_contain_text("No map location found")

--- a/tests/e2e/test_map_deep_link.py
+++ b/tests/e2e/test_map_deep_link.py
@@ -1,0 +1,122 @@
+from playwright.sync_api import expect
+
+LEAFLET_STUB = """
+window.L = {
+  tileLayer: function() {
+    return { addTo: function() { return this; } };
+  },
+  map: function() {
+    return {
+      setView: function(latlng, zoom) {
+        window.__lastMapSetView = { latlng: latlng, zoom: zoom };
+        return this;
+      },
+      addLayer: function() { return this; },
+      fitBounds: function(bounds) {
+        window.__lastFitBounds = bounds;
+        return this;
+      },
+      getZoom: function() { return 2; }
+    };
+  },
+  control: {
+    layers: function() {
+      return { addTo: function() { return this; } };
+    }
+  },
+  markerClusterGroup: function() {
+    var layers = [];
+    return {
+      addLayer: function(marker) { layers.push(marker); return this; },
+      clearLayers: function() { layers = []; return this; },
+      getBounds: function() { return [[0, 0], [1, 1]]; },
+      zoomToShowLayer: function(marker, cb) {
+        window.__zoomedToMarker = marker.getLatLng();
+        if (cb) cb();
+      },
+      on: function() { return this; }
+    };
+  },
+  divIcon: function(opts) { return opts; },
+  marker: function(latlng) {
+    return {
+      _latlng: latlng,
+      bindPopup: function(popup) { this._popup = popup; return this; },
+      on: function(name, handler) {
+        this._handlers = this._handlers || {};
+        this._handlers[name] = handler;
+        return this;
+      },
+      getLatLng: function() { return this._latlng; },
+      openPopup: function() {
+        window.__openedPopup = this._popup;
+        return this;
+      }
+    };
+  },
+  Control: {
+    extend: function(definition) {
+      function Control() {}
+      Control.prototype.addTo = function(map) {
+        this._div = definition.onAdd.call(this, map);
+        return this;
+      };
+      Object.keys(definition).forEach(function(key) {
+        if (key !== "onAdd") Control.prototype[key] = definition[key];
+      });
+      return Control;
+    }
+  },
+  DomUtil: {
+    create: function(tag, className) {
+      var el = document.createElement(tag);
+      el.className = className;
+      return el;
+    }
+  },
+  DomEvent: {
+    disableClickPropagation: function() {},
+    disableScrollPropagation: function() {}
+  }
+};
+"""
+
+
+def _stub_leaflet(route):
+    url = route.request.url
+    if url.endswith(".css"):
+        route.fulfill(status=200, content_type="text/css", body="")
+        return
+    route.fulfill(status=200, content_type="application/javascript", body=LEAFLET_STUB)
+
+
+def test_map_photo_id_deep_link_focuses_marker(live_server, page):
+    """The map page zooms to and opens the marker named by ?photo_id=."""
+    pid = live_server["data"]["photos"][0]
+    live_server["db"].conn.execute(
+        "UPDATE photos SET latitude = ?, longitude = ? WHERE id = ?",
+        (37.7749, -122.4194, pid),
+    )
+    live_server["db"].conn.commit()
+
+    page.route("https://unpkg.com/**", _stub_leaflet)
+    page.goto(f"{live_server['url']}/map?photo_id={pid}")
+
+    page.wait_for_function(
+        "pid => window.activePhotoId === pid && !!window.__openedPopup",
+        arg=pid,
+        timeout=3000,
+    )
+    active_card = page.locator(f".sidebar-card.active[data-id='{pid}']")
+    expect(active_card).to_be_visible()
+    expect(page.locator("#mapStatus")).to_contain_text("Showing 1 of 1 geolocated photos")
+
+
+def test_map_photo_id_deep_link_reports_missing_location(live_server, page):
+    """A map deep link to an unplottable photo gives a targeted status."""
+    pid = live_server["data"]["photos"][0]
+
+    page.route("https://unpkg.com/**", _stub_leaflet)
+    page.goto(f"{live_server['url']}/map?photo_id={pid}")
+
+    expect(page.locator("#mapStatus")).to_contain_text("No map location found for this photo.")

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -5948,6 +5948,10 @@ function revealPhoto(photoId) {
   }, { toast: false }).catch(function(){});
 }
 
+function viewPhotoOnMap(photoId) {
+  window.location.href = '/map?photo_id=' + encodeURIComponent(photoId);
+}
+
 async function copyPhotoPaths(photoIds) {
   var settled = await Promise.allSettled(photoIds.map(function(id) {
     return safeFetch('/api/photos/' + id, {}, { toast: false });
@@ -6035,6 +6039,8 @@ function buildPhotoContextMenu(photoIds) {
     { separator: true },
     { label: 'Find Similar', disabled: !one, disabledHint: hint,
       onClick: function() { if (typeof findSimilar === 'function') findSimilar(photoIds[0]); } },
+    { label: 'View on Map', disabled: !one, disabledHint: hint,
+      onClick: function() { viewPhotoOnMap(photoIds[0]); } },
     { label: 'Compare', disabled: photoIds.length < 2, disabledHint: 'Select at least two photos',
       onClick: function() { openBrowseCompare(); } },
     { label: 'Best Batch',

--- a/vireo/templates/map.html
+++ b/vireo/templates/map.html
@@ -548,6 +548,8 @@ markers.on('clusterclick', hideClusterPreview);
 
 /* ── Load photos ── */
 async function loadPhotos() {
+  var focusPhotoId = requestedPhotoId;
+  requestedPhotoId = null;
   var params = new URLSearchParams();
   var folder = document.getElementById('filterFolder').value;
   var rating = document.getElementById('filterRating').value;
@@ -574,7 +576,7 @@ async function loadPhotos() {
 
     if (data.photos.length === 0) {
       renderSidebar([]);
-      document.getElementById('mapStatus').textContent = requestedPhotoId !== null
+      document.getElementById('mapStatus').textContent = focusPhotoId !== null
         ? 'No map location found for this photo.'
         : 'No geolocated photos found. Photos with GPS data in their EXIF metadata will appear here.';
       legendControl.update({});
@@ -625,8 +627,8 @@ async function loadPhotos() {
 
     map.fitBounds(markers.getBounds(), { padding: [30, 30] });
     renderSidebar(data.photos);
-    if (requestedPhotoId !== null) {
-      if (!openPhotoMarker(requestedPhotoId)) {
+    if (focusPhotoId !== null) {
+      if (!openPhotoMarker(focusPhotoId)) {
         document.getElementById('mapStatus').textContent =
           'No map location found for this photo.';
       }
@@ -645,7 +647,7 @@ async function loadPhotos() {
     if (missingGps > 0) {
       parts.push('<a href="/browse?missing_gps=1">' + missingGps + ' missing GPS</a>');
     }
-    if (requestedPhotoId === null || photoMarkers[requestedPhotoId]) {
+    if (focusPhotoId === null || photoMarkers[focusPhotoId]) {
       statusEl.innerHTML = parts.join(' &mdash; ');
     }
   } catch (e) {

--- a/vireo/templates/map.html
+++ b/vireo/templates/map.html
@@ -439,6 +439,12 @@ function formatDate(ts) {
 /* ── State for bi-directional sync ── */
 var photoMarkers = {};  /* photo id -> marker */
 var activePhotoId = null;
+var requestedPhotoId = (function() {
+  var raw = new URLSearchParams(window.location.search).get('photo_id');
+  if (!raw) return null;
+  var parsed = parseInt(raw, 10);
+  return isNaN(parsed) ? null : parsed;
+})();
 
 function setActiveCard(photoId) {
   if (activePhotoId !== null) {
@@ -453,6 +459,17 @@ function setActiveCard(photoId) {
       card.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
     }
   }
+}
+
+function openPhotoMarker(photoId) {
+  var marker = photoMarkers[photoId];
+  if (!marker) return false;
+  setActiveCard(photoId);
+  markers.zoomToShowLayer(marker, function() {
+    map.setView(marker.getLatLng(), Math.max(map.getZoom(), 14));
+    marker.openPopup();
+  });
+  return true;
 }
 
 /* ── Sidebar rendering ── */
@@ -482,14 +499,7 @@ function renderSidebar(photos) {
       + '</div>';
 
     card.addEventListener('click', function() {
-      var marker = photoMarkers[p.id];
-      if (marker) {
-        map.setView(marker.getLatLng(), Math.max(map.getZoom(), 14));
-        markers.zoomToShowLayer(marker, function() {
-          marker.openPopup();
-        });
-      }
-      setActiveCard(p.id);
+      openPhotoMarker(p.id);
     });
 
     list.appendChild(card);
@@ -564,8 +574,9 @@ async function loadPhotos() {
 
     if (data.photos.length === 0) {
       renderSidebar([]);
-      document.getElementById('mapStatus').textContent =
-        'No geolocated photos found. Photos with GPS data in their EXIF metadata will appear here.';
+      document.getElementById('mapStatus').textContent = requestedPhotoId !== null
+        ? 'No map location found for this photo.'
+        : 'No geolocated photos found. Photos with GPS data in their EXIF metadata will appear here.';
       legendControl.update({});
       return;
     }
@@ -614,6 +625,12 @@ async function loadPhotos() {
 
     map.fitBounds(markers.getBounds(), { padding: [30, 30] });
     renderSidebar(data.photos);
+    if (requestedPhotoId !== null) {
+      if (!openPhotoMarker(requestedPhotoId)) {
+        document.getElementById('mapStatus').textContent =
+          'No map location found for this photo.';
+      }
+    }
 
     /* GPS coverage stats — global (unfiltered) for consistency */
     var totalFiltered = data.total_filtered;
@@ -628,7 +645,9 @@ async function loadPhotos() {
     if (missingGps > 0) {
       parts.push('<a href="/browse?missing_gps=1">' + missingGps + ' missing GPS</a>');
     }
-    statusEl.innerHTML = parts.join(' &mdash; ');
+    if (requestedPhotoId === null || photoMarkers[requestedPhotoId]) {
+      statusEl.innerHTML = parts.join(' &mdash; ');
+    }
   } catch (e) {
     document.getElementById('mapStatus').textContent = 'Failed to load photos.';
   }


### PR DESCRIPTION
Adds a single-photo Browse context-menu action that opens the selected photo on the Map page. The Map page now accepts a photo_id query parameter, zooms to that marker, opens its popup, and shows a targeted message when the photo has no plottable location. Includes focused Playwright coverage for the Browse action and Map deep-link behavior.\n\nValidation: pytest -q tests/e2e/test_browse_context_menu.py::test_right_click_photo_opens_menu tests/e2e/test_browse_context_menu.py::test_view_on_map_context_action_targets_right_clicked_photo tests/e2e/test_map_deep_link.py