### PR TITLE
Fix eight low-severity bugs from the app review (final batch)

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -10982,7 +10982,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         for h in hashes:
             rows = db.conn.execute(
                 "SELECT id FROM photos "
-                "WHERE file_hash = ? AND flag != 'rejected'",
+                "WHERE file_hash = ? AND (flag IS NULL OR flag != 'rejected')",
                 (h,),
             ).fetchall()
             if len(rows) < 2:
@@ -11192,7 +11192,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         for h in hashes:
             anchor = db.conn.execute(
                 "SELECT 1 FROM photos "
-                "WHERE file_hash = ? AND flag != 'rejected' LIMIT 1",
+                "WHERE file_hash = ? AND (flag IS NULL OR flag != 'rejected') LIMIT 1",
                 (h,),
             ).fetchone()
             if anchor is not None:
@@ -11347,7 +11347,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
               AND p.file_hash IS NOT NULL
               AND EXISTS (
                   SELECT 1 FROM photos q
-                  WHERE q.file_hash = p.file_hash AND q.flag != 'rejected'
+                  WHERE q.file_hash = p.file_hash AND (q.flag IS NULL OR q.flag != 'rejected')
               )
             """
         ).fetchone()

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -11711,7 +11711,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # `bool` is a subclass of `int`, and `int(1.9)` silently
             # truncates to `1` — reject both so the wrong photo can't be
             # cached without any client-visible error.
-            if isinstance(pid, (bool, float)):
+            if isinstance(pid, bool | float):
                 return json_error("photo_ids must be integers")
             try:
                 photo_ids.append(int(pid))
@@ -14706,7 +14706,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 # bool is an int subclass — reject explicitly so True/False
                 # don't silently succeed for numeric keys.
                 return json_error(f"{k} must be a number, got bool")
-            if not isinstance(raw_v, (int, float)):
+            if not isinstance(raw_v, int | float):
                 return json_error(f"{k} must be a number")
             v = float(raw_v)
             if v != v or v in (float("inf"), float("-inf")):

--- a/vireo/classifier.py
+++ b/vireo/classifier.py
@@ -619,7 +619,7 @@ class Classifier:
         from PIL import Image as PILImage
         from pipeline_locks import acquire_gpu_if_session_uses_it
 
-        if isinstance(image, (str, os.PathLike)):
+        if isinstance(image, str | os.PathLike):
             with PILImage.open(image) as img:
                 input_arr = self._preprocess(img)
         else:

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -1604,7 +1604,7 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
         kept_raw = getattr(
             thread_db, "filter_out_wildlife_excluded", lambda ids: ids
         )(photo_ids)
-        if not isinstance(kept_raw, (list, tuple, set)):
+        if not isinstance(kept_raw, list | tuple | set):
             kept_raw = photo_ids
         kept_ids = set(kept_raw)
         photos = [p for p in photos if p["id"] in kept_ids]

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -518,8 +518,12 @@ def _detect_batch(photos, folders, runner, job, reclassify, db,
 
             processed_ids.add(photo["id"])
 
-    except (ImportError, RuntimeError):
-        pass
+    except (ImportError, RuntimeError) as e:
+        # Detection unavailable (missing weights/backend) — non-fatal, the
+        # caller degrades to full-image classification. Previously silenced
+        # entirely, which let the detect stage report success while the
+        # batch's remaining photos were silently skipped.
+        log.warning("Detection unavailable for batch (non-fatal): %s", e)
     except Exception:
         log.warning("Detection failed for batch (non-fatal)", exc_info=True)
 

--- a/vireo/config_schema.py
+++ b/vireo/config_schema.py
@@ -723,7 +723,7 @@ def _coerce(raw, kind):
     if kind == "bool":
         if isinstance(raw, bool):
             return raw
-        if isinstance(raw, (int, float)):
+        if isinstance(raw, int | float):
             return bool(raw)
         if isinstance(raw, str):
             low = raw.strip().lower()

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2793,7 +2793,7 @@ class Database:
             return None
         try:
             dup_rows = self.conn.execute(
-                "SELECT id FROM photos WHERE file_hash = ? AND flag != 'rejected'",
+                "SELECT id FROM photos WHERE file_hash = ? AND (flag IS NULL OR flag != 'rejected')",
                 (file_hash,),
             ).fetchall()
             if len(dup_rows) > 1:
@@ -2828,7 +2828,7 @@ class Database:
             """
             SELECT file_hash, GROUP_CONCAT(id) AS ids
             FROM photos
