### PR TITLE
Skip Apple Music libraries during scans

### DIFF
--- a/vireo/image_loader.py
+++ b/vireo/image_loader.py
@@ -35,11 +35,14 @@ SUPPORTED_EXTENSIONS = IMAGE_EXTENSIONS | RAW_EXTENSIONS
 # apps" (kTCCServiceSystemPolicyAppData) consent prompt — and because such a
 # bundle holds thousands of files, the prompt reappears on every file the
 # walk touches, so clicking Allow never makes it stop. The contents are also
-# app-managed derivatives we'd never want to ingest. Any directory walker
+# app-managed derivatives or media-library internals we'd never want to ingest.
+# Any directory walker
 # that traverses user-chosen roots (~/Pictures by default contains
-# "Photos Library.photoslibrary") must prune these. Matched case-insensitively.
+# "Photos Library.photoslibrary"; ~/Music can contain
+# "Music Library.musiclibrary") must prune these. Matched case-insensitively.
 _EXCLUDED_DIR_SUFFIXES = (
     ".photoslibrary",          # Apple Photos
+    ".musiclibrary",           # Apple Music
     ".photolibrary",           # legacy iPhoto / older Photos
     ".migratedphotolibrary",
     ".aplibrary",              # Aperture

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -3405,52 +3405,61 @@ def test_api_browse_invalid_path(app_and_db):
 
 
 def test_api_browse_rejects_macos_other_app_bundle_root(app_and_db, tmp_path, monkeypatch):
-    """GET /api/browse must reject a ``.photoslibrary`` root BEFORE ``os.path.isdir``.
+    """GET /api/browse must reject an app-managed bundle root BEFORE ``os.path.isdir``.
 
     The folder picker passes the user-selected path straight to this endpoint;
-    ``os.path.isdir`` on a Photos Library bundle (or a symlink to one) trips
-    the macOS "access data from other apps" TCC prompt the exclusion guards
+    ``os.path.isdir`` on a Photos or Music Library bundle (or a symlink to one)
+    trips the macOS "access data from other apps" TCC prompt the exclusion guards
     exist to avoid, so the check has to happen first. Monkey-patch
     ``os.path.isdir`` to fail loudly if it ever runs on the bundle path.
     """
-    bundle = tmp_path / "Photos Library.photoslibrary"
-    bundle.mkdir()
+    bundles = [
+        tmp_path / "Photos Library.photoslibrary",
+        tmp_path / "Music Library.musiclibrary",
+    ]
+    for bundle in bundles:
+        bundle.mkdir()
 
     real_isdir = os.path.isdir
 
     def guarded_isdir(p):
-        if str(p) == str(bundle):
+        if any(str(p) == str(bundle) for bundle in bundles):
             raise AssertionError(f"os.path.isdir called on excluded bundle: {p}")
         return real_isdir(p)
 
     monkeypatch.setattr(os.path, "isdir", guarded_isdir)
     app, _ = app_and_db
     client = app.test_client()
-    resp = client.get(f'/api/browse?path={bundle}')
-    assert resp.status_code == 400
+    for bundle in bundles:
+        resp = client.get(f'/api/browse?path={bundle}')
+        assert resp.status_code == 400
 
 
 def test_api_browse_skips_macos_other_app_bundle_children(app_and_db, tmp_path, monkeypatch):
-    """GET /api/browse must omit ``.photoslibrary`` children from the listing
+    """GET /api/browse must omit app-managed bundle children from the listing
     without stat'ing them.
 
     When the picker opens ``~/Pictures``, this endpoint enumerates every child
     and would normally call ``os.path.isdir`` on each. For a sibling like
-    ``Photos Library.photoslibrary`` that stat itself trips the macOS TCC
-    prompt; verify the guard skips it before any stat and that regular
-    siblings are still returned.
+    ``Photos Library.photoslibrary`` or ``Music Library.musiclibrary`` that
+    stat itself trips the macOS TCC prompt; verify the guard skips it before
+    any stat and that regular siblings are still returned.
     """
     parent = tmp_path / "pictures"
     parent.mkdir()
     (parent / "real").mkdir()
-    bundle = parent / "Photos Library.photoslibrary"
-    bundle.mkdir()
-    (bundle / "originals").mkdir()
+    photos_bundle = parent / "Photos Library.photoslibrary"
+    photos_bundle.mkdir()
+    (photos_bundle / "originals").mkdir()
+    music_bundle = parent / "Music Library.musiclibrary"
+    music_bundle.mkdir()
+    (music_bundle / "Media.localized").mkdir()
+    bundles = [photos_bundle, music_bundle]
 
     real_isdir = os.path.isdir
 
     def guarded_isdir(p):
-        if str(p).startswith(str(bundle)):
+        if any(str(p).startswith(str(bundle)) for bundle in bundles):
             raise AssertionError(f"os.path.isdir called on excluded bundle child: {p}")
         return real_isdir(p)
 
@@ -3462,6 +3471,7 @@ def test_api_browse_skips_macos_other_app_bundle_children(app_and_db, tmp_path, 
     names = [d['name'] for d in resp.get_json()['dirs']]
     assert 'real' in names
     assert 'Photos Library.photoslibrary' not in names
+    assert 'Music Library.musiclibrary' not in names
 
 
 def test_api_browse_mkdir(app_and_db, tmp_path):

--- a/vireo/tests/test_image_loader.py
+++ b/vireo/tests/test_image_loader.py
@@ -495,18 +495,21 @@ def test_load_image_does_not_retry_on_unsupported_format(tmp_path, monkeypatch):
     assert calls["n"] == 1  # no retry
 
 
-def test_is_excluded_scan_dir_matches_photo_library_bundles():
+def test_is_excluded_scan_dir_matches_app_managed_library_bundles():
     from image_loader import is_excluded_scan_dir
 
     assert is_excluded_scan_dir("Photos Library.photoslibrary")
+    assert is_excluded_scan_dir("Music Library.musiclibrary")
     assert is_excluded_scan_dir("Old Library.photolibrary")
     assert is_excluded_scan_dir("Aperture.aplibrary")
     assert is_excluded_scan_dir("PHOTOS LIBRARY.PHOTOSLIBRARY")  # case-insensitive
+    assert is_excluded_scan_dir("MUSIC LIBRARY.MUSICLIBRARY")  # case-insensitive
     assert is_excluded_scan_dir("Photo Booth Library")
     # Real photo folders must NOT be excluded.
     assert not is_excluded_scan_dir("2026")
     assert not is_excluded_scan_dir("Pictures")
     assert not is_excluded_scan_dir("photoslibrary_backup")  # not a suffix match
+    assert not is_excluded_scan_dir("musiclibrary_backup")  # not a suffix match
 
 
 def test_prune_scan_dirs_removes_in_place_and_reports():
@@ -547,9 +550,15 @@ def test_is_excluded_scan_path_matches_nested_paths():
     assert is_excluded_scan_path(
         "/Users/me/Photo Booth Library/Pictures/IMG.jpg"
     )
+    assert is_excluded_scan_path(
+        "/Users/me/Music/Music Library.musiclibrary/Library.musicdb"
+    )
     # Case-insensitive on the bundle component.
     assert is_excluded_scan_path(
         "/Users/me/PHOTOS LIBRARY.PHOTOSLIBRARY/originals"
+    )
+    assert is_excluded_scan_path(
+        "/Users/me/MUSIC LIBRARY.MUSICLIBRARY/Library.musicdb"
     )
     # Real photo folders must NOT be excluded.
     assert not is_excluded_scan_path("/Users/me/Pictures/2026/January")
@@ -557,6 +566,9 @@ def test_is_excluded_scan_path_matches_nested_paths():
     # Substring matches on non-bundle component names must NOT trigger.
     assert not is_excluded_scan_path(
         "/Users/me/Pictures/photoslibrary_backup/2024"
+    )
+    assert not is_excluded_scan_path(
+        "/Users/me/Music/musiclibrary_backup/2024"
     )
 
 

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -54,13 +54,14 @@ def test_scan_discovers_folders(tmp_path):
     assert os.path.join(root, '2024', 'January') in paths
 
 
-def test_scan_skips_photos_library_bundle(tmp_path):
-    """scan() must not descend into a macOS Photos library bundle.
+def test_scan_skips_app_managed_library_bundles(tmp_path):
+    """scan() must not descend into macOS app-managed library bundles.
 
     Walking into "*.photoslibrary" (which ~/Pictures contains by default)
-    triggers the recurring macOS "access data from other apps" TCC prompt and
-    would ingest app-managed derivatives. Images inside the bundle must be
-    ignored while real sibling photos are still discovered.
+    or "*.musiclibrary" (which ~/Music can contain) triggers the recurring
+    macOS "access data from other apps" TCC prompt and would ingest
+    app-managed derivatives or media internals. Images inside the bundle must
+    be ignored while real sibling photos are still discovered.
     """
     from db import Database
     from scanner import scan
@@ -69,6 +70,7 @@ def test_scan_skips_photos_library_bundle(tmp_path):
     _create_test_images(root, {
         '': ['real.jpg'],
         'Photos Library.photoslibrary/originals/0': ['managed.jpg'],
+        'Music Library.musiclibrary/Media.localized': ['cover.jpg'],
         'Photo Booth Library/Pictures': ['booth.jpg'],
     })
 
@@ -81,6 +83,7 @@ def test_scan_skips_photos_library_bundle(tmp_path):
 
     folder_paths = [f['path'] for f in db.get_folder_tree()]
     assert not any('.photoslibrary' in p for p in folder_paths)
+    assert not any('.musiclibrary' in p for p in folder_paths)
     assert not any('Photo Booth Library' in p for p in folder_paths)
 
 


### PR DESCRIPTION
Adds Apple Music `.musiclibrary` packages to the macOS app-managed library exclusion list so Vireo skips them before filesystem stats or recursive scans can trigger repeated privacy prompts. Updates scan and folder-browser tests to cover both Photos and Music library packages, including pre-stat rejection. Validated with focused pytest coverage for image loader exclusions, scanner traversal, and browse endpoint behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scanning and browsing of macOS home folders so Apple Music library bundles are skipped alongside Photos libraries.
  * Prevented excluded library folders from appearing in browse results or being processed during directory scans.
  * Expanded macOS handling to avoid false matches with similarly named folders, while keeping normal directories visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->