### PR TITLE
Move folder: merge/resume into an existing destination

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -13314,13 +13314,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     @app.route("/api/jobs/move-folder", methods=["POST"])
     def api_job_move_folder():
         """Move an entire folder to a destination."""
-        body = request.get_json(silent=True) or {}
+        body = request.get_json(silent=True)
+        if not isinstance(body, dict):
+            return json_error("JSON body must be an object")
         folder_id = body.get("folder_id")
         destination = body.get("destination", "")
-        merge = bool(body.get("merge", False))
+        merge_raw = body.get("merge", False)
+        if not isinstance(merge_raw, bool):
+            return json_error("merge must be a boolean")
+        merge = merge_raw
 
         if not folder_id:
             return json_error("folder_id required")
+        if not isinstance(destination, str):
+            return json_error("destination must be a string")
         if not destination:
             return json_error("destination required")
         if not os.path.isabs(destination):
@@ -13375,12 +13382,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         instead of silently failing on an existing destination."""
         from move import resolve_folder_dest
 
-        body = request.get_json(silent=True) or {}
+        body = request.get_json(silent=True)
+        if not isinstance(body, dict):
+            return json_error("JSON body must be an object")
         folder_id = body.get("folder_id")
         destination = body.get("destination", "")
 
         if not folder_id:
             return json_error("folder_id required")
+        if not isinstance(destination, str):
+            return json_error("destination must be a string")
         if not destination:
             return json_error("destination required")
         if not os.path.isabs(destination):

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -13317,6 +13317,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         body = request.get_json(silent=True) or {}
         folder_id = body.get("folder_id")
         destination = body.get("destination", "")
+        merge = bool(body.get("merge", False))
 
         if not folder_id:
             return json_error("folder_id required")
@@ -13357,14 +13358,51 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 destination=destination,
                 progress_cb=progress_cb,
                 developed_dir=developed_dir,
+                merge=merge,
             )
 
         job_id = runner.start(
             "move-folder", work,
-            config={"folder_id": folder_id, "destination": destination},
+            config={"folder_id": folder_id, "destination": destination, "merge": merge},
             workspace_id=active_ws,
         )
         return jsonify({"job_id": job_id})
+
+    @app.route("/api/move-folder/preflight", methods=["POST"])
+    def api_move_folder_preflight():
+        """Report the resolved destination for a folder move and whether it
+        already exists, so the UI can offer a merge/resume confirmation
+        instead of silently failing on an existing destination."""
+        from move import resolve_folder_dest
+
+        body = request.get_json(silent=True) or {}
+        folder_id = body.get("folder_id")
+        destination = body.get("destination", "")
+
+        if not folder_id:
+            return json_error("folder_id required")
+        if not destination:
+            return json_error("destination required")
+        if not os.path.isabs(destination):
+            return json_error("destination must be an absolute path")
+
+        folder = _get_db().conn.execute(
+            "SELECT path, name FROM folders WHERE id = ?", (folder_id,)
+        ).fetchone()
+        if not folder:
+            return json_error("Folder not found", status=404)
+
+        resolved = resolve_folder_dest(folder["path"], folder["name"], destination)
+        exists = os.path.isdir(resolved)
+        file_count = 0
+        if exists:
+            file_count = sum(1 for _, _, files in os.walk(resolved) for _ in files)
+
+        return jsonify({
+            "resolved_dest": resolved,
+            "exists": exists,
+            "file_count": file_count,
+        })
 
     @app.route("/api/jobs/import-full", methods=["POST"])
     def api_job_import_full():

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -275,11 +275,13 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
     # rmtree(src) delete the only copy of the files. This is especially
     # dangerous for a merge, where a destination equal to the source passes
     # verification trivially (every source file is already "there") before the
-    # delete wipes everything.
-    abs_src = os.path.abspath(src_path)
-    abs_dest = os.path.abspath(dest_path)
-    if abs_dest == abs_src or abs_dest.startswith(abs_src + os.sep) \
-            or abs_src.startswith(abs_dest + os.sep):
+    # delete wipes everything. Resolve symlinks (realpath) and normalize case
+    # so a symlinked or differently-cased alias of the same directory is still
+    # caught — abspath alone would miss a symlinked destination.
+    real_src = os.path.normcase(os.path.realpath(src_path))
+    real_dest = os.path.normcase(os.path.realpath(dest_path))
+    if real_dest == real_src or real_dest.startswith(real_src + os.sep) \
+            or real_src.startswith(real_dest + os.sep):
         return {"moved": 0, "errors": [
             f"Destination overlaps the source folder: {dest_path}"
         ]}
@@ -293,20 +295,25 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
         }
 
     if dest_exists:
-        # Refuse merging into a destination Vireo already tracks as a folder.
-        # A correct merge of two tracked trees needs recursive folder/photo
-        # reconciliation we don't do here; a partial attempt would leave
-        # descendant folders pointing at the deleted source path. The cases
-        # this feature exists for — resuming an interrupted move, or moving
-        # into an untracked folder — never hit this.
+        # Refuse merging into — or around — a destination Vireo already tracks
+        # as a folder. A correct merge of two tracked trees needs recursive
+        # folder/photo reconciliation we don't do here; a partial attempt would
+        # leave folders pointing at the deleted source path, or collide on the
+        # folders.path UNIQUE constraint when the source's children cascade onto
+        # a tracked descendant. Match the destination itself and anything below
+        # it. The cases this feature exists for — resuming an interrupted move,
+        # or moving into an untracked folder — never hit this.
+        prefix = dest_path + os.sep
         tracked = db.conn.execute(
-            "SELECT id FROM folders WHERE path = ? AND id != ?",
-            (dest_path, folder_id),
+            "SELECT id, path FROM folders "
+            "WHERE (path = ? OR substr(path, 1, ?) = ?) AND id != ?",
+            (dest_path, len(prefix), prefix, folder_id),
         ).fetchone()
         if tracked:
             return {"moved": 0, "errors": [
-                f"Destination is already managed by Vireo as folder {tracked['id']}. "
-                f"Merging into a tracked folder isn't supported."
+                f"Destination overlaps a folder Vireo already manages "
+                f"({tracked['path']}). Merging into or around a tracked folder "
+                f"isn't supported."
             ]}
 
         # Refuse if any same-name file already at the destination differs in

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -36,6 +36,34 @@ def _copy_and_verify(src, dst):
     return True
 
 
+def resolve_folder_dest(folder_path, folder_name, destination):
+    """Compute the final landing path for a folder move.
+
+    The source folder is placed *inside* destination, keeping its name —
+    e.g. moving /local/birds to /nas/photos yields /nas/photos/birds.
+    Shared by move_folder() and the preflight route so the resolved path
+    is computed in exactly one place.
+    """
+    name = folder_name or os.path.basename(folder_path.rstrip("/\\"))
+    return os.path.join(destination, name)
+
+
+def _first_missing_source_file(src_path, dest_path):
+    """Return the relative path of the first source file absent (or
+    size-mismatched) at dest_path, or None if every source file is present
+    and matches. Used to verify a merge before deleting originals."""
+    for root, _, files in os.walk(src_path):
+        rel = os.path.relpath(root, src_path)
+        for fn in files:
+            src_file = os.path.join(root, fn)
+            rel_name = fn if rel == "." else os.path.join(rel, fn)
+            dst_file = os.path.join(dest_path, rel_name)
+            if not os.path.isfile(dst_file) or \
+                    os.path.getsize(src_file) != os.path.getsize(dst_file):
+                return rel_name
+    return None
+
+
 def move_photos(db, photo_ids, destination, progress_cb=None):
     """Move individual photos to a destination directory.
 
@@ -168,7 +196,8 @@ def move_photos(db, photo_ids, destination, progress_cb=None):
     return {"moved": moved, "errors": errors, "destination_folder_id": dest_folder_id}
 
 
