### PR TITLE
ci: authenticate MegaDetector pre-download with HF_TOKEN

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,24 +118,32 @@ jobs:
           path: ~/.vireo/models/megadetector-v6
           key: megadetector-v6-${{ runner.os }}-v1
 
-      # Sequential single-process pre-download. If the cache missed we run
-      # one HEAD+GET against HF Hub before the tests fan out — orders of
-      # magnitude less likely to trip the 429 rate limiter than two xdist
-      # workers each starting their own download simultaneously. Retry a
-      # few times with backoff so a single transient throttle doesn't
-      # poison the whole CI run.
+      # Sequential single-process pre-download. If the cache missed we fetch
+      # the weights once before the tests fan out — orders of magnitude less
+      # likely to trip the 429 rate limiter than two xdist workers each
+      # starting their own download simultaneously. Retry a few times with
+      # backoff so a single transient throttle doesn't poison the whole run.
+      #
+      # We fetch with curl rather than importing the app's downloader
+      # (``from detector import ensure_megadetector_weights``) on purpose: this
+      # is a ``pull_request`` workflow, so the checkout is PR-authored code.
+      # Running that code with HF_TOKEN in the environment would expose the
+      # secret to any same-repo PR that edits detector.py (or its imports).
+      # curl keeps the token out of PR-controlled Python; it only authenticates
+      # the initial huggingface.co request (the redirect target is a presigned
+      # CDN URL), and ``-f`` makes a 429 fail the attempt so the loop retries
+      # instead of saving an error page as the model. Tests never download —
+      # they mock the downloader / detect_animals or skip when the file is
+      # absent — so the weights just need to land where detector.py expects.
       - name: Pre-download MegaDetector weights
         if: needs.changes.outputs.python == 'true' && steps.cache-mdv6.outputs.cache-hit != 'true'
         shell: bash
-        # Authenticate the Hugging Face download. Unauthenticated requests share
-        # a low anonymous rate limit, so a cold cache (notably Windows, whose
-        # cache never warms while these runs keep failing) gets throttled with
-        # 429s and the step fails. A read-only token raises the limit enough for
-        # the single sequential pre-download to succeed and warm the cache.
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
-          cd vireo
+          dest="$HOME/.vireo/models/megadetector-v6"
+          url="https://huggingface.co/jss367/vireo-onnx-models/resolve/main/megadetector-v6/model.onnx"
+          mkdir -p "$dest"
           # Track success explicitly: a bash ``for`` loop exits with the
           # status of its last command, and ``sleep`` always succeeds —
           # without this flag, five consecutive download failures would
@@ -144,7 +152,8 @@ jobs:
           # pre-download is meant to prevent.
           success=0
           for i in 1 2 3 4 5; do
-            if python -c "import sys; sys.path.insert(0, '.'); from detector import ensure_megadetector_weights; ensure_megadetector_weights()"; then
+            if curl -fL -H "Authorization: Bearer $HF_TOKEN" "$url" -o "$dest/model.onnx.part"; then
+              mv "$dest/model.onnx.part" "$dest/model.onnx"
               success=1
               break
             fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,11 +97,11 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install dependencies
+      - name: Install test dependencies
         if: needs.changes.outputs.python == 'true'
         run: |
-          pip install pytest pytest-cov pytest-timeout pytest-xdist
-          pip install -e .
+          cd "$RUNNER_TEMP"
+          pip install pytest pytest-cov pytest-timeout pytest-xdist "huggingface_hub>=1.4.1"
 
       # Cache MegaDetector V6 weights across runs so the Windows/macOS legs
       # don't restart a cold ~300 MB download for every PR. Without this,
@@ -124,17 +124,17 @@ jobs:
       # starting their own download simultaneously. Retry a few times with
       # backoff so a single transient throttle doesn't poison the whole run.
       #
