### PR TITLE
Move: show destination state live in the folder-move form

### DIFF
--- a/vireo/templates/move.html
+++ b/vireo/templates/move.html
@@ -292,6 +292,10 @@ body { padding-bottom: 36px; }
   color: var(--text-secondary);
   font-family: var(--font-mono, monospace);
 }
+.dest-status {
+  margin-top: 4px;
+  line-height: 1.4;
+}
 
 /* Empty state */
 .empty-state {
@@ -608,11 +612,78 @@ function updateQuickMovePreview() {
   }
   var folder = allFolders.find(function(f) { return f.id === fid; });
   var finalPath = resolvedMoveDest(folder, dest);
-  preview.textContent = 'Folder will be moved to: ';
+
+  // The resolved path is computable client-side, so show it instantly.
+  preview.textContent = '';
+  var pathLine = document.createElement('div');
+  pathLine.textContent = 'Folder will be moved to: ';
   var pathSpan = document.createElement('span');
   pathSpan.className = 'dest-preview-path';
   pathSpan.textContent = finalPath;
-  preview.appendChild(pathSpan);
+  pathLine.appendChild(pathSpan);
+  preview.appendChild(pathLine);
+
+  // Whether the destination already exists (and how much is in it) requires
+  // hitting the filesystem, so fetch it from the preflight endpoint and fill
+  // in this line asynchronously. Debounced so typing a path doesn't spam it.
+  var status = document.createElement('div');
+  status.id = 'quickDestStatus';
+  status.className = 'dest-status';
+  preview.appendChild(status);
+  scheduleQuickPreflight(fid, dest);
+}
+
+var quickPreflightSeq = 0;
+var quickPreflightTimer = null;
+
+function scheduleQuickPreflight(fid, dest) {
+  if (quickPreflightTimer) clearTimeout(quickPreflightTimer);
+  // The preflight route rejects non-absolute paths, so wait until the input
+  // looks absolute (POSIX '/...' or Windows 'C:\...') before asking.
+  var isAbs = dest.charAt(0) === '/' || /^[A-Za-z]:[\\\/]/.test(dest);
+  if (!isAbs) return;
+  quickPreflightTimer = setTimeout(function() { runQuickPreflight(fid, dest); }, 350);
+}
+
+async function runQuickPreflight(fid, dest) {
+  var seq = ++quickPreflightSeq;
+  var status = document.getElementById('quickDestStatus');
+  if (status) {
+    status.textContent = 'Checking destination…';
+    status.style.color = 'var(--text-dim)';
+  }
+  // Plain fetch (not safeFetch): this fires while the user types, so a
+  // transient failure must stay silent rather than raising an error toast.
+  var data;
+  try {
+    var resp = await fetch('/api/move-folder/preflight', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({folder_id: fid, destination: dest}),
+    });
+    if (!resp.ok) { if (seq === quickPreflightSeq) clearQuickDestStatus(); return; }
+    data = await resp.json();
+  } catch (e) {
+    if (seq === quickPreflightSeq) clearQuickDestStatus();
+    return;
+  }
+  if (seq !== quickPreflightSeq) return;  // a newer keystroke superseded us
+  status = document.getElementById('quickDestStatus');
+  if (!status) return;
+  if (data.exists) {
+    var n = data.file_count;
+    status.textContent = '⚠ Destination already exists — contains ' + n + ' file' +
+      (n !== 1 ? 's' : '') + '. Existing files with a matching size are skipped; only missing files are copied.';
+    status.style.color = 'var(--warning)';
+  } else {
+    status.textContent = '✓ New folder — nothing exists at this location yet.';
+    status.style.color = 'var(--text-dim)';
+  }
+}
+
+function clearQuickDestStatus() {
+  var status = document.getElementById('quickDestStatus');
+  if (status) status.textContent = '';
 }
 
 async function startQuickMove() {

--- a/vireo/templates/move.html
+++ b/vireo/templates/move.html
@@ -638,15 +638,21 @@ var quickPreflightTimer = null;
 
 function scheduleQuickPreflight(fid, dest) {
   if (quickPreflightTimer) clearTimeout(quickPreflightTimer);
+  // Bump the sequence on *every* call, not just when a request starts. Any
+  // change to the destination must immediately invalidate an in-flight
+  // response for the previous value — otherwise a response landing during the
+  // 350ms debounce window, or when the new value is non-absolute (so no new
+  // request is scheduled), would still pass the seq guard and write stale
+  // exists/new-folder text for the wrong destination.
+  var seq = ++quickPreflightSeq;
   // The preflight route rejects non-absolute paths, so wait until the input
   // looks absolute (POSIX '/...' or Windows 'C:\...') before asking.
   var isAbs = dest.charAt(0) === '/' || /^[A-Za-z]:[\\\/]/.test(dest);
   if (!isAbs) return;
-  quickPreflightTimer = setTimeout(function() { runQuickPreflight(fid, dest); }, 350);
+  quickPreflightTimer = setTimeout(function() { runQuickPreflight(fid, dest, seq); }, 350);
 }
 
-async function runQuickPreflight(fid, dest) {
-  var seq = ++quickPreflightSeq;
+async function runQuickPreflight(fid, dest, seq) {
   var status = document.getElementById('quickDestStatus');
   if (status) {
     status.textContent = 'Checking destination…';

--- a/vireo/templates/move.html
+++ b/vireo/templates/move.html
@@ -646,8 +646,10 @@ function scheduleQuickPreflight(fid, dest) {
   // exists/new-folder text for the wrong destination.
   var seq = ++quickPreflightSeq;
   // The preflight route rejects non-absolute paths, so wait until the input
-  // looks absolute (POSIX '/...' or Windows 'C:\...') before asking.
-  var isAbs = dest.charAt(0) === '/' || /^[A-Za-z]:[\\\/]/.test(dest);
+  // looks absolute before asking. Accept POSIX '/...', Windows drive paths
+  // ('C:\...'), and Windows UNC paths ('\\server\share') — all of which
+  // os.path.isabs() treats as absolute on their respective backends.
+  var isAbs = dest.charAt(0) === '/' || /^[A-Za-z]:[\\\/]/.test(dest) || /^\\\\/.test(dest);
   if (!isAbs) return;
   quickPreflightTimer = setTimeout(function() { runQuickPreflight(fid, dest, seq); }, 350);
 }


### PR DESCRIPTION
## What

The **Move Entire Folder** form now tells you, *while you're choosing a destination*, whether that destination already exists and how much is in it — instead of only revealing it in the confirmation dialog after you click Move.

As soon as a destination path looks absolute, the form (debounced 350ms) calls the existing `/api/move-folder/preflight` endpoint and shows one of:

- ⚠ *Destination already exists — contains N files. Existing files with a matching size are skipped; only missing files are copied.*
- ✓ *New folder — nothing exists at this location yet.*

This is the small, no-backend-change version of the idea: the preflight endpoint already computed `exists` / `file_count`; it just wasn't surfaced until commit time.

## Why "files", not "photos"

`preflight` counts every file recursively (`os.walk` — RAW files **and** XMP sidecars, etc.), so the label says "files" to match what the number actually is. Saying "photos" would not reconcile with the folder's photo count, which `CORE_PHILOSOPHY.md`'s no-black-boxes rule forbids.

## Implementation notes

- Plain `fetch` (not `safeFetch`) so a transient failure mid-typing stays silent rather than raising an error toast.
- Sequence guard so a slow response can't overwrite a newer keystroke's result.
- The resolved-path line still renders instantly (client-side); only the exists/count line is async.
- The confirmation dialog still re-runs preflight at submit time — it remains the authoritative check.

## Testing

- `python -m pytest vireo/tests/test_move_api.py vireo/tests/test_app.py -q` → **257 passed**
- Verified the `/api/move-folder/preflight` response contract against a running instance — both branches: `{"exists":false,...}` for a missing dest and `{"exists":true,"file_count":2,...}` for a dest containing a `.jpg` + `.xmp` (confirming the count includes sidecars).

🤖 Generated with [Claude Code](https://claude.com/claude-code)