### PR TITLE
Fix four high-severity bugs found in app review

### DIFF
--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2376,6 +2376,31 @@ class Database:
         ).fetchall()
         return [r["id"] for r in rows]
 
+    def _folders_rooted_in_other_workspace(self, folder_ids, active_ws):
+        """Return the subset of folder_ids that a workspace other than
+        active_ws explicitly imported as its own root (is_root = 1).
+
+        Scanner-registered links (is_root = 0) don't count — they belong
+        to a shared ancestor root and don't protect the folder on their
+        own. With active_ws None, any is_root = 1 link qualifies.
+        """
+        rooted = set()
+        for chunk in _chunks(folder_ids):
+            placeholders = ",".join("?" for _ in chunk)
+            sql = (
+                f"SELECT DISTINCT folder_id FROM workspace_folders "
+                f"WHERE folder_id IN ({placeholders}) AND is_root = 1"
+            )
+            params = list(chunk)
+            if active_ws is not None:
+                sql += " AND workspace_id != ?"
+                params.append(active_ws)
+            rooted.update(
+                row["folder_id"]
+                for row in self.conn.execute(sql, params).fetchall()
+            )
+        return rooted
+
     def delete_folder(self, folder_id):
         """Delete a folder, its descendant folders, and all their photos/data.
 
@@ -2384,21 +2409,46 @@ class Database:
         set, so deleting a non-leaf folder row alone trips the FK — and
         descendants of a deleted folder would be unreachable anyway.
 
-        Descendants that another workspace imported as its own root
+        A folder that another workspace imported as its own root
         (``workspace_folders.is_root = 1`` for a workspace other than the
-        active one) are preserved along with their entire subtrees and
-        photos — deleting a parent in one workspace must not destroy data
-        still reachable in another. Kept subtree heads are reparented to
-        NULL (their parent row is going away) and unlinked from the active
-        workspace so they stop being visible here.
+        active one) is never deleted — it is only unlinked from the active
+        workspace. That applies to the target folder itself (in which case
+        nothing is deleted at all: the folder, its subtree, and its photos
+        survive untouched and only the active workspace's links are
+        removed) and to any descendant (the descendant's subtree and
+        photos are preserved; its head is reparented to NULL because the
+        parent row is going away). Deleting in one workspace must not
+        destroy data still reachable in another.
 
         Returns dict with 'deleted_photos' count and 'files' (list from
         delete_photos) so the caller can remove cached thumbnails, previews,
         and working copies — the FK cascade drops preview_cache rows but
         leaves the on-disk files, which would otherwise become untracked
-        orphans that eviction can't reclaim.
+        orphans that eviction can't reclaim. When the target is protected
+        by another workspace's root link, that's {'deleted_photos': 0,
+        'files': []}.
         """
         active_ws = self._active_workspace_id
+        # If the target itself is another workspace's root, delete nothing:
+        # just drop the active workspace's links for it and its subtree so
+        # it disappears from this workspace's view. The folder row survives
+        # with its parent chain intact, so no reparenting is needed.
+        if self._folders_rooted_in_other_workspace([folder_id], active_ws):
+            if active_ws is not None:
+                try:
+                    for chunk in _chunks(self._folder_subtree_ids_by_path(folder_id)):
+                        placeholders = ",".join("?" for _ in chunk)
+                        self.conn.execute(
+                            f"DELETE FROM workspace_folders WHERE workspace_id = ? "
+                            f"AND folder_id IN ({placeholders})",
+                            [active_ws] + chunk,
+                        )
+                    self.conn.commit()
+                except Exception:
+                    self.conn.rollback()
+                    raise
+            return {"deleted_photos": 0, "files": []}
+
         # BFS so the list is ordered parents-first; deleted in reverse below.
         subtree_ids = [folder_id]
         kept_root_ids = []
@@ -2419,21 +2469,7 @@ class Database:
             # scanner-registered (is_root = 0) links from other workspaces
             # belong to a shared ancestor root that is itself being deleted.
             if children:
-                kept = set()
-                for chunk in _chunks(children):
-                    placeholders = ",".join("?" for _ in chunk)
-                    sql = (
-                        f"SELECT DISTINCT folder_id FROM workspace_folders "
-                        f"WHERE folder_id IN ({placeholders}) AND is_root = 1"
-                    )
-                    params = list(chunk)
-                    if active_ws is not None:
-                        sql += " AND workspace_id != ?"
-                        params.append(active_ws)
-                    kept.update(
-                        row["folder_id"]
-                        for row in self.conn.execute(sql, params).fetchall()
-                    )
+                kept = self._folders_rooted_in_other_workspace(children, active_ws)
                 if kept:
                     kept_root_ids.extend(c for c in children if c in kept)
                     children = [c for c in children if c not in kept]

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2377,7 +2377,12 @@ class Database:
         return [r["id"] for r in rows]
 
     def delete_folder(self, folder_id):
-        """Delete a folder and all its photos/data from the database.
+        """Delete a folder, its descendant folders, and all their photos/data.
+
+        Must cover the whole subtree: folders.parent_id has no ON DELETE
+        action and the scanner registers every subdirectory with parent_id
+        set, so deleting a non-leaf folder row alone trips the FK — and
+        descendants of a deleted folder would be unreachable anyway.
 
         Returns dict with 'deleted_photos' count and 'files' (list from
         delete_photos) so the caller can remove cached thumbnails, previews,
