### PR TITLE
Add highlights confirmation filter

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -308,13 +308,31 @@ def _highlight_confidence_label(confidence, is_accepted):
     return "candidate"
 
 
-def _collect_highlight_buckets(candidates, confidence_threshold):
+def _normalize_highlight_confirmation_filter(value):
+    value = (value or "all").strip().lower()
+    if value not in {"all", "confirmed", "unconfirmed"}:
+        return "all"
+    return value
+
+
+def _collect_highlight_buckets(
+    candidates,
+    confidence_threshold,
+    confirmation_filter="all",
+):
+    confirmation_filter = _normalize_highlight_confirmation_filter(
+        confirmation_filter
+    )
     bucket_map = {}
     unidentified_photos = []
 
     for row in candidates:
         r = dict(row)
         accepted = r.get("species")
+        if confirmation_filter == "confirmed" and accepted is None:
+            continue
+        if confirmation_filter == "unconfirmed" and accepted is not None:
+            continue
         predicted_conf = r.get("predicted_confidence")
         if accepted:
             species = accepted
@@ -6282,6 +6300,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         confidence_threshold=0.70,
         limit_per_bucket=20,
         species_filter="",
+        confirmation_filter="all",
     ):
         folders = db.get_folders_with_quality_data()
         if scope == "workspace":
@@ -6290,12 +6309,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             folder_id = folders[0]["id"]  # Most recent
         limit_per_bucket = max(1, min(int(limit_per_bucket), 100))
         species_filter = (species_filter or "").strip().lower()
+        confirmation_filter = _normalize_highlight_confirmation_filter(
+            confirmation_filter
+        )
 
         candidates = db.get_highlights_candidates(folder_id, min_quality=min_quality)
         total_in_scope = db.count_filtered_photos(folder_id=folder_id)
 
         buckets, unidentified_photos = _collect_highlight_buckets(
-            candidates, confidence_threshold
+            candidates, confidence_threshold, confirmation_filter
+        )
+        eligible_count = sum(b["photo_count"] for b in buckets) + len(
+            unidentified_photos
         )
         _apply_highlight_preferences(db, buckets)
         if species_filter:
@@ -6337,8 +6362,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             ],
             "meta": {
                 "total_in_scope": total_in_scope,
-                "eligible": len(candidates),
+                "eligible": eligible_count,
                 "limit_per_bucket": limit_per_bucket,
+                "confirmation": confirmation_filter,
             },
             "scope": "workspace" if folder_id is None else "folder",
         }
@@ -6356,6 +6382,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             ),
             limit_per_bucket=request.args.get("limit_per_bucket", 20, type=int),
             species_filter=request.args.get("species") or "",
+            confirmation_filter=request.args.get("confirmation") or "all",
         )
         return jsonify(payload)
 
@@ -6693,6 +6720,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         confidence_threshold = request.args.get(
             "confidence_threshold", 0.70, type=float
         )
+        confirmation_filter = _normalize_highlight_confirmation_filter(
+            request.args.get("confirmation") or "all"
+        )
         species = (request.args.get("species") or "").strip()
         offset = max(0, request.args.get("offset", 0, type=int))
         limit = max(1, min(request.args.get("limit", 100, type=int), 500))
@@ -6701,7 +6731,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         candidates = db.get_highlights_candidates(folder_id, min_quality=min_quality)
         buckets, unidentified_photos = _collect_highlight_buckets(
-            candidates, confidence_threshold
+            candidates, confidence_threshold, confirmation_filter
         )
         _apply_highlight_preferences(db, buckets)
         if species == "__unidentified__":

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -99,6 +99,14 @@
     <input type="search" id="speciesSearch" placeholder="Cardinal">
   </div>
   <div class="control-group">
+    <label for="confirmationFilter">Status</label>
+    <select id="confirmationFilter">
+      <option value="all">All</option>
+      <option value="confirmed">Confirmed only</option>
+      <option value="unconfirmed">Unconfirmed only</option>
+    </select>
+  </div>
+  <div class="control-group">
     <label for="qualitySlider">Min quality</label>
     <input type="range" id="qualitySlider" min="0" max="100" value="0" step="5">
     <span class="control-value" id="qualityValue">0.00</span>
@@ -217,6 +225,7 @@ function requestScopeParams() {
   }
   params.set('min_quality', (parseInt(document.getElementById('qualitySlider').value) / 100).toFixed(2));
   params.set('confidence_threshold', (parseInt(document.getElementById('confidenceSlider').value) / 100).toFixed(2));
+  params.set('confirmation', document.getElementById('confirmationFilter').value || 'all');
   return params;
 }
 
