### PR TITLE
[codex] Clarify iNaturalist upload modes

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -10911,6 +10911,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "edit_recipe": db.get_photo_edit_recipe(photo_id),
             "upload_url": upload_url,
             "mode": mode,
+            "direct_upload_enabled": mode == "direct",
+            "photo_upload_requires_token": mode != "direct",
             "already_submitted": already,
             "existing_observation_url": subs[photo_id]["observation_url"] if already else None,
         })

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -6658,7 +6658,7 @@ async function inatDoSubmit() {
       } else {
         statusEl.className = 'inat-card-status success';
         statusEl.innerHTML = '&#10003; Submitted — <a href="' + escapeAttr(result.observation_url) + '" target="_blank" onclick="return openExternalLink(event, this.href)" style="color:var(--accent);">View on iNaturalist</a>';
-        if (total === 1 && result.observation_url) {
+        if (total === 1 && result.observation_url && isTauri()) {
           var opened = await openExternal(result.observation_url);
           if (!opened) showToast('Submitted, but could not open iNaturalist: ' + result.observation_url, 'error');
         }

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -6490,13 +6490,20 @@ async function submitToInat(photoId) {
 
     if (data.mode === 'quick') {
       // No API token configured: open the iNaturalist upload page (prefilled
-      // with taxon/date/location) in the user's browser. A bare window.open is
-      // silently dropped inside the desktop webview, so route through
-      // openExternal and tell the user if nothing opened instead of failing
-      // invisibly.
+      // with taxon/date/location) in the user's browser. The local image
+      // cannot be attached this way; direct photo upload requires the iNat API
+      // token configured in Settings. A bare window.open is silently dropped
+      // inside the desktop webview, so route through openExternal and tell the
+      // user if nothing opened instead of failing invisibly.
+      var proceed = confirm(
+        'Vireo cannot upload the photo to iNaturalist unless you add an API token in Settings.\n\n' +
+        'It can still open the iNaturalist web uploader with the taxon, date, and location filled in. You will need to add the photo there.\n\n' +
+        'Open iNaturalist?'
+      );
+      if (!proceed) return;
       var opened = await openExternal(data.upload_url);
       if (opened) {
-        showToast('Opening iNaturalist in your browser…', 'info');
+        showToast('Opening iNaturalist web uploader. Add the photo there, or configure an API token for direct upload.', 'info');
       } else {
         showToast('Could not open iNaturalist. Add an API token in Settings to submit directly from Vireo.', 'error');
       }
@@ -6651,6 +6658,10 @@ async function inatDoSubmit() {
       } else {
         statusEl.className = 'inat-card-status success';
         statusEl.innerHTML = '&#10003; Submitted — <a href="' + escapeAttr(result.observation_url) + '" target="_blank" onclick="return openExternalLink(event, this.href)" style="color:var(--accent);">View on iNaturalist</a>';
+        if (total === 1 && result.observation_url) {
+          var opened = await openExternal(result.observation_url);
+          if (!opened) showToast('Submitted, but could not open iNaturalist: ' + result.observation_url, 'error');
+        }
         succeeded++;
       }
     } catch(e) {

--- a/vireo/tests/test_inat.py
+++ b/vireo/tests/test_inat.py
@@ -229,6 +229,33 @@ def test_api_inat_prepare_url_encodes_query_params(app_and_db):
     assert qs["taxon_name"] == ["Cardinalis cardinalis"]
 
 
+def test_api_inat_prepare_marks_quick_mode_as_not_photo_upload(app_and_db):
+    app, _db, pid = app_and_db
+    client = app.test_client()
+    resp = client.get(f'/api/inat/prepare/{pid}')
+    assert resp.status_code == 200
+    data = resp.get_json()
+
+    assert data["mode"] == "quick"
+    assert data["direct_upload_enabled"] is False
+    assert data["photo_upload_requires_token"] is True
+
+
+def test_api_inat_prepare_marks_direct_mode_with_token(app_and_db):
+    app, _db, pid = app_and_db
+    import config as cfg
+    cfg.save({"inat_token": "fake-token"})
+
+    client = app.test_client()
+    resp = client.get(f'/api/inat/prepare/{pid}')
+    assert resp.status_code == 200
+    data = resp.get_json()
+
+    assert data["mode"] == "direct"
+    assert data["direct_upload_enabled"] is True
+    assert data["photo_upload_requires_token"] is False
+
+
 def _add_out_of_workspace_photo(db):
     active_ws = db._active_workspace_id
     base_dir = db.conn.execute("SELECT path FROM folders LIMIT 1").fetchone()["path"]


### PR DESCRIPTION
## Summary
- Add explicit iNaturalist prepare-response flags for direct upload availability.
- Warn users in no-token quick mode that Vireo can open the iNaturalist web uploader, but cannot attach the local photo without an API token.
- Open the created iNaturalist observation page automatically after a successful single-photo direct upload.

## Root Cause
The recent failure was not an iNaturalist API upload error. The app was in quick mode because `inat_token` was empty, so it only opened the web uploader and never called the direct submit endpoint.

## Validation
- `pytest vireo/tests/test_inat.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added direct upload mode indicator—displays whether direct upload is enabled based on API token configuration
  * Enhanced iNaturalist submission workflow with user confirmation steps when API token is required
  * Observation URLs now automatically open in external browser following successful submission

<!-- end of auto-generated comment: release notes by coderabbit.ai -->