@@ -2385,24 +2390,64 @@ class Database:
         leaves the on-disk files, which would otherwise become untracked
         orphans that eviction can't reclaim.
         """
-        photo_ids = [
-            row["id"]
-            for row in self.conn.execute(
-                "SELECT id FROM photos WHERE folder_id = ?", (folder_id,)
-            ).fetchall()
-        ]
+        # BFS so the list is ordered parents-first; deleted in reverse below.
+        subtree_ids = [folder_id]
+        frontier = [folder_id]
+        while frontier:
+            children = []
+            for chunk in _chunks(frontier):
+                placeholders = ",".join("?" for _ in chunk)
+                children.extend(
+                    row["id"]
+                    for row in self.conn.execute(
+                        f"SELECT id FROM folders WHERE parent_id IN ({placeholders})",
+                        chunk,
+                    ).fetchall()
+                )
+            subtree_ids.extend(children)
+            frontier = children
 
+        photo_ids = []
+        for chunk in _chunks(subtree_ids):
+            placeholders = ",".join("?" for _ in chunk)
+            photo_ids.extend(
+                row["id"]
+                for row in self.conn.execute(
+                    f"SELECT id FROM photos WHERE folder_id IN ({placeholders})",
+                    chunk,
+                ).fetchall()
+            )
+
+        # One outer transaction so a failure partway can't commit the photo
+        # deletes while leaving the folder rows behind. ``commit=False`` also
+        # defers delete_photos' pipeline-cache prune (a non-transactional
+        # file write) until after the commit succeeds.
         files = []
-        if photo_ids:
-            inner = self.delete_photos(photo_ids)
-            files = inner.get("files", [])
+        deleted_ids = []
+        try:
+            for chunk in _chunks(photo_ids):
+                inner = self.delete_photos(chunk, commit=False)
+                files.extend(inner.get("files", []))
+                deleted_ids.extend(inner.get("ids", []))
+            # Children before parents, else the multi-statement delete trips
+            # the parent_id FK at the end of an earlier chunk's statement.
+            for chunk in _chunks(list(reversed(subtree_ids))):
+                placeholders = ",".join("?" for _ in chunk)
+                self.conn.execute(
+                    f"DELETE FROM workspace_folders WHERE folder_id IN ({placeholders})",
+                    chunk,
+                )
+                self.conn.execute(
+                    f"DELETE FROM folders WHERE id IN ({placeholders})",
+                    chunk,
+                )
+            self.conn.commit()
+        except Exception:
+            self.conn.rollback()
+            raise
+        self.prune_pipeline_cache_for_ids(deleted_ids)
 
-        # Remove folder from workspace_folders and folders
-        self.conn.execute("DELETE FROM workspace_folders WHERE folder_id = ?", (folder_id,))
-        self.conn.execute("DELETE FROM folders WHERE id = ?", (folder_id,))
-        self.conn.commit()
-
-        return {"deleted_photos": len(photo_ids), "files": files}
+        return {"deleted_photos": len(deleted_ids), "files": files}
 
     # -- Photos --
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2376,30 +2376,31 @@ class Database:
         ).fetchall()
         return [r["id"] for r in rows]
 
-    def _folders_rooted_in_other_workspace(self, folder_ids, active_ws):
-        """Return the subset of folder_ids that a workspace other than
-        active_ws explicitly imported as its own root (is_root = 1).
+    def _folders_linked_in_other_workspace(self, folder_ids, active_ws):
+        """Return the subset of folder_ids that any workspace other than
+        active_ws has a workspace_folders link for (root or not).
 
-        Scanner-registered links (is_root = 0) don't count — they belong
-        to a shared ancestor root and don't protect the folder on their
-        own. With active_ws None, any is_root = 1 link qualifies.
+        Any foreign link — an explicit root import (is_root = 1) or a
+        scanner-materialized descendant of one (is_root = 0) — is evidence
+        the folder is still visible in that workspace, so it must never be
+        deleted, only unlinked. With active_ws None, any link qualifies.
         """
-        rooted = set()
+        linked = set()
         for chunk in _chunks(folder_ids):
             placeholders = ",".join("?" for _ in chunk)
             sql = (
                 f"SELECT DISTINCT folder_id FROM workspace_folders "
-                f"WHERE folder_id IN ({placeholders}) AND is_root = 1"
+                f"WHERE folder_id IN ({placeholders})"
             )
             params = list(chunk)
             if active_ws is not None:
                 sql += " AND workspace_id != ?"
                 params.append(active_ws)
-            rooted.update(
+            linked.update(
                 row["folder_id"]
                 for row in self.conn.execute(sql, params).fetchall()
             )
-        return rooted
+        return linked
 
     def delete_folder(self, folder_id):
         """Delete a folder, its descendant folders, and all their photos/data.
@@ -2409,31 +2410,33 @@ class Database:
         set, so deleting a non-leaf folder row alone trips the FK — and
         descendants of a deleted folder would be unreachable anyway.
 
-        A folder that another workspace imported as its own root
-        (``workspace_folders.is_root = 1`` for a workspace other than the
-        active one) is never deleted — it is only unlinked from the active
-        workspace. That applies to the target folder itself (in which case
-        nothing is deleted at all: the folder, its subtree, and its photos
-        survive untouched and only the active workspace's links are
-        removed) and to any descendant (the descendant's subtree and
-        photos are preserved; its head is reparented to NULL because the
-        parent row is going away). Deleting in one workspace must not
-        destroy data still reachable in another.
+        A folder with any ``workspace_folders`` link from a workspace
+        other than the active one is never deleted — it is only unlinked
+        from the active workspace. A foreign link, root or
+        scanner-materialized, means the folder is still reachable in that
+        workspace (an is_root = 0 link is always covered by a root
+        ancestor there). That applies to the target folder itself (in
+        which case nothing is deleted at all: the folder, its subtree,
+        and its photos survive untouched and only the active workspace's
+        links are removed) and to any descendant (the descendant's
+        subtree and photos are preserved; its head is reparented to NULL
+        because the parent row is going away). Deleting in one workspace
+        must not destroy data still reachable in another.
 
         Returns dict with 'deleted_photos' count and 'files' (list from
         delete_photos) so the caller can remove cached thumbnails, previews,
         and working copies — the FK cascade drops preview_cache rows but
         leaves the on-disk files, which would otherwise become untracked
         orphans that eviction can't reclaim. When the target is protected
-        by another workspace's root link, that's {'deleted_photos': 0,
+        by another workspace's link, that's {'deleted_photos': 0,
         'files': []}.
         """
         active_ws = self._active_workspace_id
-        # If the target itself is another workspace's root, delete nothing:
+        # If the target is linked in another workspace, delete nothing:
         # just drop the active workspace's links for it and its subtree so
         # it disappears from this workspace's view. The folder row survives
         # with its parent chain intact, so no reparenting is needed.
-        if self._folders_rooted_in_other_workspace([folder_id], active_ws):
+        if self._folders_linked_in_other_workspace([folder_id], active_ws):
             if active_ws is not None:
                 try:
                     for chunk in _chunks(self._folder_subtree_ids_by_path(folder_id)):
@@ -2464,12 +2467,12 @@ class Database:
                         chunk,
                     ).fetchall()
                 )
-            # Prune children that another workspace explicitly imported as a
-            # root: their subtrees stay. Only is_root = 1 links count —
-            # scanner-registered (is_root = 0) links from other workspaces
-            # belong to a shared ancestor root that is itself being deleted.
+            # Prune children that another workspace has a link for: their
+            # subtrees stay. Any foreign link counts — root or
+            # scanner-materialized — since either means the folder is still
+            # visible in that workspace.
             if children:
-                kept = self._folders_rooted_in_other_workspace(children, active_ws)
+                kept = self._folders_linked_in_other_workspace(children, active_ws)
                 if kept:
                     kept_root_ids.extend(c for c in children if c in kept)
                     children = [c for c in children if c not in kept]
@@ -2477,7 +2480,7 @@ class Database:
             frontier = children
 
         # Active-workspace links to drop for kept subtrees (they remain
-        # visible only in the workspaces that imported them as roots).
+        # visible only in the other workspaces that link them).
         kept_subtree_ids = []
         for kid in kept_root_ids:
             kept_subtree_ids.extend(self._folder_subtree_ids_by_path(kid))

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2408,7 +2408,11 @@ class Database:
         Must cover the whole subtree: folders.parent_id has no ON DELETE
         action and the scanner registers every subdirectory with parent_id
         set, so deleting a non-leaf folder row alone trips the FK — and
