### PR TITLE
Fix pipeline cache recovery and classify wording

### DIFF
--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -13,11 +13,73 @@ import json
 import logging
 import math
 import os
+import tempfile
+import time
 from collections import defaultdict
+from contextlib import suppress
 
 import numpy as np
 
 log = logging.getLogger(__name__)
+
+
+def _results_cache_path(cache_dir, workspace_id):
+    return os.path.join(cache_dir, f"pipeline_results_ws{workspace_id}.json")
+
+
+def _atomic_json_dump(data, path):
+    """Write JSON via same-directory temp file, then atomically replace."""
+    cache_dir = os.path.dirname(path) or "."
+    os.makedirs(cache_dir, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=f".{os.path.basename(path)}.",
+        suffix=".tmp",
+        dir=cache_dir,
+        text=True,
+    )
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f)
+        os.replace(tmp_path, path)
+    except Exception:
+        with suppress(OSError):
+            os.unlink(tmp_path)
+        raise
+
+
+def _quarantine_corrupt_cache(path, exc):
+    backup = f"{path}.corrupt-{int(time.time())}"
+    n = 1
+    while os.path.exists(backup):
+        n += 1
+        backup = f"{path}.corrupt-{int(time.time())}-{n}"
+    try:
+        os.replace(path, backup)
+    except OSError:
+        log.warning(
+            "Pipeline cache at %s is invalid JSON and could not be moved aside: %s",
+            path,
+            exc,
+        )
+        return None
+    log.warning(
+        "Pipeline cache at %s is invalid JSON; moved corrupt file to %s: %s",
+        path,
+        backup,
+        exc,
+    )
+    return backup
+
+
+def _load_results_json(path):
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except json.JSONDecodeError as exc:
+        _quarantine_corrupt_cache(path, exc)
+        return None
 
 # Columns needed from photos table for pipeline stages 2-6
 _PIPELINE_PHOTO_COLS = """
@@ -828,7 +890,7 @@ def save_results(results, cache_dir, workspace_id):
         path to the saved JSON file
     """
     serialized = serialize_results(results)
-    path = os.path.join(cache_dir, f"pipeline_results_ws{workspace_id}.json")
+    path = _results_cache_path(cache_dir, workspace_id)
     # Preserve miss_computed_at across reflow/regroup-live saves: it's
     # written by pipeline_job's miss_stage and gates the review UI's
     # "Review misses" shortcut on whether misses were recomputed in
@@ -836,15 +898,10 @@ def save_results(results, cache_dir, workspace_id):
     # so overwriting this marker with a fresh save would make the
     # shortcut hide itself after every threshold tweak.
     if "miss_computed_at" not in serialized and os.path.exists(path):
-        try:
-            with open(path) as f:
-                existing = json.load(f)
-            if existing.get("miss_computed_at"):
-                serialized["miss_computed_at"] = existing["miss_computed_at"]
-        except (OSError, json.JSONDecodeError):
-            pass
-    with open(path, "w") as f:
-        json.dump(serialized, f)
+        existing = _load_results_json(path)
+        if existing and existing.get("miss_computed_at"):
+            serialized["miss_computed_at"] = existing["miss_computed_at"]
+    _atomic_json_dump(serialized, path)
     log.info("Pipeline results saved to %s", path)
     return path
 
@@ -859,11 +916,10 @@ def load_results(cache_dir, workspace_id):
     Returns:
         dict or None if no cache exists
     """
-    path = os.path.join(cache_dir, f"pipeline_results_ws{workspace_id}.json")
-    if not os.path.exists(path):
+    path = _results_cache_path(cache_dir, workspace_id)
+    data = _load_results_json(path)
+    if data is None:
         return None
-    with open(path) as f:
-        data = json.load(f)
     refresh_serialized_summary(data)
     return data
 
@@ -894,11 +950,10 @@ def prune_missing_photos(cache_dir, workspace_id, db):
 
     Returns True if the cache was rewritten, False otherwise.
     """
-    path = os.path.join(cache_dir, f"pipeline_results_ws{workspace_id}.json")
-    if not os.path.exists(path):
+    path = _results_cache_path(cache_dir, workspace_id)
+    data = _load_results_json(path)
+    if data is None:
         return False
