### PR TITLE
Add selected burst box alignment

### DIFF
--- a/tests/e2e/test_burst_group_context_menu.py
+++ b/tests/e2e/test_burst_group_context_menu.py
@@ -2,11 +2,11 @@ import pytest
 from playwright.sync_api import expect
 
 
-def _seed_burst_group(db, group_id="grp-test-1", model="test-classifier"):
+def _seed_burst_group(db, group_id="grp-test-1", model="BioCLIP-2"):
     """Promote the fixture's three hawk predictions into a single burst group.
 
     ``seed_e2e_data`` in conftest.py creates three hawk photos with one
-    prediction each (species=Red-tailed Hawk, classifier_model=test-classifier).
+    prediction each (species=Red-tailed Hawk, classifier_model=BioCLIP-2).
     Group state (``group_id``, ``vote_count``, ``total_votes``) lives in the
     workspace-scoped ``prediction_review`` table, so we upsert one row per
     prediction in the active workspace. Setting a non-null ``quality_score``
@@ -211,7 +211,8 @@ def test_burst_multi_selected_cards_drag_together(live_server, page):
     assert first_pid and second_pid
 
     # Start from an empty selection so this exercises normal click + additive
-    # Ctrl-click rather than depending on the modal's auto-selected AI best.
+    # Cmd-style additive click rather than depending on the modal's
+    # auto-selected AI best.
     page.evaluate(
         """() => {
           grmState.selected = null;
@@ -224,7 +225,7 @@ def test_burst_multi_selected_cards_drag_together(live_server, page):
     first = page.locator(f'#grmOverlay .grm-card[data-photo-id="{first_pid}"]')
     second = page.locator(f'#grmOverlay .grm-card[data-photo-id="{second_pid}"]')
     first.click()
-    second.click(modifiers=["Control"])
+    second.click(modifiers=["Meta"])
 
     selected = page.evaluate("Array.from(grmState.selectedIds).map(String).sort()")
     assert selected == sorted([first_pid, second_pid])
@@ -250,6 +251,74 @@ def test_burst_multi_selected_cards_drag_together(live_server, page):
     assert abs(offsets["a"]["ty"] - offsets["b"]["ty"]) < 0.01
     assert abs(offsets["a"]["tx"]) > 0
     assert abs(offsets["a"]["ty"]) > 0
+
+
+def test_burst_loupe_drag_offsets_selected_cards_only(live_server, page):
+    """Dragging the right preview should nudge only the selected burst cards."""
+    n = _seed_burst_group(live_server["db"])
+    if n < 2:
+        pytest.skip("need at least 2 burst cards")
+
+    url = live_server["url"]
+    page.goto(f"{url}/review")
+    page.wait_for_load_state("networkidle")
+    _open_burst_modal(page)
+
+    cards = page.locator("#grmOverlay .grm-card[data-photo-id]")
+    assert cards.count() >= 2
+    first_pid = cards.nth(0).get_attribute("data-photo-id")
+    second_pid = cards.nth(1).get_attribute("data-photo-id")
+    third_pid = cards.nth(2).get_attribute("data-photo-id") if cards.count() >= 3 else None
+    assert first_pid and second_pid
+
+    page.evaluate(
+        """() => {
+          grmState.selected = null;
+          grmState.selectedIds.clear();
+          grmState.selectionAnchor = null;
+          renderGroupModal();
+        }"""
+    )
+
+    page.locator(f'#grmOverlay .grm-card[data-photo-id="{first_pid}"]').click()
+    selected_pids = [first_pid]
+    untouched_pid = second_pid
+    if third_pid:
+        page.locator(f'#grmOverlay .grm-card[data-photo-id="{second_pid}"]').click(modifiers=["Meta"])
+        selected_pids.append(second_pid)
+        untouched_pid = third_pid
+    selected = page.evaluate("Array.from(grmState.selectedIds).map(String).sort()")
+    assert selected == sorted(selected_pids)
+
+    loupe = page.locator("#grmLoupeImg")
+    bbox = loupe.bounding_box()
+    assert bbox is not None
+    x = bbox["x"] + bbox["width"] / 2
+    y = bbox["y"] + bbox["height"] / 2
+    page.mouse.move(x, y)
+    page.mouse.down()
+    drag_started = page.evaluate("_grmLoupeAlignDragging ? _grmLoupeAlignDragging.targets.length : 0")
+    assert drag_started == len(selected_pids)
+    page.mouse.move(x + 28, y + 14)
+    page.mouse.up()
+
+    offsets = page.evaluate(
+        """([selected, untouched]) => ({
+          selected: selected.map((pid) => _grmOffsets[pid]),
+          untouched: _grmOffsets[untouched],
+          locked: _grmLoupeLocked,
+        })""",
+        [selected_pids, untouched_pid],
+    )
+    assert all(offsets["selected"])
+    assert offsets["untouched"] is None
+    assert offsets["locked"] is False
+    first_offset = offsets["selected"][0]
+    for offset in offsets["selected"][1:]:
+        assert abs(first_offset["tx"] - offset["tx"]) < 0.01
+        assert abs(first_offset["ty"] - offset["ty"]) < 0.01
+    assert abs(first_offset["tx"]) > 0
+    assert abs(first_offset["ty"]) > 0
 
 
 def test_review_card_menu_has_no_burst_items(live_server, page):

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -1154,6 +1154,7 @@ input[type="range"]::-moz-range-thumb {
   min-height: 200px;
   max-height: 50vh;
 }
+.grm-loupe-img.align-dragging { cursor: grabbing; }
 .grm-loupe-img img {
   width: 100%;
   height: 100%;
@@ -1550,8 +1551,8 @@ input[type="range"]::-moz-range-thumb {
       </div>
     </div>
     <div class="grm-loupe" id="grmLoupe">
-      <div class="grm-loupe-img" id="grmLoupeImg" onmousemove="grmLoupeMove(event)" onmouseleave="grmLoupeReset()" onclick="grmLoupeToggleLock(event)" onwheel="grmLoupeZoom(event)">
-        <img id="grmLoupePhoto" alt="" onload="grmLoupeImgLoaded(this)">
+      <div class="grm-loupe-img" id="grmLoupeImg" onmousedown="grmLoupeMouseDown(event)" onmousemove="grmLoupeMove(event)" onmouseleave="grmLoupeReset()" onclick="grmLoupeToggleLock(event)" onwheel="grmLoupeZoom(event)">
+        <img id="grmLoupePhoto" alt="" onload="grmLoupeImgLoaded(this)" draggable="false">
         <div class="grm-loupe-crosshair-h" id="grmCrosshairH"></div>
         <div class="grm-loupe-crosshair-v" id="grmCrosshairV"></div>
       </div>
@@ -1609,6 +1610,7 @@ input[type="range"]::-moz-range-thumb {
       <span class="grm-mouse-pop">
         <strong>Mouse</strong>
         Click the preview to lock/unlock zoom<br>
+        Drag the preview to nudge selected thumbnails<br>
         Drag a thumbnail to pan it<br>
         Double-click a thumbnail to reset pan
       </span>
@@ -3842,7 +3844,11 @@ function openGroupReview(encIdx, burstIdx, selectPhotoId) {
   _grmLastHoverY = null;
   _grmOffsets = {};
   _grmDragging = null;
+  _grmLoupeAlignDragging = null;
+  document.removeEventListener('mousemove', grmLoupeMouseMove);
+  document.removeEventListener('mouseup', grmLoupeMouseUp);
   _grmSuppressNextClick = false;
+  _grmSuppressLoupeClick = false;
   grmRefreshResetAllVisibility();
 
   document.getElementById('grmOverlay').classList.add('open');
@@ -3996,6 +4002,9 @@ function closeGroupReview() {
   document.getElementById('grmOverlay').classList.remove('open');
   _grmOffsets = {};
   _grmDragging = null;
+  _grmLoupeAlignDragging = null;
+  document.removeEventListener('mousemove', grmLoupeMouseMove);
+  document.removeEventListener('mouseup', grmLoupeMouseUp);
   grmRefreshResetAllVisibility();
 }
 
@@ -4645,7 +4654,9 @@ var _grmLastHoverY = null;
 // space — so offsets stay correct as the shared zoom changes between frames.
 var _grmOffsets = {};
 var _grmDragging = null;
+var _grmLoupeAlignDragging = null;
 var _grmSuppressNextClick = false;
+var _grmSuppressLoupeClick = false;
 
 function _grmInitialThumbSize() {
   try {
@@ -4710,6 +4721,12 @@ function grmCardCoverFit(card) {
   var W = parseFloat(card.dataset.natW) || GRM_CARD_W;
   var H = parseFloat(card.dataset.natH) || GRM_CARD_H;
   return Math.max(GRM_CARD_W / W, GRM_CARD_H / H);
+}
+
+function _grmCardDisplayedScale(card) {
+  var coverFit = grmCardCoverFit(card);
+  var hovering = _grmLastHoverX != null;
+  return hovering ? Math.max(coverFit, _grmZoomMultiplier) : coverFit;
 }
 
 // Effective max for `_grmZoomMultiplier`. Since the <img> is laid out at
@@ -4832,6 +4849,10 @@ function grmPositionCrosshair(x, y) {
 }
 
 function grmLoupeToggleLock(e) {
+  if (_grmSuppressLoupeClick) {
+    _grmSuppressLoupeClick = false;
+    return;
+  }
   _grmLoupeLocked = !_grmLoupeLocked;
   var ch = document.getElementById('grmCrosshairH');
   var cv = document.getElementById('grmCrosshairV');
@@ -4846,6 +4867,7 @@ function grmLoupeToggleLock(e) {
 }
 
 function grmLoupeMove(e) {
+  if (_grmLoupeAlignDragging) return;
   if (_grmLoupeLocked) return;
 
   var rect = e.currentTarget.getBoundingClientRect();
@@ -4858,6 +4880,84 @@ function grmLoupeMove(e) {
   grmApplyLoupeZoom();
 
   grmApplyCardTransforms();
+}
+
+function _grmSelectedOffsetTargets() {
+  var ids = [];
+  if (grmState && grmState.selectedIds && grmState.selectedIds.size) {
+    ids = Array.from(grmState.selectedIds);
+  } else if (grmState && grmState.selected) {
+    ids = [grmState.selected];
+  }
+  var seen = {};
+  return ids.map(function(pid) {
+    var key = String(pid);
+    if (seen[key]) return null;
+    seen[key] = true;
+    var targetCard = document.querySelector('#grmOverlay .grm-card[data-photo-id="' + key + '"]');
+    if (!targetCard) return null;
+    var cur = _grmOffsets[key] || _grmOffsets[pid] || { tx: 0, ty: 0 };
+    return { card: targetCard, photoId: key, origTx: cur.tx, origTy: cur.ty };
+  }).filter(Boolean);
+}
+
+function grmLoupeMouseDown(e) {
+  if (e.button !== 0) return;
+  var targets = _grmSelectedOffsetTargets();
+  if (!targets.length) return;
+  _grmLoupeAlignDragging = {
+    targets: targets,
+    startX: e.clientX,
+    startY: e.clientY,
+    moved: false,
+  };
+  document.addEventListener('mousemove', grmLoupeMouseMove);
+  document.addEventListener('mouseup', grmLoupeMouseUp);
+  e.preventDefault();
+}
+
+function grmLoupeMouseMove(e) {
+  if (!_grmLoupeAlignDragging) return;
+  if ((e.buttons & 1) === 0) {
+    grmLoupeMouseUp(e);
+    return;
+  }
+  var dx = e.clientX - _grmLoupeAlignDragging.startX;
+  var dy = e.clientY - _grmLoupeAlignDragging.startY;
+  if (!_grmLoupeAlignDragging.moved && (Math.abs(dx) > 3 || Math.abs(dy) > 3)) {
+    _grmLoupeAlignDragging.moved = true;
+    var loupe = document.getElementById('grmLoupeImg');
+    if (loupe) loupe.classList.add('align-dragging');
+    _grmLoupeAlignDragging.targets.forEach(function(target) {
+      target.card.classList.add('dragging');
+    });
+  }
+  if (!_grmLoupeAlignDragging.moved) return;
+  _grmLoupeAlignDragging.targets.forEach(function(target) {
+    var scale = _grmCardDisplayedScale(target.card);
+    var z = scale > 0.01 ? scale : 1;
+    var newTx = target.origTx + dx / z;
+    var newTy = target.origTy + dy / z;
+    _grmOffsets[target.photoId] = { tx: newTx, ty: newTy };
+    _grmApplyCardTransform(target.card);
+    _grmUpdateIndicator(target.card);
+  });
+  e.preventDefault();
+}
+
+function grmLoupeMouseUp(e) {
+  if (!_grmLoupeAlignDragging) return;
+  var moved = _grmLoupeAlignDragging.moved;
+  _grmLoupeAlignDragging.targets.forEach(function(target) {
+    target.card.classList.remove('dragging');
+  });
+  var loupe = document.getElementById('grmLoupeImg');
+  if (loupe) loupe.classList.remove('align-dragging');
+  document.removeEventListener('mousemove', grmLoupeMouseMove);
+  document.removeEventListener('mouseup', grmLoupeMouseUp);
+  _grmLoupeAlignDragging = null;
+  if (moved) _grmSuppressLoupeClick = true;
+  grmRefreshResetAllVisibility();
 }
 
 function grmLoupeZoom(e) {
@@ -4880,6 +4980,7 @@ function grmLoupeZoom(e) {
 function grmLoupeReset() {
   if (_grmLoupeLocked) return;
   if (_grmDragging) return;
+  if (_grmLoupeAlignDragging) return;
   _grmLastHoverX = null;
   _grmLastHoverY = null;
   // Re-apply transforms in their default (non-hovered, cover-fit, centred)
@@ -4941,14 +5042,7 @@ function grmCardMouseMove(e) {
   // Use each card's actual displayed scale so the same screen drag produces
   // the same visible pan on every selected photo, even across mixed sizes.
   _grmDragging.targets.forEach(function(target) {
-    // Must mirror _grmComputeCardTransform's hover/non-hover branch: after a
-    // zoom-in followed by mouseleave (grmLoupeReset clears _grmLastHoverX) the
-    // card is displayed at cover-fit while _grmZoomMultiplier stays at its
-    // hovered value, so the denominator must match what's actually on screen
-    // or pans would jump when hover resumes.
-    var coverFit = grmCardCoverFit(target.card);
-    var hovering = _grmLastHoverX != null;
-    var scale = hovering ? Math.max(coverFit, _grmZoomMultiplier) : coverFit;
+    var scale = _grmCardDisplayedScale(target.card);
     var z = scale > 0.01 ? scale : 1;
     var newTx = target.origTx + dx / z;
     var newTy = target.origTy + dy / z;

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -610,6 +610,7 @@
     overflow: hidden;
     cursor: crosshair;
   }
+  .grm-loupe-img.align-dragging { cursor: grabbing; }
   .grm-loupe-img img {
     width: 100%;
     height: 100%;
@@ -1589,7 +1590,11 @@ function openGroupReview(groupId, model) {
   _grmLoupeZoomLevel = 1;
   _grmOffsets = {};
   _grmDragging = null;
+  _grmLoupeAlignDragging = null;
+  document.removeEventListener('mousemove', grmLoupeMouseMove);
+  document.removeEventListener('mouseup', grmLoupeMouseUp);
   _grmSuppressNextClick = false;
+  _grmSuppressLoupeClick = false;
   _grmLoupeLastX = 50;
   _grmLoupeLastY = 50;
   _grmLoupeHovering = false;
@@ -1610,6 +1615,9 @@ function closeGroupReview() {
   document.getElementById('grmOverlay').classList.remove('open');
   _grmOffsets = {};
   _grmDragging = null;
+  _grmLoupeAlignDragging = null;
+  document.removeEventListener('mousemove', grmLoupeMouseMove);
+  document.removeEventListener('mouseup', grmLoupeMouseUp);
   grmRefreshResetAllVisibility();
 }
 
@@ -1874,7 +1882,9 @@ var _grmLoupeLocked = false;
 // the underlying image as the shared zoom changes.
 var _grmOffsets = {};
 var _grmDragging = null;
+var _grmLoupeAlignDragging = null;
 var _grmSuppressNextClick = false;
+var _grmSuppressLoupeClick = false;
 // Latest cursor position over the loupe image (in %), used as the transform
 // origin when zoom is applied outside a mouse event (e.g. wheel after drag,
 // 1:1 snap, drag-induced re-apply). Initialized to centre so pre-hover zoom
@@ -2186,6 +2196,10 @@ function _grmMaxZoom() {
 }
 
 function grmLoupeToggleLock(e) {
+  if (_grmSuppressLoupeClick) {
+    _grmSuppressLoupeClick = false;
+    return;
+  }
   _grmLoupeLocked = !_grmLoupeLocked;
   var ch = document.getElementById('grmCrosshairH');
   var cv = document.getElementById('grmCrosshairV');
@@ -2200,6 +2214,7 @@ function grmLoupeToggleLock(e) {
 }
 
 function grmLoupeMove(e) {
+  if (_grmLoupeAlignDragging) return;
   if (_grmLoupeLocked) return;
 
   var rect = e.currentTarget.getBoundingClientRect();
@@ -2218,6 +2233,90 @@ function grmLoupeMove(e) {
   // for every strip card. Upgrade only when the user expresses zoom intent via
   // the wheel or the 1:1 snap key.
   _grmApplyAllCardTransforms(x, y);
+}
+
+function _grmCardDisplayedScale(card) {
+  var coverFit = _grmCardCoverFit(card);
+  var hovering = _grmLoupeHovering || _grmLoupeLocked;
+  return hovering ? Math.max(coverFit, coverFit * _grmZoomLevel) : coverFit;
+}
+
+function _grmSelectedOffsetTargets() {
+  var ids = [];
+  if (grmState && grmState.selectedIds && grmState.selectedIds.size) {
+    ids = Array.from(grmState.selectedIds);
+  } else if (grmState && grmState.selected) {
+    ids = [grmState.selected];
+  }
+  var seen = {};
+  return ids.map(function(pid) {
+    var key = String(pid);
+    if (seen[key]) return null;
+    seen[key] = true;
+    var targetCard = document.querySelector('.grm-card[data-photo-id="' + key + '"]');
+    if (!targetCard) return null;
+    var cur = _grmOffsets[key] || _grmOffsets[pid] || { tx: 0, ty: 0 };
+    return { card: targetCard, photoId: key, origTx: cur.tx, origTy: cur.ty };
+  }).filter(Boolean);
+}
+
+function grmLoupeMouseDown(e) {
+  if (e.button !== 0) return;
+  var targets = _grmSelectedOffsetTargets();
+  if (!targets.length) return;
+  _grmLoupeAlignDragging = {
+    targets: targets,
+    startX: e.clientX,
+    startY: e.clientY,
+    moved: false,
+  };
+  document.addEventListener('mousemove', grmLoupeMouseMove);
+  document.addEventListener('mouseup', grmLoupeMouseUp);
+  e.preventDefault();
+}
+
+function grmLoupeMouseMove(e) {
+  if (!_grmLoupeAlignDragging) return;
+  if ((e.buttons & 1) === 0) {
+    grmLoupeMouseUp(e);
+    return;
+  }
+  var dx = e.clientX - _grmLoupeAlignDragging.startX;
+  var dy = e.clientY - _grmLoupeAlignDragging.startY;
+  if (!_grmLoupeAlignDragging.moved && (Math.abs(dx) > 3 || Math.abs(dy) > 3)) {
+    _grmLoupeAlignDragging.moved = true;
+    var loupe = document.getElementById('grmLoupeImg');
+    if (loupe) loupe.classList.add('align-dragging');
+    _grmLoupeAlignDragging.targets.forEach(function(target) {
+      target.card.classList.add('dragging');
+    });
+  }
+  if (!_grmLoupeAlignDragging.moved) return;
+  _grmLoupeAlignDragging.targets.forEach(function(target) {
+    var scale = _grmCardDisplayedScale(target.card);
+    var z = scale > 0.001 ? scale : 1;
+    var newTx = target.origTx + dx / z;
+    var newTy = target.origTy + dy / z;
+    _grmOffsets[target.photoId] = { tx: newTx, ty: newTy };
+    _grmApplyCardTransform(target.card);
+    _grmUpdateIndicator(target.card);
+  });
+  e.preventDefault();
+}
+
+function grmLoupeMouseUp(e) {
+  if (!_grmLoupeAlignDragging) return;
+  var moved = _grmLoupeAlignDragging.moved;
+  _grmLoupeAlignDragging.targets.forEach(function(target) {
+    target.card.classList.remove('dragging');
+  });
+  var loupe = document.getElementById('grmLoupeImg');
+  if (loupe) loupe.classList.remove('align-dragging');
+  document.removeEventListener('mousemove', grmLoupeMouseMove);
+  document.removeEventListener('mouseup', grmLoupeMouseUp);
+  _grmLoupeAlignDragging = null;
+  if (moved) _grmSuppressLoupeClick = true;
+  grmRefreshResetAllVisibility();
 }
 
 function _grmCardCoverFit(card) {
@@ -2334,6 +2433,7 @@ function _grmFinishSnap() {
 function grmLoupeReset() {
   if (_grmLoupeLocked) return;
   if (_grmDragging) return;
+  if (_grmLoupeAlignDragging) return;
   // Re-apply transforms in their default (cover-fit, centred) state. We
   // can't just clear `style.transform` because the natural-size <img> needs
   // a scale-down transform at all times to fit the thumbnail viewport.
@@ -2392,9 +2492,7 @@ function grmCardMouseMove(e) {
   // space. That keeps the visible pan delta identical across selected cards
   // even when their displayed scales differ.
   _grmDragging.targets.forEach(function(target) {
-    var coverFit = _grmCardCoverFit(target.card);
-    var hovering = _grmLoupeHovering || _grmLoupeLocked;
-    var s = hovering ? Math.max(coverFit, coverFit * _grmZoomLevel) : coverFit;
+    var s = _grmCardDisplayedScale(target.card);
     var z = s > 0.001 ? s : 1;
     var newTx = target.origTx + dx / z;
     var newTy = target.origTy + dy / z;
@@ -2713,8 +2811,8 @@ document.addEventListener('keydown', function(e) {
       </div>
     </div>
     <div class="grm-loupe" id="grmLoupe">
-      <div class="grm-loupe-img" id="grmLoupeImg" onmousemove="grmLoupeMove(event)" onmouseleave="grmLoupeReset()" onclick="grmLoupeToggleLock(event)" onwheel="grmLoupeZoom(event)">
-        <img id="grmLoupePhoto" src="" alt="" onload="grmLoupeImgLoaded(this)">
+      <div class="grm-loupe-img" id="grmLoupeImg" onmousedown="grmLoupeMouseDown(event)" onmousemove="grmLoupeMove(event)" onmouseleave="grmLoupeReset()" onclick="grmLoupeToggleLock(event)" onwheel="grmLoupeZoom(event)">
+        <img id="grmLoupePhoto" src="" alt="" onload="grmLoupeImgLoaded(this)" draggable="false">
         <div class="grm-loupe-crosshair-h" id="grmCrosshairH"></div>
         <div class="grm-loupe-crosshair-v" id="grmCrosshairV"></div>
       </div>
@@ -2757,6 +2855,7 @@ document.addEventListener('keydown', function(e) {
       <span class="grm-mouse-pop">
         <strong>Mouse</strong>
         Click the preview to lock/unlock zoom<br>
+        Drag the preview to nudge selected thumbnails<br>
         Drag a thumbnail to pan it<br>
         Double-click a thumbnail to reset pan
       </span>


### PR DESCRIPTION
Adds right-preview dragging in burst review so selected thumbnail crop boxes can be nudged together without moving the rest of the group.

This applies the behavior to both the classic review burst modal and the pipeline review burst modal, sharing the existing per-photo offset math and preventing drag gestures from toggling preview lock.

It also updates burst e2e coverage so the current fixture model is exercised and verifies preview dragging only offsets the selected cards.

Validation: `python -m pytest tests/e2e/test_burst_group_context_menu.py tests/e2e/test_burst_group_natural_size.py -q` and `git diff --check`.
