### PR TITLE
Add export format controls

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -12384,6 +12384,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         naming_template = body.get("naming_template", "{original}")
         max_size = body.get("max_size")
         quality = body.get("quality", 92)
+        output_format = body.get("format", body.get("output_format", "jpg"))
 
         if not raw_ids:
             return json_error("photo_ids required")
@@ -12395,6 +12396,24 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("destination required")
         if not os.path.isabs(destination):
             return json_error("destination must be an absolute path")
+        if max_size in ("", 0):
+            max_size = None
+        if max_size is not None:
+            if isinstance(max_size, bool):
+                return json_error("max_size must be a positive integer")
+            try:
+                max_size = int(max_size)
+            except (TypeError, ValueError):
+                return json_error("max_size must be a positive integer")
+            if max_size < 1 or max_size > 50000:
+                return json_error("max_size must be between 1 and 50000")
+        try:
+            from export import normalize_output_format, normalize_quality
+            output_format_info = normalize_output_format(output_format)
+            output_format = output_format_info["extension"]
+            quality = normalize_quality(quality)
+        except ValueError as exc:
+            return json_error(str(exc))
 
         db = _get_db()
         runner = app._job_runner
@@ -12455,6 +12474,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     "naming_template": naming_template,
                     "max_size": max_size,
                     "quality": quality,
+                    "format": output_format,
                     "working_copy_max_size": wc_max_size,
                     "developed_dir": developed_dir,
                 },
@@ -12467,6 +12487,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "photo_ids": photo_ids,
                 "destination": destination,
                 "naming_template": naming_template,
+                "format": output_format,
             },
             workspace_id=active_ws,
         )

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -190,6 +190,7 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
             folder_path,
             developed_dir,
             developed_index,
+            preferred_exts=_developed_ext_preference(output_ext),
         )
         # Guard against silent downscaling: darktable's develop job can
         # write the output at --width=N, so a developed file may be
@@ -312,6 +313,14 @@ def _save_export_image(img, out_path, format_info, quality):
 
 
 _PREFERRED_DEVELOPED_EXTS = ("jpg", "jpeg", "tiff", "tif")
+_TIFF_FIRST_DEVELOPED_EXTS = ("tiff", "tif", "jpg", "jpeg")
+
+
+def _developed_ext_preference(output_ext):
+    """Return source developed-output preference for the requested export type."""
+    if output_ext == "tiff":
+        return _TIFF_FIRST_DEVELOPED_EXTS
+    return _PREFERRED_DEVELOPED_EXTS
 
 
 def _get_photo_exif_data(db, photo_ids):
@@ -540,7 +549,7 @@ class _DevelopedDirIndex:
     def __init__(self):
         self._cache = {}
 
-    def lookup(self, base, stem):
+    def lookup(self, base, stem, preferred_exts=None):
         entries = self._cache.get(base)
         if entries is None:
             entries = {}
@@ -574,14 +583,16 @@ class _DevelopedDirIndex:
                 if raw_ext == ext_key and existing_ext != ext_key:
                     entries[key] = os.path.join(base, name)
             self._cache[base] = entries
-        for ext in _PREFERRED_DEVELOPED_EXTS:
+        for ext in preferred_exts or _PREFERRED_DEVELOPED_EXTS:
             path = entries.get((stem, ext))
             if path and os.path.isfile(path):
                 return path
         return None
 
 
