### PR TITLE
Add crop and straighten editing

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1549,6 +1549,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 log.warning("Failed to remove stale original cache %s", original_cache)
         db.conn.commit()
 
+    def _queue_edit_recipe_sync(db, photo_id, recipe_json):
+        """Queue the current non-destructive edit recipe for XMP sync."""
+        db.remove_pending_changes(
+            photo_id, "edit_recipe", workspace_id=db._ws_id(), _commit=False,
+        )
+        db.queue_change(
+            photo_id, "edit_recipe", recipe_json or "",
+            workspace_id=db._ws_id(), _commit=False,
+        )
+        db.conn.commit()
+
     def _rendered_recipe_long_edge(width, height, recipe):
         rotation = (recipe or {}).get("rotation", 0)
         if rotation in (90, 270):
@@ -3871,6 +3882,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error(str(e), 403)
         _invalidate_photo_render_cache(db, [photo_id])
         if old_value != new_value:
+            _queue_edit_recipe_sync(db, photo_id, new_value)
             db.record_edit(
                 "edit_recipe",
                 "Updated photo edit recipe",
@@ -3894,6 +3906,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error(str(e), 403)
         _invalidate_photo_render_cache(db, [photo_id])
         if old_value:
+            _queue_edit_recipe_sync(db, photo_id, "")
             db.record_edit(
                 "edit_recipe",
                 "Cleared photo edit recipe",
@@ -5388,11 +5401,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if result is None:
             return json_error("nothing to undo")
         if result.get("action_type") == "edit_recipe":
+            from image_edits import recipe_to_json
             rows = db.conn.execute(
                 "SELECT photo_id FROM edit_history_items WHERE edit_id = ?",
                 (result["id"],),
             ).fetchall()
-            _invalidate_photo_render_cache(db, [r["photo_id"] for r in rows])
+            photo_ids = [r["photo_id"] for r in rows]
+            _invalidate_photo_render_cache(db, photo_ids)
+            for pid in photo_ids:
+                _queue_edit_recipe_sync(
+                    db, pid, recipe_to_json(db.get_photo_edit_recipe(pid)) or "",
+                )
         return jsonify({"ok": True, "undone": result["description"]})
 
     @app.route("/api/undo/status")
@@ -5425,11 +5444,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if result is None:
             return json_error("nothing to redo")
         if result.get("action_type") == "edit_recipe":
+            from image_edits import recipe_to_json
             rows = db.conn.execute(
                 "SELECT photo_id FROM edit_history_items WHERE edit_id = ?",
                 (result["id"],),
             ).fetchall()
-            _invalidate_photo_render_cache(db, [r["photo_id"] for r in rows])
+            photo_ids = [r["photo_id"] for r in rows]
+            _invalidate_photo_render_cache(db, photo_ids)
+            for pid in photo_ids:
+                _queue_edit_recipe_sync(
+                    db, pid, recipe_to_json(db.get_photo_edit_recipe(pid)) or "",
+                )
         return jsonify({"ok": True, "redone": result["description"]})
 
     @app.route("/api/redo/status")
@@ -16866,6 +16891,61 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if size not in allowed_preview_sizes():
             return "Unsupported size", 400
         return _serve_preview(photo_id, size)
+
+    @app.route("/photos/<int:photo_id>/edit-preview")
+    def serve_photo_edit_preview(photo_id):
+        """Serve an uncropped preview for an in-progress edit recipe."""
+        import io
+
+        import config as cfg
+
+        db = _get_db()
+        photo = db.get_photo(photo_id, verify_workspace=True)
+        if not photo:
+            return "Not found", 404
+        try:
+            size = int(request.args.get("size", "1920"))
+        except ValueError:
+            return "Invalid size", 400
+        size = max(256, min(3840, size))
+
+        raw_recipe = request.args.get("recipe")
+        if raw_recipe:
+            try:
+                recipe = json.loads(raw_recipe)
+            except (TypeError, ValueError):
+                return "Invalid recipe", 400
+        else:
+            recipe = db.get_photo_edit_recipe(photo_id) or {}
+        if not isinstance(recipe, dict):
+            return "Invalid recipe", 400
+        display_recipe = dict(recipe)
+        display_recipe.pop("crop", None)
+
+        try:
+            from image_edits import RecipeError, apply_recipe_to_loaded_image
+            from image_loader import load_image
+            recipe_json = display_recipe
+            vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+            folder_row = db.conn.execute(
+                "SELECT id, path FROM folders WHERE id=?", (photo["folder_id"],)
+            ).fetchone()
+            if not folder_row:
+                return "Not found", 404
+            canonical, _using_working_copy = _recipe_render_source(
+                photo, None, size, vireo_dir, {folder_row["id"]: folder_row["path"]},
+            )
+            img = load_image(canonical, max_size=size)
+            if img is None:
+                return "Could not load image", 500
+            img = apply_recipe_to_loaded_image(img, recipe_json, max_size=size)
+        except RecipeError as e:
+            return str(e), 400
+
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG", quality=cfg.load().get("preview_quality", 90))
+        img.close()
+        return Response(buf.getvalue(), mimetype="image/jpeg")
 
     @app.route("/photos/<int:photo_id>/original")
     def serve_original_photo(photo_id):

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -16924,7 +16924,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         try:
             from image_edits import RecipeError, apply_recipe_to_loaded_image
-            from image_loader import load_image
+            from image_loader import RAW_EXTENSIONS, load_image
             recipe_json = display_recipe
             vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
             folder_row = db.conn.execute(
@@ -16932,11 +16932,30 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             ).fetchone()
             if not folder_row:
                 return "Not found", 404
-            canonical, _using_working_copy = _recipe_render_source(
+            canonical, using_working_copy = _recipe_render_source(
                 photo, None, size, vireo_dir, {folder_row["id"]: folder_row["path"]},
             )
+            selected_ext = os.path.splitext(canonical)[1].lower()
+            if (
+                not using_working_copy
+                and selected_ext in RAW_EXTENSIONS
+                and _has_current_working_copy_failure(
+                    photo,
+                    vireo_dir,
+                    trust_existing_working_copy=False,
+                    live_source_path=canonical,
+                    folder_path=folder_row["path"],
+                )
+            ):
+                log.info(
+                    "Skipping edit-preview generation for photo %s; RAW "
+                    "working-copy extraction already failed for current source mtime",
+                    photo_id,
+                )
+                return "Could not load image", 500
             img = load_image(canonical, max_size=size)
             if img is None:
+                _record_working_copy_failure(db, photo, canonical)
                 return "Could not load image", 500
             img = apply_recipe_to_loaded_image(img, recipe_json, max_size=size)
         except RecipeError as e:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5400,6 +5400,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         result = db.undo_last_edit()
         if result is None:
             return json_error("nothing to undo")
+        edit_recipe_updates = None
         if result.get("action_type") == "edit_recipe":
             from image_edits import recipe_to_json
             rows = db.conn.execute(
@@ -5408,11 +5409,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             ).fetchall()
             photo_ids = [r["photo_id"] for r in rows]
             _invalidate_photo_render_cache(db, photo_ids)
+            edit_recipe_updates = {}
             for pid in photo_ids:
+                recipe = db.get_photo_edit_recipe(pid)
+                edit_recipe_updates[str(pid)] = recipe
                 _queue_edit_recipe_sync(
-                    db, pid, recipe_to_json(db.get_photo_edit_recipe(pid)) or "",
+                    db, pid, recipe_to_json(recipe) or "",
                 )
-        return jsonify({"ok": True, "undone": result["description"]})
+        response = {"ok": True, "undone": result["description"]}
+        if edit_recipe_updates is not None:
+            response["action_type"] = "edit_recipe"
+            response["edit_recipes"] = edit_recipe_updates
+        return jsonify(response)
 
     @app.route("/api/undo/status")
     def api_undo_status():
@@ -5443,6 +5451,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         result = db.redo_last_undo()
         if result is None:
             return json_error("nothing to redo")
+        edit_recipe_updates = None
         if result.get("action_type") == "edit_recipe":
             from image_edits import recipe_to_json
             rows = db.conn.execute(
@@ -5451,11 +5460,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             ).fetchall()
             photo_ids = [r["photo_id"] for r in rows]
             _invalidate_photo_render_cache(db, photo_ids)
+            edit_recipe_updates = {}
             for pid in photo_ids:
+                recipe = db.get_photo_edit_recipe(pid)
+                edit_recipe_updates[str(pid)] = recipe
                 _queue_edit_recipe_sync(
-                    db, pid, recipe_to_json(db.get_photo_edit_recipe(pid)) or "",
+                    db, pid, recipe_to_json(recipe) or "",
                 )
-        return jsonify({"ok": True, "redone": result["description"]})
+        response = {"ok": True, "redone": result["description"]}
+        if edit_recipe_updates is not None:
+            response["action_type"] = "edit_recipe"
+            response["edit_recipes"] = edit_recipe_updates
+        return jsonify(response)
 
     @app.route("/api/redo/status")
     def api_redo_status():

--- a/vireo/image_edits.py
+++ b/vireo/image_edits.py
@@ -26,9 +26,9 @@ def normalize_recipe(recipe):
     """Validate and canonicalize a non-destructive image edit recipe.
 
     The crop rectangle uses normalized coordinates in the image space after
-    rotation and flips have been applied. Rotation is limited to right angles;
-    arbitrary straightening can be added to this schema without changing the
-    storage model.
+    rotation, flips, and straightening have been applied. Rotation is limited
+    to right angles; straightening is a small arbitrary clockwise angle applied
+    in-place so crop coordinates remain stable.
     """
     if recipe in (None, "", {}):
         return None
@@ -52,6 +52,17 @@ def normalize_recipe(recipe):
         raise RecipeError("rotation must be one of 0, 90, 180, or 270")
     if rotation:
         out["rotation"] = rotation
+
+    straighten = recipe.get("straighten", 0)
+    if straighten in (None, ""):
+        straighten = 0
+    if isinstance(straighten, bool) or not isinstance(straighten, (int, float)):
+        raise RecipeError("straighten must be numeric")
+    straighten = float(straighten)
+    if not math.isfinite(straighten) or straighten < -45.0 or straighten > 45.0:
+        raise RecipeError("straighten must be between -45 and 45 degrees")
+    if abs(straighten) > 1e-9:
+        out["straighten"] = round(straighten, 4)
 
     flip = recipe.get("flip")
     if flip is None:
@@ -158,6 +169,14 @@ def apply_recipe(img, recipe):
         result = result.transpose(Image.Transpose.FLIP_LEFT_RIGHT)
     if flip.get("vertical"):
         result = result.transpose(Image.Transpose.FLIP_TOP_BOTTOM)
+
+    straighten = normalized.get("straighten", 0)
+    if straighten:
+        result = result.rotate(
+            -straighten,
+            resample=Image.Resampling.BICUBIC,
+            expand=False,
+        )
 
     crop = normalized.get("crop")
     if crop:

--- a/vireo/sync.py
+++ b/vireo/sync.py
@@ -8,6 +8,7 @@ from xmp import (
     read_keywords,
     remove_keywords,
     remove_vireo_gps_location,
+    write_edit_recipe,
     write_gps_location,
     write_pick_flag,
     write_rating,
@@ -108,6 +109,7 @@ def sync_to_xmp(db, progress_callback=None, change_ids=None):
             keywords_to_remove = set()
             new_rating = None
             new_flag = None
+            edit_recipe_json = None
             sync_location = False
             cleanup_location = False
             supported_ids = []
@@ -135,6 +137,9 @@ def sync_to_xmp(db, progress_callback=None, change_ids=None):
                         sync_location = True
                     else:
                         cleanup_location = True
+                elif c["change_type"] == "edit_recipe":
+                    edit_recipe_json = c["value"] or ""
+                    supported_ids.append(c["id"])
 
             # Write keywords
             if keywords_to_add:
@@ -169,6 +174,9 @@ def sync_to_xmp(db, progress_callback=None, change_ids=None):
                     remove_vireo_gps_location(xmp_path)
             elif cleanup_location:
                 remove_vireo_gps_location(xmp_path)
+
+            if edit_recipe_json is not None:
+                write_edit_recipe(xmp_path, edit_recipe_json)
 
             if supported_ids:
                 synced += 1

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -4458,6 +4458,20 @@ async function cropClearEdits() {
   }
 }
 
+function _lbRefreshEditRecipeCache(updates) {
+  if (!updates || typeof updates !== 'object') return;
+  var version = String(Date.now());
+  Object.keys(updates).forEach(function(photoId) {
+    _lbEditVersionByPhoto[String(photoId)] = version;
+    var numericId = Number(photoId);
+    var p = _lightboxPhotoList.find(function(x) { return x.id === numericId; });
+    if (p) p.edit_recipe = updates[photoId] || null;
+    if (_lightboxCurrentId === numericId) {
+      _lbCurrentEditRecipe = updates[photoId] || null;
+    }
+  });
+}
+
 function openLightbox(photoId, filename, photoList, options) {
   var alreadyOpen = !!window._lbEscToken;
   options = options || {};
@@ -7229,6 +7243,7 @@ function formatDuration(seconds) {
     safeFetch('/api/undo', {method: 'POST'})
       .then(function(data) {
         if (data && data.ok) {
+          _lbRefreshEditRecipeCache(data.edit_recipes);
           showToast('Undone: ' + data.undone + ' — press Ctrl+Shift+Z to redo', 'success');
           _historySessionCount = Math.max(0, _historySessionCount - 1);
           document.getElementById('historyBadge').textContent = _historySessionCount || '';
@@ -7243,6 +7258,7 @@ function formatDuration(seconds) {
     safeFetch('/api/redo', {method: 'POST'})
       .then(function(data) {
         if (data && data.ok) {
+          _lbRefreshEditRecipeCache(data.edit_recipes);
           showToast('Redone: ' + data.redone, 'success');
           _historySessionCount++;
           document.getElementById('historyBadge').textContent = _historySessionCount || '';

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3726,6 +3726,15 @@ function _lbRecipeHasCrop(recipe) {
   return !!(recipe && recipe.crop && Number(recipe.crop.w) > 0 && Number(recipe.crop.h) > 0);
 }
 
+function _lbRecipeHasGeometricEdit(recipe) {
+  if (!recipe || typeof recipe !== 'object') return false;
+  if (_lbRecipeHasCrop(recipe)) return true;
+  if (Number(recipe.rotation || 0)) return true;
+  if (Math.abs(Number(recipe.straighten || 0)) > 1e-9) return true;
+  var flip = recipe.flip || {};
+  return !!(flip.horizontal || flip.vertical);
+}
+
 function _lbMetadataOrientation(metadata) {
   if (!metadata || typeof metadata !== 'object') return null;
   var groups = ['EXIF', 'TIFF', 'Image'];
@@ -3754,7 +3763,7 @@ function _lbOrientationSwapsAxes(orientation) {
 }
 
 function _lbSourceOverlaysAvailable() {
-  return !_lbRecipeHasCrop(_lbCurrentEditRecipe);
+  return !_lbRecipeHasGeometricEdit(_lbCurrentEditRecipe);
 }
 
 function _lbApplyBoxesVisibility() {
@@ -3764,9 +3773,9 @@ function _lbApplyBoxesVisibility() {
   var btn = document.getElementById('lightboxToggleBoxes');
   if (btn) {
     btn.disabled = !available;
-    btn.textContent = !available ? 'Boxes Cropped' : (_lbBoxesVisible ? 'Hide Boxes' : 'Show Boxes');
+    btn.textContent = !available ? 'Boxes Edited' : (_lbBoxesVisible ? 'Hide Boxes' : 'Show Boxes');
     btn.title = !available
-      ? 'Detection boxes are hidden for cropped photos'
+      ? 'Detection boxes are hidden for geometrically edited photos'
       : 'Toggle detection boxes (b)';
   }
 }
@@ -3813,9 +3822,9 @@ function _lbApplyEyeVisibility() {
   var btn = document.getElementById('lightboxToggleEye');
   if (btn) {
     btn.disabled = !available;
-    btn.textContent = !available ? 'Eye Cropped' : (_lbEyeVisible ? 'Hide Eye' : 'Show Eye');
+    btn.textContent = !available ? 'Eye Edited' : (_lbEyeVisible ? 'Hide Eye' : 'Show Eye');
     btn.title = !available
-      ? 'Eye marker is hidden for cropped photos'
+      ? 'Eye marker is hidden for geometrically edited photos'
       : 'Toggle eye marker';
   }
 }
@@ -4003,9 +4012,9 @@ function _lbApplyMaskToggleButton() {
   if (btn) {
     var available = _lbSourceOverlaysAvailable();
     btn.disabled = !available;
-    btn.textContent = !available ? 'Masks Cropped' : (_lbMasksVisible ? 'Hide Masks' : 'Show Masks');
+    btn.textContent = !available ? 'Masks Edited' : (_lbMasksVisible ? 'Hide Masks' : 'Show Masks');
     btn.title = !available
-      ? 'Mask overlay is hidden for cropped photos'
+      ? 'Mask overlay is hidden for geometrically edited photos'
       : 'Toggle mask overlay';
   }
 }
@@ -4548,7 +4557,7 @@ function openLightbox(photoId, filename, photoList, options) {
       _lbPhotoH = data.height || null;
       _lbPhotoOrientation = _lbMetadataOrientation(data.metadata);
       _lbCurrentEditRecipe = data.edit_recipe || null;
-      if (_lbRecipeHasCrop(_lbCurrentEditRecipe)) {
+      if (!_lbSourceOverlaysAvailable()) {
         var detContainer2 = document.getElementById('lightboxDetections');
         if (detContainer2) detContainer2.innerHTML = '';
         var eyeContainer2 = document.getElementById('lightboxEye');

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3357,6 +3357,7 @@ var _lbEditVersionByPhoto = {};
 var _cropRecipe = null;
 var _cropPhotoId = null;
 var _cropPreviewSeq = 0;
+var _cropSessionSeq = 0;
 var _cropDrag = null;
 var _cropPreviewTimer = null;
 var _cropEscToken = null;
@@ -4154,6 +4155,10 @@ function _cropSetStatus(message, isError) {
   el.classList.toggle('error', !!isError);
 }
 
+function _cropIsActiveSession(photoId, session) {
+  return _cropPhotoId === photoId && _cropSessionSeq === session;
+}
+
 function _cropDisplayRecipe() {
   var recipe = _cropCloneRecipe(_cropRecipe);
   delete recipe.crop;
@@ -4312,10 +4317,11 @@ async function openCropEditor() {
   _cropInitEvents();
   var requestedPhotoId = _lightboxCurrentId;
   _cropPhotoId = requestedPhotoId;
+  var session = ++_cropSessionSeq;
   _cropSetStatus('Loading recipe...');
   try {
     var data = await safeFetch('/api/photos/' + requestedPhotoId + '/edit-recipe', {}, { toast: false });
-    if (_lightboxCurrentId !== requestedPhotoId || _cropPhotoId !== requestedPhotoId) return;
+    if (_lightboxCurrentId !== requestedPhotoId || !_cropIsActiveSession(requestedPhotoId, session)) return;
     _cropRecipe = _cropCloneRecipe(data.recipe || {});
     _cropDefaultCrop(_cropRecipe);
     _cropSyncControls();
@@ -4325,7 +4331,9 @@ async function openCropEditor() {
     if (modal) modal.classList.add('open');
     _cropUpdatePreview();
   } catch (e) {
-    _cropSetStatus(e.message || 'Could not load recipe', true);
+    if (_cropIsActiveSession(requestedPhotoId, session)) {
+      _cropSetStatus(e.message || 'Could not load recipe', true);
+    }
   }
 }
 
@@ -4340,6 +4348,7 @@ function closeCropEditor(event) {
     Keymap.popEsc(_cropEscToken);
     _cropEscToken = null;
   }
+  _cropSessionSeq++;
   _cropPhotoId = null;
   _cropRecipe = null;
   _cropDrag = null;
@@ -4389,6 +4398,7 @@ function cropSetAspect(aspect) {
 async function saveCropEditor() {
   if (!_cropPhotoId || !_cropRecipe) return;
   var pid = _cropPhotoId;
+  var session = _cropSessionSeq;
   var btn = document.getElementById('cropSaveBtn');
   if (btn) btn.disabled = true;
   _cropSetStatus('Saving...');
@@ -4402,22 +4412,27 @@ async function saveCropEditor() {
     _lbEditVersionByPhoto[String(pid)] = String(Date.now());
     var p = _lightboxPhotoList.find(function(x) { return x.id === pid; });
     if (p) p.edit_recipe = data.recipe;
-    closeCropEditor();
-    if (_lightboxCurrentId === pid) {
-      var filename = p ? p.filename : document.getElementById('lightboxFilename').textContent;
-      openLightbox(pid, filename, _lightboxPhotoList);
+    if (_cropIsActiveSession(pid, session)) {
+      closeCropEditor();
+      if (_lightboxCurrentId === pid) {
+        var filename = p ? p.filename : document.getElementById('lightboxFilename').textContent;
+        openLightbox(pid, filename, _lightboxPhotoList);
+      }
+      showToast('Crop saved', 'success');
     }
-    showToast('Crop saved', 'success');
   } catch (e) {
-    _cropSetStatus(e.message || 'Could not save crop', true);
+    if (_cropIsActiveSession(pid, session)) {
+      _cropSetStatus(e.message || 'Could not save crop', true);
+    }
   } finally {
-    if (btn) btn.disabled = false;
+    if (btn && _cropIsActiveSession(pid, session)) btn.disabled = false;
   }
 }
 
 async function cropClearEdits() {
   if (!_cropPhotoId) return;
   var pid = _cropPhotoId;
+  var session = _cropSessionSeq;
   _cropSetStatus('Clearing...');
   try {
     await safeFetch('/api/photos/' + pid + '/edit-recipe', {
@@ -4426,14 +4441,18 @@ async function cropClearEdits() {
     _lbEditVersionByPhoto[String(pid)] = String(Date.now());
     var p = _lightboxPhotoList.find(function(x) { return x.id === pid; });
     if (p) p.edit_recipe = null;
-    closeCropEditor();
-    if (_lightboxCurrentId === pid) {
-      var filename = p ? p.filename : document.getElementById('lightboxFilename').textContent;
-      openLightbox(pid, filename, _lightboxPhotoList);
+    if (_cropIsActiveSession(pid, session)) {
+      closeCropEditor();
+      if (_lightboxCurrentId === pid) {
+        var filename = p ? p.filename : document.getElementById('lightboxFilename').textContent;
+        openLightbox(pid, filename, _lightboxPhotoList);
+      }
+      showToast('Edits cleared', 'success');
     }
-    showToast('Edits cleared', 'success');
   } catch (e) {
-    _cropSetStatus(e.message || 'Could not clear edits', true);
+    if (_cropIsActiveSession(pid, session)) {
+      _cropSetStatus(e.message || 'Could not clear edits', true);
+    }
   }
 }
 

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3721,11 +3721,26 @@ var _lbEyeVisible = _lbStoredBool('vireo.lb.eyeVisible', true);
 var _lbInfoVisible = _lbStoredBool('vireo.lb.infoVisible', true);
 var _lbChromeVisible = _lbStoredBool('vireo.lb.chromeVisible', true);
 
+function _lbRecipeHasCrop(recipe) {
+  return !!(recipe && recipe.crop && Number(recipe.crop.w) > 0 && Number(recipe.crop.h) > 0);
+}
+
+function _lbSourceOverlaysAvailable() {
+  return !_lbRecipeHasCrop(_lbCurrentEditRecipe);
+}
+
 function _lbApplyBoxesVisibility() {
   var container = document.getElementById('lightboxDetections');
-  if (container) container.style.display = _lbBoxesVisible ? '' : 'none';
+  var available = _lbSourceOverlaysAvailable();
+  if (container) container.style.display = (_lbBoxesVisible && available) ? '' : 'none';
   var btn = document.getElementById('lightboxToggleBoxes');
-  if (btn) btn.textContent = _lbBoxesVisible ? 'Hide Boxes' : 'Show Boxes';
+  if (btn) {
+    btn.disabled = !available;
+    btn.textContent = !available ? 'Boxes Cropped' : (_lbBoxesVisible ? 'Hide Boxes' : 'Show Boxes');
+    btn.title = !available
+      ? 'Detection boxes are hidden for cropped photos'
+      : 'Toggle detection boxes (b)';
+  }
 }
 
 function toggleLightboxBoxes() {
@@ -3762,12 +3777,19 @@ function toggleLightboxChrome() {
 
 function _lbApplyEyeVisibility() {
   var container = document.getElementById('lightboxEye');
+  var available = _lbSourceOverlaysAvailable();
   if (container) {
     container.style.display =
-      (_lbEyeVisible && container.childElementCount > 0) ? 'block' : 'none';
+      (_lbEyeVisible && available && container.childElementCount > 0) ? 'block' : 'none';
   }
   var btn = document.getElementById('lightboxToggleEye');
-  if (btn) btn.textContent = _lbEyeVisible ? 'Hide Eye' : 'Show Eye';
+  if (btn) {
+    btn.disabled = !available;
+    btn.textContent = !available ? 'Eye Cropped' : (_lbEyeVisible ? 'Hide Eye' : 'Show Eye');
+    btn.title = !available
+      ? 'Eye marker is hidden for cropped photos'
+      : 'Toggle eye marker';
+  }
 }
 
 function toggleLightboxEye() {
@@ -3825,6 +3847,10 @@ function _lbLoadDetections(photoId) {
   var container = document.getElementById('lightboxDetections');
   if (!container) return;
   container.innerHTML = '';
+  if (!_lbSourceOverlaysAvailable()) {
+    _lbApplyBoxesVisibility();
+    return;
+  }
   fetch('/api/detections/' + photoId)
     .then(function(r) { return r.json(); })
     .then(function(detections) {
@@ -3886,7 +3912,7 @@ function _lbResetMaskOverlay() {
 function _lbApplyMaskVisibility() {
   var img = document.getElementById('lightboxMaskOverlay');
   if (!img) return;
-  if (!_lbMasksVisible || !_lbMaskCurrentUrl) {
+  if (!_lbSourceOverlaysAvailable() || !_lbMasksVisible || !_lbMaskCurrentUrl) {
     img.classList.remove('show');
     // A previous call may have assigned onload to re-add `show` once
     // the mask image finished loading. If the user toggles masks off
@@ -3946,7 +3972,14 @@ function _lbApplyMaskUrl(url) {
 
 function _lbApplyMaskToggleButton() {
   var btn = document.getElementById('lightboxToggleMasks');
-  if (btn) btn.textContent = _lbMasksVisible ? 'Hide Masks' : 'Show Masks';
+  if (btn) {
+    var available = _lbSourceOverlaysAvailable();
+    btn.disabled = !available;
+    btn.textContent = !available ? 'Masks Cropped' : (_lbMasksVisible ? 'Hide Masks' : 'Show Masks');
+    btn.title = !available
+      ? 'Mask overlay is hidden for cropped photos'
+      : 'Toggle mask overlay';
+  }
 }
 
 function _lbApplyWildlifeExcludedButton() {
@@ -4003,6 +4036,7 @@ function _lbLoadMaskVariants(photoId) {
       // Bail if the user navigated to a different photo while the
       // request was in flight.
       if (!data || _lightboxCurrentId !== photoId) return;
+      if (!_lbSourceOverlaysAvailable()) return;
       _lbMaskActiveVariant = data.active || null;
       _lbMaskAvailable = data.variants || [];
       if (_lbMaskAvailable.length === 0) {
@@ -4239,10 +4273,12 @@ function _cropInitEvents() {
 async function openCropEditor() {
   if (!_lightboxCurrentId) return;
   _cropInitEvents();
-  _cropPhotoId = _lightboxCurrentId;
+  var requestedPhotoId = _lightboxCurrentId;
+  _cropPhotoId = requestedPhotoId;
   _cropSetStatus('Loading recipe...');
   try {
-    var data = await safeFetch('/api/photos/' + _cropPhotoId + '/edit-recipe', {}, { toast: false });
+    var data = await safeFetch('/api/photos/' + requestedPhotoId + '/edit-recipe', {}, { toast: false });
+    if (_lightboxCurrentId !== requestedPhotoId || _cropPhotoId !== requestedPhotoId) return;
     _cropRecipe = _cropCloneRecipe(data.recipe || {});
     _cropDefaultCrop(_cropRecipe);
     _cropSyncControls();
@@ -4452,7 +4488,7 @@ function openLightbox(photoId, filename, photoList, options) {
   _lbNativeZoom = null;
   _lbPhotoW = null;
   _lbPhotoH = null;
-  _lbCurrentEditRecipe = null;
+  _lbCurrentEditRecipe = currentFromList && currentFromList.edit_recipe || null;
   _lbCurrentSrcKey = (
     restoreWantsOneToOne ||
     (
@@ -4482,12 +4518,23 @@ function openLightbox(photoId, filename, photoList, options) {
       _lbPhotoW = data.width || null;
       _lbPhotoH = data.height || null;
       _lbCurrentEditRecipe = data.edit_recipe || null;
+      if (_lbRecipeHasCrop(_lbCurrentEditRecipe)) {
+        var detContainer2 = document.getElementById('lightboxDetections');
+        if (detContainer2) detContainer2.innerHTML = '';
+        var eyeContainer2 = document.getElementById('lightboxEye');
+        if (eyeContainer2) eyeContainer2.innerHTML = '';
+        _lbResetMaskOverlay();
+      }
       _lbCurrentWildlifeExcluded = !!data.wildlife_excluded;
       _lbApplyWildlifeExcludedButton();
       _lbRecordFetchedFlag(photoId, data.flag, flagFetchSeq);
       _lbRecomputeNativeZoom();
       if (!_lbTryApplyPendingViewportState()) _lbApplyPendingOneToOneZoom();
       _lbRenderEyeCrosshair(data);
+      _lbApplyBoxesVisibility();
+      _lbApplyEyeVisibility();
+      _lbApplyMaskToggleButton();
+      _lbApplyMaskVisibility();
     })
     .catch(function() {});
 

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -643,6 +643,171 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
   font-size: 12px;
   padding: 2px 6px;
 }
+.crop-editor-overlay {
+  z-index: 10003;
+  background: rgba(0, 0, 0, 0.82);
+}
+.crop-editor-modal {
+  width: min(1120px, calc(100vw - 40px));
+  max-height: calc(100vh - 40px);
+  display: flex;
+  flex-direction: column;
+  background: #111417;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 8px;
+  color: #f4f7f8;
+  overflow: hidden;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.55);
+}
+.crop-editor-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+}
+.crop-editor-header h3 {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 650;
+}
+.crop-editor-close {
+  width: 32px;
+  height: 32px;
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.06);
+  color: #f4f7f8;
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+}
+.crop-editor-body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 280px;
+  gap: 16px;
+  padding: 16px;
+  min-height: 0;
+}
+.crop-stage-shell {
+  min-width: 0;
+  min-height: 360px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #050607;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 6px;
+  overflow: auto;
+}
+.crop-stage {
+  position: relative;
+  display: inline-block;
+  line-height: 0;
+}
+#cropEditorImg {
+  max-width: min(100%, 760px);
+  max-height: min(68vh, 720px);
+  display: block;
+  user-select: none;
+  -webkit-user-drag: none;
+}
+.crop-box {
+  position: absolute;
+  box-sizing: border-box;
+  border: 2px solid #ffe066;
+  box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.42);
+  cursor: move;
+  touch-action: none;
+}
+.crop-box::before,
+.crop-box::after {
+  content: "";
+  position: absolute;
+  pointer-events: none;
+}
+.crop-box::before {
+  inset: 33.333% 0 auto 0;
+  height: 33.333%;
+  border-top: 1px solid rgba(255, 255, 255, 0.55);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.55);
+}
+.crop-box::after {
+  inset: 0 33.333% 0 auto;
+  width: 33.333%;
+  border-left: 1px solid rgba(255, 255, 255, 0.55);
+  border-right: 1px solid rgba(255, 255, 255, 0.55);
+}
+.crop-handle {
+  position: absolute;
+  width: 13px;
+  height: 13px;
+  background: #ffe066;
+  border: 2px solid #111417;
+  border-radius: 50%;
+  box-sizing: border-box;
+  z-index: 1;
+}
+.crop-handle.nw { left: -7px; top: -7px; cursor: nwse-resize; }
+.crop-handle.ne { right: -7px; top: -7px; cursor: nesw-resize; }
+.crop-handle.sw { left: -7px; bottom: -7px; cursor: nesw-resize; }
+.crop-handle.se { right: -7px; bottom: -7px; cursor: nwse-resize; }
+.crop-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  min-width: 0;
+}
+.crop-control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.crop-control-label {
+  font-size: 12px;
+  color: rgba(244, 247, 248, 0.72);
+  font-weight: 650;
+}
+.crop-control-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.crop-control-row input[type="range"] {
+  flex: 1;
+}
+.crop-control-row input[type="number"] {
+  width: 76px;
+  background: #1b2025;
+  color: #f4f7f8;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  border-radius: 4px;
+  padding: 6px 7px;
+  font-size: 12px;
+}
+.crop-button-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+.crop-editor-status {
+  min-height: 18px;
+  font-size: 12px;
+  color: rgba(244, 247, 248, 0.72);
+}
+.crop-editor-status.error { color: #ff8a80; }
+@media (max-width: 820px) {
+  .crop-editor-body {
+    grid-template-columns: 1fr;
+  }
+  .crop-stage-shell {
+    min-height: 280px;
+  }
+  .crop-controls {
+    max-height: 32vh;
+    overflow: auto;
+  }
+}
 /* Crosshair over the detected eye keypoint. Scales with the image via
    position:% — parent .lightbox-transform absorbs the zoom transform. */
 .lb-eye-crosshair {
@@ -3057,7 +3222,64 @@ async function createWorkspace() {
     <button class="lb-action-btn" id="lightboxOpenEditor" onclick="">
       Open in Editor
     </button>
+    <button class="lb-action-btn lb-action-accent" id="lightboxCropEdit" onclick="event.stopPropagation(); openCropEditor();">
+      Crop
+    </button>
     <button class="lb-action-btn lb-action-danger" onclick="lightboxDelete()" title="Delete photo">Delete</button>
+  </div>
+</div>
+
+<!-- Crop and straighten modal -->
+<div class="modal-overlay crop-editor-overlay" id="cropEditorModal" onclick="closeCropEditor(event)">
+  <div class="crop-editor-modal" onclick="event.stopPropagation();">
+    <div class="crop-editor-header">
+      <h3>Crop and Straighten</h3>
+      <button class="crop-editor-close" onclick="closeCropEditor(event)" title="Close">&times;</button>
+    </div>
+    <div class="crop-editor-body">
+      <div class="crop-stage-shell">
+        <div class="crop-stage" id="cropStage">
+          <img id="cropEditorImg" src="" alt="">
+          <div class="crop-box" id="cropBox">
+            <span class="crop-handle nw" data-handle="nw"></span>
+            <span class="crop-handle ne" data-handle="ne"></span>
+            <span class="crop-handle sw" data-handle="sw"></span>
+            <span class="crop-handle se" data-handle="se"></span>
+          </div>
+        </div>
+      </div>
+      <div class="crop-controls">
+        <div class="crop-control-group">
+          <div class="crop-control-label">Straighten</div>
+          <div class="crop-control-row">
+            <input type="range" id="cropStraightenRange" min="-10" max="10" step="0.1" value="0">
+            <input type="number" id="cropStraightenInput" min="-45" max="45" step="0.1" value="0">
+          </div>
+        </div>
+        <div class="crop-control-group">
+          <div class="crop-control-label">Rotate</div>
+          <div class="crop-button-grid">
+            <button class="lb-action-btn" type="button" onclick="cropRotate(-90)">Left</button>
+            <button class="lb-action-btn" type="button" onclick="cropRotate(90)">Right</button>
+          </div>
+        </div>
+        <div class="crop-control-group">
+          <div class="crop-control-label">Frame</div>
+          <div class="crop-button-grid">
+            <button class="lb-action-btn" type="button" onclick="cropResetFrame()">Full Frame</button>
+            <button class="lb-action-btn" type="button" onclick="cropSetAspect(1.5)">3:2</button>
+            <button class="lb-action-btn" type="button" onclick="cropSetAspect(1.3333333333)">4:3</button>
+            <button class="lb-action-btn" type="button" onclick="cropSetAspect(1)">1:1</button>
+          </div>
+        </div>
+        <div class="crop-editor-status" id="cropEditorStatus"></div>
+        <div class="modal-actions" style="margin-top:auto;">
+          <button class="modal-btn modal-btn-cancel" type="button" onclick="cropClearEdits()">Clear</button>
+          <button class="modal-btn modal-btn-cancel" type="button" onclick="closeCropEditor(event)">Cancel</button>
+          <button class="modal-btn modal-btn-primary" type="button" id="cropSaveBtn" onclick="saveCropEditor()">Save</button>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 
@@ -3129,6 +3351,13 @@ var _lbFlagPendingByPhoto = {};  // count of in-flight flag writes PER photo; li
 var _lbConfirmedFlags = {};   // last server-confirmed flag per photo, isolated from optimistic page helpers
 var _lbViewportByPhotoId = {};  // per-session lightbox viewport cache keyed by photo id
 var _lbPendingViewportState = null;
+var _lbEditVersionByPhoto = {};
+var _cropRecipe = null;
+var _cropPhotoId = null;
+var _cropPreviewSeq = 0;
+var _cropDrag = null;
+var _cropPreviewTimer = null;
+var _cropEscToken = null;
 
 function _lbIsOneToOneZoom() {
   if (_lbPending1To1) return true;
@@ -3806,6 +4035,334 @@ function _lbLoadMaskVariants(photoId) {
     .catch(function() { /* network error → leave control hidden */ });
 }
 
+function _cropCloneRecipe(recipe) {
+  if (!recipe || typeof recipe !== 'object') return {};
+  try { return JSON.parse(JSON.stringify(recipe)); }
+  catch (_) { return {}; }
+}
+
+function _cropDefaultCrop(recipe) {
+  if (!recipe.crop || typeof recipe.crop !== 'object') {
+    recipe.crop = { x: 0, y: 0, w: 1, h: 1 };
+  }
+  recipe.crop.x = Number(recipe.crop.x) || 0;
+  recipe.crop.y = Number(recipe.crop.y) || 0;
+  recipe.crop.w = Number(recipe.crop.w) || 1;
+  recipe.crop.h = Number(recipe.crop.h) || 1;
+  recipe.crop = _cropClampBox(recipe.crop);
+  return recipe.crop;
+}
+
+function _cropClampBox(crop) {
+  var min = 0.02;
+  var x = Number(crop.x) || 0;
+  var y = Number(crop.y) || 0;
+  var w = Number(crop.w) || 1;
+  var h = Number(crop.h) || 1;
+  w = Math.max(min, Math.min(1, w));
+  h = Math.max(min, Math.min(1, h));
+  x = Math.max(0, Math.min(1 - w, x));
+  y = Math.max(0, Math.min(1 - h, y));
+  return { x: x, y: y, w: w, h: h };
+}
+
+function _cropIsFullFrame(crop) {
+  return !crop || (
+    Math.abs((Number(crop.x) || 0)) < 0.0005 &&
+    Math.abs((Number(crop.y) || 0)) < 0.0005 &&
+    Math.abs((Number(crop.w) || 1) - 1) < 0.0005 &&
+    Math.abs((Number(crop.h) || 1) - 1) < 0.0005
+  );
+}
+
+function _cropSetStatus(message, isError) {
+  var el = document.getElementById('cropEditorStatus');
+  if (!el) return;
+  el.textContent = message || '';
+  el.classList.toggle('error', !!isError);
+}
+
+function _cropDisplayRecipe() {
+  var recipe = _cropCloneRecipe(_cropRecipe);
+  delete recipe.crop;
+  return recipe;
+}
+
+function _cropSyncControls() {
+  if (!_cropRecipe) return;
+  var value = Number(_cropRecipe.straighten || 0);
+  var range = document.getElementById('cropStraightenRange');
+  var input = document.getElementById('cropStraightenInput');
+  if (range) range.value = Math.max(-10, Math.min(10, value));
+  if (input) input.value = String(Math.round(value * 10) / 10);
+}
+
+function _cropRenderBox() {
+  if (!_cropRecipe) return;
+  var img = document.getElementById('cropEditorImg');
+  var box = document.getElementById('cropBox');
+  if (!img || !box || !img.complete || !img.clientWidth || !img.clientHeight) return;
+  var crop = _cropDefaultCrop(_cropRecipe);
+  box.style.left = (crop.x * img.clientWidth) + 'px';
+  box.style.top = (crop.y * img.clientHeight) + 'px';
+  box.style.width = (crop.w * img.clientWidth) + 'px';
+  box.style.height = (crop.h * img.clientHeight) + 'px';
+}
+
+function _cropUpdatePreview() {
+  if (!_cropPhotoId || !_cropRecipe) return;
+  var img = document.getElementById('cropEditorImg');
+  if (!img) return;
+  var seq = ++_cropPreviewSeq;
+  var recipe = _cropDisplayRecipe();
+  _cropSetStatus('Loading preview...');
+  img.onload = function() {
+    if (seq !== _cropPreviewSeq) return;
+    _cropRenderBox();
+    _cropSetStatus('');
+  };
+  img.onerror = function() {
+    if (seq !== _cropPreviewSeq) return;
+    _cropSetStatus('Could not render preview', true);
+  };
+  img.src = '/photos/' + _cropPhotoId + '/edit-preview?size=1920&recipe=' +
+    encodeURIComponent(JSON.stringify(recipe)) + '&v=' + seq;
+}
+
+function _cropSchedulePreview() {
+  if (_cropPreviewTimer) clearTimeout(_cropPreviewTimer);
+  _cropPreviewTimer = setTimeout(function() {
+    _cropPreviewTimer = null;
+    _cropUpdatePreview();
+  }, 120);
+}
+
+function _cropNormalizeRecipeForSave() {
+  var recipe = _cropCloneRecipe(_cropRecipe);
+  var crop = _cropDefaultCrop(recipe);
+  delete recipe.version;
+  if (!recipe.rotation) delete recipe.rotation;
+  if (Math.abs(Number(recipe.straighten || 0)) < 0.0001) delete recipe.straighten;
+  else recipe.straighten = Math.round(Number(recipe.straighten) * 10000) / 10000;
+  if (_cropIsFullFrame(crop)) delete recipe.crop;
+  else {
+    recipe.crop = {
+      x: Math.round(crop.x * 1000000) / 1000000,
+      y: Math.round(crop.y * 1000000) / 1000000,
+      w: Math.round(crop.w * 1000000) / 1000000,
+      h: Math.round(crop.h * 1000000) / 1000000,
+    };
+  }
+  return recipe;
+}
+
+function _cropInitEvents() {
+  if (window._cropEventsReady) return;
+  window._cropEventsReady = true;
+  var range = document.getElementById('cropStraightenRange');
+  var input = document.getElementById('cropStraightenInput');
+  function setStraighten(value) {
+    if (!_cropRecipe) return;
+    var v = Number(value);
+    if (!Number.isFinite(v)) v = 0;
+    v = Math.max(-45, Math.min(45, v));
+    _cropRecipe.straighten = v;
+    _cropSyncControls();
+    _cropSchedulePreview();
+  }
+  if (range) range.addEventListener('input', function() { setStraighten(range.value); });
+  if (input) input.addEventListener('input', function() { setStraighten(input.value); });
+
+  var box = document.getElementById('cropBox');
+  if (box) {
+    box.addEventListener('pointerdown', function(e) {
+      if (!_cropRecipe) return;
+      var img = document.getElementById('cropEditorImg');
+      if (!img || !img.clientWidth || !img.clientHeight) return;
+      var handle = e.target && e.target.dataset ? e.target.dataset.handle : '';
+      _cropDrag = {
+        handle: handle || 'move',
+        startX: e.clientX,
+        startY: e.clientY,
+        startCrop: _cropCloneRecipe({ crop: _cropDefaultCrop(_cropRecipe) }).crop,
+        imgW: img.clientWidth,
+        imgH: img.clientHeight,
+      };
+      box.setPointerCapture(e.pointerId);
+      e.preventDefault();
+      e.stopPropagation();
+    });
+  }
+
+  document.addEventListener('pointermove', function(e) {
+    if (!_cropDrag || !_cropRecipe) return;
+    var dx = (e.clientX - _cropDrag.startX) / _cropDrag.imgW;
+    var dy = (e.clientY - _cropDrag.startY) / _cropDrag.imgH;
+    var c = _cropCloneRecipe({ crop: _cropDrag.startCrop }).crop;
+    var min = 0.02;
+    if (_cropDrag.handle === 'move') {
+      c.x += dx;
+      c.y += dy;
+    } else {
+      if (_cropDrag.handle.indexOf('w') !== -1) {
+        c.x += dx;
+        c.w -= dx;
+      }
+      if (_cropDrag.handle.indexOf('e') !== -1) c.w += dx;
+      if (_cropDrag.handle.indexOf('n') !== -1) {
+        c.y += dy;
+        c.h -= dy;
+      }
+      if (_cropDrag.handle.indexOf('s') !== -1) c.h += dy;
+      if (c.w < min) {
+        if (_cropDrag.handle.indexOf('w') !== -1) c.x = _cropDrag.startCrop.x + _cropDrag.startCrop.w - min;
+        c.w = min;
+      }
+      if (c.h < min) {
+        if (_cropDrag.handle.indexOf('n') !== -1) c.y = _cropDrag.startCrop.y + _cropDrag.startCrop.h - min;
+        c.h = min;
+      }
+    }
+    _cropRecipe.crop = _cropClampBox(c);
+    _cropRenderBox();
+    e.preventDefault();
+  });
+  document.addEventListener('pointerup', function() {
+    _cropDrag = null;
+  });
+  window.addEventListener('resize', function() {
+    if (_cropPhotoId) _cropRenderBox();
+  });
+}
+
+async function openCropEditor() {
+  if (!_lightboxCurrentId) return;
+  _cropInitEvents();
+  _cropPhotoId = _lightboxCurrentId;
+  _cropSetStatus('Loading recipe...');
+  try {
+    var data = await safeFetch('/api/photos/' + _cropPhotoId + '/edit-recipe', {}, { toast: false });
+    _cropRecipe = _cropCloneRecipe(data.recipe || {});
+    _cropDefaultCrop(_cropRecipe);
+    _cropSyncControls();
+    var modal = document.getElementById('cropEditorModal');
+    if (_cropEscToken) Keymap.popEsc(_cropEscToken);
+    _cropEscToken = Keymap.pushEsc(function() { closeCropEditor(); });
+    if (modal) modal.classList.add('open');
+    _cropUpdatePreview();
+  } catch (e) {
+    _cropSetStatus(e.message || 'Could not load recipe', true);
+  }
+}
+
+function closeCropEditor(event) {
+  if (event) {
+    event.preventDefault();
+    event.stopPropagation();
+  }
+  var modal = document.getElementById('cropEditorModal');
+  if (modal) modal.classList.remove('open');
+  if (_cropEscToken) {
+    Keymap.popEsc(_cropEscToken);
+    _cropEscToken = null;
+  }
+  _cropPhotoId = null;
+  _cropRecipe = null;
+  _cropDrag = null;
+  if (_cropPreviewTimer) {
+    clearTimeout(_cropPreviewTimer);
+    _cropPreviewTimer = null;
+  }
+}
+
+function cropRotate(delta) {
+  if (!_cropRecipe) return;
+  var current = Number(_cropRecipe.rotation || 0);
+  var next = (current + delta) % 360;
+  if (next < 0) next += 360;
+  _cropRecipe.rotation = next;
+  cropResetFrame();
+  _cropSchedulePreview();
+}
+
+function cropResetFrame() {
+  if (!_cropRecipe) return;
+  _cropRecipe.crop = { x: 0, y: 0, w: 1, h: 1 };
+  _cropRenderBox();
+}
+
+function cropSetAspect(aspect) {
+  if (!_cropRecipe) return;
+  var img = document.getElementById('cropEditorImg');
+  if (!img || !img.clientWidth || !img.clientHeight) return;
+  var imageAspect = img.clientWidth / img.clientHeight;
+  var normalizedRatio = aspect / imageAspect;
+  var w = 0.9;
+  var h = w / normalizedRatio;
+  if (h > 0.9) {
+    h = 0.9;
+    w = h * normalizedRatio;
+  }
+  _cropRecipe.crop = {
+    x: (1 - w) / 2,
+    y: (1 - h) / 2,
+    w: w,
+    h: h,
+  };
+  _cropRenderBox();
+}
+
+async function saveCropEditor() {
+  if (!_cropPhotoId || !_cropRecipe) return;
+  var pid = _cropPhotoId;
+  var btn = document.getElementById('cropSaveBtn');
+  if (btn) btn.disabled = true;
+  _cropSetStatus('Saving...');
+  try {
+    var recipe = _cropNormalizeRecipeForSave();
+    var data = await safeFetch('/api/photos/' + pid + '/edit-recipe', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ recipe: recipe }),
+    }, { toast: false });
+    _lbEditVersionByPhoto[String(pid)] = String(Date.now());
+    var p = _lightboxPhotoList.find(function(x) { return x.id === pid; });
+    if (p) p.edit_recipe = data.recipe;
+    closeCropEditor();
+    if (_lightboxCurrentId === pid) {
+      var filename = p ? p.filename : document.getElementById('lightboxFilename').textContent;
+      openLightbox(pid, filename, _lightboxPhotoList);
+    }
+    showToast('Crop saved', 'success');
+  } catch (e) {
+    _cropSetStatus(e.message || 'Could not save crop', true);
+  } finally {
+    if (btn) btn.disabled = false;
+  }
+}
+
+async function cropClearEdits() {
+  if (!_cropPhotoId) return;
+  var pid = _cropPhotoId;
+  _cropSetStatus('Clearing...');
+  try {
+    await safeFetch('/api/photos/' + pid + '/edit-recipe', {
+      method: 'DELETE',
+    }, { toast: false });
+    _lbEditVersionByPhoto[String(pid)] = String(Date.now());
+    var p = _lightboxPhotoList.find(function(x) { return x.id === pid; });
+    if (p) p.edit_recipe = null;
+    closeCropEditor();
+    if (_lightboxCurrentId === pid) {
+      var filename = p ? p.filename : document.getElementById('lightboxFilename').textContent;
+      openLightbox(pid, filename, _lightboxPhotoList);
+    }
+    showToast('Edits cleared', 'success');
+  } catch (e) {
+    _cropSetStatus(e.message || 'Could not clear edits', true);
+  }
+}
+
 function openLightbox(photoId, filename, photoList, options) {
   var alreadyOpen = !!window._lbEscToken;
   options = options || {};
@@ -3920,8 +4477,9 @@ function openLightbox(photoId, filename, photoList, options) {
     .then(function(r) { return r.ok ? r.json() : null; })
     .then(function(data) {
       if (!data || _lightboxCurrentId !== photoId || _lbOpenSeq !== openSeq) return;
-      _lbPhotoW = data.width || null;
-      _lbPhotoH = data.height || null;
+      var displayDims = _lbDisplayDimsForRecipe(data.width, data.height, data.edit_recipe);
+      _lbPhotoW = displayDims.w || data.width || null;
+      _lbPhotoH = displayDims.h || data.height || null;
       _lbCurrentWildlifeExcluded = !!data.wildlife_excluded;
       _lbApplyWildlifeExcludedButton();
       _lbRecordFetchedFlag(photoId, data.flag, flagFetchSeq);
@@ -4948,6 +5506,23 @@ function _lbOrientedPhotoDims(img) {
   return { w: w, h: h };
 }
 
+function _lbDisplayDimsForRecipe(width, height, recipe) {
+  var w = Number(width) || 0;
+  var h = Number(height) || 0;
+  if (!w || !h) return { w: null, h: null };
+  recipe = recipe || {};
+  var rotation = Number(recipe.rotation || 0);
+  if (rotation === 90 || rotation === 270) {
+    var tmp = w; w = h; h = tmp;
+  }
+  var crop = recipe.crop;
+  if (crop && Number(crop.w) > 0 && Number(crop.h) > 0) {
+    w = Math.max(1, Math.round(w * Number(crop.w)));
+    h = Math.max(1, Math.round(h * Number(crop.h)));
+  }
+  return { w: w, h: h };
+}
+
 function _lbLayoutDims() {
   var img = document.getElementById('lightboxImg');
   if (!img) return null;
@@ -5129,9 +5704,13 @@ function _lbPickSourceKey(targetZoom) {
 }
 
 function _lbSrcUrl(photoId, key) {
-  if (key === 'original') return '/photos/' + photoId + '/original';
-  if (key === 'full') return '/photos/' + photoId + '/full';
-  return '/photos/' + photoId + '/preview?size=' + key;
+  var url;
+  if (key === 'original') url = '/photos/' + photoId + '/original';
+  else if (key === 'full') url = '/photos/' + photoId + '/full';
+  else url = '/photos/' + photoId + '/preview?size=' + key;
+  var version = _lbEditVersionByPhoto[String(photoId)];
+  if (version) url += (url.indexOf('?') === -1 ? '?' : '&') + 'editv=' + encodeURIComponent(version);
+  return url;
 }
 
 function _lbScheduleSourceSwap(targetZoom) {

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3738,7 +3738,7 @@ function _lbRecipeHasGeometricEdit(recipe) {
 
 function _lbMetadataOrientation(metadata) {
   if (!metadata || typeof metadata !== 'object') return null;
-  var groups = ['EXIF', 'TIFF', 'Image'];
+  var groups = ['EXIF', 'IFD0', 'TIFF', 'File'];
   for (var i = 0; i < groups.length; i++) {
     var group = metadata[groups[i]];
     if (group && Object.prototype.hasOwnProperty.call(group, 'Orientation')) {
@@ -4318,6 +4318,8 @@ async function openCropEditor() {
   var requestedPhotoId = _lightboxCurrentId;
   _cropPhotoId = requestedPhotoId;
   var session = ++_cropSessionSeq;
+  var saveBtn = document.getElementById('cropSaveBtn');
+  if (saveBtn) saveBtn.disabled = false;
   _cropSetStatus('Loading recipe...');
   try {
     var data = await safeFetch('/api/photos/' + requestedPhotoId + '/edit-recipe', {}, { toast: false });

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3895,6 +3895,11 @@ function _lbLoadDetections(photoId) {
       if (!detections || detections.length === 0) return;
       // Only render if still viewing the same photo
       if (_lightboxCurrentId !== photoId) return;
+      if (!_lbSourceOverlaysAvailable()) {
+        container.innerHTML = '';
+        _lbApplyBoxesVisibility();
+        return;
+      }
       detections.forEach(function(det) {
         if (det.box_x == null || det.box_y == null) return;
         var color = _lbGetSpeciesColor(det.category || 'animal');
@@ -4411,9 +4416,10 @@ async function saveCropEditor() {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ recipe: recipe }),
     }, { toast: false });
-    _lbEditVersionByPhoto[String(pid)] = String(Date.now());
+    var updates = {};
+    updates[String(pid)] = data.recipe;
+    _lbRefreshEditRecipeCache(updates);
     var p = _lightboxPhotoList.find(function(x) { return x.id === pid; });
-    if (p) p.edit_recipe = data.recipe;
     if (_cropIsActiveSession(pid, session)) {
       closeCropEditor();
       if (_lightboxCurrentId === pid) {
@@ -4440,9 +4446,10 @@ async function cropClearEdits() {
     await safeFetch('/api/photos/' + pid + '/edit-recipe', {
       method: 'DELETE',
     }, { toast: false });
-    _lbEditVersionByPhoto[String(pid)] = String(Date.now());
+    var updates = {};
+    updates[String(pid)] = null;
+    _lbRefreshEditRecipeCache(updates);
     var p = _lightboxPhotoList.find(function(x) { return x.id === pid; });
-    if (p) p.edit_recipe = null;
     if (_cropIsActiveSession(pid, session)) {
       closeCropEditor();
       if (_lightboxCurrentId === pid) {
@@ -4458,11 +4465,40 @@ async function cropClearEdits() {
   }
 }
 
+function _lbThumbnailUrl(photoId, version) {
+  var url = '/thumbnails/' + photoId + '.jpg';
+  if (version) url += '?editv=' + encodeURIComponent(version);
+  return url;
+}
+
+function _lbRefreshThumbnailCache(photoId, version) {
+  var id = String(photoId);
+  var refreshedUrl = _lbThumbnailUrl(id, version);
+  document.querySelectorAll('img').forEach(function(img) {
+    var rawSrc = img.getAttribute('src') || '';
+    if (!rawSrc) return;
+    var url;
+    try {
+      url = new URL(rawSrc, window.location.href);
+    } catch (_) {
+      return;
+    }
+    if (url.pathname !== '/thumbnails/' + id + '.jpg') return;
+    img.src = refreshedUrl;
+  });
+  try {
+    document.dispatchEvent(new CustomEvent('vireo:thumbnail-invalidated', {
+      detail: { photoId: Number(photoId), version: version }
+    }));
+  } catch (_) {}
+}
+
 function _lbRefreshEditRecipeCache(updates) {
   if (!updates || typeof updates !== 'object') return;
   var version = String(Date.now());
   Object.keys(updates).forEach(function(photoId) {
     _lbEditVersionByPhoto[String(photoId)] = version;
+    _lbRefreshThumbnailCache(photoId, version);
     var numericId = Number(photoId);
     var p = _lightboxPhotoList.find(function(x) { return x.id === numericId; });
     if (p) p.edit_recipe = updates[photoId] || null;

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3337,6 +3337,7 @@ var _lbNativeZoom = null;   // zoom value corresponding to 1:1 for current photo
 var _lbFitScale = 1.0;      // natural image scale at zoom=1.0
 var _lbPhotoW = null;       // original photo width (px)
 var _lbPhotoH = null;       // original photo height (px)
+var _lbCurrentEditRecipe = null; // active non-destructive recipe for layout math
 var _lbCurrentSrcKey = null; // 'full' | '2560' | '3840' | 'original'
 var _lbFullLongEdge = null;  // actual long edge of /full for current photo (may be < 1920 if preview_max_size is configured low)
 var _lbSessionFullLongEdge = null;  // last learned /full size across photos; better fallback than hardcoded 1920 for custom preview_max_size
@@ -4451,6 +4452,7 @@ function openLightbox(photoId, filename, photoList, options) {
   _lbNativeZoom = null;
   _lbPhotoW = null;
   _lbPhotoH = null;
+  _lbCurrentEditRecipe = null;
   _lbCurrentSrcKey = (
     restoreWantsOneToOne ||
     (
@@ -4477,9 +4479,9 @@ function openLightbox(photoId, filename, photoList, options) {
     .then(function(r) { return r.ok ? r.json() : null; })
     .then(function(data) {
       if (!data || _lightboxCurrentId !== photoId || _lbOpenSeq !== openSeq) return;
-      var displayDims = _lbDisplayDimsForRecipe(data.width, data.height, data.edit_recipe);
-      _lbPhotoW = displayDims.w || data.width || null;
-      _lbPhotoH = displayDims.h || data.height || null;
+      _lbPhotoW = data.width || null;
+      _lbPhotoH = data.height || null;
+      _lbCurrentEditRecipe = data.edit_recipe || null;
       _lbCurrentWildlifeExcluded = !!data.wildlife_excluded;
       _lbApplyWildlifeExcludedButton();
       _lbRecordFetchedFlag(photoId, data.flag, flagFetchSeq);
@@ -5530,7 +5532,13 @@ function _lbLayoutDims() {
   // coordinates even if the currently displayed tier is /full. That matches the
   // sharp zoom-test path and avoids recalibrating pan/zoom when the source swaps.
   var originalDims = !_lbOriginalUnavailable ? _lbOrientedPhotoDims(img) : null;
-  if (originalDims) return originalDims;
+  if (originalDims) {
+    return _lbDisplayDimsForRecipe(
+      originalDims.w,
+      originalDims.h,
+      _lbCurrentEditRecipe
+    );
+  }
   if (img.naturalWidth && img.naturalHeight) {
     return { w: img.naturalWidth, h: img.naturalHeight };
   }

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3337,6 +3337,7 @@ var _lbNativeZoom = null;   // zoom value corresponding to 1:1 for current photo
 var _lbFitScale = 1.0;      // natural image scale at zoom=1.0
 var _lbPhotoW = null;       // original photo width (px)
 var _lbPhotoH = null;       // original photo height (px)
+var _lbPhotoOrientation = null; // original EXIF orientation, when API metadata has it
 var _lbCurrentEditRecipe = null; // active non-destructive recipe for layout math
 var _lbCurrentSrcKey = null; // 'full' | '2560' | '3840' | 'original'
 var _lbFullLongEdge = null;  // actual long edge of /full for current photo (may be < 1920 if preview_max_size is configured low)
@@ -3723,6 +3724,33 @@ var _lbChromeVisible = _lbStoredBool('vireo.lb.chromeVisible', true);
 
 function _lbRecipeHasCrop(recipe) {
   return !!(recipe && recipe.crop && Number(recipe.crop.w) > 0 && Number(recipe.crop.h) > 0);
+}
+
+function _lbMetadataOrientation(metadata) {
+  if (!metadata || typeof metadata !== 'object') return null;
+  var groups = ['EXIF', 'TIFF', 'Image'];
+  for (var i = 0; i < groups.length; i++) {
+    var group = metadata[groups[i]];
+    if (group && Object.prototype.hasOwnProperty.call(group, 'Orientation')) {
+      return group.Orientation;
+    }
+  }
+  if (Object.prototype.hasOwnProperty.call(metadata, 'Orientation')) {
+    return metadata.Orientation;
+  }
+  return null;
+}
+
+function _lbOrientationSwapsAxes(orientation) {
+  if (orientation == null || typeof orientation === 'boolean') return false;
+  if (typeof orientation === 'number') {
+    return [5, 6, 7, 8].indexOf(Math.round(orientation)) !== -1;
+  }
+  var text = String(orientation).trim().toLowerCase();
+  if (!text) return false;
+  var parsed = Number(text);
+  if (Number.isFinite(parsed)) return [5, 6, 7, 8].indexOf(Math.round(parsed)) !== -1;
+  return text.indexOf('90') !== -1 || text.indexOf('270') !== -1;
 }
 
 function _lbSourceOverlaysAvailable() {
@@ -4488,6 +4516,7 @@ function openLightbox(photoId, filename, photoList, options) {
   _lbNativeZoom = null;
   _lbPhotoW = null;
   _lbPhotoH = null;
+  _lbPhotoOrientation = null;
   _lbCurrentEditRecipe = currentFromList && currentFromList.edit_recipe || null;
   _lbCurrentSrcKey = (
     restoreWantsOneToOne ||
@@ -4517,6 +4546,7 @@ function openLightbox(photoId, filename, photoList, options) {
       if (!data || _lightboxCurrentId !== photoId || _lbOpenSeq !== openSeq) return;
       _lbPhotoW = data.width || null;
       _lbPhotoH = data.height || null;
+      _lbPhotoOrientation = _lbMetadataOrientation(data.metadata);
       _lbCurrentEditRecipe = data.edit_recipe || null;
       if (_lbRecipeHasCrop(_lbCurrentEditRecipe)) {
         var detContainer2 = document.getElementById('lightboxDetections');
@@ -5544,7 +5574,10 @@ function _lbOrientedPhotoDims(img) {
   if (!_lbPhotoW || !_lbPhotoH) return null;
   var w = _lbPhotoW;
   var h = _lbPhotoH;
-  if (img && img.naturalWidth && img.naturalHeight) {
+  if (_lbOrientationSwapsAxes(_lbPhotoOrientation)) {
+    w = _lbPhotoH;
+    h = _lbPhotoW;
+  } else if (img && img.naturalWidth && img.naturalHeight) {
     var storedAspect = w / h;
     var imgAspect = img.naturalWidth / img.naturalHeight;
     if (Math.abs(storedAspect - imgAspect) > Math.abs((1 / storedAspect) - imgAspect)) {

--- a/vireo/tests/test_image_edits.py
+++ b/vireo/tests/test_image_edits.py
@@ -34,6 +34,18 @@ def test_normalize_recipe_rejects_fractional_rotation():
         normalize_recipe({"rotation": 90.9})
 
 
+def test_normalize_recipe_accepts_straighten():
+    assert normalize_recipe({"straighten": 1.23456}) == {
+        "version": 1,
+        "straighten": 1.2346,
+    }
+
+
+def test_normalize_recipe_rejects_out_of_range_straighten():
+    with pytest.raises(RecipeError, match="straighten"):
+        normalize_recipe({"straighten": 46})
+
+
 def test_normalize_recipe_rejects_non_boolean_flip():
     with pytest.raises(RecipeError, match="flip.horizontal"):
         normalize_recipe({"flip": {"horizontal": "false"}})
@@ -69,3 +81,10 @@ def test_apply_recipe_rotates_flips_and_crops():
     )
 
     assert edited.size == (30, 50)
+
+
+def test_apply_recipe_straightens_in_place():
+    img = Image.new("RGB", (100, 60), "white")
+    edited = apply_recipe(img, {"straighten": 3.5})
+
+    assert edited.size == (100, 60)

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1393,6 +1393,45 @@ def test_edit_recipe_api_invalidates_preview_cache_and_renders(client_with_photo
         assert img.size == (600, 800)
 
 
+def test_edit_recipe_api_queues_xmp_sync(client_with_photo):
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+
+    resp = client.put(
+        f"/api/photos/{photo_id}/edit-recipe",
+        json={"recipe": {"straighten": 2.5}},
+    )
+
+    assert resp.status_code == 200
+    changes = db.get_pending_changes()
+    assert len(changes) == 1
+    assert changes[0]["photo_id"] == photo_id
+    assert changes[0]["change_type"] == "edit_recipe"
+    assert '"straighten":2.5' in changes[0]["value"]
+
+
+def test_edit_preview_renders_uncommitted_recipe_without_storing(client_with_photo):
+    import io
+
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+
+    rendered = client.get(
+        f"/photos/{photo_id}/edit-preview",
+        query_string={
+            "size": "1920",
+            "recipe": '{"rotation":90,"crop":{"x":0,"y":0,"w":0.5,"h":0.5}}',
+        },
+    )
+
+    assert rendered.status_code == 200
+    assert db.get_photo_edit_recipe(photo_id) is None
+    with Image.open(io.BytesIO(rendered.data)) as img:
+        assert img.size == (600, 800)
+
+
 def test_non_crop_preview_loads_with_requested_size(client_with_photo, monkeypatch):
     import image_loader
 

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -2034,10 +2034,16 @@ def test_edit_recipe_api_undo_redo(client_with_photo):
 
     undo = client.post("/api/undo")
     assert undo.status_code == 200
+    assert undo.get_json()["action_type"] == "edit_recipe"
+    assert undo.get_json()["edit_recipes"] == {str(photo_id): None}
     assert db.get_photo_edit_recipe(photo_id) is None
 
     redo = client.post("/api/redo")
     assert redo.status_code == 200
+    assert redo.get_json()["action_type"] == "edit_recipe"
+    assert redo.get_json()["edit_recipes"] == {
+        str(photo_id): {"rotation": 180, "version": 1}
+    }
     assert db.get_photo_edit_recipe(photo_id)["rotation"] == 180
 
 

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1432,6 +1432,44 @@ def test_edit_preview_renders_uncommitted_recipe_without_storing(client_with_pho
         assert img.size == (600, 800)
 
 
+def test_edit_preview_skips_recent_failed_raw_before_decode(
+    client_with_photo, monkeypatch,
+):
+    """The crop editor preview should not retry known-bad RAW decodes."""
+    import image_loader
+
+    app, db, photo_id = client_with_photo
+    file_mtime = db.conn.execute(
+        "SELECT file_mtime FROM photos WHERE id=?", (photo_id,)
+    ).fetchone()["file_mtime"]
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='bad.NEF', extension='.nef',
+               working_copy_path=NULL,
+               working_copy_failed_at=datetime('now'),
+               working_copy_failed_mtime=?
+           WHERE id=?""",
+        (file_mtime, photo_id),
+    )
+    db.conn.commit()
+
+    called = {"load": False}
+
+    def fail_load_if_called(*_args, **_kwargs):
+        called["load"] = True
+        raise AssertionError("edit-preview retried failed RAW decode")
+
+    monkeypatch.setattr(image_loader, "load_image", fail_load_if_called)
+
+    resp = app.test_client().get(
+        f"/photos/{photo_id}/edit-preview",
+        query_string={"recipe": '{"straighten":1.5}'},
+    )
+
+    assert resp.status_code == 500
+    assert called["load"] is False
+
+
 def test_non_crop_preview_loads_with_requested_size(client_with_photo, monkeypatch):
     import image_loader
 

--- a/vireo/tests/test_sync.py
+++ b/vireo/tests/test_sync.py
@@ -79,6 +79,51 @@ def test_sync_to_xmp_writes_rating(tmp_path):
     assert rating == '4'
 
 
+def test_sync_to_xmp_writes_edit_recipe(tmp_path):
+    """sync_to_xmp writes Vireo edit recipes to XMP sidecars."""
+    from db import Database
+    from sync import sync_to_xmp
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    pid, xmp_path = _setup_photo_with_xmp(tmp_path, db)
+
+    db.queue_change(
+        pid,
+        "edit_recipe",
+        '{"crop":{"h":0.8,"w":0.7,"x":0.1,"y":0.1},"version":1}',
+    )
+
+    result = sync_to_xmp(db)
+
+    assert result["synced"] == 1
+    assert result["failed"] == 0
+    content = open(xmp_path).read()
+    assert "vireo:editRecipe" in content
+    assert "&quot;crop&quot;" in content
+    assert len(db.get_pending_changes()) == 0
+
+
+def test_sync_to_xmp_clears_edit_recipe_marker(tmp_path):
+    """An empty edit_recipe change removes Vireo's XMP recipe marker."""
+    from db import Database
+    from sync import sync_to_xmp
+    from xmp import write_edit_recipe
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    pid, xmp_path = _setup_photo_with_xmp(tmp_path, db)
+    write_edit_recipe(xmp_path, '{"rotation":90,"version":1}')
+
+    db.queue_change(pid, "edit_recipe", "")
+    result = sync_to_xmp(db)
+
+    assert result["synced"] == 1
+    assert "vireo:editRecipe" not in open(xmp_path).read()
+
+
 def test_sync_to_xmp_limits_sync_to_selected_change_ids(tmp_path):
     """sync_to_xmp can write only the checked pending changes."""
     from xml.etree import ElementTree as ET

--- a/vireo/tests/test_xmp.py
+++ b/vireo/tests/test_xmp.py
@@ -11,6 +11,7 @@ from xmp import (
     read_keywords,
     remove_keywords,
     remove_vireo_gps_location,
+    write_edit_recipe,
     write_gps_location,
     write_pick_flag,
     write_rating,
@@ -223,6 +224,31 @@ def test_write_gps_location_rejects_out_of_range_coords(sample_xmp):
         write_gps_location(sample_xmp, 91.0, 2.3522)
     with pytest.raises(ValueError, match="longitude"):
         write_gps_location(sample_xmp, 48.8566, 181.0)
+
+
+# ── write_edit_recipe ───────────────────────────────────────────────────
+
+def test_write_edit_recipe_creates_vireo_marker(missing_xmp):
+    recipe_json = '{"crop":{"h":0.8,"w":0.7,"x":0.1,"y":0.1},"version":1}'
+
+    assert write_edit_recipe(missing_xmp, recipe_json) is True
+
+    with open(missing_xmp) as f:
+        content = f.read()
+    assert 'vireo:editRecipe="' in content
+    assert "&quot;crop&quot;" in content
+    assert 'vireo:editRecipeSchema="1"' in content
+
+
+def test_write_edit_recipe_removes_vireo_marker(missing_xmp):
+    write_edit_recipe(missing_xmp, '{"rotation":90,"version":1}')
+
+    assert write_edit_recipe(missing_xmp, "") is True
+
+    with open(missing_xmp) as f:
+        content = f.read()
+    assert "vireo:editRecipe" not in content
+    assert "vireo:editRecipeSchema" not in content
 
 
 # ── remove_keywords ─────────────────────────────────────────────────────

--- a/vireo/xmp.py
+++ b/vireo/xmp.py
@@ -328,6 +328,38 @@ def remove_vireo_gps_location(xmp_path):
     return removed
 
 
+def write_edit_recipe(xmp_path, recipe_json):
+    """Write or clear Vireo's non-destructive edit recipe marker."""
+    recipe_json = recipe_json or ""
+    recipe_attr = f"{{{NS_VIREO}}}editRecipe"
+    version_attr = f"{{{NS_VIREO}}}editRecipeSchema"
+
+    if recipe_json:
+        root, tree = _load_or_create_xmp(xmp_path)
+        desc = _get_or_create_description(root)
+        desc.set(recipe_attr, recipe_json)
+        desc.set(version_attr, "1")
+    else:
+        result = _parse_xmp(xmp_path)
+        if result is None:
+            return False
+        root, tree = result
+        desc = root.find(f".//{{{NS_RDF}}}Description")
+        if desc is None:
+            return False
+        removed = False
+        for attr in (recipe_attr, version_attr):
+            if attr in desc.attrib:
+                del desc.attrib[attr]
+                removed = True
+        if not removed:
+            return False
+
+    ET.indent(tree, space="  ")
+    tree.write(xmp_path, xml_declaration=True, encoding="unicode")
+    return True
+
+
 def remove_keywords(xmp_path, keywords_to_remove):
     """Remove keywords from dc:subject and lr:hierarchicalSubject in an XMP file.
 


### PR DESCRIPTION
Adds a lightbox crop and straighten editor backed by stored non-destructive edit recipes. Preview and full-resolution routes now render in-progress and saved recipes correctly, invalidate stale cache entries, and preserve edited aspect ratios in the lightbox. Export, thumbnails, and XMP sync now understand crop/straighten recipes, including Vireo namespaced sidecar metadata. Validated with targeted image edit, XMP, sync, photo API, export, and thumbnail tests.