### PR TITLE
Remote (SSH) folder moves to a NAS

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -13469,6 +13469,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     "photos couldn't stay in your library. Add a mount path "
                     "under Settings → Remote targets."
                 )
+            # The Settings field is free text, so a saved target could carry
+            # a relative path (e.g. "Photos"). Local moves require an absolute
+            # destination — remote moves must too, because mount_path is what
+            # the catalog gets repointed to after the transfer, and a
+            # server-cwd-relative path there would make every moved photo
+            # appear missing.
+            if not os.path.isabs(target["mount_path"]):
+                return json_error(
+                    "This remote target's local mount path isn't absolute "
+                    f"(\"{target['mount_path']}\"). Moved photos would be "
+                    "repointed to a path relative to the server's working "
+                    "directory and appear missing. Set an absolute mount "
+                    "path under Settings → Remote targets."
+                )
             rsync_bin = move_mod.resolve_rsync_bin(
                 effective_cfg.get("rsync_bin", "") or "")
             if not rsync_bin:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -13463,25 +13463,25 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             target = cfg.get_remote_target(remote_target_id)
             if not target:
                 return json_error("Remote target not found", status=404)
-            if not target.get("mount_path"):
+            mount_path = (target.get("mount_path") or "").strip()
+            if not mount_path:
                 return json_error(
                     "This remote target has no local mount path, so moved "
                     "photos couldn't stay in your library. Add a mount path "
                     "under Settings → Remote targets."
                 )
-            # The Settings field is free text, so a saved target could carry
-            # a relative path (e.g. "Photos"). Local moves require an absolute
-            # destination — remote moves must too, because mount_path is what
-            # the catalog gets repointed to after the transfer, and a
-            # server-cwd-relative path there would make every moved photo
-            # appear missing.
-            if not os.path.isabs(target["mount_path"]):
+            # Reject a relative mount path (e.g. saved as "Photos" instead of
+            # "/Volumes/Photos") before any transfer runs. move_folder also
+            # refuses as a defense-in-depth check, but failing here gives the
+            # UI a clean error instead of starting a job that immediately
+            # reports failure.
+            if not os.path.isabs(mount_path):
                 return json_error(
                     "This remote target's local mount path isn't absolute "
-                    f"(\"{target['mount_path']}\"). Moved photos would be "
-                    "repointed to a path relative to the server's working "
-                    "directory and appear missing. Set an absolute mount "
-                    "path under Settings → Remote targets."
+                    f"(\"{mount_path}\"). Moved photos would be repointed "
+                    "to a path relative to the server's working directory "
+                    "and appear missing. Set an absolute mount path under "
+                    "Settings → Remote targets."
                 )
             rsync_bin = move_mod.resolve_rsync_bin(
                 effective_cfg.get("rsync_bin", "") or "")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -13500,8 +13500,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # Pass the mount path as `destination` for informational use; the
             # move uses the SSH base from `remote`.
             destination = remote["mount_dest_base"]
-            display_dest = (f'{target["user"]}@{target["host"]}:'
-                            f'{remote["ssh_dest_base"]}')
+            display_dest = move_mod.rsync_dest_spec(
+                target, remote["ssh_dest_base"])
         else:
             if not isinstance(destination, str):
                 return json_error("destination must be a string")
@@ -13680,7 +13680,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             exists, fcount, truncated, reachable, err = \
                 move_mod.remote_preflight(target, resolved)
             return jsonify({
-                "resolved_dest": f'{target["user"]}@{target["host"]}:{resolved}',
+                "resolved_dest": move_mod.rsync_dest_spec(target, resolved),
                 "exists": exists,
                 "file_count": fcount,
                 "file_count_truncated": truncated,

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -13657,6 +13657,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         # Remote target: resolve the NAS-side dest and probe it over SSH.
         if remote_target_id:
+            import posixpath
+
             import config as cfg
             target = cfg.get_remote_target(remote_target_id)
             if not target:
@@ -13665,8 +13667,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 spec = move_mod.build_remote_move_spec(target, subpath, "")
             except ValueError as exc:
                 return json_error(str(exc))
-            resolved = resolve_folder_dest(
-                folder["path"], folder["name"], spec["ssh_dest_base"])
+            # The NAS path is POSIX, so the preview/probe path must join with
+            # '/' even when this server runs on Windows — resolve_folder_dest
+            # uses os.path.join and would produce ``/volume1/Photo\trip``,
+            # which the SSH ``test -d`` probe would then look up at a
+            # different remote path than the actual transfer (move_folder
+            # uses posixpath.join), so an existing destination would be
+            # reported as new and the first non-merge move would fail.
+            folder_name = (folder["name"]
+                           or os.path.basename(folder["path"].rstrip("/\\")))
+            resolved = posixpath.join(spec["ssh_dest_base"], folder_name)
             exists, fcount, truncated, reachable, err = \
                 move_mod.remote_preflight(target, resolved)
             return jsonify({

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -8571,8 +8571,27 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         cfg.DEFAULTS["keyboard_shortcuts"], validated
                     )
 
+            # Normalize remote_targets on save (assign stable ids, coerce
+            # field types, drop unusable entries) so stored entries always
+            # have the shape get_remote_targets() guarantees on read.
+            if "remote_targets" in body:
+                raw_targets = body["remote_targets"]
+                normalized = []
+                if isinstance(raw_targets, list):
+                    import uuid
+                    for entry in raw_targets:
+                        coerced = cfg._coerce_remote_target(entry)
+                        if coerced is None:
+                            continue
+                        # A client-supplied id wins (stable across edits);
+                        # otherwise mint one so future edits can key the row.
+                        if not (isinstance(entry, dict) and (entry.get("id") or "").strip()):
+                            coerced["id"] = uuid.uuid4().hex
+                        normalized.append(coerced)
+                current["remote_targets"] = normalized
+
             for key in body:
-                if key == "keyboard_shortcuts":
+                if key in ("keyboard_shortcuts", "remote_targets"):
                     continue
                 if key in cfg.DEFAULTS:
                     current[key] = body[key]
@@ -13421,6 +13440,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("JSON body must be an object")
         folder_id = body.get("folder_id")
         destination = body.get("destination", "")
+        remote_target_id = (body.get("remote_target_id") or "").strip()
+        subpath = body.get("subpath", "")
         merge_raw = body.get("merge", False)
         if not isinstance(merge_raw, bool):
             return json_error("merge must be a boolean")
@@ -13428,19 +13449,56 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         if not folder_id:
             return json_error("folder_id required")
-        if not isinstance(destination, str):
-            return json_error("destination must be a string")
-        if not destination:
-            return json_error("destination required")
-        if not os.path.isabs(destination):
-            return json_error("destination must be an absolute path")
+
+        import config as cfg
+        import move as move_mod
+        effective_cfg = _get_db().get_effective_config(cfg.load())
+        developed_dir = effective_cfg.get("darktable_output_dir", "") or ""
+
+        # Remote (SSH) destination vs local path. A remote target carries its
+        # own destination (remote_path + optional subpath), so `destination`
+        # is not required in that case.
+        remote = None
+        if remote_target_id:
+            target = cfg.get_remote_target(remote_target_id)
+            if not target:
+                return json_error("Remote target not found", status=404)
+            if not target.get("mount_path"):
+                return json_error(
+                    "This remote target has no local mount path, so moved "
+                    "photos couldn't stay in your library. Add a mount path "
+                    "under Settings → Remote targets."
+                )
+            rsync_bin = move_mod.resolve_rsync_bin(
+                effective_cfg.get("rsync_bin", "") or "")
+            if not rsync_bin:
+                return json_error(
+                    "No GNU rsync found for remote moves — macOS's "
+                    "built-in rsync can't drive rsync-over-SSH. Install GNU "
+                    "rsync (e.g. `brew install rsync`) or set its path under "
+                    "Settings → Paths."
+                )
+            try:
+                remote = move_mod.build_remote_move_spec(
+                    target, subpath, rsync_bin)
+            except ValueError as exc:
+                return json_error(str(exc))
+            # Pass the mount path as `destination` for informational use; the
+            # move uses the SSH base from `remote`.
+            destination = remote["mount_dest_base"]
+            display_dest = (f'{target["user"]}@{target["host"]}:'
+                            f'{remote["ssh_dest_base"]}')
+        else:
+            if not isinstance(destination, str):
+                return json_error("destination must be a string")
+            if not destination:
+                return json_error("destination required")
+            if not os.path.isabs(destination):
+                return json_error("destination must be an absolute path")
+            display_dest = destination
 
         runner = app._job_runner
         active_ws = _get_db()._active_workspace_id
-
-        import config as cfg
-        effective_cfg = _get_db().get_effective_config(cfg.load())
-        developed_dir = effective_cfg.get("darktable_output_dir", "") or ""
 
         def work(job):
             from move import move_folder
@@ -13485,6 +13543,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 progress_cb=progress_cb,
                 developed_dir=developed_dir,
                 merge=merge,
+                remote=remote,
             )
 
             # Tell the JobRunner whether the move actually succeeded. Without
@@ -13508,9 +13567,21 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     )
             return result
 
+        job_config = {
+            "folder_id": folder_id, "destination": display_dest, "merge": merge,
+        }
+        if remote:
+            # Surface that this is an SSH transfer (and to where) so the job
+            # panel can show it, per the UI-transparency rule.
+            job_config["remote"] = {
+                "host": remote["host"], "user": remote["user"],
+                "ssh_dest_base": remote["ssh_dest_base"],
+                "mount_dest_base": remote["mount_dest_base"],
+                "bwlimit_kbps": remote["bwlimit_kbps"],
+            }
         job_id = runner.start(
             "move-folder", work,
-            config={"folder_id": folder_id, "destination": destination, "merge": merge},
+            config=job_config,
             workspace_id=active_ws,
         )
         return jsonify({"job_id": job_id})
@@ -13519,9 +13590,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def api_move_folder_preflight():
         """Report the resolved destination for a folder move and whether it
         already exists, so the UI can offer a merge/resume confirmation
-        instead of silently failing on an existing destination.
+        instead of silently failing on an existing destination. Handles both
+        local-path and remote-target (SSH) destinations.
 
-        ``mode`` controls how much work the endpoint does:
+        ``mode`` controls how much work the endpoint does (local paths only;
+        a remote target returns its SSH-probed result and ignores ``mode``):
 
         * ``"quick"`` (default) — caps the destination file count at 1000 so
           the live, keystroke-debounced status line stays instant even when
@@ -13545,6 +13618,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
           Flask worker free even when the resume target is a NAS folder
           with millions of unrelated files.
         """
+        import move as move_mod
         from move import preview_merge, resolve_folder_dest
 
         body = request.get_json(silent=True)
@@ -13555,21 +13629,49 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         mode = body.get("mode", "quick")
         if mode not in ("quick", "exact", "preview"):
             mode = "quick"
+        remote_target_id = (body.get("remote_target_id") or "").strip()
+        subpath = body.get("subpath", "")
 
         if not folder_id:
             return json_error("folder_id required")
-        if not isinstance(destination, str):
-            return json_error("destination must be a string")
-        if not destination:
-            return json_error("destination required")
-        if not os.path.isabs(destination):
-            return json_error("destination must be an absolute path")
 
         folder = _get_db().conn.execute(
             "SELECT path, name FROM folders WHERE id = ?", (folder_id,)
         ).fetchone()
         if not folder:
             return json_error("Folder not found", status=404)
+
+        # Remote target: resolve the NAS-side dest and probe it over SSH.
+        if remote_target_id:
+            import config as cfg
+            target = cfg.get_remote_target(remote_target_id)
+            if not target:
+                return json_error("Remote target not found", status=404)
+            try:
+                spec = move_mod.build_remote_move_spec(target, subpath, "")
+            except ValueError as exc:
+                return json_error(str(exc))
+            resolved = resolve_folder_dest(
+                folder["path"], folder["name"], spec["ssh_dest_base"])
+            exists, fcount, truncated, reachable, err = \
+                move_mod.remote_preflight(target, resolved)
+            return jsonify({
+                "resolved_dest": f'{target["user"]}@{target["host"]}:{resolved}',
+                "exists": exists,
+                "file_count": fcount,
+                "file_count_truncated": truncated,
+                "remote": True,
+                "reachable": reachable,
+                "error": err,
+                "mount_path_set": bool(target.get("mount_path")),
+            })
+
+        if not isinstance(destination, str):
+            return json_error("destination must be a string")
+        if not destination:
+            return json_error("destination required")
+        if not os.path.isabs(destination):
+            return json_error("destination must be an absolute path")
 
         resolved = resolve_folder_dest(folder["path"], folder["name"], destination)
         exists = os.path.isdir(resolved)
@@ -13603,6 +13705,49 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if mode == "preview" and exists:
             result["preview"] = preview_merge(folder["path"], resolved)
         return jsonify(result)
+
+    @app.route("/api/remote-targets")
+    def api_remote_targets_list():
+        """List configured remote (SSH) move targets for the move-form picker,
+        plus whether a usable GNU rsync is available for the transfer."""
+        import config as cfg
+        import move as move_mod
+
+        effective_cfg = _get_db().get_effective_config(cfg.load())
+        rsync_bin = move_mod.resolve_rsync_bin(
+            effective_cfg.get("rsync_bin", "") or "")
+        usable = bool(rsync_bin and move_mod.is_gnu_rsync(rsync_bin))
+        return jsonify({
+            "targets": cfg.get_remote_targets(),
+            "rsync_available": usable,
+            "rsync_bin": rsync_bin if usable else None,
+        })
+
+    @app.route("/api/remote-targets/test", methods=["POST"])
+    def api_remote_target_test():
+        """Test connectivity for a remote target (saved or in-progress edit):
+        SSH reachability, remote-path writability, GNU rsync availability, and
+        whether the local mount path is currently present."""
+        import config as cfg
+        import move as move_mod
+
+        body = request.get_json(silent=True) or {}
+        target = cfg._coerce_remote_target(body)
+        if target is None:
+            return json_error("Host, user, and remote path are required.")
+
+        effective_cfg = _get_db().get_effective_config(cfg.load())
+        rsync_bin = move_mod.resolve_rsync_bin(
+            effective_cfg.get("rsync_bin", "") or "")
+        # Apple openrsync resolves but can't drive SSH — treat as unusable.
+        if rsync_bin and not move_mod.is_gnu_rsync(rsync_bin):
+            rsync_bin = ""
+        res = move_mod.test_remote_connection(target, rsync_bin)
+        mount = target.get("mount_path")
+        res["mount_path"] = mount
+        res["mount_present"] = bool(mount and os.path.isdir(mount))
+        res["rsync_bin"] = rsync_bin or None
+        return jsonify(res)
 
     @app.route("/api/jobs/import-full", methods=["POST"])
     def api_job_import_full():

--- a/vireo/config.py
+++ b/vireo/config.py
@@ -387,11 +387,19 @@ def get_editors():
 def _coerce_remote_target(entry):
     """Validate/normalize one remote-target dict, or return None if unusable.
 
-    A usable target needs at least a host, user, and remote_path (the rest
-    have sane fallbacks). `mount_path` may be empty — a target with no local
-    mount simply can't keep its photos catalogued after a move (the move
-    route enforces that where it matters), but the entry is still valid for
-    transfer. Numeric fields are coerced; junk falls back to defaults.
+    A usable target needs at least a host, user, and an *absolute POSIX*
+    remote_path (the rest have sane fallbacks). A relative remote_path like
+    "Photos" would be sent unchanged to ``user@host:Photos/<folder>`` —
+    rsync and the checksum verify would then operate under the SSH user's
+    remote cwd, while the catalog gets repointed to the absolute local
+    mount_path. The original source would be deleted on a verified copy
+    that lives at a different remote location than the path Vireo records,
+    so reject relative remote paths at the entry boundary rather than
+    after a move is already in flight. ``mount_path`` may be empty — a
+    target with no local mount simply can't keep its photos catalogued
+    after a move (the move route enforces that where it matters), but the
+    entry is still valid for transfer. Numeric fields are coerced; junk
+    falls back to defaults.
     """
     if not isinstance(entry, dict):
         return None
@@ -399,6 +407,12 @@ def _coerce_remote_target(entry):
     user = (entry.get("user") or "").strip()
     remote_path = (entry.get("remote_path") or "").strip()
     if not host or not user or not remote_path:
+        return None
+    # POSIX-absolute only: rsync ships this path to the NAS-side shell, so
+    # Windows drive forms / backslashes are also non-starters (the NAS is
+    # POSIX). Comparing to "/" handles every absolute form that survives a
+    # POSIX shell intact.
+    if not remote_path.startswith("/"):
         return None
     name = (entry.get("name") or "").strip() or f"{user}@{host}"
     try:

--- a/vireo/config.py
+++ b/vireo/config.py
@@ -31,6 +31,21 @@ DEFAULTS = {
     "scan_roots": [],
     "scan_workers": 0,
     "setup_complete": False,
+    # Path to a GNU rsync binary used for remote (SSH) folder moves. macOS
+    # ships Apple's `openrsync`, which cannot drive rsync-over-SSH, so a
+    # remote move needs real GNU rsync. Empty = auto-resolve (bundled binary,
+    # then a few known install paths) via move.resolve_rsync_bin(). Local
+    # moves are unaffected and keep using whatever `rsync` is on PATH.
+    "rsync_bin": "",
+    # Saved remote (NAS) destinations for folder moves over SSH. Each entry:
+    #   {"id", "name", "host", "user", "port", "ssh_key",
+    #    "remote_path", "mount_path", "bwlimit_kbps"}
+    # `remote_path` is the NAS-side filesystem path used for the rsync-over-SSH
+    # transfer; `mount_path` is the local path (e.g. an SMB mount) where Vireo
+    # can read those same files afterward, and is what the catalog points at
+    # once a move completes. Custom settings UI (like external_editors), so
+    # it's excluded from SCHEMA.
+    "remote_targets": [],
     "darktable_bin": "",
     # Legacy single-editor field. Kept for one-cycle migration: if
     # `external_editors` is empty and this is set, get_editors() synthesizes
@@ -367,3 +382,73 @@ def get_editors():
         if isinstance(legacy, str) and legacy.strip():
             editors.append({"name": "Editor", "path": legacy.strip()})
     return editors
+
+
+def _coerce_remote_target(entry):
+    """Validate/normalize one remote-target dict, or return None if unusable.
+
+    A usable target needs at least a host, user, and remote_path (the rest
+    have sane fallbacks). `mount_path` may be empty — a target with no local
+    mount simply can't keep its photos catalogued after a move (the move
+    route enforces that where it matters), but the entry is still valid for
+    transfer. Numeric fields are coerced; junk falls back to defaults.
+    """
+    if not isinstance(entry, dict):
+        return None
+    host = (entry.get("host") or "").strip()
+    user = (entry.get("user") or "").strip()
+    remote_path = (entry.get("remote_path") or "").strip()
+    if not host or not user or not remote_path:
+        return None
+    name = (entry.get("name") or "").strip() or f"{user}@{host}"
+    try:
+        port = int(entry.get("port") or 22)
+    except (TypeError, ValueError):
+        port = 22
+    try:
+        bwlimit = int(entry.get("bwlimit_kbps") or 0)
+    except (TypeError, ValueError):
+        bwlimit = 0
+    tid = (entry.get("id") or "").strip()
+    if not tid:
+        # Stable-ish id derived from the connection tuple so the UI can key
+        # rows even for legacy entries saved before ids existed.
+        tid = f"{user}@{host}:{remote_path}"
+    return {
+        "id": tid,
+        "name": name,
+        "host": host,
+        "user": user,
+        "port": port,
+        "ssh_key": (entry.get("ssh_key") or "").strip(),
+        "remote_path": remote_path,
+        "mount_path": (entry.get("mount_path") or "").strip(),
+        "bwlimit_kbps": max(0, bwlimit),
+    }
+
+
+def get_remote_targets():
+    """Return configured remote (SSH) move targets, validated/normalized.
+
+    Malformed entries (missing host/user/remote_path) are dropped so callers
+    can trust the shape. See DEFAULTS["remote_targets"] for the field set.
+    """
+    raw = load().get("remote_targets") or []
+    if not isinstance(raw, list):
+        return []
+    targets = []
+    for entry in raw:
+        coerced = _coerce_remote_target(entry)
+        if coerced is not None:
+            targets.append(coerced)
+    return targets
+
+
+def get_remote_target(target_id):
+    """Return the validated remote target with the given id, or None."""
+    if not target_id:
+        return None
+    for t in get_remote_targets():
+        if t["id"] == target_id:
+            return t
+    return None

--- a/vireo/config_schema.py
+++ b/vireo/config_schema.py
@@ -23,6 +23,9 @@ EXCLUDED = (
     # List of {name, path} dicts — has custom settings UI rather than a
     # generic widget, so it lives outside SCHEMA.
     "external_editors",
+    # List of remote-target dicts — custom settings UI (Remote targets
+    # section), so it lives outside SCHEMA like external_editors.
+    "remote_targets",
 )
 
 
@@ -294,6 +297,14 @@ SCHEMA = {
         "category": "Paths", "scope": "global",
         "label": "Adobe DNG Converter path",
         "desc": "Optional path to Adobe DNG Converter. Leave empty to auto-detect the app.",
+    },
+    "rsync_bin": {
+        "type": "path",
+        "category": "Paths", "scope": "global",
+        "label": "GNU rsync path (remote moves)",
+        "desc": "Path to a GNU rsync binary for remote (SSH) folder moves. "
+                "macOS ships openrsync, which can't do rsync-over-SSH. "
+                "Leave empty to auto-detect.",
     },
 
     # --- Integrations -----------------------------------------------------

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -8,6 +8,7 @@ import posixpath
 import shlex
 import shutil
 import subprocess
+import sys
 import tempfile
 import threading
 import time
@@ -232,15 +233,40 @@ def _is_executable_file(path):
     return os.access(path, os.X_OK)
 
 
+def _platform_rsync_candidates():
+    """Standard GNU rsync locations on non-macOS platforms.
+
+    The openrsync-at-/usr/bin avoidance baked into _BUNDLED_RSYNC_CANDIDATES is
+    macOS-specific: every other major OS ships GNU rsync as ``/usr/bin/rsync``
+    and on ``$PATH``, so on Linux/BSD/Windows a usable rsync is normally just
+    there and ``resolve_rsync_bin("")`` should find it without the user setting
+    anything. We probe ``$PATH`` via shutil.which first so a custom rsync
+    earlier on PATH (e.g. /usr/local/bin) is preferred over /usr/bin's, and
+    fall back to /usr/bin/rsync explicitly in case PATH is unset/sparse in a
+    headless context. Returns an empty tuple on darwin so this never
+    short-circuits the Homebrew/MacPorts candidates above.
+    """
+    if sys.platform == "darwin":
+        return ()
+    cands = []
+    found = shutil.which("rsync")
+    if found:
+        cands.append(found)
+    cands.append("/usr/bin/rsync")
+    return tuple(cands)
+
+
 def resolve_rsync_bin(configured=""):
     """Return an absolute path to a GNU rsync binary for remote moves, or None.
 
     Resolution order: an explicit ``configured`` path (the ``rsync_bin``
-    config value), the ``VIREO_RSYNC_BIN`` environment override, then the
-    bundled/known-install candidates. Apple's openrsync at /usr/bin/rsync is
-    never auto-selected — it can't do rsync-over-SSH — so a host with only
-    that returns None, and the caller surfaces a clear "install GNU rsync"
-    error rather than failing mid-transfer.
+    config value), the ``VIREO_RSYNC_BIN`` environment override, the
+    bundled/known-install candidates, then on non-macOS platforms ``$PATH``
+    and ``/usr/bin/rsync`` (where GNU rsync normally lives). Apple's openrsync
+    at /usr/bin/rsync is never auto-selected on macOS — it can't do
+    rsync-over-SSH — so a macOS host with only that returns None, and the
+    caller surfaces a clear "install GNU rsync" error rather than failing
+    mid-transfer.
     """
     candidates = []
     if configured:
@@ -249,9 +275,17 @@ def resolve_rsync_bin(configured=""):
     if env:
         candidates.append(env)
     candidates.extend(_BUNDLED_RSYNC_CANDIDATES)
+    candidates.extend(_platform_rsync_candidates())
+    seen = set()
     for c in candidates:
-        if _is_executable_file(c):
-            return os.path.abspath(c)
+        if not c:
+            continue
+        ap = os.path.abspath(c)
+        if ap in seen:
+            continue
+        seen.add(ap)
+        if _is_executable_file(ap):
+            return ap
     return None
 
 
@@ -305,14 +339,34 @@ def _ssh_target(remote):
 
 
 def _remote_dir_exists(remote, path):
-    """True if ``path`` is a directory on the remote host (via SSH)."""
+    """Probe whether ``path`` is a directory on the remote host (via SSH).
+
+    Returns True if it is, False if the SSH command ran and reported it isn't,
+    and None if the probe itself couldn't run cleanly — SSH connect failure,
+    auth failure, timeout, ``ssh`` binary missing, etc. The caller MUST treat
+    None as "inconclusive, refuse the move" rather than as "destination
+    absent": if a transient SSH glitch on an actually-existing destination
+    were collapsed to False, the move would proceed as a fresh transfer
+    (omitting --ignore-existing) and rsync would happily overwrite same-name
+    files before the post-transfer --checksum verify could preserve the
+    originals.
+
+    ``test -d`` exit codes: 0 = directory, 1 = not a directory / absent. SSH
+    returns the remote command's exit code on success, or 255 when SSH itself
+    couldn't complete the session — so any other return code (255 or
+    otherwise unexpected) is bucketed with the OSError/SubprocessError path.
+    """
     cmd = (["ssh"] + ssh_base_args(remote)
            + [_ssh_target(remote), f"test -d {shlex.quote(path)}"])
     try:
-        return subprocess.run(cmd, capture_output=True,
-                              timeout=30).returncode == 0
+        rc = subprocess.run(cmd, capture_output=True, timeout=30).returncode
     except (OSError, subprocess.SubprocessError):
+        return None
+    if rc == 0:
+        return True
+    if rc == 1:
         return False
+    return None
 
 
 def remote_preflight(remote, dest_path, file_cap=1000):
@@ -1256,7 +1310,19 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
         ]}
 
     if remote:
-        dest_exists = _remote_dir_exists(remote, transfer_dest)
+        probe = _remote_dir_exists(remote, transfer_dest)
+        if probe is None:
+            # Refuse rather than proceed as a fresh transfer: a transient SSH
+            # failure on a real existing destination would otherwise omit
+            # --ignore-existing and let rsync overwrite same-name files before
+            # the post-transfer --checksum verify could preserve the originals.
+            return {"moved": 0, "errors": [
+                f"Couldn't probe remote destination via SSH: "
+                f"{remote['user']}@{remote['host']}:{transfer_dest}. "
+                f"Refusing the move so a transient SSH error isn't confused "
+                f"with an absent destination."
+            ]}
+        dest_exists = probe
     else:
         dest_exists = os.path.exists(transfer_dest)
     if dest_exists and not merge:

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -357,6 +357,38 @@ def _ssh_target(remote):
     return f'{remote["user"]}@{remote["host"]}'
 
 
+def _rsync_host_token(host):
+    """Bracket a host for rsync's ``user@host:path`` syntax when needed.
+
+    The rsync remote-shell form uses the FIRST colon as the host/path
+    separator (see the rsync(1) manpage). An IPv6 literal like
+    ``2001:db8::1`` therefore can't be passed bare: ``me@2001:db8::1:/path``
+    ships to ssh as host ``2001`` and remote command ``db8::1:/path``, so
+    rsync's preflight probe of THIS routine's target can succeed (we use
+    direct ssh, where user@host parses cleanly without brackets) while the
+    actual transfer goes to the wrong host or fails entirely. Wrapping the
+    host in brackets disambiguates it and is rsync's documented IPv6 form;
+    DNS names and IPv4 addresses don't contain colons so are passed through
+    unchanged. Plain ssh invocations stay unbracketed because OpenSSH parses
+    ``user@host`` unambiguously without a trailing path component.
+    """
+    if ":" in host:
+        return f"[{host}]"
+    return host
+
+
+def rsync_dest_spec(remote, path):
+    """Format ``user@host:path`` for rsync, bracketing the host iff it's IPv6.
+
+    The single place every rsync transfer/verify spec is built so the IPv6
+    wrap can't be forgotten at one call site and silently land in the wrong
+    place. Display strings (the move preflight's ``resolved_dest``, the
+    move-form's SSH preview) use this too, so a value the user sees and a
+    value rsync would actually accept are the same string.
+    """
+    return f'{remote["user"]}@{_rsync_host_token(remote["host"])}:{path}'
+
+
 def _remote_mkdir_p(remote, path):
     """Create ``path`` (and any missing intermediate parents) on the remote
     host via SSH. Idempotent — ``mkdir -p`` accepts an already-existing
@@ -1361,7 +1393,7 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
         transfer_dest = posixpath.join(remote["ssh_dest_base"], name)
         catalog_path = resolve_folder_dest(
             src_path, folder["name"], mount_base)
-        rsync_target = f'{remote["user"]}@{remote["host"]}:{transfer_dest}'
+        rsync_target = rsync_dest_spec(remote, transfer_dest)
     else:
         transfer_dest = resolve_folder_dest(src_path, folder["name"], destination)
         catalog_path = transfer_dest
@@ -1435,7 +1467,7 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
             # the post-transfer --checksum verify could preserve the originals.
             return {"moved": 0, "errors": [
                 f"Couldn't probe remote destination via SSH: "
-                f"{remote['user']}@{remote['host']}:{transfer_dest}. "
+                f"{rsync_dest_spec(remote, transfer_dest)}. "
                 f"Refusing the move so a transient SSH error isn't confused "
                 f"with an absent destination."
             ]}

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -76,11 +76,18 @@ def sanitize_subpath(subpath):
     configured remote_path/mount_path. Returns a clean ``/``-joined relative
     path (possibly empty).
     """
-    sub = (subpath or "").strip()
-    if not sub:
+    raw = (subpath or "").strip()
+    if not raw:
         return ""
+    sub = raw.replace("\\", "/")
+    # Reject absolute inputs BEFORE the segment loop strips leading separators.
+    # Without this, '/foo' and '\foo' silently land as 'foo' and slip into a
+    # different target than the user typed; Windows drive prefixes ('C:...')
+    # would also slip through to a non-relative target.
+    if sub.startswith("/") or (len(sub) >= 2 and sub[1] == ":"):
+        raise ValueError("Subpath must be relative")
     parts = []
-    for seg in sub.replace("\\", "/").split("/"):
+    for seg in sub.split("/"):
         if seg in ("", "."):
             continue
         if seg == "..":
