### PR TITLE
Retry failed ExifTool metadata batches

### DIFF
--- a/vireo/metadata.py
+++ b/vireo/metadata.py
@@ -13,6 +13,8 @@ log = logging.getLogger(__name__)
 # Batch size for ExifTool invocations
 _BATCH_SIZE = 100
 _EXIFTOOL_TIMEOUT = 120
+_MAX_TIMEOUT_SPLIT_DEPTH = 2
+_TIMEOUT = object()
 
 
 def _run_exiftool(file_paths, extra_args=None):
@@ -44,7 +46,7 @@ def _run_exiftool(file_paths, extra_args=None):
         if result.returncode not in (0, 1):
             # returncode 1 = warnings (e.g. minor errors), still has output
             log.warning("exiftool returned %d: %s", result.returncode, result.stderr[:200])
-            return None
+            return []
         if result.stdout.strip():
             return json.loads(result.stdout)
         return []
@@ -52,29 +54,34 @@ def _run_exiftool(file_paths, extra_args=None):
         log.error("exiftool not found — install it with: brew install exiftool")
     except subprocess.TimeoutExpired:
         log.error("exiftool timed out processing %d files", len(file_paths))
+        return _TIMEOUT
     except json.JSONDecodeError as e:
         log.error("Failed to parse exiftool JSON output: %s", e)
 
-    return None
+    return []
 
 
-def _run_exiftool_with_retries(file_paths, extra_args=None):
-    """Run ExifTool, splitting failed batches to salvage per-file metadata."""
+def _run_exiftool_with_retries(file_paths, extra_args=None, depth=0):
+    """Run ExifTool, splitting timed-out batches to salvage metadata."""
     raw = _run_exiftool(file_paths, extra_args=extra_args)
-    if raw is not None:
+    if raw is not _TIMEOUT:
         return raw
 
-    if len(file_paths) <= 1:
+    if len(file_paths) <= 1 or depth >= _MAX_TIMEOUT_SPLIT_DEPTH:
         return []
 
     mid = len(file_paths) // 2
     log.warning(
-        "Retrying failed exiftool batch of %d files as %d + %d",
+        "Retrying timed-out exiftool batch of %d files as %d + %d",
         len(file_paths), mid, len(file_paths) - mid,
     )
     return (
-        _run_exiftool_with_retries(file_paths[:mid], extra_args=extra_args)
-        + _run_exiftool_with_retries(file_paths[mid:], extra_args=extra_args)
+        _run_exiftool_with_retries(
+            file_paths[:mid], extra_args=extra_args, depth=depth + 1
+        )
+        + _run_exiftool_with_retries(
+            file_paths[mid:], extra_args=extra_args, depth=depth + 1
+        )
     )
 
 

--- a/vireo/metadata.py
+++ b/vireo/metadata.py
@@ -12,6 +12,7 @@ log = logging.getLogger(__name__)
 
 # Batch size for ExifTool invocations
 _BATCH_SIZE = 100
+_EXIFTOOL_TIMEOUT = 120
 
 
 def _run_exiftool(file_paths, extra_args=None):
@@ -38,14 +39,15 @@ def _run_exiftool(file_paths, extra_args=None):
             cmd,
             capture_output=True,
             text=True,
-            timeout=120,
+            timeout=_EXIFTOOL_TIMEOUT,
         )
         if result.returncode not in (0, 1):
             # returncode 1 = warnings (e.g. minor errors), still has output
             log.warning("exiftool returned %d: %s", result.returncode, result.stderr[:200])
-            return []
+            return None
         if result.stdout.strip():
             return json.loads(result.stdout)
+        return []
     except FileNotFoundError:
         log.error("exiftool not found — install it with: brew install exiftool")
     except subprocess.TimeoutExpired:
@@ -53,7 +55,27 @@ def _run_exiftool(file_paths, extra_args=None):
     except json.JSONDecodeError as e:
         log.error("Failed to parse exiftool JSON output: %s", e)
 
-    return []
+    return None
+
+
+def _run_exiftool_with_retries(file_paths, extra_args=None):
+    """Run ExifTool, splitting failed batches to salvage per-file metadata."""
+    raw = _run_exiftool(file_paths, extra_args=extra_args)
+    if raw is not None:
+        return raw
+
+    if len(file_paths) <= 1:
+        return []
+
+    mid = len(file_paths) // 2
+    log.warning(
+        "Retrying failed exiftool batch of %d files as %d + %d",
+        len(file_paths), mid, len(file_paths) - mid,
+    )
+    return (
+        _run_exiftool_with_retries(file_paths[:mid], extra_args=extra_args)
+        + _run_exiftool_with_retries(file_paths[mid:], extra_args=extra_args)
+    )
 
 
 def _group_tags(flat_dict):
