### PR TITLE
ci: cap Linux test xdist workers at 2 to stop OOM runner cancellations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -179,9 +179,16 @@ jobs:
         run: pip install -e .
 
       # Linux is the canonical full run and enforces the coverage threshold.
+      # Cap xdist workers at 2 for the same reason as macOS/Windows below: with
+      # ``-n auto`` (one worker per core) several heavy ML/pipeline tests can
+      # load models on parallel workers at once, spike memory, and trip the
+      # Linux OOM killer — which takes out the runner agent and surfaces as an
+      # intermittent ``The runner has received a shutdown signal`` cancellation
+      # rather than a test failure. ``-n 2`` halves peak memory; the canonical
+      # run is a few minutes slower but well under the 60-minute job timeout.
       - name: Run tests with coverage (Linux)
         if: needs.changes.outputs.python == 'true' && runner.os == 'Linux'
-        run: python -m pytest tests/ vireo/tests/ -n auto -v --tb=short --cov=vireo --cov-report=term-missing --cov-fail-under=40
+        run: python -m pytest tests/ vireo/tests/ -n 2 -v --tb=short --cov=vireo --cov-report=term-missing --cov-fail-under=40
 
       # macOS/Windows verify platform-specific code paths. The coverage gate is
       # skipped here because POSIX-only tests don't run on Windows, which would


### PR DESCRIPTION
## Problem

The `test-os (ubuntu-latest)` leg intermittently fails — not with a test failure, but with:

```
##[error]The runner has received a shutdown signal. This can happen when the
runner service is stopped, or a manually started runner is canceled.
##[error]The operation was canceled.
```

Observed three times in a short window, **across multiple branches** (e.g. `debug-vireo-pipeline-start` and `davis`), each time while running the heavy model-loading pipeline tests — two of them on the *exact same test*, `test_pipeline_loader_failure_marks_classify_rows_failed_not_skipped`. Never on macOS/Windows.

## Root cause

`test.yml` runs the Linux leg with `-n auto` (one xdist worker per core → 4 on `ubuntu-latest`), while macOS/Windows are already capped at `-n 2` with a comment stating that cap exists *"to avoid OOM worker crashes on the heavier ML tests."*

Linux was left uncapped. When several model-loading tests land on parallel workers at the same moment, peak memory spikes and the Linux OOM killer takes out the **runner agent** — which the Actions runner reports as a "shutdown signal" cancellation rather than a normal test failure. It's timing-dependent, which is why ubuntu passes most of the time but flakes intermittently.

## Fix

Cap the Linux leg at `-n 2`, matching macOS/Windows.

- Coverage is unaffected — worker count doesn't change which tests run, and the `--cov-fail-under=40` gate stays on the Linux leg.
- The canonical run is a few minutes slower (~4.5 min → ~8–9 min) but far under the `timeout-minutes: 60` job limit.

## Testing

No application code changed — this is a CI parallelism/memory tuning change. Validation is the green `test-os (ubuntu-latest)` leg on this PR (and the absence of further shutdown-signal cancellations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized test parallelization configuration to improve testing stability and prevent infrastructure issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->