### PR TITLE
Add rotate and flip image edits

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -8764,23 +8764,32 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             img = load_image(source_path, max_size=None)
             if img is None:
                 return None, f"{photo['filename']}: failed to load image"
-            rendered = apply_recipe(img, recipe)
-            quality = cfg.load().get("working_copy_quality", 92)
-            fd, tmp_path = tempfile.mkstemp(
-                prefix=f".{photo['id']}.", suffix=".jpg.tmp", dir=out_dir,
-            )
-            os.close(fd)
+            rendered = None
+            tmp_path = None
+            fd = None
             try:
+                rendered = apply_recipe(img, recipe)
+                quality = cfg.load().get("working_copy_quality", 92)
+                fd, tmp_path = tempfile.mkstemp(
+                    prefix=f".{photo['id']}.", suffix=".jpg.tmp", dir=out_dir,
+                )
+                os.close(fd)
+                fd = None
                 rendered.save(tmp_path, format="JPEG", quality=quality)
                 os.replace(tmp_path, out_path)
                 with open(meta_path, "w", encoding="utf-8") as f:
                     json.dump(expected_meta, f, sort_keys=True)
             except Exception:
+                if fd is not None:
+                    with contextlib.suppress(OSError):
+                        os.close(fd)
                 with contextlib.suppress(OSError):
-                    os.unlink(tmp_path)
+                    if tmp_path:
+                        os.unlink(tmp_path)
                 raise
             finally:
-                rendered.close()
+                if rendered is not None:
+                    rendered.close()
                 if rendered is not img:
                     img.close()
             return out_path, None

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2522,7 +2522,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         def visit(value):
             if isinstance(value, dict):