-        descendants of a deleted folder would be unreachable anyway.
+        descendants of a deleted folder would be unreachable anyway. The
+        subtree is collected by path prefix (``_folder_subtree_ids_by_path``),
+        not a parent_id walk, so legacy rows whose parent_id is NULL but
+        whose path lives under the target are deleted too — the same shape
+        the workspace link/unlink paths already handle.
 
         A folder with any ``workspace_folders`` link from a workspace
         other than the active one is never deleted — it is only unlinked
@@ -2432,68 +2436,59 @@ class Database:
         'files': []}.
         """
         active_ws = self._active_workspace_id
-        # If the target is linked in another workspace, delete nothing:
-        # just drop the active workspace's links for it and its subtree so
-        # it disappears from this workspace's view. The folder row survives
-        # with its parent chain intact, so no reparenting is needed.
-        if self._folders_linked_in_other_workspace([folder_id], active_ws):
-            if active_ws is not None:
-                try:
-                    for chunk in _chunks(self._folder_subtree_ids_by_path(folder_id)):
-                        placeholders = ",".join("?" for _ in chunk)
-                        self.conn.execute(
-                            f"DELETE FROM workspace_folders WHERE workspace_id = ? "
-                            f"AND folder_id IN ({placeholders})",
-                            [active_ws] + chunk,
-                        )
-                    self.conn.commit()
-                except Exception:
-                    self.conn.rollback()
-                    raise
-                # The subtree no longer contributes to this workspace's
-                # new-images backlog. Drop the cached payload so the banner
-                # doesn't keep serving the pre-unlink count until the TTL
-                # expires (same as remove_workspace_folder_tree).
-                self._new_images_cache.invalidate_workspaces(
-                    self._db_path, [active_ws]
-                )
-            return {"deleted_photos": 0, "files": []}
+        # Everything under the target, by path, including legacy
+        # NULL-parent_id descendants a parent_id walk would miss.
+        candidates = set(self._folder_subtree_ids_by_path(folder_id))
 
-        # BFS so the list is ordered parents-first; deleted in reverse below.
-        subtree_ids = [folder_id]
-        kept_root_ids = []
-        frontier = [folder_id]
-        while frontier:
-            children = []
-            for chunk in _chunks(frontier):
-                placeholders = ",".join("?" for _ in chunk)
-                children.extend(
-                    row["id"]
-                    for row in self.conn.execute(
-                        f"SELECT id FROM folders WHERE parent_id IN ({placeholders})",
-                        chunk,
-                    ).fetchall()
-                )
-            # Prune children that another workspace has a link for: their
-            # subtrees stay. Any foreign link counts — root or
-            # scanner-materialized — since either means the folder is still
-            # visible in that workspace.
-            if children:
-                kept = self._folders_linked_in_other_workspace(children, active_ws)
-                if kept:
-                    kept_root_ids.extend(c for c in children if c in kept)
-                    children = [c for c in children if c not in kept]
-            subtree_ids.extend(children)
-            frontier = children
+        # Candidates that another workspace has a link for are never
+        # deleted, and each protected folder keeps its whole subtree. Any
+        # foreign link counts — root or scanner-materialized — since either
+        # means the folder is still visible in that workspace. When the
+        # target itself is protected, the kept set covers every candidate
+        # and this degenerates to unlink-only: nothing is deleted, no
+        # reparenting happens, and only the active workspace's links go.
+        protected = self._folders_linked_in_other_workspace(candidates, active_ws)
+        kept_subtree_ids = set()
+        for fid in protected:
+            kept_subtree_ids.update(self._folder_subtree_ids_by_path(fid))
+        delete_ids = candidates - kept_subtree_ids
 
-        # Active-workspace links to drop for kept subtrees (they remain
-        # visible only in the other workspaces that link them).
-        kept_subtree_ids = []
-        for kid in kept_root_ids:
-            kept_subtree_ids.extend(self._folder_subtree_ids_by_path(kid))
+        # Kept folders whose parent row is being deleted must be reparented
+        # to NULL before the folder DELETE — folders.parent_id has no ON
+        # DELETE action. (Kept folders whose parent also survives keep
+        # their chain intact.)
+        kept_head_ids = []
+        for chunk in _chunks(kept_subtree_ids):
+            placeholders = ",".join("?" for _ in chunk)
+            kept_head_ids.extend(
+                row["id"]
+                for row in self.conn.execute(
+                    f"SELECT id, parent_id FROM folders WHERE id IN ({placeholders})",
+                    chunk,
+                ).fetchall()
+                if row["parent_id"] in delete_ids
+            )
+
+        # Delete children before parents, else the multi-statement delete
+        # trips the parent_id FK at the end of an earlier chunk's statement.
+        # Order by path depth descending — a parent's normalized path always
+        # has fewer separators than its child's, and parent_id order can't
+        # be trusted for the legacy path-only rows.
+        depth_by_id = {}
+        for chunk in _chunks(delete_ids):
+            placeholders = ",".join("?" for _ in chunk)
+            for row in self.conn.execute(
+                f"SELECT id, path FROM folders WHERE id IN ({placeholders})",
+                chunk,
+            ).fetchall():
+                path = _path_for_subtree_match(row["path"] or "")
+                depth_by_id[row["id"]] = path.count("/")
+        ordered_delete_ids = sorted(
+            delete_ids, key=lambda fid: depth_by_id.get(fid, 0), reverse=True
+        )
 
         photo_ids = []
-        for chunk in _chunks(subtree_ids):
+        for chunk in _chunks(ordered_delete_ids):
             placeholders = ",".join("?" for _ in chunk)
             photo_ids.extend(
                 row["id"]
@@ -2517,13 +2512,16 @@ class Database:
             # Reparent kept subtree heads before any folder DELETE — their
             # parent_id points at a row being deleted, and the FK has no ON
             # DELETE action.
-            for chunk in _chunks(kept_root_ids):
+            for chunk in _chunks(kept_head_ids):
                 placeholders = ",".join("?" for _ in chunk)
                 self.conn.execute(
                     f"UPDATE folders SET parent_id = NULL "
                     f"WHERE id IN ({placeholders})",
                     chunk,
                 )
+            # Kept subtrees disappear from this workspace's view: drop the
+            # active workspace's links, leaving the other workspaces' links
+            # (and the folder rows and photos) untouched.
             if active_ws is not None:
                 for chunk in _chunks(kept_subtree_ids):
                     placeholders = ",".join("?" for _ in chunk)
@@ -2532,9 +2530,7 @@ class Database:
                         f"AND folder_id IN ({placeholders})",
                         [active_ws] + chunk,
                     )
-            # Children before parents, else the multi-statement delete trips
-            # the parent_id FK at the end of an earlier chunk's statement.
-            for chunk in _chunks(list(reversed(subtree_ids))):
+            for chunk in _chunks(ordered_delete_ids):
                 placeholders = ",".join("?" for _ in chunk)
                 self.conn.execute(
                     f"DELETE FROM workspace_folders WHERE folder_id IN ({placeholders})",

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2384,14 +2384,24 @@ class Database:
         set, so deleting a non-leaf folder row alone trips the FK — and
         descendants of a deleted folder would be unreachable anyway.
 
+        Descendants that another workspace imported as its own root
+        (``workspace_folders.is_root = 1`` for a workspace other than the
+        active one) are preserved along with their entire subtrees and
+        photos — deleting a parent in one workspace must not destroy data
+        still reachable in another. Kept subtree heads are reparented to
+        NULL (their parent row is going away) and unlinked from the active
+        workspace so they stop being visible here.
+
         Returns dict with 'deleted_photos' count and 'files' (list from
         delete_photos) so the caller can remove cached thumbnails, previews,
         and working copies — the FK cascade drops preview_cache rows but
         leaves the on-disk files, which would otherwise become untracked
         orphans that eviction can't reclaim.
         """
