### PR TITLE
Refresh Needs Identification after keyword edits

### DIFF
--- a/tests/e2e/test_browse_single_select.py
+++ b/tests/e2e/test_browse_single_select.py
@@ -160,6 +160,39 @@ def test_add_keyword_input_suggests_existing_keyword(live_server, page):
     expect(page.locator("#detailKeywords")).to_contain_text("Alan's Hummingbird")
 
 
+def test_needs_identification_refreshes_after_identification_added(live_server, page):
+    """A photo should leave the active Needs Identification grid after tagging."""
+    db = live_server["db"]
+    target_id = live_server["data"]["photos"][1]
+    collection = db.conn.execute(
+        "SELECT id FROM collections WHERE name = 'Needs Identification'"
+    ).fetchone()
+    assert collection is not None
+    collection_id = collection["id"]
+
+    page.goto(f"{live_server['url']}/browse")
+    page.evaluate("(id) => filterByCollection(id)", collection_id)
+
+    target_card = page.locator(f'.grid-card[data-id="{target_id}"]').first
+    expect(target_card).to_be_visible()
+    target_card.click()
+
+    keyword_input = page.locator("#addKeywordInput")
+    keyword_input.fill("Red-tailed Hawk")
+
+    with page.expect_response(
+        lambda r: f"/api/photos/{target_id}/keywords" in r.url
+        and r.request.method == "POST"
+        and r.status == 200
+    ), page.expect_response(
+        lambda r: f"/api/collections/{collection_id}/photos" in r.url
+        and r.status == 200
+    ):
+        keyword_input.press("Enter")
+
+    expect(page.locator(f'.grid-card[data-id="{target_id}"]')).to_have_count(0)
+
+
 def test_add_keyword_autocomplete_retries_after_fetch_failure(live_server, page):
     """A transient keyword suggestion fetch failure must not poison the cache."""
     db = live_server["db"]

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2512,7 +2512,7 @@ function scheduleCollectionCountsRefresh() {
 
 function refreshActiveCollectionAfterMembershipChange() {
   if (!activeCollectionId) return;
-  filterByCollection(activeCollectionId);
+  filterByCollection(activeCollectionId, { preserveAnchor: false });
 }
 
 function refreshBrowseSidebarCounts() {
@@ -2521,9 +2521,10 @@ function refreshBrowseSidebarCounts() {
   loadCollectionCounts();
 }
 
-async function filterByCollection(id) {
+async function filterByCollection(id, options) {
   cancelScheduledSearchFilter();
-  var anchor = captureSelectedPhotoAnchor();
+  var preserveAnchor = !(options && options.preserveAnchor === false);
+  var anchor = preserveAnchor ? captureSelectedPhotoAnchor() : null;
   var restoreEpoch = anchor ? ++anchorRestoreEpoch : null;
   activeFolderId = null;
   activeKeyword = null;

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2510,6 +2510,11 @@ function scheduleCollectionCountsRefresh() {
   }, 150);
 }
 
+function refreshActiveCollectionAfterMembershipChange() {
+  if (!activeCollectionId) return;
+  filterByCollection(activeCollectionId);
+}
+
 function refreshBrowseSidebarCounts() {
   loadFolders();
   loadKeywords();
@@ -4251,6 +4256,8 @@ async function applySelectionKeyword(keywordId) {
   selectionKeywordKey = '';
   loadSelectionKeywordSuggestions(getActiveSelection());
   loadKeywords();
+  scheduleCollectionCountsRefresh();
+  refreshActiveCollectionAfterMembershipChange();
   refreshPendingSyncBanner();
   showUndoToast();
 }
@@ -4351,6 +4358,7 @@ async function confirmBatchKeyword() {
   loadSelectionKeywordSuggestions(ids);
   loadKeywords();
   scheduleCollectionCountsRefresh();
+  refreshActiveCollectionAfterMembershipChange();
   refreshPendingSyncBanner();
   showUndoToast();
 }
@@ -5332,6 +5340,7 @@ async function addKeyword(keyword) {
     }
     loadKeywords();
     scheduleCollectionCountsRefresh();
+    refreshActiveCollectionAfterMembershipChange();
     refreshPendingSyncBanner();
   } catch(e) {}
 }
@@ -5344,6 +5353,7 @@ async function removeKeyword(photoId, keywordId) {
     loadDetail(photoId);
     loadKeywords();
     scheduleCollectionCountsRefresh();
+    refreshActiveCollectionAfterMembershipChange();
     refreshPendingSyncBanner();
   } catch(e) {}
 }


### PR DESCRIPTION
Refreshes the active Browse smart collection after keyword add/remove flows so photos leave Needs Identification immediately when an identifying keyword is added. Adds a Playwright regression that tags a photo from the Needs Identification collection and verifies the grid reloads without that photo. Root cause: keyword mutations refreshed sidebar counts but left the active collection grid using stale results. Validated with Browse E2E coverage and focused backend Needs Identification rule tests.