### PR TITLE
Move preflight: honest file counts + transfer preview

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -450,6 +450,55 @@ def _chunked(seq, size=_SQL_PARAM_CHUNK):
         yield seq[i:i + size]
 
 
+def _scan_dir_file_count(root_path, file_limit=None, dir_limit=None):
+    """Count files (non-directory entries) under ``root_path`` with a lazy
+    ``os.scandir`` walk. ``os.scandir`` yields entries one at a time, so with
+    ``file_limit``/``dir_limit`` set we bail the moment either cap is reached
+    rather than waiting for the OS to enumerate a directory with millions of
+    entries. Pass ``None`` for both to count the whole tree exactly.
+
+    Returns ``(file_count, truncated)`` where ``truncated`` is True iff a cap
+    stopped the walk early.
+    """
+    file_count = 0
+    dirs_seen = 0
+    truncated = False
+    stack = [root_path]
+    while stack:
+        if file_limit is not None and file_count >= file_limit:
+            truncated = True
+            break
+        if dir_limit is not None and dirs_seen >= dir_limit:
+            truncated = True
+            break
+        current = stack.pop()
+        dirs_seen += 1
+        try:
+            scanner = os.scandir(current)
+        except OSError:
+            continue
+        with scanner:
+            for entry in scanner:
+                # Check the caps inside the inner loop so a single directory
+                # with a huge number of children cannot blow past either limit
+                # before we bail out.
+                if file_limit is not None and file_count >= file_limit:
+                    truncated = True
+                    break
+                if dir_limit is not None and dirs_seen + len(stack) >= dir_limit:
+                    truncated = True
+                    break
+                try:
+                    is_dir = entry.is_dir(follow_symlinks=False)
+                except OSError:
+                    is_dir = False
+                if is_dir:
+                    stack.append(entry.path)
+                else:
+                    file_count += 1
+    return file_count, truncated
+
+
 def _filename_sequence_key(filename):
     """Return (prefix, number, width, ext) for names like DSC_3069.NEF."""
     stem, ext = os.path.splitext(filename or "")
@@ -13465,14 +13514,31 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def api_move_folder_preflight():
         """Report the resolved destination for a folder move and whether it
         already exists, so the UI can offer a merge/resume confirmation
-        instead of silently failing on an existing destination."""
-        from move import resolve_folder_dest
+        instead of silently failing on an existing destination.
+
+        ``mode`` controls how much work the endpoint does:
+
+        * ``"quick"`` (default) — caps the destination file count at 1000 so
+          the live, keystroke-debounced status line stays instant even when
+          the destination holds millions of files.
+        * ``"exact"`` — walks the destination uncapped for the true file
+          count. The UI fires this in the background to replace the capped
+          "at least 1000" line once the fast check reported a truncation.
+        * ``"preview"`` — also runs ``preview_merge`` to report how many
+          source files would actually copy vs. be skipped as already present.
+          Fired on the deliberate merge-confirm click, where a source-tree
+          walk is acceptable.
+        """
+        from move import preview_merge, resolve_folder_dest
 
         body = request.get_json(silent=True)
         if not isinstance(body, dict):
             return json_error("JSON body must be an object")
         folder_id = body.get("folder_id")
         destination = body.get("destination", "")
+        mode = body.get("mode", "quick")
+        if mode not in ("quick", "exact", "preview"):
+            mode = "quick"
 
         if not folder_id:
             return json_error("folder_id required")
@@ -13494,46 +13560,21 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         file_count = 0
         file_count_truncated = False
         if exists:
-            # os.scandir yields entries lazily, so we can bail out the moment
-            # the cap is reached without waiting for the OS to enumerate a
-            # directory with millions of files.
-            file_limit = 1000
-            dir_limit = 2000
-            stack = [resolved]
-            dirs_seen = 0
-            while stack and not file_count_truncated:
-                if file_count >= file_limit or dirs_seen >= dir_limit:
-                    file_count_truncated = True
-                    break
-                current = stack.pop()
-                dirs_seen += 1
-                try:
-                    scanner = os.scandir(current)
-                except OSError:
-                    continue
-                with scanner:
-                    for entry in scanner:
-                        # Check the caps inside the inner loop so a single
-                        # directory with a huge number of children cannot
-                        # blow past either limit before we bail out.
-                        if file_count >= file_limit or dirs_seen + len(stack) >= dir_limit:
-                            file_count_truncated = True
-                            break
-                        try:
-                            is_dir = entry.is_dir(follow_symlinks=False)
-                        except OSError:
-                            is_dir = False
-                        if is_dir:
-                            stack.append(entry.path)
-                        else:
-                            file_count += 1
+            if mode == "quick":
+                file_count, file_count_truncated = _scan_dir_file_count(
+                    resolved, file_limit=1000, dir_limit=2000)
+            else:
+                file_count, file_count_truncated = _scan_dir_file_count(resolved)
 
-        return jsonify({
+        result = {
             "resolved_dest": resolved,
             "exists": exists,
             "file_count": file_count,
             "file_count_truncated": file_count_truncated,
-        })
+        }
+        if mode == "preview" and exists:
+            result["preview"] = preview_merge(folder["path"], resolved)
+        return jsonify(result)
 
     @app.route("/api/jobs/import-full", methods=["POST"])
     def api_job_import_full():

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -464,7 +464,12 @@ def _scan_dir_file_count(root_path, file_limit=None, dir_limit=None):
     dirs_seen = 0
     truncated = False
     stack = [root_path]
-    while stack:
+    # `not truncated` in the outer condition stops the walk the moment the
+    # inner loop trips a cap. Without it, we'd keep popping queued sibling
+    # directories until `dirs_seen` mechanically caught up to `dir_limit` —
+    # which on a flat fanout means opening every already-queued child, the
+    # exact worker-stalling case the cap is supposed to prevent.
+    while stack and not truncated:
         if file_limit is not None and file_count >= file_limit:
             truncated = True
             break

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -13524,10 +13524,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         * ``"exact"`` — walks the destination uncapped for the true file
           count. The UI fires this in the background to replace the capped
           "at least 1000" line once the fast check reported a truncation.
-        * ``"preview"`` — also runs ``preview_merge`` to report how many
-          source files would actually copy vs. be skipped as already present.
-          Fired on the deliberate merge-confirm click, where a source-tree
-          walk is acceptable.
+        * ``"preview"`` — keeps the destination count on the capped fast
+          path (same as ``quick``) and adds a ``preview_merge`` block
+          reporting how many source files would actually copy vs. be
+          skipped as already present. The deliberate merge-confirm click
+          fires this; the source-tree walk for ``preview_merge`` is
+          acceptable there, but a second uncapped destination walk is not
+          — the dialog displays the preview's copy/skip counts, not the
+          raw destination count, so capping the destination here keeps the
+          Flask worker free even when the resume target is a NAS folder
+          with millions of unrelated files.
         """
         from move import preview_merge, resolve_folder_dest
 
