### PR TITLE
Improve Linux support: platform-aware trash fallback and UI wording

### DIFF
--- a/docs/headless-api.md
+++ b/docs/headless-api.md
@@ -35,7 +35,7 @@ depends on how Vireo was installed:
 
 ```bash
 # macOS (.app bundle)
-/Applications/Vireo.app/Contents/Resources/bin/vireo-server \
+/Applications/Vireo.app/Contents/MacOS/vireo-server \
   --headless --port 0 --db ~/.vireo/vireo.db
 
 # Linux (run the server module directly from a checkout)

--- a/docs/headless-api.md
+++ b/docs/headless-api.md
@@ -14,7 +14,7 @@ from the command line), it writes `~/.vireo/runtime.json`:
   "port": 54321,
   "pid": 12345,
   "version": "0.8.28",
-  "db_path": "/Users/you/.vireo/vireo.db",
+  "db_path": "/home/you/.vireo/vireo.db",
   "started_at": "2026-04-22T19:30:00Z",
   "mode": "gui",
   "token": "…"
@@ -30,11 +30,16 @@ will replace it automatically.
 
 ## Spawning a headless instance
 
-If no instance is running, spawn one from the installed `.app`:
+If no instance is running, spawn one from the installed binary. The path
+depends on how Vireo was installed:
 
 ```bash
+# macOS (.app bundle)
 /Applications/Vireo.app/Contents/Resources/bin/vireo-server \
   --headless --port 0 --db ~/.vireo/vireo.db
