### PR TITLE
Remove Open in Editor buttons

### DIFF
--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3288,9 +3288,6 @@ async function createWorkspace() {
     <button class="lb-action-btn lb-action-accent" id="lightboxEditPhoto" onclick="">
       Edit Photo
     </button>
-    <button class="lb-action-btn" id="lightboxOpenEditor" onclick="">
-      Open in Editor
-    </button>
     <button class="lb-action-btn lb-action-danger" onclick="lightboxDelete()" title="Delete photo">Delete</button>
   </div>
 </div>
@@ -5815,15 +5812,6 @@ function openLightbox(photoId, filename, photoList, options) {
       window.location.href = '/edit/' + photoId;
     };
   }
-  var editorBtn = document.getElementById('lightboxOpenEditor');
-  if (editorBtn) {
-    if (typeof openInEditorWithPicker === 'function') {
-      editorBtn.style.display = '';
-      editorBtn.onclick = function(e) { openInEditorWithPicker([photoId], e); };
-    } else {
-      editorBtn.style.display = 'none';
-    }
-  }
   overlay.classList.add('active');
   _lbApplyInfoVisibility();
   _lbApplyChromeVisibility();
@@ -7894,17 +7882,14 @@ window.handleNativeMenuCommand = async function(command) {
 };
 
 /* ---------- Open in External Editor ----------
- * Three entry points for opening photos in an external editor:
+ * Two entry points for opening photos in an external editor:
  *   - openInEditor(ids, editorIndex)         — direct call, posts to backend
- *   - openInEditorWithPicker(ids, event)     — for buttons: shows a picker
- *                                              menu when 2+ editors exist,
- *                                              otherwise opens directly.
  *   - getExternalEditorsSync()               — for context-menu builders that
  *                                              need to inline editor entries
  *                                              synchronously; reads the cache.
  *
  * Editors are cached on first read of /api/config; settings.html invalidates
- * via window.invalidateEditorsCache() after saving so the next click picks
+ * via window.invalidateEditorsCache() after saving so the next action picks
  * up changes.
  */
 var _externalEditorsCache = null;
