### PR TITLE
Linear-light exposure with highlight rolloff + GPU live preview

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1367,6 +1367,28 @@ def _migrate_edit_math_render_caches(app):
         ).fetchall()
         photo_ids = [row["photo_id"] for row in rows]
 
+        # Scan preview_dir once and group untracked preview files by photo id.
+        # The per-photo listdir would otherwise be O(N*M) (N edited photos x M
+        # preview files) and can spend minutes just rescanning the same
+        # directory on a large library before the server even starts.
+        edited_set = set(photo_ids)
+        untracked_previews_by_pid = {}
+        try:
+            for name in os.listdir(preview_dir):
+                if not name.endswith(".jpg"):
+                    continue
+                underscore = name.find("_")
+                if underscore <= 0:
+                    continue
+                try:
+                    file_pid = int(name[:underscore])
+                except ValueError:
+                    continue
+                if file_pid in edited_set:
+                    untracked_previews_by_pid.setdefault(file_pid, []).append(name)
+        except FileNotFoundError:
+            pass
+
         invalidated_previews = 0
         invalidated_thumbs = 0
         # If any unlink fails (locked file on Windows, transient permission
@@ -1396,15 +1418,13 @@ def _migrate_edit_math_render_caches(app):
                     (pid, size_value),
                 )
                 invalidated_previews += 1
-            try:
-                for name in os.listdir(preview_dir):
-                    if name.startswith(f"{pid}_") and name.endswith(".jpg"):
-                        try:
-                            os.remove(os.path.join(preview_dir, name))
-                        except OSError:
-                            purge_failed = True
-            except FileNotFoundError:
-                pass
+            for name in untracked_previews_by_pid.get(pid, ()):
+                path = os.path.join(preview_dir, name)
+                try:
+                    if os.path.exists(path):
+                        os.remove(path)
+                except OSError:
+                    purge_failed = True
             thumb_cache = os.path.join(thumb_dir, f"{pid}.jpg")
             try:
                 if os.path.exists(thumb_cache):

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1369,6 +1369,12 @@ def _migrate_edit_math_render_caches(app):
 
         invalidated_previews = 0
         invalidated_thumbs = 0
+        # If any unlink fails (locked file on Windows, transient permission
+        # error), we must NOT stamp the new version: a stale file/preview_cache
+        # row could still be served, and bumping the version would make the
+        # next boot skip the migration and never retry. Leaving the version
+        # behind makes the migration idempotent and self-retrying.
+        purge_failed = False
         for pid in photo_ids:
             for row in db.conn.execute(
                 "SELECT size FROM preview_cache WHERE photo_id = ?", (pid,)
@@ -1383,6 +1389,7 @@ def _migrate_edit_math_render_caches(app):
                         "Failed to remove stale preview cache %s during "
                         "edit-math migration", path, exc_info=True,
                     )
+                    purge_failed = True
                     continue
                 db.conn.execute(
                     "DELETE FROM preview_cache WHERE photo_id=? AND size=?",
@@ -1395,7 +1402,7 @@ def _migrate_edit_math_render_caches(app):
                         try:
                             os.remove(os.path.join(preview_dir, name))
                         except OSError:
-                            pass
+                            purge_failed = True
             except FileNotFoundError:
                 pass
             thumb_cache = os.path.join(thumb_dir, f"{pid}.jpg")
@@ -1408,10 +1415,25 @@ def _migrate_edit_math_render_caches(app):
                     "Failed to remove stale thumbnail %s during "
                     "edit-math migration", thumb_cache, exc_info=True,
                 )
+                purge_failed = True
                 continue
             db.conn.execute(
                 "UPDATE photos SET thumb_path = NULL WHERE id = ?", (pid,),
             )
+
+        if purge_failed:
+            # Commit the row deletions that did succeed, but leave the stored
+            # version unchanged so the next boot re-runs and retries the
+            # paths that couldn't be purged this time.
+            db.conn.commit()
+            log.warning(
+                "edit_math_version %s -> %s: some cache purges failed; "
+                "leaving version at %s so the migration retries next boot "
+                "(invalidated %d preview-cache entries, %d thumbnails so far)",
+                stored_version, EDIT_MATH_VERSION, stored_version,
+                invalidated_previews, invalidated_thumbs,
+            )
+            return
 
         db.set_meta("edit_math_version", EDIT_MATH_VERSION, _commit=False)
         db.conn.commit()
@@ -9180,7 +9202,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if not recipe:
                 return fallback_path, None
 
