### PR TITLE
website: update download links for v0.10.5

### DIFF
--- a/website/src/pages/download.astro
+++ b/website/src/pages/download.astro
@@ -6,9 +6,9 @@ const base = import.meta.env.BASE_URL;
 const releaseUrl = (v: string) => `https://github.com/jss367/vireo/releases/download/v${v}`;
 
 // Per-platform versions — updated independently by CI when each platform builds
-const macosArm64Version = '0.10.4';
-const windowsVersion = '0.10.4';
-const linuxVersion = '0.10.4';
+const macosArm64Version = '0.10.5';
+const windowsVersion = '0.10.5';
+const linuxVersion = '0.10.5';
 ---
 
 <Base title="Download — Vireo" description="Download Vireo for macOS, Windows, or Linux. Free, open source, no account required.">


### PR DESCRIPTION
Automated update of download links following the v0.10.5 release. Auto-merges once required checks pass; deploy-website.yml runs on the resulting push to main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the download page to point to the latest Vireo release for macOS (Apple Silicon), Windows, and Linux.
  * Ensured platform download links now use version **0.10.5**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->