### PR TITLE
Fix six frontend bugs from the app review: XSS escaping and UI honesty

### DIFF
--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -5140,12 +5140,14 @@ function renderPipeline(data, photoId) {
     data.predictions.forEach(function(p) {
       var pct = Math.round(p.confidence * 100);
       var statusColor = p.status === 'accepted' ? 'var(--accent)' : p.status === 'rejected' ? 'var(--danger)' : 'var(--text-dim)';
+      // Species/model values can carry user-typed text (freeform species
+      // confirms, custom label files) — escape before interpolating.
       html += '<tr>' +
-        '<td>' + p.species + (p.scientific_name ? '<br><span style="font-size:11px;color:var(--text-dim);font-style:italic;">' + p.scientific_name + '</span>' : '') + '</td>' +
+        '<td>' + escapeHtml(p.species) + (p.scientific_name ? '<br><span style="font-size:11px;color:var(--text-dim);font-style:italic;">' + escapeHtml(p.scientific_name) + '</span>' : '') + '</td>' +
         '<td><span class="pipeline-conf-bar" style="width:' + pct + 'px;"></span> ' + pct + '%</td>' +
-        '<td style="color:var(--text-dim);">' + p.model + '</td>' +
-        '<td style="color:' + statusColor + ';">' + p.status + '</td>' +
-        '<td style="color:var(--text-dim);">' + p.category + '</td>' +
+        '<td style="color:var(--text-dim);">' + escapeHtml(p.model) + '</td>' +
+        '<td style="color:' + statusColor + ';">' + escapeHtml(p.status) + '</td>' +
+        '<td style="color:var(--text-dim);">' + escapeHtml(p.category) + '</td>' +
       '</tr>';
     });
     html += '</table>';
@@ -5162,7 +5164,7 @@ function renderPipeline(data, photoId) {
       if (withTax.taxonomy_genus) parts.push(withTax.taxonomy_genus);
       html += '<div style="margin-top:8px;font-size:12px;color:var(--text-dim);">' +
         '<span style="color:var(--text-muted);">Taxonomy:</span> ' +
-        parts.join(' &rsaquo; ') +
+        parts.map(escapeHtml).join(' &rsaquo; ') +
       '</div>';
     }
 
@@ -5214,7 +5216,8 @@ function renderPipeline(data, photoId) {
       '<div class="pipeline-step-header"><span class="pipeline-step-num">6</span><span class="pipeline-step-title">Current Keywords</span></div>' +
       '<div style="display:flex;gap:6px;flex-wrap:wrap;">';
     data.keywords.forEach(function(k) {
-      html += '<span style="background:var(--bg-tertiary);padding:3px 8px;border-radius:4px;font-size:12px;">' + k.name + '</span>';
+      // Keyword names are user-controlled (typed confirms, XMP imports).
+      html += '<span style="background:var(--bg-tertiary);padding:3px 8px;border-radius:4px;font-size:12px;">' + escapeHtml(k.name) + '</span>';
     });
     html += '</div></div>';
   }
@@ -7127,16 +7130,34 @@ async function loadMissingFolders() {
       checkMissingFolders();  // update banner
       return;
     }
-    container.innerHTML = folders.map(f => `
-      <div class="missing-folder-row">
-        <div class="missing-folder-path" title="${f.path}">${f.path}</div>
-        <div class="missing-folder-count">${f.photo_count} photo${f.photo_count !== 1 ? 's' : ''}</div>
-        <div class="missing-folder-actions">
-          <button onclick="startRelocate(${f.id}, '${f.path.replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/"/g, '&quot;')}')">Relocate</button>
-          <button class="danger" onclick="startRemoveFolder(${f.id}, '${f.path.replace(/'/g, "\\'")}', ${f.photo_count})">Remove</button>
-        </div>
-      </div>
-    `).join('');
+    // Paths are user-controlled: build rows with DOM methods instead of
+    // interpolating into HTML/onclick strings — a quote, backslash, or
+    // angle bracket in a folder name broke the inline handlers (and could
+    // inject markup). Closures carry the path values safely.
+    container.textContent = '';
+    folders.forEach(f => {
+      const row = document.createElement('div');
+      row.className = 'missing-folder-row';
+      const pathEl = document.createElement('div');
+      pathEl.className = 'missing-folder-path';
+      pathEl.title = f.path;
+      pathEl.textContent = f.path;
+      const countEl = document.createElement('div');
+      countEl.className = 'missing-folder-count';
+      countEl.textContent = `${f.photo_count} photo${f.photo_count !== 1 ? 's' : ''}`;
+      const actions = document.createElement('div');
+      actions.className = 'missing-folder-actions';
+      const relocateBtn = document.createElement('button');
+      relocateBtn.textContent = 'Relocate';
+      relocateBtn.addEventListener('click', () => startRelocate(f.id, f.path));
+      const removeBtn = document.createElement('button');
+      removeBtn.className = 'danger';
+      removeBtn.textContent = 'Remove';
+      removeBtn.addEventListener('click', () => startRemoveFolder(f.id, f.path, f.photo_count));
+      actions.append(relocateBtn, removeBtn);
+      row.append(pathEl, countEl, actions);
+      container.appendChild(row);
+    });
   } catch (e) {
     container.innerHTML = '<p style="color:var(--text-secondary);">Failed to check folders.</p>';
   }

