### PR TITLE
Refuse stale tracked folder destinations

### DIFF
--- a/vireo/move.py
+++ b/vireo/move.py
@@ -177,10 +177,11 @@ def _is_case_insensitive_path(path):
     `/Photos/dst/src`.
 
     Returns False on case-sensitive POSIX (Linux ext4/btrfs, opt-in APFS)
-    and when no probe is possible at all (ancestor unreadable, not a
-    directory, or read-only so the temp-probe can't write) — the safe
-    default, since spuriously folding case could merge two genuinely
-    distinct paths.
+    and when no probe is possible at all (ancestor not a directory, or
+    read-only so the temp-probe can't write) — the safe default, since
+    spuriously folding case could merge two genuinely distinct paths.
+    An unreadable but writable+executable ancestor (drop-box style) is
+    still classified via the temp probe alone.
     """
     if os.name == "nt":
         return True
@@ -195,7 +196,11 @@ def _is_case_insensitive_path(path):
     try:
         entries = os.listdir(cur)
     except OSError:
-        return False
+        # Listing denied (e.g., a +wx drop-box ancestor with no read perm).
+        # Inconclusive, not negative — the temp probe below can still write
+        # into a +wx directory, so skip the child-pair short-circuit rather
+        # than silently classifying a case-folding FS as case-sensitive.
+        entries = ()
     # Scan children for a definitive False (two distinct names both exist,
     # impossible on a case-folding FS). Ignore None (samefile raised — broken
     # symlink, permission/race, or any entry whose flipped spelling can't be

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -350,8 +350,23 @@ def _path_equal_or_descends(candidate, ancestor,
         root_with_sep = root + os.sep
         if not (real_a == root or real_a.startswith(root_with_sep)):
             return False  # ancestor isn't actually inside the probed root.
-        if not (real_c == root or real_c.startswith(root_with_sep)):
+        # The case-fold root can appear under a case-only alias in the
+        # candidate (stale row `/Photos/DST/src` against probed root
+        # `/Photos/dst`). Match the root prefix case-insensitively, then
+        # confirm via samefile that the candidate's variant is the same
+        # on-disk directory — that distinguishes a real case-fold alias
+        # from a distinct path on a case-sensitive parent FS (e.g. `/mnt`
+        # vs `/MNT` mount-point pair on Linux), where the case-only twin
+        # of the root doesn't exist and samefile raises.
+        real_c_low = real_c.lower()
+        root_low = root.lower()
+        if real_c_low != root_low \
+                and not real_c_low.startswith(root_low + os.sep):
             return False  # candidate is above or beside the case-fold subtree.
+        candidate_root = real_c[:len(root)]
+        if candidate_root != root \
+                and not _samefile_or_false(candidate_root, root):
+            return False  # case-variant of the root is distinct on the parent FS.
         suffix_c = real_c[len(root):].lower()
         suffix_a = real_a[len(root):].lower()
         if suffix_c == suffix_a or suffix_c.startswith(suffix_a + os.sep):

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -149,9 +149,7 @@ def _is_case_insensitive_path(path):
     same name (default macOS APFS, Windows).
 
     Walks up to the deepest existing ancestor of `path`, then probes the FS
-    *at* that ancestor by case-flipping one of its child entries: if both
-    spellings resolve (samefile) to the same inode, the FS at the ancestor
-    folds case. Probing via a child name rather than the ancestor's own
+    *at* that ancestor. Probing inside the ancestor rather than via its own
     basename matters when the deepest existing ancestor is a mount point —
     a case-sensitive APFS volume mounted at `/Volumes/Photos` under default
     case-insensitive macOS HFS+ would otherwise be misread as
@@ -159,19 +157,29 @@ def _is_case_insensitive_path(path):
     `Photos`, not what the mounted volume does below it), causing valid
     moves into the mount to be refused as "already managed".
 
-    When the ancestor has no letter-bearing existing child to flip (empty,
-    or only digit/symbol-named entries), creates a short-lived temp dir
-    *inside* the ancestor with a case-flippable suffix and probes via that
-    instead — otherwise a fresh destination tree on case-insensitive POSIX
-    (default macOS APFS at `/Volumes/Photos` with nothing in it yet) would
-    fall through as "case-sensitive" and let a stale tracked row like
-    `/Photos/Dst/src` slip past the case-folded overlap check against a
-    move landing at `/Photos/dst/src`.
+    Children give only NEGATIVE evidence: if any letter-bearing child's
+    case-flipped spelling also exists as a DISTINCT file (`samefile` ==
+    False), the FS is case-sensitive — that can't happen on a case-folding
+    FS. `samefile` == True via a child name is NOT confirmation of case
+    folding: `foo` and `FOO` can both be hard links or symlink aliases to
+    the same inode on a case-sensitive FS by user choice (or via a
+    symlinked parent), which would misread Linux ext4 as case-insensitive
+    and let `_tracked_destination_overlap` refuse a valid move because a
+    stale row differs from the destination only by case. So the positive
+    answer is always confirmed via a short-lived temp dir created *inside*
+    the ancestor with a case-flippable suffix — its flipped spelling can't
+    be a pre-existing user alias, so samefile on (probe, flipped_probe)
+    reflects FS behavior. The temp probe also covers the empty / no-letter-
+    children case, where a fresh case-insensitive POSIX destination
+    (`/Volumes/Photos` with nothing in it yet) would otherwise fall through
+    as "case-sensitive" and let a stale tracked row like `/Photos/Dst/src`
+    slip past the case-folded overlap check against a move into
+    `/Photos/dst/src`.
 
     Returns False on case-sensitive POSIX (Linux ext4/btrfs, opt-in APFS)
     and when no probe is possible at all (ancestor unreadable, not a
-    directory, or read-only so the temp-probe fallback can't write) — the
-    safe default, since spuriously folding case could merge two genuinely
+    directory, or read-only so the temp-probe can't write) — the safe
+    default, since spuriously folding case could merge two genuinely
     distinct paths.
     """
     if os.name == "nt":
@@ -188,30 +196,24 @@ def _is_case_insensitive_path(path):
         entries = os.listdir(cur)
     except OSError:
         return False
+    # Scan children for a definitive False (two distinct names both exist,
+    # impossible on a case-folding FS). Ignore None (samefile raised — broken
+    # symlink, permission/race, or any entry whose flipped spelling can't be
+    # stat'd; inconclusive, not negative) and ignore True (could be a real
+    # case fold OR a user-created hard link / symlink alias — confirmed below).
     for entry in entries:
         flipped = entry.swapcase()
         if flipped == entry:
             continue
-        same = _samefile_tristate(
+        if _samefile_tristate(
             os.path.join(cur, entry),
             os.path.join(cur, flipped),
-        )
-        # None means samefile raised (e.g. a broken symlink, permission/race
-        # error, or any entry whose flipped spelling can't be stat'd) — the
-        # child probe is inconclusive, not negative. Keep scanning later
-        # entries, and fall through to the temp-dir probe if every
-        # letter-bearing child is inconclusive: returning False off one
-        # unstatable entry would misread a case-insensitive POSIX FS as
-        # case-sensitive whenever such an entry happens to come first in
-        # the listdir order, letting stale case-only tracked rows slip past
-        # the overlap check.
-        if same is None:
-            continue
-        return same
-    # No conclusive letter-bearing child probe (either no letter children,
-    # or every probe raised). Probe by creating our own temp dir inside
-    # `cur` with a known case-flippable suffix and asking samefile whether
-    # the flipped spelling resolves to the same inode.
+        ) is False:
+            return False
+    # No child pair proved case-sensitive. Confirm case-insensitivity by
+    # creating our own probe dir with a known case-flippable suffix — the
+    # flipped name didn't exist a moment ago, so samefile reflects FS
+    # behavior rather than a pre-existing alias on a case-sensitive FS.
     try:
         probe = tempfile.mkdtemp(prefix=".vireo_case_probe_", suffix="A",
                                  dir=cur)

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -178,6 +178,16 @@ def _destination_overlaps_source(src_path, dest_path):
             or _path_equal_or_descends(src_path, dest_path))
 
 
+def _tracked_destination_overlap(db, folder_id, dest_path):
+    """Return another tracked folder at or below dest_path, if one exists."""
+    for row in db.conn.execute(
+        "SELECT id, path FROM folders WHERE id != ?", (folder_id,)
+    ):
+        if _path_equal_or_descends(row["path"], dest_path):
+            return row
+    return None
+
+
 def move_photos(db, photo_ids, destination, progress_cb=None):
     """Move individual photos to a destination directory.
 
@@ -362,6 +372,29 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
             f"Destination overlaps the source folder: {dest_path}"
         ]}
 
+    # Refuse moving into — or around — a destination Vireo already tracks as a
+    # folder, regardless of whether that path currently exists on disk. A
+    # correct tracked-tree merge needs recursive folder/photo reconciliation we
+    # don't do here; a partial attempt would leave folders pointing at the
+    # deleted source path, or collide on the folders.path UNIQUE constraint when
+    # the source's children cascade onto a tracked descendant. Match the
+    # destination itself and anything below it. The cases this feature exists
+    # for — resuming an interrupted move, or moving into an untracked folder —
+    # never hit this.
+    #
+    # Comparison goes through _path_equal_or_descends so symlink aliases, Windows
+    # case folding, AND case-only aliases on case-insensitive POSIX (default
+    # macOS APFS) all collapse to the same tracked row — otherwise a destination
+    # reached via any of those would slip past and leave two folder rows managing
+    # the same on-disk tree.
+    tracked = _tracked_destination_overlap(db, folder_id, dest_path)
+    if tracked:
+        return {"moved": 0, "errors": [
+            f"Destination overlaps a folder Vireo already manages "
+            f"({tracked['path']}). Merging into or around a tracked folder "
+            f"isn't supported."
+        ]}
+
     dest_exists = os.path.exists(dest_path)
     if dest_exists and not merge:
         return {
@@ -371,32 +404,6 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
         }
 
     if dest_exists:
-        # Refuse merging into — or around — a destination Vireo already tracks
-        # as a folder. A correct merge of two tracked trees needs recursive
-        # folder/photo reconciliation we don't do here; a partial attempt would
-        # leave folders pointing at the deleted source path, or collide on the
-        # folders.path UNIQUE constraint when the source's children cascade onto
-        # a tracked descendant. Match the destination itself and anything below
-        # it. The cases this feature exists for — resuming an interrupted move,
-        # or moving into an untracked folder — never hit this.
-        # Comparison goes through _path_equal_or_descends so symlink aliases,
-        # Windows case folding, AND case-only aliases on case-insensitive POSIX
-        # (default macOS APFS) all collapse to the same tracked row — otherwise
-        # a destination reached via any of those would slip past and leave two
-        # folder rows managing the same on-disk tree.
-        tracked = None
-        for row in db.conn.execute(
-            "SELECT id, path FROM folders WHERE id != ?", (folder_id,)
-        ):
-            if _path_equal_or_descends(row["path"], dest_path):
-                tracked = row
-                break
-        if tracked:
-            return {"moved": 0, "errors": [
-                f"Destination overlaps a folder Vireo already manages "
-                f"({tracked['path']}). Merging into or around a tracked folder "
-                f"isn't supported."
-            ]}
 
         # Refuse if any same-name file already at the destination differs in
         # content. Never overwrite or later delete the user's data over a real

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -232,7 +232,56 @@ def _is_case_insensitive_path(path):
             os.rmdir(probe)
 
 
-def _path_equal_or_descends(candidate, ancestor, ancestor_case_insensitive=None):
+def _case_insensitive_root(path):
+    """Realpath of the deepest existing ancestor of `path` whose filesystem
+    folds case, or None when no such ancestor exists. Used to scope the
+    case-folded fallback in `_path_equal_or_descends` to the subtree that
+    actually folds — see that function's docstring for why a full-path
+    `.lower()` would otherwise collapse genuinely distinct paths on the
+    parent (case-sensitive) filesystem.
+
+    Walks the same deepest-existing-ancestor path as the probe inside
+    `_is_case_insensitive_path` and delegates to it for the fold check, so
+    test monkeypatches of `_is_case_insensitive_path` still take effect.
+    On Windows, the boundary is the deepest existing ancestor's drive root.
+    """
+    if os.name == "nt":
+        if not _is_case_insensitive_path(path):
+            return None
+        cur = path
+        while cur and not os.path.exists(cur):
+            parent = os.path.dirname(cur)
+            if parent == cur:
+                return None
+            cur = parent
+        if not cur:
+            return None
+        drive, _ = os.path.splitdrive(os.path.realpath(cur))
+        return (drive + os.sep) if drive else os.path.realpath(cur)
+    if not _is_case_insensitive_path(path):
+        return None
+    cur = path
+    while cur and not os.path.exists(cur):
+        parent = os.path.dirname(cur)
+        if parent == cur:
+            return None
+        cur = parent
+    if not cur or not os.path.isdir(cur):
+        return None
+    return os.path.realpath(cur)
+
+
+# Sentinel for "case-insensitive root not yet probed" — distinct from the
+# probed-and-None result (the FS is case-sensitive). Callers inside a loop
+# pass the probed value, including a literal None, so lazy re-probing per
+# row never happens — the regression `_tracked_destination_overlap` is
+# guarding against would otherwise re-run the probe per scanned row on any
+# case-sensitive POSIX host (Linux ext4, opt-in APFS).
+_UNPROBED_CI_ROOT = object()
+
+
+def _path_equal_or_descends(candidate, ancestor,
+                            case_insensitive_root=_UNPROBED_CI_ROOT):
     """True if `candidate` resolves to the same directory as `ancestor`, or is
     a descendant of it.
 
@@ -249,11 +298,23 @@ def _path_equal_or_descends(candidate, ancestor, ancestor_case_insensitive=None)
       - Two missing leaves on case-insensitive POSIX, where neither path
         exists yet so samefile has nothing to compare: probe the FS for
         case-insensitivity via the deepest existing ancestor and, if so,
-        redo the string compare case-folded.
+        redo the string compare case-folded — but only over the portion of
+        the path actually on the case-folding filesystem.
 
-    `ancestor_case_insensitive`: pass the result of `_is_case_insensitive_path(
-    ancestor)` if you've already computed it (e.g. inside a loop with a fixed
-    ancestor) so the probe doesn't re-run per call. None means probe lazily.
+    `case_insensitive_root`: realpath of the deepest existing case-insensitive
+    ancestor of `ancestor`, or None for case-sensitive (no case-folded fallback
+    runs). Pass the result of `_case_insensitive_root(ancestor)` if you've
+    already computed it (e.g., inside a loop with a fixed ancestor) so the
+    probe doesn't re-run per call. Omit (sentinel default) to probe lazily;
+    an explicit None means "already probed, no case-insensitive root" and
+    skips the lazy probe.
+
+    Scoping the case fold to inside this root matters when only part of the
+    path tree folds — a case-insensitive APFS/CIFS volume mounted at
+    `/mnt/photos` on a case-sensitive Linux root FS, for example. A stale row
+    `/MNT/photos/dst/src` and a move into `/mnt/photos/dst/src` are distinct
+    paths because `/MNT` does not resolve to `/mnt` on the parent FS; folding
+    the full path with `.lower()` would wrongly refuse the valid move.
     """
     real_c = os.path.normcase(os.path.realpath(candidate))
     real_a = os.path.normcase(os.path.realpath(ancestor))
@@ -278,15 +339,23 @@ def _path_equal_or_descends(candidate, ancestor, ancestor_case_insensitive=None)
     # case before either path has been created on disk. samefile can't fold
     # case for paths that don't exist; probe the FS for case-insensitivity
     # and redo the string compare case-folded so the stale row is still
-    # caught before any copy.
-    if os.name != "nt":
-        if ancestor_case_insensitive is None:
-            ancestor_case_insensitive = _is_case_insensitive_path(ancestor)
-        if ancestor_case_insensitive:
-            lower_c = real_c.lower()
-            lower_a = real_a.lower()
-            if lower_c == lower_a or lower_c.startswith(lower_a + os.sep):
-                return True
+    # caught before any copy. Restrict the case-folded compare to the subtree
+    # below the probed case-insensitive ancestor — anything above it is on
+    # the parent (case-sensitive) FS and must match exactly, character-for-
+    # character, or we'd collapse distinct paths.
+    if case_insensitive_root is _UNPROBED_CI_ROOT:
+        case_insensitive_root = _case_insensitive_root(ancestor)
+    if case_insensitive_root:
+        root = case_insensitive_root
+        root_with_sep = root + os.sep
+        if not (real_a == root or real_a.startswith(root_with_sep)):
+            return False  # ancestor isn't actually inside the probed root.
+        if not (real_c == root or real_c.startswith(root_with_sep)):
+            return False  # candidate is above or beside the case-fold subtree.
+        suffix_c = real_c[len(root):].lower()
+        suffix_a = real_a[len(root):].lower()
+        if suffix_c == suffix_a or suffix_c.startswith(suffix_a + os.sep):
+            return True
     return False
 
 
@@ -304,21 +373,19 @@ def _destination_overlaps_source(src_path, dest_path):
 def _tracked_destination_overlap(db, folder_id, dest_path):
     """Return another tracked folder at or below dest_path, if one exists.
 