@@ -7929,7 +7914,7 @@ async function getExternalEditors() {
     // shape-validate this key) can yield {"path": 123} or similar. Without
     // the typeof guard, path.replace() would throw TypeError inside this
     // async IIFE, leaving _externalEditorsLoading as a rejected promise
-    // that every later "Open in Editor" click resolves against.
+    // that every later "Open in Editor" action resolves against.
     _externalEditorsCache = [];
     arr.forEach(function(e) {
       if (!e || typeof e !== 'object') return;
@@ -7978,27 +7963,6 @@ async function openInEditor(photoIds, editorIndex) {
     showToast('Opened ' + data.opened + ' photo(s) in editor', 'success');
   } catch(e) {
     showToast(e.message || 'Failed to open in editor');
-  }
-}
-
-async function openInEditorWithPicker(photoIds, event) {
-  if (!photoIds || !photoIds.length) return;
-  var editors = await getExternalEditors();
-  if (editors.length <= 1) {
-    // 0 editors → backend uses OS default. 1 editor → that one is the default.
-    return openInEditor(photoIds);
-  }
-  var items = editors.map(function(ed, idx) {
-    return {
-      label: 'Open in ' + ed.name,
-      onClick: function() { openInEditor(photoIds, idx); },
-    };
-  });
-  if (event && typeof window.openContextMenu === 'function') {
-    window.openContextMenu(event, items);
-  } else {
-    // No anchor event — fall back to the first editor rather than swallowing.
-    openInEditor(photoIds, 0);
   }
 }
 

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1421,7 +1421,6 @@ body {
       <button id="bestBatchBtn" onclick="openBestBatch()" title="Find and rank neighboring frames around the selected photo" style="display:none;background:var(--bg-tertiary);color:var(--accent);border:1px solid var(--accent);border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Best Batch</button>
       <button id="burstReviewBtn" onclick="openSelectedInBurstReview()" title="Open selected photos in burst review" style="display:none;background:var(--bg-tertiary);color:var(--accent);border:1px solid var(--accent);border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Review Burst</button>
       <button id="developBtn" onclick="developSelected()" title="Develop selected RAW photos with darktable" style="background:var(--bg-tertiary);color:var(--text-secondary);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Develop</button>
-      <button onclick="openInEditorBatch(event)" style="background:var(--bg-tertiary);color:var(--text-secondary);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Open in Editor</button>
       <button onclick="batchSubmitInat()" style="background:var(--bg-tertiary);color:#74ac00;border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">iNaturalist</button>
       <button onclick="makeAvailableOffline()" style="background:var(--bg-tertiary);color:var(--text-secondary);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Make Offline</button>
       <button onclick="openExportModal()" style="background:var(--bg-tertiary);color:var(--text-secondary);border:none;border-radius:3px;padding:4px 8px;font-size:12px;cursor:pointer;">Export</button>
@@ -1625,9 +1624,6 @@ body {
         </button>
         <button onclick="openPipeline(window._detailPhotoId)" style="flex:1;background:var(--bg-tertiary);color:var(--accent);border:1px solid var(--border-secondary);border-radius:4px;padding:8px;font-size:12px;cursor:pointer;">
           Inspect Pipeline
-        </button>
-        <button onclick="openInEditorWithPicker([window._detailPhotoId], event)" style="flex:1;background:var(--bg-tertiary);color:var(--text-secondary);border:1px solid var(--border-secondary);border-radius:4px;padding:8px;font-size:12px;cursor:pointer;">
-          Open in Editor
         </button>
       </div>
     </div>
@@ -6243,15 +6239,6 @@ function developSelected() {
   var ids = getActiveSelection();
   if (!ids.length) return;
   developPhotos(ids);
-}
-
-function openInEditorBatch(event) {
-  var ids = getActiveSelection();
-  if (!ids.length) return;
-  if (ids.length > 20) {
-    if (!confirm('Open ' + ids.length + ' photos in editor?')) return;
-  }
-  openInEditorWithPicker(ids, event);
 }
 
 /* ---------- Right-click context menu on grid cards ---------- */

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -899,7 +899,7 @@
   <div class="section">
     <div class="section-title">External Editors</div>
     <p style="font-size:12px;color:var(--text-dim);margin-bottom:12px;">
-      Applications used when clicking "Open in Editor" in the browse tab, lightbox, or burst review. Add as many as you like (e.g. Lightroom, Affinity, Photoshop) — when more than one is configured you'll get a picker. With none configured, photos open in the OS default app.
+      Applications used by "Open in Editor" context-menu and app-menu actions. Add as many as you like (e.g. Lightroom, Affinity, Photoshop); context menus show each configured editor, while the app menu uses the first. With none configured, photos open in the OS default app.
     </p>
     <div id="cfgExternalEditorsList" style="display:flex;flex-direction:column;gap:6px;margin-bottom:8px;"></div>
     <button type="button" onclick="addExternalEditor()" style="background:var(--bg-tertiary);color:var(--text-secondary);border:1px solid var(--border-secondary);border-radius:4px;padding:6px 12px;font-size:12px;cursor:pointer;">+ Add editor</button>
@@ -1920,7 +1920,7 @@ function saveConfig() {
         }),
       });
       if (typeof loadPreviewCacheStatus === 'function') loadPreviewCacheStatus();
-      // Drop the cached editor list so the next "Open in Editor" click
+      // Drop the cached editor list so the next "Open in Editor" action
       // sees changes to the editors list without a page reload.
       if (typeof window.invalidateEditorsCache === 'function') {
         window.invalidateEditorsCache();


### PR DESCRIPTION
Removes the visible Open in Editor buttons from the browse batch bar, browse detail panel, and lightbox controls now that Vireo has its own editor entry point.

The external-editor backend and context/app-menu actions remain available, and settings copy now describes those remaining entry points.

Validation: python -m pytest vireo/tests/test_open_external.py; git diff --check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added right-click context menu for photos with common actions
  * Enabled deep-linking to specific photos using URL parameters

* **Changes**
  * Updated photo editing workflow with new "Develop" and "Inspect Pipeline" actions

* **Documentation**
  * Updated External Editors settings description to clarify context-menu behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->