### PR TITLE
Fix four data-integrity bugs from the app review

### DIFF
--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -996,6 +996,56 @@ def test_merge_duplicate_keywords_merges_exact_name_children(db):
         assert tagged == {herons[0]["id"]}
 
 
+def test_merge_duplicate_keywords_handles_stale_group_after_parent_merge(db):
+    """A pass that contains both duplicate parents AND duplicate children
+    under those parents must not crash when the parent merge recursively
+    deletes one of the child group's ids. Without checking that each
+    group's keep_id still exists, the loop would UPDATE photo_keywords
+    toward a non-existent FK target and trip an IntegrityError."""
+    ws = db.create_workspace("A")
+    fid = db.add_folder("/photos", name="photos")
+    db.add_workspace_folder(ws, fid)
+    pid = db.add_photo(folder_id=fid, filename="a.jpg", extension=".jpg",
+                       file_size=100, file_mtime=1.0)
+    db.set_active_workspace(ws)
+
+    # Parents: Birds (keep) and birds (dup). Birds already has a Heron
+    # child; birds has both 'Heron' and 'heron' children — these form
+    # their own duplicate group under birds, and the parent merge will
+    # collapse 'Heron@birds' into 'Heron@Birds' before that group is
+    # processed.
+    db.conn.execute("INSERT INTO keywords (name) VALUES ('Birds')")
+    db.conn.execute("INSERT INTO keywords (name) VALUES ('birds')")
+    upper = db.conn.execute("SELECT id FROM keywords WHERE name='Birds'").fetchone()[0]
+    lower = db.conn.execute("SELECT id FROM keywords WHERE name='birds'").fetchone()[0]
+    db.conn.execute("INSERT INTO keywords (name, parent_id) VALUES ('Heron', ?)", (upper,))
+    db.conn.execute("INSERT INTO keywords (name, parent_id) VALUES ('Heron', ?)", (lower,))
+    db.conn.execute("INSERT INTO keywords (name, parent_id) VALUES ('heron', ?)", (lower,))
+    db.conn.commit()
+
+    for row in db.conn.execute(
+        "SELECT id FROM keywords WHERE LOWER(name) = 'heron'"
+    ).fetchall():
+        db.tag_photo(pid, row[0])
+
+    # Must not raise; converges to one Birds with one Heron child.
+    db.merge_duplicate_keywords()
+
+    birds = db.conn.execute(
+        "SELECT id FROM keywords WHERE LOWER(name) = 'birds'"
+    ).fetchall()
+    herons = db.conn.execute(
+        "SELECT id, parent_id FROM keywords WHERE LOWER(name) = 'heron'"
+    ).fetchall()
+    assert len(birds) == 1
+    assert len(herons) == 1
+    assert herons[0]["parent_id"] == birds[0]["id"]
+    tagged = {r[0] for r in db.conn.execute(
+        "SELECT keyword_id FROM photo_keywords WHERE photo_id = ?", (pid,)
+    ).fetchall()}
+    assert tagged == {herons[0]["id"]}
+
+
 def test_empty_workspace_labels_does_not_fallback_to_global(db):
     """An explicit empty active_labels [] should NOT fall back to global labels."""
     ws = db.create_workspace("Empty Labels")

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -862,6 +862,89 @@ def test_merge_duplicate_keywords_scoped_by_workspace(db):
     assert sparrows == 2
 
 
+def test_merge_duplicate_keywords_respects_parent_and_type(db):
+    """Same-name keywords under different parents (Springfield, IL vs MO) or
+    with different types are distinct by design and must NOT merge; only
+    case-variants in the same (parent, type) slot are duplicates."""
+    ws = db.create_workspace("A")
+    fid = db.add_folder("/photos", name="photos")
+    db.add_workspace_folder(ws, fid)
+    pid = db.add_photo(folder_id=fid, filename="a.jpg", extension=".jpg",
+                       file_size=100, file_mtime=1.0)
+    db.set_active_workspace(ws)
+
+    db.conn.execute("INSERT INTO keywords (name, type) VALUES ('Illinois', 'location')")
+    db.conn.execute("INSERT INTO keywords (name, type) VALUES ('Missouri', 'location')")
+    il = db.conn.execute("SELECT id FROM keywords WHERE name='Illinois'").fetchone()[0]
+    mo = db.conn.execute("SELECT id FROM keywords WHERE name='Missouri'").fetchone()[0]
+    db.conn.execute(
+        "INSERT INTO keywords (name, parent_id, type) VALUES ('Springfield', ?, 'location')", (il,))
+    db.conn.execute(
+        "INSERT INTO keywords (name, parent_id, type) VALUES ('Springfield', ?, 'location')", (mo,))
+    # Same name, same NULL parent, different type — also distinct
+    db.conn.execute("INSERT INTO keywords (name, type) VALUES ('Macro', 'genre')")
+    db.conn.execute("INSERT INTO keywords (name, type) VALUES ('macro', 'general')")
+    db.conn.commit()
+
+    for row in db.conn.execute(
+        "SELECT id FROM keywords WHERE name IN ('Springfield', 'Macro', 'macro')"
+    ).fetchall():
+        db.tag_photo(pid, row[0])
+
+    merged = db.merge_duplicate_keywords()
+    assert merged == 0
+
+    assert db.conn.execute(
+        "SELECT COUNT(*) FROM keywords WHERE name = 'Springfield'"
+    ).fetchone()[0] == 2
+    assert db.conn.execute(
+        "SELECT COUNT(*) FROM keywords WHERE LOWER(name) = 'macro'"
+    ).fetchone()[0] == 2
+
+
+def test_merge_duplicate_keywords_reparents_children(db):
+    """A duplicate with child keywords merges without tripping the
+    keywords.parent_id FK; children move to the survivor, and a follow-up
+    pass collapses children that became same-parent case-duplicates."""
+    ws = db.create_workspace("A")
+    fid = db.add_folder("/photos", name="photos")
+    db.add_workspace_folder(ws, fid)
+    pid = db.add_photo(folder_id=fid, filename="a.jpg", extension=".jpg",
+                       file_size=100, file_mtime=1.0)
+    db.set_active_workspace(ws)
+
+    # Case-duplicate parents, each with a case-duplicate child chain
+    db.conn.execute("INSERT INTO keywords (name) VALUES ('Birds')")
+    db.conn.execute("INSERT INTO keywords (name) VALUES ('birds')")
+    upper = db.conn.execute("SELECT id FROM keywords WHERE name='Birds'").fetchone()[0]
+    lower = db.conn.execute("SELECT id FROM keywords WHERE name='birds'").fetchone()[0]
+    db.conn.execute("INSERT INTO keywords (name, parent_id) VALUES ('Heron', ?)", (upper,))
+    db.conn.execute("INSERT INTO keywords (name, parent_id) VALUES ('heron', ?)", (lower,))
+    db.conn.commit()
+
+    for row in db.conn.execute(
+        "SELECT id FROM keywords WHERE LOWER(name) IN ('birds', 'heron')"
+    ).fetchall():
+        db.tag_photo(pid, row[0])
+
+    merged = db.merge_duplicate_keywords()
+    assert merged == 2  # Birds/birds, then Heron/heron once same-parent
+
+    birds = db.conn.execute(
+        "SELECT id FROM keywords WHERE LOWER(name) = 'birds'"
+    ).fetchall()
+    herons = db.conn.execute(
+        "SELECT id, parent_id FROM keywords WHERE LOWER(name) = 'heron'"
+    ).fetchall()
+    assert len(birds) == 1 and len(herons) == 1
+    assert herons[0]["parent_id"] == birds[0]["id"]
+    # Photo keeps both associations, now on the survivors
+    tagged = {r[0] for r in db.conn.execute(
+        "SELECT keyword_id FROM photo_keywords WHERE photo_id = ?", (pid,)
+    ).fetchall()}
+    assert tagged == {birds[0]["id"], herons[0]["id"]}
+
+
 def test_empty_workspace_labels_does_not_fallback_to_global(db):
     """An explicit empty active_labels [] should NOT fall back to global labels."""
     ws = db.create_workspace("Empty Labels")

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -1028,6 +1028,14 @@ def test_merge_duplicate_keywords_handles_stale_group_after_parent_merge(db):
     ).fetchall():
         db.tag_photo(pid, row[0])
 