-            WHERE file_hash IS NOT NULL AND flag != 'rejected'
+            WHERE file_hash IS NOT NULL AND (flag IS NULL OR flag != 'rejected')
             GROUP BY file_hash
             HAVING COUNT(*) > 1
             """
@@ -2854,7 +2854,7 @@ class Database:
             """
             SELECT file_hash,
                    GROUP_CONCAT(id) AS ids,
-                   SUM(CASE WHEN flag != 'rejected' THEN 1 ELSE 0 END) AS kept,
+                   SUM(CASE WHEN flag IS NULL OR flag != 'rejected' THEN 1 ELSE 0 END) AS kept,
                    SUM(CASE WHEN flag  = 'rejected' THEN 1 ELSE 0 END) AS rejected
             FROM photos
             WHERE file_hash IS NOT NULL
@@ -2897,7 +2897,7 @@ class Database:
                        f.path AS folder_path
                 FROM photos p
                 LEFT JOIN folders f ON f.id = p.folder_id
-                WHERE p.id IN ({placeholders}) AND p.flag != 'rejected'""",
+                WHERE p.id IN ({placeholders}) AND (p.flag IS NULL OR p.flag != 'rejected')""",
             list(photo_ids),
         ).fetchall()
         if len(rows) < 2:
@@ -3035,7 +3035,7 @@ class Database:
                           f.path AS folder_path
                    FROM photos p
                    LEFT JOIN folders f ON f.id = p.folder_id
-                   WHERE p.file_hash = ? AND p.flag != 'rejected'""",
+                   WHERE p.file_hash = ? AND (p.flag IS NULL OR p.flag != 'rejected')""",
                 (file_hash,),
             ).fetchall()
             if not rows:
@@ -7702,7 +7702,7 @@ class Database:
                  {folder_filter}
                  AND p.quality_score IS NOT NULL
                  AND p.quality_score >= ?
-                 AND p.flag != 'rejected'
+                 AND (p.flag IS NULL OR p.flag != 'rejected')
                ORDER BY p.quality_score DESC""",
             (ws, ws, *folder_params, min_quality),
         ).fetchall()
@@ -10600,7 +10600,7 @@ class Database:
                     "JOIN workspace_folders wf2 ON wf2.folder_id = p2.folder_id "
                     "AND wf2.workspace_id = ? "
                     "WHERE p2.id != p.id AND p2.file_hash = p.file_hash "
-                    "AND p2.flag != 'rejected')"
+                    "AND (p2.flag IS NULL OR p2.flag != 'rejected'))"
                 )
                 return (has if _truthy(value) else f"NOT ({has})"), [self._ws_id()]
             raise ValueError(f"unsupported collection rule field/op: {field}/{op}")

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -10321,7 +10321,7 @@ class Database:
             raise ValueError("rules must be a list or group object")
 
         def _is_scalar(value):
-            return value is None or isinstance(value, (str, int, float, bool))
+            return value is None or isinstance(value, str | int | float | bool)
 
         def _validate_node(node):
             if not isinstance(node, dict):

--- a/vireo/duplicate_scan.py
+++ b/vireo/duplicate_scan.py
@@ -59,7 +59,7 @@ def _build_unresolved_proposal(db, group):
         db, group["photo_ids"],
         columns="p.id, p.filename, p.file_mtime, p.rating, p.file_size, "
                 "f.path AS folder_path",
-        where_extra=" AND p.flag != 'rejected'",
+        where_extra=" AND (p.flag IS NULL OR p.flag != 'rejected')",
     )
 
     info_by_id = {r["id"]: _row_to_info(r, r["folder_path"]) for r in rows}

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -266,6 +266,11 @@ class JobRunner:
                         "ephemeral": False,
                         "counts_for_badge": True,
                         "runtime_warning": ctx["runtime_warning"],
+                        # Pre-seeded for iteration safety — see start().
+                        "_start_time": time.time(),
+                        "_ended_at": None,
+                        "_persisted": False,
+                        "_fatal_error": None,
                     }
                     self._prune_finished_jobs()
                     self._jobs[job_id] = job
@@ -370,7 +375,14 @@ class JobRunner:
         Returns:
             job_id string
         """
