### PR TITLE
Treat 'cancelled' as a terminal step status in update_step

### DIFF
--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -806,7 +806,10 @@ class JobRunner:
                     new_status = kwargs.get("status")
                     if new_status == "running" and step["status"] == "pending":
                         step["started_at"] = datetime.now().isoformat()
-                    if new_status in ("completed", "failed") and step["started_at"]:
+                    # "cancelled" is terminal too — classify/pipeline steps
+                    # report it on user cancel; without it here those steps
+                    # persist with no finished_at/duration.
+                    if new_status in ("completed", "failed", "cancelled") and step["started_at"]:
                         step["finished_at"] = datetime.now().isoformat()
                         start = datetime.fromisoformat(step["started_at"])
                         end = datetime.fromisoformat(step["finished_at"])

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -605,6 +605,33 @@ def test_update_step_current_file(app_and_db):
     assert runner._jobs[job_id]["steps"][0]["current_file"] == "DSC_0001.NEF"
 
 
+def test_update_step_cancelled_is_terminal(app_and_db):
+    """status='cancelled' finalizes a step (finished_at + duration), same as
+    completed/failed — classify/pipeline steps report it on user cancel."""
+    from jobs import JobRunner
+    runner = JobRunner.__new__(JobRunner)
+    runner._jobs = {}
+    runner._subscribers = {}
+    runner._lock = __import__('threading').Lock()
+    runner._history_db_path = None
+
+    job_id = "test-cancel-step"
+    runner._jobs[job_id] = {
+        "id": job_id,
+        "steps": [
+            {"id": "classify", "label": "Classify", "status": "pending",
+             "started_at": None, "finished_at": None, "duration": None},
+        ],
+    }
+    runner.update_step(job_id, "classify", status="running")
+    runner.update_step(job_id, "classify", status="cancelled",
+                       summary="Cancelled (3 of 10 processed)")
+    step = runner._jobs[job_id]["steps"][0]
+    assert step["status"] == "cancelled"
+    assert step["finished_at"] is not None
+    assert step["duration"] is not None
+
+
 def test_scan_step_has_progress(app_and_db, tmp_path):
     """Scan step reports step-level progress with current/total."""
     app, _ = app_and_db


### PR DESCRIPTION
## What changed

Follow-up to the unresolved review threads on #970 (merged before the last bot round was addressed).

Of the seven leftover threads, six were already fixed on the branch before merge (export helpers and `get_detections_for_photos` chunk internally; the reclassify fallback purge tracks cleared photos via `processed_for_rebuild` and intentionally clears across fingerprints with a documented rationale). This PR fixes the one remaining item:

- `JobRunner.update_step` only treated `completed`/`failed` as terminal, so the `status="cancelled"` step writes introduced in #970 persisted with no `finished_at`/`duration`. `cancelled` now finalizes the step like the other terminal states.

Replies are being posted on all seven #970 threads pointing at where each was resolved.

## Tests

New `test_update_step_cancelled_is_terminal`. Required suite: **1083 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pipeline steps marked as "cancelled" now correctly finalize timing information (finish time and duration) when execution had started, matching behavior for completed and failed steps.

* **Tests**
  * Added test coverage to verify cancelled steps transition to terminal state and populate timing fields as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->