+        active_ws = self._active_workspace_id
         # BFS so the list is ordered parents-first; deleted in reverse below.
         subtree_ids = [folder_id]
+        kept_root_ids = []
         frontier = [folder_id]
         while frontier:
             children = []
@@ -2404,8 +2414,37 @@ class Database:
                         chunk,
                     ).fetchall()
                 )
+            # Prune children that another workspace explicitly imported as a
+            # root: their subtrees stay. Only is_root = 1 links count —
+            # scanner-registered (is_root = 0) links from other workspaces
+            # belong to a shared ancestor root that is itself being deleted.
+            if children:
+                kept = set()
+                for chunk in _chunks(children):
+                    placeholders = ",".join("?" for _ in chunk)
+                    sql = (
+                        f"SELECT DISTINCT folder_id FROM workspace_folders "
+                        f"WHERE folder_id IN ({placeholders}) AND is_root = 1"
+                    )
+                    params = list(chunk)
+                    if active_ws is not None:
+                        sql += " AND workspace_id != ?"
+                        params.append(active_ws)
+                    kept.update(
+                        row["folder_id"]
+                        for row in self.conn.execute(sql, params).fetchall()
+                    )
+                if kept:
+                    kept_root_ids.extend(c for c in children if c in kept)
+                    children = [c for c in children if c not in kept]
             subtree_ids.extend(children)
             frontier = children
+
+        # Active-workspace links to drop for kept subtrees (they remain
+        # visible only in the workspaces that imported them as roots).
+        kept_subtree_ids = []
+        for kid in kept_root_ids:
+            kept_subtree_ids.extend(self._folder_subtree_ids_by_path(kid))
 
         photo_ids = []
         for chunk in _chunks(subtree_ids):
@@ -2429,6 +2468,24 @@ class Database:
                 inner = self.delete_photos(chunk, commit=False)
                 files.extend(inner.get("files", []))
                 deleted_ids.extend(inner.get("ids", []))
