### PR TITLE
[codex] Add representative photos for life list and highlights

### DIFF
--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -1217,6 +1217,25 @@ def test_move_folders_moves_pending_changes(db_with_workspace):
     assert len(db.get_pending_changes()) == 0
 
 
+def test_move_folders_moves_photo_preferences(db_with_workspace):
+    """Representative Life List / Highlights choices follow moved photos."""
+    db, ws1, folder_id, photo_id = db_with_workspace
+    db.set_photo_preference("life_list", "Robin", photo_id)
+    db.set_photo_preference("highlights", "Robin", photo_id)
+
+    ws2 = db.create_workspace("Target")
+    result = db.move_folders_to_workspace(ws1, ws2, [folder_id])
+
+    assert result["photo_preferences_moved"] == 2
+    db.set_active_workspace(ws2)
+    assert db.get_photo_preferences("life_list") == {"Robin": photo_id}
+    assert db.get_photo_preferences("highlights") == {"Robin": photo_id}
+
+    db.set_active_workspace(ws1)
+    assert db.get_photo_preferences("life_list") == {}
+    assert db.get_photo_preferences("highlights") == {}
+
+
 def test_move_folders_collections_stay_behind(db_with_workspace):
     """Collections in the source workspace are NOT moved."""
     db, ws1, folder_id, photo_id = db_with_workspace

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -260,6 +260,35 @@ def _highlight_score_bucket(photos):
     )
 
 
+def _apply_preferred_photo(photos, preferred_photo_id, marker_key):
+    """Move a valid preferred photo to the front of an already-ranked list."""
+    for p in photos:
+        p[marker_key] = False
+    if preferred_photo_id is None:
+        return False
+    for idx, photo in enumerate(photos):
+        if photo.get("id") == preferred_photo_id:
+            photo[marker_key] = True
+            if idx:
+                photos.insert(0, photos.pop(idx))
+            return True
+    return False
+
+
+def _apply_highlight_preferences(db, buckets):
+    preferences = db.get_photo_preferences("highlights")
+    for bucket in buckets:
+        preferred_id = preferences.get(bucket["species"])
+        applied = _apply_preferred_photo(
+            bucket["photos"], preferred_id, "is_highlights_photo"
+        )
+        best = bucket["photos"][0] if bucket["photos"] else {}
+        bucket["preferred_photo_id"] = preferred_id
+        bucket["has_preferred_photo"] = applied
+        bucket["best_quality"] = best.get("quality_score")
+        bucket["best_score"] = best.get("highlight_score")
+
+
 def _highlight_confidence_label(confidence, is_accepted):
     if is_accepted:
         return "confirmed"
@@ -5649,6 +5678,99 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 results[row["photo_id"]] = row
         return results
 