@@ -94,7 +116,7 @@ def extract_metadata(file_paths, restricted_tags=None):
     # Process in batches
     for i in range(0, len(file_paths), _BATCH_SIZE):
         batch = file_paths[i:i + _BATCH_SIZE]
-        raw = _run_exiftool(batch, extra_args=restricted_tags)
+        raw = _run_exiftool_with_retries(batch, extra_args=restricted_tags)
         for entry in raw:
             source = entry.get("SourceFile")
             if source:

--- a/vireo/metadata.py
+++ b/vireo/metadata.py
@@ -13,7 +13,7 @@ log = logging.getLogger(__name__)
 # Batch size for ExifTool invocations
 _BATCH_SIZE = 100
 _EXIFTOOL_TIMEOUT = 120
-_MAX_TIMEOUT_SPLIT_DEPTH = 2
+_MAX_TIMEOUT_SPLIT_ATTEMPTS = 16
 _TIMEOUT = object()
 
 
@@ -61,26 +61,40 @@ def _run_exiftool(file_paths, extra_args=None):
     return []
 
 
-def _run_exiftool_with_retries(file_paths, extra_args=None, depth=0):
+def _run_exiftool_with_retries(file_paths, extra_args=None, split_budget=None):
     """Run ExifTool, splitting timed-out batches to salvage metadata."""
+    if split_budget is None:
+        split_budget = [_MAX_TIMEOUT_SPLIT_ATTEMPTS]
+
     raw = _run_exiftool(file_paths, extra_args=extra_args)
     if raw is not _TIMEOUT:
         return raw
 
-    if len(file_paths) <= 1 or depth >= _MAX_TIMEOUT_SPLIT_DEPTH:
+    if len(file_paths) <= 1:
         return []
 
+    if split_budget[0] <= 0:
+        log.warning(
+            "Stopping exiftool timeout retries for %d files after exhausting split budget",
+            len(file_paths),
+        )
+        return []
+
+    split_budget[0] -= 1
     mid = len(file_paths) // 2
     log.warning(
-        "Retrying timed-out exiftool batch of %d files as %d + %d",
-        len(file_paths), mid, len(file_paths) - mid,
+        "Retrying timed-out exiftool batch of %d files as %d + %d (%d splits left)",
+        len(file_paths),
+        mid,
+        len(file_paths) - mid,
+        split_budget[0],
     )
     return (
         _run_exiftool_with_retries(
-            file_paths[:mid], extra_args=extra_args, depth=depth + 1
+            file_paths[:mid], extra_args=extra_args, split_budget=split_budget
         )
         + _run_exiftool_with_retries(
-            file_paths[mid:], extra_args=extra_args, depth=depth + 1
+            file_paths[mid:], extra_args=extra_args, split_budget=split_budget
         )
     )
 

--- a/vireo/tests/test_metadata.py
+++ b/vireo/tests/test_metadata.py
@@ -115,7 +115,7 @@ def test_extract_metadata_retries_failed_batches(monkeypatch):
     def fake_run(file_paths, extra_args=None):
         calls.append(list(file_paths))
         if len(file_paths) > 1:
-            return None
+            return metadata._TIMEOUT
         path = file_paths[0]
         return [{"SourceFile": path, "EXIF:Make": "TestCam"}]
 
@@ -133,6 +133,48 @@ def test_extract_metadata_retries_failed_batches(monkeypatch):
         paths[2:],
         paths[2:3],
         paths[3:],
+    ]
+
+
+def test_extract_metadata_does_not_retry_permanent_failures(monkeypatch):
+    """Permanent ExifTool failures should not split into many retries."""
+    import metadata
+
+    paths = [f"/photos/img{i}.jpg" for i in range(4)]
+    calls = []
+
+    def fake_run(file_paths, extra_args=None):
+        calls.append(list(file_paths))
+        return []
+
+    monkeypatch.setattr(metadata, "_run_exiftool", fake_run)
+
+    assert metadata.extract_metadata(paths) == {}
+    assert calls == [paths]
+
+
+def test_extract_metadata_timeout_retries_are_bounded(monkeypatch):
+    """Repeated ExifTool timeouts stop after the configured split depth."""
+    import metadata
+
+    paths = [f"/photos/img{i}.jpg" for i in range(8)]
+    calls = []
+
+    def fake_run(file_paths, extra_args=None):
+        calls.append(list(file_paths))
+        return metadata._TIMEOUT
+
+    monkeypatch.setattr(metadata, "_run_exiftool", fake_run)
+
+    assert metadata.extract_metadata(paths) == {}
+    assert calls == [
+        paths,
+        paths[:4],
+        paths[:2],
+        paths[2:4],
+        paths[4:],
+        paths[4:6],
+        paths[6:],
     ]
 
 