+            # Reparent kept subtree heads before any folder DELETE — their
+            # parent_id points at a row being deleted, and the FK has no ON
+            # DELETE action.
+            for chunk in _chunks(kept_root_ids):
+                placeholders = ",".join("?" for _ in chunk)
+                self.conn.execute(
+                    f"UPDATE folders SET parent_id = NULL "
+                    f"WHERE id IN ({placeholders})",
+                    chunk,
+                )
+            if active_ws is not None:
+                for chunk in _chunks(kept_subtree_ids):
+                    placeholders = ",".join("?" for _ in chunk)
+                    self.conn.execute(
+                        f"DELETE FROM workspace_folders WHERE workspace_id = ? "
+                        f"AND folder_id IN ({placeholders})",
+                        [active_ws] + chunk,
+                    )
             # Children before parents, else the multi-statement delete trips
             # the parent_id FK at the end of an earlier chunk's statement.
             for chunk in _chunks(list(reversed(subtree_ids))):

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2435,7 +2435,7 @@ class Database:
         by another workspace's link, that's {'deleted_photos': 0,
         'files': []}.
         """
-        active_ws = self._active_workspace_id
+        active_ws = self._ws_id()
         # Everything under the target, by path, including legacy
         # NULL-parent_id descendants a parent_id walk would miss.
         candidates = set(self._folder_subtree_ids_by_path(folder_id))

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2450,6 +2450,13 @@ class Database:
                 except Exception:
                     self.conn.rollback()
                     raise
+                # The subtree no longer contributes to this workspace's
+                # new-images backlog. Drop the cached payload so the banner
+                # doesn't keep serving the pre-unlink count until the TTL
+                # expires (same as remove_workspace_folder_tree).
+                self._new_images_cache.invalidate_workspaces(
+                    self._db_path, [active_ws]
+                )
             return {"deleted_photos": 0, "files": []}
 
         # BFS so the list is ordered parents-first; deleted in reverse below.
@@ -2542,6 +2549,18 @@ class Database:
             self.conn.rollback()
             raise
         self.prune_pipeline_cache_for_ids(deleted_ids)
+
+        # delete_photos' finally-clause invalidation only covers folders that
+        # had photo rows. Photo-less deleted folders (whose untracked on-disk
+        # files counted as "new") and kept subtrees unlinked from the active
+        # workspace above would otherwise keep serving a stale new-images
+        # count until the TTL expires. Deleted folders are only ever linked
+        # in the active workspace (foreign links protect from deletion), so
+        # invalidating it post-commit covers every affected workspace.
+        if active_ws is not None:
+            self._new_images_cache.invalidate_workspaces(
+                self._db_path, [active_ws]
+            )
 
         return {"deleted_photos": len(deleted_ids), "files": files}
 

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -1443,12 +1443,23 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                 # was passed never reach an existing row. Without these the
                 # incremental pre-pass keeps comparing against the stale
                 # stored mtime and re-processes a changed file on every scan
-                # forever. xmp_mtime may be None here — writing NULL is
+                # forever. Only advance file_mtime/file_size when the content
+                # hash succeeded: _compute_file_features hashes every
+                # processed file, so file_hash is None only when the bytes
+                # couldn't be read (transient permission/I-O error). Marking
+                # such a file's mtime current would make the next incremental
+                # scan skip it forever with a stale hash and stale derived
+                # caches; leaving the old mtime in place retries it instead.
+                if file_hash is not None:
+                    updates.extend(["file_mtime=?", "file_size=?"])
+                    update_params.extend([file_mtime, file_size])
+                # xmp_mtime stays unconditional — the sidecar is a separate
+                # file whose keyword import below runs regardless of image
+                # hash success, and it may be None here: writing NULL is
                 # correct (a deleted sidecar otherwise re-trips the "XMP
-                # changed" check on every scan), and the sidecar's keywords
-                # are re-imported below whenever it exists.
-                updates.extend(["file_mtime=?", "file_size=?", "xmp_mtime=?"])
-                update_params.extend([file_mtime, file_size, xmp_mtime])
+                # changed" check on every scan).
+                updates.append("xmp_mtime=?")
+                update_params.append(xmp_mtime)
             if updates:
                 update_params.append(photo_id)
                 db.conn.execute(

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -1219,6 +1219,16 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                             (xmp_mtime, existing["id"]),
                         )
                         commit_with_retry(db.conn)
+                    elif not xmp_unchanged:
+                        # Sidecar deleted: clear the stored mtime so the row
+                        # converges instead of looking "XMP changed" on every
+                        # later scan (this skip path never reaches the main
+                        # loop, so nothing else would ever reset it).
+                        db.conn.execute(
+                            "UPDATE photos SET xmp_mtime = NULL WHERE id = ?",
+                            (existing["id"],),
+                        )
+                        commit_with_retry(db.conn)
 
                     if file_unchanged and not metadata_missing:
                         processed_count += 1
@@ -1428,6 +1438,17 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                 # extract_full_metadata is off) — prevents perpetual retry
                 updates.append("exif_data=COALESCE(exif_data, ?)")
                 update_params.append("{}")
+            if row_already_existed:
+                # add_photo is INSERT OR IGNORE, so the fresh stat values it
+                # was passed never reach an existing row. Without these the
+                # incremental pre-pass keeps comparing against the stale
+                # stored mtime and re-processes a changed file on every scan
+                # forever. xmp_mtime may be None here — writing NULL is
+                # correct (a deleted sidecar otherwise re-trips the "XMP
+                # changed" check on every scan), and the sidecar's keywords
+                # are re-imported below whenever it exists.
+                updates.extend(["file_mtime=?", "file_size=?", "xmp_mtime=?"])
+                update_params.extend([file_mtime, file_size, xmp_mtime])
             if updates:
                 update_params.append(photo_id)
                 db.conn.execute(

--- a/vireo/templates/move.html
+++ b/vireo/templates/move.html
@@ -606,7 +606,7 @@ function renderPhotoGrid() {
   photoList.forEach(function(p, idx) {
     var selClass = selectedPhotos.has(p.id) ? ' selected' : '';
     html += '<div class="grid-card' + selClass + '" data-id="' + p.id + '" data-idx="' + idx + '" onclick="handlePhotoClick(event, ' + p.id + ', ' + idx + ')">';
-    html += '<div class="grid-card-img-wrap"><img src="/thumb/' + p.id + '" loading="lazy" alt=""></div>';
+    html += '<div class="grid-card-img-wrap"><img src="/thumbnails/' + p.id + '.jpg" loading="lazy" alt=""></div>';
     html += '<div class="grid-card-info"><div class="grid-card-name" title="' + escapeAttr(p.filename) + '">' + escapeHtml(p.filename) + '</div></div>';
     html += '</div>';
   });

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -983,7 +983,9 @@ function renderStats() {
       '<span class="stat accepted-count">' + accepted + ' Accepted</span>' +
       '<span class="stat">' + predictions.length + ' Total</span>';
   } else {
-    el.innerHTML = '<span class="stat">' + allData.photos.length + ' photos</span>';
+    // Browse mode means zero predictions loaded — the grid's empty state
+    // explains the situation, so there's no count worth showing here.
+    el.textContent = '';
   }
 }
 

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -6357,6 +6357,36 @@ def test_delete_folder(tmp_path):
     assert db.conn.execute("SELECT id FROM photos WHERE id = ?", (pid,)).fetchone() is None
 
 
+def test_delete_folder_with_descendants(tmp_path):
+    """delete_folder removes the whole subtree — folders.parent_id has no ON
+    DELETE action, so deleting a non-leaf folder row alone would trip the FK
+    after its photos were already deleted."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+
+    parent = db.add_folder("/tree", name="tree")
+    child = db.add_folder("/tree/sub", name="sub", parent_id=parent)
+    grand = db.add_folder("/tree/sub/deep", name="deep", parent_id=child)
+    pids = [
+        db.add_photo(folder_id=fid, filename=f"bird{fid}.jpg", extension=".jpg",
+                     file_size=1000, file_mtime=1.0)
+        for fid in (parent, child, grand)
+    ]
+
+    result = db.delete_folder(parent)
+    assert result["deleted_photos"] == 3
+
+    for fid in (parent, child, grand):
+        assert db.conn.execute("SELECT id FROM folders WHERE id = ?", (fid,)).fetchone() is None
+        assert db.conn.execute(
+            "SELECT folder_id FROM workspace_folders WHERE folder_id = ?", (fid,)
+        ).fetchone() is None
+    for pid in pids:
+        assert db.conn.execute("SELECT id FROM photos WHERE id = ?", (pid,)).fetchone() is None
+
+
 def test_missing_folder_photos_hidden_from_browse(tmp_path):
     """Photos in missing folders don't appear in get_photos or count_photos."""
     from db import Database

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -6450,6 +6450,59 @@ def test_delete_folder_keeps_descendant_rooted_in_other_workspace(tmp_path):
     ).fetchall() == []
 
 
+def test_delete_folder_keeps_target_rooted_in_other_workspace(tmp_path):
+    """Deleting a folder that another workspace imported as its own root
+    must not delete anything — the folder row, subtree, and photos survive;
+    only the deleting workspace's links are removed."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_a = db.ensure_default_workspace()
+    db.set_active_workspace(ws_a)
+
+    parent = db.add_folder("/tree", name="tree")
+    child = db.add_folder("/tree/sub", name="sub", parent_id=parent,
+                          workspace_root=False)
+
+    # Workspace B imports /tree itself as its own root.
+    ws_b = db.create_workspace("B")
+    db.add_workspace_folder(ws_b, parent, is_root=True)
+    db.add_workspace_folder(ws_b, child, is_root=False)
+
+    pid_parent = db.add_photo(folder_id=parent, filename="p.jpg", extension=".jpg",
+                              file_size=1000, file_mtime=1.0)
+    pid_child = db.add_photo(folder_id=child, filename="c.jpg", extension=".jpg",
+                             file_size=1000, file_mtime=1.0)
+
+    result = db.delete_folder(parent)
+    assert result["deleted_photos"] == 0
+    assert result["files"] == []
+
+    # Folder rows and photos all survive, parent chain intact.
+    row = db.conn.execute(
+        "SELECT parent_id FROM folders WHERE id = ?", (child,)
+    ).fetchone()
+    assert row is not None
+    assert row["parent_id"] == parent
+    assert db.conn.execute("SELECT id FROM folders WHERE id = ?", (parent,)).fetchone() is not None
+    for pid in (pid_parent, pid_child):
+        assert db.conn.execute("SELECT id FROM photos WHERE id = ?", (pid,)).fetchone() is not None
+
+    # B's links survive, including the root flag.
+    assert db.conn.execute(
+        "SELECT is_root FROM workspace_folders WHERE workspace_id = ? AND folder_id = ?",
+        (ws_b, parent),
+    ).fetchone()["is_root"] == 1
+    assert db.conn.execute(
+        "SELECT folder_id FROM workspace_folders WHERE workspace_id = ? AND folder_id = ?",
+        (ws_b, child),
+    ).fetchone() is not None
+
+    # Workspace A no longer sees any of it.
+    assert db.conn.execute(
+        "SELECT folder_id FROM workspace_folders WHERE workspace_id = ?", (ws_a,)
+    ).fetchall() == []
+
+
 def test_missing_folder_photos_hidden_from_browse(tmp_path):
     """Photos in missing folders don't appear in get_photos or count_photos."""
     from db import Database

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -6418,9 +6418,16 @@ def test_delete_folder_keeps_descendant_rooted_in_other_workspace(tmp_path):
     pid_other = db.add_photo(folder_id=other, filename="o.jpg", extension=".jpg",
                              file_size=1000, file_mtime=1.0)
 