+    # Species/location metadata carried only by the duplicate must fold
+    # into the survivor instead of being deleted with it. (Set after
+    # tagging so the auto-Wildlife rule doesn't muddy the tag assertions.)
+    db.conn.execute(
+        "UPDATE keywords SET is_species = 1, latitude = -33.9, longitude = 18.4 "
+        "WHERE name = 'heron' AND parent_id = ?", (lower,))
+    db.conn.commit()
+
     # Must not raise; converges to one Birds with one Heron child.
     db.merge_duplicate_keywords()
 
@@ -1035,11 +1043,15 @@ def test_merge_duplicate_keywords_handles_stale_group_after_parent_merge(db):
         "SELECT id FROM keywords WHERE LOWER(name) = 'birds'"
     ).fetchall()
     herons = db.conn.execute(
-        "SELECT id, parent_id FROM keywords WHERE LOWER(name) = 'heron'"
+        "SELECT id, parent_id, is_species, latitude, longitude "
+        "FROM keywords WHERE LOWER(name) = 'heron'"
     ).fetchall()
     assert len(birds) == 1
     assert len(herons) == 1
     assert herons[0]["parent_id"] == birds[0]["id"]
+    assert herons[0]["is_species"] == 1
+    assert herons[0]["latitude"] == -33.9
+    assert herons[0]["longitude"] == 18.4
     tagged = {r[0] for r in db.conn.execute(
         "SELECT keyword_id FROM photo_keywords WHERE photo_id = ?", (pid,)
     ).fetchall()}

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -905,7 +905,10 @@ def test_merge_duplicate_keywords_respects_parent_and_type(db):
 def test_merge_duplicate_keywords_reparents_children(db):
     """A duplicate with child keywords merges without tripping the
     keywords.parent_id FK; children move to the survivor, and a follow-up
-    pass collapses children that became same-parent case-duplicates."""
+    pass collapses children that became same-parent case-duplicates.
+    Only the leaves are photo-tagged — XMP import never tags ancestors —
+    so the untagged Birds/birds parents must still be found via the
+    descendant walk."""
     ws = db.create_workspace("A")
     fid = db.add_folder("/photos", name="photos")
     db.add_workspace_folder(ws, fid)
@@ -922,8 +925,9 @@ def test_merge_duplicate_keywords_reparents_children(db):
     db.conn.execute("INSERT INTO keywords (name, parent_id) VALUES ('heron', ?)", (lower,))
     db.conn.commit()
 
+    # Tag only the leaves, mirroring _import_keywords_for_photo
     for row in db.conn.execute(
-        "SELECT id FROM keywords WHERE LOWER(name) IN ('birds', 'heron')"
+        "SELECT id FROM keywords WHERE LOWER(name) = 'heron'"
     ).fetchall():
         db.tag_photo(pid, row[0])
 
@@ -938,11 +942,58 @@ def test_merge_duplicate_keywords_reparents_children(db):
     ).fetchall()
     assert len(birds) == 1 and len(herons) == 1
     assert herons[0]["parent_id"] == birds[0]["id"]
-    # Photo keeps both associations, now on the survivors
+    # Photo keeps its leaf association, now on the surviving heron
     tagged = {r[0] for r in db.conn.execute(
         "SELECT keyword_id FROM photo_keywords WHERE photo_id = ?", (pid,)
     ).fetchall()}
-    assert tagged == {birds[0]["id"], herons[0]["id"]}
+    assert tagged == {herons[0]["id"]}
+
+
+def test_merge_duplicate_keywords_merges_exact_name_children(db):
+    """When duplicate parents both have a child with the exact same name,
+    the UNIQUE(name, parent_id) clash on reparenting means the child is a
+    duplicate of the survivor's sibling — it must merge into it (keeping
+    its photo associations), not get renamed to 'Heron (id-N)'."""
+    ws = db.create_workspace("A")
+    fid = db.add_folder("/photos", name="photos")
+    db.add_workspace_folder(ws, fid)
+    pid1 = db.add_photo(folder_id=fid, filename="a.jpg", extension=".jpg",
+                        file_size=100, file_mtime=1.0)
+    pid2 = db.add_photo(folder_id=fid, filename="b.jpg", extension=".jpg",
+                        file_size=100, file_mtime=1.0)
+    db.set_active_workspace(ws)
+
+    # Case-duplicate parents, each with an exact-same-name child
+    db.conn.execute("INSERT INTO keywords (name) VALUES ('Birds')")
+    db.conn.execute("INSERT INTO keywords (name) VALUES ('birds')")
+    upper = db.conn.execute("SELECT id FROM keywords WHERE name='Birds'").fetchone()[0]
+    lower = db.conn.execute("SELECT id FROM keywords WHERE name='birds'").fetchone()[0]
+    db.conn.execute("INSERT INTO keywords (name, parent_id) VALUES ('Heron', ?)", (upper,))
+    db.conn.execute("INSERT INTO keywords (name, parent_id) VALUES ('Heron', ?)", (lower,))
+    h1 = db.conn.execute(
+        "SELECT id FROM keywords WHERE name='Heron' AND parent_id=?", (upper,)).fetchone()[0]
+    h2 = db.conn.execute(
+        "SELECT id FROM keywords WHERE name='Heron' AND parent_id=?", (lower,)).fetchone()[0]
+    db.conn.commit()
+
+    db.tag_photo(pid1, h1)
+    db.tag_photo(pid2, h2)
+
+    merged = db.merge_duplicate_keywords()
+    assert merged == 2  # birds into Birds, then its Heron into Birds' Heron
+
+    herons = db.conn.execute(
+        "SELECT id, name, parent_id FROM keywords WHERE name LIKE 'Heron%'"
+    ).fetchall()
+    assert len(herons) == 1
+    assert herons[0]["name"] == "Heron"  # no 'Heron (id-N)' mangling
+    assert herons[0]["parent_id"] == upper
+    # Both photos' associations converge on the surviving Heron
+    for pid in (pid1, pid2):
+        tagged = {r[0] for r in db.conn.execute(
+            "SELECT keyword_id FROM photo_keywords WHERE photo_id = ?", (pid,)
+        ).fetchall()}
+        assert tagged == {herons[0]["id"]}
 
 
 def test_empty_workspace_labels_does_not_fallback_to_global(db):

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -1058,6 +1058,85 @@ def test_merge_duplicate_keywords_handles_stale_group_after_parent_merge(db):
     assert tagged == {herons[0]["id"]}
 
 
+def test_merge_duplicate_keywords_preserves_differently_typed_children(db):
+    """A child name-collision on reparent is only a duplicate when both
+    children share a type. With 'Birds > Macro' (general) under one parent
+    and 'birds > Macro' (genre) under its case-duplicate, the parent merge
+    triggers a UNIQUE(name, parent_id) clash on the migrating Macro. The
+    dedup boundary is (LOWER(name), parent_id, type), so these aren't
+    duplicates; the migrating one must be preserved (disambiguated by
+    name), not silently merged into a different-type sibling — that would
+    retag photos across the type boundary and drop one typed keyword."""
+    ws = db.create_workspace("A")
+    fid = db.add_folder("/photos", name="photos")
+    db.add_workspace_folder(ws, fid)
+    pid_general = db.add_photo(folder_id=fid, filename="a.jpg", extension=".jpg",
+                               file_size=100, file_mtime=1.0)
+    pid_genre = db.add_photo(folder_id=fid, filename="b.jpg", extension=".jpg",
+                             file_size=100, file_mtime=1.0)
+    db.set_active_workspace(ws)
+
+    db.conn.execute("INSERT INTO keywords (name) VALUES ('Birds')")
+    db.conn.execute("INSERT INTO keywords (name) VALUES ('birds')")
+    upper = db.conn.execute("SELECT id FROM keywords WHERE name='Birds'").fetchone()[0]
+    lower = db.conn.execute("SELECT id FROM keywords WHERE name='birds'").fetchone()[0]
+    db.conn.execute(
+        "INSERT INTO keywords (name, parent_id, type) VALUES ('Macro', ?, 'general')",
+        (upper,),
+    )
+    db.conn.execute(
+        "INSERT INTO keywords (name, parent_id, type) VALUES ('Macro', ?, 'genre')",
+        (lower,),
+    )
+    m_general = db.conn.execute(
+        "SELECT id FROM keywords WHERE name='Macro' AND parent_id=?", (upper,)
+    ).fetchone()[0]
+    m_genre = db.conn.execute(
+        "SELECT id FROM keywords WHERE name='Macro' AND parent_id=?", (lower,)
+    ).fetchone()[0]
+    db.conn.commit()
+
+    db.tag_photo(pid_general, m_general)
+    db.tag_photo(pid_genre, m_genre)
+
+    db.merge_duplicate_keywords()
+
+    # Birds/birds collapsed to one parent.
+    birds = db.conn.execute(
+        "SELECT id FROM keywords WHERE LOWER(name) = 'birds'"
+    ).fetchall()
+    assert len(birds) == 1
+    assert birds[0]["id"] == upper
+
+    # Both typed Macros survive under the survivor parent; the migrating
+    # one was disambiguated rather than merged across the type boundary.
+    macros = db.conn.execute(
+        "SELECT id, name, parent_id, type FROM keywords WHERE LOWER(name) LIKE 'macro%' "
+        "ORDER BY type"
+    ).fetchall()
+    assert len(macros) == 2
+    assert {m["parent_id"] for m in macros} == {upper}
+    assert {m["type"] for m in macros} == {"general", "genre"}
+    # The original general Macro keeps its name; the migrating genre Macro
+    # was disambiguated with an id suffix.
+    by_type = {m["type"]: m for m in macros}
+    assert by_type["general"]["id"] == m_general
+    assert by_type["general"]["name"] == "Macro"
+    assert by_type["genre"]["id"] == m_genre
+    assert by_type["genre"]["name"] == f"Macro (id-{m_genre})"
+
+    # Each photo's association sticks to its own type — neither got
+    # silently retagged onto the other-type Macro.
+    general_tags = {r[0] for r in db.conn.execute(
+        "SELECT keyword_id FROM photo_keywords WHERE photo_id = ?", (pid_general,)
+    ).fetchall()}
+    genre_tags = {r[0] for r in db.conn.execute(
+        "SELECT keyword_id FROM photo_keywords WHERE photo_id = ?", (pid_genre,)
+    ).fetchall()}
+    assert general_tags == {m_general}
+    assert genre_tags == {m_genre}
+
+
 def test_empty_workspace_labels_does_not_fallback_to_global(db):
     """An explicit empty active_labels [] should NOT fall back to global labels."""
     ws = db.create_workspace("Empty Labels")

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -7075,7 +7075,25 @@ class Database:
             for d in dupes:
                 keep_id = d["keep_id"]
                 all_ids = [int(x) for x in d["all_ids"].split(",")]
-                remove_ids = [x for x in all_ids if x != keep_id]
+
+                # A prior group in this pass can recursively delete ids
+                # from later groups: merging duplicate parents cascades
+                # into their duplicate children, so a child group whose
+                # keep_id was one of those children is now stale. Skip
+                # groups whose keep_id is gone (the next while iteration
+                # re-queries and picks a fresh survivor) and drop dead
+                # remove_ids so we don't UPDATE photo_keywords toward a
+                # non-existent FK target.
+                placeholders = ",".join("?" * len(all_ids))
+                alive = {
+                    row["id"] for row in self.conn.execute(
+                        f"SELECT id FROM keywords WHERE id IN ({placeholders})",
+                        all_ids,
+                    )
+                }
+                if keep_id not in alive:
+                    continue
+                remove_ids = [x for x in all_ids if x != keep_id and x in alive]
 
                 for rid in remove_ids:
                     total_merged += self._merge_keyword_into(rid, keep_id)
@@ -10144,14 +10162,20 @@ class Database:
                 # Match the folder itself plus separator-delimited descendants.
                 # A bare prefix LIKE would also match siblings ("/photos/2023"
                 # matching "/photos/2023-trip") and treat _/% in the value as
-                # wildcards.
-                base = str(value or "").rstrip("/")
+                # wildcards. Stored folder paths use the platform separator
+                # (``str(Path(...))`` in scanner.scan — backslashes on Windows),
+                # so normalize both sides to forward slashes the same way
+                # ``_folder_subtree_ids_by_path`` does; otherwise a Windows
+                # library's ``C:\Photos\Birds`` row never matches a rule whose
+                # LIKE pattern hard-codes ``C:/Photos/%``.
+                base = _path_for_subtree_match(str(value or ""))
                 subtree_params = [base, _escape_like(base) + "/%"]
+                norm = "REPLACE(f.path, '\\', '/')"
                 if op == "under":
-                    return "(f.path = ? OR f.path LIKE ? ESCAPE '\\')", subtree_params
+                    return f"({norm} = ? OR {norm} LIKE ? ESCAPE '\\')", subtree_params
                 if op == "not_under":
                     return (
-                        "(f.path IS NULL OR (f.path != ? AND f.path NOT LIKE ? ESCAPE '\\'))",
+                        f"(f.path IS NULL OR ({norm} != ? AND {norm} NOT LIKE ? ESCAPE '\\'))",
                         subtree_params,
                     )
             if field == "flag":

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -7120,17 +7120,21 @@ class Database:
 
         Moves photo associations, then reparents the source's children onto
         the destination. A child whose exact name already exists under the
-        destination (UNIQUE(name, parent_id) clash) is itself a duplicate of
-        that sibling, so it merges into it recursively instead of being
-        renamed — "Birds > Heron" and "birds > Heron" must converge on one
-        Heron. Case-variant children don't clash (the UNIQUE index is
-        case-sensitive); they reparent cleanly and collapse on the caller's
-        next convergence pass. Cycles are impossible: parent_id chains are
-        acyclic by construction. Non-link metadata (is_species, coordinates,
-        taxon_id) folds into the destination when it lacks its own, so
-        deleting the source can't silently drop species/location info that
-        only the duplicate carried. Returns the number of keyword rows
-        merged away (>= 1). Caller commits.
+        destination (UNIQUE(name, parent_id) clash) merges into that sibling
+        recursively only when both share the same ``type`` — "Birds > Heron"
+        and "birds > Heron" must converge on one Heron. When the existing
+        sibling has a different ``type`` (e.g. a 'general' Macro vs. a
+        'genre' Macro), the dedup boundary is (LOWER(name), parent_id, type),
+        so they are NOT duplicates; preserve both by disambiguating the
+        migrating child's name with an id suffix. Case-variant children
+        don't clash (the UNIQUE index is case-sensitive); they reparent
+        cleanly and collapse on the caller's next convergence pass. Cycles
+        are impossible: parent_id chains are acyclic by construction.
+        Non-link metadata (is_species, coordinates, taxon_id) folds into
+        the destination when it lacks its own, so deleting the source can't
+        silently drop species/location info that only the duplicate carried.
+        Returns the number of keyword rows merged away (>= 1). Caller
+        commits.
         """
         merged = 1
         src = self.conn.execute(
@@ -7159,7 +7163,7 @@ class Database:
         # Reparent children onto the destination before deleting, or the
         # keywords.parent_id FK aborts the merge mid-way.
         children = self.conn.execute(
-            "SELECT id, name FROM keywords WHERE parent_id = ?", (src_id,)
+            "SELECT id, name, type FROM keywords WHERE parent_id = ?", (src_id,)
         ).fetchall()
         for child in children:
             try:
@@ -7169,10 +7173,21 @@ class Database:
                 )
             except sqlite3.IntegrityError:
                 existing = self.conn.execute(
-                    "SELECT id FROM keywords WHERE parent_id = ? AND name = ?",
+                    "SELECT id, type FROM keywords WHERE parent_id = ? AND name = ?",
                     (dst_id, child["name"]),
                 ).fetchone()
