### PR TITLE
Add Life List page: every confirmed species with its best photo

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5615,6 +5615,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "scientific_name": None,
                 "common_name": None,
                 "photos": [],
+                "seen_ids": set(),
             })
             # Two keyword rows can share a name (different parents); take
             # the first linked taxon's names for the species entry.
@@ -5622,6 +5623,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 entry["scientific_name"] = r.get("scientific_name")
             if entry["common_name"] is None:
                 entry["common_name"] = r.get("common_name")
+            # A photo tagged with two same-name species keywords would
+            # otherwise be appended once per row, inflating photo_count
+            # and duplicating cards in the lightbox.
+            if r["id"] in entry["seen_ids"]:
+                continue
+            entry["seen_ids"].add(r["id"])
             entry["photos"].append({
                 "id": r["id"],
                 "filename": r["filename"],

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -59,6 +59,7 @@ ALL_PAGES = [
     {"id": "cull",            "label": "Cull",            "href": "/cull"},
     {"id": "misses",          "label": "Misses",          "href": "/misses"},
     {"id": "highlights",      "label": "Highlights",      "href": "/highlights"},
+    {"id": "life_list",       "label": "Life List",       "href": "/life-list"},
     {"id": "browse",          "label": "Browse",          "href": "/browse"},
     {"id": "map",             "label": "Map",             "href": "/map"},
     {"id": "variants",        "label": "Variants",        "href": "/variants"},
@@ -2061,6 +2062,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     @app.route("/highlights")
     def highlights_page():
         return render_template("highlights.html")
+
+    @app.route("/life-list")
+    def life_list_page():
+        return render_template("life_list.html")
 
     @app.route("/misses")
     def misses_page():
@@ -5592,6 +5597,100 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "limit_per_bucket": limit_per_bucket,
             },
             "scope": "workspace" if folder_id is None else "folder",
+        })
+
+    @app.route("/api/life-list")
+    def api_life_list():
+        db = _get_db()
+        rows = db.get_life_list_candidates()
+        locations_by_species = db.get_life_list_locations()
+        photos_per_species = max(
+            1, min(request.args.get("photos_per_species", 12, type=int), 100)
+        )
+
+        buckets = {}
+        for row in rows:
+            r = dict(row)
+            entry = buckets.setdefault(r["species"], {
+                "scientific_name": None,
+                "common_name": None,
+                "photos": [],
+            })
+            # Two keyword rows can share a name (different parents); take
+            # the first linked taxon's names for the species entry.
+            if entry["scientific_name"] is None:
+                entry["scientific_name"] = r.get("scientific_name")
+            if entry["common_name"] is None:
+                entry["common_name"] = r.get("common_name")
+            entry["photos"].append({
+                "id": r["id"],
+                "filename": r["filename"],
+                "timestamp": r.get("timestamp"),
+                "rating": r.get("rating") or 0,
+                "flag": r.get("flag") or "none",
+                "quality_score": r.get("quality_score"),
+                "subject_sharpness": r.get("subject_sharpness"),
+                "subject_size": r.get("subject_size"),
+                "sharpness": r.get("sharpness"),
+                "subject_tenengrad": r.get("subject_tenengrad"),
+                "bg_tenengrad": r.get("bg_tenengrad"),
+                "crop_complete": r.get("crop_complete"),
+                "bg_separation": r.get("bg_separation"),
+                "subject_clip_high": r.get("subject_clip_high"),
+                "subject_clip_low": r.get("subject_clip_low"),
+                "subject_y_median": r.get("subject_y_median"),
+                "noise_estimate": r.get("noise_estimate"),
+                "eye_tenengrad": r.get("eye_tenengrad"),
+            })
+
+        def compact(photo):
+            return {
+                "id": photo["id"],
+                "filename": photo["filename"],
+                "timestamp": photo.get("timestamp"),
+                "quality_score": photo.get("quality_score"),
+                "highlight_score": photo.get("highlight_score"),
+                "reasons": photo.get("reasons") or [],
+            }
+
+        species_entries = []
+        distinct_photo_ids = set()
+        for species, entry in buckets.items():
+            photos = entry["photos"]
+            distinct_photo_ids.update(p["id"] for p in photos)
+            timestamps = [p["timestamp"] for p in photos if p.get("timestamp")]
+            _highlight_score_bucket(photos)
+            top = photos[:photos_per_species]
+            species_entries.append({
+                "species": species,
+                "scientific_name": entry["scientific_name"],
+                "common_name": entry["common_name"],
+                "photo_count": len(photos),
+                "first_seen": min(timestamps) if timestamps else None,
+                "last_seen": max(timestamps) if timestamps else None,
+                "locations": locations_by_species.get(species, []),
+                "best": compact(top[0]) if top else None,
+                "photos": [compact(p) for p in top],
+            })
+
+        # Life-list numbering: chronological by first photographed date,
+        # the way birders count lifers. Species with no capture time go
+        # last, alphabetically, so they still get a stable number.
+        species_entries.sort(key=lambda e: (
+            e["first_seen"] is None,
+            e["first_seen"] or "",
+            e["species"].lower(),
+        ))
+        for i, e in enumerate(species_entries, start=1):
+            e["number"] = i
+
+        return jsonify({
+            "species": species_entries,
+            "meta": {
+                "species_count": len(species_entries),
+                "photo_count": len(distinct_photo_ids),
+                "photos_per_species": photos_per_species,
+            },
         })
 
     @app.route("/api/highlights/confirm", methods=["POST"])

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -98,7 +98,7 @@ NO_LOCATION_INFORMATION_RULES = {
 
 ALL_NAV_IDS = frozenset({
     "pipeline", "jobs", "pipeline_review", "pipeline_rapid_review", "review", "cull",
-    "misses", "highlights", "browse", "map", "variants",
+    "misses", "highlights", "life_list", "browse", "map", "variants",
     "dashboard", "audit", "compare",
     "zoom_test", "settings", "workspace", "lightroom", "shortcuts",
     "keywords", "duplicates", "logs",
@@ -7201,6 +7201,77 @@ class Database:
             (ws, ws, *folder_params, min_quality),
         ).fetchall()
         return rows
+
+    def get_life_list_candidates(self):
+        """Return (photo x accepted-species-keyword) rows for the life list.
+
+        Every non-rejected photo in a workspace-visible folder carrying an
+        accepted species keyword (``is_species = 1`` or ``type = 'taxonomy'``)
+        produces one row per species keyword. Taxonomy names ride along from
+        ``taxa`` when the keyword is linked.
+
+        Unlike :meth:`get_highlights_candidates`, photos without a
+        ``quality_score`` are included — a species the user confirmed but
+        never ran through the pipeline still belongs on the life list. The
+        API layer ranks each species' photos with the highlights scorer,
+        which falls back gracefully when metric columns are NULL.
+        """
+        ws = self._ws_id()
+        return self.conn.execute(
+            """SELECT p.id, p.folder_id, p.filename, p.timestamp,
+                      p.rating, p.flag, p.quality_score,
+                      p.subject_sharpness, p.subject_size, p.sharpness,
+                      p.mask_path, p.subject_tenengrad, p.bg_tenengrad,
+                      p.crop_complete, p.bg_separation,
+                      p.subject_clip_high, p.subject_clip_low,
+                      p.subject_y_median, p.noise_estimate,
+                      p.eye_tenengrad,
+                      k.name AS species,
+                      t.name AS scientific_name,
+                      t.common_name
+               FROM photo_keywords pk
+               JOIN keywords k ON k.id = pk.keyword_id
+                AND (k.is_species = 1 OR k.type = 'taxonomy')
+               JOIN photos p ON p.id = pk.photo_id
+               JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+                AND wf.workspace_id = ?
+               JOIN folders f ON f.id = p.folder_id
+                AND f.status IN ('ok', 'partial')
+               LEFT JOIN taxa t ON t.id = k.taxon_id
+               WHERE p.flag != 'rejected'
+               ORDER BY k.name, p.timestamp""",
+            (ws,),
+        ).fetchall()
+
+    def get_life_list_locations(self):
+        """Return {species name: [location keyword names]} for the life list.
+
+        A location is attributed to a species when at least one
+        workspace-visible, non-rejected photo carries both the species
+        keyword and a ``type = 'location'`` keyword.
+        """
+        ws = self._ws_id()
+        rows = self.conn.execute(
+            """SELECT DISTINCT k.name AS species, lk.name AS location
+               FROM photo_keywords pk
+               JOIN keywords k ON k.id = pk.keyword_id
+                AND (k.is_species = 1 OR k.type = 'taxonomy')
+               JOIN photos p ON p.id = pk.photo_id
+                AND p.flag != 'rejected'
+               JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+                AND wf.workspace_id = ?
+               JOIN folders f ON f.id = p.folder_id
+                AND f.status IN ('ok', 'partial')
+               JOIN photo_keywords plk ON plk.photo_id = p.id
+               JOIN keywords lk ON lk.id = plk.keyword_id
+                AND lk.type = 'location'
+               ORDER BY k.name, lk.name""",
+            (ws,),
+        ).fetchall()
+        result = {}
+        for r in rows:
+            result.setdefault(r["species"], []).append(r["location"])
+        return result
 
     def get_folders_with_quality_data(self):
         """Return folders with at least one scored photo in their subtree.

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -7238,7 +7238,7 @@ class Database:
                JOIN folders f ON f.id = p.folder_id
                 AND f.status IN ('ok', 'partial')
                LEFT JOIN taxa t ON t.id = k.taxon_id
-               WHERE p.flag != 'rejected'
+               WHERE COALESCE(p.flag, 'none') != 'rejected'
                ORDER BY k.name, p.timestamp""",
             (ws,),
         ).fetchall()
@@ -7257,7 +7257,7 @@ class Database:
                JOIN keywords k ON k.id = pk.keyword_id
                 AND (k.is_species = 1 OR k.type = 'taxonomy')
                JOIN photos p ON p.id = pk.photo_id
-                AND p.flag != 'rejected'
+                AND COALESCE(p.flag, 'none') != 'rejected'
                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
                 AND wf.workspace_id = ?
                JOIN folders f ON f.id = p.folder_id

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1864,6 +1864,7 @@ window.NAV_ALL_PAGES = [
   {id: 'cull',            label: 'Cull',            href: '/cull'},
   {id: 'misses',          label: 'Misses',          href: '/misses'},
   {id: 'highlights',      label: 'Highlights',      href: '/highlights'},
+  {id: 'life_list',       label: 'Life List',       href: '/life-list'},
   {id: 'browse',          label: 'Browse',          href: '/browse'},
   {id: 'map',             label: 'Map',             href: '/map'},
   {id: 'variants',        label: 'Variants',        href: '/variants'},

--- a/vireo/templates/life_list.html
+++ b/vireo/templates/life_list.html
@@ -81,7 +81,14 @@ function formatDate(iso) {
 }
 
 async function loadLifeList() {
-  currentData = await safeFetch('/api/life-list');
+  var meta = document.getElementById('meta');
+  meta.textContent = 'Loading life list…';
+  try {
+    currentData = await safeFetch('/api/life-list');
+  } catch (e) {
+    meta.textContent = 'Failed to load life list.';
+    return;
+  }
   render();
 }
 
@@ -116,7 +123,7 @@ function renderCard(entry) {
   return '<div class="species-card" data-species="' + escapeAttr(entry.species) + '" title="'
     + escapeAttr((entry.locations || []).join(', ')) + '">'
     + '<div class="lifer-number">#' + entry.number + '</div>'
-    + (best ? '<img src="' + thumb + '" alt="' + escapeAttr(best.filename) + '" loading="lazy">' : '')
+    + (best ? '<img src="' + escapeAttr(thumb) + '" alt="' + escapeAttr(best.filename) + '" loading="lazy">' : '')
     + '<div class="species-info">'
     + '<div class="species-name">' + escapeAttr(entry.species) + '</div>'
     + sci

--- a/vireo/templates/life_list.html
+++ b/vireo/templates/life_list.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="icon" type="image/png" href="/favicon.ico">
+<link rel="apple-touch-icon" href="/static/apple-touch-icon.png">
+<link rel="stylesheet" href="/static/vireo-base.css">
+<title>Vireo - Life List</title>
+<style>
+  .lifelist-controls { display:flex; align-items:center; gap:20px; padding:12px 24px; background:var(--bg-secondary); border-bottom:1px solid var(--border-primary); flex-wrap:wrap; }
+  .control-group { display:flex; align-items:center; gap:8px; }
+  .control-group label { font-size:13px; color:var(--text-secondary); white-space:nowrap; }
+  .control-group input[type=search], .control-group select { font-size:13px; padding:4px 8px; background:var(--bg-input); color:var(--text-primary); border:1px solid var(--border-secondary); border-radius:4px; }
+  .control-group input[type=search] { width:180px; }
+
+  .lifelist-meta { padding:8px 24px; font-size:12px; color:var(--text-secondary); }
+
+  .lifelist-grid { display:grid; grid-template-columns:repeat(auto-fill, minmax(240px, 1fr)); gap:16px; padding:16px 24px; }
+  .species-card { position:relative; border-radius:8px; overflow:hidden; background:var(--bg-secondary); border:1px solid var(--border-primary); cursor:pointer; }
+  .species-card:hover { border-color:var(--accent); }
+  .species-card img { width:100%; aspect-ratio:3/2; object-fit:cover; display:block; background:var(--bg-tertiary); }
+  .lifer-number { position:absolute; top:8px; left:8px; padding:2px 8px; border-radius:999px; background:rgba(0,0,0,0.65); color:#fff; font-size:11px; font-weight:700; letter-spacing:0.5px; }
+  .species-info { padding:10px 12px 12px; }
+  .species-name { font-size:15px; font-weight:600; color:var(--text-primary); }
+  .species-sci { font-size:12px; font-style:italic; color:var(--text-secondary); margin-top:1px; }
+  .species-meta { font-size:12px; color:var(--text-secondary); margin-top:6px; }
+  .species-locations { display:flex; flex-wrap:wrap; gap:4px; margin-top:6px; }
+  .loc-chip { padding:1px 7px; border-radius:999px; background:var(--bg-tertiary); color:var(--text-secondary); font-size:11px; white-space:nowrap; }
+
+  .lifelist-empty { text-align:center; padding:80px 24px; color:var(--text-secondary); }
+  .lifelist-empty a { color:var(--accent); }
+</style>
+</head>
+<body>
+{% include '_navbar.html' %}
+
+<div class="lifelist-controls" id="controlsBar">
+  <div class="control-group">
+    <label for="speciesSearch">Species</label>
+    <input type="search" id="speciesSearch" placeholder="Cardinal">
+  </div>
+  <div class="control-group">
+    <label for="sortSelect">Sort</label>
+    <select id="sortSelect">
+      <option value="newest">Newest lifer first</option>
+      <option value="life-order">Life order (oldest first)</option>
+      <option value="alpha">A&ndash;Z</option>
+      <option value="most-photos">Most photos</option>
+    </select>
+  </div>
+</div>
+
+<div class="lifelist-meta" id="meta"></div>
+
+<div class="lifelist-grid" id="content"></div>
+
+<div id="emptyState" class="lifelist-empty" style="display:none;">
+  <p>No confirmed species yet.</p>
+  <p>Your life list grows as you tag photos with species &mdash; confirm
+     predictions on the <a href="/highlights">Highlights</a> page or tag
+     photos while browsing.</p>
+</div>
+
+<script>
+var currentData = null;
+var debounceTimer = null;
+
+// All dynamic values rendered into card HTML pass through escapeAttr —
+// same escaping convention as highlights.html.
+function escapeAttr(s) {
+  if (s === null || s === undefined) return '';
+  return String(s).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#39;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function formatDate(iso) {
+  if (!iso) return null;
+  var d = new Date(iso);
+  if (isNaN(d.getTime())) return null;
+  return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+async function loadLifeList() {
+  currentData = await safeFetch('/api/life-list');
+  render();
+}
+
+function sortedSpecies() {
+  var sort = document.getElementById('sortSelect').value;
+  var list = (currentData.species || []).slice();
+  list.sort(function(a, b) {
+    if (sort === 'alpha') return a.species.localeCompare(b.species);
+    if (sort === 'most-photos') return b.photo_count - a.photo_count;
+    if (sort === 'life-order') return a.number - b.number;
+    return b.number - a.number; // 'newest' default
+  });
+  return list;
+}
+
+function renderCard(entry) {
+  var best = entry.best;
+  var thumb = best ? '/thumbnails/' + best.id + '.jpg' : '';
+  var sci = entry.scientific_name && entry.scientific_name !== entry.species
+    ? '<div class="species-sci">' + escapeAttr(entry.scientific_name) + '</div>'
+    : '';
+  var metaParts = [entry.photo_count + ' photo' + (entry.photo_count === 1 ? '' : 's')];
+  var first = formatDate(entry.first_seen);
+  var last = formatDate(entry.last_seen);
+  if (first) metaParts.push('first ' + first);
+  if (last && last !== first) metaParts.push('latest ' + last);
+  var locations = (entry.locations || []).slice(0, 3).map(function(l) {
+    return '<span class="loc-chip">' + escapeAttr(l) + '</span>';
+  }).join('');
+  var extraLocs = (entry.locations || []).length - 3;
+  if (extraLocs > 0) locations += '<span class="loc-chip">+' + extraLocs + ' more</span>';
+  return '<div class="species-card" data-species="' + escapeAttr(entry.species) + '" title="'
+    + escapeAttr((entry.locations || []).join(', ')) + '">'
+    + '<div class="lifer-number">#' + entry.number + '</div>'
+    + (best ? '<img src="' + thumb + '" alt="' + escapeAttr(best.filename) + '" loading="lazy">' : '')
+    + '<div class="species-info">'
+    + '<div class="species-name">' + escapeAttr(entry.species) + '</div>'
+    + sci
+    + '<div class="species-meta">' + metaParts.join(' &middot; ') + '</div>'
+    + (locations ? '<div class="species-locations">' + locations + '</div>' : '')
+    + '</div></div>';
+}
+
+function render() {
+  var content = document.getElementById('content');
+  var empty = document.getElementById('emptyState');
+  var meta = document.getElementById('meta');
+  var controls = document.getElementById('controlsBar');
+
+  if (!currentData || !currentData.species.length) {
+    content.innerHTML = '';
+    meta.textContent = '';
+    controls.style.display = 'none';
+    empty.style.display = 'block';
+    return;
+  }
+  empty.style.display = 'none';
+  controls.style.display = '';
+
+  var search = document.getElementById('speciesSearch').value.trim().toLowerCase();
+  var list = sortedSpecies();
+  if (search) {
+    list = list.filter(function(e) {
+      return e.species.toLowerCase().indexOf(search) >= 0
+        || (e.scientific_name || '').toLowerCase().indexOf(search) >= 0
+        || (e.common_name || '').toLowerCase().indexOf(search) >= 0;
+    });
+  }
+
+  meta.textContent = currentData.meta.species_count + ' species on your life list · '
+    + currentData.meta.photo_count + ' tagged photos'
+    + (search ? ' · ' + list.length + ' matching' : '');
+
+  content.innerHTML = list.map(renderCard).join('')
+    || '<div class="lifelist-empty" style="grid-column:1/-1;"><p>No species match this search.</p></div>';
+
+  content.querySelectorAll('.species-card').forEach(function(card) {
+    card.addEventListener('click', function() {
+      var sp = card.getAttribute('data-species');
+      var entry = (currentData.species || []).find(function(e) { return e.species === sp; });
+      if (entry && entry.best && window.openLightbox) {
+        // The lightbox set is this species' top photos so the user can
+        // flip through their best shots of the lifer.
+        openLightbox(entry.best.id, entry.best.filename, entry.photos || [entry.best]);
+      }
+    });
+  });
+}
+
+function debounceRender() {
+  clearTimeout(debounceTimer);
+  debounceTimer = setTimeout(render, 150);
+}
+
+document.getElementById('speciesSearch').addEventListener('input', debounceRender);
+document.getElementById('sortSelect').addEventListener('change', function() {
+  if (currentData) render();
+});
+
+loadLifeList();
+</script>
+</body>
+</html>

--- a/vireo/templates/life_list.html
+++ b/vireo/templates/life_list.html
@@ -99,7 +99,16 @@ function sortedSpecies() {
     if (sort === 'alpha') return a.species.localeCompare(b.species);
     if (sort === 'most-photos') return b.photo_count - a.photo_count;
     if (sort === 'life-order') return a.number - b.number;
-    return b.number - a.number; // 'newest' default
+    // 'newest' default — by first_seen desc, undated species last so they
+    // don't masquerade as the newest lifers (server gives them the highest
+    // life-list numbers for stable numbering, so reversing number is wrong).
+    var af = a.first_seen, bf = b.first_seen;
+    if (!af && !bf) return a.species.localeCompare(b.species);
+    if (!af) return 1;
+    if (!bf) return -1;
+    if (af < bf) return 1;
+    if (af > bf) return -1;
+    return a.species.localeCompare(b.species);
   });
   return list;
 }

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -11204,7 +11204,7 @@ def test_all_nav_ids_covers_every_page():
     from db import ALL_NAV_IDS
     expected = {
         "pipeline", "jobs", "pipeline_review", "pipeline_rapid_review", "review", "cull",
-        "misses", "highlights", "browse", "map", "variants",
+        "misses", "highlights", "life_list", "browse", "map", "variants",
         "dashboard", "audit", "compare",
         "zoom_test", "settings", "workspace", "lightroom", "shortcuts",
         "keywords", "duplicates", "logs",

--- a/vireo/tests/test_life_list.py
+++ b/vireo/tests/test_life_list.py
@@ -193,3 +193,31 @@ def test_workspace_scoping(life_app):
     data = _get_life_list(app)
     assert data["species"] == []
     assert data["meta"]["species_count"] == 0
+
+
+def test_same_named_species_keywords_dedupe_photos(life_app):
+    """A photo tagged with two species keywords sharing a display name
+    (different parents — allowed by UNIQUE(name, parent_id)) must count
+    once: photo_count and the lightbox set both dedupe by photo id."""
+    app, db, ids = life_app
+    # Two parent rows so the children can share a name.
+    parent_a = db.add_keyword("Cardinalidae", kw_type="taxonomy")
+    parent_b = db.add_keyword("Cardinalis", kw_type="taxonomy")
+    twin_a = db.add_keyword(
+        "Northern Cardinal", parent_id=parent_a, is_species=True)
+    twin_b = db.add_keyword(
+        "Northern Cardinal", parent_id=parent_b, is_species=True)
+    assert twin_a != twin_b
+    db.tag_photo(ids["p2"], twin_a)
+    db.tag_photo(ids["p2"], twin_b)
+    db.conn.commit()
+
+    data = _get_life_list(app)
+    cardinal = _entry(data, "Northern Cardinal")
+    # Still two distinct photos (p1, p2) — not four.
+    assert cardinal["photo_count"] == 2
+    photo_ids = [p["id"] for p in cardinal["photos"]]
+    assert sorted(photo_ids) == sorted([ids["p1"], ids["p2"]])
+    assert len(photo_ids) == len(set(photo_ids))
+    # Workspace-wide distinct-photo count is unaffected.
+    assert data["meta"]["photo_count"] == 3

--- a/vireo/tests/test_life_list.py
+++ b/vireo/tests/test_life_list.py
@@ -166,6 +166,24 @@ def test_unscored_photo_still_listed(life_app):
     assert sparrow["best"]["quality_score"] is None
 
 
+def test_null_flag_photo_included(life_app):
+    """Older or manually edited databases can have NULL flags; those photos
+    are kept (treated like 'none'), not filtered out as rejected."""
+    app, db, ids = life_app
+    db.conn.execute(
+        "UPDATE photos SET flag = NULL WHERE id IN (?, ?)",
+        (ids["p2"], ids["p3"]))
+    db.conn.commit()
+    data = _get_life_list(app)
+    assert data["meta"]["species_count"] == 2
+    assert data["meta"]["photo_count"] == 3
+    cardinal = _entry(data, "Northern Cardinal")
+    assert cardinal["photo_count"] == 2
+    # p2 (now NULL-flagged) carries the location tag — the locations
+    # query must include it too.
+    assert cardinal["locations"] == ["Backyard"]
+
+
 def test_workspace_scoping(life_app):
     app, db, ids = life_app
     # Hide the folder from the active workspace: the life list empties.

--- a/vireo/tests/test_life_list.py
+++ b/vireo/tests/test_life_list.py
@@ -1,0 +1,177 @@
+"""Tests for the Life List page and /api/life-list."""
+import os
+
+import pytest
+from PIL import Image
+
+
+@pytest.fixture
+def life_app(tmp_path, monkeypatch):
+    """App seeded with two confirmed species, a taxon link, a location
+    keyword, a rejected photo, and an untagged photo."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import config as cfg
+    import models
+    from app import create_app
+    from db import Database
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setattr(
+        models, "DEFAULT_MODELS_DIR", str(tmp_path / "vireo-models"),
+    )
+    monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
+
+    db_path = str(tmp_path / "test.db")
+    thumb_dir = str(tmp_path / "thumbs")
+    os.makedirs(thumb_dir)
+
+    db = Database(db_path)
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    fid = db.add_folder("/photos/2024", name="2024")
+
+    # Cardinal: two keepers (p2 outscores p1) plus one rejected photo
+    # that must not count.
+    p1 = db.add_photo(folder_id=fid, filename="card1.jpg", extension=".jpg",
+                      file_size=1000, file_mtime=1.0,
+                      timestamp="2024-01-15T10:00:00")
+    p2 = db.add_photo(folder_id=fid, filename="card2.jpg", extension=".jpg",
+                      file_size=1000, file_mtime=2.0,
+                      timestamp="2024-03-10T09:00:00")
+    p_rej = db.add_photo(folder_id=fid, filename="card3.jpg", extension=".jpg",
+                         file_size=1000, file_mtime=3.0,
+                         timestamp="2024-04-01T08:00:00")
+    db.conn.execute(
+        "UPDATE photos SET quality_score = 0.5 WHERE id = ?", (p1,))
+    db.conn.execute(
+        "UPDATE photos SET quality_score = 0.9 WHERE id = ?", (p2,))
+    db.conn.execute(
+        "UPDATE photos SET flag = 'rejected' WHERE id = ?", (p_rej,))
+
+    # Sparrow: earlier capture, keyword linked to a taxon. No
+    # quality_score — unscored photos must still make the life list.
+    p3 = db.add_photo(folder_id=fid, filename="sparrow1.jpg", extension=".jpg",
+                      file_size=1000, file_mtime=4.0,
+                      timestamp="2023-06-01T07:00:00")
+
+    # Untagged photo: must not appear anywhere.
+    db.add_photo(folder_id=fid, filename="empty.jpg", extension=".jpg",
+                 file_size=1000, file_mtime=5.0,
+                 timestamp="2024-05-01T12:00:00")
+
+    k_card = db.add_keyword("Northern Cardinal", is_species=True)
+    cur = db.conn.execute(
+        "INSERT INTO taxa (name, common_name, rank) VALUES (?, ?, ?)",
+        ("Passer domesticus", "House Sparrow", "species"))
+    taxon_id = cur.lastrowid
+    k_sparrow = db.add_keyword("House Sparrow", kw_type="taxonomy")
+    db.conn.execute(
+        "UPDATE keywords SET taxon_id = ? WHERE id = ?", (taxon_id, k_sparrow))
+    k_loc = db.add_keyword("Backyard", kw_type="location")
+    db.conn.commit()
+
+    db.tag_photo(p1, k_card)
+    db.tag_photo(p2, k_card)
+    db.tag_photo(p_rej, k_card)
+    db.tag_photo(p3, k_sparrow)
+    db.tag_photo(p2, k_loc)
+
+    for pid in (p1, p2, p3):
+        Image.new("RGB", (100, 100)).save(os.path.join(thumb_dir, f"{pid}.jpg"))
+
+    app = create_app(db_path=db_path, thumb_cache_dir=thumb_dir)
+    yield app, db, {"p1": p1, "p2": p2, "p3": p3, "folder": fid}
+    db.close()
+
+
+def _get_life_list(app):
+    client = app.test_client()
+    resp = client.get("/api/life-list")
+    assert resp.status_code == 200
+    return resp.get_json()
+
+
+def _entry(data, species):
+    matches = [e for e in data["species"] if e["species"] == species]
+    assert len(matches) == 1, f"expected one entry for {species}"
+    return matches[0]
+
+
+def test_page_renders(life_app):
+    app, _, _ = life_app
+    resp = app.test_client().get("/life-list")
+    assert resp.status_code == 200
+    assert b"Life List" in resp.data
+
+
+def test_groups_by_species_and_counts(life_app):
+    app, _, _ = life_app
+    data = _get_life_list(app)
+    assert data["meta"]["species_count"] == 2
+    # p1, p2, p3 — the rejected and untagged photos don't count.
+    assert data["meta"]["photo_count"] == 3
+    cardinal = _entry(data, "Northern Cardinal")
+    assert cardinal["photo_count"] == 2
+    sparrow = _entry(data, "House Sparrow")
+    assert sparrow["photo_count"] == 1
+
+
+def test_best_photo_is_highest_scored(life_app):
+    app, _, ids = life_app
+    data = _get_life_list(app)
+    cardinal = _entry(data, "Northern Cardinal")
+    assert cardinal["best"]["id"] == ids["p2"]
+    # Photos are returned best-first for the lightbox set.
+    assert [p["id"] for p in cardinal["photos"]] == [ids["p2"], ids["p1"]]
+
+
+def test_life_order_numbering_and_dates(life_app):
+    app, _, _ = life_app
+    data = _get_life_list(app)
+    sparrow = _entry(data, "House Sparrow")
+    cardinal = _entry(data, "Northern Cardinal")
+    # Sparrow was photographed first (2023) so it's lifer #1.
+    assert sparrow["number"] == 1
+    assert cardinal["number"] == 2
+    assert cardinal["first_seen"] == "2024-01-15T10:00:00"
+    assert cardinal["last_seen"] == "2024-03-10T09:00:00"
+    # Entries arrive in life order.
+    assert [e["number"] for e in data["species"]] == [1, 2]
+
+
+def test_taxon_names_attached(life_app):
+    app, _, _ = life_app
+    data = _get_life_list(app)
+    sparrow = _entry(data, "House Sparrow")
+    assert sparrow["scientific_name"] == "Passer domesticus"
+    assert sparrow["common_name"] == "House Sparrow"
+    cardinal = _entry(data, "Northern Cardinal")
+    assert cardinal["scientific_name"] is None
+
+
+def test_locations_from_location_keywords(life_app):
+    app, _, _ = life_app
+    data = _get_life_list(app)
+    cardinal = _entry(data, "Northern Cardinal")
+    assert cardinal["locations"] == ["Backyard"]
+    sparrow = _entry(data, "House Sparrow")
+    assert sparrow["locations"] == []
+
+
+def test_unscored_photo_still_listed(life_app):
+    app, _, ids = life_app
+    data = _get_life_list(app)
+    sparrow = _entry(data, "House Sparrow")
+    assert sparrow["best"]["id"] == ids["p3"]
+    assert sparrow["best"]["quality_score"] is None
+
+
+def test_workspace_scoping(life_app):
+    app, db, ids = life_app
+    # Hide the folder from the active workspace: the life list empties.
+    db.conn.execute(
+        "DELETE FROM workspace_folders WHERE folder_id = ?", (ids["folder"],))
+    db.conn.commit()
+    data = _get_life_list(app)
+    assert data["species"] == []
+    assert data["meta"]["species_count"] == 0


### PR DESCRIPTION
## What changed

New **Life List** page (`/life-list`) — every species the user has confirmed at least one photo of, shown as a card grid:

- **Lifer numbering**: species are numbered chronologically by first-photographed date, the way birders count lifers. Species with no capture time sort last (alphabetically) so numbering stays stable.
- **Best photo per species**: each card's hero image is picked by the existing highlights scorer (`_highlight_score_bucket`), so eye focus / exposure / composition and user ratings all factor in. Clicking a card opens the lightbox over the species' top photos.
- **Card details**: photo count, first/latest photographed dates, scientific name in italics when the keyword is linked to a taxon, and location-keyword chips.
- **Controls**: client-side species search (matches keyword, scientific, and common names) and sort (newest lifer / life order / A–Z / most photos).

### Semantics

- **Confirmed species only** — a prediction alone doesn't put a species on your life list (AI suggests, humans decide). Species keywords are recognized the same way as everywhere else (`is_species = 1` OR `type = 'taxonomy'`).
- **Unscored photos still count** — unlike Highlights, photos with no `quality_score` are included, so a species confirmed before any pipeline run isn't dropped from the list. The scorer falls back gracefully.
- Rejected photos and folders outside the active workspace are excluded.

### Implementation

- `vireo/db.py`: `get_life_list_candidates()` (photo × species-keyword rows with quality metrics + taxa names) and `get_life_list_locations()`; `life_list` added to `ALL_NAV_IDS`.
- `vireo/app.py`: `/life-list` page route, `/api/life-list` endpoint, `ALL_PAGES` entry.
- `vireo/templates/_navbar.html`: `NAV_ALL_PAGES` fallback kept in sync.
- `vireo/templates/life_list.html`: new page, modeled on highlights.html conventions (escaped string templates, vireo-base.css variables, shared lightbox).
- Not added to `DEFAULT_TABS` — reachable via the palette/overflow like Map or Dashboard.

## Tests

- New `vireo/tests/test_life_list.py` (8 tests): grouping/counts, best-photo ranking, lifer numbering and first/last dates, taxon names, location chips, unscored-photo inclusion, workspace scoping, page render.
- Updated the hardcoded `ALL_NAV_IDS` parity test in `test_db.py`.
- Full standard suite: **1089 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Life List" page to navigation with a searchable, sortable species grid and thumbnails.
  * Species cards show first/last seen dates, up to three location chips, photo counts, and open a lightbox of best photos.
  * Added sort options: newest, life-order/oldest-first, A–Z, and most-photos.

* **Tests**
  * Expanded test coverage for Life List behavior and edge cases (null flags, duplicate-named species tags).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->