### PR TITLE
Fix pytest timeout warning config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -188,7 +188,7 @@ jobs:
       # run is a few minutes slower but well under the 60-minute job timeout.
       - name: Run tests with coverage (Linux)
         if: needs.changes.outputs.python == 'true' && runner.os == 'Linux'
-        run: python -m pytest tests/ vireo/tests/ -n 2 -v --tb=short --cov=vireo --cov-report=term-missing --cov-fail-under=40
+        run: python -m pytest tests/ vireo/tests/ -n 2 -v --tb=short --timeout=120 --timeout-method=thread --cov=vireo --cov-report=term-missing --cov-fail-under=40
 
       # macOS/Windows verify platform-specific code paths. The coverage gate is
       # skipped here because POSIX-only tests don't run on Windows, which would
@@ -197,7 +197,7 @@ jobs:
       # worker crashes on the heavier ML tests.
       - name: Run tests (macOS / Windows)
         if: needs.changes.outputs.python == 'true' && runner.os != 'Linux'
-        run: python -m pytest tests/ vireo/tests/ -n 2 -v --tb=short
+        run: python -m pytest tests/ vireo/tests/ -n 2 -v --tb=short --timeout=120 --timeout-method=thread
 
   # Aggregate gate: a single check named ``test`` that branch protection can
   # require, independent of how many OS legs the matrix above runs. A matrix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,8 +63,6 @@ include = ["vireo*"]
 testpaths = ["tests", "vireo/tests"]
 markers = ["e2e: end-to-end browser tests (require Playwright)"]
 addopts = "--ignore=tests/e2e"
-timeout = 120
-timeout_method = "thread"
 
 [tool.ruff]
 target-version = "py311"


### PR DESCRIPTION
Removes pytest-timeout-specific options from the global pytest config so contributors without the plugin do not see unknown-option warnings.
CI still enforces the 120-second timeout by passing pytest-timeout flags on the test commands where the plugin is explicitly installed.
Validated with `python -m pytest tests/test_update_manifest.py -q`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test execution timeout configuration in CI/CD workflow to explicitly define timeout parameters.
  * Removed timeout settings from project configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->