+    def _parse_photo_preference_body(body, require_photo=True):
+        purpose = body.get("purpose", "")
+        species = body.get("species", "")
+        purpose = purpose.strip() if isinstance(purpose, str) else ""
+        species = species.strip() if isinstance(species, str) else ""
+        if purpose not in {"life_list", "highlights"}:
+            return None, "purpose must be life_list or highlights"
+        if not species:
+            return None, "species required"
+
+        photo_id = body.get("photo_id")
+        if require_photo:
+            if isinstance(photo_id, bool) or not isinstance(photo_id, int):
+                return None, "photo_id must be an integer"
+        else:
+            photo_id = None
+
+        return {
+            "purpose": purpose,
+            "species": species,
+            "photo_id": photo_id,
+        }, None
+
+    def _photo_can_be_life_list_preference(db, species, photo_id):
+        ws = db._ws_id()
+        row = db.conn.execute(
+            """SELECT 1
+               FROM photo_keywords pk
+               JOIN keywords k ON k.id = pk.keyword_id
+                AND (k.is_species = 1 OR k.type = 'taxonomy')
+               JOIN photos p ON p.id = pk.photo_id
+                AND COALESCE(p.flag, 'none') != 'rejected'
+               JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+                AND wf.workspace_id = ?
+               JOIN folders f ON f.id = p.folder_id
+                AND f.status IN ('ok', 'partial')
+               WHERE pk.photo_id = ? AND k.name = ?
+               LIMIT 1""",
+            (ws, photo_id, species),
+        ).fetchone()
+        return row is not None
+
+    def _photo_can_be_highlights_preference(db, species, photo_id):
+        candidates = db.get_highlights_candidates(None, min_quality=0.0)
+        buckets, _unidentified = _collect_highlight_buckets(
+            candidates, confidence_threshold=0.0
+        )
+        for bucket in buckets:
+            if bucket["species"] != species:
+                continue
+            return any(p["id"] == photo_id for p in bucket["photos"])
+        return False
+
+    def _photo_can_be_preference(db, purpose, species, photo_id):
+        if purpose == "life_list":
+            return _photo_can_be_life_list_preference(db, species, photo_id)
+        return _photo_can_be_highlights_preference(db, species, photo_id)
+
+    @app.route("/api/photo-preferences", methods=["POST"])
+    def api_photo_preferences_set():
+        db = _get_db()
+        body = request.get_json(silent=True) or {}
+        parsed, error = _parse_photo_preference_body(body)
+        if error:
+            return json_error(error)
+        error, status = _validate_highlight_photo_ids(db, [parsed["photo_id"]])
+        if error:
+            return json_error(error, status)
+        if not _photo_can_be_preference(
+            db, parsed["purpose"], parsed["species"], parsed["photo_id"]
+        ):
+            return json_error(
+                "photo_id is not eligible for that purpose/species", 400,
+            )
+        db.set_photo_preference(
+            parsed["purpose"], parsed["species"], parsed["photo_id"]
+        )
+        return jsonify({"ok": True, **parsed})
+
+    @app.route("/api/photo-preferences", methods=["DELETE"])
+    def api_photo_preferences_clear():
+        db = _get_db()
+        body = request.get_json(silent=True) or {}
+        parsed, error = _parse_photo_preference_body(body, require_photo=False)
+        if error:
+            return json_error(error)
+        db.clear_photo_preference(parsed["purpose"], parsed["species"])
+        return jsonify({
+            "ok": True,
+            "purpose": parsed["purpose"],
+            "species": parsed["species"],
+        })
+
     @app.route("/api/highlights")
     def api_highlights():
         db = _get_db()
@@ -5677,6 +5799,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         buckets, unidentified_photos = _collect_highlight_buckets(
             candidates, confidence_threshold
         )
+        _apply_highlight_preferences(db, buckets)
         if species_filter:
             buckets = [
                 b for b in buckets if species_filter in b["species"].lower()
@@ -5775,15 +5898,21 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "quality_score": photo.get("quality_score"),
                 "highlight_score": photo.get("highlight_score"),
                 "reasons": photo.get("reasons") or [],
+                "is_life_list_photo": bool(photo.get("is_life_list_photo")),
             }
 
         species_entries = []
         distinct_photo_ids = set()
+        life_list_preferences = db.get_photo_preferences("life_list")
         for species, entry in buckets.items():
             photos = entry["photos"]
             distinct_photo_ids.update(p["id"] for p in photos)
             timestamps = [p["timestamp"] for p in photos if p.get("timestamp")]
             _highlight_score_bucket(photos)
+            preferred_id = life_list_preferences.get(species)
+            preferred_applied = _apply_preferred_photo(
+                photos, preferred_id, "is_life_list_photo"
+            )
             top = photos[:photos_per_species]
             species_entries.append({
                 "species": species,
@@ -5793,6 +5922,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "first_seen": min(timestamps) if timestamps else None,
                 "last_seen": max(timestamps) if timestamps else None,
                 "locations": locations_by_species.get(species, []),
+                "preferred_photo_id": preferred_id,
+                "has_preferred_photo": preferred_applied,
                 "best": compact(top[0]) if top else None,
                 "photos": [compact(p) for p in top],
             })
@@ -6039,6 +6170,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         buckets, unidentified_photos = _collect_highlight_buckets(
             candidates, confidence_threshold
         )
+        _apply_highlight_preferences(db, buckets)
         if species == "__unidentified__":
             photos = unidentified_photos
             label = "Unidentified"

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3779,6 +3779,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error(str(e), 400)
         # Queue sidecar updates only after successful DB update, for all affected workspaces
         if old_name:
+            db.rename_photo_preferences_species(old_name, new_name)
             affected = db.conn.execute(
                 """SELECT pk.photo_id, wf.workspace_id
                    FROM photo_keywords pk

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3766,12 +3766,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # Capture old name before update for sidecar queuing
         new_name = body.get("name")
         old_name = None
+        old_is_species_keyword = False
         if new_name:
             old_row = db.conn.execute(
-                "SELECT name FROM keywords WHERE id = ?", (keyword_id,)
+                """SELECT name, is_species, type
+                   FROM keywords WHERE id = ?""",
+                (keyword_id,),
             ).fetchone()
             if old_row and old_row["name"] != new_name:
                 old_name = old_row["name"]
+                old_is_species_keyword = (
+                    old_row["is_species"] == 1 or old_row["type"] == "taxonomy"
+                )
         # Apply the update first — if it raises, no sidecar changes are queued
         try:
             db.update_keyword(keyword_id, **body)
@@ -3779,7 +3785,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error(str(e), 400)
         # Queue sidecar updates only after successful DB update, for all affected workspaces
         if old_name:
-            db.rename_photo_preferences_species(old_name, new_name)
             affected = db.conn.execute(
                 """SELECT pk.photo_id, wf.workspace_id
                    FROM photo_keywords pk
@@ -3788,6 +3793,21 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                    WHERE pk.keyword_id = ?""",
                 (keyword_id,),
             ).fetchall()
+            new_row = db.conn.execute(
+                """SELECT is_species, type
+                   FROM keywords WHERE id = ?""",
+                (keyword_id,),
+            ).fetchone()
+            new_is_species_keyword = (
+                new_row is not None
+                and (new_row["is_species"] == 1 or new_row["type"] == "taxonomy")
+            )
+            if old_is_species_keyword and new_is_species_keyword:
+                db.rename_photo_preferences_species(
+                    old_name,
+                    new_name,
+                    [(row["photo_id"], row["workspace_id"]) for row in affected],
+                )
             for row in affected:
                 _queue_keyword_remove(row["photo_id"], old_name, workspace_id=row["workspace_id"])
                 _queue_keyword_add(row["photo_id"], new_name, workspace_id=row["workspace_id"])

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1574,13 +1574,15 @@ class Database:
     def move_folders_to_workspace(self, source_ws_id, target_ws_id, folder_ids):
         """Move folders and their workspace-scoped data to another workspace.
 
-        Moves: workspace_folders rows and pending_changes. Detections and
-        predictions are global (no workspace_id), so they follow the folder
-        via workspace_folders membership rather than being reassigned.
-        Collections and edit_history stay behind.
+        Moves: workspace_folders rows, pending_changes, prediction_review,
+        and photo_preferences. Detections and predictions are global (no
+        workspace_id), so they follow the folder via workspace_folders
+        membership rather than being reassigned. Collections and edit_history
+        stay behind.
 
         Returns:
-            dict with keys: folders_moved, pending_changes_moved
+            dict with keys: folders_moved, pending_changes_moved,
+            photo_preferences_moved
         """
         if not self.get_workspace(source_ws_id):
             raise ValueError(f"Source workspace {source_ws_id} not found")
@@ -1598,7 +1600,11 @@ class Database:
                 )
 
         if not folder_ids:
-            return {"folders_moved": 0, "pending_changes_moved": 0}
+            return {
+                "folders_moved": 0,
+                "pending_changes_moved": 0,
+                "photo_preferences_moved": 0,
+            }
 
         selected_folder_ids = set(folder_ids)
         source_folder_paths = {
@@ -1687,6 +1693,36 @@ class Database:
                     [source_ws_id, source_ws_id] + chunk,
                 )
 
+            # Move manually selected Life List / Highlights representative
+            # photos with the folder. If the target already has a preference
+            # for the same (purpose, species), keep the target value and drop
+            # the now-stale source row.
+            photo_preferences_moved = 0
+            for chunk in _chunks(moved_folder_ids):
+                placeholders = ",".join("?" for _ in chunk)
+                cur = self.conn.execute(
+                    f"""INSERT OR IGNORE INTO photo_preferences
+                          (workspace_id, purpose, species, photo_id,
+                           created_at, updated_at)
+                        SELECT ?, purpose, species, photo_id,
+                               created_at, updated_at
+                        FROM photo_preferences
+                        WHERE workspace_id = ?
+                          AND photo_id IN (
+                              SELECT id FROM photos WHERE folder_id IN ({placeholders})
+                          )""",
+                    [target_ws_id, source_ws_id] + chunk,
+                )
+                photo_preferences_moved += cur.rowcount
+                self.conn.execute(
+                    f"""DELETE FROM photo_preferences
+                        WHERE workspace_id = ?
+                          AND photo_id IN (
+                              SELECT id FROM photos WHERE folder_id IN ({placeholders})
+                          )""",
+                    [source_ws_id] + chunk,
+                )
+
             # Move workspace_folders: remove from source, add to target
             for chunk in _chunks(moved_folder_ids):
                 placeholders = ",".join("?" for _ in chunk)
@@ -1724,6 +1760,7 @@ class Database:
         return {
             "folders_moved": len(folder_ids),
             "pending_changes_moved": pending_changes_moved,
+            "photo_preferences_moved": photo_preferences_moved,
         }
 
     def ensure_default_workspace(self):

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -611,6 +611,16 @@ class Database:
                 PRIMARY KEY (photo_id, workspace_id)
             );
 
+            CREATE TABLE IF NOT EXISTS photo_preferences (
+                workspace_id  INTEGER NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+                purpose       TEXT NOT NULL,
+                species       TEXT NOT NULL,
+                photo_id      INTEGER NOT NULL REFERENCES photos(id) ON DELETE CASCADE,
+                created_at    TEXT DEFAULT (datetime('now')),
+                updated_at    TEXT DEFAULT (datetime('now')),
+                PRIMARY KEY (workspace_id, purpose, species)
+            );
+
             CREATE TABLE IF NOT EXISTS preview_cache (
                 photo_id INTEGER NOT NULL,
                 size INTEGER NOT NULL,
@@ -691,6 +701,8 @@ class Database:
             CREATE INDEX IF NOT EXISTS idx_photo_keywords_keyword ON photo_keywords(keyword_id);
             CREATE INDEX IF NOT EXISTS idx_photo_color_labels_ws
                 ON photo_color_labels(workspace_id);
+            CREATE INDEX IF NOT EXISTS idx_photo_preferences_photo
+                ON photo_preferences(photo_id);
             CREATE INDEX IF NOT EXISTS preview_cache_last_access
                 ON preview_cache(last_access_at);
             CREATE INDEX IF NOT EXISTS idx_offline_originals_status
@@ -7825,6 +7837,43 @@ class Database:
         for r in rows:
             result.setdefault(r["species"], []).append(r["location"])
         return result
+
+    def get_photo_preferences(self, purpose):
+        """Return {species: photo_id} preferences for the active workspace."""
+        ws = self._ws_id()
+        rows = self.conn.execute(
+            """SELECT species, photo_id
+               FROM photo_preferences
+               WHERE workspace_id = ? AND purpose = ?""",
+            (ws, purpose),
+        ).fetchall()
+        return {r["species"]: r["photo_id"] for r in rows}
+
+    def set_photo_preference(self, purpose, species, photo_id, _commit=True):
+        """Set the preferred photo for a species/purpose in this workspace."""
+        ws = self._ws_id()
+        self.conn.execute(
+            """INSERT INTO photo_preferences
+                   (workspace_id, purpose, species, photo_id, created_at, updated_at)
+               VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))
+               ON CONFLICT(workspace_id, purpose, species) DO UPDATE SET
+                   photo_id = excluded.photo_id,
+                   updated_at = excluded.updated_at""",
+            (ws, purpose, species, photo_id),
+        )
+        if _commit:
+            self.conn.commit()
+
+    def clear_photo_preference(self, purpose, species, _commit=True):
+        """Clear the preferred photo for a species/purpose in this workspace."""
+        ws = self._ws_id()
+        self.conn.execute(
+            """DELETE FROM photo_preferences
+               WHERE workspace_id = ? AND purpose = ? AND species = ?""",
+            (ws, purpose, species),
+        )
+        if _commit:
+            self.conn.commit()
 
     def get_folders_with_quality_data(self):
         """Return folders with at least one scored photo in their subtree.

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -7912,6 +7912,28 @@ class Database:
         if _commit:
             self.conn.commit()
 
