### PR TITLE
website: update download links for v0.10.3

### DIFF
--- a/website/src/pages/download.astro
+++ b/website/src/pages/download.astro
@@ -7,8 +7,8 @@ const releaseUrl = (v: string) => `https://github.com/jss367/vireo/releases/down
 
 // Per-platform versions — updated independently by CI when each platform builds
 const macosArm64Version = '0.10.2';
-const windowsVersion = '0.10.2';
-const linuxVersion = '0.10.2';
+const windowsVersion = '0.10.3';
+const linuxVersion = '0.10.3';
 ---
 
 <Base title="Download — Vireo" description="Download Vireo for macOS, Windows, or Linux. Free, open source, no account required.">


### PR DESCRIPTION
Automated update of download links following the v0.10.3 release. Auto-merges once required checks pass; deploy-website.yml runs on the resulting push to main.