### PR TITLE
Fix iNaturalist external links silently failing in desktop app

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -24,6 +24,7 @@
     "core:tray:default",
     "core:tray:allow-set-icon",
     "core:tray:allow-set-tooltip",
-    "opener:allow-open-url"
+    "opener:allow-open-url",
+    "opener:allow-default-urls"
   ]
 }

--- a/vireo/static/tauri-bridge.js
+++ b/vireo/static/tauri-bridge.js
@@ -65,9 +65,16 @@ async function openExternal(url) {
       return false;
     }
   }
-  // Browser: window.open returns null if a popup blocker stopped it.
-  var win = window.open(url, '_blank', 'noopener');
-  return !!win;
+  // Browser fallback. We deliberately omit the 'noopener' window feature: with
+  // it, window.open returns null even on a *successful* open (MDN), which would
+  // make us report a false "could not open". Instead open about:blank first so
+  // we can null the opener same-origin, then navigate — this keeps popup-block
+  // detection (a real null return) and still prevents reverse-tabnabbing.
+  var win = window.open('about:blank', '_blank');
+  if (!win) return false;
+  try { win.opener = null; } catch (e) {}
+  win.location = url;
+  return true;
 }
 
 /**

--- a/vireo/static/tauri-bridge.js
+++ b/vireo/static/tauri-bridge.js
@@ -44,6 +44,33 @@ async function pickFile(opts) {
 }
 
 /**
+ * Open an external URL in the user's default browser.
+ *
+ * Inside the Tauri desktop webview a bare `window.open(url, '_blank')` is
+ * silently dropped — no tab opens and no error fires — so external links must
+ * be routed through the opener plugin instead. In a normal browser we fall
+ * back to window.open (which also lets us detect a popup blocker).
+ *
+ * @param {string} url - The http(s) URL to open
+ * @returns {Promise<boolean>} true if the open was dispatched successfully
+ */
+async function openExternal(url) {
+  if (!url) return false;
+  if (isTauri()) {
+    try {
+      await window.__TAURI_INTERNALS__.invoke('plugin:opener|open_url', { url: url, with: null });
+      return true;
+    } catch (e) {
+      console.error('openExternal failed:', e);
+      return false;
+    }
+  }
+  // Browser: window.open returns null if a popup blocker stopped it.
+  var win = window.open(url, '_blank', 'noopener');
+  return !!win;
+}
+
+/**
  * Check for an available update via the Rust command.
  * @returns {Promise<{available: boolean, version: string|null, notes: string|null, date: string|null}|null>}
  *   Returns null if not running in Tauri or on error.

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -4425,8 +4425,17 @@ async function submitToInat(photoId) {
     if (data.error) { alert(data.error); return; }
 
     if (data.mode === 'quick') {
-      // Fallback: open iNat in browser
-      window.open(data.upload_url, '_blank');
+      // No API token configured: open the iNaturalist upload page (prefilled
+      // with taxon/date/location) in the user's browser. A bare window.open is
+      // silently dropped inside the desktop webview, so route through
+      // openExternal and tell the user if nothing opened instead of failing
+      // invisibly.
+      var opened = await openExternal(data.upload_url);
+      if (opened) {
+        showToast('Opening iNaturalist in your browser…', 'info');
+      } else {
+        showToast('Could not open iNaturalist. Add an API token in Settings to submit directly from Vireo.', 'error');
+      }
       return;
     }
 
@@ -4488,7 +4497,7 @@ function openInatModal() {
   inatQueue.forEach(function(item, idx) {
     var warn = '';
     if (item.already_submitted) {
-      warn = '<div class="inat-card-status warning">&#9888; Already submitted: <a href="' + escapeAttr(item.existing_url) + '" target="_blank" style="color:var(--warning);">' + escapeHtml(item.existing_url) + '</a></div>';
+      warn = '<div class="inat-card-status warning">&#9888; Already submitted: <a href="' + escapeAttr(item.existing_url) + '" target="_blank" onclick="return openExternalLink(event, this.href)" style="color:var(--warning);">' + escapeHtml(item.existing_url) + '</a></div>';
     }
     html += '<div class="inat-card" id="inatCard' + idx + '">' +
       '<div class="inat-card-header">' +
@@ -4574,7 +4583,7 @@ async function inatDoSubmit() {
         statusEl.textContent = '✗ ' + result.error;
       } else {
         statusEl.className = 'inat-card-status success';
-        statusEl.innerHTML = '&#10003; Submitted — <a href="' + escapeAttr(result.observation_url) + '" target="_blank" style="color:var(--accent);">View on iNaturalist</a>';
+        statusEl.innerHTML = '&#10003; Submitted — <a href="' + escapeAttr(result.observation_url) + '" target="_blank" onclick="return openExternalLink(event, this.href)" style="color:var(--accent);">View on iNaturalist</a>';
         succeeded++;
       }
     } catch(e) {
@@ -5409,6 +5418,19 @@ function showToast(msg, type) {
     toast.style.opacity = '0';
     setTimeout(function() { toast.remove(); }, 200);
   }, 5000);
+}
+
+/* ---------- External links ---------- */
+// Click handler for external (http/https) links. Inside the desktop webview a
+// plain `target="_blank"` anchor does nothing, so route the open through the
+// OS browser via openExternal (tauri-bridge.js) and prevent the dead in-app
+// navigation. Use on <a> tags as: onclick="return openExternalLink(event, this.href)".
+function openExternalLink(event, url) {
+  if (event) event.preventDefault();
+  openExternal(url).then(function(ok) {
+    if (!ok) showToast('Could not open link: ' + url, 'error');
+  });
+  return false;
 }
 
 /* ---------- Safe Fetch ---------- */

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -857,7 +857,7 @@
     <div class="section-title">iNaturalist</div>
     <p style="font-size:12px;color:var(--text-dim);margin-bottom:12px;">
       Submit observations directly from Vireo.
-      Get your API token from <a href="https://www.inaturalist.org/users/api_token" target="_blank" style="color:var(--accent);text-decoration:none;">inaturalist.org/users/api_token</a>
+      Get your API token from <a href="https://www.inaturalist.org/users/api_token" target="_blank" onclick="return openExternalLink(event, this.href)" style="color:var(--accent);text-decoration:none;">inaturalist.org/users/api_token</a>
     </p>
     <div class="setting-row">
       <div class="setting-label">


### PR DESCRIPTION
Inside the Tauri desktop webview, `window.open('_blank')` and plain `target="_blank"` anchors are silently dropped, so the iNaturalist quick-mode button, the post-submit "View on iNaturalist" link, the "already submitted" link, and the Settings "Get your API token" link all did nothing in the desktop app. This adds an `openExternal()` bridge helper (routes through the bundled `opener` plugin in Tauri, falls back to `window.open` in a browser) plus an `openExternalLink()` anchor click handler, and routes all four iNaturalist links through them. Quick mode now shows a toast confirming the browser hand-off and an actionable error if nothing opens, instead of failing invisibly.

Verified: `node --check` on the bridge JS, Tauri invoke signature confirmed against `tauri-plugin-opener-2.5.4`, all four links confirmed wired via the Flask test client, and the full suite passes (1114 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)