### PR TITLE
Resolve photo locations from GPS in bulk

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3135,7 +3135,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return None, json_error("photo_ids required", 400)
         return photo_ids, None
 
-    def _chunked(values, size=800):
+    def _gps_location_chunks(values, size=800):
         values = list(values)
         for idx in range(0, len(values), size):
             yield values[idx:idx + size]
@@ -3145,7 +3145,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not photo_ids:
             return set()
         found = set()
-        for chunk in _chunked(photo_ids):
+        for chunk in _gps_location_chunks(photo_ids):
             placeholders = ",".join("?" for _ in chunk)
             rows = db.conn.execute(
                 "SELECT DISTINCT pk.photo_id "

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3119,6 +3119,233 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             )
         return None
 
+    def _normalize_photo_id_list(raw_ids):
+        """Validate and de-dupe a JSON ``photo_ids`` list, preserving order."""
+        if not isinstance(raw_ids, list) or not raw_ids:
+            return None, json_error("photo_ids required", 400)
+        photo_ids = []
+        seen = set()
+        for raw in raw_ids:
+            if isinstance(raw, bool) or not isinstance(raw, int):
+                return None, json_error("photo_ids must contain only integers", 400)
+            if raw not in seen:
+                photo_ids.append(raw)
+                seen.add(raw)
+        if not photo_ids:
+            return None, json_error("photo_ids required", 400)
+        return photo_ids, None
+
+    def _chunked(values, size=800):
+        values = list(values)
+        for idx in range(0, len(values), size):
+            yield values[idx:idx + size]
+
+    def _location_keyword_photo_ids(db, photo_ids):
+        """Return ids that already have any linked location keyword."""
+        if not photo_ids:
+            return set()
+        found = set()
+        for chunk in _chunked(photo_ids):
+            placeholders = ",".join("?" for _ in chunk)
+            rows = db.conn.execute(
+                "SELECT DISTINCT pk.photo_id "
+                "FROM photo_keywords pk "
+                "JOIN keywords k ON k.id = pk.keyword_id "
+                f"WHERE k.type = 'location' AND pk.photo_id IN ({placeholders})",
+                chunk,
+            ).fetchall()
+            found.update(row["photo_id"] for row in rows)
+        return found
+
+    def _resolve_exif_place_for_photo(db, photo, api_key, grid_cache):
+        """Resolve one photo's EXIF coordinates into normalized place details.
+
+        Returns ``(details, reason)`` where ``details`` is the normalized
+        Google-place dict on success and ``reason`` is a short unresolved code
+        on failure. Results are de-duped by the DB's reverse-geocode grid so a
+        burst in the same cell only performs/cache-checks one lookup.
+        """
+        lat = photo["latitude"]
+        lng = photo["longitude"]
+        if lat is None or lng is None:
+            return None, "missing_gps"
+        try:
+            lat = float(lat)
+            lng = float(lng)
+        except (TypeError, ValueError):
+            return None, "invalid_gps"
+        if not (math.isfinite(lat) and math.isfinite(lng)):
+            return None, "invalid_gps"
+
+        grid = Database._reverse_geocode_grid(lat, lng)
+        if grid in grid_cache:
+            return grid_cache[grid]
+
+        cached = db.reverse_geocode_cache_get(lat, lng)
+        if cached is not None:
+            if cached["place_id"] is None:
+                result = (None, "no_match")
+                grid_cache[grid] = result
+                return result
+            try:
+                details = json.loads(cached["response"] or "{}")
+            except (ValueError, TypeError):
+                details = {}
+            if not isinstance(details, dict):
+                details = {}
+            if not details.get("place_id"):
+                details["place_id"] = cached["place_id"]
+            if details.get("place_id"):
+                result = (details, None)
+            else:
+                result = (None, "no_match")
+            grid_cache[grid] = result
+            return result
+
+        if not api_key:
+            result = (None, "no_api_key")
+            grid_cache[grid] = result
+            return result
+
+        try:
+            details = places.reverse_geocode(lat, lng, api_key)
+        except places.PlacesTransientError:
+            app.logger.warning(
+                "bulk reverse_geocode transient failure for photo=%s lat=%s lng=%s",
+                photo["id"],
+                lat,
+                lng,
+            )
+            result = (None, "transient_error")
+            grid_cache[grid] = result
+            return result
+
+        cache_place_id = details.get("place_id") if details else None
+        db.reverse_geocode_cache_put(
+            lat,
+            lng,
+            place_id=cache_place_id,
+            response_json=json.dumps(details or {}),
+        )
+        if not details or not details.get("place_id"):
+            result = (None, "no_match")
+        else:
+            result = (details, None)
+        grid_cache[grid] = result
+        return result
+
+    def _bulk_gps_location_source_ids(db, body):
+        """Return source photo ids from either ``photo_ids`` or ``collection_id``."""
+        raw_ids = body.get("photo_ids")
+        if raw_ids:
+            return _normalize_photo_id_list(raw_ids)
+
+        collection_id = _coerce_collection_id(body.get("collection_id"))
+        if collection_id is False:
+            return None, json_error("collection_id must be an integer", 400)
+        if collection_id is None:
+            return None, json_error("photo_ids or collection_id required", 400)
+
+        row = db.conn.execute(
+            "SELECT id FROM collections WHERE id = ? AND workspace_id = ?",
+            (collection_id, db._ws_id()),
+        ).fetchone()
+        if row is None:
+            return None, json_error("collection not found", 404)
+        return db.get_collection_photo_ids(collection_id), None
+
+    def _bulk_gps_location_payload(db, body):
+        """Build preview/apply data for resolving locations from EXIF GPS."""
+        photo_ids, error = _bulk_gps_location_source_ids(db, body)
+        if error is not None:
+            return None, error
+        if not photo_ids:
+            return {
+                "total": 0,
+                "resolvable": 0,
+                "updated": 0,
+                "groups": [],
+                "unresolved": [],
+                "skipped": [],
+            }, None
+        if len(photo_ids) > 10000:
+            return None, json_error("too many photo_ids", 400)
+
+        photos_map = db.get_photos_by_ids(photo_ids)
+        if len(photos_map) != len(photo_ids):
+            return None, json_error("One or more photos were not found", 404)
+        for pid in photo_ids:
+            edit_error = _photo_location_edit_error(db, pid)
+            if edit_error is not None:
+                return None, edit_error
+
+        assigned_ids = _location_keyword_photo_ids(db, photo_ids)
+        import config as cfg
+        api_key = (cfg.load().get("google_maps_api_key", "") or "").strip()
+
+        grid_cache = {}
+        groups = {}
+        unresolved = []
+        skipped = []
+        ordered_group_keys = []
+        for pid in photo_ids:
+            photo = photos_map[pid]
+            if pid in assigned_ids:
+                skipped.append({
+                    "photo_id": pid,
+                    "filename": photo["filename"],
+                    "reason": "already_has_location",
+                })
+                continue
+            details, reason = _resolve_exif_place_for_photo(
+                db, photo, api_key, grid_cache,
+            )
+            if reason is not None:
+                unresolved.append({
+                    "photo_id": pid,
+                    "filename": photo["filename"],
+                    "reason": reason,
+                })
+                continue
+
+            place_id = details.get("place_id")
+            if place_id not in groups:
+                groups[place_id] = {
+                    "place_id": place_id,
+                    "summary": _summarize_details(details),
+                    "name": details.get("name") or "",
+                    "details": details,
+                    "photo_ids": [],
+                    "sample_filenames": [],
+                }
+                ordered_group_keys.append(place_id)
+            group = groups[place_id]
+            group["photo_ids"].append(pid)
+            if len(group["sample_filenames"]) < 3:
+                group["sample_filenames"].append(photo["filename"])
+
+        group_list = []
+        for place_id in ordered_group_keys:
+            group = groups[place_id]
+            group_list.append({
+                "place_id": group["place_id"],
+                "summary": group["summary"],
+                "name": group["name"],
+                "count": len(group["photo_ids"]),
+                "photo_ids": group["photo_ids"],
+                "sample_filenames": group["sample_filenames"],
+            })
+
+        return {
+            "total": len(photo_ids),
+            "resolvable": sum(group["count"] for group in group_list),
+            "updated": 0,
+            "groups": group_list,
+            "unresolved": unresolved,
+            "skipped": skipped,
+            "_details_by_place_id": {k: v["details"] for k, v in groups.items()},
+        }, None
+
     # -- Edit API routes --
 
     @app.route("/api/photos/<int:photo_id>/rating", methods=["POST"])
