### PR TITLE
website: update download links for v0.9.1

### DIFF
--- a/website/src/pages/download.astro
+++ b/website/src/pages/download.astro
@@ -6,9 +6,9 @@ const base = import.meta.env.BASE_URL;
 const releaseUrl = (v: string) => `https://github.com/jss367/vireo/releases/download/v${v}`;
 
 // Per-platform versions — updated independently by CI when each platform builds
-const macosArm64Version = '0.9.0';
-const windowsVersion = '0.9.0';
-const linuxVersion = '0.9.0';
+const macosArm64Version = '0.9.1';
+const windowsVersion = '0.9.1';
+const linuxVersion = '0.9.1';
 ---
 
 <Base title="Download — Vireo" description="Download Vireo for macOS, Windows, or Linux. Free, open source, no account required.">


### PR DESCRIPTION
Automated update of download links following the v0.9.1 release. Auto-merges once required checks pass; deploy-website.yml runs on the resulting push to main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Update**
  * Version 0.9.1 is now available for download on macOS (Apple Silicon), Windows, and Linux platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->