### PR TITLE
Fix "Open in Browse Mode" doing nothing in the Tauri app window

### DIFF
--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1720,6 +1720,20 @@ function sendReport() {
     }
     return Array.from(selectionSet);
   };
+
+  // Open Browse mode focused on a photo. In a real browser we open a new tab so
+  // the caller (pipeline review, group review, etc.) keeps its state. Inside the
+  // Tauri app window there are no tabs and the webview ignores
+  // window.open(_, '_blank'), so navigate the single window in place instead —
+  // matching how the native View menu switches pages.
+  window.openInBrowse = function(photoId){
+    var url = '/browse?photo_id=' + photoId;
+    if (typeof isTauri === 'function' && isTauri()) {
+      window.location.href = url;
+    } else {
+      window.open(url, '_blank', 'noopener');
+    }
+  };
 })();
 </script>
 

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -5196,15 +5196,15 @@ function buildPipelinePhotoContextMenu(photoId) {
   return [
     {
       label: 'Open in Browse Mode',
-      onClick: function() { window.open('/browse?photo_id=' + photoId, '_blank', 'noopener'); },
+      onClick: function() { window.openInBrowse(photoId); },
     },
   ];
 }
 
 /* --- Right-click menu ---
  * Catches contextmenu on photo cards (main grid) and grm-cards (group review
- * modal). Browse opens in a new tab so the user keeps their pipeline-review
- * state intact. */
+ * modal). Browse opens in a new tab (browser) or navigates in place (Tauri app
+ * window) via openInBrowse, so the user reaches the photo either way. */
 document.addEventListener('contextmenu', function(e) {
   var card = e.target.closest('.photo-card[data-photo-id], .grm-card[data-photo-id]');
   if (!card) return;
@@ -5214,7 +5214,7 @@ document.addEventListener('contextmenu', function(e) {
   if (typeof openContextMenu === 'function') {
     openContextMenu(e, buildPipelinePhotoContextMenu(pid));
   } else {
-    window.open('/browse?photo_id=' + pid, '_blank', 'noopener');
+    window.openInBrowse(pid);
   }
 });
 

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1538,7 +1538,7 @@ function buildBurstGroupContextMenu(photoId, filename) {
         if (typeof window.developPhotos === 'function') window.developPhotos([photoId]);
       } },
     { label: 'Open in Browse Mode',
-      onClick: function() { window.open('/browse?photo_id=' + photoId, '_blank'); } },
+      onClick: function() { window.openInBrowse(photoId); } },
     { separator: true },
     { label: 'Remove from Group',       onClick: function() { grmRemoveFromGroup(); } },
   ]);


### PR DESCRIPTION
The "Open in Browse Mode" context-menu item used `window.open(url, '_blank')`, which Tauri's single-window webview silently ignores (no tabs, no new-window handler), so clicking it did nothing in the desktop app — it only worked when Vireo was launched in a browser. This adds a shared `window.openInBrowse()` helper that opens a new tab in a browser but navigates the window in place inside Tauri (matching the native View menu's navigation), then routes the pipeline-review and review context-menu items through it. Frontend-only change; `vireo/tests/test_app.py` passes (226/226).

🤖 Generated with [Claude Code](https://claude.com/claude-code)