### PR TITLE
Serialize XMP sync jobs

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -11987,7 +11987,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         "phase": "Waiting for current XMP sync",
                     },
                 )
-                app._sync_job_lock.acquire()
+                while not lock_acquired:
+                    if runner.is_cancelled(job["id"]):
+                        return {"synced": 0, "failed": 0, "failures": []}
+                    lock_acquired = app._sync_job_lock.acquire(timeout=0.1)
 
             try:
                 if runner.is_cancelled(job["id"]):

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1750,6 +1750,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     threading.Thread(target=_folder_health_loop, daemon=True).start()
 
     app._job_runner = JobRunner(db=init_db)
+    # XMP sidecars are read-modify-written files; serialize sync jobs so
+    # repeated clicks cannot race while touching the same sidecar.
+    app._sync_job_lock = threading.Lock()
     app._log_broadcaster = LogBroadcaster(buffer_size=500)
     app._log_broadcaster.install()
 
@@ -11970,7 +11973,32 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     },
                 )
 
-            return sync_to_xmp(thread_db, progress_callback=progress_cb, change_ids=change_ids)
+            runner.push_event(
+                job["id"],
+                "progress",
+                {
+                    "current": 0,
+                    "total": 0,
+                    "current_file": "Waiting for current XMP sync...",
+                    "phase": "Waiting for current XMP sync",
+                },
+            )
+            with app._sync_job_lock:
+                runner.push_event(
+                    job["id"],
+                    "progress",
+                    {
+                        "current": 0,
+                        "total": 0,
+                        "current_file": "Preparing XMP sync...",
+                        "phase": "Writing XMP metadata",
+                    },
+                )
+                return sync_to_xmp(
+                    thread_db,
+                    progress_callback=progress_cb,
+                    change_ids=change_ids,
+                )
 
         config = {"change_ids": change_ids} if change_ids is not None else {}
         job_id = runner.start("sync", work, config=config, workspace_id=active_ws)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -11984,6 +11984,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 },
             )
             with app._sync_job_lock:
+                if runner.is_cancelled(job["id"]):
+                    return {"synced": 0, "failed": 0, "failures": []}
                 runner.push_event(
                     job["id"],
                     "progress",

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -11970,20 +11970,26 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     {
                         "current": current,
                         "total": total,
+                        "current_file": "Writing XMP metadata...",
+                        "phase": "Writing XMP metadata",
                     },
                 )
 
-            runner.push_event(
-                job["id"],
-                "progress",
-                {
-                    "current": 0,
-                    "total": 0,
-                    "current_file": "Waiting for current XMP sync...",
-                    "phase": "Waiting for current XMP sync",
-                },
-            )
-            with app._sync_job_lock:
+            lock_acquired = app._sync_job_lock.acquire(blocking=False)
+            if not lock_acquired:
+                runner.push_event(
+                    job["id"],
+                    "progress",
+                    {
+                        "current": 0,
+                        "total": 0,
+                        "current_file": "Waiting for current XMP sync...",
+                        "phase": "Waiting for current XMP sync",
+                    },
+                )
+                app._sync_job_lock.acquire()
+
+            try:
                 if runner.is_cancelled(job["id"]):
                     return {"synced": 0, "failed": 0, "failures": []}
                 runner.push_event(
@@ -11993,7 +11999,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         "current": 0,
                         "total": 0,
                         "current_file": "Preparing XMP sync...",
-                        "phase": "Writing XMP metadata",
+                        "phase": "Preparing XMP sync",
                     },
                 )
                 return sync_to_xmp(
@@ -12001,6 +12007,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     progress_callback=progress_cb,
                     change_ids=change_ids,
                 )
+            finally:
+                app._sync_job_lock.release()
 
         config = {"change_ids": change_ids} if change_ids is not None else {}
         job_id = runner.start("sync", work, config=config, workspace_id=active_ws)

