### PR TITLE
Fix highlights reject undo flow

### DIFF
--- a/tests/e2e/test_highlights_initial_scope.py
+++ b/tests/e2e/test_highlights_initial_scope.py
@@ -10,6 +10,8 @@ the photos shown reflect workspace scope (blending every folder with quality
 data) and the dropdown selection matches.
 """
 import json
+import re
+import time
 from urllib.parse import quote
 from urllib.request import urlopen
 
@@ -42,6 +44,18 @@ def _seed_quality_scores_and_species(db, data):
             (pid, species_map[i]),
         )
     db.conn.commit()
+
+
+def _wait_for_flag(db, photo_id, expected, timeout=3.0):
+    deadline = time.time() + timeout
+    flag = None
+    while time.time() < deadline:
+        photo = db.get_photo(photo_id)
+        flag = photo["flag"] if photo else None
+        if flag == expected:
+            return flag
+        time.sleep(0.05)
+    return flag
 
 
 def test_initial_load_matches_default_workspace_scope(live_server, page):
@@ -159,6 +173,52 @@ def test_highlights_species_search_filters_buckets(live_server, page):
         "Red-tailed Hawk" in title
         for title in page.locator(".bucket-title").all_inner_texts()
     )
+
+
+def test_highlights_lightbox_reject_advances_and_can_restore(live_server, page):
+    db = live_server["db"]
+    data = live_server["data"]
+    _seed_quality_scores_and_species(db, data)
+
+    page.goto(f"{live_server['url']}/highlights", timeout=5000)
+    hawk_section = page.locator("section.bucket").filter(has_text="Red-tailed Hawk")
+    first_card = hawk_section.locator(".highlights-card").nth(0)
+    second_card = hawk_section.locator(".highlights-card").nth(1)
+    expect(first_card).to_be_visible(timeout=5000)
+    expect(second_card).to_be_visible(timeout=5000)
+    first_pid = int(first_card.get_attribute("data-photo-id"))
+    second_pid = int(second_card.get_attribute("data-photo-id"))
+
+    first_card.click()
+    page.wait_for_function(
+        "document.getElementById('lightboxOverlay').classList.contains('active')",
+        timeout=3000,
+    )
+    page.wait_for_function(
+        "pid => _lightboxCurrentId === pid",
+        arg=first_pid,
+        timeout=3000,
+    )
+
+    page.keyboard.press("x")
+
+    assert _wait_for_flag(db, first_pid, "rejected") == "rejected"
+    page.wait_for_function(
+        "pid => _lightboxCurrentId === pid",
+        arg=second_pid,
+        timeout=3000,
+    )
+    expect(page.locator(f'.highlights-card[data-photo-id="{first_pid}"]')).to_have_count(0)
+    expect(page.locator("#highlightUndo")).to_have_class(re.compile(r"\bopen\b"))
+
+    page.locator('#highlightLightboxPanel button[data-lb-action="undo-reject"]').click()
+
+    assert _wait_for_flag(db, first_pid, "none") == "none"
+    expect(page.locator(f'.highlights-card[data-photo-id="{first_pid}"]')).to_have_count(
+        1,
+        timeout=5000,
+    )
+    expect(page.locator("#highlightUndo")).not_to_have_class(re.compile(r"\bopen\b"))
 
 
 def test_highlights_api_limits_initial_bucket_and_loads_more(live_server):

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3405,6 +3405,7 @@ function _lbRecordFetchedFlag(photoId, flag, flagFetchSeq) {
 function _lbApplyFlag(photoId, flag) {
   var normalized = _lbNormalizeFlag(flag);
   if (!normalized || photoId == null) return false;
+  var previousFlag = _lbNormalizeFlag(_lbConfirmedFlagFor(photoId)) || 'none';
   var seq = _lbFlagEditSeq + 1;
   _lbFlagEditSeq = seq;
   _lbFlagPendingWrites += 1;
@@ -3454,7 +3455,11 @@ function _lbApplyFlag(photoId, flag) {
     if (!Object.prototype.hasOwnProperty.call(_lbFlagPendingByPhoto, photoId)) {
       try {
         document.dispatchEvent(new CustomEvent('lightbox:flagchanged', {
-          detail: { photoId: photoId, flag: _lbConfirmedFlagFor(photoId) },
+          detail: {
+            photoId: photoId,
+            flag: _lbConfirmedFlagFor(photoId),
+            previousFlag: previousFlag,
+          },
         }));
       } catch (_) {}
     }

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -52,6 +52,13 @@
   .highlights-empty { text-align:center; padding:80px 24px; color:var(--text-secondary); }
   .highlights-empty a { color:var(--accent); }
   .highlights-meta { padding:8px 24px; font-size:12px; color:var(--text-secondary); }
+  .highlight-undo { display:none; align-items:center; justify-content:space-between; gap:12px; margin:8px 24px 0; padding:8px 12px; border:1px solid var(--border-secondary); border-radius:6px; background:var(--bg-secondary); color:var(--text-primary); font-size:13px; }
+  .highlight-undo.open { display:flex; }
+  .highlight-undo span { min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+  .highlight-undo-actions { display:flex; align-items:center; gap:8px; flex-shrink:0; }
+  .highlight-undo button { padding:4px 10px; border-radius:4px; border:1px solid var(--border-secondary); background:var(--bg-tertiary); color:var(--text-primary); cursor:pointer; font-size:12px; }
+  .highlight-undo button.primary { background:var(--accent); color:var(--accent-text); border-color:var(--accent); }
+  .highlight-undo button:disabled { opacity:0.6; cursor:default; }
 
   /* Save modal (unchanged) */
   .save-modal-overlay { display:none; position:fixed; inset:0; background:rgba(0,0,0,0.5); z-index:500; align-items:center; justify-content:center; }
@@ -119,6 +126,13 @@
 </div>
 
 <div class="highlights-meta" id="meta"></div>
+<div id="highlightUndo" class="highlight-undo" role="status" aria-live="polite">
+  <span id="highlightUndoText"></span>
+  <div class="highlight-undo-actions">
+    <button id="highlightUndoBtn" class="primary" type="button" onclick="undoLastHighlightReject()">Undo</button>
+    <button type="button" onclick="hideHighlightUndo()">Dismiss</button>
+  </div>
+</div>
 
 <div id="content"></div>
 
@@ -170,6 +184,7 @@ var activeLightboxPhotoId = null;
 // Photos the user has rejected from the lightbox this session and not since
 // un-rejected. Drives grid removal AND guards reloads (see loadHighlights).
 var rejectedFromGrid = new Set();
+var lastHighlightReject = null;
 // Monotonic counter bumped each time a highlights reload is *issued*, plus the
 // counter value captured at each photo's rejection. Together they let the
 // reload prune ONLY photos rejected at/after the in-flight request was sent
@@ -624,6 +639,77 @@ function findHighlightPhoto(photoId) {
   return unid.find(function(p) { return p.id === photoId; }) || null;
 }
 
+function lightboxIsOpenOnPhoto(photoId) {
+  var overlay = document.getElementById('lightboxOverlay');
+  return !!(
+    overlay &&
+    overlay.classList.contains('active') &&
+    typeof _lightboxCurrentId !== 'undefined' &&
+    _lightboxCurrentId === photoId
+  );
+}
+
+function advanceHighlightLightboxAfterReject(photoId) {
+  if (!lightboxIsOpenOnPhoto(photoId)) return;
+  if (!Array.isArray(_lightboxPhotoList) || !_lightboxPhotoList.length) return;
+
+  var idx = _lightboxPhotoList.findIndex(function(p) { return p.id === photoId; });
+  if (idx < 0) return;
+  var nextList = _lightboxPhotoList.filter(function(p) {
+    return p.id !== photoId && p.flag !== 'rejected';
+  });
+  if (!nextList.length) {
+    closeLightbox();
+    return;
+  }
+  var nextIdx = Math.min(idx, nextList.length - 1);
+  var next = nextList[nextIdx];
+  openLightbox(next.id, next.filename || '', nextList);
+}
+
+function showHighlightUndo(photo, previousFlag) {
+  lastHighlightReject = {
+    photoId: photo.id,
+    filename: photo.filename || 'photo',
+    previousFlag: previousFlag || 'none',
+  };
+  var bar = document.getElementById('highlightUndo');
+  var text = document.getElementById('highlightUndoText');
+  var btn = document.getElementById('highlightUndoBtn');
+  if (!bar || !text || !btn) return;
+  text.textContent = 'Rejected ' + lastHighlightReject.filename + '.';
+  btn.disabled = false;
+  bar.classList.add('open');
+}
+
+function hideHighlightUndo() {
+  lastHighlightReject = null;
+  var bar = document.getElementById('highlightUndo');
+  if (bar) bar.classList.remove('open');
+}
+
+async function undoLastHighlightReject() {
+  if (!lastHighlightReject) return;
+  var undo = lastHighlightReject;
+  var btn = document.getElementById('highlightUndoBtn');
+  if (btn) btn.disabled = true;
+  try {
+    await safeFetch('/api/photos/' + undo.photoId + '/flag', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ flag: undo.previousFlag }),
+    });
+    rejectedFromGrid.delete(undo.photoId);
+    delete rejectedAtLoadSeq[undo.photoId];
+    hideHighlightUndo();
+    await loadHighlights();
+    updateHighlightsLightboxControls(activeLightboxPhotoId);
+    if (typeof showToast === 'function') showToast('Reject undone', 'success');
+  } finally {
+    if (btn) btn.disabled = false;
+  }
+}
+
 function ensureHighlightsLightboxPanel() {
   var actions = document.getElementById('lightboxActions');
   if (!actions) return null;
@@ -641,32 +727,43 @@ function updateHighlightsLightboxControls(photoId) {
   var panel = ensureHighlightsLightboxPanel();
   if (!panel) return;
   var photo = findHighlightPhoto(photoId);
-  if (!photo) {
+  if (!photo && !lastHighlightReject) {
     panel.style.display = 'none';
     panel.innerHTML = '';
     return;
   }
   panel.style.display = '';
-  var html = '<span>' + escapeAttr(photoCurrentLabel(photo)) + '</span>';
-  var highlightSpecies = photoSpeciesName(photo);
-  if (highlightSpecies) {
-    html += '<button data-lb-action="set-highlight"'
-      + (photo.is_highlights_photo ? ' class="primary"' : '') + '>'
-      + (photo.is_highlights_photo ? 'Highlights Photo' : 'Use as Highlights') + '</button>';
+  var html = photo
+    ? '<span>' + escapeAttr(photoCurrentLabel(photo)) + '</span>'
+    : '<span>Highlight photo removed</span>';
+  if (photo) {
+    var highlightSpecies = photoSpeciesName(photo);
+    if (highlightSpecies) {
+      html += '<button data-lb-action="set-highlight"'
+        + (photo.is_highlights_photo ? ' class="primary"' : '') + '>'
+        + (photo.is_highlights_photo ? 'Highlights Photo' : 'Use as Highlights') + '</button>';
+    }
+    if (photo.has_accepted_species && photo.species) {
+      html += '<button data-lb-action="set-life-list">Use as Life List</button>';
+    }
+    if (photo.is_confirmable_prediction) {
+      html += '<button class="primary" data-lb-action="confirm">Confirm</button>';
+    }
+    html += '<button data-lb-action="change">' + (photo.is_confirmable_prediction || photo.has_accepted_species ? 'Change' : 'Set species') + '</button>';
   }
-  if (photo.has_accepted_species && photo.species) {
-    html += '<button data-lb-action="set-life-list">Use as Life List</button>';
+  if (lastHighlightReject) {
+    html += '<button class="primary" data-lb-action="undo-reject">Undo Reject</button>';
   }
-  if (photo.is_confirmable_prediction) {
-    html += '<button class="primary" data-lb-action="confirm">Confirm</button>';
-  }
-  html += '<button data-lb-action="change">' + (photo.is_confirmable_prediction || photo.has_accepted_species ? 'Change' : 'Set species') + '</button>';
   panel.innerHTML = html;
   panel.querySelectorAll('button').forEach(function(btn) {
     btn.addEventListener('click', function(event) {
       event.stopPropagation();
       var action = btn.getAttribute('data-lb-action');
-      if (action === 'confirm') {
+      if (action === 'undo-reject') {
+        undoLastHighlightReject();
+      } else if (!photo) {
+        return;
+      } else if (action === 'confirm') {
         confirmPhotoIds([photo.id], btn);
       } else if (action === 'set-highlight') {
         setPhotoPreference('highlights', photoSpeciesName(photo), photo.id, btn);
@@ -840,6 +937,9 @@ document.addEventListener('lightbox:flagchanged', function(e) {
   var detail = e && e.detail;
   if (!detail || detail.photoId == null) return;
   if (detail.flag === 'rejected') {
+    var photo = findHighlightPhoto(detail.photoId);
+    if (photo) showHighlightUndo(photo, detail.previousFlag || photo.flag || 'none');
+    advanceHighlightLightboxAfterReject(detail.photoId);
     // Track before mutating: during an in-flight restore reload the photo may
     // not be in currentData yet, so removeRejectedPhotoFromModel returns false
     // — but the id must still be remembered so the reload's prune drops it.


### PR DESCRIPTION
## Summary
- Advance the highlights lightbox to the next eligible photo after rejecting with `X`
- Remove rejected highlights from the grid immediately and keep an undo affordance available in the lightbox
- Include the previous flag in shared lightbox flag-change events so highlights can restore the correct state
- Add E2E coverage for reject, advance, and undo restore

## Validation
- `python -m pytest tests/e2e/test_highlights_initial_scope.py -q`
- `python -m pytest tests/e2e/test_lightbox_flag_hotkeys.py -q`