-def move_folder(db, folder_id, destination, progress_cb=None, developed_dir=""):
+def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
+                merge=False):
     """Move an entire folder (and subfolders) to a destination.
 
     The folder is placed inside the destination, preserving its name.
@@ -179,6 +208,14 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir=""):
         folder_id: ID of the source folder
         destination: absolute path to parent destination directory
         progress_cb: optional callback(current, total, filename)
+        merge: when False (default), refuse to write into a destination
+            that already exists — the safe all-or-nothing behavior. When
+            True, merge/resume into the existing destination: rsync skips
+            files already present with a matching checksum and copies only
+            what is missing (this is how an interrupted move is resumed).
+            Originals are deleted only after every source file is verified
+            present at the destination. A failed merge never removes the
+            destination, since it may hold the user's pre-existing files.
         developed_dir: optional path to the configured
             `darktable_output_dir`. When set, the folder's developed
             subdirectory — nested under a hash of its source path, see
@@ -197,14 +234,22 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir=""):
 
     src_path = folder["path"]
     folder_name = folder["name"] or os.path.basename(src_path)
-    dest_path = os.path.join(destination, folder_name)
+    dest_path = resolve_folder_dest(src_path, folder["name"], destination)
 
-    if os.path.exists(dest_path):
-        return {"moved": 0, "errors": [f"Destination already exists: {dest_path}"]}
+    dest_exists = os.path.exists(dest_path)
+    if dest_exists and not merge:
+        return {
+            "moved": 0,
+            "errors": [f"Destination already exists: {dest_path}"],
+            "needs_merge": True,
+        }
 
-    log.info("Moving folder %s -> %s", src_path, dest_path)
+    log.info("%s folder %s -> %s",
+             "Merging" if dest_exists else "Moving", src_path, dest_path)
 
-    # Use rsync for robust copy with checksums
+    # Use rsync for robust copy with checksums. With --checksum, a merge
+    # skips files already present and identical and copies only what's
+    # missing — exactly what resuming an interrupted move requires.
     try:
         result = subprocess.run(
             ["rsync", "-a", "--checksum", src_path + "/", dest_path + "/"],
@@ -215,21 +260,38 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir=""):
     except FileNotFoundError:
         # rsync not available, fall back to shutil
         try:
-            shutil.copytree(src_path, dest_path)
+            shutil.copytree(src_path, dest_path, dirs_exist_ok=dest_exists)
         except Exception as exc:
-            shutil.rmtree(dest_path, ignore_errors=True)
+            # Only remove a destination we created — never one that
+            # pre-existed (a merge target may hold the user's own files).
+            if not dest_exists:
+                shutil.rmtree(dest_path, ignore_errors=True)
             return {"moved": 0, "errors": [f"Copy failed: {exc}"]}
     except subprocess.TimeoutExpired:
         return {"moved": 0, "errors": ["rsync timed out after 1 hour"]}
 
-    # Verify file count
-    src_count = sum(1 for _, _, files in os.walk(src_path) for _ in files)
-    dst_count = sum(1 for _, _, files in os.walk(dest_path) for _ in files)
-    if src_count != dst_count:
-        shutil.rmtree(dest_path, ignore_errors=True)
-        return {"moved": 0, "errors": [
-            f"File count mismatch: source={src_count}, dest={dst_count}. Originals preserved."
-        ]}
+    # Verify before deleting originals.
+    if dest_exists:
+        # Merge: the destination may legitimately hold extra unrelated
+        # files (and leftover temp files from an interrupted run), so a
+        # count comparison is meaningless. Instead require that every
+        # source file is present at the destination with a matching size.
+        missing = _first_missing_source_file(src_path, dest_path)
+        if missing is not None:
+            return {"moved": 0, "errors": [
+                f"Verification failed: '{missing}' missing or size mismatch "
+                f"at destination. Originals preserved."
+            ]}
+    else:
+        # Fresh move into a destination we created: a whole-tree file
+        # count is a cheap, sufficient integrity check.
+        src_count = sum(1 for _, _, files in os.walk(src_path) for _ in files)
+        dst_count = sum(1 for _, _, files in os.walk(dest_path) for _ in files)
+        if src_count != dst_count:
+            shutil.rmtree(dest_path, ignore_errors=True)
+            return {"moved": 0, "errors": [
+                f"File count mismatch: source={src_count}, dest={dst_count}. Originals preserved."
+            ]}
 
     # Count photos for progress
     all_photos = db.conn.execute(

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -98,59 +98,65 @@ def _first_missing_source_file(src_path, dest_path):
     return None
 
 
+def _samefile_or_false(a, b):
+    try:
+        return os.path.samefile(a, b)
+    except OSError:
+        return False
+
+
+def _walk_up_paths(p):
+    prev = None
+    while p and p != prev:
+        yield p
+        prev = p
+        p = os.path.dirname(p)
+
+
+def _path_equal_or_descends(candidate, ancestor):
+    """True if `candidate` resolves to the same directory as `ancestor`, or is
+    a descendant of it.
+
+    Folds together every directory-alias surface the move guards need:
+      - Symlinks: os.path.realpath.
+      - Windows case folding: os.path.normcase.
+      - Case-insensitive POSIX (default macOS APFS), where the above two are
+        not enough — os.path.realpath does not fold case and os.path.normcase
+        is a no-op on POSIX, so paths differing only by case string-compare
+        unequal even though they resolve to the same inode: os.path.samefile
+        (device + inode) is FS-truth on every platform and is used as a
+        fallback, including a walk-up ancestor check for the descendant case
+        where `candidate` itself doesn't exist yet.
+    """
+    real_c = os.path.normcase(os.path.realpath(candidate))
+    real_a = os.path.normcase(os.path.realpath(ancestor))
+    if real_c == real_a or real_c.startswith(real_a + os.sep):
+        return True
+
+    if os.path.exists(candidate) and os.path.exists(ancestor) \
+            and _samefile_or_false(candidate, ancestor):
+        return True
+
+    # Containment via case-only alias: walk up candidate's existing ancestors
+    # looking for one whose inode matches `ancestor`. Handles the case where
+    # the candidate leaf doesn't exist yet but its parent (or an ancestor) is
+    # a case-only alias of `ancestor` on a case-insensitive POSIX filesystem.
+    if os.path.exists(ancestor):
+        for anc in _walk_up_paths(os.path.dirname(candidate)):
+            if os.path.exists(anc) and _samefile_or_false(anc, ancestor):
+                return True
+    return False
+
+
 def _destination_overlaps_source(src_path, dest_path):
     """True if dest_path equals src_path or one is a descendant of the other.
 
     The post-copy rmtree(src_path) would delete the only copy of the files if
     dest and src refer to the same on-disk directory, so this is checked
