### PR TITLE
Align photo-edit schema and white-balance preview with the renderer

### DIFF
--- a/vireo/image_edits.py
+++ b/vireo/image_edits.py
@@ -12,7 +12,6 @@ SCHEMA_VERSION = 1
 
 _ADJUSTMENT_RANGES = {
     "exposure": (-5.0, 5.0),
-    "brightness": (-100.0, 100.0),
     "contrast": (-100.0, 100.0),
     "saturation": (-100.0, 100.0),
 }
@@ -266,10 +265,6 @@ def apply_recipe(img, recipe):
         result = _apply_white_balance(result, adjustments["white_balance"])
     if "exposure" in adjustments:
         result = ImageEnhance.Brightness(result).enhance(2 ** adjustments["exposure"])
-    if "brightness" in adjustments:
-        result = ImageEnhance.Brightness(result).enhance(
-            max(0.0, 1.0 + adjustments["brightness"] / 100.0)
-        )
     if "contrast" in adjustments:
         result = ImageEnhance.Contrast(result).enhance(
             max(0.0, 1.0 + adjustments["contrast"] / 100.0)

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -4187,6 +4187,52 @@ function _lbRecipeWithAdjustments(values) {
   return recipe;
 }
 
+// Mirror image_edits._apply_white_balance: per-channel sRGB gains. Keep these
+// coefficients in sync with the server so the live preview matches the render.
+function _lbWhiteBalanceGains(temperature, tint) {
+  var t = Number(temperature || 0) / 100;
+  var ti = Number(tint || 0) / 100;
+  return {
+    r: Math.max(0.05, 1 + 0.26 * t + 0.06 * ti),
+    g: Math.max(0.05, 1 - 0.18 * ti),
+    b: Math.max(0.05, 1 - 0.26 * t + 0.06 * ti),
+  };
+}
+
+// Lazily build the SVG filter used to apply white-balance gains in the preview.
+// color-interpolation-filters="sRGB" matches PIL, which scales raw sRGB bytes
+// rather than linear-light values.
+function _lbEnsureWbFilter() {
+  if (document.getElementById('lbWbFilterFuncR')) return;
+  var ns = 'http://www.w3.org/2000/svg';
+  var svg = document.createElementNS(ns, 'svg');
+  svg.setAttribute('width', '0');
+  svg.setAttribute('height', '0');
+  svg.setAttribute('aria-hidden', 'true');
+  svg.style.position = 'absolute';
+  svg.style.pointerEvents = 'none';
+  var filter = document.createElementNS(ns, 'filter');
+  filter.setAttribute('id', 'lbWbFilter');
+  filter.setAttribute('color-interpolation-filters', 'sRGB');
+  var fct = document.createElementNS(ns, 'feComponentTransfer');
+  ['R', 'G', 'B'].forEach(function(ch) {
+    var f = document.createElementNS(ns, 'feFunc' + ch);
+    f.setAttribute('id', 'lbWbFilterFunc' + ch);
+    f.setAttribute('type', 'linear');
+    f.setAttribute('slope', '1');
+    f.setAttribute('intercept', '0');
+    fct.appendChild(f);
+  });
+  filter.appendChild(fct);
+  svg.appendChild(filter);
+  document.body.appendChild(svg);
+}
+
+function _lbSetWbSlope(channel, slope) {
+  var f = document.getElementById('lbWbFilterFunc' + channel);
+  if (f) f.setAttribute('slope', slope.toFixed(4));
+}
+
 function _lbApplyAdjustmentPreviewCss(values) {
   var img = document.getElementById('lightboxImg');
   if (!img) return;
@@ -4196,14 +4242,29 @@ function _lbApplyAdjustmentPreviewCss(values) {
   var contrast = Math.max(0, 1 + Number(values.contrast || 0) / 100) / baseContrast;
   var baseSaturation = Math.max(0.001, 1 + Number(base.saturation || 0) / 100);
   var saturation = Math.max(0, 1 + Number(values.saturation || 0) / 100) / baseSaturation;
-  var hue = (Number(values.tint || 0) - Number(base.tint || 0)) * 0.2
-    - (Number(values.temperature || 0) - Number(base.temperature || 0)) * 0.08;
-  img.style.filter = [
-    'brightness(' + exposure.toFixed(3) + ')',
-    'contrast(' + contrast.toFixed(3) + ')',
-    'saturate(' + saturation.toFixed(3) + ')',
-    'hue-rotate(' + hue.toFixed(2) + 'deg)'
-  ].join(' ');
+  // White balance: the displayed source already has the saved WB baked in, so
+  // preview the delta as new-gain / rendered-gain per channel.
+  var valGains = _lbWhiteBalanceGains(values.temperature, values.tint);
+  var baseGains = _lbWhiteBalanceGains(base.temperature, base.tint);
+  var rSlope = valGains.r / baseGains.r;
+  var gSlope = valGains.g / baseGains.g;
+  var bSlope = valGains.b / baseGains.b;
+  var wbActive = Math.abs(rSlope - 1) > 1e-4
+    || Math.abs(gSlope - 1) > 1e-4
+    || Math.abs(bSlope - 1) > 1e-4;
+  var filters = [];
+  // Match the server order: white balance, then exposure, contrast, saturation.
+  if (wbActive) {
+    _lbEnsureWbFilter();
+    _lbSetWbSlope('R', rSlope);
+    _lbSetWbSlope('G', gSlope);
+    _lbSetWbSlope('B', bSlope);
+    filters.push('url(#lbWbFilter)');
+  }
+  filters.push('brightness(' + exposure.toFixed(3) + ')');
+  filters.push('contrast(' + contrast.toFixed(3) + ')');
+  filters.push('saturate(' + saturation.toFixed(3) + ')');
+  img.style.filter = filters.join(' ');
 }
 
 function _lbClearAdjustmentPreviewCss() {


### PR DESCRIPTION
## What & why

Coherence pass over the recently-merged photo-editing tools (#998–#1002, built on the recipe foundation in #988). The tools were structurally sound — one recipe schema, one save endpoint (`/api/photos/{id}/edit-recipe`), one storage table, one server-side `apply_recipe` — but two seams between the schema/preview and the actual render were off. Both fixed here.

### 1. Remove the dead `brightness` adjustment
`brightness` lived in the recipe schema and in `apply_recipe`, but **no UI control ever set it**, and it was a redundant copy of `exposure`'s operation (both are `ImageEnhance.Brightness`, a linear RGB multiply — exposure in stops, brightness in percent). Exposing it would have meant two sliders doing the same thing; the coherent fix is to drop it so **schema = UI = server**.

### 2. White-balance live preview now matches the render
The adjustment-slider preview approximated temperature/tint with CSS `hue-rotate` — a color *rotation*, the wrong model. The server applies per-channel RGB *gain* (`_apply_white_balance`). So warming a photo looked one way mid-drag and different once saved.

Replaced with an SVG `feComponentTransfer` filter (lazily built, `color-interpolation-filters="sRGB"` to match PIL's byte-LUT space) whose per-channel slopes mirror the server gain coefficients exactly, applied as a delta from the already-rendered base and ordered before exposure/contrast/saturation to match `apply_recipe`.

### Not changed
`/photos/{id}/crop` (the BioCLIP detection crop) intentionally skips the recipe — detection boxes are stored in original-image coordinates, so applying user rotation/crop there would misalign them. Left as-is.

## Testing
- Full mandated suite: **1158 passed, 1 skipped**.
- Editing suites (`test_image_edits`, `test_export`, `test_photos_api`, `test_thumbnails`): **308 passed**.
- **WebKit pixel check** (Playwright WebKit = Tauri's engine): a gray pixel through the new WB filter at temp +80 renders `(154,128,101)` vs the server's `(155,128,101)` — a 1-level rounding diff, confirming the preview filter matches the render in the actual desktop engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image editing now features exposure-based luminosity adjustments as the primary control, delivering more precise and granular image lighting modifications in place of the previous brightness adjustment method.

* **Bug Fixes**
  * White-balance preview rendering in the image lightbox has been enhanced, ensuring more accurate and immediate visual representation of color temperature and tint adjustment effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->