### PR TITLE
Fix four robustness bugs from the app review

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2189,12 +2189,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         results = load_results(cache_dir, db._active_workspace_id)
         if results and results.get("photos"):
             photo_ids = [p["id"] for p in results["photos"]]
-            placeholders = ",".join("?" for _ in photo_ids)
-            rows = db.conn.execute(
-                f"SELECT id, flag, rating FROM photos WHERE id IN ({placeholders})",
-                photo_ids,
-            ).fetchall()
-            flag_map = {r["id"]: (r["flag"], r["rating"]) for r in rows}
+            # Chunked: cached pipeline results can span the whole workspace,
+            # exceeding SQLite's bound-parameter cap in one IN clause.
+            flag_map = {}
+            for chunk in _chunked(photo_ids):
+                placeholders = ",".join("?" for _ in chunk)
+                rows = db.conn.execute(
+                    f"SELECT id, flag, rating FROM photos WHERE id IN ({placeholders})",
+                    chunk,
+                ).fetchall()
+                flag_map.update({r["id"]: (r["flag"], r["rating"]) for r in rows})
             for p in results["photos"]:
                 f, r = flag_map.get(p["id"], ("none", 0))
                 p["flag"] = f
@@ -4751,10 +4755,28 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         paths = body.get("paths", [])
 
         if mode == "disk_permanent" and paths:
-            # Retry path: DB already cleaned up, just delete files
+            # Retry path: DB rows were already deleted by the initial
+            # disk-mode call, so the photos table can't vouch for these
+            # paths — but their parent directories still have folders rows.
+            # Only delete files that live directly in a Vireo-managed
+            # folder; anything else (a crafted request naming arbitrary
+            # files) is refused, not removed.
             trashed = 0
             trash_failed = []
             for p in paths:
+                if not isinstance(p, str) or not p:
+                    continue
+                candidates = {os.path.dirname(p), os.path.dirname(os.path.realpath(p))}
+                known = db.conn.execute(
+                    f"SELECT 1 FROM folders WHERE path IN ({','.join('?' for _ in candidates)})",
+                    list(candidates),
+                ).fetchone()
+                if not known:
+                    log.warning(
+                        "Refusing disk_permanent retry for path outside Vireo folders: %s", p
+                    )
+                    trash_failed.append({"path": p, "error": "not in a Vireo folder"})
+                    continue
                 if not os.path.isfile(p):
                     continue
                 try:
@@ -11589,15 +11611,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         active_ws = db._active_workspace_id
 
         # Filter to only photos visible in the active workspace,
-        # preserving the caller's original ordering.
-        placeholders = ",".join("?" for _ in photo_ids)
-        visible = db.conn.execute(
-            f"""SELECT p.id FROM photos p
-                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-                WHERE wf.workspace_id = ? AND p.id IN ({placeholders})""",
-            [active_ws] + list(photo_ids),
-        ).fetchall()
-        visible_set = {r["id"] for r in visible}
+        # preserving the caller's original ordering. Chunked so a large
+        # selection doesn't exceed SQLite's bound-parameter cap.
+        visible_set = set()
+        for chunk in _chunked(photo_ids):
+            placeholders = ",".join("?" for _ in chunk)
+            visible = db.conn.execute(
+                f"""SELECT p.id FROM photos p
+                    JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+                    WHERE wf.workspace_id = ? AND p.id IN ({placeholders})""",
+                [active_ws] + list(chunk),
+            ).fetchall()
+            visible_set.update(r["id"] for r in visible)
         photo_ids = [pid for pid in photo_ids if pid in visible_set]
         if not photo_ids:
             return json_error("no exportable photos in current workspace")

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -577,6 +577,17 @@ def _detect_subjects(photos, folders, runner, job, reclassify, db):
                     },
                 )
 
