### PR TITLE
Highlights: remove rejected photos from the grid immediately

### DIFF
--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3343,13 +3343,19 @@ function _lbApplyFlag(photoId, flag) {
       return;
     }
     // Notify pages (e.g. Highlights) that a flag write landed so they can
-    // reconcile their grid — fire even when the user has navigated to another
-    // photo, since the write still succeeded for `photoId`.
-    try {
-      document.dispatchEvent(new CustomEvent('lightbox:flagchanged', {
-        detail: { photoId: photoId, flag: normalized },
-      }));
-    } catch (_) {}
+    // reconcile their grid. Fire only for the latest flag edit: if the user
+    // rapidly changed the flag again (e.g. reject then clear) before this write
+    // resolved, an earlier/superseded write must not drive the grid — otherwise
+    // Highlights could hide a photo whose final backend flag is not 'rejected'.
+    // Arrow-navigating to another photo does not bump _lbFlagEditSeq, so the
+    // event still fires for the photo whose flag was actually changed.
+    if (_lbFlagEditSeq === seq) {
+      try {
+        document.dispatchEvent(new CustomEvent('lightbox:flagchanged', {
+          detail: { photoId: photoId, flag: normalized },
+        }));
+      } catch (_) {}
+    }
     if (_lightboxCurrentId !== photoId) return;
     if (_lbFlagEditSeq === seq || _lbFlagPendingWrites === 0) {
       _lbRecordFlag(photoId, normalized);

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3336,11 +3336,21 @@ function _lbApplyFlag(photoId, flag) {
 
   Promise.resolve(write).then(function(ok) {
     _lbFlagPendingWrites = Math.max(0, _lbFlagPendingWrites - 1);
-    if (_lightboxCurrentId !== photoId) return;
     if (ok === false) {
-      if (_lbFlagEditSeq === seq) _lbSetFlagStatus(_lbConfirmedFlagFor(photoId));
+      if (_lightboxCurrentId === photoId && _lbFlagEditSeq === seq) {
+        _lbSetFlagStatus(_lbConfirmedFlagFor(photoId));
+      }
       return;
     }
+    // Notify pages (e.g. Highlights) that a flag write landed so they can
+    // reconcile their grid — fire even when the user has navigated to another
+    // photo, since the write still succeeded for `photoId`.
+    try {
+      document.dispatchEvent(new CustomEvent('lightbox:flagchanged', {
+        detail: { photoId: photoId, flag: normalized },
+      }));
+    } catch (_) {}
+    if (_lightboxCurrentId !== photoId) return;
     if (_lbFlagEditSeq === seq || _lbFlagPendingWrites === 0) {
       _lbRecordFlag(photoId, normalized);
     } else {

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3035,7 +3035,7 @@ var _lbCurrentWildlifeExcluded = false;
 var _lbFlagEditSeq = 0;      // increments for local flag writes so stale metadata fetches cannot overwrite the chip
 var _lbOpenSeq = 0;          // increments for every lightbox open so old metadata fetches cannot reapply after reopen
 var _lbFlagPendingWrites = 0;
-var _lbFlagWriteSeqByPhoto = {};  // latest flag-write seq PER photo, so a stale write only suppresses events for that same photo (not a later edit on a different photo)
+var _lbFlagPendingByPhoto = {};  // count of in-flight flag writes PER photo; lightbox:flagchanged is emitted once a photo's count hits 0 so listeners see its settled flag, not a guessed per-write one
 var _lbConfirmedFlags = {};   // last server-confirmed flag per photo, isolated from optimistic page helpers
 var _lbViewportByPhotoId = {};  // per-session lightbox viewport cache keyed by photo id
 var _lbPendingViewportState = null;
@@ -3317,12 +3317,8 @@ function _lbApplyFlag(photoId, flag) {
   if (!normalized || photoId == null) return false;
   var seq = _lbFlagEditSeq + 1;
   _lbFlagEditSeq = seq;
-  // Per-photo write seq: lets us tell whether *this* photo's flag was changed
-  // again after this write was issued, without conflating it with flag edits
-  // the user made on other photos in between (rapid lightbox culling).
-  var photoSeq = (_lbFlagWriteSeqByPhoto[photoId] || 0) + 1;
-  _lbFlagWriteSeqByPhoto[photoId] = photoSeq;
   _lbFlagPendingWrites += 1;
+  _lbFlagPendingByPhoto[photoId] = (_lbFlagPendingByPhoto[photoId] || 0) + 1;
   _lbSetPendingFlagStatus(normalized);
   var write;
 
@@ -3340,39 +3336,43 @@ function _lbApplyFlag(photoId, flag) {
     return false;
   }
 
-  Promise.resolve(write).then(function(ok) {
+  // Resolve both success and rejection through one settle path so the per-photo
+  // pending count is always balanced and the quiescence event always fires.
+  function settle(landed) {
     _lbFlagPendingWrites = Math.max(0, _lbFlagPendingWrites - 1);
-    if (ok === false) {
-      if (_lightboxCurrentId === photoId && _lbFlagEditSeq === seq) {
-        _lbSetFlagStatus(_lbConfirmedFlagFor(photoId));
+    var remaining = (_lbFlagPendingByPhoto[photoId] || 1) - 1;
+    if (remaining > 0) _lbFlagPendingByPhoto[photoId] = remaining;
+    else delete _lbFlagPendingByPhoto[photoId];
+
+    if (landed) {
+      // Cache the confirmed flag even if the user has navigated away, so the
+      // quiescence emit below reflects what actually landed for this photo.
+      _lbCacheFlag(photoId, normalized);
+      if (_lightboxCurrentId === photoId && (_lbFlagEditSeq === seq || _lbFlagPendingWrites === 0)) {
+        _lbSetFlagStatus(normalized);
       }
-      return;
+    } else if (_lightboxCurrentId === photoId && _lbFlagEditSeq === seq) {
+      // Write failed: the prior confirmed flag stands; restore the chip to it.
+      _lbSetFlagStatus(_lbConfirmedFlagFor(photoId));
     }
-    // Notify pages (e.g. Highlights) that a flag write landed so they can
-    // reconcile their grid. Gate on the per-photo write seq, NOT the global
-    // edit seq: fire only when this is the latest write for THIS photo, so a
-    // reject-then-clear on the same photo is suppressed (the later 'kept' write
-    // wins), while rejecting photo A, arrowing to B, then rejecting B still
-    // emits A's event — B's edit bumps the global seq but not A's per-photo seq.
-    if (_lbFlagWriteSeqByPhoto[photoId] === photoSeq) {
+
+    // Once every in-flight write for THIS photo has settled, tell listeners
+    // (e.g. Highlights) the photo's final confirmed flag. Emitting on
+    // quiescence — rather than per write — means a landed reject whose
+    // superseding clear/flag write later FAILED is still reflected, and rapid
+    // same-photo toggling collapses to one correct event instead of a guess.
+    if (!Object.prototype.hasOwnProperty.call(_lbFlagPendingByPhoto, photoId)) {
       try {
         document.dispatchEvent(new CustomEvent('lightbox:flagchanged', {
-          detail: { photoId: photoId, flag: normalized },
+          detail: { photoId: photoId, flag: _lbConfirmedFlagFor(photoId) },
         }));
       } catch (_) {}
     }
-    if (_lightboxCurrentId !== photoId) return;
-    if (_lbFlagEditSeq === seq || _lbFlagPendingWrites === 0) {
-      _lbRecordFlag(photoId, normalized);
-    } else {
-      _lbCacheFlag(photoId, normalized);
-    }
-  }).catch(function() {
-    _lbFlagPendingWrites = Math.max(0, _lbFlagPendingWrites - 1);
-    if (_lbFlagEditSeq === seq && _lightboxCurrentId === photoId) {
-      _lbSetFlagStatus(_lbConfirmedFlagFor(photoId));
-    }
-  });
+  }
+
+  Promise.resolve(write)
+    .then(function(ok) { settle(ok !== false); })
+    .catch(function() { settle(false); });
 
   return true;
 }

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3035,6 +3035,7 @@ var _lbCurrentWildlifeExcluded = false;
 var _lbFlagEditSeq = 0;      // increments for local flag writes so stale metadata fetches cannot overwrite the chip
 var _lbOpenSeq = 0;          // increments for every lightbox open so old metadata fetches cannot reapply after reopen
 var _lbFlagPendingWrites = 0;
+var _lbFlagWriteSeqByPhoto = {};  // latest flag-write seq PER photo, so a stale write only suppresses events for that same photo (not a later edit on a different photo)
 var _lbConfirmedFlags = {};   // last server-confirmed flag per photo, isolated from optimistic page helpers
 var _lbViewportByPhotoId = {};  // per-session lightbox viewport cache keyed by photo id
 var _lbPendingViewportState = null;
@@ -3316,6 +3317,11 @@ function _lbApplyFlag(photoId, flag) {
   if (!normalized || photoId == null) return false;
   var seq = _lbFlagEditSeq + 1;
   _lbFlagEditSeq = seq;
+  // Per-photo write seq: lets us tell whether *this* photo's flag was changed
+  // again after this write was issued, without conflating it with flag edits
+  // the user made on other photos in between (rapid lightbox culling).
+  var photoSeq = (_lbFlagWriteSeqByPhoto[photoId] || 0) + 1;
+  _lbFlagWriteSeqByPhoto[photoId] = photoSeq;
   _lbFlagPendingWrites += 1;
   _lbSetPendingFlagStatus(normalized);
   var write;
@@ -3343,13 +3349,12 @@ function _lbApplyFlag(photoId, flag) {
       return;
     }
     // Notify pages (e.g. Highlights) that a flag write landed so they can
-    // reconcile their grid. Fire only for the latest flag edit: if the user
-    // rapidly changed the flag again (e.g. reject then clear) before this write
-    // resolved, an earlier/superseded write must not drive the grid — otherwise
-    // Highlights could hide a photo whose final backend flag is not 'rejected'.
-    // Arrow-navigating to another photo does not bump _lbFlagEditSeq, so the
-    // event still fires for the photo whose flag was actually changed.
-    if (_lbFlagEditSeq === seq) {
+    // reconcile their grid. Gate on the per-photo write seq, NOT the global
+    // edit seq: fire only when this is the latest write for THIS photo, so a
+    // reject-then-clear on the same photo is suppressed (the later 'kept' write
+    // wins), while rejecting photo A, arrowing to B, then rejecting B still
+    // emits A's event — B's edit bumps the global seq but not A's per-photo seq.
+    if (_lbFlagWriteSeqByPhoto[photoId] === photoSeq) {
       try {
         document.dispatchEvent(new CustomEvent('lightbox:flagchanged', {
           detail: { photoId: photoId, flag: normalized },

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -751,10 +751,13 @@ function removeRejectedPhotoFromModel(photoId) {
   pruneSection(currentData.unidentified);
 
   if (changed) {
-    // Drop buckets emptied by the rejection.
+    // Drop only buckets fully emptied by the rejection. A large bucket may
+    // still have eligible photos behind `has_more` even after every loaded
+    // card is rejected (photo_count stays positive), so keep it — its expand
+    // button is the user's only way to load the rest without a refresh.
     if (currentData.buckets) {
       currentData.buckets = currentData.buckets.filter(function(b) {
-        return (b.photo_count || 0) > 0 && (b.photos || []).length > 0;
+        return (b.photo_count || 0) > 0 || (b.photos || []).length > 0;
       });
     }
     if (currentData.meta && typeof currentData.meta.eligible === 'number') {

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -724,6 +724,54 @@ async function doSave(mode) {
   closeSaveModal();
 }
 
+// Drop a photo from the in-memory model after it is rejected, so the grid
+// matches the backend query (which excludes rejected photos). Returns true if
+// anything changed.
+function removeRejectedPhotoFromModel(photoId) {
+  if (!currentData) return false;
+  var changed = false;
+
+  function pruneSection(section) {
+    if (!section || !Array.isArray(section.photos)) return;
+    var before = section.photos.length;
+    // Replace (don't splice) the array so any open lightbox keeps navigating
+    // its original, stable photo set.
+    var kept = section.photos.filter(function(p) { return p.id !== photoId; });
+    if (kept.length !== before) {
+      section.photos = kept;
+      section.photo_count = Math.max(0, (section.photo_count || before) - 1);
+      if (typeof section.loaded_count === 'number') {
+        section.loaded_count = Math.max(0, section.loaded_count - 1);
+      }
+      changed = true;
+    }
+  }
+
+  (currentData.buckets || []).forEach(pruneSection);
+  pruneSection(currentData.unidentified);
+
+  if (changed) {
+    // Drop buckets emptied by the rejection.
+    if (currentData.buckets) {
+      currentData.buckets = currentData.buckets.filter(function(b) {
+        return (b.photo_count || 0) > 0 && (b.photos || []).length > 0;
+      });
+    }
+    if (currentData.meta && typeof currentData.meta.eligible === 'number') {
+      currentData.meta.eligible = Math.max(0, currentData.meta.eligible - 1);
+    }
+  }
+  return changed;
+}
+
+document.addEventListener('lightbox:flagchanged', function(e) {
+  var detail = e && e.detail;
+  if (!detail || detail.flag !== 'rejected' || detail.photoId == null) return;
+  if (removeRejectedPhotoFromModel(detail.photoId)) {
+    render();
+  }
+});
+
 loadHighlights();
 </script>
 </body>

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -774,11 +774,26 @@ function removeRejectedPhotoFromModel(photoId) {
   return changed;
 }
 
+// Photos this page pulled out of the grid because they were rejected. If the
+// user clears/changes that flag from the still-open lightbox, the backend
+// includes the photo again — we resync so it (and the Save-as-Collection list)
+// no longer omits it. Tracking the set lets us reload only for genuine
+// reappearances, not for every Pick/Unflag on a photo still in the grid.
+var rejectedFromGrid = new Set();
+
 document.addEventListener('lightbox:flagchanged', function(e) {
   var detail = e && e.detail;
-  if (!detail || detail.flag !== 'rejected' || detail.photoId == null) return;
-  if (removeRejectedPhotoFromModel(detail.photoId)) {
-    render();
+  if (!detail || detail.photoId == null) return;
+  if (detail.flag === 'rejected') {
+    if (removeRejectedPhotoFromModel(detail.photoId)) {
+      rejectedFromGrid.add(detail.photoId);
+      render();
+    }
+  } else if (rejectedFromGrid.has(detail.photoId)) {
+    // A previously-rejected photo was un-rejected — it re-qualifies for
+    // highlights, so refetch to restore it in its correct bucket.
+    rejectedFromGrid.delete(detail.photoId);
+    loadHighlights();
   }
 });
 

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -397,7 +397,11 @@ function renderBucket(bucket) {
     + ' · best ' + formatScore(bucket.best_score);
   if (!bucket.is_accepted && bucket.avg_confidence != null) meta += ' · ID ' + formatPercent(bucket.avg_confidence);
   var expandBtn = '';
-  if (bucket.photo_count > perRow) {
+  // Show the affordance whenever photos are hidden (more loaded than one row)
+  // or unloaded (has_more). Gating on photo_count > perRow alone would strand
+  // backend rows after a rejection drops photo_count to perRow while has_more
+  // is still true — leaving no way to load the rest without a refresh.
+  if (bucket.photos.length > perRow || bucket.has_more) {
     expandBtn = '<button class="bucket-expand" data-species="'
       + escapeAttr(bucket.species) + '">'
       + (expanded ? (bucket.has_more ? 'Load more' : 'Show fewer') : '+ ' + remaining + ' more')
@@ -428,7 +432,10 @@ function renderUnidentified() {
   var visible = unidentifiedExpanded ? unid.photos : unid.photos.slice(0, perRow);
   var remaining = unid.photo_count - visible.length;
   var expandBtn = '';
-  if (unid.photo_count > perRow) {
+  // Same as renderBucket: keep the load/expand affordance while photos are
+  // hidden or unloaded, so a rejection that drops photo_count to perRow with
+  // has_more still true doesn't strand the remaining backend rows.
+  if (unid.photos.length > perRow || unid.has_more) {
     expandBtn = '<button class="bucket-expand" data-unid="1">'
       + (unidentifiedExpanded ? (unid.has_more ? 'Load more' : 'Show fewer') : '+ ' + remaining + ' more')
       + '</button>';

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -166,10 +166,15 @@ var speciesSuggestionsLoaded = false;
 var speciesModalPhotoIds = [];
 var activeLightboxPhotoId = null;
 // Photos the user has rejected from the lightbox this session and not since
-// un-rejected. Drives grid removal AND guards reloads: loadHighlights() prunes
-// these after applying its response, so a restore/filter reload issued against
-// backend state from before a (re-)rejection can't reinsert a rejected photo.
+// un-rejected. Drives grid removal AND guards reloads (see loadHighlights).
 var rejectedFromGrid = new Set();
+// Monotonic counter bumped each time a highlights reload is *issued*, plus the
+// counter value captured at each photo's rejection. Together they let the
+// reload prune ONLY photos rejected at/after the in-flight request was sent
+// (whose response predates the rejection) — never photos the backend restored
+// out-of-band (another tab, Undo panel), which it must be trusted to include.
+var highlightsLoadSeq = 0;
+var rejectedAtLoadSeq = {};
 
 function escapeAttr(s) {
   if (s === null || s === undefined) return '';
@@ -205,14 +210,22 @@ async function loadHighlights() {
   params.set('limit_per_bucket', Math.max(20, parseInt(document.getElementById('perRowSlider').value)));
   if (speciesSearch) params.set('species', speciesSearch);
 
+  // Capture the issue-time sequence so the prune below can tell rejections that
+  // happened after this request was sent (response is stale for them) from
+  // older ones the backend already excludes — or out-of-band restores it now
+  // includes and we must not strip.
+  var loadSeq = ++highlightsLoadSeq;
   var data = await safeFetch('/api/highlights?' + params);
   currentData = data;
 
-  // Guard against a reload that was issued against backend state from before a
-  // rejection landed (e.g. un-reject starts a restore reload, then the photo is
-  // rejected again before it returns): drop any still-rejected photo the
-  // response may have reincluded so the grid matches the final flag.
-  rejectedFromGrid.forEach(function(id) { removeRejectedPhotoFromModel(id); });
+  // Guard against a reload issued against backend state from before a rejection
+  // landed (e.g. un-reject starts a restore reload, then the photo is rejected
+  // again before it returns). Only prune photos rejected at/after this request
+  // was issued; a photo restored out-of-band has an older rejection seq, so the
+  // authoritative response that now includes it is left intact.
+  rejectedFromGrid.forEach(function(id) {
+    if ((rejectedAtLoadSeq[id] || 0) >= loadSeq) removeRejectedPhotoFromModel(id);
+  });
 
   // Populate folder dropdown on first load.
   if (!folderSelect.options.length) {
@@ -792,7 +805,10 @@ document.addEventListener('lightbox:flagchanged', function(e) {
     // Track before mutating: during an in-flight restore reload the photo may
     // not be in currentData yet, so removeRejectedPhotoFromModel returns false
     // — but the id must still be remembered so the reload's prune drops it.
+    // Stamp the current load seq so only reloads issued no later than now prune
+    // it (a reload issued afterward already reflects the rejection server-side).
     rejectedFromGrid.add(detail.photoId);
+    rejectedAtLoadSeq[detail.photoId] = highlightsLoadSeq;
     if (removeRejectedPhotoFromModel(detail.photoId)) render();
   } else if (rejectedFromGrid.has(detail.photoId)) {
     // A previously-rejected photo was un-rejected — it re-qualifies for
@@ -800,6 +816,7 @@ document.addEventListener('lightbox:flagchanged', function(e) {
     // in its correct bucket. Tracking the set keeps this scoped to genuine
     // reappearances, not every Pick/Unflag on a photo still in the grid.
     rejectedFromGrid.delete(detail.photoId);
+    delete rejectedAtLoadSeq[detail.photoId];
     loadHighlights();
   }
 });

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -165,6 +165,11 @@ var existingCollections = [];
 var speciesSuggestionsLoaded = false;
 var speciesModalPhotoIds = [];
 var activeLightboxPhotoId = null;
+// Photos the user has rejected from the lightbox this session and not since
+// un-rejected. Drives grid removal AND guards reloads: loadHighlights() prunes
+// these after applying its response, so a restore/filter reload issued against
+// backend state from before a (re-)rejection can't reinsert a rejected photo.
+var rejectedFromGrid = new Set();
 
 function escapeAttr(s) {
   if (s === null || s === undefined) return '';
@@ -202,6 +207,12 @@ async function loadHighlights() {
 
   var data = await safeFetch('/api/highlights?' + params);
   currentData = data;
+
+  // Guard against a reload that was issued against backend state from before a
+  // rejection landed (e.g. un-reject starts a restore reload, then the photo is
+  // rejected again before it returns): drop any still-rejected photo the
+  // response may have reincluded so the grid matches the final flag.
+  rejectedFromGrid.forEach(function(id) { removeRejectedPhotoFromModel(id); });
 
   // Populate folder dropdown on first load.
   if (!folderSelect.options.length) {
@@ -774,24 +785,20 @@ function removeRejectedPhotoFromModel(photoId) {
   return changed;
 }
 
-// Photos this page pulled out of the grid because they were rejected. If the
-// user clears/changes that flag from the still-open lightbox, the backend
-// includes the photo again — we resync so it (and the Save-as-Collection list)
-// no longer omits it. Tracking the set lets us reload only for genuine
-// reappearances, not for every Pick/Unflag on a photo still in the grid.
-var rejectedFromGrid = new Set();
-
 document.addEventListener('lightbox:flagchanged', function(e) {
   var detail = e && e.detail;
   if (!detail || detail.photoId == null) return;
   if (detail.flag === 'rejected') {
-    if (removeRejectedPhotoFromModel(detail.photoId)) {
-      rejectedFromGrid.add(detail.photoId);
-      render();
-    }
+    // Track before mutating: during an in-flight restore reload the photo may
+    // not be in currentData yet, so removeRejectedPhotoFromModel returns false
+    // — but the id must still be remembered so the reload's prune drops it.
+    rejectedFromGrid.add(detail.photoId);
+    if (removeRejectedPhotoFromModel(detail.photoId)) render();
   } else if (rejectedFromGrid.has(detail.photoId)) {
     // A previously-rejected photo was un-rejected — it re-qualifies for
-    // highlights, so refetch to restore it in its correct bucket.
+    // highlights, so refetch to restore it (and the Save-as-Collection list)
+    // in its correct bucket. Tracking the set keeps this scoped to genuine
+    // reappearances, not every Pick/Unflag on a photo still in the grid.
     rejectedFromGrid.delete(detail.photoId);
     loadHighlights();
   }


### PR DESCRIPTION
## What

When you reject a photo from the lightbox on the **Highlights** page, the photo now disappears from the grid immediately instead of lingering until a manual refresh.

## Why

The backend highlights query already excludes rejected photos (`get_highlights_candidates` in `vireo/db.py` filters `p.flag != 'rejected'`). But the frontend never reloaded or pruned the grid after a flag change — `loadHighlights()` only re-runs on confirm/relabel/filter/folder/initial-load — so a photo you'd just rejected stayed on screen, contradicting what the next reload would show.

## How

- **`_navbar.html`**: the shared lightbox now dispatches a `lightbox:flagchanged` CustomEvent on a successful flag write (mirrors the existing `lightbox:photochanged` event). It fires even if the user has navigated to another photo, since the write still landed for that photo id.
- **`highlights.html`**: listens for the event; when the new flag is `rejected`, it removes the photo from the in-memory model (decrements bucket `photo_count`/`loaded_count`, drops emptied buckets, decrements `meta.eligible`) and re-renders. Pruned arrays are **replaced, not spliced**, so an open lightbox keeps navigating its original, stable photo set while the grid behind it updates.

Other pages share the lightbox but don't listen for the event, so this is additive and inert for them.

## Testing

- `python -m pytest vireo/tests/test_app.py -q` → 226 passed (templates render).
- JS syntax-checked the edited `highlights.html` script block and the `_lbApplyFlag` function with `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)