-    The FS case-insensitivity of `dest_path` is probed once and reused for
+    The case-insensitive root of `dest_path` is probed once and reused for
     every row — otherwise the probe (an os.listdir of the deepest existing
     ancestor, plus samefile of two child paths) re-runs per non-matching row,
     making this O(tracked_folders × destination_entries) before any copy on
     large catalogs or network-backed destinations.
     """
-    dest_case_insensitive = (
-        True if os.name == "nt" else _is_case_insensitive_path(dest_path)
-    )
+    dest_ci_root = _case_insensitive_root(dest_path)
     for row in db.conn.execute(
         "SELECT id, path FROM folders WHERE id != ?", (folder_id,)
     ):
         if _path_equal_or_descends(
             row["path"], dest_path,
-            ancestor_case_insensitive=dest_case_insensitive,
+            case_insensitive_root=dest_ci_root,
         ):
             return row
     return None

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -177,7 +177,7 @@ def _is_case_insensitive_path(path):
     return False
 
 
-def _path_equal_or_descends(candidate, ancestor):
+def _path_equal_or_descends(candidate, ancestor, ancestor_case_insensitive=None):
     """True if `candidate` resolves to the same directory as `ancestor`, or is
     a descendant of it.
 
@@ -195,6 +195,10 @@ def _path_equal_or_descends(candidate, ancestor):
         exists yet so samefile has nothing to compare: probe the FS for
         case-insensitivity via the deepest existing ancestor and, if so,
         redo the string compare case-folded.
+
+    `ancestor_case_insensitive`: pass the result of `_is_case_insensitive_path(
+    ancestor)` if you've already computed it (e.g. inside a loop with a fixed
+    ancestor) so the probe doesn't re-run per call. None means probe lazily.
     """
     real_c = os.path.normcase(os.path.realpath(candidate))
     real_a = os.path.normcase(os.path.realpath(ancestor))
@@ -220,11 +224,14 @@ def _path_equal_or_descends(candidate, ancestor):
     # case for paths that don't exist; probe the FS for case-insensitivity
     # and redo the string compare case-folded so the stale row is still
     # caught before any copy.
-    if os.name != "nt" and _is_case_insensitive_path(ancestor):
-        lower_c = real_c.lower()
-        lower_a = real_a.lower()
-        if lower_c == lower_a or lower_c.startswith(lower_a + os.sep):
-            return True
+    if os.name != "nt":
+        if ancestor_case_insensitive is None:
+            ancestor_case_insensitive = _is_case_insensitive_path(ancestor)
+        if ancestor_case_insensitive:
+            lower_c = real_c.lower()
+            lower_a = real_a.lower()
+            if lower_c == lower_a or lower_c.startswith(lower_a + os.sep):
+                return True
     return False
 
 
@@ -240,11 +247,24 @@ def _destination_overlaps_source(src_path, dest_path):
 
 
 def _tracked_destination_overlap(db, folder_id, dest_path):
-    """Return another tracked folder at or below dest_path, if one exists."""
+    """Return another tracked folder at or below dest_path, if one exists.
+
+    The FS case-insensitivity of `dest_path` is probed once and reused for
+    every row — otherwise the probe (an os.listdir of the deepest existing
+    ancestor, plus samefile of two child paths) re-runs per non-matching row,
+    making this O(tracked_folders × destination_entries) before any copy on
+    large catalogs or network-backed destinations.
+    """
+    dest_case_insensitive = (
+        True if os.name == "nt" else _is_case_insensitive_path(dest_path)
+    )
     for row in db.conn.execute(
         "SELECT id, path FROM folders WHERE id != ?", (folder_id,)
     ):
-        if _path_equal_or_descends(row["path"], dest_path):
+        if _path_equal_or_descends(
+            row["path"], dest_path,
+            ancestor_case_insensitive=dest_case_insensitive,
+        ):
             return row
     return None
 

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -1,10 +1,12 @@
 """Photo and folder move operations with copy-verify-delete safety."""
 
+import contextlib
 import filecmp
 import logging
 import os
 import shutil
 import subprocess
+import tempfile
 
 log = logging.getLogger(__name__)
 
@@ -147,10 +149,20 @@ def _is_case_insensitive_path(path):
     `Photos`, not what the mounted volume does below it), causing valid
     moves into the mount to be refused as "already managed".
 
+    When the ancestor has no letter-bearing existing child to flip (empty,
+    or only digit/symbol-named entries), creates a short-lived temp dir
+    *inside* the ancestor with a case-flippable suffix and probes via that
+    instead — otherwise a fresh destination tree on case-insensitive POSIX
+    (default macOS APFS at `/Volumes/Photos` with nothing in it yet) would
+    fall through as "case-sensitive" and let a stale tracked row like
+    `/Photos/Dst/src` slip past the case-folded overlap check against a
+    move landing at `/Photos/dst/src`.
+
     Returns False on case-sensitive POSIX (Linux ext4/btrfs, opt-in APFS)
-    and when the ancestor has no probe-able child entry (empty, unreadable,
-    or only no-letter names) — the safe default, since spuriously folding
-    case could merge two genuinely distinct paths.
+    and when no probe is possible at all (ancestor unreadable, not a
+    directory, or read-only so the temp-probe fallback can't write) — the
+    safe default, since spuriously folding case could merge two genuinely
+    distinct paths.
     """
     if os.name == "nt":
         return True
