### PR TITLE
Point README getting started to website

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,22 +35,22 @@ See [CORE_PHILOSOPHY.md](CORE_PHILOSOPHY.md) for more.
 
 ## Getting started
 
+For downloads, system requirements, and user documentation, visit [vireo.photo](https://vireo.photo).
+
+AI models are downloaded automatically on first use.
+
+## Developing from source
+
 ### Requirements
 
 - Python 3.11+
 - A GPU is recommended for classification but not required
 
-### Install
+### Install for development
 
 ```bash
 git clone https://github.com/jss367/vireo.git
 cd vireo
-pip install -e .
-```
-
-For development:
-
-```bash
 pip install -e ".[dev]"
 ```
 
@@ -61,8 +61,6 @@ python vireo/app.py --db ~/.vireo/vireo.db --port 8080
 ```
 
 Then open [http://localhost:8080](http://localhost:8080).
-
-ML models are downloaded automatically from HuggingFace on first use.
 
 ## Tests
 


### PR DESCRIPTION
Updates the README so the primary getting-started path points users to vireo.photo for downloads, system requirements, and documentation. Moves the Python 3.11+ requirement under source development, where it still applies. No runtime tests were run because this is a documentation-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated getting-started instructions with clearer guidance for downloading the app and finding user documentation.
  * Revised setup wording to say models are loaded on first use.
  * Added a dedicated “Developing from source” section with required tools and a development install command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->