### PR TITLE
Fix red main: add "move" to nav-ids coverage test

### DIFF
--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -11822,7 +11822,7 @@ def test_all_nav_ids_covers_every_page():
     expected = {
         "pipeline", "jobs", "pipeline_review", "pipeline_rapid_review", "review", "cull",
         "misses", "highlights", "life_list", "browse", "map", "variants",
-        "dashboard", "audit", "compare",
+        "dashboard", "audit", "move", "compare",
         "zoom_test", "settings", "workspace", "lightroom", "shortcuts",
         "keywords", "duplicates", "logs",
     }


### PR DESCRIPTION
## Problem

`main` is currently **red**: `vireo/tests/test_db.py::test_all_nav_ids_covers_every_page` fails, which blocks the required `test-os` checks on every open PR (including #1020).

## Cause

#1019 added the Move page — `/move` route, `move.html`, and `"move"` registered in `ALL_NAV_IDS` (`db.py`) — but did not add `"move"` to the **hardcoded `expected` set** inside `test_all_nav_ids_covers_every_page`. The test just compares those two sets, so they now diverge:

```
Extra items in the right set: 'move'
```

## Fix

Add `"move"` to the test's `expected` set. The page is real, so the test set was simply stale. One line.

Verified: `test_all_nav_ids_covers_every_page` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)