-def _find_developed_output(filename, folder_path, developed_dir, index=None):
+def _find_developed_output(
+    filename, folder_path, developed_dir, index=None, preferred_exts=None,
+):
     """Return the path to a darktable-developed output for this photo, or None.
 
     Lookup locations are probed in order:
@@ -611,7 +622,8 @@ def _find_developed_output(filename, folder_path, developed_dir, index=None):
     the same folder on a case-sensitive filesystem) resolve to distinct
     developed files.
 
-    JPG is preferred over TIFF when both exist.
+    JPG is preferred over TIFF when both exist unless the caller passes a
+    TIFF-first preference for TIFF exports.
 
     Pass `index` (a _DevelopedDirIndex) to amortize directory scans
     across many photos in the same export.
@@ -627,7 +639,7 @@ def _find_developed_output(filename, folder_path, developed_dir, index=None):
     if index is None:
         index = _DevelopedDirIndex()
     for base in candidates:
-        hit = index.lookup(base, stem)
+        hit = index.lookup(base, stem, preferred_exts=preferred_exts)
         if hit:
             return hit
     return None

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -318,7 +318,7 @@ _TIFF_FIRST_DEVELOPED_EXTS = ("tiff", "tif", "jpg", "jpeg")
 
 def _developed_ext_preference(output_ext):
     """Return source developed-output preference for the requested export type."""
-    if output_ext == "tiff":
+    if output_ext != "jpg":
         return _TIFF_FIRST_DEVELOPED_EXTS
     return _PREFERRED_DEVELOPED_EXTS
 

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -185,22 +185,24 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
         folder_path = folders.get(photo["folder_id"], "")
         recipe = edit_recipes.get(pid)
         exif_data = exif_data_map.get(pid)
-        source_path = _find_developed_output(
+        source_path = None
+        for dev_candidate in _iter_developed_outputs(
             photo["filename"],
             folder_path,
             developed_dir,
             developed_index,
             preferred_exts=_developed_ext_preference(output_ext),
-        )
-        # Guard against silent downscaling: darktable's develop job can
-        # write the output at --width=N, so a developed file may be
-        # smaller than the original. If it can't satisfy the requested
-        # export size, fall through to the working-copy / original
-        # source.
-        if source_path and not _developed_can_satisfy_size(
-            source_path, photo, max_size, recipe, exif_data=exif_data
         ):
-            source_path = None
+            # Guard against silent downscaling: darktable's develop job
+            # can write the output at --width=N, so a developed file may
+            # be smaller than the original. Keep trying lower-preference
+            # developed candidates before falling through to the working
+            # copy / original source.
+            if _developed_can_satisfy_size(
+                dev_candidate, photo, max_size, recipe, exif_data=exif_data
+            ):
+                source_path = dev_candidate
+                break
         if not source_path:
             use_wc = _working_copy_can_satisfy_export(
                 photo, recipe, max_size, wc_max, vireo_dir, exif_data=exif_data
@@ -549,7 +551,7 @@ class _DevelopedDirIndex:
     def __init__(self):
         self._cache = {}
 
-    def lookup(self, base, stem, preferred_exts=None):
+    def _entries_for_base(self, base):
         entries = self._cache.get(base)
         if entries is None:
             entries = {}
@@ -583,17 +585,25 @@ class _DevelopedDirIndex:
                 if raw_ext == ext_key and existing_ext != ext_key:
                     entries[key] = os.path.join(base, name)
             self._cache[base] = entries
+        return entries
+
+    def iter_matches(self, base, stem, preferred_exts=None):
+        entries = self._entries_for_base(base)
         for ext in preferred_exts or _PREFERRED_DEVELOPED_EXTS:
             path = entries.get((stem, ext))
             if path and os.path.isfile(path):
-                return path
+                yield path
+
+    def lookup(self, base, stem, preferred_exts=None):
+        for path in self.iter_matches(base, stem, preferred_exts=preferred_exts):
+            return path
         return None
 
 
-def _find_developed_output(
+def _iter_developed_outputs(
     filename, folder_path, developed_dir, index=None, preferred_exts=None,
 ):
-    """Return the path to a darktable-developed output for this photo, or None.
+    """Yield darktable-developed outputs for this photo in preference order.
 
     Lookup locations are probed in order:
 
@@ -639,9 +649,17 @@ def _find_developed_output(
     if index is None:
         index = _DevelopedDirIndex()
     for base in candidates:
-        hit = index.lookup(base, stem, preferred_exts=preferred_exts)
-        if hit:
-            return hit
+        yield from index.iter_matches(base, stem, preferred_exts=preferred_exts)
+
+
+def _find_developed_output(
+    filename, folder_path, developed_dir, index=None, preferred_exts=None,
+):
+    """Return the first darktable-developed output for this photo, or None."""
+    for path in _iter_developed_outputs(
+        filename, folder_path, developed_dir, index, preferred_exts=preferred_exts,
+    ):
+        return path
     return None
 
 

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -16,11 +16,42 @@ log = logging.getLogger(__name__)
 # Characters not allowed in filenames (covers Windows + macOS + Linux)
 _UNSAFE_RE = re.compile(r'[<>:"/|?*\\]')
 _EXIF_ORIENTATION_TAG = 274
+_OUTPUT_FORMATS = {
+    "jpg": {"extension": "jpg", "pil_format": "JPEG", "quality": True},
+    "jpeg": {"extension": "jpg", "pil_format": "JPEG", "quality": True},
+    "png": {"extension": "png", "pil_format": "PNG", "quality": False},
+    "tif": {"extension": "tiff", "pil_format": "TIFF", "quality": False},
+    "tiff": {"extension": "tiff", "pil_format": "TIFF", "quality": False},
+}
 
 
 def sanitize_filename(name):
     """Replace filesystem-unsafe characters with underscores."""
     return _UNSAFE_RE.sub("_", name)
+
+
+def normalize_output_format(output_format):
+    """Return export format metadata for a user/API format value."""
+    fmt = str(output_format or "jpg").strip().lower()
+    if fmt not in _OUTPUT_FORMATS:
+        supported = ", ".join(sorted({"jpg", "png", "tiff"}))
+        raise ValueError(f"format must be one of: {supported}")
+    return _OUTPUT_FORMATS[fmt]
+
+
+def normalize_quality(quality, default=92):
+    """Return an integer JPEG quality in Pillow's accepted 1-100 range."""
+    if quality in (None, ""):
+        quality = default
+    if isinstance(quality, bool):
+        raise ValueError("quality must be an integer from 1 to 100")
+    try:
+        value = int(quality)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("quality must be an integer from 1 to 100") from exc
+    if value < 1 or value > 100:
+        raise ValueError("quality must be an integer from 1 to 100")
+    return value
 
 
 def resolve_template(template, photo, species=None, seq=1):