-                merged += self._merge_keyword_into(child["id"], existing["id"])
+                if existing["type"] == child["type"]:
+                    merged += self._merge_keyword_into(child["id"], existing["id"])
+                else:
+                    # Same name + parent but different type: outside the
+                    # (LOWER(name), parent_id, type) dedup boundary, so
+                    # preserve both by renaming the migrating child rather
+                    # than retagging photos across types.
+                    disambiguated = f"{child['name']} (id-{child['id']})"
+                    self.conn.execute(
+                        "UPDATE keywords SET parent_id = ?, name = ? WHERE id = ?",
+                        (dst_id, disambiguated, child["id"]),
+                    )
         self.conn.execute("DELETE FROM keywords WHERE id = ?", (src_id,))
         return merged
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -41,6 +41,18 @@ def _path_for_subtree_match(value: str) -> str:
     return value.replace("\\", "/").rstrip("/")
 
 
+def _escape_like(s: str) -> str:
+    """Escape SQL LIKE metacharacters so a path is matched literally.
+
+    LIKE treats ``%`` and ``_`` as wildcards unconditionally — an unescaped
+    folder path like ``/pics/my_dir`` also matches ``/pics/myXdir``, which
+    silently corrupts sibling folders in path-cascade UPDATEs. Pair with
+    ``LIKE ? ESCAPE '\\'`` at the call site (same convention as ingest.py
+    and scanner.py).
+    """
+    return s.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
 def _chunks(values, size=_SQLITE_PARAM_CHUNK_SIZE):
     values = list(values)
     for idx in range(0, len(values), size):