-        job_id = f"{job_type}-{int(time.time() * 1000)}"
+        # Monotonic suffix (shared with enqueue_pipeline) so two same-type
+        # starts in the same millisecond can't collide — a collision makes
+        # the second registration overwrite the first in _jobs/_events and
+        # clobber its history row.
+        with self._lock:
+            self._enqueue_counter += 1
+            seq = self._enqueue_counter
+        job_id = f"{job_type}-{int(time.time() * 1000)}-{seq}"
         now = datetime.now().isoformat()
 
         job = {
@@ -388,6 +400,15 @@ class JobRunner:
             "ephemeral": ephemeral,
             "counts_for_badge": counts_for_badge,
             "runtime_warning": runtime_warning,
+            # Pre-seeded so later writes from worker threads update an
+            # existing key instead of inserting a new one: key insertion
+            # while a request handler iterates the same dict (jsonify of
+            # /api/jobs) raises "dictionary changed size during iteration";
+            # same-key updates don't resize the dict.
+            "_start_time": time.time(),
+            "_ended_at": None,
+            "_persisted": False,
+            "_fatal_error": None,
         }
 
         with self._lock:
@@ -528,6 +549,7 @@ class JobRunner:
         )
 
         for attempt in range(3):
+            conn = None
             try:
                 conn = sqlite3.connect(self._db_path, timeout=30)
                 conn.execute(
@@ -560,7 +582,6 @@ class JobRunner:
                         (ws_id, ws_id),
                     )
                 conn.commit()
-                conn.close()
                 return
             except sqlite3.OperationalError:
                 if attempt < 2:
@@ -570,6 +591,11 @@ class JobRunner:
                         "Failed to persist job history for %s after 3 attempts",
                         job["id"],
                     )
+            finally:
+                # Close on every path — a failed execute/commit previously
+                # leaked the connection (one per retry).
+                if conn is not None:
+                    conn.close()
 
     def _build_summary(self, job):
         """Build a one-line summary from job steps or result."""
@@ -627,12 +653,28 @@ class JobRunner:
             "runtime_warning": ctx.get("runtime_warning"),
         }
 
+    @staticmethod
+    def _snapshot_job(job):
+        """Copy a job dict for callers outside the lock.
+
+        The top-level copy alone isn't enough: handlers jsonify the nested
+        progress/steps containers while worker threads mutate them, and a
+        key insertion during that iteration raises RuntimeError. Snapshot
+        the nested mutable containers under the lock too.
+        """
+        snap = dict(job)
+        snap["progress"] = dict(job.get("progress") or {})
+        snap["steps"] = [dict(s) for s in (job.get("steps") or [])]
+        snap["errors"] = list(job.get("errors") or [])
+        return snap
+
     def get(self, job_id):
-        """Get a job by id. Returns a shallow copy so callers don't mutate shared state."""
+        """Get a job by id. Returns a copy so callers don't mutate (or race
+        with) shared state."""
         with self._lock:
             job = self._jobs.get(job_id)
             if job is not None:
-                return dict(job)
+                return self._snapshot_job(job)
             ctx = self._queued_pipelines.get(job_id)
             if ctx is None:
                 return None
@@ -643,10 +685,11 @@ class JobRunner:
 
         Includes synthetic queued-pipeline entries so the navbar and
         /jobs page can render and cancel them; otherwise a queued run