+            # Gate the download. The classifier-init phase (run by the
+            # caller before _detect_subjects) has no internal cancel check,
+            # so a cancel during model load would otherwise land here only
+            # to be ignored: hf_hub_download can't be interrupted once it
+            # starts, so the per-photo cancel check below runs too late.
+            if runner.is_cancelled(job["id"]):
+                log.info(
+                    "Classify job cancelled before MegaDetector weights download"
+                )
+                return {}, 0
+
             ensure_megadetector_weights(progress_callback=_dl_progress)
 
         runner.push_event(

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -903,16 +903,20 @@ def _classify_photos(
     skipped_existing = 0
     total = len(photos)
     batch = []
+    cancelled = False
 
     start_time = time.time()
 
     for i, photo in enumerate(photos):
         if runner.is_cancelled(job["id"]):
-            # The post-loop flush below still commits the pending batch, so
-            # work completed before the cancel is preserved.
+            # Already-classified work is in raw_results (committed via the
+            # in-loop flushes); the pending `batch` is only queued items
+            # that haven't run through the model yet, so it gets dropped
+            # below instead of flushed.
             log.info(
                 "Classify job cancelled during classification (%d/%d)", i, total
             )
+            cancelled = True
             break
         job["progress"]["current"] = i + 1
         job["progress"]["current_file"] = photo["filename"]
@@ -1115,8 +1119,11 @@ def _classify_photos(
                 _record_batch_classifier_runs(db, batch, model_name, fp, raw_results, pre_len)
                 batch = []
 
-    # Flush remaining images
-    if batch:
+    # Flush remaining images — but not on cancel. The pending batch holds
+    # photos that haven't been classified yet; running inference on them
+    # here would write predictions and classifier_runs rows for photos the
+    # user just told us to drop.
+    if batch and not cancelled:
         pre_len = len(raw_results)
         failed += _flush_batch(batch, clf, model_type, model_name, db, raw_results, top_k=top_k)
         _record_batch_classifier_runs(db, batch, model_name, fp, raw_results, pre_len)

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -526,17 +526,19 @@ def _detect_batch(photos, folders, runner, job, reclassify, db,
     return detection_map, detected, processed_ids
 
 
-def _detect_subjects(photos, folders, runner, job, reclassify, db,
-                      classifier_model=None):
+def _detect_subjects(photos, folders, runner, job, reclassify, db):
     """Run MegaDetector on photos, storing quality metrics.
 
     Wraps _detect_batch with progress reporting for the standalone classify job.
 
-    When ``reclassify`` is True and ``classifier_model`` is provided, prior
-    predictions and detections for each photo are cleared *just before*
-    that photo is re-detected — not upfront for the whole scope. Cancelling
-    mid-loop therefore leaves the unprocessed tail with its old state
-    intact instead of an empty cache it can't rebuild.
+    When ``reclassify`` is True, each photo's prior detections are cleared
+    *just before* that photo is re-detected — not upfront for the whole
+    scope. Cancelling mid-loop therefore leaves the unprocessed tail with
+    its old state intact instead of an empty cache it can't rebuild. The
+    cascaded predictions purge is handled by ``_classify_photos`` so that a
+    mid-classify cancel (or a detection-setup failure that skips this loop
+    entirely) doesn't strand photos with cleared predictions and no
+    replacement.
 
     Returns:
         (detection_map, detected_count) where detection_map is
@@ -651,18 +653,23 @@ def _detect_subjects(photos, folders, runner, job, reclassify, db,
             )
 
             # Per-photo reclassify purge: wipe this photo's prior
-            # predictions/detections immediately before re-detecting. The
-            # old global-upfront purge wiped the entire scope before
-            # detection started, so a mid-detection cancel stranded the
-            # unprocessed tail with no predictions and no detections.
-            # Doing it per-photo means an early cancel preserves the
-            # untouched photos' cached state.
+            # detections immediately before re-detecting. The old
+            # global-upfront purge wiped the entire scope before detection
+            # started, so a mid-detection cancel stranded the unprocessed
+            # tail with no predictions and no detections. Doing it per-photo
+            # means an early cancel preserves the untouched photos' cached
+            # state.
+            #
+            # The cascaded ``predictions`` clear is deferred to the
+            # classification loop's own per-photo purge: a mid-classify
+            # cancel would otherwise leave the unclassified tail with
+            # fresh detections but zero predictions, and a detection-setup
+            # failure (missing weights, etc.) that skips this loop entirely
+            # would leave stale predictions alongside the fallback
+            # full-image classifier's output. Tying the predictions clear
+            # to the classify loop instead means both cases preserve or
+            # rebuild the predictions in lockstep with the new run.
             if reclassify:
-                if classifier_model:
-                    db.clear_predictions(
-                        model=classifier_model,
-                        collection_photo_ids=[photo["id"]],
-                    )
                 db.clear_detections(photo["id"])
 
             batch_map, batch_detected, _batch_processed = _detect_batch(
@@ -934,12 +941,35 @@ def _classify_photos(
             # Already-classified work is in raw_results (committed via the
             # in-loop flushes); the pending `batch` is only queued items
             # that haven't run through the model yet, so it gets dropped
-            # below instead of flushed.
+            # below instead of flushed. The per-photo reclassify clear
+            # below only fires for photos we actually reach, so the
+            # unclassified tail keeps its old predictions intact.
             log.info(
                 "Classify job cancelled during classification (%d/%d)", i, total
             )
             cancelled = True
             break
+
+        # Per-photo reclassify predictions purge. Lives here (rather than
+        # alongside ``clear_detections`` in the detection loop) so that:
+        #   1. A mid-classify cancel leaves the unprocessed tail with its
+        #      old predictions intact — without this gate they'd already
+        #      be cleared and the cancel would strand them with new
+        #      detections and no predictions.
+        #   2. When detection setup fails (missing weights, etc.) and the
+        #      job degrades to full-image classification, the stale
+        #      detector-based predictions still get replaced rather than
+        #      lingering alongside the fallback model's output.
+        # ``clear_predictions`` also wipes the matching ``classifier_runs``
+        # rows so the per-detection skip gate doesn't short-circuit the
+        # fresh inference about to run.
+        if reclassify:
+            db.clear_predictions(
+                model=model_name,
+                collection_photo_ids=[photo["id"]],
+                labels_fingerprint=fp,
+            )
+
         job["progress"]["current"] = i + 1
         job["progress"]["current_file"] = photo["filename"]
         runner.update_step(
@@ -1790,7 +1820,6 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
             job=job,
             reclassify=params.reclassify,
             db=thread_db,
-            classifier_model=effective_name,
         )
         if runner.is_cancelled(job["id"]):
             # Detections are committed per-photo, so everything before the

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -545,7 +545,16 @@ def _detect_subjects(photos, folders, runner, job, reclassify, db):
         db.get_detector_run_photo_ids("megadetector-v6") if not reclassify else set()
     )
 
-    if detect_animals is not None and get_primary_detection is not None:
+    try:
+        if detect_animals is None or get_primary_detection is None:
+            raise ImportError(
+                "MegaDetector ONNX model not available — cannot run detection"
+            )
+
+        # Inside the try so a weights-download failure (e.g. network down)
+        # degrades to full-image classification like every other detection
+        # failure, instead of failing the whole job — which on a reclassify
+        # run would strike after predictions/detections were already purged.
         # Require at least one photo — a no-op reclassify over 0 photos should
         # not trigger a ~300 MB MegaDetector download.
         needs_fresh_detection = bool(photos) and (
@@ -569,12 +578,6 @@ def _detect_subjects(photos, folders, runner, job, reclassify, db):
                 )
 
             ensure_megadetector_weights(progress_callback=_dl_progress)
-
-    try:
-        if detect_animals is None or get_primary_detection is None:
-            raise ImportError(
-                "MegaDetector ONNX model not available — cannot run detection"
-            )
 
         runner.push_event(
             job["id"],
@@ -601,6 +604,11 @@ def _detect_subjects(photos, folders, runner, job, reclassify, db):
         start_time = job.get("_start_time", time.time())
 
         for i, photo in enumerate(photos):
+            if runner.is_cancelled(job["id"]):
+                log.info(
+                    "Classify job cancelled during detection (%d/%d)", i, total
+                )
+                break
             runner.update_step(
                 job["id"], "detect",
                 progress={"current": i + 1, "total": total},
@@ -888,6 +896,13 @@ def _classify_photos(
     start_time = time.time()
 
     for i, photo in enumerate(photos):
+        if runner.is_cancelled(job["id"]):
+            # The post-loop flush below still commits the pending batch, so
+            # work completed before the cancel is preserved.
+            log.info(
+                "Classify job cancelled during classification (%d/%d)", i, total
+            )
+            break
         job["progress"]["current"] = i + 1
         job["progress"]["current_file"] = photo["filename"]
         runner.update_step(
@@ -1555,6 +1570,21 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
                 "failed": 0,
             }
 
+        # Cancellation gate before the expensive phases (model resolution,
+        # weight download, inference). The job loops below also check
+        # per-photo; _run_job flips the terminal status to 'cancelled'.
+        if runner.is_cancelled(job["id"]):
+            log.info("Classify job cancelled before model resolution")
+            return {
+                "total": total,
+                "predictions_stored": 0,
+                "burst_groups": 0,
+                "already_classified": 0,
+                "already_labeled": 0,
+                "detected": 0,
+                "failed": 0,
+            }
+
         # Resolve model (deferred until we know there is work to do)
         if params.model_id:
             all_models = get_models()
@@ -1709,6 +1739,22 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
             reclassify=params.reclassify,
             db=thread_db,
         )
+        if runner.is_cancelled(job["id"]):
+            # Detections are committed per-photo, so everything before the
+            # cancel is already cached for the next run; skip classification.
+            runner.update_step(
+                job["id"], "detect", status="cancelled",
+                summary=f"Cancelled ({detected} animals detected so far)",
+            )
+            return {
+                "total": total,
+                "predictions_stored": 0,
+                "burst_groups": 0,
+                "already_classified": 0,
+                "already_labeled": 0,
+                "detected": detected,
+                "failed": 0,
+            }
         runner.update_step(
             job["id"], "detect", status="completed",
             summary=f"{detected} animals detected in {total} photos",
@@ -1751,10 +1797,21 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
             parts.append(f"{skipped_existing} cached")
         if failed:
             parts.append(f"{failed} failed")
-        runner.update_step(
-            job["id"], "classify", status="completed",
-            summary=", ".join(parts),
-        )
+        cancelled_mid_classify = runner.is_cancelled(job["id"])
+        if cancelled_mid_classify:
+            # Fall through to finalize: raw_results holds real classifications
+            # for the photos completed before the cancel — storing them
+            # preserves that work (and matches the per-detection cache, which
+            # is already committed).
+            runner.update_step(
+                job["id"], "classify", status="cancelled",
+                summary="Cancelled (" + ", ".join(parts) + ")",
+            )
+        else:
+            runner.update_step(
+                job["id"], "classify", status="completed",
+                summary=", ".join(parts),
+            )
 
         # Phase 7: Group and store predictions
         runner.update_step(job["id"], "finalize", status="running")

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -554,6 +554,14 @@ def _detect_subjects(photos, folders, runner, job, reclassify, db):
         db.get_detector_run_photo_ids("megadetector-v6") if not reclassify else set()
     )
 
+    # Track photos whose state we mutated (clear_detections + write_detection_batch
+    # in reclassify mode). Declared up here so the except handlers and early
+    # returns can stash whatever was accumulated before the failure. The caller
+    # reads ``job["_detect_processed_ids"]`` to decide which photos to classify
+    # on a post-detect cancel — using ``detection_map.keys()`` alone would miss
+    # empty-scene photos whose old predictions were already cascaded away.
+    processed_for_rebuild: set[int] = set()
+
     try:
         if detect_animals is None or get_primary_detection is None:
             raise ImportError(
@@ -595,6 +603,7 @@ def _detect_subjects(photos, folders, runner, job, reclassify, db):
                 log.info(
                     "Classify job cancelled before MegaDetector weights download"
                 )
+                job["_detect_processed_ids"] = processed_for_rebuild
                 return {}, 0
 
             ensure_megadetector_weights(progress_callback=_dl_progress)
@@ -672,13 +681,25 @@ def _detect_subjects(photos, folders, runner, job, reclassify, db):
             if reclassify:
                 db.clear_detections(photo["id"])
 
-            batch_map, batch_detected, _batch_processed = _detect_batch(
+            batch_map, batch_detected, batch_processed = _detect_batch(
                 [photo], folders, runner, job, reclassify, db,
                 det_conf_threshold=det_conf_threshold,
                 already_detected_ids=already_detected_ids,
             )
             detection_map.update(batch_map)
             detected += batch_detected
+
+            if reclassify and photo["id"] in batch_processed:
+                # ``_detect_batch.processed_ids`` is the truthful set of
+                # photos whose iteration completed — including empty-scene
+                # ones that recorded a detector_runs row but added nothing
+                # to ``detection_map``. In reclassify mode their old
+                # predictions were cascaded away by ``clear_detections``
+                # above, so the caller must classify them on cancel even
+                # though they have no detection rows to drive a cropped
+                # classifier pass (the full-image fallback in
+                # ``_classify_photos`` handles them).
+                processed_for_rebuild.add(photo["id"])
 
             if was_cached and batch_detected:
                 skipped_det += 1
@@ -746,6 +767,7 @@ def _detect_subjects(photos, folders, runner, job, reclassify, db):
         detection_map = {}
         detected = 0
 
+    job["_detect_processed_ids"] = processed_for_rebuild
     return detection_map, detected
 
 
@@ -1848,17 +1870,30 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
         # the processed subset with fresh detections but zero predictions
         # until a manual rerun. Fall through to classify just that subset
         # so cancel preserves the rebuild work already in flight. The
-        # unprocessed tail (``photo["id"] not in detection_map``) is
-        # dropped — its old state was never touched, so dropping it keeps
-        # the cached predictions intact.
+        # unprocessed tail is dropped — its old state was never touched,
+        # so dropping it keeps the cached predictions intact.
+        #
+        # The processed subset comes from ``job["_detect_processed_ids"]``,
+        # which is the union of (a) photos with at least one detection and
+        # (b) empty-scene photos that recorded a detector_runs row but
+        # added nothing to ``detection_map``. Using ``detection_map``
+        # alone would miss case (b), stranding empty-scene reclassified
+        # photos with cleared predictions and no replacement. Older test
+        # fakes for ``_detect_subjects`` that don't stash this key fall
+        # back to ``detection_map.keys()`` for backwards compatibility.
         finish_cleared_only = False
         if cancelled_after_detect:
             runner.update_step(
                 job["id"], "detect", status="cancelled",
                 summary=f"Cancelled ({detected} animals detected so far)",
             )
-            if params.reclassify and detection_map:
-                processed = [p for p in photos if p["id"] in detection_map]
+            processed_ids = job.get("_detect_processed_ids")
+            if processed_ids is None:
+                processed_ids = set(detection_map.keys())
+            else:
+                processed_ids = set(processed_ids) | set(detection_map.keys())
+            if params.reclassify and processed_ids:
+                processed = [p for p in photos if p["id"] in processed_ids]
                 if processed:
                     finish_cleared_only = True
                     photos = processed

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -902,6 +902,7 @@ def _classify_photos(
     photos, folders, detection_map, existing_preds, clf, model_type,
     model_name, runner, job, db, top_k=1, vireo_dir=None,
     labels_fingerprint=None, reclassify=False,
+    finish_cleared_only=False,
 ):
     """Classify detections in batches, cropping to each detection's bounding box.
 
@@ -915,6 +916,15 @@ def _classify_photos(
     A per-detection classifier_runs gate keyed on (detection_id, model_name,
     labels_fingerprint) short-circuits re-work when the same triple already
     ran. reclassify=True bypasses the gate.
+
+    ``finish_cleared_only`` is set by ``run_classify_job`` when a post-detect
+    cancel landed in reclassify mode. The processed subset of ``photos``
+    already had its prior detections + cascaded predictions wiped during
+    detection; we must run classification on them anyway to avoid stranding
+    them with no predictions. In this mode the per-photo predictions clear
+    is skipped (the cascade in ``_detect_subjects`` already did it) and the
+    cancel-break at the top of the loop is suppressed (we're rebuilding the
+    already-cleared work, not starting new work).
 
     Returns:
         (raw_results, failed_count, skipped_existing_count)
@@ -937,11 +947,14 @@ def _classify_photos(
     start_time = time.time()
 
     for i, photo in enumerate(photos):
-        if runner.is_cancelled(job["id"]):
+        if not finish_cleared_only and runner.is_cancelled(job["id"]):
             # Already-classified work is in raw_results (committed via the
-            # in-loop flushes); the pending `batch` is only queued items
-            # that haven't run through the model yet, so it gets dropped
-            # below instead of flushed. The per-photo reclassify clear
+            # in-loop flushes); the pending `batch` is queued items that
+            # haven't run through the model yet. In reclassify mode the
+            # final flush still drains the batch (those photos already had
+            # their old predictions cleared above and would otherwise end
+            # up empty); in non-reclassify mode the batch is dropped to
+            # honor the cancel signal. The per-photo reclassify clear
             # below only fires for photos we actually reach, so the
             # unclassified tail keeps its old predictions intact.
             log.info(
@@ -962,8 +975,10 @@ def _classify_photos(
         #      lingering alongside the fallback model's output.
         # ``clear_predictions`` also wipes the matching ``classifier_runs``
         # rows so the per-detection skip gate doesn't short-circuit the
-        # fresh inference about to run.
-        if reclassify:
+        # fresh inference about to run. Skipped in ``finish_cleared_only``
+        # mode because the cascade in ``_detect_subjects`` already wiped
+        # the prior predictions for these photos.
+        if reclassify and not finish_cleared_only:
             db.clear_predictions(
                 model=model_name,
                 collection_photo_ids=[photo["id"]],
@@ -1171,11 +1186,16 @@ def _classify_photos(
                 _record_batch_classifier_runs(db, batch, model_name, fp, raw_results, pre_len)
                 batch = []
 
-    # Flush remaining images — but not on cancel. The pending batch holds
-    # photos that haven't been classified yet; running inference on them
-    # here would write predictions and classifier_runs rows for photos the
-    # user just told us to drop.
-    if batch and not cancelled:
+    # Flush remaining images. The pending batch holds photos that haven't
+    # been classified yet — for non-reclassify cancels we drop it (those
+    # photos still have their cached predictions, so honoring the cancel
+    # signal here just skips wasted inference). For reclassify cancels we
+    # must flush instead: each queued photo already had its old predictions
+    # wiped by the per-photo ``clear_predictions`` above, and bailing here
+    # would strand them with no predictions until a manual rerun. Flushing
+    # finishes the rebuild for the queued tail without picking up any new
+    # photos (the cancel check at the top of the loop still blocks those).
+    if batch and (not cancelled or reclassify):
         pre_len = len(raw_results)
         failed += _flush_batch(batch, clf, model_type, model_name, db, raw_results, top_k=top_k)
         _record_batch_classifier_runs(db, batch, model_name, fp, raw_results, pre_len)
@@ -1821,26 +1841,54 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
             reclassify=params.reclassify,
             db=thread_db,
         )
-        if runner.is_cancelled(job["id"]):
-            # Detections are committed per-photo, so everything before the
-            # cancel is already cached for the next run; skip classification.
+        cancelled_after_detect = runner.is_cancelled(job["id"])
+        # In reclassify mode, ``_detect_subjects`` clears each processed
+        # photo's prior detections before re-running detection — and that
+        # cascade-deletes its old predictions. Bailing out here would leave
+        # the processed subset with fresh detections but zero predictions
+        # until a manual rerun. Fall through to classify just that subset
+        # so cancel preserves the rebuild work already in flight. The
+        # unprocessed tail (``photo["id"] not in detection_map``) is
+        # dropped — its old state was never touched, so dropping it keeps
+        # the cached predictions intact.
+        finish_cleared_only = False
+        if cancelled_after_detect:
             runner.update_step(
                 job["id"], "detect", status="cancelled",
                 summary=f"Cancelled ({detected} animals detected so far)",
             )
-            return {
-                "total": total,
-                "predictions_stored": 0,
-                "burst_groups": 0,
-                "already_classified": 0,
-                "already_labeled": 0,
-                "detected": detected,
-                "failed": 0,
-            }
-        runner.update_step(
-            job["id"], "detect", status="completed",
-            summary=f"{detected} animals detected in {total} photos",
-        )
+            if params.reclassify and detection_map:
+                processed = [p for p in photos if p["id"] in detection_map]
+                if processed:
+                    finish_cleared_only = True
+                    photos = processed
+                    total = len(photos)
+                    job["progress"]["total"] = total
+                else:
+                    return {
+                        "total": total,
+                        "predictions_stored": 0,
+                        "burst_groups": 0,
+                        "already_classified": 0,
+                        "already_labeled": 0,
+                        "detected": detected,
+                        "failed": 0,
+                    }
+            else:
+                return {
+                    "total": total,
+                    "predictions_stored": 0,
+                    "burst_groups": 0,
+                    "already_classified": 0,
+                    "already_labeled": 0,
+                    "detected": detected,
+                    "failed": 0,
+                }
+        else:
+            runner.update_step(
+                job["id"], "detect", status="completed",
+                summary=f"{detected} animals detected in {total} photos",
+            )
 
         # Phase 6: Classify each photo. The per-detection classifier_runs
         # gate inside _classify_photos skips already-done detections and
@@ -1872,6 +1920,7 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
             vireo_dir=vireo_dir,
             labels_fingerprint=fp,
             reclassify=params.reclassify,
+            finish_cleared_only=finish_cleared_only,
         )
         classified_count = len(raw_results) - skipped_existing
         parts = [f"{classified_count} classified"]
@@ -1885,9 +1934,17 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
             # for the photos completed before the cancel — storing them
             # preserves that work (and matches the per-detection cache, which
             # is already committed).
+            if finish_cleared_only:
+                summary = (
+                    "Cancelled mid-detect — finished "
+                    + ", ".join(parts)
+                    + " for already-cleared photos"
+                )
+            else:
+                summary = "Cancelled (" + ", ".join(parts) + ")"
             runner.update_step(
                 job["id"], "classify", status="cancelled",
-                summary="Cancelled (" + ", ".join(parts) + ")",
+                summary=summary,
             )
         else:
             runner.update_step(

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -998,11 +998,22 @@ def _classify_photos(
         # fresh inference about to run. Skipped in ``finish_cleared_only``
         # mode because the cascade in ``_detect_subjects`` already wiped
         # the prior predictions for these photos.
+        #
+        # No ``labels_fingerprint`` filter: in the normal reclassify path
+        # ``clear_detections`` already cascade-wiped this photo's
+        # predictions (across all fingerprints) before we got here, so a
+        # filtered clear would just be a no-op repeat. In the fallback
+        # path (detection setup failed → empty ``detection_map`` for this
+        # photo, old detector detections still on disk) this clear is the
+        # ONLY purge before the full-image fallback writes new predictions;
+        # scoping it to the current fingerprint would leave predictions
+        # under prior fingerprints intact (e.g. after a workspace
+        # label-set change), and ``get_predictions``' latest-fingerprint
+        # filter would then surface them alongside the new fallback rows.
         if reclassify and not finish_cleared_only:
             db.clear_predictions(
                 model=model_name,
                 collection_photo_ids=[photo["id"]],
-                labels_fingerprint=fp,
             )
 
         job["progress"]["current"] = i + 1

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -680,26 +680,24 @@ def _detect_subjects(photos, folders, runner, job, reclassify, db):
             # rebuild the predictions in lockstep with the new run.
             if reclassify:
                 db.clear_detections(photo["id"])
+                # Once the clear has run we own rebuilding this photo on
+                # cancel — including the cases where ``_detect_batch``
+                # doesn't add the id to ``batch_processed`` (e.g.
+                # ``detect_animals`` returns None for a decode failure,
+                # or the batch swallows an exception). Without this the
+                # photo would be left with cleared detections/predictions
+                # and no replacement. The full-image fallback in
+                # ``_classify_photos`` handles photos with no detection
+                # rows, so registering here unconditionally is safe.
+                processed_for_rebuild.add(photo["id"])
 
-            batch_map, batch_detected, batch_processed = _detect_batch(
+            batch_map, batch_detected, _batch_processed = _detect_batch(
                 [photo], folders, runner, job, reclassify, db,
                 det_conf_threshold=det_conf_threshold,
                 already_detected_ids=already_detected_ids,
             )
             detection_map.update(batch_map)
             detected += batch_detected
-
-            if reclassify and photo["id"] in batch_processed:
-                # ``_detect_batch.processed_ids`` is the truthful set of
-                # photos whose iteration completed — including empty-scene
-                # ones that recorded a detector_runs row but added nothing
-                # to ``detection_map``. In reclassify mode their old
-                # predictions were cascaded away by ``clear_detections``
-                # above, so the caller must classify them on cancel even
-                # though they have no detection rows to drive a cropped
-                # classifier pass (the full-image fallback in
-                # ``_classify_photos`` handles them).
-                processed_for_rebuild.add(photo["id"])
 
             if was_cached and batch_detected:
                 skipped_det += 1

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -1733,6 +1733,23 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
         # Classifier init succeeded — now it's safe to purge existing
         # cache for reclassify. Any failure before this point leaves the
         # cache intact (see comment at the top of this function).
+        #
+        # A cancel that arrived during taxonomy/label/model init would
+        # otherwise still run the destructive purge below, then the
+        # post-detection cancel gate would return with predictions_stored=0
+        # — leaving the cancelled run with predictions/detections wiped
+        # but not rebuilt. Gate the purge on cancellation explicitly.
+        if runner.is_cancelled(job["id"]):
+            log.info("Classify job cancelled before reclassify purge")
+            return {
+                "total": total,
+                "predictions_stored": 0,
+                "burst_groups": 0,
+                "already_classified": 0,
+                "already_labeled": 0,
+                "detected": 0,
+                "failed": 0,
+            }
         if params.reclassify:
             photo_ids = [p["id"] for p in photos]
             thread_db.clear_predictions(

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -526,10 +526,17 @@ def _detect_batch(photos, folders, runner, job, reclassify, db,
     return detection_map, detected, processed_ids
 
 
-def _detect_subjects(photos, folders, runner, job, reclassify, db):
+def _detect_subjects(photos, folders, runner, job, reclassify, db,
+                      classifier_model=None):
     """Run MegaDetector on photos, storing quality metrics.
 
     Wraps _detect_batch with progress reporting for the standalone classify job.
+
+    When ``reclassify`` is True and ``classifier_model`` is provided, prior
+    predictions and detections for each photo are cleared *just before*
+    that photo is re-detected — not upfront for the whole scope. Cancelling
+    mid-loop therefore leaves the unprocessed tail with its old state
+    intact instead of an empty cache it can't rebuild.
 
     Returns:
         (detection_map, detected_count) where detection_map is
@@ -642,6 +649,21 @@ def _detect_subjects(photos, folders, runner, job, reclassify, db):
                 not reclassify
                 and photo["id"] in already_detected_ids
             )
+
+            # Per-photo reclassify purge: wipe this photo's prior
+            # predictions/detections immediately before re-detecting. The
+            # old global-upfront purge wiped the entire scope before
+            # detection started, so a mid-detection cancel stranded the
+            # unprocessed tail with no predictions and no detections.
+            # Doing it per-photo means an early cancel preserves the
+            # untouched photos' cached state.
+            if reclassify:
+                if classifier_model:
+                    db.clear_predictions(
+                        model=classifier_model,
+                        collection_photo_ids=[photo["id"]],
+                    )
+                db.clear_detections(photo["id"])
 
             batch_map, batch_detected, _batch_processed = _detect_batch(
                 [photo], folders, runner, job, reclassify, db,
@@ -1730,15 +1752,23 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
             summary=effective_name,
         )
 
-        # Classifier init succeeded — now it's safe to purge existing
-        # cache for reclassify. Any failure before this point leaves the
-        # cache intact (see comment at the top of this function).
+        # Classifier init succeeded — now it's safe to start the
+        # reclassify purge for any failure before this point would leave
+        # the cache intact (see comment at the top of this function).
         #
-        # A cancel that arrived during taxonomy/label/model init would
-        # otherwise still run the destructive purge below, then the
-        # post-detection cancel gate would return with predictions_stored=0
-        # — leaving the cancelled run with predictions/detections wiped
-        # but not rebuilt. Gate the purge on cancellation explicitly.
+        # The actual destructive clears happen per-photo inside
+        # ``_detect_subjects`` rather than upfront for the whole scope.
+        # An upfront clear over the full collection meant a mid-detection
+        # cancel left the unprocessed tail with both predictions and
+        # detections wiped, since the post-detection return gates
+        # classification off too. Doing the clear immediately before each
+        # photo's re-detection means cancelled photos retain their old
+        # state intact.
+        #
+        # This pre-detection cancel gate still applies: a cancel that
+        # landed during taxonomy/label/model init would otherwise advance
+        # to the detection loop's per-photo clear and start wiping rows
+        # before the user's cancel takes effect.
         if runner.is_cancelled(job["id"]):
             log.info("Classify job cancelled before reclassify purge")
             return {
@@ -1750,19 +1780,6 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
                 "detected": 0,
                 "failed": 0,
             }
-        if params.reclassify:
-            photo_ids = [p["id"] for p in photos]
-            thread_db.clear_predictions(
-                model=effective_name, collection_photo_ids=photo_ids,
-            )
-            # Also clear existing detections so they get re-detected.
-            for pid in photo_ids:
-                thread_db.clear_detections(pid)
-            log.info(
-                "Cleared existing predictions and detections for %d photos, "
-                "model=%s (re-classify, post-model-load)",
-                len(photo_ids), effective_name,
-            )
 
         # Phase 5: Detect subjects
         runner.update_step(job["id"], "detect", status="running")
@@ -1773,6 +1790,7 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
             job=job,
             reclassify=params.reclassify,
             db=thread_db,
+            classifier_model=effective_name,
         )
         if runner.is_cancelled(job["id"]):
             # Detections are committed per-photo, so everything before the

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -5479,7 +5479,6 @@ class Database:
                 rows = list(rows) + list(comp_rows)
 
         all_ids = list({row["id"] for row in rows})
-        ph = ",".join("?" for _ in all_ids)
 
         # Collect file info before deleting
         files = [
@@ -5505,12 +5504,21 @@ class Database:
         # serving the stale pre-delete ``new_count`` until the TTL expired.
         affected_folder_ids = list(folder_counts.keys())
 
+        # Chunk the all_ids IN-clauses. ``include_companions=True`` can double
+        # the id count from the caller's input chunk (companions get merged in
+        # above), so a 900-id outer chunk can reach ~1800 here — past the 999
+        # SQLITE_MAX_VARIABLE_NUMBER on legacy builds. All chunked statements
+        # share the same transaction, so partial-failure rollback still works.
+        id_chunks = list(_chunks(all_ids))
+
         try:
             # Delete associated data (non-cascading FKs)
-            self.conn.execute(f"DELETE FROM photo_keywords WHERE photo_id IN ({ph})", all_ids)
-            self.conn.execute(f"DELETE FROM pending_changes WHERE photo_id IN ({ph})", all_ids)
-            # Deleting detections cascades to predictions via ON DELETE CASCADE
-            self.conn.execute(f"DELETE FROM detections WHERE photo_id IN ({ph})", all_ids)
+            for chunk in id_chunks:
+                ph = ",".join("?" for _ in chunk)
+                self.conn.execute(f"DELETE FROM photo_keywords WHERE photo_id IN ({ph})", chunk)
+                self.conn.execute(f"DELETE FROM pending_changes WHERE photo_id IN ({ph})", chunk)
+                # Deleting detections cascades to predictions via ON DELETE CASCADE
+                self.conn.execute(f"DELETE FROM detections WHERE photo_id IN ({ph})", chunk)
 
             # Clean collection rules
             import json as _json
@@ -5547,7 +5555,9 @@ class Database:
                     )
 
             # Delete photos (cascades to edit_history_items, inat_submissions)
-            self.conn.execute(f"DELETE FROM photos WHERE id IN ({ph})", all_ids)
+            for chunk in id_chunks:
+                ph = ",".join("?" for _ in chunk)
+                self.conn.execute(f"DELETE FROM photos WHERE id IN ({ph})", chunk)
 
             # Update folder counts
             for fid, count in folder_counts.items():

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -5298,13 +5298,21 @@ class Database:
                 self._verify_photo_in_workspace(pid)
         # Chunked: a select-all on a large library exceeds SQLite's
         # bound-parameter cap (999 on legacy builds) in one IN clause.
-        for chunk in _chunks(photo_ids):
-            placeholders = ",".join("?" for _ in chunk)
-            self.conn.execute(
-                f"UPDATE photos SET rating = ? WHERE id IN ({placeholders})",
-                [rating] + list(chunk),
-            )
-        self.conn.commit()
+        # Rolled back on error: sqlite3 leaves earlier DML pending in
+        # the open transaction after an exception, so a subsequent
+        # unrelated commit() on this connection would persist a
+        # half-applied batch.
+        try:
+            for chunk in _chunks(photo_ids):
+                placeholders = ",".join("?" for _ in chunk)
+                self.conn.execute(
+                    f"UPDATE photos SET rating = ? WHERE id IN ({placeholders})",
+                    [rating] + list(chunk),
+                )
+            self.conn.commit()
+        except Exception:
+            self.conn.rollback()
+            raise
 
     def update_photo_flag(self, photo_id, flag, verify_workspace=True):
         """Set photo flag ('none', 'flagged', 'rejected').
@@ -5340,14 +5348,18 @@ class Database:
         if verify_workspace:
             for pid in photo_ids:
                 self._verify_photo_in_workspace(pid)
-        # Chunked: see batch_update_photo_rating.
-        for chunk in _chunks(photo_ids):
-            placeholders = ",".join("?" for _ in chunk)
-            self.conn.execute(
-                f"UPDATE photos SET flag = ? WHERE id IN ({placeholders})",
-                [flag] + list(chunk),
-            )
-        self.conn.commit()
+        # Chunked + rolled back on error: see batch_update_photo_rating.
+        try:
+            for chunk in _chunks(photo_ids):
+                placeholders = ",".join("?" for _ in chunk)
+                self.conn.execute(
+                    f"UPDATE photos SET flag = ? WHERE id IN ({placeholders})",
+                    [flag] + list(chunk),
+                )
+            self.conn.commit()
+        except Exception:
+            self.conn.rollback()
+            raise
 
     VALID_COLOR_LABELS = ('red', 'yellow', 'green', 'blue', 'purple')
 
@@ -7582,6 +7594,9 @@ class Database:
         """
         if not photo_ids:
             return {}
+        # Dedup-preserving-order: chunking that re-queries the same id
+        # in a later chunk would double-append it under setdefault.
+        photo_ids = list(dict.fromkeys(photo_ids))
         result = {}
         for chunk in _chunks(photo_ids):
             placeholders = ",".join("?" for _ in chunk)
@@ -9280,6 +9295,9 @@ class Database:
             import config as cfg
             effective = self.get_effective_config(cfg.load())
             min_conf = effective.get("detector_confidence", 0.2)
+        # Dedup-preserving-order: same id appearing in two chunks would
+        # cause setdefault(...).append(...) below to emit each row twice.
+        photo_ids = list(dict.fromkeys(photo_ids))
         result = {}
         for chunk in _chunks(photo_ids):
             placeholders = ",".join("?" for _ in chunk)

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3156,18 +3156,24 @@ class Database:
         ).fetchone()
 
     def get_photos_by_ids(self, photo_ids):
-        """Return photos for a list of IDs in a single query.
+        """Return photos for a list of IDs.
 
-        Returns a dict mapping photo_id -> Row for efficient lookup.
+        Returns a dict mapping photo_id -> Row for efficient lookup. Large
+        id lists are chunked so the IN-clause stays under SQLite's
+        bound-parameter cap (999 on legacy builds, 32766 modern).
         """
         if not photo_ids:
             return {}
-        placeholders = ",".join("?" for _ in photo_ids)
-        rows = self.conn.execute(
-            f"SELECT {self.PHOTO_COLS} FROM photos WHERE id IN ({placeholders})",
-            photo_ids,
-        ).fetchall()
-        return {row["id"]: row for row in rows}
+        result = {}
+        for chunk in _chunks(photo_ids):
+            placeholders = ",".join("?" for _ in chunk)
+            rows = self.conn.execute(
+                f"SELECT {self.PHOTO_COLS} FROM photos WHERE id IN ({placeholders})",
+                list(chunk),
+            ).fetchall()
+            for row in rows:
+                result[row["id"]] = row
+        return result
 
     def count_photos(self):
         """Return photo count for the active workspace.
@@ -7576,19 +7582,20 @@ class Database:
         """
         if not photo_ids:
             return {}
-        placeholders = ",".join("?" for _ in photo_ids)
-        rows = self.conn.execute(
-            f"""SELECT DISTINCT pk.photo_id, k.name
-                FROM photo_keywords pk
-                JOIN keywords k ON k.id = pk.keyword_id
-                WHERE pk.photo_id IN ({placeholders})
-                  AND (k.is_species = 1 OR k.type = 'taxonomy')
-                ORDER BY k.name""",
-            list(photo_ids),
-        ).fetchall()
         result = {}
-        for r in rows:
-            result.setdefault(r["photo_id"], []).append(r["name"])
+        for chunk in _chunks(photo_ids):
+            placeholders = ",".join("?" for _ in chunk)
+            rows = self.conn.execute(
+                f"""SELECT DISTINCT pk.photo_id, k.name
+                    FROM photo_keywords pk
+                    JOIN keywords k ON k.id = pk.keyword_id
+                    WHERE pk.photo_id IN ({placeholders})
+                      AND (k.is_species = 1 OR k.type = 'taxonomy')
+                    ORDER BY k.name""",
+                list(chunk),
+            ).fetchall()
+            for r in rows:
+                result.setdefault(r["photo_id"], []).append(r["name"])
         return result
 
     def get_highlights_candidates(self, folder_id, min_quality=0.0):
@@ -9273,30 +9280,31 @@ class Database:
             import config as cfg
             effective = self.get_effective_config(cfg.load())
             min_conf = effective.get("detector_confidence", 0.2)
-        placeholders = ",".join("?" for _ in photo_ids)
-        q = (
-            f"SELECT photo_id, box_x, box_y, box_w, box_h, "
-            f"       detector_confidence, category "
-            f"FROM detections "
-            f"WHERE photo_id IN ({placeholders}) "
-            f"  AND detector_confidence >= ?"
-        )
-        params = [*photo_ids, min_conf]
-        if detector_model is not None:
-            q += " AND detector_model = ?"
-            params.append(detector_model)
-        q += " ORDER BY photo_id, detector_confidence DESC"
-        rows = self.conn.execute(q, params).fetchall()
         result = {}
-        for r in rows:
-            result.setdefault(r["photo_id"], []).append({
-                "x": r["box_x"],
-                "y": r["box_y"],
-                "w": r["box_w"],
-                "h": r["box_h"],
-                "confidence": r["detector_confidence"],
-                "category": r["category"],
-            })
+        for chunk in _chunks(photo_ids):
+            placeholders = ",".join("?" for _ in chunk)
+            q = (
+                f"SELECT photo_id, box_x, box_y, box_w, box_h, "
+                f"       detector_confidence, category "
+                f"FROM detections "
+                f"WHERE photo_id IN ({placeholders}) "
+                f"  AND detector_confidence >= ?"
+            )
+            params = [*chunk, min_conf]
+            if detector_model is not None:
+                q += " AND detector_model = ?"
+                params.append(detector_model)
+            q += " ORDER BY photo_id, detector_confidence DESC"
+            rows = self.conn.execute(q, params).fetchall()
+            for r in rows:
+                result.setdefault(r["photo_id"], []).append({
+                    "x": r["box_x"],
+                    "y": r["box_y"],
+                    "w": r["box_w"],
+                    "h": r["box_h"],
+                    "confidence": r["detector_confidence"],
+                    "category": r["category"],
+                })
         return result
 
     def get_predictions_for_detection(self, detection_id,

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3493,14 +3493,31 @@ class Database:
         Returns (' AND p.id IN (NULL)', []) for an empty set, which is the
         intentional "no photos in scope" sentinel — callers asked for
         "this collection" and the collection resolved to zero photos.
+
+        Scopes larger than one parameter chunk are staged in a
+        connection-local temp table instead of inline placeholders, which
+        would exceed SQLITE_MAX_VARIABLE_NUMBER (999 on legacy builds) for
+        big collections. The staged scope is only valid for the query the
+        caller runs immediately after this call — the next large-scope call
+        overwrites it.
         """
         if photo_ids is None:
             return "", []
         ids = list(photo_ids)
         if not ids:
             return f" AND {table_alias}.id IN (NULL)", []
-        placeholders = ",".join("?" for _ in ids)
-        return f" AND {table_alias}.id IN ({placeholders})", ids
+        if len(ids) <= _SQLITE_PARAM_CHUNK_SIZE:
+            placeholders = ",".join("?" for _ in ids)
+            return f" AND {table_alias}.id IN ({placeholders})", ids
+        self.conn.execute(
+            "CREATE TEMP TABLE IF NOT EXISTS scope_ids (id INTEGER PRIMARY KEY)"
+        )
+        self.conn.execute("DELETE FROM scope_ids")
+        self.conn.executemany(
+            "INSERT OR IGNORE INTO scope_ids (id) VALUES (?)",
+            [(i,) for i in ids],
+        )
+        return f" AND {table_alias}.id IN (SELECT id FROM scope_ids)", []
 
     def count_real_detections_in_scope(self, photo_ids=None, min_conf=None):
         """Count (photos_with_real_dets, total_real_dets) for the workspace.
@@ -5273,11 +5290,14 @@ class Database:
         if verify_workspace:
             for pid in photo_ids:
                 self._verify_photo_in_workspace(pid)
-        placeholders = ",".join("?" for _ in photo_ids)
-        self.conn.execute(
-            f"UPDATE photos SET rating = ? WHERE id IN ({placeholders})",
-            [rating] + list(photo_ids),
-        )
+        # Chunked: a select-all on a large library exceeds SQLite's
+        # bound-parameter cap (999 on legacy builds) in one IN clause.
+        for chunk in _chunks(photo_ids):
+            placeholders = ",".join("?" for _ in chunk)
+            self.conn.execute(
+                f"UPDATE photos SET rating = ? WHERE id IN ({placeholders})",
+                [rating] + list(chunk),
+            )
         self.conn.commit()
 
     def update_photo_flag(self, photo_id, flag, verify_workspace=True):
@@ -5314,11 +5334,13 @@ class Database:
         if verify_workspace:
             for pid in photo_ids:
                 self._verify_photo_in_workspace(pid)
-        placeholders = ",".join("?" for _ in photo_ids)
-        self.conn.execute(
-            f"UPDATE photos SET flag = ? WHERE id IN ({placeholders})",
-            [flag] + list(photo_ids),
-        )
+        # Chunked: see batch_update_photo_rating.
+        for chunk in _chunks(photo_ids):
+            placeholders = ",".join("?" for _ in chunk)
+            self.conn.execute(
+                f"UPDATE photos SET flag = ? WHERE id IN ({placeholders})",
+                [flag] + list(chunk),
+            )
         self.conn.commit()
 
     VALID_COLOR_LABELS = ('red', 'yellow', 'green', 'blue', 'purple')
@@ -5353,12 +5375,15 @@ class Database:
         """Return a dict of {photo_id: color} for the active workspace."""
         if not photo_ids:
             return {}
-        placeholders = ",".join("?" for _ in photo_ids)
-        rows = self.conn.execute(
-            f"SELECT photo_id, color FROM photo_color_labels WHERE workspace_id = ? AND photo_id IN ({placeholders})",
-            [self._ws_id()] + list(photo_ids),
-        ).fetchall()
-        return {row['photo_id']: row['color'] for row in rows}
+        out = {}
+        for chunk in _chunks(photo_ids):
+            placeholders = ",".join("?" for _ in chunk)
+            rows = self.conn.execute(
+                f"SELECT photo_id, color FROM photo_color_labels WHERE workspace_id = ? AND photo_id IN ({placeholders})",
+                [self._ws_id()] + list(chunk),
+            ).fetchall()
+            out.update({row['photo_id']: row['color'] for row in rows})
+        return out
 
     def batch_set_color_label(self, photo_ids, color):
         """Set or remove color label for multiple photos in the active workspace."""
@@ -5366,11 +5391,12 @@ class Database:
             return
         ws_id = self._ws_id()
         if color is None:
-            placeholders = ",".join("?" for _ in photo_ids)
-            self.conn.execute(
-                f"DELETE FROM photo_color_labels WHERE workspace_id = ? AND photo_id IN ({placeholders})",
-                [ws_id] + list(photo_ids),
-            )
+            for chunk in _chunks(photo_ids):
+                placeholders = ",".join("?" for _ in chunk)
+                self.conn.execute(
+                    f"DELETE FROM photo_color_labels WHERE workspace_id = ? AND photo_id IN ({placeholders})",
+                    [ws_id] + list(chunk),
+                )
         else:
             if color not in self.VALID_COLOR_LABELS:
                 raise ValueError(f"Invalid color label: {color}. Must be one of {self.VALID_COLOR_LABELS}")
@@ -8120,23 +8146,35 @@ class Database:
             extra_conds.append("pr.labels_fingerprint = ?")
             extra_params.append(labels_fingerprint)
 
+        # The photo-id filter is chunked (one DELETE per id chunk) — a
+        # reclassify over a collection larger than SQLite's bound-parameter
+        # cap would otherwise fail with "too many SQL variables" after the
+        # model already loaded. Chunks partition disjoint photo ids, so the
+        # union of chunked DELETEs equals the single big one.
         if collection_photo_ids is not None:
-            placeholders = ",".join("?" for _ in collection_photo_ids)
-            extra_conds.append(f"d.photo_id IN ({placeholders})")
-            extra_params.extend(collection_photo_ids)
+            id_chunks = list(_chunks(collection_photo_ids))
+        else:
+            id_chunks = [None]
 
-        where_clause = (" WHERE " + " AND ".join(extra_conds)) if extra_conds else ""
-        self.conn.execute(
-            f"""DELETE FROM predictions WHERE id IN (
-                SELECT pr.id FROM predictions pr
-                JOIN detections d ON d.id = pr.detection_id
-                JOIN photos ph ON ph.id = d.photo_id
-                JOIN workspace_folders wf
-                  ON wf.folder_id = ph.folder_id AND wf.workspace_id = ?
-                {where_clause}
-            )""",
-            [ws, *extra_params],
-        )
+        for chunk in id_chunks:
+            conds = list(extra_conds)
+            params = list(extra_params)
+            if chunk is not None:
+                placeholders = ",".join("?" for _ in chunk)
+                conds.append(f"d.photo_id IN ({placeholders})")
+                params.extend(chunk)
+            where_clause = (" WHERE " + " AND ".join(conds)) if conds else ""
+            self.conn.execute(
+                f"""DELETE FROM predictions WHERE id IN (
+                    SELECT pr.id FROM predictions pr
+                    JOIN detections d ON d.id = pr.detection_id
+                    JOIN photos ph ON ph.id = d.photo_id
+                    JOIN workspace_folders wf
+                      ON wf.folder_id = ph.folder_id AND wf.workspace_id = ?
+                    {where_clause}
+                )""",
+                [ws, *params],
+            )
 
         if not clear_run_keys:
             self.conn.commit()
@@ -8157,20 +8195,15 @@ class Database:
         # built a workspace-wide DELETE on predictions, so leaving the run
         # keys behind would strand those detections (the (detection, model,
         # fingerprint) gate would treat them as already classified).
-        run_conds = []
-        run_params = []
+        base_run_conds = []
+        base_run_params = []
         if model is not None:
-            run_conds.append("cr.classifier_model = ?")
-            run_params.append(model)
+            base_run_conds.append("cr.classifier_model = ?")
+            base_run_params.append(model)
         if labels_fingerprint is not None:
-            run_conds.append("cr.labels_fingerprint = ?")
-            run_params.append(labels_fingerprint)
-        if collection_photo_ids is not None:
-            placeholders = ",".join("?" for _ in collection_photo_ids)
-            run_conds.append(f"d.photo_id IN ({placeholders})")
-            run_params.extend(collection_photo_ids)
-        run_where = (" WHERE " + " AND ".join(run_conds)) if run_conds else ""
-        # Single set-based DELETE via a rowid subquery — the previous
+            base_run_conds.append("cr.labels_fingerprint = ?")
+            base_run_params.append(labels_fingerprint)
+        # Set-based DELETE via a rowid subquery — the previous
         # SELECT + per-row DELETE loop issued one statement per matching
         # run, which on a reclassify of a multi-thousand-detection
         # workspace dominates wall time on the startup-blocking thread.
@@ -8178,19 +8211,28 @@ class Database:
         # (JOIN through detections/photos/workspace_folders, same
         # optional filters), and rowid uniquely identifies each
         # classifier_runs row under the implicit-rowid default.
-        self.conn.execute(
-            f"""DELETE FROM classifier_runs
-                WHERE rowid IN (
-                    SELECT cr.rowid
-                    FROM classifier_runs cr
-                    JOIN detections d ON d.id = cr.detection_id
-                    JOIN photos ph ON ph.id = d.photo_id
-                    JOIN workspace_folders wf
-                      ON wf.folder_id = ph.folder_id AND wf.workspace_id = ?
-                    {run_where}
-                )""",
-            [ws, *run_params],
-        )
+        # Photo-id chunking mirrors the predictions DELETE above.
+        for chunk in id_chunks:
+            run_conds = list(base_run_conds)
+            run_params = list(base_run_params)
+            if chunk is not None:
+                placeholders = ",".join("?" for _ in chunk)
+                run_conds.append(f"d.photo_id IN ({placeholders})")
+                run_params.extend(chunk)
+            run_where = (" WHERE " + " AND ".join(run_conds)) if run_conds else ""
+            self.conn.execute(
+                f"""DELETE FROM classifier_runs
+                    WHERE rowid IN (
+                        SELECT cr.rowid
+                        FROM classifier_runs cr
+                        JOIN detections d ON d.id = cr.detection_id
+                        JOIN photos ph ON ph.id = d.photo_id
+                        JOIN workspace_folders wf
+                          ON wf.folder_id = ph.folder_id AND wf.workspace_id = ?
+                        {run_where}
+                    )""",
+                [ws, *run_params],
+            )
         self.conn.commit()
 
     def get_predictions(self, photo_ids=None, model=None, status=None):

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -189,14 +189,27 @@ def load_photo_features(db, collection_id=None, config=None,
 
     if scoped_photo_ids is not None:
         scoped_photo_ids = sorted(scoped_photo_ids)
-        placeholders = ",".join("?" for _ in scoped_photo_ids)
+        # Stage the scope in a connection-local temp table instead of inline
+        # placeholders — a large collection exceeds SQLite's bound-parameter
+        # cap (999 on legacy builds), and this scope is interpolated into
+        # three queries below.
+        db.conn.execute(
+            "CREATE TEMP TABLE IF NOT EXISTS pipeline_scope_ids "
+            "(id INTEGER PRIMARY KEY)"
+        )
+        db.conn.execute("DELETE FROM pipeline_scope_ids")
+        db.conn.executemany(
+            "INSERT OR IGNORE INTO pipeline_scope_ids (id) VALUES (?)",
+            [(i,) for i in scoped_photo_ids],
+        )
         rows = db.conn.execute(
             f"""SELECT {_PIPELINE_PHOTO_COLS}
                 FROM photos p
                 JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-                WHERE wf.workspace_id = ? AND p.id IN ({placeholders})
+                WHERE wf.workspace_id = ?
+                  AND p.id IN (SELECT id FROM pipeline_scope_ids)
                 ORDER BY p.timestamp, p.filename ASC, p.id ASC""",
-            (ws_id, *scoped_photo_ids),
+            (ws_id,),
         ).fetchall()
     else:
         rows = db.conn.execute(
@@ -211,9 +224,7 @@ def load_photo_features(db, collection_id=None, config=None,
     scope_sql = ""
     scope_params = ()
     if scoped_photo_ids is not None:
-        scope_placeholders = ",".join("?" for _ in scoped_photo_ids)
-        scope_sql = f" AND p.id IN ({scope_placeholders})"
-        scope_params = tuple(scoped_photo_ids)
+        scope_sql = " AND p.id IN (SELECT id FROM pipeline_scope_ids)"
 
     # Resolve the workspace-effective detector_confidence threshold once.
     # The detections table is global (no workspace_id); threshold filtering

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -1181,10 +1181,25 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
 
         for image_path in image_files:
             _check_cancelled()
-            stat = image_path.stat()
+            try:
+                stat = image_path.stat()
+            except OSError:
+                # File deleted/renamed between discovery and this pass —
+                # skip it instead of aborting the whole scan (the discovery
+                # walk has the same guard for broken symlinks).
+                log.info("File vanished during scan, skipping: %s", image_path)
+                processed_count += 1
+                if progress_callback:
+                    progress_callback(processed_count, total)
+                continue
             file_mtime = stat.st_mtime
             xmp_path = image_path.with_suffix(".xmp")
-            xmp_mtime = xmp_path.stat().st_mtime if xmp_path.exists() else None
+            try:
+                xmp_mtime = xmp_path.stat().st_mtime
+            except OSError:
+                # Covers both "no sidecar" and a sidecar deleted between
+                # exists() and stat() — same outcome either way.
+                xmp_mtime = None
 
             if incremental:
                 full_path_str = str(image_path)
@@ -1324,17 +1339,30 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
     try:
         for image_path, (phash, file_hash) in _iter_features():
             _check_cancelled()
+
+            # File stats — first touch of the path in this loop. A file
+            # deleted/renamed between discovery and here must skip, not
+            # abort the scan and flag every folder in scope 'partial'.
+            try:
+                stat = image_path.stat()
+            except OSError:
+                log.info("File vanished during scan, skipping: %s", image_path)
+                processed_count += 1
+                if progress_callback:
+                    progress_callback(processed_count, total)
+                continue
+
             folder_id = _ensure_folder(image_path.parent)
             touched_folder_ids.add(folder_id)
-
-            # File stats
-            stat = image_path.stat()
             file_size = stat.st_size
             file_mtime = stat.st_mtime
 
             # XMP sidecar
             xmp_path = image_path.with_suffix(".xmp")
-            xmp_mtime = xmp_path.stat().st_mtime if xmp_path.exists() else None
+            try:
+                xmp_mtime = xmp_path.stat().st_mtime
+            except OSError:
+                xmp_mtime = None
 
             # Get pre-extracted metadata for this file
             file_meta = metadata_map.get(str(image_path), {})

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -2988,6 +2988,48 @@ def test_detect_subjects_stops_when_cancelled(tmp_path):
     detect.assert_not_called()
 
 
+def test_detect_subjects_skips_weight_download_when_cancelled(tmp_path):
+    """A cancel landing during classifier-init must skip the ~300 MB
+    MegaDetector weights download. The per-photo cancel check in the
+    detection loop runs too late — hf_hub_download can't be interrupted
+    once started, so the gate has to live before the download call."""
+    from unittest.mock import MagicMock, patch
+
+    from classify_job import _detect_subjects
+
+    runner = FakeRunner()
+    runner.cancelled = True
+    job = _make_job()
+
+    photos = [
+        {"id": 1, "filename": "a.jpg", "folder_id": 10},
+        {"id": 2, "filename": "b.jpg", "folder_id": 10},
+    ]
+    mock_db = MagicMock()
+    # Nothing cached → needs_fresh_detection is True, the un-fixed code
+    # would call ensure_megadetector_weights before noticing the cancel.
+    mock_db.get_detector_run_photo_ids.return_value = set()
+
+    detect = MagicMock()
+    weights = MagicMock()
+    with patch("classify_job.detect_animals", detect), \
+         patch("classify_job.get_primary_detection", MagicMock()), \
+         patch("detector.ensure_megadetector_weights", weights):
+        detection_map, detected = _detect_subjects(
+            photos=photos,
+            folders={10: str(tmp_path)},
+            runner=runner,
+            job=job,
+            reclassify=False,
+            db=mock_db,
+        )
+
+    assert detection_map == {}
+    assert detected == 0
+    weights.assert_not_called()
+    detect.assert_not_called()
+
+
 def test_classify_photos_stops_when_cancelled(tmp_path):
     """A cancelled job exits the classification loop without inference."""
     from unittest.mock import MagicMock, patch

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -3511,10 +3511,18 @@ def test_classify_photos_reclassify_clears_predictions_per_photo(tmp_path):
             f"clear_predictions must scope to the model being run; got "
             f"{call.kwargs.get('model')!r}"
         )
-        assert call.kwargs["labels_fingerprint"] == "fp-x", (
-            "clear_predictions must scope to the labels fingerprint so "
-            "shared-folder workspaces with different label sets don't "
-            "wipe each other's cache"
+        # No fingerprint filter: stale predictions tagged with prior
+        # fingerprints (e.g. before a workspace label-set change) must
+        # also be wiped in the fallback path, otherwise the
+        # latest-fingerprint-per-detection filter in get_predictions
+        # would surface them alongside the new fallback rows. The
+        # normal reclassify path's per-photo clear_detections cascade
+        # has already wiped predictions across all fingerprints, so an
+        # unfiltered clear here is a no-op repeat in that path.
+        assert call.kwargs.get("labels_fingerprint") is None, (
+            "clear_predictions must NOT scope to the current "
+            "fingerprint: that would leave stale predictions under "
+            f"prior fingerprints visible; got {call.kwargs.get('labels_fingerprint')!r}"
         )
 
 
@@ -3768,6 +3776,104 @@ def test_classify_photos_full_image_fallback_replaces_stale_predictions_on_recla
     )
     # Sanity: the fallback path actually produced a result so the test
     # didn't pass vacuously.
+    assert len(raw_results) == 1
+    assert raw_results[0]["prediction"] == "Sparrow"
+
+
+def test_classify_photos_full_image_fallback_clears_stale_predictions_across_fingerprints(
+    tmp_path, monkeypatch,
+):
+    """Stale detector predictions tagged with a PRIOR ``labels_fingerprint``
+    must also be wiped when the reclassify run falls back to full-image
+    classification under a NEW fingerprint.
+
+    Regression for Codex P2 review on vireo/classify_job.py line 1006.
+    Before the fix, the per-photo purge filtered by the current fingerprint,
+    so a workspace label-set change between runs left stale detector-based
+    predictions under the old fingerprint untouched. ``get_predictions``'
+    latest-fingerprint-per-(detection, classifier_model) filter then surfaces
+    those stale rows for the old detection alongside the new fallback rows
+    for the synthetic full-image detection, leaving users with mixed-model
+    output for the same photo.
+    """
+    from unittest.mock import MagicMock, patch
+
+    import config as cfg
+    from classify_job import _classify_photos
+    from db import Database
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    folder_id = db.add_folder(str(tmp_path), name="p")
+
+    pid = db.add_photo(
+        folder_id, "a.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    # Prior run: megadetector detection + prediction under the OLD
+    # workspace label fingerprint.
+    stale_det = db.save_detections(pid, [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.4, "h": 0.4},
+         "confidence": 0.9, "category": "animal"},
+    ], detector_model="megadetector-v6")[0]
+    db.add_prediction(stale_det, species="Robin", confidence=0.9,
+                      model="BioCLIP", labels_fingerprint="fp-old")
+    db.record_classifier_run(stale_det, "BioCLIP", "fp-old",
+                             prediction_count=1)
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    clf = MagicMock()
+    clf.classify_batch_with_embedding.return_value = [
+        ([{"species": "Sparrow", "score": 0.88, "taxonomy": None}], None),
+    ]
+
+    # Empty detection_map (setup failure) + new fingerprint = the bug case.
+    fake_img = MagicMock()
+    with patch("classify_job._prepare_image",
+               return_value=(fake_img, str(tmp_path), "p")):
+        raw_results, _, _ = _classify_photos(
+            photos=[{"id": pid, "filename": "a.jpg", "folder_id": folder_id,
+                     "timestamp": None}],
+            folders={folder_id: str(tmp_path)},
+            detection_map={},
+            existing_preds=set(),
+            clf=clf,
+            model_type="bioclip",
+            model_name="BioCLIP",
+            runner=runner,
+            job=job,
+            db=db,
+            labels_fingerprint="fp-new",
+            reclassify=True,
+        )
+
+    db2 = Database(db_path)
+    db2.set_active_workspace(ws)
+    stale_preds = db2.conn.execute(
+        "SELECT COUNT(*) AS n FROM predictions "
+        "WHERE detection_id = ? AND classifier_model = ?",
+        (stale_det, "BioCLIP"),
+    ).fetchone()["n"]
+    assert stale_preds == 0, (
+        "Stale fp-old prediction on the old megadetector detection must be "
+        "cleared even though the current run uses fp-new — otherwise "
+        "get_predictions' latest-fp-per-detection filter still surfaces it "
+        "alongside the new full-image fallback prediction."
+    )
+    # The classifier_runs row under the old fingerprint must also be gone
+    # so the next non-reclassify pass actually re-runs inference for that
+    # detection if it ever reappears in detection_map.
+    run_keys = db2.get_classifier_run_keys(stale_det)
+    assert ("BioCLIP", "fp-old") not in run_keys, (
+        "Stale fp-old classifier_runs row must be cleared alongside the "
+        "stale prediction."
+    )
     assert len(raw_results) == 1
     assert raw_results[0]["prediction"] == "Sparrow"
 

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -3682,3 +3682,375 @@ def test_classify_photos_full_image_fallback_replaces_stale_predictions_on_recla
     # didn't pass vacuously.
     assert len(raw_results) == 1
     assert raw_results[0]["prediction"] == "Sparrow"
+
+
+def test_classify_photos_reclassify_flushes_pending_batch_on_cancel(tmp_path):
+    """For reclassify runs, a mid-loop cancel must still flush the pending
+    batch — its queued photos already had their old predictions cleared by
+    the per-photo purge at the top of the iteration, so dropping the batch
+    strands them with no predictions until a manual rerun.
+
+    Regression for Codex P1 review on vireo/classify_job.py line 1178.
+    Before the fix, the post-loop ``if batch and not cancelled`` gate
+    dropped the pending batch on every cancel, including reclassify runs
+    where each batched photo had a destructive ``clear_predictions`` fire
+    just before it was queued.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from classify_job import _classify_photos
+    from db import Database
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    folder_id = db.add_folder(str(tmp_path), name="p")
+
+    pid_a = db.add_photo(
+        folder_id, "a.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    pid_b = db.add_photo(
+        folder_id, "b.jpg", extension=".jpg",
+        file_size=100, file_mtime=2.0,
+    )
+    det_a = db.save_detections(pid_a, [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1},
+         "confidence": 0.9, "category": "animal"},
+    ], detector_model="megadetector-v6")[0]
+    det_b = db.save_detections(pid_b, [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1},
+         "confidence": 0.9, "category": "animal"},
+    ], detector_model="megadetector-v6")[0]
+    # Each photo has a prior prediction; the reclassify clear will wipe
+    # them per-photo, and the test asserts the new run replaced them
+    # rather than leaving them empty after the cancel.
+    db.add_prediction(det_a, species="OldA", confidence=0.5,
+                      model="BioCLIP", labels_fingerprint="legacy")
+    db.add_prediction(det_b, species="OldB", confidence=0.5,
+                      model="BioCLIP", labels_fingerprint="legacy")
+
+    class FlipRunner(FakeRunner):
+        """Cancel flips on after the second photo enters the loop."""
+
+        def __init__(self):
+            super().__init__()
+            self._calls = 0
+
+        def is_cancelled(self, job_id):
+            self._calls += 1
+            # Calls 1 + 2: iterations 0 and 1 — let both through so both
+            # land in ``batch``. Calls 3+: cancelled, breaking the loop
+            # without flushing mid-iteration (batch < _BATCH_SIZE).
+            return self._calls >= 3
+
+    runner = FlipRunner()
+    job = _make_job()
+    photos = [
+        {"id": pid_a, "filename": "a.jpg", "folder_id": folder_id,
+         "timestamp": None},
+        {"id": pid_b, "filename": "b.jpg", "folder_id": folder_id,
+         "timestamp": None},
+    ]
+    folders = {folder_id: str(tmp_path)}
+
+    detection_map = {
+        pid_a: [{"id": det_a}],
+        pid_b: [{"id": det_b}],
+    }
+
+    clf = MagicMock()
+    clf.classify_batch_with_embedding.return_value = [
+        ([{"species": "NewA", "score": 0.92, "taxonomy": None}], None),
+        ([{"species": "NewB", "score": 0.91, "taxonomy": None}], None),
+    ]
+
+    fake_img = MagicMock()
+    with patch("classify_job._prepare_image",
+               return_value=(fake_img, str(tmp_path), "p")):
+        raw_results, _, _ = _classify_photos(
+            photos=photos,
+            folders=folders,
+            detection_map=detection_map,
+            existing_preds=set(),
+            clf=clf,
+            model_type="bioclip",
+            model_name="BioCLIP",
+            runner=runner,
+            job=job,
+            db=db,
+            labels_fingerprint="legacy",
+            reclassify=True,
+        )
+
+    # The pending batch must have flushed: both photos that had their old
+    # predictions cleared got new predictions written, so raw_results
+    # contains them both.
+    assert len(raw_results) == 2, (
+        "Reclassify mid-loop cancel must flush the pending batch — its "
+        "queued photos already had their old predictions cleared and "
+        "would otherwise be stranded empty. "
+        f"Got {len(raw_results)} results."
+    )
+    predictions = {r["photo"]["id"]: r["prediction"] for r in raw_results}
+    assert predictions == {pid_a: "NewA", pid_b: "NewB"}
+
+
+def test_classify_photos_no_reclassify_drops_pending_batch_on_cancel(tmp_path):
+    """The non-reclassify path must still drop the pending batch on cancel.
+
+    Without a reclassify, those photos' cached predictions are untouched,
+    so honoring the cancel signal here just skips wasted inference (and
+    avoids writing classifier_runs rows for photos the user just said
+    they're done with).
+    """
+    from unittest.mock import MagicMock, patch
+
+    from classify_job import _classify_photos
+
+    class FlipRunner(FakeRunner):
+        def __init__(self):
+            super().__init__()
+            self._calls = 0
+
+        def is_cancelled(self, job_id):
+            self._calls += 1
+            return self._calls >= 2
+
+    runner = FlipRunner()
+    job = _make_job()
+    clf = MagicMock()
+
+    mock_db = MagicMock()
+    mock_db.get_detections.return_value = []
+    mock_db.save_detections.return_value = [101]
+    mock_db.get_classifier_run_keys.return_value = set()
+    mock_db.get_predictions_for_detection.return_value = []
+
+    photos = [
+        {"id": 1, "filename": "a.jpg", "folder_id": 10, "timestamp": None},
+        {"id": 2, "filename": "b.jpg", "folder_id": 10, "timestamp": None},
+    ]
+    folders = {10: str(tmp_path)}
+
+    fake_img = MagicMock()
+    with patch("classify_job._prepare_image",
+               return_value=(fake_img, str(tmp_path), "p")):
+        raw_results, _, _ = _classify_photos(
+            photos=photos,
+            folders=folders,
+            detection_map={},
+            existing_preds=set(),
+            clf=clf,
+            model_type="bioclip",
+            model_name="test-model",
+            runner=runner,
+            job=job,
+            db=mock_db,
+            reclassify=False,
+        )
+
+    clf.classify_batch.assert_not_called()
+    clf.classify_batch_with_embedding.assert_not_called()
+    mock_db.record_classifier_run.assert_not_called()
+    assert raw_results == []
+
+
+def test_classify_photos_finish_cleared_only_ignores_cancel(tmp_path):
+    """When ``finish_cleared_only=True`` (set by ``run_classify_job`` after a
+    post-detect cancel landed on a reclassify run), the classify loop must
+    process every photo despite the cancel signal. The photos in this
+    subset already had their old detections + cascaded predictions wiped
+    during detection; bailing now would strand them empty.
+
+    Also asserts the per-photo ``clear_predictions`` is NOT re-run — the
+    cascade in ``_detect_subjects`` already did that, and re-issuing the
+    DELETE would just waste a transaction.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from classify_job import _classify_photos
+
+    runner = FakeRunner()
+    runner.cancelled = True  # post-detect cancel signal already set
+    job = _make_job()
+
+    clf = MagicMock()
+    clf.classify_batch_with_embedding.return_value = [
+        ([{"species": "Sparrow", "score": 0.92, "taxonomy": None}], None),
+    ]
+
+    mock_db = MagicMock()
+    mock_db.get_classifier_run_keys.return_value = set()
+    mock_db.get_predictions_for_detection.return_value = []
+
+    photos = [{"id": 1, "filename": "a.jpg", "folder_id": 10,
+               "timestamp": None}]
+    # Pre-populated detection_map: detection already done.
+    detection_map = {
+        1: [{"id": 999, "box_x": 0, "box_y": 0, "box_w": 1, "h": 1,
+             "box_h": 1, "confidence": 0.9, "category": "animal"}],
+    }
+    folders = {10: str(tmp_path)}
+
+    fake_img = MagicMock()
+    with patch("classify_job._prepare_image",
+               return_value=(fake_img, str(tmp_path), "p")):
+        raw_results, _, _ = _classify_photos(
+            photos=photos,
+            folders=folders,
+            detection_map=detection_map,
+            existing_preds=set(),
+            clf=clf,
+            model_type="bioclip",
+            model_name="BioCLIP",
+            runner=runner,
+            job=job,
+            db=mock_db,
+            labels_fingerprint="fp-x",
+            reclassify=True,
+            finish_cleared_only=True,
+        )
+
+    # Classification happened despite cancel = True.
+    assert len(raw_results) == 1
+    assert raw_results[0]["prediction"] == "Sparrow"
+    # Per-photo clear must not have re-fired — the detection-loop cascade
+    # already handled it.
+    mock_db.clear_predictions.assert_not_called()
+
+
+def test_run_classify_job_reclassify_cancel_after_detect_classifies_processed(tmp_path):
+    """End-to-end: a reclassify run cancelled after detection has processed
+    some photos must still classify that processed subset. Without this,
+    the photos with completed detection would be stranded with new
+    detections but no predictions until a manual rerun.
+
+    Regression for Codex P1 review on vireo/classify_job.py line 1824
+    (and the related Iu_1R / IubrR / IupmJ findings that flag the same
+    half-state for the reclassify path).
+    """
+    from unittest.mock import MagicMock, patch
+
+    import numpy as np
+    from classify_job import ClassifyParams, run_classify_job
+
+    # The runner reports "cancelled" only after _detect_subjects returns,
+    # mirroring a real user cancel landing during the detection phase but
+    # only being observed when run_classify_job rechecks afterward.
+    class PostDetectCancelRunner(FakeRunner):
+        def __init__(self):
+            super().__init__()
+            self.flipped = False
+
+        def is_cancelled(self, job_id):
+            return self.flipped
+
+    runner = PostDetectCancelRunner()
+    job = _make_job()
+
+    # Mock DB: two photos in the collection, both with prior detections
+    # and predictions. The "processed" one will be rebuilt via the
+    # cancel-recovery path; the "untouched" one was never reached by
+    # detection so it has no entry in detection_map.
+    mock_db_instance = MagicMock()
+    mock_db_instance.get_collection_photos.return_value = [
+        {"id": 1, "filename": "processed.jpg", "folder_id": 10,
+         "timestamp": "2024-01-15T10:00:00"},
+        {"id": 2, "filename": "untouched.jpg", "folder_id": 10,
+         "timestamp": "2024-01-15T11:00:00"},
+    ]
+    mock_db_instance.get_folder_tree.return_value = [
+        {"id": 10, "path": str(tmp_path), "name": "test"},
+    ]
+    mock_db_instance.get_existing_prediction_photo_ids.return_value = set()
+    mock_db_instance.get_photo_embedding.return_value = None
+    mock_db_instance.get_subject_types.return_value = set()
+    mock_db_instance.filter_out_subject_tagged.side_effect = (
+        lambda pids, _types: list(pids)
+    )
+    # The classify loop uses these to gate-check; empty returns force
+    # full re-classification (which is what reclassify means anyway).
+    mock_db_instance.get_classifier_run_keys.return_value = set()
+    mock_db_instance.get_predictions_for_detection.return_value = []
+    mock_db_instance.get_detections.return_value = []
+
+    fake_model = {
+        "id": "test-model",
+        "name": "TestModel",
+        "model_str": "hf-hub:imageomics/bioclip",
+        "weights_path": "/tmp/weights.bin",
+        "model_type": "bioclip",
+        "downloaded": True,
+    }
+    fake_embedding = np.ones(512, dtype=np.float32)
+    fake_preds = [{"species": "NewProcessed", "score": 0.95, "taxonomy": None}]
+    mock_clf = MagicMock()
+    mock_clf.classify_with_embedding.return_value = (fake_preds, fake_embedding)
+    mock_clf.classify_batch_with_embedding.return_value = [
+        (fake_preds, fake_embedding)
+    ]
+
+    # Stub _detect_subjects: only photo 1 ("processed") completed
+    # detection. Flip cancel on as it returns.
+    detect_called = {"n": 0}
+
+    def fake_detect_subjects(photos, folders, runner, job, reclassify, db):
+        detect_called["n"] += 1
+        assert reclassify is True
+        runner.flipped = True
+        # detection_map only includes the processed photo; the untouched
+        # one was never reached (mid-detection cancel).
+        return ({1: [{"id": 101, "box_x": 0, "box_y": 0,
+                      "box_w": 0.4, "box_h": 0.4, "confidence": 0.85,
+                      "category": "animal",
+                      "detector_model": "megadetector-v6"}]}, 1)
+
+    params = ClassifyParams(
+        collection_id="col-1",
+        labels_file=None,
+        labels_files=None,
+        model_id=None,
+        model_name=None,
+        grouping_window=10,
+        similarity_threshold=0.85,
+        reclassify=True,
+    )
+
+    fake_img = MagicMock()
+    with patch("classify_job.Database", return_value=mock_db_instance), \
+         patch("classify_job.get_active_model", return_value=fake_model), \
+         patch("classify_job.get_models", return_value=[fake_model]), \
+         patch("classify_job._load_taxonomy", return_value=None), \
+         patch("classify_job._load_labels",
+               return_value=(["NewProcessed"], False)), \
+         patch("classify_job.Classifier", return_value=mock_clf), \
+         patch("classify_job._detect_subjects",
+               side_effect=fake_detect_subjects), \
+         patch("classify_job._prepare_image",
+               return_value=(fake_img, str(tmp_path), "p")):
+        result = run_classify_job(job, runner, str(tmp_path / "test.db"),
+                                  1, params)
+
+    assert detect_called["n"] == 1, "_detect_subjects must have been called"
+    # The processed photo's classification was rebuilt despite the cancel —
+    # add_prediction was called for it via finalization.
+    assert mock_db_instance.add_prediction.call_count >= 1, (
+        "Post-detect cancel on reclassify with non-empty detection_map "
+        "must classify the processed subset and store predictions. "
+        "add_prediction was never called — the recovery path bailed "
+        "instead of classifying."
+    )
+    # All add_prediction calls must be for the processed photo (id 1).
+    # The untouched photo (id 2) is not in detection_map and must not
+    # be touched by the recovery path.
+    for call in mock_db_instance.add_prediction.call_args_list:
+        # add_prediction(detection_id, species=..., ...) — detection_id is
+        # the first positional arg. Photo 1's stub detection id is 101.
+        det_id = call.args[0] if call.args else call.kwargs.get("detection_id")
+        assert det_id == 101, (
+            f"Recovery path wrote a prediction for unexpected detection "
+            f"{det_id}; only the processed subset should be classified."
+        )
+    assert result["detected"] == 1

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -2763,8 +2763,7 @@ def _run_classify_capturing_photos(db_path, ws, col_id, reclassify):
 
     captured_photos = []
 
-    def _fake_detect_subjects(photos, folders, runner, job, reclassify, db,
-                                classifier_model=None):
+    def _fake_detect_subjects(photos, folders, runner, job, reclassify, db):
         captured_photos.extend([p["id"] for p in photos])
         return ({}, 0)
 
@@ -3124,11 +3123,17 @@ def test_detect_subjects_skips_weight_download_when_cancelled(tmp_path):
 
 def test_detect_subjects_reclassify_preserves_unprocessed_photos_on_cancel(tmp_path):
     """For reclassify runs, cancellation mid-detection must NOT have wiped
-    the predictions and detections of photos that hadn't been re-detected
-    yet. Doing the clear upfront for the whole scope (the old behavior)
-    stranded the unprocessed tail with empty state — worse than before
-    the run started. The fix clears per-photo immediately before each
-    photo is re-detected, so cancelled photos keep their cache."""
+    the detections of photos that hadn't been re-detected yet. Doing the
+    clear upfront for the whole scope (the old behavior) stranded the
+    unprocessed tail with empty state — worse than before the run started.
+    The fix clears per-photo immediately before each photo is re-detected,
+    so cancelled photos keep their cache.
+
+    The cascaded predictions clear lives in ``_classify_photos`` instead of
+    here, so this test verifies both the touched and untouched photos'
+    predictions survive ``_detect_subjects`` — the classify loop is what
+    rebuilds them.
+    """
     from unittest.mock import patch
 
     from classify_job import _detect_subjects
@@ -3197,7 +3202,6 @@ def test_detect_subjects_reclassify_preserves_unprocessed_photos_on_cancel(tmp_p
             job=job,
             reclassify=True,
             db=db,
-            classifier_model="BioCLIP",
         )
 
     # The second photo's cached prediction and detection must survive
@@ -3298,8 +3302,9 @@ def test_classify_photos_drops_pending_batch_on_mid_loop_cancel(tmp_path):
     folders = {10: str(tmp_path)}
 
     # Make _prepare_image succeed without touching disk.
+    fake_img = MagicMock()
     with patch("classify_job._prepare_image",
-               return_value=("img-obj", str(tmp_path), "p")):
+               return_value=(fake_img, str(tmp_path), "p")):
         raw_results, failed, skipped = _classify_photos(
             photos=photos,
             folders=folders,
@@ -3354,3 +3359,326 @@ def test_weights_download_failure_degrades_to_full_image(tmp_path):
     assert detection_map == {}
     assert detected == 0
     assert any("Detection unavailable" in e for e in job["errors"])
+
+
+def test_classify_photos_reclassify_clears_predictions_per_photo(tmp_path):
+    """For reclassify runs, _classify_photos must clear each photo's old
+    predictions immediately before classifying it. The clear sits inside
+    the loop so a mid-classify cancel leaves the unprocessed tail's old
+    predictions intact, and a detection-setup failure that skips the
+    detect loop entirely still has its stale predictions replaced by the
+    fallback full-image classifier rather than coexisting with it.
+
+    Verified at the DB API boundary: clear_predictions is called once per
+    photo with the right (model, photo_id, fingerprint) triple.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from classify_job import _classify_photos
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    photos = [
+        {"id": 1, "filename": "a.jpg", "folder_id": 10, "timestamp": None},
+        {"id": 2, "filename": "b.jpg", "folder_id": 10, "timestamp": None},
+    ]
+    folders = {10: str(tmp_path)}
+
+    mock_db = MagicMock()
+    mock_db.get_detections.return_value = []
+    mock_db.save_detections.return_value = [101]
+    mock_db.get_classifier_run_keys.return_value = set()
+    mock_db.get_predictions_for_detection.return_value = []
+
+    clf = MagicMock()
+    clf.classify_batch_with_embedding.return_value = [
+        ([{"species": "Sparrow", "score": 0.92, "taxonomy": None}], None),
+        ([{"species": "Robin", "score": 0.88, "taxonomy": None}], None),
+    ]
+    fake_img = MagicMock()
+    with patch("classify_job._prepare_image",
+               return_value=(fake_img, str(tmp_path), "p")):
+        _classify_photos(
+            photos=photos,
+            folders=folders,
+            detection_map={},
+            existing_preds=set(),
+            clf=clf,
+            model_type="bioclip",
+            model_name="BioCLIP",
+            runner=runner,
+            job=job,
+            db=mock_db,
+            labels_fingerprint="fp-x",
+            reclassify=True,
+        )
+
+    clear_calls = mock_db.clear_predictions.call_args_list
+    assert len(clear_calls) == 2, (
+        f"clear_predictions must be called once per photo for reclassify; "
+        f"got {len(clear_calls)} calls"
+    )
+    photo_ids_cleared = {
+        call.kwargs["collection_photo_ids"][0] for call in clear_calls
+    }
+    assert photo_ids_cleared == {1, 2}, (
+        f"clear_predictions must target each photo individually; "
+        f"got {photo_ids_cleared}"
+    )
+    for call in clear_calls:
+        assert call.kwargs["model"] == "BioCLIP", (
+            f"clear_predictions must scope to the model being run; got "
+            f"{call.kwargs.get('model')!r}"
+        )
+        assert call.kwargs["labels_fingerprint"] == "fp-x", (
+            "clear_predictions must scope to the labels fingerprint so "
+            "shared-folder workspaces with different label sets don't "
+            "wipe each other's cache"
+        )
+
+
+def test_classify_photos_no_reclassify_skips_predictions_clear(tmp_path):
+    """The per-photo predictions clear must NOT fire for non-reclassify
+    runs — otherwise every cached classification would be invalidated on
+    every normal pass."""
+    from unittest.mock import MagicMock, patch
+
+    from classify_job import _classify_photos
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    photos = [{"id": 1, "filename": "a.jpg", "folder_id": 10, "timestamp": None}]
+    folders = {10: str(tmp_path)}
+
+    mock_db = MagicMock()
+    mock_db.get_detections.return_value = []
+    mock_db.save_detections.return_value = [101]
+    mock_db.get_classifier_run_keys.return_value = set()
+    mock_db.get_predictions_for_detection.return_value = []
+
+    clf = MagicMock()
+    clf.classify_batch_with_embedding.return_value = [
+        ([{"species": "Sparrow", "score": 0.92, "taxonomy": None}], None),
+    ]
+    fake_img = MagicMock()
+    with patch("classify_job._prepare_image",
+               return_value=(fake_img, str(tmp_path), "p")):
+        _classify_photos(
+            photos=photos,
+            folders=folders,
+            detection_map={},
+            existing_preds=set(),
+            clf=clf,
+            model_type="bioclip",
+            model_name="BioCLIP",
+            runner=runner,
+            job=job,
+            db=mock_db,
+            labels_fingerprint="fp-x",
+            reclassify=False,
+        )
+
+    mock_db.clear_predictions.assert_not_called()
+
+
+def test_classify_photos_reclassify_preserves_unclassified_tail_on_cancel(tmp_path):
+    """For reclassify runs, cancelling mid-classify must leave the
+    unclassified tail's old predictions intact.
+
+    Regression for Codex P1 review on vireo/classify_job.py line 933.
+    Before the fix, the per-photo predictions clear ran in the detection
+    loop, so every photo's old predictions were wiped before any
+    classification happened — a cancel that landed mid-classify stranded
+    the tail with cleared predictions and no replacement. The fix moves
+    the clear into the classify loop so unreached photos never have it
+    fire.
+    """
+    from unittest.mock import patch
+
+    from classify_job import _classify_photos
+    from db import Database
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    folder_id = db.add_folder(str(tmp_path), name="p")
+
+    pid_first = db.add_photo(
+        folder_id, "first.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    pid_second = db.add_photo(
+        folder_id, "second.jpg", extension=".jpg",
+        file_size=100, file_mtime=2.0,
+    )
+    det_first = db.save_detections(pid_first, [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1},
+         "confidence": 0.9, "category": "animal"},
+    ], detector_model="megadetector-v6")[0]
+    det_second = db.save_detections(pid_second, [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1},
+         "confidence": 0.9, "category": "animal"},
+    ], detector_model="megadetector-v6")[0]
+    db.add_prediction(det_first, species="Robin", confidence=0.9,
+                      model="BioCLIP", labels_fingerprint="legacy")
+    db.add_prediction(det_second, species="Robin", confidence=0.9,
+                      model="BioCLIP", labels_fingerprint="legacy")
+
+    class FlipRunner(FakeRunner):
+        """Cancel flips on right after the first photo enters the loop."""
+
+        def __init__(self):
+            super().__init__()
+            self._calls = 0
+
+        def is_cancelled(self, job_id):
+            self._calls += 1
+            # First call: top of iteration 0 → not cancelled (process first).
+            # Subsequent calls: top of iteration 1+ → cancelled.
+            return self._calls >= 2
+
+    runner = FlipRunner()
+    job = _make_job()
+    photos = [
+        {"id": pid_first, "filename": "first.jpg", "folder_id": folder_id,
+         "timestamp": None},
+        {"id": pid_second, "filename": "second.jpg", "folder_id": folder_id,
+         "timestamp": None},
+    ]
+    folders = {folder_id: str(tmp_path)}
+
+    detection_map = {
+        pid_first: [{"id": det_first}],
+        pid_second: [{"id": det_second}],
+    }
+
+    from unittest.mock import MagicMock
+    clf = MagicMock()
+    clf.classify_batch_with_embedding.return_value = [
+        ([{"species": "Sparrow", "score": 0.92, "taxonomy": None}], None),
+    ]
+
+    # _prepare_image returns a dummy so we never touch real image files;
+    # the test is about the clear-call boundary, not classification accuracy.
+    fake_img = MagicMock()
+    with patch("classify_job._prepare_image",
+               return_value=(fake_img, str(tmp_path), "p")):
+        _classify_photos(
+            photos=photos,
+            folders=folders,
+            detection_map=detection_map,
+            existing_preds=set(),
+            clf=clf,
+            model_type="bioclip",
+            model_name="BioCLIP",
+            runner=runner,
+            job=job,
+            db=db,
+            labels_fingerprint="legacy",
+            reclassify=True,
+        )
+
+    # The second photo's cached prediction must survive intact: its
+    # iteration never started, so the per-photo clear never ran.
+    db2 = Database(db_path)
+    db2.set_active_workspace(ws)
+    preds_second = db2.conn.execute(
+        "SELECT COUNT(*) AS n FROM predictions WHERE detection_id = ?",
+        (det_second,),
+    ).fetchone()["n"]
+    assert preds_second == 1, (
+        "Mid-classify cancel on a reclassify run wiped the cache of a "
+        "photo whose classify-loop iteration never started — the clear "
+        "leaked out of the loop body."
+    )
+
+
+def test_classify_photos_full_image_fallback_replaces_stale_predictions_on_reclassify(tmp_path):
+    """When MegaDetector setup fails for a reclassify run, ``_classify_photos``
+    runs full-image classification. The stale detector-based predictions
+    must be cleared so they don't coexist with the fallback model's output.
+
+    Regression for Codex P2 review on vireo/classify_job.py line 666.
+    Before the fix, the per-photo clear lived inside ``_detect_subjects``
+    so it was bypassed entirely when the try block raised; the fallback
+    full-image classifier then wrote new predictions alongside the
+    untouched stale rows.
+    """
+    from unittest.mock import patch
+
+    from classify_job import _classify_photos
+    from db import Database
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    folder_id = db.add_folder(str(tmp_path), name="p")
+
+    pid = db.add_photo(
+        folder_id, "a.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    # Pretend a prior megadetector run left a detection + prediction
+    # behind. The reclassify-with-weights-failure path must not let this
+    # prediction linger alongside the new full-image one.
+    stale_det = db.save_detections(pid, [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.4, "h": 0.4},
+         "confidence": 0.9, "category": "animal"},
+    ], detector_model="megadetector-v6")[0]
+    db.add_prediction(stale_det, species="Robin", confidence=0.9,
+                      model="BioCLIP", labels_fingerprint="legacy")
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    from unittest.mock import MagicMock
+    clf = MagicMock()
+    clf.classify_batch_with_embedding.return_value = [
+        ([{"species": "Sparrow", "score": 0.88, "taxonomy": None}], None),
+    ]
+
+    # detection_map is empty (the simulated setup failure produced
+    # nothing) → the function takes the full-image synthetic branch.
+    fake_img = MagicMock()
+    with patch("classify_job._prepare_image",
+               return_value=(fake_img, str(tmp_path), "p")):
+        raw_results, _, _ = _classify_photos(
+            photos=[{"id": pid, "filename": "a.jpg", "folder_id": folder_id,
+                     "timestamp": None}],
+            folders={folder_id: str(tmp_path)},
+            detection_map={},
+            existing_preds=set(),
+            clf=clf,
+            model_type="bioclip",
+            model_name="BioCLIP",
+            runner=runner,
+            job=job,
+            db=db,
+            labels_fingerprint="legacy",
+            reclassify=True,
+        )
+
+    db2 = Database(db_path)
+    db2.set_active_workspace(ws)
+    # Stale BioCLIP prediction on the old megadetector detection must
+    # be gone. The fallback classifier wrote a new prediction on the
+    # synthetic full-image detection.
+    stale_preds = db2.conn.execute(
+        "SELECT COUNT(*) AS n FROM predictions "
+        "WHERE detection_id = ? AND classifier_model = ?",
+        (stale_det, "BioCLIP"),
+    ).fetchone()["n"]
+    assert stale_preds == 0, (
+        "Stale detector-based predictions must be cleared by the classify "
+        "loop's per-photo purge when reclassify falls back to full-image "
+        "(detection setup failure). Found stale rows still attached to "
+        f"the old megadetector detection ({stale_det})."
+    )
+    # Sanity: the fallback path actually produced a result so the test
+    # didn't pass vacuously.
+    assert len(raw_results) == 1
+    assert raw_results[0]["prediction"] == "Sparrow"

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -973,8 +973,13 @@ def test_reclassify_skips_purge_when_cancelled_during_model_load(tmp_path, monke
     gate, the post-detection gate returns with predictions_stored=0 but
     the cache is already wiped.
     """
+    import config as cfg
     from classify_job import ClassifyParams, run_classify_job
     from db import Database
+
+    # Hermetic global config so the run doesn't read or write the user's
+    # ~/.vireo/config.json (per repo testing conventions).
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
 
     db_path = str(tmp_path / "test.db")
     db = Database(db_path)
@@ -3121,7 +3126,7 @@ def test_detect_subjects_skips_weight_download_when_cancelled(tmp_path):
     detect.assert_not_called()
 
 
-def test_detect_subjects_reclassify_preserves_unprocessed_photos_on_cancel(tmp_path):
+def test_detect_subjects_reclassify_preserves_unprocessed_photos_on_cancel(tmp_path, monkeypatch):
     """For reclassify runs, cancellation mid-detection must NOT have wiped
     the detections of photos that hadn't been re-detected yet. Doing the
     clear upfront for the whole scope (the old behavior) stranded the
@@ -3136,8 +3141,12 @@ def test_detect_subjects_reclassify_preserves_unprocessed_photos_on_cancel(tmp_p
     """
     from unittest.mock import patch
 
+    import config as cfg
     from classify_job import _detect_subjects
     from db import Database
+
+    # Hermetic global config (per repo testing conventions).
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
 
     db_path = str(tmp_path / "test.db")
     db = Database(db_path)
@@ -3187,14 +3196,17 @@ def test_detect_subjects_reclassify_preserves_unprocessed_photos_on_cancel(tmp_p
     ]
 
     # detect_animals returns one detection for the first (only) photo
-    # that completes; the second photo is never reached.
+    # that completes; the second photo is never reached. compute_sharpness
+    # is patched to a real callable (rather than ``None``) so that a stray
+    # invocation would surface as an assertion failure on the real
+    # behavior, not a ``TypeError`` from calling ``None``.
     with patch("classify_job.detect_animals",
                return_value=[{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
                               "confidence": 0.8, "category": "animal"}]), \
          patch("classify_job.get_primary_detection",
                return_value={"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
                              "confidence": 0.8}), \
-         patch("classify_job.compute_sharpness", None):
+         patch("classify_job.compute_sharpness", return_value=0.0):
         detection_map, detected = _detect_subjects(
             photos=photos,
             folders={folder_id: str(tmp_path)},
@@ -3224,6 +3236,74 @@ def test_detect_subjects_reclassify_preserves_unprocessed_photos_on_cancel(tmp_p
     assert dets_second == 1, (
         "Mid-detection cancel on a reclassify run cleared detections of "
         "a photo that was never reached."
+    )
+
+
+def test_detect_subjects_reclassify_tracks_clear_when_detect_returns_none(tmp_path, monkeypatch):
+    """For reclassify runs, ``_detect_subjects`` must record a photo for
+    rebuild as soon as its prior detections have been cleared — not only
+    when ``_detect_batch`` reports it processed.
+
+    Regression for Codex P2: if ``detect_animals`` returns ``None`` (image
+    decode failure / ONNX hiccup), ``_detect_batch`` deliberately omits
+    the id from ``processed_ids`` so a future non-reclassify pass retries
+    it. But in reclassify mode the per-photo ``clear_detections`` has
+    already cascaded away the old detections + predictions; if the user
+    then cancels before the next iteration, the run_classify_job cancel
+    path sees an empty processed set and skips classification, leaving
+    the photo with no detections and no predictions.
+
+    The fix marks the photo for rebuild immediately after the clear, so
+    the full-image fallback in ``_classify_photos`` rebuilds it.
+    """
+    from unittest.mock import patch
+
+    import config as cfg
+    from classify_job import _detect_subjects
+    from db import Database
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    folder_id = db.add_folder(str(tmp_path), name="p")
+
+    pid = db.add_photo(
+        folder_id, "a.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    db.save_detections(pid, [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1},
+         "confidence": 0.9, "category": "animal"},
+    ], detector_model="megadetector-v6")
+
+    runner = FakeRunner()
+    job = _make_job()
+    photos = [{"id": pid, "filename": "a.jpg", "folder_id": folder_id}]
+
+    # detect_animals returns None → _detect_batch hits its early-continue
+    # and the id never lands in batch_processed. The clear above still ran.
+    with patch("classify_job.detect_animals", return_value=None), \
+         patch("classify_job.get_primary_detection", return_value=None), \
+         patch("classify_job.compute_sharpness", return_value=0.0):
+        _detect_subjects(
+            photos=photos,
+            folders={folder_id: str(tmp_path)},
+            runner=runner,
+            job=job,
+            reclassify=True,
+            db=db,
+        )
+
+    processed = job.get("_detect_processed_ids")
+    assert processed and pid in processed, (
+        "Reclassify with detect_animals returning None must still mark "
+        "the photo for rebuild — its prior detections were cleared and "
+        "the classify path needs to know to replace them. Without this, "
+        "a post-detect cancel strands the photo with no detections and "
+        "no predictions."
     )
 
 
@@ -3483,7 +3563,7 @@ def test_classify_photos_no_reclassify_skips_predictions_clear(tmp_path):
     mock_db.clear_predictions.assert_not_called()
 
 
-def test_classify_photos_reclassify_preserves_unclassified_tail_on_cancel(tmp_path):
+def test_classify_photos_reclassify_preserves_unclassified_tail_on_cancel(tmp_path, monkeypatch):
     """For reclassify runs, cancelling mid-classify must leave the
     unclassified tail's old predictions intact.
 
@@ -3497,8 +3577,12 @@ def test_classify_photos_reclassify_preserves_unclassified_tail_on_cancel(tmp_pa
     """
     from unittest.mock import patch
 
+    import config as cfg
     from classify_job import _classify_photos
     from db import Database
+
+    # Hermetic global config (per repo testing conventions).
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
 
     db_path = str(tmp_path / "test.db")
     db = Database(db_path)
@@ -3596,7 +3680,7 @@ def test_classify_photos_reclassify_preserves_unclassified_tail_on_cancel(tmp_pa
     )
 
 
-def test_classify_photos_full_image_fallback_replaces_stale_predictions_on_reclassify(tmp_path):
+def test_classify_photos_full_image_fallback_replaces_stale_predictions_on_reclassify(tmp_path, monkeypatch):
     """When MegaDetector setup fails for a reclassify run, ``_classify_photos``
     runs full-image classification. The stale detector-based predictions
     must be cleared so they don't coexist with the fallback model's output.
@@ -3609,8 +3693,12 @@ def test_classify_photos_full_image_fallback_replaces_stale_predictions_on_recla
     """
     from unittest.mock import patch
 
+    import config as cfg
     from classify_job import _classify_photos
     from db import Database
+
+    # Hermetic global config (per repo testing conventions).
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
 
     db_path = str(tmp_path / "test.db")
     db = Database(db_path)

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -966,6 +966,97 @@ def test_reclassify_preserves_cache_on_model_load_failure(tmp_path, monkeypatch)
     )
 
 
+def test_reclassify_skips_purge_when_cancelled_during_model_load(tmp_path, monkeypatch):
+    """If the user cancels while model load / embedding computation is
+    running, the destructive reclassify purge (clear_predictions /
+    clear_detections) MUST NOT execute. Without the pre-purge cancel
+    gate, the post-detection gate returns with predictions_stored=0 but
+    the cache is already wiped.
+    """
+    from classify_job import ClassifyParams, run_classify_job
+    from db import Database
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    folder_id = db.add_folder("/tmp/p", name="p")
+    pid = db.add_photo(
+        folder_id, "a.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    det_id = db.save_detections(pid, [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}
+    ], detector_model="megadetector-v6")[0]
+    db.add_prediction(det_id, species="Robin", confidence=0.9,
+                      model="BioCLIP", labels_fingerprint="legacy")
+
+    coll_id = db.add_collection("c", '[{"field":"photo_ids","value":[' + str(pid) + ']}]')
+
+    runner = FakeRunner()
+
+    # Classifier "loads" successfully but flips the runner to cancelled
+    # mid-init, simulating a user clicking cancel during the (otherwise
+    # uninterruptible) embedding computation. classify_job imports
+    # Classifier at module load time, so the patch has to target that
+    # reference rather than classifier.Classifier.
+    import classify_job as cj
+    class CancellingClassifier:
+        def __init__(self, *a, **kw):
+            runner.cancelled = True
+    monkeypatch.setattr(cj, "Classifier", CancellingClassifier)
+
+    # Bypass the on-disk model registry — the test doesn't need weights
+    # since CancellingClassifier ignores its args.
+    monkeypatch.setattr(cj, "get_active_model", lambda: {
+        "id": "BioCLIP",
+        "name": "BioCLIP",
+        "model_str": "hf-hub:imageomics/bioclip",
+        "weights_path": "/dev/null",
+        "model_type": "bioclip",
+        "downloaded": True,
+    })
+
+    job = _make_job()
+    params = ClassifyParams(
+        collection_id=coll_id,
+        labels_files=None,
+        labels_file=None,
+        model_id=None,
+        model_name="BioCLIP",
+        grouping_window=0,
+        similarity_threshold=0.99,
+        reclassify=True,
+    )
+
+    result = run_classify_job(job, runner, db_path, ws, params)
+
+    # The cancel-before-purge gate returns a no-op result.
+    assert result["predictions_stored"] == 0
+    assert result["detected"] == 0
+
+    # And — the whole point of the gate — cached predictions and
+    # detections survive the cancelled run intact.
+    db2 = Database(db_path)
+    db2.set_active_workspace(ws)
+    preds_after = db2.conn.execute(
+        "SELECT COUNT(*) AS n FROM predictions WHERE detection_id=?",
+        (det_id,),
+    ).fetchone()["n"]
+    dets_after = db2.conn.execute(
+        "SELECT COUNT(*) AS n FROM detections WHERE id=?",
+        (det_id,),
+    ).fetchone()["n"]
+    assert preds_after == 1, (
+        "Reclassify purge ran despite cancel during model load — "
+        "cached predictions were destroyed without replacement."
+    )
+    assert dets_after == 1, (
+        "Reclassify purge ran despite cancel during model load — "
+        "cached detections were destroyed without replacement."
+    )
+
+
 def test_classify_photos_surfaces_cached_full_image_predictions(tmp_path):
     """When a photo has no real detections and the full-image synthetic
     detection is gated by classifier_runs, the cached top prediction

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -3062,6 +3062,73 @@ def test_classify_photos_stops_when_cancelled(tmp_path):
     clf.classify_batch_with_embedding.assert_not_called()
 
 
+def test_classify_photos_drops_pending_batch_on_mid_loop_cancel(tmp_path):
+    """A cancel that lands after some photos queued into ``batch`` but
+    before it reaches ``_BATCH_SIZE`` must drop the pending batch — not
+    fall through to the post-loop flush. Otherwise the job runs classifier
+    inference and writes classifier_runs rows for photos the user just
+    cancelled."""
+    from unittest.mock import MagicMock, patch
+
+    from classify_job import _classify_photos
+
+    # Flip cancelled to True after the first photo has been processed
+    # (queued into batch, but batch < _BATCH_SIZE so not yet flushed).
+    class FlipRunner(FakeRunner):
+        def __init__(self):
+            super().__init__()
+            self._calls = 0
+
+        def is_cancelled(self, job_id):
+            self._calls += 1
+            # First call: start of iteration 0 — let it through.
+            # Second call: start of iteration 1 — flip to cancelled.
+            return self._calls >= 2
+
+    runner = FlipRunner()
+    job = _make_job()
+    clf = MagicMock()
+
+    # Two photos, each with a synthetic full-image detection. _BATCH_SIZE
+    # is well over 2, so neither flushes mid-loop — the only flush path is
+    # the post-loop one, which must be skipped on cancel.
+    mock_db = MagicMock()
+    mock_db.get_detections.return_value = []
+    mock_db.save_detections.return_value = [101]
+    mock_db.get_classifier_run_keys.return_value = set()
+    mock_db.get_predictions_for_detection.return_value = []
+
+    photos = [
+        {"id": 1, "filename": "a.jpg", "folder_id": 10, "timestamp": None},
+        {"id": 2, "filename": "b.jpg", "folder_id": 10, "timestamp": None},
+    ]
+    folders = {10: str(tmp_path)}
+
+    # Make _prepare_image succeed without touching disk.
+    with patch("classify_job._prepare_image",
+               return_value=("img-obj", str(tmp_path), "p")):
+        raw_results, failed, skipped = _classify_photos(
+            photos=photos,
+            folders=folders,
+            detection_map={},
+            existing_preds=set(),
+            clf=clf,
+            model_type="bioclip",
+            model_name="test-model",
+            runner=runner,
+            job=job,
+            db=mock_db,
+        )
+
+    # The post-loop flush must be gated on the cancel — classifier inference
+    # never runs, and no classifier_runs rows are written for the pending
+    # batch contents.
+    clf.classify_batch.assert_not_called()
+    clf.classify_batch_with_embedding.assert_not_called()
+    mock_db.record_classifier_run.assert_not_called()
+    assert raw_results == []
+
+
 def test_weights_download_failure_degrades_to_full_image(tmp_path):
     """A failed MegaDetector weights download (e.g. network down) must
     degrade to full-image classification like any other detection failure,

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -2763,7 +2763,8 @@ def _run_classify_capturing_photos(db_path, ws, col_id, reclassify):
 
     captured_photos = []
 
-    def _fake_detect_subjects(photos, folders, runner, job, reclassify, db):
+    def _fake_detect_subjects(photos, folders, runner, job, reclassify, db,
+                                classifier_model=None):
         captured_photos.extend([p["id"] for p in photos])
         return ({}, 0)
 
@@ -3119,6 +3120,107 @@ def test_detect_subjects_skips_weight_download_when_cancelled(tmp_path):
     assert detected == 0
     weights.assert_not_called()
     detect.assert_not_called()
+
+
+def test_detect_subjects_reclassify_preserves_unprocessed_photos_on_cancel(tmp_path):
+    """For reclassify runs, cancellation mid-detection must NOT have wiped
+    the predictions and detections of photos that hadn't been re-detected
+    yet. Doing the clear upfront for the whole scope (the old behavior)
+    stranded the unprocessed tail with empty state — worse than before
+    the run started. The fix clears per-photo immediately before each
+    photo is re-detected, so cancelled photos keep their cache."""
+    from unittest.mock import patch
+
+    from classify_job import _detect_subjects
+    from db import Database
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    folder_id = db.add_folder(str(tmp_path), name="p")
+
+    pid_first = db.add_photo(
+        folder_id, "first.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    pid_second = db.add_photo(
+        folder_id, "second.jpg", extension=".jpg",
+        file_size=100, file_mtime=2.0,
+    )
+    det_first = db.save_detections(pid_first, [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1},
+         "confidence": 0.9, "category": "animal"},
+    ], detector_model="megadetector-v6")[0]
+    det_second = db.save_detections(pid_second, [
+        {"box": {"x": 0, "y": 0, "w": 1, "h": 1},
+         "confidence": 0.9, "category": "animal"},
+    ], detector_model="megadetector-v6")[0]
+    db.add_prediction(det_first, species="Robin", confidence=0.9,
+                      model="BioCLIP", labels_fingerprint="legacy")
+    db.add_prediction(det_second, species="Robin", confidence=0.9,
+                      model="BioCLIP", labels_fingerprint="legacy")
+
+    class FlipRunner(FakeRunner):
+        """Cancel flips on right after the first photo has been processed."""
+
+        def __init__(self):
+            super().__init__()
+            self._calls = 0
+
+        def is_cancelled(self, job_id):
+            self._calls += 1
+            # First call: top of iteration 0 → not cancelled (process first).
+            # Subsequent calls (top of iteration 1+) → cancelled (skip rest).
+            return self._calls >= 2
+
+    runner = FlipRunner()
+    job = _make_job()
+    photos = [
+        {"id": pid_first, "filename": "first.jpg", "folder_id": folder_id},
+        {"id": pid_second, "filename": "second.jpg", "folder_id": folder_id},
+    ]
+
+    # detect_animals returns one detection for the first (only) photo
+    # that completes; the second photo is never reached.
+    with patch("classify_job.detect_animals",
+               return_value=[{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+                              "confidence": 0.8, "category": "animal"}]), \
+         patch("classify_job.get_primary_detection",
+               return_value={"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+                             "confidence": 0.8}), \
+         patch("classify_job.compute_sharpness", None):
+        detection_map, detected = _detect_subjects(
+            photos=photos,
+            folders={folder_id: str(tmp_path)},
+            runner=runner,
+            job=job,
+            reclassify=True,
+            db=db,
+            classifier_model="BioCLIP",
+        )
+
+    # The second photo's cached prediction and detection must survive
+    # intact: it was never reached, so the per-photo clear never ran.
+    db2 = Database(db_path)
+    db2.set_active_workspace(ws)
+    preds_second = db2.conn.execute(
+        "SELECT COUNT(*) AS n FROM predictions WHERE detection_id = ?",
+        (det_second,),
+    ).fetchone()["n"]
+    dets_second = db2.conn.execute(
+        "SELECT COUNT(*) AS n FROM detections WHERE id = ?",
+        (det_second,),
+    ).fetchone()["n"]
+    assert preds_second == 1, (
+        "Mid-detection cancel on a reclassify run wiped the cache of a "
+        "photo that was never reached — the upfront global purge leaked "
+        "back in."
+    )
+    assert dets_second == 1, (
+        "Mid-detection cancel on a reclassify run cleared detections of "
+        "a photo that was never reached."
+    )
 
 
 def test_classify_photos_stops_when_cancelled(tmp_path):

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -35,6 +35,8 @@ class FakeRunner:
 
     def __init__(self):
         self.events = []
+        self.cancelled = False
+        self.steps = []
 
     def push_event(self, job_id, event_type, data):
         self.events.append((job_id, event_type, data))
@@ -43,7 +45,10 @@ class FakeRunner:
         pass
 
     def update_step(self, job_id, step_id, **kwargs):
-        pass
+        self.steps.append((step_id, kwargs))
+
+    def is_cancelled(self, job_id):
+        return self.cancelled
 
 
 def _make_job(job_id="classify-test"):
@@ -2943,3 +2948,107 @@ def test_run_classifier_retries_on_database_is_locked(tmp_path):
         (det_id,),
     ).fetchone()["n"]
     assert n == 1, "prediction must be persisted after transient lock retries"
+
+
+# ── Cancellation and weights-degrade regressions ────────────────────────────
+
+
+def test_detect_subjects_stops_when_cancelled(tmp_path):
+    """A cancelled job exits the detection loop without processing photos."""
+    from unittest.mock import MagicMock, patch
+
+    from classify_job import _detect_subjects
+
+    runner = FakeRunner()
+    runner.cancelled = True
+    job = _make_job()
+
+    photos = [
+        {"id": 1, "filename": "a.jpg", "folder_id": 10},
+        {"id": 2, "filename": "b.jpg", "folder_id": 10},
+    ]
+    mock_db = MagicMock()
+    # Everything cached → no weights download attempt before the loop.
+    mock_db.get_detector_run_photo_ids.return_value = {1, 2}
+
+    detect = MagicMock()
+    with patch("classify_job.detect_animals", detect), \
+         patch("classify_job.get_primary_detection", MagicMock()):
+        detection_map, detected = _detect_subjects(
+            photos=photos,
+            folders={10: str(tmp_path)},
+            runner=runner,
+            job=job,
+            reclassify=False,
+            db=mock_db,
+        )
+
+    assert detection_map == {}
+    assert detected == 0
+    detect.assert_not_called()
+
+
+def test_classify_photos_stops_when_cancelled(tmp_path):
+    """A cancelled job exits the classification loop without inference."""
+    from unittest.mock import MagicMock, patch
+
+    from classify_job import _classify_photos
+
+    runner = FakeRunner()
+    runner.cancelled = True
+    job = _make_job()
+    clf = MagicMock()
+
+    with patch("classify_job.load_image", MagicMock()):
+        raw_results, failed, skipped = _classify_photos(
+            photos=[{"id": 1, "filename": "a.jpg", "folder_id": 10,
+                     "timestamp": None}],
+            folders={10: str(tmp_path)},
+            detection_map={},
+            existing_preds=set(),
+            clf=clf,
+            model_type="bioclip",
+            model_name="test-model",
+            runner=runner,
+            job=job,
+            db=MagicMock(),
+        )
+
+    assert raw_results == []
+    assert failed == 0
+    clf.classify_batch.assert_not_called()
+    clf.classify_batch_with_embedding.assert_not_called()
+
+
+def test_weights_download_failure_degrades_to_full_image(tmp_path):
+    """A failed MegaDetector weights download (e.g. network down) must
+    degrade to full-image classification like any other detection failure,
+    not propagate and fail the job — on reclassify runs the purge has
+    already happened by then."""
+    from unittest.mock import MagicMock, patch
+
+    from classify_job import _detect_subjects
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    photos = [{"id": 1, "filename": "a.jpg", "folder_id": 10}]
+    mock_db = MagicMock()
+    mock_db.get_detector_run_photo_ids.return_value = set()  # needs download
+
+    with patch("classify_job.detect_animals", MagicMock()), \
+         patch("classify_job.get_primary_detection", MagicMock()), \
+         patch("detector.ensure_megadetector_weights",
+               side_effect=RuntimeError("network down")):
+        detection_map, detected = _detect_subjects(
+            photos=photos,
+            folders={10: str(tmp_path)},
+            runner=runner,
+            job=job,
+            reclassify=False,
+            db=mock_db,
+        )
+
+    assert detection_map == {}
+    assert detected == 0
+    assert any("Detection unavailable" in e for e in job["errors"])

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -4054,3 +4054,140 @@ def test_run_classify_job_reclassify_cancel_after_detect_classifies_processed(tm
             f"{det_id}; only the processed subset should be classified."
         )
     assert result["detected"] == 1
+
+
+def test_run_classify_job_reclassify_cancel_classifies_empty_scene_processed(tmp_path):
+    """End-to-end: a reclassify run cancelled after detection must still
+    classify photos that were re-detected as empty scenes (no detections
+    in detection_map). Their old detections+predictions were already
+    cascaded away by the per-photo ``clear_detections`` call in
+    ``_detect_subjects``; without a full-image fallback classify pass they
+    would be stranded with cleared predictions and no replacement.
+
+    Regression for the Codex P1 review on commit faa47a43ad
+    (vireo/classify_job.py line 1861 — "Track re-detected empty photos
+    before returning"). The gate uses ``job["_detect_processed_ids"]``
+    rather than ``detection_map.keys()`` so empty-scene photos are
+    included in the rebuild subset.
+    """
+    from unittest.mock import MagicMock, patch
+
+    import numpy as np
+    from classify_job import ClassifyParams, run_classify_job
+
+    class PostDetectCancelRunner(FakeRunner):
+        def __init__(self):
+            super().__init__()
+            self.flipped = False
+
+        def is_cancelled(self, job_id):
+            return self.flipped
+
+    runner = PostDetectCancelRunner()
+    job = _make_job()
+
+    mock_db_instance = MagicMock()
+    # Two photos: photo 1 was re-detected as empty (state mutated),
+    # photo 2 was never reached.
+    mock_db_instance.get_collection_photos.return_value = [
+        {"id": 1, "filename": "empty.jpg", "folder_id": 10,
+         "timestamp": "2024-01-15T10:00:00"},
+        {"id": 2, "filename": "untouched.jpg", "folder_id": 10,
+         "timestamp": "2024-01-15T11:00:00"},
+    ]
+    mock_db_instance.get_folder_tree.return_value = [
+        {"id": 10, "path": str(tmp_path), "name": "test"},
+    ]
+    mock_db_instance.get_existing_prediction_photo_ids.return_value = set()
+    mock_db_instance.get_photo_embedding.return_value = None
+    mock_db_instance.get_subject_types.return_value = set()
+    mock_db_instance.filter_out_subject_tagged.side_effect = (
+        lambda pids, _types: list(pids)
+    )
+    mock_db_instance.get_classifier_run_keys.return_value = set()
+    mock_db_instance.get_predictions_for_detection.return_value = []
+    # No prior full-image synthetic detection exists for photo 1 — the
+    # classifier creates one for the full-image fallback path.
+    mock_db_instance.get_detections.return_value = []
+    # save_detections returns a synthetic detection id for the full-image
+    # fallback that _classify_photos creates for empty-scene photos.
+    mock_db_instance.save_detections.return_value = [201]
+
+    fake_model = {
+        "id": "test-model",
+        "name": "TestModel",
+        "model_str": "hf-hub:imageomics/bioclip",
+        "weights_path": "/tmp/weights.bin",
+        "model_type": "bioclip",
+        "downloaded": True,
+    }
+    fake_embedding = np.ones(512, dtype=np.float32)
+    fake_preds = [{"species": "NewEmpty", "score": 0.95, "taxonomy": None}]
+    mock_clf = MagicMock()
+    mock_clf.classify_with_embedding.return_value = (fake_preds, fake_embedding)
+    mock_clf.classify_batch_with_embedding.return_value = [
+        (fake_preds, fake_embedding)
+    ]
+
+    # Stub _detect_subjects: photo 1 was processed but found empty
+    # (recorded a detector_runs row, no detection_map entry). Photo 2 was
+    # never reached. The processed set is stashed on the job so
+    # run_classify_job's rebuild gate can include the empty-scene photo
+    # — using detection_map.keys() alone would miss it.
+    detect_called = {"n": 0}
+
+    def fake_detect_subjects(photos, folders, runner, job, reclassify, db):
+        detect_called["n"] += 1
+        assert reclassify is True
+        # Mirror what production _detect_subjects does: stash the processed
+        # set on job for run_classify_job to consume on cancel.
+        job["_detect_processed_ids"] = {1}
+        runner.flipped = True
+        return ({}, 0)
+
+    params = ClassifyParams(
+        collection_id="col-1",
+        labels_file=None,
+        labels_files=None,
+        model_id=None,
+        model_name=None,
+        grouping_window=10,
+        similarity_threshold=0.85,
+        reclassify=True,
+    )
+
+    fake_img = MagicMock()
+    with patch("classify_job.Database", return_value=mock_db_instance), \
+         patch("classify_job.get_active_model", return_value=fake_model), \
+         patch("classify_job.get_models", return_value=[fake_model]), \
+         patch("classify_job._load_taxonomy", return_value=None), \
+         patch("classify_job._load_labels",
+               return_value=(["NewEmpty"], False)), \
+         patch("classify_job.Classifier", return_value=mock_clf), \
+         patch("classify_job._detect_subjects",
+               side_effect=fake_detect_subjects), \
+         patch("classify_job._prepare_image",
+               return_value=(fake_img, str(tmp_path), "p")):
+        result = run_classify_job(job, runner, str(tmp_path / "test.db"),
+                                  1, params)
+
+    assert detect_called["n"] == 1, "_detect_subjects must have been called"
+    # The empty-scene photo (id 1) had its predictions cascaded away by
+    # _detect_subjects.clear_detections; the recovery path must classify
+    # it via the full-image fallback so it doesn't end up empty.
+    assert mock_db_instance.add_prediction.call_count >= 1, (
+        "Post-detect cancel on reclassify with an empty-scene processed "
+        "photo must classify it via the full-image fallback. Without the "
+        "_detect_processed_ids tracking, the photo is stranded with "
+        "cleared predictions and no replacement."
+    )
+    # All add_prediction calls must be for the empty-scene photo's
+    # synthetic full-image detection (id 201). Photo 2 was never
+    # processed and must not be touched.
+    for call in mock_db_instance.add_prediction.call_args_list:
+        det_id = call.args[0] if call.args else call.kwargs.get("detection_id")
+        assert det_id == 201, (
+            f"Recovery path wrote a prediction for unexpected detection "
+            f"{det_id}; only the processed empty-scene photo's synthetic "
+            f"full-image detection (201) should be classified."
+        )

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -7051,6 +7051,40 @@ def test_move_folder_path_cascade(db):
     assert grandchild["path"] == "/nas/photos/2024/march/birds"
 
 
+def test_bulk_photo_id_apis_chunk_param_lists(tmp_path):
+    """Select-all on a large library produces id lists beyond
+    SQLITE_MAX_VARIABLE_NUMBER (32766 on modern builds) — every bulk-id
+    API must chunk or stage rather than inline one placeholder per id."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    fid = db.add_folder("/photos", name="photos")
+    pid = db.add_photo(folder_id=fid, filename="a.jpg", extension=".jpg",
+                       file_size=100, file_mtime=1.0)
+
+    huge = [pid] + list(range(10_000_000, 10_033_000))  # > 32766 ids
+
+    db.batch_update_photo_rating(huge, 4, verify_workspace=False)
+    db.batch_update_photo_flag(huge, "flagged", verify_workspace=False)
+    # The set path inserts per-id (no IN clause); only the lookup and
+    # removal paths take id lists into one statement.
+    db.batch_set_color_label([pid], "red")
+    labels = db.get_color_labels_for_photos(huge)
+    db.batch_set_color_label(huge, None)
+
+    photo = db.get_photo(pid)
+    assert photo["rating"] == 4
+    assert photo["flag"] == "flagged"
+    assert labels == {pid: "red"}
+    assert db.get_color_labels_for_photos([pid]) == {}  # removal applied
+
+    # Scope-clause consumers and the reclassify purge must not raise either.
+    counts = db.count_real_detections_in_scope(photo_ids=huge, min_conf=0.2)
+    assert counts is not None
+    db.clear_predictions(model="some-model", collection_photo_ids=huge)
+
+
 def test_move_folder_path_does_not_touch_wildcard_siblings(db):
     """LIKE treats _ and % as wildcards — moving /pics/my_dir must not
     rewrite the unrelated sibling /pics/myXdir's children."""

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -7084,6 +7084,18 @@ def test_bulk_photo_id_apis_chunk_param_lists(tmp_path):
     assert counts is not None
     db.clear_predictions(model="some-model", collection_photo_ids=huge)
 
+    # Downstream lookups invoked by export/pipeline jobs after the outer
+    # query/scope chunks must also chunk — the export job feeds the entire
+    # filtered id list into get_photos_by_ids + get_species_keywords_for_photos,
+    # and pipeline.load_photo_features feeds the entire scoped id list into
+    # get_detections_for_photos twice.
+    photos_map = db.get_photos_by_ids(huge)
+    assert pid in photos_map  # the one real row survives the chunked select
+    species_map = db.get_species_keywords_for_photos(huge)
+    assert species_map == {}  # no keywords attached, but no OperationalError
+    det_map = db.get_detections_for_photos(huge, min_conf=0)
+    assert det_map == {}
+
 
 def test_move_folder_path_does_not_touch_wildcard_siblings(db):
     """LIKE treats _ and % as wildcards — moving /pics/my_dir must not

--- a/vireo/tests/test_delete_api.py
+++ b/vireo/tests/test_delete_api.py
@@ -590,11 +590,16 @@ def test_api_batch_delete_chunked_success_prunes_pipeline_cache(
 
 
 def test_api_batch_delete_disk_permanent_retry_with_paths(app_and_db, tmp_path):
-    """disk_permanent retry works with paths after DB rows are already gone."""
+    """disk_permanent retry works with paths after DB rows are already gone.
+
+    The photo rows are deleted by the initial call, but their folder rows
+    survive — the retry validates paths against those.
+    """
     app, db = app_and_db
     client = app.test_client()
 
-    # Create files to delete
+    # Create files to delete, inside a Vireo-managed folder
+    db.add_folder(str(tmp_path), name=tmp_path.name)
     file1 = str(tmp_path / "photo1.jpg")
     file2 = str(tmp_path / "photo2.jpg")
     Image.new("RGB", (10, 10)).save(file1)
@@ -614,6 +619,31 @@ def test_api_batch_delete_disk_permanent_retry_with_paths(app_and_db, tmp_path):
     assert data["trashed"] == 2
     assert not os.path.exists(file1)
     assert not os.path.exists(file2)
+
+
+def test_api_batch_delete_retry_refuses_paths_outside_vireo_folders(app_and_db, tmp_path):
+    """The disk_permanent retry must not delete arbitrary client-supplied
+    paths — only files directly inside a known Vireo folder."""
+    app, db = app_and_db
+    client = app.test_client()
+
+    outside = str(tmp_path / "secrets.txt")
+    with open(outside, "w") as f:
+        f.write("not a vireo photo")
+
+    resp = client.post("/api/batch/delete", json={
+        "mode": "disk_permanent",
+        "paths": [outside],
+    })
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["trashed"] == 0
+    assert os.path.exists(outside)  # file untouched
+    assert any(
+        t["path"] == outside and "not in a Vireo folder" in t.get("error", "")
+        for t in data["trash_failed"]
+    )
 
 
 def test_api_batch_delete_disk_deletes_companion_file(app_and_db, tmp_path):

--- a/vireo/tests/test_delete_api.py
+++ b/vireo/tests/test_delete_api.py
@@ -819,3 +819,59 @@ def test_delete_photos_no_pipeline_cache_does_not_raise(app_and_db):
 
     result = db.delete_photos([photos[0]["id"]])
     assert result["deleted"] == 1
+
+
+def test_delete_photos_with_companions_chunks_expanded_ids(tmp_path):
+    """``include_companions=True`` can double the id count inside
+    ``delete_photos`` (each input id may pull in its companion), so the
+    internal ``IN (?, ?, …)`` DELETEs must chunk on the expanded list,
+    not on the caller's input. The api/batch/delete endpoint pre-chunks
+    by 900 (under SQLite's legacy 999 ``SQLITE_LIMIT_VARIABLE_NUMBER``),
+    but after companion expansion the all_ids list can reach ~1800 —
+    which then trips "too many SQL variables" after the file-trash
+    step already ran.
+
+    The host's actual cap is build-dependent (999 on old, 250000+ on
+    new), so we lower the cap via ``setlimit`` to the legacy value. The
+    input chunk (900) stays under it, but the expanded all_ids (1800)
+    would exceed it without internal chunking.
+    """
+    import sqlite3
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    fid = db.add_folder(str(tmp_path / "lib"), name="lib")
+
+    # 900 primaries + 900 companions = 1800 expanded ids.
+    primary_ids = []
+    companion_filenames = []
+    for i in range(900):
+        comp_name = f"img_{i:04d}.jpg.xmp"
+        companion_filenames.append(comp_name)
+        pid = db.add_photo(
+            folder_id=fid, filename=f"img_{i:04d}.jpg", extension=".jpg",
+            file_size=100, file_mtime=1.0,
+        )
+        db.add_photo(
+            folder_id=fid, filename=comp_name, extension=".xmp",
+            file_size=10, file_mtime=1.0,
+        )
+        primary_ids.append(pid)
+
+    # Link primary → companion so include_companions resolves the sidecar.
+    db.conn.executemany(
+        "UPDATE photos SET companion_path = ? WHERE id = ?",
+        list(zip(companion_filenames, primary_ids)),
+    )
+    db.conn.commit()
+
+    # Legacy SQLite cap — 900 input fits, 1800 expanded does not.
+    db.conn.setlimit(sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER, 999)
+
+    result = db.delete_photos(primary_ids, include_companions=True)
+
+    assert result["deleted"] == 1800  # primaries + companions
+    remaining = db.conn.execute("SELECT COUNT(*) AS n FROM photos").fetchone()["n"]
+    assert remaining == 0

--- a/vireo/tests/test_delete_api.py
+++ b/vireo/tests/test_delete_api.py
@@ -837,6 +837,7 @@ def test_delete_photos_with_companions_chunks_expanded_ids(tmp_path):
     would exceed it without internal chunking.
     """
     import sqlite3
+
     from db import Database
 
     db = Database(str(tmp_path / "test.db"))
@@ -863,7 +864,7 @@ def test_delete_photos_with_companions_chunks_expanded_ids(tmp_path):
     # Link primary → companion so include_companions resolves the sidecar.
     db.conn.executemany(
         "UPDATE photos SET companion_path = ? WHERE id = ?",
-        list(zip(companion_filenames, primary_ids)),
+        list(zip(companion_filenames, primary_ids, strict=True)),
     )
     db.conn.commit()
 

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -456,6 +456,39 @@ def test_incremental_scan_forgets_deleted_xmp(tmp_path):
     )
 
 
+def test_scan_survives_file_vanishing_mid_scan(tmp_path):
+    """A file deleted between discovery and processing is skipped — it must
+    not abort the scan and flag every folder in scope 'partial'."""
+    from db import Database
+    from scanner import scan
+
+    root = str(tmp_path / "photos")
+    os.makedirs(root)
+    Image.new('RGB', (100, 100)).save(os.path.join(root, 'a.jpg'))
+    Image.new('RGB', (100, 100)).save(os.path.join(root, 'b.jpg'))
+
+    db = Database(str(tmp_path / "test.db"))
+
+    # On the first processed photo, delete the other file — it has been
+    # discovered but not yet processed.
+    deleted = []
+    def cb(photo_id, path_str):
+        if deleted:
+            return
+        other = 'b.jpg' if path_str.endswith('a.jpg') else 'a.jpg'
+        os.remove(os.path.join(root, other))
+        deleted.append(other)
+
+    scan(root, db, photo_callback=cb)
+
+    photos = db.get_photos(per_page=100)
+    assert len(photos) == 1  # only the survivor was ingested
+    status = db.conn.execute(
+        "SELECT status FROM folders WHERE path = ?", (root,)
+    ).fetchone()["status"]
+    assert status == "ok"
+
+
 def test_incremental_scan_detects_xmp_changes(tmp_path):
     """Incremental scan re-reads XMP when xmp_mtime changes."""
     from db import Database


### PR DESCRIPTION
## What changed

Batch 2 (robustness) from the full-app bug review — follow-up to #967 and #969.

### 1. Classify jobs now honor cancellation (`vireo/classify_job.py`)
`run_classify_job` never called `runner.is_cancelled`, so cancelling returned 200 while the ~300 MB weight download and full-collection inference continued for potentially hours. The detect and classify loops now exit on cancel, with a phase gate before model resolution. Completed work is preserved: detections commit per photo, and the classify loop's post-loop batch flush plus finalize store classifications finished before the cancel (matching the per-detection `classifier_runs` cache, which is already committed). Step rows report "Cancelled (…)" summaries.

Also: `ensure_megadetector_weights` ran *outside* the try-block whose `except (ImportError, RuntimeError)` degrades to full-image classification — a transient network failure failed the whole job, and on reclassify runs it struck after the purge had already cleared predictions and detections. It's now inside, so download failures degrade like every other detection failure (the pipeline job already did this).

### 2. Scans survive files vanishing mid-scan (`vireo/scanner.py`)
`image_path.stat()` in the pre-pass and main loop had no error handling — one file deleted or renamed between discovery and processing aborted the whole scan and flagged every folder in scope `partial`. Both sites now skip vanished files (the discovery walk already had this guard for broken symlinks). The `xmp_path.exists()`/`stat()` TOCTOU race is folded into the same try/except.

### 3. Unbounded SQL `IN` clauses chunked or staged (`db.py`, `pipeline.py`, `app.py`)
A select-all on a large library exceeds `SQLITE_MAX_VARIABLE_NUMBER` (999 on legacy builds, 32766 modern) → `OperationalError` → 500. Fixed: `batch_update_photo_rating`/`batch_update_photo_flag`, color-label lookup/removal, `clear_predictions` photo filters (both the predictions and classifier_runs DELETEs), `_scope_clause` (large scopes staged in a connection-local temp table so its 15 call sites stay untouched), `load_photo_features` (same temp-table approach across its three scoped queries), the pipeline page-init flag refresh, and the export endpoint's visibility filter.

### 4. Batch-delete retry path no longer deletes arbitrary paths (`app.py`)
The `disk_permanent` retry branch `os.remove()`d every path in the request body with no validation — an arbitrary-file-deletion primitive. Photo rows are already gone by retry time, but their folder rows survive, so paths are now refused unless their parent directory (raw or realpath) is a known Vireo folder. Refusals are reported in `trash_failed` with an error reason.

## Tests

New: `test_detect_subjects_stops_when_cancelled`, `test_classify_photos_stops_when_cancelled`, `test_weights_download_failure_degrades_to_full_image`, `test_scan_survives_file_vanishing_mid_scan`, `test_bulk_photo_id_apis_chunk_param_lists` (33k-id list, genuinely over the modern cap), `test_api_batch_delete_retry_refuses_paths_outside_vireo_folders`; the existing retry test updated to register its folder (the realistic post-delete state).

Required suite + scanner/duplicates/classify/delete/pipeline: **1491 passed, 2 skipped**. Pipeline job + queue suites: **168 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Early cancellation for classification jobs that preserves partial results and avoids destructive purges
  * Path validation for permanent disk deletions so only files inside managed folders are retried/removed
  * Export and workspace queries now handle very large photo lists reliably

* **Bug Fixes**
  * Avoided SQL parameter errors by chunking large ID lists and using safer scoping
  * Scanner tolerates files vanishing mid-scan
  * Missing detector weights now degrade gracefully

* **Tests**
  * Added extensive cancellation, large-input, deletion-validation, and scanner-resilience tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->