### PR TITLE
Move page: show resolved final path for Move Entire Folder

### DIFF
--- a/vireo/templates/move.html
+++ b/vireo/templates/move.html
@@ -556,10 +556,20 @@ function updateQuickMoveBtn() {
 
 // Compute the final landing path, mirroring move.py move_folder():
 // the source folder is placed *inside* the destination, keeping its name.
+// Detect Windows-style paths (containing '\') so the preview matches
+// os.path.join on a Windows backend, where 'C:\Archive\' + 'Birds' is
+// 'C:\Archive\Birds', not 'C:\Archive\/Birds'. Also lets the folder.name
+// fallback split a backslash-delimited source path.
 function resolvedMoveDest(folder, destination) {
+  var srcPath = (folder && folder.path) || '';
+  var winStyle = destination.indexOf('\\') !== -1 || srcPath.indexOf('\\') !== -1;
+  var sep = winStyle ? '\\' : '/';
+  var trimRe = winStyle ? /[\\\/]+$/ : /\/+$/;
+  var splitRe = winStyle ? /[\\\/]/ : /\//;
+
   var folderName = (folder && folder.name) ||
-    (folder ? folder.path.replace(/\/+$/, '').split('/').pop() : '');
-  return destination.replace(/\/+$/, '') + '/' + folderName;
+    srcPath.replace(trimRe, '').split(splitRe).pop();
+  return destination.replace(trimRe, '') + sep + folderName;
 }
 
 function updateQuickMovePreview() {

--- a/vireo/templates/move.html
+++ b/vireo/templates/move.html
@@ -281,6 +281,18 @@ body { padding-bottom: 36px; }
   margin-top: 4px;
 }
 
+/* Resolved-destination preview under the Move-folder destination input */
+.dest-preview {
+  font-size: 12px;
+  color: var(--text-dim);
+  margin-top: 6px;
+  word-break: break-all;
+}
+.dest-preview .dest-preview-path {
+  color: var(--text-secondary);
+  font-family: var(--font-mono, monospace);
+}
+
 /* Empty state */
 .empty-state {
   text-align: center;
@@ -361,10 +373,11 @@ body { padding-bottom: 36px; }
       <div class="form-row">
         <label>Destination</label>
         <div class="dest-row">
-          <input type="text" id="quickDestInput" placeholder="/path/to/destination">
+          <input type="text" id="quickDestInput" placeholder="/path/to/destination" oninput="updateQuickMoveBtn()">
           <button class="btn btn-secondary btn-small" onclick="openBrowser('quickDestInput')">Browse</button>
         </div>
       </div>
+      <div class="dest-preview" id="quickDestPreview"></div>
 
       <div style="margin-top:16px;">
         <button class="btn btn-primary" id="quickMoveBtn" onclick="startQuickMove()" disabled>Move Folder</button>
@@ -538,6 +551,32 @@ function updateQuickMoveBtn() {
   var fid = document.getElementById('quickFolderSelect').value;
   var dest = document.getElementById('quickDestInput').value.trim();
   document.getElementById('quickMoveBtn').disabled = !(fid && dest);
+  updateQuickMovePreview();
+}
+
+// Compute the final landing path, mirroring move.py move_folder():
+// the source folder is placed *inside* the destination, keeping its name.
+function resolvedMoveDest(folder, destination) {
+  var folderName = (folder && folder.name) ||
+    (folder ? folder.path.replace(/\/+$/, '').split('/').pop() : '');
+  return destination.replace(/\/+$/, '') + '/' + folderName;
+}
+
+function updateQuickMovePreview() {
+  var preview = document.getElementById('quickDestPreview');
+  var fid = parseInt(document.getElementById('quickFolderSelect').value);
+  var dest = document.getElementById('quickDestInput').value.trim();
+  if (!fid || !dest) {
+    preview.textContent = '';
+    return;
+  }
+  var folder = allFolders.find(function(f) { return f.id === fid; });
+  var finalPath = resolvedMoveDest(folder, dest);
+  preview.textContent = 'Folder will be moved to: ';
+  var pathSpan = document.createElement('span');
+  pathSpan.className = 'dest-preview-path';
+  pathSpan.textContent = finalPath;
+  preview.appendChild(pathSpan);
 }
 
 function startQuickMove() {
@@ -548,10 +587,11 @@ function startQuickMove() {
   var folder = allFolders.find(function(f) { return f.id === fid; });
   var folderName = folder ? folder.path : 'folder #' + fid;
   var photoCount = folder ? (folder.photo_count || 0) : '?';
+  var finalPath = resolvedMoveDest(folder, dest);
 
   showConfirm(
     'Move Folder',
-    'Move "' + folderName + '" (' + photoCount + ' photos) to "' + dest + '"? Files will be copied and verified before originals are removed.',
+    'Move "' + folderName + '" (' + photoCount + ' photos) to "' + finalPath + '"? Files will be copied and verified before originals are removed.',
     function() {
       executeQuickMove(fid, dest);
     }


### PR DESCRIPTION
## What & why

On the Move page, the **Move Entire Folder** Destination field shows the parent destination (e.g. `/Volumes/Photography/Raw Files/USA/2026`), but `move_folder()` in `vireo/move.py` places the source folder *inside* the destination, preserving its name:

```python
folder_name = folder["name"] or os.path.basename(src_path)
dest_path = os.path.join(destination, folder_name)
```

So the files actually land at `.../2026/<source-folder-name>` — one level deeper than the field implies. This contradicts the project's UI-transparency rule (the field told the user something different from what would happen).

## Change

- Add a live preview line under the Destination input: **"Folder will be moved to: `<resolved path>`"**, computed client-side from the selected source folder's name + destination (mirrors the backend exactly — no new endpoint).
- Preview updates on source-folder change, manual destination typing (new `oninput`), and Browse-modal selection (all route through `updateQuickMoveBtn`).
- Update the confirmation dialog to state the resolved final path instead of the raw destination.

Frontend-only. Uses safe DOM construction (`textContent` + `createElement`), no `innerHTML`.

## Testing

```
python -m pytest vireo/tests/test_move.py vireo/tests/test_move_api.py vireo/tests/test_app.py -q
# 250 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)