### PR TITLE
Fix fresh-install pipeline failure: onboard species labels + gate classify

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2024,13 +2024,29 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         labels_ready = False
         if model_downloaded and not label_free:
             try:
-                from labels import get_active_labels
+                from labels import (
+                    get_active_labels,
+                    get_saved_labels,
+                    load_merged_labels,
+                )
 
                 ws_labels = _get_db().get_workspace_active_labels()
                 if ws_labels is not None:
-                    labels_ready = any(os.path.exists(p) for p in ws_labels)
+                    saved_by_file = {
+                        s["labels_file"]: s for s in get_saved_labels()
+                    }
+                    active_sets = [
+                        saved_by_file.get(p, {"labels_file": p}) for p in ws_labels
+                    ]
                 else:
-                    labels_ready = bool(get_active_labels())
+                    active_sets = get_active_labels()
+                # Require a non-empty MERGED label list, not just an existing
+                # path. classify_job._load_labels and the planner load the
+                # files and treat an empty merged list as "no labels", so an
+                # active-but-blank file must not report ready — otherwise we'd
+                # redirect to /browse and then block/fail at classify.
+                merged = load_merged_labels(active_sets) if active_sets else []
+                labels_ready = len(merged) > 0
             except Exception:
                 labels_ready = False
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1996,29 +1996,33 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         threading.Timer(0.5, _shutdown).start()
         return jsonify({"status": "shutting_down"})
 
-    @app.route("/api/models/status")
-    def api_models_status():
-        """Lightweight model readiness check for first-launch detection."""
-        from models import get_active_model, get_models
+    def _classification_readiness():
+        """Whether the active model can actually classify right now.
+
+        A downloaded model is only usable if it can run label-free — a
+        Tree-of-Life BioCLIP model, or a timm model with its intrinsic fixed
+        class head — or an active species list exists. Mirrors the label
+        gate in classify_job._load_labels and pipeline_plan
+        (model_type == "timm" is never blocked) so this readiness signal
+        answers the question callers actually ask — "can this install
+        classify?" — not the cheaper "is a model on disk?" (CORE_PHILOSOPHY:
+        no black boxes). Returns a dict with the active model and the flags
+        the status endpoint and the onboarding redirects both consume.
+        """
+        from models import get_active_model
 
         active = get_active_model()
         model_downloaded = bool(active and active.get("downloaded"))
-
-        # A downloaded model is only usable if it can actually classify:
-        # either it supports label-free Tree-of-Life mode, or there is an
-        # active species list. Mirrors classify_job._load_labels' resolution
-        # order + TOL gate so this readiness signal answers the question the
-        # caller actually asks — "can this install classify?" — rather than
-        # the cheaper "is a model on disk?" (CORE_PHILOSOPHY: no black boxes).
-        # Without this, a fresh install with the default label-needing model
-        # but no labels reports ready and then fails mid-pipeline at classify.
         tol_models = {
             "hf-hub:imageomics/bioclip",
             "hf-hub:imageomics/bioclip-2",
         }
-        model_is_tol = bool(active and active.get("model_str") in tol_models)
+        label_free = bool(active and (
+            active.get("model_str") in tol_models
+            or active.get("model_type") == "timm"
+        ))
         labels_ready = False
-        if model_downloaded and not model_is_tol:
+        if model_downloaded and not label_free:
             try:
                 from labels import get_active_labels
 
@@ -2030,17 +2034,31 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             except Exception:
                 labels_ready = False
 