--- a/vireo/templates/_sync_panel.html
+++ b/vireo/templates/_sync_panel.html
@@ -54,6 +54,7 @@ async function checkPendingSync() {
 async function runSync(changeIds) {
   var status = document.getElementById('syncStatus');
   status.textContent = 'Syncing...';
+  status.style.color = 'var(--text-dim)';
   try {
     var requestOptions = {method: 'POST'};
     if (Array.isArray(changeIds)) {
@@ -71,6 +72,8 @@ async function runSync(changeIds) {
       onProgress: function(p) {
         if (p.total > 0) {
           status.textContent = 'Writing XMP: ' + p.current + '/' + p.total;
+        } else if (p.current_file || p.phase) {
+          status.textContent = p.current_file || p.phase;
         }
       },
       onComplete: function(result) {

--- a/vireo/tests/test_job_submission_api.py
+++ b/vireo/tests/test_job_submission_api.py
@@ -475,9 +475,10 @@ def test_cancelled_waiting_sync_does_not_write_xmp(app_and_db, monkeypatch):
     assert cancel.status_code == 200
     assert cancel.get_json()["cancelled"] is True
 
-    release_first.set()
-    wait_for_job_via_runner(app._job_runner, first)
     second_job = wait_for_job_via_runner(app._job_runner, second)
 
     assert second_job["status"] == "cancelled"
     assert len(calls) == 1
+
+    release_first.set()
+    wait_for_job_via_runner(app._job_runner, first)

--- a/vireo/tests/test_job_submission_api.py
+++ b/vireo/tests/test_job_submission_api.py
@@ -428,3 +428,56 @@ def test_job_sync_requests_serialize_xmp_work(app_and_db, monkeypatch):
     assert second_entered.is_set()
     assert len(calls) == 2
     assert max_active == 1
+
+
+def test_cancelled_waiting_sync_does_not_write_xmp(app_and_db, monkeypatch):
+    """A sync cancelled while waiting for the lock must not run sync_to_xmp."""
+    app, _ = app_and_db
+    client = app.test_client()
+
+    import sync as sync_module
+
+    first_entered = threading.Event()
+    release_first = threading.Event()
+    state_lock = threading.Lock()
+    calls = []
+
+    def fake_sync_to_xmp(db, progress_callback=None, change_ids=None):
+        with state_lock:
+            calls.append(change_ids)
+            call_number = len(calls)
+
+        if call_number == 1:
+            first_entered.set()
+            assert release_first.wait(timeout=2), "first sync was not released"
+
+        if progress_callback:
+            progress_callback(1, 1)
+
+        return {"synced": 0, "failed": 0, "failures": []}
+
+    monkeypatch.setattr(sync_module, "sync_to_xmp", fake_sync_to_xmp)
+
+    first = client.post("/api/jobs/sync").get_json()["job_id"]
+    assert first_entered.wait(timeout=2), "first sync did not start"
+
+    second = client.post("/api/jobs/sync").get_json()["job_id"]
+    deadline = time.time() + 2
+    while time.time() < deadline:
+        job = app._job_runner.get(second)
+        if job and job["progress"].get("phase") == "Waiting for current XMP sync":
+            break
+        time.sleep(0.01)
+    else:
+        raise AssertionError("second sync did not reach the serialized wait point")
+
+    cancel = client.post(f"/api/jobs/{second}/cancel")
+    assert cancel.status_code == 200
+    assert cancel.get_json()["cancelled"] is True
+
+    release_first.set()
+    wait_for_job_via_runner(app._job_runner, first)
+    second_job = wait_for_job_via_runner(app._job_runner, second)
+
+    assert second_job["status"] == "cancelled"
+    assert len(calls) == 1

--- a/vireo/tests/test_job_submission_api.py
+++ b/vireo/tests/test_job_submission_api.py
@@ -3,11 +3,12 @@
 import json
 import os
 import sys
+import threading
 import time
 from types import SimpleNamespace
 
 from PIL import Image
-from wait import wait_for_job_via_client
+from wait import wait_for_job_via_client, wait_for_job_via_runner
 
 
 def _stub_classify_job(monkeypatch, sleep=0.2):
@@ -360,3 +361,70 @@ def test_job_sync_rejects_empty_selected_change_ids(app_and_db):
 
     assert resp.status_code == 400
     assert "change_ids" in resp.get_json()["error"]
+
+
+def test_job_sync_requests_serialize_xmp_work(app_and_db, monkeypatch):
+    """Repeated sync submissions must not enter sync_to_xmp concurrently."""
+    app, _ = app_and_db
+    client = app.test_client()
+
+    import sync as sync_module
+
+    first_entered = threading.Event()
+    second_entered = threading.Event()
+    release_first = threading.Event()
+    state_lock = threading.Lock()
+    calls = []
+    active = 0
+    max_active = 0
+
+    def fake_sync_to_xmp(db, progress_callback=None, change_ids=None):
+        nonlocal active, max_active
+        with state_lock:
+            calls.append(change_ids)
+            active += 1
+            max_active = max(max_active, active)
+            call_number = len(calls)
+
+        try:
+            if call_number == 1:
+                first_entered.set()
+                assert release_first.wait(timeout=2), "first sync was not released"
+            else:
+                second_entered.set()
+
+            if progress_callback:
+                progress_callback(1, 1)
+
+            return {"synced": 0, "failed": 0, "failures": []}
+        finally:
+            with state_lock:
+                active -= 1
+
+    monkeypatch.setattr(sync_module, "sync_to_xmp", fake_sync_to_xmp)
+
+    first = client.post("/api/jobs/sync").get_json()["job_id"]
+    assert first_entered.wait(timeout=2), "first sync did not start"
+
+    second = client.post("/api/jobs/sync").get_json()["job_id"]
+
+    deadline = time.time() + 2
+    while time.time() < deadline:
+        job = app._job_runner.get(second)
+        if job and job["progress"].get("phase") == "Waiting for current XMP sync":
+            break
+        time.sleep(0.01)
+    else:
+        raise AssertionError("second sync did not reach the serialized wait point")
+
+    assert not second_entered.is_set(), (
+        "second sync entered sync_to_xmp while the first sync was still running"
+    )
+
+    release_first.set()
+    wait_for_job_via_runner(app._job_runner, first)
+    wait_for_job_via_runner(app._job_runner, second)
+
+    assert second_entered.is_set()
+    assert len(calls) == 2
+    assert max_active == 1


### PR DESCRIPTION
## Summary
Serialize XMP sync jobs with an app-level lock so repeated Sync to XMP clicks cannot race while read-modify-writing the same sidecar.
Expose waiting/preparing sync status in the banner so queued sync jobs do not appear stuck.
Add regression coverage proving repeated sync submissions do not enter the XMP write path concurrently.

## Validation
pytest vireo/tests/test_job_submission_api.py::test_job_sync_requests_serialize_xmp_work vireo/tests/test_job_submission_api.py::test_job_sync_returns_job_id vireo/tests/test_sync.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * XMP sync operations now execute sequentially to prevent conflicts from concurrent requests, ensuring data integrity during metadata synchronization.
  * Enhanced sync status display with more detailed progress messages during metadata synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->