-            from image_edits import apply_recipe, recipe_to_json
+            from image_edits import (
+                EDIT_MATH_VERSION,
+                apply_recipe,
+                recipe_to_json,
+            )
             from image_loader import load_image
 
             source_path = _external_edit_recipe_source(
@@ -9195,10 +9221,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             meta_path = os.path.join(out_dir, f"{photo['id']}.json")
             source_mtime = os.path.getmtime(source_path)
             recipe_json = recipe_to_json(recipe) or ""
+            # Include the edit-math version so a math bump invalidates this
+            # handoff render: the JPEG is keyed by recipe/source/mtime, none
+            # of which change when only the per-pixel rendering math changes,
+            # so without this we'd keep handing editors the stale render.
             expected_meta = {
                 "recipe": recipe_json,
                 "source_path": source_path,
                 "source_mtime": source_mtime,
+                "edit_math_version": EDIT_MATH_VERSION,
             }
             try:
                 if os.path.isfile(out_path) and os.path.isfile(meta_path):

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -11406,7 +11406,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not recipe:
             return fallback_path, None
 
-        from image_edits import apply_recipe, recipe_to_json
+        from image_edits import EDIT_MATH_VERSION, apply_recipe, recipe_to_json
         from image_loader import load_image
 
         source_path = _inat_edit_recipe_source(photo, recipe, fallback_path)
@@ -11419,10 +11419,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         meta_path = os.path.join(out_dir, f"{photo['id']}.json")
         source_mtime = os.path.getmtime(source_path)
         recipe_json = recipe_to_json(recipe) or ""
+        # Include the edit-math version so a math bump invalidates this cached
+        # render — the JPEG is keyed by recipe/source/mtime, none of which
+        # change when only the per-pixel rendering math does, so without this
+        # we'd keep submitting stale renders to iNaturalist after a deploy.
         expected_meta = {
             "recipe": recipe_json,
             "source_path": source_path,
             "source_mtime": source_mtime,
+            "edit_math_version": EDIT_MATH_VERSION,
         }
         try:
             if os.path.isfile(out_path) and os.path.isfile(meta_path):

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1325,6 +1325,116 @@ def _migrate_legacy_preview_cache(app):
             pass
 
 
+def _migrate_edit_math_render_caches(app):
+    """Invalidate rendered caches when the edit-math version has bumped.
+
+    Cached previews/thumbnails are keyed by ``(photo_id, size)`` only — the
+    edit recipe isn't part of the key. When the per-pixel rendering math in
+    ``image_edits`` / ``tone`` changes, the old bytes on disk are no longer
+    what we'd produce now, but a recipe-unchanged photo would otherwise keep
+    serving them until the user manually cleared the cache.
+
+    On each startup we compare ``db_meta["edit_math_version"]`` against
+    ``image_edits.EDIT_MATH_VERSION``. If it lags, we drop:
+
+      * every ``preview_cache`` row plus its on-disk JPEG
+      * every per-photo thumbnail file plus its ``photos.thumb_path``
+
+    for photos that have a non-null edit recipe (recipe-free photos render
+    identically across math versions and don't need re-rendering). Then we
+    write the new version so the migration is a no-op next boot.
+
+    On a fresh DB with no recipes, the walk does nothing and we still bump
+    the version so future deploys only act on real prior state.
+    """
+    from image_edits import EDIT_MATH_VERSION
+
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    thumb_dir = app.config["THUMB_CACHE_DIR"]
+    preview_dir = os.path.join(vireo_dir, "previews")
+    db = Database(app.config["DB_PATH"])
+    try:
+        stored = db.get_meta("edit_math_version")
+        try:
+            stored_version = int(stored) if stored is not None else 1
+        except (TypeError, ValueError):
+            stored_version = 1
+        if stored_version >= EDIT_MATH_VERSION:
+            return
+
+        rows = db.conn.execute(
+            "SELECT photo_id FROM photo_edit_recipes"
+        ).fetchall()
+        photo_ids = [row["photo_id"] for row in rows]
+
+        invalidated_previews = 0
+        invalidated_thumbs = 0
+        for pid in photo_ids:
+            for row in db.conn.execute(
+                "SELECT size FROM preview_cache WHERE photo_id = ?", (pid,)
+            ).fetchall():
+                size_value = row["size"]
+                path = os.path.join(preview_dir, f"{pid}_{size_value}.jpg")
+                try:
+                    if os.path.exists(path):
+                        os.remove(path)
+                except OSError:
+                    log.warning(
+                        "Failed to remove stale preview cache %s during "
+                        "edit-math migration", path, exc_info=True,
+                    )
+                    continue
+                db.conn.execute(
+                    "DELETE FROM preview_cache WHERE photo_id=? AND size=?",
+                    (pid, size_value),
+                )
+                invalidated_previews += 1
+            try:
+                for name in os.listdir(preview_dir):
+                    if name.startswith(f"{pid}_") and name.endswith(".jpg"):
+                        try:
+                            os.remove(os.path.join(preview_dir, name))
+                        except OSError:
+                            pass
+            except FileNotFoundError:
+                pass
+            thumb_cache = os.path.join(thumb_dir, f"{pid}.jpg")
+            try:
+                if os.path.exists(thumb_cache):
+                    os.remove(thumb_cache)
+                    invalidated_thumbs += 1
+            except OSError:
+                log.warning(
+                    "Failed to remove stale thumbnail %s during "
+                    "edit-math migration", thumb_cache, exc_info=True,
+                )
+                continue
+            db.conn.execute(
+                "UPDATE photos SET thumb_path = NULL WHERE id = ?", (pid,),
+            )
+
+        db.set_meta("edit_math_version", EDIT_MATH_VERSION, _commit=False)
+        db.conn.commit()
+
+        if photo_ids:
+            log.info(
+                "edit_math_version %s -> %s: invalidated %d preview-cache "
+                "entries and %d thumbnails across %d edited photos",
+                stored_version, EDIT_MATH_VERSION,
+                invalidated_previews, invalidated_thumbs, len(photo_ids),
+            )
+        else:
+            log.info(
+                "edit_math_version %s -> %s: no edited photos, nothing to "
+                "invalidate", stored_version, EDIT_MATH_VERSION,
+            )
+    finally:
+        try:
+            db.conn.close()
+        except Exception:
+            pass
+
+
 def _enforce_preview_cache_quota_at_startup(app):
     """Reconcile and evict at startup so prior runs / external deletes
     can't leave the table out of sync or over quota.
@@ -1404,6 +1514,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     app.config["API_TOKEN"] = api_token
 
     _migrate_legacy_preview_cache(app)
+    _migrate_edit_math_render_caches(app)
     _enforce_preview_cache_quota_at_startup(app)
 
     # Request timing middleware — logs slow requests and user actions

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1367,28 +1367,6 @@ def _migrate_edit_math_render_caches(app):
         ).fetchall()
         photo_ids = [row["photo_id"] for row in rows]
 
-        # Scan preview_dir once and group untracked preview files by photo id.
-        # The per-photo listdir would otherwise be O(N*M) (N edited photos x M
-        # preview files) and can spend minutes just rescanning the same
-        # directory on a large library before the server even starts.
-        edited_set = set(photo_ids)
-        untracked_previews_by_pid = {}
-        try:
-            for name in os.listdir(preview_dir):
-                if not name.endswith(".jpg"):
-                    continue
-                underscore = name.find("_")
-                if underscore <= 0:
-                    continue
-                try:
-                    file_pid = int(name[:underscore])
-                except ValueError:
-                    continue
-                if file_pid in edited_set:
-                    untracked_previews_by_pid.setdefault(file_pid, []).append(name)
-        except FileNotFoundError:
-            pass
-
         invalidated_previews = 0
         invalidated_thumbs = 0
         # If any unlink fails (locked file on Windows, transient permission
@@ -1397,6 +1375,45 @@ def _migrate_edit_math_render_caches(app):
         # next boot skip the migration and never retry. Leaving the version
         # behind makes the migration idempotent and self-retrying.
         purge_failed = False
+
+        # Scan preview_dir once and group untracked preview files by photo id.
+        # The per-photo listdir would otherwise be O(N*M) (N edited photos x M
+        # preview files) and can spend minutes just rescanning the same
+        # directory on a large library before the server even starts.
+        edited_set = set(photo_ids)
+        untracked_previews_by_pid = {}
+        try:
+            preview_names = os.listdir(preview_dir)
+        except FileNotFoundError:
+            # Cache dir doesn't exist yet — nothing untracked to clean up.
+            preview_names = ()
+        except OSError:
+            # Permissions / locked network volume / other transient read
+            # failure: we can't see what's in there, so we don't know whether
+            # there are stale orphans to purge. Skip the scan but leave the
+            # version old so the next boot retries — matches the unlink-error
+            # contract instead of taking the app down for a disposable cache
+            # problem.
+            log.warning(
+                "Failed to list preview cache dir %s during edit-math "
+                "migration; leaving version at %s to retry next boot",
+                preview_dir, stored_version, exc_info=True,
+            )
+            preview_names = ()
+            purge_failed = True
+
+        for name in preview_names:
+            if not name.endswith(".jpg"):
+                continue
+            underscore = name.find("_")
+            if underscore <= 0:
+                continue
+            try:
+                file_pid = int(name[:underscore])
+            except ValueError:
+                continue
+            if file_pid in edited_set:
+                untracked_previews_by_pid.setdefault(file_pid, []).append(name)
         for pid in photo_ids:
             for row in db.conn.execute(
                 "SELECT size FROM preview_cache WHERE photo_id = ?", (pid,)

--- a/vireo/image_edits.py
+++ b/vireo/image_edits.py
@@ -6,7 +6,7 @@ import copy
 import json
 import math
 
-from PIL import Image, ImageEnhance
+from PIL import Image
 
 SCHEMA_VERSION = 1
 
@@ -183,19 +183,20 @@ def recipe_to_json(recipe):
     return json.dumps(normalized, sort_keys=True, separators=(",", ":"))
 
 
-def _clamp_channel(value):
-    return max(0, min(255, int(round(value))))
+def _apply_adjustments(img, adjustments):
+    """Apply tonal adjustments to a PIL image via the linear tone pipeline.
 
+    Bridges PIL <-> numpy: promotes the image to RGB(A), runs the shared
+    per-pixel pipeline in :mod:`tone` (linear-light exposure/white balance with
+    a highlight shoulder, then display-space contrast/saturation), and merges
+    any alpha channel back unchanged.
+    """
+    import numpy as np
 
-def _channel_lut(gain):
-    return [_clamp_channel(i * gain) for i in range(256)]
-
-
-def _apply_white_balance(img, white_balance):
-    temperature = float((white_balance or {}).get("temperature") or 0.0) / 100.0
-    tint = float((white_balance or {}).get("tint") or 0.0) / 100.0
-    if abs(temperature) < 1e-9 and abs(tint) < 1e-9:
-        return img
+    try:
+        from .tone import apply_adjustments
+    except ImportError:
+        from tone import apply_adjustments
 
     has_alpha = "A" in img.getbands() or "transparency" in img.info
     if img.mode not in ("RGB", "RGBA"):
@@ -203,22 +204,20 @@ def _apply_white_balance(img, white_balance):
     elif img.mode == "RGB" and "transparency" in img.info:
         img = img.convert("RGBA")
 
-    bands = img.split()
-    red_gain = 1.0 + (0.26 * temperature) + (0.06 * tint)
-    green_gain = 1.0 - (0.18 * tint)
-    blue_gain = 1.0 - (0.26 * temperature) + (0.06 * tint)
-    red_gain = max(0.05, red_gain)
-    green_gain = max(0.05, green_gain)
-    blue_gain = max(0.05, blue_gain)
-
-    adjusted = (
-        bands[0].point(_channel_lut(red_gain)),
-        bands[1].point(_channel_lut(green_gain)),
-        bands[2].point(_channel_lut(blue_gain)),
+    arr = np.asarray(img, dtype=np.float32) / 255.0
+    out = apply_adjustments(
+        arr[..., :3],
+        exposure=adjustments.get("exposure", 0.0),
+        white_balance=adjustments.get("white_balance"),
+        contrast=adjustments.get("contrast", 0.0),
+        saturation=adjustments.get("saturation", 0.0),
     )
-    if "A" in img.getbands():
-        return Image.merge("RGBA", adjusted + (bands[3],))
-    return Image.merge("RGB", adjusted)
+    out8 = np.clip(out * 255.0 + 0.5, 0, 255).astype(np.uint8)
+
+    if img.mode == "RGBA":
+        a8 = np.clip(arr[..., 3:4] * 255.0 + 0.5, 0, 255).astype(np.uint8)
+        return Image.fromarray(np.concatenate([out8, a8], axis=-1), "RGBA")
+    return Image.fromarray(out8, "RGB")
 
 
 def apply_recipe(img, recipe):
@@ -261,18 +260,8 @@ def apply_recipe(img, recipe):
         result = result.crop((left, top, right, bottom))
 
     adjustments = normalized.get("adjustments") or {}
-    if "white_balance" in adjustments:
-        result = _apply_white_balance(result, adjustments["white_balance"])
-    if "exposure" in adjustments:
-        result = ImageEnhance.Brightness(result).enhance(2 ** adjustments["exposure"])
-    if "contrast" in adjustments:
-        result = ImageEnhance.Contrast(result).enhance(
-            max(0.0, 1.0 + adjustments["contrast"] / 100.0)
-        )
-    if "saturation" in adjustments:
-        result = ImageEnhance.Color(result).enhance(
-            max(0.0, 1.0 + adjustments["saturation"] / 100.0)
-        )
+    if adjustments:
+        result = _apply_adjustments(result, adjustments)
 
     return result
 

--- a/vireo/image_edits.py
+++ b/vireo/image_edits.py
@@ -10,6 +10,19 @@ from PIL import Image
 
 SCHEMA_VERSION = 1
 
+# Bump whenever the per-pixel rendering math in this module or `tone.py` changes
+# in a way that produces different output bytes for the same recipe. Cached
+# previews/thumbnails are keyed by (photo_id, size) — they have no recipe hash,
+# so without this version a deploy that changes the math keeps serving the old
+# bytes until each recipe is touched again. `app._migrate_edit_math_render_caches`
+# reads `db_meta["edit_math_version"]` at startup and purges stale renders when
+# it lags behind this constant.
+#
+# History:
+#   1 — original gamma-encoded sRGB multiply with hard clip at white.
+#   2 — linear-light pipeline with gated highlight shoulder (this PR).
+EDIT_MATH_VERSION = 2
+
 _ADJUSTMENT_RANGES = {
     "exposure": (-5.0, 5.0),
     "contrast": (-100.0, 100.0),

--- a/vireo/image_edits.py
+++ b/vireo/image_edits.py
@@ -196,6 +196,11 @@ def recipe_to_json(recipe):
     return json.dumps(normalized, sort_keys=True, separators=(",", ":"))
 
 
+# Row-tile budget for the tone pass, in pixels. Bounds peak memory on
+# full-resolution originals/exports; overridable in tests to force many tiles.
+_ADJUST_TILE_PIXELS = 4_000_000
+
+
 def _apply_adjustments(img, adjustments):
     """Apply tonal adjustments to a PIL image via the linear tone pipeline.
 
@@ -217,19 +222,41 @@ def _apply_adjustments(img, adjustments):
     elif img.mode == "RGB" and "transparency" in img.info:
         img = img.convert("RGBA")
 
-    arr = np.asarray(img, dtype=np.float32) / 255.0
-    out = apply_adjustments(
-        arr[..., :3],
-        exposure=adjustments.get("exposure", 0.0),
-        white_balance=adjustments.get("white_balance"),
-        contrast=adjustments.get("contrast", 0.0),
-        saturation=adjustments.get("saturation", 0.0),
-    )
-    out8 = np.clip(out * 255.0 + 0.5, 0, 255).astype(np.uint8)
+    exposure = adjustments.get("exposure", 0.0)
+    white_balance = adjustments.get("white_balance")
+    contrast = adjustments.get("contrast", 0.0)
+    saturation = adjustments.get("saturation", 0.0)
+
+    src = np.asarray(img)  # uint8, view onto the PIL buffer (no copy)
+    height, width = src.shape[:2]
+    channels = src.shape[2]
+    out8 = np.empty((height, width, channels), dtype=np.uint8)
+
+    # Process in row blocks so peak memory stays bounded on full-resolution
+    # originals/exports (45MP+). The tone pass is strictly per-pixel, so tiling
+    # is numerically identical to a single whole-frame pass. ~4M pixels per tile
+    # keeps the transient float arrays to a few hundred MB.
+    rows_per_tile = max(1, _ADJUST_TILE_PIXELS // max(1, width))
+    for top in range(0, height, rows_per_tile):
+        bottom = min(top + rows_per_tile, height)
+        tile = src[top:bottom].astype(np.float32) / 255.0
+        adj = apply_adjustments(
+            tile[..., :3],
+            exposure=exposure,
+            white_balance=white_balance,
+            contrast=contrast,
+            saturation=saturation,
+        )
+        out8[top:bottom, :, :3] = np.clip(adj * 255.0 + 0.5, 0, 255).astype(
+            np.uint8
+        )
+        if channels == 4:
+            # Alpha passes through unchanged (round-trip uint8->float->uint8 is
+            # identity for 8-bit values).
+            out8[top:bottom, :, 3] = src[top:bottom, :, 3]
 
     if img.mode == "RGBA":
-        a8 = np.clip(arr[..., 3:4] * 255.0 + 0.5, 0, 255).astype(np.uint8)
-        return Image.fromarray(np.concatenate([out8, a8], axis=-1), "RGBA")
+        return Image.fromarray(out8, "RGBA")
     return Image.fromarray(out8, "RGB")
 
 

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -4235,10 +4235,18 @@ var VireoToneGL = (function() {
     '}',
     'void main(){',
     '  vec4 src = texture2D(uTex, vUv);',
-    '  vec3 lin = srgbToLinear(src.rgb);',
+    '  vec3 linPre = srgbToLinear(src.rgb);',
+    '  vec3 lin = linPre;',
     '  lin *= exp2(uExposure);',
     '  lin *= uWbGain;',
-    '  if (uRolloff > 0.5) { lin = vec3(roll(lin.r), roll(lin.g), roll(lin.b)); }',
+    // Mirror tone.apply_adjustments' monotonicity clamp: the shoulder is below
+    // identity in (knee, ∞), so a 0.95-linear pixel at +0.1 EV would otherwise
+    // darken to ~0.929. Clamp per channel to min(linPre, lin) so the rolloff
+    // can only raise values toward white, never below the natural floor.
+    '  if (uRolloff > 0.5) {',
+    '    vec3 rolled = vec3(roll(lin.r), roll(lin.g), roll(lin.b));',
+    '    lin = max(rolled, min(linPre, lin));',
+    '  }',
     '  vec3 disp = linearToSrgb(lin);',
     '  disp = (disp - 0.5) * uContrast + 0.5;',
     '  float luma = dot(disp, vec3(0.2126, 0.7152, 0.0722));',

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -4223,7 +4223,8 @@ var VireoToneGL = (function() {
     '  return x > uKnee ? r : x;',
     '}',
     'void main(){',
-    '  vec3 lin = srgbToLinear(texture2D(uTex, vUv).rgb);',
+    '  vec4 src = texture2D(uTex, vUv);',
+    '  vec3 lin = srgbToLinear(src.rgb);',
     '  lin *= exp2(uExposure);',
     '  lin *= uWbGain;',
     '  if (uRolloff > 0.5) { lin = vec3(roll(lin.r), roll(lin.g), roll(lin.b)); }',
@@ -4231,7 +4232,11 @@ var VireoToneGL = (function() {
     '  disp = (disp - 0.5) * uContrast + 0.5;',
     '  float luma = dot(disp, vec3(0.2126, 0.7152, 0.0722));',
     '  disp = vec3(luma) + (disp - vec3(luma)) * uSaturation;',
-    '  gl_FragColor = vec4(clamp(disp, 0.0, 1.0), 1.0);',
+    // Pass through the source alpha (don't force 1.0) so transparent or
+    // semi-transparent sources preview correctly, matching tone.py which
+    // merges alpha back unchanged. Lightbox images are opaque JPEGs in
+    // practice, so src.a == 1.0 there and the common case is unchanged.
+    '  gl_FragColor = vec4(clamp(disp, 0.0, 1.0), src.a);',
     '}'
   ].join('\n');
 
@@ -4347,10 +4352,19 @@ var VireoToneGL = (function() {
   };
 })();
 
-// Dispatcher: prefer the GPU (linear-light, matches tone.py); fall back to the
-// approximate CSS-filter preview when WebGL is unavailable or upload fails.
-// Both work on the displayed image, which already has the saved recipe baked
-// in, so adjustments are previewed as a delta from the rendered values.
+// Dispatcher: prefer the GPU (linear-light, same formula as tone.py); fall back
+// to the cruder CSS-filter preview when WebGL is unavailable or upload fails.
+// Both work on the *displayed* image, which already has the saved recipe baked
+// in, so adjustments are previewed as a delta applied on top of the rendered
+// values.
+//
+// Parity caveat: the GPU preview reproduces tone.py exactly only for a first
+// edit (no baked adjustments, base == zeros) — then the delta equals the full
+// recipe. For a re-edit the delta is applied to already tone-mapped pixels, and
+// highlight rolloff / clamping are neither reversible nor associative, so the
+// preview is an approximation that snaps to the exact server render once the
+// recipe is saved and the image is re-fetched. test_tone_shader_parity asserts
+// only the first-edit (exact) case for that reason.
 function _lbApplyAdjustmentPreview(values) {
   var img = document.getElementById('lightboxImg');
   var canvas = document.getElementById('lightboxToneCanvas');

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -686,6 +686,20 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
   display: none;
 }
 .lb-mask-overlay.show { display: block; }
+/* GPU adjustment preview (Tier 3). Sits over #lightboxImg inside
+   .lightbox-transform so it inherits the same zoom + pan transform and
+   overlays the exact same pixels. Shown only while previewing slider edits. */
+.lb-tone-canvas {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 4px;
+  pointer-events: none;
+  display: none;
+}
+.lb-tone-canvas.show { display: block; }
 .lb-mask-controls {
   display: none;
   align-items: center;
@@ -3246,6 +3260,7 @@ async function createWorkspace() {
     <span class="lightbox-zoom-badge" id="lightboxZoomBadge" style="display:none;">1:1</span>
     <div class="lightbox-transform" id="lightboxTransform">
       <img id="lightboxImg" src="" alt="">
+      <canvas id="lightboxToneCanvas" class="lb-tone-canvas" aria-hidden="true"></canvas>
       <img id="lightboxMaskOverlay" class="lb-mask-overlay" src="" alt="">
       <div id="lightboxDetections" style="position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none;"></div>
       <div id="lightboxEye" style="position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none;display:none;"></div>
@@ -4166,6 +4181,203 @@ function _lbClearAdjustmentPreviewCss() {
   if (img) img.style.filter = '';
 }
 
+// --- Tier 3: GPU live preview -------------------------------------------------
+// WebGL transcription of vireo/tone.py. The CSS-filter preview above operates
+// in gamma-encoded sRGB and cannot express linear-light exposure or the
+// highlight rolloff, so when WebGL is available we render the adjustment
+// preview through this shader instead and it matches the server's tone.py
+// render. The shader math below MUST stay in sync with vireo/tone.py
+// (sRGB<->linear transfer, HIGHLIGHT_KNEE, white-balance gains, op order).
+var VireoToneGL = (function() {
+  var KNEE = 0.85; // == tone.HIGHLIGHT_KNEE
+  var canvas = null, gl = null, prog = null, tex = null, locs = null;
+  var texKey = null, failed = false;
+
+  var VERT = [
+    'attribute vec2 aPos;',
+    'varying vec2 vUv;',
+    'void main(){ vUv = aPos * 0.5 + 0.5; gl_Position = vec4(aPos, 0.0, 1.0); }'
+  ].join('\n');
+
+  var FRAG = [
+    'precision highp float;',
+    'varying vec2 vUv;',
+    'uniform sampler2D uTex;',
+    'uniform float uExposure;',   // stops (linear gain = exp2(uExposure))
+    'uniform vec3 uWbGain;',      // per-channel linear gains
+    'uniform float uContrast;',   // display-space contrast factor about 0.5
+    'uniform float uSaturation;', // display-space luma-preserving factor
+    'uniform float uRolloff;',    // 1.0 -> apply highlight shoulder, else 0.0
+    'uniform float uKnee;',
+    'vec3 srgbToLinear(vec3 c){',
+    '  return mix(c / 12.92, pow((c + 0.055) / 1.055, vec3(2.4)), step(0.04045, c));',
+    '}',
+    'vec3 linearToSrgb(vec3 c){',
+    '  c = max(c, 0.0);',
+    '  return mix(c * 12.92, 1.055 * pow(c, vec3(1.0 / 2.4)) - 0.055, step(0.0031308, c));',
+    '}',
+    'float roll(float x){',
+    '  float h = 1.0 - uKnee;',
+    '  float o = max(x - uKnee, 0.0);',
+    '  float r = uKnee + h * (o / (o + h));',
+    '  return x > uKnee ? r : x;',
+    '}',
+    'void main(){',
+    '  vec3 lin = srgbToLinear(texture2D(uTex, vUv).rgb);',
+    '  lin *= exp2(uExposure);',
+    '  lin *= uWbGain;',
+    '  if (uRolloff > 0.5) { lin = vec3(roll(lin.r), roll(lin.g), roll(lin.b)); }',
+    '  vec3 disp = linearToSrgb(lin);',
+    '  disp = (disp - 0.5) * uContrast + 0.5;',
+    '  float luma = dot(disp, vec3(0.2126, 0.7152, 0.0722));',
+    '  disp = vec3(luma) + (disp - vec3(luma)) * uSaturation;',
+    '  gl_FragColor = vec4(clamp(disp, 0.0, 1.0), 1.0);',
+    '}'
+  ].join('\n');
+
+  function compile(type, src) {
+    var s = gl.createShader(type);
+    gl.shaderSource(s, src);
+    gl.compileShader(s);
+    if (!gl.getShaderParameter(s, gl.COMPILE_STATUS)) {
+      console.warn('VireoToneGL shader compile error:', gl.getShaderInfoLog(s));
+      return null;
+    }
+    return s;
+  }
+
+  function init() {
+    if (gl) return true;
+    if (failed) return false;
+    canvas = document.getElementById('lightboxToneCanvas');
+    if (!canvas) { failed = true; return false; }
+    try {
+      var opts = { premultipliedAlpha: false, preserveDrawingBuffer: false };
+      gl = canvas.getContext('webgl', opts) || canvas.getContext('experimental-webgl', opts);
+    } catch (e) { gl = null; }
+    if (!gl) { failed = true; return false; }
+    var vs = compile(gl.VERTEX_SHADER, VERT);
+    var fs = compile(gl.FRAGMENT_SHADER, FRAG);
+    if (!vs || !fs) { failed = true; gl = null; return false; }
+    prog = gl.createProgram();
+    gl.attachShader(prog, vs);
+    gl.attachShader(prog, fs);
+    gl.linkProgram(prog);
+    if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) {
+      console.warn('VireoToneGL link error:', gl.getProgramInfoLog(prog));
+      failed = true; gl = null; return false;
+    }
+    gl.useProgram(prog);
+    var buf = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1, -1, 1, -1, -1, 1, 1, 1]), gl.STATIC_DRAW);
+    var aPos = gl.getAttribLocation(prog, 'aPos');
+    gl.enableVertexAttribArray(aPos);
+    gl.vertexAttribPointer(aPos, 2, gl.FLOAT, false, 0, 0);
+    tex = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
+    locs = {
+      tex: gl.getUniformLocation(prog, 'uTex'),
+      exposure: gl.getUniformLocation(prog, 'uExposure'),
+      wbGain: gl.getUniformLocation(prog, 'uWbGain'),
+      contrast: gl.getUniformLocation(prog, 'uContrast'),
+      saturation: gl.getUniformLocation(prog, 'uSaturation'),
+      rolloff: gl.getUniformLocation(prog, 'uRolloff'),
+      knee: gl.getUniformLocation(prog, 'uKnee')
+    };
+    gl.uniform1i(locs.tex, 0);
+    gl.uniform1f(locs.knee, KNEE);
+    return true;
+  }
+
+  function uploadSource(img) {
+    var w = img.naturalWidth, h = img.naturalHeight;
+    if (!w || !h) return false;
+    if (canvas.width !== w || canvas.height !== h) { canvas.width = w; canvas.height = h; }
+    var key = img.currentSrc || img.src;
+    if (key !== texKey) {
+      gl.bindTexture(gl.TEXTURE_2D, tex);
+      try {
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, img);
+      } catch (e) {
+        console.warn('VireoToneGL texture upload failed:', e);
+        return false;
+      }
+      texKey = key;
+    }
+    return true;
+  }
+
+  return {
+    supported: function() { return init(); },
+    // Force a texture re-upload (call when the underlying image pixels change).
+    invalidate: function() { texKey = null; },
+    render: function(img, u) {
+      if (!init() || !uploadSource(img)) return false;
+      gl.viewport(0, 0, canvas.width, canvas.height);
+      gl.uniform1f(locs.exposure, u.exposure);
+      gl.uniform3f(locs.wbGain, u.wbGain[0], u.wbGain[1], u.wbGain[2]);
+      gl.uniform1f(locs.contrast, u.contrast);
+      gl.uniform1f(locs.saturation, u.saturation);
+      gl.uniform1f(locs.rolloff, u.rolloff ? 1.0 : 0.0);
+      gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+      return true;
+    }
+  };
+})();
+
+// Dispatcher: prefer the GPU (linear-light, matches tone.py); fall back to the
+// approximate CSS-filter preview when WebGL is unavailable or upload fails.
+// Both work on the displayed image, which already has the saved recipe baked
+// in, so adjustments are previewed as a delta from the rendered values.
+function _lbApplyAdjustmentPreview(values) {
+  var img = document.getElementById('lightboxImg');
+  var canvas = document.getElementById('lightboxToneCanvas');
+  if (img && canvas && img.naturalWidth && VireoToneGL.supported()) {
+    var base = _lbRenderedAdjustmentValues || _lbAdjustmentValues(null);
+    var dExposure = Number(values.exposure || 0) - Number(base.exposure || 0);
+    var valGains = _lbWhiteBalanceGains(values.temperature, values.tint);
+    var baseGains = _lbWhiteBalanceGains(base.temperature, base.tint);
+    var wbGain = [
+      valGains.r / baseGains.r,
+      valGains.g / baseGains.g,
+      valGains.b / baseGains.b
+    ];
+    var dContrast = Math.max(0, 1 + Number(values.contrast || 0) / 100)
+      / Math.max(0.001, 1 + Number(base.contrast || 0) / 100);
+    var dSaturation = Math.max(0, 1 + Number(values.saturation || 0) / 100)
+      / Math.max(0.001, 1 + Number(base.saturation || 0) / 100);
+    // Roll highlights off only when the net change actually pushes values up,
+    // matching tone.apply_adjustments' gate so an un-pushed preview is a no-op.
+    var pushed = Math.pow(2, dExposure) * Math.max(wbGain[0], wbGain[1], wbGain[2]) > 1.000001;
+    var ok = VireoToneGL.render(img, {
+      exposure: dExposure,
+      wbGain: wbGain,
+      contrast: dContrast,
+      saturation: dSaturation,
+      rolloff: pushed
+    });
+    if (ok) {
+      img.style.filter = '';
+      canvas.classList.add('show');
+      return;
+    }
+  }
+  if (canvas) canvas.classList.remove('show');
+  _lbApplyAdjustmentPreviewCss(values);
+}
+
+function _lbClearAdjustmentPreview() {
+  var canvas = document.getElementById('lightboxToneCanvas');
+  if (canvas) canvas.classList.remove('show');
+  _lbClearAdjustmentPreviewCss();
+}
+
 function _lbBumpRecipeBust(photoId) {
   var key = String(photoId);
   _lbRecipeBustByPhotoId[key] = Date.now();
@@ -4214,7 +4426,10 @@ function _lbReloadEditedSource(photoId, seq) {
     img.removeEventListener('load', onEditedReload);
     if (_lightboxCurrentId !== photoId || seq !== _lbAdjustSeq) return;
     _lbRenderedAdjustmentValues = _lbAdjustmentValues(_lbEditRecipe);
-    _lbClearAdjustmentPreviewCss();
+    // The image just reloaded with the new render baked in; drop the cached
+    // GPU texture so the next preview re-uploads the fresh pixels.
+    VireoToneGL.invalidate();
+    _lbClearAdjustmentPreview();
     _lbRecomputeNativeZoom();
     _lbApplyTransform();
   });
@@ -4330,7 +4545,7 @@ function onLightboxAdjustmentInput(input) {
   _lbBumpAdjustmentInputSeq(_lightboxCurrentId);
   var values = _lbReadAdjustmentControls();
   _lbEditRecipe = _lbRecipeWithAdjustments(values);
-  _lbApplyAdjustmentPreviewCss(values);
+  _lbApplyAdjustmentPreview(values);
   _lbSetAdjustmentStatus('Previewing...');
   if (_lbAdjustSaveTimer) clearTimeout(_lbAdjustSaveTimer);
   _lbAdjustSaveTimer = setTimeout(function() {
@@ -4351,7 +4566,7 @@ function resetLightboxAdjustments() {
   _lbSetAdjustmentControl('lbAdjSaturation', 0);
   var values = _lbReadAdjustmentControls();
   _lbEditRecipe = _lbRecipeWithAdjustments(values);
-  _lbApplyAdjustmentPreviewCss(values);
+  _lbApplyAdjustmentPreview(values);
   _lbBumpAdjustmentInputSeq(_lightboxCurrentId);
   if (_lbAdjustSaveTimer) {
     clearTimeout(_lbAdjustSaveTimer);
@@ -5681,7 +5896,7 @@ function openLightbox(photoId, filename, photoList, options) {
     _lbAdjustSaveTimer = null;
   }
   _lbAdjustSeq += 1;
-  _lbClearAdjustmentPreviewCss();
+  _lbClearAdjustmentPreview();
   _lbRenderAdjustmentControls();
   _lbSetAdjustmentControlsDisabled(true);
   _lbSetAdjustmentStatus('');
@@ -6063,7 +6278,7 @@ function closeLightbox(e) {
   _lbClearPendingViewportRestore();
   if (_lbSwapTimer) { clearTimeout(_lbSwapTimer); _lbSwapTimer = null; }
   _lbDesiredSrcKey = null;
-  _lbClearAdjustmentPreviewCss();
+  _lbClearAdjustmentPreview();
   var adjustPanel = document.getElementById('lightboxAdjustPanel');
   if (adjustPanel) adjustPanel.classList.remove('open');
   var adjustBtn = document.getElementById('lightboxAdjustBtn');

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -4191,7 +4191,7 @@ function _lbClearAdjustmentPreviewCss() {
 var VireoToneGL = (function() {
   var KNEE = 0.85; // == tone.HIGHLIGHT_KNEE
   var canvas = null, gl = null, prog = null, tex = null, locs = null;
-  var texKey = null, failed = false;
+  var texKey = null, failed = false, maxTextureSize = 0;
 
   var VERT = [
     'attribute vec2 aPos;',
@@ -4292,20 +4292,36 @@ var VireoToneGL = (function() {
     };
     gl.uniform1i(locs.tex, 0);
     gl.uniform1f(locs.knee, KNEE);
+    maxTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE) || 0;
     return true;
   }
 
   function uploadSource(img) {
     var w = img.naturalWidth, h = img.naturalHeight;
     if (!w || !h) return false;
+    // GPU limit: oversized images make texImage2D emit a GL error (e.g.
+    // INVALID_VALUE) rather than throw, so the upload would otherwise look
+    // successful and the canvas would render black. Bail to the CSS fallback.
+    if (maxTextureSize && (w > maxTextureSize || h > maxTextureSize)) return false;
     if (canvas.width !== w || canvas.height !== h) { canvas.width = w; canvas.height = h; }
     var key = img.currentSrc || img.src;
     if (key !== texKey) {
       gl.bindTexture(gl.TEXTURE_2D, tex);
+      // Drain any prior error so getError() below reflects only this upload.
+      while (gl.getError() !== gl.NO_ERROR) {}
       try {
         gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, img);
       } catch (e) {
         console.warn('VireoToneGL texture upload failed:', e);
+        return false;
+      }
+      // texImage2D signals failures (e.g. cross-origin canvas tainting,
+      // GPU limits the MAX_TEXTURE_SIZE check above didn't already catch)
+      // through the GL error flag, not exceptions. Leaving texKey unset
+      // forces a retry on the next frame.
+      if (gl.getError() !== gl.NO_ERROR) {
+        console.warn('VireoToneGL texture upload reported a GL error; '
+          + 'falling back to CSS preview');
         return false;
       }
       texKey = key;

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3585,10 +3585,21 @@ function _vireoHashString(s) {
   return (hash >>> 0).toString(36);
 }
 
+// Must equal image_edits.EDIT_MATH_VERSION. Folded into the `er` query
+// param below so a math bump invalidates the browser cache for every
+// edited render — server-side purges alone are not enough because the
+// thumbnail response is `Cache-Control: public, max-age=86400`, so a user
+// who viewed an edited photo before the deploy would otherwise keep
+// seeing the old bytes from their own browser cache until they expire.
+// test_edit_math_version_template_constant_matches_python locks the two
+// constants together.
+var _VIREO_EDIT_MATH_VERSION = 2;
+
 function _vireoEditRecipeCacheKey(recipe) {
   var normalized = _lbCloneEditRecipe(recipe);
   if (!_lbRecipeHasEdits(normalized)) return '';
-  return _vireoHashString(JSON.stringify(normalized));
+  return _vireoHashString(JSON.stringify(normalized))
+    + '.m' + _VIREO_EDIT_MATH_VERSION;
 }
 
 function _lbRecipeHasEdits(recipe) {

--- a/vireo/tests/test_image_edits.py
+++ b/vireo/tests/test_image_edits.py
@@ -208,3 +208,27 @@ def test_apply_recipe_white_balance_preserves_palette_transparency():
 
     assert edited.mode == "RGBA"
     assert edited.getpixel((0, 0))[3] == 123
+
+
+def test_edit_math_version_template_constant_matches_python():
+    """The client-side `_VIREO_EDIT_MATH_VERSION` in `_navbar.html` is folded
+    into the `er` query param on every rendered URL so a math bump busts the
+    browser's cached thumbnail/preview bytes (server response is
+    `Cache-Control: public, max-age=86400`, so server purges alone are not
+    enough). The JS literal must stay in sync with `image_edits.EDIT_MATH_VERSION`
+    or the cache key drifts and stale renders survive deploys.
+    """
+    import re
+
+    navbar = os.path.join(
+        os.path.dirname(__file__), '..', 'templates', '_navbar.html',
+    )
+    with open(navbar, encoding='utf-8') as f:
+        src = f.read()
+    match = re.search(
+        r'var\s+_VIREO_EDIT_MATH_VERSION\s*=\s*([0-9]+)\s*;', src,
+    )
+    assert match, (
+        'could not find `var _VIREO_EDIT_MATH_VERSION = ...;` in _navbar.html'
+    )
+    assert int(match.group(1)) == image_edits.EDIT_MATH_VERSION

--- a/vireo/tests/test_image_edits.py
+++ b/vireo/tests/test_image_edits.py
@@ -1,11 +1,13 @@
 import os
 import sys
 
+import numpy as np
 import pytest
 from PIL import Image
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
+import image_edits
 from image_edits import RecipeError, apply_recipe, normalize_recipe, recipe_to_json
 
 
@@ -126,6 +128,52 @@ def test_apply_recipe_adjusts_exposure_white_balance_contrast_and_saturation():
     assert r > b
     assert g > b
     assert max(r, g, b) > 100
+
+
+@pytest.mark.parametrize("mode", ["RGB", "RGBA"])
+def test_apply_recipe_tiling_matches_single_pass(mode, monkeypatch):
+    """A multi-tile image must be byte-identical to a whole-frame pass.
+
+    Shrinks the tile budget so a small test image spans many row tiles, then
+    compares against a single-pass reference computed directly through the tone
+    pipeline. Proves tiling does not change results.
+    """
+    from tone import apply_adjustments
+
+    width, height = 13, 97
+    rng = np.random.default_rng(1234)
+    channels = 4 if mode == "RGBA" else 3
+    src = rng.integers(0, 256, size=(height, width, channels), dtype=np.uint8)
+    img = Image.fromarray(src, mode)
+
+    recipe = {
+        "adjustments": {
+            "exposure": 1.3,
+            "contrast": 15,
+            "white_balance": {"temperature": 40, "tint": -20},
+            "saturation": 25,
+        }
+    }
+
+    # Force many tiles: at width 13, one row per tile.
+    monkeypatch.setattr(image_edits, "_ADJUST_TILE_PIXELS", width)
+    tiled = np.asarray(apply_recipe(img, recipe))
+
+    # Single whole-frame reference.
+    arr = src.astype(np.float32) / 255.0
+    ref_rgb = apply_adjustments(
+        arr[..., :3],
+        exposure=1.3,
+        white_balance={"temperature": 40, "tint": -20},
+        contrast=15,
+        saturation=25,
+    )
+    ref8 = np.clip(ref_rgb * 255.0 + 0.5, 0, 255).astype(np.uint8)
+    if channels == 4:
+        ref8 = np.concatenate([ref8, src[..., 3:4]], axis=-1)
+
+    assert tiled.shape == ref8.shape
+    assert np.array_equal(tiled, ref8)
 
 
 def test_apply_recipe_straightens_in_place():

--- a/vireo/tests/test_inat.py
+++ b/vireo/tests/test_inat.py
@@ -343,6 +343,45 @@ def test_api_inat_submit_uses_edited_render(app_and_db):
         assert img.size == (40, 80)
 
 
+def test_inat_upload_handoff_meta_includes_math_version(app_and_db):
+    """The iNat upload render reuses inat-uploads/<id>.jpg only when its
+    cached metadata matches. That metadata must carry EDIT_MATH_VERSION so a
+    math bump (which changes per-pixel output but not recipe/source/mtime)
+    invalidates the stale render — otherwise unchanged recipes would keep
+    submitting the old hard-clipped JPEG to iNaturalist after a deploy."""
+    import json as _json
+
+    from image_edits import EDIT_MATH_VERSION
+
+    app, db, pid = app_and_db
+    import config as cfg
+    cfg.save({"inat_token": "fake-token"})
+
+    folder = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id = p.folder_id WHERE p.id = ?",
+        (pid,),
+    ).fetchone()
+    Image.new("RGB", (80, 40), (220, 30, 20)).save(
+        os.path.join(folder["path"], "bird.jpg"),
+    )
+    db.set_photo_edit_recipe(pid, {"adjustments": {"exposure": 0.5}})
+
+    client = app.test_client()
+    with patch(
+        "inat.submit_observation",
+        return_value=(12345, "https://www.inaturalist.org/observations/12345"),
+    ):
+        resp = client.post("/api/inat/submit", json={"photo_id": pid})
+    assert resp.status_code == 200
+
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    meta_path = os.path.join(vireo_dir, "inat-uploads", f"{pid}.json")
+    assert os.path.exists(meta_path)
+    with open(meta_path, encoding="utf-8") as f:
+        meta = _json.load(f)
+    assert meta.get("edit_math_version") == EDIT_MATH_VERSION
+
+
 def test_api_inat_submit_uses_assigned_location_coords(app_and_db):
     app, db, pid = app_and_db
     import config as cfg

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -3925,6 +3925,72 @@ def test_edit_math_version_migration_leaves_version_on_failed_purge(
     assert db.get_meta("edit_math_version") == str(EDIT_MATH_VERSION)
 
 
+def test_edit_math_version_migration_survives_unreadable_preview_dir(
+    tmp_path, monkeypatch,
+):
+    """If preview_dir exists but is temporarily unreadable (locked network
+    volume, permission flap), os.listdir raises OSError; create_app must NOT
+    abort startup. Skip the orphan scan and leave the version old so the
+    migration self-retries — matching the unlink-error contract."""
+    import os
+    from types import SimpleNamespace
+
+    import app as app_module
+    from db import Database
+    from image_edits import EDIT_MATH_VERSION
+
+    vireo_dir = tmp_path / "vireo"
+    thumb_dir = vireo_dir / "thumbnails"
+    thumb_dir.mkdir(parents=True)
+    preview_dir = vireo_dir / "previews"
+    preview_dir.mkdir()
+    db_path = str(vireo_dir / "vireo.db")
+
+    db = Database(db_path)
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    fid = db.add_folder(str(tmp_path), name="photos")
+    pid = db.add_photo(
+        folder_id=fid, filename="edited.jpg", extension=".jpg",
+        file_size=100, file_mtime=0.0, width=40, height=30,
+    )
+    db.set_photo_edit_recipe(pid, {"adjustments": {"exposure": 0.5}})
+    db.set_meta("edit_math_version", str(EDIT_MATH_VERSION - 1))
+    db.conn.commit()
+    db.conn.close()
+
+    real_listdir = app_module.os.listdir
+
+    def failing_listdir(path):
+        if os.path.abspath(path) == os.path.abspath(str(preview_dir)):
+            raise PermissionError(path)
+        return real_listdir(path)
+
+    monkeypatch.setattr(app_module.os, "listdir", failing_listdir)
+
+    fake_app = SimpleNamespace(
+        config={"THUMB_CACHE_DIR": str(thumb_dir), "DB_PATH": db_path},
+    )
+    # Must NOT raise — disposable cache problem can't take down startup.
+    app_module._migrate_edit_math_render_caches(fake_app)
+
+    db2 = Database(db_path)
+    try:
+        # Version stays old so the next boot retries the scan.
+        assert db2.get_meta("edit_math_version") == str(EDIT_MATH_VERSION - 1)
+    finally:
+        db2.conn.close()
+
+    # Once the dir becomes readable, a later boot completes the migration.
+    monkeypatch.setattr(app_module.os, "listdir", real_listdir)
+    app_module._migrate_edit_math_render_caches(fake_app)
+    db3 = Database(db_path)
+    try:
+        assert db3.get_meta("edit_math_version") == str(EDIT_MATH_VERSION)
+    finally:
+        db3.conn.close()
+
+
 def test_external_edit_handoff_meta_includes_math_version(client_with_photo):
     """The external-editor handoff render reuses external-edits/<id>.jpg only
     when its cached metadata matches. That metadata must carry

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -3953,6 +3953,77 @@ def test_external_edit_handoff_meta_includes_math_version(client_with_photo):
     assert meta.get("edit_math_version") == EDIT_MATH_VERSION
 
 
+def test_edit_math_version_migration_scans_preview_dir_once(
+    tmp_path, monkeypatch,
+):
+    """The migration must scan preview_dir once, not once per edited photo.
+    With N edited photos and M preview files the old per-photo os.listdir
+    was O(N*M) and could stall startup on large libraries — guard against
+    a regression by counting calls."""
+    import os
+    from types import SimpleNamespace
+
+    import app as app_module
+    from db import Database
+    from image_edits import EDIT_MATH_VERSION
+
+    vireo_dir = tmp_path / "vireo"
+    thumb_dir = vireo_dir / "thumbnails"
+    thumb_dir.mkdir(parents=True)
+    preview_dir = vireo_dir / "previews"
+    preview_dir.mkdir()
+    db_path = str(vireo_dir / "vireo.db")
+
+    db = Database(db_path)
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    fid = db.add_folder(str(tmp_path), name="photos")
+
+    edited_pids = []
+    for i in range(5):
+        pid = db.add_photo(
+            folder_id=fid, filename=f"edited_{i}.jpg", extension=".jpg",
+            file_size=100, file_mtime=0.0, width=40, height=30,
+        )
+        db.set_photo_edit_recipe(
+            pid, {"adjustments": {"exposure": 0.2 * (i + 1)}},
+        )
+        edited_pids.append(pid)
+        # An untracked preview file (not in preview_cache) so the migration
+        # actually exercises the listdir-driven orphan sweep.
+        (preview_dir / f"{pid}_640.jpg").write_bytes(b"\xff\xd8\xff\xe0junk")
+
+    db.set_meta("edit_math_version", str(EDIT_MATH_VERSION - 1))
+    db.conn.commit()
+    db.conn.close()
+
+    real_listdir = app_module.os.listdir
+    calls = []
+
+    def counting_listdir(path):
+        if os.path.abspath(path) == os.path.abspath(str(preview_dir)):
+            calls.append(path)
+        return real_listdir(path)
+
+    monkeypatch.setattr(app_module.os, "listdir", counting_listdir)
+
+    fake_app = SimpleNamespace(
+        config={"THUMB_CACHE_DIR": str(thumb_dir), "DB_PATH": db_path},
+    )
+    app_module._migrate_edit_math_render_caches(fake_app)
+
+    # One scan total, regardless of how many edited photos there are.
+    assert len(calls) == 1, calls
+    # And the orphans were actually purged.
+    for pid in edited_pids:
+        assert not (preview_dir / f"{pid}_640.jpg").exists()
+    db2 = Database(db_path)
+    try:
+        assert db2.get_meta("edit_math_version") == str(EDIT_MATH_VERSION)
+    finally:
+        db2.conn.close()
+
+
 def test_edit_math_version_migration_is_noop_on_fresh_db(tmp_path, monkeypatch):
     """A brand-new DB has no recipes and no stored version. The migration
     must just stamp the current version so the next deploy bumps cleanly."""

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -3849,6 +3849,110 @@ def test_edit_math_version_bump_invalidates_edited_photo_caches(tmp_path, monkey
     assert db.preview_cache_get(pid_edited, 1920) is not None
 
 
+def test_edit_math_version_migration_leaves_version_on_failed_purge(
+    tmp_path, monkeypatch,
+):
+    """If a cache unlink fails mid-migration (locked file, transient perm
+    error), we must NOT stamp the new version — otherwise the next boot
+    skips the migration and the stale render keeps being served. Leaving
+    the version old makes the migration self-retry on the next boot."""
+    import os
+
+    import app as app_module
+    import config as cfg
+    from app import create_app
+    from db import Database
+    from image_edits import EDIT_MATH_VERSION
+    from PIL import Image
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    cfg.save({**cfg.DEFAULTS, "preview_max_size": 1920})
+
+    photos_dir = tmp_path / "photos"
+    photos_dir.mkdir()
+    src_edited = photos_dir / "edited.jpg"
+    Image.new("RGB", (200, 150), (40, 90, 180)).save(
+        str(src_edited), "JPEG", quality=85,
+    )
+
+    vireo_dir = tmp_path / "vireo"
+    thumb_dir = vireo_dir / "thumbnails"
+    thumb_dir.mkdir(parents=True)
+    preview_dir = vireo_dir / "previews"
+    preview_dir.mkdir()
+    db_path = str(vireo_dir / "vireo.db")
+
+    db = Database(db_path)
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    fid = db.add_folder(str(photos_dir), name="photos")
+    pid_edited = db.add_photo(
+        folder_id=fid, filename="edited.jpg", extension=".jpg",
+        file_size=os.path.getsize(src_edited),
+        file_mtime=os.path.getmtime(src_edited),
+        width=200, height=150,
+    )
+    db.set_photo_edit_recipe(pid_edited, {"adjustments": {"exposure": 1.0}})
+
+    edited_thumb = thumb_dir / f"{pid_edited}.jpg"
+    edited_thumb.write_bytes(b"\xff\xd8\xff\xe0" + b"t" * 1024)
+    db.conn.execute(
+        "UPDATE photos SET thumb_path = ? WHERE id = ?",
+        (f"{pid_edited}.jpg", pid_edited),
+    )
+    db.set_meta("edit_math_version", str(EDIT_MATH_VERSION - 1))
+    db.conn.commit()
+
+    original_remove = app_module.os.remove
+
+    def locked_remove(path):
+        if path == str(edited_thumb):
+            raise OSError("locked")
+        return original_remove(path)
+
+    monkeypatch.setattr(app_module.os, "remove", locked_remove)
+
+    create_app(db_path=db_path, thumb_cache_dir=str(thumb_dir))
+
+    # The unlink failed, so the version must stay behind for a retry.
+    assert db.get_meta("edit_math_version") == str(EDIT_MATH_VERSION - 1)
+
+    # Once the file is unlockable, a later boot completes the migration.
+    monkeypatch.setattr(app_module.os, "remove", original_remove)
+    create_app(db_path=db_path, thumb_cache_dir=str(thumb_dir))
+    assert not edited_thumb.exists()
+    assert db.get_meta("edit_math_version") == str(EDIT_MATH_VERSION)
+
+
+def test_external_edit_handoff_meta_includes_math_version(client_with_photo):
+    """The external-editor handoff render reuses external-edits/<id>.jpg only
+    when its cached metadata matches. That metadata must carry
+    EDIT_MATH_VERSION so a math bump (which changes per-pixel output but not
+    recipe/source/mtime) invalidates the stale hard-clipped render."""
+    import json
+    import os
+
+    from image_edits import EDIT_MATH_VERSION
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    db.set_photo_edit_recipe(photo_id, {"adjustments": {"exposure": 0.5}})
+
+    resp = client.post(
+        "/api/photos/open-external",
+        json={"photo_ids": [photo_id], "editor_index": None},
+    )
+    # Open may fail (no editor configured) but the handoff render + meta
+    # are written before the editor launch.
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    meta_path = os.path.join(vireo_dir, "external-edits", f"{photo_id}.json")
+    assert os.path.exists(meta_path), resp.get_data(as_text=True)
+    with open(meta_path, encoding="utf-8") as f:
+        meta = json.load(f)
+    assert meta.get("edit_math_version") == EDIT_MATH_VERSION
+
+
 def test_edit_math_version_migration_is_noop_on_fresh_db(tmp_path, monkeypatch):
     """A brand-new DB has no recipes and no stored version. The migration
     must just stamp the current version so the next deploy bumps cleanly."""

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -3747,6 +3747,131 @@ def test_legacy_migration_preserves_preview_max_size_zero(tmp_path, monkeypatch)
     assert not (preview_dir / "42_1920.jpg").exists()
 
 
+def test_edit_math_version_bump_invalidates_edited_photo_caches(tmp_path, monkeypatch):
+    """When EDIT_MATH_VERSION bumps, startup must purge cached renders for
+    photos that have a non-null edit recipe — keeping them would serve the
+    old tone-math bytes after the deploy that changed the math. Recipe-free
+    photos render identically across versions and must be left alone."""
+    import os
+
+    import config as cfg
+    from app import create_app
+    from db import Database
+    from image_edits import EDIT_MATH_VERSION
+    from PIL import Image
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    cfg.save({**cfg.DEFAULTS, "preview_max_size": 1920})
+
+    photos_dir = tmp_path / "photos"
+    photos_dir.mkdir()
+    src_edited = photos_dir / "edited.jpg"
+    src_plain = photos_dir / "plain.jpg"
+    Image.new("RGB", (200, 150), (40, 90, 180)).save(str(src_edited), "JPEG", quality=85)
+    Image.new("RGB", (200, 150), (200, 90, 40)).save(str(src_plain), "JPEG", quality=85)
+
+    vireo_dir = tmp_path / "vireo"
+    thumb_dir = vireo_dir / "thumbnails"
+    thumb_dir.mkdir(parents=True)
+    preview_dir = vireo_dir / "previews"
+    preview_dir.mkdir()
+    db_path = str(vireo_dir / "vireo.db")
+
+    db = Database(db_path)
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    fid = db.add_folder(str(photos_dir), name="photos")
+    pid_edited = db.add_photo(
+        folder_id=fid, filename="edited.jpg", extension=".jpg",
+        file_size=os.path.getsize(src_edited),
+        file_mtime=os.path.getmtime(src_edited),
+        width=200, height=150,
+    )
+    pid_plain = db.add_photo(
+        folder_id=fid, filename="plain.jpg", extension=".jpg",
+        file_size=os.path.getsize(src_plain),
+        file_mtime=os.path.getmtime(src_plain),
+        width=200, height=150,
+    )
+    db.set_photo_edit_recipe(pid_edited, {"adjustments": {"exposure": 1.0}})
+
+    # Simulate a pre-version-bump deployment: cached renders exist on disk
+    # and in preview_cache, and the stored version lags behind the current.
+    edited_preview = preview_dir / f"{pid_edited}_1920.jpg"
+    plain_preview = preview_dir / f"{pid_plain}_1920.jpg"
+    edited_thumb = thumb_dir / f"{pid_edited}.jpg"
+    plain_thumb = thumb_dir / f"{pid_plain}.jpg"
+    edited_preview.write_bytes(b"\xff\xd8\xff\xe0" + b"o" * 1024)
+    plain_preview.write_bytes(b"\xff\xd8\xff\xe0" + b"p" * 1024)
+    edited_thumb.write_bytes(b"\xff\xd8\xff\xe0" + b"t" * 1024)
+    plain_thumb.write_bytes(b"\xff\xd8\xff\xe0" + b"u" * 1024)
+    db.preview_cache_insert(pid_edited, 1920, edited_preview.stat().st_size)
+    db.preview_cache_insert(pid_plain, 1920, plain_preview.stat().st_size)
+    db.conn.execute(
+        "UPDATE photos SET thumb_path = ? WHERE id = ?",
+        (f"{pid_edited}.jpg", pid_edited),
+    )
+    db.conn.execute(
+        "UPDATE photos SET thumb_path = ? WHERE id = ?",
+        (f"{pid_plain}.jpg", pid_plain),
+    )
+    db.set_meta("edit_math_version", str(EDIT_MATH_VERSION - 1))
+    db.conn.commit()
+
+    create_app(db_path=db_path, thumb_cache_dir=str(thumb_dir))
+
+    # Edited photo: preview and thumb gone, thumb_path cleared, no row.
+    assert not edited_preview.exists()
+    assert not edited_thumb.exists()
+    assert db.preview_cache_get(pid_edited, 1920) is None
+    edited_row = db.conn.execute(
+        "SELECT thumb_path FROM photos WHERE id = ?", (pid_edited,),
+    ).fetchone()
+    assert edited_row["thumb_path"] is None
+
+    # Plain photo: cache survives because no recipe → output bytes unchanged.
+    assert plain_preview.exists()
+    assert plain_thumb.exists()
+    assert db.preview_cache_get(pid_plain, 1920) is not None
+    plain_row = db.conn.execute(
+        "SELECT thumb_path FROM photos WHERE id = ?", (pid_plain,),
+    ).fetchone()
+    assert plain_row["thumb_path"] == f"{pid_plain}.jpg"
+
+    # Version is bumped, so a second create_app is a no-op.
+    assert db.get_meta("edit_math_version") == str(EDIT_MATH_VERSION)
+    new_preview = preview_dir / f"{pid_edited}_1920.jpg"
+    new_preview.write_bytes(b"\xff\xd8\xff\xe0" + b"x" * 1024)
+    db.preview_cache_insert(pid_edited, 1920, new_preview.stat().st_size)
+    create_app(db_path=db_path, thumb_cache_dir=str(thumb_dir))
+    assert new_preview.exists()
+    assert db.preview_cache_get(pid_edited, 1920) is not None
+
+
+def test_edit_math_version_migration_is_noop_on_fresh_db(tmp_path, monkeypatch):
+    """A brand-new DB has no recipes and no stored version. The migration
+    must just stamp the current version so the next deploy bumps cleanly."""
+    import config as cfg
+    from app import create_app
+    from db import Database
+    from image_edits import EDIT_MATH_VERSION
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    cfg.save({**cfg.DEFAULTS, "preview_max_size": 1920})
+
+    vireo_dir = tmp_path / "vireo"
+    thumb_dir = vireo_dir / "thumbnails"
+    thumb_dir.mkdir(parents=True)
+    db_path = str(vireo_dir / "vireo.db")
+
+    create_app(db_path=db_path, thumb_cache_dir=str(thumb_dir))
+
+    db = Database(db_path)
+    assert db.get_meta("edit_math_version") == str(EDIT_MATH_VERSION)
+
+
 def test_storage_clear_previews_resets_preview_cache(client_with_photo):
     """/api/storage/clear type=previews drops preview_cache rows so
     Settings "Current usage" doesn't report phantom bytes."""

--- a/vireo/tests/test_tone.py
+++ b/vireo/tests/test_tone.py
@@ -1,0 +1,87 @@
+import os
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from tone import (
+    HIGHLIGHT_KNEE,
+    apply_adjustments,
+    highlight_rolloff,
+    linear_to_srgb,
+    srgb_to_linear,
+    white_balance_gains,
+)
+
+
+def test_srgb_linear_round_trips():
+    c = np.linspace(0.0, 1.0, 256, dtype=np.float32)
+    back = linear_to_srgb(srgb_to_linear(c))
+    assert np.allclose(c, back, atol=1e-4)
+
+
+def test_no_adjustments_is_near_identity():
+    # The de-gamma -> re-gamma round trip plus an untouched highlight shoulder
+    # must leave an un-pushed image essentially unchanged (<= 1 code value).
+    rgb = np.random.default_rng(0).random((32, 32, 3), dtype=np.float32)
+    out = apply_adjustments(rgb)
+    assert np.max(np.abs(out - rgb) * 255.0) <= 1.0
+
+
+def test_exposure_is_a_linear_multiply_in_shadows():
+    # A mid-shadow tone pushed +1 stop should roughly double in linear light
+    # (well below the highlight knee, so the shoulder does not engage).
+    rgb = np.full((1, 1, 3), 0.2, dtype=np.float32)
+    out = apply_adjustments(rgb, exposure=1.0)
+    lin_in = srgb_to_linear(np.float32(0.2))
+    lin_out = srgb_to_linear(out[0, 0, 0])
+    assert lin_out == float(lin_out)  # finite
+    assert abs(lin_out - 2.0 * lin_in) < 0.02
+
+
+def test_highlights_roll_off_instead_of_clipping():
+    # Pushing a bright tone hard must compress toward white, never reach a flat
+    # 1.0, and stay monotonic across increasing exposure.
+    rgb = np.full((1, 1, 3), 0.7, dtype=np.float32)
+    prev = -1.0
+    for ev in (0.0, 1.0, 2.0, 4.0):
+        out = float(apply_adjustments(rgb, exposure=ev)[0, 0, 0])
+        assert out < 1.0  # never hard-clips to flat white
+        assert out > prev  # monotonic increase with exposure
+        prev = out
+
+
+def test_highlight_rolloff_is_identity_below_knee():
+    lin = np.array([0.0, 0.25, 0.5, HIGHLIGHT_KNEE], dtype=np.float32)
+    assert np.allclose(highlight_rolloff(lin), lin, atol=1e-6)
+
+
+def test_highlight_rolloff_never_exceeds_one():
+    lin = np.array([1.0, 4.0, 100.0], dtype=np.float32)
+    assert np.all(highlight_rolloff(lin) < 1.0)
+
+
+def test_negative_exposure_darkens():
+    rgb = np.full((1, 1, 3), 0.5, dtype=np.float32)
+    out = float(apply_adjustments(rgb, exposure=-1.0)[0, 0, 0])
+    assert out < 0.5
+
+
+def test_white_balance_gains_default_to_unity():
+    assert white_balance_gains(None) == (1.0, 1.0, 1.0)
+    assert white_balance_gains({}) == (1.0, 1.0, 1.0)
+
+
+def test_warm_white_balance_pushes_red_over_blue():
+    rgb = np.full((1, 1, 3), 0.5, dtype=np.float32)
+    out = apply_adjustments(rgb, white_balance={"temperature": 60})
+    r, g, b = out[0, 0]
+    assert r > b
+
+
+def test_saturation_zero_is_grey_and_preserves_luma():
+    rgb = np.array([[[0.8, 0.3, 0.1]]], dtype=np.float32)
+    out = apply_adjustments(rgb, saturation=-100.0)
+    r, g, b = out[0, 0]
+    assert abs(r - g) < 1e-3 and abs(g - b) < 1e-3  # fully desaturated -> grey

--- a/vireo/tests/test_tone.py
+++ b/vireo/tests/test_tone.py
@@ -52,6 +52,27 @@ def test_highlights_roll_off_instead_of_clipping():
         prev = out
 
 
+def test_positive_exposure_never_darkens_near_white_highlights():
+    # Regression: before the per-channel ``max(rolled, min(lin_pre, lin))``
+    # clamp, the shoulder curve being below identity on (knee, 1.0] meant a
+    # 0.95-linear pixel (sRGB ~0.977, already above the 0.85 knee) at +0.1 EV
+    # would darken to ~0.929 — non-monotonic in exposure. Lock the contract:
+    # a positive exposure can only raise or hold the output, never lower it.
+    srgb_in = float(linear_to_srgb(np.array([0.95], dtype=np.float32))[0])
+    rgb = np.full((1, 1, 3), srgb_in, dtype=np.float32)
+    base = float(apply_adjustments(rgb)[0, 0, 0])
+    prev = base
+    for ev in (0.05, 0.1, 0.25, 0.5, 1.0, 2.0):
+        out = float(apply_adjustments(rgb, exposure=ev)[0, 0, 0])
+        assert out >= base - 1e-5, (
+            f"+{ev} EV darkened below the ev=0 baseline: {base:.4f} -> {out:.4f}"
+        )
+        assert out >= prev - 1e-5, (
+            f"+{ev} EV non-monotonic vs prev step: {prev:.4f} -> {out:.4f}"
+        )
+        prev = out
+
+
 def test_highlight_rolloff_is_identity_below_knee():
     lin = np.array([0.0, 0.25, 0.5, HIGHLIGHT_KNEE], dtype=np.float32)
     assert np.allclose(highlight_rolloff(lin), lin, atol=1e-6)

--- a/vireo/tests/test_tone_shader_parity.py
+++ b/vireo/tests/test_tone_shader_parity.py
@@ -63,9 +63,13 @@ def _shader_mirror(c, exposure, wb_gain, contrast, saturation, rolloff):
         r = KNEE + h * (o / (o + h))
         return np.where(x > KNEE, r, x)
 
-    lin = srgb_to_linear(c) * (2.0 ** exposure) * np.asarray(wb_gain)
+    lin_pre = srgb_to_linear(c)
+    lin = lin_pre * (2.0 ** exposure) * np.asarray(wb_gain)
     if rolloff:
-        lin = roll(lin)
+        # Per-channel clamp matches the shader's `max(rolled, min(linPre, lin))`
+        # which keeps the shoulder from darkening pixels below their natural
+        # (unrolled) value — see the monotonicity note in apply_adjustments.
+        lin = np.maximum(roll(lin), np.minimum(lin_pre, lin))
     disp = linear_to_srgb(lin)
     disp = (disp - 0.5) * contrast + 0.5
     luma = disp @ np.array([0.2126, 0.7152, 0.0722])

--- a/vireo/tests/test_tone_shader_parity.py
+++ b/vireo/tests/test_tone_shader_parity.py
@@ -1,0 +1,86 @@
+"""Guards that the WebGL live-preview shader matches the server tone pipeline.
+
+The live preview in ``_navbar.html`` (``VireoToneGL``) is a GLSL transcription
+of :mod:`tone`. This test mirrors that GLSL arithmetic in numpy and asserts it
+reproduces ``tone.apply_adjustments`` for the first-edit case the shader is
+exact on (the displayed image has no baked adjustments, so the previewed
+"delta" equals the full recipe). If the two pipelines drift, this fails.
+
+It can't execute the actual shader headlessly, but it locks the *formula*:
+sRGB<->linear transfer, the highlight-knee rolloff, the white-balance gains and
+push-gate, and the display-space contrast/saturation — in the same order.
+"""
+
+import os
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import tone
+
+KNEE = 0.85  # must equal VireoToneGL KNEE and tone.HIGHLIGHT_KNEE
+
+
+def test_shader_knee_constant_matches_tone():
+    assert KNEE == tone.HIGHLIGHT_KNEE
+
+
+def _shader_mirror(c, exposure, wb_gain, contrast, saturation, rolloff):
+    """numpy mirror of the GLSL fragment shader in VireoToneGL."""
+    def srgb_to_linear(x):
+        # GLSL: mix(x/12.92, pow((x+0.055)/1.055, 2.4), step(0.04045, x))
+        return np.where(x >= 0.04045, ((x + 0.055) / 1.055) ** 2.4, x / 12.92)
+
+    def linear_to_srgb(x):
+        x = np.maximum(x, 0.0)
+        return np.where(x >= 0.0031308, 1.055 * x ** (1.0 / 2.4) - 0.055, x * 12.92)
+
+    def roll(x):
+        h = 1.0 - KNEE
+        o = np.maximum(x - KNEE, 0.0)
+        r = KNEE + h * (o / (o + h))
+        return np.where(x > KNEE, r, x)
+
+    lin = srgb_to_linear(c) * (2.0 ** exposure) * np.asarray(wb_gain)
+    if rolloff:
+        lin = roll(lin)
+    disp = linear_to_srgb(lin)
+    disp = (disp - 0.5) * contrast + 0.5
+    luma = disp @ np.array([0.2126, 0.7152, 0.0722])
+    disp = luma[..., None] + (disp - luma[..., None]) * saturation
+    return np.clip(disp, 0.0, 1.0)
+
+
+def test_shader_matches_tone_for_full_recipe():
+    rng = np.random.default_rng(1)
+    px = rng.random((256, 3)).astype(np.float32)
+    cases = [
+        (0.0, 0, 0, 0, 0),
+        (1.5, 0, 0, 0, 0),
+        (2.0, 60, -30, 10, 20),
+        (-1.0, 0, 0, 40, -50),
+        (0.0, 0, 0, 0, -100),
+        (3.0, -40, 25, -20, 35),
+    ]
+    for ev, temp, tint, con, sat in cases:
+        wb = {"temperature": temp, "tint": tint} if (temp or tint) else None
+        expected = tone.apply_adjustments(
+            px[None, :, :], exposure=ev, white_balance=wb, contrast=con, saturation=sat
+        )[0]
+
+        # The dispatcher (_lbApplyAdjustmentPreview) derives these from a base of
+        # all-zeros for a first edit, so the deltas equal the full values.
+        gr, gg, gb = tone.white_balance_gains(wb)
+        pushed = (2.0 ** ev) * max(gr, gg, gb) > 1.0 + 1e-6
+        got = _shader_mirror(
+            px,
+            exposure=ev,
+            wb_gain=(gr, gg, gb),
+            contrast=max(0.0, 1.0 + con / 100.0),
+            saturation=max(0.0, 1.0 + sat / 100.0),
+            rolloff=pushed,
+        )
+        max_err = float(np.max(np.abs(got - expected)))
+        assert max_err < 2e-4, (ev, temp, tint, con, sat, max_err)

--- a/vireo/tests/test_tone_shader_parity.py
+++ b/vireo/tests/test_tone_shader_parity.py
@@ -2,9 +2,16 @@
 
 The live preview in ``_navbar.html`` (``VireoToneGL``) is a GLSL transcription
 of :mod:`tone`. This test mirrors that GLSL arithmetic in numpy and asserts it
-reproduces ``tone.apply_adjustments`` for the first-edit case the shader is
-exact on (the displayed image has no baked adjustments, so the previewed
-"delta" equals the full recipe). If the two pipelines drift, this fails.
+reproduces ``tone.apply_adjustments`` for the **first-edit case only** — the
+displayed image has no baked adjustments (base == zeros), so the previewed
+"delta" equals the full recipe and the two pipelines must agree exactly.
+
+It deliberately does *not* claim parity for re-edits: there the preview applies
+a delta on top of already tone-mapped pixels, and the highlight rolloff /
+clamping are neither reversible nor associative, so the preview is only an
+approximation that snaps to the exact server render after save. We test the
+exact case because it's the one the two formulas are supposed to match; if they
+drift, that case fails.
 
 It can't execute the actual shader headlessly, but it locks the *formula*:
 sRGB<->linear transfer, the highlight-knee rolloff, the white-balance gains and
@@ -12,6 +19,7 @@ push-gate, and the display-space contrast/saturation — in the same order.
 """
 
 import os
+import re
 import sys
 
 import numpy as np
@@ -20,11 +28,23 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 import tone
 
+NAVBAR = os.path.join(
+    os.path.dirname(__file__), '..', 'templates', '_navbar.html'
+)
+
 KNEE = 0.85  # must equal VireoToneGL KNEE and tone.HIGHLIGHT_KNEE
 
 
 def test_shader_knee_constant_matches_tone():
+    # The local KNEE used by _shader_mirror must equal the server constant...
     assert KNEE == tone.HIGHLIGHT_KNEE
+    # ...and the literal baked into the actual shader must match too, so the
+    # template can't silently drift away from tone.HIGHLIGHT_KNEE.
+    with open(NAVBAR, encoding='utf-8') as f:
+        src = f.read()
+    match = re.search(r'var\s+KNEE\s*=\s*([0-9.]+)\s*;', src)
+    assert match, 'could not find `var KNEE = ...;` in VireoToneGL'
+    assert float(match.group(1)) == tone.HIGHLIGHT_KNEE
 
 
 def _shader_mirror(c, exposure, wb_gain, contrast, saturation, rolloff):

--- a/vireo/tone.py
+++ b/vireo/tone.py
@@ -1,0 +1,161 @@
+"""Scene-referred tone pipeline for non-destructive photo edits.
+
+This module is the single source of truth for how the editable adjustments
+(exposure, white balance, contrast, saturation) map input pixels to output
+pixels. Geometry (rotate/flip/straighten/crop) lives in ``image_edits`` and is
+not part of this pipeline.
+
+Why this exists
+---------------
+The original editor multiplied gamma-encoded sRGB bytes (``2 ** ev`` brightness
+in 8-bit space) and hard-clipped anything that exceeded white. That is
+photometrically wrong: a real exposure change scales *linear* radiance, and
+pushing exposure should roll highlights off smoothly rather than clip them to a
+flat white. This pipeline therefore:
+
+  1. de-gammas sRGB -> linear light,
+  2. applies the scene-referred ops (exposure, white balance) in linear,
+  3. rolls highlights off with a smooth shoulder (no hard clip to 1.0),
+  4. re-encodes linear -> sRGB,
+  5. applies the display-referred ops (contrast, saturation) in sRGB.
+
+Data ceiling: this operates on whatever 8-bit source it is handed. It produces
+a pleasing rolloff but cannot *recover* highlights that were already clipped
+upstream (e.g. in a camera JPEG or an auto-brightened RAW decode). Recovering
+real highlight detail requires decoding RAW to linear with auto-bright off
+(a separate, larger change).
+
+Keep-in-sync contract (Tier 3 / live preview)
+---------------------------------------------
+Every function here is strictly per-pixel: each output channel depends only on
+the input pixel's own channels and the scalar parameters. That means this maps
+1:1 onto a GLSL fragment shader for the live WebGL preview. When the preview is
+ported, transcribe these functions verbatim and reuse the constants below; the
+CSS-``filter`` preview in ``_navbar.html`` cannot express the linear-light
+rolloff and only approximates this render.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+# --- constants (keep in sync with the live-preview shader) ---------------------
+
+# Linear value at which the highlight shoulder begins. Below the knee the
+# pipeline is identity (no tone change); above it, values are compressed toward
+# 1.0 so that boosting exposure desaturates and rolls off highlights instead of
+# clipping. 0.85 linear ~= 0.94 sRGB, so an un-pushed image is essentially
+# untouched and only genuinely bright pixels ever enter the shoulder.
+HIGHLIGHT_KNEE = 0.85
+
+# White-balance channel-gain coefficients. Mirrors the original
+# ``_apply_white_balance`` so saved recipes keep their intended colour cast;
+# the only change is that the gains are now applied in linear light.
+WB_TEMP_R = 0.26
+WB_TEMP_B = 0.26
+WB_TINT_R = 0.06
+WB_TINT_G = 0.18
+WB_TINT_B = 0.06
+WB_MIN_GAIN = 0.05
+
+# Rec. 709 luma weights, used for luma-preserving saturation in display space.
+LUMA_R = 0.2126
+LUMA_G = 0.7152
+LUMA_B = 0.0722
+
+
+def srgb_to_linear(c):
+    """sRGB-encoded [0,1] -> linear light. Standard IEC 61966-2-1 transfer."""
+    c = np.asarray(c, dtype=np.float32)
+    return np.where(c <= 0.04045, c / 12.92, ((c + 0.055) / 1.055) ** 2.4)
+
+
+def linear_to_srgb(c):
+    """Linear light -> sRGB-encoded [0,1]. Inverse of :func:`srgb_to_linear`."""
+    c = np.clip(np.asarray(c, dtype=np.float32), 0.0, None)
+    return np.where(c <= 0.0031308, c * 12.92, 1.055 * (c ** (1.0 / 2.4)) - 0.055)
+
+
+def highlight_rolloff(lin, knee=HIGHLIGHT_KNEE):
+    """Smoothly compress linear highlights above ``knee`` toward 1.0.
+
+    Identity for ``lin <= knee``; above the knee a rational (Reinhard-style)
+    shoulder asymptotes to 1.0 and never reaches or exceeds it, so highlights
+    keep gradient instead of flattening to pure white. The two branches share
+    value and first derivative at the knee (C1-continuous), so there is no
+    visible seam.
+    """
+    lin = np.asarray(lin, dtype=np.float32)
+    headroom = 1.0 - knee
+    over = np.maximum(lin - knee, 0.0)
+    rolled = knee + headroom * (over / (over + headroom))
+    return np.where(lin > knee, rolled, lin)
+
+
+def white_balance_gains(white_balance):
+    """Return per-channel linear gains (r, g, b) for a white-balance dict.
+
+    ``temperature`` and ``tint`` are in [-100, 100]; both default to 0 (no-op
+    gains of 1.0). Coefficients match the original sRGB implementation.
+    """
+    wb = white_balance or {}
+    temperature = float(wb.get("temperature") or 0.0) / 100.0
+    tint = float(wb.get("tint") or 0.0) / 100.0
+    r = max(WB_MIN_GAIN, 1.0 + WB_TEMP_R * temperature + WB_TINT_R * tint)
+    g = max(WB_MIN_GAIN, 1.0 - WB_TINT_G * tint)
+    b = max(WB_MIN_GAIN, 1.0 - WB_TEMP_B * temperature + WB_TINT_B * tint)
+    return r, g, b
+
+
+def apply_adjustments(
+    rgb,
+    *,
+    exposure=0.0,
+    white_balance=None,
+    contrast=0.0,
+    saturation=0.0,
+):
+    """Apply tonal adjustments to an sRGB float image and return sRGB float.
+
+    Args:
+        rgb: float array shaped ``(..., 3)`` with sRGB-encoded values in [0,1].
+        exposure: stops of exposure (linear gain ``2 ** exposure``).
+        white_balance: dict with ``temperature``/``tint`` in [-100, 100], or None.
+        contrast: [-100, 100]; a linear contrast around mid-grey (0.5).
+        saturation: [-100, 100]; luma-preserving saturation in display space.
+
+    Returns:
+        float32 array, same shape, sRGB-encoded and clipped to [0,1].
+    """
+    rgb = np.asarray(rgb, dtype=np.float32)
+
+    # --- scene-referred ops, in linear light ---
+    lin = srgb_to_linear(rgb)
+    exp_gain = 2.0 ** float(exposure)
+    if exposure:
+        lin = lin * np.float32(exp_gain)
+    gr = gg = gb = 1.0
+    if white_balance:
+        gr, gg, gb = white_balance_gains(white_balance)
+        lin = lin * np.array([gr, gg, gb], dtype=np.float32)
+    # Roll highlights off only when something actually pushes values up. With
+    # no net gain, nothing can exceed display white, so the shoulder must stay
+    # disabled to keep an un-pushed image a true no-op (ev=0 == original).
+    if exp_gain * max(gr, gg, gb) > 1.0 + 1e-6:
+        lin = highlight_rolloff(lin)
+
+    # --- display-referred ops, in sRGB ---
+    disp = linear_to_srgb(lin)
+    if contrast:
+        c = np.float32(1.0 + float(contrast) / 100.0)
+        disp = (disp - 0.5) * c + 0.5
+    if saturation:
+        s = np.float32(max(0.0, 1.0 + float(saturation) / 100.0))
+        luma = (
+            LUMA_R * disp[..., 0]
+            + LUMA_G * disp[..., 1]
+            + LUMA_B * disp[..., 2]
+        )[..., None]
+        disp = luma + (disp - luma) * s
+
+    return np.clip(disp, 0.0, 1.0)

--- a/vireo/tone.py
+++ b/vireo/tone.py
@@ -130,7 +130,8 @@ def apply_adjustments(
     rgb = np.asarray(rgb, dtype=np.float32)
 
     # --- scene-referred ops, in linear light ---
-    lin = srgb_to_linear(rgb)
+    lin_pre = srgb_to_linear(rgb)
+    lin = lin_pre
     exp_gain = 2.0 ** float(exposure)
     if exposure:
         lin = lin * np.float32(exp_gain)
@@ -142,7 +143,19 @@ def apply_adjustments(
     # no net gain, nothing can exceed display white, so the shoulder must stay
     # disabled to keep an un-pushed image a true no-op (ev=0 == original).
     if exp_gain * max(gr, gg, gb) > 1.0 + 1e-6:
-        lin = highlight_rolloff(lin)
+        # The shoulder curve is below identity for inputs in (knee, ∞), so
+        # naively rolling every post-gain value above the knee can darken
+        # near-white pixels — e.g. a 0.95-linear pixel at +0.1 EV becomes
+        # 1.018 post-gain and the shoulder maps that to 0.929. That violates
+        # monotonicity in exposure: a positive boost must never lower a
+        # pixel's output. Clamp per channel to the channel's "would-be" value
+        # without rolloff: that's lin_pre when the channel's net gain >= 1
+        # (the channel can only brighten, so its floor is the input), and
+        # the post-gain value itself when the channel's net gain < 1 (e.g.
+        # a negative-tint blue channel that WB legitimately reduces).
+        # ``min(lin_pre, lin)`` collapses to whichever is the natural floor.
+        rolled = highlight_rolloff(lin)
+        lin = np.maximum(rolled, np.minimum(lin_pre, lin))
 
     # --- display-referred ops, in sRGB ---
     disp = linear_to_srgb(lin)


### PR DESCRIPTION
## What & why

Makes exposure adjustment photographically correct, and gives the editor a live preview that matches the committed render.

The old editor multiplied gamma-encoded 8-bit sRGB (`2 ** ev` brightness) and hard-clipped anything over white — flat, blown highlights. This reworks the edit math to work in linear light with a smooth highlight rolloff, and ports the live preview to a WebGL shader running the **same** math so the preview no longer diverges from the render.

## Tier 1 — server math (`vireo/tone.py`, `vireo/image_edits.py`)

- New `tone.py` is the single per-pixel source of truth: sRGB→linear → exposure/white-balance in linear → smooth **highlight rolloff** (rational shoulder, asymptotes to 1.0, never hard-clips) → linear→sRGB → display-space contrast/saturation. `apply_recipe` routes adjustments through it via a PIL↔numpy bridge.
- The rolloff is **gated** to engage only when exposure/WB push values up, so an un-pushed edit (`ev=0`, or contrast/saturation only) is a pixel-exact no-op — important for a non-destructive editor.
- **Effect:** pushing +1.5 stops on a foreground→sky gradient blew **~78%** of the sky to flat white before; **0%** now (highlights roll off, gradient preserved).

## Tier 3 — GPU live preview (`vireo/templates/_navbar.html`)

- `VireoToneGL`: a WebGL fragment shader that transcribes `tone.py` verbatim (same `HIGHLIGHT_KNEE`, WB coeffs, op order, push-gate). An overlay `<canvas>` inside `.lightbox-transform` inherits the lightbox's zoom/pan and overlays the displayed image.
- `_lbApplyAdjustmentPreview` / `_lbClearAdjustmentPreview` dispatch to the GPU and **fall back to the existing CSS-filter preview** when WebGL is unavailable, so the editor can't break on unsupported hardware.
- Same delta-from-rendered-values model as the prior CSS preview: **exact for a first edit** (displayed image has no baked adjustments → delta = full recipe), approximate for re-edits (snaps to the exact server render after the 350 ms debounced save) — now in correct linear math, so the snap is small instead of the old highlight blowout.

## Testing

- `python -m pytest vireo/tests/test_tone.py vireo/tests/test_tone_shader_parity.py vireo/tests/test_image_edits.py tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_config.py vireo/tests/test_export.py vireo/tests/test_pipeline.py` → **1349 passed, 3 skipped**.
- `test_tone.py` locks the tone properties (linear exposure, graceful rolloff, monotonicity, no-op at rest, luma-preserving saturation).
- `test_tone_shader_parity.py` mirrors the GLSL in numpy and asserts it equals `tone.py`, guarding against the two pipelines drifting.
- The **actual shader** was run on real WebGL and matched `tone.py` to **≤1/255**, confirming it compiles and the texture/viewport plumbing is correct.
- **Not covered by automated tests:** the DOM overlay alignment / show-hide in the live adjust panel (needs the running app + photos) — verify interactively.

## ⚠️ Deploy note

Changing the edit math re-renders existing saved recipes differently. Cached previews/thumbnails are keyed by `photo_id + size` with no math version, so they won't auto-refresh — a cache invalidation / render-version bump is needed on deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GPU-based “Adjust” lightbox preview with smoother highlight handling and more consistent color processing.
  * Upgraded the underlying tone adjustments for exposure, white balance, contrast, and saturation.

* **Bug Fixes**
  * Improved match between edit preview and saved results.
  * More reliable transparency preservation during edits.
  * Automatic fallback to the existing preview mode when GPU rendering isn’t available.
  * Ensured edit-related previews and thumbnails refresh correctly after math changes.

* **Tests / Chores**
  * Added coverage to verify tone math/shader parity and edit-version cache synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->