### PR TITLE
Percent-encode iNaturalist prefilled upload URL

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -10236,19 +10236,22 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         species = pred["species"] if pred else ""
         scientific = pred["scientific_name"] if pred else ""
 
+        # Percent-encode every value: scientific names contain spaces, and an
+        # unencoded space makes the URL invalid, so the desktop opener plugin
+        # rejects it and nothing opens.
         params = []
         if scientific:
-            params.append("taxon_name=" + scientific)
+            params.append("taxon_name=" + quote(scientific))
         elif species:
-            params.append("taxon_name=" + species)
+            params.append("taxon_name=" + quote(species))
         if photo["timestamp"]:
-            params.append("observed_on=" + photo["timestamp"][:10])
+            params.append("observed_on=" + quote(photo["timestamp"][:10]))
         loc = db.get_effective_photo_location(photo_id)
         lat = loc["latitude"] if loc else None
         lng = loc["longitude"] if loc else None
         if lat is not None and lng is not None:
-            params.append("lat=" + str(lat))
-            params.append("lng=" + str(lng))
+            params.append("lat=" + quote(str(lat)))
+            params.append("lng=" + quote(str(lng)))
 
         upload_url = "https://www.inaturalist.org/observations/upload"
         if params:

--- a/vireo/tests/test_inat.py
+++ b/vireo/tests/test_inat.py
@@ -209,6 +209,26 @@ def test_api_inat_prepare_uses_assigned_location_coords(app_and_db):
     assert "lng=2.3522" in data["upload_url"]
 
 
+def test_api_inat_prepare_url_encodes_query_params(app_and_db):
+    """The prefilled upload URL must be valid: a scientific name with a space
+    (e.g. "Cardinalis cardinalis") has to be percent-encoded, otherwise the
+    desktop opener plugin rejects the malformed URL and nothing opens."""
+    from urllib.parse import parse_qs, urlparse
+
+    app, _db, pid = app_and_db
+    client = app.test_client()
+    resp = client.get(f'/api/inat/prepare/{pid}')
+    assert resp.status_code == 200
+    data = resp.get_json()
+
+    url = data["upload_url"]
+    # No raw spaces anywhere in the URL.
+    assert " " not in url
+    # The taxon name still round-trips back to the real binomial.
+    qs = parse_qs(urlparse(url).query)
+    assert qs["taxon_name"] == ["Cardinalis cardinalis"]
+
+
 def _add_out_of_workspace_photo(db):
     active_ws = db._active_workspace_id
     base_dir = db.conn.execute("SELECT path FROM folders LIMIT 1").fetchone()["path"]


### PR DESCRIPTION
## Problem

Clicking the **iNaturalist** button on a photo did nothing. The backend `GET /api/inat/prepare/<id>` returned 200, but the browser/external page never opened.

Root cause: in the "quick" flow (no API token configured), the prefilled upload URL is built by raw string concatenation in `api_inat_prepare`. A scientific name with a space — i.e. every binomial, e.g. `Copsychus malabaricus` — produces an invalid URL with an **unencoded space**:

```
https://www.inaturalist.org/observations/upload?taxon_name=Copsychus malabaricus&observed_on=2026-05-23
```

The Tauri desktop opener plugin validates the URL against its scope before opening; a literal space makes it invalid, so the open is rejected and the click appears to do nothing.

This is a follow-up to #987, which fixed the **routing** layer (`window.open` → `openExternal` + the `opener:allow-default-urls` capability) but left this URL-building bug, so quick-mode submits still failed for any multi-word taxon.

## Fix

`quote()` every query value (`taxon_name`, `observed_on`, `lat`, `lng`) when assembling `upload_url`.

## Tests

- New regression test `test_api_inat_prepare_url_encodes_query_params`: asserts the URL contains no raw spaces and the taxon name round-trips back to the real binomial.
- `python -m pytest vireo/tests/test_inat.py` — 22 passed (incl. the existing lat/lng test, confirming `quote` doesn't disturb coordinate formatting).
- Core suite (`test_workspaces`, `test_db`, `test_app`, `test_photos_api`, `test_config`) — 1007 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)