+    def rename_photo_preferences_species(self, old_species, new_species, _commit=True):
+        """Rename stored representative-photo preferences across workspaces."""
+        if not old_species or not new_species or old_species == new_species:
+            return 0
+        cur = self.conn.execute(
+            """INSERT OR IGNORE INTO photo_preferences
+                  (workspace_id, purpose, species, photo_id,
+                   created_at, updated_at)
+               SELECT workspace_id, purpose, ?, photo_id,
+                      created_at, datetime('now')
+               FROM photo_preferences
+               WHERE species = ?""",
+            (new_species, old_species),
+        )
+        self.conn.execute(
+            "DELETE FROM photo_preferences WHERE species = ?",
+            (old_species,),
+        )
+        if _commit:
+            self.conn.commit()
+        return cur.rowcount
+
     def get_folders_with_quality_data(self):
         """Return folders with at least one scored photo in their subtree.
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -7912,10 +7912,44 @@ class Database:
         if _commit:
             self.conn.commit()
 
-    def rename_photo_preferences_species(self, old_species, new_species, _commit=True):
+    def rename_photo_preferences_species(
+        self, old_species, new_species, photo_workspace_pairs=None, _commit=True,
+    ):
         """Rename stored representative-photo preferences across workspaces."""
         if not old_species or not new_species or old_species == new_species:
             return 0
+        if photo_workspace_pairs is not None:
+            moved = 0
+            seen = set()
+            for photo_id, workspace_id in photo_workspace_pairs:
+                key = (photo_id, workspace_id)
+                if key in seen:
+                    continue
+                seen.add(key)
+                cur = self.conn.execute(
+                    """INSERT OR IGNORE INTO photo_preferences
+                          (workspace_id, purpose, species, photo_id,
+                           created_at, updated_at)
+                       SELECT workspace_id, purpose, ?, photo_id,
+                              created_at, datetime('now')
+                       FROM photo_preferences
+                       WHERE workspace_id = ?
+                         AND species = ?
+                         AND photo_id = ?""",
+                    (new_species, workspace_id, old_species, photo_id),
+                )
+                moved += cur.rowcount
+                self.conn.execute(
+                    """DELETE FROM photo_preferences
+                       WHERE workspace_id = ?
+                         AND species = ?
+                         AND photo_id = ?""",
+                    (workspace_id, old_species, photo_id),
+                )
+            if _commit:
+                self.conn.commit()
+            return moved
+
         cur = self.conn.execute(
             """INSERT OR IGNORE INTO photo_preferences
                   (workspace_id, purpose, species, photo_id,

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -244,8 +244,11 @@ function renderCard(p, idx) {
     return '<span class="card-chip reason">' + escapeAttr(r) + '</span>';
   }).join('');
   var title = (p.reasons || []).join(', ');