-    before any copy. Aliases we must catch:
-      - Symlinks: handled by os.path.realpath.
-      - Windows case folding: handled by os.path.normcase.
-      - Case-insensitive POSIX (default macOS APFS): NOT handled by either —
-        os.path.realpath does not fold case and os.path.normcase is a no-op
-        on POSIX, so a destination differing from the source only by case
-        slips past the string comparison even though it resolves to the same
-        inode. os.path.samefile (device + inode) is FS-truth on every
-        platform, so we use it as a fallback for that case.
+    before any copy. See `_path_equal_or_descends` for the alias surface.
     """
-    real_src = os.path.normcase(os.path.realpath(src_path))
-    real_dest = os.path.normcase(os.path.realpath(dest_path))
-    if real_dest == real_src \
-            or real_dest.startswith(real_src + os.sep) \
-            or real_src.startswith(real_dest + os.sep):
-        return True
-
-    def _same(a, b):
-        try:
-            return os.path.samefile(a, b)
-        except OSError:
-            return False
-
-    if os.path.exists(src_path) and os.path.exists(dest_path) \
-            and _same(src_path, dest_path):
-        return True
-
-    # Containment via case-only alias: walk up the non-existent leaf until an
-    # extant ancestor is found, then samefile against the other path. If the
-    # existing ancestor of dest is the same inode as src (dest descends from
-    # src), or the existing ancestor of src is the same inode as dest (src
-    # descends from dest), they share storage.
-    def _walk_up(p):
-        prev = None
-        while p and p != prev:
-            yield p
-            prev = p
-            p = os.path.dirname(p)
-
-    if os.path.exists(src_path):
-        for anc in _walk_up(os.path.dirname(dest_path)):
-            if os.path.exists(anc) and _same(anc, src_path):
-                return True
-    if os.path.exists(dest_path):
-        for anc in _walk_up(os.path.dirname(src_path)):
-            if os.path.exists(anc) and _same(anc, dest_path):
-                return True
-    return False
+    return (_path_equal_or_descends(dest_path, src_path)
+            or _path_equal_or_descends(src_path, dest_path))
 
 
 def move_photos(db, photo_ids, destination, progress_cb=None):
@@ -354,18 +360,16 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
         # a tracked descendant. Match the destination itself and anything below
         # it. The cases this feature exists for — resuming an interrupted move,
         # or moving into an untracked folder — never hit this.
-        # Compare canonical (symlink-resolved, case-normalized) paths, not raw
-        # strings: a destination reached through a symlink alias of a tracked
-        # folder would slip past a string match and leave two folder rows
-        # managing the same on-disk tree.
-        real_dest = os.path.normcase(os.path.realpath(dest_path))
-        real_dest_prefix = real_dest + os.sep
+        # Comparison goes through _path_equal_or_descends so symlink aliases,
+        # Windows case folding, AND case-only aliases on case-insensitive POSIX
+        # (default macOS APFS) all collapse to the same tracked row — otherwise
+        # a destination reached via any of those would slip past and leave two
+        # folder rows managing the same on-disk tree.
         tracked = None
         for row in db.conn.execute(
             "SELECT id, path FROM folders WHERE id != ?", (folder_id,)
         ):
-            rp = os.path.normcase(os.path.realpath(row["path"]))
-            if rp == real_dest or rp.startswith(real_dest_prefix):
+            if _path_equal_or_descends(row["path"], dest_path):
                 tracked = row
                 break
         if tracked:

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -250,6 +250,20 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
     folder_name = folder["name"] or os.path.basename(src_path)
     dest_path = resolve_folder_dest(src_path, folder["name"], destination)
 
+    # Refuse a destination that overlaps the source. Moving a folder into
+    # itself (or into one of its own descendants) would make the post-copy
+    # rmtree(src) delete the only copy of the files. This is especially
+    # dangerous for a merge, where a destination equal to the source passes
+    # verification trivially (every source file is already "there") before the
+    # delete wipes everything.
+    abs_src = os.path.abspath(src_path)
+    abs_dest = os.path.abspath(dest_path)
+    if abs_dest == abs_src or abs_dest.startswith(abs_src + os.sep) \
+            or abs_src.startswith(abs_dest + os.sep):
+        return {"moved": 0, "errors": [
+            f"Destination overlaps the source folder: {dest_path}"
+        ]}
+
     dest_exists = os.path.exists(dest_path)
     if dest_exists and not merge:
         return {

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -84,14 +84,33 @@ def _find_content_conflict(src_path, dest_path):
 
 def _first_missing_source_file(src_path, dest_path):
     """Return the relative path of the first source file absent (or
-    size-mismatched) at dest_path, or None if every source file is present
-    and matches. Used to verify a merge before deleting originals."""
+    size-mismatched, or a symlink) at dest_path, or None if every source
+    file is present and matches. Used to verify a merge before deleting
+    originals.
+
+    A symlinked destination entry is treated as missing: `os.path.isfile` /
+    `os.path.getsize` follow the link, so a symlink pointing back into the
+    source tree (directly, or via a symlinked parent directory) would pass
+    a size compare even though no independent copy exists at the
+    destination — and the post-copy `shutil.rmtree(src_path)` would then
+    destroy the only copy. `lexists` lets a broken symlink count as
+    missing instead of crashing later checks; `islink` catches the direct
+    case; `samefile` catches the symlinked-parent case where `src_file`
+    and `dst_file` resolve to the same inode.
+    """
     for root, _, files in os.walk(src_path):
         rel = os.path.relpath(root, src_path)
         for fn in files:
             src_file = os.path.join(root, fn)
             rel_name = fn if rel == "." else os.path.join(rel, fn)
             dst_file = os.path.join(dest_path, rel_name)
+            if not os.path.lexists(dst_file) or os.path.islink(dst_file):
+                return rel_name
+            try:
+                if os.path.samefile(src_file, dst_file):
+                    return rel_name
+            except OSError:
+                return rel_name
             if not os.path.isfile(dst_file) or \
                     os.path.getsize(src_file) != os.path.getsize(dst_file):
                 return rel_name
@@ -434,8 +453,8 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
         missing = _first_missing_source_file(src_path, dest_path)
         if missing is not None:
             return {"moved": 0, "errors": [
-                f"Verification failed: '{missing}' missing or size mismatch "
-                f"at destination. Originals preserved."
+                f"Verification failed: '{missing}' missing, size mismatch, "
+                f"or symlinked at destination. Originals preserved."
             ]}
     else:
         # Fresh move into a destination we created: a whole-tree file

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -303,12 +303,19 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
         # a tracked descendant. Match the destination itself and anything below
         # it. The cases this feature exists for — resuming an interrupted move,
         # or moving into an untracked folder — never hit this.
-        prefix = dest_path + os.sep
-        tracked = db.conn.execute(
-            "SELECT id, path FROM folders "
-            "WHERE (path = ? OR substr(path, 1, ?) = ?) AND id != ?",
-            (dest_path, len(prefix), prefix, folder_id),
-        ).fetchone()
+        # Compare canonical (symlink-resolved, case-normalized) paths, not raw
+        # strings: a destination reached through a symlink alias of a tracked
+        # folder would slip past a string match and leave two folder rows
+        # managing the same on-disk tree. real_dest is computed above.
+        real_dest_prefix = real_dest + os.sep
+        tracked = None
+        for row in db.conn.execute(
+            "SELECT id, path FROM folders WHERE id != ?", (folder_id,)
+        ):
+            rp = os.path.normcase(os.path.realpath(row["path"]))
+            if rp == real_dest or rp.startswith(real_dest_prefix):
+                tracked = row
+                break
         if tracked:
             return {"moved": 0, "errors": [
                 f"Destination overlaps a folder Vireo already manages "

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -1,5 +1,6 @@
 """Photo and folder move operations with copy-verify-delete safety."""
 
+import filecmp
 import logging
 import os
 import shutil
@@ -60,6 +61,25 @@ def _copy_missing(src_path, dest_path):
             dst_file = os.path.join(target_dir, fn)
             if not os.path.exists(dst_file):
                 shutil.copy2(os.path.join(root, fn), dst_file)
+
+
+def _find_content_conflict(src_path, dest_path):
+    """Return the relative path of the first source file that ALSO exists at
+    dest_path but with different content, or None. Run before a merge copies
+    anything: a same-name destination file is only safe to treat as "already
+    there" if its bytes match the source. A size match alone is not enough —
+    filecmp with shallow=False compares contents — so we never overwrite or
+    later delete the source over a genuinely different destination file."""
+    for root, _, files in os.walk(src_path):
+        rel = os.path.relpath(root, src_path)
+        for fn in files:
+            src_file = os.path.join(root, fn)
+            rel_name = fn if rel == "." else os.path.join(rel, fn)
+            dst_file = os.path.join(dest_path, rel_name)
+            if os.path.isfile(dst_file) and \
+                    not filecmp.cmp(src_file, dst_file, shallow=False):
+                return rel_name
+    return None
 
 
 def _first_missing_source_file(src_path, dest_path):
@@ -272,6 +292,34 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
             "needs_merge": True,
         }
 
+    if dest_exists:
+        # Refuse merging into a destination Vireo already tracks as a folder.
+        # A correct merge of two tracked trees needs recursive folder/photo
+        # reconciliation we don't do here; a partial attempt would leave
+        # descendant folders pointing at the deleted source path. The cases
+        # this feature exists for — resuming an interrupted move, or moving
+        # into an untracked folder — never hit this.
+        tracked = db.conn.execute(
+            "SELECT id FROM folders WHERE path = ? AND id != ?",
+            (dest_path, folder_id),
+        ).fetchone()
+        if tracked:
+            return {"moved": 0, "errors": [
+                f"Destination is already managed by Vireo as folder {tracked['id']}. "
+                f"Merging into a tracked folder isn't supported."
+            ]}
+
+        # Refuse if any same-name file already at the destination differs in
+        # content. Never overwrite or later delete the user's data over a real
+        # collision — only files that are byte-identical (a genuine resume) may
+        # be treated as already-moved.
+        conflict = _find_content_conflict(src_path, dest_path)
+        if conflict is not None:
+            return {"moved": 0, "errors": [
+                f"Conflict: '{conflict}' already exists at the destination with "
+                f"different content. Nothing was copied or deleted."
+            ]}
+
     log.info("%s folder %s -> %s",
              "Merging" if dest_exists else "Moving", src_path, dest_path)
 
@@ -339,19 +387,12 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
     ).fetchall()
     total_photos = len(all_photos)
 
-    # Update DB first: cascade folder paths (safer — if rmtree fails,
-    # old folder becomes orphan on disk rather than DB pointing to deleted paths).
-    # If the destination is ALREADY a tracked folder row (a merge into a folder
-    # Vireo already knows about), folders.path is UNIQUE, so repointing the
-    # source onto it would violate the constraint and fail after copying.
-    # Reassign the source's photos into the existing row instead.
-    existing_dest = db.conn.execute(
-        "SELECT id FROM folders WHERE path = ?", (dest_path,)
-    ).fetchone()
-    if existing_dest and existing_dest["id"] != folder_id:
-        db._merge_into_existing(folder_id, existing_dest["id"], dest_path)
-    else:
-        db.move_folder_path(folder_id, dest_path)
+    # Update DB first: cascade folder paths (safer — if rmtree fails, the old
+    # folder becomes an orphan on disk rather than the DB pointing to deleted
+    # paths). A merge into an already-tracked destination is refused above, so
+    # dest_path is never a different existing folder row here and this cascade
+    # (root + all descendants) cannot collide with folders.path UNIQUE.
+    db.move_folder_path(folder_id, dest_path)
     db.update_folder_counts()
 
     # Rebase any developed-output subdirs nested under the configured

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -98,6 +98,61 @@ def _first_missing_source_file(src_path, dest_path):
     return None
 
 