--- a/vireo/templates/cull.html
+++ b/vireo/templates/cull.html
@@ -956,8 +956,12 @@ function renderCulling() {
 
         var qScore = photo.quality_score != null ? photo.quality_score.toFixed(2) : (photo.sharpness != null ? Math.round(photo.sharpness) : '-');
 
+        // Filename rides in a data attribute: interpolating it into the
+        // onclick JS string broke on double quotes (attribute terminator,
+        // which escapeHtml doesn't encode) and trailing backslashes.
         html += '<div class="' + cardClass + '" data-photo-id="' + photo.photo_id + '" ' +
-          'onclick="openLightbox(' + photo.photo_id + ',\'' + escapeHtml(photo.filename || '').replace(/'/g, "\\'") + '\', window.' + poseKey + ')" ' +
+          'data-filename="' + escapeAttr(photo.filename || '') + '" ' +
+          'onclick="openLightbox(' + photo.photo_id + ', this.dataset.filename, window.' + poseKey + ')" ' +
           'ondblclick="toggleCullAction(' + si + ',' + pi + ',' + photo.photo_id + ')">' +
           badge +
           '<img src="/thumbnails/' + photo.photo_id + '.jpg" loading="lazy">' +

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -2470,8 +2470,11 @@ async function startPipeline() {
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify({ current_path: window.location.pathname })
       });
-      // Update the navbar workspace display
-      var wsBtn = document.getElementById('wsDropdownBtn');
+      // Update the navbar workspace display ('wsCurrentName' is the
+      // navbar's actual element — the old 'wsDropdownBtn' id never
+      // existed, so the navbar kept showing the previous workspace for
+      // the whole run).
+      var wsBtn = document.getElementById('wsCurrentName');
       if (wsBtn) wsBtn.textContent = wsName;
       document.getElementById('lblCurrentWsName').textContent = '(' + wsName + ')';
     } catch(e) {

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -2409,7 +2409,7 @@ function renderPhotoCard(p, encIdx, burstIdx) {
     html += '<button class="detach-btn" onclick="event.stopPropagation();detachPhoto(' + encIdx + ',' + burstIdx + ',' + p.id + ')" title="Detach photo" style="position:absolute;top:2px;right:2px;">&times;</button>';
   }
   html += '<div class="photo-score-bar"><div class="photo-score-fill" style="width:' + qPct + '%"></div></div>';
-  html += '<div class="photo-info">' + (p.filename || '') + ' &middot; Q=' + q.toFixed(2) + '</div>';
+  html += '<div class="photo-info">' + escapeHtml(p.filename || '') + ' &middot; Q=' + q.toFixed(2) + '</div>';
   html += '</div>';
   return html;
 }
@@ -2864,7 +2864,7 @@ function openInspect(photoId) {
   ];
 
   var html = '<button class="inspect-close" onclick="closeInspect()">&times;</button>';
-  html += '<div class="inspect-title">' + (photo.filename || 'Photo ' + photoId) + '</div>';
+  html += '<div class="inspect-title">' + escapeHtml(photo.filename || 'Photo ' + photoId) + '</div>';
 
   // Image with mask toggle
   html += '<div class="inspect-img-wrap">';