+  var ribbon = p.is_highlights_photo
+    ? '<div class="best-ribbon">Highlight</div>'
+    : (idx === 0 ? '<div class="best-ribbon">Best</div>' : '');
   return '<div class="highlights-card' + (idx === 0 ? ' best-card' : '') + '" data-photo-id="' + p.id + '" title="' + escapeAttr(title) + '">'
-    + (idx === 0 ? '<div class="best-ribbon">Best</div>' : '')
+    + ribbon
     + '<img src="' + thumbSrc + '" alt="' + escapeAttr(p.filename) + '" loading="lazy">'
     + '<div class="card-info"><span class="card-chip score">' + formatScore(p.highlight_score) + '</span>' + conf + reasons + '</div>'
     + '</div>';
@@ -380,6 +383,25 @@ async function submitSpeciesModal() {
     if (typeof showToast === 'function') showToast('Species updated', 'success');
   } finally {
     submit.disabled = false;
+  }
+}
+
+async function setPhotoPreference(purpose, species, photoId, button) {
+  if (!purpose || !species || !photoId) return;
+  if (button) button.disabled = true;
+  try {
+    await safeFetch('/api/photo-preferences', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ purpose: purpose, species: species, photo_id: photoId }),
+    });
+    await loadHighlights();
+    updateHighlightsLightboxControls(activeLightboxPhotoId);
+    if (typeof showToast === 'function') {
+      showToast(purpose === 'life_list' ? 'Life List photo set' : 'Highlights photo set', 'success');
+    }
+  } finally {
+    if (button) button.disabled = false;
   }
 }
 
@@ -593,6 +615,15 @@ function updateHighlightsLightboxControls(photoId) {
   }
   panel.style.display = '';
   var html = '<span>' + escapeAttr(photoCurrentLabel(photo)) + '</span>';
+  var highlightSpecies = photoSpeciesName(photo);
+  if (highlightSpecies) {
+    html += '<button data-lb-action="set-highlight"'
+      + (photo.is_highlights_photo ? ' class="primary"' : '') + '>'
+      + (photo.is_highlights_photo ? 'Highlights Photo' : 'Use as Highlights') + '</button>';
+  }
+  if (photo.has_accepted_species && photo.species) {
+    html += '<button data-lb-action="set-life-list">Use as Life List</button>';
+  }
   if (photo.is_confirmable_prediction) {
     html += '<button class="primary" data-lb-action="confirm">Confirm</button>';
   }