-    with open(path) as f:
-        data = json.load(f)
     cached_ids = [p.get("id") for p in data.get("photos", []) if p.get("id") is not None]
     if not cached_ids:
         return False
@@ -938,11 +993,10 @@ def prune_results(cache_dir, workspace_id, deleted_ids):
     """
     if not deleted_ids:
         return False
-    path = os.path.join(cache_dir, f"pipeline_results_ws{workspace_id}.json")
-    if not os.path.exists(path):
+    path = _results_cache_path(cache_dir, workspace_id)
+    data = _load_results_json(path)
+    if data is None:
         return False
-    with open(path) as f:
-        data = json.load(f)
 
     deleted = set(deleted_ids)
     cached_ids = {p.get("id") for p in data.get("photos", [])}
@@ -983,8 +1037,7 @@ def prune_results(cache_dir, workspace_id, deleted_ids):
 
     refresh_serialized_summary(data)
 
-    with open(path, "w") as f:
-        json.dump(data, f)
+    _atomic_json_dump(data, path)
     log.info(
         "Pipeline cache pruned at %s: removed %d photo(s)",
         path,
@@ -999,11 +1052,8 @@ def load_results_raw(cache_dir, workspace_id):
     Unlike load_results, this returns the dict exactly as stored on disk,
     for in-place mutation by structural edits (detach, species confirm).
     """
-    path = os.path.join(cache_dir, f"pipeline_results_ws{workspace_id}.json")
-    if not os.path.exists(path):
-        return None
-    with open(path) as f:
-        return json.load(f)
+    path = _results_cache_path(cache_dir, workspace_id)
+    return _load_results_json(path)
 
 
 def _count_stage_targets(db):
@@ -1282,9 +1332,8 @@ def rebuild_species_predictions(results, photo_ids):
 def save_results_raw(results, cache_dir, workspace_id):
     """Save an already-serialized results dict back to the JSON cache."""
     refresh_serialized_summary(results)
-    path = os.path.join(cache_dir, f"pipeline_results_ws{workspace_id}.json")
-    with open(path, "w") as f:
-        json.dump(results, f)
+    path = _results_cache_path(cache_dir, workspace_id)
+    _atomic_json_dump(results, path)
     return path
 
 

--- a/vireo/pipeline_plan.py
+++ b/vireo/pipeline_plan.py
@@ -199,6 +199,7 @@ def _classify_plan(db, params, photo_ids, new_count=0):
             )
     # Reclassify is a user override, not a settings-change signal.
     fingerprint_outdated = stale_total > 0 and not params.reclassify
+    fingerprint_reason = "label_set_changed" if fingerprint_outdated else None
 
     if total_dets == 0:
         if new_count > 0:
@@ -223,6 +224,7 @@ def _classify_plan(db, params, photo_ids, new_count=0):
                 "new_photos": new_count,
                 "stale": stale_total,
                 "fingerprint_outdated": fingerprint_outdated,
+                "fingerprint_reason": fingerprint_reason,
             },
         }
 
@@ -265,6 +267,7 @@ def _classify_plan(db, params, photo_ids, new_count=0):
                 "eligible": 0,
                 "stale": stale_total,
                 "fingerprint_outdated": fingerprint_outdated,
+                "fingerprint_reason": fingerprint_reason,
             },
         }
 
@@ -290,6 +293,7 @@ def _classify_plan(db, params, photo_ids, new_count=0):
                     "new_photos": new_count,
                     "stale": stale_total,
                     "fingerprint_outdated": fingerprint_outdated,
+                    "fingerprint_reason": fingerprint_reason,
                 },
             }
         return {
@@ -307,6 +311,7 @@ def _classify_plan(db, params, photo_ids, new_count=0):
                 "eligible": eligible,
                 "stale": stale_total,
                 "fingerprint_outdated": fingerprint_outdated,
+                "fingerprint_reason": fingerprint_reason,
             },
         }
 
@@ -321,10 +326,17 @@ def _classify_plan(db, params, photo_ids, new_count=0):
         breakdown = ", ".join(
             f"{n} for {name}" for name, n in pending_per_model.items()
         )
