### PR TITLE
Skip macOS other-app data bundles (.photoslibrary) when scanning photo folders

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -15489,12 +15489,32 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # folders. Rejecting on stale placeholder paths would falsely 400 an
         # otherwise-valid snapshot-backed run.
         if source_snapshot_id is None:
+            from image_loader import is_excluded_scan_path
+
+            # Reject other-app data bundles (Apple Photos / Aperture / Photo
+            # Booth) before any stat: ``os.path.isdir`` on a ``.photoslibrary``
+            # path — or a symlink to one — itself trips the macOS
+            # "access data from other apps" TCC prompt, defeating the guards
+            # inside scan()/discover_source_files() that run_pipeline_job will
+            # eventually call. Mirror the same pre-stat rejection here so a
+            # saved or user-typed pipeline source can't reach isdir first.
             if sources:
                 for s in sources:
+                    if is_excluded_scan_path(s):
+                        return json_error(
+                            f"source is inside a macOS app-managed library "
+                            f"and cannot be scanned: {s}"
+                        )
                     if not os.path.isdir(s):
                         return json_error(f"source directory not found: {s}")
-            elif source and not os.path.isdir(source):
-                return json_error(f"source directory not found: {source}")
+            elif source:
+                if is_excluded_scan_path(source):
+                    return json_error(
+                        f"source is inside a macOS app-managed library and "
+                        f"cannot be scanned: {source}"
+                    )
+                if not os.path.isdir(source):
+                    return json_error(f"source directory not found: {source}")
 
         destination = body.get("destination")
         # Copy-ingest ("destination") is incompatible with snapshot runs:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -12087,7 +12087,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 return json_error("root path required")
             roots_list = [root]
 
+        from image_loader import is_excluded_scan_path
+
         for r in roots_list:
+            # Reject other-app data bundles (Apple Photos / Aperture / Photo
+            # Booth) before any stat: ``os.path.isdir`` on a ``.photoslibrary``
+            # path — or a symlink to one — itself trips the macOS
+            # "access data from other apps" TCC prompt, defeating the guards
+            # inside scan().
+            if is_excluded_scan_path(r):
+                return json_error(
+                    f"path is inside a macOS app-managed library and cannot "
+                    f"be scanned: {r}"
+                )
             if not os.path.isdir(r):
                 return json_error(f"directory not found: {r}")
 
@@ -12159,6 +12171,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not linked:
             return json_error("folder not found", 404)
         root = folder["path"]
+        from image_loader import is_excluded_scan_path
+        # See api_job_scan for why this must run before os.path.isdir.
+        if is_excluded_scan_path(root):
+            return json_error(
+                f"folder is inside a macOS app-managed library and cannot "
+                f"be scanned: {root}"
+            )
         if not os.path.isdir(root):
             return json_error(f"folder path no longer exists: {root}")
         runner = app._job_runner
@@ -12807,6 +12826,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         if not source or not destination:
             return json_error("source and destination are required")
+        from image_loader import is_excluded_scan_path
+        # See api_job_scan for why this must run before os.path.isdir.
+        if is_excluded_scan_path(source):
+            return json_error(
+                f"source is inside a macOS app-managed library and cannot "
+                f"be imported: {source}"
+            )
         if not os.path.isdir(source):
             return json_error(f"source directory not found: {source}")
         if not os.path.isabs(destination):
@@ -13380,6 +13406,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         if not source:
             return json_error("source is required")
+        from image_loader import is_excluded_scan_path
+        # See api_job_scan for why this must run before os.path.isdir.
+        if is_excluded_scan_path(source):
+            return json_error(
+                f"source is inside a macOS app-managed library and cannot "
+                f"be imported: {source}"
+            )
         if not os.path.isdir(source):
             return json_error(f"source directory not found: {source}")
         if copy:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -9933,7 +9933,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     @app.route("/api/browse", methods=["GET"])
     def api_browse():
         """List subdirectories at a given path for folder browser."""
+        from image_loader import is_excluded_scan_path
         path = request.args.get("path", os.path.expanduser("~"))
+        # Reject macOS app-managed library bundles before any stat:
+        # ``os.path.isdir`` on a ``.photoslibrary`` path — or a symlink to one
+        # — itself trips the "access data from other apps" TCC prompt, and the
+        # folder picker hits this listing endpoint before posting children to
+        # ``/api/browse/photo-counts``, so the per-child guard there is too
+        # late on its own.
+        if is_excluded_scan_path(path):
+            return json_error("path is not a valid directory")
         if not os.path.isdir(path):
             return json_error("path is not a valid directory")
         dirs = []
@@ -9942,6 +9951,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 if name.startswith("."):
                     continue
                 full = os.path.join(path, name)
+                # Skip excluded bundles (and symlinks resolving to them)
+                # before ``os.path.isdir`` would stat them.
+                if is_excluded_scan_path(full):
+                    continue
                 if os.path.isdir(full):
                     dirs.append({"name": name, "path": full})
         except PermissionError:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -9962,6 +9962,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not isinstance(paths, list):
             return json_error("paths must be a list", 400)
 
+        from image_loader import is_excluded_scan_path
         from ingest import discover_source_files
 
         ft = file_types if file_types else "both"
@@ -9970,6 +9971,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # Non-string entries (dicts, lists, numbers) can't be dict keys
             # and aren't valid paths — skip them rather than 500.
             if not isinstance(p, str):
+                continue
+            # Reject macOS app-managed library bundles before any stat:
+            # ``os.path.isdir`` on a ``.photoslibrary`` path — or a symlink to
+            # one — itself trips the "access data from other apps" TCC prompt,
+            # and the folder browser sends every child of ``~/Pictures`` here
+            # the moment the picker opens.
+            if is_excluded_scan_path(p):
+                counts[p] = 0
                 continue
             if not os.path.isdir(p):
                 counts[p] = 0

--- a/vireo/audit.py
+++ b/vireo/audit.py
@@ -158,6 +158,14 @@ def check_untracked(db, root_paths):
                 full = os.path.join(dirpath, name)
                 if full in known_paths:
                     continue
+                # os.walk lists dangling symlinks (and other non-regular
+                # entries) in `filenames`; the prior Path.rglob path gated on
+                # f.is_file(). scanner.scan skips non-files via os.path.isfile,
+                # so flagging one here would raise an untracked-image warning a
+                # rescan can never clear. os.path.isfile follows symlinks and
+                # returns False (not raise) for dangling targets.
+                if not os.path.isfile(full):
+                    continue
                 untracked.append({"path": full, "folder": dirpath})
 
     log.info("Untracked check: %d untracked files found", len(untracked))

--- a/vireo/audit.py
+++ b/vireo/audit.py
@@ -3,9 +3,8 @@ and silent file corruption (bit rot)."""
 
 import logging
 import os
-from pathlib import Path
 
-from image_loader import SUPPORTED_EXTENSIONS
+from image_loader import SUPPORTED_EXTENSIONS, prune_scan_dirs
 from xmp import read_keywords
 
 log = logging.getLogger(__name__)
@@ -146,22 +145,20 @@ def check_untracked(db, root_paths):
 
     untracked = []
     for root in root_paths:
-        root_path = Path(root)
-        if not root_path.is_dir():
+        if not os.path.isdir(root):
             continue
-        for f in root_path.rglob("*"):
-            if (
-                f.is_file()
-                and f.suffix.lower() in SUPPORTED_EXTENSIONS
-                and not f.name.startswith(".")
-                and str(f) not in known_paths
-            ):
-                untracked.append(
-                    {
-                        "path": str(f),
-                        "folder": str(f.parent),
-                    }
-                )
+        # os.walk (not Path.rglob) so we can prune other-app data bundles
+        # (e.g. "Photos Library.photoslibrary") in place — rglob offers no way
+        # to stop descending and would walk the whole Photos library.
+        for dirpath, dirnames, filenames in os.walk(root):
+            prune_scan_dirs(dirnames)
+            for name in filenames:
+                if name.startswith(".") or os.path.splitext(name)[1].lower() not in SUPPORTED_EXTENSIONS:
+                    continue
+                full = os.path.join(dirpath, name)
+                if full in known_paths:
+                    continue
+                untracked.append({"path": full, "folder": dirpath})
 
     log.info("Untracked check: %d untracked files found", len(untracked))
     return untracked
@@ -183,7 +180,8 @@ def check_stray_sidecars(root_paths):
     for root in root_paths:
         if not os.path.isdir(root):
             continue
-        for dirpath, _dirnames, filenames in os.walk(root):
+        for dirpath, dirnames, filenames in os.walk(root):
+            prune_scan_dirs(dirnames)
             image_names = set()
             xmps = []
             for name in filenames:

--- a/vireo/audit.py
+++ b/vireo/audit.py
@@ -149,14 +149,17 @@ def check_untracked(db, root_paths):
 
     untracked = []
     for root in root_paths:
-        if not os.path.isdir(root):
-            continue
         # prune_scan_dirs filters only children; if the root is, or sits
         # inside, an excluded bundle (e.g. a stale folder row pointing at
         # ``.../Photos Library.photoslibrary/originals``), os.walk would
         # still open it. Reject the whole subtree before we touch it so
-        # the audit can't trip the macOS TCC prompt either.
+        # the audit can't trip the macOS TCC prompt either. This must run
+        # BEFORE ``os.path.isdir`` — isdir follows symlinks and stat's the
+        # target, so for a directly selected bundle (or a symlink to one)
+        # the existence test alone is enough to trip TCC.
         if is_excluded_scan_path(root):
+            continue
+        if not os.path.isdir(root):
             continue
         # os.walk (not Path.rglob) so we can prune other-app data bundles
         # (e.g. "Photos Library.photoslibrary") in place — rglob offers no way
@@ -197,9 +200,12 @@ def check_stray_sidecars(root_paths):
     """
     strays = []
     for root in root_paths:
-        if not os.path.isdir(root):
-            continue
+        # Reject excluded bundles before ``os.path.isdir`` — isdir follows
+        # symlinks and stat's the target, which is enough to trip the macOS
+        # TCC prompt for a directly selected bundle or a symlink to one.
         if is_excluded_scan_path(root):
+            continue
+        if not os.path.isdir(root):
             continue
         for dirpath, dirnames, filenames in os.walk(root):
             prune_scan_dirs(dirnames)

--- a/vireo/audit.py
+++ b/vireo/audit.py
@@ -6,7 +6,7 @@ import os
 
 from image_loader import (
     SUPPORTED_EXTENSIONS,
-    is_excluded_scan_dir,
+    is_excluded_scan_path,
     prune_scan_dirs,
 )
 from xmp import read_keywords
@@ -151,10 +151,12 @@ def check_untracked(db, root_paths):
     for root in root_paths:
         if not os.path.isdir(root):
             continue
-        # prune_scan_dirs filters only children; if the root itself is the
-        # excluded bundle, os.walk would still open it. Skip the root before
-        # we touch it so the audit can't trip the macOS TCC prompt either.
-        if is_excluded_scan_dir(os.path.basename(os.path.normpath(root))):
+        # prune_scan_dirs filters only children; if the root is, or sits
+        # inside, an excluded bundle (e.g. a stale folder row pointing at
+        # ``.../Photos Library.photoslibrary/originals``), os.walk would
+        # still open it. Reject the whole subtree before we touch it so
+        # the audit can't trip the macOS TCC prompt either.
+        if is_excluded_scan_path(root):
             continue
         # os.walk (not Path.rglob) so we can prune other-app data bundles
         # (e.g. "Photos Library.photoslibrary") in place — rglob offers no way
@@ -197,7 +199,7 @@ def check_stray_sidecars(root_paths):
     for root in root_paths:
         if not os.path.isdir(root):
             continue
-        if is_excluded_scan_dir(os.path.basename(os.path.normpath(root))):
+        if is_excluded_scan_path(root):
             continue
         for dirpath, dirnames, filenames in os.walk(root):
             prune_scan_dirs(dirnames)

--- a/vireo/audit.py
+++ b/vireo/audit.py
@@ -4,7 +4,11 @@ and silent file corruption (bit rot)."""
 import logging
 import os
 
-from image_loader import SUPPORTED_EXTENSIONS, prune_scan_dirs
+from image_loader import (
+    SUPPORTED_EXTENSIONS,
+    is_excluded_scan_dir,
+    prune_scan_dirs,
+)
 from xmp import read_keywords
 
 log = logging.getLogger(__name__)
@@ -147,6 +151,11 @@ def check_untracked(db, root_paths):
     for root in root_paths:
         if not os.path.isdir(root):
             continue
+        # prune_scan_dirs filters only children; if the root itself is the
+        # excluded bundle, os.walk would still open it. Skip the root before
+        # we touch it so the audit can't trip the macOS TCC prompt either.
+        if is_excluded_scan_dir(os.path.basename(os.path.normpath(root))):
+            continue
         # os.walk (not Path.rglob) so we can prune other-app data bundles
         # (e.g. "Photos Library.photoslibrary") in place — rglob offers no way
         # to stop descending and would walk the whole Photos library.
@@ -187,6 +196,8 @@ def check_stray_sidecars(root_paths):
     strays = []
     for root in root_paths:
         if not os.path.isdir(root):
+            continue
+        if is_excluded_scan_dir(os.path.basename(os.path.normpath(root))):
             continue
         for dirpath, dirnames, filenames in os.walk(root):
             prune_scan_dirs(dirnames)

--- a/vireo/audit.py
+++ b/vireo/audit.py
@@ -217,6 +217,15 @@ def check_stray_sidecars(root_paths):
             for name in filenames:
                 if name.startswith("."):
                     continue
+                # safe_scan_walk classifies entries with follow_symlinks=False,
+                # so a symlink to a directory named like an image/sidecar (e.g.
+                # ``Albums/ghost.xmp -> RealAlbum``) lands in ``filenames``
+                # instead of ``dirnames``. Without this guard the loop would
+                # treat the link as a real sidecar or image — bogus stray
+                # reports plus a delete that would unlink a real directory.
+                # Matches the os.path.isfile guard in check_untracked_files.
+                if not os.path.isfile(os.path.join(dirpath, name)):
+                    continue
                 stem, ext = os.path.splitext(name)
                 if ext.lower() == ".xmp":
                     xmps.append(name)

--- a/vireo/audit.py
+++ b/vireo/audit.py
@@ -7,7 +7,7 @@ import os
 from image_loader import (
     SUPPORTED_EXTENSIONS,
     is_excluded_scan_path,
-    prune_scan_dirs,
+    safe_scan_walk,
 )
 from xmp import read_keywords
 
@@ -161,23 +161,25 @@ def check_untracked(db, root_paths):
             continue
         if not os.path.isdir(root):
             continue
-        # os.walk (not Path.rglob) so we can prune other-app data bundles
-        # (e.g. "Photos Library.photoslibrary") in place — rglob offers no way
-        # to stop descending and would walk the whole Photos library.
-        for dirpath, dirnames, filenames in os.walk(root):
-            prune_scan_dirs(dirnames)
+        # safe_scan_walk replaces os.walk + prune_scan_dirs so we never
+        # stat-follow a symlinked excluded bundle (e.g. a child like
+        # ``LibraryAlias -> Photos Library.photoslibrary``) — the os.walk
+        # classification call alone would re-trip the macOS TCC prompt.
+        # rglob offered no way to stop descending; this walker does.
+        for dirpath, _dirnames, filenames in safe_scan_walk(root):
             for name in filenames:
                 if name.startswith(".") or os.path.splitext(name)[1].lower() not in SUPPORTED_EXTENSIONS:
                     continue
                 full = os.path.join(dirpath, name)
                 if full in known_paths:
                     continue
-                # os.walk lists dangling symlinks (and other non-regular
-                # entries) in `filenames`; the prior Path.rglob path gated on
-                # f.is_file(). scanner.scan skips non-files via os.path.isfile,
-                # so flagging one here would raise an untracked-image warning a
-                # rescan can never clear. os.path.isfile follows symlinks and
-                # returns False (not raise) for dangling targets.
+                # safe_scan_walk surfaces dangling symlinks (and other
+                # non-regular entries) in ``filenames``; the prior
+                # Path.rglob path gated on f.is_file(). scanner.scan skips
+                # non-files via os.path.isfile, so flagging one here would
+                # raise an untracked-image warning a rescan can never
+                # clear. os.path.isfile follows symlinks and returns False
+                # (not raise) for dangling targets.
                 if not os.path.isfile(full):
                     continue
                 untracked.append({"path": full, "folder": dirpath})
@@ -207,8 +209,9 @@ def check_stray_sidecars(root_paths):
             continue
         if not os.path.isdir(root):
             continue
-        for dirpath, dirnames, filenames in os.walk(root):
-            prune_scan_dirs(dirnames)
+        # See check_untracked_files for why safe_scan_walk supersedes
+        # os.walk + prune_scan_dirs here.
+        for dirpath, _dirnames, filenames in safe_scan_walk(root):
             image_names = set()
             xmps = []
             for name in filenames:

--- a/vireo/image_loader.py
+++ b/vireo/image_loader.py
@@ -66,8 +66,27 @@ def is_excluded_scan_path(path):
     shape. Either way, opening it still trips the macOS TCC
     "access data from other apps" prompt — so we reject the whole
     subtree, not just the bundle root.
+
+    Also resolves symlinks before checking. A user-selected root may be a
+    symlink whose literal path components don't name the bundle (e.g.
+    ``~/PhotoLib -> Photos Library.photoslibrary``); ``Path.is_dir()`` and
+    ``os.walk()`` follow the link into the protected bundle regardless, so
+    skipping the resolve would let the walkers re-trip the macOS TCC prompt.
     """
-    return any(is_excluded_scan_dir(part) for part in Path(path).parts)
+    p = Path(path)
+    if any(is_excluded_scan_dir(part) for part in p.parts):
+        return True
+    # Resolve symlinks. os.path.realpath() never raises (returns its input
+    # for missing paths) and resolves intermediate links too, so an alias
+    # anywhere in the chain (e.g. ``~/Aliases/MyLib/originals`` where
+    # ``MyLib`` links to the bundle) still gets caught.
+    try:
+        resolved = Path(os.path.realpath(str(p)))
+    except OSError:
+        return False
+    if resolved == p:
+        return False
+    return any(is_excluded_scan_dir(part) for part in resolved.parts)
 
 
 def prune_scan_dirs(dirnames):

--- a/vireo/image_loader.py
+++ b/vireo/image_loader.py
@@ -72,8 +72,17 @@ def is_excluded_scan_path(path):
     ``~/PhotoLib -> Photos Library.photoslibrary``); ``Path.is_dir()`` and
     ``os.walk()`` follow the link into the protected bundle regardless, so
     skipping the resolve would let the walkers re-trip the macOS TCC prompt.