@@ -13560,11 +13566,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         file_count = 0
         file_count_truncated = False
         if exists:
-            if mode == "quick":
+            if mode == "exact":
+                file_count, file_count_truncated = _scan_dir_file_count(resolved)
+            else:
+                # Both "quick" and "preview" cap the destination scan. The
+                # merge dialog uses preview_merge's copy/skip counts, not
+                # this number, so walking the destination uncapped here
+                # would block a Flask worker for no UI benefit.
                 file_count, file_count_truncated = _scan_dir_file_count(
                     resolved, file_limit=1000, dir_limit=2000)
-            else:
-                file_count, file_count_truncated = _scan_dir_file_count(resolved)
 
         result = {
             "resolved_dest": resolved,

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -13521,9 +13521,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         * ``"quick"`` (default) — caps the destination file count at 1000 so
           the live, keystroke-debounced status line stays instant even when
           the destination holds millions of files.
-        * ``"exact"`` — walks the destination uncapped for the true file
-          count. The UI fires this in the background to replace the capped
-          "at least 1000" line once the fast check reported a truncation.
+        * ``"exact"`` — walks the destination with a much larger cap
+          (100k files / 50k dirs) than ``quick`` so the true count is
+          reported for any realistic photo library, while still bounding
+          the Flask worker thread on pathological NAS targets (millions
+          of unrelated files). The UI fires this in the background to
+          replace the capped "at least 1000" line once the fast check
+          reported a truncation, and still renders "at least N" if the
+          exact walk itself truncated.
         * ``"preview"`` — keeps the destination count on the capped fast
           path (same as ``quick``) and adds a ``preview_merge`` block
           reporting how many source files would actually copy vs. be
@@ -13567,7 +13572,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         file_count_truncated = False
         if exists:
             if mode == "exact":
-                file_count, file_count_truncated = _scan_dir_file_count(resolved)
+                # Generous cap, not uncapped: requestExactDestCount fires from
+                # the keystroke-driven path, and an unbounded walk on a NAS
+                # target with millions of files would pin a Flask worker for
+                # minutes (the UI seq guard only discards stale replies, not
+                # server-side work). 100k/50k is large enough that any
+                # realistic photo library reports its true count, and small
+                # enough that the worst case is seconds, not minutes.
+                file_count, file_count_truncated = _scan_dir_file_count(
+                    resolved, file_limit=100000, dir_limit=50000)
             else:
                 # Both "quick" and "preview" cap the destination scan. The
                 # merge dialog uses preview_merge's copy/skip counts, not

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -337,6 +337,15 @@ def preview_merge(src_path, dest_path):
     untouched". Surfaced separately so the confirm dialog can warn that
     the merge would not complete instead of implying a no-op resume.
 
+    It also covers source files that are themselves symlinks with no
+    destination entry yet. ``rsync -a`` (and the shutil fallback's
+    ``os.symlink``) recreate them as symlinks at the destination rather
+    than materializing a regular file — and the verifier then rejects the
+    freshly-created symlink and aborts the merge. Telling the user the
+    file will be copied when the job deterministically fails at verify
+    after creating it is the same false promise as the destination-entry
+    case, so it's classified as blocked too.
+
     Directory symlinks under ``src_path`` count as one transfer item each:
     the rsync ``-a`` path and the shutil fallback (see
     ``_copy_tree_with_progress``) both recreate them as symlinks at the
@@ -367,7 +376,16 @@ def preview_merge(src_path, dest_path):
             rel_name = fn if rel == "." else os.path.join(rel, fn)
             dst_file = os.path.join(dest_path, rel_name)
             if not os.path.lexists(dst_file):
-                will_copy += 1
+                # A source-file symlink gets recreated as a symlink at the
+                # destination by rsync -a / the shutil fallback's os.symlink;
+                # the verifier then rejects that symlink via its islink check
+                # and the merge aborts with "Verification failed". Surface it
+                # as blocked so the dialog never promises a copy that won't
+                # survive verification.
+                if os.path.islink(src_file):
+                    will_block += 1
+                else:
+                    will_copy += 1
             elif _verifier_would_accept_skip(src_file, dst_file):
                 will_skip += 1
             else:

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -283,6 +283,43 @@ def _first_missing_source_file(src_path, dest_path):
     return None
 
 
+def preview_merge(src_path, dest_path):
+    """Classify how a merge of ``src_path`` into an existing ``dest_path``
+    would play out, the same way the ``rsync --ignore-existing`` copy does:
+    every source file absent at the destination is copied; every source file
+    already present (by name) is left untouched.
+
+    Returns a dict with ``will_copy``, ``will_skip``, and ``source_total``
+    (their sum). The total counts *every* file under ``src_path`` — XMP
+    sidecars and other companions rsync carries along, not just tracked
+    photos — so it reflects what actually transfers, unlike a tracked-photo
+    count.
+
+    This is a name-only classification, matching what rsync actually copies:
+    a same-name destination file whose bytes differ still counts as a skip
+    here, because rsync would skip it. That genuine collision is caught
+    separately by ``_find_content_conflict``, which refuses the whole merge
+    before anything is copied — so this preview never reads file contents and
+    stays fast on large trees.
+    """
+    will_copy = 0
+    will_skip = 0
+    for root, _, files in os.walk(src_path):
+        rel = os.path.relpath(root, src_path)
+        for fn in files:
+            rel_name = fn if rel == "." else os.path.join(rel, fn)
+            dst_file = os.path.join(dest_path, rel_name)
+            if os.path.lexists(dst_file):
+                will_skip += 1
+            else:
+                will_copy += 1
+    return {
+        "will_copy": will_copy,
+        "will_skip": will_skip,
+        "source_total": will_copy + will_skip,
+    }
+
+
 def _samefile_tristate(a, b):
     """Whether two paths resolve to the same inode, or None if samefile
     raised (broken symlink, permission error, transient race — the probe

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -301,11 +301,30 @@ def preview_merge(src_path, dest_path):
     separately by ``_find_content_conflict``, which refuses the whole merge
     before anything is copied — so this preview never reads file contents and
     stays fast on large trees.
+
+    Directory symlinks under ``src_path`` count as one transfer item each:
+    the rsync ``-a`` path and the shutil fallback (see
+    ``_copy_tree_with_progress``) both recreate them as symlinks at the
+    destination without descending, so omitting them would let the confirm
+    dialog say "All 0 files are already present" for a source that is
+    actually just a directory symlink, undercounting what the move
+    transfers.
     """
     will_copy = 0
     will_skip = 0
-    for root, _, files in os.walk(src_path):
+    # os.walk defaults to followlinks=False, so a symlinked subdirectory
+    # appears in `dirs` but is not descended into — which is exactly the
+    # transfer semantics the merge applies, so each such entry is one item.
+    for root, dirs, files in os.walk(src_path):
         rel = os.path.relpath(root, src_path)
+        for d in dirs:
+            if not os.path.islink(os.path.join(root, d)):
+                continue
+            rel_name = d if rel == "." else os.path.join(rel, d)
+            if os.path.lexists(os.path.join(dest_path, rel_name)):
+                will_skip += 1
+            else:
+                will_copy += 1
         for fn in files:
             rel_name = fn if rel == "." else os.path.join(rel, fn)
             dst_file = os.path.join(dest_path, rel_name)

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -760,12 +760,14 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
         progress_cb: optional callback(current, total, filename)
         merge: when False (default), refuse to write into a destination
             that already exists — the safe all-or-nothing behavior. When
-            True, merge/resume into the existing destination: rsync skips
-            files already present with a matching checksum and copies only
-            what is missing (this is how an interrupted move is resumed).
-            Originals are deleted only after every source file is verified
-            present at the destination. A failed merge never removes the
-            destination, since it may hold the user's pre-existing files.
+            True, merge/resume into the existing destination: a pre-copy scan
+            refuses the merge if any same-name file differs in content;
+            otherwise rsync (``--ignore-existing``) copies only the files
+            missing at the destination and never overwrites one already there
+            (this is how an interrupted move is resumed). Originals are deleted
+            only after every source file is verified present at the
+            destination. A failed merge never removes the destination, since it
+            may hold the user's pre-existing files.
         developed_dir: optional path to the configured
             `darktable_output_dir`. When set, the folder's developed
             subdirectory — nested under a hash of its source path, see

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -283,24 +283,59 @@ def _first_missing_source_file(src_path, dest_path):
     return None
 
 
+def _verifier_would_accept_skip(src_file, dst_file):
+    """True iff a same-name entry at ``dst_file`` would be accepted as
+    already-present by ``_first_missing_source_file`` (the post-copy
+    verifier the merge gates the source delete on). Mirrors that
+    verifier's structural predicates — destination must exist, must NOT be
+    a symlink, must NOT resolve to the same inode as the source, and must
+    be a regular file. The size check the verifier also performs is
+    deliberately omitted: this backs ``preview_merge``, which is name-only
+    by design and must not stat the destination tree's bytes. Same-size
+    content collisions are caught separately by ``_find_content_conflict``
+    before the merge runs; this only filters entries the verifier would
+    reject structurally (symlink, directory, broken samefile probe), where
+    rsync ``--ignore-existing`` skips the copy but the verifier then
+    refuses to delete the originals with ``Verification failed``.
+    """
+    if not os.path.lexists(dst_file) or os.path.islink(dst_file):
+        return False
+    try:
+        if os.path.samefile(src_file, dst_file):
+            return False
+    except OSError:
+        return False
+    return os.path.isfile(dst_file)
+
+
 def preview_merge(src_path, dest_path):
     """Classify how a merge of ``src_path`` into an existing ``dest_path``
     would play out, the same way the ``rsync --ignore-existing`` copy does:
     every source file absent at the destination is copied; every source file
     already present (by name) is left untouched.
 
-    Returns a dict with ``will_copy``, ``will_skip``, and ``source_total``
-    (their sum). The total counts *every* file under ``src_path`` — XMP
-    sidecars and other companions rsync carries along, not just tracked
-    photos — so it reflects what actually transfers, unlike a tracked-photo
-    count.
+    Returns a dict with ``will_copy``, ``will_skip``, ``will_block``, and
+    ``source_total`` (their sum). The total counts *every* file under
+    ``src_path`` — XMP sidecars and other companions rsync carries along,
+    not just tracked photos — so it reflects what actually transfers,
+    unlike a tracked-photo count.
 
     This is a name-only classification, matching what rsync actually copies:
-    a same-name destination file whose bytes differ still counts as a skip
-    here, because rsync would skip it. That genuine collision is caught
-    separately by ``_find_content_conflict``, which refuses the whole merge
-    before anything is copied — so this preview never reads file contents and
-    stays fast on large trees.
+    a same-name destination *file* whose bytes differ still counts as a
+    skip here, because rsync would skip it. That genuine collision is
+    caught separately by ``_find_content_conflict``, which refuses the
+    whole merge before anything is copied — so this preview never reads
+    file contents and stays fast on large trees.
+
+    ``will_block`` covers source files whose destination entry is something
+    the post-copy verifier (``_first_missing_source_file``) refuses to
+    accept as already-present — a symlink, a directory, or a path that
+    resolves to the same inode as the source. ``rsync --ignore-existing``
+    silently skips those entries by name, but the verifier then rejects
+    them and the merge aborts with "Verification failed", so they must not
+    be presented to the user as "already present and will be left
+    untouched". Surfaced separately so the confirm dialog can warn that
+    the merge would not complete instead of implying a no-op resume.
 
     Directory symlinks under ``src_path`` count as one transfer item each:
     the rsync ``-a`` path and the shutil fallback (see
@@ -308,10 +343,12 @@ def preview_merge(src_path, dest_path):
     destination without descending, so omitting them would let the confirm
     dialog say "All 0 files are already present" for a source that is
     actually just a directory symlink, undercounting what the move
-    transfers.
+    transfers. The verifier does not check directory entries, so they stay
+    name-only (skip iff anything exists at the destination name).
     """
     will_copy = 0
     will_skip = 0
+    will_block = 0
     # os.walk defaults to followlinks=False, so a symlinked subdirectory
     # appears in `dirs` but is not descended into — which is exactly the
     # transfer semantics the merge applies, so each such entry is one item.
@@ -326,16 +363,20 @@ def preview_merge(src_path, dest_path):
             else:
                 will_copy += 1
         for fn in files:
+            src_file = os.path.join(root, fn)
             rel_name = fn if rel == "." else os.path.join(rel, fn)
             dst_file = os.path.join(dest_path, rel_name)
-            if os.path.lexists(dst_file):
+            if not os.path.lexists(dst_file):
+                will_copy += 1
+            elif _verifier_would_accept_skip(src_file, dst_file):
                 will_skip += 1
             else:
-                will_copy += 1
+                will_block += 1
     return {
         "will_copy": will_copy,
         "will_skip": will_skip,
-        "source_total": will_copy + will_skip,
+        "will_block": will_block,
+        "source_total": will_copy + will_skip + will_block,
     }
 
 

--- a/vireo/templates/move.html
+++ b/vireo/templates/move.html
@@ -768,6 +768,7 @@ async function startQuickMove() {
     var p = pf.preview || {};
     var copyN = p.will_copy;
     var skipN = p.will_skip;
+    var blockN = p.will_block || 0;
     var msg;
     if (typeof copyN === 'number') {
       // Truthful transfer counts. These count every file under the source
@@ -775,17 +776,27 @@ async function startQuickMove() {
       // Files already present are left untouched, never overwritten; a
       // same-name file whose content differs cancels the whole merge, so only
       // mention that caveat when there are overlapping files (skipN > 0).
+      // blockN is the count of source files whose destination entry is a
+      // symlink, a directory, or otherwise not a plain file: rsync would skip
+      // those by name, but the post-copy verifier rejects them and the merge
+      // would abort with "Verification failed". Surface the block so the
+      // dialog never says "all already present" when the move would not in
+      // fact complete.
       var conflictNote = skipN ? ' If a same-name file differs, the merge is canceled and nothing is changed.' : '';
-      if (copyN === 0) {
+      var blockNote = blockN ?
+        ' ⚠ ' + blockN.toLocaleString() + ' source file' + (blockN !== 1 ? 's have' : ' has') +
+        ' a destination entry that is a symlink or non-file — the merge will be canceled at the verify step before any originals are removed.' : '';
+      if (copyN === 0 && blockN === 0) {
         msg = 'All ' + skipN.toLocaleString() + ' file' + (skipN !== 1 ? 's' : '') +
           ' from "' + folderName + '" are already present at "' + finalPath +
           '". Merging copies nothing new.' + conflictNote +
           ' Originals are removed only after every source file is verified at the destination. Continue?';
       } else {
+        var skipPart = skipN ? ', ' + skipN.toLocaleString() + ' already present will be left untouched' : '';
+        var blockPart = blockN ? ', ' + blockN.toLocaleString() + ' blocked by a non-file at the destination' : '';
         msg = 'Merge "' + folderName + '" into "' + finalPath + '"? ' +
           copyN.toLocaleString() + ' file' + (copyN !== 1 ? 's' : '') + ' will be copied' +
-          (skipN ? ', ' + skipN.toLocaleString() + ' already present will be left untouched' : '') +
-          '.' + conflictNote +
+          skipPart + blockPart + '.' + conflictNote + blockNote +
           ' Originals are removed only after every source file is verified at the destination.';
       }
     } else {

--- a/vireo/templates/move.html
+++ b/vireo/templates/move.html
@@ -704,7 +704,7 @@ async function runQuickPreflight(fid, dest, seq) {
 function setDestExistsStatus(status, n, truncated) {
   var countText = truncated ? ('at least ' + n.toLocaleString()) : n.toLocaleString();
   status.textContent = '⚠ Destination already exists — contains ' + countText + ' file' +
-    (n !== 1 || truncated ? 's' : '') + '. Existing files with a matching size are skipped; only missing files are copied.';
+    (n !== 1 || truncated ? 's' : '') + '. Files already there are left untouched; only missing files are copied. If a same-name file differs, the merge is canceled and nothing is changed.';
   status.style.color = 'var(--warning)';
 }
 
@@ -772,15 +772,21 @@ async function startQuickMove() {
     if (typeof copyN === 'number') {
       // Truthful transfer counts. These count every file under the source
       // (sidecars included), not just tracked photos — that's what rsync moves.
+      // Files already present are left untouched, never overwritten; a
+      // same-name file whose content differs cancels the whole merge, so only
+      // mention that caveat when there are overlapping files (skipN > 0).
+      var conflictNote = skipN ? ' If a same-name file differs, the merge is canceled and nothing is changed.' : '';
       if (copyN === 0) {
         msg = 'All ' + skipN.toLocaleString() + ' file' + (skipN !== 1 ? 's' : '') +
           ' from "' + folderName + '" are already present at "' + finalPath +
-          '". Merging copies nothing new, then removes the originals after verifying every file is at the destination. Continue?';
+          '". Merging copies nothing new.' + conflictNote +
+          ' Originals are removed only after every source file is verified at the destination. Continue?';
       } else {
         msg = 'Merge "' + folderName + '" into "' + finalPath + '"? ' +
           copyN.toLocaleString() + ' file' + (copyN !== 1 ? 's' : '') + ' will be copied' +
-          (skipN ? ', ' + skipN.toLocaleString() + ' already present will be skipped' : '') +
-          '. Originals are removed only after every source file is verified at the destination.';
+          (skipN ? ', ' + skipN.toLocaleString() + ' already present will be left untouched' : '') +
+          '.' + conflictNote +
+          ' Originals are removed only after every source file is verified at the destination.';
       }
     } else {
       // Preview unavailable (e.g. server omitted it) — fall back to the
@@ -788,7 +794,7 @@ async function startQuickMove() {
       var n = pf.file_count || 0;
       var countText = pf.file_count_truncated ? ('at least ' + n.toLocaleString()) : n.toLocaleString();
       msg = '"' + finalPath + '" already exists and contains ' + countText + ' file' + (n !== 1 || pf.file_count_truncated ? 's' : '') +
-        '. Merge "' + folderName + '" (' + photoCount + ' photos) into it? Files already present with a matching size are skipped; only missing files are copied. Originals are removed only after every source file is verified at the destination.';
+        '. Merge "' + folderName + '" (' + photoCount + ' photos) into it? Files already there are left untouched; only missing files are copied. If a same-name file differs, the merge is canceled and nothing is changed. Originals are removed only after every source file is verified at the destination.';
     }
     showConfirm(
       'Destination Exists — Merge & Resume',

--- a/vireo/templates/move.html
+++ b/vireo/templates/move.html
@@ -687,14 +687,44 @@ async function runQuickPreflight(fid, dest, seq) {
   status = document.getElementById('quickDestStatus');
   if (!status) return;
   if (data.exists) {
-    var n = data.file_count;
-    status.textContent = '⚠ Destination already exists — contains ' + n + ' file' +
-      (n !== 1 ? 's' : '') + '. Existing files with a matching size are skipped; only missing files are copied.';
-    status.style.color = 'var(--warning)';
+    setDestExistsStatus(status, data.file_count, data.file_count_truncated);
+    // The fast count caps out at 1000. When it was truncated, fetch the exact
+    // number in the background and update the line in place — without blocking
+    // the user or holding up typing.
+    if (data.file_count_truncated) requestExactDestCount(fid, dest, seq);
   } else {
     status.textContent = '✓ New folder — nothing exists at this location yet.';
     status.style.color = 'var(--text-dim)';
   }
+}
+
+// Render the "destination already exists" warning. When `truncated` is true
+// the count is a floor (the fast scan stopped at its cap), so say "at least N"
+// rather than implying an exact total — the line must mean what it says.
+function setDestExistsStatus(status, n, truncated) {
+  var countText = truncated ? ('at least ' + n.toLocaleString()) : n.toLocaleString();
+  status.textContent = '⚠ Destination already exists — contains ' + countText + ' file' +
+    (n !== 1 || truncated ? 's' : '') + '. Existing files with a matching size are skipped; only missing files are copied.';
+  status.style.color = 'var(--warning)';
+}
+
+// Background, non-blocking exact count. Reuses the keystroke seq guard so a
+// result landing after the user has changed the destination is discarded
+// instead of overwriting the line for the wrong path. Stays silent on failure:
+// the capped "at least N" line is already a valid answer.
+function requestExactDestCount(fid, dest, seq) {
+  fetch('/api/move-folder/preflight', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({folder_id: fid, destination: dest, mode: 'exact'}),
+  }).then(function(resp) {
+    return resp.ok ? resp.json() : null;
+  }).then(function(data) {
+    if (!data || !data.exists) return;
+    if (seq !== quickPreflightSeq) return;  // a newer keystroke superseded us
+    var status = document.getElementById('quickDestStatus');
+    if (status) setDestExistsStatus(status, data.file_count, data.file_count_truncated);
+  }).catch(function() { /* background nicety — leave the capped line in place */ });
 }
 
 function clearQuickDestStatus() {
@@ -717,10 +747,15 @@ async function startQuickMove() {
   var pf;
   setQuickMoveBusy(true);
   try {
+    // mode:'preview' also reports how many source files would actually copy
+    // vs. be skipped as already present — the number the user really needs
+    // before committing to a merge. This is a deliberate click, so the
+    // server-side source-tree walk it triggers is acceptable here (unlike on
+    // the keystroke-driven status line above).
     pf = await safeFetch('/api/move-folder/preflight', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({folder_id: fid, destination: dest}),
+      body: JSON.stringify({folder_id: fid, destination: dest, mode: 'preview'}),
     });
   } catch (e) {
     return;  // safeFetch already shows error toast
@@ -730,12 +765,34 @@ async function startQuickMove() {
 
   var finalPath = pf.resolved_dest;
   if (pf.exists) {
-    var n = pf.file_count || 0;
-    var countText = pf.file_count_truncated ? ('at least ' + n) : String(n);
+    var p = pf.preview || {};
+    var copyN = p.will_copy;
+    var skipN = p.will_skip;
+    var msg;
+    if (typeof copyN === 'number') {
+      // Truthful transfer counts. These count every file under the source
+      // (sidecars included), not just tracked photos — that's what rsync moves.
+      if (copyN === 0) {
+        msg = 'All ' + skipN.toLocaleString() + ' file' + (skipN !== 1 ? 's' : '') +
+          ' from "' + folderName + '" are already present at "' + finalPath +
+          '". Merging copies nothing new, then removes the originals after verifying every file is at the destination. Continue?';
+      } else {
+        msg = 'Merge "' + folderName + '" into "' + finalPath + '"? ' +
+          copyN.toLocaleString() + ' file' + (copyN !== 1 ? 's' : '') + ' will be copied' +
+          (skipN ? ', ' + skipN.toLocaleString() + ' already present will be skipped' : '') +
+          '. Originals are removed only after every source file is verified at the destination.';
+      }
+    } else {
+      // Preview unavailable (e.g. server omitted it) — fall back to the
+      // destination file count rather than inventing a transfer number.
+      var n = pf.file_count || 0;
+      var countText = pf.file_count_truncated ? ('at least ' + n.toLocaleString()) : n.toLocaleString();
+      msg = '"' + finalPath + '" already exists and contains ' + countText + ' file' + (n !== 1 || pf.file_count_truncated ? 's' : '') +
+        '. Merge "' + folderName + '" (' + photoCount + ' photos) into it? Files already present with a matching size are skipped; only missing files are copied. Originals are removed only after every source file is verified at the destination.';
+    }
     showConfirm(
       'Destination Exists — Merge & Resume',
-      '"' + finalPath + '" already exists and contains ' + countText + ' file' + (n !== 1 || pf.file_count_truncated ? 's' : '') +
-        '. Merge "' + folderName + '" (' + photoCount + ' photos) into it? Files already present with a matching size are skipped; only missing files are copied. Originals are removed only after every source file is verified at the destination.',
+      msg,
       function() {
         executeQuickMove(fid, dest, true);
       }

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -212,6 +212,41 @@ def test_move_folder_merge_resumes(move_env):
     assert folder["path"] == str(landing)
 
 
+def test_preview_merge_counts_copy_and_skip(move_env):
+    """preview_merge classifies every source file (sidecars included) as copy
+    or skip by name, matching what rsync --ignore-existing actually does."""
+    from move import preview_merge
+
+    env = move_env
+    landing = env["dst"] / "src"
+    landing.mkdir()
+    # bird1.jpg already present at the destination -> skip; bird1.xmp and
+    # bird2.jpg are missing -> copy.
+    (landing / "bird1.jpg").write_bytes((env["src"] / "bird1.jpg").read_bytes())
+
+    preview = preview_merge(str(env["src"]), str(landing))
+    assert preview["will_skip"] == 1
+    assert preview["will_copy"] == 2
+    assert preview["source_total"] == 3
+
+
+def test_preview_merge_is_name_only(move_env):
+    """A same-name destination file counts as a skip even when its bytes
+    differ — rsync --ignore-existing skips by name, and the differing-content
+    case is caught separately as a hard conflict at merge time."""
+    from move import preview_merge
+
+    env = move_env
+    landing = env["dst"] / "src"
+    landing.mkdir()
+    # Same name, different content: still classified as a skip by the preview.
+    (landing / "bird1.jpg").write_bytes(b"totally different bytes")
+
+    preview = preview_merge(str(env["src"]), str(landing))
+    assert preview["will_skip"] == 1
+    assert preview["will_copy"] == 2
+
+
 def test_move_folder_merge_never_overwrites_differing_dest_file(move_env):
     """A same-name destination file with DIFFERENT content (different size)
     is a hard conflict: the merge aborts before copying, leaving both the

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -341,6 +341,40 @@ def test_preview_merge_counts_directory_symlinks(move_env, tmp_path):
     assert preview["source_total"] == 4
 
 
+def test_preview_merge_blocks_source_file_symlinks_with_missing_dest(move_env, tmp_path):
+    """A source file that is itself a symlink, with nothing yet at the
+    destination, must surface as ``will_block`` — not ``will_copy``.
+
+    rsync -a (and the shutil fallback's os.symlink) recreate it as a
+    symlink at the destination rather than materializing a regular file,
+    and ``_first_missing_source_file`` then rejects the freshly-created
+    symlink via its islink check. The merge aborts at the verify step
+    after creating the link. Reporting it as "will be copied" would be a
+    false promise: the dialog must warn instead so the user can choose
+    not to commit to a merge that deterministically fails.
+    """
+    from move import preview_merge
+
+    env = move_env
+    # Source file symlink pointing outside the source tree. The link target
+    # itself doesn't matter — the merge would create a symlink at the
+    # destination either way, and the verifier rejects on islink alone.
+    link_target = tmp_path / "real_bird3.jpg"
+    link_target.write_bytes(b"x")
+    os.symlink(str(link_target), str(env["src"] / "bird3.jpg"))
+
+    landing = env["dst"] / "src"
+    landing.mkdir()
+    preview = preview_merge(str(env["src"]), str(landing))
+    # 3 plain source files (bird1.jpg, bird1.xmp, bird2.jpg) are missing
+    # at the destination — those are honest copies. bird3.jpg is a source
+    # symlink with no destination entry — would-fail-verify after copy.
+    assert preview["will_copy"] == 3
+    assert preview["will_block"] == 1
+    assert preview["will_skip"] == 0
+    assert preview["source_total"] == 4
+
+
 def test_preview_merge_is_name_only(move_env):
     """A same-name destination file counts as a skip even when its bytes
     differ — rsync --ignore-existing skips by name, and the differing-content

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -227,7 +227,85 @@ def test_preview_merge_counts_copy_and_skip(move_env):
     preview = preview_merge(str(env["src"]), str(landing))
     assert preview["will_skip"] == 1
     assert preview["will_copy"] == 2
+    assert preview["will_block"] == 0
     assert preview["source_total"] == 3
+
+
+def test_preview_merge_blocks_unverifiable_destination_entries(move_env, tmp_path):
+    """A source file whose destination entry is something the post-copy
+    verifier rejects — a symlink, a directory, or a path that resolves to
+    the same inode as the source — must surface as ``will_block``, not
+    ``will_skip``. rsync --ignore-existing would silently skip these by
+    name, but _first_missing_source_file then refuses to delete the
+    originals and the move aborts with "Verification failed". Reporting
+    them as "already present and will be left untouched" would tell the
+    user the merge is a no-op resume when it actually wouldn't complete.
+    """
+    from move import preview_merge
+
+    env = move_env
+    landing = env["dst"] / "src"
+    landing.mkdir()
+
+    # bird1.jpg at the destination is a symlink — the verifier's islink
+    # check rejects this even when the link target's bytes match.
+    real_bird1 = tmp_path / "real_bird1.jpg"
+    real_bird1.write_bytes((env["src"] / "bird1.jpg").read_bytes())
+    os.symlink(str(real_bird1), str(landing / "bird1.jpg"))
+
+    # bird1.xmp at the destination is a directory, not a file — the
+    # verifier's isfile check rejects.
+    (landing / "bird1.xmp").mkdir()
+
+    # bird2.jpg missing -> a normal will_copy. Establishes that blocks
+    # don't displace genuine copies.
+    preview = preview_merge(str(env["src"]), str(landing))
+    assert preview["will_block"] == 2
+    assert preview["will_copy"] == 1
+    assert preview["will_skip"] == 0
+    assert preview["source_total"] == 3
+
+
+def test_preview_merge_blocks_samefile_via_symlinked_parent(move_env, tmp_path):
+    """A destination path that resolves to the same inode as the source
+    file (e.g. the destination's parent is a symlink back into the source
+    tree) is rejected by the verifier's samefile probe. preview_merge must
+    classify it as ``will_block`` so the merge dialog doesn't claim the
+    merge is a no-op when it would in fact fail to verify and abort.
+
+    The trap this catches: rmtree(src) after a merge that "verified" via
+    an aliased destination would destroy the only on-disk copy.
+    """
+    from move import preview_merge
+
+    env = move_env
+    # Add a nested source file that we can reach at the destination via a
+    # symlinked parent (not a symlinked leaf — the islink branch already
+    # catches that case; samefile guards the parent-alias path).
+    sub = env["src"] / "nested"
+    sub.mkdir()
+    (sub / "bird3.jpg").write_bytes(b"x")
+
+    landing = env["dst"] / "src"
+    landing.mkdir()
+    # landing/nested -> src/nested: when preview_merge computes dst_file =
+    # landing/nested/bird3.jpg, path resolution follows the symlinked
+    # parent so the leaf itself is a regular file (islink check is False),
+    # but the inode matches the source — the case _first_missing_source_file
+    # protects against by calling samefile.
+    os.symlink(str(env["src"] / "nested"), str(landing / "nested"))
+
+    dst_leaf = landing / "nested" / "bird3.jpg"
+    assert os.path.samefile(str(env["src"] / "nested" / "bird3.jpg"), str(dst_leaf))
+    assert not os.path.islink(str(dst_leaf))  # parent is the symlink, not the leaf
+
+    preview = preview_merge(str(env["src"]), str(landing))
+    # bird1.jpg, bird1.xmp, bird2.jpg at top-level: all missing -> copy.
+    # nested/bird3.jpg: samefile with the source -> blocked.
+    assert preview["will_block"] == 1
+    assert preview["will_skip"] == 0
+    assert preview["will_copy"] == 3
+    assert preview["source_total"] == 4
 
 
 def test_preview_merge_counts_directory_symlinks(move_env, tmp_path):

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -230,6 +230,39 @@ def test_preview_merge_counts_copy_and_skip(move_env):
     assert preview["source_total"] == 3
 
 
+def test_preview_merge_counts_directory_symlinks(move_env, tmp_path):
+    """A directory symlink under the source is one transfer item: rsync -a /
+    the shutil fallback recreate it as a symlink without descending. Omitting
+    it would make the confirm dialog undercount and, for a source that's just
+    a symlinked subdir, claim 0 files would transfer."""
+    from move import preview_merge
+
+    env = move_env
+    # Real directory the symlinked subdir points at — kept outside the source
+    # tree so its contents don't count on their own. The number of files it
+    # holds is irrelevant: the preview must not descend.
+    link_target = tmp_path / "linked_tree"
+    link_target.mkdir()
+    (link_target / "unused.jpg").write_bytes(b"x")
+    os.symlink(str(link_target), str(env["src"] / "extras"))
+
+    landing = env["dst"] / "src"
+    landing.mkdir()
+    preview = preview_merge(str(env["src"]), str(landing))
+    # 3 source files + 1 directory symlink, none present at destination.
+    assert preview["will_copy"] == 4
+    assert preview["will_skip"] == 0
+    assert preview["source_total"] == 4
+
+    # Re-create the symlink at the destination — now the preview must classify
+    # it as a skip rather than a copy, mirroring rsync --ignore-existing.
+    os.symlink(str(link_target), str(landing / "extras"))
+    preview = preview_merge(str(env["src"]), str(landing))
+    assert preview["will_copy"] == 3
+    assert preview["will_skip"] == 1
+    assert preview["source_total"] == 4
+
+
 def test_preview_merge_is_name_only(move_env):
     """A same-name destination file counts as a skip even when its bytes
     differ — rsync --ignore-existing skips by name, and the differing-content

--- a/vireo/tests/test_move_api.py
+++ b/vireo/tests/test_move_api.py
@@ -284,9 +284,10 @@ def test_move_folder_preflight_caps_existing_destination_dir_fanout(app_and_db, 
     assert data["file_count_truncated"] is True
 
 
-def test_move_folder_preflight_exact_mode_counts_uncapped(app_and_db, tmp_path):
-    """mode='exact' walks the destination uncapped, returning the true count
-    and truncated=False even past the 1000-file quick-scan cap."""
+def test_move_folder_preflight_exact_mode_counts_past_quick_cap(app_and_db, tmp_path):
+    """mode='exact' counts past the 1000-file quick-scan cap and reports the
+    true number with truncated=False, since the destination's true size is
+    well under the larger exact-mode cap."""
     app, db = app_and_db
     dst = tmp_path / "dest"
     dst.mkdir()
@@ -310,6 +311,55 @@ def test_move_folder_preflight_exact_mode_counts_uncapped(app_and_db, tmp_path):
     assert data["file_count"] == 1001
     assert data["file_count_truncated"] is False
     assert "preview" not in data
+
+
+def test_move_folder_preflight_exact_mode_is_capped_not_unbounded(
+    app_and_db, tmp_path, monkeypatch,
+):
+    """mode='exact' must NOT walk the destination tree uncapped. The UI's
+    requestExactDestCount fires from the keystroke-driven path, so an
+    unbounded walk on a hoarder-NAS target with millions of files would pin
+    a Flask worker for minutes (the UI seq guard only discards stale replies,
+    not server-side work). Exact mode passes a generous but finite cap so the
+    worst case is seconds, and the response surfaces truncated=True if the
+    cap was hit — the UI already renders that as 'at least N'."""
+    import app as app_module
+
+    app, db = app_and_db
+    dst = tmp_path / "dest"
+    dst.mkdir()
+    folder = db.get_folder_tree()[0]
+    folder_name = folder["name"] or os.path.basename(folder["path"].rstrip("/\\"))
+    landing = dst / folder_name
+    landing.mkdir()
+
+    captured = {}
+
+    def fake_scan(root_path, file_limit=None, dir_limit=None):
+        captured["file_limit"] = file_limit
+        captured["dir_limit"] = dir_limit
+        # Pretend the cap was hit so the truncated flag can be checked too.
+        return file_limit or 0, True
+
+    monkeypatch.setattr(app_module, "_scan_dir_file_count", fake_scan)
+
+    client = app.test_client()
+    resp = client.post("/api/move-folder/preflight", json={
+        "folder_id": folder["id"],
+        "destination": str(dst),
+        "mode": "exact",
+    })
+    assert resp.status_code == 200
+    data = resp.get_json()
+    # Both caps must be set (not None) so the walk is bounded, and both must
+    # be much larger than the quick-mode caps so realistic libraries never
+    # see "at least N" from exact mode.
+    assert captured["file_limit"] is not None and captured["file_limit"] >= 100000
+    assert captured["dir_limit"] is not None and captured["dir_limit"] >= 50000
+    # Truncation from the helper must surface in the response so the UI can
+    # render "at least N" instead of implying an exact total.
+    assert data["file_count_truncated"] is True
+    assert data["file_count"] == captured["file_limit"]
 
 
 def test_move_folder_preflight_preview_reports_transfer_counts(app_and_db, tmp_path):

--- a/vireo/tests/test_move_api.py
+++ b/vireo/tests/test_move_api.py
@@ -284,6 +284,47 @@ def test_move_folder_preflight_caps_existing_destination_dir_fanout(app_and_db, 
     assert data["file_count_truncated"] is True
 
 
+def test_scan_dir_file_count_stops_walking_after_truncation(tmp_path, monkeypatch):
+    """Once the inner-loop cap trips ``truncated`` mid-scan, the outer walk
+    must stop immediately — not keep popping the already-queued sibling
+    directories until ``dirs_seen`` mechanically catches up to ``dir_limit``.
+
+    On a flat fanout NAS target, the queued-sibling drain is the same
+    worker-stalling behavior the cap is meant to avoid: it can open ~dir_limit
+    extra directories after the decision to truncate is already made.
+    """
+    import app as app_module
+
+    # 30 subdirectories under one root. With dir_limit=10, the inner for-loop
+    # appends children to the stack one at a time. After the 9th append the
+    # check ``dirs_seen (1) + len(stack) (9) >= 10`` trips and sets
+    # ``truncated`` — but the stack still holds 9 queued sibling dirs.
+    root = tmp_path / "fanout"
+    root.mkdir()
+    for d in range(30):
+        (root / f"sub-{d:02d}").mkdir()
+
+    real_scandir = os.scandir
+    scanned = []
+
+    def counting_scandir(path):
+        scanned.append(str(path))
+        return real_scandir(path)
+
+    monkeypatch.setattr(app_module.os, "scandir", counting_scandir)
+
+    file_count, truncated = app_module._scan_dir_file_count(
+        str(root), file_limit=None, dir_limit=10)
+
+    assert truncated is True
+    assert file_count == 0
+    # Only the root dir should have been scanned. Before the fix, the outer
+    # ``while stack:`` would have kept popping the 9 already-queued children
+    # and called os.scandir on each one even though ``truncated`` was already
+    # True — exactly the worker-stalling drain the cap is meant to prevent.
+    assert len(scanned) == 1, scanned
+
+
 def test_move_folder_preflight_exact_mode_counts_past_quick_cap(app_and_db, tmp_path):
     """mode='exact' counts past the 1000-file quick-scan cap and reports the
     true number with truncated=False, since the destination's true size is

--- a/vireo/tests/test_move_api.py
+++ b/vireo/tests/test_move_api.py
@@ -350,6 +350,42 @@ def test_move_folder_preflight_preview_reports_transfer_counts(app_and_db, tmp_p
     assert preview["source_total"] == 3
 
 
+def test_move_folder_preflight_preview_caps_destination_scan(app_and_db, tmp_path):
+    """mode='preview' must NOT walk the destination uncapped. The merge dialog
+    uses the preview's copy/skip counts, not the raw destination file_count, so
+    a full destination-tree walk here would block a Flask worker on large
+    resume targets (NAS folders with millions of unrelated files) for no UI
+    benefit. Capped behavior matches mode='quick': file_count plateaus at the
+    cap and file_count_truncated flips to True."""
+    app, db = app_and_db
+
+    src = tmp_path / "src_folder"
+    src.mkdir()
+    (src / "a.jpg").write_bytes(b"a")
+    fid = db.add_folder(str(src), name="src_folder")
+
+    dst = tmp_path / "dest"
+    dst.mkdir()
+    landing = dst / "src_folder"
+    landing.mkdir()
+    for idx in range(1001):
+        (landing / f"already-{idx}.jpg").write_bytes(b"x")
+
+    client = app.test_client()
+    resp = client.post("/api/move-folder/preflight", json={
+        "folder_id": fid,
+        "destination": str(dst),
+        "mode": "preview",
+    })
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["exists"] is True
+    assert data["file_count"] == 1000
+    assert data["file_count_truncated"] is True
+    # The preview block still describes the source -> destination transfer.
+    assert "preview" in data
+
+
 def test_move_folder_preflight_preview_omitted_when_dest_missing(app_and_db, tmp_path):
     """No preview block when the destination doesn't exist — there is nothing
     to merge into, so a fresh move copies everything."""

--- a/vireo/tests/test_move_api.py
+++ b/vireo/tests/test_move_api.py
@@ -438,6 +438,7 @@ def test_move_folder_preflight_preview_reports_transfer_counts(app_and_db, tmp_p
     # a.jpg already present -> skip; a.jpg.xmp and sub/c.jpg missing -> copy.
     assert preview["will_skip"] == 1
     assert preview["will_copy"] == 2
+    assert preview["will_block"] == 0
     assert preview["source_total"] == 3
 
 

--- a/vireo/tests/test_move_api.py
+++ b/vireo/tests/test_move_api.py
@@ -284,6 +284,90 @@ def test_move_folder_preflight_caps_existing_destination_dir_fanout(app_and_db, 
     assert data["file_count_truncated"] is True
 
 
+def test_move_folder_preflight_exact_mode_counts_uncapped(app_and_db, tmp_path):
+    """mode='exact' walks the destination uncapped, returning the true count
+    and truncated=False even past the 1000-file quick-scan cap."""
+    app, db = app_and_db
+    dst = tmp_path / "dest"
+    dst.mkdir()
+
+    folder = db.get_folder_tree()[0]
+    folder_name = folder["name"] or os.path.basename(folder["path"].rstrip("/\\"))
+    landing = dst / folder_name
+    landing.mkdir()
+    for idx in range(1001):
+        (landing / f"already-{idx}.jpg").write_bytes(b"x")
+
+    client = app.test_client()
+    resp = client.post("/api/move-folder/preflight", json={
+        "folder_id": folder["id"],
+        "destination": str(dst),
+        "mode": "exact",
+    })
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["exists"] is True
+    assert data["file_count"] == 1001
+    assert data["file_count_truncated"] is False
+    assert "preview" not in data
+
+
+def test_move_folder_preflight_preview_reports_transfer_counts(app_and_db, tmp_path):
+    """mode='preview' reports how many source files would copy vs. be skipped
+    as already present — counting every file (sidecars included), not just
+    tracked photos."""
+    app, db = app_and_db
+
+    # Real on-disk source folder with a nested file and an XMP sidecar.
+    src = tmp_path / "src_folder"
+    src.mkdir()
+    (src / "a.jpg").write_bytes(b"a")
+    (src / "a.jpg.xmp").write_bytes(b"sidecar")
+    (src / "sub").mkdir()
+    (src / "sub" / "c.jpg").write_bytes(b"c")
+    fid = db.add_folder(str(src), name="src_folder")
+
+    # Destination already holds one of the source files (a resume scenario).
+    dst = tmp_path / "dest"
+    dst.mkdir()
+    landing = dst / "src_folder"
+    landing.mkdir()
+    (landing / "a.jpg").write_bytes(b"a")
+
+    client = app.test_client()
+    resp = client.post("/api/move-folder/preflight", json={
+        "folder_id": fid,
+        "destination": str(dst),
+        "mode": "preview",
+    })
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["exists"] is True
+    preview = data["preview"]
+    # a.jpg already present -> skip; a.jpg.xmp and sub/c.jpg missing -> copy.
+    assert preview["will_skip"] == 1
+    assert preview["will_copy"] == 2
+    assert preview["source_total"] == 3
+
+
+def test_move_folder_preflight_preview_omitted_when_dest_missing(app_and_db, tmp_path):
+    """No preview block when the destination doesn't exist — there is nothing
+    to merge into, so a fresh move copies everything."""
+    app, db = app_and_db
+    folder = db.get_folder_tree()[0]
+
+    client = app.test_client()
+    resp = client.post("/api/move-folder/preflight", json={
+        "folder_id": folder["id"],
+        "destination": str(tmp_path / "nonexistent"),
+        "mode": "preview",
+    })
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["exists"] is False
+    assert "preview" not in data
+
+
 def test_move_folder_preflight_requires_params(app_and_db):
     """Preflight without folder_id returns 400."""
     app, _ = app_and_db


### PR DESCRIPTION
## What & why

The folder-move preflight question started this: *"⚠ Destination already exists — contains 1000 files"* — is that exact, or a cap? It was a **cap** (`file_limit = 1000`), but the inline status line printed it as if it were the exact total. The merge dialog also never told the user how many files would **actually transfer** — it showed the source folder's tracked-photo count, which ignores sidecars/companions and the skip-already-present rule.

## Changes

**A. Honesty fix (inline status line)** — now says **"contains at least 1,000 files"** when the fast scan was truncated, mirroring logic the merge dialog already had. The pill now means what it says (per `CORE_PHILOSOPHY.md` "no black boxes").

**B. Background exact count (non-blocking)** — when the fast capped scan truncates, the UI fires a `mode='exact'` request that walks the destination uncapped and updates the line in place. Reuses the keystroke seq guard so a result landing after the user changed the path is discarded instead of overwriting the line for the wrong destination. Stays silent on failure — the capped line is already valid.

**C. Transfer preview (merge-confirm dialog)** — the dialog now fires `mode='preview'`, which runs `preview_merge()` and reports **how many source files will copy vs. be skipped** as already present. Counts *every* file under the source (sidecars included), using the same name-only classification `rsync --ignore-existing` performs. Fired only on the deliberate merge click (the "Checking..." button state already covers the spinner), so the source-tree walk isn't run per keystroke.

Refactors the capped `os.scandir` walk into `_scan_dir_file_count(root, file_limit, dir_limit)` so quick (capped) and exact (uncapped) modes share one path; passing `None` caps counts the whole tree exactly.

### Example dialog text
- Resume: *"Merge "birds" into "…"? 47 files will be copied, 473 already present will be skipped."*
- Already complete: *"All 520 files from "birds" are already present at "…". Merging copies nothing new, then removes the originals after verifying every file is at the destination."*

## Notes / scope
- Content **conflicts** (same-name, differing bytes) are still detected and surfaced safely at move time by the existing `_find_content_conflict` scan — the preview stays name-only on purpose so it never reads file contents and stays fast on large trees.
- The fresh-move (destination doesn't exist) dialog is unchanged.

## Tests
New: exact-mode uncapped count, preview transfer counts incl. sidecars, preview omitted when dest missing, and `preview_merge` name-only semantics. Existing capped-count tests unchanged (default `mode='quick'`).

```
python -m pytest vireo/tests/test_move.py vireo/tests/test_move_api.py -q  # 74 passed, 4 skipped
```
Required suite: **1178 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced move-folder preflight with selectable `mode` (`quick`, `exact`, `preview`), including capped destination counts that report whether totals are approximate.
  * Preview mode now shows detailed merge metrics (copy/skip/block) and updates the merge confirmation with “blocked” warnings when destination items can’t be safely verified.
  * When totals are approximate, the UI can refresh to an exact destination count in the background.
* **Bug Fixes**
  * Improved validation of preflight request payloads and more accurate merge/resume prompts for existing destinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->