-        disappears from the UI between enqueue and promotion.
+        disappears from the UI between enqueue and promotion. Returns
+        snapshots, not live dicts — see _snapshot_job.
         """
         with self._lock:
-            jobs = list(self._jobs.values())
+            jobs = [self._snapshot_job(j) for j in self._jobs.values()]
             for job_id, ctx in self._queued_pipelines.items():
                 jobs.append(self._synthesize_queued_view(job_id, ctx))
             return jobs

--- a/vireo/models.py
+++ b/vireo/models.py
@@ -494,8 +494,13 @@ def _hf_download_with_retry(repo_id, filename, local_dir,
             # uses clonefile() (copy-on-write metadata-only), so cloning a
             # 1+ GB blob takes milliseconds and shares disk pages with the
             # cache until either side is modified.
-            os.makedirs(local_dir, exist_ok=True)
             dest_path = os.path.join(local_dir, filename)
+            # filename can be repo-relative (e.g. "onnx/model.onnx" for
+            # custom HF repos with the standard onnx/ layout) — create the
+            # full destination directory, not just local_dir, or copy2
+            # raises FileNotFoundError that the retry loop misclassifies
+            # as a connection failure.
+            os.makedirs(os.path.dirname(dest_path), exist_ok=True)
             if cached_path != dest_path:
                 shutil.copy2(cached_path, dest_path)
 

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -783,7 +783,7 @@ def serialize_results(results):
         for k, v in p.items():
             if isinstance(v, np.ndarray):
                 continue  # skip embedding arrays
-            if isinstance(v, (np.floating, np.integer)):
+            if isinstance(v, np.floating | np.integer):
                 cleaned[k] = float(v)
             else:
                 cleaned[k] = v

--- a/vireo/pipeline_plan.py
+++ b/vireo/pipeline_plan.py
@@ -996,9 +996,6 @@ def compute_plan(db, params, db_path):
     if params.collection_id is not None:
         from pipeline import _resolve_collection_photo_ids
         photo_ids = _resolve_collection_photo_ids(db, params.collection_id)
-        if params.exclude_photo_ids:
-            excl = set(params.exclude_photo_ids)
-            photo_ids = {pid for pid in photo_ids if pid not in excl}
     elif params.source_paths is not None:
         if not params.source_paths:
             # Import / new-images mode with every preview file deselected.
@@ -1050,6 +1047,17 @@ def compute_plan(db, params, db_path):
         unlinked_folder_count = db.workspace_unlinked_folder_count(
             {os.path.dirname(p) for p in unique_paths if p not in hash_dup_paths}
         )
+
+    # Exclusions apply in EVERY mode — the running job filters excluded ids
+    # in every stage, so a plan that only honored them for collections
+    # overstated the pending counts (the proxy drift this module forbids).
+    # Whole-workspace scope materializes the id set first so the same
+    # subtraction works; _scope_clause stages large sets in a temp table.
+    if params.exclude_photo_ids:
+        excl = set(params.exclude_photo_ids)
+        if photo_ids is None:
+            photo_ids = set(db.get_photo_ids())
+        photo_ids = {pid for pid in photo_ids if pid not in excl}
 
     classify = _classify_plan(db, params, photo_ids, new_count)
     extract = _extract_plan(db, params, photo_ids, pipeline_cfg, new_count)

--- a/vireo/taxonomy.py
+++ b/vireo/taxonomy.py
@@ -455,9 +455,15 @@ def load_taxa_from_file(db, gz_path):
         for row in reader:
             if len(row) < 6:
                 continue
-            inat_id = int(row[0])
+            try:
+                inat_id = int(row[0])
+                rank_level = float(row[2])
+            except ValueError:
+                # The real iNaturalist open-data dump ships with a header
+                # row (taxon_id\tancestry\t...) — skip it (and any other
+                # malformed line) instead of aborting the whole import.
+                continue
             ancestry_str = row[1]
-            rank_level = float(row[2])
             rank = row[3]
             name = row[4]
             active = row[5].lower() == 'true'

--- a/vireo/tests/test_api_v1_aliases.py
+++ b/vireo/tests/test_api_v1_aliases.py
@@ -7,7 +7,7 @@ def test_api_v1_photos_returns_list(app_and_db):
     client = app.test_client()
     resp = client.get("/api/v1/photos", headers=_auth(app))
     assert resp.status_code == 200
-    assert isinstance(resp.get_json(), (list, dict))
+    assert isinstance(resp.get_json(), list | dict)
 
 
 def test_api_v1_photo_by_id(app_and_db):

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -5862,19 +5862,19 @@ def test_save_grouping_defaults_rejects_bad_values(tmp_path, monkeypatch):
     saved = cfg.load()
     pipe = saved.get("pipeline", {})
     if "hard_cut_time" in pipe:
-        assert isinstance(pipe["hard_cut_time"], (int, float))
+        assert isinstance(pipe["hard_cut_time"], int | float)
     if "w_species" in pipe:
-        assert isinstance(pipe["w_species"], (int, float))
+        assert isinstance(pipe["w_species"], int | float)
         assert 0.0 <= pipe["w_species"] <= 1.0
     if "hard_cut_score" in pipe:
-        assert isinstance(pipe["hard_cut_score"], (int, float))
+        assert isinstance(pipe["hard_cut_score"], int | float)
         assert 0.0 <= pipe["hard_cut_score"] <= 1.0
     if "w_time" in pipe:
-        assert isinstance(pipe["w_time"], (int, float))
+        assert isinstance(pipe["w_time"], int | float)
         assert pipe["w_time"] is not True  # bool guard
     if "tau_enc" in pipe:
         import math as _math
-        assert isinstance(pipe["tau_enc"], (int, float))
+        assert isinstance(pipe["tau_enc"], int | float)
         assert _math.isfinite(pipe["tau_enc"])
 
 

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -3010,6 +3010,7 @@ def test_run_classifier_retries_on_database_is_locked(tmp_path):
 
     import classify_job
     from db import Database
+
     from tests.test_scanner import _FlakyConn
 
     db = Database(str(tmp_path / "test.db"))

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -3010,7 +3010,6 @@ def test_run_classifier_retries_on_database_is_locked(tmp_path):
 
     import classify_job
     from db import Database
-
     from tests.test_scanner import _FlakyConn
 
     db = Database(str(tmp_path / "test.db"))

--- a/vireo/tests/test_duplicates_db.py
+++ b/vireo/tests/test_duplicates_db.py
@@ -849,3 +849,32 @@ def test_run_duplicate_scan_all_missing_flag(tmp_path):
     assert prop["all_missing"] is True
     assert prop["winner"]["exists"] is False
     assert all(l["exists"] is False for l in prop["losers"])
+
+
+# -----------------------------------------------------------------------------
+# NULL-flag visibility
+# -----------------------------------------------------------------------------
+
+def test_null_flag_photos_participate_in_duplicate_resolution(tmp_path):
+    """Photos with a NULL flag (undo paths restore them) were invisible to
+    duplicate resolution: `flag != 'rejected'` is NULL-false, so a NULL-flag
+    twin was treated as if rejected and never resolved."""
+    db = Database(str(tmp_path / "t.db"))
+    fid = db.add_folder(str(tmp_path))
+    p1 = _add(db, fid, "owl.jpg", file_hash="HASHN")
+    p2 = _add(db, fid, "owl (2).jpg", file_hash="HASHN")
+    # Simulate the undo path: restore both flags to NULL.
+    db.conn.execute("UPDATE photos SET flag = NULL WHERE file_hash = 'HASHN'")
+    db.conn.commit()
+
+    groups = db.find_duplicate_groups()
+    unresolved_hashes = {g["file_hash"] for g in groups}
+    assert "HASHN" in unresolved_hashes
+
+    result = db.apply_duplicate_resolution([p1, p2])
+    assert result["winner_id"] == p1
+    assert result["loser_ids"] == [p2]
+    flag = db.conn.execute(
+        "SELECT flag FROM photos WHERE id = ?", (p2,)
+    ).fetchone()["flag"]
+    assert flag == "rejected"

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -610,6 +610,7 @@ def test_start_job_ids_unique_within_same_millisecond(app_and_db):
     the same millisecond previously collided, overwriting each other's
     registration and history row."""
     import time as _time