+def _destination_overlaps_source(src_path, dest_path):
+    """True if dest_path equals src_path or one is a descendant of the other.
+
+    The post-copy rmtree(src_path) would delete the only copy of the files if
+    dest and src refer to the same on-disk directory, so this is checked
+    before any copy. Aliases we must catch:
+      - Symlinks: handled by os.path.realpath.
+      - Windows case folding: handled by os.path.normcase.
+      - Case-insensitive POSIX (default macOS APFS): NOT handled by either —
+        os.path.realpath does not fold case and os.path.normcase is a no-op
+        on POSIX, so a destination differing from the source only by case
+        slips past the string comparison even though it resolves to the same
+        inode. os.path.samefile (device + inode) is FS-truth on every
+        platform, so we use it as a fallback for that case.
+    """
+    real_src = os.path.normcase(os.path.realpath(src_path))
+    real_dest = os.path.normcase(os.path.realpath(dest_path))
+    if real_dest == real_src \
+            or real_dest.startswith(real_src + os.sep) \
+            or real_src.startswith(real_dest + os.sep):
+        return True
+
+    def _same(a, b):
+        try:
+            return os.path.samefile(a, b)
+        except OSError:
+            return False
+
+    if os.path.exists(src_path) and os.path.exists(dest_path) \
+            and _same(src_path, dest_path):
+        return True
+
+    # Containment via case-only alias: walk up the non-existent leaf until an
+    # extant ancestor is found, then samefile against the other path. If the
+    # existing ancestor of dest is the same inode as src (dest descends from
+    # src), or the existing ancestor of src is the same inode as dest (src
+    # descends from dest), they share storage.
+    def _walk_up(p):
+        prev = None
+        while p and p != prev:
+            yield p
+            prev = p
+            p = os.path.dirname(p)
+
+    if os.path.exists(src_path):
+        for anc in _walk_up(os.path.dirname(dest_path)):
+            if os.path.exists(anc) and _same(anc, src_path):
+                return True
+    if os.path.exists(dest_path):
+        for anc in _walk_up(os.path.dirname(src_path)):
+            if os.path.exists(anc) and _same(anc, dest_path):
+                return True
+    return False
+
+
 def move_photos(db, photo_ids, destination, progress_cb=None):
     """Move individual photos to a destination directory.
 
@@ -275,13 +330,9 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
     # rmtree(src) delete the only copy of the files. This is especially
     # dangerous for a merge, where a destination equal to the source passes
     # verification trivially (every source file is already "there") before the
-    # delete wipes everything. Resolve symlinks (realpath) and normalize case
-    # so a symlinked or differently-cased alias of the same directory is still
-    # caught — abspath alone would miss a symlinked destination.
-    real_src = os.path.normcase(os.path.realpath(src_path))
-    real_dest = os.path.normcase(os.path.realpath(dest_path))
-    if real_dest == real_src or real_dest.startswith(real_src + os.sep) \
-            or real_src.startswith(real_dest + os.sep):
+    # delete wipes everything. See _destination_overlaps_source for the alias
+    # surface (symlinks, Windows case folding, case-insensitive POSIX).
+    if _destination_overlaps_source(src_path, dest_path):
         return {"moved": 0, "errors": [
             f"Destination overlaps the source folder: {dest_path}"
         ]}
@@ -306,7 +357,8 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
         # Compare canonical (symlink-resolved, case-normalized) paths, not raw
         # strings: a destination reached through a symlink alias of a tracked
         # folder would slip past a string match and leave two folder rows
-        # managing the same on-disk tree. real_dest is computed above.
+        # managing the same on-disk tree.
+        real_dest = os.path.normcase(os.path.realpath(dest_path))
         real_dest_prefix = real_dest + os.sep
         tracked = None
         for row in db.conn.execute(

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -48,6 +48,20 @@ def resolve_folder_dest(folder_path, folder_name, destination):
     return os.path.join(destination, name)
 
 
+def _copy_missing(src_path, dest_path):
+    """Recursively copy only files that don't already exist at dest_path,
+    never overwriting an existing destination file. shutil fallback for a
+    merge when rsync is unavailable; mirrors rsync --ignore-existing."""
+    for root, _, files in os.walk(src_path):
+        rel = os.path.relpath(root, src_path)
+        target_dir = dest_path if rel == "." else os.path.join(dest_path, rel)
+        os.makedirs(target_dir, exist_ok=True)
+        for fn in files:
+            dst_file = os.path.join(target_dir, fn)
+            if not os.path.exists(dst_file):
+                shutil.copy2(os.path.join(root, fn), dst_file)
+
+
 def _first_missing_source_file(src_path, dest_path):
     """Return the relative path of the first source file absent (or
     size-mismatched) at dest_path, or None if every source file is present
@@ -247,12 +261,18 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
     log.info("%s folder %s -> %s",
              "Merging" if dest_exists else "Moving", src_path, dest_path)
 
-    # Use rsync for robust copy with checksums. With --checksum, a merge
-    # skips files already present and identical and copies only what's
-    # missing — exactly what resuming an interrupted move requires.
+    # Use rsync for a robust copy. A merge/resume uses --ignore-existing so
+    # rsync only creates files absent at the destination and NEVER overwrites
+    # a file already there: this resumes an interrupted move (missing files get
+    # copied, already-copied ones are left alone) while guaranteeing a merge
+    # cannot destroy pre-existing destination data. A fresh move uses --checksum
+    # for integrity. Any genuine same-name collision (an existing dest file that
+    # differs from the source) is left untouched here and caught by the
+    # post-copy verification below, which then refuses to delete the originals.
+    rsync_flag = "--ignore-existing" if dest_exists else "--checksum"
     try:
         result = subprocess.run(
-            ["rsync", "-a", "--checksum", src_path + "/", dest_path + "/"],
+            ["rsync", "-a", rsync_flag, src_path + "/", dest_path + "/"],
             capture_output=True, text=True, timeout=3600,
         )
         if result.returncode != 0:
@@ -260,7 +280,10 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
     except FileNotFoundError:
         # rsync not available, fall back to shutil
         try:
-            shutil.copytree(src_path, dest_path, dirs_exist_ok=dest_exists)
+            if dest_exists:
+                _copy_missing(src_path, dest_path)  # never overwrites
+            else:
+                shutil.copytree(src_path, dest_path)
         except Exception as exc:
             # Only remove a destination we created — never one that
             # pre-existed (a merge target may hold the user's own files).
@@ -303,8 +326,18 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
     total_photos = len(all_photos)
 
     # Update DB first: cascade folder paths (safer — if rmtree fails,
-    # old folder becomes orphan on disk rather than DB pointing to deleted paths)
-    db.move_folder_path(folder_id, dest_path)
+    # old folder becomes orphan on disk rather than DB pointing to deleted paths).
+    # If the destination is ALREADY a tracked folder row (a merge into a folder
+    # Vireo already knows about), folders.path is UNIQUE, so repointing the
+    # source onto it would violate the constraint and fail after copying.
+    # Reassign the source's photos into the existing row instead.
+    existing_dest = db.conn.execute(
+        "SELECT id FROM folders WHERE path = ?", (dest_path,)
+    ).fetchone()
+    if existing_dest and existing_dest["id"] != folder_id:
+        db._merge_into_existing(folder_id, existing_dest["id"], dest_path)
+    else:
+        db.move_folder_path(folder_id, dest_path)
     db.update_folder_counts()
 
     # Rebase any developed-output subdirs nested under the configured

--- a/vireo/templates/move.html
+++ b/vireo/templates/move.html
@@ -589,7 +589,7 @@ function updateQuickMovePreview() {
   preview.appendChild(pathSpan);
 }
 