@@ -75,6 +106,7 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
         options: dict with keys:
             naming_template: str (default "{original}")
             max_size: int or None -- max long-edge pixels
+            format: str -- output format: jpg, png, or tiff (default jpg)
             quality: int 1-100 (default 92)
             working_copy_max_size: int -- the cap used when generating
                 working copies (default 4096); used to decide whether
@@ -103,7 +135,11 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
     max_size = options.get("max_size")
     if max_size is not None:
         max_size = int(max_size)
-    quality = options.get("quality", 92)
+    format_info = normalize_output_format(
+        options.get("format", options.get("output_format", "jpg"))
+    )
+    output_ext = format_info["extension"]
+    quality = normalize_quality(options.get("quality", 92))
     try:
         wc_max = int(options.get("working_copy_max_size", 4096))
     except (ValueError, TypeError):
@@ -210,7 +246,7 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
         # Guard against path traversal: strip leading slashes/dots so that
         # absolute paths and ".." segments cannot escape the destination dir.
         rel_path_safe = os.path.normpath(rel_path).lstrip(os.sep + ".")
-        out_path = os.path.join(destination, rel_path_safe + ".jpg")
+        out_path = os.path.join(destination, rel_path_safe + f".{output_ext}")
         # Final containment check: resolved path must start with destination.
         # dest_real may already end with os.sep when destination is a root dir
         # (e.g. "/" on POSIX), so avoid doubling the separator.
@@ -244,7 +280,7 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
                 continue
             if recipe:
                 img = apply_recipe_to_loaded_image(img, recipe, max_size=max_size)
