### PR TITLE
Fix native Open in Browse from group review

### DIFF
--- a/tests/e2e/test_burst_group_context_menu.py
+++ b/tests/e2e/test_burst_group_context_menu.py
@@ -137,6 +137,31 @@ def test_burst_right_click_force_selects_card(live_server, page):
     assert str(selected) == target_pid
 
 
+def test_burst_native_open_browse_uses_selected_card(live_server, page):
+    """Native Photo > Open in Browse should understand burst modal selection."""
+    n = _seed_burst_group(live_server["db"])
+    if n < 1:
+        pytest.skip("could not seed burst group")
+
+    url = live_server["url"]
+    page.goto(f"{url}/review")
+    page.wait_for_load_state("networkidle")
+    _open_burst_modal(page)
+
+    page.locator("#grmOverlay .grm-card[data-photo-id]").first.wait_for(
+        state="visible", timeout=2000,
+    )
+    pid = page.evaluate("String(grmState.selected)")
+    assert pid and pid != "null"
+
+    page.evaluate("window.handleNativeMenuCommand('photo_open_browse')")
+
+    page.wait_for_function(
+        f"location.pathname === '/browse' && new URLSearchParams(location.search).get('photo_id') === '{pid}'",
+        timeout=5000,
+    )
+
+
 def test_burst_menu_has_chip_rows(live_server, page):
     """Burst menu includes rating chips (0-5) and flag chips (3)."""
     n = _seed_burst_group(live_server["db"])

--- a/tests/e2e/test_burst_group_context_menu.py
+++ b/tests/e2e/test_burst_group_context_menu.py
@@ -157,7 +157,9 @@ def test_burst_native_open_browse_uses_selected_card(live_server, page):
     page.evaluate("window.handleNativeMenuCommand('photo_open_browse')")
 
     page.wait_for_function(
-        f"location.pathname === '/browse' && new URLSearchParams(location.search).get('photo_id') === '{pid}'",
+        "expectedPid => location.pathname === '/browse'"
+        " && new URLSearchParams(location.search).get('photo_id') === expectedPid",
+        arg=pid,
         timeout=5000,
     )
 

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -7499,6 +7499,16 @@ function nativeMenuActivePhotoIds() {
   ) {
     return [_lightboxCurrentId];
   }
+  if (
+    typeof grmState !== 'undefined' &&
+    document.getElementById('grmOverlay') &&
+    document.getElementById('grmOverlay').classList.contains('open')
+  ) {
+    if (grmState.selectedIds && grmState.selectedIds.size) {
+      return Array.from(grmState.selectedIds);
+    }
+    if (grmState.selected != null) return [grmState.selected];
+  }
   if (typeof getActiveSelection === 'function') {
     var ids = getActiveSelection();
     if (ids && ids.length) return ids;


### PR DESCRIPTION
Fixes the native Photo > Open in Browse command when a group review modal owns the active photo. The native menu resolver now reads the open group-review modal's selected photo state before falling back to page-level selection. Adds an e2e regression test that dispatches the native menu command from the burst modal and verifies Browse opens on the selected photo. Validated with `python -m pytest tests/e2e/test_burst_group_context_menu.py -q` and `git diff --check origin/main...`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced photo selection behavior when modals are active, ensuring correct selection context is used in context menus.

* **Tests**
  * Added test coverage for burst group context menu native open functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->