+    # Prime A's new-images cache: the delete changes what A can see (kept
+    # subtree unlinked), so the cached count must be dropped.
+    db._new_images_cache.set(db._db_path, ws_a, {"new_count": 7})
+
     result = db.delete_folder(parent)
     # Only the photos outside B's root are deleted.
     assert result["deleted_photos"] == 2
+
+    # A's cached new-images payload is invalidated by the delete.
+    assert db._new_images_cache.get(db._db_path, ws_a) is None
 
     # Parent and the unshared sibling are gone, with their photos.
     for fid in (parent, other):
@@ -6473,9 +6480,16 @@ def test_delete_folder_keeps_target_rooted_in_other_workspace(tmp_path):
     pid_child = db.add_photo(folder_id=child, filename="c.jpg", extension=".jpg",
                              file_size=1000, file_mtime=1.0)
 
+    # Prime A's new-images cache: the unlink-only path must still drop it,
+    # since the folder no longer contributes to A's backlog.
+    db._new_images_cache.set(db._db_path, ws_a, {"new_count": 7})
+
     result = db.delete_folder(parent)
     assert result["deleted_photos"] == 0
     assert result["files"] == []
+
+    # A's cached new-images payload is invalidated by the unlink.
+    assert db._new_images_cache.get(db._db_path, ws_a) is None
 
     # Folder rows and photos all survive, parent chain intact.
     row = db.conn.execute(

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -6387,6 +6387,69 @@ def test_delete_folder_with_descendants(tmp_path):
         assert db.conn.execute("SELECT id FROM photos WHERE id = ?", (pid,)).fetchone() is None
 
 
+def test_delete_folder_keeps_descendant_rooted_in_other_workspace(tmp_path):
+    """Deleting a folder in one workspace must not destroy a descendant that
+    another workspace imported as its own root (is_root = 1) — that subtree
+    is still reachable there. The kept head is reparented to NULL and only
+    unlinked from the deleting workspace."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_a = db.ensure_default_workspace()
+    db.set_active_workspace(ws_a)
+
+    parent = db.add_folder("/tree", name="tree")
+    child = db.add_folder("/tree/sub", name="sub", parent_id=parent,
+                          workspace_root=False)
+    grand = db.add_folder("/tree/sub/deep", name="deep", parent_id=child,
+                          workspace_root=False)
+    other = db.add_folder("/tree/other", name="other", parent_id=parent,
+                          workspace_root=False)
+
+    # Workspace B imports /tree/sub as its own root.
+    ws_b = db.create_workspace("B")
+    db.add_workspace_folder(ws_b, child, is_root=True)
+
+    pid_parent = db.add_photo(folder_id=parent, filename="p.jpg", extension=".jpg",
+                              file_size=1000, file_mtime=1.0)
+    pid_child = db.add_photo(folder_id=child, filename="c.jpg", extension=".jpg",
+                             file_size=1000, file_mtime=1.0)
+    pid_grand = db.add_photo(folder_id=grand, filename="g.jpg", extension=".jpg",
+                             file_size=1000, file_mtime=1.0)
+    pid_other = db.add_photo(folder_id=other, filename="o.jpg", extension=".jpg",
+                             file_size=1000, file_mtime=1.0)
+
+    result = db.delete_folder(parent)
+    # Only the photos outside B's root are deleted.
+    assert result["deleted_photos"] == 2
+
+    # Parent and the unshared sibling are gone, with their photos.
+    for fid in (parent, other):
+        assert db.conn.execute("SELECT id FROM folders WHERE id = ?", (fid,)).fetchone() is None
+    for pid in (pid_parent, pid_other):
+        assert db.conn.execute("SELECT id FROM photos WHERE id = ?", (pid,)).fetchone() is None
+
+    # B's subtree survives: folder rows, photos, and B's links.
+    row = db.conn.execute("SELECT parent_id FROM folders WHERE id = ?", (child,)).fetchone()
+    assert row is not None
+    assert row["parent_id"] is None  # reparented — old parent row is gone
+    assert db.conn.execute("SELECT id FROM folders WHERE id = ?", (grand,)).fetchone() is not None
+    for pid in (pid_child, pid_grand):
+        assert db.conn.execute("SELECT id FROM photos WHERE id = ?", (pid,)).fetchone() is not None
+    assert db.conn.execute(
+        "SELECT is_root FROM workspace_folders WHERE workspace_id = ? AND folder_id = ?",
+        (ws_b, child),
+    ).fetchone()["is_root"] == 1
+    assert db.conn.execute(
+        "SELECT folder_id FROM workspace_folders WHERE workspace_id = ? AND folder_id = ?",
+        (ws_b, grand),
+    ).fetchone() is not None
+
+    # Workspace A no longer sees any of it.
+    assert db.conn.execute(
+        "SELECT folder_id FROM workspace_folders WHERE workspace_id = ?", (ws_a,)
+    ).fetchall() == []
+
+
 def test_missing_folder_photos_hidden_from_browse(tmp_path):
     """Photos in missing folders don't appear in get_photos or count_photos."""
     from db import Database

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -6574,6 +6574,84 @@ def test_delete_folder_keeps_target_covered_by_other_workspace_ancestor_root(tmp
     ).fetchone() is not None
 
 
+def test_delete_folder_includes_path_only_descendants(tmp_path):
+    """Legacy databases can hold descendants whose parent_id is NULL even
+    though their path lives under the deleted folder. The deletion walk
+    must collect the subtree by path (like the workspace link/unlink
+    paths), not by parent_id, or those rows and their photos survive."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+
+    parent = db.add_folder("/photos", name="photos")
+    # Legacy shape: path is under /photos but parent_id was never set.
+    child = db.add_folder("/photos/2024", name="2024")
+    assert db.conn.execute(
+        "SELECT parent_id FROM folders WHERE id = ?", (child,)
+    ).fetchone()["parent_id"] is None
+
+    pids = [
+        db.add_photo(folder_id=fid, filename=f"bird{fid}.jpg", extension=".jpg",
+                     file_size=1000, file_mtime=1.0)
+        for fid in (parent, child)
+    ]
+
+    result = db.delete_folder(parent)
+    assert result["deleted_photos"] == 2
+
+    for fid in (parent, child):
+        assert db.conn.execute("SELECT id FROM folders WHERE id = ?", (fid,)).fetchone() is None
+        assert db.conn.execute(
+            "SELECT folder_id FROM workspace_folders WHERE folder_id = ?", (fid,)
+        ).fetchone() is None
+    for pid in pids:
+        assert db.conn.execute("SELECT id FROM photos WHERE id = ?", (pid,)).fetchone() is None
+
+
+def test_delete_folder_keeps_path_only_descendant_linked_in_other_workspace(tmp_path):
+    """A path-only legacy descendant that another workspace links must be
+    preserved by the same foreign-link protection as parent_id-linked
+    descendants: its row and photos survive, only the deleting workspace's
+    links go."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_a = db.ensure_default_workspace()
+    db.set_active_workspace(ws_a)
+
+    parent = db.add_folder("/photos", name="photos")
+    # Legacy shape: under /photos by path, parent_id NULL.
+    child = db.add_folder("/photos/2024", name="2024", workspace_root=False)
+
+    ws_b = db.create_workspace("B")
+    db.add_workspace_folder(ws_b, child, is_root=True)
+
+    pid_parent = db.add_photo(folder_id=parent, filename="p.jpg", extension=".jpg",
+                              file_size=1000, file_mtime=1.0)
+    pid_child = db.add_photo(folder_id=child, filename="c.jpg", extension=".jpg",
+                             file_size=1000, file_mtime=1.0)
+
+    result = db.delete_folder(parent)
+    assert result["deleted_photos"] == 1
+
+    # /photos and its photo are gone.
+    assert db.conn.execute("SELECT id FROM folders WHERE id = ?", (parent,)).fetchone() is None
+    assert db.conn.execute("SELECT id FROM photos WHERE id = ?", (pid_parent,)).fetchone() is None
+
+    # B's legacy-shaped subtree survives with its photo and link.
+    assert db.conn.execute("SELECT id FROM folders WHERE id = ?", (child,)).fetchone() is not None
+    assert db.conn.execute("SELECT id FROM photos WHERE id = ?", (pid_child,)).fetchone() is not None
+    assert db.conn.execute(
+        "SELECT is_root FROM workspace_folders WHERE workspace_id = ? AND folder_id = ?",
+        (ws_b, child),
+    ).fetchone()["is_root"] == 1
+
+    # Workspace A no longer sees any of it.
+    assert db.conn.execute(
+        "SELECT folder_id FROM workspace_folders WHERE workspace_id = ?", (ws_a,)
+    ).fetchall() == []
+
+
 def test_missing_folder_photos_hidden_from_browse(tmp_path):
     """Photos in missing folders don't appear in get_photos or count_photos."""
     from db import Database

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -6503,6 +6503,63 @@ def test_delete_folder_keeps_target_rooted_in_other_workspace(tmp_path):
     ).fetchall() == []
 
 