+
     from jobs import JobRunner
     runner = JobRunner()
     ids = [runner.start("scan", lambda j: None) for _ in range(10)]

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -605,6 +605,18 @@ def test_update_step_current_file(app_and_db):
     assert runner._jobs[job_id]["steps"][0]["current_file"] == "DSC_0001.NEF"
 
 
+def test_start_job_ids_unique_within_same_millisecond(app_and_db):
+    """start() ids carry a monotonic suffix — two same-type jobs started in
+    the same millisecond previously collided, overwriting each other's
+    registration and history row."""
+    import time as _time
+    from jobs import JobRunner
+    runner = JobRunner()
+    ids = [runner.start("scan", lambda j: None) for _ in range(10)]
+    assert len(set(ids)) == 10
+    _time.sleep(0.05)  # let the trivial workers finish
+
+
 def test_update_step_cancelled_is_terminal(app_and_db):
     """status='cancelled' finalizes a step (finished_at + duration), same as
     completed/failed — classify/pipeline steps report it on user cancel."""

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -605,17 +605,22 @@ def test_update_step_current_file(app_and_db):
     assert runner._jobs[job_id]["steps"][0]["current_file"] == "DSC_0001.NEF"
 
 
-def test_start_job_ids_unique_within_same_millisecond(app_and_db):
+def test_start_job_ids_unique_within_same_millisecond(app_and_db, monkeypatch):
     """start() ids carry a monotonic suffix — two same-type jobs started in
     the same millisecond previously collided, overwriting each other's
     registration and history row."""
     import time as _time
 