-            img.save(out_path, "JPEG", quality=quality)
+            _save_export_image(img, out_path, format_info, quality)
             img.close()
             exported += 1
         except Exception as exc:
@@ -255,6 +291,24 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
             progress_cb(i + 1, len(photo_ids), photo["filename"])
 
     return {"exported": exported, "errors": errors, "destination": destination}
+
+
+def _save_export_image(img, out_path, format_info, quality):
+    """Save a rendered export image in the requested output format."""
+    pil_format = format_info["pil_format"]
+    save_img = img
+    if pil_format == "JPEG" and img.mode not in ("RGB", "L"):
+        save_img = img.convert("RGB")
+    save_kwargs = {}
+    if format_info["quality"]:
+        save_kwargs["quality"] = quality
+    elif pil_format == "TIFF":
+        save_kwargs["compression"] = "tiff_lzw"
+    try:
+        save_img.save(out_path, pil_format, **save_kwargs)
+    finally:
+        if save_img is not img:
+            save_img.close()
 
 
 _PREFERRED_DEVELOPED_EXTS = ("jpg", "jpeg", "tiff", "tif")

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1431,11 +1431,28 @@ body {
 
     <!-- Export Modal -->
     <div id="exportOverlay" class="modal-overlay">
-      <div class="modal" style="width:500px;">
+      <div class="modal" style="width:540px;">
         <h3>Export Photos</h3>
 
         <label style="font-size:12px;color:var(--text-secondary);display:block;margin-bottom:4px;">Destination folder</label>
         <input id="exportDest" class="modal-input" type="text" placeholder="/path/to/export/folder">
+
+        <label style="font-size:12px;color:var(--text-secondary);display:block;margin-bottom:4px;">Preset</label>
+        <select id="exportPreset" class="modal-input" style="cursor:pointer;">
+          <option value="original-jpg">Full-size JPEG</option>
+          <option value="web-jpg">Web JPEG, 2048 px</option>
+          <option value="small-jpg">Small JPEG, 1080 px</option>
+          <option value="archive-tiff">Full-size TIFF</option>
+          <option value="png">Full-size PNG</option>
+          <option value="custom">Custom</option>
+        </select>
+
+        <label style="font-size:12px;color:var(--text-secondary);display:block;margin-bottom:4px;">Format</label>
+        <select id="exportFormat" class="modal-input" style="cursor:pointer;">
+          <option value="jpg">JPEG</option>
+          <option value="png">PNG</option>
+          <option value="tiff">TIFF</option>
+        </select>
 
         <label style="font-size:12px;color:var(--text-secondary);display:block;margin-bottom:4px;">Resize (max long edge)</label>
         <select id="exportResize" class="modal-input" style="cursor:pointer;">
@@ -1448,8 +1465,8 @@ body {
         </select>
         <input id="exportResizeCustom" class="modal-input" type="number" placeholder="Max pixels (long edge)" min="100" max="20000" style="display:none;">
 
-        <label style="font-size:12px;color:var(--text-secondary);display:block;margin-bottom:4px;">Quality</label>
-        <div style="display:flex;align-items:center;gap:10px;margin-bottom:12px;">
+        <label id="exportQualityLabel" style="font-size:12px;color:var(--text-secondary);display:block;margin-bottom:4px;">Quality</label>
+        <div id="exportQualityRow" style="display:flex;align-items:center;gap:10px;margin-bottom:12px;">
           <input id="exportQuality" type="range" min="1" max="100" value="92" style="flex:1;">
           <span id="exportQualityVal" style="font-size:13px;color:var(--text-secondary);min-width:32px;">92</span>
         </div>
@@ -6614,11 +6631,8 @@ function openExportModal() {
   if (activeIds.length === 0) return;
   document.getElementById('exportSubmitBtn').textContent = 'Export ' + activeIds.length + ' photo' + (activeIds.length === 1 ? '' : 's');
   document.getElementById('exportSubmitBtn').disabled = false;
-  document.getElementById('exportResize').value = '';
-  document.getElementById('exportResizeCustom').style.display = 'none';
-  document.getElementById('exportResizeCustom').value = '';
-  document.getElementById('exportQuality').value = 92;
-  document.getElementById('exportQualityVal').textContent = '92';
+  document.getElementById('exportPreset').value = 'original-jpg';
+  applyExportPreset('original-jpg');
   document.getElementById('exportTemplate').value = '{original}';
   document.getElementById('exportOverlay').classList.add('open');
   updateExportPreview();
@@ -6637,6 +6651,50 @@ function insertTemplateVar(v) {
   input.selectionStart = input.selectionEnd = start + v.length;
   input.focus();
   updateExportPreview();
+}
+
+function exportExtensionForFormat(format) {
+  if (format === 'png') return 'png';
+  if (format === 'tiff') return 'tiff';
+  return 'jpg';
+}
+
+function updateExportFormatControls() {
+  var isJpeg = document.getElementById('exportFormat').value === 'jpg';
+  document.getElementById('exportQualityLabel').style.display = isJpeg ? 'block' : 'none';
+  document.getElementById('exportQualityRow').style.display = isJpeg ? 'flex' : 'none';
+}
+
+function applyExportPreset(preset) {
+  var resize = '';
+  var customResize = '';
+  var format = 'jpg';
+  var quality = 92;
+  if (preset === 'web-jpg') {
+    resize = '2048';
+    quality = 85;
+  } else if (preset === 'small-jpg') {
+    resize = '1080';
+    quality = 82;
+  } else if (preset === 'archive-tiff') {
+    format = 'tiff';
+  } else if (preset === 'png') {
+    format = 'png';
+  } else if (preset === 'custom') {
+    return;
+  }
+  document.getElementById('exportFormat').value = format;
+  document.getElementById('exportResize').value = resize;
+  document.getElementById('exportResizeCustom').value = customResize;
+  document.getElementById('exportResizeCustom').style.display = resize === 'custom' ? 'block' : 'none';
+  document.getElementById('exportQuality').value = quality;
+  document.getElementById('exportQualityVal').textContent = String(quality);
+  updateExportFormatControls();
+  updateExportPreview();
+}
+
+function markExportCustom() {
+  document.getElementById('exportPreset').value = 'custom';
 }
 
 function updateExportPreview() {
@@ -6659,17 +6717,31 @@ function updateExportPreview() {
     .replace('{rating}', String(photo.rating || 0))
     .replace('{seq}', '0001')
     .replace('{folder}', '');
-  document.getElementById('exportPreview').textContent = 'Preview: ' + preview + '.jpg';
+  var ext = exportExtensionForFormat(document.getElementById('exportFormat').value);
+  document.getElementById('exportPreview').textContent = 'Preview: ' + preview + '.' + ext;
 }
 
 document.getElementById('exportTemplate').addEventListener('input', updateExportPreview);
 
+document.getElementById('exportPreset').addEventListener('change', function() {
+  applyExportPreset(this.value);
+});
+
+document.getElementById('exportFormat').addEventListener('change', function() {
+  markExportCustom();
+  updateExportFormatControls();
+  updateExportPreview();
+});
+
 document.getElementById('exportResize').addEventListener('change', function() {
+  markExportCustom();
   document.getElementById('exportResizeCustom').style.display =
     this.value === 'custom' ? 'block' : 'none';
+  updateExportPreview();
 });
 
 document.getElementById('exportQuality').addEventListener('input', function() {
+  markExportCustom();
   document.getElementById('exportQualityVal').textContent = this.value;
 });
 
@@ -6686,6 +6758,7 @@ async function startExport() {
   }
 
   var quality = parseInt(document.getElementById('exportQuality').value) || 92;
+  var format = document.getElementById('exportFormat').value || 'jpg';
   var template = document.getElementById('exportTemplate').value || '{original}';
   var btn = document.getElementById('exportSubmitBtn');
   var activeIds = getActiveSelection();
@@ -6702,6 +6775,7 @@ async function startExport() {
         naming_template: template,
         max_size: maxSize,
         quality: quality,
+        format: format,
       }),
     });
     if (data.error) { alert('Export error: ' + data.error); btn.disabled = false; return; }

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -887,6 +887,36 @@ def test_export_png_prefers_developed_tiff_over_developed_jpg(export_env):
     )
 
 