-        summary = (
-            f"Will classify {pending_total} new "
-            f"pair{_plural(pending_total)} ({breakdown})"
-        )
+        if fingerprint_outdated:
+            summary = (
+                f"Current label set differs from cached classifications — "
+                f"will classify {pending_total} "
+                f"pair{_plural(pending_total)} ({breakdown})"
+            )
+        else:
+            summary = (
+                f"Will classify {pending_total} new "
+                f"pair{_plural(pending_total)} ({breakdown})"
+            )
     if new_count > 0:
         # Mixed scope: some existing detections still to classify *and*
         # N new photos coming in (each will get its own detections + class).
@@ -341,6 +353,7 @@ def _classify_plan(db, params, photo_ids, new_count=0):
         "eligible": eligible + new_count,
         "stale": stale_total,
         "fingerprint_outdated": fingerprint_outdated,
+        "fingerprint_reason": fingerprint_reason,
     }
     if new_count > 0:
         detail["new_photos"] = new_count

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -3887,10 +3887,9 @@ var _PILL_LABELS = {
 // staleness signal. Returns the literal string to display.
 //
 // The plan endpoint emits `state: 'will-run'` for both fresh and
-// outdated cases; the distinction lives in `detail.fingerprint_outdated`
-// / `detail.fingerprint_invalidated`. We surface that here as a distinct
-// "Outdated" label so users see settings-changed staleness directly,
-// not buried in the summary text.
+// settings-changed cases; the distinction lives in
+// `detail.fingerprint_outdated` / `detail.fingerprint_invalidated`.
+// Classify gets a more specific label when only the BioCLIP label set changed.
 function _formatPillLabel(stage, planEntry, state) {
   // Special-cased states (running/done/failed/will-skip) have static
   // labels — counts during a run come from a separate channel.
@@ -3908,11 +3907,16 @@ function _formatPillLabel(stage, planEntry, state) {
   var pending  = (typeof detail.pending  === 'number') ? detail.pending  : null;
   var eligible = (typeof detail.eligible === 'number') ? detail.eligible : null;
   var outdated = !!(detail.fingerprint_outdated || detail.fingerprint_invalidated);
+  var labelSetChanged = outdated
+    && stage
+    && stage.suffix === 'Classify'
+    && detail.fingerprint_reason === 'label_set_changed';
 
   // No quantifiable work — fall back to the state-only label, but still
   // surface the outdated flag for stages that don't have a per-photo
   // unit (e.g., Group emits fingerprint_outdated with no eligible count).
   if (eligible === null || eligible === 0) {
+    if (state === 'will-run' && labelSetChanged) return 'Different label set';
     if (state === 'will-run' && outdated) return 'Outdated';
     return state === 'done-prior' ? 'Already done' : 'Will run';
   }
@@ -3922,6 +3926,7 @@ function _formatPillLabel(stage, planEntry, state) {
   }
 
   // state === 'will-run' from here on.
+  if (labelSetChanged)           return 'Different label set (' + (pending || eligible) + ' to classify)';
   if (outdated)                  return 'Outdated (' + (pending || eligible) + ' to redo)';
   if (pending !== null && pending > 0 && pending < eligible) {
     return 'Resume (' + pending + ' left)';

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -591,6 +591,31 @@ def test_encounter_species_confirm(app_and_db):
     assert len(kw_adds) == len(photo_ids)
 
 
+def test_encounter_species_confirm_ignores_corrupt_pipeline_cache(app_and_db):
+    """A bad pipeline cache must not turn species confirmation into a 500."""
+    app, db = app_and_db
+    client = app.test_client()
+
+    photo_id = db.conn.execute("SELECT id FROM photos ORDER BY id LIMIT 1").fetchone()["id"]
+    cache_dir = os.path.dirname(db._db_path)
+    cache_path = os.path.join(cache_dir, f"pipeline_results_ws{db._active_workspace_id}.json")
+    with open(cache_path, "w") as f:
+        f.write('{"photos": [], "encounters": [{"photo_ids"')
+
+    resp = client.post(
+        "/api/encounters/species",
+        json={"species": "Blue Jay", "photo_ids": [photo_id]},
+    )
+
+    assert resp.status_code == 200
+    assert any(t["name"] == "Blue Jay" for t in db.get_photo_keywords(photo_id))
+    assert not os.path.exists(cache_path)
+    assert len([
+        name for name in os.listdir(cache_dir)
+        if name.startswith(f"pipeline_results_ws{db._active_workspace_id}.json.corrupt-")
+    ]) == 1
+
+
 def test_encounter_species_validation(app_and_db):
     """POST /api/encounters/species validates required fields."""
     app, _ = app_and_db

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -472,6 +472,43 @@ def test_load_results_missing(tmp_path):
     assert load_results(str(tmp_path), workspace_id=999) is None
 
 
+def test_load_results_quarantines_corrupt_cache(tmp_path):
+    """A malformed cache should not crash request handlers that read it."""
+    from pipeline import load_results, load_results_raw
+
+    path = tmp_path / "pipeline_results_ws1.json"
+    path.write_text('{"photos": [], "encounters": [{"photo_ids"')
+
+    assert load_results(str(tmp_path), workspace_id=1) is None
+    assert not path.exists()
+    backups = list(tmp_path.glob("pipeline_results_ws1.json.corrupt-*"))
+    assert len(backups) == 1
+    assert backups[0].read_text().startswith('{"photos"')
+
+    # Subsequent raw reads see a missing cache, not the original JSON error.
+    assert load_results_raw(str(tmp_path), workspace_id=1) is None
+
+
+def test_save_results_raw_replaces_corrupt_cache_atomically(tmp_path):
+    """Saving raw results should replace an unusable cache with valid JSON."""
+    from pipeline import load_results_raw, save_results_raw
+
+    path = tmp_path / "pipeline_results_ws1.json"
+    path.write_text('{"photos": [')
+
+    saved = save_results_raw({"photos": [], "encounters": []}, str(tmp_path), 1)
+
+    assert saved == str(path)
+    loaded = load_results_raw(str(tmp_path), workspace_id=1)
+    assert loaded["photos"] == []
+    assert loaded["encounters"] == []
+    assert loaded["summary"]["total_photos"] == 0
+    assert loaded["summary"]["encounter_count"] == 0
+    assert loaded["summary"]["confirmed_count"] == 0
+    assert loaded["summary"]["unconfirmed_count"] == 0
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
 # -- prune_results --
 
 

--- a/vireo/tests/test_pipeline_plan.py
+++ b/vireo/tests/test_pipeline_plan.py
@@ -1056,7 +1056,10 @@ def test_classify_plan_exposes_pending_and_eligible_mixed_blocked_and_done(
 def test_classify_plan_emits_fingerprint_outdated_when_stale(
     tmp_path, monkeypatch,
 ):
-    """A detection classified under fp_old + no current-fp row → outdated."""
+    """A detection classified under fp_old + no current-fp row needs the
+    current label set, and the plan should explain that without implying
+    the old classifications or user's keywords are bad.
+    """
     from pipeline_plan import compute_plan
     db, folder_id = _make_db(tmp_path)
     _, did = _add_photo_with_detection(db, folder_id, "a.jpg")
@@ -1074,8 +1077,10 @@ def test_classify_plan_emits_fingerprint_outdated_when_stale(
 
     plan = compute_plan(db, _params(model_ids=["m1"]), str(tmp_path / "test.db"))
     detail = plan["stages"]["Classify"]["detail"]
+    assert "Current label set differs" in plan["stages"]["Classify"]["summary"]
     assert detail["stale"] == 1
     assert detail["fingerprint_outdated"] is True
+    assert detail["fingerprint_reason"] == "label_set_changed"
 
 
 def test_classify_plan_no_outdated_flag_when_current(


### PR DESCRIPTION
Pipeline result cache reads now quarantine malformed JSON instead of raising 500s, and cache writes use an atomic temp-file replace to avoid leaving partial JSON behind. The classify plan now explains BioCLIP label-set fingerprint mismatches as a different label set rather than generic outdated work, while preserving existing outdated behavior for other stages. Added regression coverage for corrupt cache handling, species confirmation with a bad cache, and the classify planner wording. Validated with pytest for pipeline, pipeline-plan, and encounter-species tests plus ruff on touched files.