+def test_delete_folder_keeps_target_covered_by_other_workspace_ancestor_root(tmp_path):
+    """Deleting a folder whose only foreign link is scanner-materialized
+    (is_root = 0) must not delete anything: that link means another
+    workspace reaches the folder through a root ancestor outside the
+    deleted subtree. Any foreign link protects — not just is_root = 1."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_a = db.ensure_default_workspace()
+    db.set_active_workspace(ws_a)
+
+    parent = db.add_folder("/photos", name="photos")
+    child = db.add_folder("/photos/2024", name="2024", parent_id=parent,
+                          workspace_root=False)
+
+    # Workspace B imports /photos as its root; the scanner materializes the
+    # descendant /photos/2024 as a non-root link.
+    ws_b = db.create_workspace("B")
+    db.add_workspace_folder(ws_b, parent, is_root=True)
+    db.add_workspace_folder(ws_b, child, is_root=False)
+
+    pid_child = db.add_photo(folder_id=child, filename="c.jpg", extension=".jpg",
+                             file_size=1000, file_mtime=1.0)
+
+    # Workspace A deletes /photos/2024 — B still sees it via its /photos root.
+    result = db.delete_folder(child)
+    assert result["deleted_photos"] == 0
+    assert result["files"] == []
+
+    # Folder row and photo survive, parent chain intact.
+    row = db.conn.execute(
+        "SELECT parent_id FROM folders WHERE id = ?", (child,)
+    ).fetchone()
+    assert row is not None
+    assert row["parent_id"] == parent
+    assert db.conn.execute("SELECT id FROM photos WHERE id = ?", (pid_child,)).fetchone() is not None
+
+    # B's links survive.
+    assert db.conn.execute(
+        "SELECT is_root FROM workspace_folders WHERE workspace_id = ? AND folder_id = ?",
+        (ws_b, parent),
+    ).fetchone()["is_root"] == 1
+    assert db.conn.execute(
+        "SELECT folder_id FROM workspace_folders WHERE workspace_id = ? AND folder_id = ?",
+        (ws_b, child),
+    ).fetchone() is not None
+
+    # Workspace A no longer links the deleted subtree, but keeps /photos.
+    assert db.conn.execute(
+        "SELECT folder_id FROM workspace_folders WHERE workspace_id = ? AND folder_id = ?",
+        (ws_a, child),
+    ).fetchone() is None
+    assert db.conn.execute(
+        "SELECT folder_id FROM workspace_folders WHERE workspace_id = ? AND folder_id = ?",
+        (ws_a, parent),
+    ).fetchone() is not None
+
+
 def test_missing_folder_photos_hidden_from_browse(tmp_path):
     """Photos in missing folders don't appear in get_photos or count_photos."""
     from db import Database

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -364,6 +364,61 @@ def test_incremental_scan_converges_after_file_change(tmp_path):
     )
 
 
+def test_incremental_scan_retries_after_hash_failure(tmp_path, monkeypatch):
+    """A changed file whose content hash fails is retried on the next scan.
+
+    When _compute_file_features can't read the file (transient permission /
+    I-O error → file_hash None), the scan loop must NOT advance the stored
+    file_mtime — otherwise the next incremental scan sees the mtime as
+    current and skips the file forever with a stale hash and stale derived
+    caches.
+    """
+    import scanner
+    from db import Database
+    from scanner import scan
+
+    root = str(tmp_path / "photos")
+    os.makedirs(root)
+    path = os.path.join(root, 'bird.jpg')
+    Image.new('RGB', (100, 100)).save(path)
+
+    db = Database(str(tmp_path / "test.db"))
+    scan(root, db)
+
+    def _row():
+        return db.conn.execute(
+            "SELECT file_hash, file_mtime FROM photos"
+        ).fetchone()
+
+    old_row = _row()
+    assert old_row['file_hash'] is not None
+
+    # Simulate ExifTool having run (it isn't installed in CI) so the
+    # metadata_missing retry path doesn't mask the mtime-based check.
+    db.conn.execute("UPDATE photos SET exif_data = '{}' WHERE exif_data IS NULL")
+    db.conn.commit()
+
+    # Modify the file's content (and mtime)
+    time.sleep(0.05)
+    Image.new('RGB', (150, 150)).save(path)
+
+    # Scan with feature computation failing (simulated unreadable file)
+    monkeypatch.setattr(scanner, '_compute_file_features', lambda p: (None, None))
+    scan(root, db, incremental=True)
+    photo = _row()
+    assert photo['file_hash'] == old_row['file_hash']  # hash untouched
+    # Stored mtime must remain stale so the file is retried next scan
+    assert photo['file_mtime'] == old_row['file_mtime']
+    assert photo['file_mtime'] != os.stat(path).st_mtime
+
+    # With hashing working again, the next incremental scan picks it up
+    monkeypatch.undo()
+    scan(root, db, incremental=True)
+    photo = _row()
+    assert photo['file_hash'] != old_row['file_hash']
+    assert photo['file_mtime'] == os.stat(path).st_mtime
+
+
 def test_incremental_scan_forgets_deleted_xmp(tmp_path):
     """Deleting an XMP sidecar clears the stored xmp_mtime after one
     re-process, so later scans don't re-trip the "XMP changed" check."""

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -319,6 +319,88 @@ def test_incremental_scan_skips_unchanged(tmp_path):
     assert 'new.jpg' in filenames
 
 