-      # We download with the ``huggingface_hub`` library — a third-party
-      # installed dependency, NOT code from the PR checkout. The inline script
-      # imports only huggingface_hub + stdlib and hard-codes the repo/filename,
-      # so no PR-authored module (detector.py, models.py, …) ever runs with the
-      # token in scope (addresses the secret-exposure concern of importing the
-      # app's downloader). huggingface_hub also sends HF_TOKEN only to
-      # huggingface.co and follows the presigned CDN redirect *without* it, so
-      # the secret is never forwarded across the cross-host redirect the way a
-      # hand-rolled ``curl -L -H Authorization`` can. Tests never download —
+      # We download with the ``huggingface_hub`` library before installing the
+      # PR package, so PR-controlled editable installs/dependency hooks cannot
+      # affect this token-bearing interpreter. The inline script imports only
+      # huggingface_hub + stdlib and hard-codes the repo/filename, so no
+      # PR-authored module (detector.py, models.py, ...) ever runs with the
+      # token in scope. huggingface_hub also sends HF_TOKEN only to
+      # huggingface.co and follows the presigned CDN redirect without it, so the
+      # secret is never forwarded across the cross-host redirect the way a
+      # hand-rolled ``curl -L -H Authorization`` can. Tests never download -
       # they mock the downloader / detect_animals or skip when the file is
-      # absent — so the weights just need to land where detector.py expects.
+      # absent - so the weights just need to land where detector.py expects.
       - name: Pre-download MegaDetector weights
         if: needs.changes.outputs.python == 'true' && steps.cache-mdv6.outputs.cache-hit != 'true'
         shell: bash
@@ -169,6 +169,10 @@ jobs:
             echo "Pre-download failed after 5 attempts; failing the step to avoid cascading xdist worker failures."
             exit 1
           fi
+
+      - name: Install package
+        if: needs.changes.outputs.python == 'true'
+        run: pip install -e .
 
       # Linux is the canonical full run and enforces the coverage threshold.
       - name: Run tests with coverage (Linux)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,6 +127,13 @@ jobs:
       - name: Pre-download MegaDetector weights
         if: needs.changes.outputs.python == 'true' && steps.cache-mdv6.outputs.cache-hit != 'true'
         shell: bash
+        # Authenticate the Hugging Face download. Unauthenticated requests share
+        # a low anonymous rate limit, so a cold cache (notably Windows, whose
+        # cache never warms while these runs keep failing) gets throttled with
+        # 429s and the step fails. A read-only token raises the limit enough for
+        # the single sequential pre-download to succeed and warm the cache.
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           cd vireo
           # Track success explicitly: a bash ``for`` loop exits with the

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,7 +140,16 @@ jobs:
         shell: bash
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # Keep the PR-controlled checkout off sys.path so the ``import
+          # huggingface_hub`` below resolves to the installed package and can't
+          # be shadowed by a PR-added huggingface_hub.py — ``python -c``
+          # otherwise prepends the working directory as sys.path[0].
+          PYTHONSAFEPATH: "1"
         run: |
+          # Belt-and-suspenders with PYTHONSAFEPATH: run from outside the
+          # checkout too, so even the cwd that ``python -c`` uses for
+          # sys.path[0] holds no PR-authored files.
+          cd "$RUNNER_TEMP"
           # Track success explicitly: a bash ``for`` loop exits with the
           # status of its last command, and ``sleep`` always succeeds —
           # without this flag, five consecutive download failures would

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,15 +124,15 @@ jobs:
       # starting their own download simultaneously. Retry a few times with
       # backoff so a single transient throttle doesn't poison the whole run.
       #
-      # We fetch with curl rather than importing the app's downloader
-      # (``from detector import ensure_megadetector_weights``) on purpose: this
-      # is a ``pull_request`` workflow, so the checkout is PR-authored code.
-      # Running that code with HF_TOKEN in the environment would expose the
-      # secret to any same-repo PR that edits detector.py (or its imports).
-      # curl keeps the token out of PR-controlled Python; it only authenticates
-      # the initial huggingface.co request (the redirect target is a presigned
-      # CDN URL), and ``-f`` makes a 429 fail the attempt so the loop retries
-      # instead of saving an error page as the model. Tests never download —
+      # We download with the ``huggingface_hub`` library — a third-party
+      # installed dependency, NOT code from the PR checkout. The inline script
+      # imports only huggingface_hub + stdlib and hard-codes the repo/filename,
+      # so no PR-authored module (detector.py, models.py, …) ever runs with the
+      # token in scope (addresses the secret-exposure concern of importing the
+      # app's downloader). huggingface_hub also sends HF_TOKEN only to
+      # huggingface.co and follows the presigned CDN redirect *without* it, so
+      # the secret is never forwarded across the cross-host redirect the way a
+      # hand-rolled ``curl -L -H Authorization`` can. Tests never download —
       # they mock the downloader / detect_animals or skip when the file is
       # absent — so the weights just need to land where detector.py expects.
       - name: Pre-download MegaDetector weights
