### PR TITLE
Add image adjustment sliders

### DIFF
--- a/vireo/image_edits.py
+++ b/vireo/image_edits.py
@@ -17,6 +17,11 @@ _ADJUSTMENT_RANGES = {
     "saturation": (-100.0, 100.0),
 }
 
+_WHITE_BALANCE_RANGES = {
+    "temperature": (-100.0, 100.0),
+    "tint": (-100.0, 100.0),
+}
+
 
 class RecipeError(ValueError):
     """Raised when an edit recipe is malformed or unsupported."""
@@ -125,6 +130,35 @@ def normalize_recipe(recipe):
             raise RecipeError(f"{name} adjustment must be between {lo:g} and {hi:g}")
         if abs(val) > 1e-9:
             normalized_adjustments[name] = round(val, 6)
+
+    white_balance = adjustments.get("white_balance")
+    if white_balance is None:
+        white_balance = {
+            key: adjustments[key]
+            for key in _WHITE_BALANCE_RANGES
+            if key in adjustments
+        }
+    if white_balance in (None, "", {}):
+        white_balance = {}
+    if not isinstance(white_balance, dict):
+        raise RecipeError("white_balance adjustment must be an object")
+    normalized_wb = {}
+    for name, (lo, hi) in _WHITE_BALANCE_RANGES.items():
+        raw = white_balance.get(name)
+        if raw in (None, ""):
+            continue
+        if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+            raise RecipeError(f"white_balance.{name} adjustment must be numeric")
+        val = float(raw)
+        if not math.isfinite(val) or val < lo or val > hi:
+            raise RecipeError(
+                f"white_balance.{name} adjustment must be between {lo:g} and {hi:g}"
+            )
+        if abs(val) > 1e-9:
+            normalized_wb[name] = round(val, 6)
+    if normalized_wb:
+        normalized_adjustments["white_balance"] = normalized_wb
+
     if normalized_adjustments:
         out["adjustments"] = normalized_adjustments
 
@@ -137,6 +171,42 @@ def recipe_to_json(recipe):
     if normalized is None:
         return None
     return json.dumps(normalized, sort_keys=True, separators=(",", ":"))
+
+
+def _clamp_channel(value):
+    return max(0, min(255, int(round(value))))
+
+
+def _channel_lut(gain):
+    return [_clamp_channel(i * gain) for i in range(256)]
+
+
+def _apply_white_balance(img, white_balance):
+    temperature = float((white_balance or {}).get("temperature") or 0.0) / 100.0
+    tint = float((white_balance or {}).get("tint") or 0.0) / 100.0
+    if abs(temperature) < 1e-9 and abs(tint) < 1e-9:
+        return img
+
+    has_alpha = img.mode == "RGBA"
+    if img.mode not in ("RGB", "RGBA"):
+        img = img.convert("RGB")
+
+    bands = img.split()
+    red_gain = 1.0 + (0.26 * temperature) + (0.06 * tint)
+    green_gain = 1.0 - (0.18 * tint)
+    blue_gain = 1.0 - (0.26 * temperature) + (0.06 * tint)
+    red_gain = max(0.05, red_gain)
+    green_gain = max(0.05, green_gain)
+    blue_gain = max(0.05, blue_gain)
+
+    adjusted = (
+        bands[0].point(_channel_lut(red_gain)),
+        bands[1].point(_channel_lut(green_gain)),
+        bands[2].point(_channel_lut(blue_gain)),
+    )
+    if has_alpha:
+        return Image.merge("RGBA", adjusted + (bands[3],))
+    return Image.merge("RGB", adjusted)
 
 
 def apply_recipe(img, recipe):
@@ -171,6 +241,8 @@ def apply_recipe(img, recipe):
         result = result.crop((left, top, right, bottom))
 
     adjustments = normalized.get("adjustments") or {}
+    if "white_balance" in adjustments:
+        result = _apply_white_balance(result, adjustments["white_balance"])
     if "exposure" in adjustments:
         result = ImageEnhance.Brightness(result).enhance(2 ** adjustments["exposure"])
     if "brightness" in adjustments:

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3231,6 +3231,7 @@ var _lbConfirmedFlags = {};   // last server-confirmed flag per photo, isolated 
 var _lbViewportByPhotoId = {};  // per-session lightbox viewport cache keyed by photo id
 var _lbPendingViewportState = null;
 var _lbEditRecipe = null;
+var _lbEditRecipeLoaded = false;
 var _lbRenderedAdjustmentValues = null;
 var _lbAdjustSaveTimer = null;
 var _lbAdjustSeq = 0;
