### PR TITLE
Surface pipeline failures in a prominent error banner

### DIFF
--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1119,6 +1119,11 @@ body { padding-bottom: 36px; }
     <span id="modelWarningText"></span>
     <button onclick="this.parentElement.style.display='none'" style="float:right;background:none;border:none;cursor:pointer;font-size:16px;line-height:1;padding:0 4px;">&times;</button>
   </div>
+  <div id="pipelineErrorBanner" data-testid="pipeline-error-banner" style="display:none;background:var(--danger,#e5484d);color:#fff;padding:10px 14px;border-radius:6px;margin:8px 0;font-size:13px;">
+    <button onclick="this.parentElement.style.display='none'" style="float:right;background:none;border:none;color:#fff;cursor:pointer;font-size:16px;line-height:1;padding:0 4px;">&times;</button>
+    <strong>Pipeline failed</strong>
+    <div id="pipelineErrorText" style="margin-top:4px;white-space:pre-line;"></div>
+  </div>
 </div><!-- end pipeline-left -->
 
 <div class="pipeline-right">
@@ -2452,6 +2457,8 @@ async function startPipeline() {
   _pipelineCancelling = false;
   _currentPipelineJobId = null;
   document.getElementById('modelWarningBanner').style.display = 'none';
+  var _prevErrBanner = document.getElementById('pipelineErrorBanner');
+  if (_prevErrBanner) _prevErrBanner.style.display = 'none';
 
   // Create new workspace if requested
   if (_destWorkspaceMode === 'new') {
@@ -2885,6 +2892,22 @@ function _updatePipelineStageUI(p) {
   }
 }
 
+// Strip the internal "[stage] Fatal:" prefix so the banner reads as a plain,
+// actionable sentence (the stage is already conveyed by the failed card pill).
+function _humanizePipelineError(msg) {
+  return String(msg).replace(/^\[\w+\]\s*/, '').replace(/^Fatal:\s*/i, '');
+}
+
+// Show a prominent, dismissible error banner with the full failure message(s).
+function _showPipelineError(messages) {
+  var banner = document.getElementById('pipelineErrorBanner');
+  var text = document.getElementById('pipelineErrorText');
+  if (!banner || !text) return;
+  text.textContent = messages.join('\n');
+  banner.style.display = '';
+  banner.scrollIntoView({behavior: 'smooth', block: 'nearest'});
+}
+
 function _onPipelineComplete(result) {
   if (result.status === 'cancelled') {
     var actionStatus = document.getElementById('pipelineActionStatus');
@@ -3021,6 +3044,7 @@ function _onPipelineComplete(result) {
       var stage = match ? match[1] : 'unknown';
       errorStages[stage] = err;
     });
+    var firstFailedCard = null;
     for (var stage in errorStages) {
       var cardSuffix = _stageToCard[stage];
       if (cardSuffix) {
@@ -3029,7 +3053,19 @@ function _onPipelineComplete(result) {
         delete _runningStages[cardSuffix];
         _stageOutcomes[cardSuffix] = 'failed';
         _setPill(cardSuffix, 'failed');
+        if (!firstFailedCard) firstFailedCard = cardSuffix;
       }
+    }
+    // The per-card status span is easy to miss (and invisible when the card
+    // is collapsed), and errors whose stage has no card aren't shown at all.
+    // Surface the full, actionable message in a top-level banner and open the
+    // failed card so the user actually sees why the run stopped.
+    _showPipelineError(Object.keys(errorStages).map(function(s) {
+      return _humanizePipelineError(errorStages[s]);
+    }));
+    if (firstFailedCard) {
+      var failedCardEl = document.getElementById('card-' + firstFailedCard.toLowerCase());
+      if (failedCardEl) failedCardEl.classList.add('expanded');
     }
   }
 


### PR DESCRIPTION
## What

When a Vireo pipeline run fails (e.g. the `model_loader` stage aborts because no species labels are available for the selected model), the user got **no visible error message** — even though the backend produces a clear, actionable one.

### Why the message was invisible

The backend already does the right thing: the fatal message is captured (`pipeline_job.py`), attached to the failed job, and streamed to the browser in the `complete` SSE event. The gap was entirely in `pipeline.html` rendering:

- On failure, `_onPipelineComplete` only wrote `"Failed: …"` into the relevant stage card's small `#status<Card>` sub-text span and flipped the pill to "failed".
- Only the **Source** card is auto-expanded at run start, so the Classify card's status text was hidden inside a collapsed card.
- Errors whose stage had no card mapping were dropped entirely.
- On page reload, nothing showed at all.

This violates the project's "show the user what's happening / no black boxes" rule (`CORE_PHILOSOPHY.md`).

## Change

- Add a dedicated, dismissible **error banner** (`#pipelineErrorBanner`) at the top of the pipeline page.
- On any run failure, show the full humanized message(s) in the banner (stripping the internal `[stage] Fatal:` prefix), scroll it into view, and **auto-expand the first failed stage card** so its inline status is visible too.
- Clear the banner at the start of each run.
- The existing per-card pill/status behavior is preserved.

The shared yellow `#modelWarningBanner` (keyed by `dataset.kind` for model / sam-variant warnings) is intentionally left alone — a fatal error gets its own red banner so the two don't collide.

## Testing

- `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py -q` → **1162 passed, 1 skipped**.
- Change is frontend template JS (no Python behavior change); the suite confirms nothing else broke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)