+def test_export_tries_next_developed_candidate_when_preferred_is_too_small(export_env):
+    """A too-small preferred developed file should not hide a usable fallback."""
+    env = export_env
+    developed_dir = env["src"] / "developed"
+    developed_dir.mkdir()
+    Image.new("RGB", (800, 600), color=(10, 200, 40)).save(
+        str(developed_dir / "bird1.jpg"), "JPEG", quality=95,
+    )
+    Image.new("RGB", (200, 150), color=(20, 30, 220)).save(
+        str(developed_dir / "bird1.tiff"), "TIFF",
+    )
+
+    result = export_photos(
+        db=env["db"],
+        vireo_dir=env["vireo_dir"],
+        photo_ids=[env["p1"]],
+        destination=env["dest"],
+        options={"naming_template": "{original}", "format": "png", "max_size": 400},
+    )
+
+    assert result["exported"] == 1
+    out_path = os.path.join(env["dest"], "bird1.png")
+    with Image.open(out_path) as img:
+        assert max(img.size) == 400
+    r, g, b = _avg_rgb(out_path)
+    assert g > r and g > b, (
+        f"expected green-dominant from sufficient developed JPG, got rgb=({r},{g},{b})"
+    )
+
+
 def test_export_falls_back_to_original_when_no_developed(export_env):
     """No developed output → export uses the original file (existing behavior)."""
     env = export_env

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -528,6 +528,72 @@ def test_export_photos_collision_renames(export_env):
     assert os.path.isfile(os.path.join(env["dest"], "photo_2.jpg"))
 
 