@@ -204,9 +211,12 @@ def _copy_tree_with_progress(src_path, dest_path, skip_existing, total_files,
 
 # Path candidates for a GNU rsync usable for remote (SSH) moves. macOS's
 # /usr/bin/rsync is Apple's openrsync, which can't drive rsync-over-SSH to a
-# GNU rsync peer, so it is deliberately absent here. A packaged build drops a
+# GNU rsync peer; it is intentionally absent here AND the resolver verifies
+# any PATH/`/usr/bin/rsync` candidate with is_gnu_rsync before returning it,
+# so a host with only openrsync still returns None. A packaged build drops a
 # bundled static GNU rsync next to this module (vireo/bin/rsync) or in the
-# app's Resources dir; dev machines fall back to a Homebrew/MacPorts install.
+# app's Resources dir; dev machines fall back to a Homebrew/MacPorts install
+# or the distro's `/usr/bin/rsync` (GNU rsync on every Linux distro).
 _BUNDLED_RSYNC_CANDIDATES = (
     os.path.join(os.path.dirname(os.path.abspath(__file__)), "bin", "rsync"),
     os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "Resources", "rsync"),
@@ -214,6 +224,13 @@ _BUNDLED_RSYNC_CANDIDATES = (
     "/usr/local/bin/rsync",
     "/opt/local/bin/rsync",
 )
+
+# Candidates that may resolve to Apple's openrsync on macOS (PATH lookup and
+# the system /usr/bin/rsync). These are checked LAST so an explicit config or
+# bundled GNU rsync always wins, and each is probed with is_gnu_rsync before
+# being returned — so a macOS host with only openrsync still gets None, while
+# every Linux distro (where /usr/bin/rsync IS GNU rsync) gets remote moves.
+_FALLBACK_RSYNC_CANDIDATES = ("/usr/bin/rsync",)
 
 
 def _is_executable_file(path):
@@ -325,13 +342,15 @@ def ssh_base_args(remote):
 
 
 def _ssh_rsh_string(remote):
-    """The ``-e`` value for rsync: an ``ssh ...`` command string.
+    """The ``-e`` value for rsync: a shell-quoted ``ssh ...`` command string.
 
-    rsync splits this on whitespace (no shell quoting), so identity-file paths
-    containing spaces aren't supported — an accepted limitation; the default
-    key needs no -i, and key paths almost never contain spaces.
+    rsync's ``-e`` argument is parsed with popt-style tokenisation that
+    respects shell-style quoting — quoting an identity-file path with spaces
+    keeps it as a single argument when rsync re-splits the string. Use
+    ``shlex.join`` so a key path like ``/Users/me/My Keys/id_ed25519`` (or a
+    port flag carrying any whitespace) survives the round-trip intact.
     """
-    return " ".join(["ssh"] + ssh_base_args(remote))
+    return shlex.join(["ssh"] + ssh_base_args(remote))
 
 
 def _ssh_target(remote):
@@ -1243,13 +1262,28 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
     #     destination and catalog coincide; for remote they diverge because
     #     the NAS path isn't reachable through the local filesystem.
     if remote:
+        mount_base = remote.get("mount_dest_base") or ""
+        # Without an absolute mount path, resolve_folder_dest below would
+        # produce a relative catalog_path like 'Birds' — then after the SSH
+        # copy succeeds and originals are deleted, the catalog row points at
+        # a non-resolving location relative to the server cwd. The
+        # /api/jobs/move-folder route also validates this, but move_folder is
+        # called directly from tests and other code paths; checking here too
+        # means the bug can't slip past whichever caller forgets.
+        if not os.path.isabs(mount_base):
+            return {"moved": 0, "errors": [
+                "Remote target needs an absolute local mount path before "
+                "moving files — otherwise the catalog would point at a "
+                "relative location after the move. Set the mount path under "
+                "Settings → Remote targets."
+            ]}
         # The NAS side is POSIX, so the SSH dest must be joined with '/' even
         # when this code runs on Windows; os.path.join would produce a
         # backslash and rsync would treat it as a single path segment.
         name = folder["name"] or os.path.basename(src_path.rstrip("/\\"))
         transfer_dest = posixpath.join(remote["ssh_dest_base"], name)
         catalog_path = resolve_folder_dest(
-            src_path, folder["name"], remote["mount_dest_base"])
+            src_path, folder["name"], mount_base)
         rsync_target = f'{remote["user"]}@{remote["host"]}:{transfer_dest}'
     else:
         transfer_dest = resolve_folder_dest(src_path, folder["name"], destination)
@@ -1270,12 +1304,18 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
     # delete wipes everything. See _destination_overlaps_source for the alias
     # surface (symlinks, Windows case folding, case-insensitive POSIX).
     #
-    # Local-only: a remote destination lives on a different machine reached
-    # over SSH, so it can't alias the local source tree — the post-transfer
-    # --checksum verify is the safety backstop for remote.
-    if not remote and _destination_overlaps_source(src_path, transfer_dest):
+    # The NAS-side transfer_dest can't alias the local source tree for a
+    # remote move — but the LOCAL MOUNT PATH the catalog is repointed to
+    # (catalog_path) absolutely can if the source already lives on the same
+    # mount. e.g. src=/Volumes/Photography/trip with remote mount_path=
+    # /Volumes/Photography would copy a tree onto itself over SSH; the
+    # checksum verify passes (everything is "already there") and then the
+    # rmtree(src) deletes the only copy. So check the local-facing path:
+    # transfer_dest for local moves, catalog_path for remote.
+    overlap_src_check = catalog_path if remote else transfer_dest
+    if _destination_overlaps_source(src_path, overlap_src_check):
         return {"moved": 0, "errors": [
-            f"Destination overlaps the source folder: {transfer_dest}"
+            f"Destination overlaps the source folder: {overlap_src_check}"
         ]}
 
     # Refuse moving into — or around — a destination Vireo already tracks as a

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -714,6 +714,48 @@ def _find_content_conflict(src_path, dest_path):
     return None
 
 
+def _find_remote_content_conflict(rsync_bin, src_path, rsync_target, remote):
+    """Remote counterpart to ``_find_content_conflict`` — find the first
+    source file whose same-name twin at the remote destination differs in
+    content. The destination is on the NAS so we can't filecmp it directly;
+    instead run ``rsync -an --existing --checksum`` over SSH, which only
+    inspects items that ALREADY exist at the receiver and reports any whose
+    bytes don't match. Missing destination files are skipped — those are
+    legitimate transfers the merge will perform, not conflicts.
+    Returns:
+      * ``None`` — no same-name file differs; safe to start the merge.
+      * ``(name, None)`` — first colliding file (rsync's relative path).
+      * ``("__ERROR__", detail)`` — the conflict probe itself failed; the
+        caller treats this as a refusal so a half-transferred state never
+        lands on the NAS.
+    Without this, ``--ignore-existing`` would still copy every MISSING
+    source file before the post-transfer ``--checksum`` verify could spot
+    the conflict — leaving the newly-copied files orphaned on the NAS,
+    breaking the local-merge contract that a content conflict cancels with
+    nothing changed.
+    """
+    cmd = [rsync_bin, "-an", "--existing", "--checksum",
+           "--out-format=%n",
+           "-e", _ssh_rsh_string(remote),
+           src_path + "/", rsync_target + "/"]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True,
+                              timeout=REMOTE_VERIFY_TIMEOUT)
+    except subprocess.TimeoutExpired:
+        return ("__ERROR__", f"conflict check timed out after "
+                f"{REMOTE_VERIFY_TIMEOUT // 60} minutes")
+    except OSError as exc:
+        return ("__ERROR__", str(exc))
+    if proc.returncode != 0:
+        return ("__ERROR__", proc.stderr.strip() or f"rsync exit {proc.returncode}")
+    for line in proc.stdout.splitlines():
+        name = line.rstrip("\n")
+        if not name or name.endswith("/"):
+            continue  # directory entry, not a file rsync would transfer
+        return (name, None)
+    return None
+
+
 def _first_missing_source_file(src_path, dest_path):
     """Return the relative path of the first source file absent (or
     size-mismatched, or a symlink) at dest_path, or None if every source
@@ -1481,20 +1523,53 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
             "needs_merge": True,
         }
 
-    if dest_exists and not remote:
+    if dest_exists:
         # Refuse if any same-name file already at the destination differs in
         # content. Never overwrite or later delete the user's data over a real
-        # collision — only files that are byte-identical (a genuine resume) may
-        # be treated as already-moved. (Remote: the post-transfer --checksum
-        # verify catches a differing same-name file just as well, since
-        # --ignore-existing never overwrites it and the dry-run then reports it
-        # as still needing transfer — so the move refuses to delete originals.)
-        conflict = _find_content_conflict(src_path, transfer_dest)
-        if conflict is not None:
-            return {"moved": 0, "errors": [
-                f"Conflict: '{conflict}' already exists at the destination with "
-                f"different content. Nothing was copied or deleted."
-            ]}
+        # collision — only files that are byte-identical (a genuine resume)
+        # may be treated as already-moved. Both branches enforce the same
+        # contract: a content conflict cancels the move with NOTHING copied
+        # or deleted on either end.
+        if remote:
+            # The destination lives on the NAS, so the walk is delegated to
+            # rsync over SSH: ``-an --existing --checksum`` inspects only
+            # files that already exist at the receiver and reports any whose
+            # bytes don't match. Without this pre-copy check, the actual
+            # transfer (--ignore-existing + --partial-dir) would still copy
+            # every MISSING source file before the post-transfer --checksum
+            # verify could surface the conflict — leaving stray newly-copied
+            # files orphaned on the NAS instead of cancelling cleanly. A
+            # probe error is also treated as a refusal so a flaky link can't
+            # downgrade the "nothing changed" guarantee.
+            remote_rsync = remote.get("rsync_bin")
+            if not remote_rsync:
+                return {"moved": 0, "errors": [
+                    "No GNU rsync binary available for remote moves. macOS's "
+                    "built-in rsync can't do this — set the GNU rsync path "
+                    "in Settings."
+                ]}
+            conflict = _find_remote_content_conflict(
+                remote_rsync, src_path, rsync_target, remote)
+            if conflict is not None:
+                name, detail = conflict
+                if name == "__ERROR__":
+                    return {"moved": 0, "errors": [
+                        f"Pre-merge content check could not run ({detail}). "
+                        f"Nothing was copied — re-run when the connection is "
+                        f"stable."
+                    ]}
+                return {"moved": 0, "errors": [
+                    f"Conflict: '{name}' already exists at the remote "
+                    f"destination with different content. Nothing was copied "
+                    f"or deleted."
+                ]}
+        else:
+            conflict = _find_content_conflict(src_path, transfer_dest)
+            if conflict is not None:
+                return {"moved": 0, "errors": [
+                    f"Conflict: '{conflict}' already exists at the destination "
+                    f"with different content. Nothing was copied or deleted."
+                ]}
 
     log.info("%s folder %s -> %s",
              "Merging" if dest_exists else "Moving", src_path, rsync_target)

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -4,6 +4,7 @@ import contextlib
 import filecmp
 import logging
 import os
+import posixpath
 import shlex
 import shutil
 import subprocess
@@ -96,7 +97,6 @@ def build_remote_move_spec(target, subpath, rsync_bin):
     POSIX-style (the NAS is POSIX); the mount base uses the local separator.
     Raises ValueError on a bad subpath.
     """
-    import posixpath
     sub = sanitize_subpath(subpath)
     ssh_base = target["remote_path"]
     mount_base = target.get("mount_path", "")
@@ -215,6 +215,23 @@ _BUNDLED_RSYNC_CANDIDATES = (
 )
 
 
+def _is_executable_file(path):
+    """True if ``path`` is a regular file the OS would treat as executable.
+
+    On POSIX this is the X bit. Windows has no execute bit (``os.access(p,
+    os.X_OK)`` returns True for any regular file), so executability there is
+    defined by file extension via PATHEXT — match that.
+    """
+    if not path or not os.path.isfile(path):
+        return False
+    if os.name == "nt":
+        ext = os.path.splitext(path)[1].lower()
+        pathext = [e.lower() for e in os.environ.get(
+            "PATHEXT", ".COM;.EXE;.BAT;.CMD").split(os.pathsep)]
+        return ext in pathext
+    return os.access(path, os.X_OK)
+
+
 def resolve_rsync_bin(configured=""):
     """Return an absolute path to a GNU rsync binary for remote moves, or None.
 
@@ -233,7 +250,7 @@ def resolve_rsync_bin(configured=""):
         candidates.append(env)
     candidates.extend(_BUNDLED_RSYNC_CANDIDATES)
     for c in candidates:
-        if c and os.path.isfile(c) and os.access(c, os.X_OK):
+        if _is_executable_file(c):
             return os.path.abspath(c)
     return None
 
@@ -1172,8 +1189,11 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
     #     destination and catalog coincide; for remote they diverge because
     #     the NAS path isn't reachable through the local filesystem.
     if remote:
-        transfer_dest = resolve_folder_dest(
-            src_path, folder["name"], remote["ssh_dest_base"])
+        # The NAS side is POSIX, so the SSH dest must be joined with '/' even
+        # when this code runs on Windows; os.path.join would produce a
+        # backslash and rsync would treat it as a single path segment.
+        name = folder["name"] or os.path.basename(src_path.rstrip("/\\"))
+        transfer_dest = posixpath.join(remote["ssh_dest_base"], name)
         catalog_path = resolve_folder_dest(
             src_path, folder["name"], remote["mount_dest_base"])
         rsync_target = f'{remote["user"]}@{remote["host"]}:{transfer_dest}'

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -426,11 +426,20 @@ def test_remote_connection(remote, rsync_bin):
 
     ``remote`` is a coerced target dict; ``rsync_bin`` is a resolved GNU rsync
     path (or "" if none/openrsync). Returns a dict with per-check booleans
-    (``ssh``, ``remote_path_writable``, ``rsync_ok``), an overall ``ok``, and
-    a human ``message``.
+    (``ssh``, ``remote_path_writable``, ``rsync_ok``, ``remote_rsync_ok``),
+    an overall ``ok``, and a human ``message``.
+
+    Both rsync ends are probed: rsync-over-SSH needs a working rsync on the
+    REMOTE side too (the ``--rsync-path`` program the local rsync invokes
+    after SSH connects). On a Synology NAS, that program is gated by DSM's
+    "Enable rsync service" toggle: SSH and the remote path can be reachable
+    while the remote rsync binary is absent or disabled, so without this
+    probe the test reports "Connection OK" and the user only discovers the
+    misconfiguration when a real move fails mid-transfer.
     """
     result = {"ok": False, "ssh": False, "remote_path_writable": False,
-              "rsync_ok": bool(rsync_bin), "message": ""}
+              "rsync_ok": bool(rsync_bin), "remote_rsync_ok": False,
+              "message": ""}
     target = _ssh_target(remote)
     base = ["ssh"] + ssh_base_args(remote) + [target]
     try:
@@ -466,6 +475,29 @@ def test_remote_connection(remote, rsync_bin):
             "found for the transfer (macOS's built-in rsync can't do this). "
             "Install GNU rsync or set its path under Settings → Paths.")
         return result
+    # Probe the REMOTE rsync. `rsync --version` is cheap and side-effect-free;
+    # any non-zero exit (or a missing binary, which the remote shell reports
+    # as "command not found" / exit 127) means an actual move would fail at
+    # the rsync handshake. On Synology, the setuid rsync only appears on PATH
+    # when DSM's "Enable rsync service" toggle is on — the most common cause
+    # of this check failing on an otherwise reachable NAS.
+    try:
+        rr = subprocess.run(
+            base + ["rsync --version 2>/dev/null | head -n 1"],
+            capture_output=True, text=True, timeout=20)
+    except (OSError, subprocess.SubprocessError) as exc:
+        result["message"] = (
+            f"SSH and the remote path are reachable, but couldn't probe the "
+            f"remote rsync: {exc}")
+        return result
+    if rr.returncode != 0 or "rsync" not in rr.stdout.lower():
+        result["message"] = (
+            "SSH and the remote path are reachable, but rsync isn't "
+            "available on the remote — moves would fail at handshake. On a "
+            "Synology NAS, enable Control Panel → File Services → rsync → "
+            "Enable rsync service. Otherwise, install rsync on the remote.")
+        return result
+    result["remote_rsync_ok"] = True
     result["ok"] = True
     result["message"] = "Connection OK — SSH, remote path, and rsync all good."
     return result

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -4,6 +4,7 @@ import contextlib
 import filecmp
 import logging
 import os
+import shlex
 import shutil
 import subprocess
 import tempfile
@@ -11,6 +12,13 @@ import threading
 import time
 
 log = logging.getLogger(__name__)
+
+# How long the remote verification rsync (a --checksum dry-run over SSH) may
+# run before we give up and treat the move as unverified. This only gates the
+# *verify* step, never the transfer: a timeout here is conservative-safe — it
+# returns a verification failure, so the originals are preserved rather than
+# deleted against an unconfirmed copy.
+REMOTE_VERIFY_TIMEOUT = 7200  # 2 hours
 
 # How long rsync may make NO forward progress (no file transferred and no
 # stderr activity) before we treat it as wedged and kill it. This is a STALL
@@ -57,6 +65,55 @@ def _copy_and_verify(src, dst):
         os.remove(dst)
         return False
     return True
+
+
+def sanitize_subpath(subpath):
+    """Normalize an optional relative subpath under a remote target's base.
+
+    Rejects absolute paths and any ``..`` traversal so a move can't escape the
+    configured remote_path/mount_path. Returns a clean ``/``-joined relative
+    path (possibly empty).
+    """
+    sub = (subpath or "").strip()
+    if not sub:
+        return ""
+    parts = []
+    for seg in sub.replace("\\", "/").split("/"):
+        if seg in ("", "."):
+            continue
+        if seg == "..":
+            raise ValueError("Subpath may not contain '..'")
+        parts.append(seg)
+    return "/".join(parts)
+
+
+def build_remote_move_spec(target, subpath, rsync_bin):
+    """Build the ``remote`` dict ``move_folder`` expects from a config target.
+
+    ``target`` is a validated dict from ``config.get_remote_target`` (host,
+    user, port, ssh_key, remote_path, mount_path, bwlimit_kbps). ``subpath``
+    is an optional relative path under both base paths. The SSH base is joined
+    POSIX-style (the NAS is POSIX); the mount base uses the local separator.
+    Raises ValueError on a bad subpath.
+    """
+    import posixpath
+    sub = sanitize_subpath(subpath)
+    ssh_base = target["remote_path"]
+    mount_base = target.get("mount_path", "")
+    if sub:
+        ssh_base = posixpath.join(ssh_base, sub)
+        if mount_base:
+            mount_base = os.path.join(mount_base, *sub.split("/"))
+    return {
+        "host": target["host"],
+        "user": target["user"],
+        "port": target.get("port", 22),
+        "ssh_key": target.get("ssh_key", ""),
+        "bwlimit_kbps": target.get("bwlimit_kbps", 0),
+        "rsync_bin": rsync_bin,
+        "ssh_dest_base": ssh_base,
+        "mount_dest_base": mount_base,
+    }
 
 
 def resolve_folder_dest(folder_path, folder_name, destination):
@@ -144,14 +201,241 @@ def _copy_tree_with_progress(src_path, dest_path, skip_existing, total_files,
             shutil.copystat(src_dir, target_dir)
 
 
-def _run_rsync_streamed(src_path, dest_path, rsync_flag, total_files,
-                        progress_cb, stall_timeout=RSYNC_STALL_TIMEOUT):
+# Path candidates for a GNU rsync usable for remote (SSH) moves. macOS's
+# /usr/bin/rsync is Apple's openrsync, which can't drive rsync-over-SSH to a
+# GNU rsync peer, so it is deliberately absent here. A packaged build drops a
+# bundled static GNU rsync next to this module (vireo/bin/rsync) or in the
+# app's Resources dir; dev machines fall back to a Homebrew/MacPorts install.
+_BUNDLED_RSYNC_CANDIDATES = (
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "bin", "rsync"),
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "Resources", "rsync"),
+    "/opt/homebrew/bin/rsync",
+    "/usr/local/bin/rsync",
+    "/opt/local/bin/rsync",
+)
+
+
+def resolve_rsync_bin(configured=""):
+    """Return an absolute path to a GNU rsync binary for remote moves, or None.
+
+    Resolution order: an explicit ``configured`` path (the ``rsync_bin``
+    config value), the ``VIREO_RSYNC_BIN`` environment override, then the
+    bundled/known-install candidates. Apple's openrsync at /usr/bin/rsync is
+    never auto-selected — it can't do rsync-over-SSH — so a host with only
+    that returns None, and the caller surfaces a clear "install GNU rsync"
+    error rather than failing mid-transfer.
+    """
+    candidates = []
+    if configured:
+        candidates.append(configured)
+    env = os.environ.get("VIREO_RSYNC_BIN")
+    if env:
+        candidates.append(env)
+    candidates.extend(_BUNDLED_RSYNC_CANDIDATES)
+    for c in candidates:
+        if c and os.path.isfile(c) and os.access(c, os.X_OK):
+            return os.path.abspath(c)
+    return None
+
+
+def is_gnu_rsync(rsync_bin):
+    """True if ``rsync_bin`` looks like GNU rsync (not Apple openrsync).
+
+    Used by the connection test to give a precise error before a move: Apple's
+    openrsync reports ``openrsync:`` in --version and can't drive SSH. Failures
+    to execute return False (treated as unusable).
+    """
+    try:
+        out = subprocess.run([rsync_bin, "--version"], capture_output=True,
+                             text=True, timeout=10).stdout.lower()
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return "openrsync" not in out and "rsync" in out
+
+
+def ssh_base_args(remote):
+    """Base ``ssh`` option args (list) for connecting to a remote target.
+
+    Non-interactive (BatchMode) so a headless job thread can never hang on a
+    password prompt; ``accept-new`` trust-on-first-use for the host key so the
+    first move from a freshly configured target doesn't fail host-key
+    verification. Port and identity file are added only when set.
+    """
+    args = ["-o", "BatchMode=yes", "-o", "StrictHostKeyChecking=accept-new",
+            "-o", "ConnectTimeout=10"]
+    port = remote.get("port") or 22
+    with contextlib.suppress(TypeError, ValueError):
+        if int(port) != 22:
+            args += ["-p", str(int(port))]
+    key = remote.get("ssh_key")
+    if key:
+        args += ["-i", key]
+    return args
+
+
+def _ssh_rsh_string(remote):
+    """The ``-e`` value for rsync: an ``ssh ...`` command string.
+
+    rsync splits this on whitespace (no shell quoting), so identity-file paths
+    containing spaces aren't supported — an accepted limitation; the default
+    key needs no -i, and key paths almost never contain spaces.
+    """
+    return " ".join(["ssh"] + ssh_base_args(remote))
+
+
+def _ssh_target(remote):
+    return f'{remote["user"]}@{remote["host"]}'
+
+
+def _remote_dir_exists(remote, path):
+    """True if ``path`` is a directory on the remote host (via SSH)."""
+    cmd = (["ssh"] + ssh_base_args(remote)
+           + [_ssh_target(remote), f"test -d {shlex.quote(path)}"])
+    try:
+        return subprocess.run(cmd, capture_output=True,
+                              timeout=30).returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+def remote_preflight(remote, dest_path, file_cap=1000):
+    """Probe a remote destination for the move UI's merge/resume prompt.
+
+    Returns ``(exists, file_count, truncated, reachable, error)``:
+      * reachable=False + error — couldn't connect/run over SSH.
+      * exists — whether ``dest_path`` is already a directory on the remote.
+      * file_count/truncated — capped count of files already there (so the
+        UI can say "N files present" before a merge), via
+        ``find | head | wc -l`` so a huge tree can't hang the probe.
+    """
+    target = _ssh_target(remote)
+    base = ["ssh"] + ssh_base_args(remote) + [target]
+    q = shlex.quote(dest_path)
+    probe = base + [f"if [ -d {q} ]; then echo EXISTS; else echo NOPE; fi"]
+    try:
+        r = subprocess.run(probe, capture_output=True, text=True, timeout=30)
+    except (OSError, subprocess.SubprocessError) as exc:
+        return (False, 0, False, False, str(exc))
+    if r.returncode != 0:
+        return (False, 0, False, False,
+                r.stderr.strip() or "SSH connection failed")
+    if "EXISTS" not in r.stdout:
+        return (False, 0, False, True, None)
+    cnt_cmd = base + [
+        f"find {q} -type f 2>/dev/null | head -n {file_cap + 1} | wc -l"]
+    try:
+        c = subprocess.run(cnt_cmd, capture_output=True, text=True, timeout=120)
+        n = int((c.stdout or "0").strip() or 0)
+    except (OSError, subprocess.SubprocessError, ValueError):
+        return (True, 0, False, True, None)
+    return (True, min(n, file_cap), n > file_cap, True, None)
+
+
+def test_remote_connection(remote, rsync_bin):
+    """Run the checks the settings UI shows when testing a remote target.
+
+    ``remote`` is a coerced target dict; ``rsync_bin`` is a resolved GNU rsync
+    path (or "" if none/openrsync). Returns a dict with per-check booleans
+    (``ssh``, ``remote_path_writable``, ``rsync_ok``), an overall ``ok``, and
+    a human ``message``.
+    """
+    result = {"ok": False, "ssh": False, "remote_path_writable": False,
+              "rsync_ok": bool(rsync_bin), "message": ""}
+    target = _ssh_target(remote)
+    base = ["ssh"] + ssh_base_args(remote) + [target]
+    try:
+        r = subprocess.run(base + ["echo vireo_ok"], capture_output=True,
+                           text=True, timeout=20)
+    except (OSError, subprocess.SubprocessError) as exc:
+        result["message"] = f"SSH connection failed: {exc}"
+        return result
+    if r.returncode != 0 or "vireo_ok" not in r.stdout:
+        result["message"] = (r.stderr.strip()
+                             or "SSH connection failed — check host, user, "
+                                "and that your key is authorized.")
+        return result
+    result["ssh"] = True
+    rp = shlex.quote(remote["remote_path"])
+    try:
+        w = subprocess.run(
+            base + [f"test -d {rp} && test -w {rp} && echo WRITABLE"],
+            capture_output=True, text=True, timeout=20)
+    except (OSError, subprocess.SubprocessError) as exc:
+        result["message"] = f"SSH connection failed: {exc}"
+        return result
+    if "WRITABLE" not in w.stdout:
+        result["message"] = (
+            f"Connected, but '{remote['remote_path']}' isn't a writable "
+            f"directory for {remote['user']}. Check the path and that the "
+            f"Synology rsync service is enabled.")
+        return result
+    result["remote_path_writable"] = True
+    if not rsync_bin:
+        result["message"] = (
+            "SSH and the remote path are reachable, but no GNU rsync was "
+            "found for the transfer (macOS's built-in rsync can't do this). "
+            "Install GNU rsync or set its path under Settings → Paths.")
+        return result
+    result["ok"] = True
+    result["message"] = "Connection OK — SSH, remote path, and rsync all good."
+    return result
+
+
+def _remote_verify_complete(rsync_bin, src_path, rsync_target, remote):
+    """Independent verification that the remote copy is complete and correct.
+
+    The local move's safety check walks the destination filesystem before
+    deleting originals; a remote destination isn't locally walkable, so this
+    runs ``rsync -an --checksum`` (a dry run) and inspects what it WOULD
+    transfer. rsync prints (via ``--out-format=%n``) only items it would
+    change, comparing by *checksum* — so any regular-file line means that
+    file is missing at the destination OR present with different content.
+    Returns:
+      * ``None`` — every source file is present at the destination with
+        matching content; safe to delete originals.
+      * ``(name, None)`` — first source file still absent/different; the
+        move must preserve originals.
+      * ``("__ERROR__", detail)`` — the verification rsync itself failed or
+        timed out; treated as a verification failure (originals preserved).
+    Bandwidth-cheap: the NAS checksums its own local disk and only hashes
+    cross the wire, so no bulk data is re-transferred.
+    """
+    cmd = [rsync_bin, "-an", "--checksum", "--out-format=%n",
+           "-e", _ssh_rsh_string(remote),
+           src_path + "/", rsync_target + "/"]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True,
+                              timeout=REMOTE_VERIFY_TIMEOUT)
+    except subprocess.TimeoutExpired:
+        return ("__ERROR__", f"verification timed out after "
+                f"{REMOTE_VERIFY_TIMEOUT // 60} minutes")
+    except OSError as exc:
+        return ("__ERROR__", str(exc))
+    if proc.returncode != 0:
+        return ("__ERROR__", proc.stderr.strip() or f"rsync exit {proc.returncode}")
+    for line in proc.stdout.splitlines():
+        name = line.rstrip("\n")
+        if not name or name.endswith("/"):
+            continue  # directory entry, not a file needing transfer
+        return (name, None)
+    return None
+
+
+def _run_rsync_streamed(src_path, dest_spec, rsync_flags, total_files,
+                        progress_cb, rsync_bin="rsync", extra_args=None,
+                        stall_timeout=RSYNC_STALL_TIMEOUT):
     """Run rsync, reporting each transferred file through progress_cb.
 
     rsync's ``--out-format=%n`` prints the relative name of every item it
     transfers (directories end in ``/``). Streaming that line-by-line lets
     the move job show live per-file progress instead of a frozen bar while a
     large copy runs, without changing rsync's copy semantics.
+
+    ``dest_spec`` is a local path for a local move or ``user@host:/path`` for
+    a remote (SSH) move; ``rsync_bin`` selects the binary (a bundled GNU rsync
+    for remote moves) and ``extra_args`` carries the SSH transport flags
+    (``-e ssh ...``, ``--partial``, ``--bwlimit``). ``rsync_flags`` is a list;
+    empty strings are dropped so a fresh move can pass no extra flag.
 
     Returns ``(returncode, stderr, timed_out)``. ``timed_out`` is True when
     rsync made no forward progress for ``stall_timeout`` seconds and was
@@ -162,10 +446,12 @@ def _run_rsync_streamed(src_path, dest_path, rsync_flag, total_files,
     subprocess — still gets reaped. The clock resets on every transferred
     file and on stderr activity, so only true silence trips it.
     """
+    cmd = [rsync_bin, "-a", "--out-format=%n"]
+    cmd += list(extra_args or [])
+    cmd += [f for f in (rsync_flags or []) if f]
+    cmd += [src_path + "/", dest_spec + "/"]
     proc = subprocess.Popen(
-        ["rsync", "-a", "--out-format=%n", rsync_flag,
-         src_path + "/", dest_path + "/"],
-        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
     )
     state = {"timed_out": False}
     # Last time rsync showed any sign of life (process start counts, so the
@@ -825,7 +1111,7 @@ def move_photos(db, photo_ids, destination, progress_cb=None):
 
 
 def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
-                merge=False):
+                merge=False, remote=None):
     """Move an entire folder (and subfolders) to a destination.
 
     The folder is placed inside the destination, preserving its name.
@@ -834,7 +1120,8 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
     Args:
         db: Database instance
         folder_id: ID of the source folder
-        destination: absolute path to parent destination directory
+        destination: absolute path to parent destination directory. Ignored
+            for a remote move (the destination comes from ``remote``).
         progress_cb: optional callback(current, total, filename)
         merge: when False (default), refuse to write into a destination
             that already exists — the safe all-or-nothing behavior. When
@@ -853,6 +1140,16 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
             path after the move. Without this, exports silently fall
             back to RAW for every previously-developed photo in the
             moved folder.
+        remote: optional dict to transfer over SSH instead of to a local
+            path. Keys: ``host``, ``user``, ``port``, ``ssh_key``,
+            ``bwlimit_kbps``, ``rsync_bin`` (a GNU rsync path), and the two
+            destination *parents* — ``ssh_dest_base`` (the NAS-side
+            filesystem path rsync writes to) and ``mount_dest_base`` (the
+            local path, e.g. an SMB mount, where Vireo can read those same
+            files afterward). The transfer and verification use the SSH
+            path; the catalog is repointed at the mount path once the move
+            succeeds, so the photos stay in the library and resolve whenever
+            the NAS is mounted.
 
     Returns dict with keys: moved (int), errors (list of str)
     """
@@ -864,7 +1161,26 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
 
     src_path = folder["path"]
     folder_name = folder["name"] or os.path.basename(src_path)
-    dest_path = resolve_folder_dest(src_path, folder["name"], destination)
+
+    # Three destination views:
+    #   transfer_dest — where rsync writes (NAS-side path for remote, local
+    #     path otherwise); also the path used for existence/verify.
+    #   rsync_target  — transfer_dest addressed for rsync (user@host:path
+    #     remote, bare path local).
+    #   catalog_path  — where the catalog points AFTER the move (the local
+    #     mount path for remote, same as transfer_dest local). The local
+    #     destination and catalog coincide; for remote they diverge because
+    #     the NAS path isn't reachable through the local filesystem.
+    if remote:
+        transfer_dest = resolve_folder_dest(
+            src_path, folder["name"], remote["ssh_dest_base"])
+        catalog_path = resolve_folder_dest(
+            src_path, folder["name"], remote["mount_dest_base"])
+        rsync_target = f'{remote["user"]}@{remote["host"]}:{transfer_dest}'
+    else:
+        transfer_dest = resolve_folder_dest(src_path, folder["name"], destination)
+        catalog_path = transfer_dest
+        rsync_target = transfer_dest
 
     # Validation (overlap, tracked-folder, and the per-file content-conflict
     # scan a merge runs) can take a noticeable moment on a large tree, so name
@@ -872,56 +1188,69 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
     if progress_cb:
         progress_cb(0, 0, "", "Checking destination")
 
-    # Refuse a destination that overlaps the source. Moving a folder into
-    # itself (or into one of its own descendants) would make the post-copy
-    # rmtree(src) delete the only copy of the files. This is especially
-    # dangerous for a merge, where a destination equal to the source passes
-    # verification trivially (every source file is already "there") before the
-    # delete wipes everything. See _destination_overlaps_source for the alias
-    # surface (symlinks, Windows case folding, case-insensitive POSIX).
-    if _destination_overlaps_source(src_path, dest_path):
-        return {"moved": 0, "errors": [
-            f"Destination overlaps the source folder: {dest_path}"
-        ]}
+    # Overlap and tracked-folder guards exist to stop a local move from
+    # deleting the only copy of files (dest equals/contains src) or colliding
+    # with another tracked folder row. A remote destination lives on a
+    # different machine's filesystem reached over SSH, so it can neither be
+    # the local source tree nor a locally tracked folder — these path-aliasing
+    # checks are meaningless there, and the post-transfer --checksum verify is
+    # the safety backstop for remote.
+    if not remote:
+        # Refuse a destination that overlaps the source. Moving a folder into
+        # itself (or into one of its own descendants) would make the post-copy
+        # rmtree(src) delete the only copy of the files. This is especially
+        # dangerous for a merge, where a destination equal to the source passes
+        # verification trivially (every source file is already "there") before
+        # the delete wipes everything. See _destination_overlaps_source for the
+        # alias surface (symlinks, Windows case folding, case-insensitive POSIX).
+        if _destination_overlaps_source(src_path, transfer_dest):
+            return {"moved": 0, "errors": [
+                f"Destination overlaps the source folder: {transfer_dest}"
+            ]}
 
-    # Refuse moving into — or around — a destination Vireo already tracks as a
-    # folder, regardless of whether that path currently exists on disk. A
-    # correct tracked-tree merge needs recursive folder/photo reconciliation we
-    # don't do here; a partial attempt would leave folders pointing at the
-    # deleted source path, or collide on the folders.path UNIQUE constraint when
-    # the source's children cascade onto a tracked descendant. Match the
-    # destination itself and anything below it. The cases this feature exists
-    # for — resuming an interrupted move, or moving into an untracked folder —
-    # never hit this.
-    #
-    # Comparison goes through _path_equal_or_descends so symlink aliases, Windows
-    # case folding, AND case-only aliases on case-insensitive POSIX (default
-    # macOS APFS) all collapse to the same tracked row — otherwise a destination
-    # reached via any of those would slip past and leave two folder rows managing
-    # the same on-disk tree.
-    tracked = _tracked_destination_overlap(db, folder_id, dest_path)
-    if tracked:
-        return {"moved": 0, "errors": [
-            f"Destination overlaps a folder Vireo already manages "
-            f"({tracked['path']}). Merging into or around a tracked folder "
-            f"isn't supported."
-        ]}
+        # Refuse moving into — or around — a destination Vireo already tracks
+        # as a folder, regardless of whether that path currently exists on
+        # disk. A correct tracked-tree merge needs recursive folder/photo
+        # reconciliation we don't do here; a partial attempt would leave
+        # folders pointing at the deleted source path, or collide on the
+        # folders.path UNIQUE constraint when the source's children cascade
+        # onto a tracked descendant. Match the destination itself and anything
+        # below it. The cases this feature exists for — resuming an interrupted
+        # move, or moving into an untracked folder — never hit this.
+        #
+        # Comparison goes through _path_equal_or_descends so symlink aliases,
+        # Windows case folding, AND case-only aliases on case-insensitive POSIX
+        # (default macOS APFS) all collapse to the same tracked row — otherwise
+        # a destination reached via any of those would slip past and leave two
+        # folder rows managing the same on-disk tree.
+        tracked = _tracked_destination_overlap(db, folder_id, transfer_dest)
+        if tracked:
+            return {"moved": 0, "errors": [
+                f"Destination overlaps a folder Vireo already manages "
+                f"({tracked['path']}). Merging into or around a tracked folder "
+                f"isn't supported."
+            ]}
 
-    dest_exists = os.path.exists(dest_path)
+    if remote:
+        dest_exists = _remote_dir_exists(remote, transfer_dest)
+    else:
+        dest_exists = os.path.exists(transfer_dest)
     if dest_exists and not merge:
         return {
             "moved": 0,
-            "errors": [f"Destination already exists: {dest_path}"],
+            "errors": [f"Destination already exists: {transfer_dest}"],
             "needs_merge": True,
         }
 
-    if dest_exists:
-
+    if dest_exists and not remote:
         # Refuse if any same-name file already at the destination differs in
         # content. Never overwrite or later delete the user's data over a real
         # collision — only files that are byte-identical (a genuine resume) may
-        # be treated as already-moved.
-        conflict = _find_content_conflict(src_path, dest_path)
+        # be treated as already-moved. (Remote: the post-transfer --checksum
+        # verify catches a differing same-name file just as well, since
+        # --ignore-existing never overwrites it and the dry-run then reports it
+        # as still needing transfer — so the move refuses to delete originals.)
+        conflict = _find_content_conflict(src_path, transfer_dest)
         if conflict is not None:
             return {"moved": 0, "errors": [
                 f"Conflict: '{conflict}' already exists at the destination with "
@@ -929,7 +1258,7 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
             ]}
 
     log.info("%s folder %s -> %s",
-             "Merging" if dest_exists else "Moving", src_path, dest_path)
+             "Merging" if dest_exists else "Moving", src_path, rsync_target)
 
     # Count source files up front so the copy phase reports against a real
     # denominator from the first file. This count is the progress denominator
@@ -943,47 +1272,93 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
     # rsync only creates files absent at the destination and NEVER overwrites
     # a file already there: this resumes an interrupted move (missing files get
     # copied, already-copied ones are left alone) while guaranteeing a merge
-    # cannot destroy pre-existing destination data. A fresh move uses --checksum
-    # for integrity. Any genuine same-name collision (an existing dest file that
-    # differs from the source) is left untouched here and caught by the
-    # post-copy verification below, which then refuses to delete the originals.
-    rsync_flag = "--ignore-existing" if dest_exists else "--checksum"
+    # cannot destroy pre-existing destination data. A local fresh move uses
+    # --checksum for integrity; a remote fresh move skips it (the destination
+    # is empty, and the post-transfer --checksum dry-run verifies integrity).
+    # Any genuine same-name collision (an existing dest file that differs from
+    # the source) is left untouched here and caught by the post-copy
+    # verification below, which then refuses to delete the originals.
+    rsync_bin = "rsync"
+    extra_args = None
+    if remote:
+        rsync_bin = remote.get("rsync_bin")
+        if not rsync_bin:
+            return {"moved": 0, "errors": [
+                "No GNU rsync binary available for remote moves. macOS's "
+                "built-in rsync can't do this — set the GNU rsync path in "
+                "Settings."
+            ]}
+        extra_args = ["-e", _ssh_rsh_string(remote), "--partial"]
+        if remote.get("bwlimit_kbps"):
+            extra_args.append(f"--bwlimit={int(remote['bwlimit_kbps'])}")
+        rsync_flags = ["--ignore-existing"] if dest_exists else []
+    else:
+        rsync_flags = ["--ignore-existing"] if dest_exists else ["--checksum"]
+
     try:
         returncode, stderr, timed_out = _run_rsync_streamed(
-            src_path, dest_path, rsync_flag, total_files, progress_cb,
+            src_path, rsync_target, rsync_flags, total_files, progress_cb,
+            rsync_bin=rsync_bin, extra_args=extra_args,
         )
-        if timed_out:
-            mins = RSYNC_STALL_TIMEOUT // 60
-            return {"moved": 0, "errors": [
-                f"rsync stalled — no progress for over {mins} minutes, so the "
-                f"copy was stopped. Originals are untouched; re-run with "
-                f"merge/resume to continue from where it left off."
-            ]}
-        if returncode != 0:
-            return {"moved": 0, "errors": [f"rsync failed: {stderr.strip()}"]}
     except FileNotFoundError:
-        # rsync not available, fall back to shutil. skip_existing mirrors
+        if remote:
+            # No shutil fallback over SSH — the binary path was resolved before
+            # the move started, so this means it vanished. Surface it plainly.
+            return {"moved": 0, "errors": [
+                f"GNU rsync not found at '{rsync_bin}'. Install GNU rsync or "
+                f"set its path in Settings."
+            ]}
+        # Local rsync missing: fall back to shutil. skip_existing mirrors
         # --ignore-existing for a merge; a fresh move copies everything.
         try:
             _copy_tree_with_progress(
-                src_path, dest_path, dest_exists, total_files, progress_cb,
+                src_path, catalog_path, dest_exists, total_files, progress_cb,
             )
+            returncode, stderr, timed_out = 0, "", False
         except Exception as exc:
             # Only remove a destination we created — never one that
             # pre-existed (a merge target may hold the user's own files).
             if not dest_exists:
-                shutil.rmtree(dest_path, ignore_errors=True)
+                shutil.rmtree(catalog_path, ignore_errors=True)
             return {"moved": 0, "errors": [f"Copy failed: {exc}"]}
+
+    if timed_out:
+        mins = RSYNC_STALL_TIMEOUT // 60
+        return {"moved": 0, "errors": [
+            f"rsync stalled — no progress for over {mins} minutes, so the "
+            f"copy was stopped. Originals are untouched; re-run with "
+            f"merge/resume to continue from where it left off."
+        ]}
+    if returncode != 0:
+        return {"moved": 0, "errors": [f"rsync failed: {stderr.strip()}"]}
 
     # Verify before deleting originals.
     if progress_cb:
         progress_cb(total_files, total_files, "", "Verifying copy")
-    if dest_exists:
+    if remote:
+        # The local filesystem can't be walked to confirm a remote copy, so
+        # run a --checksum dry-run over SSH: any file it would still transfer
+        # is missing or differs at the destination. Covers both fresh and
+        # merge moves, and is the safety backstop replacing the local
+        # content-conflict and file-count checks.
+        verify = _remote_verify_complete(rsync_bin, src_path, rsync_target, remote)
+        if verify is not None:
+            name, detail = verify
+            if name == "__ERROR__":
+                return {"moved": 0, "errors": [
+                    f"Verification could not be completed ({detail}). "
+                    f"Originals preserved."
+                ]}
+            return {"moved": 0, "errors": [
+                f"Verification failed: '{name}' is missing or differs at the "
+                f"destination. Originals preserved."
+            ]}
+    elif dest_exists:
         # Merge: the destination may legitimately hold extra unrelated
         # files (and leftover temp files from an interrupted run), so a
         # count comparison is meaningless. Instead require that every
         # source file is present at the destination with a matching size.
-        missing = _first_missing_source_file(src_path, dest_path)
+        missing = _first_missing_source_file(src_path, transfer_dest)
         if missing is not None:
             return {"moved": 0, "errors": [
                 f"Verification failed: '{missing}' missing, size mismatch, "
@@ -998,9 +1373,9 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
         # the rmtree below would delete the never-copied file. The fresh
         # walk catches that mismatch and preserves the originals.
         src_count = sum(1 for _, _, files in os.walk(src_path) for _ in files)
-        dst_count = sum(1 for _, _, files in os.walk(dest_path) for _ in files)
+        dst_count = sum(1 for _, _, files in os.walk(transfer_dest) for _ in files)
         if src_count != dst_count:
-            shutil.rmtree(dest_path, ignore_errors=True)
+            shutil.rmtree(transfer_dest, ignore_errors=True)
             return {"moved": 0, "errors": [
                 f"File count mismatch: source={src_count}, dest={dst_count}. Originals preserved."
             ]}
@@ -1017,11 +1392,13 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
     # Update DB first: cascade folder paths (safer — if rmtree fails, the old
     # folder becomes an orphan on disk rather than the DB pointing to deleted
     # paths). A merge into an already-tracked destination is refused above, so
-    # dest_path is never a different existing folder row here and this cascade
-    # (root + all descendants) cannot collide with folders.path UNIQUE.
+    # catalog_path is never a different existing folder row here and this
+    # cascade (root + all descendants) cannot collide with folders.path UNIQUE.
+    # For a remote move catalog_path is the local mount path, so the catalog
+    # keeps resolving to the photos whenever the NAS is mounted.
     if progress_cb:
         progress_cb(total_files, total_files, "", "Updating catalog")
-    db.move_folder_path(folder_id, dest_path)
+    db.move_folder_path(folder_id, catalog_path)
     db.update_folder_counts()
 
     # Rebase any developed-output subdirs nested under the configured
@@ -1031,7 +1408,7 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
     # to any descendant folders whose paths also shifted.
     if developed_dir:
         from export import relocate_developed_dir
-        relocate_developed_dir(developed_dir, src_path, dest_path)
+        relocate_developed_dir(developed_dir, src_path, catalog_path)
         # SQL LIKE treats `_` and `%` (and the escape char) as wildcards,
         # all of which are valid POSIX path characters. Without a strict
         # prefix guard, an unrelated folder like `/dXst/birds/fake` would
@@ -1040,14 +1417,14 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
         # developed subdir. Filter results by a literal prefix check.
         descendant_rows = db.conn.execute(
             "SELECT path FROM folders WHERE path LIKE ?",
-            (dest_path + "/%",),
+            (catalog_path + "/%",),
         ).fetchall()
-        prefix = dest_path + "/"
+        prefix = catalog_path + "/"
         for row in descendant_rows:
             new_child = row["path"]
             if not new_child.startswith(prefix):
                 continue
-            old_child = src_path + new_child[len(dest_path):]
+            old_child = src_path + new_child[len(catalog_path):]
             relocate_developed_dir(developed_dir, old_child, new_child)
 
     # Delete originals

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -1188,48 +1188,52 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
     if progress_cb:
         progress_cb(0, 0, "", "Checking destination")
 
-    # Overlap and tracked-folder guards exist to stop a local move from
-    # deleting the only copy of files (dest equals/contains src) or colliding
-    # with another tracked folder row. A remote destination lives on a
-    # different machine's filesystem reached over SSH, so it can neither be
-    # the local source tree nor a locally tracked folder — these path-aliasing
-    # checks are meaningless there, and the post-transfer --checksum verify is
-    # the safety backstop for remote.
-    if not remote:
-        # Refuse a destination that overlaps the source. Moving a folder into
-        # itself (or into one of its own descendants) would make the post-copy
-        # rmtree(src) delete the only copy of the files. This is especially
-        # dangerous for a merge, where a destination equal to the source passes
-        # verification trivially (every source file is already "there") before
-        # the delete wipes everything. See _destination_overlaps_source for the
-        # alias surface (symlinks, Windows case folding, case-insensitive POSIX).
-        if _destination_overlaps_source(src_path, transfer_dest):
-            return {"moved": 0, "errors": [
-                f"Destination overlaps the source folder: {transfer_dest}"
-            ]}
+    # Refuse a destination that overlaps the source. Moving a folder into
+    # itself (or into one of its own descendants) would make the post-copy
+    # rmtree(src) delete the only copy of the files. This is especially
+    # dangerous for a merge, where a destination equal to the source passes
+    # verification trivially (every source file is already "there") before the
+    # delete wipes everything. See _destination_overlaps_source for the alias
+    # surface (symlinks, Windows case folding, case-insensitive POSIX).
+    #
+    # Local-only: a remote destination lives on a different machine reached
+    # over SSH, so it can't alias the local source tree — the post-transfer
+    # --checksum verify is the safety backstop for remote.
+    if not remote and _destination_overlaps_source(src_path, transfer_dest):
+        return {"moved": 0, "errors": [
+            f"Destination overlaps the source folder: {transfer_dest}"
+        ]}
 
-        # Refuse moving into — or around — a destination Vireo already tracks
-        # as a folder, regardless of whether that path currently exists on
-        # disk. A correct tracked-tree merge needs recursive folder/photo
-        # reconciliation we don't do here; a partial attempt would leave
-        # folders pointing at the deleted source path, or collide on the
-        # folders.path UNIQUE constraint when the source's children cascade
-        # onto a tracked descendant. Match the destination itself and anything
-        # below it. The cases this feature exists for — resuming an interrupted
-        # move, or moving into an untracked folder — never hit this.
-        #
-        # Comparison goes through _path_equal_or_descends so symlink aliases,
-        # Windows case folding, AND case-only aliases on case-insensitive POSIX
-        # (default macOS APFS) all collapse to the same tracked row — otherwise
-        # a destination reached via any of those would slip past and leave two
-        # folder rows managing the same on-disk tree.
-        tracked = _tracked_destination_overlap(db, folder_id, transfer_dest)
-        if tracked:
-            return {"moved": 0, "errors": [
-                f"Destination overlaps a folder Vireo already manages "
-                f"({tracked['path']}). Merging into or around a tracked folder "
-                f"isn't supported."
-            ]}
+    # Refuse moving into — or around — a destination Vireo already tracks as a
+    # folder, regardless of whether that path currently exists on disk. A
+    # correct tracked-tree merge needs recursive folder/photo reconciliation we
+    # don't do here; a partial attempt would leave folders pointing at the
+    # deleted source path, or collide on the folders.path UNIQUE constraint
+    # when the source's children cascade onto a tracked descendant. Match the
+    # destination itself and anything below it. The cases this feature exists
+    # for — resuming an interrupted move, or moving into an untracked folder —
+    # never hit this.
+    #
+    # For remote, check against `catalog_path` (the local mount path the
+    # catalog is repointed to after the move) rather than `transfer_dest` (the
+    # NAS-side path, which isn't in the local catalog). Without this guard, a
+    # remote move into a mount path that overlaps an already-scanned folder
+    # would copy the whole tree over SSH and then hit folders.path UNIQUE on
+    # the post-move db.move_folder_path cascade.
+    #
+    # Comparison goes through _path_equal_or_descends so symlink aliases,
+    # Windows case folding, AND case-only aliases on case-insensitive POSIX
+    # (default macOS APFS) all collapse to the same tracked row — otherwise
+    # a destination reached via any of those would slip past and leave two
+    # folder rows managing the same on-disk tree.
+    overlap_check_path = catalog_path if remote else transfer_dest
+    tracked = _tracked_destination_overlap(db, folder_id, overlap_check_path)
+    if tracked:
+        return {"moved": 0, "errors": [
+            f"Destination overlaps a folder Vireo already manages "
+            f"({tracked['path']}). Merging into or around a tracked folder "
+            f"isn't supported."
+        ]}
 
     if remote:
         dest_exists = _remote_dir_exists(remote, transfer_dest)
@@ -1278,6 +1282,14 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
     # Any genuine same-name collision (an existing dest file that differs from
     # the source) is left untouched here and caught by the post-copy
     # verification below, which then refuses to delete the originals.
+    #
+    # Remote uses --partial-dir (instead of plain --partial) so a stalled or
+    # cancelled transfer leaves the partial in `.rsync-partial/` rather than
+    # at the destination filename. That keeps --ignore-existing honest: only
+    # *complete* dest files are skipped, so the next run resumes the partial
+    # from `.rsync-partial/` instead of treating it as already-moved (which
+    # would then fail the --checksum verify forever, stranding the partial
+    # until the user manually deletes it).
     rsync_bin = "rsync"
     extra_args = None
     if remote:
@@ -1288,7 +1300,10 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
                 "built-in rsync can't do this — set the GNU rsync path in "
                 "Settings."
             ]}
-        extra_args = ["-e", _ssh_rsh_string(remote), "--partial"]
+        extra_args = [
+            "-e", _ssh_rsh_string(remote),
+            "--partial-dir=.rsync-partial",
+        ]
         if remote.get("bwlimit_kbps"):
             extra_args.append(f"--bwlimit={int(remote['bwlimit_kbps'])}")
         rsync_flags = ["--ignore-existing"] if dest_exists else []

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -357,6 +357,32 @@ def _ssh_target(remote):
     return f'{remote["user"]}@{remote["host"]}'
 
 
+def _remote_mkdir_p(remote, path):
+    """Create ``path`` (and any missing intermediate parents) on the remote
+    host via SSH. Idempotent — ``mkdir -p`` accepts an already-existing
+    directory.
+
+    Without this, a remote move into a configured subpath like ``USA/2026``
+    that has never been written before fails at rsync with
+    ``mkdir ... failed: No such file or directory`` — rsync creates the
+    leaf folder but not its intermediate parents. The UI advertises a
+    free-text subpath, so users wouldn't otherwise know to pre-create
+    every level manually on the NAS.
+
+    Returns ``(True, "")`` on success or ``(False, detail)`` where
+    ``detail`` is a short message suitable for surfacing to the user.
+    """
+    cmd = (["ssh"] + ssh_base_args(remote) + [_ssh_target(remote)]
+           + [f"mkdir -p {shlex.quote(path)}"])
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    except (OSError, subprocess.SubprocessError) as exc:
+        return False, str(exc)
+    if r.returncode != 0:
+        return False, r.stderr.strip() or f"ssh mkdir exit {r.returncode}"
+    return True, ""
+
+
 def _remote_dir_exists(remote, path):
     """Probe whether ``path`` is a directory on the remote host (via SSH).
 
@@ -1294,6 +1320,25 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
     #     destination and catalog coincide; for remote they diverge because
     #     the NAS path isn't reachable through the local filesystem.
     if remote:
+        ssh_base = remote.get("ssh_dest_base") or ""
+        # Same hazard as the mount-path check below, on the NAS side: a
+        # relative ssh_dest_base like "Photos" would ship to rsync as
+        # ``user@host:Photos/<folder>`` and resolve under the SSH user's
+        # remote cwd — but the catalog gets repointed to the absolute
+        # mount_dest_base, so a verified copy can live at a different
+        # remote location than the path Vireo records before originals are
+        # deleted. ``_coerce_remote_target`` already drops relative-path
+        # entries at the config boundary; this is the defense-in-depth
+        # check for callers (tests, direct use) that build a remote dict
+        # themselves. POSIX-absolute (startswith "/") because the NAS is
+        # POSIX — os.path.isabs would accept ``C:\foo`` on Windows.
+        if not ssh_base.startswith("/"):
+            return {"moved": 0, "errors": [
+                "Remote target needs an absolute remote (NAS) path before "
+                "moving files — otherwise rsync would write under the SSH "
+                "user's cwd, not where the catalog will point. Set the "
+                "remote path under Settings → Remote targets."
+            ]}
         mount_base = remote.get("mount_dest_base") or ""
         # Without an absolute mount path, resolve_folder_dest below would
         # produce a relative catalog_path like 'Birds' — then after the SSH
@@ -1421,6 +1466,25 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
 
     log.info("%s folder %s -> %s",
              "Merging" if dest_exists else "Moving", src_path, rsync_target)
+
+    # For a fresh remote move, ensure the destination's PARENT directory
+    # exists on the NAS. rsync creates the leaf folder itself but not its
+    # intermediate parents, so a configured subpath like ``USA/2026`` that
+    # has never been written before would fail with ``mkdir ... failed: No
+    # such file or directory`` even though every preceding check passed.
+    # Skip on a merge — if the leaf exists, the parents must too. Skip when
+    # the parent is empty (the bare base "/", or a transfer_dest with no
+    # parent component) since mkdir-p there is meaningless.
+    if remote and not dest_exists:
+        parent_dir = posixpath.dirname(transfer_dest)
+        if parent_dir and parent_dir != "/":
+            ok, detail = _remote_mkdir_p(remote, parent_dir)
+            if not ok:
+                return {"moved": 0, "errors": [
+                    f"Couldn't create the remote destination's parent "
+                    f"directory '{parent_dir}' on the NAS: {detail}. "
+                    f"Check permissions or pre-create the subpath."
+                ]}
 
     # Count source files up front so the copy phase reports against a real
     # denominator from the first file. This count is the progress denominator

--- a/vireo/templates/move.html
+++ b/vireo/templates/move.html
@@ -676,8 +676,19 @@ function updateQuickMovePreview() {
   if (remoteId) {
     var t = quickRemoteTargets.find(function(x) { return x.id === remoteId; });
     if (!t) { preview.textContent = ''; return; }
-    var sub = document.getElementById('quickSubpathInput').value.trim()
-      .replace(/^\/+|\/+$/g, '');
+    // Use the same normalization the backend does, so the preview path
+    // matches what move.py / sanitize_subpath will actually write. Without
+    // this the UI can show e.g. "/volume1/Photo/USA" while the move
+    // ultimately rejects "/USA" (absolute) or lands at a different path
+    // because the backend collapses ".", strips backslashes, etc.
+    var subResult = normalizeRemoteSubpath(
+      document.getElementById('quickSubpathInput').value);
+    if (subResult.error) {
+      preview.textContent = '';
+      preview.appendChild(_destWarn('⚠ ' + subResult.error));
+      return;
+    }
+    var sub = subResult.value;
     var folderName = (folder && folder.name) ||
       ((folder && folder.path) || '').replace(/\/+$/, '').split('/').pop();
     var base = t.remote_path.replace(/\/+$/, '') + (sub ? '/' + sub : '');
@@ -699,6 +710,13 @@ function updateQuickMovePreview() {
     if (!t.mount_path) {
       preview.appendChild(_destWarn('⚠ This target has no local mount path, so '
         + 'moved photos can’t stay in your library. Add one in Settings.'));
+    } else if (!_isAbsolutePath(t.mount_path)) {
+      // The backend refuses a relative mount path before starting the
+      // move (the catalog would point at a non-resolving location after).
+      // Surface that here so the user sees it before clicking Move.
+      preview.appendChild(_destWarn('⚠ This target’s local mount path must be '
+        + 'absolute (e.g. "/Volumes/Photos"). Fix it under Settings → '
+        + 'Remote targets.'));
     }
     var rstatus = document.createElement('div');
     rstatus.id = 'quickDestStatus';
@@ -738,6 +756,42 @@ function _destWarn(text) {
   d.style.color = 'var(--warning)';
   d.textContent = text;
   return d;
+}
+
+// True if `p` looks absolute on either backend OS (POSIX leading slash,
+// Windows drive like "C:\foo", or UNC "\\server\share"). Matches what
+// Python's os.path.isabs would say on the corresponding platform — the
+// JS side has no way to know which platform the backend is running, so
+// accept any form. Used to warn before the backend refuses a relative
+// mount path on the remote target.
+function _isAbsolutePath(p) {
+  if (!p) return false;
+  return p.charAt(0) === '/' || /^[A-Za-z]:[\\\/]/.test(p) || /^\\\\/.test(p);
+}
+
+// Normalize a remote-target subpath the same way move.py sanitize_subpath
+// does: trim, fold backslashes to forward slashes, reject absolute paths
+// (POSIX, Windows drive, or UNC), drop empty / `.` segments, and reject any
+// `..` traversal. Returns {value, error}: callers either use `value` or
+// surface `error`. Sharing one helper between the preview, scheduled
+// preflight, and the actual move submission means the path the UI shows
+// matches the path the backend will write — a UI-transparency requirement.
+function normalizeRemoteSubpath(raw) {
+  var trimmed = (raw || '').trim();
+  if (!trimmed) return {value: '', error: ''};
+  var s = trimmed.replace(/\\/g, '/');
+  if (s.charAt(0) === '/' || /^[A-Za-z]:/.test(s)) {
+    return {value: '', error: 'Subpath must be relative.'};
+  }
+  var parts = [];
+  var segs = s.split('/');
+  for (var i = 0; i < segs.length; i++) {
+    var seg = segs[i];
+    if (seg === '' || seg === '.') continue;
+    if (seg === '..') return {value: '', error: "Subpath may not contain '..'."};
+    parts.push(seg);
+  }
+  return {value: parts.join('/'), error: ''};
 }
 
 var quickPreflightSeq = 0;
@@ -861,9 +915,20 @@ async function startQuickMove() {
         + 'path under Settings → Paths.', 'error');
       return;
     }
+    // Normalize once, here, so the path the user is about to confirm matches
+    // the path the backend will actually write. A raw .trim() would let an
+    // absolute or `..` subpath through; the move would then fail mid-flight
+    // after the user has clicked "Move", which is a worse UX than refusing
+    // here with the same error string the preview surfaces.
+    var subResult = normalizeRemoteSubpath(
+      document.getElementById('quickSubpathInput').value);
+    if (subResult.error) {
+      showToast(subResult.error, 'error');
+      return;
+    }
     destBody = {
       remote_target_id: remoteId,
-      subpath: document.getElementById('quickSubpathInput').value.trim(),
+      subpath: subResult.value,
     };
   } else {
     var dest = document.getElementById('quickDestInput').value.trim();

--- a/vireo/templates/move.html
+++ b/vireo/templates/move.html
@@ -699,7 +699,7 @@ function updateQuickMovePreview() {
     line.textContent = 'Transferring over SSH to: ';
     var span = document.createElement('span');
     span.className = 'dest-preview-path';
-    span.textContent = t.user + '@' + t.host + ':' + finalPath;
+    span.textContent = rsyncDestSpec(t.user, t.host, finalPath);
     line.appendChild(span);
     preview.appendChild(line);
 
@@ -767,6 +767,18 @@ function _destWarn(text) {
 function _isAbsolutePath(p) {
   if (!p) return false;
   return p.charAt(0) === '/' || /^[A-Za-z]:[\\\/]/.test(p) || /^\\\\/.test(p);
+}
+
+// Mirror move.py rsync_dest_spec(): rsync's user@host:path form parses the
+// FIRST colon as the host/path separator, so an IPv6 literal like
+// 2001:db8::1 needs brackets to avoid being chopped at "2001". DNS/IPv4
+// hosts have no colons and pass through unchanged. The backend formats the
+// /api/move-folder/preflight resolved_dest with the same rule; this helper
+// keeps the move-form's local preview honest before the user has typed
+// anything that would trigger the preflight call.
+function rsyncDestSpec(user, host, path) {
+  var hostToken = host && host.indexOf(':') !== -1 ? '[' + host + ']' : host;
+  return user + '@' + hostToken + ':' + path;
 }
 
 // Normalize a remote-target subpath the same way move.py sanitize_subpath

--- a/vireo/templates/move.html
+++ b/vireo/templates/move.html
@@ -396,9 +396,17 @@ body { padding-bottom: 36px; }
       <div class="form-row">
         <label>Destination</label>
         <div class="dest-row">
-          <input type="text" id="quickDestInput" placeholder="/path/to/destination" oninput="updateQuickMoveBtn()">
-          <button class="btn btn-secondary btn-small" onclick="openBrowser('quickDestInput')">Browse</button>
+          <select id="quickDestMode" onchange="onQuickDestModeChange()">
+            <option value="local">Local path</option>
+          </select>
         </div>
+      </div>
+      <div class="dest-row" id="quickLocalRow" style="margin-bottom:8px;">
+        <input type="text" id="quickDestInput" placeholder="/path/to/destination" oninput="updateQuickMoveBtn()">
+        <button class="btn btn-secondary btn-small" onclick="openBrowser('quickDestInput')">Browse</button>
+      </div>
+      <div class="dest-row" id="quickRemoteRow" style="display:none; margin-bottom:8px;">
+        <input type="text" id="quickSubpathInput" placeholder="Optional subfolder under the target (e.g. USA/2026)" oninput="updateQuickMoveBtn()">
       </div>
       <div class="dest-preview" id="quickDestPreview"></div>
 
@@ -512,8 +520,48 @@ var quickMoveBusy = false;
 /* ---------- Init ---------- */
 document.addEventListener('DOMContentLoaded', function() {
   loadFolders();
+  loadRemoteTargets();
   loadRules();
 });
+
+/* ---------- Remote (SSH) move targets ---------- */
+var quickRemoteTargets = [];
+var quickRsyncAvailable = false;
+
+async function loadRemoteTargets() {
+  try {
+    var data = await safeFetch('/api/remote-targets');
+    quickRemoteTargets = (data && data.targets) || [];
+    quickRsyncAvailable = !!(data && data.rsync_available);
+  } catch (e) {
+    quickRemoteTargets = [];
+    quickRsyncAvailable = false;
+  }
+  var sel = document.getElementById('quickDestMode');
+  if (!sel) return;
+  // Rebuild remote options, keeping the "Local path" option at index 0.
+  while (sel.options.length > 1) sel.remove(1);
+  quickRemoteTargets.forEach(function(t) {
+    var opt = document.createElement('option');
+    opt.value = 'remote:' + t.id;
+    opt.textContent = t.name + ' — ' + t.user + '@' + t.host + ' (SSH)';
+    sel.appendChild(opt);
+  });
+}
+
+// The remote target id when the destination mode is a remote target, else ''.
+function quickRemoteTargetId() {
+  var el = document.getElementById('quickDestMode');
+  var v = el ? el.value : 'local';
+  return v.indexOf('remote:') === 0 ? v.slice(7) : '';
+}
+
+function onQuickDestModeChange() {
+  var remoteId = quickRemoteTargetId();
+  document.getElementById('quickLocalRow').style.display = remoteId ? 'none' : '';
+  document.getElementById('quickRemoteRow').style.display = remoteId ? '' : 'none';
+  updateQuickMoveBtn();
+}
 
 /* ---------- Tab Switching ---------- */
 function switchTab(name) {
@@ -580,9 +628,17 @@ function onQuickFolderChange() {
 
 function updateQuickMoveBtn() {
   var fid = document.getElementById('quickFolderSelect').value;
-  var dest = document.getElementById('quickDestInput').value.trim();
+  var remoteId = quickRemoteTargetId();
   var btn = document.getElementById('quickMoveBtn');
-  btn.disabled = quickMoveBusy || !(fid && dest);
+  var ready;
+  if (remoteId) {
+    // Remote needs a usable GNU rsync; no destination text is required (the
+    // target carries it). An optional subpath refines where under it.
+    ready = !!fid && quickRsyncAvailable;
+  } else {
+    ready = !!(fid && document.getElementById('quickDestInput').value.trim());
+  }
+  btn.disabled = quickMoveBusy || !ready;
   btn.textContent = quickMoveBusy ? 'Checking...' : 'Move Folder';
   updateQuickMovePreview();
 }
@@ -613,12 +669,47 @@ function resolvedMoveDest(folder, destination) {
 function updateQuickMovePreview() {
   var preview = document.getElementById('quickDestPreview');
   var fid = parseInt(document.getElementById('quickFolderSelect').value);
-  var dest = document.getElementById('quickDestInput').value.trim();
-  if (!fid || !dest) {
+  var remoteId = quickRemoteTargetId();
+  if (!fid) { preview.textContent = ''; return; }
+  var folder = allFolders.find(function(f) { return f.id === fid; });
+
+  if (remoteId) {
+    var t = quickRemoteTargets.find(function(x) { return x.id === remoteId; });
+    if (!t) { preview.textContent = ''; return; }
+    var sub = document.getElementById('quickSubpathInput').value.trim()
+      .replace(/^\/+|\/+$/g, '');
+    var folderName = (folder && folder.name) ||
+      ((folder && folder.path) || '').replace(/\/+$/, '').split('/').pop();
+    var base = t.remote_path.replace(/\/+$/, '') + (sub ? '/' + sub : '');
+    var finalPath = base + '/' + folderName;
+
     preview.textContent = '';
+    var line = document.createElement('div');
+    line.textContent = 'Transferring over SSH to: ';
+    var span = document.createElement('span');
+    span.className = 'dest-preview-path';
+    span.textContent = t.user + '@' + t.host + ':' + finalPath;
+    line.appendChild(span);
+    preview.appendChild(line);
+
+    if (!quickRsyncAvailable) {
+      preview.appendChild(_destWarn('⚠ No GNU rsync found — remote moves need '
+        + 'it. Install GNU rsync or set its path under Settings → Paths.'));
+    }
+    if (!t.mount_path) {
+      preview.appendChild(_destWarn('⚠ This target has no local mount path, so '
+        + 'moved photos can’t stay in your library. Add one in Settings.'));
+    }
+    var rstatus = document.createElement('div');
+    rstatus.id = 'quickDestStatus';
+    rstatus.className = 'dest-status';
+    preview.appendChild(rstatus);
+    scheduleQuickPreflight(fid, null, remoteId, sub);
     return;
   }
-  var folder = allFolders.find(function(f) { return f.id === fid; });
+
+  var dest = document.getElementById('quickDestInput').value.trim();
+  if (!dest) { preview.textContent = ''; return; }
   var finalPath = resolvedMoveDest(folder, dest);
 
   // The resolved path is computable client-side, so show it instantly.
@@ -638,13 +729,21 @@ function updateQuickMovePreview() {
   status.id = 'quickDestStatus';
   status.className = 'dest-status';
   preview.appendChild(status);
-  scheduleQuickPreflight(fid, dest);
+  scheduleQuickPreflight(fid, dest, '', '');
+}
+
+function _destWarn(text) {
+  var d = document.createElement('div');
+  d.className = 'dest-status';
+  d.style.color = 'var(--warning)';
+  d.textContent = text;
+  return d;
 }
 
 var quickPreflightSeq = 0;
 var quickPreflightTimer = null;
 
-function scheduleQuickPreflight(fid, dest) {
+function scheduleQuickPreflight(fid, dest, remoteId, subpath) {
   if (quickPreflightTimer) clearTimeout(quickPreflightTimer);
   // Bump the sequence on *every* call, not just when a request starts. Any
   // change to the destination must immediately invalidate an in-flight
@@ -653,16 +752,23 @@ function scheduleQuickPreflight(fid, dest) {
   // request is scheduled), would still pass the seq guard and write stale
   // exists/new-folder text for the wrong destination.
   var seq = ++quickPreflightSeq;
+  if (remoteId) {
+    var body = {folder_id: fid, remote_target_id: remoteId, subpath: subpath || ''};
+    quickPreflightTimer = setTimeout(function() { runQuickPreflight(seq, body); }, 350);
+    return;
+  }
   // The preflight route rejects non-absolute paths, so wait until the input
   // looks absolute before asking. Accept POSIX '/...', Windows drive paths
   // ('C:\...'), and Windows UNC paths ('\\server\share') — all of which
   // os.path.isabs() treats as absolute on their respective backends.
   var isAbs = dest.charAt(0) === '/' || /^[A-Za-z]:[\\\/]/.test(dest) || /^\\\\/.test(dest);
   if (!isAbs) return;
-  quickPreflightTimer = setTimeout(function() { runQuickPreflight(fid, dest, seq); }, 350);
+  quickPreflightTimer = setTimeout(function() {
+    runQuickPreflight(seq, {folder_id: fid, destination: dest});
+  }, 350);
 }
 
-async function runQuickPreflight(fid, dest, seq) {
+async function runQuickPreflight(seq, body) {
   var status = document.getElementById('quickDestStatus');
   if (status) {
     status.textContent = 'Checking destination…';
@@ -675,7 +781,7 @@ async function runQuickPreflight(fid, dest, seq) {
     var resp = await fetch('/api/move-folder/preflight', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({folder_id: fid, destination: dest}),
+      body: JSON.stringify(body),
     });
     if (!resp.ok) { if (seq === quickPreflightSeq) clearQuickDestStatus(); return; }
     data = await resp.json();
@@ -686,12 +792,19 @@ async function runQuickPreflight(fid, dest, seq) {
   if (seq !== quickPreflightSeq) return;  // a newer keystroke superseded us
   status = document.getElementById('quickDestStatus');
   if (!status) return;
-  if (data.exists) {
+  if (data.remote && data.reachable === false) {
+    status.textContent = '⚠ Couldn’t reach the target over SSH'
+      + (data.error ? (': ' + data.error) : '') + '.';
+    status.style.color = 'var(--warning)';
+  } else if (data.exists) {
     setDestExistsStatus(status, data.file_count, data.file_count_truncated);
     // The fast count caps out at 1000. When it was truncated, fetch the exact
     // number in the background and update the line in place — without blocking
-    // the user or holding up typing.
-    if (data.file_count_truncated) requestExactDestCount(fid, dest, seq);
+    // the user or holding up typing. Local-path only: the exact walk re-scans
+    // a local dir, so for a remote target the capped "at least N" line stands.
+    if (!data.remote && data.file_count_truncated) {
+      requestExactDestCount(body.folder_id, body.destination, seq);
+    }
   } else {
     status.textContent = '✓ New folder — nothing exists at this location yet.';
     status.style.color = 'var(--text-dim)';
@@ -735,8 +848,28 @@ function clearQuickDestStatus() {
 async function startQuickMove() {
   if (quickMoveBusy) return;
   var fid = parseInt(document.getElementById('quickFolderSelect').value);
-  var dest = document.getElementById('quickDestInput').value.trim();
-  if (!fid || !dest) return;
+  if (!fid) return;
+  var remoteId = quickRemoteTargetId();
+
+  // Build the destination half of the request body — a local path or a
+  // remote target + optional subpath. The same shape is reused for both the
+  // preflight and the move so they can't disagree.
+  var destBody;
+  if (remoteId) {
+    if (!quickRsyncAvailable) {
+      showToast('No GNU rsync found for remote moves. Install it or set its '
+        + 'path under Settings → Paths.', 'error');
+      return;
+    }
+    destBody = {
+      remote_target_id: remoteId,
+      subpath: document.getElementById('quickSubpathInput').value.trim(),
+    };
+  } else {
+    var dest = document.getElementById('quickDestInput').value.trim();
+    if (!dest) return;
+    destBody = {destination: dest};
+  }
 
   var folder = allFolders.find(function(f) { return f.id === fid; });
   var folderName = folder ? folder.path : 'folder #' + fid;
@@ -755,7 +888,7 @@ async function startQuickMove() {
     pf = await safeFetch('/api/move-folder/preflight', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({folder_id: fid, destination: dest, mode: 'preview'}),
+      body: JSON.stringify(Object.assign({folder_id: fid, mode: 'preview'}, destBody)),
     });
   } catch (e) {
     return;  // safeFetch already shows error toast
@@ -763,7 +896,16 @@ async function startQuickMove() {
     setQuickMoveBusy(false);
   }
 
+  if (pf.remote && pf.reachable === false) {
+    showToast('Couldn’t reach the remote target over SSH'
+      + (pf.error ? (': ' + pf.error) : '') + '.', 'error');
+    return;
+  }
+
   var finalPath = pf.resolved_dest;
+  var verifyText = remoteId
+    ? ' Transferred over SSH and verified by checksum before originals are removed.'
+    : ' Files will be copied and verified before originals are removed.';
   if (pf.exists) {
     var p = pf.preview || {};
     var copyN = p.will_copy;
@@ -811,28 +953,28 @@ async function startQuickMove() {
       'Destination Exists — Merge & Resume',
       msg,
       function() {
-        executeQuickMove(fid, dest, true);
+        executeQuickMove(Object.assign({folder_id: fid, merge: true}, destBody));
       }
     );
   } else {
     showConfirm(
       'Move Folder',
-      'Move "' + folderName + '" (' + photoCount + ' photos) to "' + finalPath + '"? Files will be copied and verified before originals are removed.',
+      'Move "' + folderName + '" (' + photoCount + ' photos) to "' + finalPath + '"?' + verifyText,
       function() {
-        executeQuickMove(fid, dest, false);
+        executeQuickMove(Object.assign({folder_id: fid, merge: false}, destBody));
       }
     );
   }
 }
 
-async function executeQuickMove(folderId, destination, merge) {
+async function executeQuickMove(body) {
   try {
     var resp = await safeFetch('/api/jobs/move-folder', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({folder_id: folderId, destination: destination, merge: !!merge}),
+      body: JSON.stringify(body),
     });
-    showToast((merge ? 'Merge' : 'Move') + ' started (job ' + resp.job_id + ') — track progress in the bottom panel', 'info');
+    showToast((body.merge ? 'Merge' : 'Move') + ' started (job ' + resp.job_id + ') — track progress in the bottom panel', 'info');
   } catch (e) {
     // safeFetch already shows error toast
   }

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -905,6 +905,16 @@
     <button type="button" onclick="addExternalEditor()" style="background:var(--bg-tertiary);color:var(--text-secondary);border:1px solid var(--border-secondary);border-radius:4px;padding:6px 12px;font-size:12px;cursor:pointer;">+ Add editor</button>
   </div>
 
+  <!-- Remote targets (SSH folder moves) -->
+  <div class="section">
+    <div class="section-title">Remote targets (NAS / SSH)</div>
+    <p style="font-size:12px;color:var(--text-dim);margin-bottom:12px;">
+      Destinations for moving folders to a NAS over SSH — far more reliable than an SMB mount over a slow/remote link, with resume and integrity verification. The <b>Remote path</b> is the NAS-side filesystem path rsync writes to (e.g. <code>/volume1/Photography</code>); the <b>Local mount path</b> is where you can read those same files afterward (e.g. <code>/Volumes/Photography</code>) — moved photos are repointed there so they stay in your library. Remote moves need GNU rsync (set its path under “GNU rsync path” in the Paths settings if auto-detect fails).
+    </p>
+    <div id="cfgRemoteTargetsList" style="display:flex;flex-direction:column;gap:10px;margin-bottom:8px;"></div>
+    <button type="button" onclick="addRemoteTarget()" style="background:var(--bg-tertiary);color:var(--text-secondary);border:1px solid var(--border-secondary);border-radius:4px;padding:6px 12px;font-size:12px;cursor:pointer;">+ Add remote target</button>
+  </div>
+
   <!-- darktable Development -->
   <div class="section">
     <div class="section-title">RAW Development (darktable)</div>
@@ -1602,6 +1612,158 @@ function collectExternalEditors() {
     });
 }
 
+// ---------- Remote targets (SSH) list ----------
+// Source-of-truth for the remote-target editor. Populated by loadConfig()
+// and read back on save via collectRemoteTargets().
+var _remoteTargetsState = [];
+
+function _genTargetId() {
+  if (window.crypto && crypto.randomUUID) return crypto.randomUUID();
+  return 'rt-' + Date.now().toString(36) + '-' + Math.floor(Math.random() * 1e9).toString(36);
+}
+
+var _rtInputCss = 'background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border-secondary);border-radius:4px;padding:6px 10px;font-size:12px;';
+
+function _rtField(label, value, placeholder, onInput, opts) {
+  opts = opts || {};
+  var wrap = document.createElement('div');
+  wrap.style.cssText = 'display:flex;flex-direction:column;gap:3px;'
+    + (opts.flex ? ('flex:' + opts.flex + ';') : '') + (opts.width ? ('width:' + opts.width + ';') : '');
+  var lab = document.createElement('label');
+  lab.textContent = label;
+  lab.style.cssText = 'font-size:11px;color:var(--text-dim);';
+  var inp = document.createElement('input');
+  inp.type = opts.type || 'text';
+  inp.value = (value == null ? '' : value);
+  inp.placeholder = placeholder || '';
+  inp.style.cssText = _rtInputCss + (opts.mono ? 'font-family:monospace;' : '');
+  inp.addEventListener('input', function() { onInput(inp.value); });
+  wrap.appendChild(lab);
+  wrap.appendChild(inp);
+  return wrap;
+}
+
+function renderRemoteTargets() {
+  var container = document.getElementById('cfgRemoteTargetsList');
+  if (!container) return;
+  container.replaceChildren();
+  if (_remoteTargetsState.length === 0) {
+    var empty = document.createElement('div');
+    empty.style.cssText = 'color:var(--text-dim);font-size:12px;font-style:italic;';
+    empty.textContent = 'No remote targets configured.';
+    container.appendChild(empty);
+    return;
+  }
+  _remoteTargetsState.forEach(function(t, i) {
+    var card = document.createElement('div');
+    card.style.cssText = 'border:1px solid var(--border-secondary);border-radius:6px;padding:10px;display:flex;flex-direction:column;gap:8px;background:var(--bg-secondary);';
+
+    var save = function(field) {
+      return function(v) { _remoteTargetsState[i][field] = v; saveConfig(); };
+    };
+
+    var r1 = document.createElement('div');
+    r1.style.cssText = 'display:flex;gap:8px;flex-wrap:wrap;';
+    r1.appendChild(_rtField('Name', t.name, 'My NAS', save('name'), {flex: '2'}));
+    r1.appendChild(_rtField('User', t.user, 'admin', save('user'), {flex: '1'}));
+    r1.appendChild(_rtField('Host', t.host, 'synology-nas', save('host'), {flex: '2', mono: true}));
+    r1.appendChild(_rtField('Port', t.port, '22', save('port'), {width: '70px'}));
+    card.appendChild(r1);
+
+    var r2 = document.createElement('div');
+    r2.style.cssText = 'display:flex;gap:8px;flex-wrap:wrap;';
+    r2.appendChild(_rtField('Remote path (NAS side)', t.remote_path, '/volume1/Photography', save('remote_path'), {flex: '1', mono: true}));
+    r2.appendChild(_rtField('Local mount path', t.mount_path, '/Volumes/Photography', save('mount_path'), {flex: '1', mono: true}));
+    card.appendChild(r2);
+
+    var r3 = document.createElement('div');
+    r3.style.cssText = 'display:flex;gap:8px;flex-wrap:wrap;';
+    r3.appendChild(_rtField('SSH key (optional)', t.ssh_key, 'default key if blank', save('ssh_key'), {flex: '2', mono: true}));
+    r3.appendChild(_rtField('Bandwidth limit KB/s (0 = none)', t.bwlimit_kbps, '0', save('bwlimit_kbps'), {width: '160px'}));
+    card.appendChild(r3);
+
+    var r4 = document.createElement('div');
+    r4.style.cssText = 'display:flex;align-items:center;gap:10px;';
+    var testBtn = document.createElement('button');
+    testBtn.type = 'button';
+    testBtn.textContent = 'Test connection';
+    testBtn.style.cssText = 'background:var(--bg-tertiary);color:var(--text-secondary);border:1px solid var(--border-secondary);border-radius:4px;padding:6px 12px;font-size:12px;cursor:pointer;';
+    var statusEl = document.createElement('span');
+    statusEl.style.cssText = 'font-size:12px;color:var(--text-dim);flex:1;';
+    testBtn.addEventListener('click', function() { testRemoteTarget(i, testBtn, statusEl); });
+
+    var removeBtn = document.createElement('button');
+    removeBtn.type = 'button';
+    removeBtn.textContent = 'Remove';
+    removeBtn.style.cssText = 'background:var(--bg-tertiary);color:var(--text-dim);border:1px solid var(--border-secondary);border-radius:4px;padding:6px 12px;font-size:12px;cursor:pointer;';
+    removeBtn.addEventListener('click', function() {
+      _remoteTargetsState.splice(i, 1);
+      renderRemoteTargets();
+      saveConfig();
+    });
+
+    r4.appendChild(testBtn);
+    r4.appendChild(statusEl);
+    r4.appendChild(removeBtn);
+    card.appendChild(r4);
+    container.appendChild(card);
+  });
+}
+
+function addRemoteTarget() {
+  _remoteTargetsState.push({
+    id: _genTargetId(), name: '', host: '', user: '', port: 22,
+    ssh_key: '', remote_path: '', mount_path: '', bwlimit_kbps: 0,
+  });
+  renderRemoteTargets();
+  // Defer save until fields are filled — _coerce_remote_target drops empty
+  // entries server-side anyway, so an empty save would be a no-op write.
+}
+
+function collectRemoteTargets() {
+  // Mirror config._coerce_remote_target: drop entries missing host/user/
+  // remote_path; coerce numeric fields. Keep ids stable across edits.
+  var asStr = function(v) { return typeof v === 'string' ? v.trim() : (v == null ? '' : String(v).trim()); };
+  var asInt = function(v, d) { var n = parseInt(v, 10); return isNaN(n) ? d : n; };
+  return _remoteTargetsState
+    .map(function(t) {
+      return {
+        id: t.id || _genTargetId(),
+        name: asStr(t.name), host: asStr(t.host), user: asStr(t.user),
+        port: asInt(t.port, 22), ssh_key: asStr(t.ssh_key),
+        remote_path: asStr(t.remote_path), mount_path: asStr(t.mount_path),
+        bwlimit_kbps: Math.max(0, asInt(t.bwlimit_kbps, 0)),
+      };
+    })
+    .filter(function(t) { return t.host && t.user && t.remote_path; });
+}
+
+async function testRemoteTarget(i, btn, statusEl) {
+  var t = _remoteTargetsState[i];
+  btn.disabled = true;
+  var orig = btn.textContent;
+  btn.textContent = 'Testing…';
+  statusEl.textContent = 'Connecting…';
+  statusEl.style.color = 'var(--text-dim)';
+  try {
+    var res = await safeFetch('/api/remote-targets/test', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(t),
+    }, { toast: false });
+    statusEl.textContent = (res.ok ? '✓ ' : '⚠ ') + (res.message || '')
+      + (res.mount_path && !res.mount_present
+          ? ' (mount path not currently present — fine if the NAS just isn’t mounted right now.)' : '');
+    statusEl.style.color = res.ok ? 'var(--success, #4caf50)' : 'var(--warning)';
+  } catch (e) {
+    statusEl.textContent = '⚠ ' + (e && e.message ? e.message : 'Test failed.');
+    statusEl.style.color = 'var(--warning)';
+  } finally {
+    btn.disabled = false;
+    btn.textContent = orig;
+  }
+}
+
 async function loadConfig() {
   try {
     var cfg = await safeFetch('/api/config', {}, { toast: false });
@@ -1636,6 +1798,25 @@ async function loadConfig() {
       _editorsState = [{ name: 'Editor', path: cfg.external_editor.trim() }];
     }
     renderExternalEditors();
+    // Remote (SSH) move targets. Coerce defensively against a hand-edited
+    // config.json so a malformed entry can't crash the settings page.
+    var rawTargets = Array.isArray(cfg.remote_targets) ? cfg.remote_targets : [];
+    _remoteTargetsState = [];
+    rawTargets.forEach(function(t) {
+      if (!t || typeof t !== 'object') return;
+      _remoteTargetsState.push({
+        id: typeof t.id === 'string' && t.id ? t.id : _genTargetId(),
+        name: typeof t.name === 'string' ? t.name : '',
+        host: typeof t.host === 'string' ? t.host : '',
+        user: typeof t.user === 'string' ? t.user : '',
+        port: t.port == null ? 22 : t.port,
+        ssh_key: typeof t.ssh_key === 'string' ? t.ssh_key : '',
+        remote_path: typeof t.remote_path === 'string' ? t.remote_path : '',
+        mount_path: typeof t.mount_path === 'string' ? t.mount_path : '',
+        bwlimit_kbps: t.bwlimit_kbps == null ? 0 : t.bwlimit_kbps,
+      });
+    });
+    renderRemoteTargets();
     document.getElementById('cfgDarktableBin').value = cfg.darktable_bin || '';
     document.getElementById('cfgDarktableStyle').value = cfg.darktable_style || '';
     document.getElementById('cfgDarktableFormat').value = cfg.darktable_output_format || 'jpg';
@@ -1835,6 +2016,7 @@ function saveConfig() {
           inat_token: document.getElementById('cfgInatToken').value.trim(),
           google_maps_api_key: document.getElementById('cfgGoogleMapsApiKey').value.trim(),
           external_editors: collectExternalEditors(),
+          remote_targets: collectRemoteTargets(),
           // Always clear the legacy single-editor field when we save the new
           // list. Otherwise a user who once had `external_editor` set and now
           // removes every editor from the list can't get back to OS-default

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -1907,7 +1907,7 @@ def test_rsync_stall_watchdog_kills_silent_process(monkeypatch):
     monkeypatch.setattr(move_mod.subprocess, "Popen", _fake_popen)
 
     rc, stderr, timed_out = move_mod._run_rsync_streamed(
-        "/src", "/dst", "--checksum", 10, None, stall_timeout=0.3,
+        "/src", "/dst", ["--checksum"], 10, None, stall_timeout=0.3,
     )
     assert timed_out is True
     assert proc_holder["proc"].killed.is_set()
@@ -1928,7 +1928,7 @@ def test_rsync_streamed_runs_as_long_as_it_progresses(monkeypatch):
 
     seen = []
     rc, stderr, timed_out = move_mod._run_rsync_streamed(
-        "/src", "/dst", "--ignore-existing", 8,
+        "/src", "/dst", ["--ignore-existing"], 8,
         lambda cur, tot, name, phase: seen.append(name),
         stall_timeout=0.3,
     )

--- a/vireo/tests/test_move_api.py
+++ b/vireo/tests/test_move_api.py
@@ -541,6 +541,39 @@ def test_move_folder_rejects_non_bool_merge(app_and_db):
     assert "boolean" in resp.get_json()["error"].lower()
 
 
+def test_move_folder_rejects_remote_target_with_relative_mount_path(
+        app_and_db, tmp_path, monkeypatch):
+    """A remote target whose mount_path is relative (e.g. "Photos") must be
+    rejected before the job starts. The catalog gets repointed to mount_path
+    after the move; a server-cwd-relative value there would leave every moved
+    photo appearing missing."""
+    import config as cfg
+
+    app, db = app_and_db
+    folders = db.get_folder_tree()
+    fid = folders[0]["id"]
+
+    fake_target = {
+        "id": "t1", "name": "nas", "host": "nas", "user": "me",
+        "port": 22, "ssh_key": "", "remote_path": "/volume1/Photo",
+        "mount_path": "Photos",  # relative — the bug
+        "bwlimit_kbps": 0,
+    }
+    monkeypatch.setattr(cfg, "get_remote_target",
+                        lambda tid: fake_target if tid == "t1" else None)
+
+    client = app.test_client()
+    resp = client.post("/api/jobs/move-folder", json={
+        "folder_id": fid,
+        "remote_target_id": "t1",
+        "subpath": "",
+    })
+    assert resp.status_code == 400
+    body = resp.get_json()["error"].lower()
+    assert "absolute" in body
+    assert "mount" in body
+
+
 def test_move_folder_preflight_rejects_non_object_body(app_and_db):
     """Preflight: same type guard as the job endpoint."""
     app, _ = app_and_db

--- a/vireo/tests/test_move_api.py
+++ b/vireo/tests/test_move_api.py
@@ -582,6 +582,57 @@ def test_move_folder_preflight_rejects_non_object_body(app_and_db):
     assert resp.status_code == 400
 
 
+def test_move_folder_preflight_remote_uses_posix_join_for_dest(
+        app_and_db, tmp_path, monkeypatch):
+    """The remote preflight builds the NAS-side path the SSH probe will look
+    up. On a Windows client, resolve_folder_dest would use os.path.join and
+    produce ``/volume1/Photo\trip`` — but move_folder transfers to the POSIX
+    path ``/volume1/Photo/trip``, so the existence probe would miss an
+    existing destination (reporting it as new) and the user's first
+    non-merge move would fail at rsync. Pin that the preflight joins NAS
+    paths with '/' regardless of os.path semantics."""
+    import config as cfg
+    import move as move_mod
+
+    app, db = app_and_db
+    # Use a folder whose path is recorded with POSIX separators so the
+    # basename derivation matches the transfer-side derivation in move_folder
+    # (which strips both / and \ before taking the basename).
+    fid = db.add_folder("/srv/photos/trip", name="trip")
+
+    fake_target = {
+        "id": "t1", "name": "nas", "host": "nas", "user": "me",
+        "port": 22, "ssh_key": "", "remote_path": "/volume1/Photo",
+        "mount_path": "/mnt/nas", "bwlimit_kbps": 0,
+    }
+    monkeypatch.setattr(cfg, "get_remote_target",
+                        lambda tid: fake_target if tid == "t1" else None)
+    # The probe itself isn't under test — stub it so we only inspect the
+    # resolved_dest the route built before calling it.
+    captured = {}
+
+    def fake_preflight(remote, dest_path, file_cap=1000):
+        captured["dest_path"] = dest_path
+        return (False, 0, False, True, None)
+
+    monkeypatch.setattr(move_mod, "remote_preflight", fake_preflight)
+
+    client = app.test_client()
+    resp = client.post("/api/move-folder/preflight", json={
+        "folder_id": fid,
+        "remote_target_id": "t1",
+        "subpath": "",
+    })
+    assert resp.status_code == 200, resp.data
+    body = resp.get_json()
+    # Both the probed NAS path and the displayed resolved_dest must be the
+    # POSIX-joined target — no backslashes, no os.path.join surprises.
+    assert captured["dest_path"] == "/volume1/Photo/trip"
+    assert "\\" not in captured["dest_path"]
+    assert body["resolved_dest"] == "me@nas:/volume1/Photo/trip"
+    assert "\\" not in body["resolved_dest"]
+
+
 def test_move_rules_crud(app_and_db):
     """CRUD operations on move rules via API."""
     app, _ = app_and_db

--- a/vireo/tests/test_move_remote.py
+++ b/vireo/tests/test_move_remote.py
@@ -68,6 +68,7 @@ _EXE_SUFFIX = ".exe" if sys.platform == "win32" else ""
 
 def test_resolve_rsync_bin(tmp_path, monkeypatch):
     monkeypatch.setattr(move_mod, "_BUNDLED_RSYNC_CANDIDATES", ())
+    monkeypatch.setattr(move_mod, "_platform_rsync_candidates", lambda: ())
     monkeypatch.delenv("VIREO_RSYNC_BIN", raising=False)
     # Nothing available -> None.
     assert move_mod.resolve_rsync_bin("") is None
@@ -85,11 +86,52 @@ def test_resolve_rsync_bin(tmp_path, monkeypatch):
 
 def test_resolve_rsync_bin_env_override(tmp_path, monkeypatch):
     monkeypatch.setattr(move_mod, "_BUNDLED_RSYNC_CANDIDATES", ())
+    monkeypatch.setattr(move_mod, "_platform_rsync_candidates", lambda: ())
     fake = tmp_path / f"rsync{_EXE_SUFFIX}"
     fake.write_text("#!/bin/sh\n")
     fake.chmod(0o755)
     monkeypatch.setenv("VIREO_RSYNC_BIN", str(fake))
     assert move_mod.resolve_rsync_bin("") == str(fake)
+
+
+def test_resolve_rsync_bin_finds_linux_path_via_platform_candidates(
+        tmp_path, monkeypatch):
+    """On a Linux host with no config and no bundled rsync, resolve_rsync_bin
+    should still find a usable GNU rsync via the platform-aware candidates
+    ($PATH / /usr/bin/rsync). macOS-only candidate avoidance is intentionally
+    macOS-only — every other major OS ships GNU rsync at those locations."""
+    monkeypatch.setattr(move_mod, "_BUNDLED_RSYNC_CANDIDATES", ())
+    monkeypatch.delenv("VIREO_RSYNC_BIN", raising=False)
+
+    # Pretend a usable rsync is discoverable on $PATH at tmp_path/rsync.
+    # Use _EXE_SUFFIX so the Windows leg of the CI matrix (which judges
+    # executability by PATHEXT) treats this file as executable.
+    fake = tmp_path / f"rsync{_EXE_SUFFIX}"
+    fake.write_text("#!/bin/sh\n")
+    fake.chmod(0o755)
+
+    monkeypatch.setattr(
+        move_mod, "_platform_rsync_candidates",
+        lambda: (str(fake),))
+
+    assert move_mod.resolve_rsync_bin("") == str(fake)
+
+
+def test_platform_rsync_candidates_excludes_darwin(monkeypatch):
+    """macOS's /usr/bin/rsync is openrsync (can't drive SSH), so on darwin the
+    platform-aware probe must return empty — the bundled Homebrew/MacPorts
+    candidates handle macOS, and including /usr/bin/rsync would silently
+    auto-select an unusable binary."""
+    monkeypatch.setattr(move_mod.sys, "platform", "darwin")
+    assert move_mod._platform_rsync_candidates() == ()
+
+
+def test_platform_rsync_candidates_includes_usr_bin_on_linux(monkeypatch):
+    """On Linux/BSD/Windows, /usr/bin/rsync is GNU rsync. The probe must offer
+    it as a candidate so an unconfigured Linux install has a usable default."""
+    monkeypatch.setattr(move_mod.sys, "platform", "linux")
+    monkeypatch.setattr(move_mod.shutil, "which", lambda name: None)
+    assert "/usr/bin/rsync" in move_mod._platform_rsync_candidates()
 
 
 def test_coerce_remote_target_drops_incomplete():
@@ -338,3 +380,71 @@ def test_remote_move_refuses_when_catalog_path_overlaps_tracked(remote_env, monk
     assert called["rsync"] is False
     # Source untouched.
     assert (env["src"] / "a.nef").exists()
+
+
+def test_remote_move_refuses_when_ssh_probe_fails(remote_env, monkeypatch):
+    """A failed SSH ``test -d`` probe (auth failure, connect timeout, ssh
+    binary missing, etc.) must NOT collapse to "destination absent". Otherwise
+    the move would proceed as a fresh transfer (omitting --ignore-existing)
+    and overwrite same-name files on a real existing destination before the
+    --checksum verify could preserve the originals. _remote_dir_exists returns
+    None on probe failure; the caller must refuse the move."""
+    env = remote_env
+    called = {"rsync": False}
+
+    def fake_rsync(*a, **k):
+        called["rsync"] = True
+        return (0, "", False)
+
+    # None == "probe couldn't conclude" — caller must refuse, not assume False.
+    monkeypatch.setattr(move_mod, "_remote_dir_exists", lambda r, p: None)
+    monkeypatch.setattr(move_mod, "_run_rsync_streamed", fake_rsync)
+    monkeypatch.setattr(move_mod, "_remote_verify_complete",
+                        lambda *a, **k: None)
+
+    result = move_mod.move_folder(
+        db=env["db"], folder_id=env["fid"], destination="",
+        remote=env["remote"])
+
+    assert result["moved"] == 0
+    assert any("ssh" in e.lower() or "probe" in e.lower()
+               for e in result["errors"])
+    # Crucially: rsync was NOT invoked. The transient probe failure must not
+    # be silently treated as "fresh transfer ok".
+    assert called["rsync"] is False
+    # Source untouched.
+    assert (env["src"] / "a.nef").exists()
+
+
+def test_remote_dir_exists_tri_state(monkeypatch):
+    """_remote_dir_exists distinguishes exists / absent / probe-failed.
+
+    test -d exits 0 if dir, 1 if not; ssh returns 255 on its own failure. Any
+    return code outside {0, 1} or an OSError must collapse to None (the caller
+    refuses), not to False (the caller would proceed without --ignore-existing
+    on a real existing destination).
+    """
+    remote = {"host": "h", "user": "u", "port": 22, "ssh_key": ""}
+
+    class FakeCompleted:
+        def __init__(self, rc):
+            self.returncode = rc
+
+    monkeypatch.setattr(move_mod.subprocess, "run",
+                        lambda *a, **k: FakeCompleted(0))
+    assert move_mod._remote_dir_exists(remote, "/p") is True
+
+    monkeypatch.setattr(move_mod.subprocess, "run",
+                        lambda *a, **k: FakeCompleted(1))
+    assert move_mod._remote_dir_exists(remote, "/p") is False
+
+    # SSH-level failure (returncode 255).
+    monkeypatch.setattr(move_mod.subprocess, "run",
+                        lambda *a, **k: FakeCompleted(255))
+    assert move_mod._remote_dir_exists(remote, "/p") is None
+
+    # subprocess raising (ssh binary missing, timeout, etc.).
+    def boom(*a, **k):
+        raise OSError("ssh: not found")
+    monkeypatch.setattr(move_mod.subprocess, "run", boom)
+    assert move_mod._remote_dir_exists(remote, "/p") is None

--- a/vireo/tests/test_move_remote.py
+++ b/vireo/tests/test_move_remote.py
@@ -22,7 +22,7 @@ from db import Database
 def test_sanitize_subpath_basic():
     assert move_mod.sanitize_subpath("") == ""
     assert move_mod.sanitize_subpath(None) == ""
-    assert move_mod.sanitize_subpath("/USA/2026/") == "USA/2026"
+    assert move_mod.sanitize_subpath("USA/2026/") == "USA/2026"
     assert move_mod.sanitize_subpath("USA//2026") == "USA/2026"
     assert move_mod.sanitize_subpath("a/./b") == "a/b"
 
@@ -32,6 +32,19 @@ def test_sanitize_subpath_rejects_traversal():
         move_mod.sanitize_subpath("../escape")
     with pytest.raises(ValueError):
         move_mod.sanitize_subpath("a/../../b")
+
+
+def test_sanitize_subpath_rejects_absolute():
+    # An absolute input must not be silently normalized into a relative segment:
+    # '/foo' previously slipped through as 'foo' and landed under a different
+    # base than the user typed. Reject POSIX, Windows-backslash, and drive
+    # forms so the contract matches the docstring.
+    with pytest.raises(ValueError):
+        move_mod.sanitize_subpath("/USA/2026")
+    with pytest.raises(ValueError):
+        move_mod.sanitize_subpath("\\\\server\\share")
+    with pytest.raises(ValueError):
+        move_mod.sanitize_subpath("C:\\foo")
 
 
 def test_build_remote_move_spec_joins_both_bases():
@@ -342,6 +355,107 @@ def test_remote_move_merge_uses_partial_dir_for_resume(remote_env, monkeypatch):
     # Bare --partial must not also appear: it would put partials back at the
     # destination filename and re-introduce the --ignore-existing collision.
     assert "--partial" not in seen["extra_args"]
+
+
+def test_remote_move_refuses_relative_mount_dest_base(remote_env, monkeypatch):
+    """A relative mount_dest_base would make resolve_folder_dest produce a
+    relative catalog_path. After the SSH copy succeeds and originals are
+    deleted, the DB row would point at a non-resolving path relative to the
+    server cwd. Refuse before any transfer happens."""
+    env = remote_env
+    env["remote"]["mount_dest_base"] = "Photos"  # relative — not absolute
+
+    called = {"rsync": False, "exists": False}
+
+    def fake_rsync(*a, **k):
+        called["rsync"] = True
+        return (0, "", False)
+
+    def fake_exists(*a, **k):
+        called["exists"] = True
+        return False
+
+    monkeypatch.setattr(move_mod, "_remote_dir_exists", fake_exists)
+    monkeypatch.setattr(move_mod, "_run_rsync_streamed", fake_rsync)
+
+    result = move_mod.move_folder(
+        db=env["db"], folder_id=env["fid"], destination="",
+        remote=env["remote"])
+
+    assert result["moved"] == 0
+    assert any("absolute" in e.lower() for e in result["errors"])
+    # No SSH calls at all — refusal happens before any probing or transfer.
+    assert called["rsync"] is False
+    assert called["exists"] is False
+    assert (env["src"] / "a.nef").exists()
+
+
+def test_remote_move_refuses_when_catalog_path_overlaps_source(
+        remote_env, monkeypatch):
+    """Codex P1: if the source folder is already on the configured local
+    mount (src=/Volumes/Photography/trip, mount=/Volumes/Photography), the
+    catalog_path the move resolves to overlaps the source. The SSH copy and
+    --checksum verify would both pass against the same underlying tree, and
+    the post-move rmtree(src) would wipe the only copy. The overlap guard
+    must check catalog_path for remote moves, not just transfer_dest."""
+    env = remote_env
+    # Set the mount path to the source itself so the resolved catalog_path
+    # (mount + folder name) is a child of the source — i.e. moving into a
+    # subdirectory of the source via the configured local mount. After the
+    # "copy" and verify, rmtree(src) would wipe both source and copy.
+    env["remote"]["mount_dest_base"] = str(env["src"])
+
+    called = {"rsync": False, "exists": False}
+
+    def fake_rsync(*a, **k):
+        called["rsync"] = True
+        return (0, "", False)
+
+    def fake_exists(*a, **k):
+        called["exists"] = True
+        return False
+
+    monkeypatch.setattr(move_mod, "_remote_dir_exists", fake_exists)
+    monkeypatch.setattr(move_mod, "_run_rsync_streamed", fake_rsync)
+
+    result = move_mod.move_folder(
+        db=env["db"], folder_id=env["fid"], destination="",
+        remote=env["remote"])
+
+    assert result["moved"] == 0
+    assert any("overlap" in e.lower() for e in result["errors"])
+    # No transfer happens.
+    assert called["rsync"] is False
+    # Source untouched.
+    assert (env["src"] / "a.nef").exists()
+
+
+def test_remote_move_uses_posix_join_for_transfer_dest(remote_env, monkeypatch):
+    """The NAS-side rsync target must use forward slashes regardless of the
+    client OS. os.path.join on Windows would build
+    "/volume1/Photo\\trip"; rsync would then ship the backslash as part of
+    the remote path and fail or write to the wrong directory."""
+    env = remote_env
+    captured = {}
+
+    def fake_rsync(src_path, dest_spec, flags, total, cb, rsync_bin="rsync",
+                   extra_args=None, **kw):
+        captured["dest_spec"] = dest_spec
+        return (0, "", False)
+
+    monkeypatch.setattr(move_mod, "_remote_dir_exists", lambda r, p: False)
+    monkeypatch.setattr(move_mod, "_run_rsync_streamed", fake_rsync)
+    monkeypatch.setattr(move_mod, "_remote_verify_complete",
+                        lambda *a, **k: None)
+
+    move_mod.move_folder(
+        db=env["db"], folder_id=env["fid"], destination="",
+        remote=env["remote"])
+
+    # No backslashes in the rsync target — even though os.path.join on
+    # Windows would have inserted one. Asserts the join was POSIX-only.
+    assert "\\" not in captured["dest_spec"]
+    assert captured["dest_spec"] == "me@nas:/volume1/Photography/trip"
 
 
 def test_remote_move_refuses_when_catalog_path_overlaps_tracked(remote_env, monkeypatch):

--- a/vireo/tests/test_move_remote.py
+++ b/vireo/tests/test_move_remote.py
@@ -10,12 +10,10 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
+import config as cfg
+import move as move_mod
 import pytest
 from db import Database
-
-import move as move_mod
-import config as cfg
-
 
 # --------------------------------------------------------------------------
 # Pure helpers — no SSH/rsync needed.

--- a/vireo/tests/test_move_remote.py
+++ b/vireo/tests/test_move_remote.py
@@ -163,7 +163,10 @@ def test_remote_move_success_repoints_catalog_to_mount(remote_env, monkeypatch):
     # rsync addressed the SSH target, with the bundled binary + ssh transport.
     assert calls["dest_spec"] == "me@nas:/volume1/Photography/trip"
     assert calls["rsync_bin"] == "/usr/bin/rsync"
-    assert "-e" in calls["extra_args"] and "--partial" in calls["extra_args"]
+    # Partials go to a dot-prefixed subdir so they don't collide with
+    # --ignore-existing on retry; --partial-dir implies --partial.
+    assert "-e" in calls["extra_args"]
+    assert "--partial-dir=.rsync-partial" in calls["extra_args"]
     # Originals deleted.
     assert not env["src"].exists()
     # Catalog now points at the LOCAL MOUNT path, not the NAS path.
@@ -266,3 +269,68 @@ def test_remote_move_merge_uses_ignore_existing(remote_env, monkeypatch):
 
     assert result["moved"] == 2
     assert "--ignore-existing" in seen["flags"]
+
+
+def test_remote_move_merge_uses_partial_dir_for_resume(remote_env, monkeypatch):
+    """A merge/resume must use --partial-dir, not bare --partial: otherwise a
+    stalled file would be left at the destination filename and skipped by
+    --ignore-existing on every retry, stranding it short of complete forever."""
+    env = remote_env
+    seen = {}
+
+    def fake_rsync(src_path, dest_spec, flags, total, cb, rsync_bin="rsync",
+                   extra_args=None, **kw):
+        seen["extra_args"] = list(extra_args or [])
+        return (0, "", False)
+
+    monkeypatch.setattr(move_mod, "_remote_dir_exists", lambda r, p: True)
+    monkeypatch.setattr(move_mod, "_run_rsync_streamed", fake_rsync)
+    monkeypatch.setattr(move_mod, "_remote_verify_complete",
+                        lambda *a, **k: None)
+
+    move_mod.move_folder(
+        db=env["db"], folder_id=env["fid"], destination="", merge=True,
+        remote=env["remote"])
+
+    assert "--partial-dir=.rsync-partial" in seen["extra_args"]
+    # Bare --partial must not also appear: it would put partials back at the
+    # destination filename and re-introduce the --ignore-existing collision.
+    assert "--partial" not in seen["extra_args"]
+
+
+def test_remote_move_refuses_when_catalog_path_overlaps_tracked(remote_env, monkeypatch):
+    """The local mount path the catalog is repointed to after a remote move
+    must not overlap another tracked folder — that would copy the tree over
+    SSH only to hit folders.path UNIQUE on the post-move repoint. Refuse the
+    move before any SSH transfer happens."""
+    env = remote_env
+    # Pre-register a tracked folder at the resolved catalog_path.
+    catalog_path = os.path.join(env["remote"]["mount_dest_base"], "trip")
+    other_fid = env["db"].add_folder(catalog_path, name="trip")
+    assert other_fid != env["fid"]
+
+    called = {"rsync": False, "exists": False}
+
+    def fake_rsync(*a, **k):
+        called["rsync"] = True
+        return (0, "", False)
+
+    def fake_exists(*a, **k):
+        called["exists"] = True
+        return False
+
+    monkeypatch.setattr(move_mod, "_remote_dir_exists", fake_exists)
+    monkeypatch.setattr(move_mod, "_run_rsync_streamed", fake_rsync)
+    monkeypatch.setattr(move_mod, "_remote_verify_complete",
+                        lambda *a, **k: None)
+
+    result = move_mod.move_folder(
+        db=env["db"], folder_id=env["fid"], destination="",
+        remote=env["remote"])
+
+    assert result["moved"] == 0
+    assert any("already manages" in e for e in result["errors"])
+    # Nothing transferred — overlap detected before any SSH call.
+    assert called["rsync"] is False
+    # Source untouched.
+    assert (env["src"] / "a.nef").exists()

--- a/vireo/tests/test_move_remote.py
+++ b/vireo/tests/test_move_remote.py
@@ -153,6 +153,30 @@ def test_coerce_remote_target_drops_incomplete():
     assert cfg._coerce_remote_target("not a dict") is None
 
 
+def test_coerce_remote_target_drops_relative_remote_path():
+    """A relative remote_path like "Photos" would ship to rsync as
+    user@host:Photos/<folder> and resolve under the SSH user's remote cwd,
+    while the catalog gets repointed to the absolute mount_path — i.e. the
+    verified copy ends up at a different remote location than the path Vireo
+    records. The coerce path drops these entries so they never reach the
+    settings dropdown."""
+    assert cfg._coerce_remote_target({
+        "host": "nas", "user": "me", "remote_path": "Photos",
+    }) is None
+    assert cfg._coerce_remote_target({
+        "host": "nas", "user": "me", "remote_path": "volume1/Photo",
+    }) is None
+    # A Windows-form path is also rejected — the NAS is POSIX, and
+    # backslashes/drive letters wouldn't survive the SSH-side shell intact.
+    assert cfg._coerce_remote_target({
+        "host": "nas", "user": "me", "remote_path": r"C:\Photos",
+    }) is None
+    # The absolute counterpart is accepted.
+    assert cfg._coerce_remote_target({
+        "host": "nas", "user": "me", "remote_path": "/volume1/Photo",
+    }) is not None
+
+
 def test_coerce_remote_target_coerces_and_defaults():
     t = cfg._coerce_remote_target({
         "host": "nas", "user": "me", "remote_path": "/volume1/Photo",
@@ -170,7 +194,7 @@ def test_coerce_remote_target_coerces_and_defaults():
 # --------------------------------------------------------------------------
 
 @pytest.fixture
-def remote_env(tmp_path):
+def remote_env(tmp_path, monkeypatch):
     db = Database(str(tmp_path / "test.db"))
     ws_id = db.ensure_default_workspace()
     db.set_active_workspace(ws_id)
@@ -191,6 +215,10 @@ def remote_env(tmp_path):
         "ssh_dest_base": "/volume1/Photography",
         "mount_dest_base": str(tmp_path / "mount"),
     }
+    # Default the parent-dir mkdir to success so individual tests don't have
+    # to. The dedicated mkdir tests below override this where it matters.
+    monkeypatch.setattr(move_mod, "_remote_mkdir_p",
+                        lambda r, p: (True, ""))
     return {"db": db, "src": src, "fid": fid, "remote": remote,
             "tmp_path": tmp_path}
 
@@ -355,6 +383,44 @@ def test_remote_move_merge_uses_partial_dir_for_resume(remote_env, monkeypatch):
     # Bare --partial must not also appear: it would put partials back at the
     # destination filename and re-introduce the --ignore-existing collision.
     assert "--partial" not in seen["extra_args"]
+
+
+def test_remote_move_refuses_relative_ssh_dest_base(remote_env, monkeypatch):
+    """A relative ssh_dest_base would resolve under the SSH user's remote cwd
+    (rsync target ``user@host:Photos/<folder>``), while catalog_path is the
+    absolute mount_dest_base. A "verified" copy would then live at a
+    different remote location than the path Vireo records — and the
+    original would be deleted on that mis-recorded state. Refuse before
+    any SSH probing or transfer happens. ``_coerce_remote_target`` already
+    drops these at the config boundary; this guards direct callers
+    (tests, ad-hoc scripts) that hand-build the remote dict."""
+    env = remote_env
+    env["remote"]["ssh_dest_base"] = "Photos"  # relative — not absolute POSIX
+
+    called = {"rsync": False, "exists": False}
+
+    def fake_rsync(*a, **k):
+        called["rsync"] = True
+        return (0, "", False)
+
+    def fake_exists(*a, **k):
+        called["exists"] = True
+        return False
+
+    monkeypatch.setattr(move_mod, "_remote_dir_exists", fake_exists)
+    monkeypatch.setattr(move_mod, "_run_rsync_streamed", fake_rsync)
+
+    result = move_mod.move_folder(
+        db=env["db"], folder_id=env["fid"], destination="",
+        remote=env["remote"])
+
+    assert result["moved"] == 0
+    assert any("absolute" in e.lower() and "remote" in e.lower()
+               for e in result["errors"])
+    # No SSH calls at all — refusal happens before any probing or transfer.
+    assert called["rsync"] is False
+    assert called["exists"] is False
+    assert (env["src"] / "a.nef").exists()
 
 
 def test_remote_move_refuses_relative_mount_dest_base(remote_env, monkeypatch):
@@ -528,6 +594,103 @@ def test_remote_move_refuses_when_ssh_probe_fails(remote_env, monkeypatch):
     assert called["rsync"] is False
     # Source untouched.
     assert (env["src"] / "a.nef").exists()
+
+
+def test_remote_move_creates_subpath_parents_before_rsync(remote_env, monkeypatch):
+    """When the configured subpath has missing intermediate parents (e.g.
+    "USA/2026" under /volume1/Photography), the move must ``mkdir -p`` the
+    parent on the NAS before rsync runs. rsync creates the leaf folder
+    itself but not intermediate parents, so without this the move fails
+    with ``mkdir ... failed: No such file or directory`` for any subpath
+    the user hasn't already pre-created.
+
+    Verify the mkdir is called with the parent of the transfer destination
+    and that it runs BEFORE the rsync transfer."""
+    env = remote_env
+    env["remote"]["ssh_dest_base"] = "/volume1/Photography/USA/2026"
+
+    order = []
+
+    def fake_mkdir(remote, path):
+        order.append(("mkdir", path))
+        return (True, "")
+
+    def fake_rsync(*a, **k):
+        order.append(("rsync", None))
+        return (0, "", False)
+
+    monkeypatch.setattr(move_mod, "_remote_dir_exists", lambda r, p: False)
+    monkeypatch.setattr(move_mod, "_remote_mkdir_p", fake_mkdir)
+    monkeypatch.setattr(move_mod, "_run_rsync_streamed", fake_rsync)
+    monkeypatch.setattr(move_mod, "_remote_verify_complete",
+                        lambda *a, **k: None)
+
+    result = move_mod.move_folder(
+        db=env["db"], folder_id=env["fid"], destination="",
+        remote=env["remote"])
+
+    assert result["moved"] == 2
+    # mkdir was called with the configured subpath as the parent (not the
+    # leaf "trip" folder — rsync handles that). And it ran BEFORE rsync, so
+    # rsync never sees a missing parent.
+    mkdir_calls = [p for kind, p in order if kind == "mkdir"]
+    assert mkdir_calls == ["/volume1/Photography/USA/2026"]
+    assert order.index(("mkdir", "/volume1/Photography/USA/2026")) < \
+           order.index(("rsync", None))
+
+
+def test_remote_move_refuses_when_mkdir_p_fails(remote_env, monkeypatch):
+    """If the SSH mkdir -p fails (permission denied, broken connection,
+    read-only share), the move must NOT proceed to rsync — otherwise rsync
+    would fail with the same underlying error but in a noisier way, and the
+    user wouldn't get a clear "fix permissions / pre-create the subpath"
+    pointer. Source must remain intact."""
+    env = remote_env
+
+    called = {"rsync": False}
+
+    def fake_rsync(*a, **k):
+        called["rsync"] = True
+        return (0, "", False)
+
+    monkeypatch.setattr(move_mod, "_remote_dir_exists", lambda r, p: False)
+    monkeypatch.setattr(move_mod, "_remote_mkdir_p",
+                        lambda r, p: (False, "Permission denied"))
+    monkeypatch.setattr(move_mod, "_run_rsync_streamed", fake_rsync)
+
+    result = move_mod.move_folder(
+        db=env["db"], folder_id=env["fid"], destination="",
+        remote=env["remote"])
+
+    assert result["moved"] == 0
+    assert any("Permission denied" in e for e in result["errors"])
+    assert called["rsync"] is False
+    assert (env["src"] / "a.nef").exists()
+
+
+def test_remote_move_merge_skips_mkdir_p(remote_env, monkeypatch):
+    """On merge/resume the leaf already exists, so the parent must too — the
+    mkdir is unnecessary work over SSH on every retry. Verify it's skipped
+    for merge moves (dest_exists=True)."""
+    env = remote_env
+    mkdir_calls = []
+
+    def fake_mkdir(remote, path):
+        mkdir_calls.append(path)
+        return (True, "")
+
+    monkeypatch.setattr(move_mod, "_remote_dir_exists", lambda r, p: True)
+    monkeypatch.setattr(move_mod, "_remote_mkdir_p", fake_mkdir)
+    monkeypatch.setattr(move_mod, "_run_rsync_streamed",
+                        lambda *a, **k: (0, "", False))
+    monkeypatch.setattr(move_mod, "_remote_verify_complete",
+                        lambda *a, **k: None)
+
+    move_mod.move_folder(
+        db=env["db"], folder_id=env["fid"], destination="", merge=True,
+        remote=env["remote"])
+
+    assert mkdir_calls == []  # No mkdir on merge.
 
 
 def test_remote_dir_exists_tri_state(monkeypatch):

--- a/vireo/tests/test_move_remote.py
+++ b/vireo/tests/test_move_remote.py
@@ -245,6 +245,12 @@ def remote_env(tmp_path, monkeypatch):
     # to. The dedicated mkdir tests below override this where it matters.
     monkeypatch.setattr(move_mod, "_remote_mkdir_p",
                         lambda r, p: (True, ""))
+    # Default the pre-merge content-conflict probe to "no conflict" so the
+    # existing merge tests don't have to shell out to rsync just to traverse
+    # the conflict gate. The dedicated tests below override it where the
+    # probe finding (or failing) is the point.
+    monkeypatch.setattr(move_mod, "_find_remote_content_conflict",
+                        lambda *a, **k: None)
     return {"db": db, "src": src, "fid": fid, "remote": remote,
             "tmp_path": tmp_path}
 
@@ -409,6 +415,143 @@ def test_remote_move_merge_uses_partial_dir_for_resume(remote_env, monkeypatch):
     # Bare --partial must not also appear: it would put partials back at the
     # destination filename and re-introduce the --ignore-existing collision.
     assert "--partial" not in seen["extra_args"]
+
+
+def test_remote_merge_refuses_when_content_conflict_found(
+        remote_env, monkeypatch):
+    """A remote merge must run the same pre-copy content-conflict check the
+    local path runs. If a same-name destination file differs in content,
+    refuse with NOTHING copied — otherwise --ignore-existing would still copy
+    every MISSING source file to the NAS first, and only the post-transfer
+    --checksum verify would catch the conflict, leaving stray files behind."""
+    env = remote_env
+    called = {"rsync": False, "verify": False}
+
+    def fake_rsync(*a, **k):
+        called["rsync"] = True
+        return (0, "", False)
+
+    def fake_verify(*a, **k):
+        called["verify"] = True
+        return None
+
+    monkeypatch.setattr(move_mod, "_remote_dir_exists", lambda r, p: True)
+    monkeypatch.setattr(move_mod, "_find_remote_content_conflict",
+                        lambda *a, **k: ("b.nef", None))
+    monkeypatch.setattr(move_mod, "_run_rsync_streamed", fake_rsync)
+    monkeypatch.setattr(move_mod, "_remote_verify_complete", fake_verify)
+
+    result = move_mod.move_folder(
+        db=env["db"], folder_id=env["fid"], destination="", merge=True,
+        remote=env["remote"])
+
+    assert result["moved"] == 0
+    assert any("b.nef" in e and "different content" in e
+               for e in result["errors"])
+    # Refusal must precede any transfer or verify SSH call so nothing lands
+    # on the NAS.
+    assert called["rsync"] is False
+    assert called["verify"] is False
+    assert (env["src"] / "a.nef").exists()
+
+
+def test_remote_merge_refuses_when_conflict_probe_errors(
+        remote_env, monkeypatch):
+    """A pre-merge conflict check that itself can't complete (SSH error,
+    timeout, missing rsync) is treated as a refusal — proceeding would risk
+    a partial transfer landing on the NAS without ever confirming the merge
+    is safe. Same defensive stance as the inconclusive dest-exists probe."""
+    env = remote_env
+    called = {"rsync": False}
+
+    def fake_rsync(*a, **k):
+        called["rsync"] = True
+        return (0, "", False)
+
+    monkeypatch.setattr(move_mod, "_remote_dir_exists", lambda r, p: True)
+    monkeypatch.setattr(
+        move_mod, "_find_remote_content_conflict",
+        lambda *a, **k: ("__ERROR__", "connection reset"))
+    monkeypatch.setattr(move_mod, "_run_rsync_streamed", fake_rsync)
+
+    result = move_mod.move_folder(
+        db=env["db"], folder_id=env["fid"], destination="", merge=True,
+        remote=env["remote"])
+
+    assert result["moved"] == 0
+    assert any("could not run" in e.lower() and "connection reset" in e
+               for e in result["errors"])
+    assert called["rsync"] is False
+    assert (env["src"] / "a.nef").exists()
+
+
+def test_remote_merge_skips_conflict_check_for_fresh_move(
+        remote_env, monkeypatch):
+    """A FRESH remote move (dest doesn't exist) has nothing to conflict
+    against — the destination tree is empty by definition. The conflict probe
+    must NOT run, both to avoid the SSH round-trip and to preserve the
+    "fresh transfer" semantics that omit --ignore-existing."""
+    env = remote_env
+    called = {"conflict": False}
+
+    def fake_conflict(*a, **k):
+        called["conflict"] = True
+        return None
+
+    monkeypatch.setattr(move_mod, "_remote_dir_exists", lambda r, p: False)
+    monkeypatch.setattr(move_mod, "_find_remote_content_conflict",
+                        fake_conflict)
+    monkeypatch.setattr(move_mod, "_run_rsync_streamed",
+                        lambda *a, **k: (0, "", False))
+    monkeypatch.setattr(move_mod, "_remote_verify_complete",
+                        lambda *a, **k: None)
+
+    result = move_mod.move_folder(
+        db=env["db"], folder_id=env["fid"], destination="",
+        remote=env["remote"])
+
+    assert result["moved"] == 2
+    assert called["conflict"] is False
+
+
+def test_remote_merge_conflict_check_targets_existing_files_only(
+        tmp_path, monkeypatch):
+    """The pre-merge probe must use ``rsync -an --existing --checksum``: any
+    other shape silently breaks the contract. ``--existing`` is what filters
+    out missing source files (legitimate transfers, not conflicts); without
+    ``--checksum`` rsync would compare on size+mtime and miss same-size
+    edits; without ``-n`` it would mutate the destination. Lock the shape in
+    a test so a refactor can't quietly drop one of these flags."""
+    seen = {"cmd": None}
+
+    def fake_run(cmd, **kwargs):
+        seen["cmd"] = list(cmd)
+        # Mimic rsync's "nothing to transfer" output: empty stdout, rc=0.
+        class _R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+        return _R()
+
+    monkeypatch.setattr(move_mod.subprocess, "run", fake_run)
+
+    remote = {
+        "host": "nas", "user": "me", "port": 22, "ssh_key": "",
+        "bwlimit_kbps": 0, "rsync_bin": "/usr/bin/rsync",
+        "ssh_dest_base": "/volume1/Photography",
+        "mount_dest_base": str(tmp_path / "mount"),
+    }
+    out = move_mod._find_remote_content_conflict(
+        "/usr/bin/rsync", str(tmp_path),
+        "me@nas:/volume1/Photography/trip", remote)
+
+    assert out is None
+    cmd = seen["cmd"]
+    assert "-an" in cmd
+    assert "--existing" in cmd
+    assert "--checksum" in cmd
+    # Must address the SSH target, not a local path.
+    assert any(arg.startswith("me@nas:") for arg in cmd)
 
 
 def test_remote_move_refuses_relative_ssh_dest_base(remote_env, monkeypatch):

--- a/vireo/tests/test_move_remote.py
+++ b/vireo/tests/test_move_remote.py
@@ -1,0 +1,270 @@
+"""Tests for remote (SSH) folder moves and the remote-target plumbing.
+
+The transport/verify/existence touchpoints shell out to ssh/rsync, so the
+move_folder tests here monkeypatch those three seams and exercise the
+branching, catalog-repoint, and verify-gated delete logic without a network.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from db import Database
+
+import move as move_mod
+import config as cfg
+
+
+# --------------------------------------------------------------------------
+# Pure helpers — no SSH/rsync needed.
+# --------------------------------------------------------------------------
+
+def test_sanitize_subpath_basic():
+    assert move_mod.sanitize_subpath("") == ""
+    assert move_mod.sanitize_subpath(None) == ""
+    assert move_mod.sanitize_subpath("/USA/2026/") == "USA/2026"
+    assert move_mod.sanitize_subpath("USA//2026") == "USA/2026"
+    assert move_mod.sanitize_subpath("a/./b") == "a/b"
+
+
+def test_sanitize_subpath_rejects_traversal():
+    with pytest.raises(ValueError):
+        move_mod.sanitize_subpath("../escape")
+    with pytest.raises(ValueError):
+        move_mod.sanitize_subpath("a/../../b")
+
+
+def test_build_remote_move_spec_joins_both_bases():
+    target = {
+        "host": "nas", "user": "me", "port": 22, "ssh_key": "",
+        "remote_path": "/volume1/Photography",
+        "mount_path": "/Volumes/Photography", "bwlimit_kbps": 0,
+    }
+    spec = move_mod.build_remote_move_spec(target, "USA/2026", "/usr/bin/rsync")
+    assert spec["ssh_dest_base"] == "/volume1/Photography/USA/2026"
+    assert spec["mount_dest_base"] == os.path.join(
+        "/Volumes/Photography", "USA", "2026")
+    assert spec["rsync_bin"] == "/usr/bin/rsync"
+    assert spec["host"] == "nas" and spec["user"] == "me"
+
+
+def test_build_remote_move_spec_no_subpath():
+    target = {"host": "nas", "user": "me", "remote_path": "/volume1/Photo",
+              "mount_path": "/Volumes/Photo"}
+    spec = move_mod.build_remote_move_spec(target, "", "rsync")
+    assert spec["ssh_dest_base"] == "/volume1/Photo"
+    assert spec["mount_dest_base"] == "/Volumes/Photo"
+
+
+def test_build_remote_move_spec_bad_subpath_raises():
+    target = {"host": "nas", "user": "me", "remote_path": "/v", "mount_path": "/m"}
+    with pytest.raises(ValueError):
+        move_mod.build_remote_move_spec(target, "../x", "rsync")
+
+
+def test_resolve_rsync_bin(tmp_path, monkeypatch):
+    monkeypatch.setattr(move_mod, "_BUNDLED_RSYNC_CANDIDATES", ())
+    monkeypatch.delenv("VIREO_RSYNC_BIN", raising=False)
+    # Nothing available -> None.
+    assert move_mod.resolve_rsync_bin("") is None
+    # An explicit executable path wins.
+    fake = tmp_path / "rsync"
+    fake.write_text("#!/bin/sh\n")
+    fake.chmod(0o755)
+    assert move_mod.resolve_rsync_bin(str(fake)) == str(fake)
+    # A configured non-executable path is ignored.
+    plain = tmp_path / "notexec"
+    plain.write_text("x")
+    plain.chmod(0o644)
+    assert move_mod.resolve_rsync_bin(str(plain)) is None
+
+
+def test_resolve_rsync_bin_env_override(tmp_path, monkeypatch):
+    monkeypatch.setattr(move_mod, "_BUNDLED_RSYNC_CANDIDATES", ())
+    fake = tmp_path / "rsync"
+    fake.write_text("#!/bin/sh\n")
+    fake.chmod(0o755)
+    monkeypatch.setenv("VIREO_RSYNC_BIN", str(fake))
+    assert move_mod.resolve_rsync_bin("") == str(fake)
+
+
+def test_coerce_remote_target_drops_incomplete():
+    assert cfg._coerce_remote_target({"host": "h", "user": "u"}) is None
+    assert cfg._coerce_remote_target({"host": "h", "remote_path": "/p"}) is None
+    assert cfg._coerce_remote_target("not a dict") is None
+
+
+def test_coerce_remote_target_coerces_and_defaults():
+    t = cfg._coerce_remote_target({
+        "host": "nas", "user": "me", "remote_path": "/volume1/Photo",
+        "port": "2222", "bwlimit_kbps": "2048",
+    })
+    assert t["port"] == 2222
+    assert t["bwlimit_kbps"] == 2048
+    assert t["name"] == "me@nas"  # default name
+    assert t["id"]  # an id is always assigned
+    assert t["mount_path"] == ""
+
+
+# --------------------------------------------------------------------------
+# Remote move_folder — SSH seams monkeypatched.
+# --------------------------------------------------------------------------
+
+@pytest.fixture
+def remote_env(tmp_path):
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "a.nef").write_bytes(b"\x00" * 50)
+    (src / "b.nef").write_bytes(b"\x00" * 60)
+    fid = db.add_folder(str(src), name="trip")
+    db.add_photo(folder_id=fid, filename="a.nef", extension=".nef",
+                 file_size=50, file_mtime=1.0)
+    db.add_photo(folder_id=fid, filename="b.nef", extension=".nef",
+                 file_size=60, file_mtime=2.0)
+
+    remote = {
+        "host": "nas", "user": "me", "port": 22, "ssh_key": "",
+        "bwlimit_kbps": 0, "rsync_bin": "/usr/bin/rsync",
+        "ssh_dest_base": "/volume1/Photography",
+        "mount_dest_base": str(tmp_path / "mount"),
+    }
+    return {"db": db, "src": src, "fid": fid, "remote": remote,
+            "tmp_path": tmp_path}
+
+
+def test_remote_move_success_repoints_catalog_to_mount(remote_env, monkeypatch):
+    """A verified remote move deletes originals and repoints the folder at the
+    LOCAL MOUNT path (not the NAS path), so photos stay in the library."""
+    env = remote_env
+    calls = {}
+
+    def fake_rsync(src_path, dest_spec, flags, total, cb, rsync_bin="rsync",
+                   extra_args=None, **kw):
+        calls["dest_spec"] = dest_spec
+        calls["rsync_bin"] = rsync_bin
+        calls["extra_args"] = list(extra_args or [])
+        return (0, "", False)
+
+    monkeypatch.setattr(move_mod, "_remote_dir_exists", lambda r, p: False)
+    monkeypatch.setattr(move_mod, "_run_rsync_streamed", fake_rsync)
+    monkeypatch.setattr(move_mod, "_remote_verify_complete",
+                        lambda *a, **k: None)
+
+    result = move_mod.move_folder(
+        db=env["db"], folder_id=env["fid"], destination="",
+        remote=env["remote"])
+
+    assert result["moved"] == 2
+    assert result["errors"] == []
+    # rsync addressed the SSH target, with the bundled binary + ssh transport.
+    assert calls["dest_spec"] == "me@nas:/volume1/Photography/trip"
+    assert calls["rsync_bin"] == "/usr/bin/rsync"
+    assert "-e" in calls["extra_args"] and "--partial" in calls["extra_args"]
+    # Originals deleted.
+    assert not env["src"].exists()
+    # Catalog now points at the LOCAL MOUNT path, not the NAS path.
+    row = env["db"].conn.execute(
+        "SELECT path FROM folders WHERE id = ?", (env["fid"],)).fetchone()
+    assert row["path"] == os.path.join(str(env["tmp_path"] / "mount"), "trip")
+
+
+def test_remote_move_verify_failure_preserves_originals(remote_env, monkeypatch):
+    """If the remote --checksum verify reports a missing/differing file, the
+    move must NOT delete the originals."""
+    env = remote_env
+    monkeypatch.setattr(move_mod, "_remote_dir_exists", lambda r, p: False)
+    monkeypatch.setattr(move_mod, "_run_rsync_streamed",
+                        lambda *a, **k: (0, "", False))
+    monkeypatch.setattr(move_mod, "_remote_verify_complete",
+                        lambda *a, **k: ("b.nef", None))
+
+    result = move_mod.move_folder(
+        db=env["db"], folder_id=env["fid"], destination="",
+        remote=env["remote"])
+
+    assert result["moved"] == 0
+    assert any("b.nef" in e for e in result["errors"])
+    # Originals intact; catalog unchanged.
+    assert (env["src"] / "a.nef").exists()
+    row = env["db"].conn.execute(
+        "SELECT path FROM folders WHERE id = ?", (env["fid"],)).fetchone()
+    assert row["path"] == str(env["src"])
+
+
+def test_remote_move_verify_error_preserves_originals(remote_env, monkeypatch):
+    """A verification that couldn't run (SSH/rsync error) is treated as a
+    failure — originals preserved, not deleted on an unconfirmed copy."""
+    env = remote_env
+    monkeypatch.setattr(move_mod, "_remote_dir_exists", lambda r, p: False)
+    monkeypatch.setattr(move_mod, "_run_rsync_streamed",
+                        lambda *a, **k: (0, "", False))
+    monkeypatch.setattr(move_mod, "_remote_verify_complete",
+                        lambda *a, **k: ("__ERROR__", "connection reset"))
+
+    result = move_mod.move_folder(
+        db=env["db"], folder_id=env["fid"], destination="",
+        remote=env["remote"])
+
+    assert result["moved"] == 0
+    assert (env["src"] / "a.nef").exists()
+
+
+def test_remote_move_missing_rsync_bin_errors(remote_env, monkeypatch):
+    """No resolved GNU rsync -> clear error, nothing transferred or deleted."""
+    env = remote_env
+    env["remote"]["rsync_bin"] = None
+    monkeypatch.setattr(move_mod, "_remote_dir_exists", lambda r, p: False)
+
+    result = move_mod.move_folder(
+        db=env["db"], folder_id=env["fid"], destination="",
+        remote=env["remote"])
+
+    assert result["moved"] == 0
+    assert any("rsync" in e.lower() for e in result["errors"])
+    assert (env["src"] / "a.nef").exists()
+
+
+def test_remote_move_existing_dest_without_merge_needs_merge(remote_env, monkeypatch):
+    """An existing remote destination without merge returns needs_merge, like
+    the local path, so the UI can prompt to merge/resume."""
+    env = remote_env
+    monkeypatch.setattr(move_mod, "_remote_dir_exists", lambda r, p: True)
+    monkeypatch.setattr(move_mod, "_run_rsync_streamed",
+                        lambda *a, **k: (0, "", False))
+
+    result = move_mod.move_folder(
+        db=env["db"], folder_id=env["fid"], destination="", merge=False,
+        remote=env["remote"])
+
+    assert result.get("needs_merge") is True
+    assert result["moved"] == 0
+    assert (env["src"] / "a.nef").exists()
+
+
+def test_remote_move_merge_uses_ignore_existing(remote_env, monkeypatch):
+    """A merge into an existing remote dest passes --ignore-existing to rsync."""
+    env = remote_env
+    seen = {}
+
+    def fake_rsync(src_path, dest_spec, flags, total, cb, rsync_bin="rsync",
+                   extra_args=None, **kw):
+        seen["flags"] = list(flags or [])
+        return (0, "", False)
+
+    monkeypatch.setattr(move_mod, "_remote_dir_exists", lambda r, p: True)
+    monkeypatch.setattr(move_mod, "_run_rsync_streamed", fake_rsync)
+    monkeypatch.setattr(move_mod, "_remote_verify_complete",
+                        lambda *a, **k: None)
+
+    result = move_mod.move_folder(
+        db=env["db"], folder_id=env["fid"], destination="", merge=True,
+        remote=env["remote"])
+
+    assert result["moved"] == 2
+    assert "--ignore-existing" in seen["flags"]

--- a/vireo/tests/test_move_remote.py
+++ b/vireo/tests/test_move_remote.py
@@ -62,13 +62,17 @@ def test_build_remote_move_spec_bad_subpath_raises():
         move_mod.build_remote_move_spec(target, "../x", "rsync")
 
 
+# Windows has no execute bit; executability is defined by extension (PATHEXT).
+_EXE_SUFFIX = ".exe" if sys.platform == "win32" else ""
+
+
 def test_resolve_rsync_bin(tmp_path, monkeypatch):
     monkeypatch.setattr(move_mod, "_BUNDLED_RSYNC_CANDIDATES", ())
     monkeypatch.delenv("VIREO_RSYNC_BIN", raising=False)
     # Nothing available -> None.
     assert move_mod.resolve_rsync_bin("") is None
     # An explicit executable path wins.
-    fake = tmp_path / "rsync"
+    fake = tmp_path / f"rsync{_EXE_SUFFIX}"
     fake.write_text("#!/bin/sh\n")
     fake.chmod(0o755)
     assert move_mod.resolve_rsync_bin(str(fake)) == str(fake)
@@ -81,7 +85,7 @@ def test_resolve_rsync_bin(tmp_path, monkeypatch):
 
 def test_resolve_rsync_bin_env_override(tmp_path, monkeypatch):
     monkeypatch.setattr(move_mod, "_BUNDLED_RSYNC_CANDIDATES", ())
-    fake = tmp_path / "rsync"
+    fake = tmp_path / f"rsync{_EXE_SUFFIX}"
     fake.write_text("#!/bin/sh\n")
     fake.chmod(0o755)
     monkeypatch.setenv("VIREO_RSYNC_BIN", str(fake))

--- a/vireo/tests/test_move_remote.py
+++ b/vireo/tests/test_move_remote.py
@@ -177,6 +177,32 @@ def test_coerce_remote_target_drops_relative_remote_path():
     }) is not None
 
 
+def test_rsync_dest_spec_brackets_ipv6_hosts():
+    """rsync parses the FIRST colon in ``user@host:path`` as the host/path
+    separator, so an IPv6 literal like ``2001:db8::1`` must be wrapped in
+    brackets — ``me@2001:db8::1:/volume/x`` ships to ssh as host ``2001``
+    with remote command ``db8::1:/volume/x``, so the transfer goes to the
+    wrong machine or fails. DNS names and IPv4 addresses don't contain a
+    colon and pass through unchanged."""
+    # IPv4 / DNS host — bare host, no brackets.
+    assert move_mod.rsync_dest_spec(
+        {"user": "me", "host": "nas"}, "/volume1/x") == "me@nas:/volume1/x"
+    assert move_mod.rsync_dest_spec(
+        {"user": "me", "host": "10.0.0.5"}, "/x") == "me@10.0.0.5:/x"
+
+    # IPv6 literal — bracketed.
+    assert move_mod.rsync_dest_spec(
+        {"user": "me", "host": "2001:db8::1"}, "/volume1/x"
+    ) == "me@[2001:db8::1]:/volume1/x"
+    # Compressed form is also IPv6 — must bracket.
+    assert move_mod.rsync_dest_spec(
+        {"user": "me", "host": "::1"}, "/x") == "me@[::1]:/x"
+    # IPv6 with zone id (uncommon but legal) still contains colons.
+    assert move_mod.rsync_dest_spec(
+        {"user": "me", "host": "fe80::1%eth0"}, "/x"
+    ) == "me@[fe80::1%eth0]:/x"
+
+
 def test_coerce_remote_target_coerces_and_defaults():
     t = cfg._coerce_remote_target({
         "host": "nas", "user": "me", "remote_path": "/volume1/Photo",
@@ -522,6 +548,36 @@ def test_remote_move_uses_posix_join_for_transfer_dest(remote_env, monkeypatch):
     # Windows would have inserted one. Asserts the join was POSIX-only.
     assert "\\" not in captured["dest_spec"]
     assert captured["dest_spec"] == "me@nas:/volume1/Photography/trip"
+
+
+def test_remote_move_brackets_ipv6_host_in_rsync_target(remote_env, monkeypatch):
+    """End-to-end: an IPv6-literal host on the remote target must reach rsync
+    as ``user@[addr]:path``. Otherwise rsync would parse the first colon as
+    the host/path separator (rsync(1) single-colon remote form), ship to ssh
+    as the wrong host, and the SSH probe at ``_remote_dir_exists`` — which
+    talks directly to ssh, where ``user@host`` parses unambiguously — could
+    succeed beforehand, masking the bug until the transfer itself."""
+    env = remote_env
+    env["remote"]["host"] = "2001:db8::1"
+    captured = {}
+
+    def fake_rsync(src_path, dest_spec, flags, total, cb, rsync_bin="rsync",
+                   extra_args=None, **kw):
+        captured["dest_spec"] = dest_spec
+        return (0, "", False)
+
+    monkeypatch.setattr(move_mod, "_remote_dir_exists", lambda r, p: False)
+    monkeypatch.setattr(move_mod, "_run_rsync_streamed", fake_rsync)
+    monkeypatch.setattr(move_mod, "_remote_verify_complete",
+                        lambda *a, **k: None)
+
+    move_mod.move_folder(
+        db=env["db"], folder_id=env["fid"], destination="",
+        remote=env["remote"])
+
+    # The IPv6 host is wrapped; the rsync side now has an unambiguous
+    # host/path split at the bracket-then-colon boundary.
+    assert captured["dest_spec"] == "me@[2001:db8::1]:/volume1/Photography/trip"
 
 
 def test_remote_move_refuses_when_catalog_path_overlaps_tracked(remote_env, monkeypatch):

--- a/vireo/tests/test_move_remote.py
+++ b/vireo/tests/test_move_remote.py
@@ -562,3 +562,59 @@ def test_remote_dir_exists_tri_state(monkeypatch):
         raise OSError("ssh: not found")
     monkeypatch.setattr(move_mod.subprocess, "run", boom)
     assert move_mod._remote_dir_exists(remote, "/p") is None
+
+
+def test_test_remote_connection_probes_remote_rsync(monkeypatch):
+    """test_remote_connection must verify rsync is available on the REMOTE
+    side, not just locally. SSH + writable remote_path + a local rsync_bin
+    isn't enough on its own: rsync-over-SSH invokes a `--rsync-path` program
+    on the remote, and on a Synology NAS that program is gated by DSM's
+    "Enable rsync service" toggle. Without this probe the test reports
+    "Connection OK" and the user only finds out at first move."""
+    remote = {"host": "nas", "user": "me", "port": 22, "ssh_key": "",
+              "remote_path": "/volume1/Photography"}
+
+    class FakeCompleted:
+        def __init__(self, rc=0, stdout="", stderr=""):
+            self.returncode = rc
+            self.stdout = stdout
+            self.stderr = stderr
+
+    # Three SSH commands run in order: echo probe, writable check, rsync
+    # probe. A step counter lets the fake return the appropriate response.
+    calls = {"n": 0}
+
+    def fake_run_remote_rsync_missing(cmd, **kw):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return FakeCompleted(0, "vireo_ok\n", "")
+        if calls["n"] == 2:
+            return FakeCompleted(0, "WRITABLE\n", "")
+        # Remote rsync probe — simulate command-not-found (exit 127).
+        return FakeCompleted(127, "", "rsync: command not found\n")
+
+    monkeypatch.setattr(move_mod.subprocess, "run",
+                        fake_run_remote_rsync_missing)
+    res = move_mod.test_remote_connection(remote, "/usr/bin/rsync")
+    assert res["ssh"] is True
+    assert res["remote_path_writable"] is True
+    assert res["rsync_ok"] is True  # local rsync_bin was provided
+    assert res["remote_rsync_ok"] is False
+    assert res["ok"] is False
+    assert "remote" in res["message"].lower()
+
+    # Now stage the rsync probe to succeed — full green path.
+    calls["n"] = 0
+
+    def fake_run_all_ok(cmd, **kw):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return FakeCompleted(0, "vireo_ok\n", "")
+        if calls["n"] == 2:
+            return FakeCompleted(0, "WRITABLE\n", "")
+        return FakeCompleted(0, "rsync  version 3.2.7\n", "")
+
+    monkeypatch.setattr(move_mod.subprocess, "run", fake_run_all_ok)
+    res = move_mod.test_remote_connection(remote, "/usr/bin/rsync")
+    assert res["remote_rsync_ok"] is True
+    assert res["ok"] is True


### PR DESCRIPTION
## What & why

Moving a folder to the NAS over the **SMB mount** is slow and unreliable over a remote/Tailscale link — SMB's per-file round-trips stall and trip the move job's 30-min watchdog, so moves fail with `moved: 0`. This adds a **remote (rsync-over-SSH)** destination option that's far more reliable, with **resume**, **bandwidth limiting**, and **checksum verification**.

Local moves are unchanged: the default path stays plain `rsync` to a mounted path. SSH is purely additive, behind an "advanced" destination picker.

### Why rsync-over-SSH (investigation summary)
Benchmarked against the real Synology NAS over Tailscale: SMB ~0.85 MB/s and stalls; a single SSH stream ~1.18 MB/s and completes cleanly (parallel streams gave **no** gain — the link is the limit). Three blockers were found and resolved: macOS ships `openrsync` (can't drive SSH → need GNU rsync); the NAS's setuid rsync is gated by DSM's "Enable rsync service"; and the catalog needs to keep resolving the moved photos.

## How

- **`config.py` / `config_schema.py`** — `rsync_bin` (GNU rsync path, Paths) + `remote_targets` list, with `get_remote_targets()` / `_coerce_remote_target()` validators.
- **`move.py`** — `resolve_rsync_bin()`, SSH helpers, `_run_rsync_streamed()` now takes a binary + `-e ssh --partial --bwlimit` args, and `move_folder(remote=…)`. The key safety change: a remote destination isn't locally walkable, so the verify-before-delete step runs an **`rsync -an --checksum` dry-run over SSH** — any file it would still transfer means missing/different, and originals are preserved. The catalog is repointed to the target's **local mount path** so photos stay in the library (visible when the NAS is mounted).
- **`app.py`** — move-folder + preflight accept `remote_target_id`/`subpath` (reconciled with the new `mode` preview logic from #1040); new `GET /api/remote-targets` and `POST /api/remote-targets/test`.
- **UI** — move form gains a Local/remote destination picker with an SSH transfer preview + remote preflight; settings gains a remote-targets editor with per-target **Test connection**.

## Decision baked in
After a remote move deletes the local originals, the catalog points at the target's **local mount path** (option chosen with the maintainer) — so moved photos stay catalogued and resolve whenever the NAS is mounted, rather than being archived out or pointing at an unreadable NAS path.

## Tests
- New `vireo/tests/test_move_remote.py`: helpers (`sanitize_subpath`, `build_remote_move_spec`, `resolve_rsync_bin`, target coercion) + remote `move_folder` (success repoints catalog to mount; verify-failure and verify-error preserve originals; missing rsync errors; needs-merge; merge uses `--ignore-existing`).
- Full relevant suite green: `test_move`, `test_move_remote`, `test_config`, `test_config_schema`, `test_jobs_api`, `test_app` (+ workspaces/db/photos/edits/darktable earlier) — **all passing**.
- Validated end-to-end against the real Synology NAS: rsync resolves to GNU rsync, connection test passes all checks, spec builder handles the `Raw Files` space, remote preflight reads the existing dir.

## Follow-up (not in this PR)
Bundling a **static GNU rsync** into the packaged app. The resolver already looks for a bundled binary (`vireo/bin/rsync`, app Resources, or `VIREO_RSYNC_BIN`) and works today with a Homebrew rsync; shipping it to users needs a universal static rsync committed + wired through the Tauri bundle/codesigning, which I didn't want to commit untested (a missing resource would break the Tauri build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added remote folder move support via SSH/rsync, including optional subpaths, preflight metadata, and remote target selection.
  * Added UI settings to manage remote targets, including per-target “Test connection”, plus a new remote target list/test API.
* **Bug Fixes**
  * Improved saving/normalization of remote targets (drops invalid entries, generates stable IDs).
  * Strengthened remote move integrity verification and safer handling of verification failures and destination preflight edge cases.
* **Tests**
  * Expanded remote move and move-folder API coverage for rsync/SSH, path validation, and merge/resume behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->