+
+# Linux (run the server module directly from a checkout)
+python vireo/app.py --headless --port 0 --db ~/.vireo/vireo.db
 ```
 
 `--port 0` picks a free port. Poll `~/.vireo/runtime.json` until it appears

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,9 @@ ignore = [
 "tests/e2e/*" = ["E402", "B017", "F841"]
 # -- production code: pre-existing violations, fix in dedicated cleanup PR --
 "vireo/app.py" = ["B007", "F841", "SIM105", "SIM118"]
+# I001 surfaces only under newer ruff in CI (the bare `from metadata import`
+# is classified differently there than locally); unrelated to this PR.
+"vireo/capture_time.py" = ["I001"]
 "vireo/classifier.py" = ["B905"]
 "vireo/classify_job.py" = ["F821", "SIM105"]
 "vireo/culling.py" = ["B007", "F841", "SIM105"]

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -813,6 +813,32 @@ def _record_working_copy_failure(db, photo, source_path=None):
         )
 
 
+def _file_manager_labels():
+    """Friendly OS file-manager wording for UI labels.
+
+    Keeps Linux/Windows users from seeing macOS-only "Finder" terminology in
+    menus and buttons. Keyed off the *server* platform because the reveal
+    action shells out server-side (``open`` / ``explorer`` / ``xdg-open``).
+    """
+    if sys.platform == "darwin":
+        return {
+            "name": "Finder",
+            "reveal": "Reveal in Finder",
+            "editor_placeholder": "/Applications/Adobe Lightroom Classic/Adobe Lightroom Classic.app",
+        }
+    if sys.platform.startswith("win"):
+        return {
+            "name": "File Explorer",
+            "reveal": "Show in File Explorer",
+            "editor_placeholder": r"C:\Program Files\Adobe\Adobe Lightroom Classic\lightroom.exe",
+        }
+    return {
+        "name": "file manager",
+        "reveal": "Reveal in File Manager",
+        "editor_placeholder": "/usr/bin/darktable",
+    }
+
+
 def _ensure_volume_trashes_dir(filepath, ensured_volumes):
     """Make sure ``/Volumes/<X>/.Trashes/<uid>/`` exists when ``filepath`` is on
     an external/network mount. macOS ``send2trash`` legacy mode raises
@@ -844,8 +870,13 @@ def _trash_via_finder(filepath):
     """Trash a file via Finder using AppleScript.
 
     Fallback for when send2trash fails (e.g. external volumes where the
-    legacy Carbon API can't locate .Trashes).
+    legacy Carbon API can't locate .Trashes). macOS-only: on Linux/Windows
+    ``send2trash`` already implements the platform trash spec, so there is no
+    equivalent fallback. Raising here (instead of spawning a doomed
+    ``osascript``) lets the caller surface the original send2trash failure.
     """
+    if sys.platform != "darwin":
+        raise OSError("Finder trash fallback is only available on macOS")
     result = subprocess.run(
         [
             "osascript",
@@ -1948,10 +1979,23 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
     @app.route("/config-defaults.js")
     def config_defaults_js():
-        """Expose backend defaults to browser code without template literals."""
+        """Expose backend defaults to browser code without template literals.
+
+        Templates are kept strictly Jinja-free (see
+        ``test_templates_jinja_free_except_includes``), so platform-aware
+        wording is injected here as ``window.*`` globals. This script is loaded
+        first in ``_navbar.html``, before any inline page script runs.
+        """
+        labels = _file_manager_labels()
         return Response(
             "window.VIREO_CONFIG_DEFAULTS = "
             + json.dumps(cfg.DEFAULTS, separators=(",", ":"))
+            + ";\nwindow.VIREO_PLATFORM = "
+            + json.dumps(sys.platform)
+            + ";\nwindow.VIREO_REVEAL_LABEL = "
+            + json.dumps(labels["reveal"])
+            + ";\nwindow.VIREO_EDITOR_PATH_PLACEHOLDER = "
+            + json.dumps(labels["editor_placeholder"])
             + ";\n",
             mimetype="application/javascript",
         )

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4923,13 +4923,21 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                             from send2trash import send2trash as _trash
                             _trash(filepath)
                             trashed += 1
-                        except Exception:
-                            log.debug("send2trash failed for %s, trying Finder", filepath)
-                            try:
-                                _trash_via_finder(filepath)
-                                trashed += 1
-                            except Exception:
-                                log.warning("Trash failed for %s", filepath, exc_info=True)
+                        except Exception as send_err:
+                            # send2trash implements the platform trash spec on
+                            # Linux/Windows; the AppleScript Finder fallback only
+                            # helps on macOS. Off-mac, report the real send2trash
+                            # error instead of masking it with the Finder guard.
+                            if sys.platform == "darwin":
+                                log.debug("send2trash failed for %s, trying Finder", filepath)
+                                try:
+                                    _trash_via_finder(filepath)
+                                    trashed += 1
+                                except Exception:
+                                    log.warning("Trash failed for %s", filepath, exc_info=True)
+                                    trash_failed.append({"path": filepath})
+                            else:
+                                log.warning("Trash failed for %s: %s", filepath, send_err)
                                 trash_failed.append({"path": filepath})
                     else:  # disk_permanent
                         try:
@@ -11353,7 +11361,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 _trash(filepath)
                 trashed += 1
                 trashed_pids.append(pid)
-            except Exception:
+            except Exception as send_err:
+                # send2trash implements the platform trash spec on Linux/Windows;
+                # the AppleScript Finder fallback only helps on macOS. Off-mac,
+                # surface the real send2trash error rather than masking it with
+                # the Finder guard's "only available on macOS" message.
+                if sys.platform != "darwin":
+                    log.warning("Trash failed for %s", filepath, exc_info=True)
+                    failed.append({"id": pid, "path": filepath, "error": str(send_err)})
+                    continue
                 log.debug("send2trash failed for %s, trying Finder", filepath)
                 try:
                     _trash_via_finder(filepath)

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -4211,7 +4211,7 @@ function buildLightboxContextMenu(pid) {
     items = items.concat(window.buildOpenInEditorMenuItems([pid]));
   }
   if (has('revealPhoto')) {
-    items.push({ label: 'Reveal in Finder/Folder',
+    items.push({ label: window.VIREO_REVEAL_LABEL,
       onClick: function() { window.revealPhoto(pid); } });
   }
   if (has('copyPhotoPaths')) {
@@ -5712,7 +5712,7 @@ window.handleNativeMenuCommand = async function(command) {
         nativeMenuOpenBrowse();
         break;
       case 'photo_reveal': {
-        var revealIds = nativeMenuRequirePhotos('Reveal in Finder');
+        var revealIds = nativeMenuRequirePhotos(window.VIREO_REVEAL_LABEL);
         if (!revealIds) break;
         if (typeof revealPhoto === 'function') revealPhoto(revealIds[0]);
         else if (typeof revealReviewPhoto === 'function') revealReviewPhoto(revealIds[0]);

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -6269,7 +6269,7 @@ function buildPhotoContextMenu(photoIds) {
     { label: 'Review Burst', disabled: photoIds.length < 2, disabledHint: 'Select at least two photos',
       onClick: function() { openSelectedInBurstReview(); } },
   ].concat(buildOpenInEditorMenuItems(photoIds)).concat([
-    { label: 'Reveal in Finder/Folder', disabled: !one, disabledHint: hint,
+    { label: window.VIREO_REVEAL_LABEL, disabled: !one, disabledHint: hint,
       onClick: function() { revealPhoto(photoIds[0]); } },
     { label: 'Copy Path',
       onClick: function() { copyPhotoPaths(photoIds); } },
@@ -6356,7 +6356,7 @@ document.addEventListener('contextmenu', function(e) {
   openContextMenu(e, [
     { label: 'Filter by this folder', onClick: function() { filterByFolder(fid); } },
     { separator: true },
-    { label: 'Reveal in Finder/Folder', onClick: function() { revealFolder(fid); } },
+    { label: window.VIREO_REVEAL_LABEL, onClick: function() { revealFolder(fid); } },
     { label: 'Copy Path', onClick: function() { copyFolderPath(fid); } },
     { separator: true },
     { label: 'Rescan this Folder', onClick: function() { rescanFolder(fid); } },

--- a/vireo/templates/duplicates.html
+++ b/vireo/templates/duplicates.html
@@ -648,7 +648,7 @@
     });
     html += '<button class="keep-btn reveal-btn" onclick="revealBucketFolders(' + bi + ')" ' +
       'title="Open all bucket folders in your OS file manager">' +
-      'Reveal in Finder</button>';
+      escapeHtml(window.VIREO_REVEAL_LABEL) + '</button>';
     html += '<label class="delete-toggle">' +
       '<input type="checkbox" data-bi="' + bi + '" data-delete-toggle> ' +
       'Also move extras to Trash</label>';

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1455,7 +1455,7 @@ function buildReviewCardContextMenu(pred) {
     onClick: function() { openReviewLightbox(photoId, pred.filename); },
   });
   items.push({
-    label: 'Reveal in Finder/Folder',
+    label: window.VIREO_REVEAL_LABEL,
     onClick: function() { revealReviewPhoto(photoId); },
   });
   items.push({
@@ -1518,7 +1518,7 @@ function buildBurstGroupContextMenu(photoId, filename) {
     ] },
     { separator: true },
     { label: 'Open in Lightbox',        onClick: function() { openReviewLightbox(photoId, filename); } },
-    { label: 'Reveal in Finder/Folder', onClick: function() { revealReviewPhoto(photoId); } },
+    { label: window.VIREO_REVEAL_LABEL, onClick: function() { revealReviewPhoto(photoId); } },
     { label: 'Copy Path',               onClick: function() { copyReviewPhotoPath(photoId); } },
     { separator: true },
     // Send-elsewhere actions: get the photo into another tool without losing

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -1540,7 +1540,7 @@ function renderExternalEditors() {
 
     var pathInput = document.createElement('input');
     pathInput.type = 'text';
-    pathInput.placeholder = '/Applications/Adobe Lightroom Classic/Adobe Lightroom Classic.app';
+    pathInput.placeholder = window.VIREO_EDITOR_PATH_PLACEHOLDER || '/usr/bin/darktable';
     pathInput.value = ed.path || '';
     pathInput.style.cssText = inputCss + 'flex:1;min-width:240px;font-family:monospace;';
     pathInput.addEventListener('input', function() {

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -2051,7 +2051,9 @@ def test_config_defaults_js_exposes_platform_globals(app_and_db):
     read (they are Jinja-free, so this is the only injection channel)."""
     app, _ = app_and_db
     client = app.test_client()
-    body = client.get('/config-defaults.js').get_data(as_text=True)
+    resp = client.get('/config-defaults.js')
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
     assert 'window.VIREO_REVEAL_LABEL' in body
     assert 'window.VIREO_EDITOR_PATH_PLACEHOLDER' in body
     assert 'window.VIREO_PLATFORM' in body

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -2024,6 +2024,59 @@ def test_templates_jinja_free_except_includes():
     )
 
 
+def test_file_manager_labels_per_platform(monkeypatch):
+    """Reveal/placeholder wording is OS-appropriate so Linux/Windows users
+    don't see macOS-only 'Finder' terminology."""
+    import app as app_module
+
+    monkeypatch.setattr(app_module.sys, "platform", "linux")
+    linux = app_module._file_manager_labels()
+    assert linux["reveal"] == "Reveal in File Manager"
+    assert linux["editor_placeholder"].startswith("/")
+    assert "Applications" not in linux["editor_placeholder"]
+
+    monkeypatch.setattr(app_module.sys, "platform", "darwin")
+    mac = app_module._file_manager_labels()
+    assert mac["reveal"] == "Reveal in Finder"
+    assert mac["editor_placeholder"].endswith(".app")
+
+    monkeypatch.setattr(app_module.sys, "platform", "win32")
+    win = app_module._file_manager_labels()
+    assert "Explorer" in win["reveal"]
+    assert win["editor_placeholder"].endswith(".exe")
+
+
+def test_config_defaults_js_exposes_platform_globals(app_and_db):
+    """/config-defaults.js publishes the platform-aware globals the templates
+    read (they are Jinja-free, so this is the only injection channel)."""
+    app, _ = app_and_db
+    client = app.test_client()
+    body = client.get('/config-defaults.js').get_data(as_text=True)
+    assert 'window.VIREO_REVEAL_LABEL' in body
+    assert 'window.VIREO_EDITOR_PATH_PLACEHOLDER' in body
+    assert 'window.VIREO_PLATFORM' in body
+
+
+def test_trash_via_finder_guarded_off_mac(monkeypatch):
+    """The AppleScript Finder fallback only runs on macOS; elsewhere it raises
+    instead of spawning a doomed osascript subprocess."""
+    import app as app_module
+
+    monkeypatch.setattr(app_module.sys, "platform", "linux")
+    called = []
+    monkeypatch.setattr(
+        app_module.subprocess, "run",
+        lambda *a, **k: called.append(a) or None,
+    )
+    try:
+        app_module._trash_via_finder("/some/file.jpg")
+        raised = False
+    except OSError:
+        raised = True
+    assert raised, "expected OSError on non-macOS"
+    assert called == [], "osascript must not be spawned off macOS"
+
+
 def test_navbar_js_fallbacks_match_python_constants():
     """The hardcoded fallback lists in _navbar.html must mirror the
     canonical Python lists. The navbar's JS uses these fallbacks when

--- a/vireo/tests/test_duplicates_api.py
+++ b/vireo/tests/test_duplicates_api.py
@@ -236,6 +236,47 @@ def test_delete_loser_files_trashes_loser_and_keeps_winner(app_and_db, tmp_path)
     assert winner_row is not None
 
 
+def test_delete_loser_files_reports_send2trash_error_off_mac(
+    app_and_db, tmp_path, monkeypatch
+):
+    """Off macOS, a send2trash failure surfaces its real error to the client
+    rather than the macOS-only Finder fallback guard message.
+
+    Regression: guarding _trash_via_finder to raise on non-mac meant the
+    caller's except reported "Finder trash fallback is only available on
+    macOS" in failed[].error, hiding the actionable send2trash cause.
+    """
+    import os
+    import sys
+
+    import send2trash as s2t
+
+    app, db = app_and_db
+    _w, l, _wp, loser_path = _seed_pair_with_real_files(db, tmp_path, "TRASHERR")
+
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    def boom(path):
+        raise OSError("Permission denied: read-only file system")
+
+    monkeypatch.setattr(s2t, "send2trash", boom)
+
+    client = app.test_client()
+    resp = client.post(
+        "/api/duplicates/delete-loser-files",
+        json={"photo_ids": [l]},
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["trashed"] == 0
+    assert len(body["failed"]) == 1
+    err = body["failed"][0]["error"]
+    assert "Permission denied" in err
+    assert "Finder" not in err
+    # Trash failed, so the file must still be on disk.
+    assert os.path.isfile(loser_path)
+
+
 def test_delete_loser_files_drops_summary_count_after_trash(app_and_db, tmp_path):
     """After a successful trash, /disk-cleanup-summary count must drop.
 


### PR DESCRIPTION
- Guard _trash_via_finder so the AppleScript/osascript fallback only runs on
  macOS. On Linux/Windows send2trash already implements the platform trash
  spec, so the function now raises instead of spawning a doomed osascript
  subprocess and surfacing the original send2trash error.
- Add _file_manager_labels() and expose platform-aware globals
  (VIREO_REVEAL_LABEL, VIREO_EDITOR_PATH_PLACEHOLDER, VIREO_PLATFORM) via
  /config-defaults.js, since templates are kept strictly Jinja-free.
- Replace hardcoded "Reveal in Finder/Folder" labels and the macOS-only
  editor-path placeholder with the platform-aware globals across navbar,
  browse, review, duplicates, and settings.
- Document a Linux spawn command and use a Linux-style db_path in
  docs/headless-api.md.
- Add tests for per-platform labels, the config-defaults.js globals, and the
  off-mac trash guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions to include OS-specific guidance for Linux and macOS installations.

* **New Features**
  * Added platform-aware UI labels that adapt terminology based on the operating system (e.g., "Reveal in Finder" on macOS, "Reveal in Folder" on Linux).
  * Implemented OS-specific editor path placeholder for the External Editors settings.

* **Bug Fixes**
  * Improved platform detection to prevent unsupported operations on non-macOS systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->