@@ -2046,8 +2058,8 @@ class Database:
         cascaded = []
         skipped_prefixes = []
         children = self.conn.execute(
-            "SELECT id, path FROM folders WHERE status = 'missing' AND path LIKE ? ORDER BY path",
-            (old_path + "/%",),
+            "SELECT id, path FROM folders WHERE status = 'missing' AND path LIKE ? ESCAPE '\\' ORDER BY path",
+            (_escape_like(old_path) + "/%",),
         ).fetchall()
         for child in children:
             # Skip descendants of conflicted folders
@@ -2168,8 +2180,8 @@ class Database:
         cascaded = []
         skipped_prefixes = []
         children = self.conn.execute(
-            "SELECT id, path FROM folders WHERE status = 'missing' AND path LIKE ? ORDER BY path",
-            (old_path + "/%",),
+            "SELECT id, path FROM folders WHERE status = 'missing' AND path LIKE ? ESCAPE '\\' ORDER BY path",
+            (_escape_like(old_path) + "/%",),
         ).fetchall()
         for child in children:
             if any(child["path"].startswith(p + "/") for p in skipped_prefixes):
@@ -2276,8 +2288,8 @@ class Database:
             "UPDATE folders SET path = ? WHERE id = ?", (new_path, folder_id)
         )
         children = self.conn.execute(
-            "SELECT id, path FROM folders WHERE path LIKE ?",
-            (old_path + "/%",),
+            "SELECT id, path FROM folders WHERE path LIKE ? ESCAPE '\\'",
+            (_escape_like(old_path) + "/%",),
         ).fetchall()
         for child in children:
             child_new = new_path + child["path"][len(old_path):]
@@ -7007,46 +7019,83 @@ class Database:
     def merge_duplicate_keywords(self):
         """Find and merge case-insensitive duplicate keywords in active workspace.
 
+        Duplicates are grouped by (LOWER(name), parent_id, type) — name alone
+        is not identity: the location system deliberately creates same-name
+        keywords under different parents (Springfield under Illinois vs.
+        Missouri), and same-name keywords of different types (species vs.
+        genre) are distinct by design. Merging across those slots retags
+        photos with the wrong place/kind.
+
         Only merges keywords that are used by photos in the active workspace.
         Keeps the lowest ID (earliest created), moves all photo associations,
-        and deletes the duplicates. Returns count of merges performed.
+        reparents any child keywords onto the survivor (the parent_id FK
+        would otherwise block the DELETE), and deletes the duplicates.
+        Runs passes until convergence so case-duplicate parent chains
+        ("Birds">"Heron" vs "birds">"heron") fully collapse: the children
+        only become same-parent duplicates after their parents merge.
+        Returns count of merges performed.
         """
         ws = self._ws_id()
-        dupes = self.conn.execute(
-            """SELECT LOWER(k.name) as lname, MIN(k.id) as keep_id,
-                      GROUP_CONCAT(DISTINCT k.id) as all_ids
-               FROM keywords k
-               JOIN photo_keywords pk ON pk.keyword_id = k.id
-               JOIN photos p ON p.id = pk.photo_id
-               JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-               WHERE wf.workspace_id = ?
-               GROUP BY LOWER(k.name) HAVING COUNT(DISTINCT k.id) > 1""",
-            (ws,),
-        ).fetchall()
+        total_merged = 0
+        while True:
+            dupes = self.conn.execute(
+                """SELECT LOWER(k.name) as lname, MIN(k.id) as keep_id,
+                          GROUP_CONCAT(DISTINCT k.id) as all_ids
+                   FROM keywords k
+                   JOIN photo_keywords pk ON pk.keyword_id = k.id
+                   JOIN photos p ON p.id = pk.photo_id
+                   JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+                   WHERE wf.workspace_id = ?
+                   GROUP BY LOWER(k.name), k.parent_id, k.type
+                   HAVING COUNT(DISTINCT k.id) > 1""",
+                (ws,),
+            ).fetchall()
+            if not dupes:
+                break
 
-        merged = 0
-        for d in dupes:
-            keep_id = d["keep_id"]
-            all_ids = [int(x) for x in d["all_ids"].split(",")]
-            remove_ids = [x for x in all_ids if x != keep_id]
+            for d in dupes:
+                keep_id = d["keep_id"]
+                all_ids = [int(x) for x in d["all_ids"].split(",")]
+                remove_ids = [x for x in all_ids if x != keep_id]
 