+def test_incremental_scan_converges_after_file_change(tmp_path):
+    """A changed file is re-processed once, then skipped on later scans.
+
+    add_photo is INSERT OR IGNORE, so the scan loop must explicitly persist
+    the fresh file_mtime/file_size onto existing rows — without that, the
+    pre-pass compares against the stale stored mtime and re-hashes the file
+    on every incremental scan forever.
+    """
+    from db import Database
+    from scanner import scan
+
+    root = str(tmp_path / "photos")
+    os.makedirs(root)
+    path = os.path.join(root, 'bird.jpg')
+    Image.new('RGB', (100, 100)).save(path)
+
+    db = Database(str(tmp_path / "test.db"))
+    scan(root, db)
+
+    # Modify the file's content (and mtime)
+    time.sleep(0.05)
+    Image.new('RGB', (150, 150)).save(path)
+
+    scan(root, db, incremental=True)
+    photo = db.get_photos()[0]
+    assert photo['width'] == 150  # re-processed
+    assert photo['file_mtime'] == os.stat(path).st_mtime  # fresh mtime stored
+
+    # Simulate ExifTool having run (it isn't installed in CI) — without the
+    # exif_data marker the metadata_missing retry path re-processes the file
+    # regardless of mtime, masking what this test asserts.
+    db.conn.execute("UPDATE photos SET exif_data = '{}' WHERE exif_data IS NULL")
+    db.conn.commit()
+
+    # Next incremental scan must skip the file entirely — metadata
+    # extraction / hashing phases only announce themselves when there is
+    # at least one file to process.
+    statuses = []
+    scan(root, db, incremental=True, status_callback=statuses.append)
+    assert not any(
+        s.startswith('Extracting metadata') or s.startswith('Hashing')
+        for s in statuses
+    )
+
+
+def test_incremental_scan_forgets_deleted_xmp(tmp_path):
+    """Deleting an XMP sidecar clears the stored xmp_mtime after one
+    re-process, so later scans don't re-trip the "XMP changed" check."""
+    from db import Database
+    from scanner import scan
+    from xmp import write_sidecar
+
+    root = str(tmp_path / "photos")
+    os.makedirs(root)
+    Image.new('RGB', (100, 100)).save(os.path.join(root, 'bird.jpg'))
+    write_sidecar(
+        os.path.join(root, 'bird.xmp'),
+        flat_keywords={'Sparrow'},
+        hierarchical_keywords=set(),
+    )
+
+    db = Database(str(tmp_path / "test.db"))
+    scan(root, db)
+    assert db.get_photos()[0]['xmp_mtime'] is not None
+
+    # Simulate ExifTool having run (it isn't installed in CI) so the
+    # metadata_missing retry path doesn't force re-processing.
+    db.conn.execute("UPDATE photos SET exif_data = '{}' WHERE exif_data IS NULL")
+    db.conn.commit()
+
+    os.remove(os.path.join(root, 'bird.xmp'))
+    scan(root, db, incremental=True)
+    assert db.get_photos()[0]['xmp_mtime'] is None
+
+    statuses = []
+    scan(root, db, incremental=True, status_callback=statuses.append)
+    assert not any(
+        s.startswith('Extracting metadata') or s.startswith('Hashing')
+        for s in statuses
+    )
+
+
 def test_incremental_scan_detects_xmp_changes(tmp_path):
     """Incremental scan re-reads XMP when xmp_mtime changes."""
     from db import Database


### PR DESCRIPTION
## What changed

Four verified high-severity bugs from a full-app bug review, each small and self-contained:

### 1. `delete_folder` crashed on non-leaf folders — after deleting their photos (`vireo/db.py`)
`folders.parent_id` has no `ON DELETE` action and the scanner registers every subdirectory with `parent_id` set, so deleting a folder with children raised `IntegrityError` — *after* `delete_photos()` had already committed. The request 500'd, the folder stayed, but its photos were permanently gone. Reproduced against the real `Database` class before fixing.

Now: collects the whole subtree (descendants of a deleted folder are unreachable anyway), deletes photos via `delete_photos(commit=False)` chunks, removes `workspace_folders`/`folders` rows children-first, and commits once — a failure partway can no longer leave photos deleted with the folder behind. The deferred pipeline-cache prune runs only after the commit succeeds.

### 2. Changed files were re-processed on every incremental scan, forever (`vireo/scanner.py`)
`add_photo` is `INSERT OR IGNORE`, so the fresh `file_mtime`/`file_size`/`xmp_mtime` it was passed never reached an existing row, and the follow-up UPDATE didn't include them either. Once a file's content changed, the pre-pass mtime check stayed false on every later scan — full re-hash + re-ExifTool + XMP re-import each time, and the `working_copy_failed_mtime` retry gate was defeated. Also fixed the related convergence bug: deleting an XMP sidecar now clears the stored `xmp_mtime` instead of looking "XMP changed" on every scan.

### 3. Move page thumbnails all 404'd (`vireo/templates/move.html`)
The grid requested `/thumb/<id>`; no such route exists. Now uses `/thumbnails/<id>.jpg` like every other page.

### 4. Review page broken on workspaces with zero predictions (`vireo/templates/review.html`)
Browse-mode `renderStats()` referenced `allData`, which is never declared — the `ReferenceError` aborted `renderAll()` before the grid or empty state rendered. The grid's empty state already explains the situation, so the stat line now renders nothing in that mode.

## Tests

- New: `test_delete_folder_with_descendants`, `test_incremental_scan_converges_after_file_change`, `test_incremental_scan_forgets_deleted_xmp` (the scanner tests seed the `exif_data` marker to simulate ExifTool having run, since CI doesn't install it — without that the `metadata_missing` retry path masks the mtime assertions).
- Required suite (workspaces/db/app/photos/edits/jobs/darktable/config): **1068 passed, 1 skipped**.
- Full `vireo/tests/`: **3140 passed, 11 skipped, 4 failed** — the 4 failures are `test_grouping.py` exif-timestamp tests that fail identically on a clean checkout (missing `exifread` module locally; pre-existing, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced folder deletion to safely handle multi-workspace setups, preventing accidental data loss when workspaces share imported folders
  * Improved incremental scan efficiency to avoid repeated reprocessing of files when metadata sidecars are deleted
  * Corrected stats display behavior in browse mode for clearer information presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->