+def test_export_photos_convert_png_batch_deduplicates_extension(export_env):
+    """Batch conversion uses the selected extension for every output/collision."""
+    env = export_env
+    result = export_photos(
+        db=env["db"],
+        vireo_dir=env["vireo_dir"],
+        photo_ids=[env["p1"], env["p2"]],
+        destination=env["dest"],
+        options={"naming_template": "converted", "format": "png"},
+    )
+
+    assert result["exported"] == 2
+    first = os.path.join(env["dest"], "converted.png")
+    second = os.path.join(env["dest"], "converted_2.png")
+    assert os.path.isfile(first)
+    assert os.path.isfile(second)
+    assert not os.path.exists(os.path.join(env["dest"], "converted.jpg"))
+    with Image.open(first) as img:
+        assert img.format == "PNG"
+    with Image.open(second) as img:
+        assert img.format == "PNG"
+
+
+def test_export_photos_convert_tiff_applies_recipe_and_resize(export_env):
+    """Converted exports still apply edit recipes before final resizing."""
+    env = export_env
+    env["db"].set_photo_edit_recipe(
+        env["p1"],
+        {
+            "rotation": 90,
+            "crop": {"x": 0, "y": 0, "w": 0.5, "h": 1},
+        },
+    )
+
+    result = export_photos(
+        db=env["db"],
+        vireo_dir=env["vireo_dir"],
+        photo_ids=[env["p1"]],
+        destination=env["dest"],
+        options={
+            "naming_template": "{original}",
+            "format": "tiff",
+            "max_size": 400,
+        },
+    )
+
+    assert result["exported"] == 1
+    out_path = os.path.join(env["dest"], "bird1.tiff")
+    with Image.open(out_path) as img:
+        assert img.format == "TIFF"
+        assert img.size == (150, 400)
+
+
+def test_export_rejects_unknown_output_format(export_env):
+    """Unknown export formats fail before writing partial outputs."""
+    env = export_env
+    with pytest.raises(ValueError, match="format must be one of"):
+        export_photos(
+            db=env["db"],
+            vireo_dir=env["vireo_dir"],
+            photo_ids=[env["p1"]],
+            destination=env["dest"],
+            options={"naming_template": "{original}", "format": "bmp"},
+        )
+
+
 def test_export_photos_quality(export_env):
     """export_photos respects quality setting."""
     env = export_env

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -860,6 +860,33 @@ def test_export_tiff_prefers_developed_tiff_over_developed_jpg(export_env):
     )
 
 
