### PR TITLE
Fix 27 verified bugs from a full-repo review

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1978,9 +1978,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     @app.route("/api/setup/complete", methods=["POST"])
     def api_setup_complete():
         """Mark first-launch setup as done (called after download or skip)."""
-        user_cfg = cfg.load()
-        user_cfg["setup_complete"] = True
-        cfg.save(user_cfg)
+        # Lock + raw read-modify-write so a concurrent settings PATCH isn't
+        # reverted and we don't pin every DEFAULTS value into the user's
+        # file (see api_pipeline_save_grouping_defaults).
+        with _settings_write_lock:
+            raw = _read_raw_config_file()
+            raw["setup_complete"] = True
+            cfg.save(raw)
         return jsonify({"ok": True})
 
     @app.route("/browse")
@@ -2730,7 +2734,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     @app.route("/api/photos/<int:photo_id>")
     def api_photo_detail(photo_id):
         db = _get_db()
-        photo = db.get_photo(photo_id)
+        # verify_workspace: this response exposes the absolute path and
+        # xmp_path, so a photo outside the active workspace must 404 —
+        # mirrors serve_thumbnail / api_files_reveal.
+        photo = db.get_photo(photo_id, verify_workspace=True)
         if not photo:
             return json_error("not found", 404)
 
@@ -3428,6 +3435,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         color = body.get("color")
         if color is not None and color not in db.VALID_COLOR_LABELS:
             return json_error(f"color must be one of {db.VALID_COLOR_LABELS}")
+        # Existence + workspace checks mirror the rating/flag endpoints. A
+        # stale id from an open browse tab would otherwise hit the
+        # photo_color_labels FK and 500.
+        if db.get_photo(photo_id) is None:
+            return json_error("not found", 404)
+        try:
+            db._verify_photo_in_workspace(photo_id)
+        except ValueError as e:
+            return json_error(str(e), 403)
         old_color = db.get_color_label(photo_id) or ''
         new_color = color or ''
         if color:
@@ -4677,14 +4693,30 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error(f"color must be one of {db.VALID_COLOR_LABELS}")
         if not photo_ids:
             return json_error("photo_ids required")
-        old_labels = db.get_color_labels_for_photos(photo_ids)
+        # Filter to photos that exist AND are visible in the active workspace
+        # (mirrors api_batch_rating's stale-id filtering). Stale ids would
+        # otherwise hit the photo_color_labels FK and abort the batch with a
+        # 500 partway through.
+        photos_map = db.get_photos_by_ids(photo_ids)
+        ws_folder_ids = {
+            r["folder_id"] for r in db.conn.execute(
+                "SELECT folder_id FROM workspace_folders WHERE workspace_id = ?",
+                (db._ws_id(),),
+            )
+        }
+        valid_ids = list(dict.fromkeys(
+            pid for pid in photo_ids
+            if pid in photos_map and photos_map[pid]["folder_id"] in ws_folder_ids
+        ))
+        old_labels = db.get_color_labels_for_photos(valid_ids)
         new_color = color or ''
-        db.batch_set_color_label(photo_ids, color)
+        db.batch_set_color_label(valid_ids, color)
         items = [{'photo_id': pid, 'old_value': old_labels.get(pid, ''), 'new_value': new_color}
-                 for pid in photo_ids]
-        db.record_edit('color_label', f'Set color to {color or "none"} on {len(photo_ids)} photos',
-                       new_color, items, is_batch=True)
-        return jsonify({"ok": True, "updated": len(photo_ids)})
+                 for pid in valid_ids]
+        if items:
+            db.record_edit('color_label', f'Set color to {color or "none"} on {len(valid_ids)} photos',
+                           new_color, items, is_batch=True)
+        return jsonify({"ok": True, "updated": len(valid_ids)})
 
     @app.route("/api/batch/keyword", methods=["POST"])
     def api_batch_keyword():
@@ -5256,8 +5288,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                            f'Discarded {len(changes)} pending changes',
                            '', items, is_batch=len(changes) > 1)
 
-        log.info("Discarded %d pending changes", len(change_ids))
-        return jsonify({"ok": True, "discarded": len(change_ids)})
+        # Report what was actually deleted: clear_pending only removes rows
+        # that exist in the active workspace, which is exactly the set the
+        # SELECT above found.
+        log.info("Discarded %d pending changes", len(changes))
+        return jsonify({"ok": True, "discarded": len(changes)})
 
     # -- Collection API routes --
 
@@ -5383,8 +5418,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         db = _get_db()
         body = request.get_json(silent=True) or {}
         photo_ids = body.get("photo_ids", [])
+        if not isinstance(photo_ids, list):
+            return json_error("photo_ids must be a list")
         if not photo_ids:
             return json_error("photo_ids required")