@@ -553,7 +562,11 @@ function render() {
 
   var buckets = sortedBuckets();
   var speciesSearch = document.getElementById('speciesSearch').value.trim();
-  meta.textContent = buckets.length + (speciesSearch ? ' matching' : '') + ' species · '
+  var confirmation = document.getElementById('confirmationFilter').value;
+  var filterLabel = speciesSearch ? ' matching' : '';
+  if (confirmation === 'confirmed') filterLabel += ' confirmed';
+  if (confirmation === 'unconfirmed') filterLabel += ' unconfirmed';
+  meta.textContent = buckets.length + filterLabel + ' species · '
     + currentData.meta.eligible + ' of '
     + currentData.meta.total_in_scope + ' photos scored';
 
@@ -815,6 +828,11 @@ document.getElementById('confidenceSlider').addEventListener('input', function()
 });
 document.getElementById('speciesSearch').addEventListener('input', function() {
   debounceLoad();
+});
+document.getElementById('confirmationFilter').addEventListener('change', function() {
+  expandedBuckets.clear();
+  unidentifiedExpanded = false;
+  loadHighlights();
 });
 document.getElementById('perRowSlider').addEventListener('input', function() {
   document.getElementById('perRowValue').textContent = this.value;

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -4609,6 +4609,103 @@ def test_highlights_bucket_mixed_accepted_predicted_is_not_accepted(app_and_db):
     assert bucket["is_accepted"] is False
 
 
+def test_highlights_confirmation_filter_splits_confirmed_and_unconfirmed(app_and_db):
+    app, db = app_and_db
+    client = app.test_client()
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES ('/hf', 'hf', 'ok')"
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO workspace_folders (workspace_id, folder_id) VALUES (?, ?)",
+        (db._ws_id(), fid),
+    )
+    apapane_kw = db.conn.execute(
+        "INSERT INTO keywords (name, type, is_species) VALUES ('ʻApapane', 'taxonomy', 1)"
+    ).lastrowid
+
+    accepted_pid = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+        "VALUES (?, 'accepted.jpg', 0.9, 'none')",
+        (fid,),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (accepted_pid, apapane_kw),
+    )
+
+    predicted_pid = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+        "VALUES (?, 'predicted.jpg', 0.8, 'none')",
+        (fid,),
+    ).lastrowid
+    did = db.conn.execute(
+        "INSERT INTO detections (photo_id, detector_confidence) VALUES (?, 0.9)",
+        (predicted_pid,),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO predictions (detection_id, classifier_model, species, confidence) "
+        "VALUES (?, 'm', 'ʻApapane', 0.95)",
+        (did,),
+    )
+
+    unidentified_pid = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+        "VALUES (?, 'unknown.jpg', 0.7, 'none')",
+        (fid,),
+    ).lastrowid
+    db.conn.commit()
+
+    resp = client.get(f"/api/highlights?folder_id={fid}&confirmation=all")
+    data = resp.get_json()
+    assert data["meta"]["eligible"] == 3
+    assert data["buckets"][0]["photo_count"] == 2
+    assert data["buckets"][0]["is_accepted"] is False
+    assert data["unidentified"]["photo_count"] == 1
+
+    resp = client.get(f"/api/highlights?folder_id={fid}&confirmation=confirmed")
+    data = resp.get_json()
+    assert data["meta"]["confirmation"] == "confirmed"
+    assert data["meta"]["eligible"] == 1
+    assert data["buckets"][0]["photo_count"] == 1
+    assert data["buckets"][0]["photos"][0]["id"] == accepted_pid
+    assert data["buckets"][0]["is_accepted"] is True
+    assert data["unidentified"]["photo_count"] == 0
+
+    resp = client.get(f"/api/highlights?folder_id={fid}&confirmation=unconfirmed")
+    data = resp.get_json()
+    assert data["meta"]["confirmation"] == "unconfirmed"
+    assert data["meta"]["eligible"] == 2
+    assert data["buckets"][0]["photo_count"] == 1
+    assert data["buckets"][0]["photos"][0]["id"] == predicted_pid
+    assert data["buckets"][0]["is_accepted"] is False
+    assert data["unidentified"]["photo_count"] == 1
+    assert data["unidentified"]["photos"][0]["id"] == unidentified_pid
+
+    resp = client.get(
+        "/api/highlights/bucket",
+        query_string={
+            "folder_id": fid,
+            "species": "ʻApapane",
+            "confirmation": "confirmed",
+        },
+    )
+    data = resp.get_json()
+    assert data["photo_count"] == 1
+    assert data["photos"][0]["id"] == accepted_pid
+
+    resp = client.get(
+        "/api/highlights/bucket",
+        query_string={
+            "folder_id": fid,
+            "species": "ʻApapane",
+            "confirmation": "unconfirmed",
+        },
+    )
+    data = resp.get_json()
+    assert data["photo_count"] == 1
+    assert data["photos"][0]["id"] == predicted_pid
+
+
 def test_highlights_predictions_above_threshold_populate_buckets(app_and_db):
     """Predictions at or above confidence_threshold count as the photo's species."""
     app, db = app_and_db


### PR DESCRIPTION
## Summary
- add a Highlights toolbar status filter for All, Confirmed only, and Unconfirmed only
- apply the filter in the Highlights and bucket APIs so counts, load-more, and saved visible results stay consistent
- cover mixed confirmed/prediction buckets plus unidentified photos in regression tests

## Validation
- `pytest vireo/tests/test_app.py::test_highlights_confirmation_filter_splits_confirmed_and_unconfirmed -q`
- `pytest vireo/tests/test_app.py::test_highlights_bucket_mixed_accepted_predicted_is_not_accepted vireo/tests/test_app.py::test_highlights_predictions_above_threshold_populate_buckets -q`
- `pytest tests/e2e/test_highlights_initial_scope.py -q`
- `git diff --check`