### PR TITLE
Stream Move Folder job progress with named phases

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -13396,15 +13396,27 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
             job["_start_time"] = time.time()
 
-            def progress_cb(current, total, filename):
+            last_phase = {"value": None}
+
+            def progress_cb(current, total, filename, phase="Moving folder"):
                 job["progress"]["current"] = current
                 job["progress"]["total"] = total
                 job["progress"]["current_file"] = filename
+                job["progress"]["phase"] = phase
+                # The copy phase fires once per file; on a large folder that
+                # would flood the SSE stream and tie up Flask threads. Throttle
+                # to every 10th file, but always emit on a phase change and on
+                # the first/last file so the panel never looks stalled.
+                phase_changed = phase != last_phase["value"]
+                last_phase["value"] = phase
+                if not phase_changed and current % 10 != 0 \
+                        and current not in (1, total):
+                    return
                 runner.push_event(job["id"], "progress", {
                     "current": current,
                     "total": total,
                     "current_file": filename,
-                    "phase": "Moving folder",
+                    "phase": phase,
                 })
 
             return move_folder(

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -13399,10 +13399,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             last_phase = {"value": None}
 
             def progress_cb(current, total, filename, phase="Moving folder"):
+                # Only update keys JobRunner pre-seeds in job["progress"]
+                # (current/total/current_file). Do NOT insert "phase" here:
+                # this runs on the worker thread outside the runner lock, and
+                # adding a new key races _snapshot_job's locked dict() copy
+                # ("dictionary changed size during iteration"). push_event
+                # below mirrors phase onto job["progress"] under the lock.
                 job["progress"]["current"] = current
                 job["progress"]["total"] = total
                 job["progress"]["current_file"] = filename
-                job["progress"]["phase"] = phase
                 # The copy phase fires once per file; on a large folder that
                 # would flood the SSE stream and tie up Flask threads. Throttle
                 # to every 10th file, but always emit on a phase change and on

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -94,10 +94,20 @@ def _copy_tree_with_progress(src_path, dest_path, skip_existing, total_files,
                 continue
             os.symlink(os.readlink(src_sub), dst_sub)
         for fn in files:
+            src_file = os.path.join(root, fn)
             dst_file = os.path.join(target_dir, fn)
-            if skip_existing and os.path.exists(dst_file):
+            # lexists (not exists): a broken or symlinked destination entry
+            # still counts as present for a merge, so we never dereference it
+            # and write through to its target. exists() returns False for a
+            # broken symlink and would fall through to copy2 below.
+            if skip_existing and os.path.lexists(dst_file):
                 continue
-            shutil.copy2(os.path.join(root, fn), dst_file)
+            if os.path.islink(src_file):
+                # Preserve the symlink rather than copy2's dereferenced target,
+                # matching rsync -a and the directory-symlink handling above.
+                os.symlink(os.readlink(src_file), dst_file)
+            else:
+                shutil.copy2(src_file, dst_file)
             copied += 1
             if progress_cb:
                 progress_cb(copied, total_files, fn, "Copying files")
@@ -759,9 +769,9 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
              "Merging" if dest_exists else "Moving", src_path, dest_path)
 
     # Count source files up front so the copy phase reports against a real
-    # denominator from the first file, and so the fresh-move verification
-    # below can reuse the count (rsync never mutates the source) instead of
-    # walking the tree a second time.
+    # denominator from the first file. This count is the progress denominator
+    # only — the fresh-move verification below deliberately recounts the
+    # source at verify time rather than trusting this pre-copy number.
     total_files = sum(1 for _, _, files in os.walk(src_path) for _ in files)
     if progress_cb:
         progress_cb(0, total_files, "", "Copying files")

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+import threading
 
 log = logging.getLogger(__name__)
 
@@ -51,18 +52,71 @@ def resolve_folder_dest(folder_path, folder_name, destination):
     return os.path.join(destination, name)
 
 
-def _copy_missing(src_path, dest_path):
-    """Recursively copy only files that don't already exist at dest_path,
-    never overwriting an existing destination file. shutil fallback for a
-    merge when rsync is unavailable; mirrors rsync --ignore-existing."""
+def _copy_tree_with_progress(src_path, dest_path, skip_existing, total_files,
+                             progress_cb):
+    """Recursively copy src_path into dest_path, reporting each file copied.
+
+    ``skip_existing`` mirrors rsync ``--ignore-existing`` (merge/resume): a
+    destination file that already exists is never overwritten. Used only as
+    the shutil fallback when rsync is unavailable, so a fresh move (creating
+    dest_path) and a merge share one progress-emitting walk.
+    """
+    copied = 0
     for root, _, files in os.walk(src_path):
         rel = os.path.relpath(root, src_path)
         target_dir = dest_path if rel == "." else os.path.join(dest_path, rel)
         os.makedirs(target_dir, exist_ok=True)
         for fn in files:
             dst_file = os.path.join(target_dir, fn)
-            if not os.path.exists(dst_file):
-                shutil.copy2(os.path.join(root, fn), dst_file)
+            if skip_existing and os.path.exists(dst_file):
+                continue
+            shutil.copy2(os.path.join(root, fn), dst_file)
+            copied += 1
+            if progress_cb:
+                progress_cb(copied, total_files, fn, "Copying files")
+
+
+def _run_rsync_streamed(src_path, dest_path, rsync_flag, total_files,
+                        progress_cb, timeout=3600):
+    """Run rsync, reporting each transferred file through progress_cb.
+
+    rsync's ``--out-format=%n`` prints the relative name of every item it
+    transfers (directories end in ``/``). Streaming that line-by-line lets
+    the move job show live per-file progress instead of a frozen bar while a
+    large copy runs, without changing rsync's copy semantics.
+
+    Returns ``(returncode, stderr, timed_out)``. ``timed_out`` is True when
+    the copy ran past ``timeout`` and rsync was killed — the same safety net
+    the previous ``subprocess.run(timeout=...)`` provided, preserved here
+    because a streamed Popen can't pass ``timeout`` to the read loop.
+    """
+    proc = subprocess.Popen(
+        ["rsync", "-a", "--out-format=%n", rsync_flag,
+         src_path + "/", dest_path + "/"],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+    )
+    state = {"timed_out": False}
+
+    def _kill():
+        state["timed_out"] = True
+        proc.kill()
+
+    killer = threading.Timer(timeout, _kill)
+    killer.start()
+    copied = 0
+    try:
+        for line in proc.stdout:
+            name = line.rstrip("\n")
+            if not name or name.endswith("/"):
+                continue  # directory entry, not a file
+            copied += 1
+            if progress_cb:
+                progress_cb(copied, total_files, os.path.basename(name),
+                            "Copying files")
+        proc.wait()
+    finally:
+        killer.cancel()
+    return proc.returncode, proc.stderr.read(), state["timed_out"]
 
 
 def _find_content_conflict(src_path, dest_path):
@@ -585,6 +639,12 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
     folder_name = folder["name"] or os.path.basename(src_path)
     dest_path = resolve_folder_dest(src_path, folder["name"], destination)
 
+    # Validation (overlap, tracked-folder, and the per-file content-conflict
+    # scan a merge runs) can take a noticeable moment on a large tree, so name
+    # the phase before it starts rather than leaving the bar blank.
+    if progress_cb:
+        progress_cb(0, 0, "", "Checking destination")
+
     # Refuse a destination that overlaps the source. Moving a folder into
     # itself (or into one of its own descendants) would make the post-copy
     # rmtree(src) delete the only copy of the files. This is especially
@@ -644,6 +704,14 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
     log.info("%s folder %s -> %s",
              "Merging" if dest_exists else "Moving", src_path, dest_path)
 
+    # Count source files up front so the copy phase reports against a real
+    # denominator from the first file, and so the fresh-move verification
+    # below can reuse the count (rsync never mutates the source) instead of
+    # walking the tree a second time.
+    total_files = sum(1 for _, _, files in os.walk(src_path) for _ in files)
+    if progress_cb:
+        progress_cb(0, total_files, "", "Copying files")
+
     # Use rsync for a robust copy. A merge/resume uses --ignore-existing so
     # rsync only creates files absent at the destination and NEVER overwrites
     # a file already there: this resumes an interrupted move (missing files get
@@ -654,29 +722,30 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
     # post-copy verification below, which then refuses to delete the originals.
     rsync_flag = "--ignore-existing" if dest_exists else "--checksum"
     try:
-        result = subprocess.run(
-            ["rsync", "-a", rsync_flag, src_path + "/", dest_path + "/"],
-            capture_output=True, text=True, timeout=3600,
+        returncode, stderr, timed_out = _run_rsync_streamed(
+            src_path, dest_path, rsync_flag, total_files, progress_cb,
         )
-        if result.returncode != 0:
-            return {"moved": 0, "errors": [f"rsync failed: {result.stderr.strip()}"]}
+        if timed_out:
+            return {"moved": 0, "errors": ["rsync timed out after 1 hour"]}
+        if returncode != 0:
+            return {"moved": 0, "errors": [f"rsync failed: {stderr.strip()}"]}
     except FileNotFoundError:
-        # rsync not available, fall back to shutil
+        # rsync not available, fall back to shutil. skip_existing mirrors
+        # --ignore-existing for a merge; a fresh move copies everything.
         try:
-            if dest_exists:
-                _copy_missing(src_path, dest_path)  # never overwrites
-            else:
-                shutil.copytree(src_path, dest_path)
+            _copy_tree_with_progress(
+                src_path, dest_path, dest_exists, total_files, progress_cb,
+            )
         except Exception as exc:
             # Only remove a destination we created — never one that
             # pre-existed (a merge target may hold the user's own files).
             if not dest_exists:
                 shutil.rmtree(dest_path, ignore_errors=True)
             return {"moved": 0, "errors": [f"Copy failed: {exc}"]}
-    except subprocess.TimeoutExpired:
-        return {"moved": 0, "errors": ["rsync timed out after 1 hour"]}
 
     # Verify before deleting originals.
+    if progress_cb:
+        progress_cb(total_files, total_files, "", "Verifying copy")
     if dest_exists:
         # Merge: the destination may legitimately hold extra unrelated
         # files (and leftover temp files from an interrupted run), so a
@@ -690,8 +759,9 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
             ]}
     else:
         # Fresh move into a destination we created: a whole-tree file