+def test_export_png_prefers_developed_tiff_over_developed_jpg(export_env):
+    """PNG exports use the best developed source instead of stale JPEG."""
+    env = export_env
+    developed_dir = env["src"] / "developed"
+    developed_dir.mkdir()
+    Image.new("RGB", (800, 600), color=(10, 200, 40)).save(
+        str(developed_dir / "bird1.jpg"), "JPEG", quality=95,
+    )
+    Image.new("RGB", (800, 600), color=(20, 30, 220)).save(
+        str(developed_dir / "bird1.tiff"), "TIFF",
+    )
+
+    result = export_photos(
+        db=env["db"],
+        vireo_dir=env["vireo_dir"],
+        photo_ids=[env["p1"]],
+        destination=env["dest"],
+        options={"naming_template": "{original}", "format": "png"},
+    )
+
+    assert result["exported"] == 1
+    r, g, b = _avg_rgb(os.path.join(env["dest"], "bird1.png"))
+    assert b > r and b > g, (
+        f"expected blue-dominant from developed TIFF, got rgb=({r},{g},{b})"
+    )
+
+
 def test_export_falls_back_to_original_when_no_developed(export_env):
     """No developed output → export uses the original file (existing behavior)."""
     env = export_env

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -833,6 +833,33 @@ def test_export_prefers_developed_tiff_when_jpg_absent(export_env):
     assert b > r and b > g, f"expected blue-dominant from developed TIFF, got rgb=({r},{g},{b})"
 
 
+def test_export_tiff_prefers_developed_tiff_over_developed_jpg(export_env):
+    """TIFF exports use the TIFF developed source when both formats exist."""
+    env = export_env
+    developed_dir = env["src"] / "developed"
+    developed_dir.mkdir()
+    Image.new("RGB", (800, 600), color=(10, 200, 40)).save(
+        str(developed_dir / "bird1.jpg"), "JPEG", quality=95,
+    )
+    Image.new("RGB", (800, 600), color=(20, 30, 220)).save(
+        str(developed_dir / "bird1.tiff"), "TIFF",
+    )
+
+    result = export_photos(
+        db=env["db"],
+        vireo_dir=env["vireo_dir"],
+        photo_ids=[env["p1"]],
+        destination=env["dest"],
+        options={"naming_template": "{original}", "format": "tiff"},
+    )
+
+    assert result["exported"] == 1
+    r, g, b = _avg_rgb(os.path.join(env["dest"], "bird1.tiff"))
+    assert b > r and b > g, (
+        f"expected blue-dominant from developed TIFF, got rgb=({r},{g},{b})"
+    )
+
+
 def test_export_falls_back_to_original_when_no_developed(export_env):
     """No developed output → export uses the original file (existing behavior)."""
     env = export_env

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -771,7 +771,7 @@ def test_job_export_relative_destination(app_and_db):
     assert resp.status_code == 400
 
 
-def test_job_export_invalid_format(app_and_db):
+def test_job_export_invalid_format(app_and_db, tmp_path):
     """POST /api/jobs/export rejects unsupported output formats."""
     app, db = app_and_db
     client = app.test_client()
@@ -779,7 +779,7 @@ def test_job_export_invalid_format(app_and_db):
 
     resp = client.post("/api/jobs/export", json={
         "photo_ids": [photo["id"]],
-        "destination": "/tmp/out",
+        "destination": str(tmp_path / "out"),
         "format": "bmp",
     })
 
