### PR TITLE
Record failed folder moves as failed, not completed

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -13424,7 +13424,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     "phase": phase,
                 })
 
-            return move_folder(
+            result = move_folder(
                 db=thread_db,
                 folder_id=folder_id,
                 destination=destination,
@@ -13432,6 +13432,27 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 developed_dir=developed_dir,
                 merge=merge,
             )
+
+            # Tell the JobRunner whether the move actually succeeded. Without
+            # this the runner marks any normal return "completed" — so a move
+            # that copied nothing because rsync timed out used to read as
+            # "completed, 0 errors" in the history. A `needs_merge` return is
+            # NOT a failure: it's a soft signal that the destination already
+            # exists and the UI should re-prompt for a merge/resume, so leave
+            # it for the caller without flagging the job failed.
+            if not result.get("needs_merge"):
+                errors = result.get("errors") or []
+                moved = result.get("moved", 0)
+                if errors and moved == 0:
+                    result["ok"] = False
+                    result["summary"] = f"Move failed — {errors[0]}"
+                else:
+                    result["ok"] = True
+                    result["summary"] = (
+                        f"Moved {moved} photo{'s' if moved != 1 else ''}"
+                        + (f", {len(errors)} error(s)" if errors else "")
+                    )
+            return result
 
         job_id = runner.start(
             "move-folder", work,

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -457,7 +457,27 @@ class JobRunner:
                     self._cancelled.discard(job_id)
                 else:
                     job["status"] = "completed"
+                    # A work function can return normally yet still have
+                    # failed (e.g. move-folder returns {"moved": 0, "errors":
+                    # [...]} when rsync times out). When the result opts into
+                    # the convention by carrying an "ok" key, honor it: fold
+                    # its errors into the job's tally so error_count is
+                    # accurate, and demote a falsy "ok" to "failed" so the
+                    # history doesn't read "completed, 0 errors" for a run
+                    # that accomplished nothing.
+                    if isinstance(result, dict) and "ok" in result:
+                        for err in (result.get("errors") or []):
+                            err_str = str(err)
+                            if err_str not in job["errors"]:
+                                job["errors"].append(err_str)
+                        if result["ok"] is False:
+                            job["status"] = "failed"
                 job["result"] = result
+            if job["status"] == "failed":
+                log.warning(
+                    "Job %s reported failure via result: %s",
+                    job["id"], "; ".join(job["errors"]) or "(no detail)",
+                )
         except Exception as e:
             # Cancellation takes precedence over failure: if the user cancelled
             # while the work function was raising (e.g. a stage crash happened

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -20,6 +20,14 @@ log = logging.getLogger(__name__)
 # rsync is silent during its initial file-list build and the destination scan
 # a merge (--ignore-existing) performs, which over a slow SMB share can take
 # several minutes before the first file transfers.
+#
+# Known limitation: progress is detected per FILE (rsync emits one
+# --out-format=%n line per item, not continuous byte progress), so a single
+# file whose transfer exceeds this window over a very slow link could be
+# killed mid-flight. That can't happen for Vireo's data — source files are RAW
+# frames (tens of MB; ~12s/file even on the slow SMB share this was built for),
+# orders of magnitude under the window — so it's accepted rather than paying
+# the complexity of char-level --info=progress2 byte-progress parsing.
 RSYNC_STALL_TIMEOUT = 1800  # 30 minutes
 
 

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -188,8 +188,15 @@ def _run_rsync_streamed(src_path, dest_path, rsync_flag, total_files,
     stderr_chunks = []
 
     def _drain_stderr():
-        for chunk in iter(lambda: proc.stderr.read(4096), ""):
-            stderr_chunks.append(chunk)
+        # Iterate line-by-line rather than read(4096): a fixed-size read on a
+        # buffered text stream blocks until the buffer fills or EOF, so sparse
+        # rsync diagnostics ("file vanished", permission notices) wouldn't
+        # refresh last_activity until 4096 chars had accumulated — long enough
+        # that the watchdog could kill a transfer that's still emitting
+        # stderr. Line iteration yields each message as it's flushed, so every
+        # stderr emission counts as liveness.
+        for line in proc.stderr:
+            stderr_chunks.append(line)
             last_activity["t"] = time.monotonic()
 
     stderr_thread = threading.Thread(target=_drain_stderr)

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -8,8 +8,19 @@ import shutil
 import subprocess
 import tempfile
 import threading
+import time
 
 log = logging.getLogger(__name__)
+
+# How long rsync may make NO forward progress (no file transferred and no
+# stderr activity) before we treat it as wedged and kill it. This is a STALL
+# watchdog, not a total-runtime cap: a healthy copy of thousands of RAW files
+# over a slow network share can legitimately run for many hours, and it is
+# allowed to as long as it keeps moving data. The window is generous because
+# rsync is silent during its initial file-list build and the destination scan
+# a merge (--ignore-existing) performs, which over a slow SMB share can take
+# several minutes before the first file transfers.
+RSYNC_STALL_TIMEOUT = 1800  # 30 minutes
 
 
 def _xmp_path(filepath):
@@ -126,7 +137,7 @@ def _copy_tree_with_progress(src_path, dest_path, skip_existing, total_files,
 
 
 def _run_rsync_streamed(src_path, dest_path, rsync_flag, total_files,
-                        progress_cb, timeout=3600):
+                        progress_cb, stall_timeout=RSYNC_STALL_TIMEOUT):
     """Run rsync, reporting each transferred file through progress_cb.
 
     rsync's ``--out-format=%n`` prints the relative name of every item it
@@ -135,9 +146,13 @@ def _run_rsync_streamed(src_path, dest_path, rsync_flag, total_files,
     large copy runs, without changing rsync's copy semantics.
 
     Returns ``(returncode, stderr, timed_out)``. ``timed_out`` is True when
-    the copy ran past ``timeout`` and rsync was killed — the same safety net
-    the previous ``subprocess.run(timeout=...)`` provided, preserved here
-    because a streamed Popen can't pass ``timeout`` to the read loop.
+    rsync made no forward progress for ``stall_timeout`` seconds and was
+    killed. This is a STALL watchdog rather than a total-runtime cap: a
+    healthy but slow transfer (e.g. thousands of RAW files over a network
+    share) runs for as long as it keeps moving data, while a genuinely wedged
+    rsync — which the job's cancel path can't reach, since it never sees the
+    subprocess — still gets reaped. The clock resets on every transferred
+    file and on stderr activity, so only true silence trips it.
     """
     proc = subprocess.Popen(
         ["rsync", "-a", "--out-format=%n", rsync_flag,
@@ -145,31 +160,46 @@ def _run_rsync_streamed(src_path, dest_path, rsync_flag, total_files,
         stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
     )
     state = {"timed_out": False}
+    # Last time rsync showed any sign of life (process start counts, so the
+    # silent file-list/scan phase before the first transfer isn't a stall).
+    last_activity = {"t": time.monotonic()}
+    done = threading.Event()
 
-    def _kill():
-        state["timed_out"] = True
-        proc.kill()
+    def _watchdog():
+        # Poll well below stall_timeout so a stall is detected promptly once
+        # the window elapses, without busy-waiting.
+        while not done.wait(min(stall_timeout, 30)):
+            if time.monotonic() - last_activity["t"] > stall_timeout:
+                state["timed_out"] = True
+                proc.kill()
+                return
 
-    killer = threading.Timer(timeout, _kill)
-    killer.start()
+    watchdog = threading.Thread(target=_watchdog, daemon=True)
+    watchdog.start()
 
     # Drain stderr on a separate thread. rsync can emit a lot of stderr (e.g.
     # many permission-denied or "file vanished" notices); if that fills the
     # pipe buffer while this thread is blocked reading stdout, rsync blocks on
-    # the stderr write and neither side progresses — a deadlock that would
-    # only break when the 1-hour timer kills the job. Reading both streams
+    # the stderr write and neither side progresses — a deadlock that the stall
+    # watchdog would only break after stall_timeout. Reading both streams
     # concurrently keeps the error surfacing promptly, matching the old
-    # subprocess.run(capture_output=True) behavior.
+    # subprocess.run(capture_output=True) behavior. Reading stderr is also a
+    # liveness signal, so it resets the stall clock too.
     stderr_chunks = []
-    stderr_thread = threading.Thread(
-        target=lambda: stderr_chunks.append(proc.stderr.read())
-    )
+
+    def _drain_stderr():
+        for chunk in iter(lambda: proc.stderr.read(4096), ""):
+            stderr_chunks.append(chunk)
+            last_activity["t"] = time.monotonic()
+
+    stderr_thread = threading.Thread(target=_drain_stderr)
     stderr_thread.start()
 
     copied = 0
     try:
         for line in proc.stdout:
             name = line.rstrip("\n")
+            last_activity["t"] = time.monotonic()
             if not name or name.endswith("/"):
                 continue  # directory entry, not a file
             copied += 1
@@ -178,8 +208,9 @@ def _run_rsync_streamed(src_path, dest_path, rsync_flag, total_files,
                             "Copying files")
         proc.wait()
     finally:
-        killer.cancel()
+        done.set()
     stderr_thread.join()
+    watchdog.join()
     return proc.returncode, "".join(stderr_chunks), state["timed_out"]
 
 
@@ -790,7 +821,12 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
             src_path, dest_path, rsync_flag, total_files, progress_cb,
         )
         if timed_out:
-            return {"moved": 0, "errors": ["rsync timed out after 1 hour"]}
+            mins = RSYNC_STALL_TIMEOUT // 60
+            return {"moved": 0, "errors": [
+                f"rsync stalled — no progress for over {mins} minutes, so the "
+                f"copy was stopped. Originals are untouched; re-run with "
+                f"merge/resume to continue from where it left off."
+            ]}
         if returncode != 0:
             return {"moved": 0, "errors": [f"rsync failed: {stderr.strip()}"]}
     except FileNotFoundError:

--- a/vireo/tests/test_jobs.py
+++ b/vireo/tests/test_jobs.py
@@ -101,6 +101,99 @@ def test_job_runner_still_records_novel_exception_text():
     assert "orchestrator failure: unexpected state" in job['errors']
 
 
+def test_job_result_ok_false_marks_failed(tmp_path):
+    """A work function that returns normally but signals failure via
+    {"ok": False, "errors": [...]} must be recorded as 'failed', not
+    'completed' — and its result errors must be folded into error_count.
+
+    This is the move-folder case: rsync times out, move_folder returns
+    {"moved": 0, "errors": [...]} (no exception), and the run used to read
+    as "completed, 0 errors" in history.
+    """
+    from jobs import JobRunner
+
+    runner = JobRunner()
+
+    def work(job):
+        return {"moved": 0, "errors": ["rsync timed out"], "ok": False}
+
+    job_id = runner.start('move-folder', work)
+
+    job = wait_for_job_via_runner(runner, job_id)
+    assert job['status'] == 'failed'
+    assert "rsync timed out" in job['errors']
+
+
+def test_job_result_ok_true_with_warnings_stays_completed(tmp_path):
+    """A work function returning {"ok": True, "errors": [...]} represents a
+    partial success: the job completes, but the result errors are still
+    folded into the job's error tally so the count is honest."""
+    from jobs import JobRunner
+
+    runner = JobRunner()
+
+    def work(job):
+        return {"moved": 5, "errors": ["one file skipped"], "ok": True}
+
+    job_id = runner.start('move-folder', work)
+
+    job = wait_for_job_via_runner(runner, job_id)
+    assert job['status'] == 'completed'
+    assert "one file skipped" in job['errors']
+
+
+def test_job_result_without_ok_key_unaffected(tmp_path):
+    """The ok/errors folding is opt-in: a result dict with no "ok" key keeps
+    today's behavior (completed, runner-level error list untouched)."""
+    from jobs import JobRunner
+
+    runner = JobRunner()
+
+    def work(job):
+        return {"moved": 0, "errors": ["informational note"]}
+
+    job_id = runner.start('test', work)
+
+    job = wait_for_job_via_runner(runner, job_id)
+    assert job['status'] == 'completed'
+    assert job['errors'] == []
+
+
+def test_job_result_ok_false_persists_failed_with_error_count(tmp_path):
+    """End-to-end: an ok=False result is persisted to job_history with
+    status='failed' and error_count reflecting the result errors."""
+    from db import Database
+    from jobs import JobRunner
+
+    db = Database(str(tmp_path / "test.db"))
+    runner = JobRunner(db=db)
+
+    def work(job):
+        return {
+            "moved": 0,
+            "errors": ["rsync timed out", "renameat: Operation timed out"],
+            "ok": False,
+            "summary": "Move failed — rsync timed out",
+        }
+
+    job_id = runner.start('move-folder', work)
+
+    row = None
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        row = db.conn.execute(
+            "SELECT status, error_count, summary FROM job_history WHERE id = ?",
+            (job_id,),
+        ).fetchone()
+        if row is not None:
+            break
+        time.sleep(0.05)
+    assert row is not None
+    assert row["status"] == "failed"
+    assert row["error_count"] == 2, f"expected error_count=2, got {row['error_count']}"
+    assert row["summary"] == "Move failed — rsync timed out"
+
+
 def test_failed_job_history_preserves_structured_result(tmp_path):
     """When a work function stashes a structured result on job['result']
     before raising, _persist_job must preserve that structure in history

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -3,6 +3,8 @@
 import os
 import sys
 import tempfile
+import threading
+import time
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
@@ -1643,3 +1645,113 @@ def test_move_folder_fresh_move_detects_late_source_file(move_env, monkeypatch):
     # move that aborts at verification preserves originals.
     assert (env["src"] / "bird1.jpg").exists()
     assert (env["src"] / "bird2.jpg").exists()
+
+
+class _FakeStderr:
+    """rsync stderr that's empty: the first read returns "" so the drain
+    loop (iter(read, "")) stops immediately."""
+
+    def read(self, _n=-1):
+        return ""
+
+
+class _SilentStdout:
+    """stdout that never yields a line and blocks until the process is
+    killed — simulates a wedged rsync producing no progress."""
+
+    def __init__(self, killed):
+        self._killed = killed
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        # Block until the watchdog kills the process, then end the stream.
+        self._killed.wait(timeout=5)
+        raise StopIteration
+
+
+class _StreamingStdout:
+    """stdout that emits ``n`` file lines with a small gap between each, then
+    ends — simulates a slow-but-progressing transfer."""
+
+    def __init__(self, n, gap):
+        self._remaining = n
+        self._gap = gap
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self._remaining <= 0:
+            raise StopIteration
+        time.sleep(self._gap)
+        self._remaining -= 1
+        return f"DSC_{self._remaining}.NEF\n"
+
+
+class _FakeProc:
+    def __init__(self, stdout, returncode=0):
+        self.killed = threading.Event()
+        self.stdout = stdout
+        self.stderr = _FakeStderr()
+        self.returncode = returncode
+
+    def kill(self):
+        self.returncode = -9
+        self.killed.set()
+
+    def wait(self):
+        # The streamed read loop only reaches wait() after stdout iteration
+        # has ended, so the fake "process" is already done — return at once.
+        return self.returncode
+
+
+def test_rsync_stall_watchdog_kills_silent_process(monkeypatch):
+    """A rsync that produces no output for longer than the stall window is
+    treated as wedged and killed, with timed_out=True — even though no
+    total-runtime cap was hit."""
+    import move as move_mod
+
+    proc_holder = {}
+
+    def _fake_popen(*_a, **_k):
+        proc = _FakeProc.__new__(_FakeProc)
+        proc.killed = threading.Event()
+        proc.stdout = _SilentStdout(proc.killed)
+        proc.stderr = _FakeStderr()
+        proc.returncode = 0
+        proc_holder["proc"] = proc
+        return proc
+
+    monkeypatch.setattr(move_mod.subprocess, "Popen", _fake_popen)
+
+    rc, stderr, timed_out = move_mod._run_rsync_streamed(
+        "/src", "/dst", "--checksum", 10, None, stall_timeout=0.3,
+    )
+    assert timed_out is True
+    assert proc_holder["proc"].killed.is_set()
+
+
+def test_rsync_streamed_runs_as_long_as_it_progresses(monkeypatch):
+    """A slow transfer that keeps emitting files past the stall window is NOT
+    killed: each transferred file resets the stall clock, so a copy can run
+    far longer than stall_timeout as long as it keeps moving data."""
+    import move as move_mod
+
+    def _fake_popen(*_a, **_k):
+        # 8 files, one every 0.1s = 0.8s total — well past the 0.3s stall
+        # window, but never idle for 0.3s, so the watchdog must not fire.
+        return _FakeProc(_StreamingStdout(n=8, gap=0.1))
+
+    monkeypatch.setattr(move_mod.subprocess, "Popen", _fake_popen)
+
+    seen = []
+    rc, stderr, timed_out = move_mod._run_rsync_streamed(
+        "/src", "/dst", "--ignore-existing", 8,
+        lambda cur, tot, name, phase: seen.append(name),
+        stall_timeout=0.3,
+    )
+    assert timed_out is False
+    assert rc == 0
+    assert len(seen) == 8  # progress reported for every transferred file

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -1648,11 +1648,11 @@ def test_move_folder_fresh_move_detects_late_source_file(move_env, monkeypatch):
 
 
 class _FakeStderr:
-    """rsync stderr that's empty: the first read returns "" so the drain
-    loop (iter(read, "")) stops immediately."""
+    """rsync stderr that's empty: iterating it yields no lines, so the drain
+    loop (for line in proc.stderr) ends immediately."""
 
-    def read(self, _n=-1):
-        return ""
+    def __iter__(self):
+        return iter(())
 
 
 class _SilentStdout:

--- a/vireo/tests/test_move_api.py
+++ b/vireo/tests/test_move_api.py
@@ -128,6 +128,48 @@ def test_move_folder_job_starts(app_and_db, tmp_path):
     assert data["job_id"].startswith("move-folder-")
 
 
+def test_move_folder_failed_move_recorded_as_failed(app_and_db, tmp_path):
+    """A move that copies nothing (here: a destination that overlaps the
+    source, so move_folder returns {"moved": 0, "errors": [...]} without
+    raising) must be recorded in history as 'failed', not 'completed' — and
+    error_count must reflect the failure. Regression for move jobs that read
+    "completed, 0 errors" despite moving nothing.
+    """
+    import sys
+
+    sys.path.insert(0, os.path.dirname(__file__))
+    from wait import wait_for_job_via_client
+
+    app, db = app_and_db
+
+    # Real on-disk source folder so move_folder's overlap check runs.
+    src = tmp_path / "src_folder"
+    src.mkdir()
+    (src / "a.jpg").write_bytes(b"data")
+    fid = db.add_folder(str(src), name="src_folder")
+
+    client = app.test_client()
+    # destination == source ⇒ resolved dest nests inside the source ⇒ overlap
+    # ⇒ deterministic failure with moved=0 and no needs_merge.
+    resp = client.post("/api/jobs/move-folder", json={
+        "folder_id": fid,
+        "destination": str(src),
+    })
+    assert resp.status_code == 200
+    job_id = resp.get_json()["job_id"]
+
+    job = wait_for_job_via_client(client, job_id, wait_for_history=True)
+    assert job["status"] == "failed", job
+    # The source must be untouched — a failed move never deletes originals.
+    assert (src / "a.jpg").exists()
+
+    row = db.conn.execute(
+        "SELECT status, error_count FROM job_history WHERE id = ?", (job_id,)
+    ).fetchone()
+    assert row["status"] == "failed"
+    assert row["error_count"] >= 1
+
+
 def test_move_folder_merge_param_accepted(app_and_db, tmp_path):
     """POST /api/jobs/move-folder accepts merge=true and starts a job."""
     app, db = app_and_db

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -2007,6 +2007,7 @@ def _setup_fake_downloaded_model(tmp_path, monkeypatch):
     import classify_job
     import model_verify
     import models
+    import taxonomy
     monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
     monkeypatch.setattr(models, "DEFAULT_MODELS_DIR", str(tmp_path / "models"))
     _write_fake_model_files(tmp_path / "models" / "bioclip-vit-b-16")
@@ -2017,6 +2018,14 @@ def _setup_fake_downloaded_model(tmp_path, monkeypatch):
     monkeypatch.setattr(
         classify_job, "_load_labels", lambda *a, **k: (["test-label"], False)
     )
+    # model_loader_stage triggers a real iNat DWCA download whenever
+    # params.download_taxonomy is True (the default) and no taxonomy file is
+    # available — which is always the case in the test's isolated HOME. That
+    # download is hundreds of MB and can exceed the per-test timeout on
+    # slower CI runners, surfacing as an opaque "worker crashed" failure.
+    # Stub it to a no-op; tests that exercise the real download path
+    # re-monkeypatch this after calling the helper.
+    monkeypatch.setattr(taxonomy, "download_taxonomy", lambda *a, **k: None)
     # Short-circuit hash verification — these tests use stub files that
     # would never match any real HF hash, and the verification path has
     # its own dedicated unit tests.
@@ -2032,6 +2041,7 @@ def _setup_two_fake_downloaded_models(tmp_path, monkeypatch):
     """Install two bioclip models side-by-side; both reported as downloaded."""
     import classify_job
     import models
+    import taxonomy
     monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
     monkeypatch.setattr(models, "DEFAULT_MODELS_DIR", str(tmp_path / "models"))
     _write_fake_model_files(tmp_path / "models" / "bioclip-vit-b-16")
@@ -2044,6 +2054,8 @@ def _setup_two_fake_downloaded_models(tmp_path, monkeypatch):
     monkeypatch.setattr(
         classify_job, "_load_labels", lambda *a, **k: (["test-label"], False)
     )
+    # See _setup_fake_downloaded_model for why this stub is required.
+    monkeypatch.setattr(taxonomy, "download_taxonomy", lambda *a, **k: None)
     return ["bioclip-vit-b-16", "bioclip-2"]
 
 
@@ -2450,19 +2462,22 @@ def test_pipeline_redownloads_taxonomy_when_existing_file_is_corrupt(
     )
     monkeypatch.setattr(taxonomy_mod, "load_local_taxonomy", lambda: None)
 
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    col_id = db.add_collection("Test", "[]")
+
+    # Helper installs a no-op download_taxonomy stub; override it AFTER the
+    # helper so this test's recording stub wins. Order matters: the helper's
+    # monkeypatch.setattr would clobber an earlier override.
+    _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
     download_calls = []
 
     def fake_download(output_path, progress_callback=None):
         download_calls.append(output_path)
 
     monkeypatch.setattr(taxonomy_mod, "download_taxonomy", fake_download)
-
-    db_path = str(tmp_path / "test.db")
-    db = Database(db_path)
-    ws_id = db._active_workspace_id
-    col_id = db.add_collection("Test", "[]")
-
-    _setup_fake_downloaded_model(tmp_path, monkeypatch)
 
     class FakeClassifier:
         def __init__(self, *args, **kwargs):
@@ -2515,6 +2530,15 @@ def test_pipeline_skips_taxonomy_download_when_file_is_usable(
     )
     monkeypatch.setattr(taxonomy_mod, "load_local_taxonomy", lambda: None)
 
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    col_id = db.add_collection("Test", "[]")
+
+    # Override the helper's no-op download stub AFTER calling the helper, so
+    # this test's recording stub wins. See sibling test above.
+    _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
     download_calls = []
     monkeypatch.setattr(
         taxonomy_mod,
@@ -2523,13 +2547,6 @@ def test_pipeline_skips_taxonomy_download_when_file_is_usable(
             output_path
         ),
     )
-
-    db_path = str(tmp_path / "test.db")
-    db = Database(db_path)
-    ws_id = db._active_workspace_id
-    col_id = db.add_collection("Test", "[]")
-
-    _setup_fake_downloaded_model(tmp_path, monkeypatch)
 
     class FakeClassifier:
         def __init__(self, *args, **kwargs):


### PR DESCRIPTION
## What & why

Investigating Julius's recent folder moves turned up the bug this PR fixes: **every move-folder job in the last few days copied nothing (rsync to `/Volumes/Photography` kept timing out / dropping the connection), yet four of the five were recorded as `completed` with `error_count: 0`.** Only the one that raised an exception was marked `failed`.

Root cause: `JobRunner._run_job` marks a job `completed` whenever the work function *returns* — and `move_folder` returns `{"moved": 0, "errors": [...]}` rather than raising when rsync fails. The persisted `error_count` comes from the runner's own exception list (`job["errors"]`), which stays empty on a normal return, so result-level errors were never counted. Net effect: "completed, 0 errors" for a run that moved nothing — exactly the kind of black-box status `CORE_PHILOSOPHY.md` forbids.

## Changes

- **`vireo/jobs.py`** — `_run_job` honors an opt-in `ok` key on the result dict: result-level `errors` are folded into the job's error tally (so `error_count` is honest), and `ok: False` demotes the job to `failed`. Jobs that don't set `ok` behave exactly as before.
- **`vireo/app.py`** — the move-folder work closure sets `ok=False` (plus a clean one-line `summary`) when the move copied nothing and reported errors, `ok=True` otherwise. A `needs_merge` return is left untouched — that's a soft "destination already exists, re-prompt for merge/resume" signal, not a failure.

## Tests

- Runner unit tests: `ok=False` → failed (errors folded into count); `ok=True` with warnings → completed but error_count reflects them; no `ok` key → unchanged; end-to-end persistence asserts `status='failed'` + `error_count` in `job_history`.
- Move API integration test: a real failing move (destination overlapping source) is recorded `failed` with non-zero `error_count`, and the originals are preserved.

Full mandated suite: **1178 passed, 1 skipped**. Move/jobs suites: **92 passed, 4 skipped**.

## Note for the original moves

The five failed moves left all source files intact in `~/Pictures` and nothing partial at the destination — the underlying blocker was the `/Volumes/Photography` network volume timing out (and it's currently unmounted). Re-running is safe once that drive is reliably mounted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Move jobs now show accurate outcomes in job history, including failed moves, merge-needed states, and clearer summaries.
  * Failed move attempts are recorded as failures instead of appearing successful.
  * Long-running file moves are now stopped only when they stop making progress, reducing false timeouts.

* **Tests**
  * Added coverage for move-job result handling and stalled vs. progressing transfer scenarios.
  * Added a regression test for failed folder moves being saved correctly in job history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->