### PR TITLE
Suppress console-window flash on Windows for external CLI tools

### DIFF
--- a/vireo/capture_time.py
+++ b/vireo/capture_time.py
@@ -9,6 +9,7 @@ import subprocess
 from datetime import datetime, timedelta
 
 from metadata import extract_metadata
+from proc import no_window_kwargs
 
 log = logging.getLogger(__name__)
 
@@ -374,6 +375,7 @@ def adjust_capture_time(
                 capture_output=True,
                 text=True,
                 timeout=120,
+                **no_window_kwargs(),
             )
             if result.returncode != 0:
                 # ExifTool exits 0 on success (warnings included) and 1 when

--- a/vireo/capture_time.py
+++ b/vireo/capture_time.py
@@ -9,7 +9,10 @@ import subprocess
 from datetime import datetime, timedelta
 
 from metadata import extract_metadata
-from proc import no_window_kwargs
+try:
+    from .proc import no_window_kwargs
+except ImportError:
+    from proc import no_window_kwargs
 
 log = logging.getLogger(__name__)
 

--- a/vireo/develop.py
+++ b/vireo/develop.py
@@ -7,6 +7,8 @@ import shutil
 import subprocess
 import tempfile
 
+from proc import no_window_kwargs
+
 log = logging.getLogger(__name__)
 
 _DIAG_MAX_CHARS = 500
@@ -210,7 +212,9 @@ def convert_to_dng(dng_converter_bin, input_path, output_dir):
 
     cmd = [binary, "-dng1.4", "-d", output_dir, input_path]
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=180)
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=180, **no_window_kwargs()
+        )
         if result.returncode != 0:
             diag = _format_subprocess_diag(result.stdout, result.stderr)
             return {
@@ -289,7 +293,9 @@ def develop_photo(
 
     try:
         log.info("Developing %s -> %s", os.path.basename(input_path), output_path)
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=120, **no_window_kwargs()
+        )
         if result.returncode != 0:
             # darktable-cli writes init/IO failures to stdout, not stderr.
             diag = _format_subprocess_diag(result.stdout, result.stderr)

--- a/vireo/develop.py
+++ b/vireo/develop.py
@@ -7,7 +7,10 @@ import shutil
 import subprocess
 import tempfile
 
-from proc import no_window_kwargs
+try:
+    from .proc import no_window_kwargs
+except ImportError:
+    from proc import no_window_kwargs
 
 log = logging.getLogger(__name__)
 

--- a/vireo/metadata.py
+++ b/vireo/metadata.py
@@ -9,7 +9,10 @@ import logging
 import subprocess
 import sys
 
-from proc import no_window_kwargs
+try:
+    from .proc import no_window_kwargs
+except ImportError:
+    from proc import no_window_kwargs
 
 log = logging.getLogger(__name__)
 

--- a/vireo/metadata.py
+++ b/vireo/metadata.py
@@ -7,6 +7,9 @@ Returns grouped tag dictionaries keyed by ExifTool group (EXIF, GPS, XMP, etc.).
 import json
 import logging
 import subprocess
+import sys
+
+from proc import no_window_kwargs
 
 log = logging.getLogger(__name__)
 
@@ -15,6 +18,19 @@ _BATCH_SIZE = 100
 _EXIFTOOL_TIMEOUT = 120
 _MAX_TIMEOUT_SPLIT_ATTEMPTS = 16
 _TIMEOUT = object()
+
+
+def _exiftool_install_hint() -> str:
+    """Platform-appropriate guidance for installing exiftool.
+
+    The macOS-only ``brew install exiftool`` hint is wrong on Windows
+    (no Homebrew) and Linux, so tailor the message per platform.
+    """
+    if sys.platform == "win32":
+        return "download it from https://exiftool.org"
+    if sys.platform == "darwin":
+        return "install it with: brew install exiftool"
+    return "install it with your package manager (e.g. apt install libimage-exiftool-perl)"
 
 
 def _run_exiftool(file_paths, extra_args=None):
@@ -42,6 +58,7 @@ def _run_exiftool(file_paths, extra_args=None):
             capture_output=True,
             text=True,
             timeout=_EXIFTOOL_TIMEOUT,
+            **no_window_kwargs(),
         )
         if result.returncode not in (0, 1):
             # returncode 1 = warnings (e.g. minor errors), still has output
@@ -51,7 +68,7 @@ def _run_exiftool(file_paths, extra_args=None):
             return json.loads(result.stdout)
         return []
     except FileNotFoundError:
-        log.error("exiftool not found — install it with: brew install exiftool")
+        log.error("exiftool not found — %s", _exiftool_install_hint())
     except subprocess.TimeoutExpired:
         log.error("exiftool timed out processing %d files", len(file_paths))
         return _TIMEOUT