@@ -787,7 +787,7 @@ def test_job_export_invalid_format(app_and_db):
     assert "format must be one of" in resp.get_json()["error"]
 
 
-def test_job_export_invalid_quality(app_and_db):
+def test_job_export_invalid_quality(app_and_db, tmp_path):
     """POST /api/jobs/export rejects JPEG quality outside Pillow's range."""
     app, db = app_and_db
     client = app.test_client()
@@ -795,7 +795,7 @@ def test_job_export_invalid_quality(app_and_db):
 
     resp = client.post("/api/jobs/export", json={
         "photo_ids": [photo["id"]],
-        "destination": "/tmp/out",
+        "destination": str(tmp_path / "out"),
         "quality": 101,
     })
 
@@ -803,7 +803,7 @@ def test_job_export_invalid_quality(app_and_db):
     assert "quality must be an integer" in resp.get_json()["error"]
 
 
-def test_job_export_invalid_max_size(app_and_db):
+def test_job_export_invalid_max_size(app_and_db, tmp_path):
     """POST /api/jobs/export rejects nonsensical resize settings."""
     app, db = app_and_db
     client = app.test_client()
@@ -811,7 +811,7 @@ def test_job_export_invalid_max_size(app_and_db):
 
     resp = client.post("/api/jobs/export", json={
         "photo_ids": [photo["id"]],
-        "destination": "/tmp/out",
+        "destination": str(tmp_path / "out"),
         "max_size": "large",
     })
 

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -771,6 +771,54 @@ def test_job_export_relative_destination(app_and_db):
     assert resp.status_code == 400
 
 
+def test_job_export_invalid_format(app_and_db):
+    """POST /api/jobs/export rejects unsupported output formats."""
+    app, db = app_and_db
+    client = app.test_client()
+    photo = db.conn.execute("SELECT id FROM photos LIMIT 1").fetchone()
+
+    resp = client.post("/api/jobs/export", json={
+        "photo_ids": [photo["id"]],
+        "destination": "/tmp/out",
+        "format": "bmp",
+    })
+
+    assert resp.status_code == 400
+    assert "format must be one of" in resp.get_json()["error"]
+
+
+def test_job_export_invalid_quality(app_and_db):
+    """POST /api/jobs/export rejects JPEG quality outside Pillow's range."""
+    app, db = app_and_db
+    client = app.test_client()
+    photo = db.conn.execute("SELECT id FROM photos LIMIT 1").fetchone()
+
+    resp = client.post("/api/jobs/export", json={
+        "photo_ids": [photo["id"]],
+        "destination": "/tmp/out",
+        "quality": 101,
+    })
+
+    assert resp.status_code == 400
+    assert "quality must be an integer" in resp.get_json()["error"]
+
+
+def test_job_export_invalid_max_size(app_and_db):
+    """POST /api/jobs/export rejects nonsensical resize settings."""
+    app, db = app_and_db
+    client = app.test_client()
+    photo = db.conn.execute("SELECT id FROM photos LIMIT 1").fetchone()
+
+    resp = client.post("/api/jobs/export", json={
+        "photo_ids": [photo["id"]],
+        "destination": "/tmp/out",
+        "max_size": "large",
+    })
+
+    assert resp.status_code == 400
+    assert "max_size must be a positive integer" in resp.get_json()["error"]
+
+
 def test_pipeline_ingest_saves_recent_destination(app_and_db, tmp_path, monkeypatch):
     """Starting a pipeline with a destination saves it to recent_destinations in config."""
     import config as cfg


### PR DESCRIPTION
Adds JPEG, PNG, and TIFF output support to photo export while preserving resize and stored edit recipe application. The Browse export modal now includes presets, format selection, and JPEG-only quality controls. The export job API validates format, quality, and resize settings before enqueueing work. Validation covered by export, job API, and Browse page smoke tests.