@@ -174,7 +186,20 @@ def _is_case_insensitive_path(path):
             os.path.join(cur, entry),
             os.path.join(cur, flipped),
         )
-    return False
+    # No letter-bearing existing child to flip. Probe by creating our own
+    # temp dir inside `cur` with a known case-flippable suffix and asking
+    # samefile whether the flipped spelling resolves to the same inode.
+    try:
+        probe = tempfile.mkdtemp(prefix=".vireo_case_probe_", suffix="A",
+                                 dir=cur)
+    except OSError:
+        return False
+    try:
+        flipped = probe[:-1] + probe[-1].swapcase()
+        return _samefile_or_false(probe, flipped)
+    finally:
+        with contextlib.suppress(OSError):
+            os.rmdir(probe)
 
 
 def _path_equal_or_descends(candidate, ancestor, ancestor_case_insensitive=None):

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -148,40 +148,38 @@ def _is_case_insensitive_path(path):
     """Whether the filesystem holding `path` treats two case variants as the
     same name (default macOS APFS, Windows).
 
-    Walks up to the deepest existing ancestor of `path`, then probes the FS
-    *at* that ancestor. Probing inside the ancestor rather than via its own
+    Walks up to the deepest existing ancestor of `path`, then creates a
+    short-lived probe dir *inside* it with a known case-flippable suffix
+    and asks samefile whether the swapped spelling resolves to the same
+    inode. The probe name didn't exist a moment ago, so the result reflects
+    FS behavior rather than a pre-existing user alias (hard link / symlink
+    on a case-sensitive FS), and is conclusive in both directions — True on
+    a case-folding FS, raises (and `_samefile_or_false` returns False) on a
+    case-sensitive one. Probing inside the ancestor rather than via its own
     basename matters when the deepest existing ancestor is a mount point —
     a case-sensitive APFS volume mounted at `/Volumes/Photos` under default
     case-insensitive macOS HFS+ would otherwise be misread as
     case-insensitive (the basename probe tests `/Volumes`'s handling of
-    `Photos`, not what the mounted volume does below it), causing valid
-    moves into the mount to be refused as "already managed".
+    `Photos`, not what the mounted volume does below it).
 
-    Children give only NEGATIVE evidence: if any letter-bearing child's
-    case-flipped spelling also exists as a DISTINCT file (`samefile` ==
-    False), the FS is case-sensitive — that can't happen on a case-folding
-    FS. `samefile` == True via a child name is NOT confirmation of case
-    folding: `foo` and `FOO` can both be hard links or symlink aliases to
-    the same inode on a case-sensitive FS by user choice (or via a
-    symlinked parent), which would misread Linux ext4 as case-insensitive
-    and let `_tracked_destination_overlap` refuse a valid move because a
-    stale row differs from the destination only by case. So the positive
-    answer is always confirmed via a short-lived temp dir created *inside*
-    the ancestor with a case-flippable suffix — its flipped spelling can't
-    be a pre-existing user alias, so samefile on (probe, flipped_probe)
-    reflects FS behavior. The temp probe also covers the empty / no-letter-
-    children case, where a fresh case-insensitive POSIX destination
-    (`/Volumes/Photos` with nothing in it yet) would otherwise fall through
-    as "case-sensitive" and let a stale tracked row like `/Photos/Dst/src`
-    slip past the case-folded overlap check against a move into
-    `/Photos/dst/src`.
+    Falls back to scanning existing children for NEGATIVE evidence only
+    when the temp probe can't write (read-only ancestor): if any
+    letter-bearing child's case-flipped spelling also exists as a DISTINCT
+    file (`samefile` == False), the FS is case-sensitive — that can't
+    happen on a case-folding FS. `samefile` == True via a pre-existing
+    child name is never trusted, since it could be a user-created hard link
+    or symlink alias on a case-sensitive FS. A previous version of this
+    function scanned children first as an optimization to short-circuit on
+    that definitive False, but `move_folder()` reaches this on every move,
+    and on the typical case-sensitive destination with no case-twin
+    children every per-entry samefile probe is inconclusive (the flipped
+    name doesn't exist; samefile raises) — turning a single move into
+    O(entries) wasted stats before the temp probe ran anyway.
 
     Returns False on case-sensitive POSIX (Linux ext4/btrfs, opt-in APFS)
     and when no probe is possible at all (ancestor not a directory, or
-    read-only so the temp-probe can't write) — the safe default, since
-    spuriously folding case could merge two genuinely distinct paths.
-    An unreadable but writable+executable ancestor (drop-box style) is
-    still classified via the temp probe alone.
+    read-only AND no child evidence) — the safe default, since spuriously
+    folding case could merge two genuinely distinct paths.
     """
     if os.name == "nt":
         return True
@@ -194,18 +192,26 @@ def _is_case_insensitive_path(path):
     if not cur or not os.path.isdir(cur):
         return False
     try:
+        probe = tempfile.mkdtemp(prefix=".vireo_case_probe_", suffix="A",
+                                 dir=cur)
+    except OSError:
+        probe = None
+    if probe is not None:
+        try:
+            flipped = probe[:-1] + probe[-1].swapcase()
+            return _samefile_or_false(probe, flipped)
+        finally:
+            with contextlib.suppress(OSError):
+                os.rmdir(probe)
+    # Temp probe denied (read-only ancestor). Scan existing children for a
+    # definitive False (two distinct case-twin entries — impossible on a
+    # case-folding FS). With no temp probe available we have no way to
+    # confirm a positive answer, so True via a child name is not trusted
+    # and the function returns False if no definitive False is found.
+    try:
         entries = os.listdir(cur)
     except OSError:
-        # Listing denied (e.g., a +wx drop-box ancestor with no read perm).
-        # Inconclusive, not negative — the temp probe below can still write
-        # into a +wx directory, so skip the child-pair short-circuit rather
-        # than silently classifying a case-folding FS as case-sensitive.
-        entries = ()
-    # Scan children for a definitive False (two distinct names both exist,
-    # impossible on a case-folding FS). Ignore None (samefile raised — broken
-    # symlink, permission/race, or any entry whose flipped spelling can't be
-    # stat'd; inconclusive, not negative) and ignore True (could be a real
-    # case fold OR a user-created hard link / symlink alias — confirmed below).
+        return False
     for entry in entries:
         flipped = entry.swapcase()
         if flipped == entry:
@@ -215,21 +221,7 @@ def _is_case_insensitive_path(path):
             os.path.join(cur, flipped),
         ) is False:
             return False
-    # No child pair proved case-sensitive. Confirm case-insensitivity by
-    # creating our own probe dir with a known case-flippable suffix — the
-    # flipped name didn't exist a moment ago, so samefile reflects FS
-    # behavior rather than a pre-existing alias on a case-sensitive FS.
-    try:
-        probe = tempfile.mkdtemp(prefix=".vireo_case_probe_", suffix="A",
-                                 dir=cur)
-    except OSError:
-        return False
-    try:
-        flipped = probe[:-1] + probe[-1].swapcase()
-        return _samefile_or_false(probe, flipped)
-    finally:
-        with contextlib.suppress(OSError):
-            os.rmdir(probe)
+    return False
 
 
 def _case_insensitive_root(path):