-                pid = value.get("id", value.get("photo_id"))
+                pid = value.get("photo_id", value.get("id"))
                 if (
                     isinstance(pid, int)
                     and not isinstance(pid, bool)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -10928,6 +10928,105 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("Invalid or expired token", 401)
         return jsonify(result)
 
+    def _inat_edit_recipe_source(photo, recipe, fallback_path):
+        vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+        folders = {photo["folder_id"]: photo["folder_path"]}
+        if recipe.get("crop"):
+            source_path, _using_working_copy = _recipe_render_source(
+                photo, recipe, 0, vireo_dir, folders,
+            )
+            return source_path or fallback_path
+
+        wc_rel = photo["working_copy_path"]
+        if wc_rel:
+            wc_path = (
+                wc_rel if os.path.isabs(wc_rel)
+                else os.path.join(vireo_dir, wc_rel)
+            )
+            if (
+                os.path.exists(wc_path)
+                and _path_satisfies_recipe_render(wc_path, photo, recipe, 0)
+            ):
+                return wc_path
+
+        companion_path = photo["companion_path"]
+        if companion_path:
+            companion = os.path.join(photo["folder_path"], companion_path)
+            if (
+                os.path.exists(companion)
+                and _path_satisfies_recipe_render(companion, photo, recipe, 0)
+            ):
+                return companion
+        return fallback_path
+
+    def _inat_upload_photo_path(db, photo, fallback_path):
+        import config as cfg
+
+        vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+        recipe = db.get_photo_edit_recipe(photo["id"])
+        if not recipe:
+            return fallback_path, None
+
+        from image_edits import apply_recipe, recipe_to_json
+        from image_loader import load_image
+
+        source_path = _inat_edit_recipe_source(photo, recipe, fallback_path)
+        if not source_path or not os.path.isfile(source_path):
+            return None, f"{photo['filename']}: source file missing"
+
+        out_dir = os.path.join(vireo_dir, "inat-uploads")
+        os.makedirs(out_dir, exist_ok=True)
+        out_path = os.path.join(out_dir, f"{photo['id']}.jpg")
+        meta_path = os.path.join(out_dir, f"{photo['id']}.json")
+        source_mtime = os.path.getmtime(source_path)
+        recipe_json = recipe_to_json(recipe) or ""
+        expected_meta = {
+            "recipe": recipe_json,
+            "source_path": source_path,
+            "source_mtime": source_mtime,
+        }
+        try:
+            if os.path.isfile(out_path) and os.path.isfile(meta_path):
+                with open(meta_path, encoding="utf-8") as f:
+                    cached_meta = json.load(f)
+                if cached_meta == expected_meta:
+                    return out_path, None
+        except (OSError, ValueError, TypeError):
+            pass
+
+        img = load_image(source_path, max_size=None)
+        if img is None:
+            return None, f"{photo['filename']}: failed to load image"
+        rendered = None
+        tmp_path = None
+        fd = None
+        try:
+            rendered = apply_recipe(img, recipe)
+            quality = cfg.load().get("working_copy_quality", 92)
+            fd, tmp_path = tempfile.mkstemp(
+                prefix=f".{photo['id']}.", suffix=".jpg.tmp", dir=out_dir,
+            )
+            os.close(fd)
+            fd = None
+            rendered.save(tmp_path, format="JPEG", quality=quality)
+            os.replace(tmp_path, out_path)
+            with open(meta_path, "w", encoding="utf-8") as f:
+                json.dump(expected_meta, f, sort_keys=True)
+        except Exception:
+            if fd is not None:
+                with contextlib.suppress(OSError):
+                    os.close(fd)
+            with contextlib.suppress(OSError):
+                if tmp_path:
+                    os.unlink(tmp_path)
+            raise
+        finally:
+            if rendered is not None:
+                rendered.close()
+            if rendered is not img:
+                img.close()
+        return out_path, None
+
     @app.route("/api/inat/submit", methods=["POST"])
     def api_inat_submit():
         """Submit a single observation to iNaturalist."""
@@ -10961,6 +11060,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not os.path.isfile(photo_path):
             return json_error("Photo file not found on disk", 404)
 
+        upload_path, upload_error = _inat_upload_photo_path(db, photo, photo_path)
+        if upload_error:
+            return json_error(upload_error, 500)
+
         # Use overrides from request, or fall back to DB data. The helper
         # picks the highest-confidence prediction from the CURRENT
         # fingerprint, scoped to the active workspace, and respecting the
@@ -10985,7 +11088,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         try:
             obs_id, obs_url = inat.submit_observation(
                 token=token,
-                photo_path=photo_path,
+                photo_path=upload_path,
                 taxon_name=taxon,
                 observed_on=observed_on,
                 latitude=lat,
@@ -11048,6 +11151,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 results.append({"photo_id": photo_id, "error": "Photo file not found on disk"})
                 continue
 
+            upload_path, upload_error = _inat_upload_photo_path(
+                db, photo, photo_path,
+            )
+            if upload_error:
+                results.append({"photo_id": photo_id, "error": upload_error})
+                continue
+
             # Current-fingerprint + workspace-scoped top prediction,
             # respecting the active detector_confidence floor — avoids
             # submitting a stale-label-set or now-hidden taxon to iNaturalist.
@@ -11066,7 +11176,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             try:
                 obs_id, obs_url = inat.submit_observation(
                     token=token,
-                    photo_path=photo_path,
+                    photo_path=upload_path,
                     taxon_name=taxon,
                     observed_on=observed_on,
                     latitude=lat,

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -7634,7 +7634,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         """Get all predictions and photo data for a burst group."""
         db = _get_db()
         preds = db.get_group_predictions(group_id)
-        return jsonify([dict(p) for p in preds])
+        rows = [dict(p) for p in preds]
+        _attach_nested_edit_recipes(db, rows)
+        return jsonify(rows)
 
     @app.route("/api/photos/sharpness/regions", methods=["POST"])
     def api_photo_region_sharpness():

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1467,6 +1467,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         thumb_dir = app.config["THUMB_CACHE_DIR"]
         preview_dir = os.path.join(vireo_dir, "previews")
         originals_dir = os.path.join(vireo_dir, "originals")
+        external_edits_dir = os.path.join(vireo_dir, "external-edits")
         for pid in photo_ids:
             thumb_cache = os.path.join(thumb_dir, f"{pid}.jpg")
             clear_thumb_path = True
@@ -1547,6 +1548,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     os.remove(original_cache)
             except OSError:
                 log.warning("Failed to remove stale original cache %s", original_cache)
+            external_cache = os.path.join(external_edits_dir, f"{pid}.jpg")
+            external_meta = os.path.join(external_edits_dir, f"{pid}.json")
+            for path in (external_cache, external_meta):
+                try:
+                    if os.path.exists(path):
+                        os.remove(path)
+                except OSError:
+                    log.warning(
+                        "Failed to remove stale external edit cache %s",
+                        path, exc_info=True,
+                    )
         db.conn.commit()
 
     def _rendered_recipe_long_edge(width, height, recipe):
@@ -8620,6 +8632,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         db = _get_db()
         folders = {f["id"]: f["path"] for f in db.get_folder_tree()}
+        vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
         photo_paths = []
         for pid in photo_ids:
             photo = db.get_photo(pid)
@@ -8634,6 +8647,66 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         if not photo_paths:
             return json_error("No photos found", 404)
+
+        def _external_edit_handoff_path(photo, fallback_path):
+            recipe = db.get_photo_edit_recipe(photo["id"])
+            if not recipe:
+                return fallback_path, None
+
+            from image_edits import apply_recipe, recipe_to_json
+            from image_loader import load_image
+
+            source_path, _using_working_copy = _recipe_render_source(
+                photo, recipe, 0, vireo_dir, folders,
+            )
+            if not source_path:
+                source_path = fallback_path
+            if not source_path or not os.path.isfile(source_path):
+                return None, f"{photo['filename']}: source file missing"
+
+            out_dir = os.path.join(vireo_dir, "external-edits")
+            os.makedirs(out_dir, exist_ok=True)
+            out_path = os.path.join(out_dir, f"{photo['id']}.jpg")
+            meta_path = os.path.join(out_dir, f"{photo['id']}.json")
+            source_mtime = os.path.getmtime(source_path)
+            recipe_json = recipe_to_json(recipe) or ""
+            expected_meta = {
+                "recipe": recipe_json,
+                "source_path": source_path,
+                "source_mtime": source_mtime,
+            }
+            try:
+                if os.path.isfile(out_path) and os.path.isfile(meta_path):
+                    with open(meta_path, encoding="utf-8") as f:
+                        cached_meta = json.load(f)
+                    if cached_meta == expected_meta:
+                        return out_path, None
+            except (OSError, ValueError, TypeError):
+                pass
+
+            img = load_image(source_path, max_size=None)
+            if img is None:
+                return None, f"{photo['filename']}: failed to load image"
+            rendered = apply_recipe(img, recipe)
+            quality = cfg.load().get("working_copy_quality", 92)
+            fd, tmp_path = tempfile.mkstemp(
+                prefix=f".{photo['id']}.", suffix=".jpg.tmp", dir=out_dir,
+            )
+            os.close(fd)
+            try:
+                rendered.save(tmp_path, format="JPEG", quality=quality)
+                os.replace(tmp_path, out_path)
+                with open(meta_path, "w", encoding="utf-8") as f:
+                    json.dump(expected_meta, f, sort_keys=True)
+            except Exception:
+                with contextlib.suppress(OSError):
+                    os.unlink(tmp_path)
+                raise
+            finally:
+                rendered.close()
+                if rendered is not img:
+                    img.close()
+            return out_path, None
 
         editors = cfg.get_editors()
         selected_editor = None
@@ -8698,13 +8771,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             ]
             return "darktable" in " ".join(parts).lower()
 
-        file_paths = [path for _photo, path in photo_paths]
+        file_paths = []
+        for photo, path in photo_paths:
+            handoff_path, handoff_error = _external_edit_handoff_path(photo, path)
+            if handoff_error:
+                return json_error(handoff_error, 500)
+            file_paths.append(handoff_path)
         if _is_darktable_editor():
             from develop import convert_to_dng, is_nikon_high_efficiency_nef
 
-            vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
             converted_paths = []
-            for photo, input_path in photo_paths:
+            for (photo, _original_path), input_path in zip(
+                photo_paths, file_paths, strict=True,
+            ):
                 try:
                     metadata = (
                         json.loads(photo["exif_data"])

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -8648,6 +8648,42 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not photo_paths:
             return json_error("No photos found", 404)
 
+        def _external_edit_recipe_source(photo, recipe, fallback_path):
+            if recipe.get("crop"):
+                source_path, _using_working_copy = _recipe_render_source(
+                    photo, recipe, 0, vireo_dir, folders,
+                )
+                return source_path or fallback_path
+
+            wc_rel = photo["working_copy_path"]
+            if wc_rel:
+                wc_path = (
+                    wc_rel if os.path.isabs(wc_rel)
+                    else os.path.join(vireo_dir, wc_rel)
+                )
+                if (
+                    os.path.exists(wc_path)
+                    and _path_satisfies_recipe_render(wc_path, photo, recipe, 0)
+                ):
+                    return wc_path
+
+            folder_path = folders.get(photo["folder_id"])
+            if folder_path:
+                companion_path = photo["companion_path"]
+                if companion_path:
+                    companion = os.path.join(folder_path, companion_path)
+                    if (
+                        os.path.exists(companion)
+                        and _path_satisfies_recipe_render(
+                            companion, photo, recipe, 0,
+                        )
+                    ):
+                        return companion
+                original = os.path.join(folder_path, photo["filename"])
+                if os.path.exists(original):
+                    return original
+            return fallback_path
+
         def _external_edit_handoff_path(photo, fallback_path):
             recipe = db.get_photo_edit_recipe(photo["id"])
             if not recipe:
@@ -8656,11 +8692,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             from image_edits import apply_recipe, recipe_to_json
             from image_loader import load_image
 
-            source_path, _using_working_copy = _recipe_render_source(
-                photo, recipe, 0, vireo_dir, folders,
+            source_path = _external_edit_recipe_source(
+                photo, recipe, fallback_path,
             )
-            if not source_path:
-                source_path = fallback_path
             if not source_path or not os.path.isfile(source_path):
                 return None, f"{photo['filename']}: source file missing"
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3358,6 +3358,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         results = serialize_results(
             run_selected_batch_review(photos, config=effective_cfg)
         )
+        _attach_edit_recipes(db, results.get("photos", []))
         results["source"] = "browse-selection"
         return jsonify(results)
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2495,6 +2495,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             p["detections"] = det_map.get(p["id"], [])
         return photo_dicts
 
+    def _attach_edit_recipes(db, photo_dicts):
+        """Attach non-destructive edit recipes to photo dicts (in-place)."""
+        if not photo_dicts:
+            return photo_dicts
+        ids = [p["id"] for p in photo_dicts]
+        recipe_map = db.get_photo_edit_recipes(ids)
+        for p in photo_dicts:
+            p["edit_recipe"] = recipe_map.get(p["id"])
+        return photo_dicts
+
     def _request_flag_filter():
         flag = request.args.get("flag", None)
         if flag in (None, ""):
@@ -2522,6 +2532,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         photo_dicts = [dict(p) for p in photos]
         _attach_species(db, photo_dicts)
         _attach_detections(db, photo_dicts)
+        _attach_edit_recipes(db, photo_dicts)
         collection_dicts = []
         for c in collections:
             d = dict(c)
@@ -3029,6 +3040,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         photo_dicts = [dict(p) for p in photos]
         _attach_species(db, photo_dicts)
         _attach_detections(db, photo_dicts)
+        _attach_edit_recipes(db, photo_dicts)
 
         return jsonify(
             {
@@ -6000,6 +6012,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         photo_dicts = [dict(p) for p in photos]
         _attach_species(db, photo_dicts)
         _attach_detections(db, photo_dicts)
+        _attach_edit_recipes(db, photo_dicts)
         return jsonify(
             {
                 "photos": photo_dicts,
@@ -7219,10 +7232,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         # Enrich predictions and attach alternatives
         results = []
-        for p in preds:
-            d = dict(p)
+        pred_dicts = [dict(p) for p in preds]
+        recipes_by_photo = db.get_photo_edit_recipes({
+            p.get("photo_id") for p in pred_dicts if p.get("photo_id") is not None
+        })
+        for d in pred_dicts:
             if d.get("status") == "alternative":
                 continue  # alternatives are nested, not top-level
+            d["edit_recipe"] = recipes_by_photo.get(d.get("photo_id"))
             if d.get("category") in ("disagreement", "refinement"):
                 keywords = db.get_photo_keywords(d["photo_id"])
                 existing_species = [
@@ -16396,6 +16413,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     sims_by_pid[pid] = round(sim, 4)
             _attach_species(db, photo_dicts)
             _attach_detections(db, photo_dicts)
+            _attach_edit_recipes(db, photo_dicts)
             results = [
                 {
                     "photo": photo,

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -15810,7 +15810,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if collection_id is None:
             save_results(results, cache_dir, db._active_workspace_id)
 
-        return jsonify(serialize_results(results))
+        serialized = serialize_results(results)
+        _attach_nested_edit_recipes(db, serialized)
+        return jsonify(serialized)
 
     @app.route("/api/pipeline/regroup-live", methods=["POST"])
     def api_pipeline_regroup_live():
@@ -15866,7 +15868,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if collection_id is None:
             save_results(results, cache_dir, db._active_workspace_id)
 
-        return jsonify(serialize_results(results))
+        serialized = serialize_results(results)
+        _attach_nested_edit_recipes(db, serialized)
+        return jsonify(serialized)
 
     @app.route("/api/pipeline/save-grouping-defaults", methods=["POST"])
     def api_pipeline_save_grouping_defaults():

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5405,19 +5405,43 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
     # -- Undo --
 
+    def _edit_recipe_history_updates(db, edit_id):
+        rows = db.conn.execute(
+            "SELECT photo_id FROM edit_history_items WHERE edit_id = ?",
+            (edit_id,),
+        ).fetchall()
+        photo_ids = [r["photo_id"] for r in rows]
+        if not photo_ids:
+            return []
+        _invalidate_photo_render_cache(db, photo_ids)
+        recipes = db.get_photo_edit_recipes(photo_ids)
+        seen = set()
+        updates = []
+        for photo_id in photo_ids:
+            if photo_id in seen:
+                continue
+            seen.add(photo_id)
+            updates.append({
+                "photo_id": photo_id,
+                "recipe": recipes.get(photo_id),
+            })
+        return updates
+
     @app.route("/api/undo", methods=["POST"])
     def api_undo():
         db = _get_db()
         result = db.undo_last_edit()
         if result is None:
             return json_error("nothing to undo")
+        edit_recipe_updates = []
         if result.get("action_type") == "edit_recipe":
-            rows = db.conn.execute(
-                "SELECT photo_id FROM edit_history_items WHERE edit_id = ?",
-                (result["id"],),
-            ).fetchall()
-            _invalidate_photo_render_cache(db, [r["photo_id"] for r in rows])
-        return jsonify({"ok": True, "undone": result["description"]})
+            edit_recipe_updates = _edit_recipe_history_updates(db, result["id"])
+        return jsonify({
+            "ok": True,
+            "undone": result["description"],
+            "action_type": result.get("action_type"),
+            "edit_recipes": edit_recipe_updates,
+        })
 
     @app.route("/api/undo/status")
     def api_undo_status():
@@ -5448,13 +5472,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         result = db.redo_last_undo()
         if result is None:
             return json_error("nothing to redo")
+        edit_recipe_updates = []
         if result.get("action_type") == "edit_recipe":
-            rows = db.conn.execute(
-                "SELECT photo_id FROM edit_history_items WHERE edit_id = ?",
-                (result["id"],),
-            ).fetchall()
-            _invalidate_photo_render_cache(db, [r["photo_id"] for r in rows])
-        return jsonify({"ok": True, "redone": result["description"]})
+            edit_recipe_updates = _edit_recipe_history_updates(db, result["id"])
+        return jsonify({
+            "ok": True,
+            "redone": result["description"],
+            "action_type": result.get("action_type"),
+            "edit_recipes": edit_recipe_updates,
+        })
 
     @app.route("/api/redo/status")
     def api_redo_status():

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2516,6 +2516,33 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             p["edit_recipe"] = recipe_map.get(p["id"])
         return photo_dicts
 
+    def _attach_nested_edit_recipes(db, payload):
+        """Attach edit recipes to nested photo-like dicts in an API payload."""
+        refs = []
+
+        def visit(value):
+            if isinstance(value, dict):
+                pid = value.get("id", value.get("photo_id"))
+                if (
+                    isinstance(pid, int)
+                    and not isinstance(pid, bool)
+                    and "filename" in value
+                ):
+                    refs.append((value, pid))
+                for child in value.values():
+                    visit(child)
+            elif isinstance(value, list):
+                for child in value:
+                    visit(child)
+
+        visit(payload)
+        if not refs:
+            return payload
+        recipe_map = db.get_photo_edit_recipes(sorted({pid for _, pid in refs}))
+        for photo, pid in refs:
+            photo["edit_recipe"] = recipe_map.get(pid)
+        return payload
+
     def _request_flag_filter():
         flag = request.args.get("flag", None)
         if flag in (None, ""):
@@ -2854,6 +2881,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     or os.path.isfile(src + ".XMP")
                 ),
             })
+        _attach_nested_edit_recipes(db, out)
         return jsonify(out)
 
     @app.route("/api/folders/check-health", methods=["POST"])
@@ -3355,6 +3383,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if error:
             return json_error(error, 404)
         result["scope_method"] = method_or_error
+        _attach_nested_edit_recipes(db, result)
         return jsonify(result)
 
     @app.route("/api/photos/best-batch", methods=["POST"])
@@ -3399,6 +3428,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if error:
             return json_error(error, 404)
         result["scope_method"] = "selected_photos"
+        _attach_nested_edit_recipes(db, result)
         return jsonify(result)
 
     @app.route("/api/photos/geo")
@@ -5805,10 +5835,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "value": c["value"],
             })
 
-        return jsonify({
+        result = {
             "photos": list(by_photo.values()),
             "total_changes": len(changes),
-        })
+        }
+        _attach_nested_edit_recipes(db, result)
+        return jsonify(result)
 
     @app.route("/api/sync/discard", methods=["POST"])
     def api_sync_discard():
@@ -7336,6 +7368,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         preds = db.get_predictions(photo_ids=photo_ids)
         keywords_by_photo = db.get_keywords_for_photos(photo_ids)
         species_by_photo = db.get_species_keywords_for_photos(photo_ids)
+        edit_recipes_by_photo = db.get_photo_edit_recipes(photo_ids)
         taxonomy = load_local_taxonomy()
 
         def summarize_photo(row):
@@ -7347,6 +7380,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "flag": row["flag"],
                 "width": row["width"],
                 "height": row["height"],
+                "edit_recipe": edit_recipes_by_photo.get(row["id"]),
                 "keywords": keywords_by_photo.get(row["id"], []),
                 "species_keywords": species_by_photo.get(row["id"], []),
                 "predictions": {},
@@ -10871,6 +10905,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "latitude": lat,
             "longitude": lng,
             "filename": photo["filename"],
+            "edit_recipe": db.get_photo_edit_recipe(photo_id),
             "upload_url": upload_url,
             "mode": mode,
             "already_submitted": already,
@@ -12251,6 +12286,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             result = json.loads(row["result"])
         except (json.JSONDecodeError, TypeError):
             return jsonify({"found": False})
+        _attach_nested_edit_recipes(db, result)
         return jsonify({
             "found": True,
             "job_id": row["id"],
@@ -14262,6 +14298,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 photo = db.get_photo(r["photo_id"])
                 if photo:
                     photos.append({"photo": dict(photo), "cluster": 0})
+            _attach_nested_edit_recipes(db, photos)
             return jsonify(
                 {
                     "species": species_name,
@@ -14283,6 +14320,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 photo_data.append(dict(photo))
             else:
                 photo_data.append({"id": r["photo_id"], "filename": r["filename"]})
+        _attach_nested_edit_recipes(db, photo_data)
 
         emb_matrix = np.stack(embeddings)
 
@@ -15567,6 +15605,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         results = load_results(cache_dir, db._active_workspace_id)
         if results is None:
             return json_error("No pipeline results found. Run regroup first.", 404)
+        _attach_nested_edit_recipes(db, results)
         return jsonify(results)
 
     @app.route("/api/pipeline/photo/<int:photo_id>")
@@ -15585,6 +15624,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not row:
             return json_error("Photo not found", 404)
         result = dict(row)
+        result["edit_recipe"] = db.get_photo_edit_recipe(photo_id)
         # Get primary detection from global detections table (threshold
         # resolved from workspace-effective config inside get_detections).
         dets = db.get_detections(photo_id)
@@ -16332,6 +16372,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         photo["sharpness"] = p["sharpness"]
                         photo["subject_sharpness"] = p["subject_sharpness"]
                         photo["quality_score"] = p["quality_score"]
+        _attach_nested_edit_recipes(db, results)
 
         return jsonify(results)
 
@@ -16591,6 +16632,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         "similarity": round(sim, 4),
                     }
                 )
+        _attach_nested_edit_recipes(db, results)
 
         return jsonify(
             {

--- a/vireo/duplicate_scan.py
+++ b/vireo/duplicate_scan.py
@@ -53,6 +53,33 @@ def _row_to_info(row, folder_path):
     }
 
 
+def _attach_edit_recipes(db, proposals):
+    """Attach edit recipes to every candidate in duplicate proposals."""
+    candidates = []
+    for proposal in proposals:
+        winner = proposal.get("winner")
+        if isinstance(winner, dict):
+            candidates.append(winner)
+        candidates.extend(
+            loser for loser in proposal.get("losers", [])
+            if isinstance(loser, dict)
+        )
+    if not candidates:
+        return proposals
+    recipe_map = db.get_photo_edit_recipes(
+        sorted({
+            candidate["id"]
+            for candidate in candidates
+            if isinstance(candidate.get("id"), int)
+            and not isinstance(candidate.get("id"), bool)
+        })
+    )
+    for candidate in candidates:
+        pid = candidate.get("id")
+        candidate["edit_recipe"] = recipe_map.get(pid)
+    return proposals
+
+
 def _build_unresolved_proposal(db, group):
     """Return a proposal dict for an unresolved group, or None on race."""
     rows = _fetch_photo_rows(
@@ -187,6 +214,7 @@ def run_duplicate_scan(job, db, include_resolved=True):
         # Show the winner's path (human-readable) rather than an opaque hash.
         job["progress"]["current_file"] = proposal["winner"]["path"]
 
+    _attach_edit_recipes(db, proposals)
     return {
         "proposals": proposals,
         "buckets": bucket_unresolved_proposals(proposals),

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3633,6 +3633,12 @@ function _lbRecipeAfterEditOperation(recipe, op) {
   if (next.crop && typeof next.crop === 'object') {
     next.crop = _lbTransformBoxByEditOperation(next.crop, op);
   }
+  if (
+    (op === 'flip-horizontal' || op === 'flip-vertical') &&
+    Math.abs(Number(next.straighten || 0)) > 0.0001
+  ) {
+    next.straighten = -Number(next.straighten);
+  }
   delete next.rotation;
   delete next.flip;
   if (orientation.rotation) next.rotation = orientation.rotation;

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3253,6 +3253,11 @@ function _lbRecipeHasOrientation(recipe) {
   );
 }
 
+function _lbCurrentRecipeHasOrientation() {
+  if (_lightboxCurrentId == null) return false;
+  return _lbRecipeHasOrientation(_lbEditRecipeByPhoto[String(_lightboxCurrentId)]);
+}
+
 function _lbRememberEditRecipe(photoId, recipe) {
   if (photoId == null) return;
   _lbEditRecipeByPhoto[String(photoId)] = _lbCloneEditRecipe(recipe);
@@ -3421,6 +3426,8 @@ function _lbReloadCurrentRenderAfterEdit(photoId) {
   img.src = _lbSrcUrl(photoId, 'full');
   _lbLoadDetections(photoId);
   _lbRenderEyeCrosshair(_lbPhotoDataByPhoto[String(photoId)]);
+  _lbApplyMaskVisibility();
+  _lbLoadMaskVariants(photoId);
 }
 
 async function lightboxApplyEdit(op) {
@@ -4054,7 +4061,12 @@ function _lbResetMaskOverlay() {
 function _lbApplyMaskVisibility() {
   var img = document.getElementById('lightboxMaskOverlay');
   if (!img) return;
-  if (!_lbMasksVisible || !_lbMaskCurrentUrl) {
+  var orientationActive = _lbCurrentRecipeHasOrientation();
+  if (orientationActive) {
+    var ctrls = document.getElementById('lightboxMaskControls');
+    if (ctrls) ctrls.classList.remove('has-variants');
+  }
+  if (!_lbMasksVisible || !_lbMaskCurrentUrl || orientationActive) {
     img.classList.remove('show');
     // A previous call may have assigned onload to re-add `show` once
     // the mask image finished loading. If the user toggles masks off
@@ -4137,6 +4149,10 @@ function toggleLightboxMasks() {
 function _lbOnMaskVariantChange() {
   var sel = document.getElementById('lightboxMaskSelect');
   if (!sel) return;
+  if (_lbCurrentRecipeHasOrientation()) {
+    _lbApplyMaskUrl(null);
+    return;
+  }
   var choice = sel.value;
   if (choice === '__active__') {
     if (!_lbMaskActiveVariant) {
@@ -4173,6 +4189,10 @@ function _lbLoadMaskVariants(photoId) {
       if (!data || _lightboxCurrentId !== photoId) return;
       _lbMaskActiveVariant = data.active || null;
       _lbMaskAvailable = data.variants || [];
+      if (_lbCurrentRecipeHasOrientation()) {
+        _lbApplyMaskUrl(null);
+        return;
+      }
       if (_lbMaskAvailable.length === 0) {
         // No masks for this photo — keep the control hidden.
         return;

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3146,6 +3146,8 @@ var _lbViewportByPhotoId = {};  // per-session lightbox viewport cache keyed by 
 var _lbPendingViewportState = null;
 var _lbEditRecipeByPhoto = {};
 var _lbEditRecipeKnownByPhoto = {};
+var _lbEditRecipeWriteSeq = 0;
+var _lbEditRecipeWriteSeqByPhoto = {};
 var _lbPhotoDataByPhoto = {};
 var _lbRenderVersionByPhoto = {};
 var _lbEditWritePending = false;
@@ -3315,6 +3317,17 @@ function _lbRememberEditRecipe(photoId, recipe) {
   _lbEditRecipeByPhoto[String(photoId)] = _lbCloneEditRecipe(recipe);
   _lbEditRecipeKnownByPhoto[String(photoId)] = true;
   _lbApplyEditButtonState();
+}
+
+function _lbEditRecipeWriteSeqFor(photoId) {
+  if (photoId == null) return 0;
+  return _lbEditRecipeWriteSeqByPhoto[String(photoId)] || 0;
+}
+
+function _lbMarkEditRecipeWrite(photoId) {
+  if (photoId == null) return;
+  _lbEditRecipeWriteSeq += 1;
+  _lbEditRecipeWriteSeqByPhoto[String(photoId)] = _lbEditRecipeWriteSeq;
 }
 
 function _lbCurrentEditRecipe() {
@@ -3501,6 +3514,7 @@ async function lightboxApplyEdit(op) {
       }, { toast: false });
     }
     if (_lightboxCurrentId !== photoId) return;
+    _lbMarkEditRecipeWrite(photoId);
     _lbRememberEditRecipe(photoId, data ? data.recipe : null);
     _vireoBumpRenderVersion(photoId);
     if (typeof window.vireoRefreshPhotoRenders === 'function') {
@@ -4387,12 +4401,18 @@ function openLightbox(photoId, filename, photoList, options) {
 
   // Fetch original dimensions (async, non-blocking for image display)
   var flagFetchSeq = _lbFlagEditSeq;
+  var editRecipeFetchSeq = _lbEditRecipeWriteSeqFor(photoId);
   fetch('/api/photos/' + photoId)
     .then(function(r) { return r.ok ? r.json() : null; })
     .then(function(data) {
       if (!data || _lightboxCurrentId !== photoId || _lbOpenSeq !== openSeq) return;
+      var editRecipeFresh = _lbEditRecipeWriteSeqFor(photoId) === editRecipeFetchSeq;
+      if (!editRecipeFresh) {
+        var currentRecipe = _lbEditRecipeByPhoto[String(photoId)];
+        data.edit_recipe = _lbRecipeHasEdits(currentRecipe) ? _lbCloneEditRecipe(currentRecipe) : null;
+      }
       _lbPhotoDataByPhoto[String(photoId)] = data;
-      _lbRememberEditRecipe(photoId, data.edit_recipe);
+      if (editRecipeFresh) _lbRememberEditRecipe(photoId, data.edit_recipe);
       _lbApplyMaskVisibility();
       _lbPhotoW = data.width || null;
       _lbPhotoH = data.height || null;
@@ -7040,6 +7060,7 @@ function formatDuration(seconds) {
       var photoId = Number(update.photo_id);
       if (!Number.isFinite(photoId)) return;
       photoIds.push(photoId);
+      _lbMarkEditRecipeWrite(photoId);
       _lbRememberEditRecipe(photoId, update.recipe);
       if (_lbPhotoDataByPhoto[String(photoId)]) {
         _lbPhotoDataByPhoto[String(photoId)].edit_recipe = update.recipe || null;

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3776,7 +3776,7 @@ function _lbRecipeAfterEditOperation(recipe, op) {
       );
     }
     if (
-      (removedFlip.horizontal || removedFlip.vertical) &&
+      (!!removedFlip.horizontal !== !!removedFlip.vertical) &&
       Math.abs(Number(next.straighten || 0)) > 0.0001
     ) {
       next.straighten = -Number(next.straighten);

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3482,6 +3482,9 @@ function _lbCloneEditRecipe(recipe) {
   if (!recipe || typeof recipe !== 'object') return {};
   var out = {};
   if (recipe.rotation) out.rotation = recipe.rotation;
+  if (Math.abs(Number(recipe.straighten || 0)) > 1e-9) {
+    out.straighten = Number(recipe.straighten);
+  }
   if (recipe.flip && typeof recipe.flip === 'object') {
     out.flip = {};
     if (recipe.flip.horizontal) out.flip.horizontal = true;
@@ -3537,7 +3540,7 @@ function _lbCurrentRecipeHasOrientation() {
 
 window.vireoPhotoHasOrientationEdit = function(photoId) {
   if (photoId == null) return false;
-  return _lbRecipeHasOrientation(_lbEditRecipeByPhoto[String(photoId)]);
+  return _lbRecipeHasGeometricEdit(_lbEditRecipeByPhoto[String(photoId)]);
 };
 
 window.vireoRememberPhotoEditRecipe = function(photoId, recipe, options) {
@@ -3582,6 +3585,8 @@ function _lbCurrentEditRecipeClone() {
 function _lbNormalizeClientRecipe(recipe) {
   var out = _lbCloneEditRecipe(recipe);
   if (!out.rotation) delete out.rotation;
+  if (Math.abs(Number(out.straighten || 0)) < 0.0001) delete out.straighten;
+  else out.straighten = Math.round(Number(out.straighten) * 10000) / 10000;
   if (out.flip) {
     if (!out.flip.horizontal) delete out.flip.horizontal;
     if (!out.flip.vertical) delete out.flip.vertical;
@@ -3598,6 +3603,9 @@ function _lbRecipeAfterEditOperation(recipe, op) {
     return _lbNormalizeClientRecipe(next);
   }
   var orientation = _lbComposeDisplayedOrientation(next, op);
+  if (next.crop && typeof next.crop === 'object') {
+    next.crop = _lbTransformBoxByEditOperation(next.crop, op);
+  }
   delete next.rotation;
   delete next.flip;
   if (orientation.rotation) next.rotation = orientation.rotation;
@@ -3613,6 +3621,16 @@ function _lbApplyDisplayedOrientationOperation(point, op) {
   if (op === 'flip-horizontal') return { x: 1 - x, y: y };
   if (op === 'flip-vertical') return { x: x, y: 1 - y };
   return { x: x, y: y };
+}
+
+function _lbTransformBoxByEditOperation(box, op) {
+  var opRecipe = null;
+  if (op === 'rotate-right') opRecipe = { rotation: 90 };
+  else if (op === 'rotate-left') opRecipe = { rotation: 270 };
+  else if (op === 'flip-horizontal') opRecipe = { flip: { horizontal: true } };
+  else if (op === 'flip-vertical') opRecipe = { flip: { vertical: true } };
+  if (!opRecipe) return box;
+  return _lbTransformBoxByRecipe(box, opRecipe);
 }
 
 function _lbOrientationCandidates() {

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3481,7 +3481,7 @@ window.vireoRenderedUrl = function(url, photoId) {
 
 window.vireoThumbnailUrl = function(photoOrId) {
   var photo = photoOrId && typeof photoOrId === 'object' ? photoOrId : null;
-  var photoId = photo ? (photo.id != null ? photo.id : photo.photo_id) : photoOrId;
+  var photoId = photo ? (photo.photo_id != null ? photo.photo_id : photo.id) : photoOrId;
   if (photoId == null) return '';
   if (
     photo &&

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -6964,6 +6964,7 @@ function formatDuration(seconds) {
     safeFetch('/api/undo', {method: 'POST'})
       .then(function(data) {
         if (data && data.ok) {
+          _refreshEditRecipeHistoryChanges(data);
           showToast('Undone: ' + data.undone + ' — press Ctrl+Shift+Z to redo', 'success');
           _historySessionCount = Math.max(0, _historySessionCount - 1);
           document.getElementById('historyBadge').textContent = _historySessionCount || '';
@@ -6978,6 +6979,7 @@ function formatDuration(seconds) {
     safeFetch('/api/redo', {method: 'POST'})
       .then(function(data) {
         if (data && data.ok) {
+          _refreshEditRecipeHistoryChanges(data);
           showToast('Redone: ' + data.redone, 'success');
           _historySessionCount++;
           document.getElementById('historyBadge').textContent = _historySessionCount || '';
@@ -6986,6 +6988,29 @@ function formatDuration(seconds) {
       })
       .catch(function() { if (btn) btn.disabled = false; });
   };
+
+  function _refreshEditRecipeHistoryChanges(data) {
+    if (!data || data.action_type !== 'edit_recipe' || !Array.isArray(data.edit_recipes)) return;
+    var photoIds = [];
+    data.edit_recipes.forEach(function(update) {
+      if (!update || update.photo_id == null) return;
+      var photoId = Number(update.photo_id);
+      if (!Number.isFinite(photoId)) return;
+      photoIds.push(photoId);
+      _lbRememberEditRecipe(photoId, update.recipe);
+      if (_lbPhotoDataByPhoto[String(photoId)]) {
+        _lbPhotoDataByPhoto[String(photoId)].edit_recipe = update.recipe || null;
+      }
+      _vireoBumpRenderVersion(photoId);
+    });
+    if (!photoIds.length) return;
+    if (typeof window.vireoRefreshPhotoRenders === 'function') {
+      window.vireoRefreshPhotoRenders(photoIds);
+    }
+    if (_lightboxCurrentId != null && photoIds.indexOf(Number(_lightboxCurrentId)) !== -1) {
+      _lbReloadCurrentRenderAfterEdit(Number(_lightboxCurrentId));
+    }
+  }
 
   function _bumpHistoryBadge() {
     _historySessionCount++;

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3054,6 +3054,21 @@ async function createWorkspace() {
     <button class="lb-action-btn lb-action-accent" id="lightboxInspect" onclick="">
       Inspect Pipeline
     </button>
+    <button class="lb-action-btn" id="lightboxRotateLeft" onclick="event.stopPropagation(); lightboxApplyEdit('rotate-left');" title="Rotate left">
+      Rotate Left
+    </button>
+    <button class="lb-action-btn" id="lightboxRotateRight" onclick="event.stopPropagation(); lightboxApplyEdit('rotate-right');" title="Rotate right">
+      Rotate Right
+    </button>
+    <button class="lb-action-btn" id="lightboxFlipHorizontal" onclick="event.stopPropagation(); lightboxApplyEdit('flip-horizontal');" title="Flip horizontally">
+      Flip H
+    </button>
+    <button class="lb-action-btn" id="lightboxFlipVertical" onclick="event.stopPropagation(); lightboxApplyEdit('flip-vertical');" title="Flip vertically">
+      Flip V
+    </button>
+    <button class="lb-action-btn" id="lightboxResetEdit" onclick="event.stopPropagation(); lightboxApplyEdit('reset');" title="Reset rotate and flip edits">
+      Reset Edit
+    </button>
     <button class="lb-action-btn" id="lightboxOpenEditor" onclick="">
       Open in Editor
     </button>
@@ -3129,6 +3144,316 @@ var _lbFlagPendingByPhoto = {};  // count of in-flight flag writes PER photo; li
 var _lbConfirmedFlags = {};   // last server-confirmed flag per photo, isolated from optimistic page helpers
 var _lbViewportByPhotoId = {};  // per-session lightbox viewport cache keyed by photo id
 var _lbPendingViewportState = null;
+var _lbEditRecipeByPhoto = {};
+var _lbEditRecipeKnownByPhoto = {};
+var _lbPhotoDataByPhoto = {};
+var _lbRenderVersionByPhoto = {};
+var _lbEditWritePending = false;
+
+function _vireoUrlWithRenderVersion(url, photoId) {
+  if (!url || photoId == null) return url;
+  var version = _lbRenderVersionByPhoto[String(photoId)];
+  if (!version) return url;
+  var hash = '';
+  var hashIdx = url.indexOf('#');
+  if (hashIdx !== -1) {
+    hash = url.slice(hashIdx);
+    url = url.slice(0, hashIdx);
+  }
+  var joiner = url.indexOf('?') === -1 ? '?' : '&';
+  return url + joiner + 'rv=' + encodeURIComponent(version) + hash;
+}
+
+function _vireoBaseRenderedUrl(src) {
+  if (!src) return '';
+  try {
+    var parsed = new URL(src, window.location.origin);
+    return parsed.pathname + (parsed.search ? parsed.search.replace(/([?&])rv=[^&]*&?/, '$1').replace(/[?&]$/, '') : '');
+  } catch (_) {
+    return src.replace(/([?&])rv=[^&]*&?/, '$1').replace(/[?&]$/, '');
+  }
+}
+
+function _vireoBumpRenderVersion(photoId) {
+  if (photoId == null) return null;
+  var version = Date.now() + '-' + Math.floor(Math.random() * 1000000);
+  _lbRenderVersionByPhoto[String(photoId)] = version;
+  return version;
+}
+
+window.vireoRefreshPhotoRenders = function(photoIds) {
+  if (!Array.isArray(photoIds)) photoIds = [photoIds];
+  var idSet = {};
+  photoIds.forEach(function(id) {
+    if (id == null) return;
+    idSet[String(id)] = true;
+  });
+  if (!Object.keys(idSet).length) return;
+  var imgs = document.querySelectorAll('img[src]');
+  imgs.forEach(function(img) {
+    var attr = img.getAttribute('src') || '';
+    var base = _vireoBaseRenderedUrl(attr);
+    Object.keys(idSet).forEach(function(id) {
+      if (
+        base === '/thumbnails/' + id + '.jpg' ||
+        base === '/photos/' + id + '/full' ||
+        base === '/photos/' + id + '/original' ||
+        base.indexOf('/photos/' + id + '/preview?') === 0
+      ) {
+        img.src = _vireoUrlWithRenderVersion(base, id);
+      }
+    });
+  });
+  try {
+    document.dispatchEvent(new CustomEvent('lightbox:renderchanged', {
+      detail: { photoIds: Object.keys(idSet).map(function(id) { return parseInt(id, 10); }) },
+    }));
+  } catch (_) {}
+};
+
+window.vireoRenderedUrl = function(url, photoId) {
+  return _vireoUrlWithRenderVersion(url, photoId);
+};
+
+function _lbCloneEditRecipe(recipe) {
+  if (!recipe || typeof recipe !== 'object') return {};
+  var out = {};
+  if (recipe.rotation) out.rotation = recipe.rotation;
+  if (recipe.flip && typeof recipe.flip === 'object') {
+    out.flip = {};
+    if (recipe.flip.horizontal) out.flip.horizontal = true;
+    if (recipe.flip.vertical) out.flip.vertical = true;
+    if (!Object.keys(out.flip).length) delete out.flip;
+  }
+  if (recipe.crop && typeof recipe.crop === 'object') {
+    out.crop = {
+      x: recipe.crop.x,
+      y: recipe.crop.y,
+      w: recipe.crop.w,
+      h: recipe.crop.h,
+    };
+  }
+  if (recipe.adjustments && typeof recipe.adjustments === 'object') {
+    out.adjustments = Object.assign({}, recipe.adjustments);
+  }
+  return out;
+}
+
+function _lbRecipeHasEdits(recipe) {
+  return !!(recipe && typeof recipe === 'object' && Object.keys(recipe).some(function(k) {
+    return k !== 'version';
+  }));
+}
+
+function _lbRecipeHasOrientation(recipe) {
+  return !!(
+    recipe &&
+    typeof recipe === 'object' &&
+    (recipe.rotation || (recipe.flip && (recipe.flip.horizontal || recipe.flip.vertical)))
+  );
+}
+
+function _lbRememberEditRecipe(photoId, recipe) {
+  if (photoId == null) return;
+  _lbEditRecipeByPhoto[String(photoId)] = _lbCloneEditRecipe(recipe);
+  _lbEditRecipeKnownByPhoto[String(photoId)] = true;
+  _lbApplyEditButtonState();
+}
+
+function _lbCurrentEditRecipe() {
+  if (_lightboxCurrentId == null) return {};
+  return _lbCloneEditRecipe(_lbEditRecipeByPhoto[String(_lightboxCurrentId)]);
+}
+
+function _lbNormalizeClientRecipe(recipe) {
+  var out = _lbCloneEditRecipe(recipe);
+  if (!out.rotation) delete out.rotation;
+  if (out.flip) {
+    if (!out.flip.horizontal) delete out.flip.horizontal;
+    if (!out.flip.vertical) delete out.flip.vertical;
+    if (!Object.keys(out.flip).length) delete out.flip;
+  }
+  return _lbRecipeHasEdits(out) ? out : null;
+}
+
+function _lbRecipeAfterEditOperation(recipe, op) {
+  var next = _lbCloneEditRecipe(recipe);
+  if (op === 'reset') {
+    delete next.rotation;
+    delete next.flip;
+    return _lbNormalizeClientRecipe(next);
+  }
+  if (op === 'rotate-left' || op === 'rotate-right') {
+    var delta = op === 'rotate-left' ? 270 : 90;
+    next.rotation = ((Number(next.rotation) || 0) + delta) % 360;
+  } else if (op === 'flip-horizontal' || op === 'flip-vertical') {
+    next.flip = next.flip || {};
+    var axis = op === 'flip-horizontal' ? 'horizontal' : 'vertical';
+    next.flip[axis] = !next.flip[axis];
+  }
+  return _lbNormalizeClientRecipe(next);
+}
+
+function _lbApplyEditButtonState() {
+  var recipe = _lbCurrentEditRecipe();
+  var hasOrientation = _lbRecipeHasOrientation(recipe);
+  var known = _lightboxCurrentId != null && !!_lbEditRecipeKnownByPhoto[String(_lightboxCurrentId)];
+  var ids = [
+    'lightboxRotateLeft',
+    'lightboxRotateRight',
+    'lightboxFlipHorizontal',
+    'lightboxFlipVertical',
+    'lightboxResetEdit',
+  ];
+  ids.forEach(function(id) {
+    var btn = document.getElementById(id);
+    if (!btn) return;
+    btn.disabled = _lbEditWritePending || _lightboxCurrentId == null || !known || (id === 'lightboxResetEdit' && !hasOrientation);
+  });
+}
+
+function _lbSetEditBusy(busy) {
+  _lbEditWritePending = !!busy;
+  _lbApplyEditButtonState();
+}
+
+function _lbReloadCurrentRenderAfterEdit(photoId) {
+  if (_lightboxCurrentId !== photoId) return;
+  var img = document.getElementById('lightboxImg');
+  var wrap = document.getElementById('lightboxWrap');
+  if (!img) return;
+  _lbZoom = 1.0;
+  _lbPanX = 0;
+  _lbPanY = 0;
+  _lbNativeZoom = null;
+  _lbCurrentSrcKey = 'full';
+  _lbFullLongEdge = null;
+  _lbPending1To1 = false;
+  _lbPending1To1Anchor = null;
+  _lbPendingViewportState = null;
+  _lbOriginalUnavailable = false;
+  if (_lbSwapTimer) {
+    clearTimeout(_lbSwapTimer);
+    _lbSwapTimer = null;
+  }
+  _lbDesiredSrcKey = null;
+  if (wrap) wrap.classList.remove('zoomed');
+  _lbApplyTransform();
+  img.onload = function() {
+    img.onload = null;
+    img.onerror = null;
+    if (_lightboxCurrentId !== photoId) return;
+    if (img.naturalWidth) {
+      _lbFullLongEdge = Math.max(img.naturalWidth, img.naturalHeight);
+      _lbSessionFullLongEdge = _lbFullLongEdge;
+    }
+    _lbRecomputeNativeZoom();
+    _lbApplyTransform();
+  };
+  img.onerror = function() {
+    img.onload = null;
+    img.onerror = null;
+    if (_lightboxCurrentId === photoId && typeof showToast === 'function') {
+      showToast('Could not reload edited photo', 'error');
+    }
+  };
+  img.src = _lbSrcUrl(photoId, 'full');
+  _lbLoadDetections(photoId);
+  _lbRenderEyeCrosshair(_lbPhotoDataByPhoto[String(photoId)]);
+}
+
+async function lightboxApplyEdit(op) {
+  if (_lightboxCurrentId == null || _lbEditWritePending) return;
+  var photoId = _lightboxCurrentId;
+  var nextRecipe = _lbRecipeAfterEditOperation(_lbCurrentEditRecipe(), op);
+  _lbSetEditBusy(true);
+  try {
+    var data;
+    if (nextRecipe) {
+      data = await safeFetch('/api/photos/' + photoId + '/edit-recipe', {
+        method: 'PUT',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({ recipe: nextRecipe }),
+      }, { toast: false });
+    } else {
+      data = await safeFetch('/api/photos/' + photoId + '/edit-recipe', {
+        method: 'DELETE',
+      }, { toast: false });
+    }
+    if (_lightboxCurrentId !== photoId) return;
+    _lbRememberEditRecipe(photoId, data ? data.recipe : null);
+    _vireoBumpRenderVersion(photoId);
+    if (typeof window.vireoRefreshPhotoRenders === 'function') {
+      window.vireoRefreshPhotoRenders([photoId]);
+    }
+    _lbReloadCurrentRenderAfterEdit(photoId);
+    if (typeof showToast === 'function') showToast('Updated photo edit', 'success');
+  } catch (e) {
+    if (typeof showToast === 'function') showToast(e.message || 'Could not update photo edit', 'error');
+  } finally {
+    _lbSetEditBusy(false);
+  }
+}
+
+function _lbTransformPointByRecipe(x, y, recipe) {
+  recipe = recipe || {};
+  var rotation = Number(recipe.rotation) || 0;
+  var nx = x;
+  var ny = y;
+  if (rotation === 90) {
+    nx = 1 - y;
+    ny = x;
+  } else if (rotation === 180) {
+    nx = 1 - x;
+    ny = 1 - y;
+  } else if (rotation === 270) {
+    nx = y;
+    ny = 1 - x;
+  }
+  var flip = recipe.flip || {};
+  if (flip.horizontal) nx = 1 - nx;
+  if (flip.vertical) ny = 1 - ny;
+  return {
+    x: Math.max(0, Math.min(1, nx)),
+    y: Math.max(0, Math.min(1, ny)),
+  };
+}
+
+function _lbTransformBoxByRecipe(box, recipe) {
+  recipe = recipe || {};
+  var x = Number(box.x);
+  var y = Number(box.y);
+  var w = Number(box.w);
+  var h = Number(box.h);
+  if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(w) || !Number.isFinite(h)) return box;
+  var rotation = Number(recipe.rotation) || 0;
+  var nx = x;
+  var ny = y;
+  var nw = w;
+  var nh = h;
+  if (rotation === 90) {
+    nx = 1 - (y + h);
+    ny = x;
+    nw = h;
+    nh = w;
+  } else if (rotation === 180) {
+    nx = 1 - (x + w);
+    ny = 1 - (y + h);
+  } else if (rotation === 270) {
+    nx = y;
+    ny = 1 - (x + w);
+    nw = h;
+    nh = w;
+  }
+  var flip = recipe.flip || {};
+  if (flip.horizontal) nx = 1 - (nx + nw);
+  if (flip.vertical) ny = 1 - (ny + nh);
+  nx = Math.max(0, Math.min(1, nx));
+  ny = Math.max(0, Math.min(1, ny));
+  nw = Math.max(0, Math.min(1 - nx, nw));
+  nh = Math.max(0, Math.min(1 - ny, nh));
+  return { x: nx, y: ny, w: nw, h: nh };
+}
 
 function _lbIsOneToOneZoom() {
   if (_lbPending1To1) return true;
@@ -3576,8 +3901,13 @@ function _lbRenderEyeCrosshair(photo) {
     container.style.display = 'none';
     return;
   }
-  var xPct = photo.eye_x * 100;
-  var yPct = photo.eye_y * 100;
+  var point = _lbTransformPointByRecipe(
+    Number(photo.eye_x),
+    Number(photo.eye_y),
+    _lbEditRecipeByPhoto[String(photo.id || _lightboxCurrentId)]
+  );
+  var xPct = point.x * 100;
+  var yPct = point.y * 100;
   var marker = document.createElement('div');
   marker.className = 'lb-eye-crosshair';
   marker.style.left = xPct.toFixed(3) + '%';
@@ -3601,12 +3931,19 @@ function _lbLoadDetections(photoId) {
       if (!detections || detections.length === 0) return;
       // Only render if still viewing the same photo
       if (_lightboxCurrentId !== photoId) return;
+      var recipe = _lbEditRecipeByPhoto[String(photoId)];
       detections.forEach(function(det) {
         if (det.box_x == null || det.box_y == null) return;
         var color = _lbGetSpeciesColor(det.category || 'animal');
+        var transformed = _lbTransformBoxByRecipe({
+          x: det.box_x,
+          y: det.box_y,
+          w: det.box_w,
+          h: det.box_h,
+        }, recipe);
         var box = document.createElement('div');
         box.className = 'lb-detection-box';
-        box.style.cssText = 'left:' + (det.box_x * 100).toFixed(2) + '%;top:' + (det.box_y * 100).toFixed(2) + '%;width:' + (det.box_w * 100).toFixed(2) + '%;height:' + (det.box_h * 100).toFixed(2) + '%;border-color:' + color + ';';
+        box.style.cssText = 'left:' + (transformed.x * 100).toFixed(2) + '%;top:' + (transformed.y * 100).toFixed(2) + '%;width:' + (transformed.w * 100).toFixed(2) + '%;height:' + (transformed.h * 100).toFixed(2) + '%;border-color:' + color + ';';
         var conf = det.detector_confidence ? Math.round(det.detector_confidence * 100) + '%' : '';
         if (conf) {
           box.innerHTML = '<span class="lb-detection-label" style="background:' + color + ';color:#0A1F2E;">' + conf + '</span>';
@@ -3851,6 +4188,7 @@ function openLightbox(photoId, filename, photoList, options) {
 
   _lightboxCurrentId = photoId;
   if (photoList) _lightboxPhotoList = photoList;
+  _lbApplyEditButtonState();
   try {
     document.dispatchEvent(new CustomEvent('lightbox:photochanged', { detail: { photoId: photoId } }));
   } catch(_) {}
@@ -3920,6 +4258,8 @@ function openLightbox(photoId, filename, photoList, options) {
     .then(function(r) { return r.ok ? r.json() : null; })
     .then(function(data) {
       if (!data || _lightboxCurrentId !== photoId || _lbOpenSeq !== openSeq) return;
+      _lbPhotoDataByPhoto[String(photoId)] = data;
+      _lbRememberEditRecipe(photoId, data.edit_recipe);
       _lbPhotoW = data.width || null;
       _lbPhotoH = data.height || null;
       _lbCurrentWildlifeExcluded = !!data.wildlife_excluded;
@@ -3927,6 +4267,7 @@ function openLightbox(photoId, filename, photoList, options) {
       _lbRecordFetchedFlag(photoId, data.flag, flagFetchSeq);
       _lbRecomputeNativeZoom();
       if (!_lbTryApplyPendingViewportState()) _lbApplyPendingOneToOneZoom();
+      _lbLoadDetections(photoId);
       _lbRenderEyeCrosshair(data);
     })
     .catch(function() {});
@@ -3999,8 +4340,6 @@ function openLightbox(photoId, filename, photoList, options) {
   _lbApplyMaskToggleButton();
   _lbApplyWildlifeExcludedButton();
 
-  // Fetch and render detection bounding boxes
-  _lbLoadDetections(photoId);
   _lbApplyBoxesVisibility();
 
   // Fetch the photo's SAM mask variants and (if any) populate the
@@ -5129,9 +5468,11 @@ function _lbPickSourceKey(targetZoom) {
 }
 
 function _lbSrcUrl(photoId, key) {
-  if (key === 'original') return '/photos/' + photoId + '/original';
-  if (key === 'full') return '/photos/' + photoId + '/full';
-  return '/photos/' + photoId + '/preview?size=' + key;
+  var url;
+  if (key === 'original') url = '/photos/' + photoId + '/original';
+  else if (key === 'full') url = '/photos/' + photoId + '/full';
+  else url = '/photos/' + photoId + '/preview?size=' + key;
+  return _vireoUrlWithRenderVersion(url, photoId);
 }
 
 function _lbScheduleSourceSwap(targetZoom) {

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3409,11 +3409,12 @@ function _vireoCleanRenderSearch(search) {
     var params = new URLSearchParams(search);
     params.delete('rv');
     params.delete('er');
+    params.delete('editv');
     var qs = params.toString();
     return qs ? '?' + qs : '';
   } catch (_) {
     return search
-      .replace(/([?&])(rv|er)=[^&]*&?/g, '$1')
+      .replace(/([?&])(rv|er|editv)=[^&]*&?/g, '$1')
       .replace(/\?&/, '?')
       .replace(/[?&]$/, '');
   }

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3258,6 +3258,11 @@ function _lbCurrentRecipeHasOrientation() {
   return _lbRecipeHasOrientation(_lbEditRecipeByPhoto[String(_lightboxCurrentId)]);
 }
 
+window.vireoPhotoHasOrientationEdit = function(photoId) {
+  if (photoId == null) return false;
+  return _lbRecipeHasOrientation(_lbEditRecipeByPhoto[String(photoId)]);
+};
+
 function _lbRememberEditRecipe(photoId, recipe) {
   if (photoId == null) return;
   _lbEditRecipeByPhoto[String(photoId)] = _lbCloneEditRecipe(recipe);
@@ -4341,6 +4346,7 @@ function openLightbox(photoId, filename, photoList, options) {
       if (!data || _lightboxCurrentId !== photoId || _lbOpenSeq !== openSeq) return;
       _lbPhotoDataByPhoto[String(photoId)] = data;
       _lbRememberEditRecipe(photoId, data.edit_recipe);
+      _lbApplyMaskVisibility();
       _lbPhotoW = data.width || null;
       _lbPhotoH = data.height || null;
       _lbCurrentWildlifeExcluded = !!data.wildlife_excluded;

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3486,6 +3486,7 @@ window.vireoThumbnailUrl = function(photoOrId) {
   if (
     photo &&
     Object.prototype.hasOwnProperty.call(photo, 'edit_recipe') &&
+    typeof photo.edit_recipe !== 'undefined' &&
     typeof window.vireoRememberPhotoEditRecipe === 'function'
   ) {
     window.vireoRememberPhotoEditRecipe(photoId, photo.edit_recipe, {
@@ -3618,6 +3619,12 @@ function _lbNormalizeClientRecipe(recipe) {
 function _lbRecipeAfterEditOperation(recipe, op) {
   var next = _lbCloneEditRecipe(recipe);
   if (op === 'reset') {
+    if (next.crop && typeof next.crop === 'object') {
+      next.crop = _lbTransformBoxByRecipe(
+        next.crop,
+        _lbInverseOrientationRecipe(next)
+      );
+    }
     delete next.rotation;
     delete next.flip;
     return _lbNormalizeClientRecipe(next);
@@ -3697,6 +3704,33 @@ function _lbComposeDisplayedOrientation(recipe, op) {
       if (
         Math.abs(actual.x - desired[j].x) > 0.000001 ||
         Math.abs(actual.y - desired[j].y) > 0.000001
+      ) {
+        matches = false;
+        break;
+      }
+    }
+    if (matches) return candidate;
+  }
+  return {};
+}
+
+function _lbInverseOrientationRecipe(recipe) {
+  var samplePoints = [
+    { x: 0.125, y: 0.25 },
+    { x: 0.8, y: 0.2 },
+    { x: 0.3, y: 0.85 },
+  ];
+  var candidates = _lbOrientationCandidates();
+  for (var i = 0; i < candidates.length; i++) {
+    var candidate = candidates[i];
+    var matches = true;
+    for (var j = 0; j < samplePoints.length; j++) {
+      var original = samplePoints[j];
+      var oriented = _lbTransformPointByRecipe(original.x, original.y, recipe);
+      var restored = _lbTransformPointByRecipe(oriented.x, oriented.y, candidate);
+      if (
+        Math.abs(restored.x - original.x) > 0.000001 ||
+        Math.abs(restored.y - original.y) > 0.000001
       ) {
         matches = false;
         break;

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3150,10 +3150,8 @@ var _lbPhotoDataByPhoto = {};
 var _lbRenderVersionByPhoto = {};
 var _lbEditWritePending = false;
 
-function _vireoUrlWithRenderVersion(url, photoId) {
-  if (!url || photoId == null) return url;
-  var version = _lbRenderVersionByPhoto[String(photoId)];
-  if (!version) return url;
+function _vireoUrlWithQueryParam(url, key, value) {
+  if (!url || !key || value == null || value === '') return url;
   var hash = '';
   var hashIdx = url.indexOf('#');
   if (hashIdx !== -1) {
@@ -3161,16 +3159,42 @@ function _vireoUrlWithRenderVersion(url, photoId) {
     url = url.slice(0, hashIdx);
   }
   var joiner = url.indexOf('?') === -1 ? '?' : '&';
-  return url + joiner + 'rv=' + encodeURIComponent(version) + hash;
+  return url + joiner + encodeURIComponent(key) + '=' + encodeURIComponent(value) + hash;
+}
+
+function _vireoUrlWithRenderVersion(url, photoId) {
+  if (!url || photoId == null) return url;
+  var version = _lbRenderVersionByPhoto[String(photoId)];
+  if (!version) return url;
+  return _vireoUrlWithQueryParam(url, 'rv', version);
+}
+
+function _vireoCleanRenderSearch(search) {
+  if (!search) return '';
+  try {
+    var params = new URLSearchParams(search);
+    params.delete('rv');
+    params.delete('er');
+    var qs = params.toString();
+    return qs ? '?' + qs : '';
+  } catch (_) {
+    return search
+      .replace(/([?&])(rv|er)=[^&]*&?/g, '$1')
+      .replace(/\?&/, '?')
+      .replace(/[?&]$/, '');
+  }
 }
 
 function _vireoBaseRenderedUrl(src) {
   if (!src) return '';
   try {
     var parsed = new URL(src, window.location.origin);
-    return parsed.pathname + (parsed.search ? parsed.search.replace(/([?&])rv=[^&]*&?/, '$1').replace(/[?&]$/, '') : '');
+    return parsed.pathname + _vireoCleanRenderSearch(parsed.search);
   } catch (_) {
-    return src.replace(/([?&])rv=[^&]*&?/, '$1').replace(/[?&]$/, '');
+    return src
+      .replace(/([?&])(rv|er)=[^&]*&?/g, '$1')
+      .replace(/\?&/, '?')
+      .replace(/[?&]$/, '');
   }
 }
 
@@ -3200,7 +3224,9 @@ window.vireoRefreshPhotoRenders = function(photoIds) {
         base === '/photos/' + id + '/original' ||
         base.indexOf('/photos/' + id + '/preview?') === 0
       ) {
-        img.src = _vireoUrlWithRenderVersion(base, id);
+        img.src = window.vireoRenderedUrl
+          ? window.vireoRenderedUrl(base, id)
+          : _vireoUrlWithRenderVersion(base, id);
       }
     });
   });
@@ -3212,6 +3238,9 @@ window.vireoRefreshPhotoRenders = function(photoIds) {
 };
 
 window.vireoRenderedUrl = function(url, photoId) {
+  var recipe = photoId == null ? null : _lbEditRecipeByPhoto[String(photoId)];
+  var recipeKey = _vireoEditRecipeCacheKey(recipe);
+  if (recipeKey) url = _vireoUrlWithQueryParam(url, 'er', recipeKey);
   return _vireoUrlWithRenderVersion(url, photoId);
 };
 
@@ -3237,6 +3266,20 @@ function _lbCloneEditRecipe(recipe) {
     out.adjustments = Object.assign({}, recipe.adjustments);
   }
   return out;
+}
+
+function _vireoHashString(s) {
+  var hash = 5381;
+  for (var i = 0; i < s.length; i++) {
+    hash = ((hash << 5) + hash) ^ s.charCodeAt(i);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+function _vireoEditRecipeCacheKey(recipe) {
+  var normalized = _lbCloneEditRecipe(recipe);
+  if (!_lbRecipeHasEdits(normalized)) return '';
+  return _vireoHashString(JSON.stringify(normalized));
 }
 
 function _lbRecipeHasEdits(recipe) {

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3521,11 +3521,12 @@ function _vireoCleanRenderSearch(search) {
     params.delete('rv');
     params.delete('er');
     params.delete('editv');
+    params.delete('v');
     var qs = params.toString();
     return qs ? '?' + qs : '';
   } catch (_) {
     return search
-      .replace(/([?&])(rv|er|editv)=[^&]*&?/g, '$1')
+      .replace(/([?&])(rv|er|editv|v)=[^&]*&?/g, '$1')
       .replace(/\?&/, '?')
       .replace(/[?&]$/, '');
   }
@@ -3538,7 +3539,7 @@ function _vireoBaseRenderedUrl(src) {
     return parsed.pathname + _vireoCleanRenderSearch(parsed.search);
   } catch (_) {
     return src
-      .replace(/([?&])(rv|er)=[^&]*&?/g, '$1')
+      .replace(/([?&])(rv|er|editv|v)=[^&]*&?/g, '$1')
       .replace(/\?&/, '?')
       .replace(/[?&]$/, '');
   }
@@ -3767,11 +3768,18 @@ function _lbNormalizeClientRecipe(recipe) {
 function _lbRecipeAfterEditOperation(recipe, op) {
   var next = _lbCloneEditRecipe(recipe);
   if (op === 'reset') {
+    var removedFlip = next.flip || {};
     if (next.crop && typeof next.crop === 'object') {
       next.crop = _lbTransformBoxByRecipe(
         next.crop,
         _lbInverseOrientationRecipe(next)
       );
+    }
+    if (
+      (removedFlip.horizontal || removedFlip.vertical) &&
+      Math.abs(Number(next.straighten || 0)) > 0.0001
+    ) {
+      next.straighten = -Number(next.straighten);
     }
     delete next.rotation;
     delete next.flip;

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3478,6 +3478,25 @@ window.vireoRenderedUrl = function(url, photoId) {
   return _vireoUrlWithRenderVersion(url, photoId);
 };
 
+window.vireoThumbnailUrl = function(photoOrId) {
+  var photo = photoOrId && typeof photoOrId === 'object' ? photoOrId : null;
+  var photoId = photo ? (photo.id != null ? photo.id : photo.photo_id) : photoOrId;
+  if (photoId == null) return '';
+  if (
+    photo &&
+    Object.prototype.hasOwnProperty.call(photo, 'edit_recipe') &&
+    typeof window.vireoRememberPhotoEditRecipe === 'function'
+  ) {
+    window.vireoRememberPhotoEditRecipe(photoId, photo.edit_recipe, {
+      skipIfLocallyWritten: true
+    });
+  }
+  var url = '/thumbnails/' + photoId + '.jpg';
+  return window.vireoRenderedUrl
+    ? window.vireoRenderedUrl(url, photoId)
+    : _vireoUrlWithRenderVersion(url, photoId);
+};
+
 function _lbCloneEditRecipe(recipe) {
   if (!recipe || typeof recipe !== 'object') return {};
   var out = {};
@@ -5850,6 +5869,7 @@ async function submitToInat(photoId) {
       description: '',
       geoprivacy: 'open',
       filename: data.filename,
+      edit_recipe: data.edit_recipe,
       already_submitted: data.already_submitted,
       existing_url: data.existing_observation_url,
     }];
@@ -5875,6 +5895,7 @@ async function submitToInatBatch(photoIds) {
         description: '',
         geoprivacy: 'open',
         filename: data.filename,
+        edit_recipe: data.edit_recipe,
         already_submitted: data.already_submitted,
         existing_url: data.existing_observation_url,
       });
@@ -5900,9 +5921,10 @@ function openInatModal() {
     if (item.already_submitted) {
       warn = '<div class="inat-card-status warning">&#9888; Already submitted: <a href="' + escapeAttr(item.existing_url) + '" target="_blank" onclick="return openExternalLink(event, this.href)" style="color:var(--warning);">' + escapeHtml(item.existing_url) + '</a></div>';
     }
+    var thumbUrl = window.vireoThumbnailUrl ? window.vireoThumbnailUrl(item) : '/thumbnails/' + item.photo_id + '.jpg';
     html += '<div class="inat-card" id="inatCard' + idx + '">' +
       '<div class="inat-card-header">' +
-        '<img class="inat-card-thumb" src="/thumbnails/' + item.photo_id + '.jpg" alt="">' +
+        '<img class="inat-card-thumb" src="' + escapeAttr(thumbUrl) + '" alt="">' +
         '<div style="flex:1;min-width:0;">' +
           '<div style="font-size:13px;color:var(--text-primary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">' + escapeHtml(item.filename) + '</div>' +
           warn +
@@ -6752,7 +6774,9 @@ function findSimilar(photoId) {
             openLightbox(p.id, p.filename || '');
           });
           var img = document.createElement('img');
-          img.src = '/thumbnails/' + p.id + '.jpg';
+          img.src = window.vireoThumbnailUrl
+            ? window.vireoThumbnailUrl(p)
+            : '/thumbnails/' + p.id + '.jpg';
           img.loading = 'lazy';
           img.alt = '';
           var info = document.createElement('div');
@@ -8864,8 +8888,11 @@ async function loadMissingPhotos() {
     document.getElementById('missingPhotosSelectAll').checked = false;
     container.innerHTML = photos.map(p => {
       const ts = p.timestamp ? new Date(p.timestamp).toLocaleDateString() : '';
+      const thumbUrl = window.vireoThumbnailUrl
+        ? window.vireoThumbnailUrl(p)
+        : `/thumbnails/${p.id}.jpg`;
       const thumb = p.has_thumb
-        ? `<img src="/thumbnails/${p.id}.jpg" alt="" loading="lazy">`
+        ? `<img src="${_escapeAttr(thumbUrl)}" alt="" loading="lazy">`
         : '<span>no thumb</span>';
       const badges = [
         ['thumb', p.has_thumb],

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3308,8 +3308,14 @@ window.vireoPhotoHasOrientationEdit = function(photoId) {
   return _lbRecipeHasOrientation(_lbEditRecipeByPhoto[String(photoId)]);
 };
 
-window.vireoRememberPhotoEditRecipe = function(photoId, recipe) {
+window.vireoRememberPhotoEditRecipe = function(photoId, recipe, options) {
+  if (options && options.skipIfLocallyWritten && _lbEditRecipeWriteSeqFor(photoId)) return;
   _lbRememberEditRecipe(photoId, recipe);
+};
+
+window.vireoPhotoEditRecipe = function(photoId) {
+  if (photoId == null) return {};
+  return _lbCloneEditRecipe(_lbEditRecipeByPhoto[String(photoId)]);
 };
 
 function _lbRememberEditRecipe(photoId, recipe) {
@@ -3513,15 +3519,16 @@ async function lightboxApplyEdit(op) {
         method: 'DELETE',
       }, { toast: false });
     }
-    if (_lightboxCurrentId !== photoId) return;
     _lbMarkEditRecipeWrite(photoId);
     _lbRememberEditRecipe(photoId, data ? data.recipe : null);
     _vireoBumpRenderVersion(photoId);
     if (typeof window.vireoRefreshPhotoRenders === 'function') {
       window.vireoRefreshPhotoRenders([photoId]);
     }
-    _lbReloadCurrentRenderAfterEdit(photoId);
-    if (typeof showToast === 'function') showToast('Updated photo edit', 'success');
+    if (_lightboxCurrentId === photoId) {
+      _lbReloadCurrentRenderAfterEdit(photoId);
+      if (typeof showToast === 'function') showToast('Updated photo edit', 'success');
+    }
   } catch (e) {
     if (typeof showToast === 'function') showToast(e.message || 'Could not update photo edit', 'error');
   } finally {
@@ -4122,12 +4129,14 @@ function _lbResetMaskOverlay() {
   _lbMaskActiveVariant = null;
   _lbMaskAvailable = [];
   _lbMaskCurrentUrl = null;
+  _lbApplyMaskToggleButton();
 }
 
 function _lbApplyMaskVisibility() {
   var img = document.getElementById('lightboxMaskOverlay');
   if (!img) return;
   var orientationActive = _lbCurrentRecipeHasOrientation();
+  _lbApplyMaskToggleButton();
   if (orientationActive) {
     var ctrls = document.getElementById('lightboxMaskControls');
     if (ctrls) ctrls.classList.remove('has-variants');
@@ -4192,7 +4201,18 @@ function _lbApplyMaskUrl(url) {
 
 function _lbApplyMaskToggleButton() {
   var btn = document.getElementById('lightboxToggleMasks');
-  if (btn) btn.textContent = _lbMasksVisible ? 'Hide Masks' : 'Show Masks';
+  if (!btn) return;
+  if (_lbCurrentRecipeHasOrientation()) {
+    btn.disabled = true;
+    btn.textContent = 'Masks Hidden';
+    btn.title = 'Masks are hidden while rotate or flip edits are active';
+    btn.setAttribute('aria-label', btn.title);
+    return;
+  }
+  btn.disabled = false;
+  btn.textContent = _lbMasksVisible ? 'Hide Masks' : 'Show Masks';
+  btn.title = 'Toggle mask overlay';
+  btn.setAttribute('aria-label', btn.title);
 }
 
 function _lbApplyWildlifeExcludedButton() {
@@ -4407,12 +4427,22 @@ function openLightbox(photoId, filename, photoList, options) {
     .then(function(data) {
       if (!data || _lightboxCurrentId !== photoId || _lbOpenSeq !== openSeq) return;
       var editRecipeFresh = _lbEditRecipeWriteSeqFor(photoId) === editRecipeFetchSeq;
+      var recipeKeyBefore = _vireoEditRecipeCacheKey(_lbEditRecipeByPhoto[String(photoId)]);
       if (!editRecipeFresh) {
         var currentRecipe = _lbEditRecipeByPhoto[String(photoId)];
         data.edit_recipe = _lbRecipeHasEdits(currentRecipe) ? _lbCloneEditRecipe(currentRecipe) : null;
       }
       _lbPhotoDataByPhoto[String(photoId)] = data;
-      if (editRecipeFresh) _lbRememberEditRecipe(photoId, data.edit_recipe);
+      if (editRecipeFresh) {
+        _lbRememberEditRecipe(photoId, data.edit_recipe);
+        if (_vireoEditRecipeCacheKey(data.edit_recipe) !== recipeKeyBefore) {
+          _vireoBumpRenderVersion(photoId);
+          if (typeof window.vireoRefreshPhotoRenders === 'function') {
+            window.vireoRefreshPhotoRenders([photoId]);
+          }
+          _lbReloadCurrentRenderAfterEdit(photoId);
+        }
+      }
       _lbApplyMaskVisibility();
       _lbPhotoW = data.width || null;
       _lbPhotoH = data.height || null;
@@ -5626,7 +5656,9 @@ function _lbSrcUrl(photoId, key) {
   if (key === 'original') url = '/photos/' + photoId + '/original';
   else if (key === 'full') url = '/photos/' + photoId + '/full';
   else url = '/photos/' + photoId + '/preview?size=' + key;
-  return _vireoUrlWithRenderVersion(url, photoId);
+  return window.vireoRenderedUrl
+    ? window.vireoRenderedUrl(url, photoId)
+    : _vireoUrlWithRenderVersion(url, photoId);
 }
 
 function _lbScheduleSourceSwap(targetZoom) {

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3263,6 +3263,10 @@ window.vireoPhotoHasOrientationEdit = function(photoId) {
   return _lbRecipeHasOrientation(_lbEditRecipeByPhoto[String(photoId)]);
 };
 
+window.vireoRememberPhotoEditRecipe = function(photoId, recipe) {
+  _lbRememberEditRecipe(photoId, recipe);
+};
+
 function _lbRememberEditRecipe(photoId, recipe) {
   if (photoId == null) return;
   _lbEditRecipeByPhoto[String(photoId)] = _lbCloneEditRecipe(recipe);

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3976,9 +3976,13 @@ function _lbReloadCurrentRenderAfterEdit(photoId) {
 async function lightboxApplyEdit(op) {
   if (_lightboxCurrentId == null || _lbEditWritePending) return;
   var photoId = _lightboxCurrentId;
-  var nextRecipe = _lbRecipeAfterEditOperation(_lbCurrentEditRecipeClone(), op);
   _lbSetEditBusy(true);
   try {
+    _lbFlushPendingAdjustmentSave();
+    await _lbWaitForAdjustmentSaveIdle(photoId);
+    if (_lightboxCurrentId !== photoId) return;
+    var baseRecipe = _lbEditRecipeLoaded ? _lbCloneEditRecipe(_lbEditRecipe) : _lbCurrentEditRecipeClone();
+    var nextRecipe = _lbRecipeAfterEditOperation(baseRecipe, op);
     var data;
     if (nextRecipe) {
       data = await safeFetch('/api/photos/' + photoId + '/edit-recipe', {

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3283,15 +3283,76 @@ function _lbRecipeAfterEditOperation(recipe, op) {
     delete next.flip;
     return _lbNormalizeClientRecipe(next);
   }
-  if (op === 'rotate-left' || op === 'rotate-right') {
-    var delta = op === 'rotate-left' ? 270 : 90;
-    next.rotation = ((Number(next.rotation) || 0) + delta) % 360;
-  } else if (op === 'flip-horizontal' || op === 'flip-vertical') {
-    next.flip = next.flip || {};
-    var axis = op === 'flip-horizontal' ? 'horizontal' : 'vertical';
-    next.flip[axis] = !next.flip[axis];
-  }
+  var orientation = _lbComposeDisplayedOrientation(next, op);
+  delete next.rotation;
+  delete next.flip;
+  if (orientation.rotation) next.rotation = orientation.rotation;
+  if (orientation.flip) next.flip = orientation.flip;
   return _lbNormalizeClientRecipe(next);
+}
+
+function _lbApplyDisplayedOrientationOperation(point, op) {
+  var x = point.x;
+  var y = point.y;
+  if (op === 'rotate-right') return { x: 1 - y, y: x };
+  if (op === 'rotate-left') return { x: y, y: 1 - x };
+  if (op === 'flip-horizontal') return { x: 1 - x, y: y };
+  if (op === 'flip-vertical') return { x: x, y: 1 - y };
+  return { x: x, y: y };
+}
+
+function _lbOrientationCandidates() {
+  var candidates = [];
+  [0, 90, 180, 270].forEach(function(rotation) {
+    [false, true].forEach(function(horizontal) {
+      [false, true].forEach(function(vertical) {
+        var candidate = {};
+        if (rotation) candidate.rotation = rotation;
+        if (horizontal || vertical) {
+          candidate.flip = {};
+          if (horizontal) candidate.flip.horizontal = true;
+          if (vertical) candidate.flip.vertical = true;
+        }
+        candidates.push(candidate);
+      });
+    });
+  });
+  return candidates;
+}
+
+function _lbComposeDisplayedOrientation(recipe, op) {
+  var samplePoints = [
+    { x: 0.125, y: 0.25 },
+    { x: 0.8, y: 0.2 },
+    { x: 0.3, y: 0.85 },
+  ];
+  var desired = samplePoints.map(function(point) {
+    return _lbApplyDisplayedOrientationOperation(
+      _lbTransformPointByRecipe(point.x, point.y, recipe),
+      op
+    );
+  });
+  var candidates = _lbOrientationCandidates();
+  for (var i = 0; i < candidates.length; i++) {
+    var candidate = candidates[i];
+    var matches = true;
+    for (var j = 0; j < samplePoints.length; j++) {
+      var actual = _lbTransformPointByRecipe(
+        samplePoints[j].x,
+        samplePoints[j].y,
+        candidate
+      );
+      if (
+        Math.abs(actual.x - desired[j].x) > 0.000001 ||
+        Math.abs(actual.y - desired[j].y) > 0.000001
+      ) {
+        matches = false;
+        break;
+      }
+    }
+    if (matches) return candidate;
+  }
+  return {};
 }
 
 function _lbApplyEditButtonState() {

--- a/vireo/templates/_sync_panel.html
+++ b/vireo/templates/_sync_panel.html
@@ -175,8 +175,11 @@ function renderSyncPreview() {
 
     html += '<div style="display:flex;gap:12px;padding:12px 0;border-bottom:1px solid var(--border-subtle);">';
 
+    var thumbUrl = window.vireoThumbnailUrl
+      ? window.vireoThumbnailUrl(p)
+      : '/thumbnails/' + p.photo_id + '.jpg';
     html += '<div style="flex-shrink:0;">';
-    html += '<img class="sync-preview-thumb" src="/thumbnails/' + p.photo_id + '.jpg" style="width:' + _syncThumbSize + 'px;height:' + Math.round(_syncThumbSize * 2 / 3) + 'px;object-fit:cover;border-radius:4px;cursor:pointer;display:block;" data-photo-id="' + p.photo_id + '" data-filename="' + escapeAttr(p.filename) + '">';
+    html += '<img class="sync-preview-thumb" src="' + escapeAttr(thumbUrl) + '" style="width:' + _syncThumbSize + 'px;height:' + Math.round(_syncThumbSize * 2 / 3) + 'px;object-fit:cover;border-radius:4px;cursor:pointer;display:block;" data-photo-id="' + p.photo_id + '" data-filename="' + escapeAttr(p.filename) + '">';
     html += '</div>';
 
     html += '<div style="flex:1;min-width:0;">';

--- a/vireo/templates/best_batch.html
+++ b/vireo/templates/best_batch.html
@@ -368,8 +368,11 @@ function previewUrl(photoId, size) {
   return '/photos/' + photoId + '/preview?size=' + (size || 1920);
 }
 
-function thumbnailUrl(photoId) {
-  return '/thumbnails/' + photoId + '.jpg';
+function thumbnailUrl(photoOrId) {
+  var photoId = photoOrId && typeof photoOrId === 'object' ? photoOrId.id : photoOrId;
+  return window.vireoThumbnailUrl
+    ? window.vireoThumbnailUrl(photoOrId)
+    : '/thumbnails/' + photoId + '.jpg';
 }
 
 function roleLabel(role) {
@@ -445,7 +448,7 @@ function inspectPhoto(photoId) {
   var img = document.getElementById('inspectImg');
   img.onerror = function() {
     this.onerror = null;
-    this.src = thumbnailUrl(card.id);
+    this.src = thumbnailUrl(card);
   };
   img.src = previewUrl(card.id, 1920);
   img.alt = card.filename || '';
@@ -503,7 +506,7 @@ function renderBatch(data) {
   document.getElementById('rankList').innerHTML = cards.map(function(card) {
     var reasons = (card.reasons || []).slice(0, 2).join(' · ');
     return '<div class="rank-card ' + escapeAttr(card.role || '') + '" data-photo-id="' + card.id + '" onclick="inspectPhoto(' + card.id + ')">' +
-      '<img src="' + thumbnailUrl(card.id) + '" alt="' + escapeAttr(card.filename || '') + '" loading="lazy">' +
+      '<img src="' + thumbnailUrl(card) + '" alt="' + escapeAttr(card.filename || '') + '" loading="lazy">' +
       '<div class="rank-meta">' +
         '<div class="role ' + escapeAttr(card.role || '') + '">#' + card.rank + ' ' + roleLabel(card.role) + '</div>' +
         '<div class="filename" title="' + escapeAttr(card.filename || '') + '">' + escapeHtml(card.filename || '') + '</div>' +

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2118,6 +2118,12 @@ function renderCardInfo(p) {
 
 function renderPhotoCard(p, idx) {
   var selectedClass = (p.id === selectedPhotoId || selectedPhotos.has(p.id)) ? ' selected' : '';
+  if (
+    typeof window.vireoRememberPhotoEditRecipe === 'function' &&
+    Object.prototype.hasOwnProperty.call(p, 'edit_recipe')
+  ) {
+    window.vireoRememberPhotoEditRecipe(p.id, p.edit_recipe);
+  }
   var hideDetectionOverlays = (
     typeof window.vireoPhotoHasOrientationEdit === 'function' &&
     window.vireoPhotoHasOrientationEdit(p.id)

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2183,7 +2183,7 @@ function renderPhotoCard(p, idx) {
     speciesBadgeHtml += '</div>';
   }
 
-  var thumbUrl = window.vireoRenderedUrl ? window.vireoRenderedUrl('/thumbnails/' + p.id + '.jpg', p.id) : '/thumbnails/' + p.id + '.jpg';
+  var thumbUrl = window.vireoThumbnailUrl ? window.vireoThumbnailUrl(p) : '/thumbnails/' + p.id + '.jpg';
   return '<div class="grid-card' + selectedClass + '" data-id="' + p.id + '" data-idx="' + idx + '" data-filename="' + escapeAttr(p.filename) + '" onclick="selectPhoto(event,' + p.id + ',' + idx + ')">' +
     '<div class="grid-card-img-wrap">' +
       '<img src="' + escapeAttr(thumbUrl) + '" loading="lazy" decoding="async" alt="' + escapeAttr(p.filename) + '">' +
@@ -4048,8 +4048,9 @@ function renderBestBatch(data) {
   }).join('');
   var cards = (data.cards || []).map(function(card) {
     var reasons = (card.reasons || []).slice(0, 2).map(escapeHtml).join(' · ');
+    var thumbUrl = window.vireoThumbnailUrl ? window.vireoThumbnailUrl(card) : '/thumbnails/' + card.id + '.jpg';
     return '<div class="best-batch-card ' + escapeAttr(card.role || '') + '" data-photo-id="' + card.id + '">' +
-      '<img src="/thumbnails/' + card.id + '.jpg" alt="' + escapeAttr(card.filename || '') + '" loading="lazy">' +
+      '<img src="' + escapeAttr(thumbUrl) + '" alt="' + escapeAttr(card.filename || '') + '" loading="lazy">' +
       '<div class="best-batch-card-body">' +
         '<div class="best-batch-role ' + escapeAttr(card.role || '') + '">#' + card.rank + ' ' + bestBatchRoleLabel(card.role) + '</div>' +
         '<div class="best-batch-card-name" title="' + escapeAttr(card.filename || '') + '">' + escapeHtml(card.filename || '') + '</div>' +
@@ -4058,11 +4059,12 @@ function renderBestBatch(data) {
       '</div>' +
     '</div>';
   }).join('');
+  var bestThumbUrl = window.vireoThumbnailUrl ? window.vireoThumbnailUrl(best) : '/thumbnails/' + best.id + '.jpg';
   content.className = '';
   content.innerHTML =
     '<div class="best-batch-head">' +
       '<div class="best-batch-pick">' +
-        '<img src="/thumbnails/' + best.id + '.jpg" alt="' + escapeAttr(best.filename || '') + '">' +
+        '<img src="' + escapeAttr(bestThumbUrl) + '" alt="' + escapeAttr(best.filename || '') + '">' +
         '<div class="best-batch-pick-meta">' +
           '<div class="best-batch-eyebrow">Best Pick</div>' +
           '<div class="best-batch-title">' + escapeHtml(best.filename || '') + '</div>' +
@@ -5009,7 +5011,7 @@ function renderDetail(photo) {
       skipIfLocallyWritten: true,
     });
   }
-  var detailThumb = window.vireoRenderedUrl ? window.vireoRenderedUrl('/thumbnails/' + photo.id + '.jpg', photo.id) : '/thumbnails/' + photo.id + '.jpg';
+  var detailThumb = window.vireoThumbnailUrl ? window.vireoThumbnailUrl(photo) : '/thumbnails/' + photo.id + '.jpg';
   document.getElementById('detailImg').src = detailThumb;
   document.getElementById('detailFilename').textContent = photo.filename;
 

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -4976,6 +4976,12 @@ async function loadDetail(id) {
 
 function renderDetail(photo) {
   window._detailPhotoId = photo.id;
+  if (
+    typeof window.vireoRememberPhotoEditRecipe === 'function' &&
+    Object.prototype.hasOwnProperty.call(photo, 'edit_recipe')
+  ) {
+    window.vireoRememberPhotoEditRecipe(photo.id, photo.edit_recipe);
+  }
   var detailThumb = window.vireoRenderedUrl ? window.vireoRenderedUrl('/thumbnails/' + photo.id + '.jpg', photo.id) : '/thumbnails/' + photo.id + '.jpg';
   document.getElementById('detailImg').src = detailThumb;
   document.getElementById('detailFilename').textContent = photo.filename;

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2122,7 +2122,9 @@ function renderPhotoCard(p, idx) {
     typeof window.vireoRememberPhotoEditRecipe === 'function' &&
     Object.prototype.hasOwnProperty.call(p, 'edit_recipe')
   ) {
-    window.vireoRememberPhotoEditRecipe(p.id, p.edit_recipe);
+    window.vireoRememberPhotoEditRecipe(p.id, p.edit_recipe, {
+      skipIfLocallyWritten: true,
+    });
   }
   var hideDetectionOverlays = (
     typeof window.vireoPhotoHasOrientationEdit === 'function' &&
@@ -4980,7 +4982,9 @@ function renderDetail(photo) {
     typeof window.vireoRememberPhotoEditRecipe === 'function' &&
     Object.prototype.hasOwnProperty.call(photo, 'edit_recipe')
   ) {
-    window.vireoRememberPhotoEditRecipe(photo.id, photo.edit_recipe);
+    window.vireoRememberPhotoEditRecipe(photo.id, photo.edit_recipe, {
+      skipIfLocallyWritten: true,
+    });
   }
   var detailThumb = window.vireoRenderedUrl ? window.vireoRenderedUrl('/thumbnails/' + photo.id + '.jpg', photo.id) : '/thumbnails/' + photo.id + '.jpg';
   document.getElementById('detailImg').src = detailThumb;

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2118,6 +2118,10 @@ function renderCardInfo(p) {
 
 function renderPhotoCard(p, idx) {
   var selectedClass = (p.id === selectedPhotoId || selectedPhotos.has(p.id)) ? ' selected' : '';
+  var hideDetectionOverlays = (
+    typeof window.vireoPhotoHasOrientationEdit === 'function' &&
+    window.vireoPhotoHasOrientationEdit(p.id)
+  );
 
   // Detection box overlays — render one per detection in the photo
   var boxHtml = '';
@@ -2126,7 +2130,7 @@ function renderPhotoCard(p, idx) {
       if (d == null || d.x == null) return;
       var conf = (d.confidence != null) ? Math.round(d.confidence * 100) + '%' : '';
       var cat = (d.category && d.category !== 'animal') ? escapeHtml(d.category) + ' ' : '';
-      boxHtml += '<div class="det-box" style="left:' + (d.x * 100) + '%;top:' + (d.y * 100) + '%;width:' + (d.w * 100) + '%;height:' + (d.h * 100) + '%;">' +
+      boxHtml += '<div class="det-box" data-photo-id="' + p.id + '" style="' + (hideDetectionOverlays ? 'display:none;' : '') + 'left:' + (d.x * 100) + '%;top:' + (d.y * 100) + '%;width:' + (d.w * 100) + '%;height:' + (d.h * 100) + '%;">' +
         ((cat || conf) ? '<span class="det-box-label">' + cat + conf + '</span>' : '') +
       '</div>';
     });
@@ -2169,6 +2173,19 @@ function renderPhotoCard(p, idx) {
     '</div>' +
   '</div>';
 }
+
+document.addEventListener('lightbox:renderchanged', function(e) {
+  var ids = e && e.detail && Array.isArray(e.detail.photoIds) ? e.detail.photoIds : [];
+  ids.forEach(function(id) {
+    var hideDetectionOverlays = (
+      typeof window.vireoPhotoHasOrientationEdit === 'function' &&
+      window.vireoPhotoHasOrientationEdit(id)
+    );
+    document.querySelectorAll('.grid-card[data-id="' + id + '"] .det-box').forEach(function(box) {
+      box.style.display = hideDetectionOverlays ? 'none' : '';
+    });
+  });
+});
 
 function appendGridPhotos(newPhotos, startIdx) {
   if (!newPhotos.length) return;

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2154,9 +2154,10 @@ function renderPhotoCard(p, idx) {
     speciesBadgeHtml += '</div>';
   }
 
+  var thumbUrl = window.vireoRenderedUrl ? window.vireoRenderedUrl('/thumbnails/' + p.id + '.jpg', p.id) : '/thumbnails/' + p.id + '.jpg';
   return '<div class="grid-card' + selectedClass + '" data-id="' + p.id + '" data-idx="' + idx + '" data-filename="' + escapeAttr(p.filename) + '" onclick="selectPhoto(event,' + p.id + ',' + idx + ')">' +
     '<div class="grid-card-img-wrap">' +
-      '<img src="/thumbnails/' + p.id + '.jpg" loading="lazy" decoding="async" alt="' + escapeAttr(p.filename) + '">' +
+      '<img src="' + escapeAttr(thumbUrl) + '" loading="lazy" decoding="async" alt="' + escapeAttr(p.filename) + '">' +
       clipBadge +
       boxHtml +
       inatBadge +
@@ -4952,7 +4953,8 @@ async function loadDetail(id) {
 
 function renderDetail(photo) {
   window._detailPhotoId = photo.id;
-  document.getElementById('detailImg').src = '/thumbnails/' + photo.id + '.jpg';
+  var detailThumb = window.vireoRenderedUrl ? window.vireoRenderedUrl('/thumbnails/' + photo.id + '.jpg', photo.id) : '/thumbnails/' + photo.id + '.jpg';
+  document.getElementById('detailImg').src = detailThumb;
   document.getElementById('detailFilename').textContent = photo.filename;
 
   // Rating stars

--- a/vireo/templates/compare.html
+++ b/vireo/templates/compare.html
@@ -567,12 +567,15 @@ function renderTable(rows) {
 
 function renderPhotoCell(photo) {
   var meta = [];
+  var thumbUrl = window.vireoThumbnailUrl
+    ? window.vireoThumbnailUrl(photo)
+    : '/thumbnails/' + photo.photo_id + '.jpg';
   if (photo.timestamp) meta.push(photo.timestamp.replace('T', ' ').substring(0, 16));
   if (photo.rating) meta.push(photo.rating + ' star' + (photo.rating === 1 ? '' : 's'));
   if (photo.flag && photo.flag !== 'none') meta.push(photo.flag);
   return '<div class="photo-cell">' +
     '<button type="button" class="photo-thumb-button" title="View larger" onclick="openCompareLightbox(' +
-    photo.photo_id + ')"><img src="/thumbnails/' + photo.photo_id + '.jpg" loading="lazy" alt="' +
+    photo.photo_id + ')"><img src="' + escapeAttr(thumbUrl) + '" loading="lazy" alt="' +
     escapeAttr(photo.filename) + '"></button>' +
     '<div><div class="photo-name">' + escapeHtml(photo.filename) + '</div>' +
     '<div class="photo-meta">' + escapeHtml(meta.join(' · ')) + '</div>' +

--- a/vireo/templates/cull.html
+++ b/vireo/templates/cull.html
@@ -959,12 +959,15 @@ function renderCulling() {
         // Filename rides in a data attribute: interpolating it into the
         // onclick JS string broke on double quotes (attribute terminator,
         // which escapeHtml doesn't encode) and trailing backslashes.
+        var thumbUrl = window.vireoThumbnailUrl
+          ? window.vireoThumbnailUrl(photo)
+          : '/thumbnails/' + photo.photo_id + '.jpg';
         html += '<div class="' + cardClass + '" data-photo-id="' + photo.photo_id + '" ' +
           'data-filename="' + escapeAttr(photo.filename || '') + '" ' +
           'onclick="openLightbox(' + photo.photo_id + ', this.dataset.filename, window.' + poseKey + ')" ' +
           'ondblclick="toggleCullAction(' + si + ',' + pi + ',' + photo.photo_id + ')">' +
           badge +
-          '<img src="/thumbnails/' + photo.photo_id + '.jpg" loading="lazy">' +
+          '<img src="' + escapeAttr(thumbUrl) + '" loading="lazy">' +
           '<div class="cull-card-info">' +
             '<div class="cull-quality">' + (photo.pipeline_label || photo.action.toUpperCase()) + ' &middot; Q: ' + qScore + '</div>' +
             '<div class="cull-filename" onclick="event.stopPropagation()" onmousedown="event.stopPropagation()">' + escapeHtml(photo.filename || '') + '</div>' +

--- a/vireo/templates/duplicates.html
+++ b/vireo/templates/duplicates.html
@@ -902,7 +902,9 @@
     var missing = photo.exists === false;
     if (missing) cls += ' missing';
     var badge = isWinner ? 'KEEP' : (isResolvedLoser ? 'REJECTED' : 'WILL REJECT');
-    var thumbUrl = photo.id != null ? ('/thumbnails/' + photo.id + '.jpg') : null;
+    var thumbUrl = photo.id != null
+      ? (window.vireoThumbnailUrl ? window.vireoThumbnailUrl(photo) : '/thumbnails/' + photo.id + '.jpg')
+      : null;
     var html = '<div class="dup-card ' + cls + '" data-photo-id="' +
                (photo.id != null ? photo.id : '') + '">';
     if (thumbUrl) {

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -277,19 +277,10 @@ function sortedBuckets() {
 }
 
 function photoThumbnailUrl(p) {
-  if (
-    p &&
-    Object.prototype.hasOwnProperty.call(p, 'edit_recipe') &&
-    typeof window.vireoRememberPhotoEditRecipe === 'function'
-  ) {
-    window.vireoRememberPhotoEditRecipe(p.id, p.edit_recipe, {
-      skipIfLocallyWritten: true
-    });
-  }
-  var url = '/thumbnails/' + p.id + '.jpg';
-  return typeof window.vireoRenderedUrl === 'function'
-    ? window.vireoRenderedUrl(url, p.id)
-    : url;
+  if (!p || p.id == null) return '';
+  return window.vireoThumbnailUrl
+    ? window.vireoThumbnailUrl(p)
+    : '/thumbnails/' + p.id + '.jpg';
 }
 
 function renderCard(p, idx) {

--- a/vireo/templates/life_list.html
+++ b/vireo/templates/life_list.html
@@ -161,19 +161,10 @@ function sortedSpecies() {
 }
 
 function photoThumbnailUrl(photo) {
-  if (
-    photo &&
-    Object.prototype.hasOwnProperty.call(photo, 'edit_recipe') &&
-    typeof window.vireoRememberPhotoEditRecipe === 'function'
-  ) {
-    window.vireoRememberPhotoEditRecipe(photo.id, photo.edit_recipe, {
-      skipIfLocallyWritten: true
-    });
-  }
-  var url = '/thumbnails/' + photo.id + '.jpg';
-  return typeof window.vireoRenderedUrl === 'function'
-    ? window.vireoRenderedUrl(url, photo.id)
-    : url;
+  if (!photo || photo.id == null) return '';
+  return window.vireoThumbnailUrl
+    ? window.vireoThumbnailUrl(photo)
+    : '/thumbnails/' + photo.id + '.jpg';
 }
 
 function renderCard(entry) {

--- a/vireo/templates/map.html
+++ b/vireo/templates/map.html
@@ -474,18 +474,9 @@ function openPhotoMarker(photoId) {
 
 function photoThumbnailUrl(p) {
   if (!p || p.id == null) return '';
-  if (
-    Object.prototype.hasOwnProperty.call(p, 'edit_recipe') &&
-    typeof window.vireoRememberPhotoEditRecipe === 'function'
-  ) {
-    window.vireoRememberPhotoEditRecipe(p.id, p.edit_recipe, {
-      skipIfLocallyWritten: true
-    });
-  }
-  var url = '/thumbnails/' + p.id + '.jpg';
-  return typeof window.vireoRenderedUrl === 'function'
-    ? window.vireoRenderedUrl(url, p.id)
-    : url;
+  return window.vireoThumbnailUrl
+    ? window.vireoThumbnailUrl(p)
+    : '/thumbnails/' + p.id + '.jpg';
 }
 
 /* ── Sidebar rendering ── */

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -506,19 +506,10 @@ function escapeHtml(s) {
 function escapeAttr(s) { return escapeHtml(s); }
 
 function photoThumbnailUrl(p) {
-  if (
-    p &&
-    Object.prototype.hasOwnProperty.call(p, 'edit_recipe') &&
-    typeof window.vireoRememberPhotoEditRecipe === 'function'
-  ) {
-    window.vireoRememberPhotoEditRecipe(p.id, p.edit_recipe, {
-      skipIfLocallyWritten: true
-    });
-  }
-  var url = '/thumbnails/' + p.id + '.jpg';
-  return typeof window.vireoRenderedUrl === 'function'
-    ? window.vireoRenderedUrl(url, p.id)
-    : url;
+  if (!p || p.id == null) return '';
+  return window.vireoThumbnailUrl
+    ? window.vireoThumbnailUrl(p)
+    : '/thumbnails/' + p.id + '.jpg';
 }
 
 /* ---------- detection_box parsing ----------

--- a/vireo/templates/move.html
+++ b/vireo/templates/move.html
@@ -605,8 +605,9 @@ function renderPhotoGrid() {
   var html = '<div class="photo-grid">';
   photoList.forEach(function(p, idx) {
     var selClass = selectedPhotos.has(p.id) ? ' selected' : '';
+    var thumbUrl = window.vireoThumbnailUrl ? window.vireoThumbnailUrl(p) : '/thumbnails/' + p.id + '.jpg';
     html += '<div class="grid-card' + selClass + '" data-id="' + p.id + '" data-idx="' + idx + '" onclick="handlePhotoClick(event, ' + p.id + ', ' + idx + ')">';
-    html += '<div class="grid-card-img-wrap"><img src="/thumbnails/' + p.id + '.jpg" loading="lazy" alt=""></div>';
+    html += '<div class="grid-card-img-wrap"><img src="' + escapeAttr(thumbUrl) + '" loading="lazy" alt=""></div>';
     html += '<div class="grid-card-info"><div class="grid-card-name" title="' + escapeAttr(p.filename) + '">' + escapeHtml(p.filename) + '</div></div>';
     html += '</div>';
   });

--- a/vireo/templates/pipeline_rapid_review.html
+++ b/vireo/templates/pipeline_rapid_review.html
@@ -782,6 +782,10 @@ function escapeHtml(s) {
   });
 }
 
+function escapeAttr(s) {
+  return escapeHtml(s);
+}
+
 function photoPreviewUrl(id) {
   return '/photos/' + id + '/preview?size=2560';
 }
@@ -1519,7 +1523,7 @@ function thumbClass(p) {
 function renderFilmstrip() {
   var html = rapid.items.map(function(p) {
     return '<button class="' + thumbClass(p) + '" onclick="selectPhoto(' + p.id + ')" title="' + escapeHtml(p.filename || '') + '">' +
-      '<img src="' + thumbUrl(p) + '" alt=""></button>';
+      '<img src="' + escapeAttr(thumbUrl(p)) + '" alt=""></button>';
   }).join('');
   document.getElementById('filmstrip').innerHTML = html;
 }
@@ -1528,7 +1532,7 @@ function renderLane(id, photos) {
   var html = photos.map(function(p) {
     var muted = (!rapid.queue.includeRejected && photoFlag(p) === 'rejected') ? ' rejected-muted' : '';
     return '<button class="mini-thumb' + muted + '" onclick="selectPhoto(' + p.id + ')" title="' + escapeHtml(p.filename || '') + '">' +
-      '<img src="' + thumbUrl(p) + '" alt=""></button>';
+      '<img src="' + escapeAttr(thumbUrl(p)) + '" alt=""></button>';
   }).join('');
   document.getElementById(id).innerHTML = html;
 }

--- a/vireo/templates/pipeline_rapid_review.html
+++ b/vireo/templates/pipeline_rapid_review.html
@@ -790,8 +790,11 @@ function photoOriginalUrl(id) {
   return '/photos/' + id + '/original';
 }
 
-function thumbUrl(id) {
-  return '/thumbnails/' + id + '.jpg';
+function thumbUrl(photoOrId) {
+  var photoId = photoOrId && typeof photoOrId === 'object' ? photoOrId.id : photoOrId;
+  return window.vireoThumbnailUrl
+    ? window.vireoThumbnailUrl(photoOrId)
+    : '/thumbnails/' + photoId + '.jpg';
 }
 
 function burstIds(burst) {
@@ -1516,7 +1519,7 @@ function thumbClass(p) {
 function renderFilmstrip() {
   var html = rapid.items.map(function(p) {
     return '<button class="' + thumbClass(p) + '" onclick="selectPhoto(' + p.id + ')" title="' + escapeHtml(p.filename || '') + '">' +
-      '<img src="' + thumbUrl(p.id) + '" alt=""></button>';
+      '<img src="' + thumbUrl(p) + '" alt=""></button>';
   }).join('');
   document.getElementById('filmstrip').innerHTML = html;
 }
@@ -1525,7 +1528,7 @@ function renderLane(id, photos) {
   var html = photos.map(function(p) {
     var muted = (!rapid.queue.includeRejected && photoFlag(p) === 'rejected') ? ' rejected-muted' : '';
     return '<button class="mini-thumb' + muted + '" onclick="selectPhoto(' + p.id + ')" title="' + escapeHtml(p.filename || '') + '">' +
-      '<img src="' + thumbUrl(p.id) + '" alt=""></button>';
+      '<img src="' + thumbUrl(p) + '" alt=""></button>';
   }).join('');
   document.getElementById(id).innerHTML = html;
 }

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -2401,8 +2401,9 @@ function renderPhotoCard(p, encIdx, burstIdx) {
   var label = (p.label || '').toLowerCase();
   var q = p.quality_composite || 0;
   var qPct = Math.round(q * 100);
+  var thumbUrl = window.vireoThumbnailUrl ? window.vireoThumbnailUrl(p) : '/thumbnails/' + p.id + '.jpg';
   var html = '<div class="photo-card ' + label + '" data-photo-id="' + p.id + '">';
-  html += '<img src="/thumbnails/' + p.id + '.jpg" loading="lazy" alt="" onclick="openInspect(' + p.id + ')">';
+  html += '<img src="' + escapeAttr(thumbUrl) + '" loading="lazy" alt="" onclick="openInspect(' + p.id + ')">';
   if (p.label) html += '<span class="photo-label ' + label + '">' + p.label + '</span>';
   if (p.rarity_protected) html += '<span class="photo-rarity">protected</span>';
   if (p.flag === 'flagged') html += '<span class="photo-flag-badge flag-flagged">P</span>';
@@ -2869,8 +2870,9 @@ function openInspect(photoId) {
   html += '<div class="inspect-title">' + escapeHtml(photo.filename || 'Photo ' + photoId) + '</div>';
 
   // Image with mask toggle
+  var thumbUrl = window.vireoThumbnailUrl ? window.vireoThumbnailUrl(photo) : '/thumbnails/' + photoId + '.jpg';
   html += '<div class="inspect-img-wrap">';
-  html += '<img src="/thumbnails/' + photoId + '.jpg" alt="">';
+  html += '<img src="' + escapeAttr(thumbUrl) + '" alt="">';
   html += '<img class="mask-overlay" id="maskOverlay" src="/masks/' + photoId + '.png" alt="">';
   html += '<button class="mask-toggle" onclick="toggleMask()">Toggle Mask</button>';
   html += '</div>';
@@ -2922,7 +2924,9 @@ function openInspect(photoId) {
     html += '<div class="context-filmstrip">';
     (enc.photo_ids || []).forEach(function(pid) {
       var isCurrent = pid === photoId ? ' current' : '';
-      html += '<img src="/thumbnails/' + pid + '.jpg" class="' + isCurrent + '" onclick="openInspect(' + pid + ')" alt="">';
+      var contextPhoto = photoMap[pid] || pid;
+      var contextThumb = window.vireoThumbnailUrl ? window.vireoThumbnailUrl(contextPhoto) : '/thumbnails/' + pid + '.jpg';
+      html += '<img src="' + escapeAttr(contextThumb) + '" class="' + isCurrent + '" onclick="openInspect(' + pid + ')" alt="">';
     });
     html += '</div>';
   }

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -2924,7 +2924,7 @@ function openInspect(photoId) {
     html += '<div class="context-filmstrip">';
     (enc.photo_ids || []).forEach(function(pid) {
       var isCurrent = pid === photoId ? ' current' : '';
-      var contextPhoto = photoMap[pid] || pid;
+      var contextPhoto = findPhotoInResults(pid) || pid;
       var contextThumb = window.vireoThumbnailUrl ? window.vireoThumbnailUrl(contextPhoto) : '/thumbnails/' + pid + '.jpg';
       html += '<img src="' + escapeAttr(contextThumb) + '" class="' + isCurrent + '" onclick="openInspect(' + pid + ')" alt="">';
     });

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1139,7 +1139,9 @@ function getConsensusSpecies(pred) {
 }
 
 function renderPredictionCard(pred) {
-  var thumbUrl = '/thumbnails/' + pred.photo_id + '.jpg';
+  var thumbUrl = window.vireoRenderedUrl
+    ? window.vireoRenderedUrl('/thumbnails/' + pred.photo_id + '.jpg', pred.photo_id)
+    : '/thumbnails/' + pred.photo_id + '.jpg';
   var displaySpecies = pred.group_id ? getConsensusSpecies(pred) : pred.species;
   var confPct = Math.round(pred.confidence * 100);
   var confColor = confPct >= 70 ? 'var(--accent)' : confPct >= 50 ? 'var(--warning)' : 'var(--danger)';

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1100,6 +1100,19 @@ function renderGrid() {
   grid.innerHTML = items.map(function(p) { return renderPredictionCard(p); }).join('');
 }
 
+document.addEventListener('lightbox:renderchanged', function(e) {
+  var ids = e && e.detail && Array.isArray(e.detail.photoIds) ? e.detail.photoIds : [];
+  ids.forEach(function(id) {
+    var hideDetectionOverlay = (
+      typeof window.vireoPhotoHasOrientationEdit === 'function' &&
+      window.vireoPhotoHasOrientationEdit(id)
+    );
+    document.querySelectorAll('.detection-box[data-photo-id="' + id + '"]').forEach(function(box) {
+      box.style.display = hideDetectionOverlay ? 'none' : '';
+    });
+  });
+});
+
 /* Delegate grid clicks for lightbox and group review (XSS-safe) */
 document.getElementById('grid').addEventListener('click', function(e) {
   var img = e.target.closest('img[data-photo-id]');
@@ -1249,6 +1262,10 @@ function renderPredictionCard(pred) {
 
   // Build image with optional bounding box overlay
   var hasBox = pred.box_x != null && pred.box_y != null && pred.box_w != null && pred.box_h != null;
+  var hideDetectionOverlay = (
+    typeof window.vireoPhotoHasOrientationEdit === 'function' &&
+    window.vireoPhotoHasOrientationEdit(pred.photo_id)
+  );
   var imgStyle = hasBox ? 'cursor:pointer;object-fit:contain;' : 'cursor:pointer;';
   var imgTag = '<img src="' + thumbUrl + '" loading="lazy" alt="' + escapeAttr(pred.filename || '') +
     '" style="' + imgStyle + '" data-photo-id="' + pred.photo_id + '" data-filename="' + escapeAttr(pred.filename || '') + '">';
@@ -1261,7 +1278,7 @@ function renderPredictionCard(pred) {
     var bWidth = (pred.box_w * 100).toFixed(2) + '%';
     var bHeight = (pred.box_h * 100).toFixed(2) + '%';
     imgHtml = '<div class="card-img-wrap">' + imgTag +
-      '<div class="detection-box" style="left:' + bLeft + ';top:' + bTop +
+      '<div class="detection-box" data-photo-id="' + pred.photo_id + '" style="' + (hideDetectionOverlay ? 'display:none;' : '') + 'left:' + bLeft + ';top:' + bTop +
       ';width:' + bWidth + ';height:' + bHeight + ';border-color:' + color + ';">' +
       '<span class="detection-label" style="background:' + color +
       ';color:#0A1F2E;">' + escapeHtml(displaySpecies) + ' ' + confPct + '%</span>' +

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1160,8 +1160,8 @@ function renderPredictionCard(pred) {
       skipIfLocallyWritten: true,
     });
   }
-  var thumbUrl = window.vireoRenderedUrl
-    ? window.vireoRenderedUrl('/thumbnails/' + pred.photo_id + '.jpg', pred.photo_id)
+  var thumbUrl = window.vireoThumbnailUrl
+    ? window.vireoThumbnailUrl(pred)
     : '/thumbnails/' + pred.photo_id + '.jpg';
   var displaySpecies = pred.group_id ? getConsensusSpecies(pred) : pred.species;
   var confPct = Math.round(pred.confidence * 100);
@@ -1973,7 +1973,11 @@ GRM_CARD_H = Math.round(GRM_CARD_W * 2 / 3);
 
 function grmPhotoUrl(photoId) {
   var stop = GRM_RES_STOPS[grmResolutionIdx] || GRM_RES_STOPS[1];
-  if (stop.kind === 'thumb') return '/thumbnails/' + photoId + '.jpg';
+  if (stop.kind === 'thumb') {
+    return window.vireoThumbnailUrl
+      ? window.vireoThumbnailUrl(photoId)
+      : '/thumbnails/' + photoId + '.jpg';
+  }
   if (stop.kind === 'original') return '/photos/' + photoId + '/original';
   return '/photos/' + photoId + '/preview?size=' + stop.size;
 }

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1152,6 +1152,12 @@ function getConsensusSpecies(pred) {
 }
 
 function renderPredictionCard(pred) {
+  if (
+    typeof window.vireoRememberPhotoEditRecipe === 'function' &&
+    Object.prototype.hasOwnProperty.call(pred, 'edit_recipe')
+  ) {
+    window.vireoRememberPhotoEditRecipe(pred.photo_id, pred.edit_recipe);
+  }
   var thumbUrl = window.vireoRenderedUrl
     ? window.vireoRenderedUrl('/thumbnails/' + pred.photo_id + '.jpg', pred.photo_id)
     : '/thumbnails/' + pred.photo_id + '.jpg';

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1156,7 +1156,9 @@ function renderPredictionCard(pred) {
     typeof window.vireoRememberPhotoEditRecipe === 'function' &&
     Object.prototype.hasOwnProperty.call(pred, 'edit_recipe')
   ) {
-    window.vireoRememberPhotoEditRecipe(pred.photo_id, pred.edit_recipe);
+    window.vireoRememberPhotoEditRecipe(pred.photo_id, pred.edit_recipe, {
+      skipIfLocallyWritten: true,
+    });
   }
   var thumbUrl = window.vireoRenderedUrl
     ? window.vireoRenderedUrl('/thumbnails/' + pred.photo_id + '.jpg', pred.photo_id)

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1993,10 +1993,30 @@ function grmLoupePhotoUrl(photoId) {
   return grmPhotoUrl(photoId);
 }
 
+function grmEditedSourceDims(item) {
+  var W = (item && item.width) ? Number(item.width) : 1800;
+  var H = (item && item.height) ? Number(item.height) : 1200;
+  var recipe = (item && item.edit_recipe) || {};
+  var rotation = Number(recipe.rotation || 0);
+  if (rotation === 90 || rotation === 270) {
+    var tmp = W;
+    W = H;
+    H = tmp;
+  }
+  if (recipe.crop && typeof recipe.crop === 'object') {
+    var cropW = Number(recipe.crop.w);
+    var cropH = Number(recipe.crop.h);
+    if (Number.isFinite(cropW) && cropW > 0) W = Math.max(1, Math.round(W * cropW));
+    if (Number.isFinite(cropH) && cropH > 0) H = Math.max(1, Math.round(H * cropH));
+  }
+  return { w: W, h: H };
+}
+
 function grmNaturalDims(item) {
   var stop = GRM_RES_STOPS[grmResolutionIdx] || GRM_RES_STOPS[1];
-  var W = (item && item.width) ? item.width : 1800;
-  var H = (item && item.height) ? item.height : 1200;
+  var dims = grmEditedSourceDims(item);
+  var W = dims.w;
+  var H = dims.h;
   if (stop.kind === 'original') {
     return { w: W, h: H };
   }

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1700,7 +1700,7 @@ function renderGroupModal() {
     var boxSharp = it.box_sharpness != null ? Math.round(it.box_sharpness) : null;
     var confPct = Math.round((it.confidence || 0) * 100);
 
-    var src = grmPhotoUrl(it.photo_id);
+    var src = grmPhotoUrl(it);
     var nat = grmNaturalDims(it);
     var imgStyle = 'width:' + nat.w + 'px;height:' + nat.h + 'px;';
     var scoresHtml = 'Q: <span class="score-val">' + qScore + '</span> S: <span class="score-val">' + sharp + '</span>';
@@ -1971,11 +1971,18 @@ function grmSetThumbSize(value, persist) {
 GRM_CARD_W = _grmInitialThumbSize();
 GRM_CARD_H = Math.round(GRM_CARD_W * 2 / 3);
 
-function grmPhotoUrl(photoId) {
+function grmPhotoUrl(photoOrId) {
+  var photo = photoOrId && typeof photoOrId === 'object' ? photoOrId : null;
+  var photoId = photo ? (photo.photo_id != null ? photo.photo_id : photo.id) : photoOrId;
   var stop = GRM_RES_STOPS[grmResolutionIdx] || GRM_RES_STOPS[1];
   if (stop.kind === 'thumb') {
+    if (!photo && grmState && grmState.items) {
+      photo = grmState.items.find(function(it) {
+        return String(it.photo_id) === String(photoId);
+      }) || null;
+    }
     return window.vireoThumbnailUrl
-      ? window.vireoThumbnailUrl(photoId)
+      ? window.vireoThumbnailUrl(photo || photoId)
       : '/thumbnails/' + photoId + '.jpg';
   }
   if (stop.kind === 'original') return '/photos/' + photoId + '/original';
@@ -2041,7 +2048,7 @@ function grmSetResolution(idx) {
     card.dataset.natH = nat.h;
     img.style.width = nat.w + 'px';
     img.style.height = nat.h + 'px';
-    img.src = grmPhotoUrl(pid);
+    img.src = grmPhotoUrl(item || pid);
   });
   if (grmState && grmState.selected) {
     var loupe = document.getElementById('grmLoupePhoto');
@@ -2166,7 +2173,7 @@ function _grmUpgradeStripToOriginal() {
     card.dataset.natH = nat.h;
     img.style.width = nat.w + 'px';
     img.style.height = nat.h + 'px';
-    img.src = grmPhotoUrl(pid);
+    img.src = grmPhotoUrl(item || pid);
   });
   if (grmState && grmState.selected) {
     var loupe = document.getElementById('grmLoupePhoto');

--- a/vireo/templates/variants.html
+++ b/vireo/templates/variants.html
@@ -344,7 +344,8 @@ function renderClusters(data) {
     html += '<div class="cluster-grid">';
     cluster.photos.forEach(function(item) {
       var p = item.photo;
-      html += '<img class="cluster-thumb" src="/thumbnails/' + p.id + '.jpg" loading="lazy" ' +
+      var thumbUrl = window.vireoThumbnailUrl ? window.vireoThumbnailUrl(p) : '/thumbnails/' + p.id + '.jpg';
+      html += '<img class="cluster-thumb" src="' + escapeAttr(thumbUrl) + '" loading="lazy" ' +
         'title="' + escapeAttr(p.filename) + '" ' +
         'data-photo-id="' + p.id + '" data-filename="' + escapeAttr(p.filename) + '">';
     });

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -5898,6 +5898,7 @@ def test_regroup_live_scopes_to_collection(tmp_path, monkeypatch):
             species = "robin" if enc_idx == 0 else "eagle"
             db.add_prediction(det_ids[0], species, 0.9 - i * 0.05, "bioclip", category="match")
             (collection_pids if enc_idx == 0 else other_pids).append(pid)
+    db.set_photo_edit_recipe(collection_pids[0], {"rotation": 90})
 
     import json as _json
     cid = db.add_collection(
@@ -5934,6 +5935,8 @@ def test_regroup_live_scopes_to_collection(tmp_path, monkeypatch):
         f"scoped response leaked non-collection photos: "
         f"{scoped_pids ^ set(collection_pids)}"
     )
+    scoped_recipes = {p["id"]: p.get("edit_recipe") for p in scoped["photos"]}
+    assert scoped_recipes[collection_pids[0]] == {"version": 1, "rotation": 90}
     for enc in scoped["encounters"]:
         for pid in enc["photo_ids"]:
             assert pid in collection_pids, (
@@ -5954,8 +5957,11 @@ def test_regroup_live_scopes_to_collection(tmp_path, monkeypatch):
         json={"config": {}, "collection_id": cid},
     )
     assert resp.status_code == 200, resp.get_json()
-    reflow_pids = {p["id"] for p in resp.get_json()["photos"]}
+    reflow = resp.get_json()
+    reflow_pids = {p["id"] for p in reflow["photos"]}
     assert reflow_pids == set(collection_pids)
+    reflow_recipes = {p["id"]: p.get("edit_recipe") for p in reflow["photos"]}
+    assert reflow_recipes[collection_pids[0]] == {"version": 1, "rotation": 90}
     cached_after_reflow = load_results_raw(cache_dir, ws_id)
     assert {p["id"] for p in cached_after_reflow["photos"]} == cached_before_pids
 

--- a/vireo/tests/test_duplicates_db.py
+++ b/vireo/tests/test_duplicates_db.py
@@ -419,6 +419,28 @@ def test_run_duplicate_scan_emits_resolved_proposal(tmp_path):
     assert result["loser_count"] == 0
 
 
+def test_run_duplicate_scan_attaches_edit_recipes(tmp_path):
+    """Fresh scan results seed thumbnail edit cache keys immediately."""
+    from duplicate_scan import run_duplicate_scan
+
+    db = Database(str(tmp_path / "t.db"))
+    fid = db.add_folder(str(tmp_path))
+    p1 = _add(db, fid, "owl.jpg", file_hash="HEDIT")
+    p2 = _add(db, fid, "owl-copy.jpg", file_hash="HEDIT")
+    _reset_flags(db, "HEDIT")
+    db.set_photo_edit_recipe(p1, {"rotation": 90})
+
+    result = run_duplicate_scan({"progress": {}}, db, include_resolved=False)
+    assert len(result["proposals"]) == 1
+    prop = result["proposals"][0]
+    by_id = {
+        candidate["id"]: candidate
+        for candidate in [prop["winner"]] + prop["losers"]
+    }
+    assert by_id[p1]["edit_recipe"] == {"version": 1, "rotation": 90}
+    assert by_id[p2]["edit_recipe"] is None
+
+
 def test_run_duplicate_scan_excludes_resolved_when_opt_out(tmp_path):
     """``include_resolved=False`` preserves the legacy unresolved-only output."""
     from duplicate_scan import run_duplicate_scan

--- a/vireo/tests/test_inat.py
+++ b/vireo/tests/test_inat.py
@@ -287,6 +287,35 @@ def test_api_inat_submit_success(app_and_db):
     assert pid in subs
 
 
+def test_api_inat_submit_uses_edited_render(app_and_db):
+    app, db, pid = app_and_db
+    import config as cfg
+    cfg.save({"inat_token": "fake-token"})
+
+    folder = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id = p.folder_id WHERE p.id = ?",
+        (pid,),
+    ).fetchone()
+    original_path = os.path.join(folder["path"], "bird.jpg")
+    Image.new("RGB", (80, 40), (220, 30, 20)).save(original_path)
+    db.set_photo_edit_recipe(pid, {"rotation": 90})
+
+    client = app.test_client()
+    with patch(
+        "inat.submit_observation",
+        return_value=(12345, "https://www.inaturalist.org/observations/12345"),
+    ) as mock_submit:
+        resp = client.post("/api/inat/submit", json={"photo_id": pid})
+
+    assert resp.status_code == 200
+    upload_path = mock_submit.call_args.kwargs["photo_path"]
+    assert upload_path != original_path
+    assert os.path.basename(os.path.dirname(upload_path)) == "inat-uploads"
+    assert os.path.isfile(upload_path)
+    with Image.open(upload_path) as img:
+        assert img.size == (40, 80)
+
+
 def test_api_inat_submit_uses_assigned_location_coords(app_and_db):
     app, db, pid = app_and_db
     import config as cfg

--- a/vireo/tests/test_open_external.py
+++ b/vireo/tests/test_open_external.py
@@ -88,6 +88,33 @@ def test_open_external_uses_configured_editor(app_and_db, monkeypatch):
     assert launched[0][1][0] == '/usr/bin/gimp'
 
 
+def test_open_external_hands_off_rendered_edit_recipe(client_with_photo, monkeypatch):
+    """External editors receive a rendered derivative when Vireo edits exist."""
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    db.set_photo_edit_recipe(
+        photo_id,
+        {"rotation": 90, "flip": {"horizontal": True}},
+    )
+    client.post('/api/config',
+                data=json.dumps({"external_editor": "/usr/bin/gimp"}),
+                content_type='application/json')
+    launched = _patch_launchers(monkeypatch)
+
+    resp = client.post('/api/photos/open-external',
+                       data=json.dumps({"photo_ids": [photo_id]}),
+                       content_type='application/json')
+
+    assert resp.status_code == 200
+    opened_path = launched[0][1][1]
+    assert os.path.basename(opened_path) == f"{photo_id}.jpg"
+    assert os.path.basename(os.path.dirname(opened_path)) == "external-edits"
+    with Image.open(opened_path) as img:
+        assert img.size == (600, 800)
+
+
 def test_open_external_returns_500_on_launch_failure(app_and_db, monkeypatch):
     """POST /api/photos/open-external returns 500 when launcher raises."""
     app, _ = app_and_db

--- a/vireo/tests/test_open_external.py
+++ b/vireo/tests/test_open_external.py
@@ -115,6 +115,40 @@ def test_open_external_hands_off_rendered_edit_recipe(client_with_photo, monkeyp
         assert img.size == (600, 800)
 
 
+def test_open_external_edit_recipe_avoids_capped_working_copy(
+    client_with_photo, monkeypatch,
+):
+    """Rotate/flip handoffs should render from full-res original when wc is small."""
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    working_dir = os.path.join(vireo_dir, "working")
+    os.makedirs(working_dir, exist_ok=True)
+    working_path = os.path.join(working_dir, f"{photo_id}.jpg")
+    Image.new("RGB", (400, 300), (10, 20, 30)).save(working_path, "JPEG")
+    db.conn.execute(
+        "UPDATE photos SET working_copy_path=? WHERE id=?",
+        (f"working/{photo_id}.jpg", photo_id),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(photo_id, {"rotation": 90})
+    client.post('/api/config',
+                data=json.dumps({"external_editor": "/usr/bin/gimp"}),
+                content_type='application/json')
+    launched = _patch_launchers(monkeypatch)
+
+    resp = client.post('/api/photos/open-external',
+                       data=json.dumps({"photo_ids": [photo_id]}),
+                       content_type='application/json')
+
+    assert resp.status_code == 200
+    opened_path = launched[0][1][1]
+    with Image.open(opened_path) as img:
+        assert img.size == (600, 800)
+
+
 def test_open_external_returns_500_on_launch_failure(app_and_db, monkeypatch):
     """POST /api/photos/open-external returns 500 when launcher raises."""
     app, _ = app_and_db

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1596,6 +1596,33 @@ def test_edit_recipe_api_invalidates_thumbnail_and_renders_edit(client_with_phot
         assert img.size == (300, 400)
 
 
+def test_edit_recipe_api_invalidates_external_edit_handoff(client_with_photo):
+    import json
+    import os
+
+    from PIL import Image
+
+    app, _db, photo_id = client_with_photo
+    client = app.test_client()
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    external_dir = os.path.join(vireo_dir, "external-edits")
+    os.makedirs(external_dir, exist_ok=True)
+    external_path = os.path.join(external_dir, f"{photo_id}.jpg")
+    external_meta = os.path.join(external_dir, f"{photo_id}.json")
+    Image.new("RGB", (10, 10), "green").save(external_path, "JPEG")
+    with open(external_meta, "w", encoding="utf-8") as f:
+        json.dump({"recipe": "stale"}, f)
+
+    resp = client.put(
+        f"/api/photos/{photo_id}/edit-recipe",
+        json={"recipe": {"rotation": 90}},
+    )
+
+    assert resp.status_code == 200
+    assert not os.path.exists(external_path)
+    assert not os.path.exists(external_meta)
+
+
 def test_edit_recipe_keeps_thumb_path_when_stale_thumbnail_unlink_fails(
     client_with_photo, monkeypatch,
 ):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1998,10 +1998,18 @@ def test_edit_recipe_api_undo_redo(client_with_photo):
 
     undo = client.post("/api/undo")
     assert undo.status_code == 200
+    assert undo.get_json()["action_type"] == "edit_recipe"
+    assert undo.get_json()["edit_recipes"] == [
+        {"photo_id": photo_id, "recipe": None}
+    ]
     assert db.get_photo_edit_recipe(photo_id) is None
 
     redo = client.post("/api/redo")
     assert redo.status_code == 200
+    assert redo.get_json()["action_type"] == "edit_recipe"
+    assert redo.get_json()["edit_recipes"] == [
+        {"photo_id": photo_id, "recipe": {"version": 1, "rotation": 180}}
+    ]
     assert db.get_photo_edit_recipe(photo_id)["rotation"] == 180
 
 

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -15,6 +15,20 @@ def test_api_photos_default(app_and_db):
     assert 'total' in data
 
 
+def test_api_photos_includes_edit_recipe(app_and_db):
+    """GET /api/photos exposes edit recipes so card overlays can align."""
+    app, db = app_and_db
+    photo = db.get_photos()[0]
+    db.set_photo_edit_recipe(photo["id"], {"rotation": 90})
+
+    client = app.test_client()
+    resp = client.get('/api/photos')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    listed = {p["id"]: p for p in data["photos"]}
+    assert listed[photo["id"]]["edit_recipe"] == {"version": 1, "rotation": 90}
+
+
 def test_api_photos_pagination(app_and_db):
     """GET /api/photos supports pagination."""
     app, _ = app_and_db

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -553,6 +553,7 @@ def test_pipeline_selection_results_uses_full_review_payload(app_and_db):
             0.92 - idx * 0.05,
             "bioclip",
         )
+    db.set_photo_edit_recipe(ordered_ids[0], {"rotation": 90})
 
     client = app.test_client()
     resp = client.post("/api/pipeline/selection-results", json={"photo_ids": ordered_ids})
@@ -572,6 +573,9 @@ def test_pipeline_selection_results_uses_full_review_payload(app_and_db):
     }
     assert enc["bursts"][0]["species_predictions"] == enc["species_predictions"]
     assert all("quality_composite" in p for p in data["photos"])
+    recipes = {p["id"]: p.get("edit_recipe") for p in data["photos"]}
+    assert recipes[ordered_ids[0]] == {"version": 1, "rotation": 90}
+    assert recipes[ordered_ids[1]] is None
 
 
 def test_api_photos_calendar(app_and_db):

--- a/vireo/tests/test_predictions_api.py
+++ b/vireo/tests/test_predictions_api.py
@@ -38,6 +38,21 @@ def test_list_predictions(app_and_db):
     assert 'House Sparrow' in species_set
 
 
+def test_list_predictions_includes_photo_edit_recipe(app_and_db):
+    """GET /api/predictions exposes photo edit recipes for review cards."""
+    app, db = app_and_db
+    photos = _seed_predictions(db)
+    db.set_photo_edit_recipe(photos[0]["id"], {"rotation": 90})
+    client = app.test_client()
+
+    resp = client.get('/api/predictions')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    by_photo = {p["photo_id"]: p for p in data}
+    assert by_photo[photos[0]["id"]]["edit_recipe"] == {"version": 1, "rotation": 90}
+    assert by_photo[photos[1]["id"]]["edit_recipe"] is None
+
+
 def test_list_predictions_filter_by_status(app_and_db):
     """GET /api/predictions?status=pending returns only pending predictions."""
     app, db = app_and_db


### PR DESCRIPTION
Adds lightbox controls for non-destructive rotate and flip edits using the existing image edit recipe pipeline. Rendered thumbnails, previews, lightbox sources, export behavior, and external-editor handoff now stay consistent after recipe changes, with cache invalidation for generated external-edit derivatives. Also updates detection/eye overlays to match the edited orientation. Validated with focused image edit, external editor, and photo API tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Lightbox orientation editing (rotate/flip/reset) powered by per-photo edit recipes.
  * External editor handoff and iNaturalist submission now use recipe-aware rendered derivatives.

* **Improvements**
  * Edit recipes are included across more browse/review/pipeline/predictions API responses, with automatic thumbnail/render refresh and undo/redo support.
  * Detection overlays eye/crosshair are transformed or hidden while orientation edits are active; thumbnails can reflect edits via a shared URL helper.

* **Bug Fixes / Tests**
  * Improved invalidation for external-edit handoffs when edit recipes change; added tests covering edit handoffs and API payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->