### PR TITLE
Initialize logging in production builds + bridge webview errors to the log

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -25,6 +25,7 @@
     "core:tray:allow-set-icon",
     "core:tray:allow-set-tooltip",
     "opener:allow-open-url",
-    "opener:allow-default-urls"
+    "opener:allow-default-urls",
+    "log:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -79,9 +79,37 @@ fn set_job_progress(
         .map_err(|e| e.to_string())
 }
 
+/// Build the logging plugin used in BOTH dev and release builds.
+///
+/// Previously logging was only initialized under `cfg!(debug_assertions)`, so
+/// installed builds wrote nothing to disk — every `log::` call from the sidecar
+/// supervisor, updater, tray, and browser opener silently vanished, which made
+/// field bugs (such as the iNaturalist quick-open failing) impossible to
+/// diagnose. Now it runs everywhere, writing to the OS log directory
+/// (`~/Library/Logs/com.vireo.app/Vireo.log` on macOS) and stdout.
+///
+/// The webview forwards its own logs and uncaught errors here via the plugin's
+/// `log` command (see tauri-bridge.js), so the single file captures both the
+/// Rust side and the JS side.
+fn build_log_plugin<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
+    use tauri_plugin_log::{RotationStrategy, Target, TargetKind};
+    tauri_plugin_log::Builder::default()
+        .level(log::LevelFilter::Info)
+        // The plugin default is only 40 KB; match the Flask sidecar's 5 MB so a
+        // real debugging session's worth of logs survives before rotating.
+        .max_file_size(5 * 1024 * 1024)
+        .rotation_strategy(RotationStrategy::KeepSome(3))
+        .targets([
+            Target::new(TargetKind::Stdout),
+            Target::new(TargetKind::LogDir { file_name: None }),
+        ])
+        .build()
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .plugin(build_log_plugin())
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_process::init())
@@ -94,12 +122,9 @@ pub fn run() {
             let browser_mode = launch_cfg.open_in_browser();
 
             if cfg!(debug_assertions) {
-                // In dev mode, don't spawn sidecar — developer runs Flask manually
-                app.handle().plugin(
-                    tauri_plugin_log::Builder::default()
-                        .level(log::LevelFilter::Info)
-                        .build(),
-                )?;
+                // In dev mode, don't spawn sidecar — developer runs Flask
+                // manually. Logging is initialized unconditionally in the
+                // builder chain (see build_log_plugin), so it's already active.
                 // Use a placeholder state pointing to the dev server
                 app.manage(SidecarState::unmanaged(8080));
             } else {

--- a/vireo/static/tauri-bridge.js
+++ b/vireo/static/tauri-bridge.js
@@ -5,6 +5,53 @@ function isTauri() {
   return !!(window.__TAURI_INTERNALS__);
 }
 
+/* ---------- Logging bridge ----------
+   Forward webview-side logs and uncaught errors into the native log file
+   (~/Library/Logs/com.vireo.app/Vireo.log on macOS) via tauri-plugin-log's
+   `log` command. Without this, anything that fails inside the desktop webview
+   leaves no trace on disk — which is exactly what made the iNaturalist
+   quick-open bug so hard to diagnose across multiple attempts. In a plain
+   browser these calls just go to the devtools console. */
+var TAURI_LOG_LEVEL = { trace: 1, debug: 2, info: 3, warn: 4, error: 5 };
+
+function tauriLog(level, message) {
+  var msg = String(message);
+  // Mirror to the devtools console regardless of environment.
+  var consoleFn = console[level] || console.log;
+  try { consoleFn.call(console, msg); } catch (e) {}
+  if (!isTauri()) return;
+  try {
+    // Fire-and-forget — logging must never throw into its callers. tauri-plugin-log
+    // expects a numeric level (Trace=1 … Error=5). Swallow a rejected invoke
+    // promise too: an uncaught rejection here would re-enter via the
+    // unhandledrejection handler below and loop.
+    var p = window.__TAURI_INTERNALS__.invoke('plugin:log|log', {
+      level: TAURI_LOG_LEVEL[level] || TAURI_LOG_LEVEL.info,
+      message: msg,
+    });
+    if (p && typeof p.catch === 'function') p.catch(function() {});
+  } catch (e) { /* swallow */ }
+}
+
+function logInfo(message) { tauriLog('info', message); }
+function logWarn(message) { tauriLog('warn', message); }
+function logError(message) { tauriLog('error', message); }
+
+// Capture uncaught errors and unhandled promise rejections so they land in the
+// log file instead of only the (invisible-in-production) webview console.
+window.addEventListener('error', function(event) {
+  var where = event.filename
+    ? ' (' + event.filename + ':' + event.lineno + ':' + event.colno + ')'
+    : '';
+  var msg = event.message || (event.error && event.error.message) || 'unknown error';
+  tauriLog('error', 'Uncaught error: ' + msg + where);
+});
+window.addEventListener('unhandledrejection', function(event) {
+  var reason = event.reason;
+  var msg = (reason && (reason.stack || reason.message)) || String(reason);
+  tauriLog('error', 'Unhandled promise rejection: ' + msg);
+});
+
 /**
  * Open a native directory picker dialog.
  * @param {string} [title] - Dialog title
@@ -55,13 +102,19 @@ async function pickFile(opts) {
  * @returns {Promise<boolean>} true if the open was dispatched successfully
  */
 async function openExternal(url) {
-  if (!url) return false;
+  if (!url) {
+    logWarn('openExternal called with an empty URL');
+    return false;
+  }
   if (isTauri()) {
     try {
       await window.__TAURI_INTERNALS__.invoke('plugin:opener|open_url', { url: url, with: null });
+      logInfo('openExternal: opened ' + url);
       return true;
     } catch (e) {
-      console.error('openExternal failed:', e);
+      // Surface the *real* opener error (e.g. ForbiddenUrl from a missing
+      // capability scope) to the log file so this stops being a silent no-op.
+      logError('openExternal failed for ' + url + ': ' + (e && e.message ? e.message : e));
       return false;
     }
   }
@@ -71,7 +124,10 @@ async function openExternal(url) {
   // we can null the opener same-origin, then navigate — this keeps popup-block
   // detection (a real null return) and still prevents reverse-tabnabbing.
   var win = window.open('about:blank', '_blank');
-  if (!win) return false;
+  if (!win) {
+    logWarn('openExternal: window.open was blocked (popup blocker?) for ' + url);
+    return false;
+  }
   try { win.opener = null; } catch (e) {}
   win.location = url;
   return true;


### PR DESCRIPTION
## Why

The iNaturalist workflow has been "fixed" three times (#987, #992) and still doesn't work — and the reason every attempt was a shot in the dark is that **installed builds produce no logs at all.**

`tauri-plugin-log` was only initialized under `cfg!(debug_assertions)`, so in the release app every `log::` call from the sidecar supervisor, updater, tray, and browser opener silently vanished. The desktop log (`~/Library/Logs/com.vireo.app/Vireo.log`) was stale since May 31 while the app was actively in use. Worse, the iNaturalist quick-open failure happens entirely in **JS** (`openExternal` → opener plugin), which never touched the Rust log even when it was on.

## What changed

- **`src-tauri/src/lib.rs`** — move `tauri-plugin-log` into the builder chain so it initializes in **both dev and release**, writing to the OS log dir (`Vireo.log`, 5 MB rotation, `KeepSome(3)`) plus stdout. The default cap was 40 KB; bumped to 5 MB to match the Flask sidecar. Removed the dev-only init to avoid a double global-logger registration.
- **`vireo/static/tauri-bridge.js`** — add a `tauriLog()` bridge that forwards webview logs and **uncaught errors / unhandled promise rejections** into the same native log file via `plugin:log|log`. The fire-and-forget invoke is `.catch()`-guarded so a logging failure can't re-enter the `unhandledrejection` handler and loop.
- **`openExternal()`** — log the **real** opener error (e.g. `ForbiddenUrl`) and the URL on failure, and log popup-block in the browser fallback. This is what will finally reveal why the iNaturalist button does nothing next time it's clicked.
- **`src-tauri/capabilities/default.json`** — grant `log:default` so the webview may call the log command.

## Not a blind fourth fix for iNaturalist

This deliberately does **not** patch the iNaturalist opener again. Three fixes on that one path have failed; per systematic debugging, the missing piece was visibility. With this in place, one click in the desktop app will record the actual opener error (or confirm the browser opens but iNat ignores the prefill params), so the real root cause can be fixed with evidence instead of guesses.

## Testing

- `cargo check` clean (with a temporary sidecar-binary placeholder; the missing `binaries/vireo-server-*` is a pre-existing dev-checkout gap, unrelated to this change).
- `node --check` on tauri-bridge.js passes.
- `vireo/tests/test_inat.py` — 22 passed.
- Core Python suite (`test_workspaces`, `test_db`, `test_app`, `test_config`) — 840 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)