--- a/vireo/tests/test_metadata.py
+++ b/vireo/tests/test_metadata.py
@@ -153,8 +153,35 @@ def test_extract_metadata_does_not_retry_permanent_failures(monkeypatch):
     assert calls == [paths]
 
 
+def test_extract_metadata_timeout_retries_isolate_slow_file(monkeypatch):
+    """Timed-out ExifTool batches split until a slow file is isolated."""
+    import metadata
+
+    bad_path = "/photos/bad.jpg"
+    paths = [f"/photos/img{i}.jpg" for i in range(7)] + [bad_path]
+    calls = []
+
+    def fake_run(file_paths, extra_args=None):
+        calls.append(list(file_paths))
+        if bad_path in file_paths:
+            return metadata._TIMEOUT
+        return [
+            {"SourceFile": path, "EXIF:Make": "TestCam"}
+            for path in file_paths
+        ]
+
+    monkeypatch.setattr(metadata, "_run_exiftool", fake_run)
+
+    results = metadata.extract_metadata(paths)
+
+    assert set(results) == set(paths) - {bad_path}
+    assert bad_path not in results
+    assert [bad_path] in calls
+    assert all(results[p]["EXIF"]["Make"] == "TestCam" for p in results)
+
+
 def test_extract_metadata_timeout_retries_are_bounded(monkeypatch):
-    """Repeated ExifTool timeouts stop after the configured split depth."""
+    """Repeated ExifTool timeouts stop after the configured split budget."""
     import metadata
 
     paths = [f"/photos/img{i}.jpg" for i in range(8)]
@@ -164,6 +191,7 @@ def test_extract_metadata_timeout_retries_are_bounded(monkeypatch):
         calls.append(list(file_paths))
         return metadata._TIMEOUT
 
+    monkeypatch.setattr(metadata, "_MAX_TIMEOUT_SPLIT_ATTEMPTS", 3)
     monkeypatch.setattr(metadata, "_run_exiftool", fake_run)
 
     assert metadata.extract_metadata(paths) == {}
@@ -171,10 +199,10 @@ def test_extract_metadata_timeout_retries_are_bounded(monkeypatch):
         paths,
         paths[:4],
         paths[:2],
+        paths[:1],
+        paths[1:2],
         paths[2:4],
         paths[4:],
-        paths[4:6],
-        paths[6:],
     ]
 
 

--- a/vireo/tests/test_metadata.py
+++ b/vireo/tests/test_metadata.py
@@ -105,6 +105,37 @@ def test_extract_metadata_empty_list():
     assert extract_metadata([]) == {}
 
 
+def test_extract_metadata_retries_failed_batches(monkeypatch):
+    """A failed ExifTool batch should be split so good files still get metadata."""
+    import metadata
+
+    paths = [f"/photos/img{i}.jpg" for i in range(4)]
+    calls = []
+
+    def fake_run(file_paths, extra_args=None):
+        calls.append(list(file_paths))
+        if len(file_paths) > 1:
+            return None
+        path = file_paths[0]
+        return [{"SourceFile": path, "EXIF:Make": "TestCam"}]
+
+    monkeypatch.setattr(metadata, "_run_exiftool", fake_run)
+
+    results = metadata.extract_metadata(paths)
+
+    assert set(results) == set(paths)
+    assert all(results[p]["EXIF"]["Make"] == "TestCam" for p in paths)
+    assert calls == [
+        paths,
+        paths[:2],
+        paths[:1],
+        paths[1:2],
+        paths[2:],
+        paths[2:3],
+        paths[3:],
+    ]
+
+
 @requires_exiftool
 def test_extract_metadata_with_restricted_tags(tmp_path):
     """extract_metadata can restrict which tags are returned."""


### PR DESCRIPTION
The originals in the affected Browse set do have EXIF; the bad rows came from one 100-file ExifTool batch timing out during scan while another capture-time ExifTool job was running. This changes metadata extraction so failed batches are retried by splitting into smaller chunks, preserving metadata for good files instead of silently indexing them with null timestamps. Added a regression test for failed-batch retry behavior. Validated with focused metadata, DB, and photo API pytest coverage.