### PR TITLE
Add static site publishing for life lists

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5798,27 +5798,22 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "species": parsed["species"],
         })
 
-    @app.route("/api/highlights")
-    def api_highlights():
-        db = _get_db()
-
+    def _build_highlights_payload(
+        db,
+        scope="folder",
+        folder_id=None,
+        min_quality=0.0,
+        confidence_threshold=0.70,
+        limit_per_bucket=20,
+        species_filter="",
+    ):
         folders = db.get_folders_with_quality_data()
-
-        scope = request.args.get("scope", "folder")
-        folder_id = request.args.get("folder_id", type=int)
         if scope == "workspace":
             folder_id = None
         elif folder_id is None and folders:
             folder_id = folders[0]["id"]  # Most recent
-
-        min_quality = request.args.get("min_quality", 0.0, type=float)
-        confidence_threshold = request.args.get(
-            "confidence_threshold", 0.70, type=float
-        )
-        limit_per_bucket = max(
-            1, min(request.args.get("limit_per_bucket", 20, type=int), 100)
-        )
-        species_filter = (request.args.get("species") or "").strip().lower()
+        limit_per_bucket = max(1, min(int(limit_per_bucket), 100))
+        species_filter = (species_filter or "").strip().lower()
 
         candidates = db.get_highlights_candidates(folder_id, min_quality=min_quality)
         total_in_scope = db.count_filtered_photos(folder_id=folder_id)
@@ -5846,7 +5841,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         unidentified_limited = unidentified_photos[:limit_per_bucket]
 
-        return jsonify({
+        return {
             "buckets": [limited_bucket(b) for b in buckets],
             "unidentified": {
                 "photo_count": len(unidentified_photos),
@@ -5864,15 +5859,29 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "limit_per_bucket": limit_per_bucket,
             },
             "scope": "workspace" if folder_id is None else "folder",
-        })
+        }
 
-    @app.route("/api/life-list")
-    def api_life_list():
+    @app.route("/api/highlights")
+    def api_highlights():
         db = _get_db()
+        payload = _build_highlights_payload(
+            db,
+            scope=request.args.get("scope", "folder"),
+            folder_id=request.args.get("folder_id", type=int),
+            min_quality=request.args.get("min_quality", 0.0, type=float),
+            confidence_threshold=request.args.get(
+                "confidence_threshold", 0.70, type=float
+            ),
+            limit_per_bucket=request.args.get("limit_per_bucket", 20, type=int),
+            species_filter=request.args.get("species") or "",
+        )
+        return jsonify(payload)
+
+    def _build_life_list_payload(db, photos_per_species=12):
         rows = db.get_life_list_candidates()
         locations_by_species = db.get_life_list_locations()
         photos_per_species = max(
-            1, min(request.args.get("photos_per_species", 12, type=int), 100)
+            1, min(int(photos_per_species), 100)
         )
 
         buckets = {}
@@ -5966,14 +5975,23 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         for i, e in enumerate(species_entries, start=1):
             e["number"] = i
 
-        return jsonify({
+        return {
             "species": species_entries,
             "meta": {
                 "species_count": len(species_entries),
                 "photo_count": len(distinct_photo_ids),
                 "photos_per_species": photos_per_species,
             },
-        })
+        }
+
+    @app.route("/api/life-list")
+    def api_life_list():
+        db = _get_db()
+        payload = _build_life_list_payload(
+            db,
+            photos_per_species=request.args.get("photos_per_species", 12, type=int),
+        )
+        return jsonify(payload)
 
     @app.route("/api/highlights/confirm", methods=["POST"])
     def api_highlights_confirm():
@@ -12014,6 +12032,132 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "photo_ids": photo_ids,
                 "destination": destination,
                 "naming_template": naming_template,