-        # count is a cheap, sufficient integrity check.
-        src_count = sum(1 for _, _, files in os.walk(src_path) for _ in files)
+        # count is a cheap, sufficient integrity check. Reuse the source
+        # count taken before the copy — rsync never mutates the source.
+        src_count = total_files
         dst_count = sum(1 for _, _, files in os.walk(dest_path) for _ in files)
         if src_count != dst_count:
             shutil.rmtree(dest_path, ignore_errors=True)
@@ -713,6 +783,8 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
     # paths). A merge into an already-tracked destination is refused above, so
     # dest_path is never a different existing folder row here and this cascade
     # (root + all descendants) cannot collide with folders.path UNIQUE.
+    if progress_cb:
+        progress_cb(total_files, total_files, "", "Updating catalog")
     db.move_folder_path(folder_id, dest_path)
     db.update_folder_counts()
 
@@ -743,10 +815,12 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
             relocate_developed_dir(developed_dir, old_child, new_child)
 
     # Delete originals
+    if progress_cb:
+        progress_cb(total_files, total_files, "", "Removing originals")
     log.info("Verification passed, deleting originals: %s", src_path)
     shutil.rmtree(src_path)
 
     if progress_cb:
-        progress_cb(total_photos, total_photos, folder_name)
+        progress_cb(total_files, total_files, folder_name, "Done")
 
     return {"moved": total_photos, "errors": []}

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -61,8 +61,17 @@ def _copy_tree_with_progress(src_path, dest_path, skip_existing, total_files,
     the shutil fallback when rsync is unavailable, so a fresh move (creating
     dest_path) and a merge share one progress-emitting walk.
     """
+    # os.walk swallows scandir errors by default, so an unreadable source
+    # subdirectory would be silently skipped here — and the fresh-move count
+    # verification (also a default os.walk) would skip it too, so the counts
+    # match and the catalog update + rmtree(src) proceed on an incomplete
+    # copy. shutil.copytree (the old fallback) raised instead; re-raise so the
+    # caller aborts the move before anything is deleted.
+    def _raise(err):
+        raise err
+
     copied = 0
-    for root, dirs, files in os.walk(src_path):
+    for root, dirs, files in os.walk(src_path, onerror=_raise):
         rel = os.path.relpath(root, src_path)
         target_dir = dest_path if rel == "." else os.path.join(dest_path, rel)
         os.makedirs(target_dir, exist_ok=True)

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -103,6 +103,20 @@ def _run_rsync_streamed(src_path, dest_path, rsync_flag, total_files,
 
     killer = threading.Timer(timeout, _kill)
     killer.start()
+
+    # Drain stderr on a separate thread. rsync can emit a lot of stderr (e.g.
+    # many permission-denied or "file vanished" notices); if that fills the
+    # pipe buffer while this thread is blocked reading stdout, rsync blocks on
+    # the stderr write and neither side progresses — a deadlock that would
+    # only break when the 1-hour timer kills the job. Reading both streams
+    # concurrently keeps the error surfacing promptly, matching the old
+    # subprocess.run(capture_output=True) behavior.
+    stderr_chunks = []
+    stderr_thread = threading.Thread(
+        target=lambda: stderr_chunks.append(proc.stderr.read())
+    )
+    stderr_thread.start()
+
     copied = 0
     try:
         for line in proc.stdout:
@@ -116,7 +130,8 @@ def _run_rsync_streamed(src_path, dest_path, rsync_flag, total_files,
         proc.wait()
     finally:
         killer.cancel()
-    return proc.returncode, proc.stderr.read(), state["timed_out"]
+    stderr_thread.join()
+    return proc.returncode, "".join(stderr_chunks), state["timed_out"]
 
 
 def _find_content_conflict(src_path, dest_path):
@@ -759,9 +774,13 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
             ]}
     else:
         # Fresh move into a destination we created: a whole-tree file
-        # count is a cheap, sufficient integrity check. Reuse the source
-        # count taken before the copy — rsync never mutates the source.
-        src_count = total_files
+        # count is a cheap, sufficient integrity check. Recount the source
+        # here rather than reusing the pre-copy `total_files` — if a file
+        # appeared in the source after that upfront count (and rsync didn't
+        # pick it up), a stale count could spuriously match `dst_count` and
+        # the rmtree below would delete the never-copied file. The fresh
+        # walk catches that mismatch and preserves the originals.
+        src_count = sum(1 for _, _, files in os.walk(src_path) for _ in files)
         dst_count = sum(1 for _, _, files in os.walk(dest_path) for _ in files)
         if src_count != dst_count:
             shutil.rmtree(dest_path, ignore_errors=True)

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -62,10 +62,26 @@ def _copy_tree_with_progress(src_path, dest_path, skip_existing, total_files,
     dest_path) and a merge share one progress-emitting walk.
     """
     copied = 0
-    for root, _, files in os.walk(src_path):
+    for root, dirs, files in os.walk(src_path):
         rel = os.path.relpath(root, src_path)
         target_dir = dest_path if rel == "." else os.path.join(dest_path, rel)
         os.makedirs(target_dir, exist_ok=True)
+        # os.walk lists a symlinked subdirectory in `dirs` but, with its
+        # default followlinks=False, never recurses into it — so its contents
+        # would be silently dropped here while the post-copy file-count
+        # verification (also a default os.walk) skips it on both sides and
+        # still matches, letting rmtree(src) delete the originals. Recreate
+        # each directory symlink as a symlink at the destination, matching the
+        # primary rsync -a path (which preserves symlinks rather than
+        # following them) and keeping the verification counts consistent.
+        for d in dirs:
+            src_sub = os.path.join(root, d)
+            if not os.path.islink(src_sub):
+                continue
+            dst_sub = os.path.join(target_dir, d)
+            if skip_existing and os.path.lexists(dst_sub):
+                continue
+            os.symlink(os.readlink(src_sub), dst_sub)
         for fn in files:
             dst_file = os.path.join(target_dir, fn)
             if skip_existing and os.path.exists(dst_file):

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -71,10 +71,12 @@ def _copy_tree_with_progress(src_path, dest_path, skip_existing, total_files,
         raise err
 
     copied = 0
+    created_dirs = []
     for root, dirs, files in os.walk(src_path, onerror=_raise):
         rel = os.path.relpath(root, src_path)
         target_dir = dest_path if rel == "." else os.path.join(dest_path, rel)
         os.makedirs(target_dir, exist_ok=True)
+        created_dirs.append((root, target_dir))
         # os.walk lists a symlinked subdirectory in `dirs` but, with its
         # default followlinks=False, never recurses into it — so its contents
         # would be silently dropped here while the post-copy file-count
@@ -99,6 +101,18 @@ def _copy_tree_with_progress(src_path, dest_path, skip_existing, total_files,
             copied += 1
             if progress_cb:
                 progress_cb(copied, total_files, fn, "Copying files")
+
+    # Mirror directory metadata (mode, mtime) for a fresh move, matching the
+    # primary rsync -a path and the shutil.copytree this fallback replaced.
+    # os.makedirs creates dirs with default permissions, so without this a
+    # private 0700 source folder would land as 0755 and the original metadata
+    # is lost once the source is deleted. copy2 above already preserves file
+    # metadata. Run after all contents exist so child writes don't re-bump a
+    # parent's mtime. Skipped on a merge: a pre-existing destination dir keeps
+    # the user's own metadata rather than being overwritten with the source's.
+    if not skip_existing:
+        for src_dir, target_dir in created_dirs:
+            shutil.copystat(src_dir, target_dir)
 
 
 def _run_rsync_streamed(src_path, dest_path, rsync_flag, total_files,

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -1458,3 +1458,39 @@ def test_move_folder_progress_shutil_fallback(move_env, monkeypatch):
     copy_calls = [c for c in calls if c[3] == "Copying files" and c[0] > 0]
     assert copy_calls, "shutil fallback reported no per-file progress"
     assert copy_calls[-1][1] == 3  # same 3-file denominator
+
+
+def test_move_folder_shutil_fallback_preserves_dir_symlink(move_env, monkeypatch):
+    """The shutil fallback (rsync unavailable) must not silently drop a
+    symlinked subdirectory. os.walk doesn't recurse into one, so without
+    explicit handling its contents would never reach the destination yet the
+    count verification would still pass and delete the originals. The symlink
+    must be recreated at the destination, matching rsync -a."""
+    import move as move_mod
+
+    env = move_env
+    # A symlinked subdirectory inside the source pointing at an external dir.
+    external = env["tmp_path"] / "external"
+    external.mkdir()
+    (external / "target.txt").write_text("payload")
+    try:
+        os.symlink(str(external), str(env["src"] / "linkdir"))
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported on this platform")
+
+    monkeypatch.setattr(move_mod.subprocess, "Popen",
+                        lambda *a, **k: (_ for _ in ()).throw(
+                            FileNotFoundError("rsync")))
+
+    result = move_mod.move_folder(
+        db=env["db"], folder_id=env["fid_src"], destination=str(env["dst"])
+    )
+    assert result["errors"] == []
+    landing = env["dst"] / "src"
+    link = landing / "linkdir"
+    # The symlink is preserved as a symlink, still resolving to the payload.
+    assert link.is_symlink()
+    assert (link / "target.txt").read_text() == "payload"
+    # External target untouched; source removed after a verified copy.
+    assert (external / "target.txt").exists()
+    assert not env["src"].exists()

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -1590,7 +1590,9 @@ def test_move_folder_shutil_fallback_preserves_file_symlink(move_env, monkeypatc
     assert result["errors"] == []
     dest_link = env["dst"] / "src" / "alias.txt"
     assert dest_link.is_symlink()
-    assert os.readlink(str(dest_link)) == str(external)
+    # samefile compares by inode/device, so it tolerates the `\\?\` extended-length
+    # prefix Windows stamps onto absolute symlink targets returned by os.readlink.
+    assert os.path.samefile(str(dest_link), str(external))
     # External target untouched; source removed after a verified copy.
     assert external.read_text() == "external payload"
     assert not env["src"].exists()

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -1565,6 +1565,37 @@ def test_move_folder_shutil_fallback_preserves_dir_mode(move_env, monkeypatch):
     assert not env["src"].exists()
 
 
+def test_move_folder_shutil_fallback_preserves_file_symlink(move_env, monkeypatch):
+    """The shutil fallback must preserve a symlinked file as a symlink rather
+    than dereferencing it through copy2 (matching rsync -a). Dereferencing
+    would silently replace the link with its target's bytes and could write
+    through a symlinked destination entry."""
+    import move as move_mod
+
+    env = move_env
+    external = env["tmp_path"] / "ext_target.txt"
+    external.write_text("external payload")
+    try:
+        os.symlink(str(external), str(env["src"] / "alias.txt"))
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported on this platform")
+
+    monkeypatch.setattr(move_mod.subprocess, "Popen",
+                        lambda *a, **k: (_ for _ in ()).throw(
+                            FileNotFoundError("rsync")))
+
+    result = move_mod.move_folder(
+        db=env["db"], folder_id=env["fid_src"], destination=str(env["dst"])
+    )
+    assert result["errors"] == []
+    dest_link = env["dst"] / "src" / "alias.txt"
+    assert dest_link.is_symlink()
+    assert os.readlink(str(dest_link)) == str(external)
+    # External target untouched; source removed after a verified copy.
+    assert external.read_text() == "external payload"
+    assert not env["src"].exists()
+
+
 def test_move_folder_fresh_move_detects_late_source_file(move_env, monkeypatch):
     """A file added to the source after the upfront file count but before
     verification — a concurrent writer race rsync's scan missed — must be

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -1535,6 +1535,36 @@ def test_move_folder_shutil_fallback_aborts_on_unreadable_subdir(move_env, monke
     assert (env["src"] / "bird1.jpg").exists()
 
 
+def test_move_folder_shutil_fallback_preserves_dir_mode(move_env, monkeypatch):
+    """The shutil fallback must preserve directory permissions on a fresh
+    move (matching rsync -a / the old copytree). os.makedirs alone would
+    drop a private 0700 folder down to the umask default before the source
+    is deleted, permanently losing the metadata."""
+    import move as move_mod
+
+    if os.name == "nt":
+        pytest.skip("POSIX directory modes not meaningful on Windows")
+
+    env = move_env
+    sub = env["src"] / "private"
+    sub.mkdir()
+    (sub / "secret.jpg").write_bytes(b"\xff\xd8" + b"\x00" * 20)
+    os.chmod(str(sub), 0o700)
+
+    monkeypatch.setattr(move_mod.subprocess, "Popen",
+                        lambda *a, **k: (_ for _ in ()).throw(
+                            FileNotFoundError("rsync")))
+
+    result = move_mod.move_folder(
+        db=env["db"], folder_id=env["fid_src"], destination=str(env["dst"])
+    )
+    assert result["errors"] == []
+    dest_sub = env["dst"] / "src" / "private"
+    assert dest_sub.is_dir()
+    assert (os.stat(str(dest_sub)).st_mode & 0o777) == 0o700
+    assert not env["src"].exists()
+
+
 def test_move_folder_fresh_move_detects_late_source_file(move_env, monkeypatch):
     """A file added to the source after the upfront file count but before
     verification — a concurrent writer race rsync's scan missed — must be

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -1496,6 +1496,45 @@ def test_move_folder_shutil_fallback_preserves_dir_symlink(move_env, monkeypatch
     assert not env["src"].exists()
 
 
+def test_move_folder_shutil_fallback_aborts_on_unreadable_subdir(move_env, monkeypatch):
+    """If the shutil fallback can't read a source subdirectory, it must abort
+    the move rather than silently skip the subtree. The count verification
+    would otherwise also skip it (same default walk), match, and delete the
+    originals leaving the destination incomplete."""
+    import move as move_mod
+
+    env = move_env
+    sub = env["src"] / "sub"
+    sub.mkdir()
+    (sub / "nest.jpg").write_bytes(b"\xff\xd8" + b"\x00" * 30)
+
+    monkeypatch.setattr(move_mod.subprocess, "Popen",
+                        lambda *a, **k: (_ for _ in ()).throw(
+                            FileNotFoundError("rsync")))
+
+    # Force os.walk to surface a scandir error for the subdirectory, as it
+    # would on a permission failure (default os.walk swallows this).
+    real_walk = move_mod.os.walk
+
+    def _walk_with_error(path, *a, **k):
+        onerror = k.get("onerror")
+        for root, dirs, files in real_walk(path, *a, **k):
+            if onerror is not None and os.path.basename(root) == "sub":
+                onerror(OSError(13, "Permission denied", str(sub)))
+            yield root, dirs, files
+
+    monkeypatch.setattr(move_mod.os, "walk", _walk_with_error)
+
+    result = move_mod.move_folder(
+        db=env["db"], folder_id=env["fid_src"], destination=str(env["dst"])
+    )
+    # Move aborted, originals preserved.
+    assert result["moved"] == 0
+    assert any("Copy failed" in e for e in result["errors"])
+    assert env["src"].exists()
+    assert (env["src"] / "bird1.jpg").exists()
+
+
 def test_move_folder_fresh_move_detects_late_source_file(move_env, monkeypatch):
     """A file added to the source after the upfront file count but before
     verification — a concurrent writer race rsync's scan missed — must be

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -1239,8 +1239,8 @@ def test_move_folder_merge_verify_fail_preserves_originals_and_dest(move_env, mo
     sentinel.write_text("pre-existing")
 
     # Force the copy step to be a no-op so a source file is "missing" at dest.
-    monkeypatch.setattr(move_mod.subprocess, "run",
-                        lambda *a, **k: type("R", (), {"returncode": 0, "stderr": ""})())
+    monkeypatch.setattr(move_mod, "_run_rsync_streamed",
+                        lambda *a, **k: (0, "", False))
 
     result = move_mod.move_folder(
         db=env["db"], folder_id=env["fid_src"], destination=str(env["dst"]), merge=True
@@ -1275,8 +1275,8 @@ def test_move_folder_merge_rejects_symlinked_dest_file(move_env, monkeypatch):
 
     # Force rsync to no-op (it would normally honor --ignore-existing and
     # leave the symlink anyway; this just removes the dependency on rsync).
-    monkeypatch.setattr(move_mod.subprocess, "run",
-                        lambda *a, **k: type("R", (), {"returncode": 0, "stderr": ""})())
+    monkeypatch.setattr(move_mod, "_run_rsync_streamed",
+                        lambda *a, **k: (0, "", False))
 
     result = move_mod.move_folder(
         db=env["db"], folder_id=env["fid_src"], destination=str(env["dst"]), merge=True
@@ -1314,8 +1314,8 @@ def test_move_folder_merge_rejects_symlinked_dest_subdir(move_env, monkeypatch):
     except (OSError, NotImplementedError):
         pytest.skip("symlinks not supported on this platform")
 
-    monkeypatch.setattr(move_mod.subprocess, "run",
-                        lambda *a, **k: type("R", (), {"returncode": 0, "stderr": ""})())
+    monkeypatch.setattr(move_mod, "_run_rsync_streamed",
+                        lambda *a, **k: (0, "", False))
 
     result = move_mod.move_folder(
         db=env["db"], folder_id=env["fid_src"], destination=str(env["dst"]), merge=True
@@ -1343,8 +1343,8 @@ def test_move_folder_merge_rejects_broken_symlink(move_env, monkeypatch):
     except (OSError, NotImplementedError):
         pytest.skip("symlinks not supported on this platform")
 
-    monkeypatch.setattr(move_mod.subprocess, "run",
-                        lambda *a, **k: type("R", (), {"returncode": 0, "stderr": ""})())
+    monkeypatch.setattr(move_mod, "_run_rsync_streamed",
+                        lambda *a, **k: (0, "", False))
 
     result = move_mod.move_folder(
         db=env["db"], folder_id=env["fid_src"], destination=str(env["dst"]), merge=True
@@ -1397,3 +1397,64 @@ def test_move_photos_progress_callback(move_env):
     assert calls[0][0] == 1  # current=1
     assert calls[1][0] == 2  # current=2
     assert calls[0][1] == 2  # total=2
+
+
+def test_move_folder_reports_phases_and_per_file_progress(move_env):
+    """move_folder streams the move through named phases and reports each
+    file as it is copied, instead of one progress call at the end."""
+    from move import move_folder
+
+    env = move_env
+    calls = []
+    result = move_folder(
+        db=env["db"],
+        folder_id=env["fid_src"],
+        destination=str(env["dst"]),
+        progress_cb=lambda cur, tot, fn, phase: calls.append(
+            (cur, tot, fn, phase)
+        ),
+    )
+    assert result["errors"] == []
+    phases = [c[3] for c in calls]
+    # The move walks through these phases in order.
+    for expected in ("Checking destination", "Copying files",
+                     "Verifying copy", "Updating catalog",
+                     "Removing originals", "Done"):
+        assert expected in phases, f"missing phase {expected!r} in {phases}"
+
+    # The copy phase reports a real denominator (3 files: 2 jpgs + 1 xmp)
+    # and at least one per-file update naming the file being copied.
+    copy_calls = [c for c in calls if c[3] == "Copying files"]
+    assert copy_calls, "no copy-phase progress reported"
+    total = copy_calls[-1][1]
+    assert total == 3
+    named = [c for c in copy_calls if c[0] > 0 and c[2]]
+    assert named, "no per-file progress during copy"
+    assert all(c[1] == total for c in copy_calls)
+
+
+def test_move_folder_progress_shutil_fallback(move_env, monkeypatch):
+    """When rsync is unavailable, the shutil fallback still reports per-file
+    copy progress through the same phase contract."""
+    import move as move_mod
+
+    def _no_rsync(*a, **k):
+        raise FileNotFoundError("rsync")
+
+    monkeypatch.setattr(move_mod.subprocess, "Popen", _no_rsync)
+
+    env = move_env
+    calls = []
+    result = move_mod.move_folder(
+        db=env["db"],
+        folder_id=env["fid_src"],
+        destination=str(env["dst"]),
+        progress_cb=lambda cur, tot, fn, phase: calls.append(
+            (cur, tot, fn, phase)
+        ),
+    )
+    assert result["errors"] == []
+    assert (env["dst"] / "src" / "bird1.jpg").exists()
+    copy_calls = [c for c in calls if c[3] == "Copying files" and c[0] > 0]
+    assert copy_calls, "shutil fallback reported no per-file progress"
+    assert copy_calls[-1][1] == 3  # same 3-file denominator

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -1494,3 +1494,50 @@ def test_move_folder_shutil_fallback_preserves_dir_symlink(move_env, monkeypatch
     # External target untouched; source removed after a verified copy.
     assert (external / "target.txt").exists()
     assert not env["src"].exists()
+
+
+def test_move_folder_fresh_move_detects_late_source_file(move_env, monkeypatch):
+    """A file added to the source after the upfront file count but before
+    verification — a concurrent writer race rsync's scan missed — must be
+    detected before `shutil.rmtree(src_path)` would silently delete it.
+
+    Trusting the upfront `total_files` as the source count makes this
+    silently incorrect: src now holds total_files+1 files, rsync copied
+    only total_files of them, dst_count equals total_files, and a stale
+    count compare passes — then rmtree wipes the new source file.
+    Verification must re-examine the source against the destination
+    instead of reusing the pre-copy count."""
+    import shutil as _shutil
+
+    import move as move_mod
+
+    env = move_env
+    landing = env["dst"] / "src"
+    assert not landing.exists()  # fresh move (no merge path)
+
+    def _copy_then_inject(src_path, dest_path, *args, **kwargs):
+        # Stand in for rsync: copy the tree as it looked when scanning began,
+        # then simulate a concurrent writer adding a new file to the source
+        # before verification runs.
+        _shutil.copytree(src_path, dest_path)
+        (env["src"] / "late_arrival.jpg").write_bytes(b"new content")
+        return 0, "", False
+
+    monkeypatch.setattr(move_mod, "_run_rsync_streamed", _copy_then_inject)
+
+    result = move_mod.move_folder(
+        db=env["db"], folder_id=env["fid_src"], destination=str(env["dst"]),
+    )
+    # The move must abort — assert the safety property (originals survive,
+    # late arrival is not silently deleted) without coupling to the exact
+    # error wording. A count-mismatch fix surfaces this differently from a
+    # per-source-file presence check; both are valid signals.
+    assert result["moved"] == 0
+    assert result["errors"], "expected an error explaining why verification failed"
+    assert (env["src"] / "late_arrival.jpg").exists(), \
+        "the late source file was silently deleted"
+    assert (env["src"] / "late_arrival.jpg").read_bytes() == b"new content"
+    # The pre-existing source files must also still be present — a fresh
+    # move that aborts at verification preserves originals.
+    assert (env["src"] / "bird1.jpg").exists()
+    assert (env["src"] / "bird2.jpg").exists()


### PR DESCRIPTION
## What & why

The **Move Folder** job gave no detail about the move. `move_folder` ran `rsync` as a single blocking `subprocess.run` and called `progress_cb` exactly once — at the very end. So the bottom-panel job showed a frozen bar with no phase, no file count, and no current file, then jumped straight to done. For a large or network-backed folder this looks stalled the whole time.

This streams the move so the user can see what's happening, per `CORE_PHILOSOPHY.md` ("Show the user what's happening / No black boxes").

## Changes

- **`move.py`** — `move_folder` now reports through ordered phases: `Checking destination` → `Copying files` → `Verifying copy` → `Updating catalog` → `Removing originals` → `Done`.
  - The copy step runs rsync via a streamed `Popen` with `--out-format=%n` (`_run_rsync_streamed`), reporting **each transferred file** against a real source-file denominator counted up front. A `threading.Timer` preserves the previous 1-hour timeout safety net.
  - The shutil fallback (rsync unavailable) reports the same per-file progress via a shared `_copy_tree_with_progress` helper (replaces the old `_copy_missing`).
  - The fresh-move verification reuses the up-front file count instead of re-walking the source.
- **`app.py`** — the move-folder progress callback forwards the `phase` and throttles per-file copy events (every 10th file, always on phase change and first/last) so a large folder doesn't flood the SSE stream and exhaust Flask threads.

Copy semantics are unchanged: `--ignore-existing` for merge/resume, `--checksum` for a fresh move, post-copy verification before deleting originals.

## Tests

- Existing rsync-no-op monkeypatches updated to patch `_run_rsync_streamed` (the no-op-copy intent is now expressed directly).
- Added: phase-sequence + per-file progress coverage, and a shutil-fallback progress test.
- Verified live with real openrsync: phases fire in order, nested files report by basename, move completes correctly.
- Full required suite: **1178 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Folder moves now show clearer progress phases and more detailed file-by-file progress updates.

* **Bug Fixes**
  * Improved folder move reliability when `rsync` is unavailable by using a built-in fallback.
  * Preserved symlinked subfolders during moves.
  * Prevented moves from completing if a source folder can’t be read, avoiding accidental data loss.
  * Better handles files that appear during a move by failing verification and keeping originals intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->