+
+    Non-path inputs (e.g. JSON primitives like ``123`` or ``True`` that
+    sneak through ``body.get("root")`` before the route's directory check)
+    are treated as "not excluded" rather than raising. ``Path(int)`` raises
+    ``TypeError``; without this guard the route would return 500 instead of
+    the 400 the subsequent ``os.path.isdir`` check produces.
     """
-    p = Path(path)
+    try:
+        p = Path(path)
+    except TypeError:
+        return False
     if any(is_excluded_scan_dir(part) for part in p.parts):
         return True
     # Resolve symlinks. os.path.realpath() never raises (returns its input

--- a/vireo/image_loader.py
+++ b/vireo/image_loader.py
@@ -151,7 +151,11 @@ def _follow_symlink_chain_textually(path_str, max_depth=40):
         if any(is_excluded_scan_dir(part) for part in Path(target).parts):
             return None
         current = target
-    return current
+    # Depth cap reached without terminating in a non-link. Fail closed:
+    # the caller treats ``None`` as "excluded", so a chain longer than
+    # ``max_depth`` that might still resolve into a protected bundle never
+    # gets allowed past the guard.
+    return None
 
 
 def prune_scan_dirs(dirnames):

--- a/vireo/image_loader.py
+++ b/vireo/image_loader.py
@@ -30,6 +30,40 @@ RAW_EXTENSIONS = {".nef", ".cr2", ".cr3", ".arw", ".raf", ".dng", ".rw2", ".orf"
 IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".tiff", ".tif", ".bmp", ".webp"}
 SUPPORTED_EXTENSIONS = IMAGE_EXTENSIONS | RAW_EXTENSIONS
 
+# macOS "package" directories that hold OTHER apps' managed data. Walking
+# into them triggers Sequoia's "<app> would like to access data from other
+# apps" (kTCCServiceSystemPolicyAppData) consent prompt — and because such a
+# bundle holds thousands of files, the prompt reappears on every file the
+# walk touches, so clicking Allow never makes it stop. The contents are also
+# app-managed derivatives we'd never want to ingest. Any directory walker
+# that traverses user-chosen roots (~/Pictures by default contains
+# "Photos Library.photoslibrary") must prune these. Matched case-insensitively.
+_EXCLUDED_DIR_SUFFIXES = (
+    ".photoslibrary",          # Apple Photos
+    ".photolibrary",           # legacy iPhoto / older Photos
+    ".migratedphotolibrary",
+    ".aplibrary",              # Aperture
+    ".migratedaplibrary",
+)
+_EXCLUDED_DIR_NAMES = frozenset({"photo booth library"})
+
+
+def is_excluded_scan_dir(name):
+    """Return True if a directory basename is an other-app data bundle that
+    directory walkers must not descend into (see _EXCLUDED_DIR_* above)."""
+    lower = name.lower()
+    return lower in _EXCLUDED_DIR_NAMES or lower.endswith(_EXCLUDED_DIR_SUFFIXES)
+
+
+def prune_scan_dirs(dirnames):
+    """Mutate an ``os.walk`` *dirnames* list in place, removing excluded
+    bundles so the walk never recurses into them. Returns the removed names
+    (useful for logging what was skipped)."""
+    removed = [d for d in dirnames if is_excluded_scan_dir(d)]
+    if removed:
+        dirnames[:] = [d for d in dirnames if d not in removed]
+    return removed
+
 
 def load_image(file_path, max_size=1024):
     """Load an image file and return a PIL Image, resized to max_size.

--- a/vireo/image_loader.py
+++ b/vireo/image_loader.py
@@ -173,20 +173,36 @@ def prune_scan_dirs(dirnames):
 
 
 def _symlink_target_is_excluded(entry):
-    """Return True if *entry* is a symlink whose target path contains an
-    excluded bundle anywhere along it. Uses ``os.readlink`` (purely textual
-    — never follows the link), so a link pointing into a protected bundle
-    can be classified without statting the bundle target.
+    """Return True if *entry* is a symlink whose target sits in (or whose
+    symlink chain reaches) an excluded bundle. Uses ``os.readlink`` /
+    ``os.path.islink`` only — never a stat that follows the link — so a
+    link pointing into a protected bundle is classified without statting
+    the bundle target.
 
-    Checks every component of the target path, not just the basename: a
-    file-named link like
-    ``IMG.jpg -> ../Photos Library.photoslibrary/originals/IMG.jpg`` has a
-    basename (``IMG.jpg``) that doesn't match any bundle, yet
-    ``os.path.isfile`` / ``Path.is_file`` on the link would still follow it
-    and stat the managed Photos file, re-tripping the macOS TCC prompt.
-    Relative targets are joined against the link's parent and normalized
-    (still purely textual — ``os.path.normpath`` does not stat) so ``..``
-    segments resolve before the component check.
+    Two shapes are caught, neither matched by a basename-only check:
+
+    1. A file-named link whose target path names an excluded bundle
+       directly, e.g.
+       ``IMG.jpg -> ../Photos Library.photoslibrary/originals/IMG.jpg`` —
+       the immediate target's parts include the bundle suffix.
+    2. A chained link whose immediate target is a *plain* path that
+       itself contains, or resolves through, another link into the
+       bundle, e.g. ``LibraryAlias -> MidAlias`` where
+       ``MidAlias -> Photos Library.photoslibrary`` (or a file-named
+       variant ``IMG.jpg -> MidAlias/originals/IMG.jpg``). Without
+       chasing the chain, the immediate target ``MidAlias`` looks
+       benign, but ``os.path.isfile`` / ``Path.is_file`` would follow
+       both hops and re-trip the macOS TCC prompt.
+
+    The chain is followed via :func:`is_excluded_scan_path`, which walks
+    components one at a time using textual ``islink``+``readlink``. That
+    component-by-component walk keeps each ``lstat`` confined to the
+    link node — it never resolves an intermediate link far enough to
+    touch the protected bundle.
+
+    Relative targets are joined against the link's parent and
+    normalized (still purely textual — ``os.path.normpath`` does not
+    stat) so ``..`` segments resolve before classification.
     """
     try:
         if not entry.is_symlink():
@@ -202,7 +218,7 @@ def _symlink_target_is_excluded(entry):
     if not os.path.isabs(target):
         target = os.path.join(os.path.dirname(entry.path), target)
     target = os.path.normpath(target)
-    return any(is_excluded_scan_dir(part) for part in Path(target).parts)
+    return is_excluded_scan_path(target)
 
 
 def safe_iter_dir(top, onerror=None):

--- a/vireo/image_loader.py
+++ b/vireo/image_loader.py
@@ -101,11 +101,110 @@ def is_excluded_scan_path(path):
 def prune_scan_dirs(dirnames):
     """Mutate an ``os.walk`` *dirnames* list in place, removing excluded
     bundles so the walk never recurses into them. Returns the removed names
-    (useful for logging what was skipped)."""
+    (useful for logging what was skipped).
+
+    Note: by the time this runs, ``os.walk`` has already called
+    ``DirEntry.is_dir()`` on every child to populate ``dirnames`` — and that
+    call follows symlinks, so a child like ``LibraryAlias ->
+    Photos Library.photoslibrary`` is stat'ed against the bundle target
+    *before* pruning. Use :func:`safe_scan_walk` for user-chosen roots so
+    the symlink target is never stat-followed.
+    """
     removed = [d for d in dirnames if is_excluded_scan_dir(d)]
     if removed:
         dirnames[:] = [d for d in dirnames if d not in removed]
     return removed
+
+
+def _symlink_target_is_excluded(entry):
+    """Return True if *entry* is a symlink whose target basename names an
+    excluded bundle. Uses ``os.readlink`` (purely textual — never follows
+    the link), so a link pointing at ``Photos Library.photoslibrary`` can
+    be classified without statting the protected bundle target."""
+    try:
+        if not entry.is_symlink():
+            return False
+    except OSError:
+        return False
+    try:
+        target = os.readlink(entry.path)
+    except OSError:
+        return False
+    if not target:
+        return False
+    # Strip trailing separators before taking the basename so a link target
+    # spelled ``.../Photos Library.photoslibrary/`` is still matched.
+    target_name = os.path.basename(target.rstrip("/").rstrip("\\"))
+    return is_excluded_scan_dir(target_name)
+
+
+def safe_scan_walk(top, onerror=None):
+    """Yield ``(dirpath, dirnames, filenames)`` like ``os.walk(top,
+    followlinks=False)``, but never stat-following a symlinked excluded
+    bundle.
+
+    The stock ``os.walk`` classifies each child by calling
+    ``DirEntry.is_dir()``, which follows symlinks. If a user-chosen root
+    contains ``LibraryAlias -> Photos Library.photoslibrary``, that
+    classification stat alone reaches into the protected bundle and
+    re-trips the macOS "access data from other apps" TCC prompt — even
+    though the subsequent :func:`prune_scan_dirs` would remove the entry
+    from recursion. We need to detect symlinks pointing at excluded
+    bundles *before* any stat that follows them; ``os.readlink`` is the
+    only call here that touches a symlink, and it returns the literal
+    target string without resolving it.
+
+    Direct-name exclusion (``is_excluded_scan_dir``) is also applied
+    here, so callers don't need a separate ``prune_scan_dirs`` step on
+    ``dirnames``. Classification uses ``follow_symlinks=False``, matching
+    ``os.walk(followlinks=False)``'s recursion behaviour — symlinks to
+    non-excluded directories are surfaced in ``filenames`` (not
+    ``dirnames``) and never recursed into. Callers that already filter
+    ``filenames`` with ``os.path.isfile`` (which returns False for
+    directories, including symlinked dirs) discard those entries
+    automatically.
+    """
+    try:
+        scandir_it = os.scandir(top)
+    except OSError as exc:
+        if onerror is not None:
+            onerror(exc)
+        return
+    dirs = []
+    nondirs = []
+    skipped = []
+    with scandir_it:
+        for entry in scandir_it:
+            name = entry.name
+            # Name-based exclusion catches direct bundle entries
+            # (``Photos Library.photoslibrary``) without any stat.
+            if is_excluded_scan_dir(name):
+                skipped.append(name)
+                continue
+            # Symlink whose target names an excluded bundle. os.readlink
+            # is textual and never follows the link, so this is safe even
+            # when the target is a protected macOS bundle.
+            if _symlink_target_is_excluded(entry):
+                skipped.append(name)
+                continue
+            try:
+                entry_is_dir = entry.is_dir(follow_symlinks=False)
+            except OSError as exc:
+                if onerror is not None:
+                    onerror(exc)
+                entry_is_dir = False
+            if entry_is_dir:
+                dirs.append(name)
+            else:
+                nondirs.append(name)
+    if skipped:
+        log.info(
+            "Skipping other-app data bundle(s) under %s: %s",
+            top, ", ".join(skipped),
+        )
+    yield top, dirs, nondirs
+    for subdir in dirs:
+        yield from safe_scan_walk(os.path.join(top, subdir), onerror=onerror)
 
 
 def load_image(file_path, max_size=1024):

--- a/vireo/image_loader.py
+++ b/vireo/image_loader.py
@@ -67,11 +67,25 @@ def is_excluded_scan_path(path):
     "access data from other apps" prompt — so we reject the whole
     subtree, not just the bundle root.
 
-    Also resolves symlinks before checking. A user-selected root may be a
+    Also follows symlinks textually. A user-selected root may be a
     symlink whose literal path components don't name the bundle (e.g.
-    ``~/PhotoLib -> Photos Library.photoslibrary``); ``Path.is_dir()`` and
-    ``os.walk()`` follow the link into the protected bundle regardless, so
-    skipping the resolve would let the walkers re-trip the macOS TCC prompt.
+    ``~/PhotoLib -> Photos Library.photoslibrary``); ``Path.is_dir()``
+    and ``os.walk()`` would follow the link into the protected bundle
+    regardless, so the walkers must reject these before any stat that
+    follows the link.
+
+    We do NOT use ``os.path.realpath`` for that resolution. ``realpath``
+    walks the resolved chain by ``lstat``-ing every component along the
+    way — including the bundle target itself once a link points at it —
+    and the very reason this guard exists is to avoid any stat that
+    reaches into the protected bundle. Instead we walk the path one
+    component at a time, using ``os.path.islink`` (which ``lstat``s only
+    the link node — these live outside the bundle when the user picked
+    an alias like ``~/PhotoLibAlias``) and ``os.readlink`` (purely
+    textual — reads just the link's stored target string). Neither call
+    stats anything below a resolved link, so even a directly selected
+    alias like ``~/PhotoLibAlias -> Photos Library.photoslibrary``
+    never reaches into the protected bundle.
 
     Non-path inputs (e.g. JSON primitives like ``123`` or ``True`` that
     sneak through ``body.get("root")`` before the route's directory check)
@@ -85,17 +99,59 @@ def is_excluded_scan_path(path):
         return False
     if any(is_excluded_scan_dir(part) for part in p.parts):
         return True
-    # Resolve symlinks. os.path.realpath() never raises (returns its input
-    # for missing paths) and resolves intermediate links too, so an alias
-    # anywhere in the chain (e.g. ``~/Aliases/MyLib/originals`` where
-    # ``MyLib`` links to the bundle) still gets caught.
-    try:
-        resolved = Path(os.path.realpath(str(p)))
-    except OSError:
+    parts = p.parts
+    if not parts:
         return False
-    if resolved == p:
-        return False
-    return any(is_excluded_scan_dir(part) for part in resolved.parts)
+    # Walk component by component. Each iteration appends one literal
+    # part of the original path, then follows any symlink chain from the
+    # accumulated location purely textually. If a chain target's
+    # components name an excluded bundle, we stop immediately — so for
+    # ``~/Aliases/MyLib/originals`` (MyLib → bundle), we detect the
+    # bundle while processing ``MyLib`` and never construct or stat
+    # ``MyLib/originals`` against the resolved target.
+    current = parts[0]
+    for i, part in enumerate(parts):
+        if i > 0:
+            current = os.path.join(current, part)
+        resolved = _follow_symlink_chain_textually(current)
+        if resolved is None:
+            return True
+        current = resolved
+    return False
+
+
+def _follow_symlink_chain_textually(path_str, max_depth=40):
+    """Follow the symlink chain starting at *path_str* using only
+    ``os.path.islink`` + ``os.readlink``. Returns the chain's terminal
+    path (or *path_str* unchanged when nothing is a link) — or ``None``
+    if any link in the chain points at or into an excluded bundle.
+
+    ``os.path.islink`` ``lstat``s the link node itself, never the
+    resolved target; ``os.readlink`` only reads the link's stored
+    target bytes. Together they never stat anything under a resolved
+    link, which is what lets this helper classify
+    ``~/PhotoLibAlias -> Photos Library.photoslibrary`` without
+    reaching into the protected bundle.
+    """
+    current = path_str
+    visited = set()
+    for _ in range(max_depth):
+        if current in visited:
+            return current
+        visited.add(current)
+        try:
+            if not os.path.islink(current):
+                return current
+            target = os.readlink(current)
+        except OSError:
+            return current
+        if not os.path.isabs(target):
+            target = os.path.join(os.path.dirname(current), target)
+        target = os.path.normpath(target)
+        if any(is_excluded_scan_dir(part) for part in Path(target).parts):
+            return None
+        current = target
+    return current
 
 
 def prune_scan_dirs(dirnames):
@@ -147,6 +203,47 @@ def _symlink_target_is_excluded(entry):
         target = os.path.join(os.path.dirname(entry.path), target)
     target = os.path.normpath(target)
     return any(is_excluded_scan_dir(part) for part in Path(target).parts)
+
+
+def safe_iter_dir(top, onerror=None):
+    """Yield ``Path`` objects for direct children of *top*, skipping
+    excluded bundles by name and symlinks whose target sits inside one.
+
+    Use this instead of ``Path.iterdir()`` (or ``os.scandir``) in
+    non-recursive walks where the caller will then call ``Path.is_file()``
+    / ``Path.suffix`` / ``stat()`` on each entry. Those calls follow
+    symlinks, so a child like ``LibraryAlias -> Photos
+    Library.photoslibrary`` — or a direct bundle child ``Photos
+    Library.photoslibrary`` itself — would stat the bundle target and
+    re-trip the macOS "access data from other apps" TCC prompt this
+    guard exists to avoid, even though the caller's extension/name
+    filter would have rejected the entry afterwards.
+
+    Classification uses ``DirEntry.is_dir(follow_symlinks=False)`` and
+    ``os.readlink`` (purely textual) — never a stat that follows a link
+    into a protected bundle.
+    """
+    try:
+        scandir_it = os.scandir(top)
+    except OSError as exc:
+        if onerror is not None:
+            onerror(exc)
+        return
+    skipped = []
+    with scandir_it:
+        for entry in scandir_it:
+            if is_excluded_scan_dir(entry.name):
+                skipped.append(entry.name)
+                continue
+            if _symlink_target_is_excluded(entry):
+                skipped.append(entry.name)
+                continue
+            yield Path(entry.path)
+    if skipped:
+        log.info(
+            "Skipping other-app data bundle(s) under %s: %s",
+            top, ", ".join(skipped),
+        )
 
 
 def safe_scan_walk(top, onerror=None):

--- a/vireo/image_loader.py
+++ b/vireo/image_loader.py
@@ -117,10 +117,21 @@ def prune_scan_dirs(dirnames):
 
 
 def _symlink_target_is_excluded(entry):
-    """Return True if *entry* is a symlink whose target basename names an
-    excluded bundle. Uses ``os.readlink`` (purely textual — never follows
-    the link), so a link pointing at ``Photos Library.photoslibrary`` can
-    be classified without statting the protected bundle target."""
+    """Return True if *entry* is a symlink whose target path contains an
+    excluded bundle anywhere along it. Uses ``os.readlink`` (purely textual
+    — never follows the link), so a link pointing into a protected bundle
+    can be classified without statting the bundle target.
+
+    Checks every component of the target path, not just the basename: a
+    file-named link like
+    ``IMG.jpg -> ../Photos Library.photoslibrary/originals/IMG.jpg`` has a
+    basename (``IMG.jpg``) that doesn't match any bundle, yet
+    ``os.path.isfile`` / ``Path.is_file`` on the link would still follow it
+    and stat the managed Photos file, re-tripping the macOS TCC prompt.
+    Relative targets are joined against the link's parent and normalized
+    (still purely textual — ``os.path.normpath`` does not stat) so ``..``
+    segments resolve before the component check.
+    """
     try:
         if not entry.is_symlink():
             return False
@@ -132,10 +143,10 @@ def _symlink_target_is_excluded(entry):
         return False
     if not target:
         return False
-    # Strip trailing separators before taking the basename so a link target
-    # spelled ``.../Photos Library.photoslibrary/`` is still matched.
-    target_name = os.path.basename(target.rstrip("/").rstrip("\\"))
-    return is_excluded_scan_dir(target_name)
+    if not os.path.isabs(target):
+        target = os.path.join(os.path.dirname(entry.path), target)
+    target = os.path.normpath(target)
+    return any(is_excluded_scan_dir(part) for part in Path(target).parts)
 
 
 def safe_scan_walk(top, onerror=None):

--- a/vireo/image_loader.py
+++ b/vireo/image_loader.py
@@ -55,6 +55,21 @@ def is_excluded_scan_dir(name):
     return lower in _EXCLUDED_DIR_NAMES or lower.endswith(_EXCLUDED_DIR_SUFFIXES)
 
 
+def is_excluded_scan_path(path):
+    """Return True if *path* is, or sits inside, an excluded bundle.
+
+    Used as the root-level guard for every walker that accepts a
+    user-chosen path. A leaf-only check is insufficient: a user can
+    select a child of the bundle directly (e.g.
+    ``~/Pictures/Photos Library.photoslibrary/originals``), and stale
+    folder rows from before this guard existed can carry the same
+    shape. Either way, opening it still trips the macOS TCC
+    "access data from other apps" prompt — so we reject the whole
+    subtree, not just the bundle root.
+    """
+    return any(is_excluded_scan_dir(part) for part in Path(path).parts)
+
+
 def prune_scan_dirs(dirnames):
     """Mutate an ``os.walk`` *dirnames* list in place, removing excluded
     bundles so the walk never recurses into them. Returns the removed names

--- a/vireo/ingest.py
+++ b/vireo/ingest.py
@@ -10,7 +10,12 @@ from datetime import datetime
 from pathlib import Path
 
 from grouping import read_exif_timestamp
-from image_loader import IMAGE_EXTENSIONS, RAW_EXTENSIONS, SUPPORTED_EXTENSIONS
+from image_loader import (
+    IMAGE_EXTENSIONS,
+    RAW_EXTENSIONS,
+    SUPPORTED_EXTENSIONS,
+    prune_scan_dirs,
+)
 from scanner import compute_file_hash
 
 log = logging.getLogger(__name__)
@@ -209,7 +214,17 @@ def discover_source_files(source_dir, file_types="both", recursive=True):
     else:
         allowed = SUPPORTED_EXTENSIONS
 
-    candidates = source_path.rglob("*") if recursive else source_path.iterdir()
+    if recursive:
+        # os.walk (not Path.rglob) so we can prune other-app data bundles
+        # (e.g. "Photos Library.photoslibrary") in place — picking ~/Pictures
+        # as an import source would otherwise walk the whole Photos library
+        # and trip the macOS "access data from other apps" prompt.
+        candidates = []
+        for dirpath, dirnames, filenames in os.walk(source_path):
+            prune_scan_dirs(dirnames)
+            candidates.extend(Path(dirpath) / name for name in filenames)
+    else:
+        candidates = list(source_path.iterdir())
     return sorted(
         f
         for f in candidates

--- a/vireo/ingest.py
+++ b/vireo/ingest.py
@@ -15,7 +15,7 @@ from image_loader import (
     RAW_EXTENSIONS,
     SUPPORTED_EXTENSIONS,
     is_excluded_scan_path,
-    prune_scan_dirs,
+    safe_scan_walk,
 )
 from scanner import compute_file_hash
 
@@ -226,13 +226,13 @@ def discover_source_files(source_dir, file_types="both", recursive=True):
         allowed = SUPPORTED_EXTENSIONS
 
     if recursive:
-        # os.walk (not Path.rglob) so we can prune other-app data bundles
-        # (e.g. "Photos Library.photoslibrary") in place — picking ~/Pictures
-        # as an import source would otherwise walk the whole Photos library
-        # and trip the macOS "access data from other apps" prompt.
+        # safe_scan_walk skips other-app data bundles (e.g.
+        # "Photos Library.photoslibrary") without stat-following any
+        # symlinked child that points at one — picking ~/Pictures as an
+        # import source would otherwise walk the whole Photos library and
+        # re-trip the macOS "access data from other apps" prompt.
         candidates = []
-        for dirpath, dirnames, filenames in os.walk(source_path):
-            prune_scan_dirs(dirnames)
+        for dirpath, _dirnames, filenames in safe_scan_walk(str(source_path)):
             candidates.extend(Path(dirpath) / name for name in filenames)
     else:
         candidates = list(source_path.iterdir())

--- a/vireo/ingest.py
+++ b/vireo/ingest.py
@@ -14,6 +14,7 @@ from image_loader import (
     IMAGE_EXTENSIONS,
     RAW_EXTENSIONS,
     SUPPORTED_EXTENSIONS,
+    is_excluded_scan_dir,
     prune_scan_dirs,
 )
 from scanner import compute_file_hash
@@ -203,6 +204,12 @@ def discover_source_files(source_dir, file_types="both", recursive=True):
     """
     source_path = Path(source_dir)
     if not source_path.is_dir():
+        return []
+    # prune_scan_dirs filters only children of the walked root; if the
+    # selected source is itself an other-app data bundle (e.g. user picks
+    # ``~/Pictures/Photos Library.photoslibrary`` as an import source),
+    # os.walk would still open it and trip the macOS TCC prompt.
+    if is_excluded_scan_dir(source_path.name):
         return []
 
     if isinstance(file_types, list):

--- a/vireo/ingest.py
+++ b/vireo/ingest.py
@@ -14,7 +14,7 @@ from image_loader import (
     IMAGE_EXTENSIONS,
     RAW_EXTENSIONS,
     SUPPORTED_EXTENSIONS,
-    is_excluded_scan_dir,
+    is_excluded_scan_path,
     prune_scan_dirs,
 )
 from scanner import compute_file_hash
@@ -206,10 +206,11 @@ def discover_source_files(source_dir, file_types="both", recursive=True):
     if not source_path.is_dir():
         return []
     # prune_scan_dirs filters only children of the walked root; if the
-    # selected source is itself an other-app data bundle (e.g. user picks
-    # ``~/Pictures/Photos Library.photoslibrary`` as an import source),
-    # os.walk would still open it and trip the macOS TCC prompt.
-    if is_excluded_scan_dir(source_path.name):
+    # selected source is, or sits inside, an other-app data bundle (e.g.
+    # user picks ``~/Pictures/Photos Library.photoslibrary`` or a child
+    # like ``.../Photos Library.photoslibrary/originals`` as an import
+    # source), os.walk would still open it and trip the macOS TCC prompt.
+    if is_excluded_scan_path(source_path):
         return []
 
     if isinstance(file_types, list):

--- a/vireo/ingest.py
+++ b/vireo/ingest.py
@@ -203,14 +203,17 @@ def discover_source_files(source_dir, file_types="both", recursive=True):
         Sorted list of Path objects for matching files
     """
     source_path = Path(source_dir)
-    if not source_path.is_dir():
-        return []
     # prune_scan_dirs filters only children of the walked root; if the
     # selected source is, or sits inside, an other-app data bundle (e.g.
     # user picks ``~/Pictures/Photos Library.photoslibrary`` or a child
     # like ``.../Photos Library.photoslibrary/originals`` as an import
     # source), os.walk would still open it and trip the macOS TCC prompt.
+    # This must run BEFORE ``source_path.is_dir()`` — is_dir follows
+    # symlinks and stat's the target, so for a directly selected bundle
+    # (or a symlink to one) the existence test alone is enough to trip TCC.
     if is_excluded_scan_path(source_path):
+        return []
+    if not source_path.is_dir():
         return []
 
     if isinstance(file_types, list):

--- a/vireo/ingest.py
+++ b/vireo/ingest.py
@@ -15,6 +15,7 @@ from image_loader import (
     RAW_EXTENSIONS,
     SUPPORTED_EXTENSIONS,
     is_excluded_scan_path,
+    safe_iter_dir,
     safe_scan_walk,
 )
 from scanner import compute_file_hash
@@ -235,7 +236,15 @@ def discover_source_files(source_dir, file_types="both", recursive=True):
         for dirpath, _dirnames, filenames in safe_scan_walk(str(source_path)):
             candidates.extend(Path(dirpath) / name for name in filenames)
     else:
-        candidates = list(source_path.iterdir())
+        # safe_iter_dir drops excluded bundle children before the
+        # is_file() filter below would stat them. With recursion off, a
+        # source like ~/Pictures still contains ``Photos
+        # Library.photoslibrary`` (or a symlink to one) as a direct
+        # child; a bare iterdir + is_file() would stat that bundle and
+        # re-trip the macOS "access data from other apps" TCC prompt
+        # this guard exists to avoid, even though the extension filter
+        # would have rejected it afterwards.
+        candidates = list(safe_iter_dir(str(source_path)))
     return sorted(
         f
         for f in candidates

--- a/vireo/ingest.py
+++ b/vireo/ingest.py
@@ -232,9 +232,19 @@ def discover_source_files(source_dir, file_types="both", recursive=True):
         # symlinked child that points at one — picking ~/Pictures as an
         # import source would otherwise walk the whole Photos library and
         # re-trip the macOS "access data from other apps" prompt.
-        candidates = []
-        for dirpath, _dirnames, filenames in safe_scan_walk(str(source_path)):
-            candidates.extend(Path(dirpath) / name for name in filenames)
+        #
+        # Stream the walk into the filter below rather than collecting
+        # every walked path first: a source like a home directory or
+        # external disk root can yield millions of non-image filenames,
+        # and materializing those would make memory grow with the whole
+        # tree (and stall the preview before any photo is copied). The
+        # previous Path.rglob path was likewise consumed lazily by
+        # ``sorted()``.
+        def _candidate_paths():
+            for dirpath, _dirnames, filenames in safe_scan_walk(str(source_path)):
+                for name in filenames:
+                    yield Path(dirpath) / name
+        candidates = _candidate_paths()
     else:
         # safe_iter_dir drops excluded bundle children before the
         # is_file() filter below would stat them. With recursion off, a
@@ -243,8 +253,10 @@ def discover_source_files(source_dir, file_types="both", recursive=True):
         # child; a bare iterdir + is_file() would stat that bundle and
         # re-trip the macOS "access data from other apps" TCC prompt
         # this guard exists to avoid, even though the extension filter
-        # would have rejected it afterwards.
-        candidates = list(safe_iter_dir(str(source_path)))
+        # would have rejected it afterwards. ``safe_iter_dir`` is itself
+        # a generator — pass it straight through to the filter so we
+        # don't materialize the directory listing twice.
+        candidates = safe_iter_dir(str(source_path))
     return sorted(
         f
         for f in candidates

--- a/vireo/new_images.py
+++ b/vireo/new_images.py
@@ -5,7 +5,11 @@ import threading
 import time
 from pathlib import Path
 
-from image_loader import SUPPORTED_EXTENSIONS, prune_scan_dirs
+from image_loader import (
+    SUPPORTED_EXTENSIONS,
+    is_excluded_scan_dir,
+    prune_scan_dirs,
+)
 
 log = logging.getLogger(__name__)
 
@@ -127,6 +131,13 @@ def count_new_images_for_workspace(db, workspace_id, sample_limit=5,
     for root in roots:
         root_path = root["path"]
         if not os.path.isdir(root_path):
+            per_root.append({"folder_id": root["id"], "path": root_path, "new_count": 0})
+            continue
+        # prune_scan_dirs filters only children; if the root itself is the
+        # excluded bundle (e.g. user added ``~/Pictures/Photos Library.photoslibrary``
+        # directly), os.walk would still open it and inflate the banner with
+        # managed images the scanner never ingests.
+        if is_excluded_scan_dir(Path(root_path).name):
             per_root.append({"folder_id": root["id"], "path": root_path, "new_count": 0})
             continue
 

--- a/vireo/new_images.py
+++ b/vireo/new_images.py
@@ -155,6 +155,13 @@ def count_new_images_for_workspace(db, workspace_id, sample_limit=5,
                 if full in known:
                     _maybe_emit()
                     continue
+                # Mirror ``vireo/scanner.py``: os.walk lists broken symlinks
+                # in `filenames`, but scanner refuses to ingest them
+                # (os.path.isfile == False). Counting them as "new" would
+                # leave the banner stuck on files no scan can clear.
+                if not os.path.isfile(full):
+                    _maybe_emit()
+                    continue
                 # Suppress JPG working-copy companions of already-imported
                 # RAWs in the same folder. The scanner pairs them as
                 # ``companion_path`` rather than create a new primary photo,

--- a/vireo/new_images.py
+++ b/vireo/new_images.py
@@ -5,7 +5,7 @@ import threading
 import time
 from pathlib import Path
 
-from image_loader import SUPPORTED_EXTENSIONS
+from image_loader import SUPPORTED_EXTENSIONS, prune_scan_dirs
 
 log = logging.getLogger(__name__)
 
@@ -131,7 +131,13 @@ def count_new_images_for_workspace(db, workspace_id, sample_limit=5,
             continue
 
         root_new = 0
-        for dirpath, _dirnames, filenames in os.walk(root_path):
+        for dirpath, dirnames, filenames in os.walk(root_path):
+            # Mirror ``vireo/scanner.py``: never descend into other-app data
+            # bundles (e.g. "Photos Library.photoslibrary"). Counting files
+            # inside them would both trigger the macOS "access data from other
+            # apps" prompt and inflate the "new images" banner with photos the
+            # scanner will never ingest.
+            prune_scan_dirs(dirnames)
             for name in filenames:
                 files_checked += 1
                 # Mirror ``vireo/scanner.py``: skip dotfiles (e.g. macOS

--- a/vireo/new_images.py
+++ b/vireo/new_images.py
@@ -130,16 +130,19 @@ def count_new_images_for_workspace(db, workspace_id, sample_limit=5,
 
     for root in roots:
         root_path = root["path"]
-        if not os.path.isdir(root_path):
-            per_root.append({"folder_id": root["id"], "path": root_path, "new_count": 0})
-            continue
         # prune_scan_dirs filters only children; if the root is, or sits
         # inside, an excluded bundle (e.g. user added
         # ``~/Pictures/Photos Library.photoslibrary`` directly, or a stale
         # folder row points at ``.../Photos Library.photoslibrary/originals``),
         # os.walk would still open it and inflate the banner with managed
-        # images the scanner never ingests.
+        # images the scanner never ingests. This must run BEFORE
+        # ``os.path.isdir`` — isdir follows symlinks and stat's the target,
+        # so for a directly selected bundle (or a symlink to one) the
+        # existence test alone is enough to trip the macOS TCC prompt.
         if is_excluded_scan_path(root_path):
+            per_root.append({"folder_id": root["id"], "path": root_path, "new_count": 0})
+            continue
+        if not os.path.isdir(root_path):
             per_root.append({"folder_id": root["id"], "path": root_path, "new_count": 0})
             continue
 

--- a/vireo/new_images.py
+++ b/vireo/new_images.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from image_loader import (
     SUPPORTED_EXTENSIONS,
-    is_excluded_scan_dir,
+    is_excluded_scan_path,
     prune_scan_dirs,
 )
 
@@ -133,11 +133,13 @@ def count_new_images_for_workspace(db, workspace_id, sample_limit=5,
         if not os.path.isdir(root_path):
             per_root.append({"folder_id": root["id"], "path": root_path, "new_count": 0})
             continue
-        # prune_scan_dirs filters only children; if the root itself is the
-        # excluded bundle (e.g. user added ``~/Pictures/Photos Library.photoslibrary``
-        # directly), os.walk would still open it and inflate the banner with
-        # managed images the scanner never ingests.
-        if is_excluded_scan_dir(Path(root_path).name):
+        # prune_scan_dirs filters only children; if the root is, or sits
+        # inside, an excluded bundle (e.g. user added
+        # ``~/Pictures/Photos Library.photoslibrary`` directly, or a stale
+        # folder row points at ``.../Photos Library.photoslibrary/originals``),
+        # os.walk would still open it and inflate the banner with managed
+        # images the scanner never ingests.
+        if is_excluded_scan_path(root_path):
             per_root.append({"folder_id": root["id"], "path": root_path, "new_count": 0})
             continue
 

--- a/vireo/new_images.py
+++ b/vireo/new_images.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from image_loader import (
     SUPPORTED_EXTENSIONS,
     is_excluded_scan_path,
-    prune_scan_dirs,
+    safe_scan_walk,
 )
 
 log = logging.getLogger(__name__)
@@ -147,13 +147,13 @@ def count_new_images_for_workspace(db, workspace_id, sample_limit=5,
             continue
 
         root_new = 0
-        for dirpath, dirnames, filenames in os.walk(root_path):
-            # Mirror ``vireo/scanner.py``: never descend into other-app data
-            # bundles (e.g. "Photos Library.photoslibrary"). Counting files
-            # inside them would both trigger the macOS "access data from other
-            # apps" prompt and inflate the "new images" banner with photos the
-            # scanner will never ingest.
-            prune_scan_dirs(dirnames)
+        # safe_scan_walk skips other-app data bundles (e.g.
+        # "Photos Library.photoslibrary") without stat-following any
+        # symlinked child that points at one — the os.walk classification
+        # stat alone is enough to trip the macOS TCC prompt. Mirror what
+        # scanner.scan() will eventually pick up, so the "new images"
+        # banner can't be inflated by files the scanner will never ingest.
+        for dirpath, _dirnames, filenames in safe_scan_walk(root_path):
             for name in filenames:
                 files_checked += 1
                 # Mirror ``vireo/scanner.py``: skip dotfiles (e.g. macOS

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -19,6 +19,7 @@ from image_loader import (
     RAW_EXTENSIONS,
     SUPPORTED_EXTENSIONS,
     extract_working_copy,
+    is_excluded_scan_dir,
     prune_scan_dirs,
 )
 from metadata import extract_metadata
@@ -979,6 +980,16 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
     root_path = Path(root)
     if not root_path.is_dir():
         log.warning("Root path does not exist or is not a directory: %s", root)
+        return
+    # Don't open the root at all if the root itself is an other-app data
+    # bundle. prune_scan_dirs below only filters *children*, so a root of
+    # e.g. ``~/Pictures/Photos Library.photoslibrary`` would still trigger
+    # the macOS "access data from other apps" TCC prompt this guard exists
+    # to avoid.
+    if is_excluded_scan_dir(root_path.name):
+        log.info(
+            "Skipping other-app data bundle as scan root: %s", root_path,
+        )
         return
 
     def _check_cancelled():

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -1048,6 +1048,20 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
         for d in restrict_dirs:
             _check_cancelled()
             dp = Path(d)
+            # The outer ``is_excluded_scan_path(root_path)`` guard above only
+            # covers ``root``. restrict_dirs entries can independently point
+            # into an other-app data bundle — e.g. a stale folder row from
+            # before this guard, or a duplicate the caller built from
+            # workspace_folders pointing at
+            # ``~/Pictures/Photos Library.photoslibrary/originals``. Calling
+            # ``dp.is_dir()`` / ``dp.iterdir()`` on that subtree would still
+            # trip the macOS "access data from other apps" TCC prompt this
+            # guard exists to avoid. Reject before any filesystem access.
+            if is_excluded_scan_path(dp):
+                log.info(
+                    "Skipping other-app data bundle in restrict_dirs: %s", dp,
+                )
+                continue
             if dp.is_dir():
                 # iterdir() raises PermissionError when the kernel refuses
                 # enumeration (macOS TCC EPERM, POSIX EACCES). Route through
@@ -1241,6 +1255,11 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
         if restrict_dirs is not None:
             for d in restrict_dirs:
                 dp = Path(d)
+                # Same bundle guard as the discovery loop above — never
+                # register or stat a path inside an other-app data bundle,
+                # even when the caller stuffed one into ``restrict_dirs``.
+                if is_excluded_scan_path(dp):
+                    continue
                 if dp.is_dir():
                     _ensure_folder(dp)
 

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -15,7 +15,12 @@ from pathlib import Path
 
 import imagehash
 from db import commit_with_retry
-from image_loader import RAW_EXTENSIONS, SUPPORTED_EXTENSIONS, extract_working_copy
+from image_loader import (
+    RAW_EXTENSIONS,
+    SUPPORTED_EXTENSIONS,
+    extract_working_copy,
+    prune_scan_dirs,
+)
 from metadata import extract_metadata
 from PIL import Image
 from xmp import read_hierarchical_keywords, read_keywords
@@ -1057,10 +1062,21 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
     else:
         if recursive:
             checked = 0
-            for dirpath, _dirnames, filenames in os.walk(
+            for dirpath, dirnames, filenames in os.walk(
                 str(root_path), onerror=_on_walk_error,
             ):
                 _check_cancelled()
+                # Don't recurse into other-app data bundles (e.g.
+                # "Photos Library.photoslibrary" sitting in ~/Pictures).
+                # Pruning dirnames in place stops os.walk descending and
+                # avoids the recurring macOS "access data from other apps"
+                # TCC prompt the library would otherwise trigger.
+                skipped = prune_scan_dirs(dirnames)
+                if skipped:
+                    log.info(
+                        "Skipping other-app data bundle(s) under %s: %s",
+                        dirpath, ", ".join(skipped),
+                    )
                 for name in filenames:
                     checked += 1
                     if checked % 100 == 0:

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -1044,6 +1044,14 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
         else:
             log.warning("os.walk error at %s: %s", err.filename, err)
 
+    # Tracks restrict_dirs entries that survive the bundle guard, so the
+    # working-copy extraction pass below scopes its SQL query to the same
+    # set the discovery loop actually visited. Without this, a stale folder
+    # row inside an excluded bundle (carried over from before the guard)
+    # would be re-touched by ``_extract_working_copies`` reading
+    # ``folder_path/filename`` — re-tripping the macOS TCC prompt this guard
+    # exists to avoid.
+    effective_restrict_dirs = []
     if restrict_dirs is not None:
         # Only enumerate files in the specified directories (non-recursive).
         # root is still used as the folder hierarchy root for _ensure_folder.
@@ -1065,6 +1073,7 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                     "Skipping other-app data bundle in restrict_dirs: %s", dp,
                 )
                 continue
+            effective_restrict_dirs.append(d)
             if dp.is_dir():
                 # iterdir() raises PermissionError when the kernel refuses
                 # enumeration (macOS TCC EPERM, POSIX EACCES). Route through
@@ -1690,7 +1699,13 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
         # backward. ``status_callback`` still announces the phase.
         if vireo_dir:
             if restrict_dirs is not None:
-                wc_scope = [(str(d), "exact") for d in restrict_dirs]
+                # Use the bundle-filtered list — see ``effective_restrict_dirs``
+                # above. Reusing the raw ``restrict_dirs`` here would let a
+                # stale DB row inside an excluded bundle re-enter the
+                # working-copy extractor, which reads ``folder_path/filename``
+                # and re-trips the macOS TCC prompt the scan loop's guard
+                # already skipped.
+                wc_scope = [(str(d), "exact") for d in effective_restrict_dirs]
             elif not recursive:
                 wc_scope = [(str(root_path), "exact")]
             else:

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -20,6 +20,7 @@ from image_loader import (
     SUPPORTED_EXTENSIONS,
     extract_working_copy,
     is_excluded_scan_path,
+    safe_iter_dir,
     safe_scan_walk,
 )
 from metadata import extract_metadata
@@ -1075,21 +1076,21 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                 continue
             effective_restrict_dirs.append(d)
             if dp.is_dir():
-                # iterdir() raises PermissionError when the kernel refuses
-                # enumeration (macOS TCC EPERM, POSIX EACCES). Route through
-                # _on_walk_error so denials are surfaced via
-                # permission_error_callback the same way the recursive path
-                # does. _on_walk_error re-raises when no callback is
-                # registered, so callers like pipeline_job's repair scan
-                # (which counts unreachable folders via `except OSError`)
-                # keep their failure semantics; only callers that opted in
-                # to partial-success by passing the callback fall through to
-                # `continue`.
-                try:
-                    entries = list(dp.iterdir())
-                except PermissionError as e:
-                    _on_walk_error(e)
-                    continue
+                # safe_iter_dir mirrors iterdir() but drops excluded
+                # bundle children (direct ``Photos Library.photoslibrary``
+                # entries or symlinks pointing into one) before the
+                # is_file()/suffix filter below would stat them — that
+                # stat alone would re-trip the macOS "access data from
+                # other apps" TCC prompt this guard exists to avoid.
+                # Permission denials route through _on_walk_error: when
+                # ``permission_error_callback`` is registered the helper
+                # logs + invokes it and returns, so the generator yields
+                # nothing and the for-loop falls through to the next
+                # ``d``. Without a callback, _on_walk_error re-raises so
+                # callers like pipeline_job's repair scan (``except
+                # (OSError, RuntimeError)``) keep their loud failure
+                # semantics — we deliberately don't catch that raise.
+                entries = list(safe_iter_dir(str(dp), onerror=_on_walk_error))
                 for f in entries:
                     _check_cancelled()
                     if (f.is_file()
@@ -1138,11 +1139,18 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                             continue
                         image_files.append(Path(full))
         else:
-            try:
-                entries = list(root_path.iterdir())
-            except PermissionError as e:
-                _on_walk_error(e)
-                entries = []
+            # safe_iter_dir mirrors iterdir() but drops excluded bundle
+            # children before the is_file() filter below would stat
+            # them. A normal root like ~/Pictures can hold ``Photos
+            # Library.photoslibrary`` (or a symlink to one) as a direct
+            # child; a bare iterdir + is_file() would stat that bundle
+            # and re-trip the macOS "access data from other apps" TCC
+            # prompt this guard exists to avoid, even though the
+            # extension filter would have rejected it afterwards.
+            # Permission denials route through _on_walk_error (callback
+            # → empty entries, no callback → re-raise) the same way the
+            # restrict_dirs branch above does.
+            entries = list(safe_iter_dir(str(root_path), onerror=_on_walk_error))
             for checked, f in enumerate(entries, 1):
                 if checked % 100 == 0:
                     _check_cancelled()

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -978,9 +978,6 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
             RuntimeError("scan cancelled") at cancellation checkpoints.
     """
     root_path = Path(root)
-    if not root_path.is_dir():
-        log.warning("Root path does not exist or is not a directory: %s", root)
-        return
     # Don't open the root at all if the root is, or sits inside, an
     # other-app data bundle. prune_scan_dirs below only filters
     # *children*, so a root of e.g.
@@ -988,11 +985,17 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
     # selected/stale subfolder like ``.../Photos Library.photoslibrary/originals``
     # — would still trigger the macOS "access data from other apps" TCC
     # prompt this guard exists to avoid. Check every ancestor, not just
-    # the leaf name.
+    # the leaf name. This must run BEFORE ``root_path.is_dir()``: is_dir
+    # follows symlinks and stat's the target, so for a directly selected
+    # bundle (or a symlink to one), the existence test alone is enough
+    # to trip the TCC prompt — mirroring the restrict_dirs branch below.
     if is_excluded_scan_path(root_path):
         log.info(
             "Skipping other-app data bundle as scan root: %s", root_path,
         )
+        return
+    if not root_path.is_dir():
+        log.warning("Root path does not exist or is not a directory: %s", root)
         return
 
     def _check_cancelled():

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -19,7 +19,7 @@ from image_loader import (
     RAW_EXTENSIONS,
     SUPPORTED_EXTENSIONS,
     extract_working_copy,
-    is_excluded_scan_dir,
+    is_excluded_scan_path,
     prune_scan_dirs,
 )
 from metadata import extract_metadata
@@ -981,12 +981,15 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
     if not root_path.is_dir():
         log.warning("Root path does not exist or is not a directory: %s", root)
         return
-    # Don't open the root at all if the root itself is an other-app data
-    # bundle. prune_scan_dirs below only filters *children*, so a root of
-    # e.g. ``~/Pictures/Photos Library.photoslibrary`` would still trigger
-    # the macOS "access data from other apps" TCC prompt this guard exists
-    # to avoid.
-    if is_excluded_scan_dir(root_path.name):
+    # Don't open the root at all if the root is, or sits inside, an
+    # other-app data bundle. prune_scan_dirs below only filters
+    # *children*, so a root of e.g.
+    # ``~/Pictures/Photos Library.photoslibrary`` — or a directly
+    # selected/stale subfolder like ``.../Photos Library.photoslibrary/originals``
+    # — would still trigger the macOS "access data from other apps" TCC
+    # prompt this guard exists to avoid. Check every ancestor, not just
+    # the leaf name.
+    if is_excluded_scan_path(root_path):
         log.info(
             "Skipping other-app data bundle as scan root: %s", root_path,
         )

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -20,7 +20,7 @@ from image_loader import (
     SUPPORTED_EXTENSIONS,
     extract_working_copy,
     is_excluded_scan_path,
-    prune_scan_dirs,
+    safe_scan_walk,
 )
 from metadata import extract_metadata
 from PIL import Image
@@ -1093,21 +1093,17 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
     else:
         if recursive:
             checked = 0
-            for dirpath, dirnames, filenames in os.walk(
+            # safe_scan_walk replaces os.walk + prune_scan_dirs. It excludes
+            # other-app data bundles (e.g. "Photos Library.photoslibrary"
+            # sitting in ~/Pictures) without ever stat-following a symlink
+            # to one — os.walk's classification call follows symlinks and
+            # would re-trip the macOS "access data from other apps" TCC
+            # prompt for a child like ``LibraryAlias -> Photos
+            # Library.photoslibrary`` before prune_scan_dirs could reject it.
+            for dirpath, _dirnames, filenames in safe_scan_walk(
                 str(root_path), onerror=_on_walk_error,
             ):
                 _check_cancelled()
-                # Don't recurse into other-app data bundles (e.g.
-                # "Photos Library.photoslibrary" sitting in ~/Pictures).
-                # Pruning dirnames in place stops os.walk descending and
-                # avoids the recurring macOS "access data from other apps"
-                # TCC prompt the library would otherwise trigger.
-                skipped = prune_scan_dirs(dirnames)
-                if skipped:
-                    log.info(
-                        "Skipping other-app data bundle(s) under %s: %s",
-                        dirpath, ", ".join(skipped),
-                    )
                 for name in filenames:
                     checked += 1
                     if checked % 100 == 0:

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -3528,6 +3528,44 @@ def test_api_browse_photo_counts_skips_non_string_entries(app_and_db, tmp_path):
     assert data["counts"] == {str(real): 1}
 
 
+def test_api_browse_photo_counts_skips_macos_other_app_bundles(app_and_db, tmp_path):
+    """POST /api/browse/photo-counts must reject macOS app-managed library
+    bundles (``.photoslibrary`` etc.) BEFORE ``os.path.isdir`` runs.
+
+    The folder browser fires this endpoint with every child of the picker
+    root the moment it opens — for ``~/Pictures`` that includes ``Photos
+    Library.photoslibrary``. ``os.path.isdir`` on that path itself trips
+    the macOS "access data from other apps" TCC prompt the exclusion
+    guards exist to avoid, so the check has to happen first.
+    """
+    real = tmp_path / "real"
+    real.mkdir()
+    (real / "img.jpg").write_bytes(b"x")
+    bundle = tmp_path / "Photos Library.photoslibrary"
+    bundle.mkdir()
+    (bundle / "originals").mkdir()
+    (bundle / "originals" / "managed.jpg").write_bytes(b"x")
+    nested = bundle / "originals"
+
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post(
+        '/api/browse/photo-counts',
+        json={
+            "paths": [str(real), str(bundle), str(nested)],
+            "file_types": [".jpg"],
+        },
+        content_type='application/json',
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["counts"][str(real)] == 1
+    # Bundle root and a path nested inside it must both report 0 without
+    # recursing into the managed contents.
+    assert data["counts"][str(bundle)] == 0
+    assert data["counts"][str(nested)] == 0
+
+
 def test_api_browse_photo_counts_respects_file_types(app_and_db, tmp_path):
     """POST /api/browse/photo-counts only counts files matching requested types."""
     d = tmp_path / "mixed"

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -3404,6 +3404,66 @@ def test_api_browse_invalid_path(app_and_db):
     assert resp.status_code == 400
 
 
+def test_api_browse_rejects_macos_other_app_bundle_root(app_and_db, tmp_path, monkeypatch):
+    """GET /api/browse must reject a ``.photoslibrary`` root BEFORE ``os.path.isdir``.
+
+    The folder picker passes the user-selected path straight to this endpoint;
+    ``os.path.isdir`` on a Photos Library bundle (or a symlink to one) trips
+    the macOS "access data from other apps" TCC prompt the exclusion guards
+    exist to avoid, so the check has to happen first. Monkey-patch
+    ``os.path.isdir`` to fail loudly if it ever runs on the bundle path.
+    """
+    bundle = tmp_path / "Photos Library.photoslibrary"
+    bundle.mkdir()
+
+    real_isdir = os.path.isdir
+
+    def guarded_isdir(p):
+        if str(p) == str(bundle):
+            raise AssertionError(f"os.path.isdir called on excluded bundle: {p}")
+        return real_isdir(p)
+
+    monkeypatch.setattr(os.path, "isdir", guarded_isdir)
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.get(f'/api/browse?path={bundle}')
+    assert resp.status_code == 400
+
+
+def test_api_browse_skips_macos_other_app_bundle_children(app_and_db, tmp_path, monkeypatch):
+    """GET /api/browse must omit ``.photoslibrary`` children from the listing
+    without stat'ing them.
+
+    When the picker opens ``~/Pictures``, this endpoint enumerates every child
+    and would normally call ``os.path.isdir`` on each. For a sibling like
+    ``Photos Library.photoslibrary`` that stat itself trips the macOS TCC
+    prompt; verify the guard skips it before any stat and that regular
+    siblings are still returned.
+    """
+    parent = tmp_path / "pictures"
+    parent.mkdir()
+    (parent / "real").mkdir()
+    bundle = parent / "Photos Library.photoslibrary"
+    bundle.mkdir()
+    (bundle / "originals").mkdir()
+
+    real_isdir = os.path.isdir
+
+    def guarded_isdir(p):
+        if str(p).startswith(str(bundle)):
+            raise AssertionError(f"os.path.isdir called on excluded bundle child: {p}")
+        return real_isdir(p)
+
+    monkeypatch.setattr(os.path, "isdir", guarded_isdir)
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.get(f'/api/browse?path={parent}')
+    assert resp.status_code == 200
+    names = [d['name'] for d in resp.get_json()['dirs']]
+    assert 'real' in names
+    assert 'Photos Library.photoslibrary' not in names
+
+
 def test_api_browse_mkdir(app_and_db, tmp_path):
     """POST /api/browse/mkdir creates a new directory."""
     new_dir = str(tmp_path / "new_folder")

--- a/vireo/tests/test_audit.py
+++ b/vireo/tests/test_audit.py
@@ -146,6 +146,44 @@ def test_check_untracked_finds_new_files(tmp_path):
     assert 'new_file.jpg' in untracked[0]['path']
 
 
+def test_check_untracked_skips_dangling_symlink(tmp_path):
+    """A broken symlink with an image extension is not reported untracked.
+
+    os.walk lists dangling symlinks in filenames; since scanner.scan skips
+    non-files, flagging one would raise a warning a rescan can never clear.
+    """
+    from audit import check_untracked
+    from db import Database
+
+    root = str(tmp_path / "photos")
+    os.makedirs(root)
+    # A symlink named like an image but pointing at a nonexistent target.
+    os.symlink(os.path.join(root, 'nonexistent.jpg'),
+               os.path.join(root, 'broken.jpg'))
+
+    db = Database(str(tmp_path / "test.db"))
+    untracked = check_untracked(db, [root])
+    assert untracked == []
+
+
+def test_check_untracked_skips_photo_library_bundle(tmp_path):
+    """check_untracked must not descend into a Photos library bundle."""
+    from audit import check_untracked
+    from db import Database
+
+    root = str(tmp_path / "photos")
+    lib = os.path.join(root, 'Photos Library.photoslibrary', 'originals')
+    os.makedirs(lib)
+    Image.new('RGB', (100, 100)).save(os.path.join(lib, 'managed.jpg'))
+    Image.new('RGB', (100, 100)).save(os.path.join(root, 'real.jpg'))
+
+    db = Database(str(tmp_path / "test.db"))
+    untracked = check_untracked(db, [root])
+    paths = [u['path'] for u in untracked]
+    assert any('real.jpg' in p for p in paths)
+    assert not any('.photoslibrary' in p for p in paths)
+
+
 def test_remove_orphans(tmp_path):
     """remove_orphans deletes DB entries for missing files."""
     from audit import remove_orphans

--- a/vireo/tests/test_audit.py
+++ b/vireo/tests/test_audit.py
@@ -238,6 +238,38 @@ def test_check_stray_sidecars_skips_root_nested_in_excluded_bundle(tmp_path):
     assert check_stray_sidecars([root]) == []
 
 
+def test_audit_rejects_excluded_root_before_statting(tmp_path, monkeypatch):
+    """Both audit walkers must run the bundle guard BEFORE ``os.path.isdir``.
+
+    ``isdir`` follows symlinks and stat's the target, which alone trips the
+    macOS TCC prompt for a directly selected bundle or a symlink to one.
+    Tested by failing if ``os.path.isdir`` is called on a path the
+    exclusion check covers — if the order is wrong, the stat sneaks in
+    before the guard returns.
+    """
+    from audit import check_stray_sidecars, check_untracked
+    from db import Database
+    from image_loader import is_excluded_scan_path
+
+    real_isdir = os.path.isdir
+
+    def guarded_isdir(path):
+        if is_excluded_scan_path(path):
+            raise AssertionError(
+                f"os.path.isdir called on excluded path before guard: {path}"
+            )
+        return real_isdir(path)
+
+    monkeypatch.setattr(os.path, "isdir", guarded_isdir)
+
+    bundle = str(tmp_path / "Photos Library.photoslibrary")
+    os.makedirs(os.path.join(bundle, "originals"))
+
+    db = Database(str(tmp_path / "test.db"))
+    assert check_untracked(db, [bundle]) == []
+    assert check_stray_sidecars([bundle]) == []
+
+
 def test_remove_orphans(tmp_path):
     """remove_orphans deletes DB entries for missing files."""
     from audit import remove_orphans

--- a/vireo/tests/test_audit.py
+++ b/vireo/tests/test_audit.py
@@ -184,6 +184,26 @@ def test_check_untracked_skips_photo_library_bundle(tmp_path):
     assert not any('.photoslibrary' in p for p in paths)
 
 
+def test_check_untracked_skips_excluded_root_itself(tmp_path):
+    """check_untracked must not open a root that *is* the excluded bundle.
+
+    A configured folder root of ``~/Pictures/Photos Library.photoslibrary``
+    would otherwise have os.walk open the bundle (prune_scan_dirs only
+    filters *children*), defeating the TCC-prompt guard.
+    """
+    from audit import check_untracked
+    from db import Database
+
+    root = str(tmp_path / "Photos Library.photoslibrary")
+    os.makedirs(os.path.join(root, 'originals'))
+    Image.new('RGB', (100, 100)).save(
+        os.path.join(root, 'originals', 'managed.jpg')
+    )
+
+    db = Database(str(tmp_path / "test.db"))
+    assert check_untracked(db, [root]) == []
+
+
 def test_remove_orphans(tmp_path):
     """remove_orphans deletes DB entries for missing files."""
     from audit import remove_orphans

--- a/vireo/tests/test_audit.py
+++ b/vireo/tests/test_audit.py
@@ -286,6 +286,32 @@ def test_remove_orphans(tmp_path):
     assert photo is None
 
 
+def test_check_stray_sidecars_skips_symlinked_directory_with_image_suffix(tmp_path):
+    """A symlink to a directory whose name ends in .xmp/.jpg must not be
+    treated as a sidecar/image.
+
+    ``safe_scan_walk`` classifies entries with ``follow_symlinks=False``,
+    so a ``ghost.xmp -> RealAlbum`` link lands in ``filenames`` rather
+    than ``dirnames``. Without the ``os.path.isfile`` guard the audit
+    would report a bogus stray (and ``delete_stray_sidecars`` would then
+    unlink a real directory link).
+    """
+    from audit import check_stray_sidecars
+
+    root = str(tmp_path / "photos")
+    os.makedirs(root)
+    real_dir = os.path.join(root, "RealAlbum")
+    os.makedirs(real_dir)
+    # Symlink with a sidecar-shaped name that points at a real directory.
+    os.symlink(real_dir, os.path.join(root, "ghost.xmp"))
+    # And one shaped like an image, to confirm the image side is ignored
+    # too (so a real ``ghost.xmp`` next to it wouldn't be silently matched
+    # against the link's basename).
+    os.symlink(real_dir, os.path.join(root, "decoy.jpg"))
+
+    assert check_stray_sidecars([root]) == []
+
+
 def test_check_stray_sidecars(tmp_path):
     """check_stray_sidecars flags .xmp files with no matching image,
     in both bird.xmp and bird.jpg.xmp naming styles."""

--- a/vireo/tests/test_audit.py
+++ b/vireo/tests/test_audit.py
@@ -204,6 +204,40 @@ def test_check_untracked_skips_excluded_root_itself(tmp_path):
     assert check_untracked(db, [root]) == []
 
 
+def test_check_untracked_skips_root_nested_in_excluded_bundle(tmp_path):
+    """check_untracked must also reject roots that *sit inside* an excluded
+    bundle. A leaf-only check would let
+    ``.../Photos Library.photoslibrary/originals`` through (basename
+    ``originals`` is unremarkable) and os.walk would open the protected
+    bundle subtree, defeating the TCC-prompt guard.
+    """
+    from audit import check_untracked
+    from db import Database
+
+    root = str(tmp_path / "Photos Library.photoslibrary" / "originals")
+    os.makedirs(os.path.join(root, '0'))
+    Image.new('RGB', (100, 100)).save(os.path.join(root, '0', 'managed.jpg'))
+
+    db = Database(str(tmp_path / "test.db"))
+    assert check_untracked(db, [root]) == []
+
+
+def test_check_stray_sidecars_skips_root_nested_in_excluded_bundle(tmp_path):
+    """check_stray_sidecars must also reject roots nested inside an excluded
+    bundle so .xmp files inside the protected subtree don't trip the macOS
+    TCC prompt the bundle guard exists to avoid.
+    """
+    from audit import check_stray_sidecars
+    from xmp import write_sidecar
+
+    root = str(tmp_path / "Photos Library.photoslibrary" / "originals")
+    os.makedirs(root)
+    write_sidecar(os.path.join(root, 'ghost.xmp'),
+                  flat_keywords={'Gone'}, hierarchical_keywords=set())
+
+    assert check_stray_sidecars([root]) == []
+
+
 def test_remove_orphans(tmp_path):
     """remove_orphans deletes DB entries for missing files."""
     from audit import remove_orphans

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -11822,7 +11822,7 @@ def test_all_nav_ids_covers_every_page():
     expected = {
         "pipeline", "jobs", "pipeline_review", "pipeline_rapid_review", "review", "cull",
         "misses", "highlights", "life_list", "browse", "map", "variants",
-        "dashboard", "audit", "compare",
+        "dashboard", "audit", "move", "compare",
         "zoom_test", "settings", "workspace", "lightroom", "shortcuts",
         "keywords", "duplicates", "logs",
     }

--- a/vireo/tests/test_folder_rescan_api.py
+++ b/vireo/tests/test_folder_rescan_api.py
@@ -79,6 +79,22 @@ def test_folder_rescan_missing_path_returns_400(app_and_db, tmp_path, monkeypatc
         assert "no longer exists" in resp.get_json().get("error", "")
 
 
+def test_folder_rescan_rejects_macos_other_app_bundle(app_and_db, tmp_path):
+    """A folder row pointing inside a macOS app-managed library (e.g. a
+    stale row from before the prune guards landed) must be rejected
+    BEFORE ``os.path.isdir`` runs — that stat itself trips the macOS
+    "access data from other apps" TCC prompt the guards exist to avoid.
+    """
+    app, db = app_and_db
+    bundle = tmp_path / "Photos Library.photoslibrary"
+    bundle.mkdir()
+    fid = db.add_folder(str(bundle), name="stale-bundle")
+    with app.test_client() as c:
+        resp = c.post(f"/api/folders/{fid}/rescan", json={})
+        assert resp.status_code == 400
+        assert "macos" in resp.get_json().get("error", "").lower()
+
+
 def test_folder_rescan_rejects_folder_outside_active_workspace(app_and_db, tmp_path):
     """A folder that exists globally but is NOT linked to the active
     workspace must 404 — otherwise a rescan would pollute the active

--- a/vireo/tests/test_image_loader.py
+++ b/vireo/tests/test_image_loader.py
@@ -614,3 +614,142 @@ def test_is_excluded_scan_path_tolerates_non_string_inputs():
     assert is_excluded_scan_path(0.5) is False
     assert is_excluded_scan_path(["/Users/me/Pictures"]) is False
     assert is_excluded_scan_path({"path": "/Users/me/Pictures"}) is False
+
+
+def test_safe_scan_walk_skips_symlinked_excluded_bundle(tmp_path, caplog):
+    """A child symlink whose target is an excluded bundle must be dropped
+    before any stat that follows the link.
+
+    ``os.walk`` classifies each child by calling ``DirEntry.is_dir()``,
+    which follows symlinks. For a child like ``LibraryAlias -> Photos
+    Library.photoslibrary`` that classification stat alone reaches into
+    the protected bundle and re-trips the macOS TCC "access data from
+    other apps" prompt this guard exists to avoid — even though
+    ``prune_scan_dirs`` would have removed the entry from recursion
+    afterwards. ``safe_scan_walk`` must read the symlink target textually
+    (``os.readlink``, no stat-follow) and skip the entry before
+    classification.
+    """
+    import logging
+
+    import pytest
+    if sys.platform == "win32":
+        pytest.skip("POSIX symlinks required")
+    from image_loader import safe_scan_walk
+
+    bundle = tmp_path / "Photos Library.photoslibrary"
+    (bundle / "originals").mkdir(parents=True)
+    (bundle / "originals" / "managed.jpg").write_bytes(b"")
+
+    root = tmp_path / "photos"
+    root.mkdir()
+    (root / "real.jpg").write_bytes(b"")
+    os.symlink(str(bundle), str(root / "LibraryAlias"))
+
+    seen = []
+    with caplog.at_level(logging.INFO, logger="image_loader"):
+        for _dirpath, dirnames, filenames in safe_scan_walk(str(root)):
+            for name in filenames + dirnames:
+                seen.append(name)
+
+    assert "real.jpg" in seen
+    # The symlink must not surface as a child dir (else os.walk would
+    # recurse) or a file (else os.path.isfile would follow it and trip
+    # the same prompt).
+    assert "LibraryAlias" not in seen
+    assert "managed.jpg" not in seen
+    # The skip was deliberate, not just a missed entry — the log line
+    # records what we dropped under this root.
+    assert any(
+        "LibraryAlias" in r.getMessage()
+        for r in caplog.records
+        if r.name == "image_loader"
+    )
+
+
+def test_safe_scan_walk_skips_direct_bundle_child_without_stat(tmp_path):
+    """A direct (non-symlinked) bundle child must be dropped by name
+    before any ``is_dir()`` call. ``os.walk``'s classification stat on
+    the bundle root itself is enough to trip the macOS TCC prompt, so a
+    name match has to win before any stat happens.
+    """
+    from image_loader import safe_scan_walk
+
+    root = tmp_path / "photos"
+    root.mkdir()
+    (root / "real.jpg").write_bytes(b"")
+    bundle = root / "Photos Library.photoslibrary"
+    (bundle / "originals" / "0").mkdir(parents=True)
+    (bundle / "originals" / "0" / "managed.jpg").write_bytes(b"")
+
+    seen_paths = []
+    for dirpath, dirnames, filenames in safe_scan_walk(str(root)):
+        for name in filenames:
+            seen_paths.append(os.path.join(dirpath, name))
+        for name in dirnames:
+            seen_paths.append(os.path.join(dirpath, name))
+
+    assert any(p.endswith("real.jpg") for p in seen_paths)
+    assert not any(".photoslibrary" in p for p in seen_paths)
+    assert not any("managed.jpg" in p for p in seen_paths)
+
+
+def test_safe_scan_walk_matches_os_walk_for_normal_trees(tmp_path):
+    """Outside of bundle exclusion, ``safe_scan_walk`` yields the same
+    files as the normal walker for the same recursion semantics
+    (``followlinks=False``). Pin this so future tweaks don't accidentally
+    drop legitimate photos.
+    """
+    from image_loader import safe_scan_walk
+
+    (tmp_path / "a").mkdir()
+    (tmp_path / "a" / "b").mkdir()
+    (tmp_path / "top.jpg").write_bytes(b"")
+    (tmp_path / "a" / "mid.jpg").write_bytes(b"")
+    (tmp_path / "a" / "b" / "deep.jpg").write_bytes(b"")
+
+    collected = set()
+    for dirpath, _dirnames, filenames in safe_scan_walk(str(tmp_path)):
+        for name in filenames:
+            collected.add(os.path.relpath(
+                os.path.join(dirpath, name), str(tmp_path)
+            ))
+
+    assert collected == {
+        "top.jpg",
+        os.path.join("a", "mid.jpg"),
+        os.path.join("a", "b", "deep.jpg"),
+    }
+
+
+def test_safe_scan_walk_surfaces_permission_errors_via_onerror(tmp_path):
+    """``safe_scan_walk`` must mirror ``os.walk(onerror=...)``: a directory
+    the kernel refuses to enter is reported via the callback, not swallowed.
+    Regression guard: the scanner's partial-discovery callback relies on
+    this to surface denied paths.
+    """
+    import pytest
+    if sys.platform == "win32":
+        pytest.skip("POSIX permissions required")
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        pytest.skip("root bypasses POSIX mode bits; cannot deny self")
+    from image_loader import safe_scan_walk
+
+    (tmp_path / "ok.jpg").write_bytes(b"")
+    forbidden = tmp_path / "forbidden"
+    forbidden.mkdir()
+    (forbidden / "hidden.jpg").write_bytes(b"")
+    os.chmod(str(forbidden), 0o000)
+
+    errors = []
+    try:
+        for _dirpath, _dirnames, _filenames in safe_scan_walk(
+            str(tmp_path), onerror=errors.append
+        ):
+            pass
+        assert any(str(forbidden) in str(getattr(e, "filename", "") or e)
+                   for e in errors), (
+            f"denied path not reported via onerror callback: {errors}"
+        )
+    finally:
+        os.chmod(str(forbidden), 0o755)

--- a/vireo/tests/test_image_loader.py
+++ b/vireo/tests/test_image_loader.py
@@ -694,6 +694,54 @@ def test_safe_scan_walk_skips_direct_bundle_child_without_stat(tmp_path):
     assert not any("managed.jpg" in p for p in seen_paths)
 
 
+def test_safe_scan_walk_skips_file_symlink_into_excluded_bundle(tmp_path):
+    """A file-named symlink whose target sits inside an excluded bundle
+    must be dropped during walk classification, not surfaced as a filename.
+
+    A previous version of ``_symlink_target_is_excluded`` checked only the
+    *basename* of the symlink target. For a link like
+    ``IMG.jpg -> ../Photos Library.photoslibrary/originals/IMG.jpg`` that
+    basename (``IMG.jpg``) doesn't match any bundle, so the link surfaced
+    in ``filenames``; downstream callers then ran ``os.path.isfile`` /
+    ``Path.is_file`` which followed the link, stat'd the managed Photos
+    file, and re-tripped the macOS TCC prompt this guard exists to avoid.
+    Check every component of the target path, not just the basename.
+    """
+    import pytest
+    if sys.platform == "win32":
+        pytest.skip("POSIX symlinks required")
+    from image_loader import safe_scan_walk
+
+    bundle = tmp_path / "Photos Library.photoslibrary"
+    (bundle / "originals").mkdir(parents=True)
+    (bundle / "originals" / "managed.jpg").write_bytes(b"")
+
+    root = tmp_path / "photos"
+    root.mkdir()
+    (root / "real.jpg").write_bytes(b"")
+    # Relative link reaching into the bundle (the case the basename-only
+    # check missed).
+    os.symlink(
+        os.path.join("..", "Photos Library.photoslibrary",
+                     "originals", "managed.jpg"),
+        str(root / "IMG.jpg"),
+    )
+    # Absolute link, same shape — covers callers that pass absolute targets.
+    os.symlink(
+        str(bundle / "originals" / "managed.jpg"),
+        str(root / "ABS.jpg"),
+    )
+
+    seen = set()
+    for _dirpath, dirnames, filenames in safe_scan_walk(str(root)):
+        seen.update(filenames)
+        seen.update(dirnames)
+
+    assert "real.jpg" in seen
+    assert "IMG.jpg" not in seen
+    assert "ABS.jpg" not in seen
+
+
 def test_safe_scan_walk_matches_os_walk_for_normal_trees(tmp_path):
     """Outside of bundle exclusion, ``safe_scan_walk`` yields the same
     files as the normal walker for the same recursion semantics

--- a/vireo/tests/test_image_loader.py
+++ b/vireo/tests/test_image_loader.py
@@ -558,3 +558,42 @@ def test_is_excluded_scan_path_matches_nested_paths():
     assert not is_excluded_scan_path(
         "/Users/me/Pictures/photoslibrary_backup/2024"
     )
+
+
+def test_is_excluded_scan_path_resolves_symlinked_root(tmp_path):
+    """A symlink whose target is (or sits inside) an excluded bundle must
+    be rejected. Without resolving, ``Path(path).parts`` reveals nothing
+    about the bundle, but ``Path.is_dir()`` / ``os.walk()`` follow the
+    link anyway — so the walker would still open the protected subtree
+    and re-trip the macOS TCC prompt this guard exists to avoid.
+    """
+    import pytest
+    if sys.platform == "win32":
+        pytest.skip("POSIX symlinks required")
+    from image_loader import is_excluded_scan_path
+
+    bundle = tmp_path / "Photos Library.photoslibrary"
+    (bundle / "originals").mkdir(parents=True)
+
+    # Direct symlink at the bundle itself.
+    direct_link = tmp_path / "PhotoLibLink"
+    os.symlink(str(bundle), str(direct_link))
+    assert is_excluded_scan_path(str(direct_link))
+
+    # Symlink at a child *inside* the bundle.
+    child_link = tmp_path / "OriginalsLink"
+    os.symlink(str(bundle / "originals"), str(child_link))
+    assert is_excluded_scan_path(str(child_link))
+
+    # Intermediate symlink on the way to the bundle subtree.
+    alias_dir = tmp_path / "Aliases"
+    alias_dir.mkdir()
+    os.symlink(str(bundle), str(alias_dir / "MyLib"))
+    assert is_excluded_scan_path(str(alias_dir / "MyLib" / "originals"))
+
+    # A symlink to a normal folder must NOT be excluded.
+    normal = tmp_path / "real_photos"
+    normal.mkdir()
+    normal_link = tmp_path / "PhotosLink"
+    os.symlink(str(normal), str(normal_link))
+    assert not is_excluded_scan_path(str(normal_link))

--- a/vireo/tests/test_image_loader.py
+++ b/vireo/tests/test_image_loader.py
@@ -616,6 +616,120 @@ def test_is_excluded_scan_path_tolerates_non_string_inputs():
     assert is_excluded_scan_path({"path": "/Users/me/Pictures"}) is False
 
 
+def test_is_excluded_scan_path_resolves_symlinks_without_realpath(
+    tmp_path, monkeypatch,
+):
+    """Symlink resolution must not go through ``os.path.realpath``.
+
+    ``realpath`` walks the resolved chain by ``lstat``-ing every
+    component along the way — including the bundle target once a link
+    points at it — which is exactly the kind of stat the macOS
+    "access data from other apps" TCC prompt watches for. Fail the
+    test if the helper ever calls ``os.path.realpath`` on an input
+    that's a symlink (or contains one). With purely textual resolution
+    (``os.path.islink`` + ``os.readlink``) the call must never happen.
+    """
+    import pytest
+    if sys.platform == "win32":
+        pytest.skip("POSIX symlinks required")
+    import os.path as ospath
+
+    import image_loader
+
+    real_realpath = ospath.realpath
+    calls = []
+
+    def trapped_realpath(p, *args, **kwargs):
+        calls.append(p)
+        return real_realpath(p, *args, **kwargs)
+
+    monkeypatch.setattr(image_loader.os.path, "realpath", trapped_realpath)
+
+    bundle = tmp_path / "Photos Library.photoslibrary"
+    (bundle / "originals").mkdir(parents=True)
+
+    direct_link = tmp_path / "PhotoLibLink"
+    os.symlink(str(bundle), str(direct_link))
+    chained_link = tmp_path / "ChainLink"
+    os.symlink(str(direct_link), str(chained_link))
+    alias_dir = tmp_path / "Aliases"
+    alias_dir.mkdir()
+    os.symlink(str(bundle), str(alias_dir / "MyLib"))
+
+    assert image_loader.is_excluded_scan_path(str(direct_link))
+    assert image_loader.is_excluded_scan_path(str(chained_link))
+    assert image_loader.is_excluded_scan_path(str(alias_dir / "MyLib"))
+    assert image_loader.is_excluded_scan_path(str(alias_dir / "MyLib" / "originals"))
+
+    assert calls == [], (
+        f"is_excluded_scan_path must not call os.path.realpath "
+        f"(it lstats inside the bundle); got calls for {calls}"
+    )
+
+
+def test_safe_iter_dir_skips_bundle_children_and_yields_paths(tmp_path):
+    """``safe_iter_dir`` mirrors ``Path.iterdir`` but drops excluded
+    bundle children — direct ``Photos Library.photoslibrary`` entries
+    or symlinks pointing at one — before the caller can stat them with
+    ``f.is_file()``. Without this, a non-recursive scan/ingest of a
+    parent like ``~/Pictures`` would stat the bundle target via
+    ``is_file`` (which follows symlinks) and re-trip the macOS TCC
+    "access data from other apps" prompt this guard exists to avoid.
+    """
+    import pytest
+    if sys.platform == "win32":
+        pytest.skip("POSIX symlinks required")
+    from image_loader import safe_iter_dir
+
+    bundle = tmp_path / "Photos Library.photoslibrary"
+    (bundle / "originals").mkdir(parents=True)
+    (bundle / "originals" / "managed.jpg").write_bytes(b"")
+
+    root = tmp_path / "photos"
+    root.mkdir()
+    (root / "real.jpg").write_bytes(b"")
+    (root / "Photos Library.photoslibrary").mkdir()
+    (root / "Photos Library.photoslibrary" / "managed.jpg").write_bytes(b"")
+    os.symlink(str(bundle), str(root / "LibraryAlias"))
+    (root / "sub").mkdir()
+    (root / "sub" / "deep.jpg").write_bytes(b"")  # not yielded — only direct children
+
+    names = {p.name for p in safe_iter_dir(str(root))}
+
+    assert "real.jpg" in names
+    assert "sub" in names
+    assert "Photos Library.photoslibrary" not in names
+    assert "LibraryAlias" not in names
+
+
+def test_safe_iter_dir_surfaces_permission_errors_via_onerror(tmp_path):
+    """Mirrors ``safe_scan_walk``: a directory the kernel refuses to
+    open is reported via the callback, not swallowed. Scanner's
+    non-recursive partial-discovery callback depends on this.
+    """
+    import pytest
+    if sys.platform == "win32":
+        pytest.skip("POSIX permissions required")
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        pytest.skip("root bypasses POSIX mode bits; cannot deny self")
+    from image_loader import safe_iter_dir
+
+    forbidden = tmp_path / "forbidden"
+    forbidden.mkdir()
+    (forbidden / "hidden.jpg").write_bytes(b"")
+    os.chmod(str(forbidden), 0o000)
+
+    errors = []
+    try:
+        list(safe_iter_dir(str(forbidden), onerror=errors.append))
+        assert any(str(forbidden) in str(getattr(e, "filename", "") or e)
+                   for e in errors), (
+            f"denied path not reported via onerror callback: {errors}"
+        )
+    finally:
+        os.chmod(str(forbidden), 0o755)
+
+
 def test_safe_scan_walk_skips_symlinked_excluded_bundle(tmp_path, caplog):
     """A child symlink whose target is an excluded bundle must be dropped
     before any stat that follows the link.

--- a/vireo/tests/test_image_loader.py
+++ b/vireo/tests/test_image_loader.py
@@ -493,3 +493,35 @@ def test_load_image_does_not_retry_on_unsupported_format(tmp_path, monkeypatch):
     img = image_loader.load_image(str(src), max_size=200)
     assert img is None
     assert calls["n"] == 1  # no retry
+
+
+def test_is_excluded_scan_dir_matches_photo_library_bundles():
+    from image_loader import is_excluded_scan_dir
+
+    assert is_excluded_scan_dir("Photos Library.photoslibrary")
+    assert is_excluded_scan_dir("Old Library.photolibrary")
+    assert is_excluded_scan_dir("Aperture.aplibrary")
+    assert is_excluded_scan_dir("PHOTOS LIBRARY.PHOTOSLIBRARY")  # case-insensitive
+    assert is_excluded_scan_dir("Photo Booth Library")
+    # Real photo folders must NOT be excluded.
+    assert not is_excluded_scan_dir("2026")
+    assert not is_excluded_scan_dir("Pictures")
+    assert not is_excluded_scan_dir("photoslibrary_backup")  # not a suffix match
+
+
+def test_prune_scan_dirs_removes_in_place_and_reports():
+    from image_loader import prune_scan_dirs
+
+    dirnames = ["2026", "Photos Library.photoslibrary", "January"]
+    removed = prune_scan_dirs(dirnames)
+
+    assert removed == ["Photos Library.photoslibrary"]
+    assert dirnames == ["2026", "January"]  # mutated in place
+
+
+def test_prune_scan_dirs_noop_when_clean():
+    from image_loader import prune_scan_dirs
+
+    dirnames = ["2026", "January"]
+    assert prune_scan_dirs(dirnames) == []
+    assert dirnames == ["2026", "January"]

--- a/vireo/tests/test_image_loader.py
+++ b/vireo/tests/test_image_loader.py
@@ -856,6 +856,63 @@ def test_safe_scan_walk_skips_file_symlink_into_excluded_bundle(tmp_path):
     assert "ABS.jpg" not in seen
 
 
+def test_safe_scan_walk_skips_chained_symlink_into_bundle(tmp_path):
+    """A symlink whose *immediate* target is a plain path but resolves
+    through another link into an excluded bundle must be dropped.
+
+    Two chain shapes ``_symlink_target_is_excluded`` must catch:
+
+    * ``LibraryAlias -> MidAlias`` where ``MidAlias -> Photos
+      Library.photoslibrary``: the first readlink yields ``MidAlias``,
+      whose parts don't match any bundle, so a one-hop check would
+      surface the entry. Downstream ``Path.is_dir`` / ``os.path.isfile``
+      then follow both hops and stat the protected bundle — re-tripping
+      the macOS TCC "access data from other apps" prompt.
+    * ``IMG.jpg -> MidAlias/originals/IMG.jpg`` (same MidAlias): the
+      file-named link's immediate target is a path through MidAlias.
+      ``os.path.isfile`` follows the chain into the managed Photos file.
+
+    Use ``is_excluded_scan_path`` on the readlink target so the chain is
+    walked component-by-component textually (each ``islink`` confined to
+    the link node, never resolving deep enough to touch the bundle).
+    """
+    import pytest
+    if sys.platform == "win32":
+        pytest.skip("POSIX symlinks required")
+    from image_loader import safe_scan_walk
+
+    bundle = tmp_path / "Photos Library.photoslibrary"
+    (bundle / "originals").mkdir(parents=True)
+    (bundle / "originals" / "managed.jpg").write_bytes(b"")
+
+    root = tmp_path / "photos"
+    root.mkdir()
+    (root / "real.jpg").write_bytes(b"")
+    # The intermediate link MidAlias sits adjacent to the entries that
+    # reference it through their own targets.
+    os.symlink(str(bundle), str(root / "MidAlias"))
+    # Chained directory link: LibraryAlias -> MidAlias -> bundle.
+    os.symlink("MidAlias", str(root / "LibraryAlias"))
+    # Chained file link whose target path goes through MidAlias.
+    os.symlink(
+        os.path.join("MidAlias", "originals", "managed.jpg"),
+        str(root / "IMG.jpg"),
+    )
+
+    seen = set()
+    for _dirpath, dirnames, filenames in safe_scan_walk(str(root)):
+        seen.update(filenames)
+        seen.update(dirnames)
+
+    assert "real.jpg" in seen
+    # All three chained entries must be dropped before any stat that
+    # would follow the chain into the bundle.
+    assert "MidAlias" not in seen
+    assert "LibraryAlias" not in seen
+    assert "IMG.jpg" not in seen
+    assert "managed.jpg" not in seen
+
+
 def test_safe_scan_walk_matches_os_walk_for_normal_trees(tmp_path):
     """Outside of bundle exclusion, ``safe_scan_walk`` yields the same
     files as the normal walker for the same recursion semantics

--- a/vireo/tests/test_image_loader.py
+++ b/vireo/tests/test_image_loader.py
@@ -525,3 +525,36 @@ def test_prune_scan_dirs_noop_when_clean():
     dirnames = ["2026", "January"]
     assert prune_scan_dirs(dirnames) == []
     assert dirnames == ["2026", "January"]
+
+
+def test_is_excluded_scan_path_matches_nested_paths():
+    """The root-level guard must reject a path that *sits inside* an excluded
+    bundle, not only one whose leaf name is the bundle. Without this, a user
+    picking ``.../Photos Library.photoslibrary/originals`` directly — or a
+    stale folder row carried over from before the guard existed — still
+    drives os.walk into the protected bundle and re-trips macOS TCC."""
+    from image_loader import is_excluded_scan_path
+
+    # Leaf-is-bundle (the case the leaf-only check already caught).
+    assert is_excluded_scan_path("/Users/me/Pictures/Photos Library.photoslibrary")
+    # Nested under a bundle — the case the leaf-only check missed.
+    assert is_excluded_scan_path(
+        "/Users/me/Pictures/Photos Library.photoslibrary/originals"
+    )
+    assert is_excluded_scan_path(
+        "/Users/me/Pictures/Photos Library.photoslibrary/originals/2024/01"
+    )
+    assert is_excluded_scan_path(
+        "/Users/me/Photo Booth Library/Pictures/IMG.jpg"
+    )
+    # Case-insensitive on the bundle component.
+    assert is_excluded_scan_path(
+        "/Users/me/PHOTOS LIBRARY.PHOTOSLIBRARY/originals"
+    )
+    # Real photo folders must NOT be excluded.
+    assert not is_excluded_scan_path("/Users/me/Pictures/2026/January")
+    assert not is_excluded_scan_path("/Users/me/Pictures")
+    # Substring matches on non-bundle component names must NOT trigger.
+    assert not is_excluded_scan_path(
+        "/Users/me/Pictures/photoslibrary_backup/2024"
+    )

--- a/vireo/tests/test_image_loader.py
+++ b/vireo/tests/test_image_loader.py
@@ -597,3 +597,20 @@ def test_is_excluded_scan_path_resolves_symlinked_root(tmp_path):
     normal_link = tmp_path / "PhotosLink"
     os.symlink(str(normal), str(normal_link))
     assert not is_excluded_scan_path(str(normal_link))
+
+
+def test_is_excluded_scan_path_tolerates_non_string_inputs():
+    """Truthy non-string JSON primitives (``{"root": 123}``,
+    ``{"source": true}``) can reach this helper before the route's
+    ``os.path.isdir`` validation. ``Path(int)``/``Path(bool)`` raise
+    ``TypeError``; the helper must swallow that and return False so the
+    downstream ``isdir`` check still produces the route's 400 response
+    rather than a 500.
+    """
+    from image_loader import is_excluded_scan_path
+
+    assert is_excluded_scan_path(123) is False
+    assert is_excluded_scan_path(True) is False
+    assert is_excluded_scan_path(0.5) is False
+    assert is_excluded_scan_path(["/Users/me/Pictures"]) is False
+    assert is_excluded_scan_path({"path": "/Users/me/Pictures"}) is False

--- a/vireo/tests/test_ingest.py
+++ b/vireo/tests/test_ingest.py
@@ -143,6 +143,18 @@ def test_discover_source_files_skips_excluded_root_itself(tmp_path):
     assert discover_source_files(str(src), file_types="both") == []
 
 
+def test_discover_source_files_skips_source_nested_in_excluded_bundle(tmp_path):
+    """Picking a *subfolder* of a Photos library bundle as an import source
+    must also return no candidates. A leaf-only check would let
+    ``.../Photos Library.photoslibrary/originals`` through (basename
+    ``originals`` is unremarkable) and os.walk would open the protected
+    bundle subtree and re-trip the macOS TCC prompt this guard exists to
+    avoid. The guard must check every ancestor."""
+    src = tmp_path / "Photos Library.photoslibrary" / "originals"
+    _create_test_files(str(src / "0"), ["managed.jpg"])
+    assert discover_source_files(str(src), file_types="both") == []
+
+
 def test_ingest_copies_files_to_date_folders(tmp_path):
     """Files are copied to destination organized by EXIF date (falls back to mtime)."""
     src = tmp_path / "sd_card"

--- a/vireo/tests/test_ingest.py
+++ b/vireo/tests/test_ingest.py
@@ -155,6 +155,37 @@ def test_discover_source_files_skips_source_nested_in_excluded_bundle(tmp_path):
     assert discover_source_files(str(src), file_types="both") == []
 
 
+def test_discover_source_files_rejects_excluded_source_before_statting(
+    tmp_path, monkeypatch
+):
+    """The bundle guard must run BEFORE ``Path.is_dir`` on the source.
+
+    ``Path.is_dir`` follows symlinks and stat's the target, which alone
+    trips the macOS TCC prompt for a directly selected bundle or a
+    symlink to one. Fails the test if ``Path.is_dir`` is called on a
+    path the exclusion check covers — if the order is wrong, the stat
+    sneaks in before the guard returns.
+    """
+    from pathlib import Path
+
+    from image_loader import is_excluded_scan_path
+
+    real_is_dir = Path.is_dir
+
+    def guarded_is_dir(self):
+        if is_excluded_scan_path(self):
+            raise AssertionError(
+                f"is_dir() called on excluded path before guard: {self}"
+            )
+        return real_is_dir(self)
+
+    monkeypatch.setattr(Path, "is_dir", guarded_is_dir)
+
+    src = tmp_path / "Photos Library.photoslibrary"
+    _create_test_files(str(src / "originals"), ["managed.jpg"])
+    assert discover_source_files(str(src), file_types="both") == []
+
+
 def test_ingest_copies_files_to_date_folders(tmp_path):
     """Files are copied to destination organized by EXIF date (falls back to mtime)."""
     src = tmp_path / "sd_card"

--- a/vireo/tests/test_ingest.py
+++ b/vireo/tests/test_ingest.py
@@ -232,6 +232,65 @@ def test_discover_source_files_non_recursive_does_not_stat_bundle_children(
     assert names == {"real.jpg"}
 
 
+def test_discover_source_files_recursive_streams_candidates(
+    tmp_path, monkeypatch
+):
+    """The recursive walk must stream candidate paths through the
+    image-extension/``is_file()`` filter rather than collecting every
+    walked filename first. A source like a home directory or external
+    disk root can yield millions of non-image filenames; buffering them
+    all before the filter would balloon memory proportional to the whole
+    tree and stall the preview before any photo is copied. The previous
+    ``Path.rglob`` implementation was consumed lazily by ``sorted()`` —
+    keep the same streaming behaviour.
+
+    Verified by tracking the interleave of ``safe_scan_walk`` yields
+    and ``Path.is_file`` filter calls. If the recursive branch buffers
+    every yield first, every ``is_file`` call happens *after* every
+    yield; streaming produces interleaved calls.
+    """
+    from pathlib import Path
+
+    import ingest as ingest_mod
+
+    real_walk = ingest_mod.safe_scan_walk
+    real_is_file = Path.is_file
+
+    events = []
+
+    def tracking_walk(top, onerror=None):
+        # Yield one filename per tuple so each name's emission is its own
+        # observable event in `events`.
+        for dirpath, _dirnames, filenames in real_walk(top, onerror=onerror):
+            for name in filenames:
+                events.append(("yield", name))
+                yield dirpath, [], [name]
+
+    def tracking_is_file(self):
+        events.append(("is_file", self.name))
+        return real_is_file(self)
+
+    monkeypatch.setattr(ingest_mod, "safe_scan_walk", tracking_walk)
+    monkeypatch.setattr(Path, "is_file", tracking_is_file)
+
+    src = tmp_path / "src"
+    _create_test_files(str(src), ["a.jpg", "b.txt", "c.jpg", "d.txt"])
+
+    files = discover_source_files(str(src), file_types="both")
+    assert {f.name for f in files} == {"a.jpg", "c.jpg"}
+
+    yield_indices = [i for i, (kind, _) in enumerate(events) if kind == "yield"]
+    is_file_indices = [
+        i for i, (kind, _) in enumerate(events) if kind == "is_file"
+    ]
+    assert yield_indices and is_file_indices
+    assert min(is_file_indices) < max(yield_indices), (
+        "discover_source_files buffered every walked candidate before "
+        "running the image filter — see the streaming requirement in "
+        "ingest.discover_source_files. Event order: " + repr(events)
+    )
+
+
 def test_discover_source_files_rejects_excluded_source_before_statting(
     tmp_path, monkeypatch
 ):

--- a/vireo/tests/test_ingest.py
+++ b/vireo/tests/test_ingest.py
@@ -133,6 +133,16 @@ def test_discover_source_files_nonexistent_dir():
     assert files == []
 
 
+def test_discover_source_files_skips_excluded_root_itself(tmp_path):
+    """Picking a Photos library bundle directly as an import source must
+    return no candidates — without a root-level guard, os.walk would still
+    open the bundle (prune_scan_dirs only filters children) and trip the
+    macOS TCC prompt this guard exists to avoid."""
+    src = tmp_path / "Photos Library.photoslibrary"
+    _create_test_files(str(src / "originals"), ["managed.jpg"])
+    assert discover_source_files(str(src), file_types="both") == []
+
+
 def test_ingest_copies_files_to_date_folders(tmp_path):
     """Files are copied to destination organized by EXIF date (falls back to mtime)."""
     src = tmp_path / "sd_card"

--- a/vireo/tests/test_ingest.py
+++ b/vireo/tests/test_ingest.py
@@ -155,6 +155,83 @@ def test_discover_source_files_skips_source_nested_in_excluded_bundle(tmp_path):
     assert discover_source_files(str(src), file_types="both") == []
 
 
+def test_discover_source_files_non_recursive_skips_bundle_children(tmp_path):
+    """``discover_source_files(recursive=False)`` on a normal source
+    like ``~/Pictures`` must drop excluded bundle children (direct
+    ``Photos Library.photoslibrary`` entries or symlinks pointing at
+    one) before the ``is_file()`` filter would stat them. A bare
+    ``iterdir() + is_file()`` would follow the symlink to the bundle
+    target and re-trip the macOS "access data from other apps" TCC
+    prompt this guard exists to avoid.
+    """
+    import sys
+    if sys.platform == "win32":
+        pytest.skip("POSIX symlinks required")
+
+    bundle = tmp_path / "Photos Library.photoslibrary"
+    _create_test_files(str(bundle / "originals"), ["managed.jpg"])
+
+    src = tmp_path / "sd_card"
+    _create_test_files(str(src), ["real.jpg"])
+    # Direct bundle child as a sibling.
+    _create_test_files(
+        str(src / "Photos Library.photoslibrary" / "originals"),
+        ["direct_managed.jpg"],
+    )
+    # Symlinked bundle child.
+    os.symlink(str(bundle), str(src / "LibraryAlias"))
+
+    files = discover_source_files(
+        str(src), file_types="both", recursive=False
+    )
+    names = {f.name for f in files}
+    assert names == {"real.jpg"}
+
+
+def test_discover_source_files_non_recursive_does_not_stat_bundle_children(
+    tmp_path, monkeypatch
+):
+    """Belt-and-braces guard for the non-recursive branch. Fails if
+    ``Path.is_file`` is ever called on an excluded child — that
+    ``is_file`` follows symlinks and would re-trip the macOS TCC
+    prompt before the extension filter could reject the entry.
+    """
+    import sys
+    if sys.platform == "win32":
+        pytest.skip("POSIX symlinks required")
+    from pathlib import Path
+
+    from image_loader import is_excluded_scan_path
+
+    real_is_file = Path.is_file
+
+    def guarded_is_file(self):
+        if is_excluded_scan_path(self):
+            raise AssertionError(
+                f"is_file() called on excluded path before guard: {self}"
+            )
+        return real_is_file(self)
+
+    monkeypatch.setattr(Path, "is_file", guarded_is_file)
+
+    bundle = tmp_path / "Photos Library.photoslibrary"
+    _create_test_files(str(bundle / "originals"), ["managed.jpg"])
+
+    src = tmp_path / "sd_card"
+    _create_test_files(str(src), ["real.jpg"])
+    _create_test_files(
+        str(src / "Photos Library.photoslibrary" / "originals"),
+        ["direct_managed.jpg"],
+    )
+    os.symlink(str(bundle), str(src / "LibraryAlias"))
+
+    files = discover_source_files(
+        str(src), file_types="both", recursive=False
+    )
+    names = {f.name for f in files}
+    assert names == {"real.jpg"}
+
+
 def test_discover_source_files_rejects_excluded_source_before_statting(
     tmp_path, monkeypatch
 ):

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -420,6 +420,32 @@ def test_import_full_rejects_macos_other_app_bundle(app_and_db, tmp_path):
         assert "macos" in resp.get_json()["error"].lower()
 
 
+def test_scan_and_ingest_reject_non_string_path_with_400(app_and_db, tmp_path):
+    """JSON primitives (``{"root": 123}``, ``{"source": true}``) reach the
+    excluded-bundle helper before the directory check. The helper must not
+    raise ``TypeError`` on those — otherwise routes return 500 instead of
+    the 400 the directory validation produced before this PR.
+    """
+    app, _ = app_and_db
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/scan", json={"root": 123})
+        assert resp.status_code == 400
+
+        resp = c.post("/api/jobs/ingest", json={
+            "source": True,
+            "destination": str(dst),
+        })
+        assert resp.status_code == 400
+
+        resp = c.post("/api/jobs/import-full", json={
+            "source": 42,
+            "destination": str(dst),
+        })
+        assert resp.status_code == 400
+
+
 def test_ingest_relative_destination(app_and_db, tmp_path):
     """POST /api/jobs/ingest validates destination is absolute."""
     app, db = app_and_db

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -31,6 +31,31 @@ def test_job_scan_invalid_root(app_and_db):
     assert resp.status_code == 400
 
 
+def test_job_scan_rejects_macos_other_app_bundle(app_and_db, tmp_path):
+    """POST /api/jobs/scan must reject a ``.photoslibrary`` root before
+    calling ``os.path.isdir`` on it. ``os.path.isdir`` against an Apple
+    Photos bundle on macOS itself trips the kTCCServiceSystemPolicyAppData
+    prompt this guard exists to prevent, so the rejection must happen
+    before any stat.
+    """
+    app, _ = app_and_db
+    client = app.test_client()
+
+    bundle = tmp_path / "Photos Library.photoslibrary"
+    bundle.mkdir()
+
+    resp = client.post('/api/jobs/scan', json={'root': str(bundle)})
+    assert resp.status_code == 400
+    assert "macos" in resp.get_json()["error"].lower()
+
+    # Nested paths inside the bundle (e.g. stale folder rows pointing at
+    # ``.../Photos Library.photoslibrary/originals``) must be rejected too.
+    nested = bundle / "originals"
+    nested.mkdir()
+    resp = client.post('/api/jobs/scan', json={'root': str(nested)})
+    assert resp.status_code == 400
+
+
 def test_job_status_endpoint(app_and_db, tmp_path):
     """GET /api/jobs/<id> returns job status."""
     app, db = app_and_db
@@ -358,6 +383,41 @@ def test_ingest_nonexistent_source(app_and_db, tmp_path):
         })
         assert resp.status_code == 400
         assert "not found" in resp.get_json()["error"]
+
+
+def test_ingest_rejects_macos_other_app_bundle(app_and_db, tmp_path):
+    """POST /api/jobs/ingest must reject a ``.photoslibrary`` source before
+    calling ``os.path.isdir``. See test_job_scan_rejects_macos_other_app_bundle.
+    """
+    app, _ = app_and_db
+    bundle = tmp_path / "Photos Library.photoslibrary"
+    bundle.mkdir()
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/ingest", json={
+            "source": str(bundle),
+            "destination": str(dst),
+        })
+        assert resp.status_code == 400
+        assert "macos" in resp.get_json()["error"].lower()
+
+
+def test_import_full_rejects_macos_other_app_bundle(app_and_db, tmp_path):
+    """POST /api/jobs/import-full must reject a ``.photoslibrary`` source
+    before calling ``os.path.isdir``."""
+    app, _ = app_and_db
+    bundle = tmp_path / "Photos Library.photoslibrary"
+    bundle.mkdir()
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/import-full", json={
+            "source": str(bundle),
+            "destination": str(dst),
+        })
+        assert resp.status_code == 400
+        assert "macos" in resp.get_json()["error"].lower()
 
 
 def test_ingest_relative_destination(app_and_db, tmp_path):

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -467,6 +467,40 @@ def test_pipeline_job_requires_source_or_collection(app_and_db):
         assert resp.status_code == 400
 
 