@@ -601,8 +632,13 @@ function updateHighlightsLightboxControls(photoId) {
   panel.querySelectorAll('button').forEach(function(btn) {
     btn.addEventListener('click', function(event) {
       event.stopPropagation();
-      if (btn.getAttribute('data-lb-action') === 'confirm') {
+      var action = btn.getAttribute('data-lb-action');
+      if (action === 'confirm') {
         confirmPhotoIds([photo.id], btn);
+      } else if (action === 'set-highlight') {
+        setPhotoPreference('highlights', photoSpeciesName(photo), photo.id, btn);
+      } else if (action === 'set-life-list') {
+        setPhotoPreference('life_list', photo.species, photo.id, btn);
       } else {
         var modalTitle = (photo.is_confirmable_prediction || photo.has_accepted_species)
           ? 'Change species'

--- a/vireo/templates/life_list.html
+++ b/vireo/templates/life_list.html
@@ -21,6 +21,7 @@
   .species-card:hover { border-color:var(--accent); }
   .species-card img { width:100%; aspect-ratio:3/2; object-fit:cover; display:block; background:var(--bg-tertiary); }
   .lifer-number { position:absolute; top:8px; left:8px; padding:2px 8px; border-radius:999px; background:rgba(0,0,0,0.65); color:#fff; font-size:11px; font-weight:700; letter-spacing:0.5px; }
+  .lifelist-ribbon { position:absolute; top:8px; right:8px; padding:2px 7px; border-radius:999px; background:var(--accent); color:var(--accent-text); font-size:10px; font-weight:700; text-transform:uppercase; letter-spacing:0.5px; }
   .species-info { padding:10px 12px 12px; }
   .species-name { font-size:15px; font-weight:600; color:var(--text-primary); }
   .species-sci { font-size:12px; font-style:italic; color:var(--text-secondary); margin-top:1px; }
@@ -30,6 +31,9 @@
 
   .lifelist-empty { text-align:center; padding:80px 24px; color:var(--text-secondary); }
   .lifelist-empty a { color:var(--accent); }
+  .lifelist-lb-panel { display:flex; align-items:center; gap:8px; flex-wrap:wrap; padding:5px 8px; border-radius:4px; background:rgba(0,0,0,0.6); border:1px solid var(--text-faint); color:var(--text-secondary); font-size:12px; }
+  .lifelist-lb-panel button { border:1px solid var(--border-secondary); background:rgba(255,255,255,0.08); color:var(--text-primary); border-radius:4px; padding:4px 9px; cursor:pointer; font-size:12px; }
+  .lifelist-lb-panel button.primary { border-color:var(--accent); color:var(--accent); }
 </style>
 </head>
 <body>
@@ -65,6 +69,7 @@
 <script>
 var currentData = null;
 var debounceTimer = null;
+var activeLightboxPhotoId = null;
 
 // All dynamic values rendered into card HTML pass through escapeAttr —
 // same escaping convention as highlights.html.
@@ -132,6 +137,7 @@ function renderCard(entry) {
   return '<div class="species-card" data-species="' + escapeAttr(entry.species) + '" title="'
     + escapeAttr((entry.locations || []).join(', ')) + '">'
     + '<div class="lifer-number">#' + entry.number + '</div>'
+    + (best && best.is_life_list_photo ? '<div class="lifelist-ribbon">Life List</div>' : '')
     + (best ? '<img src="' + escapeAttr(thumb) + '" alt="' + escapeAttr(best.filename) + '" loading="lazy">' : '')
     + '<div class="species-info">'
     + '<div class="species-name">' + escapeAttr(entry.species) + '</div>'
@@ -181,10 +187,12 @@ function render() {
       if (entry && entry.best && window.openLightbox) {
         // The lightbox set is this species' top photos so the user can
         // flip through their best shots of the lifer.
+        activeLightboxPhotoId = entry.best.id;
         openLightbox(entry.best.id, entry.best.filename, entry.photos || [entry.best]);
       }
     });
   });
+  updateLifeListLightboxControls(activeLightboxPhotoId);
 }
 
 function debounceRender() {
@@ -195,6 +203,73 @@ function debounceRender() {
 document.getElementById('speciesSearch').addEventListener('input', debounceRender);
 document.getElementById('sortSelect').addEventListener('change', function() {
   if (currentData) render();
+});
+
+function findLifeListEntryForPhoto(photoId) {
+  if (!currentData || photoId == null) return null;
+  var entries = currentData.species || [];
+  for (var i = 0; i < entries.length; i++) {
+    var match = (entries[i].photos || []).find(function(p) { return p.id === photoId; });
+    if (match) return { entry: entries[i], photo: match };
+  }
+  return null;
+}
+
+function ensureLifeListLightboxPanel() {
+  var actions = document.getElementById('lightboxActions');
+  if (!actions) return null;
+  var panel = document.getElementById('lifeListLightboxPanel');
+  if (!panel) {
+    panel = document.createElement('div');
+    panel.id = 'lifeListLightboxPanel';
+    panel.className = 'lifelist-lb-panel';
+    actions.insertBefore(panel, actions.firstChild);
+  }
+  return panel;
+}
+
+async function setLifeListPhoto(species, photoId, button) {
+  if (!species || !photoId) return;
+  if (button) button.disabled = true;
+  try {
+    await safeFetch('/api/photo-preferences', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ purpose: 'life_list', species: species, photo_id: photoId }),
+    });
+    await loadLifeList();
+    updateLifeListLightboxControls(activeLightboxPhotoId);
+    if (typeof showToast === 'function') showToast('Life List photo set', 'success');
+  } finally {
+    if (button) button.disabled = false;
+  }
+}
+
+function updateLifeListLightboxControls(photoId) {
+  var panel = ensureLifeListLightboxPanel();
+  if (!panel) return;
+  var match = findLifeListEntryForPhoto(photoId);
+  if (!match) {
+    panel.style.display = 'none';
+    panel.innerHTML = '';
+    return;
+  }
+  panel.style.display = '';
+  var selected = !!match.photo.is_life_list_photo;
+  panel.innerHTML = '<span>' + escapeAttr(match.entry.species) + '</span>'
+    + '<button data-lb-action="set-life-list"'
+    + (selected ? ' class="primary"' : '') + '>'
+    + (selected ? 'Life List Photo' : 'Use as Life List') + '</button>';
+  var btn = panel.querySelector('button');
+  btn.addEventListener('click', function(event) {
+    event.stopPropagation();
+    setLifeListPhoto(match.entry.species, match.photo.id, btn);
+  });
+}
+
+document.addEventListener('lightbox:photochanged', function(event) {
+  activeLightboxPhotoId = event.detail ? event.detail.photoId : null;
+  updateLifeListLightboxControls(activeLightboxPhotoId);
 });
 
 loadLifeList();

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -3013,6 +3013,41 @@ def test_rename_keyword_queues_sidecar_changes(app_and_db):
     assert ("keyword_add", "NewBird") in actions
 
 
+def test_rename_keyword_updates_photo_preferences(app_and_db):
+    """Representative-photo preferences follow species keyword renames."""
+    app, db = app_and_db
+    client = app.test_client()
+    kid = db.add_keyword("OldBird", is_species=True)
+    p1 = db.conn.execute("SELECT id FROM photos LIMIT 1").fetchone()["id"]
+    db.tag_photo(p1, kid)
+    db.set_photo_preference("life_list", "OldBird", p1)
+    db.set_photo_preference("highlights", "OldBird", p1)
+
+    resp = client.put(f"/api/keywords/{kid}", json={"name": "NewBird"})
+    assert resp.status_code == 200
+
+    assert db.get_photo_preferences("life_list") == {"NewBird": p1}
+    assert db.get_photo_preferences("highlights") == {"NewBird": p1}
+
+
+def test_rename_keyword_photo_preferences_keep_existing_target(app_and_db):
+    """Renaming into an existing preference keeps the target preference."""
+    app, db = app_and_db
+    client = app.test_client()
+    kid_old = db.add_keyword("OldBird", is_species=True)
+    rows = db.conn.execute("SELECT id FROM photos ORDER BY id LIMIT 2").fetchall()
+    p_old = rows[0]["id"]
+    p_new = rows[1]["id"]
+    db.tag_photo(p_old, kid_old)
+    db.set_photo_preference("life_list", "OldBird", p_old)
+    db.set_photo_preference("life_list", "NewBird", p_new)
+
+    resp = client.put(f"/api/keywords/{kid_old}", json={"name": "NewBird"})
+    assert resp.status_code == 200
+
+    assert db.get_photo_preferences("life_list") == {"NewBird": p_new}
+
+
 def test_delete_keyword_queues_sidecar_removals(app_and_db):
     """Deleting a keyword queues removal pending changes for affected photos."""
     app, db = app_and_db

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -3048,6 +3048,26 @@ def test_rename_keyword_photo_preferences_keep_existing_target(app_and_db):
     assert db.get_photo_preferences("life_list") == {"NewBird": p_new}
 
 
+def test_rename_homonym_non_species_keyword_leaves_species_preferences(app_and_db):
+    """Renaming an unrelated same-name keyword must not rewrite species prefs."""
+    app, db = app_and_db
+    client = app.test_client()
+    species_kid = db.add_keyword("Robin", is_species=True)
+    parent_kid = db.add_keyword("Places", kw_type="general")
+    place_kid = db.add_keyword("Robin", parent_id=parent_kid, kw_type="general")
+    rows = db.conn.execute("SELECT id FROM photos ORDER BY id LIMIT 2").fetchall()
+    species_photo = rows[0]["id"]
+    place_photo = rows[1]["id"]
+    db.tag_photo(species_photo, species_kid)
+    db.tag_photo(place_photo, place_kid)
+    db.set_photo_preference("life_list", "Robin", species_photo)
+
+    resp = client.put(f"/api/keywords/{place_kid}", json={"name": "Backyard Robin"})
+    assert resp.status_code == 200
+
+    assert db.get_photo_preferences("life_list") == {"Robin": species_photo}
+
+
 def test_delete_keyword_queues_sidecar_removals(app_and_db):
     """Deleting a keyword queues removal pending changes for affected photos."""
     app, db = app_and_db

--- a/vireo/tests/test_life_list.py
+++ b/vireo/tests/test_life_list.py
@@ -125,6 +125,53 @@ def test_best_photo_is_highest_scored(life_app):
     assert [p["id"] for p in cardinal["photos"]] == [ids["p2"], ids["p1"]]
 
 
+def test_life_list_photo_preference_overrides_best_photo(life_app):
+    app, _, ids = life_app
+    client = app.test_client()
+    resp = client.post("/api/photo-preferences", json={
+        "purpose": "life_list",
+        "species": "Northern Cardinal",
+        "photo_id": ids["p1"],
+    })
+    assert resp.status_code == 200
+
+    data = _get_life_list(app)
+    cardinal = _entry(data, "Northern Cardinal")
+    assert cardinal["best"]["id"] == ids["p1"]
+    assert cardinal["best"]["is_life_list_photo"] is True
+    assert cardinal["has_preferred_photo"] is True
+    assert [p["id"] for p in cardinal["photos"][:2]] == [ids["p1"], ids["p2"]]
+
+
+def test_life_list_photo_preference_must_match_species(life_app):
+    app, _, ids = life_app
+    resp = app.test_client().post("/api/photo-preferences", json={
+        "purpose": "life_list",
+        "species": "Northern Cardinal",
+        "photo_id": ids["p3"],
+    })
+    assert resp.status_code == 400
+
+
+def test_highlights_photo_preference_overrides_best_photo(life_app):
+    app, _, ids = life_app
+    client = app.test_client()
+    resp = client.post("/api/photo-preferences", json={
+        "purpose": "highlights",
+        "species": "Northern Cardinal",
+        "photo_id": ids["p1"],
+    })
+    assert resp.status_code == 200
+
+    data = client.get("/api/highlights?scope=workspace").get_json()
+    cardinal = next(
+        b for b in data["buckets"] if b["species"] == "Northern Cardinal"
+    )
+    assert cardinal["photos"][0]["id"] == ids["p1"]
+    assert cardinal["photos"][0]["is_highlights_photo"] is True
+    assert cardinal["has_preferred_photo"] is True
+
+
 def test_life_order_numbering_and_dates(life_app):
     app, _, _ = life_app
     data = _get_life_list(app)


### PR DESCRIPTION
## Summary

- Add workspace-scoped photo preferences for Life List and Highlights representative photos.
- Apply selected photos ahead of automatic highlight ranking when they are still eligible.
- Add lightbox controls and card ribbons so users can mark and see the selected representative photo.

## Validation

- `python -m pytest vireo/tests/test_life_list.py -q`
- `python -m pytest tests/e2e/test_highlights_initial_scope.py::test_highlights_api_limits_initial_bucket_and_loads_more vireo/tests/test_life_list.py -q`
- `python -m py_compile vireo/app.py vireo/db.py`
- Node parser checks for changed inline scripts in `highlights.html` and `life_list.html`