+    import jobs as jobs_mod
     from jobs import JobRunner
+    # Freeze the clock so every start() provably lands in the same
+    # millisecond — without this a slow CI worker could space the calls
+    # out and the old (suffix-less) implementation would also pass.
+    frozen = _time.time()
+    monkeypatch.setattr(jobs_mod.time, "time", lambda: frozen)
     runner = JobRunner()
     ids = [runner.start("scan", lambda j: None) for _ in range(10)]
     assert len(set(ids)) == 10
-    _time.sleep(0.05)  # let the trivial workers finish
 
 
 def test_update_step_cancelled_is_terminal(app_and_db):

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -687,7 +687,7 @@ def test_pipeline_previews_stage_writes_atomically(tmp_path, monkeypatch):
     # preview path; restrict the check to saves inside preview_dir.
     preview_dir_saves = [
         p for p in saved_paths
-        if isinstance(p, (str, bytes)) and str(p).startswith(preview_dir)
+        if isinstance(p, str | bytes) and str(p).startswith(preview_dir)
     ]
     assert preview_dir_saves, "previews_stage should have written at least one file"
     for p in preview_dir_saves:
@@ -1007,8 +1007,8 @@ def test_pipeline_scan_progress_includes_rate_and_eta(tmp_path, monkeypatch):
     last = progress_events[-1]
     assert "rate" in last, "Progress event should include rate"
     assert "eta_seconds" in last, "Progress event should include eta_seconds"
-    assert isinstance(last["rate"], (int, float))
-    assert isinstance(last["eta_seconds"], (int, float))
+    assert isinstance(last["rate"], int | float)
+    assert isinstance(last["eta_seconds"], int | float)
 
 
 def test_pipeline_multi_folder_scan_progress_is_monotonic(tmp_path, monkeypatch):

--- a/vireo/tests/test_pipeline_plan.py
+++ b/vireo/tests/test_pipeline_plan.py
@@ -2817,3 +2817,25 @@ def test_api_pipeline_plan_rejects_non_string_hash_duplicate_paths_elements(app_
         },
     )
     assert resp.status_code == 400
+
+
+def test_exclusions_apply_in_whole_workspace_mode(tmp_path):
+    """The running job filters exclude_photo_ids in every mode; the plan
+    previously honored them only for collections, overstating pending
+    counts for whole-workspace runs."""
+    from pipeline_plan import PipelinePlanParams, compute_plan
+
+    db, folder_id = _make_db(tmp_path)
+    p1, _ = _add_photo_with_detection(db, folder_id, "a.jpg")
+    p2, _ = _add_photo_with_detection(db, folder_id, "b.jpg")
+
+    base = compute_plan(db, PipelinePlanParams(), str(tmp_path / "test.db"))
+    assert base["stages"]["Extract"]["detail"]["pending"] == 2
+
+    plan = compute_plan(
+        db,
+        PipelinePlanParams(exclude_photo_ids=[p2]),
+        str(tmp_path / "test.db"),
+    )
+    assert plan["stages"]["Extract"]["detail"]["pending"] == 1
+    assert plan["scope"]["photo_count"] == 1

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -2219,7 +2219,7 @@ def test_preview_sweep_chunks_large_photo_id_sets(tmp_path):
 
         def execute(self, sql, params=()):
             nonlocal max_params_seen