+def test_pipeline_job_rejects_macos_other_app_bundle(app_and_db, tmp_path):
+    """POST /api/jobs/pipeline must reject a ``.photoslibrary`` source
+    (single or in ``sources``) before calling ``os.path.isdir``.
+
+    Like /api/jobs/scan and /api/jobs/ingest, the pipeline route stat's
+    the source up front to return a clean 400 for missing dirs. On
+    macOS that pre-stat against an Apple Photos bundle trips the
+    kTCCServiceSystemPolicyAppData prompt this guard exists to prevent,
+    so the rejection must happen before any stat.
+    """
+    app, _ = app_and_db
+    bundle = tmp_path / "Photos Library.photoslibrary"
+    bundle.mkdir()
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/pipeline", json={"source": str(bundle)})
+        assert resp.status_code == 400
+        assert "macos" in resp.get_json()["error"].lower()
+
+        # Same shape via the ``sources`` list path.
+        resp = client.post(
+            "/api/jobs/pipeline", json={"sources": [str(bundle)]},
+        )
+        assert resp.status_code == 400
+        assert "macos" in resp.get_json()["error"].lower()
+
+        # Nested paths inside the bundle must be rejected too.
+        nested = bundle / "originals"
+        nested.mkdir()
+        resp = client.post(
+            "/api/jobs/pipeline", json={"source": str(nested)},
+        )
+        assert resp.status_code == 400
+
+
 def test_pipeline_job_rejects_relative_destination(app_and_db, tmp_path):
     """Pipeline endpoint should reject relative destination paths."""
     app, _ = app_and_db

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -499,6 +499,7 @@ def test_pipeline_job_rejects_macos_other_app_bundle(app_and_db, tmp_path):
             "/api/jobs/pipeline", json={"source": str(nested)},
         )
         assert resp.status_code == 400