@@ -347,7 +339,14 @@ def _path_equal_or_descends(candidate, ancestor,
         case_insensitive_root = _case_insensitive_root(ancestor)
     if case_insensitive_root:
         root = case_insensitive_root
-        root_with_sep = root + os.sep
+        # `root` may already end with `os.sep` — the filesystem root "/"
+        # (deepest existing ancestor is `/` when everything below the
+        # destination is missing on a case-insensitive POSIX volume mounted
+        # at /), or a Windows drive root like "C:\\". `root + os.sep` would
+        # double the boundary to "//" / "C:\\\\" and never match any real
+        # path, silently skipping the case-folded compare and letting a
+        # stale row like `/photos/src` slip past a move into `/Photos/src`.
+        root_with_sep = root if root.endswith(os.sep) else root + os.sep
         if not (real_a == root or real_a.startswith(root_with_sep)):
             return False  # ancestor isn't actually inside the probed root.
         # The case-fold root can appear under a case-only alias in the
@@ -360,8 +359,9 @@ def _path_equal_or_descends(candidate, ancestor,
         # of the root doesn't exist and samefile raises.
         real_c_low = real_c.lower()
         root_low = root.lower()
+        root_low_with_sep = root_with_sep.lower()
         if real_c_low != root_low \
-                and not real_c_low.startswith(root_low + os.sep):
+                and not real_c_low.startswith(root_low_with_sep):
             return False  # candidate is above or beside the case-fold subtree.
         candidate_root = real_c[:len(root)]
         if candidate_root != root \
@@ -369,7 +369,14 @@ def _path_equal_or_descends(candidate, ancestor,
             return False  # case-variant of the root is distinct on the parent FS.
         suffix_c = real_c[len(root):].lower()
         suffix_a = real_a[len(root):].lower()
-        if suffix_c == suffix_a or suffix_c.startswith(suffix_a + os.sep):
+        # suffix_a == "" means real_a IS the root itself; we've already
+        # established real_c is at or under root, so real_c descends from
+        # real_a unconditionally. Without this, a root like `/` strips
+        # to "" for the ancestor while leaving "photos/src" for the
+        # candidate — and `suffix_c.startswith("" + os.sep)` is False
+        # because the leading separator was already consumed by the root.
+        if suffix_a == "" or suffix_c == suffix_a \
+                or suffix_c.startswith(suffix_a + os.sep):
             return True
     return False
 

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -119,11 +119,21 @@ def _first_missing_source_file(src_path, dest_path):
     return None
 
 
-def _samefile_or_false(a, b):
+def _samefile_tristate(a, b):
+    """Whether two paths resolve to the same inode, or None if samefile
+    raised (broken symlink, permission error, transient race — the probe
+    is INCONCLUSIVE, not negative). Callers that need a plain boolean wrap
+    with `_samefile_or_false`; callers that have to differentiate
+    "definitely different" from "couldn't check" use this directly."""
     try:
         return os.path.samefile(a, b)
     except OSError:
-        return False
+        return None
+
+
+def _samefile_or_false(a, b):
+    result = _samefile_tristate(a, b)
+    return False if result is None else result
 
 
 def _walk_up_paths(p):
@@ -182,13 +192,26 @@ def _is_case_insensitive_path(path):
         flipped = entry.swapcase()
         if flipped == entry:
             continue
-        return _samefile_or_false(
+        same = _samefile_tristate(
             os.path.join(cur, entry),
             os.path.join(cur, flipped),
         )
-    # No letter-bearing existing child to flip. Probe by creating our own
-    # temp dir inside `cur` with a known case-flippable suffix and asking
-    # samefile whether the flipped spelling resolves to the same inode.
+        # None means samefile raised (e.g. a broken symlink, permission/race
+        # error, or any entry whose flipped spelling can't be stat'd) — the
+        # child probe is inconclusive, not negative. Keep scanning later
+        # entries, and fall through to the temp-dir probe if every
+        # letter-bearing child is inconclusive: returning False off one
+        # unstatable entry would misread a case-insensitive POSIX FS as
+        # case-sensitive whenever such an entry happens to come first in
+        # the listdir order, letting stale case-only tracked rows slip past
+        # the overlap check.
+        if same is None:
+            continue
+        return same
+    # No conclusive letter-bearing child probe (either no letter children,
+    # or every probe raised). Probe by creating our own temp dir inside
+    # `cur` with a known case-flippable suffix and asking samefile whether
+    # the flipped spelling resolves to the same inode.
     try:
         probe = tempfile.mkdtemp(prefix=".vireo_case_probe_", suffix="A",
                                  dir=cur)

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -132,6 +132,38 @@ def _walk_up_paths(p):
         p = os.path.dirname(p)
 
 
+def _is_case_insensitive_path(path):
+    """Whether the filesystem holding `path` treats two case variants as the
+    same name (default macOS APFS, Windows).
+
+    Walks up to the deepest existing ancestor of `path`, then probes by
+    swapping the case of that ancestor's basename: if the case-flipped
+    variant resolves (samefile) to the same inode, the FS folds case. Walks
+    further up when a basename has no letters to flip. Returns False on
+    case-sensitive POSIX (Linux ext4/btrfs, opt-in APFS) and when nothing
+    along the walk yields a probe-able component — the safe default, since
+    spuriously folding case could merge two genuinely distinct paths.
+    """
+    if os.name == "nt":
+        return True
+    cur = path
+    while cur and not os.path.exists(cur):
+        parent = os.path.dirname(cur)
+        if parent == cur:
+            return False
+        cur = parent
+    while cur:
+        head, tail = os.path.split(cur)
+        flipped = tail.swapcase()
+        if flipped != tail:
+            flipped_path = os.path.join(head, flipped) if head else flipped
+            return _samefile_or_false(cur, flipped_path)
+        if not head or head == cur:
+            return False
+        cur = head
+    return False
+
+
 def _path_equal_or_descends(candidate, ancestor):
     """True if `candidate` resolves to the same directory as `ancestor`, or is
     a descendant of it.
@@ -146,6 +178,10 @@ def _path_equal_or_descends(candidate, ancestor):
         (device + inode) is FS-truth on every platform and is used as a
         fallback, including a walk-up ancestor check for the descendant case
         where `candidate` itself doesn't exist yet.
+      - Two missing leaves on case-insensitive POSIX, where neither path
+        exists yet so samefile has nothing to compare: probe the FS for
+        case-insensitivity via the deepest existing ancestor and, if so,
+        redo the string compare case-folded.
     """
     real_c = os.path.normcase(os.path.realpath(candidate))
     real_a = os.path.normcase(os.path.realpath(ancestor))
@@ -164,6 +200,18 @@ def _path_equal_or_descends(candidate, ancestor):
         for anc in _walk_up_paths(os.path.dirname(candidate)):
             if os.path.exists(anc) and _samefile_or_false(anc, ancestor):
                 return True
+
+    # Both leaves missing on a case-insensitive POSIX volume: e.g., a stale
+    # folders.path row that differs from the resolved destination only by
+    # case before either path has been created on disk. samefile can't fold
+    # case for paths that don't exist; probe the FS for case-insensitivity
+    # and redo the string compare case-folded so the stale row is still
+    # caught before any copy.
+    if os.name != "nt" and _is_case_insensitive_path(ancestor):
+        lower_c = real_c.lower()
+        lower_a = real_a.lower()
+        if lower_c == lower_a or lower_c.startswith(lower_a + os.sep):
+            return True
     return False
 
 

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -136,13 +136,21 @@ def _is_case_insensitive_path(path):
     """Whether the filesystem holding `path` treats two case variants as the
     same name (default macOS APFS, Windows).
 
-    Walks up to the deepest existing ancestor of `path`, then probes by
-    swapping the case of that ancestor's basename: if the case-flipped
-    variant resolves (samefile) to the same inode, the FS folds case. Walks
-    further up when a basename has no letters to flip. Returns False on
-    case-sensitive POSIX (Linux ext4/btrfs, opt-in APFS) and when nothing
-    along the walk yields a probe-able component — the safe default, since
-    spuriously folding case could merge two genuinely distinct paths.
+    Walks up to the deepest existing ancestor of `path`, then probes the FS
+    *at* that ancestor by case-flipping one of its child entries: if both
+    spellings resolve (samefile) to the same inode, the FS at the ancestor
+    folds case. Probing via a child name rather than the ancestor's own
+    basename matters when the deepest existing ancestor is a mount point —
+    a case-sensitive APFS volume mounted at `/Volumes/Photos` under default
+    case-insensitive macOS HFS+ would otherwise be misread as
+    case-insensitive (the basename probe tests `/Volumes`'s handling of
+    `Photos`, not what the mounted volume does below it), causing valid
+    moves into the mount to be refused as "already managed".
+
+    Returns False on case-sensitive POSIX (Linux ext4/btrfs, opt-in APFS)
+    and when the ancestor has no probe-able child entry (empty, unreadable,
+    or only no-letter names) — the safe default, since spuriously folding
+    case could merge two genuinely distinct paths.
     """
     if os.name == "nt":
         return True
@@ -152,15 +160,20 @@ def _is_case_insensitive_path(path):
         if parent == cur:
             return False
         cur = parent
-    while cur:
-        head, tail = os.path.split(cur)
-        flipped = tail.swapcase()
-        if flipped != tail:
-            flipped_path = os.path.join(head, flipped) if head else flipped
-            return _samefile_or_false(cur, flipped_path)
-        if not head or head == cur:
-            return False
-        cur = head
+    if not cur or not os.path.isdir(cur):
+        return False
+    try:
+        entries = os.listdir(cur)
+    except OSError:
+        return False
+    for entry in entries:
+        flipped = entry.swapcase()
+        if flipped == entry:
+            continue
+        return _samefile_or_false(
+            os.path.join(cur, entry),
+            os.path.join(cur, flipped),
+        )
     return False
 
 

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -586,8 +586,10 @@ def test_is_case_insensitive_path_probes_inside_target_fs(tmp_path, monkeypatch)
 
 
 def test_is_case_insensitive_path_detects_case_insensitive_fs(tmp_path, monkeypatch):
-    """When the deepest existing ancestor's FS folds case on its children,
-    the probe must return True via a child-entry case-flip."""
+    """When the deepest existing ancestor's FS folds case, the probe must
+    return True — confirmed via the temp-dir probe, since `samefile` True
+    on a pre-existing child name could be a user-created hard link / symlink
+    alias rather than real case folding."""
     import move as move_mod
 
     target = tmp_path / "dir"
@@ -596,15 +598,19 @@ def test_is_case_insensitive_path_detects_case_insensitive_fs(tmp_path, monkeypa
     target_str = str(target)
 
     def fake_samefile(a, b):
-        # Mimic case-insensitive FS at `target`: any two child names that
-        # differ only by case resolve to the same inode.
+        # Mimic case-insensitive FS at `target`: any two child names
+        # (including the temp probe dir we create) that differ only by
+        # case resolve to the same inode.
         return (
             os.path.dirname(a) == target_str
             and os.path.dirname(b) == target_str
             and os.path.basename(a).lower() == os.path.basename(b).lower()
         )
 
+    # Child probe alone is no longer authoritative for True — patch both
+    # entry points so the temp-dir confirmation also sees the case fold.
     monkeypatch.setattr(move_mod, "_samefile_tristate", fake_samefile)
+    monkeypatch.setattr(move_mod, "_samefile_or_false", fake_samefile)
 
     assert move_mod._is_case_insensitive_path(
         os.path.join(target_str, "missing_leaf")
@@ -618,13 +624,11 @@ def test_is_case_insensitive_path_detects_case_insensitive_fs(tmp_path, monkeypa
 def test_is_case_insensitive_path_inconclusive_child_probe_keeps_scanning(
     tmp_path, monkeypatch,
 ):
-    """If a letter-bearing child's case-flipped probe is inconclusive
-    (samefile raises — broken symlink, permission/race error), the loop
-    must keep scanning later entries rather than immediately classifying
-    the FS as case-sensitive off one unstatable entry. Otherwise a
-    case-insensitive POSIX volume whose listdir happens to put such an
-    entry first lets stale case-only tracked rows slip past the
-    case-folded overlap check.
+    """A letter-bearing child whose case-flipped probe raises (broken
+    symlink, permission/race) must not abort the scan as case-sensitive —
+    only a definitive `samefile` False (two distinct entries) does that.
+    Inconclusive Nones are skipped; True is non-authoritative and confirmed
+    via the temp-dir probe below.
     """
     import move as move_mod
 
@@ -639,14 +643,109 @@ def test_is_case_insensitive_path_inconclusive_child_probe_keeps_scanning(
         if "broken" in names:
             # Mimic stat raising on the flipped spelling of a broken entry.
             return None
-        # Mimic case-insensitive FS folding "child"/"CHILD" to the same inode.
+        # `child`/`CHILD` looks like an alias on a case-insensitive FS, but
+        # the new logic doesn't trust child True — the result comes from the
+        # temp-probe path below.
         return os.path.basename(a).lower() == os.path.basename(b).lower()
 
+    def fake_samefile_or_false(a, b):
+        # Temp-probe confirmation: mimic case-insensitive FS at `target`.
+        return (
+            os.path.dirname(a) == target_str
+            and os.path.dirname(b) == target_str
+            and os.path.basename(a).lower() == os.path.basename(b).lower()
+        )
+
     monkeypatch.setattr(move_mod, "_samefile_tristate", fake_tristate)
+    monkeypatch.setattr(move_mod, "_samefile_or_false", fake_samefile_or_false)
 
     assert move_mod._is_case_insensitive_path(
         os.path.join(target_str, "missing_leaf")
     ) is True
+
+
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="Windows paths are treated case-insensitive without POSIX probing",
+)
+def test_is_case_insensitive_path_child_alias_confirmed_by_temp_probe(
+    tmp_path, monkeypatch,
+):
+    """On a case-SENSITIVE POSIX FS, `samefile` can be True for two distinct
+    child entries when they are hard links or symlink aliases (e.g. `foo`
+    and `FOO` both pointing to the same inode by user choice). Trusting that
+    child True would misclassify Linux ext4 as case-insensitive and let
+    `_tracked_destination_overlap` refuse a valid move into `dst/src` just
+    because a stale row `Dst/src` exists. The temp-dir probe is the
+    confirmation: it creates a fresh entry whose flipped spelling can't be
+    a pre-existing alias.
+    """
+    import move as move_mod
+
+    target = tmp_path / "dir"
+    target.mkdir()
+    (target / "foo").touch()
+    (target / "FOO").touch()  # pretend these are aliases for samefile
+    target_str = str(target)
+
+    def fake_tristate(a, b):
+        # Pre-existing children look aliased (matches a user hard-link /
+        # symlink setup on a case-sensitive FS).
+        names = {os.path.basename(a), os.path.basename(b)}
+        if names == {"foo", "FOO"}:
+            return True
+        return None
+
+    # Temp probe uses the real `_samefile_or_false`; on real case-sensitive
+    # POSIX tmp_path the probe and its flipped spelling do NOT resolve to
+    # the same inode, so the final answer is False.
+    monkeypatch.setattr(move_mod, "_samefile_tristate", fake_tristate)
+
+    assert move_mod._is_case_insensitive_path(
+        os.path.join(target_str, "missing_leaf")
+    ) is False
+
+    # Probe dir cleaned up — only the originals remain.
+    assert sorted(os.listdir(target)) == ["FOO", "foo"]
+
+
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="Windows paths are treated case-insensitive without POSIX probing",
+)
+def test_is_case_insensitive_path_definitive_false_short_circuits(
+    tmp_path, monkeypatch,
+):
+    """A child pair where `samefile` returns False — two distinct entries
+    both exist as separate files — is impossible on a case-folding FS, so
+    the loop returns False immediately without running the temp probe."""
+    import move as move_mod
+
+    target = tmp_path / "dir"
+    target.mkdir()
+    (target / "alpha").touch()
+    (target / "ALPHA").touch()
+    target_str = str(target)
+
+    def fake_tristate(a, b):
+        # Mimic real case-sensitive FS: alpha and ALPHA are distinct files
+        # and samefile returns False on the pair.
+        names = {os.path.basename(a), os.path.basename(b)}
+        if names == {"alpha", "ALPHA"}:
+            return False
+        return None
+
+    def fail_probe(*_a, **_kw):
+        raise AssertionError(
+            "temp probe should not run after a definitive False child"
+        )
+
+    monkeypatch.setattr(move_mod, "_samefile_tristate", fake_tristate)
+    monkeypatch.setattr(move_mod.tempfile, "mkdtemp", fail_probe)
+
+    assert move_mod._is_case_insensitive_path(
+        os.path.join(target_str, "missing_leaf")
+    ) is False
 
 
 @pytest.mark.skipif(

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -607,10 +607,12 @@ def test_is_case_insensitive_path_detects_case_insensitive_fs(tmp_path, monkeypa
     ) is True
 
 
-def test_is_case_insensitive_path_no_letter_children_returns_false(tmp_path):
-    """No probe-able child entry → conservative False. Otherwise a folder
-    of digit-only names could be flipped no-op-wise and report True/False
-    based on whatever samefile happened to return."""
+def test_is_case_insensitive_path_no_letter_children_falls_back_to_temp_probe(tmp_path):
+    """When no existing child has a letter to flip, the probe creates its
+    own temp dir inside the ancestor and asks samefile whether the
+    case-flipped spelling resolves to the same inode. On a case-sensitive
+    Linux FS this returns False (correct), and the probe dir must be
+    cleaned up so the destination is left as the function found it."""
     import move as move_mod
 
     target = tmp_path / "digits"
@@ -618,9 +620,72 @@ def test_is_case_insensitive_path_no_letter_children_returns_false(tmp_path):
     (target / "123").touch()
     (target / "456").mkdir()
 
+    # CI runs on case-sensitive Linux ext4: the temp-probe falls through
+    # to the same answer the digit-only listing gave before the fallback
+    # existed.
     assert move_mod._is_case_insensitive_path(
         os.path.join(str(target), "missing")
     ) is False
+
+    # No leftover probe dir — listdir still sees only the originals.
+    assert sorted(os.listdir(target)) == ["123", "456"]
+
+
+def test_is_case_insensitive_path_empty_ancestor_detects_case_insensitive_fs(
+    tmp_path, monkeypatch,
+):
+    """A fresh case-insensitive POSIX destination tree (default macOS APFS at
+    /Volumes/Photos with nothing in it yet) must still be classified as
+    case-insensitive, so a stale tracked row like /Photos/Dst/src vs a
+    move into /Photos/dst/src is still caught by the case-folded overlap
+    check. Before the temp-probe fallback, an empty ancestor returned
+    False unconditionally and let the stale alias slip through, leaving
+    two folder rows managing the same on-disk tree.
+    """
+    import move as move_mod
+
+    target = tmp_path / "empty_dest_root"
+    target.mkdir()
+    target_str = str(target)
+
+    def fake_samefile(a, b):
+        # Mimic case-insensitive FS at `target`: any two sibling names
+        # under it that differ only by case resolve to the same inode.
+        return (
+            os.path.dirname(a) == target_str
+            and os.path.dirname(b) == target_str
+            and os.path.basename(a).lower() == os.path.basename(b).lower()
+        )
+
+    monkeypatch.setattr(move_mod, "_samefile_or_false", fake_samefile)
+
+    assert move_mod._is_case_insensitive_path(
+        os.path.join(target_str, "missing", "sub")
+    ) is True
+
+    # Probe dir cleaned up — only originals (none, here) remain.
+    assert os.listdir(target) == []
+
+
+def test_is_case_insensitive_path_empty_ancestor_unwritable_returns_false(tmp_path):
+    """If the deepest existing ancestor is empty AND read-only, the
+    temp-probe fallback can't write a probe dir. Return False rather than
+    guessing — spuriously folding case could collapse two genuinely
+    distinct paths."""
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        pytest.skip("root bypasses dir-write permissions")
+    import move as move_mod
+
+    target = tmp_path / "ro_empty"
+    target.mkdir()
+    original_mode = target.stat().st_mode
+    os.chmod(target, 0o500)  # readable+executable, not writable
+    try:
+        assert move_mod._is_case_insensitive_path(
+            os.path.join(str(target), "missing")
+        ) is False
+    finally:
+        os.chmod(target, original_mode)
 
 
 def test_move_folder_refuses_self_overlapping_destination(move_env):

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -277,6 +277,52 @@ def test_move_folder_merge_refuses_tracked_descendant(move_env):
     assert (env["src"] / "bird1.jpg").exists()
 
 
+def test_move_folder_refuses_missing_tracked_destination_before_copy(move_env):
+    """A stale tracked destination row must block the move even when the
+    resolved destination does not currently exist on disk."""
+    from move import move_folder
+
+    env = move_env
+    landing = env["dst"] / "src"
+    assert not landing.exists()
+    env["db"].add_folder(str(landing), name="src")
+
+    result = move_folder(
+        db=env["db"], folder_id=env["fid_src"], destination=str(env["dst"])
+    )
+
+    assert result["moved"] == 0
+    assert any("already manage" in e for e in result["errors"])
+    assert (env["src"] / "bird1.jpg").exists()
+    assert not landing.exists()
+
+
+def test_move_folder_refuses_missing_tracked_descendant_before_copy(move_env):
+    """A stale tracked descendant row would collide when source children
+    cascade to the destination path, so it must block before any copy."""
+    from move import move_folder
+
+    env = move_env
+    source_child = env["src"] / "sub"
+    source_child.mkdir()
+    env["db"].add_folder(str(source_child), name="sub")
+
+    landing = env["dst"] / "src"
+    tracked_child = landing / "sub"
+    assert not landing.exists()
+    env["db"].add_folder(str(tracked_child), name="sub")
+
+    result = move_folder(
+        db=env["db"], folder_id=env["fid_src"], destination=str(env["dst"])
+    )
+
+    assert result["moved"] == 0
+    assert any("already manage" in e for e in result["errors"])
+    assert (env["src"] / "bird1.jpg").exists()
+    assert source_child.exists()
+    assert not landing.exists()
+
+
 def test_move_folder_merge_refuses_symlinked_tracked_destination(move_env):
     """A tracked folder reached via a symlink alias must be detected by the
     tracked-destination check (canonical realpath compare), not slip past a

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -493,6 +493,85 @@ def test_move_folder_refuses_case_alias_missing_tracked_destination(move_env, mo
     assert not dest_input.exists()
 
 
+def test_is_case_insensitive_path_probes_inside_target_fs(tmp_path, monkeypatch):
+    """The case-insensitivity probe must test the FS at the deepest existing
+    ancestor by case-flipping a CHILD entry, not by case-flipping the
+    ancestor's own basename. Otherwise a case-sensitive APFS volume mounted
+    at /Volumes/Photos under default case-insensitive macOS HFS+ is wrongly
+    classified case-insensitive (the basename probe asks /Volumes how it
+    resolves "Photos", which is case-insensitive, instead of asking the
+    mounted volume how it resolves its own children), and valid moves into
+    the volume get refused as overlapping a stale case-only alias.
+    """
+    import move as move_mod
+
+    mount = tmp_path / "Mount"
+    mount.mkdir()
+    # Letter-named child so a child probe has something to flip.
+    (mount / "child").mkdir()
+    mount_str = str(mount)
+
+    def fake_samefile(a, b):
+        # Mimic the misleading scenario: case-flipping the mount point's
+        # own basename in its parent directory collapses (the parent FS
+        # folds case), while case-flipping a child name under the mount
+        # does not (the mount's FS is case-sensitive).
+        names = {os.path.basename(a), os.path.basename(b)}
+        return names == {"Mount", "mOUNT"}
+
+    monkeypatch.setattr(move_mod, "_samefile_or_false", fake_samefile)
+
+    # Deepest existing ancestor of the missing leaf is `mount`. The fixed
+    # probe must look inside `mount` and report case-sensitive (False).
+    # The pre-fix code probed `os.path.basename(mount)` in its parent and
+    # returned True — the regression we're guarding against.
+    assert move_mod._is_case_insensitive_path(
+        os.path.join(mount_str, "missing", "sub")
+    ) is False
+
+
+def test_is_case_insensitive_path_detects_case_insensitive_fs(tmp_path, monkeypatch):
+    """When the deepest existing ancestor's FS folds case on its children,
+    the probe must return True via a child-entry case-flip."""
+    import move as move_mod
+
+    target = tmp_path / "dir"
+    target.mkdir()
+    (target / "child").touch()
+    target_str = str(target)
+
+    def fake_samefile(a, b):
+        # Mimic case-insensitive FS at `target`: any two child names that
+        # differ only by case resolve to the same inode.
+        return (
+            os.path.dirname(a) == target_str
+            and os.path.dirname(b) == target_str
+            and os.path.basename(a).lower() == os.path.basename(b).lower()
+        )
+
+    monkeypatch.setattr(move_mod, "_samefile_or_false", fake_samefile)
+
+    assert move_mod._is_case_insensitive_path(
+        os.path.join(target_str, "missing_leaf")
+    ) is True
+
+
+def test_is_case_insensitive_path_no_letter_children_returns_false(tmp_path):
+    """No probe-able child entry → conservative False. Otherwise a folder
+    of digit-only names could be flipped no-op-wise and report True/False
+    based on whatever samefile happened to return."""
+    import move as move_mod
+
+    target = tmp_path / "digits"
+    target.mkdir()
+    (target / "123").touch()
+    (target / "456").mkdir()
+
+    assert move_mod._is_case_insensitive_path(
+        os.path.join(str(target), "missing")
+    ) is False
+
+
 def test_move_folder_refuses_self_overlapping_destination(move_env):
     """A move whose resolved destination overlaps the source (here, the
     source's own parent → resolved dest == source) must be refused rather

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -885,6 +885,49 @@ def test_is_case_insensitive_path_empty_ancestor_unwritable_returns_false(tmp_pa
         os.chmod(target, original_mode)
 
 
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="Windows paths are treated case-insensitive without POSIX probing",
+)
+def test_is_case_insensitive_path_unreadable_ancestor_falls_back_to_temp_probe(
+    tmp_path, monkeypatch,
+):
+    """A +wx (drop-box) ancestor without read permission can still receive
+    a fresh temp dir, so an os.listdir denial must be inconclusive — fall
+    through to the temp probe instead of declaring the FS case-sensitive.
+    Otherwise a stale tracked row like /Photos/Dst/src can slip past the
+    case-folded overlap check on a case-insensitive POSIX destination."""
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        pytest.skip("root bypasses dir-read permissions")
+    import move as move_mod
+
+    target = tmp_path / "dropbox"
+    target.mkdir()
+    target_str = str(target)
+
+    def fake_samefile(a, b):
+        return (
+            os.path.dirname(a) == os.path.dirname(b)
+            and os.path.basename(a).lower() == os.path.basename(b).lower()
+        )
+
+    monkeypatch.setattr(move_mod, "_samefile_or_false", fake_samefile)
+
+    original_mode = target.stat().st_mode
+    os.chmod(target, 0o300)  # write+execute, not readable
+    try:
+        with pytest.raises(OSError):
+            os.listdir(target_str)
+        assert move_mod._is_case_insensitive_path(
+            os.path.join(target_str, "missing", "sub")
+        ) is True
+    finally:
+        os.chmod(target, original_mode)
+
+    # Probe dir cleaned up.
+    assert os.listdir(target) == []
+
+
 def test_move_folder_refuses_self_overlapping_destination(move_env):
     """A move whose resolved destination overlaps the source (here, the
     source's own parent → resolved dest == source) must be refused rather

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -587,6 +587,59 @@ def test_path_equal_or_descends_folds_root_case_alias_in_candidate(
     ) is False
 
 
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="POSIX filesystem-root scenario; Windows uses drive-rooted paths",
+)
+def test_path_equal_or_descends_handles_case_fold_root_at_filesystem_root():
+    """When the probed case-insensitive root is the filesystem root itself
+    (a writable case-insensitive POSIX volume mounted at `/`, or any
+    destination whose first missing component sits directly under `/`),
+    `root + os.sep` doubles to "//" and no real path starts with it.
+    Without the trailing-separator handling, the case-folded compare is
+    silently skipped and a stale tracked row like `/photos/src` slips past
+    `_tracked_destination_overlap` against a move into `/Photos/src` —
+    leaving two folder rows managing the same on-disk tree once the copy
+    starts.
+    """
+    import move as move_mod
+
+    # Both paths missing on disk (typical stale-row + fresh-move scenario).
+    # The existence-based samefile checks early-return None for missing
+    # paths, so the case-folded suffix compare is the only path that
+    # catches this — with case_insensitive_root="/", the root prefix is the
+    # bare separator and the suffix strip leaves the full path minus "/".
+    assert move_mod._path_equal_or_descends(
+        "/__vireo_missing_for_test/PHOTOS/src",
+        "/__vireo_missing_for_test/photos/src",
+        case_insensitive_root="/",
+    ) is True
+
+    # Equal paths under the root (canonical match through the case-folded
+    # fallback when both leaves are missing).
+    assert move_mod._path_equal_or_descends(
+        "/__vireo_missing_for_test/photos/src",
+        "/__vireo_missing_for_test/photos/src",
+        case_insensitive_root="/",
+    ) is True
+
+    # Descendant of a case-aliased ancestor — the candidate's longer suffix
+    # must still match the ancestor's via the prefix compare.
+    assert move_mod._path_equal_or_descends(
+        "/__vireo_missing_for_test/Photos/dst/inner",
+        "/__vireo_missing_for_test/photos/dst",
+        case_insensitive_root="/",
+    ) is True
+
+    # Genuinely distinct paths (not just case-different) still return False
+    # — the case-fold-at-root edge must not cause over-folding.
+    assert move_mod._path_equal_or_descends(
+        "/__vireo_missing_for_test/other/src",
+        "/__vireo_missing_for_test/photos/src",
+        case_insensitive_root="/",
+    ) is False
+
+
 def test_tracked_destination_overlap_skips_rows_outside_ci_root(move_env, monkeypatch):
     """End-to-end: `_tracked_destination_overlap` must NOT return a stale
     row whose path differs from the destination above the case-insensitive
@@ -843,12 +896,13 @@ def test_is_case_insensitive_path_child_alias_confirmed_by_temp_probe(
     os.name == "nt",
     reason="Windows paths are treated case-insensitive without POSIX probing",
 )
-def test_is_case_insensitive_path_definitive_false_short_circuits(
+def test_is_case_insensitive_path_child_scan_short_circuits_on_definitive_false(
     tmp_path, monkeypatch,
 ):
-    """A child pair where `samefile` returns False — two distinct entries
-    both exist as separate files — is impossible on a case-folding FS, so
-    the loop returns False immediately without running the temp probe."""
+    """When the temp probe can't write (read-only ancestor), the child-scan
+    fallback returns False as soon as it sees a case-twin pair with
+    distinct inodes (`samefile` == False) — impossible on a case-folding
+    FS — without statting every other entry under the ancestor."""
     import move as move_mod
 
     target = tmp_path / "dir"
@@ -856,6 +910,10 @@ def test_is_case_insensitive_path_definitive_false_short_circuits(
     (target / "alpha").touch()
     (target / "ALPHA").touch()
     target_str = str(target)
+
+    def fake_mkdtemp(*_a, **_kw):
+        # Simulate a read-only ancestor so the child-scan fallback runs.
+        raise OSError("read-only — exercise child-scan fallback")
 
     def fake_tristate(a, b):
         # Mimic real case-sensitive FS: alpha and ALPHA are distinct files
@@ -865,17 +923,72 @@ def test_is_case_insensitive_path_definitive_false_short_circuits(
             return False
         return None
 
-    def fail_probe(*_a, **_kw):
-        raise AssertionError(
-            "temp probe should not run after a definitive False child"
-        )
-
+    monkeypatch.setattr(move_mod.tempfile, "mkdtemp", fake_mkdtemp)
     monkeypatch.setattr(move_mod, "_samefile_tristate", fake_tristate)
-    monkeypatch.setattr(move_mod.tempfile, "mkdtemp", fail_probe)
 
     assert move_mod._is_case_insensitive_path(
         os.path.join(target_str, "missing_leaf")
     ) is False
+
+
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="Windows paths are treated case-insensitive without POSIX probing",
+)
+def test_is_case_insensitive_path_temp_probe_runs_before_child_scan(
+    tmp_path, monkeypatch,
+):
+    """The temp probe is conclusive in both directions with O(1) syscalls,
+    so it must run first when the ancestor is writable — the child-scan
+    fallback is read-only and only worthwhile when mkdtemp can't write.
+    Before this ordering, `move_folder()` re-stat'd every entry under the
+    destination's deepest existing ancestor on every move (the per-entry
+    samefile probe is inconclusive on a typical case-sensitive directory
+    with no case-twin children), turning the preflight guard into
+    O(entries) wasted syscalls per move on big photo trees.
+    """
+    import move as move_mod
+
+    target = tmp_path / "dir"
+    target.mkdir()
+    # Many letter-bearing entries — the OLD scan-first order would call
+    # _samefile_tristate once per entry before reaching the temp probe.
+    for i in range(50):
+        (target / f"entry_{i}").touch()
+
+    call_order = []
+    real_mkdtemp = move_mod.tempfile.mkdtemp
+    real_tristate = move_mod._samefile_tristate
+
+    def tracked_mkdtemp(*a, **kw):
+        call_order.append("mkdtemp")
+        return real_mkdtemp(*a, **kw)
+
+    def tracked_tristate(a, b):
+        # Only count per-entry child-scan probes against pre-existing
+        # entries; ignore the temp probe's own samefile call (which goes
+        # through _samefile_or_false → _samefile_tristate).
+        if not (os.path.basename(a).startswith(".vireo_case_probe_")
+                or os.path.basename(b).startswith(".vireo_case_probe_")):
+            call_order.append("tristate")
+        return real_tristate(a, b)
+
+    monkeypatch.setattr(move_mod.tempfile, "mkdtemp", tracked_mkdtemp)
+    monkeypatch.setattr(move_mod, "_samefile_tristate", tracked_tristate)
+
+    # Real tmp_path is case-sensitive on Linux CI; the temp probe creates
+    # a fresh dir whose flipped name doesn't exist, so samefile raises and
+    # `_samefile_or_false` returns False. That answer is final, with zero
+    # child-scan calls — the regression we're guarding against.
+    move_mod._is_case_insensitive_path(
+        os.path.join(str(target), "missing_leaf")
+    )
+
+    assert "mkdtemp" in call_order, "temp probe should have run"
+    assert "tristate" not in call_order, (
+        f"child-scan probes should not run when temp probe succeeds; "
+        f"call order was {call_order}"
+    )
 
 
 @pytest.mark.skipif(

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -451,6 +451,45 @@ def test_move_folder_merge_refuses_case_alias_tracked_destination(move_env, monk
     assert (env["src"] / "bird2.jpg").exists()
 
 
+def test_move_folder_refuses_case_alias_missing_tracked_destination(move_env, monkeypatch):
+    """On a case-insensitive POSIX filesystem (default macOS APFS), a stale
+    tracked folder row whose path differs from the resolved destination only
+    by case must still be refused even when both leaves are missing on disk.
+    realpath/normcase don't fold case there and samefile has nothing to
+    compare across two non-existing paths, so without the FS case-insensitivity
+    probe, _path_equal_or_descends would let the move copy first and leave two
+    folder rows managing the same on-disk tree.
+
+    Simulated on Linux by patching the case-insensitivity probe to True so the
+    case-folded fallback runs without requiring an actual case-insensitive FS.
+    """
+    import move as move_mod
+
+    env = move_env
+    # User asks to move src into /tmp_path/DST — case-flipped from the
+    # existing on-disk /tmp_path/dst. /tmp_path/DST does not exist on disk.
+    dest_input = env["tmp_path"] / "DST"
+    assert not dest_input.exists()
+    # Stale tracked row at /tmp_path/dst/src — on a case-insensitive FS this
+    # is the same directory as the resolved landing /tmp_path/DST/src, but
+    # neither leaf exists on disk so samefile cannot collapse them.
+    stale_landing = env["dst"] / "src"
+    assert not stale_landing.exists()
+    env["db"].add_folder(str(stale_landing), name="src")
+
+    monkeypatch.setattr(move_mod, "_is_case_insensitive_path", lambda p: True)
+
+    result = move_mod.move_folder(
+        db=env["db"], folder_id=env["fid_src"], destination=str(dest_input)
+    )
+    assert result["moved"] == 0
+    assert any("already manage" in e for e in result["errors"])
+    # Source untouched, no copy started.
+    assert (env["src"] / "bird1.jpg").exists()
+    assert not stale_landing.exists()
+    assert not dest_input.exists()
+
+
 def test_move_folder_refuses_self_overlapping_destination(move_env):
     """A move whose resolved destination overlaps the source (here, the
     source's own parent → resolved dest == source) must be refused rather

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -544,6 +544,10 @@ def test_tracked_destination_overlap_caches_case_insensitivity_probe(move_env, m
     )
 
 
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="Windows paths are treated case-insensitive without POSIX probing",
+)
 def test_is_case_insensitive_path_probes_inside_target_fs(tmp_path, monkeypatch):
     """The case-insensitivity probe must test the FS at the deepest existing
     ancestor by case-flipping a CHILD entry, not by case-flipping the
@@ -607,22 +611,26 @@ def test_is_case_insensitive_path_detects_case_insensitive_fs(tmp_path, monkeypa
     ) is True
 
 
-def test_is_case_insensitive_path_no_letter_children_falls_back_to_temp_probe(tmp_path):
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="Windows paths are treated case-insensitive without POSIX probing",
+)
+def test_is_case_insensitive_path_no_letter_children_falls_back_to_temp_probe(
+    tmp_path, monkeypatch,
+):
     """When no existing child has a letter to flip, the probe creates its
     own temp dir inside the ancestor and asks samefile whether the
-    case-flipped spelling resolves to the same inode. On a case-sensitive
-    Linux FS this returns False (correct), and the probe dir must be
-    cleaned up so the destination is left as the function found it."""
+    case-flipped spelling resolves to the same inode. The probe result is
+    returned, and the probe dir must be cleaned up so the destination is left
+    as the function found it."""
     import move as move_mod
 
     target = tmp_path / "digits"
     target.mkdir()
     (target / "123").touch()
     (target / "456").mkdir()
+    monkeypatch.setattr(move_mod, "_samefile_or_false", lambda _a, _b: False)
 
-    # CI runs on case-sensitive Linux ext4: the temp-probe falls through
-    # to the same answer the digit-only listing gave before the fallback
-    # existed.
     assert move_mod._is_case_insensitive_path(
         os.path.join(str(target), "missing")
     ) is False
@@ -667,6 +675,10 @@ def test_is_case_insensitive_path_empty_ancestor_detects_case_insensitive_fs(
     assert os.listdir(target) == []
 
 
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="Windows paths are treated case-insensitive without POSIX probing",
+)
 def test_is_case_insensitive_path_empty_ancestor_unwritable_returns_false(tmp_path):
     """If the deepest existing ancestor is empty AND read-only, the
     temp-probe fallback can't write a probe dir. Return False rather than

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -466,14 +466,16 @@ def test_move_folder_refuses_case_alias_missing_tracked_destination(move_env, mo
     import move as move_mod
 
     env = move_env
-    # User asks to move src into /tmp_path/DST — case-flipped from the
-    # existing on-disk /tmp_path/dst. /tmp_path/DST does not exist on disk.
-    dest_input = env["tmp_path"] / "DST"
+    # User asks to move src into a missing destination whose path differs only
+    # by case from a stale tracked DB row. Both parent and leaf are absent so
+    # samefile has nothing to compare, even on a case-insensitive filesystem.
+    dest_input = env["tmp_path"] / "missing_dest"
     assert not dest_input.exists()
-    # Stale tracked row at /tmp_path/dst/src — on a case-insensitive FS this
-    # is the same directory as the resolved landing /tmp_path/DST/src, but
-    # neither leaf exists on disk so samefile cannot collapse them.
-    stale_landing = env["dst"] / "src"
+    stale_parent = env["tmp_path"] / "MISSING_DEST"
+    assert not stale_parent.exists()
+    # On a case-insensitive FS this is the same directory as the resolved
+    # landing /tmp_path/missing_dest/src, but neither path exists on disk.
+    stale_landing = stale_parent / "src"
     assert not stale_landing.exists()
     env["db"].add_folder(str(stale_landing), name="src")
 
@@ -487,6 +489,7 @@ def test_move_folder_refuses_case_alias_missing_tracked_destination(move_env, mo
     # Source untouched, no copy started.
     assert (env["src"] / "bird1.jpg").exists()
     assert not stale_landing.exists()
+    assert not stale_parent.exists()
     assert not dest_input.exists()
 
 

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -533,6 +533,60 @@ def test_path_equal_or_descends_case_fold_scoped_to_ci_root(tmp_path):
     ) is False
 
 
+def test_path_equal_or_descends_folds_root_case_alias_in_candidate(
+    tmp_path, monkeypatch,
+):
+    """The probed case-insensitive root itself can be spelled differently
+    by case in a stale candidate row (e.g. row `/Photos/DST/src` against
+    move target `/Photos/dst/src`, where `/Photos/dst` is the deepest
+    existing case-folding ancestor). The literal `startswith(root)` check
+    rejected such a row before the suffix was folded, so
+    `_tracked_destination_overlap` missed the stale row and a move could
+    leave two folder rows managing the same on-disk tree. The fix matches
+    the root prefix case-insensitively and confirms via samefile that the
+    candidate's variant is the same on-disk directory."""
+    import move as move_mod
+
+    base = tmp_path / "Photos"
+    base.mkdir()
+    root_dir = base / "dst"
+    root_dir.mkdir()
+    root_real = os.path.realpath(str(root_dir))
+
+    # Move target's missing leaf under the existing case-folding root.
+    dest = str(root_dir / "src")
+    # Stale tracked row whose root-level segment is a case-only alias of
+    # `root_dir`. Missing on disk on the case-sensitive Linux CI host.
+    stale = str(base / "DST" / "src")
+
+    real_samefile = move_mod._samefile_or_false
+
+    def fake_samefile(a, b):
+        # Mimic case-folding FS at `base`: two children of `base` whose
+        # basenames differ only by case resolve to the same inode, even
+        # when one of them doesn't actually exist on the underlying
+        # case-sensitive host FS. Fall through to the real probe for
+        # everything else so unrelated paths still behave normally.
+        if os.path.dirname(a) == str(base) and os.path.dirname(b) == str(base):
+            if os.path.basename(a).lower() == os.path.basename(b).lower():
+                return True
+        return real_samefile(a, b)
+
+    monkeypatch.setattr(move_mod, "_samefile_or_false", fake_samefile)
+
+    assert move_mod._path_equal_or_descends(
+        stale, dest, case_insensitive_root=root_real
+    ) is True
+
+    # Sanity: an ABOVE-root case variant (parent FS case-sensitive) must
+    # still be rejected — the samefile check on the candidate's root-level
+    # prefix is what distinguishes the two scenarios.
+    sibling_root = str(tmp_path / "PHOTOS" / "dst" / "src")
+    assert move_mod._path_equal_or_descends(
+        sibling_root, dest, case_insensitive_root=root_real
+    ) is False
+
+
 def test_tracked_destination_overlap_skips_rows_outside_ci_root(move_env, monkeypatch):
     """End-to-end: `_tracked_destination_overlap` must NOT return a stale
     row whose path differs from the destination above the case-insensitive
@@ -605,6 +659,15 @@ def test_tracked_destination_overlap_caches_case_insensitivity_probe(move_env, m
     # the row count must not bump the probe count.
     resolved_dest = os.path.realpath(str(dest_input / "src"))
     dest_probes = [p for p in calls if os.path.realpath(p) == resolved_dest]
+    # Lower bound on POSIX: the destination probe MUST be exercised at
+    # least once. Without this, the upper-bound assertion passes vacuously
+    # if a future refactor skips the resolved-destination probe entirely.
+    # Windows short-circuits to True without listing, so no probe fires.
+    if os.name != "nt":
+        assert len(dest_probes) >= 1, (
+            f"expected at least one resolved-destination probe on POSIX, "
+            f"got 0 (all calls: {calls})"
+        )
     assert len(dest_probes) <= 2, (
         f"expected dest probe to be cached (≤2 calls), "
         f"got {len(dest_probes)} (all calls: {calls})"

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -574,7 +574,7 @@ def test_is_case_insensitive_path_probes_inside_target_fs(tmp_path, monkeypatch)
         names = {os.path.basename(a), os.path.basename(b)}
         return names == {"Mount", "mOUNT"}
 
-    monkeypatch.setattr(move_mod, "_samefile_or_false", fake_samefile)
+    monkeypatch.setattr(move_mod, "_samefile_tristate", fake_samefile)
 
     # Deepest existing ancestor of the missing leaf is `mount`. The fixed
     # probe must look inside `mount` and report case-sensitive (False).
@@ -604,11 +604,97 @@ def test_is_case_insensitive_path_detects_case_insensitive_fs(tmp_path, monkeypa
             and os.path.basename(a).lower() == os.path.basename(b).lower()
         )
 
-    monkeypatch.setattr(move_mod, "_samefile_or_false", fake_samefile)
+    monkeypatch.setattr(move_mod, "_samefile_tristate", fake_samefile)
 
     assert move_mod._is_case_insensitive_path(
         os.path.join(target_str, "missing_leaf")
     ) is True
+
+
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="Windows paths are treated case-insensitive without POSIX probing",
+)
+def test_is_case_insensitive_path_inconclusive_child_probe_keeps_scanning(
+    tmp_path, monkeypatch,
+):
+    """If a letter-bearing child's case-flipped probe is inconclusive
+    (samefile raises — broken symlink, permission/race error), the loop
+    must keep scanning later entries rather than immediately classifying
+    the FS as case-sensitive off one unstatable entry. Otherwise a
+    case-insensitive POSIX volume whose listdir happens to put such an
+    entry first lets stale case-only tracked rows slip past the
+    case-folded overlap check.
+    """
+    import move as move_mod
+
+    target = tmp_path / "dir"
+    target.mkdir()
+    (target / "broken").touch()
+    (target / "child").touch()
+    target_str = str(target)
+
+    def fake_tristate(a, b):
+        names = {os.path.basename(a).lower(), os.path.basename(b).lower()}
+        if "broken" in names:
+            # Mimic stat raising on the flipped spelling of a broken entry.
+            return None
+        # Mimic case-insensitive FS folding "child"/"CHILD" to the same inode.
+        return os.path.basename(a).lower() == os.path.basename(b).lower()
+
+    monkeypatch.setattr(move_mod, "_samefile_tristate", fake_tristate)
+
+    assert move_mod._is_case_insensitive_path(
+        os.path.join(target_str, "missing_leaf")
+    ) is True
+
+
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="Windows paths are treated case-insensitive without POSIX probing",
+)
+def test_is_case_insensitive_path_all_inconclusive_falls_back_to_temp_probe(
+    tmp_path, monkeypatch,
+):
+    """When every letter-bearing child's probe is inconclusive (every
+    flipped spelling raises), the scan must fall through to the temp-dir
+    probe rather than declaring the FS case-sensitive off the inconclusive
+    children. Mirrors the no-letter-children fallback for the case where
+    letter children exist but can't be resolved.
+    """
+    import move as move_mod
+
+    target = tmp_path / "dir"
+    target.mkdir()
+    (target / "broken1").touch()
+    (target / "broken2").touch()
+    target_str = str(target)
+
+    def fake_tristate(a, b):
+        # Every child probe inconclusive — but the temp-probe fallback
+        # uses `_samefile_or_false`, which we leave alone so the real
+        # probe-dir path runs. With the case-insensitive simulation
+        # below, the temp probe should return True.
+        return None
+
+    def fake_samefile_or_false(a, b):
+        # Mimic case-insensitive FS at `target`: anything whose dirname
+        # is `target` and whose basenames match case-folded is "same".
+        return (
+            os.path.dirname(a) == target_str
+            and os.path.dirname(b) == target_str
+            and os.path.basename(a).lower() == os.path.basename(b).lower()
+        )
+
+    monkeypatch.setattr(move_mod, "_samefile_tristate", fake_tristate)
+    monkeypatch.setattr(move_mod, "_samefile_or_false", fake_samefile_or_false)
+
+    assert move_mod._is_case_insensitive_path(
+        os.path.join(target_str, "missing_leaf")
+    ) is True
+
+    # Probe dir cleaned up — only the originals remain.
+    assert sorted(os.listdir(target)) == ["broken1", "broken2"]
 
 
 @pytest.mark.skipif(

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -493,6 +493,57 @@ def test_move_folder_refuses_case_alias_missing_tracked_destination(move_env, mo
     assert not dest_input.exists()
 
 
+def test_tracked_destination_overlap_caches_case_insensitivity_probe(move_env, monkeypatch):
+    """The FS case-insensitivity probe is os.listdir-backed and re-running it
+    per tracked-folder row turns the preflight guard into
+    O(tracked_folders × destination_entries) before any copy starts. The
+    overlap check must compute it once for the resolved destination and
+    reuse that result for every row it scans.
+    """
+    import move as move_mod
+
+    env = move_env
+    # Many unrelated tracked rows. Each forces the missing-leaves fallback
+    # in _path_equal_or_descends (realpath compare unequal, both leaves
+    # missing or ancestor missing), which is the branch that calls the
+    # probe — so without caching, the probe fires once per row.
+    dest_input = env["tmp_path"] / "missing_dest_cache_probe"
+    assert not dest_input.exists()
+    for i in range(8):
+        env["db"].add_folder(
+            str(env["tmp_path"] / f"unrelated_{i}" / "leaf"), name="leaf"
+        )
+
+    calls = []
+    real_probe = move_mod._is_case_insensitive_path
+
+    def counting_probe(path):
+        calls.append(path)
+        return real_probe(path)
+
+    monkeypatch.setattr(move_mod, "_is_case_insensitive_path", counting_probe)
+
+    move_mod.move_folder(
+        db=env["db"], folder_id=env["fid_src"], destination=str(dest_input)
+    )
+
+    # Count probes whose argument is the resolved destination. move_folder
+    # resolves `destination` to `destination/<source_folder_name>` before
+    # the overlap check, so the probed path is the landing dir, not the raw
+    # input. The expected pattern with caching is 2 probes: one from
+    # _destination_overlaps_source(src, dest)'s symmetric check against
+    # dest, and one cached probe from _tracked_destination_overlap. Without
+    # caching, the row loop would add 8 more (one per added row) — the
+    # regression we're guarding against. The exact bound matters: bumping
+    # the row count must not bump the probe count.
+    resolved_dest = os.path.realpath(str(dest_input / "src"))
+    dest_probes = [p for p in calls if os.path.realpath(p) == resolved_dest]
+    assert len(dest_probes) <= 2, (
+        f"expected dest probe to be cached (≤2 calls), "
+        f"got {len(dest_probes)} (all calls: {calls})"
+    )
+
+
 def test_is_case_insensitive_path_probes_inside_target_fs(tmp_path, monkeypatch):
     """The case-insensitivity probe must test the FS at the deepest existing
     ancestor by case-flipping a CHILD entry, not by case-flipping the

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -2,11 +2,33 @@
 
 import os
 import sys
+import tempfile
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 import pytest
 from db import Database
+
+
+def _tmp_folds_case():
+    """True if the filesystem holding pytest's temp dir folds case (macOS
+    APFS default, Windows NTFS). Some tests below build scenarios where two
+    case variants of an ancestor path must resolve to DISTINCT on-disk
+    directories — only possible on a case-sensitive parent FS. On a folding
+    host the two variants are the same directory and the assertion under
+    test can't hold; skip rather than miscompare.
+    """
+    with tempfile.TemporaryDirectory(suffix="A") as d:
+        flipped = d[:-1] + "a"
+        if flipped == d:
+            return False
+        try:
+            return os.path.samefile(d, flipped)
+        except OSError:
+            return False
+
+
+_TMP_FOLDS_CASE = _tmp_folds_case()
 
 
 @pytest.fixture
@@ -493,6 +515,11 @@ def test_move_folder_refuses_case_alias_missing_tracked_destination(move_env, mo
     assert not dest_input.exists()
 
 
+@pytest.mark.skipif(
+    _TMP_FOLDS_CASE,
+    reason="Scenario requires a case-sensitive parent FS so the "
+           "case-flipped ancestor names resolve to distinct directories.",
+)
 def test_path_equal_or_descends_case_fold_scoped_to_ci_root(tmp_path):
     """The case-folded fallback in `_path_equal_or_descends` must only fold
     the suffix below the probed case-insensitive root — not the whole path.
@@ -533,6 +560,11 @@ def test_path_equal_or_descends_case_fold_scoped_to_ci_root(tmp_path):
     ) is False
 
 
+@pytest.mark.skipif(
+    _TMP_FOLDS_CASE,
+    reason="Sibling-root assertion requires a case-sensitive parent FS so "
+           "the case-flipped root spelling is a distinct on-disk directory.",
+)
 def test_path_equal_or_descends_folds_root_case_alias_in_candidate(
     tmp_path, monkeypatch,
 ):
@@ -567,9 +599,9 @@ def test_path_equal_or_descends_folds_root_case_alias_in_candidate(
         # when one of them doesn't actually exist on the underlying
         # case-sensitive host FS. Fall through to the real probe for
         # everything else so unrelated paths still behave normally.
-        if os.path.dirname(a) == str(base) and os.path.dirname(b) == str(base):
-            if os.path.basename(a).lower() == os.path.basename(b).lower():
-                return True
+        if (os.path.dirname(a) == str(base) and os.path.dirname(b) == str(base)
+                and os.path.basename(a).lower() == os.path.basename(b).lower()):
+            return True
         return real_samefile(a, b)
 
     monkeypatch.setattr(move_mod, "_samefile_or_false", fake_samefile)
@@ -640,6 +672,11 @@ def test_path_equal_or_descends_handles_case_fold_root_at_filesystem_root():
     ) is False
 
 
+@pytest.mark.skipif(
+    _TMP_FOLDS_CASE,
+    reason="Scenario requires a case-sensitive parent FS so the "
+           "above-root case-flipped row is a distinct on-disk path.",
+)
 def test_tracked_destination_overlap_skips_rows_outside_ci_root(move_env, monkeypatch):
     """End-to-end: `_tracked_destination_overlap` must NOT return a stale
     row whose path differs from the destination above the case-insensitive
@@ -848,8 +885,9 @@ def test_is_case_insensitive_path_inconclusive_child_probe_keeps_scanning(
 
 
 @pytest.mark.skipif(
-    os.name == "nt",
-    reason="Windows paths are treated case-insensitive without POSIX probing",
+    os.name == "nt" or _TMP_FOLDS_CASE,
+    reason="Setup creates `foo` and `FOO` as distinct sibling files; only "
+           "possible on a case-sensitive parent FS (not Windows / macOS APFS).",
 )
 def test_is_case_insensitive_path_child_alias_confirmed_by_temp_probe(
     tmp_path, monkeypatch,

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -493,6 +493,73 @@ def test_move_folder_refuses_case_alias_missing_tracked_destination(move_env, mo
     assert not dest_input.exists()
 
 
+def test_path_equal_or_descends_case_fold_scoped_to_ci_root(tmp_path):
+    """The case-folded fallback in `_path_equal_or_descends` must only fold
+    the suffix below the probed case-insensitive root — not the whole path.
+    Otherwise a tracked row whose path differs from the resolved destination
+    in a component ABOVE the case-folding subtree (a case-insensitive APFS
+    or CIFS volume mounted at /mnt/photos under a case-sensitive Linux root
+    FS: stale row /MNT/photos/dst/src vs move into /mnt/photos/dst/src) would
+    falsely collapse as overlap and refuse a valid move, even though `/MNT`
+    is a distinct directory from `/mnt` on the parent (case-sensitive) FS.
+    Case-only differences BELOW the root must still collapse."""
+    import move as move_mod
+
+    ci_root = tmp_path / "ci_root"
+    ci_root.mkdir()
+    ci_root_real = os.path.realpath(str(ci_root))
+    dest = str(ci_root / "dst" / "src")
+
+    # Above the root — a case-flipped component on the case-sensitive parent
+    # FS is a genuinely distinct path. Must NOT register as overlap.
+    above_root = str(tmp_path / "CI_ROOT" / "dst" / "src")
+    assert move_mod._path_equal_or_descends(
+        above_root, dest, case_insensitive_root=ci_root_real
+    ) is False
+
+    # Below the root — case-only difference on the case-folding FS aliases
+    # to the same on-disk directory. Must register as overlap.
+    below_root = str(ci_root / "DST" / "src")
+    assert move_mod._path_equal_or_descends(
+        below_root, dest, case_insensitive_root=ci_root_real
+    ) is True
+
+    # Sibling of the root on the parent FS — distinct path, must NOT
+    # register even when both paths happen to case-fold to the same string
+    # when lowercased in full.
+    sibling = str(tmp_path / "ci_root2" / "dst" / "src")
+    assert move_mod._path_equal_or_descends(
+        sibling, dest, case_insensitive_root=ci_root_real
+    ) is False
+
+
+def test_tracked_destination_overlap_skips_rows_outside_ci_root(move_env, monkeypatch):
+    """End-to-end: `_tracked_destination_overlap` must NOT return a stale
+    row whose path differs from the destination above the case-insensitive
+    boundary. Before the fix, the full-path `.lower()` fallback collapsed
+    /MNT/photos/dst/src with /mnt/photos/dst/src on a Linux box with a
+    case-insensitive subvolume mounted at /mnt/photos and refused valid
+    moves into that subvolume as "already managed"."""
+    import move as move_mod
+
+    env = move_env
+    ci_root = env["tmp_path"] / "ci_root"
+    ci_root.mkdir()
+    dest = str(ci_root / "dst" / "src")
+    assert not os.path.exists(dest)
+
+    above_root = str(env["tmp_path"] / "CI_ROOT" / "dst" / "src")
+    env["db"].add_folder(above_root, name="src")
+
+    # Force the probe True so the case-fold branch is exercised regardless
+    # of the host FS (CI tends to be case-sensitive ext4).
+    monkeypatch.setattr(move_mod, "_is_case_insensitive_path", lambda p: True)
+
+    assert move_mod._tracked_destination_overlap(
+        env["db"], env["fid_src"], dest
+    ) is None
+
+
 def test_tracked_destination_overlap_caches_case_insensitivity_probe(move_env, monkeypatch):
     """The FS case-insensitivity probe is os.listdir-backed and re-running it
     per tracked-folder row turns the preflight guard into


### PR DESCRIPTION
This moves the tracked-destination overlap guard ahead of the filesystem existence check so stale folder rows are refused before any copy starts.

The bug could copy files into a missing-on-disk destination and then fail when db.move_folder_path hit the folders.path uniqueness contract.

Regression tests cover stale exact destination rows and stale tracked descendants with the destination tree absent.

Validation: pytest vireo/tests/test_move.py.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved folder move safety on case-insensitive filesystems by refining detection of path aliases and equality/descend relationships, including when paths don’t exist on disk yet.
  * Prevents unsafe merges into tracked folder destinations earlier, including when tracked destination rows are stale or missing.

* **Tests**
  * Expanded move-folder refusal coverage to ensure moves are stopped before any copying when destination tracking data is stale.
  * Added extensive case-insensitive filesystem detection and caching tests (skipping appropriately on Windows).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->