-            if isinstance(params, (list, tuple)):
+            if isinstance(params, list | tuple):
                 max_params_seen = max(max_params_seen, len(params))
             return self._inner.execute(sql, params)
 

--- a/vireo/timm_classifier.py
+++ b/vireo/timm_classifier.py
@@ -188,7 +188,7 @@ class TimmClassifier:
         from PIL import Image as PILImage
         from pipeline_locks import acquire_gpu_if_session_uses_it
 
-        if isinstance(image, (str, os.PathLike)):
+        if isinstance(image, str | os.PathLike):
             with PILImage.open(image) as img:
                 input_arr = self._preprocess(img)
         else:


### PR DESCRIPTION
## What changed

Batch 4 — the final tier from the full-app bug review (follow-up to #967, #969, #970, #971, #972).

### `jobs.py` thread-safety, ID collisions, connection leak
- Worker threads inserted new keys (`_start_time`, `_ended_at`, `_persisted`, `_fatal_error`) into live job dicts while request handlers jsonified them — dict resize during iteration raises `RuntimeError`, surfacing as intermittent 500s on `/api/jobs`. Keys are now pre-seeded at job creation (same-key updates don't resize), and `get()`/`list_jobs()` return snapshots of the nested `progress`/`steps`/`errors` containers taken under the lock instead of live references.
- `start()` job ids were bare millisecond timestamps; two same-type starts in the same ms collided, overwriting each other's registration and history row. They now carry the monotonic suffix `enqueue_pipeline` already had (`type-ms-seq`).
- `_persist_job` leaked its SQLite connection on every failed retry (no `finally`).

### `classify_job.py`
- `_detect_batch`'s bare `except (ImportError, RuntimeError): pass` silently truncated the batch while the detect stage reported success — now logged as a warning (the caller still degrades to full-image classification).

### `models.py`
- Custom HF repos using the standard `onnx/` layout failed to download: `dest_path` includes the repo-relative subdir but only `local_dir` was created, and the resulting `FileNotFoundError` was misclassified as a connection failure and retried 3× before surfacing as "Download failed".

### `taxonomy.py`
- The real iNaturalist open-data `taxa.csv.gz` ships with a header row; `int(row[0])` aborted the whole `--load-taxonomy` import. Non-numeric rows are skipped.

### `db.py` — NULL-flag visibility
- `flag != 'rejected'` is NULL-false in SQL, so photos with a NULL flag (the undo paths deliberately restore NULL) were invisible to duplicate resolution (never resolved, counted as neither kept nor rejected), excluded from highlights candidates, and ignored by the has-duplicate smart rule. All seven filters now use `(flag IS NULL OR flag != 'rejected')`, matching the NULL-aware pattern the misses page already used.

### `pipeline_plan.py` — exclusion drift
- `exclude_photo_ids` only applied in collection mode while the running job filters exclusions in every mode, so whole-workspace/import plan pills overstated pending counts. Exclusions now apply uniformly (whole-workspace scope materializes the id set first).

### Deliberately not changed (from the review's low tier)
- **Scan-root realpath/case canonicalization** — rewriting how roots resolve risks creating duplicate folder rows in existing catalogs whose stored paths came through symlinks; the cure is worse than the low-confidence disease.
- **Import-mode plan visibility into cross-workspace cached detections** — needs non-workspace-scoped count queries; today's pill is conservative (may say "will run" for work that turns out cached), not wrong about what work exists.

## Tests

New: `test_start_job_ids_unique_within_same_millisecond`, `test_null_flag_photos_participate_in_duplicate_resolution`, `test_exclusions_apply_in_whole_workspace_mode`.

Required suite + duplicates/plan/pipeline/classify/models/taxonomy/queue: **1512 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Detection errors now emit informative warnings instead of failing silently
  * Duplicate resolution correctly handles photos with null flags
  * Photo exclusion now consistently applies across all pipeline scope modes
  * Model file downloads improved with proper directory path handling
  * Taxonomy imports more robust when handling malformed row data
  * Enhanced job tracking for concurrent operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->