@@ -4019,6 +4246,91 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "updated": len(items),
             "location": _serialize_photo_location(db, photo_ids[0]),
         })
+
+    @app.route("/api/batch/location/from-exif", methods=["POST"])
+    def api_batch_set_photo_locations_from_exif():
+        """Resolve each photo's EXIF GPS to a place and optionally apply it.
+
+        Body:
+          - ``{"photo_ids": [1, 2], "apply": false}``
+          - ``{"collection_id": 7, "apply": true}``
+
+        Preview mode performs/caches reverse-geocode lookups and returns
+        grouped assignments without linking keywords. Apply mode reuses the
+        same resolution path, then writes each photo's own resolved place.
+        """
+        body = request.get_json(silent=True) or {}
+        apply_changes = body.get("apply") is True
+        db = _get_db()
+
+        payload, error = _bulk_gps_location_payload(db, body)
+        if error is not None:
+            return error
+        if not apply_changes:
+            payload.pop("_details_by_place_id", None)
+            return jsonify(payload)
+
+        details_by_place_id = payload.pop("_details_by_place_id", {})
+        keyword_id_by_place_id = {}
+        items = []
+        group_errors = []
+        for group in payload["groups"]:
+            place_id = group["place_id"]
+            details = details_by_place_id.get(place_id)
+            if not details:
+                group_errors.append({
+                    "place_id": place_id,
+                    "summary": group.get("summary") or place_id,
+                    "error": "missing_details",
+                })
+                continue
+            try:
+                leaf_id = db.upsert_place_chain(details)
+            except RuntimeError as err:
+                group_errors.append({
+                    "place_id": place_id,
+                    "summary": group.get("summary") or place_id,
+                    "error": "name_conflict",
+                    "error_detail": str(err),
+                })
+                continue
+            keyword_id_by_place_id[place_id] = leaf_id
+
+            for pid in group["photo_ids"]:
+                db.set_photo_location(pid, leaf_id)
+                _queue_location_sync_if_enabled(pid, _commit=False)
+                items.append({
+                    "photo_id": pid,
+                    "old_value": "",
+                    "new_value": str(leaf_id),
+                })
+
+        if items:
+            place_count = len(keyword_id_by_place_id)
+            db.record_edit(
+                "location_set",
+                (
+                    f"resolved GPS locations for {len(items)} "
+                    f"{'photo' if len(items) == 1 else 'photos'} "
+                    f"across {place_count} "
+                    f"{'place' if place_count == 1 else 'places'}"
+                ),
+                "from_exif",
+                items,
+                is_batch=True,
+                _commit=False,
+            )
+        db.conn.commit()
+        if items:
+            db._prune_edit_history()
+
+        payload["updated"] = len(items)
+        payload["group_errors"] = group_errors
+        payload["keyword_ids"] = {
+            place_id: keyword_id
+            for place_id, keyword_id in keyword_id_by_place_id.items()
+        }
+        return jsonify(payload)
 
     @app.route("/api/photos/<int:photo_id>/location", methods=["DELETE"])
     def api_clear_photo_location(photo_id):

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -4615,12 +4615,8 @@ async function applyGpsResolve() {
     loadKeywords();
     scheduleCollectionCountsRefresh();
     refreshPendingSyncBanner();
-    if (activeCollectionId) {
-      await filterByCollection(activeCollectionId);
-    } else if (updatedIds.length) {
-      refreshGridCards(updatedIds);
-      loadSummary();
-    }
+    var detailPhotoId = updatedIds.indexOf(selectedPhotoId) !== -1 ? selectedPhotoId : null;
+    await _afterLocationMutation(updatedIds, detailPhotoId);
     var errors = (data.group_errors || []).length;
     showToast(
       'Resolved GPS locations for ' + updated.toLocaleString() + ' photo' + (updated === 1 ? '' : 's')

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -88,6 +88,17 @@ body {
   border-color: var(--border-primary);
   color: var(--text-ghost);
 }
+.collection-resolve-btn {
+  background: var(--bg-tertiary);
+  color: var(--accent);
+  border: 1px solid var(--border-secondary);
+  border-radius: 3px;
+  padding: 2px 6px;
+  font-size: 10px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.collection-resolve-btn:hover { border-color: var(--accent); }
 .tree-item .folder-status-partial {
   margin-left: 6px;
   font-size: 10px;
@@ -1199,6 +1210,50 @@ body {
 .modal-btn-primary { background: var(--accent); color: var(--bg-primary); }
 .modal-btn-cancel { background: var(--bg-tertiary); color: var(--text-secondary); }
 .modal-preview { font-size: 12px; color: var(--text-dim); margin-top: 8px; }
+.gps-resolve-summary {
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin-bottom: 12px;
+  line-height: 1.4;
+}
+.gps-resolve-list {
+  max-height: 280px;
+  overflow-y: auto;
+  border: 1px solid var(--border-primary);
+  border-radius: 4px;
+  margin-bottom: 12px;
+}
+.gps-resolve-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border-primary);
+}
+.gps-resolve-row:last-child { border-bottom: 0; }
+.gps-resolve-place {
+  min-width: 0;
+  color: var(--text-primary);
+  font-size: 13px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.gps-resolve-samples {
+  color: var(--text-dim);
+  font-size: 11px;
+  margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.gps-resolve-count {
+  flex-shrink: 0;
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 600;
+}
 .export-var-pill {
   background: var(--bg-tertiary);
   color: var(--text-secondary);
@@ -1359,6 +1414,7 @@ body {
       <button onclick="batchSetFlag('flagged')" style="background:var(--bg-tertiary);color:var(--accent);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Flag</button>
       <button onclick="batchSetFlag('rejected')" style="background:var(--bg-tertiary);color:var(--danger);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Reject</button>
       <button onclick="batchAddKeyword()" style="background:var(--bg-tertiary);color:var(--text-secondary);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">+ Keyword</button>
+      <button id="resolveGpsSelectedBtn" onclick="openGpsResolveForSelection()" style="background:var(--bg-tertiary);color:var(--accent);border:1px solid var(--accent);border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Resolve GPS</button>
       <button onclick="addToCollection()" style="background:var(--bg-tertiary);color:var(--info);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">+ Collection</button>
       <button onclick="openCaptureTimeModal()" style="background:var(--bg-tertiary);color:var(--text-secondary);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Adjust Time</button>
       <button id="compareBtn" onclick="openBrowseCompare()" title="Compare two selected photos side by side" style="display:none;background:var(--bg-tertiary);color:var(--accent);border:1px solid var(--accent);border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Compare</button>
@@ -1602,6 +1658,20 @@ body {
     <div class="modal-actions">
       <button class="modal-btn modal-btn-primary" onclick="confirmBatchCollection()">Add</button>
       <button class="modal-btn modal-btn-cancel" onclick="hideBatchCollectionModal()">Cancel</button>
+    </div>
+  </div>
+</div>
+
+<!-- Resolve GPS Locations Modal -->
+<div class="modal-overlay" id="gpsResolveModal">
+  <div class="modal" style="width:560px;max-width:calc(100vw - 32px);">
+    <h3>Resolve GPS Locations</h3>
+    <div id="gpsResolveSummary" class="gps-resolve-summary">Loading...</div>
+    <div id="gpsResolveGroups" class="gps-resolve-list"></div>
+    <div class="modal-preview" id="gpsResolveNote"></div>
+    <div class="modal-actions">
+      <button class="modal-btn modal-btn-primary" id="gpsResolveApplyBtn" onclick="applyGpsResolve()">Apply</button>
+      <button class="modal-btn modal-btn-cancel" onclick="hideGpsResolveModal()">Cancel</button>
     </div>
   </div>
 </div>
@@ -2238,9 +2308,13 @@ function renderCollectionList(collections) {
     var canAddPhotos = collectionAcceptsManualPhotos(c);
     var kind = canAddPhotos ? 'manual' : 'smart';
     var kindLabel = canAddPhotos ? 'Manual' : 'Smart';
+    var resolveBtn = (c.name === 'GPS Without Location Keyword')
+      ? '<button class="collection-resolve-btn" type="button" title="Resolve locations from GPS" onclick="event.stopPropagation(); openGpsResolveForCollection(' + c.id + ')">Resolve GPS</button>'
+      : '';
     html += '<div class="tree-item" data-collection-id="' + c.id + '" data-collection-kind="' + kind + '" onclick="filterByCollection(' + c.id + ')">' +
       '<span class="collection-name">' + escapeHtml(c.name) + '</span>' +
       '<span class="collection-kind-badge ' + kind + '">' + kindLabel + '</span>' +
+      resolveBtn +
       '<span class="count">' + count + '</span></div>';
   });
   document.getElementById('collectionList').innerHTML = html || '<div style="font-size:12px;color:var(--text-ghost);padding:4px 8px;">No collections</div>';
@@ -4421,6 +4495,145 @@ async function confirmBatchCollection() {
   clearSelection();
 }
 
+var _gpsResolveSource = null;
+var _gpsResolvePreview = null;
+
+function gpsResolveReasonLabel(reason) {
+  var labels = {
+    missing_gps: 'No GPS',
+    invalid_gps: 'Invalid GPS',
+    no_api_key: 'No Google Maps key',
+    no_match: 'No place found',
+    transient_error: 'Temporary lookup failure',
+    already_has_location: 'Already has location',
+  };
+  return labels[reason] || reason || 'Unresolved';
+}
+
+function renderGpsResolvePreview(data) {
+  _gpsResolvePreview = data || {};
+  var total = _gpsResolvePreview.total || 0;
+  var resolvable = _gpsResolvePreview.resolvable || 0;
+  var groups = _gpsResolvePreview.groups || [];
+  var unresolved = _gpsResolvePreview.unresolved || [];
+  var skipped = _gpsResolvePreview.skipped || [];
+  var summary = document.getElementById('gpsResolveSummary');
+  var groupEl = document.getElementById('gpsResolveGroups');
+  var note = document.getElementById('gpsResolveNote');
+  var applyBtn = document.getElementById('gpsResolveApplyBtn');
+
+  summary.textContent = resolvable.toLocaleString() + ' of ' + total.toLocaleString()
+    + ' photos can be assigned across ' + groups.length.toLocaleString()
+    + ' place' + (groups.length === 1 ? '' : 's') + '.';
+
+  groupEl.innerHTML = groups.map(function(g) {
+    var samples = (g.sample_filenames || []).join(', ');
+    return '<div class="gps-resolve-row">' +
+      '<div style="min-width:0;">' +
+        '<div class="gps-resolve-place">' + escapeHtml(g.summary || g.name || g.place_id || 'Unknown place') + '</div>' +
+        (samples ? '<div class="gps-resolve-samples">' + escapeHtml(samples) + '</div>' : '') +
+      '</div>' +
+      '<div class="gps-resolve-count">' + (g.count || 0).toLocaleString() + '</div>' +
+    '</div>';
+  }).join('') || '<div class="gps-resolve-row"><div class="gps-resolve-place">No resolvable GPS locations</div></div>';
+
+  var notes = [];
+  if (unresolved.length) {
+    var reasonCounts = {};
+    unresolved.forEach(function(item) {
+      var reason = item.reason || 'unresolved';
+      reasonCounts[reason] = (reasonCounts[reason] || 0) + 1;
+    });
+    var reasonText = Object.keys(reasonCounts).map(function(reason) {
+      return reasonCounts[reason].toLocaleString() + ' ' + gpsResolveReasonLabel(reason);
+    }).join(', ');
+    notes.push(unresolved.length.toLocaleString() + ' unresolved: ' + reasonText);
+  }
+  if (skipped.length) {
+    notes.push(skipped.length.toLocaleString() + ' skipped because they already have a location.');
+  }
+  note.textContent = notes.join(' ');
+  applyBtn.disabled = resolvable === 0;
+  applyBtn.style.opacity = resolvable === 0 ? '0.55' : '';
+}
+
+async function openGpsResolve(source) {
+  _gpsResolveSource = source;
+  _gpsResolvePreview = null;
+  document.getElementById('gpsResolveSummary').textContent = 'Loading...';
+  document.getElementById('gpsResolveGroups').innerHTML = '';
+  document.getElementById('gpsResolveNote').textContent = '';
+  document.getElementById('gpsResolveApplyBtn').disabled = true;
+  document.getElementById('gpsResolveModal').classList.add('open');
+  try {
+    var data = await safeFetch('/api/batch/location/from-exif', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(Object.assign({apply: false}, source)),
+    });
+    renderGpsResolvePreview(data);
+  } catch(e) {
+    hideGpsResolveModal();
+  }
+}
+
+function openGpsResolveForCollection(collectionId) {
+  openGpsResolve({collection_id: collectionId});
+}
+
+function openGpsResolveForSelection() {
+  var ids = getActiveSelection();
+  if (!ids.length) return;
+  openGpsResolve({photo_ids: ids});
+}
+
+function hideGpsResolveModal() {
+  document.getElementById('gpsResolveModal').classList.remove('open');
+  _gpsResolveSource = null;
+  _gpsResolvePreview = null;
+  window._vireoNativeMenuPhotoIdsOverride = null;
+}
+
+async function applyGpsResolve() {
+  if (!_gpsResolveSource || !_gpsResolvePreview || !_gpsResolvePreview.resolvable) return;
+  var btn = document.getElementById('gpsResolveApplyBtn');
+  btn.disabled = true;
+  btn.textContent = 'Applying...';
+  try {
+    var data = await safeFetch('/api/batch/location/from-exif', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(Object.assign({apply: true}, _gpsResolveSource)),
+    });
+    var updated = data.updated || 0;
+    var updatedIds = [];
+    (data.groups || []).forEach(function(g) {
+      (g.photo_ids || []).forEach(function(id) { updatedIds.push(id); });
+    });
+    hideGpsResolveModal();
+    invalidateKeywordAutocompleteCache();
+    loadKeywords();
+    scheduleCollectionCountsRefresh();
+    refreshPendingSyncBanner();
+    if (activeCollectionId) {
+      await filterByCollection(activeCollectionId);
+    } else if (updatedIds.length) {
+      refreshGridCards(updatedIds);
+      loadSummary();
+    }
+    var errors = (data.group_errors || []).length;
+    showToast(
+      'Resolved GPS locations for ' + updated.toLocaleString() + ' photo' + (updated === 1 ? '' : 's')
+      + (errors ? '; ' + errors + ' place group' + (errors === 1 ? '' : 's') + ' failed' : '')
+    );
+    if (updated > 0) showUndoToast();
+  } catch(e) {
+    btn.disabled = false;
+  } finally {
+    btn.textContent = 'Apply';
+  }
+}
+
 var captureTimePreviewSeq = 0;
 
 function getCaptureTimeMode() {
@@ -6199,9 +6412,17 @@ document.addEventListener('contextmenu', function(e) {
   if (isNaN(cid)) return;
   var nameEl = ti.querySelector('.collection-name');
   var name = nameEl ? nameEl.textContent : '';
-  openContextMenu(e, [
+  var items = [
     { label: 'Filter by this Collection',
       onClick: function() { filterByCollection(cid); } },
+  ];
+  if (name === 'GPS Without Location Keyword') {
+    items.push({
+      label: 'Resolve GPS Locations',
+      onClick: function() { openGpsResolveForCollection(cid); },
+    });
+  }
+  items = items.concat([
     { separator: true },
     { label: 'Edit Rules',
       onClick: function() { editCollection(cid); } },
@@ -6213,6 +6434,7 @@ document.addEventListener('contextmenu', function(e) {
     { label: 'Delete Collection',
       onClick: function() { deleteCollectionById(cid, name); } },
   ]);
+  openContextMenu(e, items);
 });
 
 /* ---------- Deep-link: scroll to photo_id if present in URL ---------- */

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -3858,6 +3858,144 @@ def test_reverse_geocode_400_on_invalid_coords(app_and_db):
     assert r2.get_json()["error"] == "invalid coords"
 
 
+def _yosemite_geocode_response():
+    return {
+        "place_id": "ChIJxeyK9Z3wloAR_gOA7SycJC8",
+        "name": "Yosemite Valley",
+        "lat": 37.7456,
+        "lng": -119.5936,
+        "address_components": [
+            {"name": "Mariposa County", "short_name": "Mariposa County",
+             "types": ["administrative_area_level_2"]},
+            {"name": "California", "short_name": "CA",
+             "types": ["administrative_area_level_1"]},
+            {"name": "United States", "short_name": "US", "types": ["country"]},
+        ],
+    }
+
+
+def test_batch_location_from_exif_preview_groups_without_linking(
+    app_and_db, monkeypatch,
+):
+    """Preview resolves each photo's own GPS and does not attach locations."""
+    import config as cfg
+    import places
+    app, db = app_and_db
+    cfg.save({**cfg.load(), "google_maps_api_key": "FAKE-KEY"})
+
+    photos = db.get_photos(sort="name")
+    p1, p2, p3 = [p["id"] for p in photos]
+    db.conn.execute(
+        "UPDATE photos SET latitude = ?, longitude = ? WHERE id = ?",
+        (40.7828, -73.9654, p1),
+    )
+    db.conn.execute(
+        "UPDATE photos SET latitude = ?, longitude = ? WHERE id = ?",
+        (37.7456, -119.5936, p2),
+    )
+    db.conn.commit()
+
+    def fake_reverse_geocode(lat, lng, key):
+        if lat > 39:
+            return _central_park_geocode_response()
+        return _yosemite_geocode_response()
+
+    monkeypatch.setattr(places, "reverse_geocode", fake_reverse_geocode)
+
+    client = app.test_client()
+    resp = client.post(
+        "/api/batch/location/from-exif",
+        json={"photo_ids": [p1, p2, p3], "apply": False},
+    )
+
+    assert resp.status_code == 200, resp.get_json()
+    body = resp.get_json()
+    assert body["total"] == 3
+    assert body["resolvable"] == 2
+    assert {g["name"] for g in body["groups"]} == {"Central Park", "Yosemite Valley"}
+    assert body["unresolved"] == [
+        {"filename": "bird3.jpg", "photo_id": p3, "reason": "missing_gps"}
+    ]
+    assert "_details_by_place_id" not in body
+    # The fixture starts with two taxonomy keyword links. Preview may cache
+    # reverse-geocode results, but it must not create location links.
+    assert db.conn.execute(
+        "SELECT COUNT(*) FROM photo_keywords pk "
+        "JOIN keywords k ON k.id = pk.keyword_id "
+        "WHERE k.type = 'location'"
+    ).fetchone()[0] == 0
+
+
+def test_batch_location_from_exif_apply_assigns_per_photo_places(
+    app_and_db, monkeypatch,
+):
+    """Apply mode assigns different place keywords to different GPS photos."""
+    import config as cfg
+    import places
+    app, db = app_and_db
+    cfg.save({**cfg.load(), "google_maps_api_key": "FAKE-KEY"})
+
+    photos = db.get_photos(sort="name")
+    p1, p2, p3 = [p["id"] for p in photos]
+    db.conn.execute(
+        "UPDATE photos SET latitude = ?, longitude = ? WHERE id = ?",
+        (40.7828, -73.9654, p1),
+    )
+    db.conn.execute(
+        "UPDATE photos SET latitude = ?, longitude = ? WHERE id = ?",
+        (37.7456, -119.5936, p2),
+    )
+    db.conn.commit()
+
+    def fake_reverse_geocode(lat, lng, key):
+        if lat > 39:
+            return _central_park_geocode_response()
+        return _yosemite_geocode_response()
+
+    monkeypatch.setattr(places, "reverse_geocode", fake_reverse_geocode)
+
+    client = app.test_client()
+    resp = client.post(
+        "/api/batch/location/from-exif",
+        json={"photo_ids": [p1, p2, p3], "apply": True},
+    )
+
+    assert resp.status_code == 200, resp.get_json()
+    body = resp.get_json()
+    assert body["updated"] == 2
+    assert body["resolvable"] == 2
+    assert body["group_errors"] == []
+
+    rows = db.conn.execute(
+        "SELECT pk.photo_id, k.name, k.place_id "
+        "FROM photo_keywords pk "
+        "JOIN keywords k ON k.id = pk.keyword_id "
+        "WHERE k.type = 'location' "
+        "ORDER BY pk.photo_id"
+    ).fetchall()
+    by_photo = {row["photo_id"]: row for row in rows}
+    assert by_photo[p1]["name"] == "Central Park"
+    assert by_photo[p2]["name"] == "Yosemite Valley"
+    assert p3 not in by_photo
+
+    pending = db.conn.execute(
+        "SELECT photo_id, change_type, value FROM pending_changes "
+        "WHERE change_type = 'location' ORDER BY photo_id"
+    ).fetchall()
+    assert [(r["photo_id"], r["value"]) for r in pending] == [
+        (p1, "effective"),
+        (p2, "effective"),
+    ]
+
+    edit = db.conn.execute(
+        "SELECT action_type, is_batch, description FROM edit_history "
+        "ORDER BY id DESC LIMIT 1"
+    ).fetchone()
+    assert edit["action_type"] == "location_set"
+    assert edit["is_batch"] == 1
+    assert "resolved GPS locations for 2 photos across 2 places" in edit["description"]
+
+
 # --- POST /api/keywords/<id>/link-place -------------------------------------
 #
 # Attach Google place data to an existing free-text location keyword. Builds


### PR DESCRIPTION
Adds a bulk GPS-to-location workflow for photos with EXIF coordinates but no Vireo location keyword. The new endpoint previews per-photo reverse-geocoded place groups, then applies each photo's own resolved place while reusing the existing cache, keyword chain, sync queue, and edit history. Browse now exposes Resolve GPS from the GPS Without Location Keyword collection and for selected photos.

Validation: python -m py_compile vireo/app.py; pytest vireo/tests/test_photos_api.py; pytest tests/e2e/test_location_section.py.