+        assert "macos" in resp.get_json()["error"].lower()
 
 
 def test_pipeline_job_rejects_relative_destination(app_and_db, tmp_path):

--- a/vireo/tests/test_new_images.py
+++ b/vireo/tests/test_new_images.py
@@ -92,6 +92,29 @@ def test_count_new_images_skips_excluded_root_itself(db_with_workspace):
     assert result["per_root"][0]["new_count"] == 0
 
 
+def test_count_new_images_skips_root_nested_in_excluded_bundle(db_with_workspace):
+    """A configured root that *sits inside* an excluded bundle is reported as 0.
+
+    A leaf-only check would let ``.../Photos Library.photoslibrary/originals``
+    through (the leaf ``originals`` looks innocuous) and the banner would
+    inflate with managed images the scanner will never ingest — and re-trip
+    the macOS TCC prompt this guard exists to avoid. The root guard must
+    look at every ancestor, not just the leaf.
+    """
+    db, ws_id, tmp_path = db_with_workspace
+    nested = tmp_path / "Photos Library.photoslibrary" / "originals"
+    _touch_image(str(nested / "0" / "managed.jpg"))
+    db.add_folder(str(nested), name="originals")
+
+    from new_images import count_new_images_for_workspace
+    result = count_new_images_for_workspace(db, ws_id)
+
+    assert result["new_count"] == 0
+    assert result["sample"] == []
+    assert len(result["per_root"]) == 1
+    assert result["per_root"][0]["new_count"] == 0
+
+
 def test_count_new_images_returns_all_paths_when_sample_limit_is_none(tmp_path):
     # Set up a workspace with 10 new files on disk.
     db = Database(str(tmp_path / "test.db"))

