### PR TITLE
Stabilize lightbox zoom navigation test

### DIFF
--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -68,7 +68,12 @@ def test_browse_lightbox_arrows_preserve_one_to_one_zoom(live_server, page):
     expect(page.locator("#lightboxCounter")).to_contain_text("2 /")
     assert page.evaluate("window._lbZoom > 1.001") is True
     assert page.evaluate("window._lbPending1To1") is True
-    assert page.evaluate("window._lbCurrentSrcKey") == "original"
+    assert page.evaluate(
+        """() => (
+            window._lbCurrentSrcKey === 'original' ||
+            (window._lbOriginalUnavailable && window._lbCurrentSrcKey === 'full')
+        )"""
+    ) is True
 
     restored = page.evaluate(
         """() => {


### PR DESCRIPTION
Fixes a flaky browse lightbox E2E assertion that raced the missing-original fallback in the seeded test fixture. The test now accepts either the pending original source or the valid fallback state after /original is marked unavailable. Validated with 30 focused reruns and the full browse lightbox E2E file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved lightbox photo navigation test robustness to handle fallback image source scenarios more flexibly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->