### PR TITLE
Add image edit recipe foundation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,14 @@ from db import Database
 
 
 @pytest.fixture(autouse=True)
+def _disable_startup_backfill_timers(monkeypatch):
+    """See ``vireo/tests/conftest.py`` for the rationale — mirrored here so
+    the top-level ``tests/`` suite (which also calls ``create_app``) doesn't
+    leak Timer-driven backfill jobs across tests."""
+    monkeypatch.setenv("VIREO_DISABLE_STARTUP_BACKFILL_TIMERS", "1")
+
+
+@pytest.fixture(autouse=True)
 def _expanduser_prefers_test_home(monkeypatch):
     """Make HOME-based tests portable to Windows.
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -11985,33 +11985,52 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             job["_start_time"] = time.time()
 
             for i, photo in enumerate(photos):
+                detail_photo = thread_db.get_photo(photo["id"]) or photo
                 cache_path = os.path.join(preview_dir, f'{photo["id"]}_{max_size}.jpg')
                 recipe = thread_db.get_photo_edit_recipe(photo["id"])
                 if os.path.exists(cache_path):
-                    skipped += 1
-                    # Adopt any untracked file so precompute output is
-                    # visible to eviction and /api/preview-cache.
-                    # Best-effort: photo may be deleted mid-job (FK error).
+                    cache_row = None
                     with contextlib.suppress(Exception):
-                        if not thread_db.preview_cache_get(photo["id"], max_size):
-                            thread_db.preview_cache_insert(
-                                photo["id"], max_size, os.path.getsize(cache_path),
+                        cache_row = thread_db.preview_cache_get(photo["id"], max_size)
+                    if recipe and cache_row is None:
+                        with contextlib.suppress(OSError):
+                            os.remove(cache_path)
+                        if os.path.exists(cache_path):
+                            skipped += 1
+                            log.info(
+                                "Skipping untracked edited preview for photo %s; "
+                                "existing cache file could not be removed",
+                                photo["id"],
                             )
-                else:
+                            continue
+                    else:
+                        skipped += 1
+                        # Adopt untracked unedited files so precompute output is
+                        # visible to eviction and /api/preview-cache.
+                        # Best-effort: photo may be deleted mid-job (FK error).
+                        with contextlib.suppress(Exception):
+                            if cache_row is None:
+                                thread_db.preview_cache_insert(
+                                    photo["id"],
+                                    max_size,
+                                    os.path.getsize(cache_path),
+                                )
+                        continue
+
+                if not os.path.exists(cache_path):
                     canonical, using_working_copy = _recipe_render_source(
-                        photo, recipe, max_size, vireo_dir, folders,
+                        detail_photo, recipe, max_size, vireo_dir, folders,
                     )
                     from image_loader import RAW_EXTENSIONS
-                    marker_photo = thread_db.get_photo(photo["id"]) or photo
                     if (
                         not using_working_copy
                         and os.path.splitext(canonical)[1].lower() in RAW_EXTENSIONS
                         and _has_current_working_copy_failure(
-                            marker_photo,
+                            detail_photo,
                             vireo_dir,
                             trust_existing_working_copy=False,
                             live_source_path=canonical,
-                            folder_path=folders.get(photo["folder_id"]),
+                            folder_path=folders.get(detail_photo["folder_id"]),
                         )
                     ):
                         skipped += 1

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1671,12 +1671,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             wc_path = wc_rel if os.path.isabs(wc_rel) else os.path.join(vireo_dir, wc_rel)
             return os.path.abspath(path) == os.path.abspath(wc_path)
 
-        if not recipe or not recipe.get("crop"):
+        if not recipe:
             canonical = get_canonical_image_path(photo, vireo_dir, folders)
             return canonical, _is_working_copy_path(canonical)
 
-        if _working_copy_satisfies_recipe_render(photo, recipe, max_size, vireo_dir):
-            canonical = get_canonical_image_path(photo, vireo_dir, folders)
+        canonical = get_canonical_image_path(photo, vireo_dir, folders)
+        if _is_working_copy_path(canonical):
+            return canonical, True
+
+        if recipe.get("crop") and _working_copy_satisfies_recipe_render(
+            photo, recipe, max_size, vireo_dir,
+        ):
             return canonical, _is_working_copy_path(canonical)
 
         folder_path = folders.get(photo["folder_id"])

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -16374,7 +16374,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 photo_id,
             )
             return "Could not load image", 500
-        img = load_image(canonical, max_size=None if recipe else size)
+        load_max_size = None if recipe and recipe.get("crop") else size
+        img = load_image(canonical, max_size=load_max_size)
         if img is None:
             _record_working_copy_failure(db, photo, canonical)
             return "Could not load image", 500
@@ -16515,6 +16516,35 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         trusted_wc_path = _trusted_full_res_working_copy_path()
 
+        def _full_res_companion_path(folder_path, using_offline_cache=False):
+            companion_path = photo["companion_path"]
+            if not companion_path:
+                return None
+            companion_abs = os.path.join(folder_path, companion_path)
+            if using_offline_cache:
+                offline_row = db.offline_original_get(photo_id)
+                if offline_row and offline_row["companion_path"]:
+                    offline_companion = os.path.join(
+                        vireo_dir, offline_row["companion_path"]
+                    )
+                    if os.path.exists(offline_companion):
+                        companion_abs = offline_companion
+            if not os.path.exists(companion_abs):
+                return None
+            orig_w = photo["width"]
+            orig_h = photo["height"]
+            if not (orig_w and orig_h):
+                return None
+            from PIL import Image as _PILImage
+            try:
+                with _PILImage.open(companion_abs) as _cimg:
+                    c_w, c_h = _cimg.size
+            except Exception:
+                return None
+            if c_w >= orig_w and c_h >= orig_h:
+                return companion_abs
+            return None
+
         if recipe:
             folder = db.conn.execute(
                 "SELECT path FROM folders WHERE id=?", (photo["folder_id"],)
@@ -16531,6 +16561,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     vireo_dir,
                     {photo["folder_id"]: folder["path"]},
                 )
+                companion_source = _full_res_companion_path(
+                    folder["path"], using_offline_cache,
+                )
+                if companion_source:
+                    image_path = companion_source
             from image_loader import RAW_EXTENSIONS, load_image
             resolved_ext = os.path.splitext(image_path)[1].lower()
             if (
@@ -16613,30 +16648,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # dimensions must be at least as large as the stored original
         # dimensions.  If original dimensions are unknown (None) we cannot
         # make that guarantee, so fall back to decoding from the RAW.
-        source_for_extraction = image_path
-        if photo["companion_path"]:
-            companion_abs = os.path.join(folder["path"], photo["companion_path"])
-            if using_offline_cache:
-                offline_row = db.offline_original_get(photo_id)
-                if offline_row and offline_row["companion_path"]:
-                    offline_companion = os.path.join(
-                        vireo_dir, offline_row["companion_path"]
-                    )
-                    if os.path.exists(offline_companion):
-                        companion_abs = offline_companion
-            if os.path.exists(companion_abs):
-                orig_w = photo["width"]
-                orig_h = photo["height"]
-                if orig_w and orig_h:
-                    from PIL import Image as _PILImage
-                    try:
-                        with _PILImage.open(companion_abs) as _cimg:
-                            c_w, c_h = _cimg.size
-                        if c_w >= orig_w and c_h >= orig_h:
-                            source_for_extraction = companion_abs
-                    except Exception:
-                        pass  # unreadable companion — fall back to RAW
-                # If original dims are unknown, skip companion (can't verify resolution)
+        source_for_extraction = (
+            _full_res_companion_path(folder["path"], using_offline_cache) or image_path
+        )
 
         if extract_working_copy(source_for_extraction, wc_abs, max_size=0, quality=quality):
             # Update DB so future requests are fast; also backfill

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1676,7 +1676,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return canonical, _is_working_copy_path(canonical)
 
         canonical = get_canonical_image_path(photo, vireo_dir, folders)
-        if _is_working_copy_path(canonical):
+        if not recipe.get("crop") and _is_working_copy_path(canonical):
             return canonical, True
 
         if recipe.get("crop") and _working_copy_satisfies_recipe_render(

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1494,6 +1494,23 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         wc_render_long = _rendered_recipe_long_edge(wc_w, wc_h, recipe)
         return wc_render_long >= required_long
 
+    def _path_satisfies_recipe_render(path, photo, recipe, max_size):
+        original_w = photo["width"] or 0
+        original_h = photo["height"] or 0
+        if original_w <= 0 or original_h <= 0:
+            return False
+        try:
+            from PIL import Image as _PILImage
+            with _PILImage.open(path) as img:
+                width, height = img.size
+        except Exception:
+            return False
+        original_render_long = _rendered_recipe_long_edge(
+            original_w, original_h, recipe,
+        )
+        required_long = min(max_size, original_render_long) if max_size else original_render_long
+        return _rendered_recipe_long_edge(width, height, recipe) >= required_long
+
     def _recipe_render_source(photo, recipe, max_size, vireo_dir, folders):
         from image_loader import get_canonical_image_path
 
@@ -1510,6 +1527,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 if os.path.exists(wc_path):
                     return wc_path, True
             return "", False
+        companion_path = photo["companion_path"]
+        if companion_path:
+            companion = os.path.join(folder_path, companion_path)
+            if (
+                os.path.exists(companion)
+                and _path_satisfies_recipe_render(companion, photo, recipe, max_size)
+            ):
+                return companion, True
         original = os.path.join(
             folder_path,
             photo["filename"],

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1413,9 +1413,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def _invalidate_photo_render_cache(db, photo_ids):
         """Drop cached rendered derivatives after an edit recipe changes."""
         vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+        thumb_dir = app.config["THUMB_CACHE_DIR"]
         preview_dir = os.path.join(vireo_dir, "previews")
         originals_dir = os.path.join(vireo_dir, "originals")
         for pid in photo_ids:
+            thumb_cache = os.path.join(thumb_dir, f"{pid}.jpg")
+            try:
+                if os.path.exists(thumb_cache):
+                    os.remove(thumb_cache)
+            except OSError:
+                log.warning("Failed to remove stale thumbnail cache %s", thumb_cache)
+            db.conn.execute("UPDATE photos SET thumb_path = NULL WHERE id = ?", (pid,))
             tracked_sizes = set()
             for row in db.conn.execute(
                 "SELECT size FROM preview_cache WHERE photo_id = ?",
@@ -11826,7 +11834,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                                 photo["id"], max_size, os.path.getsize(cache_path),
                             )
                 else:
-                    canonical = get_canonical_image_path(photo, vireo_dir, folders)
+                    if recipe and recipe.get("crop"):
+                        canonical = os.path.join(
+                            folders.get(photo["folder_id"], ""),
+                            photo["filename"],
+                        )
+                    else:
+                        canonical = get_canonical_image_path(photo, vireo_dir, folders)
                     img = load_image(canonical, max_size=None if recipe else max_size)
                     if img:
                         if recipe:
@@ -13397,8 +13411,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             {folder_row["id"]: folder_row["path"]} if folder_row else {}
         )
         try:
+            recipe = db.get_photo_edit_recipe(photo_id)
             source = get_canonical_image_path(photo, vireo_dir, folders)
-            result = generate_thumbnail(photo_id, source, thumb_dir)
+            result = generate_thumbnail(photo_id, source, thumb_dir, recipe=recipe)
         except Exception:
             log.exception(
                 "Thumbnail self-heal failed for photo %s (source=%s)",
@@ -16227,7 +16242,24 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             )
             return "Could not load image", 500
 
-        canonical = get_canonical_image_path(photo, vireo_dir, folders)
+        use_original_for_crop = bool(recipe and recipe.get("crop"))
+        if use_original_for_crop:
+            if _has_current_working_copy_failure(
+                photo,
+                vireo_dir,
+                trust_existing_working_copy=False,
+                live_source_path=live_source,
+                folder_path=folder_row["path"],
+            ):
+                log.info(
+                    "Skipping cropped preview generation for photo %s; RAW "
+                    "working-copy extraction already failed for current source mtime",
+                    photo_id,
+                )
+                return "Could not load image", 500
+            canonical = live_source
+        else:
+            canonical = get_canonical_image_path(photo, vireo_dir, folders)
         img = load_image(canonical, max_size=None if recipe else size)
         if img is None:
             _record_working_copy_failure(db, photo, canonical)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1514,11 +1514,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def _recipe_render_source(photo, recipe, max_size, vireo_dir, folders):
         from image_loader import get_canonical_image_path
 
+        def _is_working_copy_path(path):
+            wc_rel = photo["working_copy_path"]
+            if not path or not wc_rel:
+                return False
+            wc_path = wc_rel if os.path.isabs(wc_rel) else os.path.join(vireo_dir, wc_rel)
+            return os.path.abspath(path) == os.path.abspath(wc_path)
+
         if not recipe or not recipe.get("crop"):
-            return get_canonical_image_path(photo, vireo_dir, folders), True
+            canonical = get_canonical_image_path(photo, vireo_dir, folders)
+            return canonical, _is_working_copy_path(canonical)
 
         if _working_copy_satisfies_recipe_render(photo, recipe, max_size, vireo_dir):
-            return get_canonical_image_path(photo, vireo_dir, folders), True
+            canonical = get_canonical_image_path(photo, vireo_dir, folders)
+            return canonical, _is_working_copy_path(canonical)
 
         folder_path = folders.get(photo["folder_id"])
         if not folder_path:
@@ -3677,8 +3686,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     @app.route("/api/photos/<int:photo_id>/edit-recipe", methods=["PUT", "POST"])
     def api_set_photo_edit_recipe(photo_id):
         db = _get_db()
-        body = request.get_json(silent=True) or {}
+        body = request.get_json(silent=True)
+        if not isinstance(body, dict):
+            return json_error("request body must be a JSON object")
         recipe = body.get("recipe", body)
+        if not isinstance(recipe, dict):
+            return json_error("recipe must be a JSON object")
         photo = db.get_photo(photo_id, verify_workspace=True)
         if not photo:
             return json_error("not found", 404)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -16371,6 +16371,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 pass
             db.preview_cache_delete(photo_id, size)  # no-op if no row
 
+        skip_untracked_preview_adoption = False
         if (
             recipe
             and os.path.exists(cache_path)
@@ -16379,7 +16380,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             try:
                 os.remove(cache_path)
             except OSError:
-                pass
+                skip_untracked_preview_adoption = True
+                log.warning(
+                    "Failed to remove stale untracked preview cache %s",
+                    cache_path, exc_info=True,
+                )
 
         # Cache hit (tracked): touch and serve. The touch is best-effort
         # bookkeeping — under concurrent traffic SQLite can raise
@@ -16399,7 +16404,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # Read bytes into memory before evicting: eviction may delete the
         # file we just adopted (e.g. preview_cache_max_mb=0), but we can
         # still serve the response from memory — mirrors the miss path.
-        if os.path.exists(cache_path):
+        if not skip_untracked_preview_adoption and os.path.exists(cache_path):
             with open(cache_path, "rb") as f:
                 data = f.read()
             try:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1420,12 +1420,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         originals_dir = os.path.join(vireo_dir, "originals")
         for pid in photo_ids:
             thumb_cache = os.path.join(thumb_dir, f"{pid}.jpg")
+            clear_thumb_path = True
             try:
                 if os.path.exists(thumb_cache):
                     os.remove(thumb_cache)
             except OSError:
-                log.warning("Failed to remove stale thumbnail cache %s", thumb_cache)
-            db.conn.execute("UPDATE photos SET thumb_path = NULL WHERE id = ?", (pid,))
+                clear_thumb_path = not os.path.exists(thumb_cache)
+                log.warning(
+                    "Failed to remove stale thumbnail cache %s", thumb_cache,
+                    exc_info=True,
+                )
+            if clear_thumb_path:
+                db.conn.execute(
+                    "UPDATE photos SET thumb_path = NULL WHERE id = ?", (pid,),
+                )
             tracked_sizes = set()
             for row in db.conn.execute(
                 "SELECT size FROM preview_cache WHERE photo_id = ?",
@@ -16635,7 +16643,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             resolved_ext = os.path.splitext(image_path)[1].lower()
             if (
                 trusted_wc_path is None
-                and (not using_offline_cache or resolved_ext in RAW_EXTENSIONS)
+                and resolved_ext in RAW_EXTENSIONS
                 and _has_current_working_copy_failure(
                     photo,
                     vireo_dir,

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -11771,6 +11771,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             import contextlib
 
             import config as cfg
+            from image_edits import apply_recipe_to_loaded_image
             from image_loader import get_canonical_image_path, load_image
 
             thread_db = Database(db_path)
@@ -11808,6 +11809,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
             for i, photo in enumerate(photos):
                 cache_path = os.path.join(preview_dir, f'{photo["id"]}_{max_size}.jpg')
+                recipe = thread_db.get_photo_edit_recipe(photo["id"])
+                if recipe and os.path.exists(cache_path):
+                    with contextlib.suppress(OSError):
+                        os.remove(cache_path)
+                    with contextlib.suppress(Exception):
+                        thread_db.preview_cache_delete(photo["id"], max_size)
                 if os.path.exists(cache_path):
                     skipped += 1
                     # Adopt any untracked file so precompute output is
@@ -11820,8 +11827,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                             )
                 else:
                     canonical = get_canonical_image_path(photo, vireo_dir, folders)
-                    img = load_image(canonical, max_size=max_size)
+                    img = load_image(canonical, max_size=None if recipe else max_size)
                     if img:
+                        if recipe:
+                            img = apply_recipe_to_loaded_image(
+                                img, recipe, max_size=max_size,
+                            )
                         img.save(cache_path, format="JPEG", quality=preview_quality)
                         with contextlib.suppress(Exception):
                             thread_db.preview_cache_insert(
@@ -16144,6 +16155,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
         preview_dir = os.path.join(vireo_dir, "previews")
         cache_path = os.path.join(preview_dir, f"{photo_id}_{size}.jpg")
+        recipe = db.get_photo_edit_recipe(photo_id)
 
         # Reject corrupt zero-byte cache files (prior write interrupted).
         # Treat them as a miss so the regeneration path below produces a
@@ -16154,6 +16166,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             except OSError:
                 pass
             db.preview_cache_delete(photo_id, size)  # no-op if no row
+
+        if (
+            recipe
+            and os.path.exists(cache_path)
+            and not db.preview_cache_get(photo_id, size)
+        ):
+            try:
+                os.remove(cache_path)
+            except OSError:
+                pass
 
         # Cache hit (tracked): touch and serve. The touch is best-effort
         # bookkeeping — under concurrent traffic SQLite can raise
@@ -16206,7 +16228,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return "Could not load image", 500
 
         canonical = get_canonical_image_path(photo, vireo_dir, folders)
-        recipe = db.get_photo_edit_recipe(photo_id)
         img = load_image(canonical, max_size=None if recipe else size)
         if img is None:
             _record_working_copy_failure(db, photo, canonical)
@@ -16355,15 +16376,34 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if not folder:
                 return "Not found", 404
             image_path = trusted_wc_path
+            using_offline_cache = False
             if image_path is None:
                 from offline_cache import resolve_original_path
-                image_path, _using_offline_cache = resolve_original_path(
+                image_path, using_offline_cache = resolve_original_path(
                     db,
                     photo,
                     vireo_dir,
                     {photo["folder_id"]: folder["path"]},
                 )
-            from image_loader import load_image
+            from image_loader import RAW_EXTENSIONS, load_image
+            resolved_ext = os.path.splitext(image_path)[1].lower()
+            if (
+                trusted_wc_path is None
+                and (not using_offline_cache or resolved_ext in RAW_EXTENSIONS)
+                and _has_current_working_copy_failure(
+                    photo,
+                    vireo_dir,
+                    trust_existing_working_copy=False,
+                    live_source_path=image_path,
+                    folder_path=folder["path"],
+                )
+            ):
+                log.info(
+                    "Skipping edited original-image extraction for photo %s; "
+                    "RAW working-copy extraction already failed for current source mtime",
+                    photo_id,
+                )
+                return "Could not load image", 500
             img = load_image(image_path, max_size=None)
             if img is None:
                 _record_working_copy_failure(db, photo, image_path)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -13446,7 +13446,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # self-heal work for cameras whose RAW format libraw cannot
         # decode (the working copy was extracted from the embedded JPEG
         # at scan time).
-        from image_loader import get_canonical_image_path
+        import config as cfg
         from thumbnails import generate_thumbnail
         vireo_dir = os.path.dirname(thumb_dir)
         # Look up the photo's folder path directly rather than via
@@ -13464,8 +13464,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         )
         try:
             recipe = db.get_photo_edit_recipe(photo_id)
-            source = get_canonical_image_path(photo, vireo_dir, folders)
-            result = generate_thumbnail(photo_id, source, thumb_dir, recipe=recipe)
+            thumb_size = cfg.load().get("thumbnail_size", 400)
+            source, _using_working_copy = _recipe_render_source(
+                photo, recipe, thumb_size, vireo_dir, folders,
+            )
+            result = generate_thumbnail(
+                photo_id,
+                source,
+                thumb_dir,
+                size=thumb_size,
+                recipe=recipe,
+            )
         except Exception:
             log.exception(
                 "Thumbnail self-heal failed for photo %s (source=%s)",

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -13506,6 +13506,23 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             source, _using_working_copy = _recipe_render_source(
                 photo, recipe, thumb_size, vireo_dir, folders,
             )
+            if (
+                not _using_working_copy
+                and _has_current_working_copy_failure(
+                    photo,
+                    vireo_dir,
+                    trust_existing_working_copy=False,
+                    live_source_path=live_source,
+                    folder_path=folder_row["path"],
+                )
+            ):
+                log.info(
+                    "Skipping thumbnail self-heal for photo %s; selected source "
+                    "would retry a RAW decode that already failed for current "
+                    "source mtime",
+                    photo_id,
+                )
+                return "", 404
             result = generate_thumbnail(
                 photo_id,
                 source,

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -16297,19 +16297,72 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
         recipe = db.get_photo_edit_recipe(photo_id)
 
+        # Decide whether to trust the working copy as the full-res asset
+        # by reading its actual on-disk dimensions, NOT the current
+        # ``working_copy_max_size`` config — the cap may have changed
+        # since the wc was generated, leaving stale capped wcs that
+        # config-based logic would misclassify as full-res.
+        #
+        # PIL.Image.open is lazy: it reads the JPEG SOF marker for
+        # ``.size`` without decoding pixels (sub-millisecond), so this
+        # is safe to do per request even during burst-review zoom. The
+        # expensive path we must avoid is the RAW re-extract below
+        # (5–7s per photo), not the header read.
+        def _trusted_full_res_working_copy_path():
+            if not photo["working_copy_path"]:
+                return None
+            wc_path = os.path.join(vireo_dir, photo["working_copy_path"])
+            if not os.path.exists(wc_path):
+                return None
+            from PIL import Image as _PILImage
+            try:
+                with _PILImage.open(wc_path) as _wc_img:
+                    wc_w, wc_h = _wc_img.size
+            except Exception:
+                wc_w = wc_h = 0
+            orig_w = photo["width"] or 0
+            orig_h = photo["height"] or 0
+            # Trust the wc when it meets/exceeds the believed original dims,
+            # or when those dims are unknown (no basis to declare the wc stale
+            # and a speculative RAW re-extract would just thrash the disk).
+            if wc_w and wc_h and (
+                (wc_w >= orig_w and wc_h >= orig_h) or not (orig_w and orig_h)
+            ):
+                return wc_path
+            # The wc is smaller than the believed original. For RAW sources
+            # this often means rawpy.postprocess() failed and we fell back to
+            # the embedded JPEG, which can be a few pixels shy of the full
+            # sensor area. Re-extracting would yield the same fallback image,
+            # just slower — so trust the wc when it is within 1% of the
+            # believed dims. This tolerance is RAW-only: for JPEG/PNG/etc.,
+            # the wc being smaller means the cap downsized it, and re-extracting
+            # WILL produce more pixels.
+            from image_loader import RAW_EXTENSIONS
+            ext = os.path.splitext(photo["filename"])[1].lower()
+            if ext in RAW_EXTENSIONS and wc_w and wc_h:
+                wc_long = max(wc_w, wc_h)
+                orig_long = max(orig_w, orig_h)
+                if orig_long and wc_long >= orig_long * 0.99:
+                    return wc_path
+            return None
+
+        trusted_wc_path = _trusted_full_res_working_copy_path()
+
         if recipe:
             folder = db.conn.execute(
                 "SELECT path FROM folders WHERE id=?", (photo["folder_id"],)
             ).fetchone()
             if not folder:
                 return "Not found", 404
-            from offline_cache import resolve_original_path
-            image_path, _using_offline_cache = resolve_original_path(
-                db,
-                photo,
-                vireo_dir,
-                {photo["folder_id"]: folder["path"]},
-            )
+            image_path = trusted_wc_path
+            if image_path is None:
+                from offline_cache import resolve_original_path
+                image_path, _using_offline_cache = resolve_original_path(
+                    db,
+                    photo,
+                    vireo_dir,
+                    {photo["folder_id"]: folder["path"]},
+                )
             from image_loader import load_image
             img = load_image(image_path, max_size=None)
             if img is None:
@@ -16325,56 +16378,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             img.close()
             return send_file(cache_path, mimetype="image/jpeg")
 
-        # Decide whether to trust the working copy as the full-res asset
-        # by reading its actual on-disk dimensions, NOT the current
-        # ``working_copy_max_size`` config — the cap may have changed
-        # since the wc was generated, leaving stale capped wcs that
-        # config-based logic would misclassify as full-res.
-        #
-        # PIL.Image.open is lazy: it reads the JPEG SOF marker for
-        # ``.size`` without decoding pixels (sub-millisecond), so this
-        # is safe to do per request even during burst-review zoom. The
-        # expensive path we must avoid is the RAW re-extract below
-        # (5–7s per photo), not the header read.
-        if photo["working_copy_path"]:
-            wc_path = os.path.join(vireo_dir, photo["working_copy_path"])
-            if os.path.exists(wc_path):
-                from PIL import Image as _PILImage
-                try:
-                    with _PILImage.open(wc_path) as _wc_img:
-                        wc_w, wc_h = _wc_img.size
-                except Exception:
-                    wc_w = wc_h = 0
-                orig_w = photo["width"] or 0
-                orig_h = photo["height"] or 0
-                # Trust the wc when it meets/exceeds the believed
-                # original dims, or when those dims are unknown (no
-                # basis to declare the wc stale and a speculative RAW
-                # re-extract would just thrash the disk).
-                if wc_w and wc_h and (
-                    (wc_w >= orig_w and wc_h >= orig_h)
-                    or not (orig_w and orig_h)
-                ):
-                    return send_file(wc_path, mimetype="image/jpeg")
-                # The wc is smaller than the believed original. For RAW
-                # sources this often means rawpy.postprocess() failed
-                # and we fell back to the embedded JPEG, which can be a
-                # few pixels shy of the full sensor area (e.g. Nikon
-                # NEFs report 8280×5520 but the embedded JPEG is
-                # 8256×5504). Re-extracting would yield the same
-                # fallback image, just slower — so trust the wc when
-                # it is within 1% of the believed dims. This tolerance
-                # is RAW-only: for JPEG/PNG/etc., the wc being smaller
-                # means the cap downsized it, and re-extracting WILL
-                # produce more pixels.
-                from image_loader import RAW_EXTENSIONS
-                ext = os.path.splitext(photo["filename"])[1].lower()
-                if ext in RAW_EXTENSIONS and wc_w and wc_h:
-                    wc_long = max(wc_w, wc_h)
-                    orig_long = max(orig_w, orig_h)
-                    if orig_long and wc_long >= orig_long * 0.99:
-                        return send_file(wc_path, mimetype="image/jpeg")
-                # Fall through to on-demand re-extract.
+        if trusted_wc_path:
+            return send_file(trusted_wc_path, mimetype="image/jpeg")
 
         # Resolve original file path
         folder = db.conn.execute(

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1416,16 +1416,32 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         preview_dir = os.path.join(vireo_dir, "previews")
         originals_dir = os.path.join(vireo_dir, "originals")
         for pid in photo_ids:
+            tracked_sizes = set()
             for row in db.conn.execute(
                 "SELECT size FROM preview_cache WHERE photo_id = ?",
                 (pid,),
             ).fetchall():
+                tracked_sizes.add(str(row["size"]))
                 path = os.path.join(preview_dir, f"{pid}_{row['size']}.jpg")
                 try:
                     if os.path.exists(path):
                         os.remove(path)
                 except OSError:
                     log.warning("Failed to remove stale preview cache %s", path)
+            try:
+                for name in os.listdir(preview_dir):
+                    if not (name.startswith(f"{pid}_") and name.endswith(".jpg")):
+                        continue
+                    size_part = name[len(f"{pid}_"):-4]
+                    if size_part in tracked_sizes:
+                        continue
+                    path = os.path.join(preview_dir, name)
+                    try:
+                        os.remove(path)
+                    except OSError:
+                        log.warning("Failed to remove stale preview cache %s", path)
+            except FileNotFoundError:
+                pass
             db.conn.execute("DELETE FROM preview_cache WHERE photo_id = ?", (pid,))
             original_cache = os.path.join(originals_dir, f"{pid}.jpg")
             try:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1503,8 +1503,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if _working_copy_satisfies_recipe_render(photo, recipe, max_size, vireo_dir):
             return get_canonical_image_path(photo, vireo_dir, folders), True
 
+        folder_path = folders.get(photo["folder_id"])
+        if not folder_path:
+            if photo["working_copy_path"]:
+                wc_path = os.path.join(vireo_dir, photo["working_copy_path"])
+                if os.path.exists(wc_path):
+                    return wc_path, True
+            return "", False
         original = os.path.join(
-            folders.get(photo["folder_id"], ""),
+            folder_path,
             photo["filename"],
         )
         if not os.path.exists(original) and photo["working_copy_path"]:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5,6 +5,7 @@ Usage:
 """
 
 import argparse
