### PR TITLE
Add volumes shortcut to move browser

### DIFF
--- a/vireo/templates/move.html
+++ b/vireo/templates/move.html
@@ -309,6 +309,25 @@ body { padding-bottom: 36px; }
 }
 
 /* Folder browser modal (move-specific, reuses modal base from navbar) */
+.browser-shortcuts {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 8px;
+  flex-wrap: wrap;
+}
+.browser-shortcuts button {
+  padding: 5px 10px;
+  border-radius: 4px;
+  font-size: 12px;
+  cursor: pointer;
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-secondary);
+}
+.browser-shortcuts button:hover {
+  color: var(--text-primary);
+  border-color: var(--accent);
+}
 .browser-breadcrumb {
   font-size: 12px;
   color: var(--text-secondary);
@@ -442,6 +461,11 @@ body { padding-bottom: 36px; }
 <div class="modal-overlay" id="moveBrowserModal" style="z-index:1001;">
   <div class="modal" style="max-width:600px;width:85%;">
     <h3>Select Folder</h3>
+    <div class="browser-shortcuts">
+      <button onclick="browseTo(null)">Home</button>
+      <button onclick="browseTo('__pictures__')">Pictures</button>
+      <button onclick="browseTo('__volumes__')">Volumes</button>
+    </div>
     <div class="browser-breadcrumb" id="moveBrowserBreadcrumb"></div>
     <div id="moveBrowserList" style="height:300px;overflow-y:auto;border:1px solid var(--border-primary);border-radius:4px;margin-bottom:12px;"></div>
     <div class="new-folder-row">
@@ -475,6 +499,7 @@ var selectedPhotos = new Set();
 var lastSelectedIdx = -1;
 var browserTargetInput = null;
 var browserPath = '';
+var browserHomePath = '';
 var confirmCallback = null;
 var editingRuleId = null;
 
@@ -1079,33 +1104,59 @@ function closeBrowser() {
 }
 
 async function browseTo(path) {
-  var url = path ? '/api/browse?path=' + encodeURIComponent(path) : '/api/browse';
+  var url = '/api/browse';
+  if (path === '__pictures__') {
+    url = '/api/browse?path=' + encodeURIComponent((browserHomePath || '') + '/Pictures');
+  } else if (path === '__volumes__') {
+    if (navigator.userAgent.indexOf('Win') >= 0) {
+      try {
+        var volumes = await safeFetch('/api/volumes');
+        browserPath = '';
+        renderBrowserList({path: '', dirs: volumes}, {syntheticRoot: true});
+      } catch (e) {
+        // safeFetch handles error toast
+      }
+      return;
+    }
+    var volDir = navigator.userAgent.indexOf('Mac') >= 0 ? '/Volumes' : '/media';
+    url = '/api/browse?path=' + encodeURIComponent(volDir);
+  } else if (path) {
+    url = '/api/browse?path=' + encodeURIComponent(path);
+  }
   try {
     var data = await safeFetch(url);
     browserPath = data.path;
-
-    document.getElementById('moveBrowserBreadcrumb').textContent = data.path;
-
-    var list = document.getElementById('moveBrowserList');
-    var html = '';
-    var parent = data.path.substring(0, data.path.lastIndexOf('/')) || '/';
-    if (data.path !== '/') {
-      html += '<div class="browser-folder-item" ondblclick="browseTo(\'' + escapeAttr(parent) + '\')">&#128194; ..</div>';
-    }
-    if (data.dirs) {
-      data.dirs.forEach(function(d) {
-        html += '<div class="browser-folder-item" ondblclick="browseTo(\'' + escapeAttr(d.path) + '\')">&#128194; ' + escapeHtml(d.name) + '</div>';
-      });
-    }
-    if (!data.dirs || data.dirs.length === 0) {
-      if (data.path === '/') {
-        html += '<div style="padding:10px;color:var(--text-dim);font-size:13px;">No subdirectories</div>';
-      }
-    }
-    list.innerHTML = html;
+    if (!path) browserHomePath = data.path;
+    renderBrowserList(data);
   } catch (e) {
     // safeFetch handles error toast
   }
+}
+
+function renderBrowserList(data, opts) {
+  document.getElementById('moveBrowserBreadcrumb').textContent = data.path || 'Volumes';
+
+  var list = document.getElementById('moveBrowserList');
+  var html = '';
+  var isSyntheticRoot = opts && opts.syntheticRoot;
+  var parent = '';
+  if (data.path && data.path.indexOf('\\') !== -1) {
+    parent = data.path.replace(/[\\\/]?[^\\\/]+[\\\/]?$/, '') || data.path;
+  } else if (data.path) {
+    parent = data.path.substring(0, data.path.lastIndexOf('/')) || '/';
+  }
+  if (data.path && data.path !== '/' && parent !== data.path) {
+    html += '<div class="browser-folder-item" ondblclick="browseTo(\'' + escapeAttr(parent) + '\')">&#128194; ..</div>';
+  }
+  if (data.dirs) {
+    data.dirs.forEach(function(d) {
+      html += '<div class="browser-folder-item" ondblclick="browseTo(\'' + escapeAttr(d.path) + '\')">&#128194; ' + escapeHtml(d.name) + '</div>';
+    });
+  }
+  if ((!data.dirs || data.dirs.length === 0) && (data.path === '/' || isSyntheticRoot)) {
+    html += '<div style="padding:10px;color:var(--text-dim);font-size:13px;">No subdirectories</div>';
+  }
+  list.innerHTML = html;
 }
 
 function selectBrowserFolder() {

--- a/vireo/templates/move.html
+++ b/vireo/templates/move.html
@@ -1146,11 +1146,11 @@ function renderBrowserList(data, opts) {
     parent = data.path.substring(0, data.path.lastIndexOf('/')) || '/';
   }
   if (data.path && data.path !== '/' && parent !== data.path) {
-    html += '<div class="browser-folder-item" ondblclick="browseTo(\'' + escapeAttr(parent) + '\')">&#128194; ..</div>';
+    html += '<div class="browser-folder-item" data-browse-path="' + escapeAttr(parent) + '">&#128194; ..</div>';
   }
   if (data.dirs) {
     data.dirs.forEach(function(d) {
-      html += '<div class="browser-folder-item" ondblclick="browseTo(\'' + escapeAttr(d.path) + '\')">&#128194; ' + escapeHtml(d.name) + '</div>';
+      html += '<div class="browser-folder-item" data-browse-path="' + escapeAttr(d.path) + '">&#128194; ' + escapeHtml(d.name) + '</div>';
     });
   }
   if ((!data.dirs || data.dirs.length === 0) && (data.path === '/' || isSyntheticRoot)) {
@@ -1213,6 +1213,16 @@ document.addEventListener('DOMContentLoaded', function() {
 
   var photoDest = document.getElementById('photoDestInput');
   if (photoDest) photoDest.addEventListener('input', updatePhotoSelectionUI);
+
+  // Delegated handler so folder paths (which can contain backslashes on
+  // Windows, e.g. C:\) don't have to be JS-escaped into inline handlers.
+  var moveBrowserList = document.getElementById('moveBrowserList');
+  if (moveBrowserList) {
+    moveBrowserList.addEventListener('dblclick', function(e) {
+      var item = e.target.closest('.browser-folder-item[data-browse-path]');
+      if (item) browseTo(item.getAttribute('data-browse-path'));
+    });
+  }
 });
 
 /* ---------- Utility ---------- */

--- a/vireo/templates/move.html
+++ b/vireo/templates/move.html
@@ -500,6 +500,7 @@ var lastSelectedIdx = -1;
 var browserTargetInput = null;
 var browserPath = '';
 var browserHomePath = '';
+var browseSeq = 0;
 var confirmCallback = null;
 var editingRuleId = null;
 
@@ -1104,6 +1105,11 @@ function closeBrowser() {
 }
 
 async function browseTo(path) {
+  // Stamp each browse so a slow initial fetch can't clobber a later
+  // shortcut click. Without this, opening the modal with a prefilled
+  // destination and immediately clicking Pictures/Volumes can leave the
+  // list and browserPath silently reverted to the destination's listing.
+  var seq = ++browseSeq;
   var url = '/api/browse';
   if (path === '__pictures__') {
     // When the modal opens with a prefilled destination we skip the
@@ -1113,6 +1119,7 @@ async function browseTo(path) {
     if (!browserHomePath) {
       try {
         var home = await safeFetch('/api/browse');
+        if (seq !== browseSeq) return;
         browserHomePath = home.path;
       } catch (e) {
         return;
@@ -1120,9 +1127,14 @@ async function browseTo(path) {
     }
     url = '/api/browse?path=' + encodeURIComponent(browserHomePath + '/Pictures');
   } else if (path === '__volumes__') {
-    if (navigator.userAgent.indexOf('Win') >= 0) {
+    // Mac's /Volumes is a real directory the browse endpoint can list.
+    // Windows drive letters and Linux mount roots (/media, /run/media,
+    // /mnt) vary per host, so use /api/volumes — which scans all of
+    // them — and render a synthetic root list.
+    if (navigator.userAgent.indexOf('Mac') < 0) {
       try {
         var volumes = await safeFetch('/api/volumes');
+        if (seq !== browseSeq) return;
         browserPath = '';
         renderBrowserList({path: '', dirs: volumes}, {syntheticRoot: true});
       } catch (e) {
@@ -1130,13 +1142,13 @@ async function browseTo(path) {
       }
       return;
     }
-    var volDir = navigator.userAgent.indexOf('Mac') >= 0 ? '/Volumes' : '/media';
-    url = '/api/browse?path=' + encodeURIComponent(volDir);
+    url = '/api/browse?path=' + encodeURIComponent('/Volumes');
   } else if (path) {
     url = '/api/browse?path=' + encodeURIComponent(path);
   }
   try {
     var data = await safeFetch(url);
+    if (seq !== browseSeq) return;
     browserPath = data.path;
     if (!path) browserHomePath = data.path;
     renderBrowserList(data);

--- a/vireo/templates/move.html
+++ b/vireo/templates/move.html
@@ -1106,7 +1106,19 @@ function closeBrowser() {
 async function browseTo(path) {
   var url = '/api/browse';
   if (path === '__pictures__') {
-    url = '/api/browse?path=' + encodeURIComponent((browserHomePath || '') + '/Pictures');
+    // When the modal opens with a prefilled destination we skip the
+    // browseTo(null) call that would otherwise cache the home path, so
+    // resolve it on demand here. Without this, '/Pictures' is sent as an
+    // absolute path and lands at the wrong root.
+    if (!browserHomePath) {
+      try {
+        var home = await safeFetch('/api/browse');
+        browserHomePath = home.path;
+      } catch (e) {
+        return;
+      }
+    }
+    url = '/api/browse?path=' + encodeURIComponent(browserHomePath + '/Pictures');
   } else if (path === '__volumes__') {
     if (navigator.userAgent.indexOf('Win') >= 0) {
       try {
@@ -1142,6 +1154,10 @@ function renderBrowserList(data, opts) {
   var parent = '';
   if (data.path && data.path.indexOf('\\') !== -1) {
     parent = data.path.replace(/[\\\/]?[^\\\/]+[\\\/]?$/, '') || data.path;
+    // Drive-root edge case: 'C:\Users'.replace(...) yields 'C:', which the
+    // backend treats as the drive's process-local cwd. Restore the trailing
+    // backslash so '..' returns to the drive root instead.
+    if (/^[A-Za-z]:$/.test(parent)) parent += '\\';
   } else if (data.path) {
     parent = data.path.substring(0, data.path.lastIndexOf('/')) || '/';
   }

--- a/vireo/tests/test_move_api.py
+++ b/vireo/tests/test_move_api.py
@@ -11,6 +11,21 @@ def test_move_page_returns_200(app_and_db):
     assert resp.status_code == 200
 
 
+def test_move_page_folder_browser_exposes_volumes_shortcut(app_and_db):
+    """Move destinations should be able to jump directly to mounted volumes."""
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.get("/move")
+    html = resp.data.decode()
+
+    assert "browseTo('__volumes__')" in html
+    assert (
+        "var volDir = navigator.userAgent.indexOf('Mac') >= 0 "
+        "? '/Volumes' : '/media';"
+    ) in html
+    assert "url = '/api/browse?path=' + encodeURIComponent(volDir);" in html
+
+
 def test_move_photos_job_starts(app_and_db, tmp_path):
     """POST /api/jobs/move-photos starts a job."""
     app, db = app_and_db

--- a/vireo/tests/test_move_api.py
+++ b/vireo/tests/test_move_api.py
@@ -12,18 +12,38 @@ def test_move_page_returns_200(app_and_db):
 
 
 def test_move_page_folder_browser_exposes_volumes_shortcut(app_and_db):
-    """Move destinations should be able to jump directly to mounted volumes."""
+    """Move destinations should be able to jump directly to mounted volumes.
+    Mac uses /Volumes (a real directory). Windows + Linux use /api/volumes
+    since mount roots vary per host (drive letters; /media, /run/media,
+    /mnt)."""
     app, _ = app_and_db
     client = app.test_client()
     resp = client.get("/move")
     html = resp.data.decode()
 
     assert "browseTo('__volumes__')" in html
+    # Non-Mac hosts (Windows + Linux) fan through /api/volumes.
+    assert "if (navigator.userAgent.indexOf('Mac') < 0)" in html
+    assert "await safeFetch('/api/volumes')" in html
+    # Mac still goes through /api/browse on /Volumes.
     assert (
-        "var volDir = navigator.userAgent.indexOf('Mac') >= 0 "
-        "? '/Volumes' : '/media';"
+        "url = '/api/browse?path=' + encodeURIComponent('/Volumes');"
     ) in html
-    assert "url = '/api/browse?path=' + encodeURIComponent(volDir);" in html
+
+
+def test_move_page_browser_stamps_requests(app_and_db):
+    """Each browseTo call must stamp a sequence number and drop stale
+    responses. Otherwise a slow initial /api/browse for the prefilled
+    destination can land after a Pictures/Volumes shortcut click and
+    silently revert the list."""
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.get("/move")
+    html = resp.data.decode()
+
+    assert "var browseSeq = 0;" in html
+    assert "var seq = ++browseSeq;" in html
+    assert "if (seq !== browseSeq) return;" in html
 
 
 def test_move_page_pictures_shortcut_resolves_home_on_demand(app_and_db):

--- a/vireo/tests/test_move_api.py
+++ b/vireo/tests/test_move_api.py
@@ -26,6 +26,39 @@ def test_move_page_folder_browser_exposes_volumes_shortcut(app_and_db):
     assert "url = '/api/browse?path=' + encodeURIComponent(volDir);" in html
 
 
+def test_move_page_pictures_shortcut_resolves_home_on_demand(app_and_db):
+    """The Pictures shortcut must resolve the user's home directory before
+    composing the path. Otherwise, opening the modal with a prefilled
+    destination (which skips the initial browseTo(null)) sends an absolute
+    '/Pictures' to the backend and lands at the wrong root."""
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.get("/move")
+    html = resp.data.decode()
+
+    assert "if (path === '__pictures__')" in html
+    # The on-demand home fetch must happen inside the Pictures branch.
+    assert "if (!browserHomePath)" in html
+    assert "await safeFetch('/api/browse')" in html
+    assert (
+        "url = '/api/browse?path=' + encodeURIComponent("
+        "browserHomePath + '/Pictures');"
+    ) in html
+
+
+def test_move_page_windows_parent_preserves_drive_root(app_and_db):
+    """When drilling up from 'C:\\Users', the parent must be 'C:\\', not 'C:'.
+    Without the trailing backslash the backend treats it as the drive's cwd
+    and the '..' link sends users to the wrong place."""
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.get("/move")
+    html = resp.data.decode()
+
+    assert "/^[A-Za-z]:$/.test(parent)" in html
+    assert "parent += '\\\\'" in html
+
+
 def test_move_photos_job_starts(app_and_db, tmp_path):
     """POST /api/jobs/move-photos starts a job."""
     app, db = app_and_db

--- a/vireo/tests/test_pipeline_queue.py
+++ b/vireo/tests/test_pipeline_queue.py
@@ -23,6 +23,15 @@ def _fill_slots(runner, workspace_id=1):
     start. Returns ``(ids, release_event)``; call ``release_event.set()``
     to let them finish. Used by tests that need the next enqueue to
     land in the ``queued`` state.
+
+    The blocker wait carries a generous safety-net timeout so a stuck
+    test still terminates, but it must comfortably outlast worst-case
+    CI scheduling delays. Under ``pytest -n 2`` an xdist worker can be
+    starved of CPU for 20+ seconds while another worker loads ONNX
+    models; a tighter timeout would let slot-fillers exit early,
+    freeing slots and promoting the supposedly-queued pipeline to
+    completion before the test can read its status. pytest-timeout's
+    project-wide cap is 120s, leaving plenty of headroom.
     """
     from jobs import SLOT_CAP
     release = threading.Event()
@@ -32,13 +41,13 @@ def _fill_slots(runner, workspace_id=1):
         evt = started_events[i]
         def work(job, _evt=evt, _release=release):
             _evt.set()
-            _release.wait(timeout=5.0)
+            _release.wait(timeout=60.0)
             return {}
         ids.append(runner.enqueue_pipeline(
             work_fn=work, config={}, workspace_id=workspace_id,
         ))
     for i, evt in enumerate(started_events):
-        assert evt.wait(timeout=2.0), f"slot-filler {i} never started"
+        assert evt.wait(timeout=10.0), f"slot-filler {i} never started"
     return ids, release
 
 


### PR DESCRIPTION
## Summary
- Add Home, Pictures, and Volumes shortcuts to the Move page folder browser so move destinations match the import picker flow.
- Route the Volumes shortcut to /Volumes on macOS, /media on Linux, and the mounted drive list on Windows.
- Add a regression test that the Move page exposes the Volumes shortcut and macOS mapping.

## Tests
- python -m pytest vireo/tests/test_move_api.py vireo/tests/test_app.py::test_templates_jinja_free_except_includes