-            for rid in remove_ids:
-                # Move photo associations (ignore if already exists for keep_id)
-                self.conn.execute(
-                    "UPDATE OR IGNORE photo_keywords SET keyword_id = ? WHERE keyword_id = ?",
-                    (keep_id, rid),
-                )
-                # Delete orphaned associations
-                self.conn.execute(
-                    "DELETE FROM photo_keywords WHERE keyword_id = ?", (rid,)
-                )
-                # Delete the duplicate keyword
-                self.conn.execute("DELETE FROM keywords WHERE id = ?", (rid,))
-                merged += 1
+                for rid in remove_ids:
+                    # Move photo associations (ignore if already exists for keep_id)
+                    self.conn.execute(
+                        "UPDATE OR IGNORE photo_keywords SET keyword_id = ? WHERE keyword_id = ?",
+                        (keep_id, rid),
+                    )
+                    # Delete orphaned associations
+                    self.conn.execute(
+                        "DELETE FROM photo_keywords WHERE keyword_id = ?", (rid,)
+                    )
+                    # Reparent children onto the survivor before deleting, or
+                    # the keywords.parent_id FK aborts the merge mid-way.
+                    # Per-child so a UNIQUE(name, parent_id) clash with an
+                    # existing child of the survivor disambiguates instead of
+                    # blowing up (same pattern as the place-label merge).
+                    children = self.conn.execute(
+                        "SELECT id, name FROM keywords WHERE parent_id = ?",
+                        (rid,),
+                    ).fetchall()
+                    for child in children:
+                        try:
+                            self.conn.execute(
+                                "UPDATE keywords SET parent_id = ? WHERE id = ?",
+                                (keep_id, child["id"]),
+                            )
+                        except sqlite3.IntegrityError:
+                            disambiguated = f"{child['name']} (id-{child['id']})"
+                            self.conn.execute(
+                                "UPDATE keywords SET parent_id = ?, name = ? WHERE id = ?",
+                                (keep_id, disambiguated, child["id"]),
+                            )
+                    # Delete the duplicate keyword
+                    self.conn.execute("DELETE FROM keywords WHERE id = ?", (rid,))
+                    total_merged += 1
 
-        if merged:
+        if total_merged:
             self.conn.commit()
-        return merged
+        return total_merged
 
     def get_keyword_tree(self):
         """Return keywords used by photos in the active workspace, plus ancestors."""
@@ -10063,10 +10112,19 @@ class Database:
                 if op == "is not":
                     return _keyword_not_exists("k.name = ?", [value])
             if field == "folder":
+                # Match the folder itself plus separator-delimited descendants.
+                # A bare prefix LIKE would also match siblings ("/photos/2023"
+                # matching "/photos/2023-trip") and treat _/% in the value as
+                # wildcards.
+                base = str(value or "").rstrip("/")
+                subtree_params = [base, _escape_like(base) + "/%"]
                 if op == "under":
-                    return "f.path LIKE ?", [f"{value}%"]
+                    return "(f.path = ? OR f.path LIKE ? ESCAPE '\\')", subtree_params
                 if op == "not_under":
-                    return "(f.path IS NULL OR f.path NOT LIKE ?)", [f"{value}%"]
+                    return (
+                        "(f.path IS NULL OR (f.path != ? AND f.path NOT LIKE ? ESCAPE '\\'))",
+                        subtree_params,
+                    )
             if field == "flag":
                 if op in ("equals", "is"):
                     return "p.flag = ?", [value]

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -7039,9 +7039,24 @@ class Database:
         Runs passes until convergence so case-duplicate parent chains
         ("Birds">"Heron" vs "birds">"heron") fully collapse: the children
         only become same-parent duplicates after their parents merge.
+        The whole pass is all-or-nothing: an exception rolls back every
+        pending merge instead of leaving a half-merged tree on the
+        connection for a later unrelated commit to persist.
         Returns count of merges performed.
         """
         ws = self._ws_id()
+        total_merged = 0
+        try:
+            total_merged = self._merge_duplicate_keywords_pass(ws)
+        except Exception:
+            self.conn.rollback()
+            raise
+        if total_merged:
+            self.conn.commit()
+        return total_merged
+
+    def _merge_duplicate_keywords_pass(self, ws):
+        """Convergence loop for merge_duplicate_keywords. Caller commits."""
         total_merged = 0
         while True:
             dupes = self.conn.execute(
@@ -7098,8 +7113,6 @@ class Database:
                 for rid in remove_ids:
                     total_merged += self._merge_keyword_into(rid, keep_id)
 
-        if total_merged:
-            self.conn.commit()
         return total_merged
 
     def _merge_keyword_into(self, src_id, dst_id):
@@ -7113,10 +7126,29 @@ class Database:
         Heron. Case-variant children don't clash (the UNIQUE index is
         case-sensitive); they reparent cleanly and collapse on the caller's
         next convergence pass. Cycles are impossible: parent_id chains are
-        acyclic by construction. Returns the number of keyword rows merged
-        away (>= 1). Caller commits.
+        acyclic by construction. Non-link metadata (is_species, coordinates,
+        taxon_id) folds into the destination when it lacks its own, so
+        deleting the source can't silently drop species/location info that
+        only the duplicate carried. Returns the number of keyword rows
+        merged away (>= 1). Caller commits.
         """
         merged = 1
+        src = self.conn.execute(
+            "SELECT is_species, latitude, longitude, taxon_id "
+            "FROM keywords WHERE id = ?",
+            (src_id,),
+        ).fetchone()
+        if src is not None:
+            self.conn.execute(
+                """UPDATE keywords
+                   SET is_species = CASE WHEN ? = 1 THEN 1 ELSE is_species END,
+                       latitude   = COALESCE(latitude, ?),
+                       longitude  = COALESCE(longitude, ?),
+                       taxon_id   = COALESCE(taxon_id, ?)
+                   WHERE id = ?""",
+                (src["is_species"], src["latitude"], src["longitude"],
+                 src["taxon_id"], dst_id),
+            )
         # Move photo associations (ignore if already exists for dst_id),
         # then drop the leftovers.
         self.conn.execute(

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -7026,7 +7026,13 @@ class Database:
         genre) are distinct by design. Merging across those slots retags
         photos with the wrong place/kind.
 
-        Only merges keywords that are used by photos in the active workspace.
+        A keyword is in scope when it — or any descendant — is tagged on a
+        photo in the active workspace. XMP import only tags the leaf of a
+        hierarchical keyword ("Birds > Heron" tags Heron, not Birds), so
+        duplicate ancestors usually have no photo_keywords rows of their
+        own; walking up from the tagged leaves brings them in scope while
+        still leaving other workspaces' keywords untouched.
+
         Keeps the lowest ID (earliest created), moves all photo associations,
         reparents any child keywords onto the survivor (the parent_id FK
         would otherwise block the DELETE), and deletes the duplicates.