+            },
+            workspace_id=active_ws,
+        )
+        return jsonify({"job_id": job_id})
+
+    @app.route("/api/jobs/publish-site", methods=["POST"])
+    def api_job_publish_site():
+        """Publish workspace life-list and highlights data for a static site."""
+        body = request.get_json(silent=True) or {}
+        destination = (body.get("destination") or "").strip()
+        if not destination:
+            return json_error("destination required")
+        if not os.path.isabs(destination):
+            return json_error("destination must be an absolute path")
+
+        try:
+            photos_per_species = int(body.get("photos_per_species") or 12)
+            limit_per_bucket = int(body.get("limit_per_bucket") or 12)
+        except (TypeError, ValueError):
+            return json_error("photos_per_species and limit_per_bucket must be numbers")
+        photos_per_species = max(1, min(photos_per_species, 100))
+        limit_per_bucket = max(1, min(limit_per_bucket, 100))
+        max_size = body.get("max_size", 2400)
+        if max_size in ("", None):
+            max_size = None
+        elif isinstance(max_size, bool):
+            return json_error("max_size must be a number")
+        else:
+            try:
+                max_size = int(max_size)
+            except (TypeError, ValueError):
+                return json_error("max_size must be a number")
+        quality = body.get("quality", 88)
+        if isinstance(quality, bool):
+            return json_error("quality must be a number")
+        try:
+            quality = int(quality)
+        except (TypeError, ValueError):
+            return json_error("quality must be a number")
+        quality = max(1, min(quality, 100))
+        raw_include_locations = body.get("include_locations", False)
+        if isinstance(raw_include_locations, str):
+            include_locations = raw_include_locations.strip().lower() in {
+                "1", "true", "yes", "on",
+            }
+        else:
+            include_locations = bool(raw_include_locations)
+
+        import config as cfg
+        db = _get_db()
+        runner = app._job_runner
+        active_ws = db._active_workspace_id
+        vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+        effective_cfg = db.get_effective_config(cfg.load())
+        wc_max_size = effective_cfg.get("working_copy_max_size", 4096)
+        developed_dir = effective_cfg.get("darktable_output_dir", "") or ""
+
+        def work(job):
+            from site_publish import publish_site
+
+            thread_db = Database(db_path)
+            thread_db.set_active_workspace(active_ws)
+            job["_start_time"] = time.time()
+
+            life_list = _build_life_list_payload(
+                thread_db,
+                photos_per_species=photos_per_species,
+            )
+            highlights = _build_highlights_payload(
+                thread_db,
+                scope="workspace",
+                min_quality=0.0,
+                limit_per_bucket=limit_per_bucket,
+            )
+            photo_ids = {
+                p["id"]
+                for entry in life_list.get("species", [])
+                for p in ([entry.get("best")] + (entry.get("photos") or []))
+                if p and p.get("id")
+            }
+            for bucket in highlights.get("buckets", []):
+                photo_ids.update(
+                    p["id"] for p in (bucket.get("photos") or []) if p.get("id")
+                )
+            job["progress"]["total"] = len(photo_ids)
+
+            def progress_cb(current, total, filename):
+                job["progress"]["current"] = current
+                job["progress"]["total"] = total
+                job["progress"]["current_file"] = filename
+                runner.push_event(job["id"], "progress", {
+                    "current": current,
+                    "total": total,
+                    "current_file": filename,
+                    "rate": round(
+                        current / max(time.time() - job["_start_time"], 0.01), 1
+                    ),
+                    "phase": "Publishing website",
+                })
+
+            return publish_site(
+                db=thread_db,
+                vireo_dir=vireo_dir,
+                destination=destination,
+                life_list=life_list,
+                highlights=highlights,
+                options={
+                    "max_size": max_size,
+                    "quality": quality,
+                    "working_copy_max_size": wc_max_size,
+                    "developed_dir": developed_dir,
+                    "include_locations": include_locations,
+                },
+                progress_cb=progress_cb,
+            )
+
+        job_id = runner.start(
+            "publish-site",
+            work,
+            config={
+                "destination": destination,
+                "photos_per_species": photos_per_species,
+                "limit_per_bucket": limit_per_bucket,
+                "max_size": max_size,
+                "quality": quality,
+                "include_locations": include_locations,
             },
             workspace_id=active_ws,
         )