@@ -3276,6 +3277,19 @@ function _lbSetAdjustmentControl(id, value) {
   if (label && input) {
     label.textContent = _lbFormatAdjustmentValue(input.dataset.adjustment, value);
   }
+}
+
+function _lbSetAdjustmentControlsDisabled(disabled) {
+  [
+    'lbAdjExposure',
+    'lbAdjContrast',
+    'lbAdjTemperature',
+    'lbAdjTint',
+    'lbAdjSaturation',
+  ].forEach(function(id) {
+    var input = document.getElementById(id);
+    if (input) input.disabled = !!disabled;
+  });
 }
 
 function _lbRenderAdjustmentControls() {
@@ -3400,7 +3414,7 @@ function _lbReloadEditedSource(photoId, seq) {
 }
 
 function _lbSaveAdjustmentRecipe(values) {
-  if (!_lightboxCurrentId) return;
+  if (!_lightboxCurrentId || !_lbEditRecipeLoaded) return;
   var photoId = _lightboxCurrentId;
   var seq = ++_lbAdjustSeq;
   var recipe = _lbRecipeWithAdjustments(values);
@@ -3446,6 +3460,11 @@ function _lbFlushPendingAdjustmentSave() {
 }
 
 function onLightboxAdjustmentInput(input) {
+  if (!_lbEditRecipeLoaded) {
+    _lbSetAdjustmentStatus('Loading recipe...');
+    _lbRenderAdjustmentControls();
+    return;
+  }
   var label = document.getElementById(input.id + 'Value');
   if (label) label.textContent = _lbFormatAdjustmentValue(input.dataset.adjustment, input.value);
   _lbAdjustSeq += 1;
@@ -3461,6 +3480,10 @@ function onLightboxAdjustmentInput(input) {
 }
 
 function resetLightboxAdjustments() {
+  if (!_lbEditRecipeLoaded) {
+    _lbSetAdjustmentStatus('Loading recipe...');
+    return;
+  }
   _lbSetAdjustmentControl('lbAdjExposure', 0);
   _lbSetAdjustmentControl('lbAdjContrast', 0);
   _lbSetAdjustmentControl('lbAdjTemperature', 0);
@@ -3483,7 +3506,11 @@ function toggleLightboxAdjustPanel() {
   var open = !panel.classList.contains('open');
   panel.classList.toggle('open', open);
   if (btn) btn.textContent = open ? 'Hide Adjust' : 'Adjust';
-  if (open) _lbRenderAdjustmentControls();
+  if (open) {
+    _lbRenderAdjustmentControls();
+    _lbSetAdjustmentControlsDisabled(!_lbEditRecipeLoaded);
+    _lbSetAdjustmentStatus(_lbEditRecipeLoaded ? '' : 'Loading recipe...');
+  }
 }
 
 function _lbIsOneToOneZoom() {
@@ -4268,6 +4295,7 @@ function openLightbox(photoId, filename, photoList, options) {
   _lbPendingViewportState = restoreViewportState;
   _lbOriginalUnavailable = false;
   _lbEditRecipe = null;
+  _lbEditRecipeLoaded = false;
   _lbRenderedAdjustmentValues = _lbAdjustmentValues(null);
   if (_lbAdjustSaveTimer) {
     clearTimeout(_lbAdjustSaveTimer);
@@ -4276,6 +4304,7 @@ function openLightbox(photoId, filename, photoList, options) {
   _lbAdjustSeq += 1;
   _lbClearAdjustmentPreviewCss();
   _lbRenderAdjustmentControls();
+  _lbSetAdjustmentControlsDisabled(true);
   _lbSetAdjustmentStatus('');
   if (_lbSwapTimer) { clearTimeout(_lbSwapTimer); _lbSwapTimer = null; }
   _lbDesiredSrcKey = null;
@@ -4293,8 +4322,11 @@ function openLightbox(photoId, filename, photoList, options) {
       _lbCurrentWildlifeExcluded = !!data.wildlife_excluded;
       if (editFetchSeq === _lbAdjustSeq) {
         _lbEditRecipe = _lbCloneRecipe(data.edit_recipe || {});
+        _lbEditRecipeLoaded = true;
         _lbRenderedAdjustmentValues = _lbAdjustmentValues(_lbEditRecipe);
         _lbRenderAdjustmentControls();
+        _lbSetAdjustmentControlsDisabled(false);
+        _lbSetAdjustmentStatus('');
       }
       _lbApplyWildlifeExcludedButton();
       _lbRecordFetchedFlag(photoId, data.flag, flagFetchSeq);
@@ -4302,7 +4334,10 @@ function openLightbox(photoId, filename, photoList, options) {
       if (!_lbTryApplyPendingViewportState()) _lbApplyPendingOneToOneZoom();
       _lbRenderEyeCrosshair(data);
     })
-    .catch(function() {});
+    .catch(function() {
+      if (_lightboxCurrentId !== photoId || _lbOpenSeq !== openSeq) return;
+      _lbSetAdjustmentStatus('Could not load recipe', true);
+    });
 
   function handleInitialImageLoad() {
     img.onload = null;

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3402,6 +3402,7 @@ function _lbSaveAdjustmentRecipe(values) {
       });
     })
     .then(function(data) {
+      if (_lightboxCurrentId === photoId && seq !== _lbAdjustSeq) return;
       _lbBumpRecipeBust(photoId);
       _lbRefreshVisiblePhotoImages(photoId);
       try {
@@ -3431,6 +3432,7 @@ function _lbFlushPendingAdjustmentSave() {
 function onLightboxAdjustmentInput(input) {
   var label = document.getElementById(input.id + 'Value');
   if (label) label.textContent = _lbFormatAdjustmentValue(input.dataset.adjustment, input.value);
+  _lbAdjustSeq += 1;
   var values = _lbReadAdjustmentControls();
   _lbEditRecipe = _lbRecipeWithAdjustments(values);
   _lbApplyAdjustmentPreviewCss(values);

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3770,6 +3770,29 @@ function _lbFlushPendingAdjustmentSave() {
   _lbSaveAdjustmentRecipe(_lbReadAdjustmentControls());
 }
 
+function _lbWaitForAdjustmentSaveIdle(photoId) {
+  var key = String(photoId);
+  return new Promise(function(resolve, reject) {
+    var started = Date.now();
+    function check() {
+      if (
+        !_lbAdjustSaveTimer &&
+        !_lbAdjustSaveInFlightByPhoto[key] &&
+        !_lbQueuedAdjustmentSaveByPhoto[key]
+      ) {
+        resolve();
+        return;
+      }
+      if (Date.now() - started > 15000) {
+        reject(new Error('Timed out waiting for adjustment save'));
+        return;
+      }
+      setTimeout(check, 25);
+    }
+    check();
+  });
+}
+
 function onLightboxAdjustmentInput(input) {
   if (!_lbEditRecipeLoaded) {
     _lbSetAdjustmentStatus('Loading recipe...');
@@ -4791,9 +4814,12 @@ async function openCropEditor() {
   if (saveBtn) saveBtn.disabled = false;
   _cropSetStatus('Loading recipe...');
   try {
+    _lbFlushPendingAdjustmentSave();
+    await _lbWaitForAdjustmentSaveIdle(requestedPhotoId);
+    if (_lightboxCurrentId !== requestedPhotoId || !_cropIsActiveSession(requestedPhotoId, session)) return;
     var data = await safeFetch('/api/photos/' + requestedPhotoId + '/edit-recipe', {}, { toast: false });
     if (_lightboxCurrentId !== requestedPhotoId || !_cropIsActiveSession(requestedPhotoId, session)) return;
-    _cropRecipe = _cropCloneRecipe(data.recipe || {});
+    _cropRecipe = _cropCloneRecipe(_lbEditRecipeLoaded ? _lbEditRecipe : (data.recipe || {}));
     _cropDefaultCrop(_cropRecipe);
     _cropSyncControls();
     var modal = document.getElementById('cropEditorModal');

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3460,6 +3460,7 @@ var _lbRenderedAdjustmentValues = null;
 var _lbAdjustSaveTimer = null;
 var _lbAdjustSeq = 0;
 var _lbAdjustmentInputSeq = 0;
+var _lbAdjustmentInputSeqByPhoto = {};
 var _lbAdjustSaveInFlightByPhoto = {};
 var _lbQueuedAdjustmentSaveByPhoto = {};
 var _lbRecipeBustByPhotoId = {};
@@ -3511,6 +3512,17 @@ function _lbCloneRecipe(recipe) {
   } catch (_) {
     return {};
   }
+}
+
+function _lbAdjustmentInputSeqFor(photoId) {
+  return _lbAdjustmentInputSeqByPhoto[String(photoId)] || 0;
+}
+
+function _lbBumpAdjustmentInputSeq(photoId) {
+  var key = String(photoId);
+  _lbAdjustmentInputSeq += 1;
+  _lbAdjustmentInputSeqByPhoto[key] = (_lbAdjustmentInputSeqByPhoto[key] || 0) + 1;
+  return _lbAdjustmentInputSeqByPhoto[key];
 }
 
 function _lbAdjustmentValues(recipe) {
@@ -3711,7 +3723,7 @@ function _lbStartAdjustmentRecipeSave(photoId, recipe, inputSeq) {
           detail: {photoId: photoId, recipe: data.recipe || null}
         }));
       } catch (_) {}
-      if (_lightboxCurrentId !== photoId || inputSeq !== _lbAdjustmentInputSeq) return;
+      if (_lightboxCurrentId !== photoId || inputSeq !== _lbAdjustmentInputSeqFor(photoId)) return;
       var activeSeq = ++_lbAdjustSeq;
       _lbEditRecipe = _lbCloneRecipe(data.recipe || {});
       _lbEditRecipeLoaded = true;
@@ -3737,7 +3749,7 @@ function _lbSaveAdjustmentRecipe(values) {
   if (!_lightboxCurrentId || !_lbEditRecipeLoaded) return;
   var photoId = _lightboxCurrentId;
   var key = String(photoId);
-  var inputSeq = _lbAdjustmentInputSeq;
+  var inputSeq = _lbAdjustmentInputSeqFor(photoId);
   var recipe = _lbRecipeWithAdjustments(values);
   _lbEditRecipe = _lbCloneRecipe(recipe);
   if (_lbAdjustSaveInFlightByPhoto[key]) {
@@ -3767,7 +3779,7 @@ function onLightboxAdjustmentInput(input) {
   var label = document.getElementById(input.id + 'Value');
   if (label) label.textContent = _lbFormatAdjustmentValue(input.dataset.adjustment, input.value);
   _lbAdjustSeq += 1;
-  _lbAdjustmentInputSeq += 1;
+  _lbBumpAdjustmentInputSeq(_lightboxCurrentId);
   var values = _lbReadAdjustmentControls();
   _lbEditRecipe = _lbRecipeWithAdjustments(values);
   _lbApplyAdjustmentPreviewCss(values);
@@ -3792,7 +3804,7 @@ function resetLightboxAdjustments() {
   var values = _lbReadAdjustmentControls();
   _lbEditRecipe = _lbRecipeWithAdjustments(values);
   _lbApplyAdjustmentPreviewCss(values);
-  _lbAdjustmentInputSeq += 1;
+  _lbBumpAdjustmentInputSeq(_lightboxCurrentId);
   if (_lbAdjustSaveTimer) {
     clearTimeout(_lbAdjustSaveTimer);
     _lbAdjustSaveTimer = null;
@@ -5832,7 +5844,7 @@ function openInatModal() {
     }
     html += '<div class="inat-card" id="inatCard' + idx + '">' +
       '<div class="inat-card-header">' +
-        '<img class="inat-card-thumb" src="' + vireoThumbnailUrl(item.photo_id) + '" alt="">' +
+        '<img class="inat-card-thumb" src="' + escapeAttr(vireoThumbnailUrl(item.photo_id)) + '" alt="">' +
         '<div style="flex:1;min-width:0;">' +
           '<div style="font-size:13px;color:var(--text-primary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">' + escapeHtml(item.filename) + '</div>' +
           warn +
@@ -8766,7 +8778,7 @@ async function loadMissingPhotos() {
     container.innerHTML = photos.map(p => {
       const ts = p.timestamp ? new Date(p.timestamp).toLocaleDateString() : '';
       const thumb = p.has_thumb
-        ? `<img src="${vireoThumbnailUrl(p.id)}" alt="" loading="lazy">`
+        ? `<img src="${_escapeAttr(vireoThumbnailUrl(p.id))}" alt="" loading="lazy">`
         : '<span>no thumb</span>';
       const badges = [
         ['thumb', p.has_thumb],

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -517,7 +517,8 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
 .lightbox-close:hover { opacity: 1; }
 .lightbox-overlay.lb-hide-chrome .lightbox-close,
 .lightbox-overlay.lb-hide-chrome .lightbox-nav,
-.lightbox-overlay.lb-hide-chrome .lightbox-actions {
+.lightbox-overlay.lb-hide-chrome .lightbox-actions,
+.lightbox-overlay.lb-hide-chrome .lightbox-adjust-panel {
   display: none !important;
 }
 .lightbox-overlay.lb-hide-info .lightbox-filename,
@@ -542,6 +543,71 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
 }
+.lightbox-adjust-panel {
+  display: none;
+  position: absolute;
+  right: 24px;
+  top: 64px;
+  width: min(320px, calc(100vw - 48px));
+  padding: 12px;
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.76);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.42);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  cursor: default;
+  z-index: 10001;
+}
+.lightbox-adjust-panel.open { display: block; }
+.lb-adjust-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 10px;
+  color: #f4f7f8;
+  font-size: 12px;
+  font-weight: 700;
+}
+.lb-adjust-reset {
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  background: rgba(12, 14, 16, 0.72);
+  color: #f4f7f8;
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: 11px;
+  cursor: pointer;
+}
+.lb-adjust-reset:hover { border-color: rgba(255, 255, 255, 0.72); }
+.lb-adjust-row {
+  display: grid;
+  grid-template-columns: 86px 1fr 44px;
+  align-items: center;
+  gap: 8px;
+  min-height: 30px;
+}
+.lb-adjust-row label {
+  color: rgba(244, 247, 248, 0.78);
+  font-size: 12px;
+}
+.lb-adjust-row input[type="range"] {
+  width: 100%;
+  accent-color: var(--accent);
+}
+.lb-adjust-value {
+  color: rgba(244, 247, 248, 0.72);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+.lb-adjust-status {
+  min-height: 16px;
+  margin-top: 8px;
+  color: rgba(244, 247, 248, 0.58);
+  font-size: 11px;
+}
+.lb-adjust-status.error { color: #ff9c90; }
 .lb-action-btn {
   min-height: 32px;
   padding: 6px 13px;
@@ -3038,6 +3104,9 @@ async function createWorkspace() {
     <button class="lb-action-btn" id="lightboxToggleChrome" onclick="event.stopPropagation(); toggleLightboxChrome();" title="Toggle lightbox controls">
       Hide UI
     </button>
+    <button class="lb-action-btn lb-action-accent" id="lightboxAdjustBtn" onclick="event.stopPropagation(); toggleLightboxAdjustPanel();" title="Adjust exposure, white balance, contrast, and saturation">
+      Adjust
+    </button>
     <span class="lb-mask-controls" id="lightboxMaskControls" onclick="event.stopPropagation();" title="SAM mask overlay">
       <span>Mask:</span>
       <select id="lightboxMaskSelect" onchange="event.stopPropagation(); _lbOnMaskVariantChange();"></select>
@@ -3058,6 +3127,38 @@ async function createWorkspace() {
       Open in Editor
     </button>
     <button class="lb-action-btn lb-action-danger" onclick="lightboxDelete()" title="Delete photo">Delete</button>
+  </div>
+  <div class="lightbox-adjust-panel" id="lightboxAdjustPanel" onclick="event.stopPropagation()">
+    <div class="lb-adjust-header">
+      <span>Adjustments</span>
+      <button class="lb-adjust-reset" type="button" onclick="resetLightboxAdjustments()">Reset</button>
+    </div>
+    <div class="lb-adjust-row">
+      <label for="lbAdjExposure">Exposure</label>
+      <input id="lbAdjExposure" data-adjustment="exposure" type="range" min="-5" max="5" step="0.1" value="0" oninput="onLightboxAdjustmentInput(this)">
+      <span class="lb-adjust-value" id="lbAdjExposureValue">0.0</span>
+    </div>
+    <div class="lb-adjust-row">
+      <label for="lbAdjContrast">Contrast</label>
+      <input id="lbAdjContrast" data-adjustment="contrast" type="range" min="-100" max="100" step="1" value="0" oninput="onLightboxAdjustmentInput(this)">
+      <span class="lb-adjust-value" id="lbAdjContrastValue">0</span>
+    </div>
+    <div class="lb-adjust-row">
+      <label for="lbAdjTemperature">Temp</label>
+      <input id="lbAdjTemperature" data-adjustment="temperature" type="range" min="-100" max="100" step="1" value="0" oninput="onLightboxAdjustmentInput(this)">
+      <span class="lb-adjust-value" id="lbAdjTemperatureValue">0</span>
+    </div>
+    <div class="lb-adjust-row">
+      <label for="lbAdjTint">Tint</label>
+      <input id="lbAdjTint" data-adjustment="tint" type="range" min="-100" max="100" step="1" value="0" oninput="onLightboxAdjustmentInput(this)">
+      <span class="lb-adjust-value" id="lbAdjTintValue">0</span>
+    </div>
+    <div class="lb-adjust-row">
+      <label for="lbAdjSaturation">Saturation</label>
+      <input id="lbAdjSaturation" data-adjustment="saturation" type="range" min="-100" max="100" step="1" value="0" oninput="onLightboxAdjustmentInput(this)">
+      <span class="lb-adjust-value" id="lbAdjSaturationValue">0</span>
+    </div>
+    <div class="lb-adjust-status" id="lightboxAdjustStatus"></div>
   </div>
 </div>
 
@@ -3129,6 +3230,243 @@ var _lbFlagPendingByPhoto = {};  // count of in-flight flag writes PER photo; li
 var _lbConfirmedFlags = {};   // last server-confirmed flag per photo, isolated from optimistic page helpers
 var _lbViewportByPhotoId = {};  // per-session lightbox viewport cache keyed by photo id
 var _lbPendingViewportState = null;
+var _lbEditRecipe = null;
+var _lbRenderedAdjustmentValues = null;
+var _lbAdjustSaveTimer = null;
+var _lbAdjustSeq = 0;
+var _lbRecipeBustByPhotoId = {};
+
+function _lbCloneRecipe(recipe) {
+  if (!recipe) return {};
+  try {
+    return JSON.parse(JSON.stringify(recipe));
+  } catch (_) {
+    return {};
+  }
+}
+
+function _lbAdjustmentValues(recipe) {
+  var adj = (recipe && recipe.adjustments) || {};
+  var wb = adj.white_balance || {};
+  return {
+    exposure: Number(adj.exposure || 0),
+    contrast: Number(adj.contrast || 0),
+    temperature: Number(wb.temperature || adj.temperature || 0),
+    tint: Number(wb.tint || adj.tint || 0),
+    saturation: Number(adj.saturation || 0),
+  };
+}
+
+function _lbSetAdjustmentStatus(text, isError) {
+  var el = document.getElementById('lightboxAdjustStatus');
+  if (!el) return;
+  el.textContent = text || '';
+  el.classList.toggle('error', !!isError);
+}
+
+function _lbFormatAdjustmentValue(name, value) {
+  if (name === 'exposure') return Number(value || 0).toFixed(1);
+  return String(Math.round(Number(value || 0)));
+}
+
+function _lbSetAdjustmentControl(id, value) {
+  var input = document.getElementById(id);
+  var label = document.getElementById(id + 'Value');
+  if (input) input.value = String(value || 0);
+  if (label && input) {
+    label.textContent = _lbFormatAdjustmentValue(input.dataset.adjustment, value);
+  }
+}
+
+function _lbRenderAdjustmentControls() {
+  var values = _lbAdjustmentValues(_lbEditRecipe);
+  _lbSetAdjustmentControl('lbAdjExposure', values.exposure);
+  _lbSetAdjustmentControl('lbAdjContrast', values.contrast);
+  _lbSetAdjustmentControl('lbAdjTemperature', values.temperature);
+  _lbSetAdjustmentControl('lbAdjTint', values.tint);
+  _lbSetAdjustmentControl('lbAdjSaturation', values.saturation);
+}
+
+function _lbReadAdjustmentControls() {
+  function val(id) {
+    var el = document.getElementById(id);
+    return el ? Number(el.value || 0) : 0;
+  }
+  return {
+    exposure: val('lbAdjExposure'),
+    contrast: val('lbAdjContrast'),
+    temperature: val('lbAdjTemperature'),
+    tint: val('lbAdjTint'),
+    saturation: val('lbAdjSaturation'),
+  };
+}
+
+function _lbRecipeWithAdjustments(values) {
+  var recipe = _lbCloneRecipe(_lbEditRecipe);
+  delete recipe.version;
+  var adj = _lbCloneRecipe(recipe.adjustments || {});
+  ['exposure', 'contrast', 'saturation'].forEach(function(key) {
+    var value = Number(values[key] || 0);
+    if (Math.abs(value) > 0.000001) adj[key] = value;
+    else delete adj[key];
+  });
+
+  var wb = _lbCloneRecipe(adj.white_balance || {});
+  delete adj.temperature;
+  delete adj.tint;
+  ['temperature', 'tint'].forEach(function(key) {
+    var value = Number(values[key] || 0);
+    if (Math.abs(value) > 0.000001) wb[key] = value;
+    else delete wb[key];
+  });
+  if (Object.keys(wb).length) adj.white_balance = wb;
+  else delete adj.white_balance;
+
+  if (Object.keys(adj).length) recipe.adjustments = adj;
+  else delete recipe.adjustments;
+  return recipe;
+}
+
+function _lbApplyAdjustmentPreviewCss(values) {
+  var img = document.getElementById('lightboxImg');
+  if (!img) return;
+  var base = _lbRenderedAdjustmentValues || _lbAdjustmentValues(null);
+  var exposure = Math.pow(2, Number(values.exposure || 0) - Number(base.exposure || 0));
+  var baseContrast = Math.max(0.001, 1 + Number(base.contrast || 0) / 100);
+  var contrast = Math.max(0, 1 + Number(values.contrast || 0) / 100) / baseContrast;
+  var baseSaturation = Math.max(0.001, 1 + Number(base.saturation || 0) / 100);
+  var saturation = Math.max(0, 1 + Number(values.saturation || 0) / 100) / baseSaturation;
+  var hue = (Number(values.tint || 0) - Number(base.tint || 0)) * 0.2
+    - (Number(values.temperature || 0) - Number(base.temperature || 0)) * 0.08;
+  img.style.filter = [
+    'brightness(' + exposure.toFixed(3) + ')',
+    'contrast(' + contrast.toFixed(3) + ')',
+    'saturate(' + saturation.toFixed(3) + ')',
+    'hue-rotate(' + hue.toFixed(2) + 'deg)'
+  ].join(' ');
+}
+
+function _lbClearAdjustmentPreviewCss() {
+  var img = document.getElementById('lightboxImg');
+  if (img) img.style.filter = '';
+}
+
+function _lbBumpRecipeBust(photoId) {
+  var key = String(photoId);
+  _lbRecipeBustByPhotoId[key] = Date.now();
+}
+
+function _lbRefreshVisiblePhotoImages(photoId) {
+  var bust = _lbRecipeBustByPhotoId[String(photoId)];
+  if (!bust) return;
+  var gridImg = document.querySelector('.grid-card[data-id="' + photoId + '"] img');
+  if (gridImg) gridImg.src = '/thumbnails/' + photoId + '.jpg?v=' + bust;
+  var detailImg = document.getElementById('detailImg');
+  if (detailImg && window._detailPhotoId === photoId) {
+    detailImg.src = '/thumbnails/' + photoId + '.jpg?v=' + bust;
+  }
+}
+
+function _lbReloadEditedSource(photoId, seq) {
+  if (_lightboxCurrentId !== photoId) return;
+  var img = document.getElementById('lightboxImg');
+  if (!img) return;
+  var key = _lbCurrentSrcKey || 'full';
+  img.addEventListener('load', function onEditedReload() {
+    img.removeEventListener('load', onEditedReload);
+    if (_lightboxCurrentId !== photoId || seq !== _lbAdjustSeq) return;
+    _lbRenderedAdjustmentValues = _lbAdjustmentValues(_lbEditRecipe);
+    _lbClearAdjustmentPreviewCss();
+    _lbRecomputeNativeZoom();
+    _lbApplyTransform();
+  });
+  img.src = _lbSrcUrl(photoId, key);
+}
+
+function _lbSaveAdjustmentRecipe(values) {
+  if (!_lightboxCurrentId) return;
+  var photoId = _lightboxCurrentId;
+  var seq = ++_lbAdjustSeq;
+  var recipe = _lbRecipeWithAdjustments(values);
+  _lbEditRecipe = _lbCloneRecipe(recipe);
+  _lbSetAdjustmentStatus('Saving...');
+  fetch('/api/photos/' + photoId + '/edit-recipe', {
+    method: 'PUT',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({recipe: recipe}),
+  })
+    .then(function(r) {
+      return r.json().then(function(data) {
+        if (!r.ok) throw new Error((data && data.error) || 'Save failed');
+        return data;
+      });
+    })
+    .then(function(data) {
+      if (_lightboxCurrentId !== photoId || seq !== _lbAdjustSeq) return;
+      _lbEditRecipe = _lbCloneRecipe(data.recipe || {});
+      _lbRenderAdjustmentControls();
+      _lbBumpRecipeBust(photoId);
+      _lbRefreshVisiblePhotoImages(photoId);
+      _lbReloadEditedSource(photoId, seq);
+      _lbSetAdjustmentStatus('Saved');
+      try {
+        document.dispatchEvent(new CustomEvent('lightbox:editchanged', {
+          detail: {photoId: photoId, recipe: data.recipe || null}
+        }));
+      } catch (_) {}
+    })
+    .catch(function(err) {
+      if (_lightboxCurrentId !== photoId || seq !== _lbAdjustSeq) return;
+      _lbSetAdjustmentStatus(err.message || 'Save failed', true);
+    });
+}
+
+function _lbFlushPendingAdjustmentSave() {
+  if (!_lbAdjustSaveTimer) return;
+  clearTimeout(_lbAdjustSaveTimer);
+  _lbAdjustSaveTimer = null;
+  _lbSaveAdjustmentRecipe(_lbReadAdjustmentControls());
+}
+
+function onLightboxAdjustmentInput(input) {
+  var label = document.getElementById(input.id + 'Value');
+  if (label) label.textContent = _lbFormatAdjustmentValue(input.dataset.adjustment, input.value);
+  var values = _lbReadAdjustmentControls();
+  _lbEditRecipe = _lbRecipeWithAdjustments(values);
+  _lbApplyAdjustmentPreviewCss(values);
+  _lbSetAdjustmentStatus('Previewing...');
+  if (_lbAdjustSaveTimer) clearTimeout(_lbAdjustSaveTimer);
+  _lbAdjustSaveTimer = setTimeout(function() {
+    _lbAdjustSaveTimer = null;
+    _lbSaveAdjustmentRecipe(_lbReadAdjustmentControls());
+  }, 350);
+}
+
+function resetLightboxAdjustments() {
+  _lbSetAdjustmentControl('lbAdjExposure', 0);
+  _lbSetAdjustmentControl('lbAdjContrast', 0);
+  _lbSetAdjustmentControl('lbAdjTemperature', 0);
+  _lbSetAdjustmentControl('lbAdjTint', 0);
+  _lbSetAdjustmentControl('lbAdjSaturation', 0);
+  var values = _lbReadAdjustmentControls();
+  _lbEditRecipe = _lbRecipeWithAdjustments(values);
+  _lbApplyAdjustmentPreviewCss(values);
+  if (_lbAdjustSaveTimer) {
+    clearTimeout(_lbAdjustSaveTimer);
+    _lbAdjustSaveTimer = null;
+  }
+  _lbSaveAdjustmentRecipe(values);
+}
+
+function toggleLightboxAdjustPanel() {
+  var panel = document.getElementById('lightboxAdjustPanel');
+  var btn = document.getElementById('lightboxAdjustBtn');
+  if (!panel) return;
+  var open = !panel.classList.contains('open');
+  panel.classList.toggle('open', open);
+  if (btn) btn.textContent = open ? 'Hide Adjust' : 'Adjust';
+  if (open) _lbRenderAdjustmentControls();
+}
 
 function _lbIsOneToOneZoom() {
   if (_lbPending1To1) return true;
@@ -3810,6 +4148,7 @@ function openLightbox(photoId, filename, photoList, options) {
   var alreadyOpen = !!window._lbEscToken;
   options = options || {};
   var fallbackViewportState = options.fallbackViewportState || null;
+  _lbFlushPendingAdjustmentSave();
   if (alreadyOpen && _lightboxCurrentId != null) {
     _lbSaveViewportState(_lightboxCurrentId);
   }
@@ -3910,12 +4249,23 @@ function openLightbox(photoId, filename, photoList, options) {
   _lbPending1To1Anchor = null;
   _lbPendingViewportState = restoreViewportState;
   _lbOriginalUnavailable = false;
+  _lbEditRecipe = null;
+  _lbRenderedAdjustmentValues = _lbAdjustmentValues(null);
+  if (_lbAdjustSaveTimer) {
+    clearTimeout(_lbAdjustSaveTimer);
+    _lbAdjustSaveTimer = null;
+  }
+  _lbAdjustSeq += 1;
+  _lbClearAdjustmentPreviewCss();
+  _lbRenderAdjustmentControls();
+  _lbSetAdjustmentStatus('');
   if (_lbSwapTimer) { clearTimeout(_lbSwapTimer); _lbSwapTimer = null; }
   _lbDesiredSrcKey = null;
   _lbApplyTransform();  // Clear stale pan while preserving 1:1 scale when requested.
 
   // Fetch original dimensions (async, non-blocking for image display)
   var flagFetchSeq = _lbFlagEditSeq;
+  var editFetchSeq = _lbAdjustSeq;
   fetch('/api/photos/' + photoId)
     .then(function(r) { return r.ok ? r.json() : null; })
     .then(function(data) {
@@ -3923,6 +4273,11 @@ function openLightbox(photoId, filename, photoList, options) {
       _lbPhotoW = data.width || null;
       _lbPhotoH = data.height || null;
       _lbCurrentWildlifeExcluded = !!data.wildlife_excluded;
+      if (editFetchSeq === _lbAdjustSeq) {
+        _lbEditRecipe = _lbCloneRecipe(data.edit_recipe || {});
+        _lbRenderedAdjustmentValues = _lbAdjustmentValues(_lbEditRecipe);
+        _lbRenderAdjustmentControls();
+      }
       _lbApplyWildlifeExcludedButton();
       _lbRecordFetchedFlag(photoId, data.flag, flagFetchSeq);
       _lbRecomputeNativeZoom();
@@ -4232,6 +4587,7 @@ function toggleLightboxZoom(e) {
 
 function closeLightbox(e) {
   if (e && e.target && e.target.tagName === 'IMG') return;
+  _lbFlushPendingAdjustmentSave();
   if (_lightboxCurrentId != null) _lbSaveViewportState(_lightboxCurrentId);
   var wasOpen = !!window._lbEscToken;
   if (wasOpen) { Keymap.popEsc(window._lbEscToken); window._lbEscToken = null; }
@@ -4243,6 +4599,11 @@ function closeLightbox(e) {
   _lbClearPendingViewportRestore();
   if (_lbSwapTimer) { clearTimeout(_lbSwapTimer); _lbSwapTimer = null; }
   _lbDesiredSrcKey = null;
+  _lbClearAdjustmentPreviewCss();
+  var adjustPanel = document.getElementById('lightboxAdjustPanel');
+  if (adjustPanel) adjustPanel.classList.remove('open');
+  var adjustBtn = document.getElementById('lightboxAdjustBtn');
+  if (adjustBtn) adjustBtn.textContent = 'Adjust';
   _lbApplyTransform();
   document.getElementById('lightboxOverlay').classList.remove('active');
   document.getElementById('lightboxImg').src = '';
@@ -5129,9 +5490,13 @@ function _lbPickSourceKey(targetZoom) {
 }
 
 function _lbSrcUrl(photoId, key) {
-  if (key === 'original') return '/photos/' + photoId + '/original';
-  if (key === 'full') return '/photos/' + photoId + '/full';
-  return '/photos/' + photoId + '/preview?size=' + key;
+  var url;
+  if (key === 'original') url = '/photos/' + photoId + '/original';
+  else if (key === 'full') url = '/photos/' + photoId + '/full';
+  else url = '/photos/' + photoId + '/preview?size=' + key;
+  var bust = _lbRecipeBustByPhotoId[String(photoId)];
+  if (bust) url += (url.indexOf('?') === -1 ? '?' : '&') + 'v=' + bust;
+  return url;
 }
 
 function _lbScheduleSourceSwap(targetZoom) {

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3359,11 +3359,27 @@ function _lbBumpRecipeBust(photoId) {
 function _lbRefreshVisiblePhotoImages(photoId) {
   var bust = _lbRecipeBustByPhotoId[String(photoId)];
   if (!bust) return;
-  var gridImg = document.querySelector('.grid-card[data-id="' + photoId + '"] img');
-  if (gridImg) gridImg.src = '/thumbnails/' + photoId + '.jpg?v=' + bust;
+  var thumbUrl = '/thumbnails/' + photoId + '.jpg?v=' + bust;
+  var refreshed = [];
+
+  function refreshImg(img) {
+    if (!img || refreshed.indexOf(img) !== -1) return;
+    refreshed.push(img);
+    img.src = thumbUrl;
+  }
+
+  refreshImg(document.querySelector('.grid-card[data-id="' + photoId + '"] img'));
+  document.querySelectorAll('img[data-photo-id="' + photoId + '"]').forEach(refreshImg);
+  document.querySelectorAll('[data-photo-id="' + photoId + '"] img').forEach(function(img) {
+    var src = img.getAttribute('src') || '';
+    if (src.indexOf('/thumbnails/' + photoId + '.jpg') !== -1) {
+      refreshImg(img);
+    }
+  });
+
   var detailImg = document.getElementById('detailImg');
   if (detailImg && window._detailPhotoId === photoId) {
-    detailImg.src = '/thumbnails/' + photoId + '.jpg?v=' + bust;
+    refreshImg(detailImg);
   }
 }
 

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3235,6 +3235,7 @@ var _lbEditRecipeLoaded = false;
 var _lbRenderedAdjustmentValues = null;
 var _lbAdjustSaveTimer = null;
 var _lbAdjustSeq = 0;
+var _lbAdjustmentInputSeq = 0;
 var _lbRecipeBustByPhotoId = {};
 
 function _lbCloneRecipe(recipe) {
@@ -3417,6 +3418,7 @@ function _lbSaveAdjustmentRecipe(values) {
   if (!_lightboxCurrentId || !_lbEditRecipeLoaded) return;
   var photoId = _lightboxCurrentId;
   var seq = ++_lbAdjustSeq;
+  var inputSeq = _lbAdjustmentInputSeq;
   var recipe = _lbRecipeWithAdjustments(values);
   _lbEditRecipe = _lbCloneRecipe(recipe);
   _lbSetAdjustmentStatus('Saving...');
@@ -3432,7 +3434,6 @@ function _lbSaveAdjustmentRecipe(values) {
       });
     })
     .then(function(data) {
-      if (_lightboxCurrentId === photoId && seq !== _lbAdjustSeq) return;
       _lbBumpRecipeBust(photoId);
       _lbRefreshVisiblePhotoImages(photoId);
       try {
@@ -3440,10 +3441,13 @@ function _lbSaveAdjustmentRecipe(values) {
           detail: {photoId: photoId, recipe: data.recipe || null}
         }));
       } catch (_) {}
-      if (_lightboxCurrentId !== photoId || seq !== _lbAdjustSeq) return;
+      if (_lightboxCurrentId !== photoId || inputSeq !== _lbAdjustmentInputSeq) return;
+      var activeSeq = _lbAdjustSeq;
       _lbEditRecipe = _lbCloneRecipe(data.recipe || {});
+      _lbEditRecipeLoaded = true;
       _lbRenderAdjustmentControls();
-      _lbReloadEditedSource(photoId, seq);
+      _lbSetAdjustmentControlsDisabled(false);
+      _lbReloadEditedSource(photoId, activeSeq);
       _lbSetAdjustmentStatus('Saved');
     })
     .catch(function(err) {
@@ -3468,6 +3472,7 @@ function onLightboxAdjustmentInput(input) {
   var label = document.getElementById(input.id + 'Value');
   if (label) label.textContent = _lbFormatAdjustmentValue(input.dataset.adjustment, input.value);
   _lbAdjustSeq += 1;
+  _lbAdjustmentInputSeq += 1;
   var values = _lbReadAdjustmentControls();
   _lbEditRecipe = _lbRecipeWithAdjustments(values);
   _lbApplyAdjustmentPreviewCss(values);
@@ -3492,6 +3497,7 @@ function resetLightboxAdjustments() {
   var values = _lbReadAdjustmentControls();
   _lbEditRecipe = _lbRecipeWithAdjustments(values);
   _lbApplyAdjustmentPreviewCss(values);
+  _lbAdjustmentInputSeq += 1;
   if (_lbAdjustSaveTimer) {
     clearTimeout(_lbAdjustSaveTimer);
     _lbAdjustSaveTimer = null;

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3236,15 +3236,31 @@ var _lbRenderedAdjustmentValues = null;
 var _lbAdjustSaveTimer = null;
 var _lbAdjustSeq = 0;
 var _lbAdjustmentInputSeq = 0;
+var _lbAdjustSaveInFlightByPhoto = {};
+var _lbQueuedAdjustmentSaveByPhoto = {};
 var _lbRecipeBustByPhotoId = {};
 
-function vireoThumbnailUrl(photoId) {
-  var url = '/thumbnails/' + photoId + '.jpg';
+function vireoCacheBustedPhotoUrl(photoId, url) {
   var bust = _lbRecipeBustByPhotoId[String(photoId)];
-  if (bust) url += '?v=' + bust;
+  if (!bust) return url;
+  url = String(url || '').replace(/([?&])v=[^&]*(&?)/, function(match, prefix, suffix) {
+    return suffix ? prefix : '';
+  }).replace(/[?&]$/, '');
+  url += (url.indexOf('?') === -1 ? '?' : '&') + 'v=' + bust;
   return url;
 }
+
+function vireoThumbnailUrl(photoId) {
+  return vireoCacheBustedPhotoUrl(photoId, '/thumbnails/' + photoId + '.jpg');
+}
+
+function vireoPreviewUrl(photoId, size) {
+  return vireoCacheBustedPhotoUrl(photoId, '/photos/' + photoId + '/preview?size=' + (size || 1920));
+}
+
 window.vireoThumbnailUrl = vireoThumbnailUrl;
+window.vireoPreviewUrl = vireoPreviewUrl;
+window.vireoCacheBustedPhotoUrl = vireoCacheBustedPhotoUrl;
 
 function _lbCloneRecipe(recipe) {
   if (!recipe) return {};
@@ -3385,10 +3401,10 @@ function _lbRefreshVisiblePhotoImages(photoId) {
   var thumbUrl = vireoThumbnailUrl(photoId);
   var refreshed = [];
 
-  function refreshImg(img) {
+  function refreshImg(img, url) {
     if (!img || refreshed.indexOf(img) !== -1) return;
     refreshed.push(img);
-    img.src = thumbUrl;
+    img.src = url || thumbUrl;
   }
 
   refreshImg(document.querySelector('.grid-card[data-id="' + photoId + '"] img'));
@@ -3397,6 +3413,11 @@ function _lbRefreshVisiblePhotoImages(photoId) {
     var src = img.getAttribute('src') || '';
     if (src.indexOf('/thumbnails/' + photoId + '.jpg') !== -1) {
       refreshImg(img);
+    } else if (
+      src.indexOf('/photos/' + photoId + '/preview') !== -1 ||
+      src.indexOf('/photos/' + photoId + '/full') !== -1
+    ) {
+      refreshImg(img, vireoCacheBustedPhotoUrl(photoId, src));
     }
   });
 
@@ -3422,14 +3443,11 @@ function _lbReloadEditedSource(photoId, seq) {
   img.src = _lbSrcUrl(photoId, key);
 }
 
-function _lbSaveAdjustmentRecipe(values) {
-  if (!_lightboxCurrentId || !_lbEditRecipeLoaded) return;
-  var photoId = _lightboxCurrentId;
-  var seq = ++_lbAdjustSeq;
-  var inputSeq = _lbAdjustmentInputSeq;
-  var recipe = _lbRecipeWithAdjustments(values);
-  _lbEditRecipe = _lbCloneRecipe(recipe);
-  _lbSetAdjustmentStatus('Saving...');
+function _lbStartAdjustmentRecipeSave(photoId, recipe, inputSeq) {
+  var seq = _lightboxCurrentId === photoId ? ++_lbAdjustSeq : _lbAdjustSeq;
+  var key = String(photoId);
+  _lbAdjustSaveInFlightByPhoto[key] = true;
+  if (_lightboxCurrentId === photoId) _lbSetAdjustmentStatus('Saving...');
   fetch('/api/photos/' + photoId + '/edit-recipe', {
     method: 'PUT',
     headers: {'Content-Type': 'application/json'},
@@ -3461,7 +3479,32 @@ function _lbSaveAdjustmentRecipe(values) {
     .catch(function(err) {
       if (_lightboxCurrentId !== photoId || seq !== _lbAdjustSeq) return;
       _lbSetAdjustmentStatus(err.message || 'Save failed', true);
+    })
+    .then(function() {
+      delete _lbAdjustSaveInFlightByPhoto[key];
+      var queued = _lbQueuedAdjustmentSaveByPhoto[key];
+      if (!queued) return;
+      delete _lbQueuedAdjustmentSaveByPhoto[key];
+      _lbStartAdjustmentRecipeSave(photoId, queued.recipe, queued.inputSeq);
     });
+}
+
+function _lbSaveAdjustmentRecipe(values) {
+  if (!_lightboxCurrentId || !_lbEditRecipeLoaded) return;
+  var photoId = _lightboxCurrentId;
+  var key = String(photoId);
+  var inputSeq = _lbAdjustmentInputSeq;
+  var recipe = _lbRecipeWithAdjustments(values);
+  _lbEditRecipe = _lbCloneRecipe(recipe);
+  if (_lbAdjustSaveInFlightByPhoto[key]) {
+    _lbQueuedAdjustmentSaveByPhoto[key] = {
+      recipe: _lbCloneRecipe(recipe),
+      inputSeq: inputSeq,
+    };
+    _lbSetAdjustmentStatus('Saving...');
+    return;
+  }
+  _lbStartAdjustmentRecipeSave(photoId, recipe, inputSeq);
 }
 
 function _lbFlushPendingAdjustmentSave() {

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3238,6 +3238,14 @@ var _lbAdjustSeq = 0;
 var _lbAdjustmentInputSeq = 0;
 var _lbRecipeBustByPhotoId = {};
 
+function vireoThumbnailUrl(photoId) {
+  var url = '/thumbnails/' + photoId + '.jpg';
+  var bust = _lbRecipeBustByPhotoId[String(photoId)];
+  if (bust) url += '?v=' + bust;
+  return url;
+}
+window.vireoThumbnailUrl = vireoThumbnailUrl;
+
 function _lbCloneRecipe(recipe) {
   if (!recipe) return {};
   try {
@@ -3374,7 +3382,7 @@ function _lbBumpRecipeBust(photoId) {
 function _lbRefreshVisiblePhotoImages(photoId) {
   var bust = _lbRecipeBustByPhotoId[String(photoId)];
   if (!bust) return;
-  var thumbUrl = '/thumbnails/' + photoId + '.jpg?v=' + bust;
+  var thumbUrl = vireoThumbnailUrl(photoId);
   var refreshed = [];
 
   function refreshImg(img) {
@@ -5052,7 +5060,7 @@ function openInatModal() {
     }
     html += '<div class="inat-card" id="inatCard' + idx + '">' +
       '<div class="inat-card-header">' +
-        '<img class="inat-card-thumb" src="/thumbnails/' + item.photo_id + '.jpg" alt="">' +
+        '<img class="inat-card-thumb" src="' + vireoThumbnailUrl(item.photo_id) + '" alt="">' +
         '<div style="flex:1;min-width:0;">' +
           '<div style="font-size:13px;color:var(--text-primary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">' + escapeHtml(item.filename) + '</div>' +
           warn +
@@ -5873,7 +5881,7 @@ function findSimilar(photoId) {
             openLightbox(p.id, p.filename || '');
           });
           var img = document.createElement('img');
-          img.src = '/thumbnails/' + p.id + '.jpg';
+          img.src = vireoThumbnailUrl(p.id);
           img.loading = 'lazy';
           img.alt = '';
           var info = document.createElement('div');
@@ -7960,7 +7968,7 @@ async function loadMissingPhotos() {
     container.innerHTML = photos.map(p => {
       const ts = p.timestamp ? new Date(p.timestamp).toLocaleDateString() : '';
       const thumb = p.has_thumb
-        ? `<img src="/thumbnails/${p.id}.jpg" alt="" loading="lazy">`
+        ? `<img src="${vireoThumbnailUrl(p.id)}" alt="" loading="lazy">`
         : '<span>no thumb</span>';
       const badges = [
         ['thumb', p.has_thumb],

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3402,18 +3402,18 @@ function _lbSaveAdjustmentRecipe(values) {
       });
     })
     .then(function(data) {
-      if (_lightboxCurrentId !== photoId || seq !== _lbAdjustSeq) return;
-      _lbEditRecipe = _lbCloneRecipe(data.recipe || {});
-      _lbRenderAdjustmentControls();
       _lbBumpRecipeBust(photoId);
       _lbRefreshVisiblePhotoImages(photoId);
-      _lbReloadEditedSource(photoId, seq);
-      _lbSetAdjustmentStatus('Saved');
       try {
         document.dispatchEvent(new CustomEvent('lightbox:editchanged', {
           detail: {photoId: photoId, recipe: data.recipe || null}
         }));
       } catch (_) {}
+      if (_lightboxCurrentId !== photoId || seq !== _lbAdjustSeq) return;
+      _lbEditRecipe = _lbCloneRecipe(data.recipe || {});
+      _lbRenderAdjustmentControls();
+      _lbReloadEditedSource(photoId, seq);
+      _lbSetAdjustmentStatus('Saved');
     })
     .catch(function(err) {
       if (_lightboxCurrentId !== photoId || seq !== _lbAdjustSeq) return;

--- a/vireo/templates/_sync_panel.html
+++ b/vireo/templates/_sync_panel.html
@@ -176,7 +176,7 @@ function renderSyncPreview() {
     html += '<div style="display:flex;gap:12px;padding:12px 0;border-bottom:1px solid var(--border-subtle);">';
 
     html += '<div style="flex-shrink:0;">';
-    html += '<img class="sync-preview-thumb" src="/thumbnails/' + p.photo_id + '.jpg" style="width:' + _syncThumbSize + 'px;height:' + Math.round(_syncThumbSize * 2 / 3) + 'px;object-fit:cover;border-radius:4px;cursor:pointer;display:block;" data-photo-id="' + p.photo_id + '" data-filename="' + escapeAttr(p.filename) + '">';
+    html += '<img class="sync-preview-thumb" src="' + vireoThumbnailUrl(p.photo_id) + '" style="width:' + _syncThumbSize + 'px;height:' + Math.round(_syncThumbSize * 2 / 3) + 'px;object-fit:cover;border-radius:4px;cursor:pointer;display:block;" data-photo-id="' + p.photo_id + '" data-filename="' + escapeAttr(p.filename) + '">';
     html += '</div>';
 
     html += '<div style="flex:1;min-width:0;">';

--- a/vireo/templates/best_batch.html
+++ b/vireo/templates/best_batch.html
@@ -369,7 +369,7 @@ function previewUrl(photoId, size) {
 }
 
 function thumbnailUrl(photoId) {
-  return '/thumbnails/' + photoId + '.jpg';
+  return vireoThumbnailUrl(photoId);
 }
 
 function roleLabel(role) {

--- a/vireo/templates/best_batch.html
+++ b/vireo/templates/best_batch.html
@@ -365,7 +365,7 @@ async function fetchJson(url, options) {
 }
 
 function previewUrl(photoId, size) {
-  return '/photos/' + photoId + '/preview?size=' + (size || 1920);
+  return vireoPreviewUrl(photoId, size || 1920);
 }
 
 function thumbnailUrl(photoId) {

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2156,7 +2156,7 @@ function renderPhotoCard(p, idx) {
 
   return '<div class="grid-card' + selectedClass + '" data-id="' + p.id + '" data-idx="' + idx + '" data-filename="' + escapeAttr(p.filename) + '" onclick="selectPhoto(event,' + p.id + ',' + idx + ')">' +
     '<div class="grid-card-img-wrap">' +
-      '<img src="/thumbnails/' + p.id + '.jpg" loading="lazy" decoding="async" alt="' + escapeAttr(p.filename) + '">' +
+      '<img src="' + vireoThumbnailUrl(p.id) + '" loading="lazy" decoding="async" alt="' + escapeAttr(p.filename) + '">' +
       clipBadge +
       boxHtml +
       inatBadge +
@@ -4006,7 +4006,7 @@ function renderBestBatch(data) {
   var cards = (data.cards || []).map(function(card) {
     var reasons = (card.reasons || []).slice(0, 2).map(escapeHtml).join(' · ');
     return '<div class="best-batch-card ' + escapeAttr(card.role || '') + '" data-photo-id="' + card.id + '">' +
-      '<img src="/thumbnails/' + card.id + '.jpg" alt="' + escapeAttr(card.filename || '') + '" loading="lazy">' +
+      '<img src="' + vireoThumbnailUrl(card.id) + '" alt="' + escapeAttr(card.filename || '') + '" loading="lazy">' +
       '<div class="best-batch-card-body">' +
         '<div class="best-batch-role ' + escapeAttr(card.role || '') + '">#' + card.rank + ' ' + bestBatchRoleLabel(card.role) + '</div>' +
         '<div class="best-batch-card-name" title="' + escapeAttr(card.filename || '') + '">' + escapeHtml(card.filename || '') + '</div>' +
@@ -4019,7 +4019,7 @@ function renderBestBatch(data) {
   content.innerHTML =
     '<div class="best-batch-head">' +
       '<div class="best-batch-pick">' +
-        '<img src="/thumbnails/' + best.id + '.jpg" alt="' + escapeAttr(best.filename || '') + '">' +
+        '<img src="' + vireoThumbnailUrl(best.id) + '" alt="' + escapeAttr(best.filename || '') + '">' +
         '<div class="best-batch-pick-meta">' +
           '<div class="best-batch-eyebrow">Best Pick</div>' +
           '<div class="best-batch-title">' + escapeHtml(best.filename || '') + '</div>' +
@@ -4952,7 +4952,7 @@ async function loadDetail(id) {
 
 function renderDetail(photo) {
   window._detailPhotoId = photo.id;
-  document.getElementById('detailImg').src = '/thumbnails/' + photo.id + '.jpg';
+  document.getElementById('detailImg').src = vireoThumbnailUrl(photo.id);
   document.getElementById('detailFilename').textContent = photo.filename;
 
   // Rating stars

--- a/vireo/templates/compare.html
+++ b/vireo/templates/compare.html
@@ -572,7 +572,7 @@ function renderPhotoCell(photo) {
   if (photo.flag && photo.flag !== 'none') meta.push(photo.flag);
   return '<div class="photo-cell">' +
     '<button type="button" class="photo-thumb-button" title="View larger" onclick="openCompareLightbox(' +
-    photo.photo_id + ')"><img src="' + vireoThumbnailUrl(photo.photo_id) + '" loading="lazy" alt="' +
+    photo.photo_id + ')"><img src="' + escapeAttr(vireoThumbnailUrl(photo.photo_id)) + '" loading="lazy" alt="' +
     escapeAttr(photo.filename) + '"></button>' +
     '<div><div class="photo-name">' + escapeHtml(photo.filename) + '</div>' +
     '<div class="photo-meta">' + escapeHtml(meta.join(' · ')) + '</div>' +

--- a/vireo/templates/compare.html
+++ b/vireo/templates/compare.html
@@ -572,7 +572,7 @@ function renderPhotoCell(photo) {
   if (photo.flag && photo.flag !== 'none') meta.push(photo.flag);
   return '<div class="photo-cell">' +
     '<button type="button" class="photo-thumb-button" title="View larger" onclick="openCompareLightbox(' +
-    photo.photo_id + ')"><img src="/thumbnails/' + photo.photo_id + '.jpg" loading="lazy" alt="' +
+    photo.photo_id + ')"><img src="' + vireoThumbnailUrl(photo.photo_id) + '" loading="lazy" alt="' +
     escapeAttr(photo.filename) + '"></button>' +
     '<div><div class="photo-name">' + escapeHtml(photo.filename) + '</div>' +
     '<div class="photo-meta">' + escapeHtml(meta.join(' · ')) + '</div>' +

--- a/vireo/templates/cull.html
+++ b/vireo/templates/cull.html
@@ -964,7 +964,7 @@ function renderCulling() {
           'onclick="openLightbox(' + photo.photo_id + ', this.dataset.filename, window.' + poseKey + ')" ' +
           'ondblclick="toggleCullAction(' + si + ',' + pi + ',' + photo.photo_id + ')">' +
           badge +
-          '<img src="' + vireoThumbnailUrl(photo.photo_id) + '" loading="lazy">' +
+          '<img src="' + escapeAttr(vireoThumbnailUrl(photo.photo_id)) + '" loading="lazy">' +
           '<div class="cull-card-info">' +
             '<div class="cull-quality">' + (photo.pipeline_label || photo.action.toUpperCase()) + ' &middot; Q: ' + qScore + '</div>' +
             '<div class="cull-filename" onclick="event.stopPropagation()" onmousedown="event.stopPropagation()">' + escapeHtml(photo.filename || '') + '</div>' +

--- a/vireo/templates/cull.html
+++ b/vireo/templates/cull.html
@@ -964,7 +964,7 @@ function renderCulling() {
           'onclick="openLightbox(' + photo.photo_id + ', this.dataset.filename, window.' + poseKey + ')" ' +
           'ondblclick="toggleCullAction(' + si + ',' + pi + ',' + photo.photo_id + ')">' +
           badge +
-          '<img src="/thumbnails/' + photo.photo_id + '.jpg" loading="lazy">' +
+          '<img src="' + vireoThumbnailUrl(photo.photo_id) + '" loading="lazy">' +
           '<div class="cull-card-info">' +
             '<div class="cull-quality">' + (photo.pipeline_label || photo.action.toUpperCase()) + ' &middot; Q: ' + qScore + '</div>' +
             '<div class="cull-filename" onclick="event.stopPropagation()" onmousedown="event.stopPropagation()">' + escapeHtml(photo.filename || '') + '</div>' +

--- a/vireo/templates/duplicates.html
+++ b/vireo/templates/duplicates.html
@@ -902,7 +902,7 @@
     var missing = photo.exists === false;
     if (missing) cls += ' missing';
     var badge = isWinner ? 'KEEP' : (isResolvedLoser ? 'REJECTED' : 'WILL REJECT');
-    var thumbUrl = photo.id != null ? ('/thumbnails/' + photo.id + '.jpg') : null;
+    var thumbUrl = photo.id != null ? vireoThumbnailUrl(photo.id) : null;
     var html = '<div class="dup-card ' + cls + '" data-photo-id="' +
                (photo.id != null ? photo.id : '') + '">';
     if (thumbUrl) {

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -277,7 +277,7 @@ function sortedBuckets() {
 }
 
 function renderCard(p, idx) {
-  var thumbSrc = '/thumbnails/' + p.id + '.jpg';
+  var thumbSrc = vireoThumbnailUrl(p.id);
   var conf = p.has_accepted_species
     ? '<span class="card-chip conf">Tagged</span>'
     : (p.predicted_confidence != null ? '<span class="card-chip conf">ID ' + formatPercent(p.predicted_confidence) + '</span>' : '');

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -277,7 +277,7 @@ function sortedBuckets() {
 }
 
 function renderCard(p, idx) {
-  var thumbSrc = vireoThumbnailUrl(p.id);
+  var thumbSrc = escapeAttr(vireoThumbnailUrl(p.id));
   var conf = p.has_accepted_species
     ? '<span class="card-chip conf">Tagged</span>'
     : (p.predicted_confidence != null ? '<span class="card-chip conf">ID ' + formatPercent(p.predicted_confidence) + '</span>' : '');

--- a/vireo/templates/life_list.html
+++ b/vireo/templates/life_list.html
@@ -162,7 +162,7 @@ function sortedSpecies() {
 
 function renderCard(entry) {
   var best = entry.best;
-  var thumb = best ? '/thumbnails/' + best.id + '.jpg' : '';
+  var thumb = best ? vireoThumbnailUrl(best.id) : '';
   var sci = entry.scientific_name && entry.scientific_name !== entry.species
     ? '<div class="species-sci">' + escapeAttr(entry.scientific_name) + '</div>'
     : '';

--- a/vireo/templates/life_list.html
+++ b/vireo/templates/life_list.html
@@ -180,7 +180,7 @@ function renderCard(entry) {
     + escapeAttr((entry.locations || []).join(', ')) + '">'
     + '<div class="lifer-number">#' + entry.number + '</div>'
     + (best && best.is_life_list_photo ? '<div class="lifelist-ribbon">Life List</div>' : '')
-    + (best ? '<img src="' + escapeAttr(thumb) + '" alt="' + escapeAttr(best.filename) + '" loading="lazy">' : '')
+    + (best ? '<img src="' + escapeAttr(thumb) + '" data-photo-id="' + escapeAttr(best.id) + '" alt="' + escapeAttr(best.filename) + '" loading="lazy">' : '')
     + '<div class="species-info">'
     + '<div class="species-name">' + escapeAttr(entry.species) + '</div>'
     + sci

--- a/vireo/templates/map.html
+++ b/vireo/templates/map.html
@@ -483,7 +483,7 @@ function renderSidebar(photos) {
     card.className = 'sidebar-card';
     card.setAttribute('data-id', p.id);
 
-    var thumbSrc = p.id != null ? '/thumbnails/' + p.id + '.jpg' : '';
+    var thumbSrc = p.id != null ? vireoThumbnailUrl(p.id) : '';
     var color = getSpeciesColor(p.species);
     var speciesHtml = p.species
       ? '<div class="card-species"><span class="species-dot" style="background:' + color + '"></span>'
@@ -518,7 +518,7 @@ function showClusterPreview(e) {
   for (var i = 0; i < previewCount; i++) {
     var p = childMarkers[i]._photoData;
     if (p && p.id != null) {
-      gridHtml += '<img src="/thumbnails/' + p.id + '.jpg"'
+      gridHtml += '<img src="' + vireoThumbnailUrl(p.id) + '"'
         + ' alt="" onerror="this.style.visibility=\'hidden\'">';
     } else {
       gridHtml += '<div style="width:56px;height:56px;background:var(--bg-tertiary,#14374E);border-radius:3px"></div>';
@@ -587,7 +587,7 @@ async function loadPhotos() {
     legendControl.update(speciesColorMap);
 
     data.photos.forEach(function(p) {
-      var thumbSrc = p.id != null ? '/thumbnails/' + p.id + '.jpg' : '';
+      var thumbSrc = p.id != null ? vireoThumbnailUrl(p.id) : '';
       var imgTag = thumbSrc
         ? '<img src="' + escapeAttr(thumbSrc) + '" alt="" onerror="this.style.display=\'none\'">'
         : '';

--- a/vireo/templates/map.html
+++ b/vireo/templates/map.html
@@ -518,7 +518,7 @@ function showClusterPreview(e) {
   for (var i = 0; i < previewCount; i++) {
     var p = childMarkers[i]._photoData;
     if (p && p.id != null) {
-      gridHtml += '<img src="' + vireoThumbnailUrl(p.id) + '"'
+      gridHtml += '<img src="' + escapeAttr(vireoThumbnailUrl(p.id)) + '"'
         + ' alt="" onerror="this.style.visibility=\'hidden\'">';
     } else {
       gridHtml += '<div style="width:56px;height:56px;background:var(--bg-tertiary,#14374E);border-radius:3px"></div>';

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -875,7 +875,7 @@ function renderCard(cat, p, idx) {
       'onclick="onCardClick(\'' + cat + '\', ' + idx + ', ' + p.id + ', event)" ' +
       'ondblclick="onCardDoubleClick(\'' + cat + '\', ' + idx + ', event)">' +
       '<div class="miss-card-img-wrap">' +
-        '<img src="' + vireoThumbnailUrl(p.id) + '" loading="lazy" alt="' + escapeAttr(p.filename || '') + '">' +
+        '<img src="' + escapeAttr(vireoThumbnailUrl(p.id)) + '" loading="lazy" alt="' + escapeAttr(p.filename || '') + '">' +
         bboxHtml +
         '<span class="miss-card-badge">' +
           '<span class="dot cat-' + cat + '"></span>' +

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -875,7 +875,7 @@ function renderCard(cat, p, idx) {
       'onclick="onCardClick(\'' + cat + '\', ' + idx + ', ' + p.id + ', event)" ' +
       'ondblclick="onCardDoubleClick(\'' + cat + '\', ' + idx + ', event)">' +
       '<div class="miss-card-img-wrap">' +
-        '<img src="/thumbnails/' + p.id + '.jpg" loading="lazy" alt="' + escapeAttr(p.filename || '') + '">' +
+        '<img src="' + vireoThumbnailUrl(p.id) + '" loading="lazy" alt="' + escapeAttr(p.filename || '') + '">' +
         bboxHtml +
         '<span class="miss-card-badge">' +
           '<span class="dot cat-' + cat + '"></span>' +

--- a/vireo/templates/move.html
+++ b/vireo/templates/move.html
@@ -606,7 +606,7 @@ function renderPhotoGrid() {
   photoList.forEach(function(p, idx) {
     var selClass = selectedPhotos.has(p.id) ? ' selected' : '';
     html += '<div class="grid-card' + selClass + '" data-id="' + p.id + '" data-idx="' + idx + '" onclick="handlePhotoClick(event, ' + p.id + ', ' + idx + ')">';
-    html += '<div class="grid-card-img-wrap"><img src="' + vireoThumbnailUrl(p.id) + '" loading="lazy" alt=""></div>';
+    html += '<div class="grid-card-img-wrap"><img src="' + escapeAttr(vireoThumbnailUrl(p.id)) + '" loading="lazy" alt=""></div>';
     html += '<div class="grid-card-info"><div class="grid-card-name" title="' + escapeAttr(p.filename) + '">' + escapeHtml(p.filename) + '</div></div>';
     html += '</div>';
   });

--- a/vireo/templates/move.html
+++ b/vireo/templates/move.html
@@ -606,7 +606,7 @@ function renderPhotoGrid() {
   photoList.forEach(function(p, idx) {
     var selClass = selectedPhotos.has(p.id) ? ' selected' : '';
     html += '<div class="grid-card' + selClass + '" data-id="' + p.id + '" data-idx="' + idx + '" onclick="handlePhotoClick(event, ' + p.id + ', ' + idx + ')">';
-    html += '<div class="grid-card-img-wrap"><img src="/thumbnails/' + p.id + '.jpg" loading="lazy" alt=""></div>';
+    html += '<div class="grid-card-img-wrap"><img src="' + vireoThumbnailUrl(p.id) + '" loading="lazy" alt=""></div>';
     html += '<div class="grid-card-info"><div class="grid-card-name" title="' + escapeAttr(p.filename) + '">' + escapeHtml(p.filename) + '</div></div>';
     html += '</div>';
   });

--- a/vireo/templates/pipeline_rapid_review.html
+++ b/vireo/templates/pipeline_rapid_review.html
@@ -791,7 +791,7 @@ function photoOriginalUrl(id) {
 }
 
 function thumbUrl(id) {
-  return '/thumbnails/' + id + '.jpg';
+  return vireoThumbnailUrl(id);
 }
 
 function burstIds(burst) {

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -2402,7 +2402,7 @@ function renderPhotoCard(p, encIdx, burstIdx) {
   var q = p.quality_composite || 0;
   var qPct = Math.round(q * 100);
   var html = '<div class="photo-card ' + label + '" data-photo-id="' + p.id + '">';
-  html += '<img src="/thumbnails/' + p.id + '.jpg" loading="lazy" alt="" onclick="openInspect(' + p.id + ')">';
+  html += '<img src="' + vireoThumbnailUrl(p.id) + '" loading="lazy" alt="" onclick="openInspect(' + p.id + ')">';
   if (p.label) html += '<span class="photo-label ' + label + '">' + p.label + '</span>';
   if (p.rarity_protected) html += '<span class="photo-rarity">protected</span>';
   if (p.flag === 'flagged') html += '<span class="photo-flag-badge flag-flagged">P</span>';
@@ -2870,7 +2870,7 @@ function openInspect(photoId) {
 
   // Image with mask toggle
   html += '<div class="inspect-img-wrap">';
-  html += '<img src="/thumbnails/' + photoId + '.jpg" alt="">';
+  html += '<img src="' + vireoThumbnailUrl(photoId) + '" alt="">';
   html += '<img class="mask-overlay" id="maskOverlay" src="/masks/' + photoId + '.png" alt="">';
   html += '<button class="mask-toggle" onclick="toggleMask()">Toggle Mask</button>';
   html += '</div>';
@@ -2922,7 +2922,7 @@ function openInspect(photoId) {
     html += '<div class="context-filmstrip">';
     (enc.photo_ids || []).forEach(function(pid) {
       var isCurrent = pid === photoId ? ' current' : '';
-      html += '<img src="/thumbnails/' + pid + '.jpg" class="' + isCurrent + '" onclick="openInspect(' + pid + ')" alt="">';
+      html += '<img src="' + vireoThumbnailUrl(pid) + '" class="' + isCurrent + '" onclick="openInspect(' + pid + ')" alt="">';
     });
     html += '</div>';
   }

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1139,7 +1139,7 @@ function getConsensusSpecies(pred) {
 }
 
 function renderPredictionCard(pred) {
-  var thumbUrl = '/thumbnails/' + pred.photo_id + '.jpg';
+  var thumbUrl = vireoThumbnailUrl(pred.photo_id);
   var displaySpecies = pred.group_id ? getConsensusSpecies(pred) : pred.species;
   var confPct = Math.round(pred.confidence * 100);
   var confColor = confPct >= 70 ? 'var(--accent)' : confPct >= 50 ? 'var(--warning)' : 'var(--danger)';
@@ -1946,7 +1946,7 @@ GRM_CARD_H = Math.round(GRM_CARD_W * 2 / 3);
 
 function grmPhotoUrl(photoId) {
   var stop = GRM_RES_STOPS[grmResolutionIdx] || GRM_RES_STOPS[1];
-  if (stop.kind === 'thumb') return '/thumbnails/' + photoId + '.jpg';
+  if (stop.kind === 'thumb') return vireoThumbnailUrl(photoId);
   if (stop.kind === 'original') return '/photos/' + photoId + '/original';
   return '/photos/' + photoId + '/preview?size=' + stop.size;
 }

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1948,7 +1948,7 @@ function grmPhotoUrl(photoId) {
   var stop = GRM_RES_STOPS[grmResolutionIdx] || GRM_RES_STOPS[1];
   if (stop.kind === 'thumb') return vireoThumbnailUrl(photoId);
   if (stop.kind === 'original') return '/photos/' + photoId + '/original';
-  return '/photos/' + photoId + '/preview?size=' + stop.size;
+  return vireoPreviewUrl(photoId, stop.size);
 }
 
 function grmLoupePhotoUrl(photoId) {

--- a/vireo/templates/variants.html
+++ b/vireo/templates/variants.html
@@ -344,7 +344,7 @@ function renderClusters(data) {
     html += '<div class="cluster-grid">';
     cluster.photos.forEach(function(item) {
       var p = item.photo;
-      html += '<img class="cluster-thumb" src="/thumbnails/' + p.id + '.jpg" loading="lazy" ' +
+      html += '<img class="cluster-thumb" src="' + vireoThumbnailUrl(p.id) + '" loading="lazy" ' +
         'title="' + escapeAttr(p.filename) + '" ' +
         'data-photo-id="' + p.id + '" data-filename="' + escapeAttr(p.filename) + '">';
     });

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -170,6 +170,40 @@ def test_export_photos_applies_edit_recipe(export_env):
         assert img.size == (300, 800)
 
 
+def test_export_photos_applies_adjustment_recipe(export_env):
+    """export_photos applies exposure, white balance, contrast, and saturation."""
+    env = export_env
+    Image.new("RGB", (80, 60), color=(100, 100, 100)).save(
+        str(env["src"] / "bird1.jpg"), "JPEG", quality=95,
+    )
+    env["db"].set_photo_edit_recipe(
+        env["p1"],
+        {
+            "adjustments": {
+                "exposure": 0.5,
+                "contrast": 15,
+                "white_balance": {"temperature": 80, "tint": -20},
+                "saturation": 10,
+            },
+        },
+    )
+
+    result = export_photos(
+        db=env["db"],
+        vireo_dir=env["vireo_dir"],
+        photo_ids=[env["p1"]],
+        destination=env["dest"],
+        options={"naming_template": "{original}"},
+    )
+
+    assert result["exported"] == 1
+    assert result["errors"] == []
+    with Image.open(os.path.join(env["dest"], "bird1.jpg")) as img:
+        r, g, b = img.getpixel((0, 0))
+    assert r > b
+    assert max(r, g, b) > 100
+
+
 def test_export_non_crop_recipe_loads_with_requested_size(export_env, monkeypatch):
     import export as export_module
 

--- a/vireo/tests/test_image_edits.py
+++ b/vireo/tests/test_image_edits.py
@@ -57,6 +57,31 @@ def test_recipe_json_is_canonical():
     )
 
 
+def test_normalize_recipe_canonicalizes_white_balance():
+    assert normalize_recipe(
+        {
+            "adjustments": {
+                "temperature": 20,
+                "tint": -10,
+                "exposure": 0,
+            }
+        }
+    ) == {
+        "version": 1,
+        "adjustments": {
+            "white_balance": {
+                "temperature": 20.0,
+                "tint": -10.0,
+            },
+        },
+    }
+
+
+def test_normalize_recipe_rejects_invalid_white_balance():
+    with pytest.raises(RecipeError, match="white_balance.temperature"):
+        normalize_recipe({"adjustments": {"white_balance": {"temperature": 200}}})
+
+
 def test_apply_recipe_rotates_flips_and_crops():
     img = Image.new("RGB", (100, 60), "white")
     edited = apply_recipe(
@@ -69,3 +94,23 @@ def test_apply_recipe_rotates_flips_and_crops():
     )
 
     assert edited.size == (30, 50)
+
+
+def test_apply_recipe_adjusts_exposure_white_balance_contrast_and_saturation():
+    img = Image.new("RGB", (1, 1), (100, 100, 100))
+    edited = apply_recipe(
+        img,
+        {
+            "adjustments": {
+                "exposure": 1,
+                "contrast": 10,
+                "white_balance": {"temperature": 60, "tint": -30},
+                "saturation": 20,
+            },
+        },
+    )
+
+    r, g, b = edited.getpixel((0, 0))
+    assert r > b
+    assert g > b
+    assert max(r, g, b) > 100

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1920,6 +1920,39 @@ def test_edit_recipe_api_rejects_invalid_recipe(client_with_photo):
     assert "rotation" in resp.get_json()["error"]
 
 
+def test_edit_recipe_api_stores_adjustments(client_with_photo):
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+
+    resp = client.put(
+        f"/api/photos/{photo_id}/edit-recipe",
+        json={
+            "recipe": {
+                "adjustments": {
+                    "exposure": 0.5,
+                    "contrast": 12,
+                    "temperature": 25,
+                    "tint": -8,
+                    "saturation": 18,
+                },
+            },
+        },
+    )
+
+    assert resp.status_code == 200
+    stored = db.get_photo_edit_recipe(photo_id)
+    assert stored["adjustments"] == {
+        "exposure": 0.5,
+        "contrast": 12.0,
+        "saturation": 18.0,
+        "white_balance": {
+            "temperature": 25.0,
+            "tint": -8.0,
+        },
+    }
+    assert resp.get_json()["recipe"] == stored
+
+
 def test_edit_recipe_api_rejects_malformed_body_without_clearing(client_with_photo):
     app, db, photo_id = client_with_photo
     client = app.test_client()


### PR DESCRIPTION
Adds non-destructive exposure, contrast, white balance, and saturation adjustments to image edit recipes and renders them through previews and exports. Adds a shared lightbox Adjust panel with debounced recipe saves, live preview feedback, cache-busted preview reloads, and thumbnail refreshes. Covers recipe normalization/rendering, API storage, and export behavior with focused tests. Validation: pytest recipe/export/edit-recipe suites and a lightbox script syntax check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added image adjustment controls to the lightbox including white balance (temperature/tint), exposure, contrast, and saturation.
  * Adjustments persist automatically and preview in real-time.

* **Improvements**
  * Edited photos now visually refresh across all thumbnails and previews.

* **Tests**
  * Added tests for adjustment recipe storage, application, and export validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->