@@ -141,9 +141,6 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
-          dest="$HOME/.vireo/models/megadetector-v6"
-          url="https://huggingface.co/jss367/vireo-onnx-models/resolve/main/megadetector-v6/model.onnx"
-          mkdir -p "$dest"
           # Track success explicitly: a bash ``for`` loop exits with the
           # status of its last command, and ``sleep`` always succeeds —
           # without this flag, five consecutive download failures would
@@ -152,8 +149,7 @@ jobs:
           # pre-download is meant to prevent.
           success=0
           for i in 1 2 3 4 5; do
-            if curl -fL -H "Authorization: Bearer $HF_TOKEN" "$url" -o "$dest/model.onnx.part"; then
-              mv "$dest/model.onnx.part" "$dest/model.onnx"
+            if python -c "import os, shutil; from huggingface_hub import hf_hub_download; d = os.path.expanduser('~/.vireo/models/megadetector-v6'); os.makedirs(d, exist_ok=True); shutil.copy2(hf_hub_download(repo_id='jss367/vireo-onnx-models', filename='model.onnx', subfolder='megadetector-v6'), os.path.join(d, 'model.onnx'))"; then
               success=1
               break
             fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,6 +99,10 @@ jobs:
 
       - name: Install test dependencies
         if: needs.changes.outputs.python == 'true'
+        # ``run`` defaults to PowerShell on Windows, where ``$RUNNER_TEMP``
+        # doesn't expand (it would need ``$env:RUNNER_TEMP``). Pin bash so the
+        # same ``cd "$RUNNER_TEMP"`` works across all three OS legs.
+        shell: bash
         run: |
           cd "$RUNNER_TEMP"
           pip install pytest pytest-cov pytest-timeout pytest-xdist "huggingface_hub>=1.4.1"


### PR DESCRIPTION
## Why

The `test-os (windows-latest)` leg has been failing on PRs (e.g. #994) at the **"Pre-download MegaDetector weights"** step with **HTTP 429 Too Many Requests** from Hugging Face.

Root cause is a self-perpetuating cycle:
1. The weights cache key is per-OS (`megadetector-v6-${{ runner.os }}-v1`), and a cache only **saves on a successful run**.
2. Windows runs keep failing, so the Windows cache **never warms** → every run re-downloads the ~300 MB model.
3. Those downloads were **unauthenticated**, so they hit HF's low anonymous rate limit → **429** → step fails → cache still cold. Repeat.

Linux/macOS warmed their caches on an earlier success and now hit the cache, which is why only Windows was affected.

## What

Pass the `HF_TOKEN` repo secret to the pre-download step via `env:`. `huggingface_hub.hf_hub_download` picks up `HF_TOKEN` automatically; authenticated requests get a much higher rate limit, so the single sequential pre-download succeeds, the cache finally warms, and later runs hit the cache instead of HF.

Only the pre-download step needs the token — **every test mocks or skips the real download**:
- `ensure_megadetector_weights` tests monkeypatch `hf_hub_download`.
- `classify_job`/`pipeline_job` tests patch `detect_animals` / `ensure_megadetector_weights`.
- The two real-model smoke tests (`test_megadetector_onnx_session_loads`, `test_megadetector_onnx_model_file_valid`) `pytest.skip` when the model is absent.

## Setup note

Requires a repository secret named `HF_TOKEN` (read-only scope is sufficient — it only pulls a public model). Already added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the test workflow to improve MegaDetector V6 model pre-download reliability, including authenticated downloads when the cache is missing and a clearer, staged install flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->