--- a/vireo/tests/test_new_images.py
+++ b/vireo/tests/test_new_images.py
@@ -70,6 +70,28 @@ def test_count_new_images_ignores_broken_symlinks(db_with_workspace):
     assert all("broken.jpg" not in p for p in result["sample"])
 
 
+def test_count_new_images_skips_excluded_root_itself(db_with_workspace):
+    """A configured root that *is* an other-app data bundle is reported as 0.
+
+    prune_scan_dirs only filters children; without a root-level guard
+    os.walk would still open ``Photos Library.photoslibrary`` and inflate
+    the banner with managed images the scanner will never ingest, plus
+    trip the macOS TCC prompt this guard exists to avoid.
+    """
+    db, ws_id, tmp_path = db_with_workspace
+    bundle = tmp_path / "Photos Library.photoslibrary"
+    _touch_image(str(bundle / "originals" / "managed.jpg"))
+    db.add_folder(str(bundle), name="Photos Library.photoslibrary")
+
+    from new_images import count_new_images_for_workspace
+    result = count_new_images_for_workspace(db, ws_id)
+
+    assert result["new_count"] == 0
+    assert result["sample"] == []
+    assert len(result["per_root"]) == 1
+    assert result["per_root"][0]["new_count"] == 0
+
+
 def test_count_new_images_returns_all_paths_when_sample_limit_is_none(tmp_path):
     # Set up a workspace with 10 new files on disk.
     db = Database(str(tmp_path / "test.db"))

