### PR TITLE
Tokenize keyword search so multi-word queries match across keywords

### DIFF
--- a/vireo/db.py
+++ b/vireo/db.py
@@ -54,6 +54,40 @@ def _escape_like(s: str) -> str:
     return s.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
+def _keyword_token_clause(keyword):
+    """Build a WHERE clause for a multi-token keyword search.
+
+    The query is split on whitespace into tokens; a photo matches only if
+    EVERY token appears (case-insensitively, as a literal substring) in the
+    photo's filename or in at least one of its keyword names. Tokens may be
+    satisfied by different keywords, so "red bill" matches a photo tagged
+    "Red-billed leiothrix" (both tokens in one keyword) as well as a photo
+    tagged both "Reddish" and "Billboard" (one token each). Tokens are escaped
+    so LIKE metacharacters (``%``/``_``) in the query match literally.
+
+    Returns ``(clause_sql, params)``. The clause references the outer photos
+    alias ``p``, so callers must expose the photos table as ``p``. Returns
+    ``(None, [])`` when the query has no tokens (caller applies no keyword
+    filter).
+    """
+    tokens = keyword.split()
+    if not tokens:
+        return None, []
+    clauses = []
+    params = []
+    for tok in tokens:
+        like = f"%{_escape_like(tok)}%"
+        clauses.append(
+            "(p.filename LIKE ? ESCAPE '\\' OR EXISTS ("
+            "SELECT 1 FROM photo_keywords pk_s "
+            "JOIN keywords k_s ON k_s.id = pk_s.keyword_id "
+            "WHERE pk_s.photo_id = p.id AND k_s.name LIKE ? ESCAPE '\\'))"
+        )
+        params.append(like)
+        params.append(like)
+    return " AND ".join(clauses), params
+
+
 def _subtree_prefix(path: str) -> str:
     return _path_for_subtree_match(path) + "/"
 
@@ -4615,13 +4649,10 @@ class Database:
             conditions.append("COALESCE(p.flag, 'none') = ?")
             where_params.append(flag)
         if keyword is not None:
-            join_clause += """
-                LEFT JOIN photo_keywords pk ON pk.photo_id = p.id
-                LEFT JOIN keywords k ON k.id = pk.keyword_id
-            """
-            conditions.append("(k.name LIKE ? OR p.filename LIKE ?)")
-            where_params.append(f"%{keyword}%")
-            where_params.append(f"%{keyword}%")
+            kw_clause, kw_params = _keyword_token_clause(keyword)
+            if kw_clause:
+                conditions.append(kw_clause)
+                where_params.extend(kw_params)
         if color_label is not None:
             join_clause += "\nJOIN photo_color_labels pcl ON pcl.photo_id = p.id AND pcl.workspace_id = ?"
             join_params.append(ws)
@@ -4698,13 +4729,10 @@ class Database:
         join_clause = ("JOIN workspace_folders wf ON wf.folder_id = p.folder_id"
                        "\nJOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')")
         if keyword is not None:
-            join_clause += """
-                LEFT JOIN photo_keywords pk ON pk.photo_id = p.id
-                LEFT JOIN keywords k ON k.id = pk.keyword_id
-            """
-            conditions.append("(k.name LIKE ? OR p.filename LIKE ?)")
-            where_params.append(f"%{keyword}%")
-            where_params.append(f"%{keyword}%")
+            kw_clause, kw_params = _keyword_token_clause(keyword)
+            if kw_clause:
+                conditions.append(kw_clause)
+                where_params.extend(kw_params)
 
         if color_label is not None:
             join_clause += "\nJOIN photo_color_labels pcl ON pcl.photo_id = p.id AND pcl.workspace_id = ?"
@@ -4782,13 +4810,10 @@ class Database:
         join_clause = ("JOIN workspace_folders wf ON wf.folder_id = p.folder_id"
                        "\nJOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')")
         if keyword is not None:
-            join_clause += """
-                LEFT JOIN photo_keywords pk ON pk.photo_id = p.id
-                LEFT JOIN keywords k ON k.id = pk.keyword_id
-            """
-            conditions.append("(k.name LIKE ? OR p.filename LIKE ?)")
-            where_params.append(f"%{keyword}%")
-            where_params.append(f"%{keyword}%")
+            kw_clause, kw_params = _keyword_token_clause(keyword)
+            if kw_clause:
+                conditions.append(kw_clause)
+                where_params.extend(kw_params)
 
         if color_label is not None:
             join_clause += "\nJOIN photo_color_labels pcl ON pcl.photo_id = p.id AND pcl.workspace_id = ?"
@@ -4855,13 +4880,10 @@ class Database:
         join_clause = ("JOIN workspace_folders wf ON wf.folder_id = p.folder_id"
                        "\nJOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')")
         if keyword is not None:
-            join_clause += """
-                LEFT JOIN photo_keywords pk ON pk.photo_id = p.id
-                LEFT JOIN keywords k ON k.id = pk.keyword_id
-            """
-            conditions.append("(k.name LIKE ? OR p.filename LIKE ?)")
-            where_params.append(f"%{keyword}%")
-            where_params.append(f"%{keyword}%")
+            kw_clause, kw_params = _keyword_token_clause(keyword)
+            if kw_clause:
+                conditions.append(kw_clause)
+                where_params.extend(kw_params)
 
         if color_label is not None:
             join_clause += "\nJOIN photo_color_labels pcl ON pcl.photo_id = p.id AND pcl.workspace_id = ?"
@@ -4938,13 +4960,10 @@ class Database:
         join_clause = ("JOIN workspace_folders wf ON wf.folder_id = p.folder_id"
                        "\nJOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')")
         if keyword is not None:
-            join_clause += """
-                LEFT JOIN photo_keywords pk ON pk.photo_id = p.id
-                LEFT JOIN keywords k ON k.id = pk.keyword_id
-            """
-            conditions.append("(k.name LIKE ? OR p.filename LIKE ?)")
-            where_params.append(f"%{keyword}%")
-            where_params.append(f"%{keyword}%")
+            kw_clause, kw_params = _keyword_token_clause(keyword)
+            if kw_clause:
+                conditions.append(kw_clause)
+                where_params.extend(kw_params)
 
         if color_label is not None:
             join_clause += "\nJOIN photo_color_labels pcl ON pcl.photo_id = p.id AND pcl.workspace_id = ?"
@@ -5121,13 +5140,10 @@ class Database:
             f"\n{location_subquery}"
         )
         if keyword is not None:
-            join_clause += """
-                LEFT JOIN photo_keywords pk ON pk.photo_id = p.id
-                LEFT JOIN keywords k ON k.id = pk.keyword_id
-            """
-            conditions.append("(k.name LIKE ? OR p.filename LIKE ?)")
-            params.append(f"%{keyword}%")
-            params.append(f"%{keyword}%")
+            kw_clause, kw_params = _keyword_token_clause(keyword)
+            if kw_clause:
+                conditions.append(kw_clause)
+                params.extend(kw_params)
 
         # Match any species tag on the photo, not just MIN(name) — a photo can be
         # tagged with multiple species keywords.

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -572,6 +572,38 @@ def test_get_photos_keyword_search(tmp_path):
     assert results[0]['filename'] == 'cardinal.jpg'
 
 
+def test_get_photos_keyword_multi_token(tmp_path):
+    """Multi-token keyword search requires every whitespace-separated token to
+    match (in the filename or some keyword), so "red bill" finds the
+    hyphenated keyword "Red-billed leiothrix" without an exact substring."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder('/photos', name='photos')
+    p1 = db.add_photo(folder_id=fid, filename='a.jpg', extension='.jpg', file_size=100, file_mtime=1.0)
+    p2 = db.add_photo(folder_id=fid, filename='b.jpg', extension='.jpg', file_size=100, file_mtime=1.0)
+    p3 = db.add_photo(folder_id=fid, filename='c.jpg', extension='.jpg', file_size=100, file_mtime=1.0)
+    db.tag_photo(p1, db.add_keyword('Red-billed leiothrix'))
+    db.tag_photo(p2, db.add_keyword('Northern Cardinal'))
+    # p3 holds each token in a *separate* keyword.
+    db.tag_photo(p3, db.add_keyword('Reddish'))
+    db.tag_photo(p3, db.add_keyword('Billboard'))
+
+    # "red bill" matches the hyphenated single keyword (p1) and the
+    # split-across-two-keywords photo (p3); token order is irrelevant.
+    assert {r['filename'] for r in db.get_photos(keyword='red bill')} == {'a.jpg', 'c.jpg'}
+    assert {r['filename'] for r in db.get_photos(keyword='bill red')} == {'a.jpg', 'c.jpg'}
+
+    # Every token must match: no photo has both a "red*" and a "cardinal*" tag.
+    assert db.get_photos(keyword='red cardinal') == []
+
+    # A token can be satisfied by a different keyword on the same photo.
+    assert {r['filename'] for r in db.get_photos(keyword='northern card')} == {'b.jpg'}
+
+    # count_filtered_photos and get_photo_ids agree with get_photos.
+    assert db.count_filtered_photos(keyword='red bill') == 2
+    assert len(db.get_photo_ids(keyword='red bill')) == 2
+
+
 def test_add_keyword_idempotent(tmp_path):
     """add_keyword returns existing id if keyword already exists."""
     from db import Database


### PR DESCRIPTION
## What

Searching the browse box for **"red bill"** previously returned nothing for photos tagged **"Red-billed leiothrix"**. The search wrapped the entire query in one SQL `LIKE '%red bill%'`, and that literal string (with a space) isn't a substring of the hyphenated keyword name.

This change tokenizes the query: it splits on whitespace and requires **every** token to match — in the filename or in at least one of the photo's keyword names — via per-token `EXISTS` subqueries.

### Matching semantics
- `red bill` → matches a photo tagged `Red-billed leiothrix` (both tokens in one keyword).
- Tokens may be satisfied by **different** keywords on the same photo, so `red bill` also matches a photo tagged `Reddish` + `Billboard`.
- Token **order is irrelevant** (`bill red` == `red bill`).
- **All** tokens must match: `red cardinal` returns a photo only if it has both a `red*` and a `cardinal*` match.
- Tokens are escaped with the existing `_escape_like` helper, so `%`/`_` in a query match literally — this also fixes a latent false-positive where filename underscores (e.g. `IMG_1234`) acted as wildcards.

### Refactor
All six keyword-search call sites — `get_photos`, `get_photo_ids`, `count_filtered_photos`, `get_browse_summary`, `get_calendar_data`, `get_geolocated_photos` — now route through one shared `_keyword_token_clause` helper instead of duplicating the `LEFT JOIN` + `LIKE` block. The `EXISTS` approach also removes the join-induced row multiplication that previously required `DISTINCT`.

No frontend change: the search box already sends the raw query string, which the backend now tokenizes.

## Testing

- New `test_get_photos_keyword_multi_token` covers the hyphenated keyword, cross-keyword tokens, token order, all-tokens-required, and agreement across `get_photos` / `count_filtered_photos` / `get_photo_ids`.
- Full project suite: **1123 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)