### PR TITLE
Add Move page to command palette (cmd+K)

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -79,6 +79,7 @@ ALL_PAGES = [
     {"id": "variants",        "label": "Variants",        "href": "/variants"},
     {"id": "dashboard",       "label": "Dashboard",       "href": "/dashboard"},
     {"id": "audit",           "label": "Audit",           "href": "/audit"},
+    {"id": "move",            "label": "Move",            "href": "/move"},
     {"id": "compare",         "label": "Compare",         "href": "/compare"},
     {"id": "zoom_test",       "label": "Zoom Test",       "href": "/zoom-test"},
     {"id": "settings",        "label": "Settings",        "href": "/settings"},

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -194,7 +194,7 @@ NO_LOCATION_INFORMATION_RULES = {
 ALL_NAV_IDS = frozenset({
     "pipeline", "jobs", "pipeline_review", "pipeline_rapid_review", "review", "cull",
     "misses", "highlights", "life_list", "browse", "map", "variants",
-    "dashboard", "audit", "compare",
+    "dashboard", "audit", "move", "compare",
     "zoom_test", "settings", "workspace", "lightroom", "shortcuts",
     "keywords", "duplicates", "logs",
 })

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -2191,6 +2191,7 @@ window.NAV_ALL_PAGES = [
   {id: 'variants',        label: 'Variants',        href: '/variants'},
   {id: 'dashboard',       label: 'Dashboard',       href: '/dashboard'},
   {id: 'audit',           label: 'Audit',           href: '/audit'},
+  {id: 'move',            label: 'Move',            href: '/move'},
   {id: 'compare',         label: 'Compare',         href: '/compare'},
   {id: 'zoom_test',       label: 'Zoom Test',       href: '/zoom-test'},
   {id: 'settings',        label: 'Settings',        href: '/settings'},


### PR DESCRIPTION
## What

The Move page is fully built and served at `/move`, but it was unreachable from the UI — it was missing from the command palette's page list, and no navbar tab or link pointed to it. The only way to open it was typing the URL by hand.

This adds a **Move** entry so `⌘K` → type "move" → Enter jumps to the page, and it pins like any other tab.

## Changes

- `vireo/app.py` — add `Move` to server `ALL_PAGES` (the palette's source list).
- `vireo/templates/_navbar.html` — add `Move` to the client `NAV_ALL_PAGES` fallback list.
- `vireo/db.py` — add `"move"` to `ALL_NAV_IDS` so it's a valid/pinnable tab id (required by `test_all_registered_pages_are_valid_tab_ids`).

`currentNavId()` already maps `/move` → `move`, so the page highlights correctly when active.

## Why it slipped through

The existing guard test only checks that palette entries map to valid nav ids — not the reverse (that every page route *has* a palette entry), which is the gap that hid `/move`. A clean reverse-guard is awkward (not every Flask route is a nav page), so it's left out here to keep scope tight.

## Tests

`python -m pytest tests/test_workspaces.py vireo/tests/test_tabs_api.py vireo/tests/test_app.py -q` → **334 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The "Move" page is now accessible and visible in the main navigation tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->