### PR TITLE
website: update download links for v0.10.2

### DIFF
--- a/website/src/pages/download.astro
+++ b/website/src/pages/download.astro
@@ -6,9 +6,9 @@ const base = import.meta.env.BASE_URL;
 const releaseUrl = (v: string) => `https://github.com/jss367/vireo/releases/download/v${v}`;
 
 // Per-platform versions — updated independently by CI when each platform builds
-const macosArm64Version = '0.10.1';
-const windowsVersion = '0.10.1';
-const linuxVersion = '0.10.1';
+const macosArm64Version = '0.10.2';
+const windowsVersion = '0.10.2';
+const linuxVersion = '0.10.2';
 ---
 
 <Base title="Download — Vireo" description="Download Vireo for macOS, Windows, or Linux. Free, open source, no account required.">


### PR DESCRIPTION
Automated update of download links following the v0.10.2 release. Auto-merges once required checks pass; deploy-website.yml runs on the resulting push to main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated download links to point to version 0.10.2 for macOS, Windows, and Linux platforms on the Download page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->