@@ -7039,15 +7045,28 @@ class Database:
         total_merged = 0
         while True:
             dupes = self.conn.execute(
-                """SELECT LOWER(k.name) as lname, MIN(k.id) as keep_id,
-                          GROUP_CONCAT(DISTINCT k.id) as all_ids
+                """WITH RECURSIVE
+                   tagged AS (
+                       SELECT DISTINCT pk.keyword_id AS id
+                       FROM photo_keywords pk
+                       JOIN photos p ON p.id = pk.photo_id
+                       JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+                       WHERE wf.workspace_id = ?
+                   ),
+                   in_scope AS (
+                       SELECT id FROM tagged
+                       UNION
+                       SELECT k.parent_id
+                       FROM keywords k
+                       JOIN in_scope s ON s.id = k.id
+                       WHERE k.parent_id IS NOT NULL
+                   )
+                   SELECT MIN(k.id) as keep_id,
+                          GROUP_CONCAT(k.id) as all_ids
                    FROM keywords k
-                   JOIN photo_keywords pk ON pk.keyword_id = k.id
-                   JOIN photos p ON p.id = pk.photo_id
-                   JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-                   WHERE wf.workspace_id = ?
+                   JOIN in_scope s ON s.id = k.id
                    GROUP BY LOWER(k.name), k.parent_id, k.type
-                   HAVING COUNT(DISTINCT k.id) > 1""",
+                   HAVING COUNT(k.id) > 1""",
                 (ws,),
             ).fetchall()
             if not dupes:
@@ -7059,43 +7078,53 @@ class Database:
                 remove_ids = [x for x in all_ids if x != keep_id]
 
                 for rid in remove_ids:
-                    # Move photo associations (ignore if already exists for keep_id)
-                    self.conn.execute(
-                        "UPDATE OR IGNORE photo_keywords SET keyword_id = ? WHERE keyword_id = ?",
-                        (keep_id, rid),
-                    )
-                    # Delete orphaned associations
-                    self.conn.execute(
-                        "DELETE FROM photo_keywords WHERE keyword_id = ?", (rid,)
-                    )
-                    # Reparent children onto the survivor before deleting, or
-                    # the keywords.parent_id FK aborts the merge mid-way.
-                    # Per-child so a UNIQUE(name, parent_id) clash with an
-                    # existing child of the survivor disambiguates instead of
-                    # blowing up (same pattern as the place-label merge).
-                    children = self.conn.execute(
-                        "SELECT id, name FROM keywords WHERE parent_id = ?",
-                        (rid,),
-                    ).fetchall()
-                    for child in children:
-                        try:
-                            self.conn.execute(
-                                "UPDATE keywords SET parent_id = ? WHERE id = ?",
-                                (keep_id, child["id"]),
-                            )
-                        except sqlite3.IntegrityError:
-                            disambiguated = f"{child['name']} (id-{child['id']})"
-                            self.conn.execute(
-                                "UPDATE keywords SET parent_id = ?, name = ? WHERE id = ?",
-                                (keep_id, disambiguated, child["id"]),
-                            )
-                    # Delete the duplicate keyword
-                    self.conn.execute("DELETE FROM keywords WHERE id = ?", (rid,))
-                    total_merged += 1
+                    total_merged += self._merge_keyword_into(rid, keep_id)
 
         if total_merged:
             self.conn.commit()
         return total_merged
+
+    def _merge_keyword_into(self, src_id, dst_id):
+        """Merge keyword ``src_id`` into ``dst_id`` and delete the source.
+
+        Moves photo associations, then reparents the source's children onto
+        the destination. A child whose exact name already exists under the
+        destination (UNIQUE(name, parent_id) clash) is itself a duplicate of
+        that sibling, so it merges into it recursively instead of being
+        renamed — "Birds > Heron" and "birds > Heron" must converge on one
+        Heron. Case-variant children don't clash (the UNIQUE index is
+        case-sensitive); they reparent cleanly and collapse on the caller's
+        next convergence pass. Cycles are impossible: parent_id chains are
+        acyclic by construction. Returns the number of keyword rows merged
+        away (>= 1). Caller commits.
+        """
+        merged = 1
+        # Move photo associations (ignore if already exists for dst_id),
+        # then drop the leftovers.
+        self.conn.execute(
+            "UPDATE OR IGNORE photo_keywords SET keyword_id = ? WHERE keyword_id = ?",
+            (dst_id, src_id),
+        )
+        self.conn.execute("DELETE FROM photo_keywords WHERE keyword_id = ?", (src_id,))
+        # Reparent children onto the destination before deleting, or the
+        # keywords.parent_id FK aborts the merge mid-way.
+        children = self.conn.execute(
+            "SELECT id, name FROM keywords WHERE parent_id = ?", (src_id,)
+        ).fetchall()
+        for child in children:
+            try:
+                self.conn.execute(
+                    "UPDATE keywords SET parent_id = ? WHERE id = ?",
+                    (dst_id, child["id"]),
+                )
+            except sqlite3.IntegrityError:
+                existing = self.conn.execute(
+                    "SELECT id FROM keywords WHERE parent_id = ? AND name = ?",
+                    (dst_id, child["name"]),
+                ).fetchone()
+                merged += self._merge_keyword_into(child["id"], existing["id"])
+        self.conn.execute("DELETE FROM keywords WHERE id = ?", (src_id,))
+        return merged
 
     def get_keyword_tree(self):
         """Return keywords used by photos in the active workspace, plus ancestors."""

--- a/vireo/duplicates.py
+++ b/vireo/duplicates.py
@@ -18,17 +18,32 @@ class DupCandidate:
     exists: bool = True
 
 