+        # Non-int entries would either crash sorted() against the existing
+        # int ids or persist strings that never match `p.id IN (...)` —
+        # mirrors api_photos_by_ids' validation.
+        for pid in photo_ids:
+            if isinstance(pid, bool) or not isinstance(pid, int):
+                return json_error("photo_ids must be integers")
 
         row = db.conn.execute(
             "SELECT rules FROM collections WHERE id = ? AND workspace_id = ?",
@@ -6027,12 +6070,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     @app.route("/api/workspaces/<int:ws_id>", methods=["PUT"])
     def api_update_workspace(ws_id):
         db = _get_db()
+        if not db.get_workspace(ws_id):
+            return json_error("Workspace not found", 404)
         body = request.get_json(silent=True) or {}
         kwargs = {}
         if "name" in body:
             kwargs["name"] = body["name"]
         if "config_overrides" in body:
-            kwargs["config_overrides"] = body["config_overrides"]
+            overrides = body["config_overrides"]
+            # Anything else would be persisted as-is and crash the labels
+            # accessors that expect a JSON object (or NULL) in this column.
+            if overrides is not None and not isinstance(overrides, dict):
+                return json_error("config_overrides must be an object or null")
+            kwargs["config_overrides"] = overrides
         if "ui_state" in body:
             kwargs["ui_state"] = body["ui_state"]
         db.update_workspace(ws_id, **kwargs)
@@ -6119,6 +6169,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         folder_id = body.get("folder_id")
         if not folder_id:
             return json_error("folder_id is required")
+        # Pre-check both sides of the link — an unknown id would otherwise
+        # hit the workspace_folders FK and 500.
+        if not db.get_workspace(ws_id):
+            return json_error("Workspace not found", 404)
+        if not db.get_folder(folder_id):
+            return json_error("Folder not found", 404)
         db.add_workspace_folder(ws_id, folder_id)
         return jsonify({"ok": True})
 
@@ -7070,6 +7126,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def api_detections(photo_id):
         """Get all detections for a photo."""
         db = _get_db()
+        # Detections are global, but exposing them for photos outside the
+        # active workspace leaks data the workspace deliberately hides
+        # (mirrors serve_thumbnail's workspace gate).
+        if db.get_photo(photo_id, verify_workspace=True) is None:
+            return json_error("not found", 404)
         dets = db.get_detections(photo_id)
         return jsonify([dict(d) for d in dets])
 
@@ -9398,6 +9459,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         body = request.get_json(silent=True) or {}
         photo_id = body.get("photo_id")
         direction = body.get("direction")
+        # resolve_drift silently no-ops on any other direction value, so a
+        # typo would otherwise return {"ok": true} without resolving anything.
+        if direction not in ("use_db", "use_xmp"):
+            return json_error("direction must be 'use_db' or 'use_xmp'")
+        if isinstance(photo_id, bool) or not isinstance(photo_id, int):
+            return json_error("photo_id must be an integer")
         from audit import resolve_drift
 
         resolve_drift(db, photo_id, direction)
@@ -9408,6 +9475,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         db = _get_db()
         body = request.get_json(silent=True) or {}
         direction = body.get("direction")
+        if direction not in ("use_db", "use_xmp"):
+            return json_error("direction must be 'use_db' or 'use_xmp'")
         from audit import check_drift, resolve_drift
 
         drifts = check_drift(db)
@@ -10816,18 +10885,24 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         import config as cfg
 
         tmp_prefix = os.path.realpath(tempfile.gettempdir())
-        user_cfg = cfg.load()
-        saved_roots = user_cfg.get("scan_roots", [])
-        changed = False
-        for r in roots_list:
-            if os.path.realpath(r).startswith(tmp_prefix):
-                continue
-            if r not in saved_roots:
-                saved_roots.insert(0, r)
-                changed = True
-        if changed:
-            user_cfg["scan_roots"] = saved_roots
-            cfg.save(user_cfg)
+        # Lock + raw read-modify-write so a concurrent settings PATCH isn't
+        # reverted and we don't pin every DEFAULTS value into the user's
+        # file (see api_pipeline_save_grouping_defaults).
+        with _settings_write_lock:
+            raw = _read_raw_config_file()
+            saved_roots = raw.get("scan_roots")
+            if not isinstance(saved_roots, list):
+                saved_roots = []
+            changed = False
+            for r in roots_list:
+                if os.path.realpath(r).startswith(tmp_prefix):
+                    continue
+                if r not in saved_roots:
+                    saved_roots.insert(0, r)
+                    changed = True
+            if changed:
+                raw["scan_roots"] = saved_roots
+                cfg.save(raw)
 
         runner = app._job_runner
         active_ws = _get_db()._active_workspace_id
@@ -14002,16 +14077,22 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if destination:
             try:
                 import config as cfg
-                _cfg = cfg.load()
-                ingest_cfg = dict(_cfg.get("ingest", {}))
-                recents = list(ingest_cfg.get("recent_destinations", []))
-                if destination in recents:
-                    recents.remove(destination)
-                recents.insert(0, destination)
-                recents = recents[:5]
-                ingest_cfg["recent_destinations"] = recents
-                _cfg["ingest"] = ingest_cfg
-                cfg.save(_cfg)
+                # Lock + raw read-modify-write so a concurrent settings PATCH
+                # isn't reverted and we don't pin every DEFAULTS value into
+                # the user's file (see api_pipeline_save_grouping_defaults).
+                with _settings_write_lock:
+                    raw = _read_raw_config_file()
+                    ingest_cfg = raw.get("ingest")
+                    ingest_cfg = dict(ingest_cfg) if isinstance(ingest_cfg, dict) else {}
+                    recents = ingest_cfg.get("recent_destinations")
+                    recents = list(recents) if isinstance(recents, list) else []
+                    if destination in recents:
+                        recents.remove(destination)
+                    recents.insert(0, destination)
+                    recents = recents[:5]
+                    ingest_cfg["recent_destinations"] = recents
+                    raw["ingest"] = ingest_cfg
+                    cfg.save(raw)
             except Exception:
                 log.warning("Failed to save recent destination to config")
 
@@ -14094,12 +14175,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not photo_ids:
             return json_error("photo_ids is required")
 
-        # Validate all photo_ids exist before mutating
-        placeholders = ",".join("?" for _ in photo_ids)
-        found = db.conn.execute(
-            f"SELECT id FROM photos WHERE id IN ({placeholders})", photo_ids
-        ).fetchall()
-        found_ids = {r["id"] for r in found}
+        # Validate all photo_ids exist before mutating. Chunked so the
+        # IN-clause stays under SQLite's bound-parameter cap.
+        found_ids = set()
+        for chunk in _chunked(photo_ids):
+            placeholders = ",".join("?" for _ in chunk)
+            rows = db.conn.execute(
+                f"SELECT id FROM photos WHERE id IN ({placeholders})", chunk
+            ).fetchall()
+            found_ids.update(r["id"] for r in rows)
         missing = [pid for pid in photo_ids if pid not in found_ids]
         if missing:
             return json_error(f"Unknown photo_ids: {missing}")
@@ -14112,14 +14196,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         import config as cfg
         effective_cfg = db.get_effective_config(cfg.load())
         det_conf_threshold = effective_cfg.get("detector_confidence", 0.2)
-        det_rows = db.conn.execute(
-            f"""SELECT photo_id,
-                       MAX(detector_confidence) AS max_conf,
-                       COUNT(*) AS n
-                FROM detections WHERE photo_id IN ({placeholders})
-                GROUP BY photo_id""",
-            photo_ids,
-        ).fetchall()
+        det_rows = []
+        for chunk in _chunked(photo_ids):
+            placeholders = ",".join("?" for _ in chunk)
+            det_rows.extend(db.conn.execute(
+                f"""SELECT photo_id,
+                           MAX(detector_confidence) AS max_conf,
+                           COUNT(*) AS n
+                    FROM detections WHERE photo_id IN ({placeholders})
+                    GROUP BY photo_id""",
+                chunk,
+            ).fetchall())
         low_confidence_photo_ids = [
             r["photo_id"] for r in det_rows
             if r["n"] > 0 and (r["max_conf"] or 0) < det_conf_threshold
@@ -14208,30 +14295,30 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # edit-history items and sidecar adds — otherwise confirming an
             # already-tagged photo would push a no-op onto the undo stack, and
             # undoing it would destructively remove the pre-existing keyword.
-            # Mirrors the precheck pattern in api_batch_keyword.
-            placeholders_ids = ",".join("?" for _ in photo_ids)
-            already_has_new = {
-                row["photo_id"]
-                for row in db.conn.execute(
-                    f"""SELECT photo_id FROM photo_keywords
-                        WHERE keyword_id = ? AND photo_id IN ({placeholders_ids})""",
-                    [kid] + list(photo_ids),
-                ).fetchall()
-            }
+            # Mirrors the precheck pattern in api_batch_keyword. Chunked so
+            # the IN-clause stays under SQLite's bound-parameter cap.
+            def _photos_with_keyword(keyword_id):
+                hits = set()
+                for chunk in _chunked(photo_ids):
+                    placeholders_ids = ",".join("?" for _ in chunk)
+                    hits.update(
+                        row["photo_id"]
+                        for row in db.conn.execute(
+                            f"""SELECT photo_id FROM photo_keywords
+                                WHERE keyword_id = ? AND photo_id IN ({placeholders_ids})""",
+                            [keyword_id] + list(chunk),
+                        ).fetchall()
+                    )
+                return hits
+
+            already_has_new = _photos_with_keyword(kid)
             newly_tagged = [pid for pid in photo_ids if pid not in already_has_new]
 
             # For a replacement, only photos that actually carry the old
             # species keyword should be untagged / generate a remove.
             had_old = set()
             if is_replacement and old_kid is not None:
-                had_old = {
-                    row["photo_id"]
-                    for row in db.conn.execute(
-                        f"""SELECT photo_id FROM photo_keywords
-                            WHERE keyword_id = ? AND photo_id IN ({placeholders_ids})""",
-                        [old_kid] + list(photo_ids),
-                    ).fetchall()
-                }
+                had_old = _photos_with_keyword(old_kid)
                 for pid in photo_ids:
                     if pid not in had_old:
                         continue
@@ -14742,6 +14829,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         burst_idx = body.get("burst_index")
         if enc_idx is None or burst_idx is None:
             return json_error("encounter_index and burst_index are required")
+        if isinstance(enc_idx, bool) or not isinstance(enc_idx, int):
+            return json_error("Invalid encounter_index")
+        if isinstance(burst_idx, bool) or not isinstance(burst_idx, int):
+            return json_error("Invalid burst_index")
 
         db = _get_db()
         cache_dir = os.path.dirname(db_path)
@@ -14823,6 +14914,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         photo_id = body.get("photo_id")
         if enc_idx is None or burst_idx is None or photo_id is None:
             return json_error("encounter_index, burst_index, and photo_id are required")
+        if isinstance(enc_idx, bool) or not isinstance(enc_idx, int):
+            return json_error("Invalid encounter_index")
+        if isinstance(burst_idx, bool) or not isinstance(burst_idx, int):
+            return json_error("Invalid burst_index")
 
         db = _get_db()
         cache_dir = os.path.dirname(db_path)
@@ -15380,6 +15475,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def api_photo_pipeline(photo_id):
         """Return full pipeline debug info for a single photo."""
         db = _get_db()
+        # Workspace gate before the raw join below: the response exposes
+        # folder_path and full photo metadata (mirrors serve_thumbnail).
+        if db.get_photo(photo_id, verify_workspace=True) is None:
+            return json_error("Photo not found", 404)
         photo = db.conn.execute(
             """SELECT p.*, f.path as folder_path FROM photos p
                JOIN folders f ON f.id = p.folder_id WHERE p.id = ?""",
@@ -15571,7 +15670,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         from PIL import Image
 
         db = _get_db()
-        photo = db.get_photo(photo_id)
+        # verify_workspace: don't serve image bytes for photos hidden from
+        # the active workspace (mirrors serve_thumbnail).
+        photo = db.get_photo(photo_id, verify_workspace=True)
         if not photo:
             return "Not found", 404
 
@@ -15655,9 +15756,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         # Confirm the photo still exists before any cache return so that a
         # deleted photo can't be served from a stale per-size cache (and so
-        # SQLite id reuse can't surface the wrong image).
+        # SQLite id reuse can't surface the wrong image). verify_workspace
+        # keeps cross-workspace photos from being served here at all
+        # (mirrors serve_thumbnail).
         db = _get_db()
-        photo = db.get_photo(photo_id)
+        photo = db.get_photo(photo_id, verify_workspace=True)
         if not photo:
             return "Not found", 404
 
@@ -15804,7 +15907,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         from flask import send_file
 
         db = _get_db()
-        photo = db.get_photo(photo_id)
+        # verify_workspace: mirrors serve_thumbnail — full-res bytes must not
+        # leak across workspaces.
+        photo = db.get_photo(photo_id, verify_workspace=True)
         if not photo:
             return "Not found", 404
 

--- a/vireo/audit.py
+++ b/vireo/audit.py
@@ -58,9 +58,20 @@ def check_drift(db):
 
         xmp_keywords = read_keywords(xmp_path)
 
-        if xmp_keywords != db_keywords:
-            added_in_xmp = xmp_keywords - db_keywords
-            removed_in_xmp = db_keywords - xmp_keywords
+        # Compare case-insensitively: resolve_drift('use_xmp') reconciles
+        # via sync_from_xmp, which treats keywords differing only by case as
+        # already in sync, so a case-only difference reported here would be
+        # permanently unresolvable. Reported values keep the actual strings.
+        db_by_lower = {k.lower(): k for k in db_keywords}
+        xmp_by_lower = {k.lower(): k for k in xmp_keywords}
+
+        if set(xmp_by_lower) != set(db_by_lower):
+            added_in_xmp = {
+                kw for low, kw in xmp_by_lower.items() if low not in db_by_lower
+            }
+            removed_in_xmp = {
+                kw for low, kw in db_by_lower.items() if low not in xmp_by_lower
+            }
 
             # Determine direction
             if added_in_xmp and not removed_in_xmp:

--- a/vireo/capture_time.py
+++ b/vireo/capture_time.py
@@ -375,7 +375,13 @@ def adjust_capture_time(
                 text=True,
                 timeout=120,
             )
-            if result.returncode not in (0, 1):
+            if result.returncode != 0:
+                # ExifTool exits 0 on success (warnings included) and 1 when
+                # any error occurred — e.g. "0 image files updated, 1 files
+                # weren't updated due to errors" for a read-only file. This
+                # is a per-photo write, so exit 1 means the write failed;
+                # don't copy the read path's (0, 1) tolerance from
+                # metadata.py, which only accepts 1 for partial batch output.
                 raise RuntimeError((result.stderr or result.stdout or "ExifTool failed").strip())
             _refresh_photo_metadata(db, photo["id"], paths[0])
             db.conn.commit()

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -1554,6 +1554,18 @@ def _store_grouped_predictions(
     }
 
 
+def _finalize_remaining_steps(runner, job_id, step_ids, status, summary):
+    """Flip not-yet-run step rows to a terminal status before an early return.
+
+    _persist_job stores whatever statuses are in the step tree at job end;
+    a row left "pending" with no finished_at renders as an indeterminate
+    spinner forever on the jobs page. Early-return paths must call this for
+    every step they are about to skip.
+    """
+    for step_id in step_ids:
+        runner.update_step(job_id, step_id, status=status, summary=summary)
+
+
 def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None):
     """Execute classification job. Called by JobRunner in a background thread.
 
@@ -1685,6 +1697,12 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
                     "phase": "Step 1/5: Loading photos",
                 },
             )
+            _finalize_remaining_steps(
+                runner, job["id"],
+                ["load_taxonomy", "load_model", "detect", "classify",
+                 "finalize"],
+                status="completed", summary="Skipped (no photos to classify)",
+            )
             return {
                 "total": 0,
                 "predictions_stored": 0,
@@ -1700,6 +1718,12 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
         # per-photo; _run_job flips the terminal status to 'cancelled'.
         if runner.is_cancelled(job["id"]):
             log.info("Classify job cancelled before model resolution")
+            _finalize_remaining_steps(
+                runner, job["id"],
+                ["load_taxonomy", "load_model", "detect", "classify",
+                 "finalize"],
+                status="cancelled", summary="Cancelled before start",
+            )
             return {
                 "total": total,
                 "predictions_stored": 0,
@@ -1856,6 +1880,10 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
         # before the user's cancel takes effect.
         if runner.is_cancelled(job["id"]):
             log.info("Classify job cancelled before reclassify purge")
+            _finalize_remaining_steps(
+                runner, job["id"], ["detect", "classify", "finalize"],
+                status="cancelled", summary="Cancelled before start",
+            )
             return {
                 "total": total,
                 "predictions_stored": 0,
@@ -1913,6 +1941,10 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
                     total = len(photos)
                     job["progress"]["total"] = total
                 else:
+                    _finalize_remaining_steps(
+                        runner, job["id"], ["classify", "finalize"],
+                        status="cancelled", summary="Cancelled",
+                    )
                     return {
                         "total": total,
                         "predictions_stored": 0,
@@ -1923,6 +1955,10 @@ def run_classify_job(job, runner, db_path, workspace_id, params, vireo_dir=None)
                         "failed": 0,
                     }
             else:
+                _finalize_remaining_steps(
+                    runner, job["id"], ["classify", "finalize"],
+                    status="cancelled", summary="Cancelled",
+                )
                 return {
                     "total": total,
                     "predictions_stored": 0,

--- a/vireo/culling.py
+++ b/vireo/culling.py
@@ -18,6 +18,31 @@ from image_loader import load_image, load_working_image
 
 log = logging.getLogger(__name__)
 
+_warned_dim_mismatch = False
+
+
+def _embedding_sim(a, b):
+    """Dot-product similarity, 0 if dims don't match.
+
+    Two photos in one species group can carry top predictions from
+    different classifier models (or stale DINOv2 variants), so their
+    embeddings can have different dimensions. Treat that as "no
+    similarity signal" instead of crashing the cull job — same
+    convention as bursts/encounters/selection._cosine_sim.
+    """
+    if a.shape != b.shape:
+        global _warned_dim_mismatch
+        if not _warned_dim_mismatch:
+            log.warning(
+                "Embedding dim mismatch in culling (%s vs %s) — embeddings "
+                "from different models can't be compared; treating as not "
+                "redundant",
+                a.shape, b.shape,
+            )
+            _warned_dim_mismatch = True
+        return 0.0
+    return float(np.dot(a, b))
+
 
 def analyze_for_culling(
     db,
@@ -249,7 +274,7 @@ def analyze_for_culling(
         for i in range(len(emb_pids)):
             for j in range(i + 1, len(emb_pids)):
                 a, b = emb_pids[i], emb_pids[j]
-                sim = float(np.dot(sp_embeddings[a], sp_embeddings[b]))
+                sim = _embedding_sim(sp_embeddings[a], sp_embeddings[b])
                 key = f"{min(a,b)}-{max(a,b)}"
                 embedding_sims[key] = round(sim, 3)
 
@@ -307,7 +332,9 @@ def _build_scene_groups(scene_clusters, redundancy_clusters, photo_data, timesta
         # Group scene pids by their redundancy cluster
         rc_groups = {}
         for pid in scene_pids:
-            rc_idx = pid_to_rc.get(pid, pid)  # fallback to self if not in any cluster
+            # Fallback to a solo group when not in any cluster. The key must
+            # not collide with cluster indices (small ints, like photo ids).
+            rc_idx = pid_to_rc.get(pid, ("solo", pid))
             if rc_idx not in rc_groups:
                 rc_groups[rc_idx] = []
             rc_groups[rc_idx].append(pid)
@@ -511,7 +538,7 @@ def _cluster_photos(embeddings_map, threshold):
         for cluster in clusters:
             for member_pid in cluster:
                 mem_emb = embeddings_map[member_pid]
-                sim = float(np.dot(emb, mem_emb))
+                sim = _embedding_sim(emb, mem_emb)
                 if sim >= threshold:
                     cluster.append(pid)
                     placed = True

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1251,6 +1251,8 @@ class Database:
             return None
         try:
             overrides = json.loads(ws["config_overrides"]) if isinstance(ws["config_overrides"], str) else ws["config_overrides"]
+            if not isinstance(overrides, dict):
+                return None
             labels = overrides.get("active_labels")
             return labels if isinstance(labels, list) else None
         except (json.JSONDecodeError, TypeError):
@@ -1349,6 +1351,8 @@ class Database:
             try:
                 overrides = json.loads(ws["config_overrides"]) if isinstance(ws["config_overrides"], str) else ws["config_overrides"]
             except (json.JSONDecodeError, TypeError):
+                overrides = {}
+            if not isinstance(overrides, dict):
                 overrides = {}
         overrides["active_labels"] = labels_files
         self.update_workspace(self._ws_id(), config_overrides=overrides)
@@ -2891,15 +2895,19 @@ class Database:
         if not photo_ids or len(photo_ids) < 2:
             return {"winner_id": None, "loser_ids": [], "rejected": 0}
 
-        placeholders = ",".join("?" * len(photo_ids))
-        rows = self.conn.execute(
-            f"""SELECT p.id, p.filename, p.file_mtime, p.rating, p.flag,
-                       f.path AS folder_path
-                FROM photos p
-                LEFT JOIN folders f ON f.id = p.folder_id
-                WHERE p.id IN ({placeholders}) AND (p.flag IS NULL OR p.flag != 'rejected')""",
-            list(photo_ids),
-        ).fetchall()
+        # Chunked — a single duplicate group can exceed the bound-parameter
+        # cap (see duplicate_scan.py, which chunks its own reads).
+        rows = []
+        for chunk in _chunks(list(dict.fromkeys(photo_ids))):
+            placeholders = ",".join("?" * len(chunk))
+            rows.extend(self.conn.execute(
+                f"""SELECT p.id, p.filename, p.file_mtime, p.rating, p.flag,
+                           f.path AS folder_path
+                    FROM photos p
+                    LEFT JOIN folders f ON f.id = p.folder_id
+                    WHERE p.id IN ({placeholders}) AND (p.flag IS NULL OR p.flag != 'rejected')""",
+                list(chunk),
+            ).fetchall())
         if len(rows) < 2:
             return {"winner_id": None, "loser_ids": [], "rejected": 0}
 
@@ -2980,11 +2988,13 @@ class Database:
             # this transaction. Rare edge case; revisit if product needs it.
             # Collections are rule-based (no junction table) so
             # merge.collection_ids_to_add has nothing to write either.
-            if loser_ids:
-                loser_placeholders = ",".join("?" * len(loser_ids))
+            # Chunked — a single duplicate group's loser list can exceed the
+            # bound-parameter cap.
+            for chunk in _chunks(loser_ids):
+                loser_placeholders = ",".join("?" * len(chunk))
                 self.conn.execute(
                     f"UPDATE photos SET flag = 'rejected' WHERE id IN ({loser_placeholders})",
-                    loser_ids,
+                    list(chunk),
                 )
 
         logging.getLogger(__name__).info(
@@ -5463,14 +5473,18 @@ class Database:
         if not photo_ids:
             return {"deleted": 0, "ids": [], "files": []}
 
-        # Resolve to actual existing photos
-        placeholders = ",".join("?" for _ in photo_ids)
-        rows = self.conn.execute(
-            f"SELECT p.id, p.filename, p.companion_path, p.folder_id, f.path AS folder_path "
-            f"FROM photos p JOIN folders f ON p.folder_id = f.id "
-            f"WHERE p.id IN ({placeholders})",
-            list(photo_ids),
-        ).fetchall()
+        # Resolve to actual existing photos. Chunked — callers like
+        # /api/audit/remove-missing pass arbitrarily large id lists straight
+        # from the request body.
+        rows = []
+        for chunk in _chunks(list(dict.fromkeys(photo_ids))):
+            placeholders = ",".join("?" for _ in chunk)
+            rows.extend(self.conn.execute(
+                f"SELECT p.id, p.filename, p.companion_path, p.folder_id, f.path AS folder_path "
+                f"FROM photos p JOIN folders f ON p.folder_id = f.id "
+                f"WHERE p.id IN ({placeholders})",
+                list(chunk),
+            ).fetchall())
 
         if not rows:
             return {"deleted": 0, "ids": [], "files": []}
@@ -5487,14 +5501,15 @@ class Database:
                     if comp and comp["id"] not in photo_ids:
                         companion_ids.append(comp["id"])
             if companion_ids:
-                comp_ph = ",".join("?" for _ in companion_ids)
-                comp_rows = self.conn.execute(
-                    f"SELECT p.id, p.filename, p.companion_path, p.folder_id, f.path AS folder_path "
-                    f"FROM photos p JOIN folders f ON p.folder_id = f.id "
-                    f"WHERE p.id IN ({comp_ph})",
-                    companion_ids,
-                ).fetchall()
-                rows = list(rows) + list(comp_rows)
+                rows = list(rows)
+                for chunk in _chunks(dict.fromkeys(companion_ids)):
+                    comp_ph = ",".join("?" for _ in chunk)
+                    rows.extend(self.conn.execute(
+                        f"SELECT p.id, p.filename, p.companion_path, p.folder_id, f.path AS folder_path "
+                        f"FROM photos p JOIN folders f ON p.folder_id = f.id "
+                        f"WHERE p.id IN ({comp_ph})",
+                        list(chunk),
+                    ).fetchall())
 
         all_ids = list({row["id"] for row in rows})
 
@@ -6351,12 +6366,8 @@ class Database:
             photo_ids = list(photo_ids)
             if not photo_ids:
                 return []
-            placeholders = ",".join("?" for _ in photo_ids)
-            extra_where = f" AND p.id IN ({placeholders})"
-            params = (ws_id, min_conf, EYE_KP_FINGERPRINT_VERSION, *photo_ids)
-        else:
-            extra_where = ""
-            params = (ws_id, min_conf, EYE_KP_FINGERPRINT_VERSION)
+        extra_where, scope_params = self._scope_clause(photo_ids)
+        params = (ws_id, min_conf, EYE_KP_FINGERPRINT_VERSION, *scope_params)
         rows = self.conn.execute(
             f"""SELECT p.id, p.folder_id, p.filename, p.width, p.height,
                       p.mask_path,
@@ -7565,19 +7576,23 @@ class Database:
         """Return keywords for a batch of photos keyed by photo id."""
         if not photo_ids:
             return {}
-        placeholders = ",".join("?" for _ in photo_ids)
-        rows = self.conn.execute(
-            f"""SELECT pk.photo_id, k.id, k.name, k.parent_id, k.type,
-                       k.is_species
-                FROM photo_keywords pk
-                JOIN keywords k ON k.id = pk.keyword_id
-                WHERE pk.photo_id IN ({placeholders})
-                ORDER BY k.type, k.name""",
-            list(photo_ids),
-        ).fetchall()
+        # Dedup-preserving-order: chunking that re-queries the same id
+        # in a later chunk would double-append it under setdefault.
+        photo_ids = list(dict.fromkeys(photo_ids))
         result = {}
-        for r in rows:
-            result.setdefault(r["photo_id"], []).append(dict(r))
+        for chunk in _chunks(photo_ids):
+            placeholders = ",".join("?" for _ in chunk)
+            rows = self.conn.execute(
+                f"""SELECT pk.photo_id, k.id, k.name, k.parent_id, k.type,
+                           k.is_species
+                    FROM photo_keywords pk
+                    JOIN keywords k ON k.id = pk.keyword_id
+                    WHERE pk.photo_id IN ({placeholders})
+                    ORDER BY k.type, k.name""",
+                list(chunk),
+            ).fetchall()
+            for r in rows:
+                result.setdefault(r["photo_id"], []).append(dict(r))
         return result
 
     def get_species_keywords_for_photos(self, photo_ids):
@@ -8281,48 +8296,67 @@ class Database:
         ``/api/predictions/compare`` after re-classification.
         """
         ws = self._ws_id()
-        conditions = ["wf.workspace_id = ?"]
-        params = [ws, ws]  # first ? = pr_rev.workspace_id, second = wf.workspace_id
-        if photo_ids is not None:
-            placeholders = ",".join("?" for _ in photo_ids)
-            conditions.append(f"d.photo_id IN ({placeholders})")
-            params.extend(photo_ids)
+        base_conditions = ["wf.workspace_id = ?"]
+        base_params = [ws]
         if model:
-            conditions.append("pr.classifier_model = ?")
-            params.append(model)
+            base_conditions.append("pr.classifier_model = ?")
+            base_params.append(model)
         if status:
-            conditions.append("COALESCE(pr_rev.status, 'pending') = ?")
-            params.append(status)
+            base_conditions.append("COALESCE(pr_rev.status, 'pending') = ?")
+            base_params.append(status)
         # Latest-fingerprint-per-(detection, classifier_model) filter — same
         # pattern used by /api/species/summary and get_top_prediction_for_photo.
-        conditions.append(
+        base_conditions.append(
             "pr.labels_fingerprint = ("
             "SELECT pr2.labels_fingerprint FROM predictions pr2 "
             "WHERE pr2.detection_id = pr.detection_id "
             "AND pr2.classifier_model = pr.classifier_model "
             "ORDER BY pr2.created_at DESC, pr2.id DESC LIMIT 1)"
         )
-        where = "WHERE " + " AND ".join(conditions)
-        return self.conn.execute(
-            f"""SELECT pr.*,
-                       pr.classifier_model AS model,
-                       COALESCE(pr_rev.status, 'pending') AS status,
-                       pr_rev.individual AS individual,
-                       pr_rev.group_id AS group_id,
-                       pr_rev.vote_count AS vote_count,
-                       pr_rev.total_votes AS total_votes,
-                       d.photo_id, d.box_x, d.box_y, d.box_w, d.box_h,
-                       d.detector_confidence, d.detector_model,
-                       p.filename, p.timestamp
-                FROM predictions pr
-                JOIN detections d ON d.id = pr.detection_id
-                JOIN photos p ON p.id = d.photo_id
-                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
-                LEFT JOIN prediction_review pr_rev
-                  ON pr_rev.prediction_id = pr.id AND pr_rev.workspace_id = ?
-                {where} ORDER BY pr.confidence DESC""",
-            params,
-        ).fetchall()
+        # The photo-id filter is chunked — /api/predictions passes the full
+        # resolved collection scope, which can exceed SQLite's bound-parameter
+        # cap. Chunks partition disjoint photo ids; the merged rows are
+        # re-sorted in Python to preserve the single-query ORDER BY.
+        if photo_ids is not None:
+            id_chunks = list(_chunks(list(dict.fromkeys(photo_ids))))
+        else:
+            id_chunks = [None]
+        rows = []
+        for chunk in id_chunks:
+            conditions = list(base_conditions)
+            # first ? = pr_rev.workspace_id, rest = WHERE params
+            params = [ws, *base_params]
+            if chunk is not None:
+                placeholders = ",".join("?" for _ in chunk)
+                conditions.append(f"d.photo_id IN ({placeholders})")
+                params.extend(chunk)
+            where = "WHERE " + " AND ".join(conditions)
+            rows.extend(self.conn.execute(
+                f"""SELECT pr.*,
+                           pr.classifier_model AS model,
+                           COALESCE(pr_rev.status, 'pending') AS status,
+                           pr_rev.individual AS individual,
+                           pr_rev.group_id AS group_id,
+                           pr_rev.vote_count AS vote_count,
+                           pr_rev.total_votes AS total_votes,
+                           d.photo_id, d.box_x, d.box_y, d.box_w, d.box_h,
+                           d.detector_confidence, d.detector_model,
+                           p.filename, p.timestamp
+                    FROM predictions pr
+                    JOIN detections d ON d.id = pr.detection_id
+                    JOIN photos p ON p.id = d.photo_id
+                    JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+                    LEFT JOIN prediction_review pr_rev
+                      ON pr_rev.prediction_id = pr.id AND pr_rev.workspace_id = ?
+                    {where} ORDER BY pr.confidence DESC""",
+                params,
+            ).fetchall())
+        if len(id_chunks) > 1:
+            # Match SQL "ORDER BY pr.confidence DESC" (NULLs sort last).
+            rows.sort(
+                key=lambda r: (r["confidence"] is None, -(r["confidence"] or 0))
+            )
+        return rows
 
     def update_prediction_status(self, prediction_id, status, _commit=True):
         """Update per-workspace review status for a prediction.
@@ -10416,8 +10450,36 @@ class Database:
                 ids = value if isinstance(value, list) else []
                 if not ids:
                     return "0", []
-                placeholders = ",".join("?" for _ in ids)
-                return f"p.id IN ({placeholders})", list(ids)
+                # Inline integer ids as SQL literals instead of binding one
+                # parameter per id — a static collection created from a large
+                # selection would otherwise exceed SQLite's bound-parameter
+                # cap on every query against the collection, permanently. A
+                # temp table (as _scope_clause uses) isn't composable here:
+                # the returned clause may be embedded in queries that run
+                # later and repeatedly. Only ints are inlined (injection-safe);
+                # any non-int leftovers (malformed rules, rare) keep the
+                # parameter-binding path so comparison semantics are unchanged.
+                int_ids = [
+                    v for v in ids
+                    if isinstance(v, int) and not isinstance(v, bool)
+                ]
+                other = [
+                    v for v in ids
+                    if not (isinstance(v, int) and not isinstance(v, bool))
+                ]
+                parts = []
+                params = []
+                if int_ids:
+                    parts.append(
+                        "p.id IN (%s)" % ",".join(str(v) for v in int_ids)
+                    )
+                if other:
+                    placeholders = ",".join("?" for _ in other)
+                    parts.append(f"p.id IN ({placeholders})")
+                    params = list(other)
+                if len(parts) == 1:
+                    return parts[0], params
+                return "(" + " OR ".join(parts) + ")", params
             if field in ("rating", "quality_score", "sharpness",
                          "subject_sharpness", "noise_estimate",
                          "crop_complete"):
@@ -11029,9 +11091,19 @@ class Database:
         """Return {photo_id: {observation_id, observation_url, submitted_at}} for given IDs."""
         if not photo_ids:
             return {}
-        placeholders = ",".join("?" * len(photo_ids))
-        rows = self.conn.execute(
-            f"SELECT photo_id, observation_id, observation_url, submitted_at FROM inat_submissions WHERE photo_id IN ({placeholders}) ORDER BY submitted_at DESC",
-            photo_ids,
-        ).fetchall()
-        return {r["photo_id"]: dict(r) for r in rows}
+        result = {}
+        for chunk in _chunks(list(dict.fromkeys(photo_ids))):
+            placeholders = ",".join("?" * len(chunk))
+            rows = self.conn.execute(
+                f"SELECT photo_id, observation_id, observation_url, submitted_at"
+                f" FROM inat_submissions WHERE photo_id IN ({placeholders})"
+                f" ORDER BY submitted_at DESC, id DESC",
+                list(chunk),
+            ).fetchall()
+            # Rows arrive newest-first; keep the first seen per photo so each
+            # photo maps to its most recent submission (a dict comprehension
+            # here would let older rows overwrite newer ones).
+            for r in rows:
+                if r["photo_id"] not in result:
+                    result[r["photo_id"]] = dict(r)
+        return result

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -664,7 +664,17 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
 
             def photo_cb(photo_id, path):
                 collected_photo_ids.append(photo_id)
-                scan_to_thumb.put((photo_id, path))
+                # Abort-aware put: a blocking no-timeout put would wedge the
+                # scanner forever if the thumbnail consumer died with a full
+                # queue (its setup can fail before its drain loop starts).
+                # On abort the item is dropped — the consumer is gone and the
+                # pipeline is tearing down anyway.
+                while not _should_abort(abort):
+                    try:
+                        scan_to_thumb.put((photo_id, path), timeout=0.5)
+                        break
+                    except queue.Full:
+                        continue
                 stages["scan"]["count"] = len(collected_photo_ids)
                 runner.update_step(job["id"], "scan",
                                    current_file=os.path.basename(path))
@@ -1324,10 +1334,35 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
             log.exception("Pipeline thumbnail stage failed")
             stages["thumbnails"]["status"] = "failed"
             runner.update_step(job["id"], "thumbnails", status="failed", error=str(e))
+            # This stage is the sole consumer of scan_to_thumb. Anything
+            # above can raise BEFORE the drain loop (import, Database(),
+            # cfg.load(), os.makedirs) — if we just returned, the scanner
+            # would eventually block forever in put() once the queue fills,
+            # wedging threads["scanner"].join() and leaking a pipeline slot
+            # until restart. Set abort so the scanner stops producing, then
+            # drain whatever is already queued. Stop at the sentinel, or
+            # when the queue stays empty (the sentinel may already have
+            # been consumed by the main loop before a late failure; with
+            # abort set, photo_cb no longer blocks, so breaking on Empty
+            # is safe).
+            abort.set()
+            while True:
+                try:
+                    item = scan_to_thumb.get(timeout=1.0)
+                except queue.Empty:
+                    break
+                if item is _SENTINEL:
+                    break
         _update_stages(runner, job["id"], stages)
 
     def previews_stage():
         """Generate preview images for browsed photos."""
+        if abort.is_set():
+            stages["previews"]["status"] = "skipped"
+            runner.update_step(job["id"], "previews", status="completed",
+                               summary="Skipped")
+            return
+
         stages["previews"]["status"] = "running"
         runner.update_step(job["id"], "previews", status="running")
         _update_stages(runner, job["id"], stages)
@@ -1357,7 +1392,12 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 return
             max_size = int(raw_size or 1920)
             preview_quality = effective.get("preview_quality", 90)
-            base_dir = os.path.dirname(db_path)
+            # Must match the Flask serve convention — app.py reads, reaps,
+            # and evicts previews under dirname(THUMB_CACHE_DIR)/previews.
+            # Using dirname(db_path) here would, with a custom --thumb-dir,
+            # warm previews (and preview_cache rows) under a root the app
+            # never serves from.
+            base_dir = effective_vireo_dir
             preview_dir = os.path.join(base_dir, "previews")
             os.makedirs(preview_dir, exist_ok=True)
 
@@ -3596,11 +3636,18 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
         # detections/classifications written by the classify stage, and
         # without them it would mass-flag "no_subject" on photos whose
         # subjects simply weren't re-evaluated this run.
+        #
+        # Also skip when regroup failed: miss classification depends on
+        # regroup's burst_id output, so running here after a regroup
+        # failure would overwrite miss_* flags with stale context during
+        # an already-failing job. regroup_stage marks itself "failed"
+        # without setting abort, so check the stage status explicitly.
         if (
             params.skip_regroup
             or params.skip_classify
             or abort.is_set()
             or not collection_id
+            or stages["regroup"].get("status") == "failed"
         ):
             stages["misses"]["status"] = "skipped"
             runner.update_step(job["id"], "misses", status="completed",
@@ -3683,9 +3730,14 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
     threads["thumbnail"].join()
     threads["model_loader"].join()
 
-    # Phase 1.5: previews (needs scan complete, runs before classify)
-    if not abort.is_set():
-        previews_stage()
+    # Phase 1.5: previews (needs scan complete, runs before classify).
+    #
+    # This and every later stage are always invoked — even when `abort`
+    # is set — so their step rows reach a terminal status. Gating the
+    # call on abort would leave the runner.set_steps-created rows
+    # persisted as "pending" with no finished_at, forever. Each stage
+    # checks abort internally and marks itself "Skipped".
+    previews_stage()
 
     # Phase 2: detect (needs collection; runs MegaDetector once across all
     # photos so each per-model classify step reuses cached detections
@@ -3704,14 +3756,12 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
     classify_stage()
 
     # Phase 3: extract-masks (needs classify output)
-    if not abort.is_set():
-        extract_masks_stage()
+    extract_masks_stage()
 
     # Phase 3.5: eye keypoints (needs masks + classifier output). No-op when
     # SuperAnimal weights are absent — users opt in on the pipeline models
     # card. Per-photo failures log and continue rather than abort the stage.
-    if not abort.is_set():
-        eye_keypoints_stage()
+    eye_keypoints_stage()
 
     # Phases 4 + 5: regroup and miss detection. Held under the
     # per-workspace regroup lock TOGETHER so a concurrent same-workspace
@@ -3721,21 +3771,22 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
     # (burst_id / pipeline_results_ws*.json) the miss computation never
     # saw. Pipelines targeting different workspaces share neither
     # stage's state and don't contend here.
-    if not abort.is_set():
+    #
+    # miss_stage's own gate covers the regroup-failed and abort cases, so
+    # both stages can be invoked unconditionally and still reach a
+    # terminal step status.
+    if abort.is_set():
+        # Both stages early-return as "Skipped" without touching grouping
+        # state, so the lock isn't needed — and skipping the calls would
+        # leave their step rows pending forever. Staying outside the lock
+        # also keeps an aborted/cancelled run from blocking behind a
+        # concurrent pipeline's regroup.
+        regroup_stage()
+        miss_stage()
+    else:
         with acquire_workspace_regroup(workspace_id):
             regroup_stage()
-            # Skip miss when regroup failed: miss classification depends
-            # on regroup's burst_id output, so running here after a
-            # regroup failure would overwrite miss_* flags with stale
-            # context during an already-failing job. regroup_stage marks
-            # itself "failed" without setting abort, so check the stage
-            # status explicitly. abort.is_set() is re-checked too — a
-            # user cancel between regroup and miss should skip miss.
-            if (
-                not abort.is_set()
-                and stages["regroup"].get("status") != "failed"
-            ):
-                miss_stage()
+            miss_stage()
 
     cancel_watcher_stop.set()
 

--- a/vireo/review_server.py
+++ b/vireo/review_server.py
@@ -7,6 +7,7 @@ Usage:
 import argparse
 import json
 import logging
+import math
 import os
 import webbrowser
 
@@ -161,11 +162,15 @@ def create_app(data_dir):
         category = body.get("category")
         model = body.get("model")
         # Coerce before any sidecar writes: a TypeError mid-loop would
-        # desync already-written XMP sidecars from results.json.
+        # desync already-written XMP sidecars from results.json. NaN must be
+        # rejected too — every `confidence < NaN` comparison is false, which
+        # would silently accept ALL pending photos.
         try:
             min_confidence = float(body.get("min_confidence", 0.0))
         except (TypeError, ValueError):
             return jsonify({"error": "min_confidence must be a number"}), 400
+        if not math.isfinite(min_confidence):
+            return jsonify({"error": "min_confidence must be a finite number"}), 400
 
         data = _load_results()
         accepted = 0

--- a/vireo/review_server.py
+++ b/vireo/review_server.py
@@ -159,8 +159,13 @@ def create_app(data_dir):
     def accept_batch():
         body = request.get_json(silent=True) or {}
         category = body.get("category")
-        min_confidence = body.get("min_confidence", 0.0)
         model = body.get("model")
+        # Coerce before any sidecar writes: a TypeError mid-loop would
+        # desync already-written XMP sidecars from results.json.
+        try:
+            min_confidence = float(body.get("min_confidence", 0.0))
+        except (TypeError, ValueError):
+            return jsonify({"error": "min_confidence must be a number"}), 400
 
         data = _load_results()
         accepted = 0

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -4416,6 +4416,8 @@ function lightboxDelete() {
 }
 /* ---------- iNat Submission ---------- */
 var inatQueue = [];  // [{photo_id, taxon_name, observed_on, latitude, longitude, description, geoprivacy, filename, already_submitted, existing_url}]
+var _inatSubmitting = false;  // true while inatDoSubmit's loop is running
+var _inatCancelled = false;   // set by closeInatModal to stop the loop gracefully
 
 async function submitToInat(photoId) {
   try {
@@ -4515,7 +4517,14 @@ function openInatModal() {
 function closeInatModal() {
   if (window._inatEscToken) { Keymap.popEsc(window._inatEscToken); window._inatEscToken = null; }
   document.getElementById('inatModal').classList.remove('open');
-  inatQueue = [];
+  if (_inatSubmitting) {
+    // Cancel/Esc during an in-flight submit: don't clear the queue out from
+    // under the loop — flag it so it stops after the current item and
+    // reports a partial result.
+    _inatCancelled = true;
+  } else {
+    inatQueue = [];
+  }
 }
 
 async function inatDoSubmit() {
@@ -4531,8 +4540,11 @@ async function inatDoSubmit() {
   var total = inatQueue.length;
   var done = 0;
   var succeeded = 0;
+  _inatSubmitting = true;
+  _inatCancelled = false;
 
   for (var i = 0; i < total; i++) {
+    if (_inatCancelled) break;
     var item = inatQueue[i];
     var statusEl = document.getElementById('inatStatus' + i);
 
@@ -4575,6 +4587,15 @@ async function inatDoSubmit() {
     text.textContent = done + ' / ' + total + ' processed (' + succeeded + ' succeeded)';
   }
 
+  _inatSubmitting = false;
+  if (_inatCancelled) {
+    // Modal is already closed (closeInatModal deferred the queue cleanup
+    // to us) — surface the partial result where the user can see it.
+    _inatCancelled = false;
+    inatQueue = [];
+    showToast('iNaturalist: submitted ' + succeeded + ' of ' + total + ', cancelled', 'info');
+    return;
+  }
   btn.textContent = 'Done';
   // Change cancel to Close
   document.querySelector('#inatActions .modal-btn-cancel').textContent = 'Close';
@@ -4591,12 +4612,18 @@ document.addEventListener('keydown', function(e) {
   // listener below still handles arrow keys / +/-/0 / B / Z / F / G while the
   // lightbox is open.
   if (!document.getElementById('lightboxOverlay').classList.contains('active')) return;
-  if (document.querySelector('.pipeline-overlay.active, .similar-overlay.active, .modal-overlay.open, .grm-overlay.open, .inspect-overlay.open, .shortcuts-overlay.open, .help-overlay.active, .report-overlay.active')) return;
-  if (e.key === 'ArrowRight') { lightboxNav(1); e.preventDefault(); }
-  if (e.key === 'ArrowLeft') { lightboxNav(-1); e.preventDefault(); }
+  // .grm-overlay.open is deliberately NOT in this suppression list: the burst
+  // modal can only sit *underneath* the lightbox (review's "Open in Lightbox"),
+  // so the lightbox keeps keyboard precedence; the burst modal's own keydown
+  // handler bails while the lightbox is open.
+  if (document.querySelector('.pipeline-overlay.active, .similar-overlay.active, .modal-overlay.open, .inspect-overlay.open, .shortcuts-overlay.open, .help-overlay.active, .report-overlay.active')) return;
   var tag0 = e.target && e.target.tagName;
   var editable0 = tag0 === 'INPUT' || tag0 === 'TEXTAREA' || tag0 === 'SELECT' ||
     (e.target && e.target.isContentEditable);
+  // Editable check must come before arrow handling so arrows inside form
+  // fields (e.g. the mask-variant <select>) change the value, not the photo.
+  if (!editable0 && e.key === 'ArrowRight') { lightboxNav(1); e.preventDefault(); }
+  if (!editable0 && e.key === 'ArrowLeft') { lightboxNav(-1); e.preventDefault(); }
   if (!editable0 && !e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey && !lightboxKeyMatchesConfiguredBrowseShortcut(e)) {
     if (e.key.toLowerCase() === 'f') {
       requestLightboxFullscreen();
@@ -5086,7 +5113,7 @@ function renderPipeline(data, photoId) {
   // Step 1: Original image
   html += '<div class="pipeline-step">' +
     '<div class="pipeline-step-header"><span class="pipeline-step-num">1</span><span class="pipeline-step-title">Original Image</span></div>' +
-    '<div class="pipeline-stat"><b>' + data.filename + '</b></div>' +
+    '<div class="pipeline-stat"><b>' + escapeHtml(data.filename) + '</b></div>' +
     (data.width ? '<div class="pipeline-stat">' + data.width + ' &times; ' + data.height + '</div>' : '') +
     (data.timestamp ? '<div class="pipeline-stat">' + data.timestamp + '</div>' : '') +
     '</div>';
@@ -5254,27 +5281,52 @@ function findSimilar(photoId) {
         content.innerHTML = '<p style="color:var(--warning);">' + escapeHtml(data.error) + '</p>';
         return;
       }
-      var html = '<p style="font-size:12px;color:var(--text-dim);margin-bottom:12px;">Compared against ' +
-        data.total_compared.toLocaleString() + ' photos with embeddings</p>';
+      // Filenames are user-controlled: build cards with DOM methods and
+      // closure-bound click handlers instead of interpolating into
+      // HTML/onclick strings — a quote or angle bracket in a filename broke
+      // the inline handler (and could inject markup).
+      content.textContent = '';
+      var summary = document.createElement('p');
+      summary.style.cssText = 'font-size:12px;color:var(--text-dim);margin-bottom:12px;';
+      summary.textContent = 'Compared against ' + data.total_compared.toLocaleString() + ' photos with embeddings';
+      content.appendChild(summary);
 
       if (data.similar.length === 0) {
-        html += '<p style="color:var(--text-dim);">No similar photos found.</p>';
+        var none = document.createElement('p');
+        none.style.color = 'var(--text-dim)';
+        none.textContent = 'No similar photos found.';
+        content.appendChild(none);
       } else {
-        html += '<div class="similar-grid">';
+        var grid = document.createElement('div');
+        grid.className = 'similar-grid';
         data.similar.forEach(function(item) {
           var p = item.photo;
           var pct = Math.round(item.similarity * 100);
-          html += '<div class="similar-card" onclick="closeSimilar(); openLightbox(' + p.id + ',\'' + (p.filename || '').replace(/'/g, "\\'") + '\')">' +
-            '<img src="/thumbnails/' + p.id + '.jpg" loading="lazy" alt="">' +
-            '<div class="similar-card-info">' +
-              '<div class="similar-card-name" title="' + (p.filename || '') + '">' + (p.filename || '') + '</div>' +
-              '<div class="similar-card-score">' + pct + '% similar</div>' +
-            '</div>' +
-          '</div>';
+          var card = document.createElement('div');
+          card.className = 'similar-card';
+          card.addEventListener('click', function() {
+            closeSimilar();
+            openLightbox(p.id, p.filename || '');
+          });
+          var img = document.createElement('img');
+          img.src = '/thumbnails/' + p.id + '.jpg';
+          img.loading = 'lazy';
+          img.alt = '';
+          var info = document.createElement('div');
+          info.className = 'similar-card-info';
+          var name = document.createElement('div');
+          name.className = 'similar-card-name';
+          name.title = p.filename || '';
+          name.textContent = p.filename || '';
+          var score = document.createElement('div');
+          score.className = 'similar-card-score';
+          score.textContent = pct + '% similar';
+          info.append(name, score);
+          card.append(img, info);
+          grid.appendChild(card);
         });
-        html += '</div>';
+        content.appendChild(grid);
       }
-      content.innerHTML = html;
     })
     .catch(function(e) {
       content.innerHTML = '<p style="color:var(--danger);">Failed: ' + escapeHtml(e.message) + '</p>';

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3365,9 +3365,12 @@ function selectCalendarDay(dateStr, count) {
   document.getElementById('calSelectionText').textContent = formatted + ' \u00b7 ' + count + ' photo' + (count !== 1 ? 's' : '');
   document.getElementById('calSelection').classList.add('active');
 
-  // Update date inputs and reload
+  // Update date inputs and reload. #dateTo is <input type="date">, which
+  // rejects datetime strings (the value would silently blank and the filter
+  // would lose its upper bound). A bare date is correct: the backend pads
+  // date_to to end-of-day (_inclusive_date_to in db.py).
   document.getElementById('dateFrom').value = dateStr;
-  document.getElementById('dateTo').value = dateStr + 'T23:59:59';
+  document.getElementById('dateTo').value = dateStr;
   resetAndLoad();
   renderCalendar(); // update selected state
 }

--- a/vireo/templates/jobs.html
+++ b/vireo/templates/jobs.html
@@ -152,6 +152,7 @@
 .tree-status-icon.running { color: var(--accent); animation: pulse-step 1.5s ease-in-out infinite; }
 .tree-status-icon.completed { color: var(--success, #4caf50); }
 .tree-status-icon.failed { color: var(--danger); }
+.tree-status-icon.cancelled { color: var(--text-muted); }
 @keyframes pulse-step {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.3; }
@@ -309,6 +310,7 @@
       case 'running': return '<span class="tree-status-icon running">\u25CB</span>';
       case 'completed': return '<span class="tree-status-icon completed">\u2713</span>';
       case 'failed': return '<span class="tree-status-icon failed">\u2717</span>';
+      case 'cancelled': return '<span class="tree-status-icon cancelled">\u2298</span>';
       default: return '<span class="tree-status-icon pending">\u25CB</span>';
     }
   }
@@ -420,8 +422,11 @@
       }
     }
 
-    // 7: Summary for completed steps
-    if (step.status === 'completed' && step.summary) {
+    // 7: Summary for terminal steps. The backend writes explanatory
+    // summaries on completed, cancelled ("Cancelled (N animals detected
+    // so far)"), and some failed steps (e.g. scan) — show them all.
+    var isTerminal = step.status === 'completed' || step.status === 'cancelled' || step.status === 'failed';
+    if (isTerminal && step.summary) {
       html += '<span class="tree-step-summary">(' + esc(step.summary) + ')</span>';
     }
 

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -97,6 +97,10 @@ body { padding-bottom: 36px; }
   background: var(--danger, #E74C3C);
   color: #fff;
 }
+.stage-status-pill.cancelled {
+  background: color-mix(in srgb, var(--warning, #F0A030) 20%, transparent);
+  color: var(--warning, #F0A030);
+}
 .stage-progress-bar {
   display: inline-flex;
   width: 80px;
@@ -190,6 +194,7 @@ body { padding-bottom: 36px; }
 }
 .pipeline-plan-summary .plan-stage-row.will-run .plan-stage-pill { color: var(--accent, #24E5CA); }
 .pipeline-plan-summary .plan-stage-row.will-skip .plan-stage-pill { color: var(--text-dim, #5A8890); font-style: italic; }
+.pipeline-plan-summary .plan-stage-row.cancelled .plan-stage-pill { color: var(--warning, #F0A030); }
 .pipeline-plan-summary .plan-stage-row.done-prior .plan-stage-pill {
   color: color-mix(in srgb, var(--accent, #24E5CA) 65%, var(--text-secondary, #B0CCCC));
 }
@@ -2890,8 +2895,11 @@ function _onPipelineComplete(result) {
     ['Source', 'Scan', 'Previews', 'Classify', 'Extract', 'EyeKeypoints', 'Group'].forEach(function(cardSuffix) {
       if (_runningStages[cardSuffix]) {
         delete _runningStages[cardSuffix];
-        _stageOutcomes[cardSuffix] = 'will-skip';
-        _setPill(cardSuffix, 'will-skip', 'Cancelled');
+        // Record a real 'cancelled' outcome so later refreshPipelineUI
+        // calls keep rendering "Cancelled" — a 'will-skip' outcome would
+        // be re-labeled with the future-tense "Will skip" on the next
+        // refresh, which lies about what happened to a mid-run stage.
+        _stageOutcomes[cardSuffix] = 'cancelled';
       }
     });
     refreshPipelineUI();
@@ -3300,18 +3308,28 @@ async function loadLabels() {
     var active = data.active || [];
     var activePaths = new Set(active.map(function(a) { return a.labels_file; }));
 
+    div.textContent = '';
     if (!data.labels || data.labels.length === 0) {
-      div.innerHTML = '<span style="color:var(--text-dim);font-size:12px;">(Tree of Life — all species)</span>';
+      var empty = document.createElement('span');
+      empty.style.cssText = 'color:var(--text-dim);font-size:12px;';
+      empty.textContent = '(Tree of Life — all species)';
+      div.appendChild(empty);
     } else {
-      var html = '';
       data.labels.forEach(function(l) {
         var isActive = activePaths.has(l.labels_file);
-        html += '<label style="display:flex;align-items:center;gap:4px;color:var(--text-secondary);cursor:pointer;padding:2px 0;">' +
-          '<input type="checkbox" class="labels-run-cb" value="' + l.labels_file.replace(/"/g, '&quot;') + '"' +
-          (isActive ? ' checked' : '') + ' onchange="updateReadiness(); schedulePlanRefresh();" style="accent-color:var(--accent);"> ' +
-          l.name + ' (' + (l.species_count || 0) + ')</label>';
+        var label = document.createElement('label');
+        label.style.cssText = 'display:flex;align-items:center;gap:4px;color:var(--text-secondary);cursor:pointer;padding:2px 0;';
+        var cb = document.createElement('input');
+        cb.type = 'checkbox';
+        cb.className = 'labels-run-cb';
+        cb.value = l.labels_file;
+        cb.checked = isActive;
+        cb.onchange = function() { updateReadiness(); schedulePlanRefresh(); };
+        cb.style.cssText = 'accent-color:var(--accent);';
+        label.appendChild(cb);
+        label.appendChild(document.createTextNode(' ' + l.name + ' (' + (l.species_count || 0) + ')'));
+        div.appendChild(label);
       });
-      div.innerHTML = html;
     }
 
   } catch(e) {}
@@ -3335,9 +3353,9 @@ async function updateReadiness() {
 
     // Model status
     if (r.model_ready) {
-      items.push('<span style="color:var(--accent,#24E5CA);">&#10003;</span> Model: <b>' + r.model_name + '</b> — ready');
+      items.push('<span style="color:var(--accent,#24E5CA);">&#10003;</span> Model: <b>' + escapeHtml(r.model_name) + '</b> — ready');
     } else if (r.needs_download) {
-      items.push('<span style="color:var(--warning,#f0c040);">&#9679;</span> Model: <b>' + r.model_name + '</b> — will download <b>' + (r.model_size_mb >= 1000 ? (r.model_size_mb / 1000).toFixed(1) + ' GB' : r.model_size_mb + ' MB') + '</b> on first run');
+      items.push('<span style="color:var(--warning,#f0c040);">&#9679;</span> Model: <b>' + escapeHtml(r.model_name) + '</b> — will download <b>' + (r.model_size_mb >= 1000 ? (r.model_size_mb / 1000).toFixed(1) + ' GB' : r.model_size_mb + ' MB') + '</b> on first run');
     } else {
       items.push('<span style="color:var(--danger,#e74c3c);">&#10007;</span> No model available — download one in Settings');
     }
@@ -3347,7 +3365,7 @@ async function updateReadiness() {
       items.push('<span style="color:var(--info,#7ec8e3);">&#9679;</span> Labels: <b>Tree of Life</b> — classifying against all species (slower, less accurate than regional labels)');
     } else if (r.labels_count > 0) {
       var labelDisplay = r.labels_name.length > 60 ? r.labels_name.substring(0, 57) + '...' : r.labels_name;
-      items.push('<span style="color:var(--accent,#24E5CA);">&#10003;</span> Labels: <b>' + labelDisplay + '</b> — ' + r.labels_count.toLocaleString() + ' species');
+      items.push('<span style="color:var(--accent,#24E5CA);">&#10003;</span> Labels: <b>' + escapeHtml(labelDisplay) + '</b> — ' + r.labels_count.toLocaleString() + ' species');
     }
 
     // Embeddings status
@@ -3838,7 +3856,7 @@ var _pipelineState = {
 // and a single global would let one stage's status update clobber another's
 // "Running…" pill on the next refresh.
 var _runningStages = {};  // suffix -> true while that stage is running
-var _stageOutcomes = {};  // suffix -> 'done' | 'failed' | 'will-skip' | 'done-prior'
+var _stageOutcomes = {};  // suffix -> 'done' | 'failed' | 'cancelled' | 'will-skip' | 'done-prior'
 
 // Plan response from POST /api/pipeline/plan, keyed by stage suffix:
 //   { Classify: { state, summary, detail }, Extract: ..., ... }
@@ -3881,6 +3899,7 @@ var _PILL_LABELS = {
   'running':    'Running…',
   'done':       'Done',
   'failed':     'Failed',
+  'cancelled':  'Cancelled',
   'will-run':   'Will run',
   'will-skip':  'Will skip',
   'done-prior': 'Already done',
@@ -3899,6 +3918,7 @@ function _formatPillLabel(stage, planEntry, state) {
   if (state === 'running')   return 'Running…';
   if (state === 'done')      return 'Done';
   if (state === 'failed')    return 'Failed';
+  if (state === 'cancelled') return 'Cancelled';
   if (state === 'will-skip') return 'Will skip';
 
   if (!planEntry) {
@@ -4013,7 +4033,7 @@ function _renderPlanSummary() {
       '<div class="plan-stage-row ' + state + '">' +
         '<span class="plan-stage-name">' + stage.label + '</span>' +
         '<span class="plan-stage-pill">' + pillLabel + '</span>' +
-        '<span class="plan-stage-summary">' + (summary || '') + '</span>' +
+        '<span class="plan-stage-summary">' + escapeHtml(summary || '') + '</span>' +
       '</div>'
     );
   });

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1344,7 +1344,12 @@ document.addEventListener('keydown', function(e) {
   if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.tagName === 'SELECT') return;
   if (mode !== 'review') return;
   if (!_shortcuts) return;
-  var pending = predictions.filter(function(p) { return p.status === 'pending'; });
+  // No-op while an overlay owns the keyboard (lightbox, burst modal, etc.) —
+  // otherwise A/S would invisibly accept/reject grid cards behind it.
+  if (document.querySelector('.lightbox-overlay.active, .pipeline-overlay.active, .similar-overlay.active, .modal-overlay.open, .grm-overlay.open, .inspect-overlay.open, .shortcuts-overlay.open, .help-overlay.active, .report-overlay.active')) return;
+  // The toolbar hint promises "first visible card": use the grid's filtered
+  // + sorted view, not the API-ordered raw predictions array.
+  var pending = getVisibleItems().filter(function(p) { return p.status === 'pending'; });
   if (pending.length === 0) return;
   if (matchesShortcut(e, _shortcuts.accept)) { e.preventDefault(); acceptPrediction(pending[0].id); }
   else if (matchesShortcut(e, _shortcuts.skip)) { e.preventDefault(); rejectPrediction(pending[0].id); }
@@ -2649,6 +2654,12 @@ async function grmApply() {
 // Keyboard handling for the modal
 document.addEventListener('keydown', function(e) {
   if (!document.getElementById('grmOverlay').classList.contains('open')) return;
+  // The lightbox can be opened on top of this modal ("Open in Lightbox").
+  // While it's open it owns the keyboard (arrows navigate photos, Esc closes
+  // it via the Keymap stack) — these shortcuts must not also fire underneath,
+  // invisibly moving photos to Picks/Rejects or removing them.
+  var lb = document.getElementById('lightboxOverlay');
+  if (lb && lb.classList.contains('active')) return;
   if (e.target.tagName === 'INPUT') return;
   // The mouse-help control is focusable so keyboard users can read its
   // popover; don't let keystrokes there (e.g. Space) fall through to the

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -1464,15 +1464,27 @@ function saveWsConfig() {
   clearTimeout(_wsSaveTimer);
   _wsSaveTimer = setTimeout(async function() {
     var overrides = {};
+    var needsResync = false;
     ['classification_threshold', 'grouping_window_seconds', 'similarity_threshold', 'detector_confidence'].forEach(function(key) {
       var checkbox = document.getElementById('wsOverride_' + key);
       var input = document.getElementById('wsVal_' + key);
       if (!checkbox || !input) return;
       if (checkbox.checked) {
+        var parsed = parseInt(input.value, 10);
+        if (isNaN(parsed)) {
+          // Cleared/invalid number field: JSON.stringify turns NaN into
+          // null, which the backend reads as "delete this override" while
+          // the checkbox stays checked — the UI would claim an override
+          // that no longer exists. Omit the key instead (the backend
+          // preserves omitted keys) and resync the input from the server
+          // afterwards so it shows the value that is actually in effect.
+          needsResync = true;
+          return;
+        }
         if (key === 'classification_threshold' || key === 'similarity_threshold' || key === 'detector_confidence') {
-          overrides[key] = parseInt(input.value) / 100;
+          overrides[key] = parsed / 100;
         } else {
-          overrides[key] = parseInt(input.value);
+          overrides[key] = parsed;
         }
       } else {
         // Explicit null tells the backend to clear this override.
@@ -1487,6 +1499,9 @@ function saveWsConfig() {
         body: JSON.stringify(overrides)
       });
     } catch(e) {}
+    // Restore any field left empty/invalid to the server's persisted value
+    // (or uncheck it if no override actually exists server-side).
+    if (needsResync) loadWsOverrides();
   }, 500);
 }
 

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -1900,6 +1900,21 @@ def test_pages_no_inline_escapeHtml(app_and_db):
             f"{page} still has inline escapeHtml definition"
 
 
+def test_browse_calendar_day_sets_bare_date(app_and_db):
+    """Heatmap day click must set #dateTo to a bare date.
+
+    #dateTo is <input type="date">: assigning 'YYYY-MM-DDT23:59:59' is
+    rejected and silently blanks the input, so the request went out with
+    no upper bound. The backend pads bare dates to end-of-day
+    (_inclusive_date_to), so the suffix is never needed client-side.
+    """
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.get('/browse')
+    assert resp.status_code == 200
+    assert "T23:59:59" not in resp.data.decode()
+
+
 def test_health_endpoint(app_and_db):
     """GET /api/health returns 200 with status ok."""
     app, _ = app_and_db

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -6023,3 +6023,167 @@ def test_collection_preview_does_not_mask_db_failures(app_and_db, monkeypatch):
     # is that it's *not* a 400, which would mislabel a backend fault as a
     # client error.
     assert resp.status_code >= 500
+
+
+# -- Regression tests: route hardening (workspace verification, validation,
+# config locking) --
+
+
+def test_update_workspace_unknown_id_returns_404(app_and_db):
+    """PUT /api/workspaces/<id> must 404 for an unknown workspace instead of
+    crashing on dict(None) after update_workspace silently no-ops."""
+    app, _db = app_and_db
+    client = app.test_client()
+    resp = client.put('/api/workspaces/999999', json={"name": "ghost"})
+    assert resp.status_code == 404
+    assert "error" in resp.get_json()
+
+
+def test_update_workspace_rejects_non_dict_config_overrides(app_and_db):
+    """PUT /api/workspaces/<id> must reject non-dict config_overrides —
+    persisting e.g. a list would crash the labels accessors later."""
+    app, db = app_and_db
+    client = app.test_client()
+    ws_id = db._active_workspace_id
+
+    for bad in ([], "x", 5, True):
+        resp = client.put(f'/api/workspaces/{ws_id}',
+                          json={"config_overrides": bad})
+        assert resp.status_code == 400, f"expected 400 for {bad!r}"
+
+    # None (clear) and a dict remain accepted.
+    resp = client.put(f'/api/workspaces/{ws_id}',
+                      json={"config_overrides": {"classification_threshold": 0.5}})
+    assert resp.status_code == 200
+    resp = client.put(f'/api/workspaces/{ws_id}', json={"config_overrides": None})
+    assert resp.status_code == 200
+
+
+def test_add_workspace_folder_unknown_ids_return_404(app_and_db):
+    """POST /api/workspaces/<ws>/folders must 404 for unknown workspace or
+    folder ids instead of hitting the workspace_folders FK and 500ing."""
+    app, db = app_and_db
+    client = app.test_client()
+    ws_id = db._active_workspace_id
+    fid = db.get_folder_tree()[0]["id"]
+
+    resp = client.post(f'/api/workspaces/{ws_id}/folders',
+                       json={"folder_id": 999999})
+    assert resp.status_code == 404
+    assert "Folder" in resp.get_json()["error"]
+
+    resp = client.post('/api/workspaces/999999/folders',
+                       json={"folder_id": fid})
+    assert resp.status_code == 404
+    assert "Workspace" in resp.get_json()["error"]
+
+
+def test_setup_complete_does_not_pin_defaults(app_and_db):
+    """POST /api/setup/complete must persist only setup_complete (plus keys
+    the user already set) — not the full DEFAULTS-merged config."""
+    import json as _json
+
+    import config as cfg
+
+    app, _db = app_and_db
+    with open(cfg.CONFIG_PATH, "w") as f:
+        _json.dump({"inat_token": "abc"}, f)
+
+    client = app.test_client()
+    resp = client.post('/api/setup/complete')
+    assert resp.status_code == 200
+
+    with open(cfg.CONFIG_PATH) as f:
+        raw = _json.load(f)
+    assert raw == {"inat_token": "abc", "setup_complete": True}
+
+
+def test_detach_endpoints_reject_non_integer_indices(app_and_db):
+    """detach-burst/detach-photo must 400 on non-integer indices instead of
+    raising TypeError at the `enc_idx < 0` comparison."""
+    app, _db = app_and_db
+    client = app.test_client()
+
+    resp = client.post('/api/pipeline/detach-burst',
+                       json={"encounter_index": "0", "burst_index": 0})
+    assert resp.status_code == 400
+    assert "encounter_index" in resp.get_json()["error"]
+
+    resp = client.post('/api/pipeline/detach-burst',
+                       json={"encounter_index": 0, "burst_index": [1]})
+    assert resp.status_code == 400
+    assert "burst_index" in resp.get_json()["error"]
+
+    resp = client.post('/api/pipeline/detach-photo',
+                       json={"encounter_index": "0", "burst_index": 0,
+                             "photo_id": 1})
+    assert resp.status_code == 400
+    assert "encounter_index" in resp.get_json()["error"]
+
+    resp = client.post('/api/pipeline/detach-photo',
+                       json={"encounter_index": 0, "burst_index": True,
+                             "photo_id": 1})
+    assert resp.status_code == 400
+    assert "burst_index" in resp.get_json()["error"]
+
+
+def test_sync_discard_reports_true_count(app_and_db):
+    """POST /api/sync/discard must report rows actually deleted, not the
+    request size — stale/foreign ids are silently skipped by clear_pending."""
+    app, db = app_and_db
+    client = app.test_client()
+    pid = db.conn.execute("SELECT id FROM photos LIMIT 1").fetchone()["id"]
+    db.queue_change(pid, "keyword_add", "Test Bird")
+    change_id = db.get_pending_changes()[0]["id"]
+
+    resp = client.post('/api/sync/discard',
+                       json={"change_ids": [change_id, 999999]})
+    assert resp.status_code == 200
+    assert resp.get_json()["discarded"] == 1
+    assert db.get_pending_changes() == []
+
+
+def test_audit_resolve_validates_direction_and_photo_id(app_and_db):
+    """POST /api/audit/resolve must 400 on unknown directions (resolve_drift
+    silently no-ops on them) and non-integer photo_id."""
+    app, db = app_and_db
+    client = app.test_client()
+    pid = db.conn.execute("SELECT id FROM photos LIMIT 1").fetchone()["id"]
+
+    resp = client.post('/api/audit/resolve',
+                       json={"photo_id": pid, "direction": "use_database"})
+    assert resp.status_code == 400
+
+    resp = client.post('/api/audit/resolve',
+                       json={"photo_id": "abc", "direction": "use_db"})
+    assert resp.status_code == 400
+
+    resp = client.post('/api/audit/resolve',
+                       json={"photo_id": pid, "direction": "use_db"})
+    assert resp.status_code == 200
+
+    # resolve-all shares the same silent no-op hazard.
+    resp = client.post('/api/audit/resolve-all', json={"direction": "bogus"})
+    assert resp.status_code == 400
+
+
+def test_encounter_species_chunks_large_photo_id_lists(app_and_db):
+    """POST /api/encounters/species must chunk its IN-clause queries so id
+    lists beyond the SQLite bound-parameter cap don't raise OperationalError."""
+    app, db = app_and_db
+    client = app.test_client()
+    fid = db.get_folder_tree()[0]["id"]
+    # More ids than one 900-param chunk so the query must split.
+    photo_ids = [
+        db.add_photo(folder_id=fid, filename=f"chunk{i}.jpg", extension=".jpg",
+                     file_size=1, file_mtime=1.0)
+        for i in range(950)
+    ]
+
+    resp = client.post('/api/encounters/species',
+                       json={"species": "Chunk Finch", "photo_ids": photo_ids})
+    assert resp.status_code == 200
+    assert resp.get_json()["photo_count"] == len(photo_ids)
+    # Both chunks were validated and tagged.
+    for pid in (photo_ids[0], photo_ids[-1]):
+        assert any(t["name"] == "Chunk Finch" for t in db.get_photo_keywords(pid))

--- a/vireo/tests/test_audit.py
+++ b/vireo/tests/test_audit.py
@@ -40,6 +40,69 @@ def test_check_drift_detects_xmp_change(tmp_path):
     assert drifts[0]['filename'] == 'bird.jpg'
 
 
+def test_check_drift_ignores_case_only_difference(tmp_path):
+    """A case-only keyword difference is not drift.
+
+    resolve_drift('use_xmp') goes through sync_from_xmp, which reconciles
+    case-insensitively and treats a case-only difference as already in
+    sync — so reporting it here would create a permanently unresolvable
+    drift entry.
+    """
+    from audit import check_drift
+    from db import Database
+    from scanner import scan
+    from xmp import write_sidecar
+
+    root = str(tmp_path / "photos")
+    os.makedirs(root)
+    Image.new('RGB', (100, 100)).save(os.path.join(root, 'bird.jpg'))
+    xmp_path = os.path.join(root, 'bird.xmp')
+    write_sidecar(xmp_path, flat_keywords={'Sparrow'}, hierarchical_keywords=set())
+
+    db = Database(str(tmp_path / "test.db"))
+    scan(root, db)
+
+    # Rewrite the sidecar with the same keyword in a different case
+    # (write_sidecar merges, so replace the file outright)
+    os.unlink(xmp_path)
+    write_sidecar(xmp_path, flat_keywords={'SPARROW'}, hierarchical_keywords=set())
+
+    assert check_drift(db) == []
+
+
+def test_check_drift_reports_real_difference_despite_case_noise(tmp_path):
+    """Genuinely different keyword sets still drift; case-only pairs don't
+    inflate the added/removed lists, and reported values keep the actual
+    stored strings."""
+    from audit import check_drift
+    from db import Database
+    from scanner import scan
+    from xmp import write_sidecar
+
+    root = str(tmp_path / "photos")
+    os.makedirs(root)
+    Image.new('RGB', (100, 100)).save(os.path.join(root, 'bird.jpg'))
+    xmp_path = os.path.join(root, 'bird.xmp')
+    write_sidecar(xmp_path, flat_keywords={'Sparrow'}, hierarchical_keywords=set())
+
+    db = Database(str(tmp_path / "test.db"))
+    scan(root, db)
+
+    os.unlink(xmp_path)
+    write_sidecar(
+        xmp_path, flat_keywords={'SPARROW', 'Cardinal'}, hierarchical_keywords=set()
+    )
+
+    drifts = check_drift(db)
+    assert len(drifts) == 1
+    assert drifts[0]['added_in_xmp'] == ['Cardinal']
+    assert drifts[0]['removed_in_xmp'] == []
+    assert drifts[0]['direction'] == 'xmp_ahead'
+    # Reported values show the strings as actually stored on each side
+    assert drifts[0]['db_value'] == ['Sparrow']
+    assert drifts[0]['xmp_value'] == ['Cardinal', 'SPARROW']
+
+
 def test_check_orphans_detects_deleted_file(tmp_path):
     """check_orphans finds DB entries with no file on disk."""
     from audit import check_orphans

--- a/vireo/tests/test_capture_time_api.py
+++ b/vireo/tests/test_capture_time_api.py
@@ -676,3 +676,63 @@ def test_capture_time_job_applies_per_photo_shifts(client_with_photo, monkeypatc
         by_file[os.path.basename(target)] = shift_args[0] if shift_args else None
     assert by_file["test.jpg"] == "-AllDates-=0:0:0 3:0:0"
     assert by_file["second.jpg"] == "-AllDates-=0:0:0 2:0:0"
+
+
+def test_capture_time_job_counts_exiftool_write_error_as_failed(client_with_photo, monkeypatch):
+    """ExifTool exits 1 when a write fails — the photo must be counted as
+    failed, not updated, and its metadata must not be refreshed."""
+    import capture_time
+
+    app, db, photo_id = client_with_photo
+    db.conn.execute(
+        "UPDATE photos SET timestamp = ?, exif_data = ? WHERE id = ?",
+        (
+            "2026-05-22T20:07:23.560000",
+            json.dumps(
+                {
+                    "EXIF": {
+                        "DateTimeOriginal": "2026:05:22 20:07:23",
+                        "SubSecTimeOriginal": "56",
+                        "OffsetTimeOriginal": "-07:00",
+                    }
+                }
+            ),
+            photo_id,
+        ),
+    )
+    db.conn.commit()
+
+    def fake_run(cmd, **_kwargs):
+        return SimpleNamespace(
+            returncode=1,
+            stdout="    0 image files updated\n    1 files weren't updated due to errors\n",
+            stderr="Error: File is read-only",
+        )
+
+    def fail_extract(paths):
+        raise AssertionError("metadata must not be refreshed after a failed write")
+
+    monkeypatch.setattr(capture_time.shutil, "which", lambda name: "/usr/bin/exiftool")
+    monkeypatch.setattr(capture_time.subprocess, "run", fake_run)
+    monkeypatch.setattr(capture_time, "extract_metadata", fail_extract)
+
+    client = app.test_client()
+    resp = client.post(
+        "/api/jobs/capture-time",
+        json={
+            "photo_ids": [photo_id],
+            "mode": "preserve_instant",
+            "target_offset": "-10:00",
+            "keep_backups": False,
+        },
+    )
+    assert resp.status_code == 200
+    job = wait_for_job_via_client(client, resp.get_json()["job_id"])
+    assert job["status"] == "completed"
+    assert job["result"]["updated"] == 0
+    assert job["result"]["failed"] == 1
+    assert "read-only" in job["result"]["failures"][0]["error"]
+
+    # Timestamp untouched — no false "updated" report
+    refreshed = db.get_photo(photo_id)
+    assert refreshed["timestamp"] == "2026-05-22T20:07:23.560000"

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -4385,3 +4385,101 @@ def test_run_classify_job_reclassify_cancel_classifies_empty_scene_processed(tmp
             f"{det_id}; only the processed empty-scene photo's synthetic "
             f"full-image detection (201) should be classified."
         )
+
+
+# ---------------------------------------------------------------------------
+# Early returns must not leave step rows stuck at "pending"
+# ---------------------------------------------------------------------------
+
+
+def _final_step_statuses(runner):
+    """Map step_id -> last status reported via update_step."""
+    finals = {}
+    for step_id, kwargs in runner.steps:
+        if "status" in kwargs:
+            finals[step_id] = kwargs["status"]
+    return finals
+
+
+def test_empty_collection_finalizes_all_step_rows(tmp_path):
+    """The total==0 short-circuit returns before model resolution; the
+    load_taxonomy/load_model/detect/classify/finalize rows it skips must
+    be flipped to a terminal status, not left pending forever.
+    """
+    from db import Database
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    coll_id = db.add_collection("empty", "[]")
+
+    runner = FakeRunner()
+    job = _make_job()
+    params = ClassifyParams(
+        collection_id=coll_id,
+        labels_files=None,
+        labels_file=None,
+        model_id=None,
+        model_name=None,
+        grouping_window=0,
+        similarity_threshold=0.99,
+        reclassify=False,
+    )
+
+    result = run_classify_job(job, runner, db_path, ws, params)
+    assert result["total"] == 0
+
+    finals = _final_step_statuses(runner)
+    terminal = {"completed", "failed", "cancelled"}
+    for step_id in ("load_photos", "load_taxonomy", "load_model",
+                    "detect", "classify", "finalize"):
+        assert finals.get(step_id) in terminal, (
+            f"Step {step_id!r} must reach a terminal status when the job "
+            f"short-circuits with no photos, got {finals.get(step_id)!r}"
+        )
+
+
+def test_precancelled_job_finalizes_all_step_rows(tmp_path):
+    """The pre-model-resolution cancel gate returns early; the remaining
+    rows must be marked cancelled rather than left pending forever.
+    """
+    from db import Database
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    folder_id = db.add_folder("/tmp/p", name="p")
+    pid = db.add_photo(
+        folder_id, "a.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    coll_id = db.add_collection(
+        "c", '[{"field":"photo_ids","value":[' + str(pid) + "]}]",
+    )
+
+    runner = FakeRunner()
+    runner.cancelled = True
+    job = _make_job()
+    params = ClassifyParams(
+        collection_id=coll_id,
+        labels_files=None,
+        labels_file=None,
+        model_id=None,
+        model_name=None,
+        grouping_window=0,
+        similarity_threshold=0.99,
+        reclassify=False,
+    )
+
+    result = run_classify_job(job, runner, db_path, ws, params)
+    assert result["predictions_stored"] == 0
+
+    finals = _final_step_statuses(runner)
+    for step_id in ("load_taxonomy", "load_model", "detect",
+                    "classify", "finalize"):
+        assert finals.get(step_id) == "cancelled", (
+            f"Step {step_id!r} must be marked cancelled on the "
+            f"pre-resolution cancel gate, got {finals.get(step_id)!r}"
+        )

--- a/vireo/tests/test_culling.py
+++ b/vireo/tests/test_culling.py
@@ -136,6 +136,31 @@ def test_cluster_photos_single_linkage():
     assert set(clusters[0]) == {1, 2, 3}
 
 
+def test_cluster_photos_mixed_dims_does_not_crash():
+    """Embeddings from different models (different dims) must not crash.
+
+    Two photos in one species group can carry top predictions from
+    different classifier models, so their embeddings can have different
+    dimensions. Mismatched shapes count as similarity 0 (separate clusters).
+    """
+    e1 = np.ones(128, dtype=np.float32)
+    e1 /= np.linalg.norm(e1)
+    e2 = np.ones(256, dtype=np.float32)
+    e2 /= np.linalg.norm(e2)
+
+    clusters = _cluster_photos({1: e1, 2: e2}, threshold=0.88)
+    assert len(clusters) == 2
+
+
+def test_embedding_sim_mismatched_dims_returns_zero():
+    from culling import _embedding_sim
+
+    a = np.ones(4, dtype=np.float32)
+    b = np.ones(8, dtype=np.float32)
+    assert _embedding_sim(a, b) == 0.0
+    assert _embedding_sim(a, a) > 0.0
+
+
 # ---------------------------------------------------------------------------
 # _phash_merge  (perceptual hash single-linkage within a group)
 # ---------------------------------------------------------------------------
@@ -412,6 +437,35 @@ def test_build_scene_groups_no_redundancy():
 
     assert keepers == 3
     assert rejects == 0
+
+
+def test_build_scene_groups_no_embedding_photo_id_colliding_with_cluster_index():
+    """A no-embedding photo whose id equals a cluster index stays solo.
+
+    pid_to_rc values are cluster indices 0..N-1 — small integers, like
+    photo ids. The fallback key for photos absent from every redundancy
+    cluster must not collide with those indices, or the photo gets merged
+    into an unrelated cluster and can be rejected as redundant with a
+    photo it has no similarity to.
+    """
+    scene_clusters = [[0, 10, 11]]
+    redundancy_clusters = [[10, 11]]  # cluster index 0; photo 0 has no embedding
+    photo_data = [
+        {"photo_id": 0, "quality": 0.1, "filename": "a.jpg", "timestamp": None, "phash": None},
+        {"photo_id": 10, "quality": 0.9, "filename": "b.jpg", "timestamp": None, "phash": None},
+        {"photo_id": 11, "quality": 0.5, "filename": "c.jpg", "timestamp": None, "phash": None},
+    ]
+
+    groups, keepers, rejects = _build_scene_groups(
+        scene_clusters, redundancy_clusters, photo_data, {}, {}
+    )
+
+    by_id = {p["photo_id"]: p for p in groups[0]["photos"]}
+    assert by_id[0]["action"] == "keep"
+    assert by_id[0]["redundant_with"] is None
+    assert keepers == 2  # photo 0 solo + photo 10 keeps its cluster
+    assert rejects == 1  # only photo 11 is redundant (with 10)
+    assert by_id[11]["redundant_with"] == 10
 
 
 # ---------------------------------------------------------------------------

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -12889,3 +12889,215 @@ def test_get_workspace_extensions_excludes_missing_folders(tmp_path):
 
     # .cr2 lives only in the missing folder — must be filtered out.
     assert db.get_workspace_extensions() == ['.jpg']
+
+
+# -- Regression tests: unbounded IN clauses, inat ordering, override guards --
+
+
+def _cap_sqlite_vars(db, cap=999):
+    """Emulate the historical SQLITE_MAX_VARIABLE_NUMBER=999 cap so an
+    unchunked IN clause fails deterministically even on modern builds."""
+    import sqlite3
+    db.conn.setlimit(sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER, cap)
+
+
+def test_eye_keypoint_stage_chunks_large_photo_id_scope(tmp_path):
+    """Pipeline callers pass the full resolved collection scope as
+    photo_ids; a single IN clause would exceed the bind-var cap for big
+    collections. Must route through _scope_clause like its count siblings."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db._active_workspace_id
+    fid = db.add_folder(str(tmp_path), name="photos")
+    db.add_workspace_folder(ws_id, fid)
+
+    pids = []
+    for i in range(2):
+        pid = db.add_photo(fid, f"p{i}.jpg", ".jpg", 1000, float(i + 1),
+                           width=800, height=600)
+        db.update_photo_pipeline_features(pid, mask_path=str(tmp_path / "mask.png"))
+        det_ids = db.save_detections(
+            pid,
+            [{"box": {"x": 0.1, "y": 0.1, "w": 0.8, "h": 0.8}, "confidence": 0.9}],
+            detector_model="MegaDetector",
+        )
+        db.add_prediction(
+            det_ids[0], species="Vulpes vulpes", confidence=0.9,
+            model="bioclip-2.5", category="match",
+            taxonomy={"class": "Mammalia", "scientific_name": "Vulpes vulpes"},
+        )
+        pids.append(pid)
+
+    _cap_sqlite_vars(db)
+    scope = pids + list(range(1_000_000, 1_001_200))  # 1202 ids > 999 cap
+    rows = db.list_photos_for_eye_keypoint_stage(photo_ids=scope)
+    assert {r["id"] for r in rows} == set(pids)
+
+
+def test_get_predictions_chunks_large_photo_id_list(tmp_path):
+    """/api/predictions passes full-collection id lists. Chunked queries
+    must merge while preserving the confidence-DESC ordering across
+    chunk boundaries."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder('/photos', name='photos')
+
+    def make_photo(name, conf):
+        pid = db.add_photo(folder_id=fid, filename=name, extension='.jpg',
+                           file_size=100, file_mtime=1.0)
+        det = db.save_detections(
+            pid,
+            [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5}, "confidence": 0.9}],
+            detector_model="MegaDetector",
+        )[0]
+        db.add_prediction(det, species=name, confidence=conf, model="bioclip")
+        return pid
+
+    p_low = make_photo("low.jpg", 0.3)
+    p_high = make_photo("high.jpg", 0.9)
+
+    _cap_sqlite_vars(db)
+    # Put the high-confidence photo in the *last* chunk so an
+    # append-without-resort implementation would order it after p_low.
+    scope = [p_low] + list(range(1_000_000, 1_001_200)) + [p_high]
+    rows = db.get_predictions(photo_ids=scope)
+    assert [r["photo_id"] for r in rows] == [p_high, p_low]
+    confs = [r["confidence"] for r in rows]
+    assert confs == sorted(confs, reverse=True)
+
+
+def test_get_keywords_for_photos_chunks_and_dedups_large_input(tmp_path):
+    """Same /api/predictions source feeds get_keywords_for_photos with the
+    full collection scope; must chunk, and duplicated input ids must not
+    double-append keywords."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder('/photos', name='photos')
+    pid = db.add_photo(folder_id=fid, filename='a.jpg', extension='.jpg',
+                       file_size=100, file_mtime=1.0)
+    kid = db.add_keyword("Robin", kw_type="general")
+    db.tag_photo(pid, kid)
+
+    _cap_sqlite_vars(db)
+    # pid appears twice, in what would be different chunks.
+    scope = [pid] + list(range(1_000_000, 1_001_200)) + [pid]
+    result = db.get_keywords_for_photos(scope)
+    assert list(result.keys()) == [pid]
+    assert [k["name"] for k in result[pid]] == ["Robin"]
+
+
+def test_delete_photos_chunks_large_resolve_list(tmp_path):
+    """api_audit_remove_missing passes a raw request-body id list straight
+    through; the initial resolve SELECT must chunk like the rest of the
+    method already does."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder('/photos', name='photos')
+    pids = [
+        db.add_photo(folder_id=fid, filename=f"p{i}.jpg", extension='.jpg',
+                     file_size=100, file_mtime=1.0)
+        for i in range(3)
+    ]
+
+    _cap_sqlite_vars(db)
+    result = db.delete_photos(pids + list(range(1_000_000, 1_001_200)))
+    assert result["deleted"] == 3
+    assert set(result["ids"]) == set(pids)
+
+
+def test_apply_duplicate_resolution_chunks_large_group(tmp_path):
+    """duplicate_scan.py documents that one duplicate group can exceed the
+    bind-var cap and chunks its own reads; the apply path must chunk both
+    the resolve SELECT and the loser-flag UPDATE."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder(str(tmp_path / "photos"), name='photos')
+    # 1100 photos in one group: 1099 losers > the legacy 999-var cap, so
+    # the rejected-flag UPDATE must chunk too.
+    pids = [
+        db.add_photo(folder_id=fid, filename=f"dup{i:04d}.jpg", extension='.jpg',
+                     file_size=100, file_mtime=float(i + 1))
+        for i in range(1100)
+    ]
+
+    _cap_sqlite_vars(db)
+    result = db.apply_duplicate_resolution(pids)
+    assert result["winner_id"] in pids
+    assert result["rejected"] == 1099
+    flagged = db.conn.execute(
+        "SELECT COUNT(*) AS n FROM photos WHERE flag = 'rejected'"
+    ).fetchone()["n"]
+    assert flagged == 1099
+
+
+def test_collection_photo_ids_rule_supports_large_selection(tmp_path):
+    """A static collection created from a large selection used to bind one
+    parameter per id, making every query against the collection fail
+    permanently. Integer ids are inlined as literals instead."""
+    import json
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder('/photos', name='photos')
+    p1 = db.add_photo(folder_id=fid, filename='a.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+    p2 = db.add_photo(folder_id=fid, filename='b.jpg', extension='.jpg',
+                      file_size=100, file_mtime=2.0)
+
+    ids = [p1, p2] + list(range(1_000_000, 1_001_200))
+    cid = db.add_collection(
+        'Big selection', json.dumps([{"field": "photo_ids", "value": ids}])
+    )
+
+    _cap_sqlite_vars(db)
+    assert db.count_collection_photos(cid) == 2
+    assert {p["id"] for p in db.get_collection_photos(cid)} == {p1, p2}
+    # Composability: the leaf still works inside a rule group with siblings.
+    assert db.count_photos_for_rules([
+        {"field": "photo_ids", "value": ids},
+        {"field": "rating", "op": ">=", "value": 0},
+    ]) == 2
+
+
+def test_get_inat_submissions_returns_newest_and_chunks(tmp_path):
+    """Each photo must map to its most recent submission (the old dict
+    comprehension over DESC-ordered rows kept the OLDEST), and the photo_id
+    IN clause must chunk."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder('/photos', name='photos')
+    pid = db.add_photo(folder_id=fid, filename='a.jpg', extension='.jpg',
+                       file_size=100, file_mtime=1.0)
+    db.conn.execute(
+        "INSERT INTO inat_submissions (photo_id, observation_id, observation_url, submitted_at) "
+        "VALUES (?, 111, 'https://inat/111', '2025-01-01 00:00:00')",
+        (pid,),
+    )
+    db.conn.execute(
+        "INSERT INTO inat_submissions (photo_id, observation_id, observation_url, submitted_at) "
+        "VALUES (?, 222, 'https://inat/222', '2026-01-01 00:00:00')",
+        (pid,),
+    )
+    db.conn.commit()
+
+    subs = db.get_inat_submissions([pid])
+    assert subs[pid]["observation_id"] == 222
+
+    _cap_sqlite_vars(db)
+    subs = db.get_inat_submissions([pid] + list(range(1_000_000, 1_001_200)))
+    assert subs[pid]["observation_id"] == 222
+
+
+def test_workspace_active_labels_survive_non_dict_overrides(tmp_path):
+    """api_update_workspace can persist non-dict config_overrides JSON; the
+    active-labels accessors must fall back like get_effective_config and
+    get_subject_types do, not raise AttributeError/TypeError."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db._active_workspace_id
+
+    for bad in (["not", "a", "dict"], "just a string", 42):
+        db.update_workspace(ws_id, config_overrides=bad)
+        assert db.get_workspace_active_labels() is None
+        # Setter must replace the junk rather than crash on item assignment.
+        db.set_workspace_active_labels(["birds.txt"])
+        assert db.get_workspace_active_labels() == ["birds.txt"]

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -13035,6 +13035,7 @@ def test_collection_photo_ids_rule_supports_large_selection(tmp_path):
     parameter per id, making every query against the collection fail
     permanently. Integer ids are inlined as literals instead."""
     import json
+
     from db import Database
     db = Database(str(tmp_path / "test.db"))
     fid = db.add_folder('/photos', name='photos')

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -4711,3 +4711,133 @@ def test_api_serve_mask_rejects_path_outside_masks_dir(app_and_db, tmp_path):
     client = app.test_client()
     resp = client.get(f"/api/masks/{pid}/sam2-small.png")
     assert resp.status_code == 404
+
+
+# -- Regression tests: workspace verification and payload validation --
+
+
+def _add_other_workspace_photo(db):
+    """Create a photo whose folder is linked only to another workspace."""
+    default_ws = db._active_workspace_id
+    other_ws = db.create_workspace("Other")
+    db.set_active_workspace(other_ws)
+    fid = db.add_folder('/secret/other', name='secret-other')
+    pid = db.add_photo(folder_id=fid, filename='hidden.jpg', extension='.jpg',
+                       file_size=10, file_mtime=1.0)
+    db.set_active_workspace(default_ws)
+    return pid
+
+
+def test_color_label_unknown_photo_returns_404(app_and_db):
+    """POST /api/photos/<id>/color_label must 404 on a stale id instead of
+    hitting the photo_color_labels FK and 500ing."""
+    app, _db = app_and_db
+    client = app.test_client()
+    resp = client.post('/api/photos/999999/color_label', json={'color': 'red'})
+    assert resp.status_code == 404
+
+
+def test_color_label_rejects_cross_workspace_photo(app_and_db):
+    """POST /api/photos/<id>/color_label must 403 for photos outside the
+    active workspace, matching the rating/flag endpoints."""
+    app, db = app_and_db
+    hidden_pid = _add_other_workspace_photo(db)
+    client = app.test_client()
+    resp = client.post(f'/api/photos/{hidden_pid}/color_label',
+                       json={'color': 'red'})
+    assert resp.status_code == 403
+    assert db.get_color_labels_for_photos([hidden_pid]) == {}
+
+
+def test_batch_color_label_skips_stale_and_cross_workspace_ids(app_and_db):
+    """POST /api/batch/color_label must filter out stale and cross-workspace
+    ids (instead of 500ing mid-batch on the FK) and report what was applied."""
+    app, db = app_and_db
+    hidden_pid = _add_other_workspace_photo(db)
+    valid_pid = db.conn.execute(
+        "SELECT id FROM photos WHERE filename = 'bird1.jpg'").fetchone()["id"]
+    client = app.test_client()
+
+    resp = client.post('/api/batch/color_label',
+                       json={'photo_ids': [valid_pid, 999999, hidden_pid],
+                             'color': 'green'})
+    assert resp.status_code == 200
+    assert resp.get_json()["updated"] == 1
+    assert db.get_color_label(valid_pid) == 'green'
+    assert db.get_color_labels_for_photos([hidden_pid]) == {}
+
+
+def test_photo_detail_rejects_cross_workspace_photo(app_and_db):
+    """GET /api/photos/<id> exposes absolute path/xmp_path — it must 404 for
+    photos hidden from the active workspace (mirrors serve_thumbnail)."""
+    app, db = app_and_db
+    hidden_pid = _add_other_workspace_photo(db)
+    client = app.test_client()
+    resp = client.get(f'/api/photos/{hidden_pid}')
+    assert resp.status_code == 404
+
+
+def test_photo_pipeline_rejects_cross_workspace_photo(app_and_db):
+    """GET /api/photos/<id>/pipeline exposes folder_path — 404 outside ws."""
+    app, db = app_and_db
+    hidden_pid = _add_other_workspace_photo(db)
+    client = app.test_client()
+    resp = client.get(f'/api/photos/{hidden_pid}/pipeline')
+    assert resp.status_code == 404
+
+
+def test_image_routes_reject_cross_workspace_photo(app_and_db):
+    """Image-serving routes must not leak bytes across workspaces."""
+    app, db = app_and_db
+    hidden_pid = _add_other_workspace_photo(db)
+    client = app.test_client()
+    for path in (f'/photos/{hidden_pid}/preview',
+                 f'/photos/{hidden_pid}/full',
+                 f'/photos/{hidden_pid}/original',
+                 f'/photos/{hidden_pid}/crop'):
+        resp = client.get(path)
+        assert resp.status_code == 404, f"expected 404 for {path}"
+
+
+def test_api_detections_rejects_cross_workspace_photo(app_and_db):
+    """GET /api/detections/<id> must 404 for photos outside the workspace."""
+    app, db = app_and_db
+    hidden_pid = _add_other_workspace_photo(db)
+    db.save_detections(hidden_pid, [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+         "confidence": 0.9, "category": "animal"},
+    ], detector_model="MDV6")
+    client = app.test_client()
+    resp = client.get(f'/api/detections/{hidden_pid}')
+    assert resp.status_code == 404
+
+
+def test_collection_add_photos_rejects_non_integer_ids(app_and_db):
+    """POST /api/collections/<id>/add-photos must 400 on non-int entries —
+    strings would persist into the photo_ids rule where they never match,
+    and mixed int/str payloads crash sorted()."""
+    import json
+
+    app, db = app_and_db
+    client = app.test_client()
+    resp = client.post('/api/collections', json={'name': 'Static'})
+    cid = resp.get_json()['id']
+    pid = db.conn.execute("SELECT id FROM photos LIMIT 1").fetchone()["id"]
+    rules_before = db.conn.execute(
+        "SELECT rules FROM collections WHERE id = ?", (cid,)).fetchone()["rules"]
+
+    for bad_ids in (["1", "2"], [pid, str(pid + 1)], [pid, True], "1,2"):
+        resp = client.post(f'/api/collections/{cid}/add-photos',
+                           json={'photo_ids': bad_ids})
+        assert resp.status_code == 400, f"expected 400 for {bad_ids!r}"
+
+    # The collection's rules must be untouched by the rejected requests.
+    rules_after = db.conn.execute(
+        "SELECT rules FROM collections WHERE id = ?", (cid,)).fetchone()["rules"]
+    assert json.loads(rules_after) == json.loads(rules_before)
+
+    # Valid ints still work.
+    resp = client.post(f'/api/collections/{cid}/add-photos',
+                       json={'photo_ids': [pid]})
+    assert resp.status_code == 200
+    assert resp.get_json()["total"] == 1

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -9039,3 +9039,264 @@ def test_weights_fingerprint_missing_file_distinguishes_from_present(tmp_path):
     assert partial_fp != full_fp
     # Missing entries collapse to a sentinel so the key still hashes.
     assert any(part[1] is None for part in partial_fp)
+
+
+# ---------------------------------------------------------------------------
+# Thumbnail-stage failure must not deadlock the scanner
+# ---------------------------------------------------------------------------
+
+
+def test_thumbnail_setup_failure_does_not_deadlock_scanner(tmp_path, monkeypatch):
+    """If thumbnail_stage dies BEFORE its drain loop (import, Database(),
+    cfg.load(), os.makedirs can all raise), the scanner's blocking
+    scan_to_thumb.put() would wedge forever once the queue fills — the
+    orchestrator's threads["scanner"].join() then never returns and the
+    job leaks a pipeline slot until restart. The failure path must set
+    abort and drain the queue so the producer can never block forever.
+
+    The scan→thumbnail queue is shrunk to maxsize=2 so a handful of photos
+    reproduces the >maxsize condition; the pipeline runs on a worker thread
+    with a timeout so a regression fails fast instead of hanging pytest.
+    """
+    import queue as queue_mod
+
+    import config as cfg
+    from db import Database
+    from PIL import Image
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    photo_dir = tmp_path / "photos"
+    photo_dir.mkdir()
+    for i in range(8):
+        Image.new("RGB", (16, 16), "red").save(str(photo_dir / f"p{i}.jpg"))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    # Shrink only the pipeline's scan→thumb queue (created with maxsize=200)
+    # so the scanner outruns the dead consumer after 2 photos.
+    real_queue_cls = queue_mod.Queue
+
+    def small_queue(maxsize=0):
+        return real_queue_cls(maxsize=2 if maxsize == 200 else maxsize)
+
+    monkeypatch.setattr(queue_mod, "Queue", small_queue)
+
+    # Break thumbnail_stage before its drain loop: deleting the symbol makes
+    # `from thumbnails import generate_thumbnail` raise ImportError.
+    import thumbnails as thumbs_mod
+    monkeypatch.delattr(thumbs_mod, "generate_thumbnail")
+
+    params = PipelineParams(
+        source=str(photo_dir),
+        skip_classify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+    runner = FakeRunner()
+    job = _make_job()
+
+    done = threading.Event()
+    outcome = {}
+
+    def _run():
+        try:
+            outcome["result"] = run_pipeline_job(job, runner, db_path, ws_id, params)
+        except Exception as e:  # stage failure propagates as RuntimeError
+            outcome["error"] = e
+        finally:
+            done.set()
+
+    worker = threading.Thread(target=_run, daemon=True)
+    worker.start()
+    assert done.wait(60), (
+        "run_pipeline_job did not terminate — the scanner is deadlocked on "
+        "scan_to_thumb.put() after the thumbnail consumer died"
+    )
+
+    # The thumbnails stage must end failed and the job must propagate it.
+    thumb_statuses = [
+        kw["status"] for (_, sid, kw) in runner.step_updates
+        if sid == "thumbnails" and "status" in kw
+    ]
+    assert thumb_statuses and thumb_statuses[-1] == "failed"
+    assert isinstance(outcome.get("error"), RuntimeError), (
+        f"expected the thumbnails stage failure to propagate, got {outcome!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Previews must land under the configured thumb dir's parent
+# ---------------------------------------------------------------------------
+
+
+def test_previews_stage_uses_thumb_cache_dir_parent(tmp_path, monkeypatch):
+    """With a custom --thumb-dir, previews_stage must write preview files,
+    preview_cache rows, and run quota eviction under
+    dirname(thumb_cache_dir)/previews — the root app.py serves, reconciles,
+    and evicts. Writing under dirname(db_path)/previews instead leaves
+    warmed previews that are never served, rows reaped as ghosts, and
+    orphan JPEGs outside the quota.
+    """
+    import config as cfg
+    from db import Database
+    from PIL import Image
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    photo_dir = tmp_path / "photos"
+    photo_dir.mkdir()
+    Image.new("RGB", (64, 64), "green").save(str(photo_dir / "a.jpg"))
+
+    db_dir = tmp_path / "dbhome"
+    db_dir.mkdir()
+    db_path = str(db_dir / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    # Custom cache root, deliberately outside dirname(db_path).
+    custom_root = tmp_path / "custom_cache"
+    thumb_dir = custom_root / "thumbnails"
+
+    params = PipelineParams(
+        source=str(photo_dir),
+        skip_classify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+        preview_max_size=1920,
+    )
+    runner = FakeRunner()
+    job = _make_job()
+    run_pipeline_job(
+        job, runner, db_path, ws_id, params, thumb_cache_dir=str(thumb_dir),
+    )
+
+    db2 = Database(db_path)
+    db2.set_active_workspace(ws_id)
+    photo_id = db2.get_photos(per_page=1)[0]["id"]
+
+    served_path = custom_root / "previews" / f"{photo_id}_1920.jpg"
+    assert served_path.is_file(), (
+        "preview must be written under dirname(thumb_cache_dir)/previews "
+        "to match the Flask serve convention"
+    )
+    orphan_path = db_dir / "previews" / f"{photo_id}_1920.jpg"
+    assert not orphan_path.exists(), (
+        "preview must NOT be written under dirname(db_path)/previews when "
+        "a custom thumb_cache_dir is configured"
+    )
+    # The preview_cache row must account for the file the app will serve.
+    assert db2.preview_cache_get(photo_id, 1920) is not None
+
+
+# ---------------------------------------------------------------------------
+# Aborted pipelines must not leave step rows stuck at "pending"
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_abort_finalizes_all_step_rows(tmp_path, monkeypatch):
+    """When the pipeline aborts early (user cancel here), every step row
+    created by runner.set_steps — including previews, extract_masks,
+    eye_keypoints, regroup, and misses — must reach a terminal status.
+    Gating those stage calls on `if not abort.is_set()` left their rows
+    persisted as "pending" with no finished_at, forever (the same defect
+    previously fixed for detect/classify).
+    """
+    import config as cfg
+    from db import Database
+    from PIL import Image
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    photo_dir = tmp_path / "photos"
+    photo_dir.mkdir()
+    for name in ("a.jpg", "b.jpg"):
+        Image.new("RGB", (16, 16), "blue").save(str(photo_dir / name))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    # All optional stages enabled so their step rows exist; classify is
+    # skipped to keep the test free of model files.
+    params = PipelineParams(
+        source=str(photo_dir),
+        skip_classify=True,
+    )
+    runner = FakeRunner()
+    job = _make_job()
+    # Pre-cancel: the cancel watcher sets the local abort event immediately,
+    # so the post-scan stages all hit their abort skip paths.
+    runner.cancelled_ids.add(job["id"])
+
+    run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    terminal = {"completed", "failed", "cancelled"}
+    for step in runner.steps_defined:
+        statuses = [
+            kw["status"] for (_, sid, kw) in runner.step_updates
+            if sid == step["id"] and "status" in kw
+        ]
+        final = statuses[-1] if statuses else None
+        assert final in terminal, (
+            f"Step {step['id']!r} must reach a terminal status on an aborted "
+            f"pipeline, got {final!r} (history={statuses})"
+        )
+
+
+def test_pipeline_regroup_failure_finalizes_miss_step_row(tmp_path, monkeypatch):
+    """When regroup_stage fails (without abort), miss_stage must still be
+    invoked so the misses row reaches a terminal "Skipped" state instead of
+    persisting as pending — while still never touching miss_* DB state
+    (regroup's burst_id output is its prerequisite).
+    """
+    import config as cfg
+    import pipeline as pipeline_mod
+    from db import Database
+    from PIL import Image
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    photo_dir = tmp_path / "photos"
+    photo_dir.mkdir()
+    Image.new("RGB", (16, 16), "black").save(str(photo_dir / "a.jpg"))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("synthetic regroup failure")
+
+    monkeypatch.setattr(pipeline_mod, "run_full_pipeline", _boom)
+
+    params = PipelineParams(
+        source=str(photo_dir),
+        skip_classify=True,
+        skip_extract_masks=True,
+    )
+    runner = FakeRunner()
+    job = _make_job()
+
+    with contextlib.suppress(Exception):
+        run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    miss_statuses = [
+        kw["status"] for (_, sid, kw) in runner.step_updates
+        if sid == "misses" and "status" in kw
+    ]
+    assert miss_statuses, "misses row got no status update after regroup failure"
+    assert miss_statuses[-1] == "completed", (
+        f"misses must finalize as a skipped/completed row, got {miss_statuses}"
+    )
+    # The skip path must not have mutated miss state.
+    db2 = Database(db_path)
+    db2.set_active_workspace(ws_id)
+    rows = db2.conn.execute("SELECT miss_computed_at FROM photos").fetchall()
+    assert rows and all(r["miss_computed_at"] is None for r in rows)

--- a/vireo/tests/test_review_server.py
+++ b/vireo/tests/test_review_server.py
@@ -276,3 +276,45 @@ def test_batch_accept_filters_by_category():
             data = json.load(f)
         assert data['photos'][0]['status'] == 'accepted'
         assert data['photos'][1]['status'] == 'pending'
+
+
+def test_batch_accept_rejects_non_numeric_min_confidence():
+    """An invalid min_confidence returns 400 before any sidecar writes,
+    so XMP sidecars and results.json can't desync mid-batch."""
+    from review_server import create_app
+    from xmp import read_keywords
+    with tempfile.TemporaryDirectory() as tmpdir:
+        results_path = _create_test_review_data(tmpdir)
+        app = create_app(tmpdir)
+        client = app.test_client()
+
+        resp = client.post('/api/accept-batch', json={'min_confidence': 'high'})
+        assert resp.status_code == 400
+
+        # Nothing was written or accepted
+        with open(results_path) as f:
+            data = json.load(f)
+        assert data['photos'][0]['status'] == 'pending'
+        assert 'Northern cardinal' not in read_keywords(
+            os.path.join(tmpdir, 'bird1.xmp')
+        )
+
+
+def test_batch_accept_coerces_numeric_string_min_confidence():
+    """A numeric string min_confidence is coerced instead of raising
+    TypeError mid-loop."""
+    from review_server import create_app
+    with tempfile.TemporaryDirectory() as tmpdir:
+        results_path = _create_test_review_data(tmpdir)
+        app = create_app(tmpdir)
+        client = app.test_client()
+
+        # Photo confidence is 0.85 — below "0.9", so nothing accepted
+        resp = client.post('/api/accept-batch', json={'min_confidence': '0.9'})
+        assert resp.status_code == 200
+        assert resp.get_json()['accepted'] == 0
+
+        # And above "0.8", it is accepted
+        resp = client.post('/api/accept-batch', json={'min_confidence': '0.8'})
+        assert resp.status_code == 200
+        assert resp.get_json()['accepted'] == 1

--- a/vireo/tests/test_review_server.py
+++ b/vireo/tests/test_review_server.py
@@ -318,3 +318,27 @@ def test_batch_accept_coerces_numeric_string_min_confidence():
         resp = client.post('/api/accept-batch', json={'min_confidence': '0.8'})
         assert resp.status_code == 200
         assert resp.get_json()['accepted'] == 1
+
+
+def test_batch_accept_rejects_non_finite_min_confidence():
+    """NaN coerces via float() but every `confidence < NaN` comparison is
+    false, which would silently accept ALL pending photos — so non-finite
+    thresholds must 400 before any sidecar writes."""
+    from review_server import create_app
+    from xmp import read_keywords
+    with tempfile.TemporaryDirectory() as tmpdir:
+        results_path = _create_test_review_data(tmpdir)
+        app = create_app(tmpdir)
+        client = app.test_client()
+
+        for bad in ('nan', 'inf', '-inf'):
+            resp = client.post('/api/accept-batch', json={'min_confidence': bad})
+            assert resp.status_code == 400, bad
+
+        # Nothing was written or accepted
+        with open(results_path) as f:
+            data = json.load(f)
+        assert data['photos'][0]['status'] == 'pending'
+        assert 'Northern cardinal' not in read_keywords(
+            os.path.join(tmpdir, 'bird1.xmp')
+        )


### PR DESCRIPTION
## Summary

A six-agent full-repo bug hunt (data layer, routes, background jobs, frontend, support modules) surfaced 27 verified bugs; this PR fixes all of them across six commits, one per subsystem.

### Pipeline jobs (`pipeline_job.py`, `classify_job.py`)
- **Thumbnail-stage setup failure no longer deadlocks the scanner** (high): the failure path now sets `abort` and drains `scan_to_thumb` to the sentinel, and the scanner's `photo_cb` uses an abort-aware put — a failed `os.makedirs` etc. can no longer wedge the job forever and leak a pipeline slot.
- previews_stage writes previews/`preview_cache` rows/eviction under `dirname(THUMB_CACHE_DIR)` (the serve convention) instead of `dirname(db_path)`, fixing never-served previews and unbounded orphan JPEGs with a custom `--thumb-dir`.
- Aborted pipelines and classify-job early returns no longer persist step rows stuck at `pending` forever.

### Routes (`app.py`)
- Cross-workspace leak closed: `/api/photos/<id>`, `/photos/<id>/preview|full|original|crop`, `/api/photos/<id>/pipeline`, `/api/detections/<id>` now pass `verify_workspace=True` (mirrors `serve_thumbnail`).
- Color-label endpoints verify existence + workspace (no more FK 500s on stale ids; batch no longer aborts mid-batch).
- Unknown workspace/folder ids return 404 instead of 500; `config_overrides` must be an object; collection `add-photos` validates integer ids; detach-burst validates index types; audit resolve validates direction; `/api/sync/discard` reports the true count.
- `config.json` read-modify-writes (`setup_complete`, scan roots, recent destinations) now run under `_settings_write_lock` with raw reads — no more lost concurrent settings writes or default-pinning.
- `api_encounter_species` chunks its IN clauses.

### Data layer (`db.py`)
- Chunked unbounded `IN` clauses in `list_photos_for_eye_keypoint_stage`, `get_predictions`, `get_keywords_for_photos`, `delete_photos`, `apply_duplicate_resolution`, `get_inat_submissions`; static-collection `photo_ids` rules inline integer literals so large collections stay queryable past the SQLite bound-parameter cap.
- `get_inat_submissions` now returns each photo's **newest** submission (dict overwrite previously inverted the ordering).
- Active-labels accessors guard against non-dict `config_overrides`.

### Frontend (`_navbar.html`, `browse.html`, `review.html`, `pipeline.html`, `jobs.html`, `settings.html`)
- Five XSS stragglers fixed (Pipeline Inspector filename, Find Similar filenames incl. attribute breakout, labels picker, readiness panel, plan summary) — DOM-node construction / `escapeHtml` per the #972 conventions.
- Jobs page renders `cancelled` steps with a distinct icon and shows summaries for all terminal statuses (follow-up to #971).
- Calendar day click now filters to exactly that day (was blanking `date_to`).
- Review `A`/`S` shortcuts act on the first *visible* pending card and no-op under overlays; lightbox takes keyboard precedence over the burst modal (arrows no longer invisibly re-triage photos); arrows respect form fields in the lightbox.
- Cancelled pipeline stages keep their "Cancelled" pill (was reverting to "Will skip"); clearing a workspace-override field no longer silently deletes the override while the UI claims it's active; iNat batch submit cancels gracefully with a partial-result toast.

### Support modules
- `capture_time.py` treats ExifTool exit 1 as a failed write (was reporting failed writes as successful updates).
- `culling.py`: solo-photo fallback key no longer collides with cluster indices (wrong keep/reject suggestions); mixed-dimension embedding dots are guarded like bursts/encounters/selection.
- Case-only keyword drift is no longer reported as permanently-unresolvable (audit now compares case-insensitively, matching sync).
- `review_server.py` validates `min_confidence` before any sidecar writes.

## Test results

- Standard suite on the merged branch: **1109 passed, 1 skipped**
- `test_pipeline_job.py` + `test_classify_job.py` on the merged branch: **228 passed**
- 20+ new regression tests added across `test_db.py`, `test_app.py`, `test_photos_api.py`, `test_pipeline_job.py`, `test_classify_job.py`, `test_culling.py`, `test_audit.py`, `test_capture_time_api.py`, `test_review_server.py`; key new tests verified to fail on pre-fix code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed job step status remaining stuck in "pending" on early exits; jobs now properly finalize all steps when cancelled or skipped.
  * Improved pipeline abort handling to prevent scanner deadlocks and ensure all stages reach terminal status.
  * Corrected calendar date filter to use bare date format instead of datetime with time suffix.
  * Enhanced keyboard shortcut handling to respect active overlays and modal states.
  * Strengthened workspace isolation to prevent cross-workspace photo data leakage.

* **New Features**
  * Added visual support for cancelled job status in job inspector UI.

* **Improvements**
  * Refined input validation for numeric settings and endpoint payloads.
  * Hardened HTML rendering to prevent injection issues from user-controlled filenames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->