+import contextlib
 import json
 import logging
 import logging.handlers
@@ -45,6 +46,7 @@ from werkzeug.exceptions import BadRequest
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 log = logging.getLogger(__name__)
+_EXIF_ORIENTATION_TAG = 274
 
 
 # Stable ordering and labels for the palette + nav rendering.
@@ -1523,6 +1525,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return height, width
         return width, height
 
+    def _image_size_after_exif_orientation(img):
+        width, height = img.size
+        orientation = None
+        with contextlib.suppress(Exception):
+            orientation = img.getexif().get(_EXIF_ORIENTATION_TAG)
+        if _orientation_swaps_axes(orientation):
+            return height, width
+        return width, height
+
     def _working_copy_satisfies_recipe_render(photo, recipe, max_size, vireo_dir):
         if not recipe or not recipe.get("crop"):
             return True
@@ -1535,7 +1546,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         try:
             from PIL import Image as _PILImage
             with _PILImage.open(wc_path) as wc_img:
-                wc_w, wc_h = wc_img.size
+                wc_w, wc_h = _image_size_after_exif_orientation(wc_img)
         except Exception:
             return False
         original_w, original_h = _recipe_source_dimensions(photo)
@@ -1553,7 +1564,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         try:
             from PIL import Image as _PILImage
             with _PILImage.open(path) as img:
-                width, height = img.size
+                width, height = _image_size_after_exif_orientation(img)
         except Exception:
             return False
         original_render_long = _rendered_recipe_long_edge(

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -11931,7 +11931,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     canonical, _using_working_copy = _recipe_render_source(
                         photo, recipe, max_size, vireo_dir, folders,
                     )
-                    img = load_image(canonical, max_size=None if recipe else max_size)
+                    load_max_size = (
+                        None if recipe and recipe.get("crop") else max_size
+                    )
+                    img = load_image(canonical, max_size=load_max_size)
                     if img:
                         if recipe:
                             img = apply_recipe_to_loaded_image(

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2216,9 +2216,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     # Daemon=True so short-lived ``create_app`` callers (tests, scripts,
     # one-shot tooling) don't get pinned waiting on the 5-second delay
     # only to fire DB work after their real work is already done.
-    _wc_backfill_timer = threading.Timer(5.0, _kickoff_working_copy_backfill)
-    _wc_backfill_timer.daemon = True
-    _wc_backfill_timer.start()
+    #
+    # Suppressed in tests via ``VIREO_DISABLE_STARTUP_BACKFILL_TIMERS``:
+    # otherwise a Timer scheduled by a fast-finishing test fires during a
+    # later test, runs a JobRunner thread against the now-stale tmp_path
+    # DB, and its ``image_loader.load_image`` call (via
+    # ``extract_working_copy``) is intercepted by the next test's
+    # monkeypatch of that same module attribute.
+    if not os.environ.get("VIREO_DISABLE_STARTUP_BACKFILL_TIMERS"):
+        _wc_backfill_timer = threading.Timer(5.0, _kickoff_working_copy_backfill)
+        _wc_backfill_timer.daemon = True
+        _wc_backfill_timer.start()
 
     # ----- thumb_path self-healing backfill -----
     # The dashboard's coverage card counts thumbnails by ``thumb_path IS NOT
@@ -2299,9 +2307,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
     app._kickoff_thumb_path_backfill = _kickoff_thumb_path_backfill
 
-    _thumb_backfill_timer = threading.Timer(6.0, _kickoff_thumb_path_backfill)
-    _thumb_backfill_timer.daemon = True
-    _thumb_backfill_timer.start()
+    if not os.environ.get("VIREO_DISABLE_STARTUP_BACKFILL_TIMERS"):
+        _thumb_backfill_timer = threading.Timer(6.0, _kickoff_thumb_path_backfill)
+        _thumb_backfill_timer.daemon = True
+        _thumb_backfill_timer.start()
 
     # -- Page routes --
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -15,6 +15,7 @@ import queue
 import re
 import subprocess
 import sys
+import tempfile
 import time
 import webbrowser
 from datetime import UTC, datetime
@@ -1412,6 +1413,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             g.db = Database(db_path)
         return g.db
 
+    _invalid_preview_cache_paths = set()
+
     def _invalidate_photo_render_cache(db, photo_ids):
         """Drop cached rendered derivatives after an edit recipe changes."""
         vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
@@ -1435,17 +1438,26 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     "UPDATE photos SET thumb_path = NULL WHERE id = ?", (pid,),
                 )
             tracked_sizes = set()
+            removed_preview_rows = []
             for row in db.conn.execute(
                 "SELECT size FROM preview_cache WHERE photo_id = ?",
                 (pid,),
             ).fetchall():
-                tracked_sizes.add(str(row["size"]))
-                path = os.path.join(preview_dir, f"{pid}_{row['size']}.jpg")
+                size_value = row["size"]
+                tracked_sizes.add(str(size_value))
+                path = os.path.join(preview_dir, f"{pid}_{size_value}.jpg")
                 try:
                     if os.path.exists(path):
                         os.remove(path)
                 except OSError:
-                    log.warning("Failed to remove stale preview cache %s", path)
+                    if os.path.exists(path):
+                        _invalid_preview_cache_paths.add(path)
+                    log.warning(
+                        "Failed to remove stale preview cache %s",
+                        path, exc_info=True,
+                    )
+                else:
+                    removed_preview_rows.append((pid, size_value))
             try:
                 for name in os.listdir(preview_dir):
                     if not (name.startswith(f"{pid}_") and name.endswith(".jpg")):
@@ -1457,10 +1469,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     try:
                         os.remove(path)
                     except OSError:
-                        log.warning("Failed to remove stale preview cache %s", path)
+                        if os.path.exists(path):
+                            _invalid_preview_cache_paths.add(path)
+                        log.warning(
+                            "Failed to remove stale preview cache %s",
+                            path, exc_info=True,
+                        )
             except FileNotFoundError:
                 pass
-            db.conn.execute("DELETE FROM preview_cache WHERE photo_id = ?", (pid,))
+            if removed_preview_rows:
+                db.conn.executemany(
+                    "DELETE FROM preview_cache WHERE photo_id = ? AND size = ?",
+                    removed_preview_rows,
+                )
             original_cache = os.path.join(originals_dir, f"{pid}.jpg")
             try:
                 if os.path.exists(original_cache):
@@ -16412,6 +16433,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             db.preview_cache_delete(photo_id, size)  # no-op if no row
 
         skip_untracked_preview_adoption = False
+        stale_after_failed_invalidation = cache_path in _invalid_preview_cache_paths
+        if stale_after_failed_invalidation and os.path.exists(cache_path):
+            try:
+                os.remove(cache_path)
+            except OSError:
+                skip_untracked_preview_adoption = True
+                log.warning(
+                    "Failed to remove previously invalidated preview cache %s",
+                    cache_path, exc_info=True,
+                )
+            else:
+                _invalid_preview_cache_paths.discard(cache_path)
+                db.preview_cache_delete(photo_id, size)
+                stale_after_failed_invalidation = False
         if (
             recipe
             and os.path.exists(cache_path)
@@ -16430,7 +16465,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # bookkeeping — under concurrent traffic SQLite can raise
         # OperationalError: database is locked, but that shouldn't turn a
         # valid cache hit into a 500 when the JPEG is right there on disk.
-        if db.preview_cache_get(photo_id, size) and os.path.exists(cache_path):
+        if (
+            not stale_after_failed_invalidation
+            and db.preview_cache_get(photo_id, size)
+            and os.path.exists(cache_path)
+        ):
             try:
                 db.preview_cache_touch(photo_id, size)
             except Exception:
@@ -16444,7 +16483,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # Read bytes into memory before evicting: eviction may delete the
         # file we just adopted (e.g. preview_cache_max_mb=0), but we can
         # still serve the response from memory — mirrors the miss path.
-        if not skip_untracked_preview_adoption and os.path.exists(cache_path):
+        if (
+            not stale_after_failed_invalidation
+            and not skip_untracked_preview_adoption
+            and os.path.exists(cache_path)
+        ):
             with open(cache_path, "rb") as f:
                 data = f.read()
             try:
@@ -16511,6 +16554,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             os.makedirs(preview_dir, exist_ok=True)
             with open(cache_path, "wb") as f:
                 f.write(data)
+            _invalid_preview_cache_paths.discard(cache_path)
             db.preview_cache_insert(photo_id, size, len(data))
             evict_preview_cache_if_over_quota(db, vireo_dir)
         except Exception as e:
@@ -16706,7 +16750,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             cache_path = os.path.join(originals_dir, f"{photo_id}.jpg")
             os.makedirs(originals_dir, exist_ok=True)
             quality = cfg.load().get("working_copy_quality", 92)
-            img.save(cache_path, format="JPEG", quality=quality)
+            fd, tmp_path = tempfile.mkstemp(
+                prefix=f".{photo_id}.", suffix=".jpg.tmp", dir=originals_dir,
+            )
+            os.close(fd)
+            try:
+                img.save(tmp_path, format="JPEG", quality=quality)
+                os.replace(tmp_path, cache_path)
+            except Exception:
+                with contextlib.suppress(OSError):
+                    os.unlink(tmp_path)
+                raise
             img.close()
             return send_file(cache_path, mimetype="image/jpeg")
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -13798,16 +13798,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not folder_row:
             return "", 404
         live_source = os.path.join(folder_row["path"], photo["filename"])
-        if _has_current_working_copy_failure(
-            photo, os.path.dirname(thumb_dir),
-            live_source_path=live_source, folder_path=folder_row["path"],
-        ):
-            log.info(
-                "Skipping thumbnail self-heal for photo %s; RAW working-copy "
-                "extraction already failed for current source mtime",
-                photo_id,
-            )
-            return "", 404
 
         # Resolve source via the canonical-path helper so we prefer the
         # JPEG working copy over the original RAW. This makes the

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -11998,9 +11998,30 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                                 photo["id"], max_size, os.path.getsize(cache_path),
                             )
                 else:
-                    canonical, _using_working_copy = _recipe_render_source(
+                    canonical, using_working_copy = _recipe_render_source(
                         photo, recipe, max_size, vireo_dir, folders,
                     )
+                    from image_loader import RAW_EXTENSIONS
+                    marker_photo = thread_db.get_photo(photo["id"]) or photo
+                    if (
+                        not using_working_copy
+                        and os.path.splitext(canonical)[1].lower() in RAW_EXTENSIONS
+                        and _has_current_working_copy_failure(
+                            marker_photo,
+                            vireo_dir,
+                            trust_existing_working_copy=False,
+                            live_source_path=canonical,
+                            folder_path=folders.get(photo["folder_id"]),
+                        )
+                    ):
+                        skipped += 1
+                        log.info(
+                            "Skipping preview warmup for photo %s; RAW "
+                            "working-copy extraction already failed for "
+                            "current source mtime",
+                            photo["id"],
+                        )
+                        continue
                     load_max_size = (
                         None if recipe and recipe.get("crop") else max_size
                     )
@@ -16415,7 +16436,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return Response(data, mimetype="image/jpeg")
 
         # Cache miss: generate, insert, evict-if-over-quota, serve.
-        from image_loader import load_image
+        from image_loader import RAW_EXTENSIONS, load_image
 
         folder_row = db.conn.execute(
             "SELECT id, path FROM folders WHERE id=?", (photo["folder_id"],)
@@ -16424,27 +16445,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return "Not found", 404
         folders = {folder_row["id"]: folder_row["path"]}
 
-        live_source = os.path.join(folder_row["path"], photo["filename"])
-        if _has_current_working_copy_failure(
-            photo, vireo_dir,
-            live_source_path=live_source, folder_path=folder_row["path"],
-        ):
-            log.info(
-                "Skipping preview generation for photo %s; RAW working-copy "
-                "extraction already failed for current source mtime",
-                photo_id,
-            )
-            return "Could not load image", 500
-
         canonical, using_working_copy = _recipe_render_source(
             photo, recipe, size, vireo_dir, folders,
         )
-        if not using_working_copy and _has_current_working_copy_failure(
-            photo,
-            vireo_dir,
-            trust_existing_working_copy=False,
-            live_source_path=live_source,
-            folder_path=folder_row["path"],
+        selected_ext = os.path.splitext(canonical)[1].lower()
+        if (
+            not using_working_copy
+            and selected_ext in RAW_EXTENSIONS
+            and _has_current_working_copy_failure(
+                photo,
+                vireo_dir,
+                trust_existing_working_copy=False,
+                live_source_path=canonical,
+                folder_path=folder_row["path"],
+            )
         ):
             log.info(
                 "Skipping cropped preview generation for photo %s; RAW "

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1421,6 +1421,46 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
     _invalid_preview_cache_paths = set()
 
+    def _ensure_preview_cache_invalidations_table(db):
+        db.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS preview_cache_invalidations (
+                photo_id INTEGER NOT NULL,
+                size INTEGER NOT NULL,
+                PRIMARY KEY (photo_id, size),
+                FOREIGN KEY (photo_id) REFERENCES photos(id) ON DELETE CASCADE
+            )
+            """,
+        )
+
+    def _mark_preview_cache_invalid(db, photo_id, size, *, commit=True):
+        _ensure_preview_cache_invalidations_table(db)
+        db.conn.execute(
+            "INSERT OR IGNORE INTO preview_cache_invalidations (photo_id, size) "
+            "VALUES (?, ?)",
+            (photo_id, size),
+        )
+        if commit:
+            db.conn.commit()
+
+    def _clear_preview_cache_invalid(db, photo_id, size, *, commit=True):
+        _ensure_preview_cache_invalidations_table(db)
+        db.conn.execute(
+            "DELETE FROM preview_cache_invalidations WHERE photo_id=? AND size=?",
+            (photo_id, size),
+        )
+        if commit:
+            db.conn.commit()
+
+    def _is_preview_cache_invalid(db, photo_id, size):
+        _ensure_preview_cache_invalidations_table(db)
+        row = db.conn.execute(
+            "SELECT 1 FROM preview_cache_invalidations "
+            "WHERE photo_id=? AND size=?",
+            (photo_id, size),
+        ).fetchone()
+        return row is not None
+
     def _invalidate_photo_render_cache(db, photo_ids):
         """Drop cached rendered derivatives after an edit recipe changes."""
         vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
@@ -1458,12 +1498,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 except OSError:
                     if os.path.exists(path):
                         _invalid_preview_cache_paths.add(path)
+                        _mark_preview_cache_invalid(
+                            db, pid, size_value, commit=False,
+                        )
                     log.warning(
                         "Failed to remove stale preview cache %s",
                         path, exc_info=True,
                     )
                 else:
                     removed_preview_rows.append((pid, size_value))
+                    _clear_preview_cache_invalid(
+                        db, pid, size_value, commit=False,
+                    )
             try:
                 for name in os.listdir(preview_dir):
                     if not (name.startswith(f"{pid}_") and name.endswith(".jpg")):
@@ -1477,9 +1523,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     except OSError:
                         if os.path.exists(path):
                             _invalid_preview_cache_paths.add(path)
+                            _mark_preview_cache_invalid(
+                                db, pid, size_part, commit=False,
+                            )
                         log.warning(
                             "Failed to remove stale preview cache %s",
                             path, exc_info=True,
+                        )
+                    else:
+                        _clear_preview_cache_invalid(
+                            db, pid, size_part, commit=False,
                         )
             except FileNotFoundError:
                 pass
@@ -16619,7 +16672,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             db.preview_cache_delete(photo_id, size)  # no-op if no row
 
         skip_untracked_preview_adoption = False
-        stale_after_failed_invalidation = cache_path in _invalid_preview_cache_paths
+        stale_after_failed_invalidation = (
+            cache_path in _invalid_preview_cache_paths
+            or _is_preview_cache_invalid(db, photo_id, size)
+        )
         if stale_after_failed_invalidation and os.path.exists(cache_path):
             try:
                 os.remove(cache_path)
@@ -16631,8 +16687,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 )
             else:
                 _invalid_preview_cache_paths.discard(cache_path)
+                _clear_preview_cache_invalid(db, photo_id, size)
                 db.preview_cache_delete(photo_id, size)
                 stale_after_failed_invalidation = False
+        elif stale_after_failed_invalidation:
+            _invalid_preview_cache_paths.discard(cache_path)
+            _clear_preview_cache_invalid(db, photo_id, size)
+            db.preview_cache_delete(photo_id, size)
+            stale_after_failed_invalidation = False
         if (
             recipe
             and os.path.exists(cache_path)
@@ -16741,6 +16803,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             with open(cache_path, "wb") as f:
                 f.write(data)
             _invalid_preview_cache_paths.discard(cache_path)
+            _clear_preview_cache_invalid(db, photo_id, size)
             db.preview_cache_insert(photo_id, size, len(data))
             evict_preview_cache_if_over_quota(db, vireo_dir)
         except Exception as e:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1468,6 +1468,61 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return max(float(crop["w"]) * width, float(crop["h"]) * height)
         return max(width, height)
 
+    def _photo_value(photo, key):
+        try:
+            return photo[key]
+        except (KeyError, IndexError, TypeError):
+            if hasattr(photo, "get"):
+                return photo.get(key)
+        return None
+
+    def _exif_orientation(exif_data):
+        if not exif_data:
+            return None
+        if isinstance(exif_data, str):
+            try:
+                metadata = json.loads(exif_data)
+            except (TypeError, ValueError):
+                return None
+        elif isinstance(exif_data, dict):
+            metadata = exif_data
+        else:
+            return None
+        if not isinstance(metadata, dict):
+            return None
+        for group in ("EXIF", "IFD0", "TIFF", "File"):
+            values = metadata.get(group)
+            if isinstance(values, dict) and "Orientation" in values:
+                return values["Orientation"]
+        return metadata.get("Orientation")
+
+    def _orientation_swaps_axes(orientation):
+        if orientation is None or isinstance(orientation, bool):
+            return False
+        if isinstance(orientation, (int, float)):
+            return int(orientation) in (5, 6, 7, 8)
+        text = str(orientation).strip().lower()
+        if not text:
+            return False
+        try:
+            return int(text) in (5, 6, 7, 8)
+        except ValueError:
+            return "90" in text or "270" in text
+
+    def _recipe_source_dimensions(photo):
+        try:
+            width = int(_photo_value(photo, "width") or 0)
+            height = int(_photo_value(photo, "height") or 0)
+        except (TypeError, ValueError):
+            return 0, 0
+        if (
+            width > 0
+            and height > 0
+            and _orientation_swaps_axes(_exif_orientation(_photo_value(photo, "exif_data")))
+        ):
+            return height, width
+        return width, height
+
     def _working_copy_satisfies_recipe_render(photo, recipe, max_size, vireo_dir):
         if not recipe or not recipe.get("crop"):
             return True
@@ -1477,26 +1532,22 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         wc_path = os.path.join(vireo_dir, wc_rel)
         if not os.path.exists(wc_path):
             return False
-        original_w = photo["width"] or 0
-        original_h = photo["height"] or 0
-        if original_w <= 0 or original_h <= 0:
-            return False
         try:
             from PIL import Image as _PILImage
             with _PILImage.open(wc_path) as wc_img:
                 wc_w, wc_h = wc_img.size
         except Exception:
             return False
-        original_render_long = _rendered_recipe_long_edge(
-            original_w, original_h, recipe,
-        )
+        original_w, original_h = _recipe_source_dimensions(photo)
+        if original_w <= 0 or original_h <= 0:
+            return False
+        original_render_long = _rendered_recipe_long_edge(original_w, original_h, recipe)
         required_long = min(max_size, original_render_long) if max_size else original_render_long
         wc_render_long = _rendered_recipe_long_edge(wc_w, wc_h, recipe)
         return wc_render_long >= required_long
 
     def _path_satisfies_recipe_render(path, photo, recipe, max_size):
-        original_w = photo["width"] or 0
-        original_h = photo["height"] or 0
+        original_w, original_h = _recipe_source_dimensions(photo)
         if original_w <= 0 or original_h <= 0:
             return False
         try:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1459,6 +1459,60 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 log.warning("Failed to remove stale original cache %s", original_cache)
         db.conn.commit()
 
+    def _rendered_recipe_long_edge(width, height, recipe):
+        rotation = (recipe or {}).get("rotation", 0)
+        if rotation in (90, 270):
+            width, height = height, width
+        crop = (recipe or {}).get("crop") if recipe else None
+        if crop:
+            return max(float(crop["w"]) * width, float(crop["h"]) * height)
+        return max(width, height)
+
+    def _working_copy_satisfies_recipe_render(photo, recipe, max_size, vireo_dir):
+        if not recipe or not recipe.get("crop"):
+            return True
+        wc_rel = photo["working_copy_path"]
+        if not wc_rel:
+            return False
+        wc_path = os.path.join(vireo_dir, wc_rel)
+        if not os.path.exists(wc_path):
+            return False
+        original_w = photo["width"] or 0
+        original_h = photo["height"] or 0
+        if original_w <= 0 or original_h <= 0:
+            return False
+        try:
+            from PIL import Image as _PILImage
+            with _PILImage.open(wc_path) as wc_img:
+                wc_w, wc_h = wc_img.size
+        except Exception:
+            return False
+        original_render_long = _rendered_recipe_long_edge(
+            original_w, original_h, recipe,
+        )
+        required_long = min(max_size, original_render_long) if max_size else original_render_long
+        wc_render_long = _rendered_recipe_long_edge(wc_w, wc_h, recipe)
+        return wc_render_long >= required_long
+
+    def _recipe_render_source(photo, recipe, max_size, vireo_dir, folders):
+        from image_loader import get_canonical_image_path
+
+        if not recipe or not recipe.get("crop"):
+            return get_canonical_image_path(photo, vireo_dir, folders), True
+
+        if _working_copy_satisfies_recipe_render(photo, recipe, max_size, vireo_dir):
+            return get_canonical_image_path(photo, vireo_dir, folders), True
+
+        original = os.path.join(
+            folders.get(photo["folder_id"], ""),
+            photo["filename"],
+        )
+        if not os.path.exists(original) and photo["working_copy_path"]:
+            wc_path = os.path.join(vireo_dir, photo["working_copy_path"])
+            if os.path.exists(wc_path):
+                return wc_path, True
+        return original, False
+
     _ACCELERATED_RUNTIME_PROVIDERS = {
         "ACLExecutionProvider",
         "ArmNNExecutionProvider",
@@ -11780,7 +11834,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
             import config as cfg
             from image_edits import apply_recipe_to_loaded_image
-            from image_loader import get_canonical_image_path, load_image
+            from image_loader import load_image
 
             thread_db = Database(db_path)
             thread_db.set_active_workspace(active_ws)
@@ -11834,13 +11888,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                                 photo["id"], max_size, os.path.getsize(cache_path),
                             )
                 else:
-                    if recipe and recipe.get("crop"):
-                        canonical = os.path.join(
-                            folders.get(photo["folder_id"], ""),
-                            photo["filename"],
-                        )
-                    else:
-                        canonical = get_canonical_image_path(photo, vireo_dir, folders)
+                    canonical, _using_working_copy = _recipe_render_source(
+                        photo, recipe, max_size, vireo_dir, folders,
+                    )
                     img = load_image(canonical, max_size=None if recipe else max_size)
                     if img:
                         if recipe:
@@ -16221,7 +16271,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return Response(data, mimetype="image/jpeg")
 
         # Cache miss: generate, insert, evict-if-over-quota, serve.
-        from image_loader import get_canonical_image_path, load_image
+        from image_loader import load_image
 
         folder_row = db.conn.execute(
             "SELECT id, path FROM folders WHERE id=?", (photo["folder_id"],)
@@ -16242,24 +16292,22 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             )
             return "Could not load image", 500
 
-        use_original_for_crop = bool(recipe and recipe.get("crop"))
-        if use_original_for_crop:
-            if _has_current_working_copy_failure(
-                photo,
-                vireo_dir,
-                trust_existing_working_copy=False,
-                live_source_path=live_source,
-                folder_path=folder_row["path"],
-            ):
-                log.info(
-                    "Skipping cropped preview generation for photo %s; RAW "
-                    "working-copy extraction already failed for current source mtime",
-                    photo_id,
-                )
-                return "Could not load image", 500
-            canonical = live_source
-        else:
-            canonical = get_canonical_image_path(photo, vireo_dir, folders)
+        canonical, using_working_copy = _recipe_render_source(
+            photo, recipe, size, vireo_dir, folders,
+        )
+        if not using_working_copy and _has_current_working_copy_failure(
+            photo,
+            vireo_dir,
+            trust_existing_working_copy=False,
+            live_source_path=live_source,
+            folder_path=folder_row["path"],
+        ):
+            log.info(
+                "Skipping cropped preview generation for photo %s; RAW "
+                "working-copy extraction already failed for current source mtime",
+                photo_id,
+            )
+            return "Could not load image", 500
         img = load_image(canonical, max_size=None if recipe else size)
         if img is None:
             _record_working_copy_failure(db, photo, canonical)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1381,6 +1381,31 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             g.db = Database(db_path)
         return g.db
 
+    def _invalidate_photo_render_cache(db, photo_ids):
+        """Drop cached rendered derivatives after an edit recipe changes."""
+        vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+        preview_dir = os.path.join(vireo_dir, "previews")
+        originals_dir = os.path.join(vireo_dir, "originals")
+        for pid in photo_ids:
+            for row in db.conn.execute(
+                "SELECT size FROM preview_cache WHERE photo_id = ?",
+                (pid,),
+            ).fetchall():
+                path = os.path.join(preview_dir, f"{pid}_{row['size']}.jpg")
+                try:
+                    if os.path.exists(path):
+                        os.remove(path)
+                except OSError:
+                    log.warning("Failed to remove stale preview cache %s", path)
+            db.conn.execute("DELETE FROM preview_cache WHERE photo_id = ?", (pid,))
+            original_cache = os.path.join(originals_dir, f"{pid}.jpg")
+            try:
+                if os.path.exists(original_cache):
+                    os.remove(original_cache)
+            except OSError:
+                log.warning("Failed to remove stale original cache %s", original_cache)
+        db.conn.commit()
+
     _ACCELERATED_RUNTIME_PROVIDERS = {
         "ACLExecutionProvider",
         "ArmNNExecutionProvider",
@@ -2803,6 +2828,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # Location section: pre-resolved leaf + parent chain so the photo
         # detail panel can render the filled state without a second roundtrip.
         result["location"] = _serialize_photo_location(db, photo_id)
+        result["edit_recipe"] = db.get_photo_edit_recipe(photo_id)
 
         # Read XMP sidecar keywords
         folder = db.conn.execute(
@@ -3497,6 +3523,68 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         db.record_edit('color_label', f'Set color to {color or "none"}', new_color,
                        [{'photo_id': photo_id, 'old_value': old_color, 'new_value': new_color}])
         return jsonify({"ok": True})
+
+    @app.route("/api/photos/<int:photo_id>/edit-recipe", methods=["GET"])
+    def api_get_photo_edit_recipe(photo_id):
+        db = _get_db()
+        photo = db.get_photo(photo_id, verify_workspace=True)
+        if not photo:
+            return json_error("not found", 404)
+        return jsonify({
+            "photo_id": photo_id,
+            "recipe": db.get_photo_edit_recipe(photo_id),
+        })
+
+    @app.route("/api/photos/<int:photo_id>/edit-recipe", methods=["PUT", "POST"])
+    def api_set_photo_edit_recipe(photo_id):
+        db = _get_db()
+        body = request.get_json(silent=True) or {}
+        recipe = body.get("recipe", body)
+        photo = db.get_photo(photo_id, verify_workspace=True)
+        if not photo:
+            return json_error("not found", 404)
+        from image_edits import RecipeError, recipe_to_json
+        old_recipe = db.get_photo_edit_recipe(photo_id)
+        try:
+            old_value = recipe_to_json(old_recipe) or ""
+            new_recipe = db.set_photo_edit_recipe(photo_id, recipe, verify_workspace=True)
+            new_value = recipe_to_json(new_recipe) or ""
+        except RecipeError as e:
+            return json_error(str(e))
+        except ValueError as e:
+            return json_error(str(e), 403)
+        _invalidate_photo_render_cache(db, [photo_id])
+        if old_value != new_value:
+            db.record_edit(
+                "edit_recipe",
+                "Updated photo edit recipe",
+                new_value,
+                [{"photo_id": photo_id, "old_value": old_value, "new_value": new_value}],
+            )
+        return jsonify({"ok": True, "recipe": new_recipe})
+
+    @app.route("/api/photos/<int:photo_id>/edit-recipe", methods=["DELETE"])
+    def api_clear_photo_edit_recipe(photo_id):
+        db = _get_db()
+        photo = db.get_photo(photo_id, verify_workspace=True)
+        if not photo:
+            return json_error("not found", 404)
+        from image_edits import recipe_to_json
+        old_recipe = db.get_photo_edit_recipe(photo_id)
+        old_value = recipe_to_json(old_recipe) or ""
+        try:
+            db.clear_photo_edit_recipe(photo_id, verify_workspace=True)
+        except ValueError as e:
+            return json_error(str(e), 403)
+        _invalidate_photo_render_cache(db, [photo_id])
+        if old_value:
+            db.record_edit(
+                "edit_recipe",
+                "Cleared photo edit recipe",
+                "",
+                [{"photo_id": photo_id, "old_value": old_value, "new_value": ""}],
+            )
+        return jsonify({"ok": True, "recipe": None})
 
     @app.route("/api/files/reveal", methods=["POST"])
     def api_files_reveal():
@@ -4962,6 +5050,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         result = db.undo_last_edit()
         if result is None:
             return json_error("nothing to undo")
+        if result.get("action_type") == "edit_recipe":
+            rows = db.conn.execute(
+                "SELECT photo_id FROM edit_history_items WHERE edit_id = ?",
+                (result["id"],),
+            ).fetchall()
+            _invalidate_photo_render_cache(db, [r["photo_id"] for r in rows])
         return jsonify({"ok": True, "undone": result["description"]})
 
     @app.route("/api/undo/status")
@@ -4993,6 +5087,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         result = db.redo_last_undo()
         if result is None:
             return json_error("nothing to redo")
+        if result.get("action_type") == "edit_recipe":
+            rows = db.conn.execute(
+                "SELECT photo_id FROM edit_history_items WHERE edit_id = ?",
+                (result["id"],),
+            ).fetchall()
+            _invalidate_photo_render_cache(db, [r["photo_id"] for r in rows])
         return jsonify({"ok": True, "redone": result["description"]})
 
     @app.route("/api/redo/status")
@@ -15937,10 +16037,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return "Could not load image", 500
 
         canonical = get_canonical_image_path(photo, vireo_dir, folders)
-        img = load_image(canonical, max_size=size)
+        recipe = db.get_photo_edit_recipe(photo_id)
+        img = load_image(canonical, max_size=None if recipe else size)
         if img is None:
             _record_working_copy_failure(db, photo, canonical)
             return "Could not load image", 500
+        if recipe:
+            from image_edits import apply_recipe_to_loaded_image
+            img = apply_recipe_to_loaded_image(img, recipe, max_size=size)
 
         preview_quality = cfg.load().get("preview_quality", 90)
 
@@ -16022,6 +16126,35 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return "Not found", 404
 
         vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+        recipe = db.get_photo_edit_recipe(photo_id)
+
+        if recipe:
+            folder = db.conn.execute(
+                "SELECT path FROM folders WHERE id=?", (photo["folder_id"],)
+            ).fetchone()
+            if not folder:
+                return "Not found", 404
+            from offline_cache import resolve_original_path
+            image_path, _using_offline_cache = resolve_original_path(
+                db,
+                photo,
+                vireo_dir,
+                {photo["folder_id"]: folder["path"]},
+            )
+            from image_loader import load_image
+            img = load_image(image_path, max_size=None)
+            if img is None:
+                _record_working_copy_failure(db, photo, image_path)
+                return "Could not load image", 500
+            from image_edits import apply_recipe
+            img = apply_recipe(img, recipe)
+            originals_dir = os.path.join(vireo_dir, "originals")
+            cache_path = os.path.join(originals_dir, f"{photo_id}.jpg")
+            os.makedirs(originals_dir, exist_ok=True)
+            quality = cfg.load().get("working_copy_quality", 92)
+            img.save(cache_path, format="JPEG", quality=quality)
+            img.close()
+            return send_file(cache_path, mimetype="image/jpeg")
 
         # Decide whether to trust the working copy as the full-res asset
         # by reading its actual on-disk dimensions, NOT the current

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -11879,11 +11879,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             for i, photo in enumerate(photos):
                 cache_path = os.path.join(preview_dir, f'{photo["id"]}_{max_size}.jpg')
                 recipe = thread_db.get_photo_edit_recipe(photo["id"])
-                if recipe and os.path.exists(cache_path):
-                    with contextlib.suppress(OSError):
-                        os.remove(cache_path)
-                    with contextlib.suppress(Exception):
-                        thread_db.preview_cache_delete(photo["id"], max_size)
                 if os.path.exists(cache_path):
                     skipped += 1
                     # Adopt any untracked file so precompute output is

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -611,6 +611,12 @@ class Database:
                 PRIMARY KEY (photo_id, workspace_id)
             );
 
+            CREATE TABLE IF NOT EXISTS photo_edit_recipes (
+                photo_id    INTEGER PRIMARY KEY REFERENCES photos(id) ON DELETE CASCADE,
+                recipe_json TEXT NOT NULL,
+                updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+
             CREATE TABLE IF NOT EXISTS preview_cache (
                 photo_id INTEGER NOT NULL,
                 size INTEGER NOT NULL,
@@ -5467,6 +5473,88 @@ class Database:
                 )
         self.conn.commit()
 
+    def get_photo_edit_recipe(self, photo_id, verify_workspace=False):
+        """Return the normalized edit recipe dict for a photo, or None."""
+        if verify_workspace:
+            self._verify_photo_in_workspace(photo_id)
+        row = self.conn.execute(
+            "SELECT recipe_json FROM photo_edit_recipes WHERE photo_id = ?",
+            (photo_id,),
+        ).fetchone()
+        if not row:
+            return None
+        try:
+            from image_edits import copy_recipe
+            return copy_recipe(row["recipe_json"])
+        except Exception:
+            log.warning("Invalid stored edit recipe for photo %s", photo_id, exc_info=True)
+            return None
+
+    def get_photo_edit_recipes(self, photo_ids):
+        """Return {photo_id: normalized recipe dict} for the given photos."""
+        if not photo_ids:
+            return {}
+        out = {}
+        from image_edits import copy_recipe
+        for chunk in _chunks(photo_ids):
+            placeholders = ",".join("?" for _ in chunk)
+            rows = self.conn.execute(
+                f"SELECT photo_id, recipe_json FROM photo_edit_recipes "
+                f"WHERE photo_id IN ({placeholders})",
+                list(chunk),
+            ).fetchall()
+            for row in rows:
+                try:
+                    recipe = copy_recipe(row["recipe_json"])
+                except Exception:
+                    log.warning(
+                        "Invalid stored edit recipe for photo %s",
+                        row["photo_id"], exc_info=True,
+                    )
+                    continue
+                if recipe:
+                    out[row["photo_id"]] = recipe
+        return out
+
+    def set_photo_edit_recipe(self, photo_id, recipe, verify_workspace=True):
+        """Set or clear a non-destructive edit recipe for a photo.
+
+        Returns the normalized recipe dict, or None when the provided recipe is
+        a no-op and the stored row was cleared.
+        """
+        if verify_workspace:
+            self._verify_photo_in_workspace(photo_id)
+        from image_edits import copy_recipe, recipe_to_json
+        recipe_json = recipe_to_json(recipe)
+        if recipe_json is None:
+            self.conn.execute(
+                "DELETE FROM photo_edit_recipes WHERE photo_id = ?",
+                (photo_id,),
+            )
+            self.conn.commit()
+            return None
+        self.conn.execute(
+            """INSERT INTO photo_edit_recipes (photo_id, recipe_json, updated_at)
+               VALUES (?, ?, datetime('now'))
+               ON CONFLICT(photo_id) DO UPDATE SET
+                   recipe_json = excluded.recipe_json,
+                   updated_at = excluded.updated_at""",
+            (photo_id, recipe_json),
+        )
+        self.conn.commit()
+        return copy_recipe(recipe_json)
+
+    def clear_photo_edit_recipe(self, photo_id, verify_workspace=True):
+        """Remove a photo's edit recipe. Returns True if a row was removed."""
+        if verify_workspace:
+            self._verify_photo_in_workspace(photo_id)
+        cur = self.conn.execute(
+            "DELETE FROM photo_edit_recipes WHERE photo_id = ?",
+            (photo_id,),
+        )
+        self.conn.commit()
+        return cur.rowcount > 0
+
     def prune_pipeline_cache_for_ids(self, ids):
         """Remove ``ids`` from the workspace's pipeline review cache file.
 
@@ -9934,6 +10022,12 @@ class Database:
                     self.set_color_label(pid, old_val)
                 else:
                     self.remove_color_label(pid)
+            elif entry['action_type'] == 'edit_recipe':
+                self.set_photo_edit_recipe(
+                    pid,
+                    old_val if old_val else None,
+                    verify_workspace=False,
+                )
             elif entry['action_type'] in ('keyword_add', 'prediction_accept'):
                 old_meta = self._edit_old_value_meta(old_val)
                 self.untag_photo(pid, int(entry['new_value']))
@@ -10065,6 +10159,12 @@ class Database:
                     self.set_color_label(pid, new_val)
                 else:
                     self.remove_color_label(pid)
+            elif entry['action_type'] == 'edit_recipe':
+                self.set_photo_edit_recipe(
+                    pid,
+                    new_val if new_val else None,
+                    verify_workspace=False,
+                )
             elif entry['action_type'] in ('keyword_add', 'prediction_accept'):
                 old_meta = self._edit_old_value_meta(item['old_value'])
                 self.tag_photo(pid, int(entry['new_value']))

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -223,7 +223,10 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
 
         # Load, resize, and save
         try:
-            img = load_image(source_path, max_size=None if recipe else (max_size or None))
+            load_max_size = (
+                None if recipe and recipe.get("crop") else (max_size or None)
+            )
+            img = load_image(source_path, max_size=load_max_size)
             if img is None:
                 errors.append(f"{photo['filename']}: failed to load image")
                 if progress_cb:

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -1,5 +1,6 @@
 """Photo export with resize, quality control, and template-based naming."""
 
+import contextlib
 import hashlib
 import json
 import logging
@@ -14,6 +15,7 @@ log = logging.getLogger(__name__)
 
 # Characters not allowed in filenames (covers Windows + macOS + Linux)
 _UNSAFE_RE = re.compile(r'[<>:"/|?*\\]')
+_EXIF_ORIENTATION_TAG = 274
 
 
 def sanitize_filename(name):
@@ -322,6 +324,16 @@ def _orientation_swaps_axes(orientation):
         return "90" in text or "270" in text
 
 
+def _image_size_after_exif_orientation(img):
+    width, height = img.size
+    orientation = None
+    with contextlib.suppress(Exception):
+        orientation = img.getexif().get(_EXIF_ORIENTATION_TAG)
+    if _orientation_swaps_axes(orientation):
+        return height, width
+    return width, height
+
+
 def _recipe_result_long_edge(width, height, recipe):
     """Return the rendered long edge after right-angle rotation and crop."""
     rotation = (recipe or {}).get("rotation", 0)
@@ -625,7 +637,7 @@ def _companion_can_satisfy_export(photo, folder_path, recipe, max_size, exif_dat
     try:
         from PIL import Image
         with Image.open(companion) as img:
-            comp_w, comp_h = img.size
+            comp_w, comp_h = _image_size_after_exif_orientation(img)
     except Exception:
         return None
 

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -367,7 +367,7 @@ def _developed_can_satisfy_size(dev_path, photo, max_size, recipe=None, exif_dat
 
     try:
         with Image.open(dev_path) as img:
-            dev_w, dev_h = img.size
+            dev_w, dev_h = _image_size_after_exif_orientation(img)
     except Exception:
         return True
     dev_long = _recipe_result_long_edge(dev_w, dev_h, recipe)

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -166,7 +166,15 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
             use_wc = _working_copy_can_satisfy_export(
                 photo, recipe, max_size, wc_max, vireo_dir, exif_data=exif_data
             )
-            source_path = _resolve_source(photo, vireo_dir, folders, use_working_copy=use_wc)
+            source_path = None
+            if not use_wc:
+                source_path = _companion_can_satisfy_export(
+                    photo, folder_path, recipe, max_size, exif_data=exif_data
+                )
+            if not source_path:
+                source_path = _resolve_source(
+                    photo, vireo_dir, folders, use_working_copy=use_wc,
+                )
         if not source_path or not os.path.isfile(source_path):
             errors.append(f"{photo['filename']}: source file missing")
             if progress_cb:
@@ -601,6 +609,35 @@ def _working_copy_can_satisfy_export(
         return False
     required_long = min(max_size, original_render_long)
     return wc_render_long >= required_long
+
+
+def _companion_can_satisfy_export(photo, folder_path, recipe, max_size, exif_data=None):
+    """Return a full-resolution companion path when it can satisfy edited export."""
+    crop = (recipe or {}).get("crop") if recipe else None
+    if not crop:
+        return None
+    companion_rel = photo["companion_path"]
+    if not companion_rel or not folder_path:
+        return None
+    companion = os.path.join(folder_path, companion_rel)
+    if not os.path.isfile(companion):
+        return None
+    try:
+        from PIL import Image
+        with Image.open(companion) as img:
+            comp_w, comp_h = img.size
+    except Exception:
+        return None
+
+    original_w, original_h = _recipe_source_dimensions(photo, exif_data)
+    if original_w <= 0 or original_h <= 0:
+        return None
+    required_long = _recipe_result_long_edge(original_w, original_h, recipe)
+    if max_size is not None:
+        required_long = min(max_size, required_long)
+    if _recipe_result_long_edge(comp_w, comp_h, recipe) >= required_long:
+        return companion
+    return None
 
 
 def _resolve_source(photo, vireo_dir, folders, use_working_copy=False):

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -1,6 +1,7 @@
 """Photo export with resize, quality control, and template-based naming."""
 
 import hashlib
+import json
 import logging
 import os
 import re
@@ -111,6 +112,7 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
 
     photos_map = db.get_photos_by_ids(photo_ids)
     folders = {f["id"]: f["path"] for f in db.get_folder_tree()}
+    exif_data_map = _get_photo_exif_data(db, photo_ids)
 
     # Get species keywords for all photos in one query
     species_map = db.get_species_keywords_for_photos(photo_ids)
@@ -144,6 +146,7 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
         #   3. original file (default; also used for full-res exports).
         folder_path = folders.get(photo["folder_id"], "")
         recipe = edit_recipes.get(pid)
+        exif_data = exif_data_map.get(pid)
         source_path = _find_developed_output(
             photo["filename"],
             folder_path,
@@ -156,12 +159,12 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
         # export size, fall through to the working-copy / original
         # source.
         if source_path and not _developed_can_satisfy_size(
-            source_path, photo, max_size, recipe
+            source_path, photo, max_size, recipe, exif_data=exif_data
         ):
             source_path = None
         if not source_path:
             use_wc = _working_copy_can_satisfy_export(
-                photo, recipe, max_size, wc_max, vireo_dir
+                photo, recipe, max_size, wc_max, vireo_dir, exif_data=exif_data
             )
             source_path = _resolve_source(photo, vireo_dir, folders, use_working_copy=use_wc)
         if not source_path or not os.path.isfile(source_path):
@@ -244,6 +247,70 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
 _PREFERRED_DEVELOPED_EXTS = ("jpg", "jpeg", "tiff", "tif")
 
 
+def _get_photo_exif_data(db, photo_ids):
+    """Return a photo_id -> exif_data map without bloating list photo queries."""
+    if not photo_ids or not hasattr(db, "conn"):
+        return {}
+    out = {}
+    for i in range(0, len(photo_ids), 999):
+        chunk = photo_ids[i:i + 999]
+        placeholders = ",".join("?" for _ in chunk)
+        rows = db.conn.execute(
+            f"SELECT id, exif_data FROM photos WHERE id IN ({placeholders})",
+            list(chunk),
+        ).fetchall()
+        for row in rows:
+            out[row["id"]] = row["exif_data"]
+    return out
+
+
+def _recipe_source_dimensions(photo, exif_data=None):
+    """Return original dimensions as load_image sees them after EXIF transpose."""
+    try:
+        width = int(photo["width"] or 0)
+        height = int(photo["height"] or 0)
+    except (KeyError, IndexError, TypeError, ValueError):
+        return 0, 0
+    if width > 0 and height > 0 and _orientation_swaps_axes(_exif_orientation(exif_data)):
+        return height, width
+    return width, height
+
+
+def _exif_orientation(exif_data):
+    if not exif_data:
+        return None
+    if isinstance(exif_data, str):
+        try:
+            metadata = json.loads(exif_data)
+        except (TypeError, ValueError):
+            return None
+    elif isinstance(exif_data, dict):
+        metadata = exif_data
+    else:
+        return None
+    if not isinstance(metadata, dict):
+        return None
+    for group in ("EXIF", "IFD0", "TIFF", "File"):
+        values = metadata.get(group)
+        if isinstance(values, dict) and "Orientation" in values:
+            return values["Orientation"]
+    return metadata.get("Orientation")
+
+
+def _orientation_swaps_axes(orientation):
+    if orientation is None or isinstance(orientation, bool):
+        return False
+    if isinstance(orientation, (int, float)):
+        return int(orientation) in (5, 6, 7, 8)
+    text = str(orientation).strip().lower()
+    if not text:
+        return False
+    try:
+        return int(text) in (5, 6, 7, 8)
+    except ValueError:
+        return "90" in text or "270" in text
+
+
 def _recipe_result_long_edge(width, height, recipe):
     """Return the rendered long edge after right-angle rotation and crop."""
     rotation = (recipe or {}).get("rotation", 0)
@@ -255,7 +322,7 @@ def _recipe_result_long_edge(width, height, recipe):
     return max(width, height)
 
 
-def _developed_can_satisfy_size(dev_path, photo, max_size, recipe=None):
+def _developed_can_satisfy_size(dev_path, photo, max_size, recipe=None, exif_data=None):
     """Return True if the developed file is large enough for this export.
 
     The develop job may have written a downscaled output (`--width` is
@@ -281,13 +348,7 @@ def _developed_can_satisfy_size(dev_path, photo, max_size, recipe=None):
     except Exception:
         return True
     dev_long = _recipe_result_long_edge(dev_w, dev_h, recipe)
-    try:
-        original_w = photo["width"]
-        original_h = photo["height"]
-    except (KeyError, IndexError):
-        if max_size is not None:
-            return dev_long >= max_size
-        return True
+    original_w, original_h = _recipe_source_dimensions(photo, exif_data)
     if original_w and original_h:
         required_long = _recipe_result_long_edge(original_w, original_h, recipe)
         if max_size is not None:
@@ -495,7 +556,9 @@ def _find_developed_output(filename, folder_path, developed_dir, index=None):
     return None
 
 
-def _working_copy_can_satisfy_export(photo, recipe, max_size, wc_max, vireo_dir):
+def _working_copy_can_satisfy_export(
+    photo, recipe, max_size, wc_max, vireo_dir, exif_data=None
+):
     """Return True when the working copy can preserve requested export pixels."""
     if not max_size or max_size <= 0:
         return False
@@ -517,8 +580,7 @@ def _working_copy_can_satisfy_export(photo, recipe, max_size, wc_max, vireo_dir)
     wc_render_long = _recipe_result_long_edge(wc_w, wc_h, recipe)
     crop = (recipe or {}).get("crop") if recipe else None
 
-    width = photo["width"] or 0
-    height = photo["height"] or 0
+    width, height = _recipe_source_dimensions(photo, exif_data)
     if not crop:
         if width > 0 and height > 0:
             required_long = min(max_size, max(width, height))

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -143,6 +143,7 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
         #   2. working copy when resizing to a size it can satisfy.
         #   3. original file (default; also used for full-res exports).
         folder_path = folders.get(photo["folder_id"], "")
+        recipe = edit_recipes.get(pid)
         source_path = _find_developed_output(
             photo["filename"],
             folder_path,
@@ -155,10 +156,9 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
         # export size, fall through to the working-copy / original
         # source.
         if source_path and not _developed_can_satisfy_size(
-            source_path, photo, max_size
+            source_path, photo, max_size, recipe
         ):
             source_path = None
-        recipe = edit_recipes.get(pid)
         if not source_path:
             use_wc = _working_copy_can_satisfy_export(
                 photo, recipe, max_size, wc_max
@@ -244,7 +244,18 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
 _PREFERRED_DEVELOPED_EXTS = ("jpg", "jpeg", "tiff", "tif")
 
 
-def _developed_can_satisfy_size(dev_path, photo, max_size):
+def _recipe_result_long_edge(width, height, recipe):
+    """Return the rendered long edge after right-angle rotation and crop."""
+    rotation = (recipe or {}).get("rotation", 0)
+    if rotation in (90, 270):
+        width, height = height, width
+    crop = (recipe or {}).get("crop") if recipe else None
+    if crop:
+        return max(float(crop["w"]) * width, float(crop["h"]) * height)
+    return max(width, height)
+
+
+def _developed_can_satisfy_size(dev_path, photo, max_size, recipe=None):
     """Return True if the developed file is large enough for this export.
 
     The develop job may have written a downscaled output (`--width` is
@@ -266,9 +277,10 @@ def _developed_can_satisfy_size(dev_path, photo, max_size):
 
     try:
         with Image.open(dev_path) as img:
-            dev_long = max(img.size)
+            dev_w, dev_h = img.size
     except Exception:
         return True
+    dev_long = _recipe_result_long_edge(dev_w, dev_h, recipe)
     if max_size is not None:
         return dev_long >= max_size
     try:
@@ -277,7 +289,8 @@ def _developed_can_satisfy_size(dev_path, photo, max_size):
     except (KeyError, IndexError):
         return True
     if original_w and original_h:
-        return dev_long >= max(original_w, original_h)
+        required_long = _recipe_result_long_edge(original_w, original_h, recipe)
+        return dev_long >= required_long
     return True
 
 
@@ -495,11 +508,8 @@ def _working_copy_can_satisfy_export(photo, recipe, max_size, wc_max):
         # cropped derivative from an undersized working copy.
         return False
 
-    rotation = (recipe or {}).get("rotation", 0)
-    if rotation in (90, 270):
-        width, height = height, width
-    source_long = max(width, height)
-    crop_long = max(float(crop["w"]) * width, float(crop["h"]) * height)
+    source_long = _recipe_result_long_edge(width, height, None)
+    crop_long = _recipe_result_long_edge(width, height, recipe)
     if crop_long <= 0:
         return False
     required_source_long = max_size * (source_long / crop_long)

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -161,7 +161,7 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
             source_path = None
         if not source_path:
             use_wc = _working_copy_can_satisfy_export(
-                photo, recipe, max_size, wc_max
+                photo, recipe, max_size, wc_max, vireo_dir
             )
             source_path = _resolve_source(photo, vireo_dir, folders, use_working_copy=use_wc)
         if not source_path or not os.path.isfile(source_path):
@@ -491,29 +491,47 @@ def _find_developed_output(filename, folder_path, developed_dir, index=None):
     return None
 
 
-def _working_copy_can_satisfy_export(photo, recipe, max_size, wc_max):
+def _working_copy_can_satisfy_export(photo, recipe, max_size, wc_max, vireo_dir):
     """Return True when the working copy can preserve requested export pixels."""
     if not max_size or max_size <= 0:
         return False
     if max_size > wc_max:
         return False
+    wc_rel = photo["working_copy_path"]
+    if not wc_rel:
+        return False
+    wc_path = os.path.join(vireo_dir, wc_rel)
+    if not os.path.exists(wc_path):
+        return False
+    try:
+        from PIL import Image
+        with Image.open(wc_path) as wc_img:
+            wc_w, wc_h = wc_img.size
+    except Exception:
+        return False
+
+    wc_render_long = _recipe_result_long_edge(wc_w, wc_h, recipe)
     crop = (recipe or {}).get("crop") if recipe else None
-    if not crop:
-        return True
 
     width = photo["width"] or 0
     height = photo["height"] or 0
+    if not crop:
+        if width > 0 and height > 0:
+            required_long = min(max_size, max(width, height))
+        else:
+            required_long = max_size
+        return wc_render_long >= required_long
+
     if width <= 0 or height <= 0:
         # Missing dimensions: prefer the original over silently exporting a
         # cropped derivative from an undersized working copy.
         return False
 
-    source_long = _recipe_result_long_edge(width, height, None)
-    crop_long = _recipe_result_long_edge(width, height, recipe)
-    if crop_long <= 0:
+    original_render_long = _recipe_result_long_edge(width, height, recipe)
+    if original_render_long <= 0:
         return False
-    required_source_long = max_size * (source_long / crop_long)
-    return required_source_long <= wc_max
+    required_long = min(max_size, original_render_long)
+    return wc_render_long >= required_long
 
 
 def _resolve_source(photo, vireo_dir, folders, use_working_copy=False):

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -281,16 +281,20 @@ def _developed_can_satisfy_size(dev_path, photo, max_size, recipe=None):
     except Exception:
         return True
     dev_long = _recipe_result_long_edge(dev_w, dev_h, recipe)
-    if max_size is not None:
-        return dev_long >= max_size
     try:
         original_w = photo["width"]
         original_h = photo["height"]
     except (KeyError, IndexError):
+        if max_size is not None:
+            return dev_long >= max_size
         return True
     if original_w and original_h:
         required_long = _recipe_result_long_edge(original_w, original_h, recipe)
+        if max_size is not None:
+            required_long = min(max_size, required_long)
         return dev_long >= required_long
+    if max_size is not None:
+        return dev_long >= max_size
     return True
 
 

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -6,6 +6,7 @@ import os
 import re
 import shutil
 
+from image_edits import apply_recipe_to_loaded_image
 from image_loader import load_image
 
 log = logging.getLogger(__name__)
@@ -113,6 +114,7 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
 
     # Get species keywords for all photos in one query
     species_map = db.get_species_keywords_for_photos(photo_ids)
+    edit_recipes = db.get_photo_edit_recipes(photo_ids)
 
     # Track sequence numbers per subdirectory
     seq_counters = {}
@@ -215,12 +217,15 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
 
         # Load, resize, and save
         try:
-            img = load_image(source_path, max_size=max_size or None)
+            recipe = edit_recipes.get(pid)
+            img = load_image(source_path, max_size=None if recipe else (max_size or None))
             if img is None:
                 errors.append(f"{photo['filename']}: failed to load image")
                 if progress_cb:
                     progress_cb(i + 1, len(photo_ids), photo["filename"])
                 continue
+            if recipe:
+                img = apply_recipe_to_loaded_image(img, recipe, max_size=max_size)
             img.save(out_path, "JPEG", quality=quality)
             img.close()
             exported += 1

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -158,8 +158,11 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
             source_path, photo, max_size
         ):
             source_path = None
+        recipe = edit_recipes.get(pid)
         if not source_path:
-            use_wc = bool(max_size) and max_size <= wc_max
+            use_wc = _working_copy_can_satisfy_export(
+                photo, recipe, max_size, wc_max
+            )
             source_path = _resolve_source(photo, vireo_dir, folders, use_working_copy=use_wc)
         if not source_path or not os.path.isfile(source_path):
             errors.append(f"{photo['filename']}: source file missing")
@@ -217,7 +220,6 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
 
         # Load, resize, and save
         try:
-            recipe = edit_recipes.get(pid)
             img = load_image(source_path, max_size=None if recipe else (max_size or None))
             if img is None:
                 errors.append(f"{photo['filename']}: failed to load image")
@@ -474,6 +476,34 @@ def _find_developed_output(filename, folder_path, developed_dir, index=None):
         if hit:
             return hit
     return None
+
+
+def _working_copy_can_satisfy_export(photo, recipe, max_size, wc_max):
+    """Return True when the working copy can preserve requested export pixels."""
+    if not max_size or max_size <= 0:
+        return False
+    if max_size > wc_max:
+        return False
+    crop = (recipe or {}).get("crop") if recipe else None
+    if not crop:
+        return True
+
+    width = photo["width"] or 0
+    height = photo["height"] or 0
+    if width <= 0 or height <= 0:
+        # Missing dimensions: prefer the original over silently exporting a
+        # cropped derivative from an undersized working copy.
+        return False
+
+    rotation = (recipe or {}).get("rotation", 0)
+    if rotation in (90, 270):
+        width, height = height, width
+    source_long = max(width, height)
+    crop_long = max(float(crop["w"]) * width, float(crop["h"]) * height)
+    if crop_long <= 0:
+        return False
+    required_source_long = max_size * (source_long / crop_long)
+    return required_source_long <= wc_max
 
 
 def _resolve_source(photo, vireo_dir, folders, use_working_copy=False):

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -625,8 +625,7 @@ def _working_copy_can_satisfy_export(
 
 def _companion_can_satisfy_export(photo, folder_path, recipe, max_size, exif_data=None):
     """Return a full-resolution companion path when it can satisfy edited export."""
-    crop = (recipe or {}).get("crop") if recipe else None
-    if not crop:
+    if not recipe:
         return None
     companion_rel = photo["companion_path"]
     if not companion_rel or not folder_path:

--- a/vireo/image_edits.py
+++ b/vireo/image_edits.py
@@ -74,12 +74,16 @@ def normalize_recipe(recipe):
     if crop is not None:
         if not isinstance(crop, dict):
             raise RecipeError("crop must be an object")
+        raw_vals = []
         try:
-            x = float(crop["x"])
-            y = float(crop["y"])
-            w = float(crop["w"])
-            h = float(crop["h"])
+            raw_vals = [crop["x"], crop["y"], crop["w"], crop["h"]]
         except (KeyError, TypeError, ValueError) as exc:
+            raise RecipeError("crop must include numeric x, y, w, and h") from exc
+        if any(isinstance(v, bool) for v in raw_vals):
+            raise RecipeError("crop must include numeric x, y, w, and h")
+        try:
+            x, y, w, h = (float(v) for v in raw_vals)
+        except (TypeError, ValueError) as exc:
             raise RecipeError("crop must include numeric x, y, w, and h") from exc
         vals = (x, y, w, h)
         if not all(math.isfinite(v) for v in vals):

--- a/vireo/image_edits.py
+++ b/vireo/image_edits.py
@@ -45,6 +45,8 @@ def normalize_recipe(recipe):
     rotation = recipe.get("rotation", 0)
     if isinstance(rotation, bool) or not isinstance(rotation, (int, float)):
         raise RecipeError("rotation must be one of 0, 90, 180, or 270")
+    if isinstance(rotation, float) and not rotation.is_integer():
+        raise RecipeError("rotation must be one of 0, 90, 180, or 270")
     rotation = int(rotation)
     if rotation not in (0, 90, 180, 270):
         raise RecipeError("rotation must be one of 0, 90, 180, or 270")
@@ -57,10 +59,14 @@ def normalize_recipe(recipe):
     if not isinstance(flip, dict):
         raise RecipeError("flip must be an object")
     normalized_flip = {}
-    if bool(flip.get("horizontal")):
-        normalized_flip["horizontal"] = True
-    if bool(flip.get("vertical")):
-        normalized_flip["vertical"] = True
+    for axis in ("horizontal", "vertical"):
+        if axis not in flip:
+            continue
+        value = flip[axis]
+        if not isinstance(value, bool):
+            raise RecipeError(f"flip.{axis} must be a boolean")
+        if value:
+            normalized_flip[axis] = True
     if normalized_flip:
         out["flip"] = normalized_flip
 

--- a/vireo/image_edits.py
+++ b/vireo/image_edits.py
@@ -1,0 +1,187 @@
+"""Non-destructive photo edit recipes and rendering helpers."""
+
+from __future__ import annotations
+
+import copy
+import json
+import math
+
+from PIL import Image, ImageEnhance
+
+SCHEMA_VERSION = 1
+
+_ADJUSTMENT_RANGES = {
+    "exposure": (-5.0, 5.0),
+    "brightness": (-100.0, 100.0),
+    "contrast": (-100.0, 100.0),
+    "saturation": (-100.0, 100.0),
+}
+
+
+class RecipeError(ValueError):
+    """Raised when an edit recipe is malformed or unsupported."""
+
+
+def normalize_recipe(recipe):
+    """Validate and canonicalize a non-destructive image edit recipe.
+
+    The crop rectangle uses normalized coordinates in the image space after
+    rotation and flips have been applied. Rotation is limited to right angles;
+    arbitrary straightening can be added to this schema without changing the
+    storage model.
+    """
+    if recipe in (None, "", {}):
+        return None
+    if isinstance(recipe, str):
+        try:
+            recipe = json.loads(recipe)
+        except (TypeError, ValueError) as exc:
+            raise RecipeError("recipe must be valid JSON") from exc
+    if not isinstance(recipe, dict):
+        raise RecipeError("recipe must be an object")
+
+    out = {"version": SCHEMA_VERSION}
+
+    rotation = recipe.get("rotation", 0)
+    if isinstance(rotation, bool) or not isinstance(rotation, (int, float)):
+        raise RecipeError("rotation must be one of 0, 90, 180, or 270")
+    rotation = int(rotation)
+    if rotation not in (0, 90, 180, 270):
+        raise RecipeError("rotation must be one of 0, 90, 180, or 270")
+    if rotation:
+        out["rotation"] = rotation
+
+    flip = recipe.get("flip") or {}
+    if flip is None:
+        flip = {}
+    if not isinstance(flip, dict):
+        raise RecipeError("flip must be an object")
+    normalized_flip = {}
+    if bool(flip.get("horizontal")):
+        normalized_flip["horizontal"] = True
+    if bool(flip.get("vertical")):
+        normalized_flip["vertical"] = True
+    if normalized_flip:
+        out["flip"] = normalized_flip
+
+    crop = recipe.get("crop")
+    if crop is not None:
+        if not isinstance(crop, dict):
+            raise RecipeError("crop must be an object")
+        try:
+            x = float(crop["x"])
+            y = float(crop["y"])
+            w = float(crop["w"])
+            h = float(crop["h"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise RecipeError("crop must include numeric x, y, w, and h") from exc
+        vals = (x, y, w, h)
+        if not all(math.isfinite(v) for v in vals):
+            raise RecipeError("crop values must be finite")
+        if x < 0 or y < 0 or w <= 0 or h <= 0 or x + w > 1 or y + h > 1:
+            raise RecipeError("crop must fit inside normalized image bounds")
+        # Treat an effectively full-frame crop as no-op.
+        if not (
+            abs(x) < 1e-9 and abs(y) < 1e-9
+            and abs(w - 1) < 1e-9 and abs(h - 1) < 1e-9
+        ):
+            out["crop"] = {
+                "x": round(x, 6),
+                "y": round(y, 6),
+                "w": round(w, 6),
+                "h": round(h, 6),
+            }
+
+    adjustments = recipe.get("adjustments") or {}
+    if adjustments is None:
+        adjustments = {}
+    if not isinstance(adjustments, dict):
+        raise RecipeError("adjustments must be an object")
+    normalized_adjustments = {}
+    for name, (lo, hi) in _ADJUSTMENT_RANGES.items():
+        raw = adjustments.get(name)
+        if raw in (None, ""):
+            continue
+        if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+            raise RecipeError(f"{name} adjustment must be numeric")
+        val = float(raw)
+        if not math.isfinite(val) or val < lo or val > hi:
+            raise RecipeError(f"{name} adjustment must be between {lo:g} and {hi:g}")
+        if abs(val) > 1e-9:
+            normalized_adjustments[name] = round(val, 6)
+    if normalized_adjustments:
+        out["adjustments"] = normalized_adjustments
+
+    return out if len(out) > 1 else None
+
+
+def recipe_to_json(recipe):
+    """Return canonical JSON for a normalized recipe, or None for no-op."""
+    normalized = normalize_recipe(recipe)
+    if normalized is None:
+        return None
+    return json.dumps(normalized, sort_keys=True, separators=(",", ":"))
+
+
+def apply_recipe(img, recipe):
+    """Apply a normalized edit recipe to a PIL image and return a new image."""
+    normalized = normalize_recipe(recipe)
+    if normalized is None:
+        return img
+
+    result = img.copy()
+
+    rotation = normalized.get("rotation", 0)
+    if rotation:
+        # PIL rotates counter-clockwise; photo-editor rotation controls are
+        # conventionally clockwise.
+        result = result.rotate(-rotation, expand=True)
+
+    flip = normalized.get("flip") or {}
+    if flip.get("horizontal"):
+        result = result.transpose(Image.Transpose.FLIP_LEFT_RIGHT)
+    if flip.get("vertical"):
+        result = result.transpose(Image.Transpose.FLIP_TOP_BOTTOM)
+
+    crop = normalized.get("crop")
+    if crop:
+        iw, ih = result.size
+        left = int(round(crop["x"] * iw))
+        top = int(round(crop["y"] * ih))
+        right = int(round((crop["x"] + crop["w"]) * iw))
+        bottom = int(round((crop["y"] + crop["h"]) * ih))
+        right = max(left + 1, min(iw, right))
+        bottom = max(top + 1, min(ih, bottom))
+        result = result.crop((left, top, right, bottom))
+
+    adjustments = normalized.get("adjustments") or {}
+    if "exposure" in adjustments:
+        result = ImageEnhance.Brightness(result).enhance(2 ** adjustments["exposure"])
+    if "brightness" in adjustments:
+        result = ImageEnhance.Brightness(result).enhance(
+            max(0.0, 1.0 + adjustments["brightness"] / 100.0)
+        )
+    if "contrast" in adjustments:
+        result = ImageEnhance.Contrast(result).enhance(
+            max(0.0, 1.0 + adjustments["contrast"] / 100.0)
+        )
+    if "saturation" in adjustments:
+        result = ImageEnhance.Color(result).enhance(
+            max(0.0, 1.0 + adjustments["saturation"] / 100.0)
+        )
+
+    return result
+
+
+def apply_recipe_to_loaded_image(img, recipe, max_size=None):
+    """Apply edits, then optionally constrain the long edge."""
+    result = apply_recipe(img, recipe)
+    if max_size and max_size > 0 and max(result.size) > max_size:
+        result.thumbnail((max_size, max_size), resample=Image.Resampling.LANCZOS)
+    return result
+
+
+def copy_recipe(recipe):
+    """Return a detached normalized recipe dict for API responses."""
+    normalized = normalize_recipe(recipe)
+    return copy.deepcopy(normalized)

--- a/vireo/image_edits.py
+++ b/vireo/image_edits.py
@@ -91,11 +91,17 @@ def normalize_recipe(recipe):
             abs(x) < 1e-9 and abs(y) < 1e-9
             and abs(w - 1) < 1e-9 and abs(h - 1) < 1e-9
         ):
+            x = round(x, 6)
+            y = round(y, 6)
+            w = round(w, 6)
+            h = round(h, 6)
+            if x < 0 or y < 0 or w <= 0 or h <= 0 or x + w > 1 or y + h > 1:
+                raise RecipeError("crop must fit inside normalized image bounds")
             out["crop"] = {
-                "x": round(x, 6),
-                "y": round(y, 6),
-                "w": round(w, 6),
-                "h": round(h, 6),
+                "x": x,
+                "y": y,
+                "w": w,
+                "h": h,
             }
 
     adjustments = recipe.get("adjustments")

--- a/vireo/image_edits.py
+++ b/vireo/image_edits.py
@@ -53,7 +53,7 @@ def normalize_recipe(recipe):
     if rotation:
         out["rotation"] = rotation
 
-    flip = recipe.get("flip") or {}
+    flip = recipe.get("flip")
     if flip is None:
         flip = {}
     if not isinstance(flip, dict):
@@ -98,7 +98,7 @@ def normalize_recipe(recipe):
                 "h": round(h, 6),
             }
 
-    adjustments = recipe.get("adjustments") or {}
+    adjustments = recipe.get("adjustments")
     if adjustments is None:
         adjustments = {}
     if not isinstance(adjustments, dict):

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -110,8 +110,15 @@ def _recipe_render_source(photo, recipe, max_size, vireo_dir, folders):
     if _working_copy_satisfies_recipe_render(photo, recipe, max_size, vireo_dir):
         return get_canonical_image_path(photo, vireo_dir, folders)
 
+    folder_path = folders.get(photo["folder_id"])
+    if not folder_path:
+        if photo["working_copy_path"]:
+            wc_path = os.path.join(vireo_dir, photo["working_copy_path"])
+            if os.path.exists(wc_path):
+                return wc_path
+        return ""
     original = os.path.join(
-        folders.get(photo["folder_id"], ""),
+        folder_path,
         photo["filename"],
     )
     if not os.path.exists(original) and photo["working_copy_path"]:

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1549,7 +1549,10 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     canonical = _recipe_render_source(
                         photo, recipe, max_size, base_dir, folders,
                     )
-                    img = load_image(canonical, max_size=None if recipe else max_size)
+                    load_max_size = (
+                        None if recipe and recipe.get("crop") else max_size
+                    )
+                    img = load_image(canonical, max_size=load_max_size)
                     if img:
                         if recipe:
                             img = apply_recipe_to_loaded_image(

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1430,6 +1430,21 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     thumb_path = os.path.join(cache_dir, f"{photo_id}.jpg")
                     already_exists = os.path.exists(thumb_path)
                     recipe = thread_db.get_photo_edit_recipe(photo_id)
+                    if recipe:
+                        detail_photo = thread_db.get_photo(photo_id)
+                        if detail_photo:
+                            folder_row = thread_db.get_folder(detail_photo["folder_id"])
+                            folders = (
+                                {folder_row["id"]: folder_row["path"]}
+                                if folder_row else {}
+                            )
+                            photo_path = _recipe_render_source(
+                                detail_photo,
+                                recipe,
+                                thumb_size,
+                                effective_vireo_dir,
+                                folders,
+                            )
                     recipe_kwargs = {"recipe": recipe} if recipe else {}
                     result_path = generate_thumbnail(
                         photo_id,

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -190,10 +190,18 @@ def _path_satisfies_recipe_render(path, photo, recipe, max_size):
 def _recipe_render_source(photo, recipe, max_size, vireo_dir, folders):
     from image_loader import get_canonical_image_path
 
-    if not recipe or not recipe.get("crop"):
+    if not recipe:
         return get_canonical_image_path(photo, vireo_dir, folders)
-    if _working_copy_satisfies_recipe_render(photo, recipe, max_size, vireo_dir):
-        return get_canonical_image_path(photo, vireo_dir, folders)
+    canonical = get_canonical_image_path(photo, vireo_dir, folders)
+    wc_rel = photo["working_copy_path"]
+    if canonical and wc_rel:
+        wc_path = wc_rel if os.path.isabs(wc_rel) else os.path.join(vireo_dir, wc_rel)
+        if os.path.abspath(canonical) == os.path.abspath(wc_path):
+            return canonical
+    if recipe.get("crop") and _working_copy_satisfies_recipe_render(
+        photo, recipe, max_size, vireo_dir,
+    ):
+        return canonical
 
     folder_path = folders.get(photo["folder_id"])
     if not folder_path:

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -65,6 +65,62 @@ def _should_abort(abort_event):
     return abort_event.is_set()
 
 
+def _rendered_recipe_long_edge(width, height, recipe):
+    rotation = (recipe or {}).get("rotation", 0)
+    if rotation in (90, 270):
+        width, height = height, width
+    crop = (recipe or {}).get("crop") if recipe else None
+    if crop:
+        return max(float(crop["w"]) * width, float(crop["h"]) * height)
+    return max(width, height)
+
+
+def _working_copy_satisfies_recipe_render(photo, recipe, max_size, vireo_dir):
+    if not recipe or not recipe.get("crop"):
+        return True
+    wc_rel = photo["working_copy_path"]
+    if not wc_rel:
+        return False
+    wc_path = os.path.join(vireo_dir, wc_rel)
+    if not os.path.exists(wc_path):
+        return False
+    original_w = photo["width"] or 0
+    original_h = photo["height"] or 0
+    if original_w <= 0 or original_h <= 0:
+        return False
+    try:
+        from PIL import Image as _PILImage
+        with _PILImage.open(wc_path) as wc_img:
+            wc_w, wc_h = wc_img.size
+    except Exception:
+        return False
+    original_render_long = _rendered_recipe_long_edge(
+        original_w, original_h, recipe,
+    )
+    required_long = min(max_size, original_render_long) if max_size else original_render_long
+    wc_render_long = _rendered_recipe_long_edge(wc_w, wc_h, recipe)
+    return wc_render_long >= required_long
+
+
+def _recipe_render_source(photo, recipe, max_size, vireo_dir, folders):
+    from image_loader import get_canonical_image_path
+
+    if not recipe or not recipe.get("crop"):
+        return get_canonical_image_path(photo, vireo_dir, folders)
+    if _working_copy_satisfies_recipe_render(photo, recipe, max_size, vireo_dir):
+        return get_canonical_image_path(photo, vireo_dir, folders)
+
+    original = os.path.join(
+        folders.get(photo["folder_id"], ""),
+        photo["filename"],
+    )
+    if not os.path.exists(original) and photo["working_copy_path"]:
+        wc_path = os.path.join(vireo_dir, photo["working_copy_path"])
+        if os.path.exists(wc_path):
+            return wc_path
+    return original
+
+
 def _incomplete_model_message(model_name, is_custom=False):
     if is_custom:
         return (
@@ -1219,7 +1275,15 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 try:
                     thumb_path = os.path.join(cache_dir, f"{photo_id}.jpg")
                     already_exists = os.path.exists(thumb_path)
-                    result_path = generate_thumbnail(photo_id, photo_path, cache_dir, size=thumb_size)
+                    recipe = thread_db.get_photo_edit_recipe(photo_id)
+                    recipe_kwargs = {"recipe": recipe} if recipe else {}
+                    result_path = generate_thumbnail(
+                        photo_id,
+                        photo_path,
+                        cache_dir,
+                        size=thumb_size,
+                        **recipe_kwargs,
+                    )
                     if result_path is None:
                         failed += 1
                     elif already_exists:
@@ -1274,8 +1338,14 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     thumb_path = os.path.join(cache_dir, f"{photo_id}.jpg")
                     already_exists = os.path.exists(thumb_path)
                     try:
+                        recipe = thread_db.get_photo_edit_recipe(photo_id)
+                        recipe_kwargs = {"recipe": recipe} if recipe else {}
                         result_path = generate_thumbnail(
-                            photo_id, photo_path, cache_dir, size=thumb_size,
+                            photo_id,
+                            photo_path,
+                            cache_dir,
+                            size=thumb_size,
+                            **recipe_kwargs,
                         )
                         if result_path is None:
                             failed += 1
@@ -1370,7 +1440,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
         try:
             import config as cfg
             from image_edits import apply_recipe_to_loaded_image
-            from image_loader import get_canonical_image_path, load_image
+            from image_loader import load_image
 
             thread_db = Database(db_path)
             thread_db.set_active_workspace(workspace_id)
@@ -1440,13 +1510,9 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     except Exception:
                         pass  # photo may have been deleted mid-pipeline
                 else:
-                    if recipe and recipe.get("crop"):
-                        canonical = os.path.join(
-                            folders.get(photo["folder_id"], ""),
-                            photo["filename"],
-                        )
-                    else:
-                        canonical = get_canonical_image_path(photo, base_dir, folders)
+                    canonical = _recipe_render_source(
+                        photo, recipe, max_size, base_dir, folders,
+                    )
                     img = load_image(canonical, max_size=None if recipe else max_size)
                     if img:
                         if recipe:

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1440,7 +1440,13 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     except Exception:
                         pass  # photo may have been deleted mid-pipeline
                 else:
-                    canonical = get_canonical_image_path(photo, base_dir, folders)
+                    if recipe and recipe.get("crop"):
+                        canonical = os.path.join(
+                            folders.get(photo["folder_id"], ""),
+                            photo["filename"],
+                        )
+                    else:
+                        canonical = get_canonical_image_path(photo, base_dir, folders)
                     img = load_image(canonical, max_size=None if recipe else max_size)
                     if img:
                         if recipe:

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1502,11 +1502,6 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     break
                 cache_path = os.path.join(preview_dir, f'{photo["id"]}_{max_size}.jpg')
                 recipe = thread_db.get_photo_edit_recipe(photo["id"])
-                if recipe and os.path.exists(cache_path):
-                    with contextlib.suppress(OSError):
-                        os.remove(cache_path)
-                    with contextlib.suppress(Exception):
-                        thread_db.preview_cache_delete(photo["id"], max_size)
                 if os.path.exists(cache_path):
                     skipped += 1
                     try:

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1369,6 +1369,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
 
         try:
             import config as cfg
+            from image_edits import apply_recipe_to_loaded_image
             from image_loader import get_canonical_image_path, load_image
 
             thread_db = Database(db_path)
@@ -1423,6 +1424,12 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 if _should_abort(abort):
                     break
                 cache_path = os.path.join(preview_dir, f'{photo["id"]}_{max_size}.jpg')
+                recipe = thread_db.get_photo_edit_recipe(photo["id"])
+                if recipe and os.path.exists(cache_path):
+                    with contextlib.suppress(OSError):
+                        os.remove(cache_path)
+                    with contextlib.suppress(Exception):
+                        thread_db.preview_cache_delete(photo["id"], max_size)
                 if os.path.exists(cache_path):
                     skipped += 1
                     try:
@@ -1434,8 +1441,12 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         pass  # photo may have been deleted mid-pipeline
                 else:
                     canonical = get_canonical_image_path(photo, base_dir, folders)
-                    img = load_image(canonical, max_size=max_size)
+                    img = load_image(canonical, max_size=None if recipe else max_size)
                     if img:
+                        if recipe:
+                            img = apply_recipe_to_loaded_image(
+                                img, recipe, max_size=max_size,
+                            )
                         # Atomic write: with SLOT_CAP > 1 two pipelines
                         # processing the same photo can both miss the
                         # os.path.exists() check above and race here on the

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -102,6 +102,24 @@ def _working_copy_satisfies_recipe_render(photo, recipe, max_size, vireo_dir):
     return wc_render_long >= required_long
 
 
+def _path_satisfies_recipe_render(path, photo, recipe, max_size):
+    original_w = photo["width"] or 0
+    original_h = photo["height"] or 0
+    if original_w <= 0 or original_h <= 0:
+        return False
+    try:
+        from PIL import Image as _PILImage
+        with _PILImage.open(path) as img:
+            width, height = img.size
+    except Exception:
+        return False
+    original_render_long = _rendered_recipe_long_edge(
+        original_w, original_h, recipe,
+    )
+    required_long = min(max_size, original_render_long) if max_size else original_render_long
+    return _rendered_recipe_long_edge(width, height, recipe) >= required_long
+
+
 def _recipe_render_source(photo, recipe, max_size, vireo_dir, folders):
     from image_loader import get_canonical_image_path
 
@@ -117,6 +135,14 @@ def _recipe_render_source(photo, recipe, max_size, vireo_dir, folders):
             if os.path.exists(wc_path):
                 return wc_path
         return ""
+    companion_path = photo["companion_path"]
+    if companion_path:
+        companion = os.path.join(folder_path, companion_path)
+        if (
+            os.path.exists(companion)
+            and _path_satisfies_recipe_render(companion, photo, recipe, max_size)
+        ):
+            return companion
     original = os.path.join(
         folder_path,
         photo["filename"],

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -75,6 +75,65 @@ def _rendered_recipe_long_edge(width, height, recipe):
     return max(width, height)
 
 
+def _photo_value(photo, key):
+    try:
+        return photo[key]
+    except (KeyError, IndexError, TypeError):
+        if hasattr(photo, "get"):
+            return photo.get(key)
+    return None
+
+
+def _exif_orientation(exif_data):
+    if not exif_data:
+        return None
+    if isinstance(exif_data, str):
+        try:
+            metadata = json.loads(exif_data)
+        except (TypeError, ValueError):
+            return None
+    elif isinstance(exif_data, dict):
+        metadata = exif_data
+    else:
+        return None
+    if not isinstance(metadata, dict):
+        return None
+    for group in ("EXIF", "IFD0", "TIFF", "File"):
+        values = metadata.get(group)
+        if isinstance(values, dict) and "Orientation" in values:
+            return values["Orientation"]
+    return metadata.get("Orientation")
+
+
+def _orientation_swaps_axes(orientation):
+    if orientation is None or isinstance(orientation, bool):
+        return False
+    if isinstance(orientation, (int, float)):
+        return int(orientation) in (5, 6, 7, 8)
+    text = str(orientation).strip().lower()
+    if not text:
+        return False
+    try:
+        return int(text) in (5, 6, 7, 8)
+    except ValueError:
+        return "90" in text or "270" in text
+
+
+def _recipe_source_dimensions(photo):
+    try:
+        width = int(_photo_value(photo, "width") or 0)
+        height = int(_photo_value(photo, "height") or 0)
+    except (TypeError, ValueError):
+        return 0, 0
+    if (
+        width > 0
+        and height > 0
+        and _orientation_swaps_axes(_exif_orientation(_photo_value(photo, "exif_data")))
+    ):
+        return height, width
+    return width, height
+
+
 def _working_copy_satisfies_recipe_render(photo, recipe, max_size, vireo_dir):
     if not recipe or not recipe.get("crop"):
         return True
@@ -84,27 +143,23 @@ def _working_copy_satisfies_recipe_render(photo, recipe, max_size, vireo_dir):
     wc_path = os.path.join(vireo_dir, wc_rel)
     if not os.path.exists(wc_path):
         return False
-    original_w = photo["width"] or 0
-    original_h = photo["height"] or 0
-    if original_w <= 0 or original_h <= 0:
-        return False
     try:
         from PIL import Image as _PILImage
         with _PILImage.open(wc_path) as wc_img:
             wc_w, wc_h = wc_img.size
     except Exception:
         return False
-    original_render_long = _rendered_recipe_long_edge(
-        original_w, original_h, recipe,
-    )
+    original_w, original_h = _recipe_source_dimensions(photo)
+    if original_w <= 0 or original_h <= 0:
+        return False
+    original_render_long = _rendered_recipe_long_edge(original_w, original_h, recipe)
     required_long = min(max_size, original_render_long) if max_size else original_render_long
     wc_render_long = _rendered_recipe_long_edge(wc_w, wc_h, recipe)
     return wc_render_long >= required_long
 
 
 def _path_satisfies_recipe_render(path, photo, recipe, max_size):
-    original_w = photo["width"] or 0
-    original_h = photo["height"] or 0
+    original_w, original_h = _recipe_source_dimensions(photo)
     if original_w <= 0 or original_h <= 0:
         return False
     try:

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1438,6 +1438,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     thumb_path = os.path.join(cache_dir, f"{photo_id}.jpg")
                     already_exists = os.path.exists(thumb_path)
                     recipe = thread_db.get_photo_edit_recipe(photo_id)
+                    detail_photo = None
                     if recipe:
                         detail_photo = thread_db.get_photo(photo_id)
                         if detail_photo:
@@ -1453,6 +1454,18 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 effective_vireo_dir,
                                 folders,
                             )
+                            if (
+                                os.path.splitext(photo_path)[1].lower() in _RAW_EXTENSIONS
+                                and _has_current_working_copy_failure(
+                                    detail_photo,
+                                    effective_vireo_dir,
+                                    trust_existing_working_copy=False,
+                                    live_source_path=photo_path,
+                                    folder_path=folders.get(detail_photo["folder_id"]),
+                                )
+                            ):
+                                skipped += 1
+                                continue
                     recipe_kwargs = {"recipe": recipe} if recipe else {}
                     result_path = generate_thumbnail(
                         photo_id,
@@ -1516,14 +1529,28 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     already_exists = os.path.exists(thumb_path)
                     try:
                         recipe = thread_db.get_photo_edit_recipe(photo_id)
+                        detail_photo = None
                         if recipe:
+                            detail_photo = thread_db.get_photo(photo_id) or photo
                             photo_path = _recipe_render_source(
-                                photo,
+                                detail_photo,
                                 recipe,
                                 thumb_size,
                                 effective_vireo_dir,
                                 folders,
                             )
+                            if (
+                                os.path.splitext(photo_path)[1].lower() in _RAW_EXTENSIONS
+                                and _has_current_working_copy_failure(
+                                    detail_photo,
+                                    effective_vireo_dir,
+                                    trust_existing_working_copy=False,
+                                    live_source_path=photo_path,
+                                    folder_path=folders.get(detail_photo["folder_id"]),
+                                )
+                            ):
+                                skipped += 1
+                                continue
                         recipe_kwargs = {"recipe": recipe} if recipe else {}
                         result_path = generate_thumbnail(
                             photo_id,

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1372,6 +1372,14 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     already_exists = os.path.exists(thumb_path)
                     try:
                         recipe = thread_db.get_photo_edit_recipe(photo_id)
+                        if recipe:
+                            photo_path = _recipe_render_source(
+                                photo,
+                                recipe,
+                                thumb_size,
+                                effective_vireo_dir,
+                                folders,
+                            )
                         recipe_kwargs = {"recipe": recipe} if recipe else {}
                         result_path = generate_thumbnail(
                             photo_id,

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -194,7 +194,7 @@ def _recipe_render_source(photo, recipe, max_size, vireo_dir, folders):
         return get_canonical_image_path(photo, vireo_dir, folders)
     canonical = get_canonical_image_path(photo, vireo_dir, folders)
     wc_rel = photo["working_copy_path"]
-    if canonical and wc_rel:
+    if not recipe.get("crop") and canonical and wc_rel:
         wc_path = wc_rel if os.path.isabs(wc_rel) else os.path.join(vireo_dir, wc_rel)
         if os.path.abspath(canonical) == os.path.abspath(wc_path):
             return canonical

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -18,6 +18,7 @@ import tempfile
 import threading
 import time
 from dataclasses import dataclass
+from datetime import UTC, datetime
 
 import numpy as np
 from db import Database, commit_with_retry
@@ -244,6 +245,60 @@ def _looks_like_missing_external_data(err):
 
 
 _RAW_EXTENSIONS = (".nef", ".cr2", ".cr3", ".arw", ".raf", ".dng", ".rw2", ".orf")
+_WORKING_COPY_FAILURE_RETRY_SECONDS = 24 * 60 * 60
+
+
+def _has_current_working_copy_failure(
+    photo, vireo_dir=None, trust_existing_working_copy=True,
+    live_source_path=None, folder_path=None,
+):
+    working_copy_path = _photo_value(photo, "working_copy_path")
+    if working_copy_path and trust_existing_working_copy:
+        if not vireo_dir:
+            return False
+        wc_abs = (
+            working_copy_path if os.path.isabs(working_copy_path)
+            else os.path.join(vireo_dir, working_copy_path)
+        )
+        if os.path.exists(wc_abs):
+            return False
+
+    filename = _photo_value(photo, "filename") or ""
+    if os.path.splitext(filename)[1].lower() not in _RAW_EXTENSIONS:
+        return False
+
+    companion_path = _photo_value(photo, "companion_path")
+    if companion_path and live_source_path and folder_path:
+        companion_abs = os.path.join(folder_path, companion_path)
+        failed_source = _photo_value(photo, "working_copy_failed_source")
+        if (
+            failed_source != "source"
+            and os.path.exists(live_source_path)
+            and os.path.exists(companion_abs)
+        ):
+            return False
+
+    failed_at = _photo_value(photo, "working_copy_failed_at")
+    failed_mtime = _photo_value(photo, "working_copy_failed_mtime")
+    file_mtime = _photo_value(photo, "file_mtime")
+    if not failed_at or failed_mtime is None or file_mtime is None:
+        return False
+    try:
+        if float(failed_mtime) != float(file_mtime):
+            return False
+    except (TypeError, ValueError):
+        return False
+    try:
+        failed_s = str(failed_at).strip()
+        if failed_s.endswith("Z"):
+            failed_s = failed_s[:-1] + "+00:00"
+        failed_dt = datetime.fromisoformat(failed_s)
+        if failed_dt.tzinfo is None:
+            failed_dt = failed_dt.replace(tzinfo=UTC)
+    except (TypeError, ValueError):
+        return False
+    age = (datetime.now(UTC) - failed_dt.astimezone(UTC)).total_seconds()
+    return age < _WORKING_COPY_FAILURE_RETRY_SECONDS
 
 
 _CLASSIFIER_BUNDLE_FIELDS = (
@@ -1600,21 +1655,58 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
             for i, photo in enumerate(photos):
                 if _should_abort(abort):
                     break
+                detail_photo = thread_db.get_photo(photo["id"]) or photo
                 cache_path = os.path.join(preview_dir, f'{photo["id"]}_{max_size}.jpg')
                 recipe = thread_db.get_photo_edit_recipe(photo["id"])
                 if os.path.exists(cache_path):
-                    skipped += 1
-                    try:
-                        if not thread_db.preview_cache_get(photo["id"], max_size):
-                            thread_db.preview_cache_insert(
-                                photo["id"], max_size, os.path.getsize(cache_path),
+                    cache_row = None
+                    with contextlib.suppress(Exception):
+                        cache_row = thread_db.preview_cache_get(photo["id"], max_size)
+                    if recipe and cache_row is None:
+                        with contextlib.suppress(OSError):
+                            os.remove(cache_path)
+                        if os.path.exists(cache_path):
+                            skipped += 1
+                            log.info(
+                                "Skipping untracked edited preview for photo %s; "
+                                "existing cache file could not be removed",
+                                photo["id"],
                             )
-                    except Exception:
-                        pass  # photo may have been deleted mid-pipeline
-                else:
+                            continue
+                    else:
+                        skipped += 1
+                        try:
+                            if cache_row is None:
+                                thread_db.preview_cache_insert(
+                                    photo["id"],
+                                    max_size,
+                                    os.path.getsize(cache_path),
+                                )
+                        except Exception:
+                            pass  # photo may have been deleted mid-pipeline
+                        continue
+                if not os.path.exists(cache_path):
                     canonical = _recipe_render_source(
-                        photo, recipe, max_size, base_dir, folders,
+                        detail_photo, recipe, max_size, base_dir, folders,
                     )
+                    if (
+                        os.path.splitext(canonical)[1].lower() in _RAW_EXTENSIONS
+                        and _has_current_working_copy_failure(
+                            detail_photo,
+                            base_dir,
+                            trust_existing_working_copy=False,
+                            live_source_path=canonical,
+                            folder_path=folders.get(detail_photo["folder_id"]),
+                        )
+                    ):
+                        skipped += 1
+                        log.info(
+                            "Skipping pipeline preview for photo %s; RAW "
+                            "working-copy extraction already failed for "
+                            "current source mtime",
+                            photo["id"],
+                        )
+                        continue
                     load_max_size = (
                         None if recipe and recipe.get("crop") else max_size
                     )

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -27,6 +27,7 @@ from pipeline_locks import acquire_photo_mask, acquire_workspace_regroup
 log = logging.getLogger(__name__)
 
 _SENTINEL = object()  # unique end-of-stream marker
+_EXIF_ORIENTATION_TAG = 274
 
 
 @dataclass
@@ -134,6 +135,16 @@ def _recipe_source_dimensions(photo):
     return width, height
 
 
+def _image_size_after_exif_orientation(img):
+    width, height = img.size
+    orientation = None
+    with contextlib.suppress(Exception):
+        orientation = img.getexif().get(_EXIF_ORIENTATION_TAG)
+    if _orientation_swaps_axes(orientation):
+        return height, width
+    return width, height
+
+
 def _working_copy_satisfies_recipe_render(photo, recipe, max_size, vireo_dir):
     if not recipe or not recipe.get("crop"):
         return True
@@ -146,7 +157,7 @@ def _working_copy_satisfies_recipe_render(photo, recipe, max_size, vireo_dir):
     try:
         from PIL import Image as _PILImage
         with _PILImage.open(wc_path) as wc_img:
-            wc_w, wc_h = wc_img.size
+            wc_w, wc_h = _image_size_after_exif_orientation(wc_img)
     except Exception:
         return False
     original_w, original_h = _recipe_source_dimensions(photo)
@@ -165,7 +176,7 @@ def _path_satisfies_recipe_render(path, photo, recipe, max_size):
     try:
         from PIL import Image as _PILImage
         with _PILImage.open(path) as img:
-            width, height = img.size
+            width, height = _image_size_after_exif_orientation(img)
     except Exception:
         return False
     original_render_long = _rendered_recipe_long_edge(

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -442,6 +442,16 @@ def _pair_raw_jpeg_companions(db, vireo_dir=None, thumb_cache_dir=None):
             (primary["id"], companion["id"]),
         )
         if transferred_recipe.rowcount:
+            db.conn.execute(
+                """UPDATE edit_history_items
+                   SET photo_id = ?
+                   WHERE photo_id = ?
+                     AND edit_id IN (
+                         SELECT id FROM edit_history
+                         WHERE action_type = 'edit_recipe'
+                     )""",
+                (primary["id"], companion["id"]),
+            )
             if vireo_dir:
                 _invalidate_derived_caches(
                     db, vireo_dir, primary["id"],

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -194,7 +194,7 @@ def _extract_timestamp(exif_group):
         return None
 
 
-def _pair_raw_jpeg_companions(db):
+def _pair_raw_jpeg_companions(db, vireo_dir=None, thumb_cache_dir=None):
     """Find raw+JPEG pairs in the same folder and merge them.
 
     When both IMG_001.cr3 and IMG_001.jpg exist in the same folder,
@@ -433,7 +433,7 @@ def _pair_raw_jpeg_companions(db):
         )
         # Preserve non-destructive edits when a JPEG companion is folded into
         # a RAW primary. If both already have recipes, the primary wins.
-        db.conn.execute(
+        transferred_recipe = db.conn.execute(
             """INSERT OR IGNORE INTO photo_edit_recipes
                    (photo_id, recipe_json, updated_at)
                SELECT ?, recipe_json, updated_at
@@ -441,6 +441,21 @@ def _pair_raw_jpeg_companions(db):
                WHERE photo_id = ?""",
             (primary["id"], companion["id"]),
         )
+        if transferred_recipe.rowcount:
+            if vireo_dir:
+                _invalidate_derived_caches(
+                    db, vireo_dir, primary["id"],
+                    thumb_cache_dir=thumb_cache_dir,
+                )
+            else:
+                db.conn.execute(
+                    "UPDATE photos SET thumb_path = NULL WHERE id = ?",
+                    (primary["id"],),
+                )
+                db.conn.execute(
+                    "DELETE FROM preview_cache WHERE photo_id = ?",
+                    (primary["id"],),
+                )
         # Remove keyword associations then the duplicate JPEG record
         db.conn.execute("DELETE FROM photo_keywords WHERE photo_id = ?", (companion["id"],))
         db.conn.execute("DELETE FROM photos WHERE id = ?", (companion["id"],))
@@ -1597,7 +1612,9 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
     # counts — otherwise update_folder_counts()'s commit would persist
     # half-applied pairing or working-copy records.
     try:
-        _pair_raw_jpeg_companions(db)
+        _pair_raw_jpeg_companions(
+            db, vireo_dir=vireo_dir, thumb_cache_dir=thumb_cache_dir,
+        )
 
         # Extract working copies for RAW photos (after pairing so companion is known).
         # Scope to the folders the caller just scanned so a fresh import doesn't

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -431,6 +431,16 @@ def _pair_raw_jpeg_companions(db):
             "UPDATE inat_submissions SET photo_id = ? WHERE photo_id = ?",
             (primary["id"], companion["id"]),
         )
+        # Preserve non-destructive edits when a JPEG companion is folded into
+        # a RAW primary. If both already have recipes, the primary wins.
+        db.conn.execute(
+            """INSERT OR IGNORE INTO photo_edit_recipes
+                   (photo_id, recipe_json, updated_at)
+               SELECT ?, recipe_json, updated_at
+               FROM photo_edit_recipes
+               WHERE photo_id = ?""",
+            (primary["id"], companion["id"]),
+        )
         # Remove keyword associations then the duplicate JPEG record
         db.conn.execute("DELETE FROM photo_keywords WHERE photo_id = ?", (companion["id"],))
         db.conn.execute("DELETE FROM photos WHERE id = ?", (companion["id"],))

--- a/vireo/tests/conftest.py
+++ b/vireo/tests/conftest.py
@@ -37,6 +37,26 @@ def _expanduser_prefers_test_home(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _disable_startup_backfill_timers(monkeypatch):
+    """Stop ``create_app``'s deferred working-copy / thumb-path backfill
+    Timers from firing during tests.
+
+    Concrete failure this prevents: a fast-finishing test (e.g. a
+    synchronous ``/photos/<id>/preview`` request) returns in milliseconds,
+    but its app's 5/6-second Timer fires later — sometimes during a
+    completely unrelated next test — and runs the JobRunner backfill
+    thread against the now-stale tmp_path DB. The backfill's
+    ``extract_working_copy`` calls ``image_loader.load_image`` via the
+    module's global binding, so the *next* test's
+    ``monkeypatch.setattr(image_loader, "load_image", ...)`` intercepts
+    the call from the *previous* test's leaked job. Tests that exercise
+    the backfill paths still invoke ``app._kickoff_*_backfill()``
+    directly, so coverage is unaffected.
+    """
+    monkeypatch.setenv("VIREO_DISABLE_STARTUP_BACKFILL_TIMERS", "1")
+
+
+@pytest.fixture(autouse=True)
 def _reset_model_cache():
     """Drop the process-wide ModelCache between tests.
 

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -1,6 +1,7 @@
 """Tests for photo export operations."""
 
 import contextlib
+import json
 import os
 import sys
 
@@ -283,6 +284,57 @@ def test_export_cropped_recipe_uses_sufficient_developed_output(export_env):
         assert img.size == (800, 600)
         r, g, b = img.resize((1, 1)).getpixel((0, 0))
     assert g > r and g > b
+
+
+def test_export_cropped_recipe_uses_exif_oriented_original_dimensions(export_env):
+    """Crop-aware export sizing must match load_image's EXIF-transposed source."""
+    env = export_env
+    db = env["db"]
+    src_path = env["src"] / "bird1.jpg"
+    original = Image.new("RGB", (600, 400), color="red")
+    exif = original.getexif()
+    exif[0x0112] = 6
+    original.save(str(src_path), "JPEG", quality=95, exif=exif.tobytes())
+    db.conn.execute(
+        "UPDATE photos SET width=?, height=?, exif_data=? WHERE id=?",
+        (
+            600,
+            400,
+            json.dumps({"EXIF": {"Orientation": 6}}),
+            env["p1"],
+        ),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(
+        env["p1"],
+        {"crop": {"x": 0, "y": 0, "w": 0.5, "h": 1}},
+    )
+
+    developed = env["tmp_path"] / "developed"
+    developed_subdir = developed / developed_folder_key(str(env["src"]))
+    developed_subdir.mkdir(parents=True)
+    Image.new("RGB", (400, 400), color="green").save(
+        str(developed_subdir / "bird1.jpg"), "JPEG", quality=95,
+    )
+
+    result = export_photos(
+        db=db,
+        vireo_dir=env["vireo_dir"],
+        photo_ids=[env["p1"]],
+        destination=env["dest"],
+        options={
+            "naming_template": "{original}",
+            "max_size": 500,
+            "developed_dir": str(developed),
+        },
+    )
+
+    assert result["exported"] == 1
+    assert result["errors"] == []
+    with Image.open(os.path.join(env["dest"], "bird1.jpg")) as img:
+        assert max(img.size) == 500
+        r, g, b = img.resize((1, 1)).getpixel((0, 0))
+    assert r > g and r > b
 
 
 def test_export_photos_subdirectories(export_env):

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -195,7 +195,6 @@ def test_export_cropped_recipe_avoids_undersized_working_copy(export_env):
         options={
             "naming_template": "{original}",
             "max_size": 300,
-            "working_copy_max_size": 400,
         },
     )
 

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -267,6 +267,55 @@ def test_export_cropped_recipe_uses_full_res_companion_before_raw(export_env):
         assert img.size == (300, 225)
 
 
+def test_export_non_crop_recipe_uses_full_res_companion_before_raw(
+    export_env, monkeypatch,
+):
+    """Non-crop RAW+JPEG edits should use a sufficient companion before RAW."""
+    import export as export_module
+
+    env = export_env
+    db = env["db"]
+    companion_path = os.path.join(env["src"], "bird1.jpg")
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='source.NEF', extension='.nef',
+               companion_path='bird1.jpg',
+               working_copy_path=NULL,
+               width=800, height=600
+           WHERE id=?""",
+        (env["p1"],),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(env["p1"], {"rotation": 90})
+    original_load_image = export_module.load_image
+    loaded_paths = []
+
+    def tracking_load_image(file_path, max_size=1024):
+        loaded_paths.append(file_path)
+        if str(file_path).lower().endswith(".nef"):
+            raise AssertionError("export decoded RAW before companion")
+        return original_load_image(file_path, max_size=max_size)
+
+    monkeypatch.setattr(export_module, "load_image", tracking_load_image)
+
+    result = export_photos(
+        db=db,
+        vireo_dir=env["vireo_dir"],
+        photo_ids=[env["p1"]],
+        destination=env["dest"],
+        options={
+            "naming_template": "{original}",
+            "max_size": 500,
+        },
+    )
+
+    assert result["exported"] == 1
+    assert result["errors"] == []
+    assert loaded_paths == [companion_path]
+    with Image.open(os.path.join(env["dest"], "source.jpg")) as img:
+        assert img.size == (375, 500)
+
+
 def test_export_cropped_recipe_uses_exif_oriented_companion(export_env):
     """Companion eligibility must match load_image's EXIF-transposed source."""
     env = export_env

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -205,6 +205,45 @@ def test_export_cropped_recipe_avoids_undersized_working_copy(export_env):
         assert img.size == (300, 225)
 
 
+def test_export_cropped_recipe_avoids_undersized_developed_output(export_env):
+    """Cropped resized exports skip developed files that lack source pixels."""
+    env = export_env
+    db = env["db"]
+    db.conn.execute(
+        "UPDATE photos SET width=800, height=600 WHERE id=?",
+        (env["p1"],),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(
+        env["p1"],
+        {"crop": {"x": 0, "y": 0, "w": 0.5, "h": 0.5}},
+    )
+
+    developed = env["tmp_path"] / "developed"
+    developed_subdir = developed / developed_folder_key(str(env["src"]))
+    developed_subdir.mkdir(parents=True)
+    Image.new("RGB", (400, 300), color="red").save(
+        str(developed_subdir / "bird1.jpg"), "JPEG", quality=95,
+    )
+
+    result = export_photos(
+        db=db,
+        vireo_dir=env["vireo_dir"],
+        photo_ids=[env["p1"]],
+        destination=env["dest"],
+        options={
+            "naming_template": "{original}",
+            "max_size": 300,
+            "developed_dir": str(developed),
+        },
+    )
+
+    assert result["exported"] == 1
+    assert result["errors"] == []
+    with Image.open(os.path.join(env["dest"], "bird1.jpg")) as img:
+        assert img.size == (300, 225)
+
+
 def test_export_photos_subdirectories(export_env):
     """export_photos creates subdirectories from template."""
     env = export_env

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -144,6 +144,31 @@ def test_export_photos_resize(export_env):
         assert max(img.size) <= 400
 
 
+def test_export_photos_applies_edit_recipe(export_env):
+    """export_photos applies the stored non-destructive edit recipe."""
+    env = export_env
+    env["db"].set_photo_edit_recipe(
+        env["p1"],
+        {
+            "rotation": 90,
+            "crop": {"x": 0, "y": 0, "w": 0.5, "h": 1},
+        },
+    )
+
+    result = export_photos(
+        db=env["db"],
+        vireo_dir=env["vireo_dir"],
+        photo_ids=[env["p1"]],
+        destination=env["dest"],
+        options={"naming_template": "{original}"},
+    )
+
+    assert result["exported"] == 1
+    assert result["errors"] == []
+    with Image.open(os.path.join(env["dest"], "bird1.jpg")) as img:
+        assert img.size == (300, 800)
+
+
 def test_export_photos_subdirectories(export_env):
     """export_photos creates subdirectories from template."""
     env = export_env

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -231,6 +231,42 @@ def test_export_cropped_recipe_avoids_undersized_working_copy(export_env):
         assert img.size == (300, 225)
 
 
+def test_export_cropped_recipe_uses_full_res_companion_before_raw(export_env):
+    """Cropped RAW+JPEG exports should use a sufficient companion before RAW."""
+    env = export_env
+    db = env["db"]
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='source.NEF', extension='.nef',
+               companion_path='bird1.jpg',
+               working_copy_path=NULL,
+               width=800, height=600
+           WHERE id=?""",
+        (env["p1"],),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(
+        env["p1"],
+        {"crop": {"x": 0, "y": 0, "w": 0.5, "h": 0.5}},
+    )
+
+    result = export_photos(
+        db=db,
+        vireo_dir=env["vireo_dir"],
+        photo_ids=[env["p1"]],
+        destination=env["dest"],
+        options={
+            "naming_template": "{original}",
+            "max_size": 300,
+        },
+    )
+
+    assert result["exported"] == 1
+    assert result["errors"] == []
+    with Image.open(os.path.join(env["dest"], "source.jpg")) as img:
+        assert img.size == (300, 225)
+
+
 def test_export_cropped_recipe_avoids_undersized_developed_output(export_env):
     """Cropped resized exports skip developed files that lack source pixels."""
     env = export_env

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -169,6 +169,42 @@ def test_export_photos_applies_edit_recipe(export_env):
         assert img.size == (300, 800)
 
 
+def test_export_cropped_recipe_avoids_undersized_working_copy(export_env):
+    """Cropped resized exports use the original when a capped WC is too small."""
+    env = export_env
+    db = env["db"]
+    working_dir = os.path.join(env["vireo_dir"], "working")
+    os.makedirs(working_dir, exist_ok=True)
+    wc_path = os.path.join(working_dir, f"{env['p1']}.jpg")
+    Image.new("RGB", (400, 300), color="red").save(wc_path, "JPEG", quality=95)
+    db.conn.execute(
+        "UPDATE photos SET width=800, height=600, working_copy_path=? WHERE id=?",
+        (f"working/{env['p1']}.jpg", env["p1"]),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(
+        env["p1"],
+        {"crop": {"x": 0, "y": 0, "w": 0.5, "h": 0.5}},
+    )
+
+    result = export_photos(
+        db=db,
+        vireo_dir=env["vireo_dir"],
+        photo_ids=[env["p1"]],
+        destination=env["dest"],
+        options={
+            "naming_template": "{original}",
+            "max_size": 300,
+            "working_copy_max_size": 400,
+        },
+    )
+
+    assert result["exported"] == 1
+    assert result["errors"] == []
+    with Image.open(os.path.join(env["dest"], "bird1.jpg")) as img:
+        assert img.size == (300, 225)
+
+
 def test_export_photos_subdirectories(export_env):
     """export_photos creates subdirectories from template."""
     env = export_env

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -170,6 +170,32 @@ def test_export_photos_applies_edit_recipe(export_env):
         assert img.size == (300, 800)
 
 
+def test_export_non_crop_recipe_loads_with_requested_size(export_env, monkeypatch):
+    import export as export_module
+
+    env = export_env
+    env["db"].set_photo_edit_recipe(env["p2"], {"rotation": 90})
+    original_load_image = export_module.load_image
+    seen_max_sizes = []
+
+    def tracking_load_image(file_path, max_size=1024):
+        seen_max_sizes.append(max_size)
+        return original_load_image(file_path, max_size=max_size)
+
+    monkeypatch.setattr(export_module, "load_image", tracking_load_image)
+
+    result = export_photos(
+        db=env["db"],
+        vireo_dir=env["vireo_dir"],
+        photo_ids=[env["p2"]],
+        destination=env["dest"],
+        options={"naming_template": "{original}", "max_size": 400},
+    )
+
+    assert result["exported"] == 1
+    assert seen_max_sizes == [400]
+
+
 def test_export_cropped_recipe_avoids_undersized_working_copy(export_env):
     """Cropped resized exports use the original when a capped WC is too small."""
     env = export_env

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -243,6 +243,48 @@ def test_export_cropped_recipe_avoids_undersized_developed_output(export_env):
         assert img.size == (300, 225)
 
 
+def test_export_cropped_recipe_uses_sufficient_developed_output(export_env):
+    """Cropped exports keep developed files that satisfy the cropped output."""
+    env = export_env
+    db = env["db"]
+    db.conn.execute(
+        "UPDATE photos SET width=8000, height=6000 WHERE id=?",
+        (env["p1"],),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(
+        env["p1"],
+        {"crop": {"x": 0, "y": 0, "w": 0.1, "h": 0.1}},
+    )
+
+    developed = env["tmp_path"] / "developed"
+    developed_subdir = developed / developed_folder_key(str(env["src"]))
+    developed_subdir.mkdir(parents=True)
+    Image.new("RGB", (8000, 6000), color="green").save(
+        str(developed_subdir / "bird1.jpg"), "JPEG", quality=95,
+    )
+    os.remove(env["src"] / "bird1.jpg")
+
+    result = export_photos(
+        db=db,
+        vireo_dir=env["vireo_dir"],
+        photo_ids=[env["p1"]],
+        destination=env["dest"],
+        options={
+            "naming_template": "{original}",
+            "max_size": 4000,
+            "developed_dir": str(developed),
+        },
+    )
+
+    assert result["exported"] == 1
+    assert result["errors"] == []
+    with Image.open(os.path.join(env["dest"], "bird1.jpg")) as img:
+        assert img.size == (800, 600)
+        r, g, b = img.resize((1, 1)).getpixel((0, 0))
+    assert g > r and g > b
+
+
 def test_export_photos_subdirectories(export_env):
     """export_photos creates subdirectories from template."""
     env = export_env

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -267,6 +267,54 @@ def test_export_cropped_recipe_uses_full_res_companion_before_raw(export_env):
         assert img.size == (300, 225)
 
 
+def test_export_cropped_recipe_uses_exif_oriented_companion(export_env):
+    """Companion eligibility must match load_image's EXIF-transposed source."""
+    env = export_env
+    db = env["db"]
+    companion_path = env["src"] / "bird1.jpg"
+    companion = Image.new("RGB", (600, 400), color="red")
+    exif = companion.getexif()
+    exif[0x0112] = 6
+    companion.save(str(companion_path), "JPEG", quality=95, exif=exif.tobytes())
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='source.NEF', extension='.nef',
+               companion_path='bird1.jpg',
+               working_copy_path=NULL,
+               width=?, height=?, exif_data=?
+           WHERE id=?""",
+        (
+            600,
+            400,
+            json.dumps({"EXIF": {"Orientation": 6}}),
+            env["p1"],
+        ),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(
+        env["p1"],
+        {"crop": {"x": 0, "y": 0, "w": 0.5, "h": 1}},
+    )
+
+    result = export_photos(
+        db=db,
+        vireo_dir=env["vireo_dir"],
+        photo_ids=[env["p1"]],
+        destination=env["dest"],
+        options={
+            "naming_template": "{original}",
+            "max_size": 500,
+        },
+    )
+
+    assert result["exported"] == 1
+    assert result["errors"] == []
+    with Image.open(os.path.join(env["dest"], "source.jpg")) as img:
+        assert max(img.size) == 500
+        r, g, b = img.resize((1, 1)).getpixel((0, 0))
+    assert r > g and r > b
+
+
 def test_export_cropped_recipe_avoids_undersized_developed_output(export_env):
     """Cropped resized exports skip developed files that lack source pixels."""
     env = export_env

--- a/vireo/tests/test_image_edits.py
+++ b/vireo/tests/test_image_edits.py
@@ -19,6 +19,11 @@ def test_normalize_recipe_rejects_out_of_bounds_crop():
         normalize_recipe({"crop": {"x": 0.5, "y": 0.5, "w": 0.6, "h": 0.6}})
 
 
+def test_normalize_recipe_rejects_crop_that_rounds_out_of_bounds():
+    with pytest.raises(RecipeError, match="crop must fit"):
+        normalize_recipe({"crop": {"x": 0, "y": 0, "w": 0.0000001, "h": 1}})
+
+
 def test_normalize_recipe_rejects_fractional_rotation():
     with pytest.raises(RecipeError, match="rotation"):
         normalize_recipe({"rotation": 90.9})

--- a/vireo/tests/test_image_edits.py
+++ b/vireo/tests/test_image_edits.py
@@ -19,6 +19,11 @@ def test_normalize_recipe_rejects_out_of_bounds_crop():
         normalize_recipe({"crop": {"x": 0.5, "y": 0.5, "w": 0.6, "h": 0.6}})
 
 
+def test_normalize_recipe_rejects_boolean_crop_coordinates():
+    with pytest.raises(RecipeError, match="crop must include numeric"):
+        normalize_recipe({"crop": {"x": False, "y": False, "w": True, "h": True}})
+
+
 def test_normalize_recipe_rejects_crop_that_rounds_out_of_bounds():
     with pytest.raises(RecipeError, match="crop must fit"):
         normalize_recipe({"crop": {"x": 0, "y": 0, "w": 0.0000001, "h": 1}})

--- a/vireo/tests/test_image_edits.py
+++ b/vireo/tests/test_image_edits.py
@@ -29,6 +29,18 @@ def test_normalize_recipe_rejects_non_boolean_flip():
         normalize_recipe({"flip": {"horizontal": "false"}})
 
 
+@pytest.mark.parametrize(
+    ("recipe", "message"),
+    [
+        ({"flip": []}, "flip must be an object"),
+        ({"adjustments": []}, "adjustments must be an object"),
+    ],
+)
+def test_normalize_recipe_rejects_falsey_non_object_sections(recipe, message):
+    with pytest.raises(RecipeError, match=message):
+        normalize_recipe(recipe)
+
+
 def test_recipe_json_is_canonical():
     assert recipe_to_json({"flip": {"vertical": True}, "rotation": 90}) == (
         '{"flip":{"vertical":true},"rotation":90,"version":1}'

--- a/vireo/tests/test_image_edits.py
+++ b/vireo/tests/test_image_edits.py
@@ -19,6 +19,16 @@ def test_normalize_recipe_rejects_out_of_bounds_crop():
         normalize_recipe({"crop": {"x": 0.5, "y": 0.5, "w": 0.6, "h": 0.6}})
 
 
+def test_normalize_recipe_rejects_fractional_rotation():
+    with pytest.raises(RecipeError, match="rotation"):
+        normalize_recipe({"rotation": 90.9})
+
+
+def test_normalize_recipe_rejects_non_boolean_flip():
+    with pytest.raises(RecipeError, match="flip.horizontal"):
+        normalize_recipe({"flip": {"horizontal": "false"}})
+
+
 def test_recipe_json_is_canonical():
     assert recipe_to_json({"flip": {"vertical": True}, "rotation": 90}) == (
         '{"flip":{"vertical":true},"rotation":90,"version":1}'

--- a/vireo/tests/test_image_edits.py
+++ b/vireo/tests/test_image_edits.py
@@ -1,0 +1,39 @@
+import os
+import sys
+
+import pytest
+from PIL import Image
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from image_edits import RecipeError, apply_recipe, normalize_recipe, recipe_to_json
+
+
+def test_normalize_recipe_drops_noop():
+    assert normalize_recipe({}) is None
+    assert normalize_recipe({"rotation": 0, "crop": {"x": 0, "y": 0, "w": 1, "h": 1}}) is None
+
+
+def test_normalize_recipe_rejects_out_of_bounds_crop():
+    with pytest.raises(RecipeError, match="crop must fit"):
+        normalize_recipe({"crop": {"x": 0.5, "y": 0.5, "w": 0.6, "h": 0.6}})
+
+
+def test_recipe_json_is_canonical():
+    assert recipe_to_json({"flip": {"vertical": True}, "rotation": 90}) == (
+        '{"flip":{"vertical":true},"rotation":90,"version":1}'
+    )
+
+
+def test_apply_recipe_rotates_flips_and_crops():
+    img = Image.new("RGB", (100, 60), "white")
+    edited = apply_recipe(
+        img,
+        {
+            "rotation": 90,
+            "flip": {"horizontal": True},
+            "crop": {"x": 0.25, "y": 0.25, "w": 0.5, "h": 0.5},
+        },
+    )
+
+    assert edited.size == (30, 50)

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1436,6 +1436,40 @@ def test_edit_recipe_api_invalidates_untracked_preview_file(client_with_photo):
     assert not os.path.exists(untracked_path)
 
 
+def test_edited_preview_does_not_adopt_stale_untracked_file_after_unlink_failure(
+    client_with_photo, monkeypatch,
+):
+    import io
+    import os
+
+    import app as app_module
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    preview_dir = os.path.join(vireo_dir, "previews")
+    os.makedirs(preview_dir, exist_ok=True)
+    stale_path = os.path.join(preview_dir, f"{photo_id}_1920.jpg")
+    Image.new("RGB", (10, 10), "purple").save(stale_path, "JPEG")
+    db.set_photo_edit_recipe(photo_id, {"rotation": 90})
+    assert db.preview_cache_get(photo_id, 1920) is None
+    original_remove = app_module.os.remove
+
+    def locked_remove(path):
+        if path == stale_path:
+            raise OSError("locked")
+        return original_remove(path)
+
+    monkeypatch.setattr(app_module.os, "remove", locked_remove)
+
+    rendered = client.get(f"/photos/{photo_id}/preview?size=1920")
+
+    assert rendered.status_code == 200
+    with Image.open(io.BytesIO(rendered.data)) as img:
+        assert img.size == (600, 800)
+
+
 def test_edit_recipe_api_invalidates_thumbnail_and_renders_edit(client_with_photo):
     import io
     import os

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -2610,10 +2610,13 @@ def test_preview_job_writes_sized_filename_and_tracks(client_with_photo):
     assert not os.path.exists(os.path.join(preview_dir, f"{photo_id}.jpg"))
 
 
-def test_preview_job_applies_edit_recipe_to_warmed_file(client_with_photo):
+def test_preview_job_applies_edit_recipe_to_warmed_file(
+    client_with_photo, monkeypatch,
+):
     import os
     import time
 
+    import image_loader
     from PIL import Image
 
     app, db, photo_id = client_with_photo
@@ -2622,6 +2625,14 @@ def test_preview_job_applies_edit_recipe_to_warmed_file(client_with_photo):
     preview_dir = os.path.join(vireo_dir, "previews")
     preview_path = os.path.join(preview_dir, f"{photo_id}_1920.jpg")
     db.set_photo_edit_recipe(photo_id, {"rotation": 90})
+    original_load_image = image_loader.load_image
+    seen_max_sizes = []
+
+    def tracking_load_image(file_path, max_size=1024):
+        seen_max_sizes.append(max_size)
+        return original_load_image(file_path, max_size=max_size)
+
+    monkeypatch.setattr(image_loader, "load_image", tracking_load_image)
 
     resp = client.post("/api/jobs/previews", json={})
     assert resp.status_code == 200
@@ -2639,6 +2650,7 @@ def test_preview_job_applies_edit_recipe_to_warmed_file(client_with_photo):
         time.sleep(0.05)
     assert data["status"] == "completed"
 
+    assert seen_max_sizes == [1920]
     assert db.preview_cache_get(photo_id, 1920) is not None
     with Image.open(preview_path) as img:
         assert img.size == (600, 800)

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1602,6 +1602,29 @@ def test_edit_recipe_api_rejects_invalid_recipe(client_with_photo):
     assert "rotation" in resp.get_json()["error"]
 
 
+def test_edit_recipe_api_rejects_malformed_body_without_clearing(client_with_photo):
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+
+    existing = {"rotation": 180}
+    assert client.put(
+        f"/api/photos/{photo_id}/edit-recipe",
+        json={"recipe": existing},
+    ).status_code == 200
+    stored = db.get_photo_edit_recipe(photo_id)
+
+    cases = [
+        {},
+        {"data": "{", "content_type": "application/json"},
+        {"json": []},
+        {"json": {"recipe": []}},
+    ]
+    for kwargs in cases:
+        resp = client.put(f"/api/photos/{photo_id}/edit-recipe", **kwargs)
+        assert resp.status_code == 400
+        assert db.get_photo_edit_recipe(photo_id) == stored
+
+
 def test_edit_recipe_api_undo_redo(client_with_photo):
     app, db, photo_id = client_with_photo
     client = app.test_client()

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1393,6 +1393,29 @@ def test_edit_recipe_api_invalidates_preview_cache_and_renders(client_with_photo
         assert img.size == (600, 800)
 
 
+def test_edit_recipe_api_invalidates_untracked_preview_file(client_with_photo):
+    import os
+
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    preview_dir = os.path.join(vireo_dir, "previews")
+    os.makedirs(preview_dir, exist_ok=True)
+    untracked_path = os.path.join(preview_dir, f"{photo_id}_2560.jpg")
+    Image.new("RGB", (10, 10), "purple").save(untracked_path, "JPEG")
+    assert db.preview_cache_get(photo_id, 2560) is None
+
+    resp = client.put(
+        f"/api/photos/{photo_id}/edit-recipe",
+        json={"recipe": {"rotation": 90}},
+    )
+
+    assert resp.status_code == 200
+    assert not os.path.exists(untracked_path)
+
+
 def test_edit_recipe_api_rejects_invalid_recipe(client_with_photo):
     app, _db, photo_id = client_with_photo
     client = app.test_client()

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -2855,6 +2855,119 @@ def test_preview_job_honors_raw_failure_marker_after_source_selection(
     )
 
 
+def test_preview_job_does_not_adopt_untracked_edited_preview_after_unlink_failure(
+    client_with_photo, monkeypatch,
+):
+    import os
+    import time
+
+    import app as app_module
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    preview_dir = os.path.join(vireo_dir, "previews")
+    os.makedirs(preview_dir, exist_ok=True)
+    preview_path = os.path.join(preview_dir, f"{photo_id}_1920.jpg")
+    db.set_photo_edit_recipe(photo_id, {"rotation": 90})
+    with open(preview_path, "wb") as f:
+        f.write(b"stale-preview")
+    assert db.preview_cache_get(photo_id, 1920) is None
+
+    original_remove = app_module.os.remove
+
+    def locked_remove(path):
+        if os.path.abspath(path) == os.path.abspath(preview_path):
+            raise OSError("locked")
+        return original_remove(path)
+
+    monkeypatch.setattr(app_module.os, "remove", locked_remove)
+
+    resp = client.post("/api/jobs/previews", json={})
+    assert resp.status_code == 200
+    job_id = resp.get_json()["job_id"]
+
+    deadline = time.time() + 10
+    while time.time() < deadline:
+        status_resp = client.get(f"/api/jobs/{job_id}")
+        if status_resp.status_code != 200:
+            time.sleep(0.05)
+            continue
+        data = status_resp.get_json()
+        if data.get("status") in ("completed", "failed"):
+            break
+        time.sleep(0.05)
+    assert data["status"] == "completed"
+
+    assert os.path.exists(preview_path)
+    assert db.preview_cache_get(photo_id, 1920) is None
+
+
+def test_preview_job_uses_detail_row_exif_for_cropped_source_selection(
+    client_with_photo, monkeypatch,
+):
+    import json
+    import os
+    import time
+
+    import image_loader
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    working_dir = os.path.join(vireo_dir, "working")
+    os.makedirs(working_dir, exist_ok=True)
+    working_path = os.path.join(working_dir, f"{photo_id}.jpg")
+    Image.new("RGB", (400, 400), "blue").save(working_path)
+    folder = db.conn.execute(
+        "SELECT path FROM folders WHERE id = (SELECT folder_id FROM photos WHERE id=?)",
+        (photo_id,),
+    ).fetchone()
+    original_path = os.path.join(folder["path"], "test.jpg")
+    db.conn.execute(
+        """UPDATE photos
+           SET width=600, height=400, exif_data=?, working_copy_path=?
+           WHERE id=?""",
+        (
+            json.dumps({"EXIF": {"Orientation": 6}}),
+            f"working/{photo_id}.jpg",
+            photo_id,
+        ),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(
+        photo_id,
+        {"crop": {"x": 0, "y": 0, "w": 0.5, "h": 1}},
+    )
+    loaded_paths = []
+
+    def tracking_load_image(file_path, max_size=1024):
+        loaded_paths.append(os.path.abspath(str(file_path)))
+        return Image.new("RGB", (600, 400), "red")
+
+    monkeypatch.setattr(image_loader, "load_image", tracking_load_image)
+
+    resp = client.post("/api/jobs/previews", json={})
+    assert resp.status_code == 200
+    job_id = resp.get_json()["job_id"]
+
+    deadline = time.time() + 10
+    while time.time() < deadline:
+        status_resp = client.get(f"/api/jobs/{job_id}")
+        if status_resp.status_code != 200:
+            time.sleep(0.05)
+            continue
+        data = status_resp.get_json()
+        if data.get("status") in ("completed", "failed"):
+            break
+        time.sleep(0.05)
+    assert data["status"] == "completed"
+
+    assert loaded_paths == [os.path.abspath(original_path)]
+    assert db.preview_cache_get(photo_id, 1920) is not None
+
+
 def test_preview_job_preserves_existing_edited_preview_when_source_missing(
     client_with_photo,
 ):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1416,6 +1416,41 @@ def test_edit_recipe_api_invalidates_untracked_preview_file(client_with_photo):
     assert not os.path.exists(untracked_path)
 
 
+def test_edit_recipe_api_invalidates_thumbnail_and_renders_edit(client_with_photo):
+    import io
+    import os
+
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    thumb_dir = app.config["THUMB_CACHE_DIR"]
+    thumb_path = os.path.join(thumb_dir, f"{photo_id}.jpg")
+    Image.new("RGB", (400, 300), "green").save(thumb_path, "JPEG")
+    db.conn.execute(
+        "UPDATE photos SET thumb_path = ? WHERE id = ?",
+        (f"{photo_id}.jpg", photo_id),
+    )
+    db.conn.commit()
+
+    resp = client.put(
+        f"/api/photos/{photo_id}/edit-recipe",
+        json={"recipe": {"rotation": 90}},
+    )
+
+    assert resp.status_code == 200
+    assert not os.path.exists(thumb_path)
+    row = db.conn.execute(
+        "SELECT thumb_path FROM photos WHERE id = ?", (photo_id,),
+    ).fetchone()
+    assert row["thumb_path"] is None
+
+    rendered = client.get(f"/thumbnails/{photo_id}.jpg")
+    assert rendered.status_code == 200
+    with Image.open(io.BytesIO(rendered.data)) as img:
+        assert img.size == (300, 400)
+
+
 def test_edited_original_uses_trusted_working_copy_when_source_missing(
     client_with_photo,
 ):
@@ -1452,6 +1487,38 @@ def test_edited_original_uses_trusted_working_copy_when_source_missing(
     assert rendered.status_code == 200
     with Image.open(io.BytesIO(rendered.data)) as img:
         assert img.size == (600, 800)
+
+
+def test_cropped_preview_uses_original_when_working_copy_is_too_small(
+    client_with_photo,
+):
+    import io
+    import os
+
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    working_dir = os.path.join(vireo_dir, "working")
+    os.makedirs(working_dir, exist_ok=True)
+    working_path = os.path.join(working_dir, f"{photo_id}.jpg")
+    Image.new("RGB", (400, 300), (30, 120, 200)).save(working_path, "JPEG")
+    db.conn.execute(
+        "UPDATE photos SET working_copy_path=? WHERE id=?",
+        (f"working/{photo_id}.jpg", photo_id),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(
+        photo_id,
+        {"crop": {"x": 0, "y": 0, "w": 0.5, "h": 0.5}},
+    )
+
+    rendered = client.get(f"/photos/{photo_id}/preview?size=1920")
+
+    assert rendered.status_code == 200
+    with Image.open(io.BytesIO(rendered.data)) as img:
+        assert img.size == (400, 300)
 
 
 def test_edit_recipe_api_rejects_invalid_recipe(client_with_photo):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1470,6 +1470,47 @@ def test_edited_preview_does_not_adopt_stale_untracked_file_after_unlink_failure
         assert img.size == (600, 800)
 
 
+def test_cleared_recipe_does_not_adopt_stale_edited_preview_after_unlink_failure(
+    client_with_photo, monkeypatch,
+):
+    import io
+    import os
+
+    import app as app_module
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    preview_path = os.path.join(vireo_dir, "previews", f"{photo_id}_1920.jpg")
+
+    db.set_photo_edit_recipe(photo_id, {"rotation": 90})
+    edited = client.get(f"/photos/{photo_id}/preview?size=1920")
+    assert edited.status_code == 200
+    assert db.preview_cache_get(photo_id, 1920) is not None
+    with Image.open(io.BytesIO(edited.data)) as img:
+        assert img.size == (600, 800)
+
+    original_remove = app_module.os.remove
+
+    def locked_remove(path):
+        if path == preview_path:
+            raise OSError("locked")
+        return original_remove(path)
+
+    monkeypatch.setattr(app_module.os, "remove", locked_remove)
+
+    cleared = client.delete(f"/api/photos/{photo_id}/edit-recipe")
+    assert cleared.status_code == 200
+    assert os.path.exists(preview_path)
+
+    rendered = client.get(f"/photos/{photo_id}/preview?size=1920")
+
+    assert rendered.status_code == 200
+    with Image.open(io.BytesIO(rendered.data)) as img:
+        assert img.size == (800, 600)
+
+
 def test_edit_recipe_api_invalidates_thumbnail_and_renders_edit(client_with_photo):
     import io
     import os
@@ -1664,6 +1705,35 @@ def test_edited_original_prefers_full_res_companion_before_raw_decode(
     assert loaded_paths == [companion_path]
     with Image.open(io.BytesIO(rendered.data)) as img:
         assert img.size == (600, 800)
+
+
+def test_edited_original_cache_write_is_atomic(client_with_photo, monkeypatch):
+    import os
+
+    import app as app_module
+
+    app, db, photo_id = client_with_photo
+    db.set_photo_edit_recipe(photo_id, {"rotation": 90})
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    final_path = os.path.join(vireo_dir, "originals", f"{photo_id}.jpg")
+    calls = []
+    original_replace = app_module.os.replace
+
+    def tracking_replace(src, dst):
+        calls.append((src, dst, os.path.exists(src)))
+        return original_replace(src, dst)
+
+    monkeypatch.setattr(app_module.os, "replace", tracking_replace)
+
+    rendered = app.test_client().get(f"/photos/{photo_id}/original")
+
+    assert rendered.status_code == 200
+    assert calls
+    tmp_path, dst_path, tmp_existed = calls[0]
+    assert tmp_existed is True
+    assert dst_path == final_path
+    assert not os.path.exists(tmp_path)
+    assert os.path.exists(final_path)
 
 
 def test_cropped_preview_uses_original_when_working_copy_is_too_small(

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -2498,11 +2498,52 @@ def test_preview_job_applies_edit_recipe_to_warmed_file(client_with_photo):
     client = app.test_client()
     vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
     preview_dir = os.path.join(vireo_dir, "previews")
-    os.makedirs(preview_dir, exist_ok=True)
     preview_path = os.path.join(preview_dir, f"{photo_id}_1920.jpg")
     db.set_photo_edit_recipe(photo_id, {"rotation": 90})
-    Image.new("RGB", (800, 600), "green").save(preview_path, "JPEG")
-    db.preview_cache_insert(photo_id, 1920, os.path.getsize(preview_path))
+
+    resp = client.post("/api/jobs/previews", json={})
+    assert resp.status_code == 200
+    job_id = resp.get_json()["job_id"]
+
+    deadline = time.time() + 10
+    while time.time() < deadline:
+        status_resp = client.get(f"/api/jobs/{job_id}")
+        if status_resp.status_code != 200:
+            time.sleep(0.05)
+            continue
+        data = status_resp.get_json()
+        if data.get("status") in ("completed", "failed"):
+            break
+        time.sleep(0.05)
+    assert data["status"] == "completed"
+
+    assert db.preview_cache_get(photo_id, 1920) is not None
+    with Image.open(preview_path) as img:
+        assert img.size == (600, 800)
+
+
+def test_preview_job_preserves_existing_edited_preview_when_source_missing(
+    client_with_photo,
+):
+    import os
+    import time
+
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    db.set_photo_edit_recipe(photo_id, {"rotation": 90})
+    rendered = client.get(f"/photos/{photo_id}/preview?size=1920")
+    assert rendered.status_code == 200
+
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    preview_path = os.path.join(vireo_dir, "previews", f"{photo_id}_1920.jpg")
+    assert os.path.exists(preview_path)
+    folder = db.conn.execute(
+        "SELECT f.path, p.filename FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (photo_id,),
+    ).fetchone()
+    os.remove(os.path.join(folder["path"], folder["filename"]))
 
     resp = client.post("/api/jobs/previews", json={})
     assert resp.status_code == 200

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -2815,11 +2815,16 @@ def test_preview_job_honors_raw_failure_marker_after_source_selection(
         photo_id,
         {"crop": {"x": 0, "y": 0, "w": 0.5, "h": 1}},
     )
+    folder = db.conn.execute(
+        "SELECT path FROM folders WHERE id = (SELECT folder_id FROM photos WHERE id=?)",
+        (photo_id,),
+    ).fetchone()
+    raw_path = os.path.join(folder["path"], "source.NEF")
     original_load_image = image_loader.load_image
     raw_loads = []
 
     def tracking_load_image(file_path, max_size=1024):
-        if str(file_path).lower().endswith(".nef"):
+        if os.path.abspath(str(file_path)) == os.path.abspath(raw_path):
             raw_loads.append(file_path)
             raise AssertionError("preview warmup retried failed RAW")
         return original_load_image(file_path, max_size=max_size)

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -3196,7 +3196,12 @@ def test_preview_job_uses_detail_row_exif_for_cropped_source_selection(
         time.sleep(0.05)
     assert data["status"] == "completed"
 
-    assert loaded_paths == [os.path.abspath(original_path)]
+    source_dir = os.path.abspath(os.path.dirname(original_path))
+    relevant_paths = [
+        path for path in loaded_paths
+        if os.path.commonpath([source_dir, path]) == source_dir
+    ]
+    assert relevant_paths == [os.path.abspath(original_path)]
     assert db.preview_cache_get(photo_id, 1920) is not None
 
 

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1511,6 +1511,56 @@ def test_cleared_recipe_does_not_adopt_stale_edited_preview_after_unlink_failure
         assert img.size == (800, 600)
 
 
+def test_failed_preview_invalidation_survives_app_restart(
+    client_with_photo, monkeypatch,
+):
+    import io
+    import os
+
+    import app as app_module
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    preview_path = os.path.join(vireo_dir, "previews", f"{photo_id}_1920.jpg")
+
+    original = client.get(f"/photos/{photo_id}/preview?size=1920")
+    assert original.status_code == 200
+    assert db.preview_cache_get(photo_id, 1920) is not None
+    with Image.open(io.BytesIO(original.data)) as img:
+        assert img.size == (800, 600)
+
+    original_remove = app_module.os.remove
+
+    def locked_remove(path):
+        if path == preview_path:
+            raise OSError("locked")
+        return original_remove(path)
+
+    monkeypatch.setattr(app_module.os, "remove", locked_remove)
+    edited = client.put(
+        f"/api/photos/{photo_id}/edit-recipe",
+        json={"recipe": {"rotation": 90}},
+    )
+    assert edited.status_code == 200
+    assert os.path.exists(preview_path)
+    assert db.preview_cache_get(photo_id, 1920) is not None
+
+    monkeypatch.setattr(app_module.os, "remove", original_remove)
+    restarted = app_module.create_app(
+        db._db_path,
+        thumb_cache_dir=app.config["THUMB_CACHE_DIR"],
+    )
+    rendered = restarted.test_client().get(
+        f"/photos/{photo_id}/preview?size=1920",
+    )
+
+    assert rendered.status_code == 200
+    with Image.open(io.BytesIO(rendered.data)) as img:
+        assert img.size == (600, 800)
+
+
 def test_edit_recipe_api_invalidates_thumbnail_and_renders_edit(client_with_photo):
     import io
     import os

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1416,6 +1416,44 @@ def test_edit_recipe_api_invalidates_untracked_preview_file(client_with_photo):
     assert not os.path.exists(untracked_path)
 
 
+def test_edited_original_uses_trusted_working_copy_when_source_missing(
+    client_with_photo,
+):
+    import io
+    import os
+
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    working_dir = os.path.join(vireo_dir, "working")
+    os.makedirs(working_dir, exist_ok=True)
+    working_path = os.path.join(working_dir, f"{photo_id}.jpg")
+    Image.new("RGB", (800, 600), (30, 120, 200)).save(working_path, "JPEG")
+    db.conn.execute(
+        "UPDATE photos SET working_copy_path=? WHERE id=?",
+        (f"working/{photo_id}.jpg", photo_id),
+    )
+    db.conn.commit()
+    folder = db.conn.execute(
+        "SELECT f.path, p.filename FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (photo_id,),
+    ).fetchone()
+    os.remove(os.path.join(folder["path"], folder["filename"]))
+
+    resp = client.put(
+        f"/api/photos/{photo_id}/edit-recipe",
+        json={"recipe": {"rotation": 90}},
+    )
+    assert resp.status_code == 200
+
+    rendered = client.get(f"/photos/{photo_id}/original")
+    assert rendered.status_code == 200
+    with Image.open(io.BytesIO(rendered.data)) as img:
+        assert img.size == (600, 800)
+
+
 def test_edit_recipe_api_rejects_invalid_recipe(client_with_photo):
     app, _db, photo_id = client_with_photo
     client = app.test_client()

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1410,7 +1410,7 @@ def test_non_crop_preview_loads_with_requested_size(client_with_photo, monkeypat
     resp = app.test_client().get(f"/photos/{photo_id}/preview?size=1920")
 
     assert resp.status_code == 200
-    assert seen_max_sizes == [1920]
+    assert 1920 in seen_max_sizes
 
 
 def test_edit_recipe_api_invalidates_untracked_preview_file(client_with_photo):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1912,6 +1912,59 @@ def test_preview_skips_recent_failed_raw_when_working_copy_path_is_stale(
     assert called["load"] is False
 
 
+def test_cropped_preview_uses_companion_before_raw_failure_marker(
+    client_with_photo, monkeypatch,
+):
+    import io
+    import os
+
+    import image_loader
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    folder = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (photo_id,),
+    ).fetchone()
+    companion_path = os.path.join(folder["path"], "test.jpg")
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='source.NEF', extension='.nef',
+               companion_path='test.jpg',
+               working_copy_path=NULL,
+               width=800, height=600,
+               file_mtime=1234.0,
+               working_copy_failed_at=datetime('now'),
+               working_copy_failed_mtime=1234.0,
+               working_copy_failed_source='source'
+           WHERE id=?""",
+        (photo_id,),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(
+        photo_id,
+        {"crop": {"x": 0, "y": 0, "w": 0.5, "h": 1}},
+    )
+    original_load_image = image_loader.load_image
+    loaded_paths = []
+
+    def tracking_load_image(file_path, max_size=1024):
+        loaded_paths.append(file_path)
+        if str(file_path).lower().endswith(".nef"):
+            raise AssertionError("preview retried RAW before companion")
+        return original_load_image(file_path, max_size=max_size)
+
+    monkeypatch.setattr(image_loader, "load_image", tracking_load_image)
+
+    rendered = client.get(f"/photos/{photo_id}/preview?size=1920")
+
+    assert rendered.status_code == 200
+    assert loaded_paths == [companion_path]
+    with Image.open(io.BytesIO(rendered.data)) as img:
+        assert img.size == (400, 600)
+
+
 def test_preview_retries_raw_when_recent_marker_came_from_companion(
     client_with_photo, monkeypatch,
 ):
@@ -2732,6 +2785,69 @@ def test_preview_job_applies_edit_recipe_to_warmed_file(
     assert db.preview_cache_get(photo_id, 1920) is not None
     with Image.open(preview_path) as img:
         assert img.size == (600, 800)
+
+
+def test_preview_job_honors_raw_failure_marker_after_source_selection(
+    client_with_photo, monkeypatch,
+):
+    import os
+    import time
+
+    import image_loader
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='source.NEF', extension='.nef',
+               companion_path=NULL,
+               working_copy_path=NULL,
+               width=800, height=600,
+               file_mtime=1234.0,
+               working_copy_failed_at=datetime('now'),
+               working_copy_failed_mtime=1234.0,
+               working_copy_failed_source='source'
+           WHERE id=?""",
+        (photo_id,),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(
+        photo_id,
+        {"crop": {"x": 0, "y": 0, "w": 0.5, "h": 1}},
+    )
+    original_load_image = image_loader.load_image
+    raw_loads = []
+
+    def tracking_load_image(file_path, max_size=1024):
+        if str(file_path).lower().endswith(".nef"):
+            raw_loads.append(file_path)
+            raise AssertionError("preview warmup retried failed RAW")
+        return original_load_image(file_path, max_size=max_size)
+
+    monkeypatch.setattr(image_loader, "load_image", tracking_load_image)
+
+    resp = client.post("/api/jobs/previews", json={})
+    assert resp.status_code == 200
+    job_id = resp.get_json()["job_id"]
+
+    deadline = time.time() + 10
+    while time.time() < deadline:
+        status_resp = client.get(f"/api/jobs/{job_id}")
+        if status_resp.status_code != 200:
+            time.sleep(0.05)
+            continue
+        data = status_resp.get_json()
+        if data.get("status") in ("completed", "failed"):
+            break
+        time.sleep(0.05)
+
+    assert data["status"] == "completed"
+    assert raw_loads == []
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    assert db.preview_cache_get(photo_id, 1920) is None
+    assert not os.path.exists(
+        os.path.join(vireo_dir, "previews", f"{photo_id}_1920.jpg"),
+    )
 
 
 def test_preview_job_preserves_existing_edited_preview_when_source_missing(

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1451,6 +1451,38 @@ def test_edit_recipe_api_invalidates_thumbnail_and_renders_edit(client_with_phot
         assert img.size == (300, 400)
 
 
+def test_cropped_thumbnail_uses_original_when_working_copy_is_too_small(
+    client_with_photo,
+):
+    import io
+    import os
+
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    working_dir = os.path.join(vireo_dir, "working")
+    os.makedirs(working_dir, exist_ok=True)
+    working_path = os.path.join(working_dir, f"{photo_id}.jpg")
+    Image.new("RGB", (400, 300), (30, 120, 200)).save(working_path, "JPEG")
+    db.conn.execute(
+        "UPDATE photos SET working_copy_path=? WHERE id=?",
+        (f"working/{photo_id}.jpg", photo_id),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(
+        photo_id,
+        {"crop": {"x": 0, "y": 0, "w": 0.5, "h": 0.5}},
+    )
+
+    rendered = client.get(f"/thumbnails/{photo_id}.jpg")
+
+    assert rendered.status_code == 200
+    with Image.open(io.BytesIO(rendered.data)) as img:
+        assert img.size == (400, 300)
+
+
 def test_edited_original_uses_trusted_working_copy_when_source_missing(
     client_with_photo,
 ):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1471,6 +1471,46 @@ def test_edit_recipe_api_invalidates_thumbnail_and_renders_edit(client_with_phot
         assert img.size == (300, 400)
 
 
+def test_edit_recipe_keeps_thumb_path_when_stale_thumbnail_unlink_fails(
+    client_with_photo, monkeypatch,
+):
+    import os
+
+    import app as app_module
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    thumb_dir = app.config["THUMB_CACHE_DIR"]
+    thumb_path = os.path.join(thumb_dir, f"{photo_id}.jpg")
+    Image.new("RGB", (400, 300), "green").save(thumb_path, "JPEG")
+    db.conn.execute(
+        "UPDATE photos SET thumb_path = ? WHERE id = ?",
+        (f"{photo_id}.jpg", photo_id),
+    )
+    db.conn.commit()
+    original_remove = app_module.os.remove
+
+    def locked_remove(path):
+        if path == thumb_path:
+            raise OSError("locked")
+        return original_remove(path)
+
+    monkeypatch.setattr(app_module.os, "remove", locked_remove)
+
+    resp = client.put(
+        f"/api/photos/{photo_id}/edit-recipe",
+        json={"recipe": {"rotation": 90}},
+    )
+
+    assert resp.status_code == 200
+    assert os.path.exists(thumb_path)
+    row = db.conn.execute(
+        "SELECT thumb_path FROM photos WHERE id = ?", (photo_id,),
+    ).fetchone()
+    assert row["thumb_path"] == f"{photo_id}.jpg"
+
+
 def test_cropped_thumbnail_uses_original_when_working_copy_is_too_small(
     client_with_photo,
 ):
@@ -1562,7 +1602,11 @@ def test_edited_original_prefers_full_res_companion_before_raw_decode(
            SET filename='source.NEF', extension='.nef',
                companion_path='test.jpg',
                working_copy_path=NULL,
-               width=800, height=600
+               width=800, height=600,
+               file_mtime=1234.0,
+               working_copy_failed_at=datetime('now'),
+               working_copy_failed_mtime=1234.0,
+               working_copy_failed_source='source'
            WHERE id=?""",
         (photo_id,),
     )

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1393,6 +1393,26 @@ def test_edit_recipe_api_invalidates_preview_cache_and_renders(client_with_photo
         assert img.size == (600, 800)
 
 
+def test_non_crop_preview_loads_with_requested_size(client_with_photo, monkeypatch):
+    import image_loader
+
+    app, db, photo_id = client_with_photo
+    db.set_photo_edit_recipe(photo_id, {"rotation": 90})
+    original_load_image = image_loader.load_image
+    seen_max_sizes = []
+
+    def tracking_load_image(file_path, max_size=1024):
+        seen_max_sizes.append(max_size)
+        return original_load_image(file_path, max_size=max_size)
+
+    monkeypatch.setattr(image_loader, "load_image", tracking_load_image)
+
+    resp = app.test_client().get(f"/photos/{photo_id}/preview?size=1920")
+
+    assert resp.status_code == 200
+    assert seen_max_sizes == [1920]
+
+
 def test_edit_recipe_api_invalidates_untracked_preview_file(client_with_photo):
     import os
 
@@ -1517,6 +1537,53 @@ def test_edited_original_uses_trusted_working_copy_when_source_missing(
 
     rendered = client.get(f"/photos/{photo_id}/original")
     assert rendered.status_code == 200
+    with Image.open(io.BytesIO(rendered.data)) as img:
+        assert img.size == (600, 800)
+
+
+def test_edited_original_prefers_full_res_companion_before_raw_decode(
+    client_with_photo, monkeypatch,
+):
+    import io
+    import os
+
+    import image_loader
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    folder = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (photo_id,),
+    ).fetchone()
+    companion_path = os.path.join(folder["path"], "test.jpg")
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='source.NEF', extension='.nef',
+               companion_path='test.jpg',
+               working_copy_path=NULL,
+               width=800, height=600
+           WHERE id=?""",
+        (photo_id,),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(photo_id, {"rotation": 90})
+
+    original_load_image = image_loader.load_image
+    loaded_paths = []
+
+    def tracking_load_image(file_path, max_size=1024):
+        loaded_paths.append(file_path)
+        if str(file_path).lower().endswith(".nef"):
+            raise AssertionError("edited original decoded RAW before companion")
+        return original_load_image(file_path, max_size=max_size)
+
+    monkeypatch.setattr(image_loader, "load_image", tracking_load_image)
+
+    rendered = client.get(f"/photos/{photo_id}/original")
+
+    assert rendered.status_code == 200
+    assert loaded_paths == [companion_path]
     with Image.open(io.BytesIO(rendered.data)) as img:
         assert img.size == (600, 800)
 

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -2307,10 +2307,18 @@ def test_edited_original_skips_recent_failed_raw_before_decode(
         (file_mtime, photo_id),
     )
     db.conn.commit()
+    folder = db.conn.execute(
+        "SELECT path FROM folders WHERE id = (SELECT folder_id FROM photos WHERE id=?)",
+        (photo_id,),
+    ).fetchone()
+    raw_path = os.path.abspath(os.path.join(folder["path"], "bad.NEF"))
+    original_load_image = image_loader.load_image
 
     called = {"load": False}
 
-    def fail_if_called(*_args, **_kwargs):
+    def fail_if_called(file_path, *args, **kwargs):
+        if os.path.abspath(os.fspath(file_path)) != raw_path:
+            return original_load_image(file_path, *args, **kwargs)
         called["load"] = True
         raise AssertionError("edited original retried failed RAW decode")
 

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1618,6 +1618,59 @@ def test_cropped_thumbnail_uses_original_when_working_copy_is_too_small(
         assert img.size == (400, 300)
 
 
+def test_cropped_thumbnail_uses_companion_before_raw_failure_marker(
+    client_with_photo, monkeypatch,
+):
+    import io
+    import os
+
+    import thumbnails
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    folder = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (photo_id,),
+    ).fetchone()
+    companion_path = os.path.join(folder["path"], "test.jpg")
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='source.NEF', extension='.nef',
+               companion_path='test.jpg',
+               working_copy_path=NULL,
+               width=800, height=600,
+               file_mtime=1234.0,
+               working_copy_failed_at=datetime('now'),
+               working_copy_failed_mtime=1234.0,
+               working_copy_failed_source='source'
+           WHERE id=?""",
+        (photo_id,),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(
+        photo_id,
+        {"crop": {"x": 0, "y": 0, "w": 0.5, "h": 1}},
+    )
+    original_load_image = thumbnails.load_image
+    loaded_paths = []
+
+    def tracking_load_image(file_path, max_size=1024):
+        loaded_paths.append(file_path)
+        if str(file_path).lower().endswith(".nef"):
+            raise AssertionError("thumbnail retried RAW before companion")
+        return original_load_image(file_path, max_size=max_size)
+
+    monkeypatch.setattr(thumbnails, "load_image", tracking_load_image)
+
+    rendered = client.get(f"/thumbnails/{photo_id}.jpg")
+
+    assert rendered.status_code == 200
+    assert loaded_paths == [companion_path]
+    with Image.open(io.BytesIO(rendered.data)) as img:
+        assert img.size == (267, 400)
+
+
 def test_edited_original_uses_trusted_working_copy_when_source_missing(
     client_with_photo,
 ):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1936,6 +1936,7 @@ def test_edit_recipe_api_rejects_malformed_body_without_clearing(client_with_pho
         {"data": "{", "content_type": "application/json"},
         {"json": []},
         {"json": {"recipe": []}},
+        {"json": {"recipe": {"crop": {"x": False, "y": False, "w": True, "h": True}}}},
     ]
     for kwargs in cases:
         resp = client.put(f"/api/photos/{photo_id}/edit-recipe", **kwargs)
@@ -2136,6 +2137,56 @@ def test_cropped_preview_uses_companion_before_raw_failure_marker(
     assert loaded_paths == [companion_path]
     with Image.open(io.BytesIO(rendered.data)) as img:
         assert img.size == (400, 600)
+
+
+def test_non_crop_preview_uses_companion_before_raw_failure_marker(
+    client_with_photo, monkeypatch,
+):
+    import io
+    import os
+
+    import image_loader
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    folder = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (photo_id,),
+    ).fetchone()
+    companion_path = os.path.join(folder["path"], "test.jpg")
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='source.NEF', extension='.nef',
+               companion_path='test.jpg',
+               working_copy_path=NULL,
+               width=800, height=600,
+               file_mtime=1234.0,
+               working_copy_failed_at=datetime('now'),
+               working_copy_failed_mtime=1234.0,
+               working_copy_failed_source='source'
+           WHERE id=?""",
+        (photo_id,),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(photo_id, {"rotation": 90})
+    original_load_image = image_loader.load_image
+    loaded_paths = []
+
+    def tracking_load_image(file_path, max_size=1024):
+        loaded_paths.append(file_path)
+        if str(file_path).lower().endswith(".nef"):
+            raise AssertionError("preview retried RAW before companion")
+        return original_load_image(file_path, max_size=max_size)
+
+    monkeypatch.setattr(image_loader, "load_image", tracking_load_image)
+
+    rendered = client.get(f"/photos/{photo_id}/preview?size=1920")
+
+    assert rendered.status_code == 200
+    assert loaded_paths == [companion_path]
+    with Image.open(io.BytesIO(rendered.data)) as img:
+        assert img.size == (600, 800)
 
 
 def test_preview_retries_raw_when_recent_marker_came_from_companion(

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1929,6 +1929,43 @@ def test_original_skips_recent_failed_raw_working_copy(
     assert called["extract"] is False
 
 
+def test_edited_original_skips_recent_failed_raw_before_decode(
+    client_with_photo, monkeypatch,
+):
+    """Edited originals should honor RAW failure markers before load_image."""
+    import image_loader
+
+    app, db, photo_id = client_with_photo
+    db.set_photo_edit_recipe(photo_id, {"rotation": 90})
+    file_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (photo_id,)
+    ).fetchone()["file_mtime"]
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='bad.NEF', extension='.nef',
+               working_copy_path=NULL,
+               working_copy_failed_at=datetime('now'),
+               working_copy_failed_mtime=?
+           WHERE id=?""",
+        (file_mtime, photo_id),
+    )
+    db.conn.commit()
+
+    called = {"load": False}
+
+    def fail_if_called(*_args, **_kwargs):
+        called["load"] = True
+        raise AssertionError("edited original retried failed RAW decode")
+
+    monkeypatch.setattr(image_loader, "load_image", fail_if_called)
+
+    client = app.test_client()
+    resp = client.get(f"/photos/{photo_id}/original")
+
+    assert resp.status_code == 500
+    assert called["load"] is False
+
+
 def test_original_skips_recent_failed_raw_after_rejecting_small_working_copy(
     client_with_photo, monkeypatch,
 ):
@@ -2345,6 +2382,43 @@ def test_preview_job_writes_sized_filename_and_tracks(client_with_photo):
 
     # Legacy naming NOT produced
     assert not os.path.exists(os.path.join(preview_dir, f"{photo_id}.jpg"))
+
+
+def test_preview_job_applies_edit_recipe_to_warmed_file(client_with_photo):
+    import os
+    import time
+
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    preview_dir = os.path.join(vireo_dir, "previews")
+    os.makedirs(preview_dir, exist_ok=True)
+    preview_path = os.path.join(preview_dir, f"{photo_id}_1920.jpg")
+    db.set_photo_edit_recipe(photo_id, {"rotation": 90})
+    Image.new("RGB", (800, 600), "green").save(preview_path, "JPEG")
+    db.preview_cache_insert(photo_id, 1920, os.path.getsize(preview_path))
+
+    resp = client.post("/api/jobs/previews", json={})
+    assert resp.status_code == 200
+    job_id = resp.get_json()["job_id"]
+
+    deadline = time.time() + 10
+    while time.time() < deadline:
+        status_resp = client.get(f"/api/jobs/{job_id}")
+        if status_resp.status_code != 200:
+            time.sleep(0.05)
+            continue
+        data = status_resp.get_json()
+        if data.get("status") in ("completed", "failed"):
+            break
+        time.sleep(0.05)
+    assert data["status"] == "completed"
+
+    assert db.preview_cache_get(photo_id, 1920) is not None
+    with Image.open(preview_path) as img:
+        assert img.size == (600, 800)
 
 
 def test_eviction_keeps_row_when_unlink_fails(client_with_photo, monkeypatch):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1521,6 +1521,43 @@ def test_cropped_preview_uses_original_when_working_copy_is_too_small(
         assert img.size == (400, 300)
 
 
+def test_cropped_preview_keeps_full_size_working_copy_fallback(
+    client_with_photo,
+):
+    import io
+    import os
+
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    working_dir = os.path.join(vireo_dir, "working")
+    os.makedirs(working_dir, exist_ok=True)
+    working_path = os.path.join(working_dir, f"{photo_id}.jpg")
+    Image.new("RGB", (800, 600), (30, 120, 200)).save(working_path, "JPEG")
+    db.conn.execute(
+        "UPDATE photos SET working_copy_path=? WHERE id=?",
+        (f"working/{photo_id}.jpg", photo_id),
+    )
+    db.conn.commit()
+    folder = db.conn.execute(
+        "SELECT f.path, p.filename FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (photo_id,),
+    ).fetchone()
+    os.remove(os.path.join(folder["path"], folder["filename"]))
+    db.set_photo_edit_recipe(
+        photo_id,
+        {"crop": {"x": 0, "y": 0, "w": 0.5, "h": 0.5}},
+    )
+
+    rendered = client.get(f"/photos/{photo_id}/preview?size=1920")
+
+    assert rendered.status_code == 200
+    with Image.open(io.BytesIO(rendered.data)) as img:
+        assert img.size == (400, 300)
+
+
 def test_edit_recipe_api_rejects_invalid_recipe(client_with_photo):
     app, _db, photo_id = client_with_photo
     client = app.test_client()

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1363,6 +1363,68 @@ def test_preview_cache_hit_updates_last_access(client_with_photo):
     assert row2["last_access_at"] > row1["last_access_at"]
 
 
+def test_edit_recipe_api_invalidates_preview_cache_and_renders(client_with_photo):
+    import io
+    import os
+
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+
+    assert client.get(f"/photos/{photo_id}/preview?size=1920").status_code == 200
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    preview_path = os.path.join(vireo_dir, "previews", f"{photo_id}_1920.jpg")
+    assert os.path.exists(preview_path)
+    assert db.preview_cache_get(photo_id, 1920) is not None
+
+    resp = client.put(
+        f"/api/photos/{photo_id}/edit-recipe",
+        json={"recipe": {"rotation": 90}},
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["recipe"] == {"version": 1, "rotation": 90}
+    assert db.preview_cache_get(photo_id, 1920) is None
+    assert not os.path.exists(preview_path)
+
+    rendered = client.get(f"/photos/{photo_id}/preview?size=1920")
+    assert rendered.status_code == 200
+    with Image.open(io.BytesIO(rendered.data)) as img:
+        assert img.size == (600, 800)
+
+
+def test_edit_recipe_api_rejects_invalid_recipe(client_with_photo):
+    app, _db, photo_id = client_with_photo
+    client = app.test_client()
+
+    resp = client.put(
+        f"/api/photos/{photo_id}/edit-recipe",
+        json={"recipe": {"rotation": 45}},
+    )
+    assert resp.status_code == 400
+    assert "rotation" in resp.get_json()["error"]
+
+
+def test_edit_recipe_api_undo_redo(client_with_photo):
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+
+    resp = client.put(
+        f"/api/photos/{photo_id}/edit-recipe",
+        json={"recipe": {"rotation": 180}},
+    )
+    assert resp.status_code == 200
+    assert db.get_photo_edit_recipe(photo_id)["rotation"] == 180
+
+    undo = client.post("/api/undo")
+    assert undo.status_code == 200
+    assert db.get_photo_edit_recipe(photo_id) is None
+
+    redo = client.post("/api/redo")
+    assert redo.status_code == 200
+    assert db.get_photo_edit_recipe(photo_id)["rotation"] == 180
+
+
 def test_preview_adopts_existing_file_on_first_access(client_with_photo):
     """A cached file left over from the old scheme is adopted into the LRU."""
     import os

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -4965,6 +4965,7 @@ def test_extract_masks_stage_warns_on_mixed_already_masked_and_subthreshold(
 
     monkeypatch.setenv("HOME", str(tmp_path))
     cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    _stub_extract_masks_heavy_ops(monkeypatch)
 
     db_path = str(tmp_path / "test.db")
     db = Database(db_path)

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -9424,6 +9424,102 @@ def test_pipeline_previews_honor_raw_failure_marker_after_source_selection(
     assert db.preview_cache_get(photo_id, 1920) is None
 
 
+def test_pipeline_scan_thumbnails_use_recipe_source_before_live_raw(
+    tmp_path, monkeypatch,
+):
+    import config as cfg
+    import scanner
+    import thumbnails
+    from db import Database
+    from PIL import Image
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    photo_dir = tmp_path / "photos"
+    photo_dir.mkdir()
+    raw_path = photo_dir / "source.NEF"
+    raw_path.write_bytes(b"raw")
+    companion_path = photo_dir / "source.jpg"
+    Image.new("RGB", (800, 600), "blue").save(companion_path)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    scanned = {"done": False}
+
+    def fake_scan(
+        root,
+        scan_db,
+        progress_callback=None,
+        photo_callback=None,
+        **_kwargs,
+    ):
+        folder_id = scan_db.add_folder(str(root), name="photos")
+        photo_id = scan_db.add_photo(
+            folder_id=folder_id,
+            filename="source.NEF",
+            extension=".nef",
+            file_size=raw_path.stat().st_size,
+            file_mtime=1234.0,
+            width=800,
+            height=600,
+        )
+        scan_db.conn.execute(
+            """UPDATE photos
+               SET companion_path='source.jpg',
+                   working_copy_path=NULL,
+                   working_copy_failed_at=datetime('now'),
+                   working_copy_failed_mtime=1234.0,
+                   working_copy_failed_source='source'
+               WHERE id=?""",
+            (photo_id,),
+        )
+        scan_db.conn.commit()
+        scan_db.set_photo_edit_recipe(
+            photo_id,
+            {"crop": {"x": 0, "y": 0, "w": 0.5, "h": 1}},
+        )
+        scanned["done"] = True
+        if progress_callback:
+            progress_callback(1, 1)
+        if photo_callback:
+            photo_callback(photo_id, str(raw_path))
+
+    thumbnail_sources = []
+
+    def fake_generate_thumbnail(photo_id, photo_path, cache_dir, size=300, **kwargs):
+        thumbnail_sources.append(photo_path)
+        if os.path.abspath(str(photo_path)) == os.path.abspath(str(raw_path)):
+            raise AssertionError("scan thumbnail used live RAW path")
+        assert kwargs.get("recipe")
+        os.makedirs(cache_dir, exist_ok=True)
+        thumb_path = os.path.join(cache_dir, f"{photo_id}.jpg")
+        Image.new("RGB", (size, size), "green").save(thumb_path)
+        return thumb_path
+
+    monkeypatch.setattr(scanner, "scan", fake_scan)
+    monkeypatch.setattr(thumbnails, "generate_thumbnail", fake_generate_thumbnail)
+
+    result = run_pipeline_job(
+        _make_job(),
+        FakeRunner(),
+        db_path,
+        ws_id,
+        PipelineParams(
+            source=str(photo_dir),
+            skip_classify=True,
+            skip_extract_masks=True,
+            skip_regroup=True,
+        ),
+    )
+
+    assert scanned["done"] is True
+    assert result["stages"]["thumbnails"]["failed"] == 0
+    assert thumbnail_sources == [str(companion_path)]
+
+
 # ---------------------------------------------------------------------------
 # Aborted pipelines must not leave step rows stuck at "pending"
 # ---------------------------------------------------------------------------

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -701,6 +701,67 @@ def test_pipeline_previews_stage_writes_atomically(tmp_path, monkeypatch):
         )
 
 
+def test_pipeline_previews_stage_bounds_non_crop_recipe_loads(tmp_path, monkeypatch):
+    import config as cfg
+    import image_loader
+    from db import Database
+    from PIL import Image
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    photo_dir = tmp_path / "photos"
+    photo_dir.mkdir()
+    source_path = photo_dir / "edited.jpg"
+    Image.new("RGB", (800, 600), "red").save(source_path, "JPEG")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    folder_id = db.add_folder(str(photo_dir), name="photos")
+    photo_id = db.add_photo(
+        folder_id=folder_id,
+        filename="edited.jpg",
+        extension=".jpg",
+        file_size=os.path.getsize(source_path),
+        file_mtime=os.path.getmtime(source_path),
+        width=800,
+        height=600,
+    )
+    db.set_photo_edit_recipe(photo_id, {"rotation": 90})
+    collection_id = db.add_collection(
+        "Edited",
+        json.dumps([{"field": "photo_ids", "op": "in", "value": [photo_id]}]),
+    )
+
+    original_load_image = image_loader.load_image
+    seen_max_sizes = []
+
+    def tracking_load_image(file_path, max_size=1024):
+        seen_max_sizes.append(max_size)
+        return original_load_image(file_path, max_size=max_size)
+
+    monkeypatch.setattr(image_loader, "load_image", tracking_load_image)
+
+    runner = FakeRunner()
+    job = _make_job()
+    run_pipeline_job(
+        job,
+        runner,
+        db_path,
+        ws_id,
+        PipelineParams(
+            collection_id=collection_id,
+            skip_classify=True,
+            skip_extract_masks=True,
+            skip_regroup=True,
+            preview_max_size=1920,
+        ),
+    )
+
+    assert seen_max_sizes[-1] == 1920
+
+
 def test_pipeline_params_sources_used_over_source():
     """When sources is provided, it should take precedence over source."""
     params = PipelineParams(source="/single", sources=["/a", "/b"])

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -9333,6 +9333,97 @@ def test_previews_stage_uses_thumb_cache_dir_parent(tmp_path, monkeypatch):
     assert db2.preview_cache_get(photo_id, 1920) is not None
 
 
+def test_pipeline_previews_honor_raw_failure_marker_after_source_selection(
+    tmp_path, monkeypatch,
+):
+    import config as cfg
+    import image_loader
+    import scanner
+    import thumbnails
+    from db import Database
+    from PIL import Image
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    photo_dir = tmp_path / "photos"
+    photo_dir.mkdir()
+    raw_path = photo_dir / "source.NEF"
+    raw_path.write_bytes(b"raw")
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    folder_id = db.add_folder(str(photo_dir), name="photos")
+    photo_id = db.add_photo(
+        folder_id=folder_id,
+        filename="source.NEF",
+        extension=".nef",
+        file_size=raw_path.stat().st_size,
+        file_mtime=1234.0,
+        width=600,
+        height=400,
+    )
+    working_dir = tmp_path / "working"
+    working_dir.mkdir()
+    Image.new("RGB", (400, 400), "blue").save(str(working_dir / f"{photo_id}.jpg"))
+    db.conn.execute(
+        """UPDATE photos
+           SET working_copy_path=?,
+               working_copy_failed_at=datetime('now'),
+               working_copy_failed_mtime=1234.0,
+               working_copy_failed_source='source'
+           WHERE id=?""",
+        (f"working/{photo_id}.jpg", photo_id),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(
+        photo_id,
+        {"crop": {"x": 0, "y": 0, "w": 0.5, "h": 1}},
+    )
+    collection_id = db.add_collection("Test", json.dumps([]))
+
+    def fake_generate_thumbnail(photo_id, photo_path, cache_dir, size=300, **kwargs):
+        os.makedirs(cache_dir, exist_ok=True)
+        thumb_path = os.path.join(cache_dir, f"{photo_id}.jpg")
+        Image.new("RGB", (size, size), "green").save(thumb_path)
+        return thumb_path
+
+    monkeypatch.setattr(thumbnails, "generate_thumbnail", fake_generate_thumbnail)
+    monkeypatch.setattr(scanner, "extract_working_copy", lambda *args, **kwargs: False)
+
+    original_load_image = image_loader.load_image
+    raw_loads = []
+
+    def tracking_load_image(file_path, max_size=1024):
+        if os.path.abspath(str(file_path)) == os.path.abspath(str(raw_path)):
+            raw_loads.append(file_path)
+            raise AssertionError("pipeline preview retried failed RAW")
+        return original_load_image(file_path, max_size=max_size)
+
+    monkeypatch.setattr(image_loader, "load_image", tracking_load_image)
+
+    result = run_pipeline_job(
+        _make_job(),
+        FakeRunner(),
+        db_path,
+        ws_id,
+        PipelineParams(
+            collection_id=collection_id,
+            skip_classify=True,
+            skip_extract_masks=True,
+            skip_regroup=True,
+            preview_max_size=1920,
+        ),
+    )
+
+    previews = result["stages"]["previews"]
+    assert previews["failed"] == 0
+    assert previews["generated"] == 0
+    assert previews["skipped"] == 1
+    assert raw_loads == []
+    assert db.preview_cache_get(photo_id, 1920) is None
+
+
 # ---------------------------------------------------------------------------
 # Aborted pipelines must not leave step rows stuck at "pending"
 # ---------------------------------------------------------------------------

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -9520,6 +9520,92 @@ def test_pipeline_scan_thumbnails_use_recipe_source_before_live_raw(
     assert thumbnail_sources == [str(companion_path)]
 
 
+def test_pipeline_scan_thumbnails_honor_raw_marker_after_source_selection(
+    tmp_path, monkeypatch,
+):
+    import config as cfg
+    import scanner
+    import thumbnails
+    from db import Database
+    from PIL import Image
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    photo_dir = tmp_path / "photos"
+    photo_dir.mkdir()
+    raw_path = photo_dir / "source.NEF"
+    raw_path.write_bytes(b"raw")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    def fake_scan(
+        root,
+        scan_db,
+        progress_callback=None,
+        photo_callback=None,
+        **_kwargs,
+    ):
+        folder_id = scan_db.add_folder(str(root), name="photos")
+        photo_id = scan_db.add_photo(
+            folder_id=folder_id,
+            filename="source.NEF",
+            extension=".nef",
+            file_size=raw_path.stat().st_size,
+            file_mtime=1234.0,
+            width=800,
+            height=600,
+        )
+        working_dir = tmp_path / "working"
+        working_dir.mkdir()
+        Image.new("RGB", (200, 150), "blue").save(
+            working_dir / f"{photo_id}.jpg",
+        )
+        scan_db.conn.execute(
+            """UPDATE photos
+               SET working_copy_path=?,
+                   working_copy_failed_at=datetime('now'),
+                   working_copy_failed_mtime=1234.0,
+                   working_copy_failed_source='source'
+               WHERE id=?""",
+            (f"working/{photo_id}.jpg", photo_id),
+        )
+        scan_db.conn.commit()
+        scan_db.set_photo_edit_recipe(
+            photo_id,
+            {"crop": {"x": 0, "y": 0, "w": 0.5, "h": 1}},
+        )
+        if progress_callback:
+            progress_callback(1, 1)
+        if photo_callback:
+            photo_callback(photo_id, str(raw_path))
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("scan thumbnail retried failed RAW")
+
+    monkeypatch.setattr(scanner, "scan", fake_scan)
+    monkeypatch.setattr(thumbnails, "generate_thumbnail", fail_if_called)
+
+    result = run_pipeline_job(
+        _make_job(),
+        FakeRunner(),
+        db_path,
+        ws_id,
+        PipelineParams(
+            source=str(photo_dir),
+            skip_classify=True,
+            skip_extract_masks=True,
+            skip_regroup=True,
+        ),
+    )
+
+    thumbnails_stage = result["stages"]["thumbnails"]
+    assert thumbnails_stage["failed"] == 0
+    assert thumbnails_stage["skipped"] == 1
+
+
 # ---------------------------------------------------------------------------
 # Aborted pipelines must not leave step rows stuck at "pending"
 # ---------------------------------------------------------------------------

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -1822,6 +1822,84 @@ def test_pipeline_collection_mode_generates_missing_thumbnails(tmp_path, monkeyp
     assert len(thumb_files) == 3
 
 
+def test_pipeline_collection_mode_edited_thumbnail_uses_working_copy(
+    tmp_path, monkeypatch,
+):
+    """Collection thumbnail replay should fall back to usable working copies."""
+    import config as cfg
+    from db import Database
+    from PIL import Image
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    photo_dir = tmp_path / "photos"
+    photo_dir.mkdir()
+    original = photo_dir / "a.jpg"
+    Image.new("RGB", (100, 100), "red").save(str(original))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    runner = FakeRunner()
+    job = _make_job()
+    result = run_pipeline_job(
+        job,
+        runner,
+        db_path,
+        ws_id,
+        PipelineParams(
+            source=str(photo_dir),
+            skip_classify=True,
+            skip_extract_masks=True,
+            skip_regroup=True,
+        ),
+    )
+    coll_id = result["collection_id"]
+
+    photo = db.get_collection_photos(coll_id, per_page=999999)[0]
+    working_dir = tmp_path / "working"
+    working_dir.mkdir()
+    Image.new("RGB", (100, 100), "blue").save(str(working_dir / f"{photo['id']}.jpg"))
+    db.conn.execute(
+        "UPDATE photos SET working_copy_path=? WHERE id=?",
+        (f"working/{photo['id']}.jpg", photo["id"]),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(
+        photo["id"],
+        {"crop": {"x": 0, "y": 0, "w": 0.5, "h": 0.5}},
+    )
+    os.remove(original)
+
+    thumb_dir = os.path.join(os.path.dirname(db_path), "thumbnails")
+    for f in os.listdir(thumb_dir):
+        os.remove(os.path.join(thumb_dir, f))
+
+    runner2 = FakeRunner()
+    job2 = _make_job()
+    result2 = run_pipeline_job(
+        job2,
+        runner2,
+        db_path,
+        ws_id,
+        PipelineParams(
+            collection_id=coll_id,
+            skip_classify=True,
+            skip_extract_masks=True,
+            skip_regroup=True,
+        ),
+    )
+
+    thumb_result = result2["stages"].get("thumbnails", {})
+    assert thumb_result.get("failed") == 0
+    assert thumb_result.get("generated") == 1
+    with Image.open(os.path.join(thumb_dir, f"{photo['id']}.jpg")) as thumb:
+        r, g, b = thumb.resize((1, 1)).getpixel((0, 0))
+    assert b > r and b > g
+
+
 # ---------------------------------------------------------------------------
 # Stage failure propagation (fixes the silent model-loader failure incident)
 # ---------------------------------------------------------------------------

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -635,6 +635,36 @@ def test_scan_late_arriving_raw_pairs_with_existing_jpeg(tmp_path):
     assert "Robin" in kw_names
 
 
+def test_pairing_transfers_edit_recipe_from_companion(tmp_path):
+    """Pairing raw+JPEG preserves a recipe stored on the deleted companion."""
+    from db import Database
+    from scanner import _pair_raw_jpeg_companions
+
+    img_dir = tmp_path / "photos"
+    img_dir.mkdir()
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder(str(img_dir), name="photos")
+    jpeg_id = db.add_photo(
+        folder_id=fid, filename="IMG_001.jpg", extension=".jpg",
+        file_size=1000, file_mtime=1.0,
+    )
+    db.add_photo(
+        folder_id=fid, filename="IMG_001.cr3", extension=".cr3",
+        file_size=2000, file_mtime=1.0,
+    )
+    db.set_photo_edit_recipe(jpeg_id, {"rotation": 90})
+
+    _pair_raw_jpeg_companions(db)
+
+    photo = db.conn.execute("SELECT id, filename FROM photos").fetchone()
+    assert photo["filename"] == "IMG_001.cr3"
+    assert db.get_photo_edit_recipe(photo["id"]) == {
+        "rotation": 90,
+        "version": 1,
+    }
+
+
 def test_pairing_does_not_copy_rejected_flag_to_raw(tmp_path):
     """A companion JPEG's 'rejected' flag (e.g. set by the duplicate
     auto-resolver when the JPEG has a byte-identical twin) must not be

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -649,20 +649,29 @@ def test_pairing_transfers_edit_recipe_from_companion(tmp_path):
         folder_id=fid, filename="IMG_001.jpg", extension=".jpg",
         file_size=1000, file_mtime=1.0,
     )
-    db.add_photo(
+    raw_id = db.add_photo(
         folder_id=fid, filename="IMG_001.cr3", extension=".cr3",
         file_size=2000, file_mtime=1.0,
     )
     db.set_photo_edit_recipe(jpeg_id, {"rotation": 90})
+    db.conn.execute(
+        "UPDATE photos SET thumb_path = ? WHERE id = ?",
+        ("thumbnails/raw.jpg", raw_id),
+    )
+    db.preview_cache_insert(raw_id, 800, 1234)
 
     _pair_raw_jpeg_companions(db)
 
-    photo = db.conn.execute("SELECT id, filename FROM photos").fetchone()
+    photo = db.conn.execute(
+        "SELECT id, filename, thumb_path FROM photos",
+    ).fetchone()
     assert photo["filename"] == "IMG_001.cr3"
     assert db.get_photo_edit_recipe(photo["id"]) == {
         "rotation": 90,
         "version": 1,
     }
+    assert photo["thumb_path"] is None
+    assert db.preview_cache_get(photo["id"], 800) is None
 
 
 def test_pairing_does_not_copy_rejected_flag_to_raw(tmp_path):

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -638,6 +638,7 @@ def test_scan_late_arriving_raw_pairs_with_existing_jpeg(tmp_path):
 def test_pairing_transfers_edit_recipe_from_companion(tmp_path):
     """Pairing raw+JPEG preserves a recipe stored on the deleted companion."""
     from db import Database
+    from image_edits import recipe_to_json
     from scanner import _pair_raw_jpeg_companions
 
     img_dir = tmp_path / "photos"
@@ -654,6 +655,13 @@ def test_pairing_transfers_edit_recipe_from_companion(tmp_path):
         file_size=2000, file_mtime=1.0,
     )
     db.set_photo_edit_recipe(jpeg_id, {"rotation": 90})
+    recipe_json = recipe_to_json({"rotation": 90}) or ""
+    db.record_edit(
+        "edit_recipe",
+        "Updated photo edit recipe",
+        recipe_json,
+        [{"photo_id": jpeg_id, "old_value": "", "new_value": recipe_json}],
+    )
     db.conn.execute(
         "UPDATE photos SET thumb_path = ? WHERE id = ?",
         ("thumbnails/raw.jpg", raw_id),
@@ -672,6 +680,14 @@ def test_pairing_transfers_edit_recipe_from_companion(tmp_path):
     }
     assert photo["thumb_path"] is None
     assert db.preview_cache_get(photo["id"], 800) is None
+    history_item = db.conn.execute(
+        "SELECT photo_id FROM edit_history_items",
+    ).fetchone()
+    assert history_item["photo_id"] == photo["id"]
+
+    undone = db.undo_last_edit()
+    assert undone is not None
+    assert db.get_photo_edit_recipe(photo["id"]) is None
 
 
 def test_pairing_does_not_copy_rejected_flag_to_raw(tmp_path):

--- a/vireo/tests/test_thumbnails.py
+++ b/vireo/tests/test_thumbnails.py
@@ -32,6 +32,30 @@ def test_generate_thumbnail_creates_jpeg(tmp_path):
         assert max(img.size) <= 400
 
 
+def test_generate_thumbnail_bounds_non_crop_recipe_load(tmp_path, monkeypatch):
+    import thumbnails
+    from thumbnails import generate_thumbnail
+
+    src = str(tmp_path / "source.jpg")
+    Image.new("RGB", (2000, 1500), color="red").save(src)
+
+    cache_dir = str(tmp_path / "thumbs")
+    os.makedirs(cache_dir)
+    original_load_image = thumbnails.load_image
+    seen_max_sizes = []
+
+    def tracking_load_image(file_path, max_size=1024):
+        seen_max_sizes.append(max_size)
+        return original_load_image(file_path, max_size=max_size)
+
+    monkeypatch.setattr(thumbnails, "load_image", tracking_load_image)
+
+    result = generate_thumbnail(1, src, cache_dir, recipe={"rotation": 90})
+
+    assert result is not None
+    assert seen_max_sizes == [400]
+
+
 def test_generate_thumbnail_skips_existing(tmp_path):
     """generate_thumbnail skips if thumbnail already exists."""
     from thumbnails import generate_thumbnail

--- a/vireo/tests/test_thumbnails.py
+++ b/vireo/tests/test_thumbnails.py
@@ -93,6 +93,18 @@ def test_recipe_source_path_uses_exif_oriented_dimensions(tmp_path):
         photo, recipe, 500, str(vireo_dir), folders,
     ) == str(original)
 
+    exif = Image.Exif()
+    exif[274] = 6
+    oriented_working = working_dir / "2.jpg"
+    Image.new("RGB", (600, 400), color="blue").save(oriented_working, exif=exif)
+
+    assert thumbnails._path_satisfies_recipe_render(
+        str(oriented_working), photo, recipe, 500,
+    )
+    assert pipeline_job._path_satisfies_recipe_render(
+        str(oriented_working), photo, recipe, 500,
+    )
+
 
 def test_generate_thumbnail_skips_existing(tmp_path):
     """generate_thumbnail skips if thumbnail already exists."""

--- a/vireo/tests/test_thumbnails.py
+++ b/vireo/tests/test_thumbnails.py
@@ -56,6 +56,44 @@ def test_generate_thumbnail_bounds_non_crop_recipe_load(tmp_path, monkeypatch):
     assert seen_max_sizes == [400]
 
 
+def test_recipe_source_path_uses_exif_oriented_dimensions(tmp_path):
+    import json
+
+    import pipeline_job
+    import thumbnails
+
+    folder = tmp_path / "photos"
+    folder.mkdir()
+    original = folder / "portrait.jpg"
+    Image.new("RGB", (600, 400), color="red").save(original)
+
+    vireo_dir = tmp_path / "vireo"
+    working_dir = vireo_dir / "working"
+    working_dir.mkdir(parents=True)
+    working = working_dir / "1.jpg"
+    Image.new("RGB", (400, 400), color="blue").save(working)
+
+    photo = {
+        "id": 1,
+        "folder_id": 10,
+        "filename": "portrait.jpg",
+        "working_copy_path": "working/1.jpg",
+        "companion_path": None,
+        "width": 600,
+        "height": 400,
+        "exif_data": json.dumps({"EXIF": {"Orientation": 6}}),
+    }
+    folders = {10: str(folder)}
+    recipe = {"crop": {"x": 0.0, "y": 0.0, "w": 0.5, "h": 1.0}}
+
+    assert thumbnails._recipe_source_path(
+        photo, recipe, 500, str(vireo_dir), folders,
+    ) == str(original)
+    assert pipeline_job._recipe_render_source(
+        photo, recipe, 500, str(vireo_dir), folders,
+    ) == str(original)
+
+
 def test_generate_thumbnail_skips_existing(tmp_path):
     """generate_thumbnail skips if thumbnail already exists."""
     from thumbnails import generate_thumbnail

--- a/vireo/tests/test_thumbnails.py
+++ b/vireo/tests/test_thumbnails.py
@@ -209,7 +209,7 @@ def test_generate_all_does_not_record_thumb_path_on_failure(tmp_path, monkeypatc
 
     monkeypatch.setattr(
         thumbnails_mod, "generate_thumbnail",
-        lambda photo_id, src, cache_dir, size=400, quality=85: None,
+        lambda photo_id, src, cache_dir, size=400, quality=85, recipe=None: None,
     )
 
     cache_dir = str(tmp_path / "thumbs")

--- a/vireo/tests/test_thumbnails.py
+++ b/vireo/tests/test_thumbnails.py
@@ -294,6 +294,70 @@ def test_generate_all_does_not_record_thumb_path_on_failure(tmp_path, monkeypatc
     assert row["thumb_path"] is None
 
 
+def test_generate_all_skips_current_raw_marker_after_crop_rejects_working_copy(
+    tmp_path, monkeypatch,
+):
+    """Batch thumbnails must not retry a RAW that has a current source failure."""
+    import thumbnails as thumbnails_mod
+    from db import Database
+
+    photos_dir = tmp_path / "photos"
+    photos_dir.mkdir()
+    raw_path = photos_dir / "bad.NEF"
+    raw_path.write_bytes(b"not a decodable raw")
+
+    vireo_dir = tmp_path / "vireo"
+    working_dir = vireo_dir / "working"
+    working_dir.mkdir(parents=True)
+    wc_path = working_dir / "1.jpg"
+    Image.new("RGB", (200, 150), color="red").save(wc_path, "JPEG")
+
+    db = Database(str(vireo_dir / "test.db"))
+    fid = db.add_folder(str(photos_dir), name="photos")
+    photo_id = db.add_photo(
+        folder_id=fid,
+        filename="bad.NEF",
+        extension=".nef",
+        file_size=raw_path.stat().st_size,
+        file_mtime=raw_path.stat().st_mtime,
+        width=800,
+        height=600,
+    )
+    file_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (photo_id,),
+    ).fetchone()["file_mtime"]
+    db.conn.execute(
+        """UPDATE photos
+           SET working_copy_path=?,
+               working_copy_failed_at=datetime('now'),
+               working_copy_failed_mtime=?,
+               working_copy_failed_source='source'
+           WHERE id=?""",
+        ("working/1.jpg", file_mtime, photo_id),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(
+        photo_id,
+        {"crop": {"x": 0, "y": 0, "w": 0.5, "h": 1}},
+    )
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("batch thumbnail generation retried failed RAW")
+
+    monkeypatch.setattr(thumbnails_mod, "generate_thumbnail", fail_if_called)
+
+    result = thumbnails_mod.generate_all(
+        db, str(vireo_dir / "thumbnails"), vireo_dir=str(vireo_dir),
+    )
+
+    assert result["generated"] == 0
+    assert result["failed"] == 1
+    row = db.conn.execute(
+        "SELECT thumb_path FROM photos WHERE id=?", (photo_id,),
+    ).fetchone()
+    assert row["thumb_path"] is None
+
+
 def test_backfill_thumb_paths_sets_path_for_existing_files(tmp_path):
     """Library-wide backfill should mark photos whose thumbnail JPEG exists on
     disk but whose thumb_path is NULL (the dashboard-coverage repair pass)."""

--- a/vireo/tests/test_thumbnails.py
+++ b/vireo/tests/test_thumbnails.py
@@ -746,6 +746,56 @@ def test_serve_thumbnail_skips_recent_failed_raw_working_copy(
     assert called["generate"] is False
 
 
+def test_serve_thumbnail_skips_failed_raw_after_crop_rejects_working_copy(
+    tmp_path, monkeypatch,
+):
+    """A crop-insufficient WC must not mask a current RAW failure marker."""
+    import thumbnails
+
+    app, db, pid, thumb_dir = _make_app_with_real_photo(
+        tmp_path, monkeypatch, filename="bad.NEF",
+    )
+    vireo_dir = os.path.dirname(thumb_dir)
+    wc_dir = os.path.join(vireo_dir, "working")
+    os.makedirs(wc_dir, exist_ok=True)
+    wc_path = os.path.join(wc_dir, f"{pid}.jpg")
+    Image.new("RGB", (200, 150), (50, 200, 50)).save(wc_path, "JPEG")
+    file_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (pid,)
+    ).fetchone()["file_mtime"]
+    db.conn.execute(
+        """UPDATE photos
+           SET extension='.nef',
+               width=800,
+               height=600,
+               working_copy_path=?,
+               working_copy_failed_at=datetime('now'),
+               working_copy_failed_mtime=?,
+               working_copy_failed_source='source'
+           WHERE id=?""",
+        (f"working/{pid}.jpg", file_mtime, pid),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(
+        pid,
+        {"crop": {"x": 0, "y": 0, "w": 0.5, "h": 1}},
+    )
+
+    called = {"generate": False}
+
+    def fail_if_called(*_args, **_kwargs):
+        called["generate"] = True
+        raise AssertionError("thumbnail request retried failed RAW decode")
+
+    monkeypatch.setattr(thumbnails, "generate_thumbnail", fail_if_called)
+
+    client = app.test_client()
+    resp = client.get(f"/thumbnails/{pid}.jpg")
+
+    assert resp.status_code == 404
+    assert called["generate"] is False
+
+
 def test_serve_thumbnail_refreshes_failure_marker_when_stale_retry_fails(
     tmp_path, monkeypatch,
 ):

--- a/vireo/thumbnails.py
+++ b/vireo/thumbnails.py
@@ -5,8 +5,9 @@ import json
 import logging
 import os
 import tempfile
+from datetime import UTC, datetime
 
-from image_loader import get_canonical_image_path, load_image
+from image_loader import RAW_EXTENSIONS, get_canonical_image_path, load_image
 
 log = logging.getLogger(__name__)
 
@@ -149,6 +150,36 @@ def _recipe_source_path(photo, recipe, max_size, vireo_dir, folders):
     return original
 
 
+def _has_current_raw_failure(photo, source_path):
+    if os.path.splitext(source_path or "")[1].lower() not in RAW_EXTENSIONS:
+        return False
+    if os.path.splitext(_photo_value(photo, "filename") or "")[1].lower() not in RAW_EXTENSIONS:
+        return False
+    if _photo_value(photo, "working_copy_failed_source") not in (None, "source"):
+        return False
+    failed_at = _photo_value(photo, "working_copy_failed_at")
+    failed_mtime = _photo_value(photo, "working_copy_failed_mtime")
+    file_mtime = _photo_value(photo, "file_mtime")
+    if not failed_at or failed_mtime is None or file_mtime is None:
+        return False
+    try:
+        if float(failed_mtime) != float(file_mtime):
+            return False
+    except (TypeError, ValueError):
+        return False
+    try:
+        failed_s = str(failed_at).strip()
+        if failed_s.endswith("Z"):
+            failed_s = failed_s[:-1] + "+00:00"
+        failed_dt = datetime.fromisoformat(failed_s)
+        if failed_dt.tzinfo is None:
+            failed_dt = failed_dt.replace(tzinfo=UTC)
+    except (TypeError, ValueError):
+        return False
+    age = (datetime.now(UTC) - failed_dt.astimezone(UTC)).total_seconds()
+    return age < 24 * 60 * 60
+
+
 def generate_thumbnail(
     photo_id, source_path, cache_dir, size=THUMB_SIZE, quality=85, recipe=None,
 ):
@@ -253,9 +284,15 @@ def generate_all(db, cache_dir, progress_callback=None, config=None, vireo_dir=N
         # have a vireo_dir; fall back to a raw folder+filename join for
         # callers that don't pass it.
         recipe = db.get_photo_edit_recipe(photo["id"])
+        source_photo = db.get_photo(photo["id"]) if recipe and vireo_dir else photo
+        if source_photo is None:
+            source_photo = photo
         source_path = _recipe_source_path(
-            photo, recipe, thumb_size, vireo_dir, folders,
+            source_photo, recipe, thumb_size, vireo_dir, folders,
         )
+        if recipe and _has_current_raw_failure(source_photo, source_path):
+            failed += 1
+            continue
         # generate_thumbnail decodes the source image (slow for RAW). Run
         # it before any UPDATE so no transaction is open while it runs;
         # then commit per photo to release the writer lock between

--- a/vireo/thumbnails.py
+++ b/vireo/thumbnails.py
@@ -126,13 +126,14 @@ def generate_all(db, cache_dir, progress_callback=None, config=None, vireo_dir=N
         # iterations and avoid blocking concurrent jobs (a parallel scan's
         # add_photo INSERT) past the 30s busy_timeout.
         recipe = db.get_photo_edit_recipe(photo["id"])
+        recipe_kwargs = {"recipe": recipe} if recipe else {}
         if generate_thumbnail(
             photo["id"],
             source_path,
             cache_dir,
             size=thumb_size,
             quality=thumb_quality,
-            recipe=recipe,
+            **recipe_kwargs,
         ) is not None:
             generated += 1
             # Record on-disk presence in the photos table so the dashboard's

--- a/vireo/thumbnails.py
+++ b/vireo/thumbnails.py
@@ -113,19 +113,24 @@ def _path_satisfies_recipe_render(path, photo, recipe, max_size):
 
 
 def _recipe_source_path(photo, recipe, max_size, vireo_dir, folders):
-    if not vireo_dir or not recipe or not recipe.get("crop"):
+    if not vireo_dir or not recipe:
         if vireo_dir:
             return get_canonical_image_path(photo, vireo_dir, folders)
         return os.path.join(folders.get(photo["folder_id"], ""), photo["filename"])
 
+    canonical = get_canonical_image_path(photo, vireo_dir, folders)
     wc_rel = photo["working_copy_path"]
-    if wc_rel:
+    if not recipe.get("crop") and canonical and wc_rel:
+        wc_path = wc_rel if os.path.isabs(wc_rel) else os.path.join(vireo_dir, wc_rel)
+        if os.path.abspath(canonical) == os.path.abspath(wc_path):
+            return canonical
+    if recipe.get("crop") and wc_rel:
         wc_path = os.path.join(vireo_dir, wc_rel)
         if (
             os.path.exists(wc_path)
             and _path_satisfies_recipe_render(wc_path, photo, recipe, max_size)
         ):
-            return get_canonical_image_path(photo, vireo_dir, folders)
+            return canonical
 
     folder_path = folders.get(photo["folder_id"])
     if not folder_path:

--- a/vireo/thumbnails.py
+++ b/vireo/thumbnails.py
@@ -12,6 +12,7 @@ log = logging.getLogger(__name__)
 
 DEFAULT_CACHE_DIR = os.path.expanduser("~/.vireo/thumbnails")
 THUMB_SIZE = 400
+_EXIF_ORIENTATION_TAG = 274
 
 
 def _rendered_recipe_long_edge(width, height, recipe):
@@ -83,6 +84,16 @@ def _recipe_source_dimensions(photo):
     return width, height
 
 
+def _image_size_after_exif_orientation(img):
+    width, height = img.size
+    orientation = None
+    with contextlib.suppress(Exception):
+        orientation = img.getexif().get(_EXIF_ORIENTATION_TAG)
+    if _orientation_swaps_axes(orientation):
+        return height, width
+    return width, height
+
+
 def _path_satisfies_recipe_render(path, photo, recipe, max_size):
     original_w, original_h = _recipe_source_dimensions(photo)
     if original_w <= 0 or original_h <= 0:
@@ -90,7 +101,7 @@ def _path_satisfies_recipe_render(path, photo, recipe, max_size):
     try:
         from PIL import Image as _PILImage
         with _PILImage.open(path) as img:
-            width, height = img.size
+            width, height = _image_size_after_exif_orientation(img)
     except Exception:
         return False
     original_render_long = _rendered_recipe_long_edge(

--- a/vireo/thumbnails.py
+++ b/vireo/thumbnails.py
@@ -13,7 +13,9 @@ DEFAULT_CACHE_DIR = os.path.expanduser("~/.vireo/thumbnails")
 THUMB_SIZE = 400
 
 
-def generate_thumbnail(photo_id, source_path, cache_dir, size=THUMB_SIZE, quality=85):
+def generate_thumbnail(
+    photo_id, source_path, cache_dir, size=THUMB_SIZE, quality=85, recipe=None,
+):
     """Generate a JPEG thumbnail for a photo.
 
     Args:
@@ -31,10 +33,13 @@ def generate_thumbnail(photo_id, source_path, cache_dir, size=THUMB_SIZE, qualit
     if os.path.exists(thumb_path):
         return thumb_path
 
-    img = load_image(source_path, max_size=size)
+    img = load_image(source_path, max_size=None if recipe else size)
     if img is None:
         log.warning("Could not load image for thumbnail: %s", source_path)
         return None
+    if recipe:
+        from image_edits import apply_recipe_to_loaded_image
+        img = apply_recipe_to_loaded_image(img, recipe, max_size=size)
 
     os.makedirs(cache_dir, exist_ok=True)
     # Atomic write: two concurrent jobs (or two iterations of the same job
@@ -120,7 +125,15 @@ def generate_all(db, cache_dir, progress_callback=None, config=None, vireo_dir=N
         # then commit per photo to release the writer lock between
         # iterations and avoid blocking concurrent jobs (a parallel scan's
         # add_photo INSERT) past the 30s busy_timeout.
-        if generate_thumbnail(photo["id"], source_path, cache_dir, size=thumb_size, quality=thumb_quality) is not None:
+        recipe = db.get_photo_edit_recipe(photo["id"])
+        if generate_thumbnail(
+            photo["id"],
+            source_path,
+            cache_dir,
+            size=thumb_size,
+            quality=thumb_quality,
+            recipe=recipe,
+        ) is not None:
             generated += 1
             # Record on-disk presence in the photos table so the dashboard's
             # coverage query (`thumb_path IS NOT NULL`) reflects this run.

--- a/vireo/thumbnails.py
+++ b/vireo/thumbnails.py
@@ -13,6 +13,72 @@ DEFAULT_CACHE_DIR = os.path.expanduser("~/.vireo/thumbnails")
 THUMB_SIZE = 400
 
 
+def _rendered_recipe_long_edge(width, height, recipe):
+    rotation = (recipe or {}).get("rotation", 0)
+    if rotation in (90, 270):
+        width, height = height, width
+    crop = (recipe or {}).get("crop") if recipe else None
+    if crop:
+        return max(float(crop["w"]) * width, float(crop["h"]) * height)
+    return max(width, height)
+
+
+def _path_satisfies_recipe_render(path, photo, recipe, max_size):
+    original_w = photo["width"] or 0
+    original_h = photo["height"] or 0
+    if original_w <= 0 or original_h <= 0:
+        return False
+    try:
+        from PIL import Image as _PILImage
+        with _PILImage.open(path) as img:
+            width, height = img.size
+    except Exception:
+        return False
+    original_render_long = _rendered_recipe_long_edge(
+        original_w, original_h, recipe,
+    )
+    required_long = min(max_size, original_render_long) if max_size else original_render_long
+    return _rendered_recipe_long_edge(width, height, recipe) >= required_long
+
+
+def _recipe_source_path(photo, recipe, max_size, vireo_dir, folders):
+    if not vireo_dir or not recipe or not recipe.get("crop"):
+        if vireo_dir:
+            return get_canonical_image_path(photo, vireo_dir, folders)
+        return os.path.join(folders.get(photo["folder_id"], ""), photo["filename"])
+
+    wc_rel = photo["working_copy_path"]
+    if wc_rel:
+        wc_path = os.path.join(vireo_dir, wc_rel)
+        if (
+            os.path.exists(wc_path)
+            and _path_satisfies_recipe_render(wc_path, photo, recipe, max_size)
+        ):
+            return get_canonical_image_path(photo, vireo_dir, folders)
+
+    folder_path = folders.get(photo["folder_id"])
+    if not folder_path:
+        if wc_rel:
+            wc_path = os.path.join(vireo_dir, wc_rel)
+            if os.path.exists(wc_path):
+                return wc_path
+        return ""
+    companion_path = photo["companion_path"]
+    if companion_path:
+        companion = os.path.join(folder_path, companion_path)
+        if (
+            os.path.exists(companion)
+            and _path_satisfies_recipe_render(companion, photo, recipe, max_size)
+        ):
+            return companion
+    original = os.path.join(folder_path, photo["filename"])
+    if not os.path.exists(original) and wc_rel:
+        wc_path = os.path.join(vireo_dir, wc_rel)
+        if os.path.exists(wc_path):
+            return wc_path
+    return original
+
+
 def generate_thumbnail(
     photo_id, source_path, cache_dir, size=THUMB_SIZE, quality=85, recipe=None,
 ):
@@ -115,17 +181,15 @@ def generate_all(db, cache_dir, progress_callback=None, config=None, vireo_dir=N
         # Resolve source via the single canonical-path helper when we
         # have a vireo_dir; fall back to a raw folder+filename join for
         # callers that don't pass it.
-        if vireo_dir:
-            source_path = get_canonical_image_path(photo, vireo_dir, folders)
-        else:
-            folder_path = folders.get(photo["folder_id"], "")
-            source_path = os.path.join(folder_path, photo["filename"])
+        recipe = db.get_photo_edit_recipe(photo["id"])
+        source_path = _recipe_source_path(
+            photo, recipe, thumb_size, vireo_dir, folders,
+        )
         # generate_thumbnail decodes the source image (slow for RAW). Run
         # it before any UPDATE so no transaction is open while it runs;
         # then commit per photo to release the writer lock between
         # iterations and avoid blocking concurrent jobs (a parallel scan's
         # add_photo INSERT) past the 30s busy_timeout.
-        recipe = db.get_photo_edit_recipe(photo["id"])
         recipe_kwargs = {"recipe": recipe} if recipe else {}
         if generate_thumbnail(
             photo["id"],

--- a/vireo/thumbnails.py
+++ b/vireo/thumbnails.py
@@ -99,7 +99,8 @@ def generate_thumbnail(
     if os.path.exists(thumb_path):
         return thumb_path
 
-    img = load_image(source_path, max_size=None if recipe else size)
+    load_max_size = None if recipe and recipe.get("crop") else size
+    img = load_image(source_path, max_size=load_max_size)
     if img is None:
         log.warning("Could not load image for thumbnail: %s", source_path)
         return None

--- a/vireo/thumbnails.py
+++ b/vireo/thumbnails.py
@@ -1,6 +1,7 @@
 """Generate and manage local thumbnail cache for the photo browser."""
 
 import contextlib
+import json
 import logging
 import os
 import tempfile
@@ -23,9 +24,67 @@ def _rendered_recipe_long_edge(width, height, recipe):
     return max(width, height)
 
 
+def _photo_value(photo, key):
+    try:
+        return photo[key]
+    except (KeyError, IndexError, TypeError):
+        if hasattr(photo, "get"):
+            return photo.get(key)
+    return None
+
+
+def _exif_orientation(exif_data):
+    if not exif_data:
+        return None
+    if isinstance(exif_data, str):
+        try:
+            metadata = json.loads(exif_data)
+        except (TypeError, ValueError):
+            return None
+    elif isinstance(exif_data, dict):
+        metadata = exif_data
+    else:
+        return None
+    if not isinstance(metadata, dict):
+        return None
+    for group in ("EXIF", "IFD0", "TIFF", "File"):
+        values = metadata.get(group)
+        if isinstance(values, dict) and "Orientation" in values:
+            return values["Orientation"]
+    return metadata.get("Orientation")
+
+
+def _orientation_swaps_axes(orientation):
+    if orientation is None or isinstance(orientation, bool):
+        return False
+    if isinstance(orientation, (int, float)):
+        return int(orientation) in (5, 6, 7, 8)
+    text = str(orientation).strip().lower()
+    if not text:
+        return False
+    try:
+        return int(text) in (5, 6, 7, 8)
+    except ValueError:
+        return "90" in text or "270" in text
+
+
+def _recipe_source_dimensions(photo):
+    try:
+        width = int(_photo_value(photo, "width") or 0)
+        height = int(_photo_value(photo, "height") or 0)
+    except (TypeError, ValueError):
+        return 0, 0
+    if (
+        width > 0
+        and height > 0
+        and _orientation_swaps_axes(_exif_orientation(_photo_value(photo, "exif_data")))
+    ):
+        return height, width
+    return width, height
+
+
 def _path_satisfies_recipe_render(path, photo, recipe, max_size):
-    original_w = photo["width"] or 0
-    original_h = photo["height"] or 0
+    original_w, original_h = _recipe_source_dimensions(photo)
     if original_w <= 0 or original_h <= 0:
         return False
     try:


### PR DESCRIPTION
Adds a non-destructive image edit recipe foundation for crop, rotate, flip, and basic adjustments. Stores normalized per-photo recipes, exposes API endpoints to read/update/clear them, and includes recipes in photo details. Applies recipes consistently to preview/original rendering and export while invalidating stale rendered caches and supporting undo/redo. Validated with focused image edit, export, preview-cache, edit-history, and compile checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added persistent per-photo non-destructive “edit recipes”, with API endpoints to get, set/replace, clear, and undo/redo recipe changes.
* **Bug Fixes**
  * Made thumbnails, previews, and exports recipe-aware, including safer cache behavior and preventing stale/untracked outputs after recipe updates.
  * Full-resolution “edited original” now renders from the trusted recipe-qualified source and serves cached edited JPEGs.
* **Tests**
  * Added coverage for recipe validation/application, cache invalidation, undo/redo, recipe-aware sizing, EXIF orientation handling, and fallback behavior when sources are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->