--- a/vireo/proc.py
+++ b/vireo/proc.py
@@ -1,0 +1,35 @@
+"""Subprocess helpers shared across Vireo.
+
+The packaged desktop app runs with ``windows_subsystem = "windows"`` on
+Windows (see ``src-tauri/src/main.rs``), so the Flask sidecar has no
+attached console. Spawning a *console* program such as ``exiftool``,
+``darktable-cli``, or the Adobe DNG converter would otherwise pop a
+visible console window for the fraction of a second the child runs —
+once per metadata read, develop, or capture-time edit. That flicker is
+the kind of "lost Windows polish" users notice immediately.
+
+``subprocess.CREATE_NO_WINDOW`` suppresses the console window. The flag
+only exists on Windows, so callers splat :func:`no_window_kwargs` into
+their ``subprocess.run`` / ``Popen`` calls and get an empty dict (a
+no-op) on POSIX, keeping the call sites portable.
+"""
+
+import subprocess
+import sys
+
+# CREATE_NO_WINDOW is defined only on the Windows build of the stdlib.
+# getattr keeps this module importable on POSIX, where the flag is absent.
+_CREATE_NO_WINDOW = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+
+
+def no_window_kwargs() -> dict:
+    """Return ``subprocess`` kwargs that hide the console window on Windows.
+
+    Splat into any ``subprocess.run`` / ``subprocess.Popen`` call that
+    launches a console program (exiftool, darktable-cli, the Adobe DNG
+    converter) so the packaged windowless GUI app doesn't flash a console
+    window. Returns ``{}`` on non-Windows platforms.
+    """
+    if sys.platform == "win32":
+        return {"creationflags": _CREATE_NO_WINDOW}
+    return {}

--- a/vireo/tests/test_proc.py
+++ b/vireo/tests/test_proc.py
@@ -1,0 +1,77 @@
+"""Tests for vireo/proc.py and the Windows console-window suppression
+applied to external CLI tool invocations (exiftool, darktable-cli, DNG).
+
+On Windows the packaged GUI app has no console, so spawning a console
+program flashes a console window unless CREATE_NO_WINDOW is passed. These
+tests assert the flag is set on win32 and absent elsewhere.
+"""
+
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import proc
+
+
+def test_no_window_kwargs_empty_on_posix(monkeypatch):
+    monkeypatch.setattr(proc.sys, "platform", "linux")
+    assert proc.no_window_kwargs() == {}
+
+
+def test_no_window_kwargs_empty_on_macos(monkeypatch):
+    monkeypatch.setattr(proc.sys, "platform", "darwin")
+    assert proc.no_window_kwargs() == {}
+
+
+def test_no_window_kwargs_sets_flag_on_windows(monkeypatch):
+    monkeypatch.setattr(proc.sys, "platform", "win32")
+    # CREATE_NO_WINDOW is absent from the POSIX stdlib, so the module
+    # captures it as 0 there. Force a representative non-zero value so the
+    # test is meaningful regardless of the host platform.
+    monkeypatch.setattr(proc, "_CREATE_NO_WINDOW", 0x08000000)
+    assert proc.no_window_kwargs() == {"creationflags": 0x08000000}
+
+
+def test_run_exiftool_passes_no_window_on_windows(monkeypatch):
+    import metadata
+
+    monkeypatch.setattr(metadata.sys, "platform", "win32")
+    monkeypatch.setattr(proc.sys, "platform", "win32")
+    monkeypatch.setattr(proc, "_CREATE_NO_WINDOW", 0x08000000)
+
+    with patch("metadata.subprocess.run") as run:
+        run.return_value = type("R", (), {"returncode": 0, "stdout": "[]", "stderr": ""})()
+        metadata._run_exiftool(["/tmp/x.jpg"])
+
+    _args, kwargs = run.call_args
+    assert kwargs.get("creationflags") == 0x08000000
+
+
+def test_run_exiftool_no_flag_on_posix(monkeypatch):
+    import metadata
+
+    monkeypatch.setattr(proc.sys, "platform", "linux")
+
+    with patch("metadata.subprocess.run") as run:
+        run.return_value = type("R", (), {"returncode": 0, "stdout": "[]", "stderr": ""})()
+        metadata._run_exiftool(["/tmp/x.jpg"])
+
+    _args, kwargs = run.call_args
+    assert "creationflags" not in kwargs
+
+
+def test_exiftool_install_hint_per_platform(monkeypatch):
+    import metadata
+
+    monkeypatch.setattr(metadata.sys, "platform", "win32")
+    assert "exiftool.org" in metadata._exiftool_install_hint()
+
+    monkeypatch.setattr(metadata.sys, "platform", "darwin")
+    assert "brew install exiftool" in metadata._exiftool_install_hint()
+
+    monkeypatch.setattr(metadata.sys, "platform", "linux")
+    hint = metadata._exiftool_install_hint()
+    assert "brew" not in hint
+    assert "package manager" in hint


### PR DESCRIPTION
The packaged desktop app runs with windows_subsystem = "windows" on
Windows, so the Flask sidecar has no attached console. Every spawn of a
console program (exiftool, darktable-cli, the Adobe DNG converter) popped
a visible console window for the moment the child ran — once per metadata
read, develop, or capture-time edit.

Add a shared proc.no_window_kwargs() helper that sets CREATE_NO_WINDOW on
Windows (and is a no-op on POSIX), and splat it into those subprocess
calls. Also make the 'exiftool not found' hint platform-aware instead of
always suggesting Homebrew, which doesn't exist on Windows or Linux.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Platform-specific installation guidance for exiftool on Windows, macOS, and Linux.

* **Improvements**
  * Enhanced handling of external tool launches with platform-aware subprocess configuration.

* **Tests**
  * Added comprehensive tests for cross-platform subprocess behavior and external tool integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->