--- a/vireo/site_publish.py
+++ b/vireo/site_publish.py
@@ -142,7 +142,7 @@ def publish_site(db, vireo_dir, destination, life_list, highlights=None, options
     """
     options = options or {}
     highlights = highlights or {"buckets": [], "meta": {}}
-    include_locations = bool(options.get("include_locations", True))
+    include_locations = bool(options.get("include_locations", False))
 
     destination_path = Path(destination)
     data_dir = destination_path / "data"

--- a/vireo/site_publish.py
+++ b/vireo/site_publish.py
@@ -1,0 +1,200 @@
+"""Export Vireo workspace data as static-site-ready JSON and images."""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+
+from export import (
+    _developed_can_satisfy_size,
+    _DevelopedDirIndex,
+    _find_developed_output,
+    _resolve_source,
+)
+from image_loader import load_image
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def slugify(value, fallback="item"):
+    """Return a lowercase URL/file safe slug."""
+    slug = _SLUG_RE.sub("-", str(value or "").lower()).strip("-")
+    return slug or fallback
+
+
+def _photo_refs(life_list, highlights):
+    refs = {}
+
+    def add(photo, context):
+        if not photo or not photo.get("id"):
+            return
+        refs.setdefault(photo["id"], []).append((photo, context))
+
+    for species in life_list.get("species", []):
+        context = species.get("species") or "life-list"
+        add(species.get("best"), context)
+        for photo in species.get("photos") or []:
+            add(photo, context)
+
+    for bucket in highlights.get("buckets", []):
+        context = bucket.get("species") or "highlights"
+        for photo in bucket.get("photos") or []:
+            add(photo, context)
+
+    return refs
+
+
+def _rel_image_path(photo, context):
+    stem = os.path.splitext(photo.get("filename") or "")[0]
+    name = slugify(stem, fallback=f"photo-{photo['id']}")
+    prefix = slugify(context, fallback="photo")
+    return f"images/photos/{prefix}-{photo['id']}-{name}.jpg"
+
+
+def _export_image(db, vireo_dir, photo, rel_path, destination, options, folders, index):
+    source = None
+    folder_path = folders.get(photo.get("folder_id"), "")
+    developed_dir = options.get("developed_dir") or ""
+    max_size = options.get("max_size")
+    if max_size is not None:
+        max_size = int(max_size)
+    if developed_dir:
+        source = _find_developed_output(
+            photo.get("filename") or "",
+            folder_path,
+            developed_dir,
+            index,
+        )
+        if source and not _developed_can_satisfy_size(source, photo, max_size):
+            source = None
+
+    if not source:
+        wc_max = int(options.get("working_copy_max_size", 4096))
+        use_working_copy = bool(max_size) and max_size <= wc_max
+        source = _resolve_source(photo, vireo_dir, folders, use_working_copy)
+
+    if not source or not os.path.isfile(source):
+        return False, f"{photo.get('filename') or photo.get('id')}: source file missing"
+
+    out_path = Path(destination) / rel_path
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    img = load_image(source, max_size=max_size)
+    if img is None:
+        return False, f"{photo.get('filename') or photo.get('id')}: failed to load image"
+    try:
+        img.save(out_path, "JPEG", quality=int(options.get("quality", 88)))
+    finally:
+        img.close()
+    return True, None
+
+
+def _write_json(path, payload):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+
+
+def publish_site(db, vireo_dir, destination, life_list, highlights=None, options=None, progress_cb=None):
+    """Write JSON manifests and optimized photos for a static website.
+
+    Args:
+        db: active-workspace Database instance.
+        vireo_dir: Vireo data directory, used to resolve working copies.
+        destination: absolute output directory.
+        life_list: payload matching ``/api/life-list``.
+        highlights: payload matching ``/api/highlights``.
+        options: max_size, quality, working_copy_max_size, developed_dir,
+            include_locations.
+        progress_cb: optional callback(current, total, current_file).
+    """
+    options = options or {}
+    highlights = highlights or {"buckets": [], "meta": {}}
+    include_locations = bool(options.get("include_locations", True))
+
+    destination_path = Path(destination)
+    data_dir = destination_path / "data"
+    destination_path.mkdir(parents=True, exist_ok=True)
+
+    published_life_list = copy.deepcopy(life_list)
+    published_highlights = copy.deepcopy(highlights)
+    if not include_locations:
+        for entry in published_life_list.get("species", []):
+            entry["locations"] = []
+
+    refs = _photo_refs(published_life_list, published_highlights)
+    photo_ids = sorted(refs)
+    photos_map = db.get_photos_by_ids(photo_ids) if photo_ids else {}
+    folders = {f["id"]: f["path"] for f in db.get_folder_tree()}
+    index = _DevelopedDirIndex()
+    exported = 0
+    errors = []
+
+    total = len(photo_ids)
+    for i, photo_id in enumerate(photo_ids, start=1):
+        db_photo_row = photos_map.get(photo_id)
+        if not db_photo_row:
+            errors.append(f"Photo {photo_id} not found in database")
+            if progress_cb:
+                progress_cb(i, total, "")
+            continue
+        db_photo = dict(db_photo_row)
+
+        context = refs[photo_id][0][1]
+        rel_path = _rel_image_path(db_photo, context)
+        ok, err = _export_image(
+            db,
+            vireo_dir,
+            db_photo,
+            rel_path,
+            destination,
+            options,
+            folders,
+            index,
+        )
+        if ok:
+            exported += 1
+            for ref, _context in refs[photo_id]:
+                ref["image"] = rel_path
+        elif err:
+            errors.append(err)
+
+        if progress_cb:
+            progress_cb(i, total, db_photo.get("filename") or "")
+
+    generated_at = datetime.now(UTC).isoformat()
+    site_manifest = {
+        "schema_version": 1,
+        "generated_at": generated_at,
+        "sections": {
+            "life_list": "data/life-list.json",
+            "highlights": "data/highlights.json",
+        },
+        "counts": {
+            "life_list_species": published_life_list.get("meta", {}).get("species_count", 0),
+            "life_list_photos": published_life_list.get("meta", {}).get("photo_count", 0),
+            "highlight_buckets": len(published_highlights.get("buckets", [])),
+            "exported_images": exported,
+        },
+    }
+    published_life_list.setdefault("meta", {})["generated_at"] = generated_at
+    published_highlights.setdefault("meta", {})["generated_at"] = generated_at
+
+    _write_json(data_dir / "site.json", site_manifest)
+    _write_json(data_dir / "life-list.json", published_life_list)
+    _write_json(data_dir / "highlights.json", published_highlights)
+
+    return {
+        "destination": destination,
+        "data_files": [
+            "data/site.json",
+            "data/life-list.json",
+            "data/highlights.json",
+        ],
+        "exported_images": exported,
+        "errors": errors,
+    }

--- a/vireo/site_publish.py
+++ b/vireo/site_publish.py
@@ -45,6 +45,10 @@ def _photo_refs(life_list, highlights):
         for photo in bucket.get("photos") or []:
             add(photo, context)
 
+    unidentified = highlights.get("unidentified") or {}
+    for photo in unidentified.get("photos") or []:
+        add(photo, "unidentified")
+
     return refs
 
 

--- a/vireo/site_publish.py
+++ b/vireo/site_publish.py
@@ -60,6 +60,16 @@ def _rel_image_path(photo, context):
     return f"images/photos/{prefix}-{photo['id']}-{name}.jpg"
 
 
+def _developed_required_size(photo, max_size):
+    if max_size is None:
+        return None
+    original_w = photo.get("width")
+    original_h = photo.get("height")
+    if original_w and original_h:
+        return min(max_size, max(original_w, original_h))
+    return max_size
+
+
 def _export_image(db, vireo_dir, photo, rel_path, destination, options, folders, index):
     source = None
     folder_path = folders.get(photo.get("folder_id"), "")
@@ -74,7 +84,8 @@ def _export_image(db, vireo_dir, photo, rel_path, destination, options, folders,
             developed_dir,
             index,
         )
-        if source and not _developed_can_satisfy_size(source, photo, max_size):
+        required_size = _developed_required_size(photo, max_size)
+        if source and not _developed_can_satisfy_size(source, photo, required_size):
             source = None
 
     if not source:

--- a/vireo/site_publish.py
+++ b/vireo/site_publish.py
@@ -116,6 +116,8 @@ def _write_json(path, payload):
 
 
 def _strip_private_photo_fields(highlights):
+    highlights.pop("folders", None)
+
     for bucket in highlights.get("buckets", []):
         for photo in bucket.get("photos") or []:
             for field in _PRIVATE_PHOTO_FIELDS:

--- a/vireo/site_publish.py
+++ b/vireo/site_publish.py
@@ -18,6 +18,7 @@ from export import (
 from image_loader import load_image
 
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
+_PRIVATE_PHOTO_FIELDS = {"mask_path"}
 
 
 def slugify(value, fallback="item"):
@@ -103,6 +104,18 @@ def _write_json(path, payload):
         f.write("\n")
 
 
+def _strip_private_photo_fields(highlights):
+    for bucket in highlights.get("buckets", []):
+        for photo in bucket.get("photos") or []:
+            for field in _PRIVATE_PHOTO_FIELDS:
+                photo.pop(field, None)
+
+    unidentified = highlights.get("unidentified") or {}
+    for photo in unidentified.get("photos") or []:
+        for field in _PRIVATE_PHOTO_FIELDS:
+            photo.pop(field, None)
+
+
 def publish_site(db, vireo_dir, destination, life_list, highlights=None, options=None, progress_cb=None):
     """Write JSON manifests and optimized photos for a static website.
 
@@ -126,6 +139,7 @@ def publish_site(db, vireo_dir, destination, life_list, highlights=None, options
 
     published_life_list = copy.deepcopy(life_list)
     published_highlights = copy.deepcopy(highlights)
+    _strip_private_photo_fields(published_highlights)
     if not include_locations:
         for entry in published_life_list.get("species", []):
             entry["locations"] = []

--- a/vireo/templates/life_list.html
+++ b/vireo/templates/life_list.html
@@ -13,6 +13,12 @@
   .control-group label { font-size:13px; color:var(--text-secondary); white-space:nowrap; }
   .control-group input[type=search], .control-group select { font-size:13px; padding:4px 8px; background:var(--bg-input); color:var(--text-primary); border:1px solid var(--border-secondary); border-radius:4px; }
   .control-group input[type=search] { width:180px; }
+  .publish-btn { margin-left:auto; border:1px solid var(--accent); background:transparent; color:var(--accent); border-radius:4px; padding:5px 10px; font-size:12px; cursor:pointer; }
+  .publish-btn:hover { background:rgba(99, 179, 237, 0.08); }
+  .publish-path-row { display:flex; gap:8px; align-items:center; }
+  .publish-path-row .modal-input { flex:1; }
+  .publish-option { display:flex; gap:8px; align-items:flex-start; margin-top:12px; font-size:13px; color:var(--text-secondary); }
+  .publish-status { min-height:16px; margin-top:10px; font-size:12px; color:var(--text-secondary); }
 
   .lifelist-meta { padding:8px 24px; font-size:12px; color:var(--text-secondary); }
 
@@ -53,9 +59,43 @@
       <option value="most-photos">Most photos</option>
     </select>
   </div>
+  <button class="publish-btn" onclick="openPublishModal()">Publish Site</button>
 </div>
 
 <div class="lifelist-meta" id="meta"></div>
+
+<div class="modal-overlay" id="publishModal">
+  <div class="modal">
+    <h3>Publish Website Data</h3>
+    <label class="modal-label" for="publishDest">Destination folder</label>
+    <div class="publish-path-row">
+      <input id="publishDest" class="modal-input" type="text" placeholder="/path/to/site/public">
+      <button class="modal-btn modal-btn-cancel" onclick="browsePublishDest()">Browse</button>
+    </div>
+    <div class="modal-hint">
+      Writes data/site.json, data/life-list.json, data/highlights.json, and optimized images.
+    </div>
+
+    <label class="publish-option">
+      <input id="publishLocations" type="checkbox">
+      <span>Include location keywords in the published life list.</span>
+    </label>
+
+    <label class="modal-label" for="publishMaxSize" style="margin-top:12px;">Image max long edge</label>
+    <select id="publishMaxSize" class="modal-input">
+      <option value="2400">2400 px</option>
+      <option value="2048">2048 px</option>
+      <option value="1600">1600 px</option>
+      <option value="">Original size</option>
+    </select>
+
+    <div class="publish-status" id="publishStatus"></div>
+    <div class="modal-actions">
+      <button id="publishSubmitBtn" class="modal-btn modal-btn-primary" onclick="startPublishSite()">Publish</button>
+      <button class="modal-btn modal-btn-cancel" onclick="closePublishModal()">Cancel</button>
+    </div>
+  </div>
+</div>
 
 <div class="lifelist-grid" id="content"></div>
 
@@ -204,6 +244,59 @@ document.getElementById('speciesSearch').addEventListener('input', debounceRende
 document.getElementById('sortSelect').addEventListener('change', function() {
   if (currentData) render();
 });
+
+function openPublishModal() {
+  var modal = document.getElementById('publishModal');
+  var status = document.getElementById('publishStatus');
+  if (status) status.textContent = '';
+  modal.classList.add('open');
+  setTimeout(function() {
+    var input = document.getElementById('publishDest');
+    if (input) input.focus();
+  }, 0);
+}
+
+function closePublishModal() {
+  document.getElementById('publishModal').classList.remove('open');
+}
+
+async function browsePublishDest() {
+  if (typeof pickDirectory !== 'function') {
+    showToast('Folder picker is available in the desktop app.', 'info');
+    return;
+  }
+  var selected = await pickDirectory('Select website publish folder');
+  if (selected) document.getElementById('publishDest').value = selected;
+}
+
+async function startPublishSite() {
+  var dest = document.getElementById('publishDest').value.trim();
+  var status = document.getElementById('publishStatus');
+  var btn = document.getElementById('publishSubmitBtn');
+  if (!dest) {
+    status.textContent = 'Destination folder is required.';
+    return;
+  }
+  btn.disabled = true;
+  status.textContent = 'Starting publish job...';
+  try {
+    var maxSize = document.getElementById('publishMaxSize').value;
+    var data = await safeFetch('/api/jobs/publish-site', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        destination: dest,
+        max_size: maxSize,
+        include_locations: document.getElementById('publishLocations').checked,
+      }),
+    });
+    status.textContent = 'Publish job started: ' + data.job_id;
+    if (typeof showToast === 'function') showToast('Publishing website data...', 'info');
+    setTimeout(closePublishModal, 700);
+  } finally {
+    btn.disabled = false;
+  }
+}
 
 function findLifeListEntryForPhoto(photoId) {
   if (!currentData || photoId == null) return null;

--- a/vireo/tests/test_site_publish.py
+++ b/vireo/tests/test_site_publish.py
@@ -106,6 +106,7 @@ def test_publish_site_job_writes_life_list_highlights_and_images(tmp_path, monke
     assert site["schema_version"] == 1
     assert site["counts"]["life_list_species"] == 2
     assert life["meta"]["species_count"] == 2
+    assert "folders" not in highlights
     cardinal = next(e for e in life["species"] if e["species"] == "Northern Cardinal")
     assert cardinal["locations"] == []
     assert cardinal["best"]["image"].startswith("images/photos/")

--- a/vireo/tests/test_site_publish.py
+++ b/vireo/tests/test_site_publish.py
@@ -177,6 +177,7 @@ def test_publish_site_uses_developed_render_when_max_exceeds_original(tmp_path, 
     assert result["errors"] == []
     life = json.loads((dest / "data" / "life-list.json").read_text())
     cardinal = next(e for e in life["species"] if e["species"] == "Northern Cardinal")
+    assert cardinal["locations"] == []
     with Image.open(dest / cardinal["best"]["image"]) as out:
         red, green, _blue = out.getpixel((0, 0))
     assert green > red

--- a/vireo/tests/test_site_publish.py
+++ b/vireo/tests/test_site_publish.py
@@ -40,6 +40,8 @@ def _seed_publish_app(tmp_path, monkeypatch):
         file_size=1000,
         file_mtime=1.0,
         timestamp="2024-01-15T10:00:00",
+        width=1200,
+        height=800,
     )
     p2 = db.add_photo(
         folder_id=fid,
@@ -48,6 +50,8 @@ def _seed_publish_app(tmp_path, monkeypatch):
         file_size=1000,
         file_mtime=2.0,
         timestamp="2024-02-01T10:00:00",
+        width=900,
+        height=900,
     )
     p3 = db.add_photo(
         folder_id=fid,
@@ -56,6 +60,8 @@ def _seed_publish_app(tmp_path, monkeypatch):
         file_size=1000,
         file_mtime=3.0,
         timestamp="2024-03-01T10:00:00",
+        width=1000,
+        height=700,
     )
     db.conn.execute("UPDATE photos SET quality_score = 0.9 WHERE id = ?", (p1,))
     db.conn.execute("UPDATE photos SET quality_score = 0.7 WHERE id = ?", (p2,))
@@ -72,11 +78,11 @@ def _seed_publish_app(tmp_path, monkeypatch):
     db.conn.commit()
 
     app = create_app(db_path=db_path, thumb_cache_dir=str(thumb_dir))
-    return app, db
+    return app, db, {"photos_dir": photos_dir, "vireo_dir": vireo_dir, "p1": p1}
 
 
 def test_publish_site_job_writes_life_list_highlights_and_images(tmp_path, monkeypatch):
-    app, db = _seed_publish_app(tmp_path, monkeypatch)
+    app, db, _meta = _seed_publish_app(tmp_path, monkeypatch)
     client = app.test_client()
     dest = tmp_path / "published"
 
@@ -118,7 +124,7 @@ def test_publish_site_job_writes_life_list_highlights_and_images(tmp_path, monke
 
 
 def test_publish_site_job_can_include_locations(tmp_path, monkeypatch):
-    app, db = _seed_publish_app(tmp_path, monkeypatch)
+    app, db, _meta = _seed_publish_app(tmp_path, monkeypatch)
     client = app.test_client()
     dest = tmp_path / "published"
 
@@ -132,6 +138,48 @@ def test_publish_site_job_can_include_locations(tmp_path, monkeypatch):
     life = json.loads((dest / "data" / "life-list.json").read_text())
     cardinal = next(e for e in life["species"] if e["species"] == "Northern Cardinal")
     assert cardinal["locations"] == ["Backyard"]
+
+    db.close()
+
+
+def test_publish_site_uses_developed_render_when_max_exceeds_original(tmp_path, monkeypatch):
+    app, db, meta = _seed_publish_app(tmp_path, monkeypatch)
+    client = app.test_client()
+    dest = tmp_path / "published"
+    developed_dir = tmp_path / "developed"
+
+    from export import developed_folder_key
+    from site_publish import publish_site
+
+    developed_subdir = developed_dir / developed_folder_key(str(meta["photos_dir"]))
+    developed_subdir.mkdir(parents=True)
+    Image.new("RGB", (1200, 800), (20, 210, 40)).save(
+        developed_subdir / "cardinal.jpg",
+        "JPEG",
+        quality=95,
+    )
+
+    life_list = client.get("/api/life-list").get_json()
+    highlights = client.get("/api/highlights?scope=workspace").get_json()
+    result = publish_site(
+        db=db,
+        vireo_dir=str(meta["vireo_dir"]),
+        destination=str(dest),
+        life_list=life_list,
+        highlights=highlights,
+        options={
+            "developed_dir": str(developed_dir),
+            "max_size": 2400,
+            "quality": 95,
+        },
+    )
+
+    assert result["errors"] == []
+    life = json.loads((dest / "data" / "life-list.json").read_text())
+    cardinal = next(e for e in life["species"] if e["species"] == "Northern Cardinal")
+    with Image.open(dest / cardinal["best"]["image"]) as out:
+        red, green, _blue = out.getpixel((0, 0))
+    assert green > red
 
     db.close()
 

--- a/vireo/tests/test_site_publish.py
+++ b/vireo/tests/test_site_publish.py
@@ -60,6 +60,8 @@ def _seed_publish_app(tmp_path, monkeypatch):
     db.conn.execute("UPDATE photos SET quality_score = 0.9 WHERE id = ?", (p1,))
     db.conn.execute("UPDATE photos SET quality_score = 0.7 WHERE id = ?", (p2,))
     db.conn.execute("UPDATE photos SET quality_score = 0.8 WHERE id = ?", (p3,))
+    db.conn.execute("UPDATE photos SET mask_path = ? WHERE id = ?", ("masks/cardinal.png", p1))
+    db.conn.execute("UPDATE photos SET mask_path = ? WHERE id = ?", ("masks/mystery.png", p3))
 
     cardinal = db.add_keyword("Northern Cardinal", is_species=True)
     sparrow = db.add_keyword("House Sparrow", is_species=True)
@@ -106,7 +108,9 @@ def test_publish_site_job_writes_life_list_highlights_and_images(tmp_path, monke
         "Northern Cardinal",
         "House Sparrow",
     ]
+    assert "mask_path" not in highlights["buckets"][0]["photos"][0]
     unidentified = highlights["unidentified"]["photos"][0]
+    assert "mask_path" not in unidentified
     assert unidentified["image"].startswith("images/photos/unidentified-")
     assert (dest / unidentified["image"]).exists()
 

--- a/vireo/tests/test_site_publish.py
+++ b/vireo/tests/test_site_publish.py
@@ -1,0 +1,127 @@
+import json
+
+from PIL import Image
+from wait import wait_for_job_via_client
+
+
+def _seed_publish_app(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import config as cfg
+    import models
+    from app import create_app
+    from db import Database
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setattr(
+        models, "DEFAULT_MODELS_DIR", str(tmp_path / "vireo-models"),
+    )
+    monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
+
+    photos_dir = tmp_path / "photos"
+    photos_dir.mkdir()
+    Image.new("RGB", (1200, 800), (180, 30, 40)).save(photos_dir / "cardinal.jpg")
+    Image.new("RGB", (900, 900), (90, 120, 40)).save(photos_dir / "sparrow.jpg")
+
+    vireo_dir = tmp_path / "vireo"
+    thumb_dir = vireo_dir / "thumbs"
+    thumb_dir.mkdir(parents=True)
+    db_path = str(vireo_dir / "vireo.db")
+
+    db = Database(db_path)
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    fid = db.add_folder(str(photos_dir), name="photos")
+
+    p1 = db.add_photo(
+        folder_id=fid,
+        filename="cardinal.jpg",
+        extension=".jpg",
+        file_size=1000,
+        file_mtime=1.0,
+        timestamp="2024-01-15T10:00:00",
+    )
+    p2 = db.add_photo(
+        folder_id=fid,
+        filename="sparrow.jpg",
+        extension=".jpg",
+        file_size=1000,
+        file_mtime=2.0,
+        timestamp="2024-02-01T10:00:00",
+    )
+    db.conn.execute("UPDATE photos SET quality_score = 0.9 WHERE id = ?", (p1,))
+    db.conn.execute("UPDATE photos SET quality_score = 0.7 WHERE id = ?", (p2,))
+
+    cardinal = db.add_keyword("Northern Cardinal", is_species=True)
+    sparrow = db.add_keyword("House Sparrow", is_species=True)
+    backyard = db.add_keyword("Backyard", kw_type="location")
+    db.tag_photo(p1, cardinal)
+    db.tag_photo(p1, backyard)
+    db.tag_photo(p2, sparrow)
+    db.conn.commit()
+
+    app = create_app(db_path=db_path, thumb_cache_dir=str(thumb_dir))
+    return app, db
+
+
+def test_publish_site_job_writes_life_list_highlights_and_images(tmp_path, monkeypatch):
+    app, db = _seed_publish_app(tmp_path, monkeypatch)
+    client = app.test_client()
+    dest = tmp_path / "published"
+
+    resp = client.post("/api/jobs/publish-site", json={
+        "destination": str(dest),
+        "photos_per_species": 2,
+        "limit_per_bucket": 2,
+        "max_size": 512,
+    })
+    assert resp.status_code == 200
+
+    job = wait_for_job_via_client(client, resp.get_json()["job_id"])
+    assert job["status"] == "completed"
+    assert job["result"]["exported_images"] == 2
+    assert job["result"]["errors"] == []
+
+    site = json.loads((dest / "data" / "site.json").read_text())
+    life = json.loads((dest / "data" / "life-list.json").read_text())
+    highlights = json.loads((dest / "data" / "highlights.json").read_text())
+
+    assert site["schema_version"] == 1
+    assert site["counts"]["life_list_species"] == 2
+    assert life["meta"]["species_count"] == 2
+    cardinal = next(e for e in life["species"] if e["species"] == "Northern Cardinal")
+    assert cardinal["locations"] == []
+    assert cardinal["best"]["image"].startswith("images/photos/")
+    assert (dest / cardinal["best"]["image"]).exists()
+    assert [b["species"] for b in highlights["buckets"]] == [
+        "Northern Cardinal",
+        "House Sparrow",
+    ]
+
+    db.close()
+
+
+def test_publish_site_job_can_include_locations(tmp_path, monkeypatch):
+    app, db = _seed_publish_app(tmp_path, monkeypatch)
+    client = app.test_client()
+    dest = tmp_path / "published"
+
+    resp = client.post("/api/jobs/publish-site", json={
+        "destination": str(dest),
+        "include_locations": True,
+    })
+    assert resp.status_code == 200
+    wait_for_job_via_client(client, resp.get_json()["job_id"])
+
+    life = json.loads((dest / "data" / "life-list.json").read_text())
+    cardinal = next(e for e in life["species"] if e["species"] == "Northern Cardinal")
+    assert cardinal["locations"] == ["Backyard"]
+
+    db.close()
+
+
+def test_publish_site_job_rejects_relative_destination(app_and_db):
+    app, _db = app_and_db
+    resp = app.test_client().post("/api/jobs/publish-site", json={
+        "destination": "relative/out",
+    })
+    assert resp.status_code == 400

--- a/vireo/tests/test_site_publish.py
+++ b/vireo/tests/test_site_publish.py
@@ -21,6 +21,7 @@ def _seed_publish_app(tmp_path, monkeypatch):
     photos_dir.mkdir()
     Image.new("RGB", (1200, 800), (180, 30, 40)).save(photos_dir / "cardinal.jpg")
     Image.new("RGB", (900, 900), (90, 120, 40)).save(photos_dir / "sparrow.jpg")
+    Image.new("RGB", (1000, 700), (40, 80, 150)).save(photos_dir / "mystery.jpg")
 
     vireo_dir = tmp_path / "vireo"
     thumb_dir = vireo_dir / "thumbs"
@@ -48,8 +49,17 @@ def _seed_publish_app(tmp_path, monkeypatch):
         file_mtime=2.0,
         timestamp="2024-02-01T10:00:00",
     )
+    p3 = db.add_photo(
+        folder_id=fid,
+        filename="mystery.jpg",
+        extension=".jpg",
+        file_size=1000,
+        file_mtime=3.0,
+        timestamp="2024-03-01T10:00:00",
+    )
     db.conn.execute("UPDATE photos SET quality_score = 0.9 WHERE id = ?", (p1,))
     db.conn.execute("UPDATE photos SET quality_score = 0.7 WHERE id = ?", (p2,))
+    db.conn.execute("UPDATE photos SET quality_score = 0.8 WHERE id = ?", (p3,))
 
     cardinal = db.add_keyword("Northern Cardinal", is_species=True)
     sparrow = db.add_keyword("House Sparrow", is_species=True)
@@ -78,7 +88,7 @@ def test_publish_site_job_writes_life_list_highlights_and_images(tmp_path, monke
 
     job = wait_for_job_via_client(client, resp.get_json()["job_id"])
     assert job["status"] == "completed"
-    assert job["result"]["exported_images"] == 2
+    assert job["result"]["exported_images"] == 3
     assert job["result"]["errors"] == []
 
     site = json.loads((dest / "data" / "site.json").read_text())
@@ -96,6 +106,9 @@ def test_publish_site_job_writes_life_list_highlights_and_images(tmp_path, monke
         "Northern Cardinal",
         "House Sparrow",
     ]
+    unidentified = highlights["unidentified"]["photos"][0]
+    assert unidentified["image"].startswith("images/photos/unidentified-")
+    assert (dest / unidentified["image"]).exists()
 
     db.close()
 


### PR DESCRIPTION
Adds a Life List publishing flow that exports workspace life-list and highlights data as static-site-ready JSON plus optimized images. Refactors the existing life-list and highlights API payload generation so the app UI and publisher share the same contract. The publisher defaults to excluding location keywords unless the user explicitly includes them. Adds tests for generated manifests, image output, privacy defaults, and destination validation.