### PR TITLE
Fix Move Folder preflight feedback

### DIFF
--- a/tests/e2e/test_move_page.py
+++ b/tests/e2e/test_move_page.py
@@ -1,0 +1,44 @@
+import json
+import re
+
+from playwright.sync_api import expect
+
+
+def test_move_folder_button_shows_preflight_progress(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/move")
+
+    held_routes = []
+
+    def hold_preflight(route):
+        held_routes.append(route)
+
+    page.route("**/api/move-folder/preflight", hold_preflight)
+    page.locator("#quickFolderSelect").select_option(index=1)
+    page.locator("#quickDestInput").fill("/tmp/vireo-archive")
+
+    btn = page.locator("#quickMoveBtn")
+    expect(btn).to_be_enabled()
+    btn.click()
+
+    for _ in range(50):
+        if held_routes:
+            break
+        page.wait_for_timeout(100)
+    assert held_routes
+
+    expect(btn).to_be_disabled()
+    expect(btn).to_have_text("Checking...")
+
+    held_routes[0].fulfill(
+        status=200,
+        content_type="application/json",
+        body=json.dumps({
+            "resolved_dest": "/tmp/vireo-archive/park",
+            "exists": False,
+            "file_count": 0,
+            "file_count_truncated": False,
+        }),
+    )
+    expect(page.locator("#confirmModal")).to_have_class(re.compile(r"\bopen\b"))
+    expect(btn).to_have_text("Move Folder")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -13454,13 +13454,29 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         resolved = resolve_folder_dest(folder["path"], folder["name"], destination)
         exists = os.path.isdir(resolved)
         file_count = 0
+        file_count_truncated = False
         if exists:
-            file_count = sum(1 for _, _, files in os.walk(resolved) for _ in files)
+            file_limit = 1000
+            dir_limit = 2000
+            dirs_seen = 0
+            for _, dirs, files in os.walk(resolved):
+                dirs_seen += 1
+                file_count += len(files)
+                if file_count >= file_limit:
+                    file_count = file_limit
+                    file_count_truncated = True
+                    dirs[:] = []
+                    break
+                if dirs_seen >= dir_limit:
+                    file_count_truncated = True
+                    dirs[:] = []
+                    break
 
         return jsonify({
             "resolved_dest": resolved,
             "exists": exists,
             "file_count": file_count,
+            "file_count_truncated": file_count_truncated,
         })
 
     @app.route("/api/jobs/import-full", methods=["POST"])

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -13463,7 +13463,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             dir_limit = 2000
             stack = [resolved]
             dirs_seen = 0
-            while stack:
+            while stack and not file_count_truncated:
                 if file_count >= file_limit or dirs_seen >= dir_limit:
                     file_count_truncated = True
                     break
@@ -13475,6 +13475,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     continue
                 with scanner:
                     for entry in scanner:
+                        # Check the caps inside the inner loop so a single
+                        # directory with a huge number of children cannot
+                        # blow past either limit before we bail out.
+                        if file_count >= file_limit or dirs_seen + len(stack) >= dir_limit:
+                            file_count_truncated = True
+                            break
                         try:
                             is_dir = entry.is_dir(follow_symlinks=False)
                         except OSError:
@@ -13483,9 +13489,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                             stack.append(entry.path)
                         else:
                             file_count += 1
-                            if file_count >= file_limit:
-                                file_count_truncated = True
-                                break
 
         return jsonify({
             "resolved_dest": resolved,

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -13456,21 +13456,36 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         file_count = 0
         file_count_truncated = False
         if exists:
+            # os.scandir yields entries lazily, so we can bail out the moment
+            # the cap is reached without waiting for the OS to enumerate a
+            # directory with millions of files.
             file_limit = 1000
             dir_limit = 2000
+            stack = [resolved]
             dirs_seen = 0
-            for _, dirs, files in os.walk(resolved):
+            while stack:
+                if file_count >= file_limit or dirs_seen >= dir_limit:
+                    file_count_truncated = True
+                    break
+                current = stack.pop()
                 dirs_seen += 1
-                file_count += len(files)
-                if file_count >= file_limit:
-                    file_count = file_limit
-                    file_count_truncated = True
-                    dirs[:] = []
-                    break
-                if dirs_seen >= dir_limit:
-                    file_count_truncated = True
-                    dirs[:] = []
-                    break
+                try:
+                    scanner = os.scandir(current)
+                except OSError:
+                    continue
+                with scanner:
+                    for entry in scanner:
+                        try:
+                            is_dir = entry.is_dir(follow_symlinks=False)
+                        except OSError:
+                            is_dir = False
+                        if is_dir:
+                            stack.append(entry.path)
+                        else:
+                            file_count += 1
+                            if file_count >= file_limit:
+                                file_count_truncated = True
+                                break
 
         return jsonify({
             "resolved_dest": resolved,

--- a/vireo/templates/move.html
+++ b/vireo/templates/move.html
@@ -477,6 +477,7 @@ var browserTargetInput = null;
 var browserPath = '';
 var confirmCallback = null;
 var editingRuleId = null;
+var quickMoveBusy = false;
 
 /* ---------- Init ---------- */
 document.addEventListener('DOMContentLoaded', function() {
@@ -550,8 +551,15 @@ function onQuickFolderChange() {
 function updateQuickMoveBtn() {
   var fid = document.getElementById('quickFolderSelect').value;
   var dest = document.getElementById('quickDestInput').value.trim();
-  document.getElementById('quickMoveBtn').disabled = !(fid && dest);
+  var btn = document.getElementById('quickMoveBtn');
+  btn.disabled = quickMoveBusy || !(fid && dest);
+  btn.textContent = quickMoveBusy ? 'Checking...' : 'Move Folder';
   updateQuickMovePreview();
+}
+
+function setQuickMoveBusy(isBusy) {
+  quickMoveBusy = !!isBusy;
+  updateQuickMoveBtn();
 }
 
 // Compute the final landing path, mirroring move.py move_folder():
@@ -590,6 +598,7 @@ function updateQuickMovePreview() {
 }
 
 async function startQuickMove() {
+  if (quickMoveBusy) return;
   var fid = parseInt(document.getElementById('quickFolderSelect').value);
   var dest = document.getElementById('quickDestInput').value.trim();
   if (!fid || !dest) return;
@@ -601,6 +610,7 @@ async function startQuickMove() {
   // Ask the backend for the resolved destination and whether it already
   // exists, so we can offer merge/resume instead of failing on collision.
   var pf;
+  setQuickMoveBusy(true);
   try {
     pf = await safeFetch('/api/move-folder/preflight', {
       method: 'POST',
@@ -609,14 +619,17 @@ async function startQuickMove() {
     });
   } catch (e) {
     return;  // safeFetch already shows error toast
+  } finally {
+    setQuickMoveBusy(false);
   }
 
   var finalPath = pf.resolved_dest;
   if (pf.exists) {
-    var n = pf.file_count;
+    var n = pf.file_count || 0;
+    var countText = pf.file_count_truncated ? ('at least ' + n) : String(n);
     showConfirm(
       'Destination Exists — Merge & Resume',
-      '"' + finalPath + '" already exists and contains ' + n + ' file' + (n !== 1 ? 's' : '') +
+      '"' + finalPath + '" already exists and contains ' + countText + ' file' + (n !== 1 || pf.file_count_truncated ? 's' : '') +
         '. Merge "' + folderName + '" (' + photoCount + ' photos) into it? Files already present with a matching size are skipped; only missing files are copied. Originals are removed only after every source file is verified at the destination.',
       function() {
         executeQuickMove(fid, dest, true);

--- a/vireo/tests/test_move_api.py
+++ b/vireo/tests/test_move_api.py
@@ -118,7 +118,33 @@ def test_move_folder_preflight_dest_exists(app_and_db, tmp_path):
     data = resp.get_json()
     assert data["exists"] is True
     assert data["file_count"] == 1
+    assert data["file_count_truncated"] is False
     assert data["resolved_dest"] == str(landing)
+
+
+def test_move_folder_preflight_caps_existing_destination_count(app_and_db, tmp_path):
+    """Preflight should not recursively count an unbounded destination tree."""
+    app, db = app_and_db
+    dst = tmp_path / "dest"
+    dst.mkdir()
+
+    folder = db.get_folder_tree()[0]
+    folder_name = folder["name"] or os.path.basename(folder["path"].rstrip("/\\"))
+    landing = dst / folder_name
+    landing.mkdir()
+    for idx in range(1001):
+        (landing / f"already-{idx}.jpg").write_bytes(b"x")
+
+    client = app.test_client()
+    resp = client.post("/api/move-folder/preflight", json={
+        "folder_id": folder["id"],
+        "destination": str(dst),
+    })
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["exists"] is True
+    assert data["file_count"] == 1000
+    assert data["file_count_truncated"] is True
 
 
 def test_move_folder_preflight_requires_params(app_and_db):

--- a/vireo/tests/test_move_api.py
+++ b/vireo/tests/test_move_api.py
@@ -147,6 +147,33 @@ def test_move_folder_preflight_caps_existing_destination_count(app_and_db, tmp_p
     assert data["file_count_truncated"] is True
 
 
+def test_move_folder_preflight_caps_existing_destination_dir_fanout(app_and_db, tmp_path):
+    """A flat fanout of subdirectories must trip the dir cap mid-scan, not after enumerating all of them."""
+    app, db = app_and_db
+    dst = tmp_path / "dest"
+    dst.mkdir()
+
+    folder = db.get_folder_tree()[0]
+    folder_name = folder["name"] or os.path.basename(folder["path"].rstrip("/\\"))
+    landing = dst / folder_name
+    landing.mkdir()
+    # No files at all; just a large flat set of subdirectories. The cap is 2000,
+    # so 2500 children must not all be queued before truncation is reported.
+    for idx in range(2500):
+        (landing / f"sub-{idx:04d}").mkdir()
+
+    client = app.test_client()
+    resp = client.post("/api/move-folder/preflight", json={
+        "folder_id": folder["id"],
+        "destination": str(dst),
+    })
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["exists"] is True
+    assert data["file_count"] == 0
+    assert data["file_count_truncated"] is True
+
+
 def test_move_folder_preflight_requires_params(app_and_db):
     """Preflight without folder_id returns 400."""
     app, _ = app_and_db

--- a/vireo/tests/test_pipeline_queue.py
+++ b/vireo/tests/test_pipeline_queue.py
@@ -23,6 +23,16 @@ def _fill_slots(runner, workspace_id=1):
     start. Returns ``(ids, release_event)``; call ``release_event.set()``
     to let them finish. Used by tests that need the next enqueue to
     land in the ``queued`` state.
+
+    The blocker work_fn's release-wait timeout is generous (60s) so the
+    slot stays occupied even when CI scheduling jitter (xdist ``-n 2``
+    with thousands of tests, OOM-prone runners) delays the surrounding
+    test work by several seconds. With a tight timeout the blocker
+    returns, the slot opens, and a queued test job auto-promotes from
+    ``queued`` to ``running`` before the assertion runs — surfacing as
+    an intermittent ``'running' == 'queued'`` failure unrelated to the
+    behavior under test. Tests are still expected to call
+    ``release.set()`` promptly; this timeout is only the safety net.
     """
     from jobs import SLOT_CAP
     release = threading.Event()
@@ -32,7 +42,7 @@ def _fill_slots(runner, workspace_id=1):
         evt = started_events[i]
         def work(job, _evt=evt, _release=release):
             _evt.set()
-            _release.wait(timeout=5.0)
+            _release.wait(timeout=60.0)
             return {}
         ids.append(runner.enqueue_pipeline(
             work_fn=work, config={}, workspace_id=workspace_id,


### PR DESCRIPTION
Fixes Move Folder feeling unresponsive by capping the existing-destination preflight scan and returning a truncated-count flag for large trees. Adds a visible Checking... disabled state while preflight runs, then restores the button before showing the move confirmation. Adds Flask and Playwright regression coverage for the capped preflight response and pending-button state. Validated with `pytest vireo/tests/test_move_api.py -q`, `pytest tests/e2e/test_move_page.py -q`, and `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * "Quick Move" button now displays "Checking..." status and becomes disabled while validating the move operation, preventing duplicate submissions.

* **Improvements**
  * Enhanced performance for move operations on large directories through optimized directory traversal.
  * Confirmation dialog now indicates when file counts are approximate, displaying "at least N files" for truncated counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->