-        classification_ready = model_downloaded and (model_is_tol or labels_ready)
+        usable = label_free or labels_ready
+        return {
+            "active": active,
+            "model_downloaded": model_downloaded,
+            "labels_ready": usable,
+            "ready": model_downloaded and usable,
+        }
+
+    @app.route("/api/models/status")
+    def api_models_status():
+        """Lightweight model readiness check for first-launch detection."""
+        from models import get_models
+
+        r = _classification_readiness()
+        active = r["active"]
 
         all_models = get_models()
         downloaded_ids = [m["id"] for m in all_models if m.get("downloaded")]
 
         return jsonify({
-            "needs_setup": not classification_ready,
+            "needs_setup": not r["ready"],
             "classification": {
-                "ready": classification_ready,
-                "model_ready": model_downloaded,
-                "labels_ready": model_is_tol or labels_ready,
+                "ready": r["ready"],
+                "model_ready": r["model_downloaded"],
+                "labels_ready": r["labels_ready"],
                 "model_name": active["name"] if active else None,
                 "model_id": active["id"] if active else None,
             },
@@ -2410,20 +2428,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
     @app.route("/")
     def index():
-        from models import get_active_model
-        active = get_active_model()
-        if active and active.get("downloaded"):
-            return redirect("/browse")
-        user_cfg = cfg.load()
-        if user_cfg.get("setup_complete"):
+        # Resume onboarding until the install can actually classify, OR the
+        # user explicitly finished/skipped setup. Redirecting on
+        # "model downloaded" alone stranded a user who bailed after the model
+        # download but before the labels step: setup_complete stays false yet
+        # the model is on disk, so they'd land back in the blocked pipeline.
+        if _classification_readiness()["ready"] or cfg.load().get("setup_complete"):
             return redirect("/browse")
         return redirect("/welcome")
 
     @app.route("/welcome")
     def welcome():
-        from models import get_active_model
-        active = get_active_model()
-        if active and active.get("downloaded") and not request.args.get("force"):
+        if request.args.get("force"):
+            return render_template("welcome.html")
+        if _classification_readiness()["ready"] or cfg.load().get("setup_complete"):
             return redirect("/browse")
         return render_template("welcome.html")
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2002,7 +2002,35 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         from models import get_active_model, get_models
 
         active = get_active_model()
-        classification_ready = bool(active and active.get("downloaded"))
+        model_downloaded = bool(active and active.get("downloaded"))
+
+        # A downloaded model is only usable if it can actually classify:
+        # either it supports label-free Tree-of-Life mode, or there is an
+        # active species list. Mirrors classify_job._load_labels' resolution
+        # order + TOL gate so this readiness signal answers the question the
+        # caller actually asks — "can this install classify?" — rather than
+        # the cheaper "is a model on disk?" (CORE_PHILOSOPHY: no black boxes).
+        # Without this, a fresh install with the default label-needing model
+        # but no labels reports ready and then fails mid-pipeline at classify.
+        tol_models = {
+            "hf-hub:imageomics/bioclip",
+            "hf-hub:imageomics/bioclip-2",
+        }
+        model_is_tol = bool(active and active.get("model_str") in tol_models)
+        labels_ready = False
+        if model_downloaded and not model_is_tol:
+            try:
+                from labels import get_active_labels
+
+                ws_labels = _get_db().get_workspace_active_labels()
+                if ws_labels is not None:
+                    labels_ready = any(os.path.exists(p) for p in ws_labels)
+                else:
+                    labels_ready = bool(get_active_labels())
+            except Exception:
+                labels_ready = False
+
+        classification_ready = model_downloaded and (model_is_tol or labels_ready)
 
         all_models = get_models()
         downloaded_ids = [m["id"] for m in all_models if m.get("downloaded")]
@@ -2011,6 +2039,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "needs_setup": not classification_ready,
             "classification": {
                 "ready": classification_ready,
+                "model_ready": model_downloaded,
+                "labels_ready": model_is_tol or labels_ready,
                 "model_name": active["name"] if active else None,
                 "model_id": active["id"] if active else None,
             },

--- a/vireo/pipeline_plan.py
+++ b/vireo/pipeline_plan.py
@@ -308,15 +308,17 @@ def _classify_plan(db, params, photo_ids, new_count=0):
             pending_per_model[m["name"]] = pending
             pending_total += pending
 
-    if blocked and not pending_total:
-        # Mixed shape: some models are blocked on missing labels and the rest
-        # have no pending work. There is nothing the stage can actually run, so
-        # emit "blocked" (not "will-run") — that's what the UI gates Start on.
-        # Returning "will-run" here showed a "Blocked" summary while leaving
-        # Start enabled, so a click still reached the unlabeled model and
-        # recorded a failed classify step. eligible=0 (not eligible>0 with
-        # pending=0, which would render "Resume (0 left)" against a blocked
-        # stage).
+    if blocked:
+        # Any selected model that's blocked on missing labels prevents
+        # launching the stage: pipeline_job.classify_stage iterates every
+        # selected resolved spec, and the blocked model fails at
+        # classify_job._load_labels. Emit "blocked" (gates Start) whether or
+        # not the other unblocked models have pending work — returning
+        # "will-run" in the mixed pending case left Start enabled and let the
+        # missing-labels failure through on launch. The user fixes labels or
+        # deselects the blocked model before the rest can run. eligible=0
+        # (not eligible>0 with pending=0, which would render "Resume (0
+        # left)" against a stage that's actually blocked).
         return {
             "state": "blocked",
             "summary": (
@@ -419,8 +421,6 @@ def _classify_plan(db, params, photo_ids, new_count=0):
     }
     if new_count > 0:
         detail["new_photos"] = new_count
-    if blocked:
-        detail["blocked_models"] = blocked
     return {"state": "will-run", "summary": summary, "detail": detail}
 
 

--- a/vireo/pipeline_plan.py
+++ b/vireo/pipeline_plan.py
@@ -275,13 +275,16 @@ def _classify_plan(db, params, photo_ids, new_count=0):
             pending_total += pending
 
     if blocked and not pending_total:
-        # eligible=0 here even when some unblocked models happen to be
-        # fully cached — the stage is functionally blocked on missing
-        # labels and the summary text already explains that. Returning
-        # eligible>0 with pending=0 would let the UI render
-        # "Resume (0 left)" against a state that's actually "Blocked".
+        # Mixed shape: some models are blocked on missing labels and the rest
+        # have no pending work. There is nothing the stage can actually run, so
+        # emit "blocked" (not "will-run") — that's what the UI gates Start on.
+        # Returning "will-run" here showed a "Blocked" summary while leaving
+        # Start enabled, so a click still reached the unlabeled model and
+        # recorded a failed classify step. eligible=0 (not eligible>0 with
+        # pending=0, which would render "Resume (0 left)" against a blocked
+        # stage).
         return {
-            "state": "will-run",
+            "state": "blocked",
             "summary": (
                 f"Blocked — {len(blocked)} model{_plural(len(blocked))} "
                 f"need labels: {', '.join(blocked)}"

--- a/vireo/pipeline_plan.py
+++ b/vireo/pipeline_plan.py
@@ -185,6 +185,31 @@ def _classify_plan(db, params, photo_ids, new_count=0):
     )
     eligible = total_dets * unblocked_count
 
+    # Every selected model is blocked on missing labels and can't run
+    # label-free (Tree of Life). The classify stage cannot do any work for
+    # ANY scope — including a fresh import with no detections cached yet, so
+    # this must run BEFORE the total_dets == 0 early-return below. Surface a
+    # distinct "blocked" state (not "will-run") so the UI can gate Start and
+    # point the user at Settings > Labels, rather than letting the job crash
+    # mid-pipeline at classify_job._load_labels (which is exactly the
+    # fresh-install failure this guards against).
+    if unblocked_count == 0:
+        blocked_all = [m["name"] for m in models]
+        return {
+            "state": "blocked",
+            "summary": (
+                "Blocked — download a species list (Settings › Labels) "
+                f"for: {', '.join(blocked_all)}"
+            ),
+            "detail": {
+                "blocked_models": blocked_all,
+                "pending": 0,
+                "eligible": 0,
+                "stale": 0,
+                "fingerprint_outdated": False,
+            },
+        }
+
     stale_total = 0
     if total_dets > 0 and not params.reclassify:
         for m in models:

--- a/vireo/pipeline_plan.py
+++ b/vireo/pipeline_plan.py
@@ -227,6 +227,40 @@ def _classify_plan(db, params, photo_ids, new_count=0):
     fingerprint_reason = "label_set_changed" if fingerprint_outdated else None
 
     if total_dets == 0:
+        # Mixed shape with no detections cached yet: some selected models
+        # can run (label-free, or have labels) and others are blocked on
+        # missing labels. The earlier unblocked_count==0 guard doesn't fire
+        # here because at least one model is runnable, but classify_job
+        # iterates every selected model and the blocked ones will fail at
+        # _load_labels once MegaDetector creates detections. Emit "blocked"
+        # (gates Start) instead of "will-run" with no blocked_models, so
+        # the user fixes labels or deselects the blocked model before
+        # launching — same failure this PR is meant to prevent.
+        blocked_now = [
+            m["name"] for m in models
+            if label_resolution[m["id"]].get("blocked")
+        ]
+        if blocked_now:
+            return {
+                "state": "blocked",
+                "summary": (
+                    f"Blocked — {len(blocked_now)} model"
+                    f"{_plural(len(blocked_now))} need labels: "
+                    f"{', '.join(blocked_now)}"
+                ),
+                "detail": {
+                    "blocked_models": blocked_now,
+                    "total_dets": 0,
+                    "photos_with_dets": 0,
+                    "models": [m["name"] for m in models],
+                    "pending": 0,
+                    "eligible": 0,
+                    "new_photos": new_count,
+                    "stale": stale_total,
+                    "fingerprint_outdated": fingerprint_outdated,
+                    "fingerprint_reason": fingerprint_reason,
+                },
+            }
         if new_count > 0:
             summary = (
                 f"Will run — {new_count} new photo{_plural(new_count)} "

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -97,6 +97,10 @@ body { padding-bottom: 36px; }
   background: var(--danger, #E74C3C);
   color: #fff;
 }
+.stage-status-pill.blocked {
+  background: color-mix(in srgb, var(--danger, #E74C3C) 18%, transparent);
+  color: var(--danger, #E74C3C);
+}
 .stage-status-pill.cancelled {
   background: color-mix(in srgb, var(--warning, #F0A030) 20%, transparent);
   color: var(--warning, #F0A030);
@@ -195,6 +199,7 @@ body { padding-bottom: 36px; }
 .pipeline-plan-summary .plan-stage-row.will-run .plan-stage-pill { color: var(--accent, #24E5CA); }
 .pipeline-plan-summary .plan-stage-row.will-skip .plan-stage-pill { color: var(--text-dim, #5A8890); font-style: italic; }
 .pipeline-plan-summary .plan-stage-row.cancelled .plan-stage-pill { color: var(--warning, #F0A030); }
+.pipeline-plan-summary .plan-stage-row.blocked .plan-stage-pill { color: var(--danger, #E74C3C); }
 .pipeline-plan-summary .plan-stage-row.done-prior .plan-stage-pill {
   color: color-mix(in srgb, var(--accent, #24E5CA) 65%, var(--text-secondary, #B0CCCC));
 }
@@ -277,6 +282,7 @@ body { padding-bottom: 36px; }
 .btn-secondary:hover { background: var(--border-secondary, #1A4560); }
 .status-msg { font-size: 13px; color: var(--text-dim, #888); }
 .status-msg.ok { color: var(--accent, #24E5CA); }
+.status-msg.error { color: var(--danger, #E74C3C); }
 
 /* Readiness panel */
 .readiness-panel {
@@ -2296,6 +2302,21 @@ function updateStartButton() {
     }
   }
 
+  // Classify is blocked on missing species labels (the selected model can't
+  // run label-free). Gate Start so the user can't launch a run that would
+  // crash mid-pipeline at the classify stage — point them at Settings ›
+  // Labels, or let them turn Classify off to run the other stages. Mirrors
+  // the plan endpoint's `blocked` state (pipeline_plan._classify_plan).
+  if (!btn.disabled && _classifyBlocked()) {
+    btn.disabled = true;
+    if (actionStatus) {
+      actionStatus.textContent =
+        'Classify needs a species list — download one in Settings › Labels, '
+        + 'or turn Classify off to run the other stages.';
+      actionStatus.className = 'status-msg error';
+    }
+  }
+
   // Update preview button state
   var previewBtn = document.getElementById('btnPreviewFolders');
   var previewHint = document.getElementById('previewFoldersHint');
@@ -3903,6 +3924,7 @@ var _PILL_LABELS = {
   'will-run':   'Will run',
   'will-skip':  'Will skip',
   'done-prior': 'Already done',
+  'blocked':    'Needs labels',
 };
 
 // Map a stage's plan entry to the pill text, including counts and the
@@ -3920,6 +3942,7 @@ function _formatPillLabel(stage, planEntry, state) {
   if (state === 'failed')    return 'Failed';
   if (state === 'cancelled') return 'Cancelled';
   if (state === 'will-skip') return 'Will skip';
+  if (state === 'blocked')   return 'Needs labels';
 
   if (!planEntry) {
     // No plan entry yet (page still loading) — fall back to the bare
@@ -4005,6 +4028,19 @@ function _stageStateFor(stage) {
   var fromPlan = _pipelinePlan.stages && _pipelinePlan.stages[stage.suffix];
   if (!fromPlan) return 'will-run';
   return fromPlan.state || 'will-run';
+}
+
+// True when the Classify stage is enabled but the plan reports it can't run
+// because the selected model(s) have no labels and can't classify label-free.
+// A user-disabled Classify stage resolves to 'will-skip' via _stageStateFor,
+// so this correctly returns false and does not gate Start in that case.
+function _classifyBlocked() {
+  for (var i = 0; i < _STAGES.length; i++) {
+    if (_STAGES[i].suffix === 'Classify') {
+      return _stageStateFor(_STAGES[i]) === 'blocked';
+    }
+  }
+  return false;
 }
 
 function _stageSummaryFor(stage) {
@@ -4214,6 +4250,9 @@ async function refreshPipelinePlan() {
     updateSamVariantWarning(null);
   }
   refreshPipelineUI();
+  // The plan can flip Classify to 'blocked' (missing labels), which gates
+  // Start — recompute the button now that _pipelinePlan has been updated.
+  updateStartButton();
 }
 
 // Debounced version for chatty controls (label checkboxes, model picker).

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -2302,18 +2302,44 @@ function updateStartButton() {
     }
   }
 
+  // Snapshot whether source + destination are configured *before* the
+  // classify gates below. The stage-1 "complete" indicator and the
+  // auto-expand of the destination card key off this; if we let the
+  // classify gate (which can flip while a plan refresh is pending) drive
+  // the source indicator, the source stage flickers between complete and
+  // incomplete every time the plan refetches.
+  var sourceReady = !btn.disabled;
+
   // Classify is blocked on missing species labels (the selected model can't
   // run label-free). Gate Start so the user can't launch a run that would
   // crash mid-pipeline at the classify stage — point them at Settings ›
   // Labels, or let them turn Classify off to run the other stages. Mirrors
   // the plan endpoint's `blocked` state (pipeline_plan._classify_plan).
-  if (!btn.disabled && _classifyBlocked()) {
-    btn.disabled = true;
-    if (actionStatus) {
-      actionStatus.textContent =
-        'Classify needs a species list — download one in Settings › Labels, '
-        + 'or turn Classify off to run the other stages.';
-      actionStatus.className = 'status-msg error';
+  //
+  // If a plan refresh is queued or in-flight and Classify is enabled, we
+  // can't trust the blocked check yet: _stageStateFor falls back to
+  // "will-run" when _pipelinePlan is null, and a stale plan from before the
+  // user's latest model/label change might still say "will-run". Treat
+  // "Classify on, plan not current" as not ready and disable Start until
+  // the fresh response lands — otherwise a fast click during the debounce
+  // window posts /api/jobs/pipeline and hits the missing-labels failure.
+  if (!btn.disabled) {
+    var classifyEnableCb = document.getElementById('enableClassify');
+    var classifyOn = classifyEnableCb && classifyEnableCb.checked;
+    if (classifyOn && (_pipelinePlan === null || _planRefreshPending)) {
+      btn.disabled = true;
+      if (actionStatus) {
+        actionStatus.textContent = 'Checking pipeline plan…';
+        actionStatus.className = 'status-msg';
+      }
+    } else if (_classifyBlocked()) {
+      btn.disabled = true;
+      if (actionStatus) {
+        actionStatus.textContent =
+          'Classify needs a species list — download one in Settings › Labels, '
+          + 'or turn Classify off to run the other stages.';
+        actionStatus.className = 'status-msg error';
+      }
     }
   }
 
@@ -2333,7 +2359,7 @@ function updateStartButton() {
   }
 
   // Update stage 1 indicator and auto-expand stage 2 when source is ready
-  var sourceReady = !btn.disabled;
+  // (sourceReady was captured above, before the classify gates).
   var numSource = document.getElementById('numSource');
   if (sourceReady) {
     numSource.classList.add('complete');
@@ -2468,6 +2494,39 @@ var _currentPipelineJobId = null;
 
 async function startPipeline() {
   if (_pipelineRunning) return;
+
+  // Belt-and-suspenders: updateStartButton() should already have disabled
+  // this button when Classify is enabled and the plan is mid-refresh, but
+  // a click can still beat the gate (race against debounce, programmatic
+  // invocation, etc.). If a refresh is queued or in-flight, await it now
+  // and bail if the fresh plan reports Classify is blocked — never POST
+  // /api/jobs/pipeline only to crash at the missing-labels classify step.
+  var classifyEnableCb = document.getElementById('enableClassify');
+  var classifyOn = classifyEnableCb && classifyEnableCb.checked;
+  if (classifyOn && (_pipelinePlan === null || _planRefreshPending)) {
+    if (_planDebounceTimer) {
+      clearTimeout(_planDebounceTimer);
+      _planDebounceTimer = null;
+    }
+    await refreshPipelinePlan();
+    // refreshPipelinePlan() already called updateStartButton(), which will
+    // have written the "Classify needs a species list" message if blocked.
+    if (_classifyBlocked()) return;
+    // If we still don't have a plan (e.g. import preview is still loading
+    // so refreshPipelinePlan returned without fetching), we genuinely can't
+    // verify whether Classify will be blocked. Bail with a clear message
+    // rather than gamble on a run that may crash mid-pipeline.
+    if (_pipelinePlan === null) {
+      var actionStatus = document.getElementById('pipelineActionStatus');
+      if (actionStatus) {
+        actionStatus.textContent =
+          'Still computing the pipeline plan — try again in a moment.';
+        actionStatus.className = 'status-msg';
+      }
+      return;
+    }
+  }
+
   _pipelineRunning = true;
   _pipelineAbort = false;
   _pipelineCancelling = false;
@@ -3889,6 +3948,12 @@ var _stageOutcomes = {};  // suffix -> 'done' | 'failed' | 'cancelled' | 'will-s
 var _pipelinePlan = null;
 var _planFetchSeq = 0;
 var _planDebounceTimer = null;
+// True while a /api/pipeline/plan refresh is queued (debounce timer set) or
+// the latest fetch is in-flight. Used by updateStartButton() so a fast click
+// during the debounce window — when _pipelinePlan is null or stale relative
+// to the user's most recent selection — can't enable Start and let the
+// missing-labels classify run slip through the blocked gate.
+var _planRefreshPending = false;
 
 var _STAGES = [
   { suffix: 'Scan',         label: 'Scan & Import',          enable: null },
@@ -4222,11 +4287,15 @@ async function refreshPipelinePlan() {
   // Don't fetch a plan while a pipeline is running — live state is
   // authoritative, and the running stages would race the plan response.
   if (_pipelineRunning) return;
+  _planRefreshPending = true;
   var seq = ++_planFetchSeq;
   if (_planIsWaitingForImportPreview()) {
     _pipelinePlan = null;
     updateSamVariantWarning(null);
+    // Preview is loading; another refresh will fire when it completes.
+    // Leave _planRefreshPending true so Start stays gated until then.
     refreshPipelineUI();
+    updateStartButton();
     return;
   }
   try {
@@ -4238,6 +4307,8 @@ async function refreshPipelinePlan() {
     // Drop responses that arrived after a newer request — otherwise a slow
     // request can overwrite the result of a fresher one and the UI flickers
     // back to stale state right after the user changed a setting.
+    // Leave _planRefreshPending alone: the newer fetch still owns it and
+    // will clear it on its own completion.
     if (seq !== _planFetchSeq) return;
     _pipelinePlan = data;
     var extract = data && data.stages ? data.stages.Extract : null;
@@ -4249,6 +4320,9 @@ async function refreshPipelinePlan() {
     _pipelinePlan = null;
     updateSamVariantWarning(null);
   }
+  // Only the latest fetch clears the pending flag (older stale responses
+  // returned above without touching it).
+  _planRefreshPending = false;
   refreshPipelineUI();
   // The plan can flip Classify to 'blocked' (missing labels), which gates
   // Start — recompute the button now that _pipelinePlan has been updated.
@@ -4258,10 +4332,15 @@ async function refreshPipelinePlan() {
 // Debounced version for chatty controls (label checkboxes, model picker).
 function schedulePlanRefresh() {
   if (_planDebounceTimer) clearTimeout(_planDebounceTimer);
+  _planRefreshPending = true;
   _planDebounceTimer = setTimeout(function() {
     _planDebounceTimer = null;
     refreshPipelinePlan();
   }, 150);
+  // Reflect the pending state on Start immediately — the control change
+  // that triggered this may have invalidated the previous classify
+  // blocked/will-run answer.
+  updateStartButton();
 }
 
 function updateCardStates() {

--- a/vireo/templates/welcome.html
+++ b/vireo/templates/welcome.html
@@ -104,39 +104,118 @@
     color: var(--text-dim); text-decoration: none;
   }
   .skip-link:hover { color: var(--text-secondary); }
+
+  /* ---- Step 2: region / species list ---- */
+  #stepLabels { display: none; text-align: left; }
+  #stepLabels .step-intro {
+    font-size: 14px; color: var(--text-secondary); line-height: 1.5;
+    margin-bottom: 20px; text-align: center;
+  }
+  .field-label {
+    display: block; font-size: 12px; font-weight: 600;
+    color: var(--text-secondary); margin: 16px 0 6px;
+  }
+  #placeSearch {
+    width: 100%; box-sizing: border-box; padding: 10px 12px;
+    background: var(--bg-tertiary); border: 1px solid var(--border-secondary);
+    border-radius: 8px; color: var(--text-primary); font-size: 14px;
+  }
+  #placeSearch:focus { outline: none; border-color: var(--accent); }
+  #placeDropdown {
+    border: 1px solid var(--border-secondary); border-radius: 8px;
+    margin-top: 4px; overflow: hidden;
+  }
+  #placeDropdown:empty { display: none; }
+  .place-option {
+    padding: 8px 10px; font-size: 13px; color: var(--text-secondary);
+    cursor: pointer; border-bottom: 1px solid var(--border-secondary);
+  }
+  .place-option:hover { background: var(--bg-tertiary); }
+  .place-empty { padding: 8px 10px; font-size: 12px; color: var(--text-dim); }
+  .place-error { padding: 8px 10px; font-size: 12px; color: var(--danger); }
+  .taxon-row { display: flex; flex-wrap: wrap; gap: 6px 16px; }
+  .taxon-row label {
+    font-size: 13px; color: var(--text-secondary);
+    display: flex; align-items: center; gap: 5px; cursor: pointer;
+  }
+  .taxon-row input { accent-color: var(--accent); }
+  #stepLabels .actions {
+    margin-top: 28px; text-align: center;
+  }
+  #labelsStatus { font-size: 12px; color: var(--text-dim); margin-top: 12px; }
+  #labelsSkip {
+    display: block; margin-top: 16px; font-size: 12px;
+    color: var(--text-dim); text-decoration: none;
+  }
+  #labelsSkip:hover { color: var(--text-secondary); }
 </style>
 </head>
 <body>
 
 <div class="setup-card">
-  <div class="setup-title">Welcome to Vireo</div>
-  <div class="setup-tagline">AI-powered wildlife photo organizer</div>
 
-  <ul class="features">
-    <li>Identify species in your photos with AI</li>
-    <li>Rate and cull your best shots</li>
-    <li>Organize photos into collections</li>
-  </ul>
+  <!-- Step 1: download the classification model -->
+  <div id="stepModel">
+    <div class="setup-title">Welcome to Vireo</div>
+    <div class="setup-tagline">AI-powered wildlife photo organizer</div>
 
-  <div>
-    <button class="btn-primary" id="downloadBtn" onclick="getStarted()" disabled>
-      Get Started
-    </button>
-  </div>
-  <div class="settings-hint">You can change models and settings anytime in Settings.</div>
+    <ul class="features">
+      <li>Identify species in your photos with AI</li>
+      <li>Rate and cull your best shots</li>
+      <li>Organize photos into collections</li>
+    </ul>
 
-  <div class="progress-container" id="progressContainer">
-    <div class="progress-bar-track"><div class="progress-bar-fill" id="progressBar"></div></div>
-    <div class="progress-label" id="progressLabel"></div>
-  </div>
+    <div>
+      <button class="btn-primary" id="downloadBtn" onclick="getStarted()" disabled>
+        Get Started
+      </button>
+    </div>
+    <div class="settings-hint">You can change models and settings anytime in Settings.</div>
 
-  <div class="error-container" id="errorContainer">
-    <div id="errorMessage"></div>
-    <div class="error-actions">
-      <button class="retry-btn" onclick="getStarted()">Retry</button>
-      <a href="#" class="skip-link" id="skipLink" onclick="skipSetup(); return false;">Skip for now</a>
+    <div class="progress-container" id="progressContainer">
+      <div class="progress-bar-track"><div class="progress-bar-fill" id="progressBar"></div></div>
+      <div class="progress-label" id="progressLabel"></div>
+    </div>
+
+    <div class="error-container" id="errorContainer">
+      <div id="errorMessage"></div>
+      <div class="error-actions">
+        <button class="retry-btn" onclick="getStarted()">Retry</button>
+        <a href="#" class="skip-link" id="skipLink" onclick="skipSetup(); return false;">Skip for now</a>
+      </div>
     </div>
   </div>
+
+  <!-- Step 2: download a species list for the user's region -->
+  <div id="stepLabels">
+    <div class="setup-title">Choose your region</div>
+    <div class="step-intro">
+      Vireo identifies species by matching them against a list for your area.
+      Pick a region and the wildlife groups you photograph, and we'll download
+      the species list. You can add more regions later in Settings.
+    </div>
+
+    <label class="field-label" for="placeSearch">Region</label>
+    <input type="text" id="placeSearch" autocomplete="off"
+           placeholder="e.g. California, Virginia, Costa Rica"
+           oninput="searchPlacesDebounced()">
+    <div id="placeDropdown"></div>
+
+    <label class="field-label">Wildlife groups</label>
+    <div class="taxon-row" id="taxonCheckboxes"></div>
+
+    <div class="actions">
+      <button class="btn-primary" id="fetchLabelsBtn" onclick="fetchLabels()" disabled>
+        Download species list
+      </button>
+      <div id="labelsStatus"></div>
+      <div class="progress-container" id="labelsProgress">
+        <div class="progress-bar-track"><div class="progress-bar-fill" id="labelsBar"></div></div>
+      </div>
+      <a href="#" id="labelsSkip" onclick="skipLabels(); return false;">Skip for now — set this up later in Settings</a>
+    </div>
+  </div>
+
 </div>
 
 <script src="/static/vireo-utils.js"></script>
@@ -199,9 +278,8 @@ async function getStarted() {
 
   if (modelAlreadyDownloaded) {
     btn.disabled = true;
-    btn.textContent = 'Redirecting...';
-    await safeFetch('/api/setup/complete', { method: 'POST' }, { toast: false });
-    window.location.href = '/browse';
+    btn.textContent = 'Loading…';
+    await proceedAfterModel();
     return;
   }
 
@@ -239,10 +317,7 @@ async function getStarted() {
         if (result.status === 'completed') {
           progressBar.style.width = '100%';
           progressLabel.textContent = 'Download complete!';
-          safeFetch('/api/setup/complete', { method: 'POST' }, { toast: false }).then(function() {
-            btn.textContent = 'Setup Complete!';
-            setTimeout(function() { window.location.href = '/browse'; }, 800);
-          });
+          proceedAfterModel();
         } else {
           var msg = (result.errors && result.errors[0]) || 'Download failed';
           showError(msg);
@@ -255,6 +330,34 @@ async function getStarted() {
   } catch(e) {
     showError(e.message || 'Download failed. Please try again.');
   }
+}
+
+/* The model is ready. The default model (BioCLIP ViT-B-16) classifies by
+   matching against a regional species list, so without labels the pipeline
+   would fail at the classify stage. Route the user to the labels step unless
+   classification is already usable (a Tree-of-Life model or labels already
+   present), in which case finish setup straight away. */
+async function proceedAfterModel() {
+  var ready = false;
+  try {
+    var status = await safeFetch('/api/models/status', {}, { toast: false });
+    ready = !!(status && status.classification && status.classification.labels_ready);
+  } catch(e) {
+    /* On error, fall through to the labels step — better to offer it than
+       to silently land the user in a configuration that can't classify. */
+  }
+  if (ready) {
+    await finishSetup();
+    return;
+  }
+  showLabelsStep();
+}
+
+async function finishSetup() {
+  try {
+    await safeFetch('/api/setup/complete', { method: 'POST' }, { toast: false });
+  } catch(e) {}
+  window.location.href = '/browse';
 }
 
 function showError(message) {
@@ -274,8 +377,175 @@ function showError(message) {
 }
 
 async function skipSetup() {
-  await safeFetch('/api/setup/complete', { method: 'POST' }, { toast: false });
-  window.location.href = '/browse';
+  await finishSetup();
+}
+
+/* ---------------- Step 2: region / species list ----------------
+   DOM is built with createElement/textContent (not innerHTML) so
+   place names returned by the iNaturalist search can't inject markup. */
+
+var selectedPlaceId = null;
+var selectedPlaceName = '';
+var placeSearchTimer = null;
+
+function showLabelsStep() {
+  document.getElementById('stepModel').style.display = 'none';
+  document.getElementById('stepLabels').style.display = 'block';
+  loadTaxonGroups();
+}
+
+async function loadTaxonGroups() {
+  var container = document.getElementById('taxonCheckboxes');
+  container.textContent = '';
+  try {
+    var groups = await safeFetch('/api/labels/taxon-groups', {}, { toast: false });
+    (groups || []).forEach(function(g) {
+      var label = document.createElement('label');
+      var cb = document.createElement('input');
+      cb.type = 'checkbox';
+      cb.className = 'taxon-cb';
+      cb.value = g.key;
+      if (g.key === 'birds') cb.checked = true;
+      label.appendChild(cb);
+      label.appendChild(document.createTextNode(' ' + g.name));
+      container.appendChild(label);
+    });
+  } catch(e) {
+    var span = document.createElement('span');
+    span.style.cssText = 'font-size:12px;color:var(--text-dim);';
+    span.textContent = 'Could not load groups.';
+    container.appendChild(span);
+  }
+}
+
+function searchPlacesDebounced() {
+  if (selectedPlaceId) {
+    selectedPlaceId = null;
+    selectedPlaceName = '';
+    document.getElementById('fetchLabelsBtn').disabled = true;
+    document.getElementById('placeSearch').style.borderColor = 'var(--border-secondary)';
+  }
+  if (placeSearchTimer) clearTimeout(placeSearchTimer);
+  placeSearchTimer = setTimeout(searchPlaces, 300);
+}
+
+function _setDropdownMessage(cls, text) {
+  var dropdown = document.getElementById('placeDropdown');
+  dropdown.textContent = '';
+  var div = document.createElement('div');
+  div.className = cls;
+  div.textContent = text;
+  dropdown.appendChild(div);
+}
+
+async function searchPlaces() {
+  var q = document.getElementById('placeSearch').value.trim();
+  var dropdown = document.getElementById('placeDropdown');
+  if (q.length < 2) { dropdown.textContent = ''; return; }
+  try {
+    var places = await safeFetch('/api/labels/search-places?q=' + encodeURIComponent(q), {}, { toast: false });
+    if (!places || places.length === 0) {
+      _setDropdownMessage('place-empty', 'No places found');
+      return;
+    }
+    dropdown.textContent = '';
+    places.slice(0, 8).forEach(function(p) {
+      var dn = p.display_name || p.name || '';
+      var opt = document.createElement('div');
+      opt.className = 'place-option';
+      opt.textContent = dn;
+      opt.addEventListener('click', function() { selectPlace(p.id, dn); });
+      dropdown.appendChild(opt);
+    });
+  } catch(e) {
+    _setDropdownMessage('place-error', 'Error: ' + (e.message || e));
+  }
+}
+
+function selectPlace(id, name) {
+  selectedPlaceId = parseInt(id);
+  selectedPlaceName = name;
+  document.getElementById('placeDropdown').textContent = '';
+  document.getElementById('placeSearch').value = name;
+  document.getElementById('placeSearch').style.borderColor = 'var(--accent)';
+  document.getElementById('fetchLabelsBtn').disabled = false;
+}
+
+async function fetchLabels() {
+  if (!selectedPlaceId) return;
+  var groups = [];
+  document.querySelectorAll('.taxon-cb:checked').forEach(function(cb) { groups.push(cb.value); });
+  var status = document.getElementById('labelsStatus');
+  if (groups.length === 0) {
+    status.style.color = 'var(--text-dim)';
+    status.textContent = 'Select at least one wildlife group.';
+    return;
+  }
+
+  var btn = document.getElementById('fetchLabelsBtn');
+  var progress = document.getElementById('labelsProgress');
+  var bar = document.getElementById('labelsBar');
+  btn.disabled = true;
+  status.style.color = 'var(--text-dim)';
+  status.textContent = 'Starting download…';
+
+  try {
+    var data = await safeFetch('/api/jobs/fetch-labels', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        place_id: selectedPlaceId,
+        place_name: selectedPlaceName,
+        taxon_groups: groups,
+        observation_filter: 'research',
+      }),
+    }, { toast: false });
+
+    if (!data || !data.job_id) {
+      status.textContent = 'Could not start the download. Please try again.';
+      btn.disabled = false;
+      return;
+    }
+
+    progress.style.display = 'block';
+    bar.style.width = '0%';
+    status.textContent = 'Fetching species…';
+
+    safeEventSource('/api/jobs/' + data.job_id + '/stream', {
+      onProgress: function(p) {
+        if (p.current_file) status.textContent = p.current_file;
+        if (p.total > 0 && p.current > 0) {
+          bar.style.width = Math.round((p.current / p.total) * 100) + '%';
+        }
+      },
+      onComplete: function(result) {
+        if (result.status === 'completed' && result.result) {
+          bar.style.width = '100%';
+          status.style.color = 'var(--accent)';
+          status.textContent = 'Done! ' + result.result.species_count +
+            ' species downloaded. Finishing setup…';
+          setTimeout(finishSetup, 800);
+        } else {
+          status.style.color = 'var(--danger)';
+          status.textContent = 'Failed: ' + ((result.errors || []).join(', ') || 'unknown error');
+          btn.disabled = false;
+        }
+      },
+      onError: function() {
+        status.style.color = 'var(--danger)';
+        status.textContent = 'Connection lost during download. Please try again.';
+        btn.disabled = false;
+      }
+    });
+  } catch(e) {
+    status.style.color = 'var(--danger)';
+    status.textContent = 'Error: ' + (e.message || e);
+    btn.disabled = false;
+  }
+}
+
+async function skipLabels() {
+  await finishSetup();
 }
 
 checkModelStatus().then(function() {

--- a/vireo/templates/welcome.html
+++ b/vireo/templates/welcome.html
@@ -258,6 +258,7 @@ if (typeof safeEventSource === 'undefined') {
 
 var MODEL_ID = 'bioclip-vit-b-16';
 var modelAlreadyDownloaded = false;
+var classificationReady = false;
 
 async function checkModelStatus() {
   try {
@@ -266,6 +267,7 @@ async function checkModelStatus() {
     if (match && match.downloaded) {
       modelAlreadyDownloaded = true;
     }
+    classificationReady = !!(data && data.classification && data.classification.labels_ready);
   } catch(e) {
     /* Ignore — we'll attempt the download when the user clicks */
   }
@@ -549,6 +551,13 @@ async function skipLabels() {
 }
 
 checkModelStatus().then(function() {
+  // Resume mid-onboarding: if the model is already on disk but classification
+  // isn't usable yet (no labels), jump straight to the labels step rather than
+  // making the user re-click "Get Started".
+  if (modelAlreadyDownloaded && !classificationReady) {
+    showLabelsStep();
+    return;
+  }
   document.getElementById('downloadBtn').disabled = false;
 });
 </script>

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -5,10 +5,12 @@ from wait import wait_for_job_via_client
 
 
 def test_index_redirects_to_browse(app_and_db, monkeypatch):
-    """GET / redirects to /browse when a model is available."""
+    """GET / redirects to /browse when classification is usable (a label-free
+    Tree-of-Life model needs no species list)."""
     import models
     monkeypatch.setattr(models, "get_active_model", lambda: {
-        "id": "test", "name": "Test", "downloaded": True
+        "id": "bioclip-2", "name": "BioCLIP-2", "downloaded": True,
+        "model_str": "hf-hub:imageomics/bioclip-2",
     })
     app, _ = app_and_db
     client = app.test_client()

--- a/vireo/tests/test_pipeline_plan.py
+++ b/vireo/tests/test_pipeline_plan.py
@@ -1035,6 +1035,49 @@ def test_classify_plan_blocked_when_no_detections_and_no_labels(tmp_path, monkey
     assert classify["detail"]["blocked_models"] == ["BioCLIP ViT-B-16"]
 
 
+def test_classify_plan_mixed_blocked_with_no_detections_emits_blocked(
+    tmp_path, monkeypatch,
+):
+    """Mixed scope, no detections cached yet: one label-free model can run,
+    another model is blocked on missing labels. The unblocked_count==0 guard
+    doesn't fire (one model is runnable), but classify_job iterates every
+    selected model and the blocked one will fail at _load_labels once
+    MegaDetector creates detections. The planner must emit "blocked" (gates
+    Start), not "will-run" — otherwise Start stays enabled, the user
+    launches, and the pipeline records the same missing-labels classify
+    failure this PR is meant to prevent.
+    """
+    from pipeline_plan import compute_plan
+    db, _ = _make_db(tmp_path)
+
+    import labels as labels_mod
+    import models as models_mod
+    monkeypatch.setattr(models_mod, "get_models", lambda: [
+        # Label-free TOL model — unblocked.
+        {"id": "m1", "name": "BioCLIP-2",
+         "model_str": "hf-hub:imageomics/bioclip-2",
+         "model_type": "bioclip", "downloaded": True},
+        # Label-needing model with no active labels — blocked.
+        {"id": "m2", "name": "BioCLIP ViT-B-16",
+         "model_str": "ViT-B-16",
+         "model_type": "bioclip", "downloaded": True},
+    ])
+    monkeypatch.setattr(labels_mod, "get_active_labels", lambda: [])
+    monkeypatch.setattr(labels_mod, "get_saved_labels", lambda: [])
+
+    plan = compute_plan(
+        db, _params(model_ids=["m1", "m2"]), str(tmp_path / "test.db"),
+    )
+    classify = plan["stages"]["Classify"]
+    assert classify["state"] == "blocked", (
+        "mixed scope with no detections + one blocked model must emit "
+        "'blocked', not slip through the total_dets==0 'will-run' branch"
+    )
+    assert classify["detail"]["blocked_models"] == ["BioCLIP ViT-B-16"]
+    assert classify["detail"]["pending"] == 0
+    assert classify["detail"]["eligible"] == 0
+
+
 def test_classify_plan_exposes_pending_and_eligible_mixed_blocked_and_done(
     tmp_path, monkeypatch,
 ):

--- a/vireo/tests/test_pipeline_plan.py
+++ b/vireo/tests/test_pipeline_plan.py
@@ -1069,7 +1069,11 @@ def test_classify_plan_exposes_pending_and_eligible_mixed_blocked_and_done(
         db, _params(model_ids=["m1", "m2"]), str(tmp_path / "test.db"),
     )
     classify = plan["stages"]["Classify"]
-    assert classify["state"] == "will-run"
+    assert classify["state"] == "blocked", (
+        "mixed blocked/done shape has no runnable work, so it must emit "
+        "'blocked' (gates Start) — not 'will-run', which left Start enabled "
+        "behind a 'Blocked' summary and reached the unlabeled model"
+    )
     assert "Blocked" in classify["summary"]
     detail = classify["detail"]
     assert detail["pending"] == 0

--- a/vireo/tests/test_pipeline_plan.py
+++ b/vireo/tests/test_pipeline_plan.py
@@ -1001,10 +1001,38 @@ def test_classify_plan_exposes_pending_and_eligible_blocked_only(tmp_path, monke
     monkeypatch.setattr(labels_mod, "get_saved_labels", lambda: [])
 
     plan = compute_plan(db, _params(model_ids=["m1"]), str(tmp_path / "test.db"))
-    detail = plan["stages"]["Classify"]["detail"]
+    classify = plan["stages"]["Classify"]
+    assert classify["state"] == "blocked"
+    assert classify["detail"]["blocked_models"] == ["SomeTimmModel"]
+    detail = classify["detail"]
     assert detail["eligible"] == 0  # no unblocked models
     assert detail["pending"] == 0
 
+
+def test_classify_plan_blocked_when_no_detections_and_no_labels(tmp_path, monkeypatch):
+    """Fresh install: a label-needing model with no labels and no detections
+    cached yet must report "blocked", not "will-run". This is the exact
+    first-run state that previously slipped through the total_dets==0
+    early-return and let the user launch a pipeline that crashes at classify.
+    """
+    from pipeline_plan import compute_plan
+    db, _ = _make_db(tmp_path)
+
+    import labels as labels_mod
+    import models as models_mod
+    monkeypatch.setattr(models_mod, "get_models", lambda: [
+        {"id": "m1", "name": "BioCLIP ViT-B-16",
+         "model_str": "ViT-B-16",
+         "model_type": "bioclip", "downloaded": True},
+    ])
+    monkeypatch.setattr(labels_mod, "get_active_labels", lambda: [])
+    monkeypatch.setattr(labels_mod, "get_saved_labels", lambda: [])
+
+    plan = compute_plan(db, _params(model_ids=["m1"]), str(tmp_path / "test.db"))
+    classify = plan["stages"]["Classify"]
+    assert classify["state"] == "blocked"
+    assert "Settings" in classify["summary"]
+    assert classify["detail"]["blocked_models"] == ["BioCLIP ViT-B-16"]
 
 
 def test_classify_plan_exposes_pending_and_eligible_mixed_blocked_and_done(

--- a/vireo/tests/test_pipeline_plan.py
+++ b/vireo/tests/test_pipeline_plan.py
@@ -1078,6 +1078,56 @@ def test_classify_plan_mixed_blocked_with_no_detections_emits_blocked(
     assert classify["detail"]["eligible"] == 0
 
 
+def test_classify_plan_mixed_blocked_with_pending_emits_blocked(
+    tmp_path, monkeypatch,
+):
+    """Mixed scope with cached detections: one unblocked model has pending
+    classify work AND another selected model is blocked on missing labels.
+    Previously the `blocked and not pending_total` guard skipped this case
+    (pending_total > 0 from the runnable model) and the planner fell through
+    to "will-run" with blocked_models only buried in detail. The Start gate
+    only disables `state === "blocked"`, so the user clicked Start, the
+    classify job iterated every selected resolved spec, and the blocked
+    model failed at _load_labels — the exact missing-labels failure this PR
+    is meant to prevent. Must emit "blocked" so Start stays disabled until
+    the user either adds labels or deselects the blocked model.
+    """
+    from pipeline_plan import compute_plan
+    db, folder_id = _make_db(tmp_path)
+    _add_photo_with_detection(db, folder_id, "a.jpg")
+
+    import labels as labels_mod
+    import models as models_mod
+    monkeypatch.setattr(models_mod, "get_models", lambda: [
+        # Label-free TOL model — unblocked, has pending work (no
+        # record_classifier_run was called for it, so the detection is
+        # uncached and pending_total > 0 for this model).
+        {"id": "m1", "name": "BioCLIP-2",
+         "model_str": "hf-hub:imageomics/bioclip-2",
+         "model_type": "bioclip", "downloaded": True},
+        # Label-needing model with no active labels — blocked.
+        {"id": "m2", "name": "BioCLIP ViT-B-16",
+         "model_str": "ViT-B-16",
+         "model_type": "bioclip", "downloaded": True},
+    ])
+    monkeypatch.setattr(labels_mod, "get_active_labels", lambda: [])
+    monkeypatch.setattr(labels_mod, "get_saved_labels", lambda: [])
+
+    plan = compute_plan(
+        db, _params(model_ids=["m1", "m2"]), str(tmp_path / "test.db"),
+    )
+    classify = plan["stages"]["Classify"]
+    assert classify["state"] == "blocked", (
+        "any blocked model in a mixed selection must emit 'blocked' (gates "
+        "Start) — falling through to 'will-run' when other models have "
+        "pending work let the missing-labels classify failure through on "
+        "launch"
+    )
+    assert classify["detail"]["blocked_models"] == ["BioCLIP ViT-B-16"]
+    assert classify["detail"]["pending"] == 0
+    assert classify["detail"]["eligible"] == 0
+
+
 def test_classify_plan_exposes_pending_and_eligible_mixed_blocked_and_done(
     tmp_path, monkeypatch,
 ):

--- a/vireo/tests/test_welcome.py
+++ b/vireo/tests/test_welcome.py
@@ -74,7 +74,6 @@ def test_models_status_label_model_without_labels_needs_setup(app_and_db, monkey
 
 def test_models_status_label_model_with_labels_ready(app_and_db, monkeypatch, tmp_path):
     """A label-needing model becomes ready once an active species list exists."""
-    import labels
     import models
     monkeypatch.setattr(models, "get_active_model", lambda: {
         "id": "bioclip-vit-b-16", "name": "BioCLIP", "downloaded": True,

--- a/vireo/tests/test_welcome.py
+++ b/vireo/tests/test_welcome.py
@@ -49,6 +49,25 @@ def test_models_status_tol_model_ready_without_labels(app_and_db, monkeypatch):
     assert data["classification"]["model_name"] == "BioCLIP-2"
 
 
+def test_models_status_timm_model_ready_without_labels(app_and_db, monkeypatch):
+    """A timm classifier (e.g. iNat21) has a fixed intrinsic class head and
+    runs without a species list, matching the planner / classify_job, which
+    never block model_type == "timm". It must report ready with no labels."""
+    import models
+    monkeypatch.setattr(models, "get_active_model", lambda: {
+        "id": "inat21", "name": "iNat21", "downloaded": True,
+        "model_str": "hf-hub:timm/something", "model_type": "timm",
+    })
+
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.get("/api/models/status")
+    data = resp.get_json()
+    assert data["needs_setup"] is False
+    assert data["classification"]["ready"] is True
+    assert data["classification"]["labels_ready"] is True
+
+
 def test_models_status_label_model_without_labels_needs_setup(app_and_db, monkeypatch):
     """The default ViT-B-16 model needs a species list to classify. Downloaded
     but with no labels, it is NOT ready — this is the fresh-install state that
@@ -105,10 +124,12 @@ def test_index_redirects_to_welcome_when_no_model(app_and_db, monkeypatch):
 
 
 def test_index_redirects_to_browse_when_model_ready(app_and_db, monkeypatch):
-    """GET / redirects to /browse when a classification model is downloaded."""
+    """GET / redirects to /browse when classification is usable (label-free
+    Tree-of-Life model, so no species list needed)."""
     import models
     monkeypatch.setattr(models, "get_active_model", lambda: {
-        "id": "bioclip-vit-b-16", "name": "BioCLIP", "downloaded": True
+        "id": "bioclip-2", "name": "BioCLIP-2", "downloaded": True,
+        "model_str": "hf-hub:imageomics/bioclip-2",
     })
 
     app, _ = app_and_db
@@ -116,6 +137,26 @@ def test_index_redirects_to_browse_when_model_ready(app_and_db, monkeypatch):
     resp = client.get("/")
     assert resp.status_code == 302
     assert "/browse" in resp.headers["Location"]
+
+
+def test_index_resumes_welcome_when_model_downloaded_but_no_labels(app_and_db, monkeypatch):
+    """A user who downloaded the model but bailed before the labels step
+    (setup_complete still false) must be sent back to /welcome to finish —
+    not stranded in /browse with a pipeline that can't classify."""
+    import labels
+    import models
+    monkeypatch.setattr(models, "get_active_model", lambda: {
+        "id": "bioclip-vit-b-16", "name": "BioCLIP", "downloaded": True,
+        "model_str": "ViT-B-16",
+    })
+    monkeypatch.setattr(labels, "get_active_labels", lambda: [])
+
+    app, db = app_and_db
+    db.set_workspace_active_labels([])
+    client = app.test_client()
+    resp = client.get("/")
+    assert resp.status_code == 302
+    assert "/welcome" in resp.headers["Location"]
 
 
 def test_welcome_page_renders(app_and_db):
@@ -128,10 +169,12 @@ def test_welcome_page_renders(app_and_db):
 
 
 def test_welcome_page_redirects_when_setup_done(app_and_db, monkeypatch):
-    """GET /welcome without ?force redirects to /browse if models are ready."""
+    """GET /welcome without ?force redirects to /browse if classification is
+    usable (label-free Tree-of-Life model)."""
     import models
     monkeypatch.setattr(models, "get_active_model", lambda: {
-        "id": "bioclip-vit-b-16", "name": "BioCLIP", "downloaded": True
+        "id": "bioclip-2", "name": "BioCLIP-2", "downloaded": True,
+        "model_str": "hf-hub:imageomics/bioclip-2",
     })
 
     app, _ = app_and_db

--- a/vireo/tests/test_welcome.py
+++ b/vireo/tests/test_welcome.py
@@ -111,6 +111,27 @@ def test_models_status_label_model_with_labels_ready(app_and_db, monkeypatch, tm
     assert data["classification"]["labels_ready"] is True
 
 
+def test_models_status_empty_label_file_not_ready(app_and_db, monkeypatch, tmp_path):
+    """An active-but-empty label file must NOT report ready: classify loads
+    and merges the files and treats an empty merged list as no labels, so
+    reporting ready here would redirect to /browse and then fail at classify."""
+    import models
+    monkeypatch.setattr(models, "get_active_model", lambda: {
+        "id": "bioclip-vit-b-16", "name": "BioCLIP", "downloaded": True,
+        "model_str": "ViT-B-16",
+    })
+    empty_file = tmp_path / "empty.txt"
+    empty_file.write_text("\n  \n")  # whitespace only — no species
+
+    app, db = app_and_db
+    db.set_workspace_active_labels([str(empty_file)])
+    client = app.test_client()
+    resp = client.get("/api/models/status")
+    data = resp.get_json()
+    assert data["needs_setup"] is True
+    assert data["classification"]["labels_ready"] is False
+
+
 def test_index_redirects_to_welcome_when_no_model(app_and_db, monkeypatch):
     """GET / redirects to /welcome when no classification model is available."""
     import models

--- a/vireo/tests/test_welcome.py
+++ b/vireo/tests/test_welcome.py
@@ -30,11 +30,13 @@ def test_models_status_no_models_needs_setup(app_and_db, monkeypatch):
     assert data["classification"]["ready"] is False
 
 
-def test_models_status_with_model_ready(app_and_db, monkeypatch):
-    """When a classification model is downloaded, needs_setup is False."""
+def test_models_status_tol_model_ready_without_labels(app_and_db, monkeypatch):
+    """A downloaded Tree-of-Life model classifies label-free, so it's ready
+    even with no species list."""
     import models
     monkeypatch.setattr(models, "get_active_model", lambda: {
-        "id": "bioclip-vit-b-16", "name": "BioCLIP", "downloaded": True
+        "id": "bioclip-2", "name": "BioCLIP-2", "downloaded": True,
+        "model_str": "hf-hub:imageomics/bioclip-2",
     })
 
     app, _ = app_and_db
@@ -43,7 +45,52 @@ def test_models_status_with_model_ready(app_and_db, monkeypatch):
     data = resp.get_json()
     assert data["needs_setup"] is False
     assert data["classification"]["ready"] is True
-    assert data["classification"]["model_name"] == "BioCLIP"
+    assert data["classification"]["labels_ready"] is True
+    assert data["classification"]["model_name"] == "BioCLIP-2"
+
+
+def test_models_status_label_model_without_labels_needs_setup(app_and_db, monkeypatch):
+    """The default ViT-B-16 model needs a species list to classify. Downloaded
+    but with no labels, it is NOT ready — this is the fresh-install state that
+    previously reported ready and then failed mid-pipeline."""
+    import labels
+    import models
+    monkeypatch.setattr(models, "get_active_model", lambda: {
+        "id": "bioclip-vit-b-16", "name": "BioCLIP", "downloaded": True,
+        "model_str": "ViT-B-16",
+    })
+    monkeypatch.setattr(labels, "get_active_labels", lambda: [])
+
+    app, db = app_and_db
+    db.set_workspace_active_labels([])  # no active labels for the workspace
+    client = app.test_client()
+    resp = client.get("/api/models/status")
+    data = resp.get_json()
+    assert data["needs_setup"] is True
+    assert data["classification"]["ready"] is False
+    assert data["classification"]["model_ready"] is True
+    assert data["classification"]["labels_ready"] is False
+
+
+def test_models_status_label_model_with_labels_ready(app_and_db, monkeypatch, tmp_path):
+    """A label-needing model becomes ready once an active species list exists."""
+    import labels
+    import models
+    monkeypatch.setattr(models, "get_active_model", lambda: {
+        "id": "bioclip-vit-b-16", "name": "BioCLIP", "downloaded": True,
+        "model_str": "ViT-B-16",
+    })
+    labels_file = tmp_path / "region.txt"
+    labels_file.write_text("Cardinalis cardinalis\n")
+
+    app, db = app_and_db
+    db.set_workspace_active_labels([str(labels_file)])
+    client = app.test_client()
+    resp = client.get("/api/models/status")
+    data = resp.get_json()
+    assert data["needs_setup"] is False
+    assert data["classification"]["ready"] is True
+    assert data["classification"]["labels_ready"] is True
 
 
 def test_index_redirects_to_welcome_when_no_model(app_and_db, monkeypatch):


### PR DESCRIPTION
A fresh install downloads the default BioCLIP ViT-B-16 model but no species list, so classification is unusable and the pipeline crashes at the classify stage with "No labels available". This fixes it three ways: onboarding (`welcome.html`) now adds a "Choose your region" step that downloads a species list and sets it active before finishing setup; `/api/models/status` is now label-aware so `needs_setup`/`ready` reflect whether the install can actually classify (Tree-of-Life model or active labels) rather than just whether a model is on disk; and the pipeline plan returns a real `blocked` state — covering the fresh-install no-detections case that previously slipped through as "will-run" — so the pipeline page shows a "Needs labels" pill, disables Start, and points the user at Settings › Labels. Added tests for the blocked plan states and the label-aware readiness cases, and updated the one test that encoded the old "model-on-disk = ready" behavior. Full required suite passes (1297 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Setup now includes a dedicated onboarding step to select a region and wildlife groups, then download the region-specific species/label data (with an option to skip for now).
  * The pipeline Classify stage can enter a **blocked** state with a “Needs labels” message, and Start/Queue is temporarily disabled while the plan is refreshing.
* **Bug Fixes**
  * Model usability and routing now correctly reflect both model download status and label/species list readiness, ensuring blocked Classify plans are surfaced consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->