@@ -2916,7 +2916,7 @@ function openInspect(photoId) {
   // Encounter context filmstrip
   if (enc) {
     var speciesName = enc.confirmed_species || (enc.species ? (enc.species[0] || 'Unknown') : 'Unknown');
-    html += '<div class="context-label">Encounter: ' + speciesName + ' (' + enc.photo_count + ' photos, ' + (enc.burst_count||0) + ' bursts)</div>';
+    html += '<div class="context-label">Encounter: ' + escapeHtml(speciesName) + ' (' + enc.photo_count + ' photos, ' + (enc.burst_count||0) + ' bursts)</div>';
     html += '<div class="context-filmstrip">';
     (enc.photo_ids || []).forEach(function(pid) {
       var isCurrent = pid === photoId ? ' current' : '';

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -2619,19 +2619,25 @@ async function grmApply() {
       }),
     });
 
-    // Update local prediction status immediately so cards reflect the change
+    // Update local prediction status immediately so cards reflect the
+    // change — mirroring what the backend just did: picks become accepted,
+    // rejects become rejected, untouched candidates stay pending. Marking
+    // the whole group accepted made rejected photos show as Accepted in
+    // the tabs/badges until a reload.
     var groupId = grmState.groupId;
     var model = grmState.model;
-    allPredictions.forEach(function(p) {
-      if (p.group_id === groupId && p.model === model) {
+    var picks = grmState.picks;
+    var rejects = grmState.rejects;
+    function applyLocalStatus(p) {
+      if (p.group_id !== groupId || p.model !== model) return;
+      if (picks.has(p.photo_id)) {
         p.status = 'accepted';
+      } else if (rejects.has(p.photo_id)) {
+        p.status = 'rejected';
       }
-    });
-    predictions.forEach(function(p) {
-      if (p.group_id === groupId && p.model === model) {
-        p.status = 'accepted';
-      }
-    });
+    }
+    allPredictions.forEach(applyLocalStatus);
+    predictions.forEach(applyLocalStatus);
 
     closeGroupReview();
     renderAll();

--- a/vireo/templates/stats.html
+++ b/vireo/templates/stats.html
@@ -943,7 +943,7 @@ async function toggleFolderDetail() {
       html += '<div class="folder-row">' +
         '<div class="fhead" onclick="toggleFolderCov(\'' + fid + '\', this)">' +
           '<span class="fchevron">\u25B8</span>' +
-          '<span class="fpath" title="' + escapeHtml(f.path) + '">' + escapeHtml(f.path) + '</span>' +
+          '<span class="fpath" title="' + escapeAttr(f.path) + '">' + escapeHtml(f.path) + '</span>' +
           '<span class="fcount">' + (f.total || 0).toLocaleString() + ' photos</span>' +
         '</div>' +
         '<div id="' + fid + '" style="display:none;">' + renderFolderCoverage(f) + '</div>' +


### PR DESCRIPTION
## What changed

Batch 3 (frontend) from the full-app bug review — follow-up to #967/#969/#970/#971.

### XSS / markup injection
User-controlled values (folder paths, filenames, keyword names, user-typed species) reached `innerHTML` or attribute contexts unescaped:

- **`_navbar.html` missing-folders modal** — rows are now built with DOM methods and closure-bound click handlers instead of interpolated HTML + inline `onclick` strings. Previously a `"` in a folder path terminated the onclick attribute, a trailing backslash broke the JS string, and `<`/`&` injected markup (the sibling missing-photos modal already escaped correctly — this one was the oversight).
- **`_navbar.html` pipeline-inspector overlay** (shared lightbox feature, reachable from every page) — species, scientific name, model, status, category, taxonomy chain, and keyword chips are now escaped. Keyword names are a stored-XSS sink (typed species confirms, XMP-imported keywords).
- **`pipeline_review.html`** — photo-card filename, inspector title, and the encounter context label (user-typed confirmed species) now go through the file's own `escapeHtml`, which was already used everywhere else.
- **`cull.html`** — the filename moved out of the onclick JS string into a `data-filename` attribute read via `this.dataset` (the global `escapeHtml` doesn't encode double quotes, so a filename containing `"` broke the handler).
- **`stats.html`** — the folder-path `title` attribute uses `escapeAttr`.

### UI honesty (CORE_PHILOSOPHY violations)
- **`review.html` group-review "Apply"** — the optimistic update marked *every* prediction in the group `accepted`, so photos the user had just rejected showed as Accepted in tab counts and badges until reload. It now mirrors the backend exactly: picks → accepted, rejects → rejected, untouched candidates stay pending.
- **`pipeline.html`** — after creating a new destination workspace, the code updated `wsDropdownBtn`, an element id that doesn't exist, so the navbar silently kept showing the *old* workspace name for the entire pipeline run. It now updates the navbar's real `wsCurrentName` element.

## Tests

Template/JS changes — no Python behavior changes. Required suite (exercises template rendering via the Flask routes): **1082 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)