### PR TITLE
CI: fail loud when Windows build produces no installer

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -358,10 +358,14 @@ jobs:
           echo "=== Tauri build finished at $(date -u) ==="
 
       # Windows: no signing needed, use tauri-action.
-      # continue-on-error because Tauri can exit non-zero after producing
-      # valid installers (e.g. post-bundle steps fail). The upload step
-      # must still run to capture .msi artifacts.
+      # continue-on-error because Tauri can exit non-zero AFTER producing
+      # valid installers (e.g. cosmetic post-bundle steps fail). We tolerate
+      # that here, then the "Verify Windows installers" step below re-asserts
+      # that real artifacts exist — so a genuinely broken build (no installer
+      # produced) still fails the job loudly instead of silently shipping
+      # nothing through the release step's `if: always()`.
       - name: Build Tauri app (Windows)
+        id: build_windows
         if: runner.os == 'Windows'
         continue-on-error: true
         uses: tauri-apps/tauri-action@v0
@@ -372,6 +376,44 @@ jobs:
         with:
           tauriScript: npx tauri
           args: --target ${{ matrix.rust-target }}
+
+      # Fail loud if the Windows build produced no installer. This step has NO
+      # continue-on-error, so an empty bundle dir fails the job — the only thing
+      # we suppress above is Tauri's non-zero-but-successful exit, not a build
+      # that genuinely produced nothing to ship.
+      - name: Verify Windows installers
+        if: runner.os == 'Windows'
+        shell: bash
+        env:
+          BUNDLE_DIR: src-tauri/target/${{ matrix.rust-target }}/release/bundle
+          BUILD_OUTCOME: ${{ steps.build_windows.outcome }}
+        run: |
+          echo "Searching for installers under: $BUNDLE_DIR"
+
+          if [[ ! -d "$BUNDLE_DIR" ]]; then
+            echo "::error::Windows build produced no bundle directory ($BUNDLE_DIR). The Tauri build failed before bundling."
+            exit 1
+          fi
+
+          mapfile -t INSTALLERS < <(find "$BUNDLE_DIR" \( -name '*.msi' -o -name '*.exe' \) -type f 2>/dev/null)
+
+          if [[ ${#INSTALLERS[@]} -eq 0 ]]; then
+            echo "::error::Windows build produced no .msi or .exe installer under $BUNDLE_DIR. Tauri exited but bundled nothing — refusing to ship a broken Windows release."
+            echo "Bundle directory contents for diagnosis:"
+            find "$BUNDLE_DIR" -type f 2>/dev/null || echo "(empty)"
+            exit 1
+          fi
+
+          echo "Found ${#INSTALLERS[@]} Windows installer(s):"
+          for f in "${INSTALLERS[@]}"; do
+            echo "  $f ($(du -h "$f" | cut -f1))"
+          done
+
+          # If Tauri itself reported failure AND yet we have installers, surface
+          # it as a warning so the cosmetic post-bundle failure stays visible.
+          if [[ "$BUILD_OUTCOME" == "failure" ]]; then
+            echo "::warning::Tauri build step reported failure but valid installers were produced (tolerated post-bundle error). Review the build log above."
+          fi
 
       # ── Dump resource monitor (Linux only) ─────────────────
       - name: Dump resource monitor log


### PR DESCRIPTION
## What

Make the Windows release build **fail loud** when it produces no installer, instead of silently shipping a release with no Windows artifact.

## Why

The Windows Tauri build step carries `continue-on-error: true` because Tauri can exit non-zero *after* successfully producing installers (cosmetic post-bundle steps fail). That tolerance was necessary — but it also masked the genuinely-broken case: if Tauri bundled **nothing**, the build job stayed green, and the `release` job's `if: always()` would publish a release with no Windows installer and no signal that anything was wrong.

This is the first of three gating items before we can honestly drop the "Not actively supported" label from the Windows download — a supported platform shouldn't be able to ship an empty/broken build undetected.

## Change

Add a strict **`Verify Windows installers`** step (no `continue-on-error`) immediately after the build:

- Asserts the bundle dir exists and contains at least one `.msi` or `.exe`.
- On failure: emits a `::error::`, dumps the bundle dir contents for diagnosis, and exits non-zero — failing the Windows build job.
- On success: lists the installers found (with sizes).
- If Tauri reported failure but installers exist, emits a `::warning::` so the tolerated post-bundle error stays visible rather than being swallowed.

We still tolerate Tauri's non-zero-but-successful exit; we no longer tolerate "produced nothing."

### Failure-path behavior (verified by tracing the workflow)

- Matrix is `fail-fast: false`, so a failed Windows leg does **not** kill macOS/Linux.
- A failed `Verify` step skips the subsequent (unconditional) artifact-upload step → no partial Windows artifact is published.
- The `release` job (`if: always()`) still runs and releases the macOS/Linux artifacts that succeeded.

Net: broken Windows build → visible red job + no Windows artifact, while other platforms release normally. Previously: green job + missing/partial Windows artifact, silently.

## Safety

Trusted interpolations (`matrix.rust-target`, `steps.build_windows.outcome`) are passed via `env:` rather than inlined into `run:`, per the GitHub Actions injection-safety convention.

## Testing

Pure GitHub Actions workflow change — no application code touched, so the Python test suite is unaffected (the test workflow's `changes` filter won't even trigger it). YAML validated locally with `yaml.safe_load`. The new step's logic only exercises on `windows-latest` runners during a tagged/dispatched release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)