-_DUP_SUFFIX_RES = [
+# Unambiguous copy markers — no camera names files this way.
+_ALWAYS_DUP_SUFFIX_RES = [
     re.compile(r" \(\d+\)$", re.IGNORECASE),
     re.compile(r" copy( \d+)?$", re.IGNORECASE),
-    re.compile(r"-\d+$"),
-    re.compile(r"_\d+$"),
+]
+
+# Trailing -N / _N are copy markers only *relative to the group*: nearly
+# every camera original ends in digits (IMG_1234, DSC_0042, DJI-0001), so
+# treating the bare pattern as dirty would invert rule 1 for the most
+# common filenames in the library — the original would lose to a renamed
+# copy. A name is a dirty variant only when stripping the suffix yields
+# another group member's stem (owl_1.jpg next to owl.jpg).
+_RELATIVE_DUP_SUFFIX_RES = [
+    re.compile(r"[-_]\d+$"),
 ]
 
 
-def _has_dup_suffix(path: str) -> bool:
+def _has_dup_suffix(path: str, other_stems=frozenset()) -> bool:
     stem = Path(path).stem
-    return any(r.search(stem) for r in _DUP_SUFFIX_RES)
+    if any(r.search(stem) for r in _ALWAYS_DUP_SUFFIX_RES):
+        return True
+    for r in _RELATIVE_DUP_SUFFIX_RES:
+        m = r.search(stem)
+        if m and stem[: m.start()].lower() in other_stems:
+            return True
+    return False
 
 
 def resolve_duplicates(candidates):
@@ -72,9 +87,17 @@ def resolve_duplicates(candidates):
     else:
         pool = candidates
 
-    # Rule 1: clean filename beats dirty (dup-suffix) filename
-    clean = [c for c in pool if not _has_dup_suffix(c.path)]
-    dirty = [c for c in pool if _has_dup_suffix(c.path)]
+    # Rule 1: clean filename beats dirty (dup-suffix) filename. The -N/_N
+    # suffix check is group-relative (see _RELATIVE_DUP_SUFFIX_RES), so each
+    # candidate is judged against the other members' stems.
+    stems_by_id = {c.id: Path(c.path).stem.lower() for c in pool}
+
+    def _dirty(c):
+        others = frozenset(s for i, s in stems_by_id.items() if i != c.id)
+        return _has_dup_suffix(c.path, others)
+
+    clean = [c for c in pool if not _dirty(c)]
+    dirty = [c for c in pool if _dirty(c)]
     if clean and dirty:
         losers_with_reasons.extend(
             (c.id, "filename has dup suffix") for c in dirty

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -251,7 +251,14 @@ def _pair_raw_jpeg_companions(db):
         if primary_full["rating"] == 0 and companion_full["rating"] != 0:
             updates.append("rating = ?")
             params.append(companion_full["rating"])
-        if primary_full["flag"] == "none" and companion_full["flag"] != "none":
+        if (
+            primary_full["flag"] == "none"
+            and companion_full["flag"] not in ("none", "rejected")
+        ):
+            # Never copy 'rejected': the duplicate auto-resolver runs earlier
+            # in the same scan and rejects companion JPEGs that lose to a
+            # byte-identical twin elsewhere — stamping that onto the RAW
+            # would silently hide a unique photo.
             updates.append("flag = ?")
             params.append(companion_full["flag"])
         if primary_full["latitude"] is None and companion_full["latitude"] is not None:

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -7068,10 +7068,12 @@ def test_move_folder_path_does_not_touch_wildcard_siblings(db):
     assert sibling_child["path"] == "/pics/myXdir/sub"
 
 
-def test_folder_under_rule_excludes_siblings_and_escapes_wildcards(tmp_path):
+def test_folder_under_rule_excludes_siblings_and_escapes_wildcards(tmp_path, monkeypatch):
     """'folder under /photos/2023' must match that folder and its
     descendants only — not the sibling /photos/2023-trip — and a _ in the
     value must not act as a LIKE wildcard."""
+    import config as cfg
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
     from db import Database
     db = Database(str(tmp_path / "test.db"))
     ws_id = db.ensure_default_workspace()
@@ -7096,12 +7098,14 @@ def test_folder_under_rule_excludes_siblings_and_escapes_wildcards(tmp_path):
     assert db.count_photos_for_rules(under_us) == 1  # not /photos/myXdir
 
 
-def test_folder_under_rule_matches_backslash_paths(tmp_path):
+def test_folder_under_rule_matches_backslash_paths(tmp_path, monkeypatch):
     """Windows libraries store folder paths with backslash separators
     (``str(Path(...))`` in scanner.scan). The 'folder under' rule must
     still match descendants of a backslash-delimited root and exclude
     siblings; a LIKE pattern that hard-codes '/%' would silently miss
     every Windows descendant."""
+    import config as cfg
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
     from db import Database
     db = Database(str(tmp_path / "test.db"))
     ws_id = db.ensure_default_workspace()
@@ -7119,8 +7123,15 @@ def test_folder_under_rule_matches_backslash_paths(tmp_path):
     under = [{"field": "folder", "op": "under", "value": "C:/Photos/2023"}]
     assert db.count_photos_for_rules(under) == 2  # root + descendant, not sibling
 
-    not_under = [{"field": "folder", "op": "under", "value": "C:/Photos/2023-trip"}]
-    assert db.count_photos_for_rules(not_under) == 1
+    # Backslash rule values match symmetrically (normalized before escaping).
+    under_bs = [{"field": "folder", "op": "under", "value": "C:\\Photos\\2023"}]
+    assert db.count_photos_for_rules(under_bs) == 2
+
+    not_under = [{"field": "folder", "op": "not_under", "value": "C:/Photos/2023"}]
+    assert db.count_photos_for_rules(not_under) == 1  # only the sibling
+
+    under_sib = [{"field": "folder", "op": "under", "value": "C:/Photos/2023-trip"}]
+    assert db.count_photos_for_rules(under_sib) == 1
 
 
 def test_check_filename_collisions(db):

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -7096,6 +7096,33 @@ def test_folder_under_rule_excludes_siblings_and_escapes_wildcards(tmp_path):
     assert db.count_photos_for_rules(under_us) == 1  # not /photos/myXdir
 
 
+def test_folder_under_rule_matches_backslash_paths(tmp_path):
+    """Windows libraries store folder paths with backslash separators
+    (``str(Path(...))`` in scanner.scan). The 'folder under' rule must
+    still match descendants of a backslash-delimited root and exclude
+    siblings; a LIKE pattern that hard-codes '/%' would silently miss
+    every Windows descendant."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+
+    f_root = db.add_folder("C:\\Photos\\2023", name="2023")
+    f_sub = db.add_folder("C:\\Photos\\2023\\trip", name="trip", parent_id=f_root)
+    f_sib = db.add_folder("C:\\Photos\\2023-trip", name="2023-trip")
+    for fid, name in [(f_root, "a"), (f_sub, "b"), (f_sib, "c")]:
+        db.add_photo(folder_id=fid, filename=f"{name}.jpg", extension=".jpg",
+                     file_size=100, file_mtime=1.0)
+
+    # Forward-slash rule value still applies to a Windows library because
+    # both sides are normalized to '/'.
+    under = [{"field": "folder", "op": "under", "value": "C:/Photos/2023"}]
+    assert db.count_photos_for_rules(under) == 2  # root + descendant, not sibling
+
+    not_under = [{"field": "folder", "op": "under", "value": "C:/Photos/2023-trip"}]
+    assert db.count_photos_for_rules(not_under) == 1
+
+
 def test_check_filename_collisions(db):
     """check_filename_collisions detects conflicts at destination folder."""
     fid1 = db.add_folder("/src", name="src")

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -7051,6 +7051,51 @@ def test_move_folder_path_cascade(db):
     assert grandchild["path"] == "/nas/photos/2024/march/birds"
 
 
+def test_move_folder_path_does_not_touch_wildcard_siblings(db):
+    """LIKE treats _ and % as wildcards — moving /pics/my_dir must not
+    rewrite the unrelated sibling /pics/myXdir's children."""
+    fid = db.add_folder("/pics/my_dir", name="my_dir")
+    sib = db.add_folder("/pics/myXdir", name="myXdir")
+    sib_child = db.add_folder("/pics/myXdir/sub", name="sub", parent_id=sib)
+
+    db.move_folder_path(fid, "/dest/dir")
+
+    moved = db.conn.execute("SELECT path FROM folders WHERE id = ?", (fid,)).fetchone()
+    sibling = db.conn.execute("SELECT path FROM folders WHERE id = ?", (sib,)).fetchone()
+    sibling_child = db.conn.execute("SELECT path FROM folders WHERE id = ?", (sib_child,)).fetchone()
+    assert moved["path"] == "/dest/dir"
+    assert sibling["path"] == "/pics/myXdir"
+    assert sibling_child["path"] == "/pics/myXdir/sub"
+
+
+def test_folder_under_rule_excludes_siblings_and_escapes_wildcards(tmp_path):
+    """'folder under /photos/2023' must match that folder and its
+    descendants only — not the sibling /photos/2023-trip — and a _ in the
+    value must not act as a LIKE wildcard."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+
+    f_2023 = db.add_folder("/photos/2023", name="2023")
+    f_sub = db.add_folder("/photos/2023/trip", name="trip", parent_id=f_2023)
+    f_sib = db.add_folder("/photos/2023-trip", name="2023-trip")
+    f_us = db.add_folder("/photos/my_dir", name="my_dir")
+    f_usx = db.add_folder("/photos/myXdir", name="myXdir")
+    for fid, name in [(f_2023, "a"), (f_sub, "b"), (f_sib, "c"), (f_us, "d"), (f_usx, "e")]:
+        db.add_photo(folder_id=fid, filename=f"{name}.jpg", extension=".jpg",
+                     file_size=100, file_mtime=1.0)
+
+    under_2023 = [{"field": "folder", "op": "under", "value": "/photos/2023"}]
+    assert db.count_photos_for_rules(under_2023) == 2  # folder itself + descendant
+
+    not_under_2023 = [{"field": "folder", "op": "not_under", "value": "/photos/2023"}]
+    assert db.count_photos_for_rules(not_under_2023) == 3
+
+    under_us = [{"field": "folder", "op": "under", "value": "/photos/my_dir"}]
+    assert db.count_photos_for_rules(under_us) == 1  # not /photos/myXdir
+
+
 def test_check_filename_collisions(db):
     """check_filename_collisions detects conflicts at destination folder."""
     fid1 = db.add_folder("/src", name="src")

--- a/vireo/tests/test_duplicates.py
+++ b/vireo/tests/test_duplicates.py
@@ -36,6 +36,30 @@ def test_resolve_prefers_clean_filename(clean_name, dup_name):
     assert _loser_ids(losers) == [2]
 
 
+@pytest.mark.parametrize("camera_name", [
+    "IMG_1234.jpg",
+    "DSC_0042.jpg",
+    "DJI-0001.jpg",
+])
+def test_camera_filenames_are_not_dup_suffixed(camera_name):
+    """A trailing _N/-N is only a copy marker relative to the group — a
+    camera-named original must not lose rule 1 to a renamed copy."""
+    original = DupCandidate(id=1, path=f"/a/{camera_name}", mtime=100.0)
+    renamed = DupCandidate(id=2, path="/b/heron-blue.jpg", mtime=200.0)
+    winner, losers = resolve_duplicates([renamed, original])
+    reasons = {lid: reason for lid, reason in losers}
+    assert reasons.get(1) != "filename has dup suffix"
+
+
+def test_camera_burst_copy_still_dup_suffixed():
+    """IMG_1234_2.jpg next to IMG_1234.jpg in the group IS a dirty copy."""
+    original = DupCandidate(id=1, path="/a/IMG_1234.jpg", mtime=100.0)
+    copy = DupCandidate(id=2, path="/a/IMG_1234_2.jpg", mtime=100.0)
+    winner, losers = resolve_duplicates([copy, original])
+    assert winner == 1
+    assert losers == [(2, "filename has dup suffix")]
+
+
 def test_resolve_prefers_shorter_path():
     shallow = DupCandidate(id=1, path="/pics/owl.jpg", mtime=100.0)
     deep = DupCandidate(id=2, path="/pics/archive/2024/owl.jpg", mtime=100.0)

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -602,6 +602,36 @@ def test_scan_late_arriving_raw_pairs_with_existing_jpeg(tmp_path):
     assert "Robin" in kw_names
 
 
+def test_pairing_does_not_copy_rejected_flag_to_raw(tmp_path):
+    """A companion JPEG's 'rejected' flag (e.g. set by the duplicate
+    auto-resolver when the JPEG has a byte-identical twin) must not be
+    stamped onto the unique RAW primary during pairing."""
+    from db import Database
+    from scanner import scan
+
+    img_dir = tmp_path / "photos"
+    img_dir.mkdir()
+
+    Image.new("RGB", (200, 100), color="green").save(str(img_dir / "IMG_001.jpg"))
+    db = Database(str(tmp_path / "test.db"))
+    scan(str(img_dir), db)
+
+    jpeg_id = db.conn.execute("SELECT id FROM photos").fetchone()["id"]
+    db.conn.execute("UPDATE photos SET flag = 'rejected' WHERE id = ?", (jpeg_id,))
+    db.conn.commit()
+
+    with open(str(img_dir / "IMG_001.cr3"), "wb") as f:
+        f.write(b"\x00" * 200)
+    scan(str(img_dir), db)
+
+    photos = db.conn.execute(
+        "SELECT filename, companion_path, flag FROM photos"
+    ).fetchall()
+    assert len(photos) == 1
+    assert photos[0]["filename"] == "IMG_001.cr3"
+    assert photos[0]["flag"] == "none"
+
+
 def test_pairing_merges_predictions_without_unique_violation(tmp_path):
     """Pairing raw+JPEG deduplicates predictions that would violate UNIQUE(photo_id, model, workspace_id)."""
     from db import Database


### PR DESCRIPTION
## What changed

Batch 1 (silent data corruption) from the full-app bug review — follow-up to #967.

### 1. "Clean keywords" merged unrelated keywords and crashed on children (`vireo/db.py`)
`merge_duplicate_keywords` grouped duplicates by `LOWER(name)` alone. The location system deliberately creates same-name keywords under different parents (Springfield under Illinois vs. Missouri) and same-name keywords of different types are distinct by design — one click of `/api/keywords/clean` silently retagged photos with the wrong place/kind. It also hit the `keywords.parent_id` FK and aborted mid-merge whenever a removed duplicate had child keywords.

Now groups by `(LOWER(name), parent_id, type)`, reparents children onto the survivor (with the same UNIQUE-clash disambiguation as the place-label merge), and repeats passes until convergence so case-duplicate parent chains (`Birds>Heron` vs `birds>heron`) still collapse fully.

### 2. LIKE-wildcard path cascades rewrote sibling folders (`vireo/db.py`)
`move_folder_path`, `relocate_folder`, and `_merge_into_existing` matched child folders with an unescaped `path LIKE old_path || '/%'`. `_` and `%` are LIKE wildcards, so moving `/pics/my_dir` also rewrote the unrelated sibling `/pics/myXdir/sub` (reproduced during the review). All three now use `ESCAPE '\'` with a shared `_escape_like` helper (same convention as `ingest.py`/`scanner.py`). Smart-collection `under`/`not_under` rules had the sibling-prefix variant (`/photos/2023` matched `/photos/2023-trip`) — now separator-aware and escaped.

### 3. RAW+JPEG pairing stamped `rejected` onto unique RAWs (`vireo/scanner.py`)
The pairing metadata transfer copied any non-`none` flag from the companion JPEG to the RAW primary — including a `rejected` flag the duplicate auto-resolver had just put on the JPEG (byte-identical twin elsewhere). A unique RAW would silently vanish from view. `rejected` is now excluded from the transfer.

### 4. Duplicate resolver counted camera filenames as "dirty" (`vireo/duplicates.py`)
The dirty-suffix regexes `-\d+$`/`_\d+$` match nearly every camera original (`IMG_1234`, `DSC_0042`, `DJI-0001`), inverting the "clean filename beats dirty" rule: the original lost to a renamed copy and got rejected. Trailing `-N`/`_N` is now a copy marker only relative to the group — dirty when stripping it yields another member's stem (`owl_1.jpg` next to `owl.jpg`), never for a standalone camera name. ` (1)`/` copy` markers stay absolute.

## Tests

New regression tests for each fix: `test_merge_duplicate_keywords_respects_parent_and_type`, `test_merge_duplicate_keywords_reparents_children`, `test_move_folder_path_does_not_touch_wildcard_siblings`, `test_folder_under_rule_excludes_siblings_and_escapes_wildcards`, `test_pairing_does_not_copy_rejected_flag_to_raw`, `test_camera_filenames_are_not_dup_suffixed`, `test_camera_burst_copy_still_dup_suffixed`.

Required suite + scanner + duplicates: **1195 passed, 2 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Folder operations now correctly handle special characters in folder names.
  * Fixed RAW and JPEG pairing to avoid unwanted flag transfers.
  * Smart collection rules properly handle folders with special characters.

* **Improvements**
  * Enhanced keyword duplicate merging to respect keyword hierarchies.
  * Improved duplicate filename detection accuracy.

* **Tests**
  * Added test coverage for keyword management, folder operations, and file pairing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->