--- a/vireo/tests/test_new_images.py
+++ b/vireo/tests/test_new_images.py
@@ -115,6 +115,40 @@ def test_count_new_images_skips_root_nested_in_excluded_bundle(db_with_workspace
     assert result["per_root"][0]["new_count"] == 0
 
 
+def test_count_new_images_rejects_excluded_root_before_statting(
+    db_with_workspace, monkeypatch
+):
+    """The bundle guard must run BEFORE ``os.path.isdir`` on each root.
+
+    ``isdir`` follows symlinks and stat's the target, which alone trips
+    the macOS TCC prompt for a directly selected bundle or a symlink to
+    one. Fails the test if ``os.path.isdir`` is called on a path the
+    exclusion check covers — if the order is wrong, the stat sneaks in
+    before the guard returns.
+    """
+    from image_loader import is_excluded_scan_path
+    from new_images import count_new_images_for_workspace
+
+    real_isdir = os.path.isdir
+
+    def guarded_isdir(path):
+        if is_excluded_scan_path(path):
+            raise AssertionError(
+                f"os.path.isdir called on excluded path before guard: {path}"
+            )
+        return real_isdir(path)
+
+    monkeypatch.setattr(os.path, "isdir", guarded_isdir)
+
+    db, ws_id, tmp_path = db_with_workspace
+    bundle = tmp_path / "Photos Library.photoslibrary"
+    _touch_image(str(bundle / "originals" / "managed.jpg"))
+    db.add_folder(str(bundle), name="Photos Library.photoslibrary")
+
+    result = count_new_images_for_workspace(db, ws_id)
+    assert result["new_count"] == 0
+
+
 def test_count_new_images_returns_all_paths_when_sample_limit_is_none(tmp_path):
     # Set up a workspace with 10 new files on disk.
     db = Database(str(tmp_path / "test.db"))

--- a/vireo/tests/test_new_images.py
+++ b/vireo/tests/test_new_images.py
@@ -46,6 +46,30 @@ def test_count_new_images_detects_unscanned_files(db_with_workspace):
     assert len(result["sample"]) == 2
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks required")
+def test_count_new_images_ignores_broken_symlinks(db_with_workspace):
+    """A dangling *.jpg symlink must not be counted as a "new image".
+
+    The os.walk path lists broken symlinks in `filenames`; the scanner
+    refuses to ingest them, so counting them inflates the banner with
+    files no scan can clear.
+    """
+    db, ws_id, tmp_path = db_with_workspace
+    root = tmp_path / "USA2026"
+    _touch_image(str(root / "real.jpg"))
+    db.add_folder(str(root), name="USA2026")
+    os.symlink(
+        str(root / "missing-target.jpg"),
+        str(root / "broken.jpg"),
+    )
+
+    from new_images import count_new_images_for_workspace
+    result = count_new_images_for_workspace(db, ws_id)
+
+    assert result["new_count"] == 1
+    assert all("broken.jpg" not in p for p in result["sample"])
+
+
 def test_count_new_images_returns_all_paths_when_sample_limit_is_none(tmp_path):
     # Set up a workspace with 10 new files on disk.
     db = Database(str(tmp_path / "test.db"))

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -107,6 +107,31 @@ def test_scan_skips_excluded_root_itself(tmp_path):
     assert db.get_folder_tree() == []
 
 
+def test_scan_skips_root_nested_in_excluded_bundle(tmp_path):
+    """scan() must reject roots that sit *inside* an excluded bundle, not
+    just roots whose leaf name matches.
+
+    A user can select ``.../Photos Library.photoslibrary/originals`` directly,
+    or a stale folder row from before this guard existed can carry the same
+    shape. The leaf basename (``originals``) is unremarkable, so a leaf-only
+    check passes — and os.walk then opens the protected bundle subtree and
+    re-trips the macOS TCC prompt this guard exists to avoid.
+    """
+    from db import Database
+    from scanner import scan
+
+    nested_root = str(tmp_path / "Photos Library.photoslibrary" / "originals")
+    _create_test_images(nested_root, {
+        '0': ['managed.jpg'],
+    })
+
+    db = Database(str(tmp_path / "test.db"))
+    scan(nested_root, db)
+
+    assert db.get_photos(per_page=100) == []
+    assert db.get_folder_tree() == []
+
+
 def test_scan_discovers_photos(tmp_path):
     """scan() creates photo entries for all image files."""
     from db import Database

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -54,6 +54,36 @@ def test_scan_discovers_folders(tmp_path):
     assert os.path.join(root, '2024', 'January') in paths
 
 
+def test_scan_skips_photos_library_bundle(tmp_path):
+    """scan() must not descend into a macOS Photos library bundle.
+
+    Walking into "*.photoslibrary" (which ~/Pictures contains by default)
+    triggers the recurring macOS "access data from other apps" TCC prompt and
+    would ingest app-managed derivatives. Images inside the bundle must be
+    ignored while real sibling photos are still discovered.
+    """
+    from db import Database
+    from scanner import scan
+
+    root = str(tmp_path / "photos")
+    _create_test_images(root, {
+        '': ['real.jpg'],
+        'Photos Library.photoslibrary/originals/0': ['managed.jpg'],
+        'Photo Booth Library/Pictures': ['booth.jpg'],
+    })
+
+    db = Database(str(tmp_path / "test.db"))
+    scan(root, db)
+
+    photos = db.get_photos(per_page=100)
+    filenames = {p['filename'] for p in photos}
+    assert filenames == {'real.jpg'}
+
+    folder_paths = [f['path'] for f in db.get_folder_tree()]
+    assert not any('.photoslibrary' in p for p in folder_paths)
+    assert not any('Photo Booth Library' in p for p in folder_paths)
+
+
 def test_scan_discovers_photos(tmp_path):
     """scan() creates photo entries for all image files."""
     from db import Database

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -168,6 +168,60 @@ def test_scan_skips_restrict_dirs_inside_excluded_bundle(tmp_path):
     assert not any('.photoslibrary' in p for p in folder_paths)
 
 
+def test_scan_filters_excluded_restrict_dirs_from_working_copy_scope(
+    tmp_path, monkeypatch,
+):
+    """The working-copy extraction pass must scope to the
+    ``restrict_dirs`` entries the discovery loop actually walked, not
+    the raw caller-supplied list.
+
+    The discovery loop already drops excluded restrict_dirs (covered by
+    :func:`test_scan_skips_restrict_dirs_inside_excluded_bundle`), but the
+    post-scan ``_extract_working_copies`` call used to reuse the raw
+    ``restrict_dirs`` to build ``wc_scope``. If a stale DB row already
+    pointed at a bundle-internal folder (e.g. from before the bundle guard
+    landed), the extractor's SQL match would still pick it up and the
+    follow-up file read of ``folder_path/filename`` would re-trip the
+    macOS "access data from other apps" TCC prompt — exactly the prompt
+    this guard exists to avoid. The scope passed to the extractor must
+    therefore mirror the filtered set.
+    """
+    import scanner
+    from db import Database
+
+    root = str(tmp_path / "photos")
+    _create_test_images(root, {'': ['real.jpg']})
+    bundle_sub = str(
+        tmp_path / "photos" / "Photos Library.photoslibrary" / "originals"
+    )
+    _create_test_images(bundle_sub, {'': ['managed.jpg']})
+
+    captured = {}
+
+    def fake_extract_working_copies(db, vireo_dir, *, progress_callback=None,
+                                    status_callback=None, scope=None,
+                                    cancel_check=None):
+        captured["scope"] = scope
+
+    monkeypatch.setattr(scanner, "_extract_working_copies",
+                        fake_extract_working_copies)
+
+    db = Database(str(tmp_path / "test.db"))
+    scanner.scan(
+        root, db,
+        restrict_dirs=[root, bundle_sub],
+        vireo_dir=str(tmp_path / "vireo_dir"),
+    )
+
+    assert "scope" in captured, "expected _extract_working_copies to be called"
+    scope_paths = [entry[0] if isinstance(entry, tuple) else entry
+                   for entry in (captured["scope"] or [])]
+    assert root in scope_paths
+    assert all(".photoslibrary" not in p for p in scope_paths), (
+        f"bundle-internal restrict_dir leaked into wc_scope: {scope_paths}"
+    )
+
+
 def test_scan_skips_symlinked_excluded_bundle_child(tmp_path):
     """A child symlink in the scan root whose target is an excluded
     bundle must be dropped before ``os.walk``'s classification stat

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -380,6 +380,88 @@ def test_scan_non_recursive_only_finds_root_photos(tmp_path):
     assert filenames == {'root.jpg'}
 
 
+def test_scan_non_recursive_skips_bundle_children_before_stat(tmp_path):
+    """In ``scan(recursive=False)``, a normal root like ``~/Pictures``
+    still contains ``Photos Library.photoslibrary`` (or a symlink to
+    one) as a direct child. A bare ``iterdir() + is_file()`` would
+    stat the bundle target while filtering by extension and re-trip
+    the macOS "access data from other apps" TCC prompt this change
+    exists to avoid. The non-recursive branch must drop excluded
+    children before any followed stat.
+    """
+    if sys.platform == "win32":
+        pytest.skip("POSIX symlinks required")
+    from db import Database
+    from scanner import scan
+
+    bundle = tmp_path / "Photos Library.photoslibrary"
+    _create_test_images(str(bundle), {'originals': ['managed.jpg']})
+
+    root = str(tmp_path / "photos")
+    _create_test_images(root, {'': ['real.jpg']})
+    # Direct bundle child as a sibling of real.jpg.
+    direct_bundle = os.path.join(root, "Photos Library.photoslibrary")
+    _create_test_images(direct_bundle, {'originals': ['direct_managed.jpg']})
+    # Symlinked bundle child.
+    os.symlink(str(bundle), os.path.join(root, "LibraryAlias"))
+
+    db = Database(str(tmp_path / "test.db"))
+    scan(root, db, recursive=False)
+
+    photos = db.get_photos(per_page=100)
+    filenames = {p['filename'] for p in photos}
+    assert filenames == {'real.jpg'}
+
+    folder_paths = [f['path'] for f in db.get_folder_tree()]
+    assert not any('.photoslibrary' in p for p in folder_paths)
+    assert not any('LibraryAlias' in p for p in folder_paths)
+
+
+def test_scan_non_recursive_does_not_stat_bundle_children(tmp_path, monkeypatch):
+    """Belt-and-braces for the non-recursive branch: if any code path
+    calls ``Path.is_file`` on a child that ``is_excluded_scan_path``
+    covers, the test fails — that ``is_file`` follows symlinks and
+    would re-trip the macOS TCC prompt before the extension filter
+    could reject the entry.
+    """
+    if sys.platform == "win32":
+        pytest.skip("POSIX symlinks required")
+    from pathlib import Path
+
+    from db import Database
+    from scanner import scan
+
+    real_is_file = Path.is_file
+
+    def guarded_is_file(self):
+        from image_loader import is_excluded_scan_path
+        if is_excluded_scan_path(self):
+            raise AssertionError(
+                f"is_file() called on excluded path before guard: {self}"
+            )
+        return real_is_file(self)
+
+    monkeypatch.setattr(Path, "is_file", guarded_is_file)
+
+    bundle = tmp_path / "Photos Library.photoslibrary"
+    _create_test_images(str(bundle), {'originals': ['managed.jpg']})
+
+    root = str(tmp_path / "photos")
+    _create_test_images(root, {'': ['real.jpg']})
+    _create_test_images(
+        os.path.join(root, "Photos Library.photoslibrary"),
+        {'originals': ['direct_managed.jpg']},
+    )
+    os.symlink(str(bundle), os.path.join(root, "LibraryAlias"))
+
+    db = Database(str(tmp_path / "test.db"))
+    scan(root, db, recursive=False)
+
+    photos = db.get_photos(per_page=100)
+    filenames = {p['filename'] for p in photos}
+    assert filenames == {'real.jpg'}
+
+
 def test_scan_reads_dimensions(tmp_path):
     """scan() reads image dimensions."""
     from db import Database
@@ -2960,13 +3042,16 @@ def test_scan_restrict_dirs_surfaces_permission_denied(tmp_path, monkeypatch):
     raised PermissionError unhandled and the entire pipeline scan stage
     failed with no PERMISSION_DENIED entry in job["errors"].
 
-    Mocks Path.iterdir for the locked subtree (rather than chmod 0o000) so
+    Mocks os.scandir for the locked subtree (rather than chmod 0o000) so
     the assertion holds regardless of test-runner uid: chmod-based denial
     silently bypasses for root, which would let the locked file slip in.
+    Targets ``image_loader.os.scandir`` because ``safe_iter_dir`` (the
+    restrict_dirs enumerator) calls ``os.scandir`` directly — patching
+    ``Path.iterdir`` would miss the actual code path.
     """
     import errno as _errno
-    from pathlib import Path as _Path
 
+    import image_loader
     from db import Database
     from scanner import scan
 
@@ -2978,16 +3063,16 @@ def test_scan_restrict_dirs_surfaces_permission_denied(tmp_path, monkeypatch):
     allowed = os.path.join(root, 'allowed')
     forbidden = os.path.join(root, 'forbidden')
 
-    real_iterdir = _Path.iterdir
+    real_scandir = image_loader.os.scandir
 
-    def fake_iterdir(self):
-        if str(self) == forbidden:
+    def fake_scandir(path):
+        if str(path) == forbidden:
             raise PermissionError(
-                _errno.EACCES, "Permission denied", str(self),
+                _errno.EACCES, "Permission denied", str(path),
             )
-        return real_iterdir(self)
+        return real_scandir(path)
 
-    monkeypatch.setattr(_Path, "iterdir", fake_iterdir)
+    monkeypatch.setattr(image_loader.os, "scandir", fake_scandir)
 
     db = Database(str(tmp_path / "test.db"))
     denied = []
@@ -3023,10 +3108,14 @@ def test_scan_restrict_dirs_raises_permission_error_without_callback(
     which silently turned denied folders into "successfully repaired" —
     a black-box regression. Partial-success is opt-in via the callback;
     every other caller must keep the loud failure semantics they had.
+
+    Patches ``image_loader.os.scandir`` because ``safe_iter_dir`` (the
+    restrict_dirs enumerator) calls ``os.scandir`` — patching
+    ``Path.iterdir`` would miss the actual code path.
     """
     import errno as _errno
-    from pathlib import Path as _Path
 
+    import image_loader
     from db import Database
     from scanner import scan
 
@@ -3034,16 +3123,16 @@ def test_scan_restrict_dirs_raises_permission_error_without_callback(
     _create_test_images(root, {'forbidden': ['hidden.jpg']})
     forbidden = os.path.join(root, 'forbidden')
 
-    real_iterdir = _Path.iterdir
+    real_scandir = image_loader.os.scandir
 
-    def fake_iterdir(self):
-        if str(self) == forbidden:
+    def fake_scandir(path):
+        if str(path) == forbidden:
             raise PermissionError(
-                _errno.EACCES, "Permission denied", str(self),
+                _errno.EACCES, "Permission denied", str(path),
             )
-        return real_iterdir(self)
+        return real_scandir(path)
 
-    monkeypatch.setattr(_Path, "iterdir", fake_iterdir)
+    monkeypatch.setattr(image_loader.os, "scandir", fake_scandir)
 
     db = Database(str(tmp_path / "test.db"))
     with pytest.raises(PermissionError):

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -84,6 +84,29 @@ def test_scan_skips_photos_library_bundle(tmp_path):
     assert not any('Photo Booth Library' in p for p in folder_paths)
 
 
+def test_scan_skips_excluded_root_itself(tmp_path):
+    """scan() must not open the root when the root *is* the excluded bundle.
+
+    prune_scan_dirs only filters children, so if a user selects (or imports)
+    ``~/Pictures/Photos Library.photoslibrary`` directly as a scan root,
+    os.walk would still open the bundle and trip the macOS TCC prompt this
+    guard exists to avoid. The guard must short-circuit before any walk.
+    """
+    from db import Database
+    from scanner import scan
+
+    root = str(tmp_path / "Photos Library.photoslibrary")
+    _create_test_images(root, {
+        'originals/0': ['managed.jpg'],
+    })
+
+    db = Database(str(tmp_path / "test.db"))
+    scan(root, db)
+
+    assert db.get_photos(per_page=100) == []
+    assert db.get_folder_tree() == []
+
+
 def test_scan_discovers_photos(tmp_path):
     """scan() creates photo entries for all image files."""
     from db import Database

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -132,6 +132,42 @@ def test_scan_skips_root_nested_in_excluded_bundle(tmp_path):
     assert db.get_folder_tree() == []
 
 
+def test_scan_skips_restrict_dirs_inside_excluded_bundle(tmp_path):
+    """scan() must reject ``restrict_dirs`` entries that point inside an
+    excluded bundle even when the outer ``root`` is unremarkable.
+
+    The pipeline / repair paths build ``restrict_dirs`` from existing
+    folder rows in the workspace, which can include stale entries from
+    before the bundle guards landed (e.g. ``.../Photos Library.photoslibrary/
+    originals``). The outer root guard (``is_excluded_scan_path(root_path)``)
+    only checks ``root``; without a per-entry guard the restrict_dirs branch
+    still calls ``dp.is_dir()`` / ``dp.iterdir()`` on the protected
+    subtree and re-trips the macOS TCC prompt this change exists to avoid.
+    """
+    from db import Database
+    from scanner import scan
+
+    root = str(tmp_path / "photos")
+    _create_test_images(root, {
+        '': ['real.jpg'],
+    })
+    bundle_sub = str(
+        tmp_path / "photos" / "Photos Library.photoslibrary" / "originals"
+    )
+    _create_test_images(bundle_sub, {'': ['managed.jpg']})
+
+    db = Database(str(tmp_path / "test.db"))
+    # Both the real top-level folder and a bundle-internal "originals"
+    # subfolder are passed as restrict_dirs (the shape pipeline_job would
+    # produce from a workspace that had previously linked the bundle).
+    scan(root, db, restrict_dirs=[root, bundle_sub])
+
+    photos = db.get_photos(per_page=100)
+    assert {p['filename'] for p in photos} == {'real.jpg'}
+    folder_paths = [f['path'] for f in db.get_folder_tree()]
+    assert not any('.photoslibrary' in p for p in folder_paths)
+
+
 def test_scan_discovers_photos(tmp_path):
     """scan() creates photo entries for all image files."""
     from db import Database

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -168,6 +168,44 @@ def test_scan_skips_restrict_dirs_inside_excluded_bundle(tmp_path):
     assert not any('.photoslibrary' in p for p in folder_paths)
 
 
+def test_scan_skips_symlinked_excluded_bundle_child(tmp_path):
+    """A child symlink in the scan root whose target is an excluded
+    bundle must be dropped before ``os.walk``'s classification stat
+    follows the link.
+
+    The previous walker called ``os.walk`` → ``DirEntry.is_dir()`` to
+    classify each child; that follows symlinks, so for a child like
+    ``LibraryAlias -> Photos Library.photoslibrary`` the stat alone
+    reached into the protected bundle and re-tripped the macOS TCC
+    prompt this change exists to avoid — even though
+    ``prune_scan_dirs`` would have removed the entry from recursion
+    afterwards. The walker has to skip the link textually
+    (``os.readlink``) before any followed call.
+    """
+    if sys.platform == "win32":
+        pytest.skip("POSIX symlinks required")
+    from db import Database
+    from scanner import scan
+
+    bundle = tmp_path / "Photos Library.photoslibrary"
+    _create_test_images(str(bundle), {'originals/0': ['managed.jpg']})
+
+    root = str(tmp_path / "photos")
+    _create_test_images(root, {'': ['real.jpg']})
+    os.symlink(str(bundle), os.path.join(root, "LibraryAlias"))
+
+    db = Database(str(tmp_path / "test.db"))
+    scan(root, db)
+
+    photos = db.get_photos(per_page=100)
+    filenames = {p['filename'] for p in photos}
+    assert filenames == {'real.jpg'}
+
+    folder_paths = [f['path'] for f in db.get_folder_tree()]
+    assert not any('.photoslibrary' in p for p in folder_paths)
+    assert not any('LibraryAlias' in p for p in folder_paths)
+
+
 def test_scan_rejects_excluded_root_before_statting(tmp_path, monkeypatch):
     """The bundle guard must run BEFORE ``Path.is_dir`` on the root.
 

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -168,6 +168,42 @@ def test_scan_skips_restrict_dirs_inside_excluded_bundle(tmp_path):
     assert not any('.photoslibrary' in p for p in folder_paths)
 
 
+def test_scan_rejects_excluded_root_before_statting(tmp_path, monkeypatch):
+    """The bundle guard must run BEFORE ``Path.is_dir`` on the root.
+
+    ``Path.is_dir`` follows symlinks and stat's the target, so for a
+    directly selected bundle (or a symlink to one) the existence test
+    alone is enough to trip the macOS "access data from other apps" TCC
+    prompt the guard exists to avoid. Tested by failing the test if
+    ``Path.is_dir`` is ever called on a path the exclusion check covers —
+    if the order is wrong, the stat sneaks in before the guard returns.
+    """
+    from pathlib import Path
+
+    from db import Database
+    from scanner import scan
+
+    real_is_dir = Path.is_dir
+
+    def guarded_is_dir(self):
+        from image_loader import is_excluded_scan_path
+        if is_excluded_scan_path(self):
+            raise AssertionError(
+                f"is_dir() called on excluded path before guard: {self}"
+            )
+        return real_is_dir(self)
+
+    monkeypatch.setattr(Path, "is_dir", guarded_is_dir)
+
+    bundle = tmp_path / "Photos Library.photoslibrary"
+    _create_test_images(str(bundle), {'originals/0': ['managed.jpg']})
+
+    db = Database(str(tmp_path / "test.db"))
+    scan(str(bundle), db)
+
+    assert db.get_photos(per_page=100) == []
+
+
 def test_scan_discovers_photos(tmp_path):
     """scan() creates photo entries for all image files."""
     from db import Database


### PR DESCRIPTION
## Problem

Vireo repeatedly popped the macOS dialog **\"Vireo.app would like to access data from other apps\"** — clicking **Allow** had no lasting effect; it just came back.

### Root cause

The default scan root `~/Pictures` contains `Photos Library.photoslibrary` — Apple Photos' private data bundle. The scanner's `os.walk` (`vireo/scanner.py`) never pruned directories, so it descended straight into that bundle. On macOS Sequoia, reading inside **another app's data area** triggers the `kTCCServiceSystemPolicyAppData` consent prompt. Because the library holds thousands of files, the walk re-trips the prompt on every file it touches — so Allow never makes it stop. The contents are app-managed derivatives Vireo would never ingest anyway.

The installed app is correctly Developer ID–signed and notarized; this was never a signing problem.

## Fix

Add `prune_scan_dirs()` / `is_excluded_scan_dir()` to `image_loader.py` and apply them at every walker that traverses user-chosen roots:

- `scanner.scan` (the reported bug) — prunes `dirnames` in place, logs what it skipped
- `new_images` — same, so the "new images" banner isn't inflated by library contents
- `audit` — untracked-files check (converted `rglob`→`os.walk` to allow pruning) and stray-sidecar check
- `ingest` — recursive source discovery (converted `rglob`→`os.walk`), so picking `~/Pictures` as an import source doesn't walk the whole library

Excluded (case-insensitive): `*.photoslibrary`, `*.photolibrary`, `*.migratedphotolibrary`, `*.aplibrary`, `*.migratedaplibrary`, and `Photo Booth Library`.

## Tests

- Helper unit tests in `test_image_loader.py` (suffix/exact/case matching, in-place prune, no-op)
- Integration test in `test_scanner.py`: images inside a `.photoslibrary` / `Photo Booth Library` are ignored while real sibling photos are still discovered

Full project suite: **1170 passed, 1 skipped**. Affected-module suite: **229 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented macOS app-managed photo library bundles (e.g., `*.photoslibrary` / `*.aplibrary`) from being traversed during browsing, scanning, ingesting, importing, rescanning, and photo counting, with early validation and clear `400` errors across relevant endpoints (including pipeline `source`/`sources`).
  * Improved traversal safety by skipping excluded bundles (including via symlinks) and ignoring broken symlink entries to avoid incorrect audit results.

* **Tests**
  * Added regression coverage for bundle exclusion, early-validation ordering, audit untracked/sidecar behavior, symlink edge cases, and job/rescan/browse API responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->