### PR TITLE
Harden lightbox native zoom tests

### DIFF
--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -528,14 +528,14 @@ def test_browse_lightbox_one_to_one_uses_device_pixels_and_natural_layout(live_s
             return img && img.complete && img.naturalWidth === 4000;
         }"""
     )
-    page.evaluate(
+    page.wait_for_function(
         """() => {
             window._lbPhotoW = 4000;
             window._lbPhotoH = 2000;
             window._lbRecomputeNativeZoom();
+            return window._lbNativeZoom > 1;
         }"""
     )
-    page.wait_for_function("window._lbNativeZoom > 1")
 
     page.keyboard.press("z")
     # The /full source is already at the original's resolution, so the 1:1 snap
@@ -827,14 +827,14 @@ def test_browse_lightbox_waits_for_original_before_one_to_one_snap(live_server, 
             return img && img.complete && img.naturalWidth === 1920;
         }"""
     )
-    page.evaluate(
+    page.wait_for_function(
         """() => {
             window._lbPhotoW = 4000;
             window._lbPhotoH = 2000;
             window._lbRecomputeNativeZoom();
+            return window._lbNativeZoom > 1;
         }"""
     )
-    page.wait_for_function("window._lbNativeZoom > 1")
 
     page.keyboard.press("z")
     page.wait_for_function(
@@ -907,14 +907,14 @@ def test_browse_lightbox_resize_preserves_deferred_one_to_one(live_server, page)
             return img && img.complete && img.naturalWidth === 1920;
         }"""
     )
-    page.evaluate(
+    page.wait_for_function(
         """() => {
             window._lbPhotoW = 4000;
             window._lbPhotoH = 2000;
             window._lbRecomputeNativeZoom();
+            return window._lbNativeZoom > 1;
         }"""
     )
-    page.wait_for_function("window._lbNativeZoom > 1")
 
     page.keyboard.press("z")
     page.wait_for_function(


### PR DESCRIPTION
## Summary
- Retry the native zoom recompute inside Playwright waits so lightbox layout readiness races do not leave tests stuck on a stale value.
- Apply the same pattern to the captured original-source wait case and adjacent native zoom tests.

## Validation
- pytest tests/e2e/test_browse_lightbox.py::test_browse_lightbox_waits_for_original_before_one_to_one_snap --browser chromium -q
- pytest tests/e2e/test_browse_lightbox.py::test_browse_lightbox_resize_preserves_deferred_one_to_one --browser chromium -q
- pytest tests/e2e/test_browse_lightbox.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved synchronization and reliability of lightbox testing through refined polling mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->