-function startQuickMove() {
+async function startQuickMove() {
   var fid = parseInt(document.getElementById('quickFolderSelect').value);
   var dest = document.getElementById('quickDestInput').value.trim();
   if (!fid || !dest) return;
@@ -597,25 +597,50 @@ function startQuickMove() {
   var folder = allFolders.find(function(f) { return f.id === fid; });
   var folderName = folder ? folder.path : 'folder #' + fid;
   var photoCount = folder ? (folder.photo_count || 0) : '?';
-  var finalPath = resolvedMoveDest(folder, dest);
 
-  showConfirm(
-    'Move Folder',
-    'Move "' + folderName + '" (' + photoCount + ' photos) to "' + finalPath + '"? Files will be copied and verified before originals are removed.',
-    function() {
-      executeQuickMove(fid, dest);
-    }
-  );
+  // Ask the backend for the resolved destination and whether it already
+  // exists, so we can offer merge/resume instead of failing on collision.
+  var pf;
+  try {
+    pf = await safeFetch('/api/move-folder/preflight', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({folder_id: fid, destination: dest}),
+    });
+  } catch (e) {
+    return;  // safeFetch already shows error toast
+  }
+
+  var finalPath = pf.resolved_dest;
+  if (pf.exists) {
+    var n = pf.file_count;
+    showConfirm(
+      'Destination Exists — Merge & Resume',
+      '"' + finalPath + '" already exists and contains ' + n + ' file' + (n !== 1 ? 's' : '') +
+        '. Merge "' + folderName + '" (' + photoCount + ' photos) into it? Files already present with a matching size are skipped; only missing files are copied. Originals are removed only after every source file is verified at the destination.',
+      function() {
+        executeQuickMove(fid, dest, true);
+      }
+    );
+  } else {
+    showConfirm(
+      'Move Folder',
+      'Move "' + folderName + '" (' + photoCount + ' photos) to "' + finalPath + '"? Files will be copied and verified before originals are removed.',
+      function() {
+        executeQuickMove(fid, dest, false);
+      }
+    );
+  }
 }
 
-async function executeQuickMove(folderId, destination) {
+async function executeQuickMove(folderId, destination, merge) {
   try {
     var resp = await safeFetch('/api/jobs/move-folder', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({folder_id: folderId, destination: destination}),
+      body: JSON.stringify({folder_id: folderId, destination: destination, merge: !!merge}),
     });
-    showToast('Move started (job ' + resp.job_id + ') — track progress in the bottom panel');
+    showToast((merge ? 'Merge' : 'Move') + ' started (job ' + resp.job_id + ') — track progress in the bottom panel');
   } catch (e) {
     // safeFetch already shows error toast
   }

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -188,10 +188,10 @@ def test_move_folder_merge_resumes(move_env):
     assert folder["path"] == str(landing)
 
 
-def test_move_folder_merge_never_overwrites_existing_dest_file(move_env):
-    """A merge must not overwrite a pre-existing destination file. A same-name
-    file with differing content is left intact and the size mismatch aborts the
-    merge, preserving the originals (no data loss on either side)."""
+def test_move_folder_merge_never_overwrites_differing_dest_file(move_env):
+    """A same-name destination file with DIFFERENT content (different size)
+    is a hard conflict: the merge aborts before copying, leaving both the
+    destination file and the originals untouched."""
     from move import move_folder
 
     env = move_env
@@ -204,41 +204,58 @@ def test_move_folder_merge_never_overwrites_existing_dest_file(move_env):
         db=env["db"], folder_id=env["fid_src"], destination=str(env["dst"]), merge=True
     )
     assert result["moved"] == 0
-    assert any("Verification failed" in e for e in result["errors"])
+    assert any("Conflict" in e for e in result["errors"])
     # Pre-existing destination file untouched, originals preserved.
     assert (landing / "bird1.jpg").read_bytes() == b"USER DATA - do not clobber"
     assert (env["src"] / "bird1.jpg").exists()
 
 
-def test_move_folder_merge_into_tracked_folder(move_env):
-    """Merging into a destination that is already a tracked folder row
-    reassigns the source's photos into that row (no folders.path UNIQUE
-    violation) and removes the source folder row."""
+def test_move_folder_merge_detects_same_size_different_content(move_env):
+    """The dangerous case: a destination file with the SAME size but different
+    bytes must still be detected as a conflict (size alone is insufficient),
+    so the source is never deleted in favor of the wrong destination bytes."""
+    from move import move_folder
+
+    env = move_env
+    src_bytes = (env["src"] / "bird1.jpg").read_bytes()
+    landing = env["dst"] / "src"
+    landing.mkdir()
+    # Same length as the source, different content.
+    decoy = bytes((b + 1) % 256 for b in src_bytes)
+    assert len(decoy) == len(src_bytes) and decoy != src_bytes
+    (landing / "bird1.jpg").write_bytes(decoy)
+
+    result = move_folder(
+        db=env["db"], folder_id=env["fid_src"], destination=str(env["dst"]), merge=True
+    )
+    assert result["moved"] == 0
+    assert any("Conflict" in e for e in result["errors"])
+    # Destination decoy untouched, source preserved (no silent data loss).
+    assert (landing / "bird1.jpg").read_bytes() == decoy
+    assert (env["src"] / "bird1.jpg").exists()
+
+
+def test_move_folder_merge_refuses_tracked_destination(move_env):
+    """Merging into a destination Vireo already tracks as a folder is refused
+    (a correct tracked-tree merge is out of scope and would dangle descendant
+    paths). Originals are preserved."""
     from move import move_folder
 
     env = move_env
     landing = env["dst"] / "src"
     landing.mkdir()
-    # Completed-but-untracked copy already on disk.
     for fn in ("bird1.jpg", "bird1.xmp", "bird2.jpg"):
         (landing / fn).write_bytes((env["src"] / fn).read_bytes())
     # Destination already exists as its own folder row in the DB.
-    dest_fid = env["db"].add_folder(str(landing), name="src")
-    src_fid = env["fid_src"]
+    env["db"].add_folder(str(landing), name="src")
 
     result = move_folder(
-        db=env["db"], folder_id=src_fid, destination=str(env["dst"]), merge=True
+        db=env["db"], folder_id=env["fid_src"], destination=str(env["dst"]), merge=True
     )
-    assert result["errors"] == []
-    # Source folder row merged away; photos now under the existing dest row.
-    assert env["db"].conn.execute(
-        "SELECT id FROM folders WHERE id = ?", (src_fid,)
-    ).fetchone() is None
-    cnt = env["db"].conn.execute(
-        "SELECT COUNT(*) c FROM photos WHERE folder_id = ?", (dest_fid,)
-    ).fetchone()["c"]
-    assert cnt == 2
-    assert not env["src"].exists()
+    assert result["moved"] == 0
+    assert any("already managed by Vireo" in e for e in result["errors"])
+    # Source intact.
+    assert (env["src"] / "bird1.jpg").exists()
 
 
 def test_move_folder_refuses_self_overlapping_destination(move_env):

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -362,6 +362,49 @@ def test_move_folder_merge_refuses_case_alias_self_destination(move_env, monkeyp
     assert (env["src"] / "bird2.jpg").exists()
 
 
+def test_move_folder_merge_refuses_case_alias_tracked_destination(move_env, monkeypatch):
+    """On a case-insensitive POSIX filesystem (default macOS APFS), a tracked
+    folder reached via a case-only alias must also be refused. realpath +
+    normcase don't fold case there, so the tracked-destination string compare
+    misses; the samefile fallback in `_path_equal_or_descends` catches it and
+    keeps two folder rows from managing the same on-disk tree.
+
+    Simulated on Linux the same way as the self-destination case-alias test:
+      1. Symlink so two distinct path strings share an inode.
+      2. realpath/normcase patched to no-ops so the string-based check doesn't
+         pre-empt the samefile fallback we want to exercise.
+    """
+    from move import move_folder
+
+    env = move_env
+    real_dst = env["tmp_path"] / "realdst"
+    landing = real_dst / "src"
+    landing.mkdir(parents=True)
+    # Pre-populate landing so dest_exists is True and the tracked check runs.
+    (landing / "bird1.jpg").write_bytes((env["src"] / "bird1.jpg").read_bytes())
+    env["db"].add_folder(str(landing), name="src")  # tracked at the real path
+
+    alias_dst = env["tmp_path"] / "alias_dst"
+    try:
+        os.symlink(str(real_dst), str(alias_dst))
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported on this platform")
+
+    monkeypatch.setattr(os.path, "realpath", lambda p: p)
+    monkeypatch.setattr(os.path, "normcase", lambda p: p)
+
+    # destination=alias_dst → resolved dest = alias_dst/src; string-compares
+    # unequal to the tracked landing path, but samefile makes them collapse.
+    result = move_folder(
+        db=env["db"], folder_id=env["fid_src"], destination=str(alias_dst), merge=True
+    )
+    assert result["moved"] == 0
+    assert any("already manage" in e for e in result["errors"])
+    # Source intact.
+    assert (env["src"] / "bird1.jpg").exists()
+    assert (env["src"] / "bird2.jpg").exists()
+
+
 def test_move_folder_refuses_self_overlapping_destination(move_env):
     """A move whose resolved destination overlaps the source (here, the
     source's own parent → resolved dest == source) must be refused rather

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -277,6 +277,33 @@ def test_move_folder_merge_refuses_tracked_descendant(move_env):
     assert (env["src"] / "bird1.jpg").exists()
 
 
+def test_move_folder_merge_refuses_symlinked_tracked_destination(move_env):
+    """A tracked folder reached via a symlink alias must be detected by the
+    tracked-destination check (canonical realpath compare), not slip past a
+    raw-string match."""
+    from move import move_folder
+
+    env = move_env
+    real_dst = env["tmp_path"] / "realdst"
+    landing = real_dst / "src"
+    landing.mkdir(parents=True)
+    env["db"].add_folder(str(landing), name="src")  # tracked at its real path
+
+    link = env["tmp_path"] / "dstlink"
+    try:
+        os.symlink(str(real_dst), str(link))
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported on this platform")
+
+    # Destination via the alias resolves (realpath) to the tracked landing.
+    result = move_folder(
+        db=env["db"], folder_id=env["fid_src"], destination=str(link), merge=True
+    )
+    assert result["moved"] == 0
+    assert any("already manage" in e for e in result["errors"])
+    assert (env["src"] / "bird1.jpg").exists()
+
+
 def test_move_folder_merge_refuses_symlinked_self_destination(move_env):
     """A destination that is a symlink alias of the source's parent resolves
     (via realpath) to the source itself and must be refused, not no-op-copied

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -241,6 +241,24 @@ def test_move_folder_merge_into_tracked_folder(move_env):
     assert not env["src"].exists()
 
 
+def test_move_folder_refuses_self_overlapping_destination(move_env):
+    """A move whose resolved destination overlaps the source (here, the
+    source's own parent → resolved dest == source) must be refused rather
+    than no-op-copy then delete the source."""
+    from move import move_folder
+
+    env = move_env
+    parent = str(env["src"].parent)  # resolve_folder_dest(...) == src path
+    result = move_folder(
+        db=env["db"], folder_id=env["fid_src"], destination=parent, merge=True
+    )
+    assert result["moved"] == 0
+    assert any("overlaps" in e for e in result["errors"])
+    # Source folder fully intact.
+    assert (env["src"] / "bird1.jpg").exists()
+    assert (env["src"] / "bird2.jpg").exists()
+
+
 def test_move_folder_merge_verify_fail_preserves_originals_and_dest(move_env, monkeypatch):
     """If a source file is missing at the destination after copy, the merge
     aborts without deleting originals or the pre-existing destination."""

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -253,8 +253,49 @@ def test_move_folder_merge_refuses_tracked_destination(move_env):
         db=env["db"], folder_id=env["fid_src"], destination=str(env["dst"]), merge=True
     )
     assert result["moved"] == 0
-    assert any("already managed by Vireo" in e for e in result["errors"])
+    assert any("already manage" in e for e in result["errors"])
     # Source intact.
+    assert (env["src"] / "bird1.jpg").exists()
+
+
+def test_move_folder_merge_refuses_tracked_descendant(move_env):
+    """A tracked folder *below* the (untracked) destination must also block the
+    merge — its path would collide when the source's children cascade onto it."""
+    from move import move_folder
+
+    env = move_env
+    landing = env["dst"] / "src"
+    (landing / "sub").mkdir(parents=True)
+    # A tracked folder below the destination root.
+    env["db"].add_folder(str(landing / "sub"), name="sub")
+
+    result = move_folder(
+        db=env["db"], folder_id=env["fid_src"], destination=str(env["dst"]), merge=True
+    )
+    assert result["moved"] == 0
+    assert any("already manage" in e for e in result["errors"])
+    assert (env["src"] / "bird1.jpg").exists()
+
+
+def test_move_folder_merge_refuses_symlinked_self_destination(move_env):
+    """A destination that is a symlink alias of the source's parent resolves
+    (via realpath) to the source itself and must be refused, not no-op-copied
+    then deleted."""
+    from move import move_folder
+
+    env = move_env
+    link = env["tmp_path"] / "alias"
+    try:
+        os.symlink(str(env["src"].parent), str(link))
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported on this platform")
+
+    # destination = alias → resolved dest == alias/src, realpath == src path
+    result = move_folder(
+        db=env["db"], folder_id=env["fid_src"], destination=str(link), merge=True
+    )
+    assert result["moved"] == 0
+    assert any("overlaps the source" in e for e in result["errors"])
     assert (env["src"] / "bird1.jpg").exists()
 
 

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -448,6 +448,108 @@ def test_move_folder_merge_verify_fail_preserves_originals_and_dest(move_env, mo
     assert sentinel.exists()
 
 
+def test_move_folder_merge_rejects_symlinked_dest_file(move_env, monkeypatch):
+    """A destination entry that is a symlink to the source file must fail
+    verification, not be accepted as an independent copy. Otherwise rsync
+    --ignore-existing leaves the symlink alone and the post-copy
+    rmtree(src_path) would destroy the symlink's target — the only copy."""
+    import move as move_mod
+
+    env = move_env
+    landing = env["dst"] / "src"
+    landing.mkdir()
+    # Place real copies of the files we DON'T want the test to trip over,
+    # so verification reaches the symlinked entry rather than failing on
+    # the first plain-missing file.
+    (landing / "bird1.xmp").write_bytes((env["src"] / "bird1.xmp").read_bytes())
+    (landing / "bird2.jpg").write_bytes((env["src"] / "bird2.jpg").read_bytes())
+    # bird1.jpg at dest is a SYMLINK back to the source file.
+    try:
+        os.symlink(str(env["src"] / "bird1.jpg"), str(landing / "bird1.jpg"))
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported on this platform")
+
+    # Force rsync to no-op (it would normally honor --ignore-existing and
+    # leave the symlink anyway; this just removes the dependency on rsync).
+    monkeypatch.setattr(move_mod.subprocess, "run",
+                        lambda *a, **k: type("R", (), {"returncode": 0, "stderr": ""})())
+
+    result = move_mod.move_folder(
+        db=env["db"], folder_id=env["fid_src"], destination=str(env["dst"]), merge=True
+    )
+    assert result["moved"] == 0
+    assert any("Verification failed" in e and "bird1.jpg" in e
+               for e in result["errors"])
+    # The source file MUST still exist — that's the safety property.
+    assert (env["src"] / "bird1.jpg").exists()
+    assert (env["src"] / "bird1.jpg").read_bytes() != b""
+
+
+def test_move_folder_merge_rejects_symlinked_dest_subdir(move_env, monkeypatch):
+    """A destination subdirectory that is a symlink back into the source
+    tree must also fail verification. os.path.isfile/getsize on the joined
+    path would silently follow the link to the source's own bytes and
+    pass — and then rmtree(src_path) would destroy the only copy."""
+    import move as move_mod
+
+    env = move_env
+    # Reshape source: put bird1 inside a real subdirectory.
+    sub_src = env["src"] / "sub"
+    sub_src.mkdir()
+    (env["src"] / "bird1.jpg").rename(sub_src / "bird1.jpg")
+    (env["src"] / "bird1.xmp").rename(sub_src / "bird1.xmp")
+
+    landing = env["dst"] / "src"
+    landing.mkdir()
+    # Real copy of the file in src root (bird2) so verification reaches
+    # the symlinked subdirectory entries.
+    (landing / "bird2.jpg").write_bytes((env["src"] / "bird2.jpg").read_bytes())
+    # The "sub" dir at the destination is a SYMLINK back into the source.
+    try:
+        os.symlink(str(sub_src), str(landing / "sub"))
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported on this platform")
+
+    monkeypatch.setattr(move_mod.subprocess, "run",
+                        lambda *a, **k: type("R", (), {"returncode": 0, "stderr": ""})())
+
+    result = move_mod.move_folder(
+        db=env["db"], folder_id=env["fid_src"], destination=str(env["dst"]), merge=True
+    )
+    assert result["moved"] == 0
+    assert any("Verification failed" in e for e in result["errors"])
+    # Source files still present at the real path — not destroyed via the
+    # symlinked-parent shortcut.
+    assert (sub_src / "bird1.jpg").exists()
+
+
+def test_move_folder_merge_rejects_broken_symlink(move_env, monkeypatch):
+    """A broken symlink at the destination (lexists True, isfile False) must
+    also fail verification, not be silently accepted as missing-then-fine."""
+    import move as move_mod
+
+    env = move_env
+    landing = env["dst"] / "src"
+    landing.mkdir()
+    (landing / "bird1.xmp").write_bytes((env["src"] / "bird1.xmp").read_bytes())
+    (landing / "bird2.jpg").write_bytes((env["src"] / "bird2.jpg").read_bytes())
+    # Broken symlink — target doesn't exist.
+    try:
+        os.symlink(str(env["tmp_path"] / "nope.jpg"), str(landing / "bird1.jpg"))
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported on this platform")
+
+    monkeypatch.setattr(move_mod.subprocess, "run",
+                        lambda *a, **k: type("R", (), {"returncode": 0, "stderr": ""})())
+
+    result = move_mod.move_folder(
+        db=env["db"], folder_id=env["fid_src"], destination=str(env["dst"]), merge=True
+    )
+    assert result["moved"] == 0
+    assert any("Verification failed" in e for e in result["errors"])
+    assert (env["src"] / "bird1.jpg").exists()
+
+
 def test_resolve_folder_dest():
     """resolve_folder_dest places the folder inside the destination."""
     from move import resolve_folder_dest

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -288,9 +288,13 @@ def test_resolve_folder_dest():
     """resolve_folder_dest places the folder inside the destination."""
     from move import resolve_folder_dest
 
-    assert resolve_folder_dest("/a/birds", "birds", "/nas/photos") == "/nas/photos/birds"
+    # Compare against os.path.join so the expectation is platform-correct
+    # (Windows joins with a backslash).
+    assert resolve_folder_dest("/a/birds", "birds", "/nas/photos") == \
+        os.path.join("/nas/photos", "birds")
     # Falls back to basename when name is empty
-    assert resolve_folder_dest("/a/birds/", "", "/nas/photos") == "/nas/photos/birds"
+    assert resolve_folder_dest("/a/birds/", "", "/nas/photos") == \
+        os.path.join("/nas/photos", "birds")
 
 
 def test_move_folder_updates_counts(move_env):

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -188,6 +188,59 @@ def test_move_folder_merge_resumes(move_env):
     assert folder["path"] == str(landing)
 
 
+def test_move_folder_merge_never_overwrites_existing_dest_file(move_env):
+    """A merge must not overwrite a pre-existing destination file. A same-name
+    file with differing content is left intact and the size mismatch aborts the
+    merge, preserving the originals (no data loss on either side)."""
+    from move import move_folder
+
+    env = move_env
+    landing = env["dst"] / "src"
+    landing.mkdir()
+    # User's own file sharing bird1's name but with different content/size.
+    (landing / "bird1.jpg").write_bytes(b"USER DATA - do not clobber")
+
+    result = move_folder(
+        db=env["db"], folder_id=env["fid_src"], destination=str(env["dst"]), merge=True
+    )
+    assert result["moved"] == 0
+    assert any("Verification failed" in e for e in result["errors"])
+    # Pre-existing destination file untouched, originals preserved.
+    assert (landing / "bird1.jpg").read_bytes() == b"USER DATA - do not clobber"
+    assert (env["src"] / "bird1.jpg").exists()
+
+
+def test_move_folder_merge_into_tracked_folder(move_env):
+    """Merging into a destination that is already a tracked folder row
+    reassigns the source's photos into that row (no folders.path UNIQUE
+    violation) and removes the source folder row."""
+    from move import move_folder
+
+    env = move_env
+    landing = env["dst"] / "src"
+    landing.mkdir()
+    # Completed-but-untracked copy already on disk.
+    for fn in ("bird1.jpg", "bird1.xmp", "bird2.jpg"):
+        (landing / fn).write_bytes((env["src"] / fn).read_bytes())
+    # Destination already exists as its own folder row in the DB.
+    dest_fid = env["db"].add_folder(str(landing), name="src")
+    src_fid = env["fid_src"]
+
+    result = move_folder(
+        db=env["db"], folder_id=src_fid, destination=str(env["dst"]), merge=True
+    )
+    assert result["errors"] == []
+    # Source folder row merged away; photos now under the existing dest row.
+    assert env["db"].conn.execute(
+        "SELECT id FROM folders WHERE id = ?", (src_fid,)
+    ).fetchone() is None
+    cnt = env["db"].conn.execute(
+        "SELECT COUNT(*) c FROM photos WHERE folder_id = ?", (dest_fid,)
+    ).fetchone()["c"]
+    assert cnt == 2
+    assert not env["src"].exists()
+
+
 def test_move_folder_merge_verify_fail_preserves_originals_and_dest(move_env, monkeypatch):
     """If a source file is missing at the destination after copy, the merge
     aborts without deleting originals or the pre-existing destination."""

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -141,6 +141,87 @@ def test_move_folder_copies_tree(move_env):
     assert folder["path"] == str(env["dst"] / "src")
 
 
+def test_move_folder_refuses_existing_dest_without_merge(move_env):
+    """move_folder refuses an existing destination and preserves originals."""
+    from move import move_folder
+
+    env = move_env
+    # Pre-create the resolved landing path (dst/src)
+    landing = env["dst"] / "src"
+    landing.mkdir()
+
+    result = move_folder(db=env["db"], folder_id=env["fid_src"], destination=str(env["dst"]))
+    assert result["moved"] == 0
+    assert result.get("needs_merge") is True
+    assert any("already exists" in e for e in result["errors"])
+    # Originals untouched
+    assert (env["src"] / "bird1.jpg").exists()
+    assert (env["src"] / "bird2.jpg").exists()
+
+
+def test_move_folder_merge_resumes(move_env):
+    """merge=True copies only missing files into an existing destination,
+    verifies, then removes originals and updates the DB path."""
+    from move import move_folder
+
+    env = move_env
+    landing = env["dst"] / "src"
+    landing.mkdir()
+    # Simulate a partially-completed prior move: bird1 already copied.
+    (landing / "bird1.jpg").write_bytes((env["src"] / "bird1.jpg").read_bytes())
+    # And a leftover rsync temp file from the interrupted run.
+    (landing / ".bird2.jpg.AbCdEf").write_bytes(b"partial")
+
+    result = move_folder(
+        db=env["db"], folder_id=env["fid_src"], destination=str(env["dst"]), merge=True
+    )
+    assert result["errors"] == []
+    # Missing file got copied; both now present at destination
+    assert (landing / "bird1.jpg").exists()
+    assert (landing / "bird2.jpg").exists()
+    # Originals removed
+    assert not env["src"].exists()
+    # DB path updated to the merged location
+    folder = env["db"].conn.execute(
+        "SELECT path FROM folders WHERE id = ?", (env["fid_src"],)
+    ).fetchone()
+    assert folder["path"] == str(landing)
+
+
+def test_move_folder_merge_verify_fail_preserves_originals_and_dest(move_env, monkeypatch):
+    """If a source file is missing at the destination after copy, the merge
+    aborts without deleting originals or the pre-existing destination."""
+    import move as move_mod
+
+    env = move_env
+    landing = env["dst"] / "src"
+    landing.mkdir()
+    sentinel = landing / "user_file.txt"
+    sentinel.write_text("pre-existing")
+
+    # Force the copy step to be a no-op so a source file is "missing" at dest.
+    monkeypatch.setattr(move_mod.subprocess, "run",
+                        lambda *a, **k: type("R", (), {"returncode": 0, "stderr": ""})())
+
+    result = move_mod.move_folder(
+        db=env["db"], folder_id=env["fid_src"], destination=str(env["dst"]), merge=True
+    )
+    assert result["moved"] == 0
+    assert any("Verification failed" in e for e in result["errors"])
+    # Originals preserved, pre-existing destination file untouched
+    assert (env["src"] / "bird1.jpg").exists()
+    assert sentinel.exists()
+
+
+def test_resolve_folder_dest():
+    """resolve_folder_dest places the folder inside the destination."""
+    from move import resolve_folder_dest
+
+    assert resolve_folder_dest("/a/birds", "birds", "/nas/photos") == "/nas/photos/birds"
+    # Falls back to basename when name is empty
+    assert resolve_folder_dest("/a/birds/", "", "/nas/photos") == "/nas/photos/birds"
+
+
 def test_move_folder_updates_counts(move_env):
     """move_folder updates photo_count on folders."""
     from move import move_folder

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -326,6 +326,42 @@ def test_move_folder_merge_refuses_symlinked_self_destination(move_env):
     assert (env["src"] / "bird1.jpg").exists()
 
 
+def test_move_folder_merge_refuses_case_alias_self_destination(move_env, monkeypatch):
+    """On a case-insensitive POSIX filesystem (default macOS APFS),
+    os.path.normcase is a no-op and os.path.realpath does not fold case, so
+    a destination that differs from the source only by case still resolves
+    to the same inode but string-compares unequal. The overlap guard must
+    fall back to os.path.samefile (device + inode) so the merge is refused
+    before shutil.rmtree deletes the only copy of the source files.
+
+    Simulated on Linux by:
+      1. Using a symlink so two distinct path strings share an inode.
+      2. Patching realpath/normcase to no-ops so the existing string-based
+         check doesn't pre-empt the samefile fallback we want to exercise.
+    """
+    from move import move_folder
+
+    env = move_env
+    alias_parent = env["tmp_path"] / "alias_parent"
+    try:
+        os.symlink(str(env["src"].parent), str(alias_parent))
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported on this platform")
+
+    monkeypatch.setattr(os.path, "realpath", lambda p: p)
+    monkeypatch.setattr(os.path, "normcase", lambda p: p)
+
+    # destination=alias_parent → resolved dest = alias_parent/src; samefile
+    # against env["src"] returns True because the symlink shares the inode.
+    result = move_folder(
+        db=env["db"], folder_id=env["fid_src"], destination=str(alias_parent), merge=True
+    )
+    assert result["moved"] == 0
+    assert any("overlaps the source" in e for e in result["errors"])
+    assert (env["src"] / "bird1.jpg").exists()
+    assert (env["src"] / "bird2.jpg").exists()
+
+
 def test_move_folder_refuses_self_overlapping_destination(move_env):
     """A move whose resolved destination overlaps the source (here, the
     source's own parent → resolved dest == source) must be refused rather

--- a/vireo/tests/test_move_api.py
+++ b/vireo/tests/test_move_api.py
@@ -60,6 +60,75 @@ def test_move_folder_job_starts(app_and_db, tmp_path):
     assert data["job_id"].startswith("move-folder-")
 
 
+def test_move_folder_merge_param_accepted(app_and_db, tmp_path):
+    """POST /api/jobs/move-folder accepts merge=true and starts a job."""
+    app, db = app_and_db
+    dst = str(tmp_path / "merge_dst")
+    os.makedirs(dst)
+
+    fid = db.get_folder_tree()[0]["id"]
+
+    client = app.test_client()
+    resp = client.post("/api/jobs/move-folder", json={
+        "folder_id": fid,
+        "destination": dst,
+        "merge": True,
+    })
+    assert resp.status_code == 200
+    assert resp.get_json()["job_id"].startswith("move-folder-")
+
+
+def test_move_folder_preflight_dest_missing(app_and_db, tmp_path):
+    """Preflight reports exists=False for a destination that doesn't exist."""
+    app, db = app_and_db
+    dst = str(tmp_path / "nowhere")  # not created on disk
+
+    folder = db.get_folder_tree()[0]
+    client = app.test_client()
+    resp = client.post("/api/move-folder/preflight", json={
+        "folder_id": folder["id"],
+        "destination": dst,
+    })
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["exists"] is False
+    assert data["file_count"] == 0
+    assert data["resolved_dest"].startswith(dst)
+
+
+def test_move_folder_preflight_dest_exists(app_and_db, tmp_path):
+    """Preflight reports exists=True and a file count when the resolved
+    destination already exists."""
+    app, db = app_and_db
+    dst = tmp_path / "dest"
+    dst.mkdir()
+
+    folder = db.get_folder_tree()[0]
+    folder_name = folder["name"] or os.path.basename(folder["path"].rstrip("/\\"))
+    landing = dst / folder_name
+    landing.mkdir()
+    (landing / "already.jpg").write_bytes(b"x")
+
+    client = app.test_client()
+    resp = client.post("/api/move-folder/preflight", json={
+        "folder_id": folder["id"],
+        "destination": str(dst),
+    })
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["exists"] is True
+    assert data["file_count"] == 1
+    assert data["resolved_dest"] == str(landing)
+
+
+def test_move_folder_preflight_requires_params(app_and_db):
+    """Preflight without folder_id returns 400."""
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post("/api/move-folder/preflight", json={"destination": "/tmp"})
+    assert resp.status_code == 400
+
+
 def test_move_rules_crud(app_and_db):
     """CRUD operations on move rules via API."""
     app, _ = app_and_db

--- a/vireo/tests/test_move_api.py
+++ b/vireo/tests/test_move_api.py
@@ -129,6 +129,51 @@ def test_move_folder_preflight_requires_params(app_and_db):
     assert resp.status_code == 400
 
 
+def test_move_folder_rejects_non_object_body(app_and_db):
+    """A JSON body that isn't an object (e.g. an array) returns 400 instead of
+    crashing on body.get(...)."""
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post("/api/jobs/move-folder", json=[1, 2, 3])
+    assert resp.status_code == 400
+    assert "object" in resp.get_json()["error"].lower()
+
+
+def test_move_folder_rejects_non_string_destination(app_and_db):
+    """A non-string destination returns 400 instead of raising TypeError in
+    os.path.isabs."""
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post("/api/jobs/move-folder", json={
+        "folder_id": 1,
+        "destination": 42,
+    })
+    assert resp.status_code == 400
+    assert "string" in resp.get_json()["error"].lower()
+
+
+def test_move_folder_rejects_non_bool_merge(app_and_db):
+    """A non-boolean merge parameter returns 400 — strings like "false" must
+    not be silently coerced to True."""
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post("/api/jobs/move-folder", json={
+        "folder_id": 1,
+        "destination": "/tmp/dest",
+        "merge": "false",  # truthy non-bool
+    })
+    assert resp.status_code == 400
+    assert "boolean" in resp.get_json()["error"].lower()
+
+
+def test_move_folder_preflight_rejects_non_object_body(app_and_db):
+    """Preflight: same type guard as the job endpoint."""
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post("/api/move-folder/preflight", json="not-an-object")
+    assert resp.status_code == 400
+
+
 def test_move_rules_crud(app_and_db):
     """CRUD operations on move rules via API."""
     app, _ = app_and_db


### PR DESCRIPTION
## What & why

**Move Entire Folder** previously hard-refused any destination that already existed (`Destination already exists: …`). When a move was interrupted partway — e.g. a NAS volume unmounting mid-`rsync` — it left a partial copy on the destination, and the only way to retry was to manually delete that partial folder first. There was no way to resume or to move into a folder that already exists.

This adds an opt-in **merge / resume** mode.

## Changes

**Backend (`vireo/move.py`)**
- `move_folder(..., merge=False)`. With `merge=True` it rsyncs into the existing destination; `--checksum` means files already present and identical are skipped and only missing files are copied — so an interrupted move resumes cleanly.
- Merge verifies **every source file is present at the destination with a matching size** before deleting originals. (A file-count comparison is meaningless once the destination holds extra/unrelated files or a leftover rsync temp file from the crashed run.)
- A failed merge **never** removes the destination — it may contain the user's pre-existing files. Fresh moves keep the old behavior (refuse existing dest, whole-tree count check, and only `rmtree` a destination we created).
- New `resolve_folder_dest()` helper so the resolved landing path is computed in one place (shared with preflight).

**Route (`vireo/app.py`)**
- `/api/jobs/move-folder` accepts `merge`.
- New `POST /api/move-folder/preflight` → `{resolved_dest, exists, file_count}`.

**UI (`vireo/templates/move.html`)**
- `startQuickMove` calls preflight first. If the destination exists it shows a distinct **"Destination Exists — Merge & Resume"** confirmation that states the resolved path, the existing file count, that matching files are skipped, and that originals are removed only after every source file is verified — in keeping with the "no black boxes" rule. Otherwise the normal move confirmation, now submitting `merge: false`.

## Tests
- `test_move.py`: refuse-without-merge (originals intact, `needs_merge` flag), merge-resume (copies only the missing file, deletes originals, updates DB path), merge-verify-failure (originals **and** pre-existing destination file preserved), and `resolve_folder_dest`.
- `test_move_api.py`: `merge` param accepted, preflight exists / missing / param-validation.

Move suite: 22 passed. Full required suite (`test_workspaces`, `test_db`, `test_app`, `test_photos_api`, `test_edits_api`, `test_jobs_api`, `test_darktable_api`, `test_config`): **1170 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Folder move operations now support a resumable “merge” mode when the destination already exists, avoiding overwrites of existing files.
  * Added a move preflight check to confirm the resolved destination, whether it exists, and how many files it contains before starting.
* **Bug Fixes**
  * Improved move safety with stronger collision/overlap prevention to avoid destructive deletions when destinations overlap, including symlink/case-alias scenarios.
  * Added protections to abort conflicting merges (e.g., differing file contents) without harming originals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->