### PR TITLE
Improve non-destructive editing controls

### DIFF
--- a/vireo/image_edits.py
+++ b/vireo/image_edits.py
@@ -20,12 +20,18 @@ SCHEMA_VERSION = 1
 #
 # History:
 #   1 — original gamma-encoded sRGB multiply with hard clip at white.
-#   2 — linear-light pipeline with gated highlight shoulder (this PR).
-EDIT_MATH_VERSION = 2
+#   2 — linear-light pipeline with gated highlight shoulder.
+#   3 — expanded tone controls: highlights/shadows/whites/blacks/vibrance.
+EDIT_MATH_VERSION = 3
 
 _ADJUSTMENT_RANGES = {
     "exposure": (-5.0, 5.0),
+    "highlights": (-100.0, 100.0),
+    "shadows": (-100.0, 100.0),
+    "whites": (-100.0, 100.0),
+    "blacks": (-100.0, 100.0),
     "contrast": (-100.0, 100.0),
+    "vibrance": (-100.0, 100.0),
     "saturation": (-100.0, 100.0),
 }
 
@@ -60,7 +66,7 @@ def normalize_recipe(recipe):
     out = {"version": SCHEMA_VERSION}
 
     rotation = recipe.get("rotation", 0)
-    if isinstance(rotation, bool) or not isinstance(rotation, (int, float)):
+    if isinstance(rotation, bool) or not isinstance(rotation, int | float):
         raise RecipeError("rotation must be one of 0, 90, 180, or 270")
     if isinstance(rotation, float) and not rotation.is_integer():
         raise RecipeError("rotation must be one of 0, 90, 180, or 270")
@@ -73,7 +79,7 @@ def normalize_recipe(recipe):
     straighten = recipe.get("straighten", 0)
     if straighten in (None, ""):
         straighten = 0
-    if isinstance(straighten, bool) or not isinstance(straighten, (int, float)):
+    if isinstance(straighten, bool) or not isinstance(straighten, int | float):
         raise RecipeError("straighten must be numeric")
     straighten = float(straighten)
     if not math.isfinite(straighten) or straighten < -45.0 or straighten > 45.0:
@@ -146,7 +152,7 @@ def normalize_recipe(recipe):
         raw = adjustments.get(name)
         if raw in (None, ""):
             continue
-        if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+        if isinstance(raw, bool) or not isinstance(raw, int | float):
             raise RecipeError(f"{name} adjustment must be numeric")
         val = float(raw)
         if not math.isfinite(val) or val < lo or val > hi:
@@ -170,7 +176,7 @@ def normalize_recipe(recipe):
         raw = white_balance.get(name)
         if raw in (None, ""):
             continue
-        if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+        if isinstance(raw, bool) or not isinstance(raw, int | float):
             raise RecipeError(f"white_balance.{name} adjustment must be numeric")
         val = float(raw)
         if not math.isfinite(val) or val < lo or val > hi:
@@ -206,7 +212,7 @@ def _apply_adjustments(img, adjustments):
 
     Bridges PIL <-> numpy: promotes the image to RGB(A), runs the shared
     per-pixel pipeline in :mod:`tone` (linear-light exposure/white balance with
-    a highlight shoulder, then display-space contrast/saturation), and merges
+    a highlight shoulder, then display-space tonal/color controls), and merges
     any alpha channel back unchanged.
     """
     import numpy as np
@@ -224,7 +230,12 @@ def _apply_adjustments(img, adjustments):
 
     exposure = adjustments.get("exposure", 0.0)
     white_balance = adjustments.get("white_balance")
+    highlights = adjustments.get("highlights", 0.0)
+    shadows = adjustments.get("shadows", 0.0)
+    whites = adjustments.get("whites", 0.0)
+    blacks = adjustments.get("blacks", 0.0)
     contrast = adjustments.get("contrast", 0.0)
+    vibrance = adjustments.get("vibrance", 0.0)
     saturation = adjustments.get("saturation", 0.0)
 
     src = np.asarray(img)  # uint8, view onto the PIL buffer (no copy)
@@ -244,7 +255,12 @@ def _apply_adjustments(img, adjustments):
             tile[..., :3],
             exposure=exposure,
             white_balance=white_balance,
+            highlights=highlights,
+            shadows=shadows,
+            whites=whites,
+            blacks=blacks,
             contrast=contrast,
+            vibrance=vibrance,
             saturation=saturation,
         )
         out8[top:bottom, :, :3] = np.clip(adj * 255.0 + 0.5, 0, 255).astype(

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -4244,6 +4244,24 @@ function _lbApplyAdjustmentPreviewCss(values) {
   var contrast = Math.max(0, 1 + Number(values.contrast || 0) / 100) / baseContrast;
   var baseSaturation = Math.max(0.001, 1 + Number(base.saturation || 0) / 100);
   var saturation = Math.max(0, 1 + Number(values.saturation || 0) / 100) / baseSaturation;
+  // CSS filters can't target tonal ranges, so the highlights/shadows/whites/
+  // blacks/vibrance sliders are folded into brightness/contrast/saturate as a
+  // directional cue. The GPU path is canonical when available; this only runs
+  // when WebGL is unavailable or uploadSource rejected the image.
+  var dHighlights = Number(values.highlights || 0) - Number(base.highlights || 0);
+  var dShadows = Number(values.shadows || 0) - Number(base.shadows || 0);
+  var dWhites = Number(values.whites || 0) - Number(base.whites || 0);
+  var dBlacks = Number(values.blacks || 0) - Number(base.blacks || 0);
+  var dVibrance = Number(values.vibrance || 0) - Number(base.vibrance || 0);
+  // Positive on any of the four lifts pixels toward white in its mask, so the
+  // net effect on average luma is a brightness shift; the denominator damps it
+  // because each slider only touches part of the tone range.
+  exposure *= Math.max(0, 1 + (dHighlights + dShadows + dWhites + dBlacks) / 400);
+  // Highlights/whites push the upper end up while shadows/blacks pull the
+  // lower end up, so their signed sum tracks apparent contrast.
+  contrast *= Math.max(0, 1 + (dHighlights + dWhites - dShadows - dBlacks) / 400);
+  // Vibrance is a gentler saturate(); weight smaller than saturation itself.
+  saturation *= Math.max(0, 1 + dVibrance / 200);
   // White balance: the displayed source already has the saved WB baked in, so
   // preview the delta as new-gain / rendered-gain per channel.
   var valGains = _lbWhiteBalanceGains(values.temperature, values.tint);

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -549,6 +549,8 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
   right: 24px;
   top: 64px;
   width: min(320px, calc(100vw - 48px));
+  max-height: calc(100vh - 112px);
+  overflow-y: auto;
   padding: 12px;
   border-radius: 6px;
   background: rgba(0, 0, 0, 0.76);
@@ -3301,10 +3303,70 @@ async function createWorkspace() {
     <button class="lb-action-btn lb-action-accent" id="lightboxInspect" onclick="">
       Inspect Pipeline
     </button>
+    <button class="lb-action-btn lb-action-accent" id="lightboxAdjustBtn" onclick="event.stopPropagation(); toggleLightboxAdjustPanel();" title="Quick non-destructive adjustments">
+      Adjust
+    </button>
     <button class="lb-action-btn lb-action-accent" id="lightboxEditPhoto" onclick="">
       Edit Photo
     </button>
     <button class="lb-action-btn lb-action-danger" onclick="lightboxDelete()" title="Delete photo">Delete</button>
+  </div>
+  <div class="lightbox-adjust-panel" id="lightboxAdjustPanel" onclick="event.stopPropagation();">
+    <div class="lb-adjust-header">
+      <span>Adjustments</span>
+      <button class="lb-adjust-reset" type="button" onclick="resetLightboxAdjustments()">Reset</button>
+    </div>
+    <div class="lb-adjust-row">
+      <label for="lbAdjExposure">Exposure</label>
+      <input id="lbAdjExposure" data-adjustment="exposure" type="range" min="-5" max="5" step="0.1" value="0" oninput="onLightboxAdjustmentInput(this)">
+      <span class="lb-adjust-value" id="lbAdjExposureValue">0.0</span>
+    </div>
+    <div class="lb-adjust-row">
+      <label for="lbAdjHighlights">Highlights</label>
+      <input id="lbAdjHighlights" data-adjustment="highlights" type="range" min="-100" max="100" step="1" value="0" oninput="onLightboxAdjustmentInput(this)">
+      <span class="lb-adjust-value" id="lbAdjHighlightsValue">0</span>
+    </div>
+    <div class="lb-adjust-row">
+      <label for="lbAdjShadows">Shadows</label>
+      <input id="lbAdjShadows" data-adjustment="shadows" type="range" min="-100" max="100" step="1" value="0" oninput="onLightboxAdjustmentInput(this)">
+      <span class="lb-adjust-value" id="lbAdjShadowsValue">0</span>
+    </div>
+    <div class="lb-adjust-row">
+      <label for="lbAdjWhites">Whites</label>
+      <input id="lbAdjWhites" data-adjustment="whites" type="range" min="-100" max="100" step="1" value="0" oninput="onLightboxAdjustmentInput(this)">
+      <span class="lb-adjust-value" id="lbAdjWhitesValue">0</span>
+    </div>
+    <div class="lb-adjust-row">
+      <label for="lbAdjBlacks">Blacks</label>
+      <input id="lbAdjBlacks" data-adjustment="blacks" type="range" min="-100" max="100" step="1" value="0" oninput="onLightboxAdjustmentInput(this)">
+      <span class="lb-adjust-value" id="lbAdjBlacksValue">0</span>
+    </div>
+    <div class="lb-adjust-row">
+      <label for="lbAdjContrast">Contrast</label>
+      <input id="lbAdjContrast" data-adjustment="contrast" type="range" min="-100" max="100" step="1" value="0" oninput="onLightboxAdjustmentInput(this)">
+      <span class="lb-adjust-value" id="lbAdjContrastValue">0</span>
+    </div>
+    <div class="lb-adjust-row">
+      <label for="lbAdjTemperature">Temp</label>
+      <input id="lbAdjTemperature" data-adjustment="temperature" type="range" min="-100" max="100" step="1" value="0" oninput="onLightboxAdjustmentInput(this)">
+      <span class="lb-adjust-value" id="lbAdjTemperatureValue">0</span>
+    </div>
+    <div class="lb-adjust-row">
+      <label for="lbAdjTint">Tint</label>
+      <input id="lbAdjTint" data-adjustment="tint" type="range" min="-100" max="100" step="1" value="0" oninput="onLightboxAdjustmentInput(this)">
+      <span class="lb-adjust-value" id="lbAdjTintValue">0</span>
+    </div>
+    <div class="lb-adjust-row">
+      <label for="lbAdjVibrance">Vibrance</label>
+      <input id="lbAdjVibrance" data-adjustment="vibrance" type="range" min="-100" max="100" step="1" value="0" oninput="onLightboxAdjustmentInput(this)">
+      <span class="lb-adjust-value" id="lbAdjVibranceValue">0</span>
+    </div>
+    <div class="lb-adjust-row">
+      <label for="lbAdjSaturation">Saturation</label>
+      <input id="lbAdjSaturation" data-adjustment="saturation" type="range" min="-100" max="100" step="1" value="0" oninput="onLightboxAdjustmentInput(this)">
+      <span class="lb-adjust-value" id="lbAdjSaturationValue">0</span>
+    </div>
+    <div class="lb-adjust-status" id="lightboxAdjustStatus"></div>
   </div>
 </div>
 
@@ -3593,7 +3655,7 @@ function _vireoHashString(s) {
 // seeing the old bytes from their own browser cache until they expire.
 // test_edit_math_version_template_constant_matches_python locks the two
 // constants together.
-var _VIREO_EDIT_MATH_VERSION = 2;
+var _VIREO_EDIT_MATH_VERSION = 3;
 
 function _vireoEditRecipeCacheKey(recipe) {
   var normalized = _lbCloneEditRecipe(recipe);
@@ -4017,9 +4079,14 @@ function _lbAdjustmentValues(recipe) {
   var wb = adj.white_balance || {};
   return {
     exposure: Number(adj.exposure || 0),
+    highlights: Number(adj.highlights || 0),
+    shadows: Number(adj.shadows || 0),
+    whites: Number(adj.whites || 0),
+    blacks: Number(adj.blacks || 0),
     contrast: Number(adj.contrast || 0),
     temperature: Number(wb.temperature || adj.temperature || 0),
     tint: Number(wb.tint || adj.tint || 0),
+    vibrance: Number(adj.vibrance || 0),
     saturation: Number(adj.saturation || 0),
   };
 }
@@ -4048,9 +4115,14 @@ function _lbSetAdjustmentControl(id, value) {
 function _lbSetAdjustmentControlsDisabled(disabled) {
   [
     'lbAdjExposure',
+    'lbAdjHighlights',
+    'lbAdjShadows',
+    'lbAdjWhites',
+    'lbAdjBlacks',
     'lbAdjContrast',
     'lbAdjTemperature',
     'lbAdjTint',
+    'lbAdjVibrance',
     'lbAdjSaturation',
   ].forEach(function(id) {
     var input = document.getElementById(id);
@@ -4061,9 +4133,14 @@ function _lbSetAdjustmentControlsDisabled(disabled) {
 function _lbRenderAdjustmentControls() {
   var values = _lbAdjustmentValues(_lbEditRecipe);
   _lbSetAdjustmentControl('lbAdjExposure', values.exposure);
+  _lbSetAdjustmentControl('lbAdjHighlights', values.highlights);
+  _lbSetAdjustmentControl('lbAdjShadows', values.shadows);
+  _lbSetAdjustmentControl('lbAdjWhites', values.whites);
+  _lbSetAdjustmentControl('lbAdjBlacks', values.blacks);
   _lbSetAdjustmentControl('lbAdjContrast', values.contrast);
   _lbSetAdjustmentControl('lbAdjTemperature', values.temperature);
   _lbSetAdjustmentControl('lbAdjTint', values.tint);
+  _lbSetAdjustmentControl('lbAdjVibrance', values.vibrance);
   _lbSetAdjustmentControl('lbAdjSaturation', values.saturation);
 }
 
@@ -4074,9 +4151,14 @@ function _lbReadAdjustmentControls() {
   }
   return {
     exposure: val('lbAdjExposure'),
+    highlights: val('lbAdjHighlights'),
+    shadows: val('lbAdjShadows'),
+    whites: val('lbAdjWhites'),
+    blacks: val('lbAdjBlacks'),
     contrast: val('lbAdjContrast'),
     temperature: val('lbAdjTemperature'),
     tint: val('lbAdjTint'),
+    vibrance: val('lbAdjVibrance'),
     saturation: val('lbAdjSaturation'),
   };
 }
@@ -4085,7 +4167,7 @@ function _lbRecipeWithAdjustments(values) {
   var recipe = _lbCloneRecipe(_lbEditRecipe);
   delete recipe.version;
   var adj = _lbCloneRecipe(recipe.adjustments || {});
-  ['exposure', 'contrast', 'saturation'].forEach(function(key) {
+  ['exposure', 'highlights', 'shadows', 'whites', 'blacks', 'contrast', 'vibrance', 'saturation'].forEach(function(key) {
     var value = Number(values[key] || 0);
     if (Math.abs(value) > 0.000001) adj[key] = value;
     else delete adj[key];
@@ -4107,7 +4189,7 @@ function _lbRecipeWithAdjustments(values) {
   return recipe;
 }
 
-// Mirror image_edits._apply_white_balance: per-channel sRGB gains. Keep these
+// Mirror tone.white_balance_gains: per-channel linear-light gains. Keep these
 // coefficients in sync with the server so the live preview matches the render.
 function _lbWhiteBalanceGains(temperature, tint) {
   var t = Number(temperature || 0) / 100;
@@ -4216,7 +4298,12 @@ var VireoToneGL = (function() {
     'uniform sampler2D uTex;',
     'uniform float uExposure;',   // stops (linear gain = exp2(uExposure))
     'uniform vec3 uWbGain;',      // per-channel linear gains
+    'uniform float uHighlights;',
+    'uniform float uShadows;',
+    'uniform float uWhites;',
+    'uniform float uBlacks;',
     'uniform float uContrast;',   // display-space contrast factor about 0.5
+    'uniform float uVibrance;',
     'uniform float uSaturation;', // display-space luma-preserving factor
     'uniform float uRolloff;',    // 1.0 -> apply highlight shoulder, else 0.0
     'uniform float uKnee;',
@@ -4233,6 +4320,22 @@ var VireoToneGL = (function() {
     '  float r = uKnee + h * (o / (o + h));',
     '  return x > uKnee ? r : x;',
     '}',
+    'vec3 blendRange(vec3 rgb, float amount, float mask){',
+    '  float a = amount / 100.0;',
+    '  float m = abs(a) * mask;',
+    '  if (a > 0.0) return rgb + (vec3(1.0) - rgb) * m;',
+    '  return rgb - rgb * m;',
+    '}',
+    'vec3 applyVibrance(vec3 rgb, float amount){',
+    '  float a = amount / 100.0;',
+    '  if (abs(a) < 0.000001) return rgb;',
+    '  float l = dot(rgb, vec3(0.2126, 0.7152, 0.0722));',
+    '  float hi = max(max(rgb.r, rgb.g), rgb.b);',
+    '  float lo = min(min(rgb.r, rgb.g), rgb.b);',
+    '  float chroma = clamp(hi - lo, 0.0, 1.0);',
+    '  float factor = a > 0.0 ? 1.0 + a * (1.0 - chroma) * 0.85 : 1.0 + a * 0.65;',
+    '  return clamp(vec3(l) + (rgb - vec3(l)) * factor, 0.0, 1.0);',
+    '}',
     'void main(){',
     '  vec4 src = texture2D(uTex, vUv);',
     '  vec3 linPre = srgbToLinear(src.rgb);',
@@ -4248,7 +4351,21 @@ var VireoToneGL = (function() {
     '    lin = max(rolled, min(linPre, lin));',
     '  }',
     '  vec3 disp = linearToSrgb(lin);',
+    '  float rangeLuma = dot(disp, vec3(0.2126, 0.7152, 0.0722));',
+    '  if (abs(uShadows) > 0.000001) {',
+    '    disp = blendRange(disp, uShadows, (1.0 - smoothstep(0.05, 0.65, rangeLuma)) * 0.48);',
+    '  }',
+    '  if (abs(uHighlights) > 0.000001) {',
+    '    disp = blendRange(disp, uHighlights, smoothstep(0.35, 0.95, rangeLuma) * 0.42);',
+    '  }',
+    '  if (abs(uBlacks) > 0.000001) {',
+    '    disp = blendRange(disp, uBlacks, (1.0 - smoothstep(0.00, 0.30, rangeLuma)) * 0.34);',
+    '  }',
+    '  if (abs(uWhites) > 0.000001) {',
+    '    disp = blendRange(disp, uWhites, smoothstep(0.70, 1.00, rangeLuma) * 0.34);',
+    '  }',
     '  disp = (disp - 0.5) * uContrast + 0.5;',
+    '  disp = applyVibrance(disp, uVibrance);',
     '  float luma = dot(disp, vec3(0.2126, 0.7152, 0.0722));',
     '  disp = vec3(luma) + (disp - vec3(luma)) * uSaturation;',
     // Pass through the source alpha (don't force 1.0) so transparent or
@@ -4309,7 +4426,12 @@ var VireoToneGL = (function() {
       tex: gl.getUniformLocation(prog, 'uTex'),
       exposure: gl.getUniformLocation(prog, 'uExposure'),
       wbGain: gl.getUniformLocation(prog, 'uWbGain'),
+      highlights: gl.getUniformLocation(prog, 'uHighlights'),
+      shadows: gl.getUniformLocation(prog, 'uShadows'),
+      whites: gl.getUniformLocation(prog, 'uWhites'),
+      blacks: gl.getUniformLocation(prog, 'uBlacks'),
       contrast: gl.getUniformLocation(prog, 'uContrast'),
+      vibrance: gl.getUniformLocation(prog, 'uVibrance'),
       saturation: gl.getUniformLocation(prog, 'uSaturation'),
       rolloff: gl.getUniformLocation(prog, 'uRolloff'),
       knee: gl.getUniformLocation(prog, 'uKnee')
@@ -4362,7 +4484,12 @@ var VireoToneGL = (function() {
       gl.viewport(0, 0, canvas.width, canvas.height);
       gl.uniform1f(locs.exposure, u.exposure);
       gl.uniform3f(locs.wbGain, u.wbGain[0], u.wbGain[1], u.wbGain[2]);
+      gl.uniform1f(locs.highlights, u.highlights);
+      gl.uniform1f(locs.shadows, u.shadows);
+      gl.uniform1f(locs.whites, u.whites);
+      gl.uniform1f(locs.blacks, u.blacks);
       gl.uniform1f(locs.contrast, u.contrast);
+      gl.uniform1f(locs.vibrance, u.vibrance);
       gl.uniform1f(locs.saturation, u.saturation);
       gl.uniform1f(locs.rolloff, u.rolloff ? 1.0 : 0.0);
       gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
@@ -4390,6 +4517,10 @@ function _lbApplyAdjustmentPreview(values) {
   if (img && canvas && img.naturalWidth && VireoToneGL.supported()) {
     var base = _lbRenderedAdjustmentValues || _lbAdjustmentValues(null);
     var dExposure = Number(values.exposure || 0) - Number(base.exposure || 0);
+    var dHighlights = Number(values.highlights || 0) - Number(base.highlights || 0);
+    var dShadows = Number(values.shadows || 0) - Number(base.shadows || 0);
+    var dWhites = Number(values.whites || 0) - Number(base.whites || 0);
+    var dBlacks = Number(values.blacks || 0) - Number(base.blacks || 0);
     var valGains = _lbWhiteBalanceGains(values.temperature, values.tint);
     var baseGains = _lbWhiteBalanceGains(base.temperature, base.tint);
     var wbGain = [
@@ -4399,6 +4530,7 @@ function _lbApplyAdjustmentPreview(values) {
     ];
     var dContrast = Math.max(0, 1 + Number(values.contrast || 0) / 100)
       / Math.max(0.001, 1 + Number(base.contrast || 0) / 100);
+    var dVibrance = Number(values.vibrance || 0) - Number(base.vibrance || 0);
     var dSaturation = Math.max(0, 1 + Number(values.saturation || 0) / 100)
       / Math.max(0.001, 1 + Number(base.saturation || 0) / 100);
     // Roll highlights off only when the net change actually pushes values up,
@@ -4407,7 +4539,12 @@ function _lbApplyAdjustmentPreview(values) {
     var ok = VireoToneGL.render(img, {
       exposure: dExposure,
       wbGain: wbGain,
+      highlights: dHighlights,
+      shadows: dShadows,
+      whites: dWhites,
+      blacks: dBlacks,
       contrast: dContrast,
+      vibrance: dVibrance,
       saturation: dSaturation,
       rolloff: pushed
     });
@@ -4609,9 +4746,14 @@ function resetLightboxAdjustments() {
     return;
   }
   _lbSetAdjustmentControl('lbAdjExposure', 0);
+  _lbSetAdjustmentControl('lbAdjHighlights', 0);
+  _lbSetAdjustmentControl('lbAdjShadows', 0);
+  _lbSetAdjustmentControl('lbAdjWhites', 0);
+  _lbSetAdjustmentControl('lbAdjBlacks', 0);
   _lbSetAdjustmentControl('lbAdjContrast', 0);
   _lbSetAdjustmentControl('lbAdjTemperature', 0);
   _lbSetAdjustmentControl('lbAdjTint', 0);
+  _lbSetAdjustmentControl('lbAdjVibrance', 0);
   _lbSetAdjustmentControl('lbAdjSaturation', 0);
   var values = _lbReadAdjustmentControls();
   _lbEditRecipe = _lbRecipeWithAdjustments(values);

--- a/vireo/templates/photo_editor.html
+++ b/vireo/templates/photo_editor.html
@@ -354,6 +354,26 @@ body {
         <span class="control-value" id="exposureValue">0.0</span>
       </div>
       <div class="control-row">
+        <label for="highlightsRange">Highlights</label>
+        <input id="highlightsRange" data-adjustment="highlights" type="range" min="-100" max="100" step="1" value="0" oninput="setAdjustment('highlights', this.value)">
+        <span class="control-value" id="highlightsValue">0</span>
+      </div>
+      <div class="control-row">
+        <label for="shadowsRange">Shadows</label>
+        <input id="shadowsRange" data-adjustment="shadows" type="range" min="-100" max="100" step="1" value="0" oninput="setAdjustment('shadows', this.value)">
+        <span class="control-value" id="shadowsValue">0</span>
+      </div>
+      <div class="control-row">
+        <label for="whitesRange">Whites</label>
+        <input id="whitesRange" data-adjustment="whites" type="range" min="-100" max="100" step="1" value="0" oninput="setAdjustment('whites', this.value)">
+        <span class="control-value" id="whitesValue">0</span>
+      </div>
+      <div class="control-row">
+        <label for="blacksRange">Blacks</label>
+        <input id="blacksRange" data-adjustment="blacks" type="range" min="-100" max="100" step="1" value="0" oninput="setAdjustment('blacks', this.value)">
+        <span class="control-value" id="blacksValue">0</span>
+      </div>
+      <div class="control-row">
         <label for="contrastRange">Contrast</label>
         <input id="contrastRange" data-adjustment="contrast" type="range" min="-100" max="100" step="1" value="0" oninput="setAdjustment('contrast', this.value)">
         <span class="control-value" id="contrastValue">0</span>
@@ -367,6 +387,11 @@ body {
         <label for="tintRange">Tint</label>
         <input id="tintRange" data-adjustment="tint" type="range" min="-100" max="100" step="1" value="0" oninput="setAdjustment('tint', this.value)">
         <span class="control-value" id="tintValue">0</span>
+      </div>
+      <div class="control-row">
+        <label for="vibranceRange">Vibrance</label>
+        <input id="vibranceRange" data-adjustment="vibrance" type="range" min="-100" max="100" step="1" value="0" oninput="setAdjustment('vibrance', this.value)">
+        <span class="control-value" id="vibranceValue">0</span>
       </div>
       <div class="control-row">
         <label for="saturationRange">Saturation</label>
@@ -537,9 +562,14 @@ function adjustmentValues(recipe) {
   var wb = adj.white_balance || {};
   return {
     exposure: Number(adj.exposure || 0),
+    highlights: Number(adj.highlights || 0),
+    shadows: Number(adj.shadows || 0),
+    whites: Number(adj.whites || 0),
+    blacks: Number(adj.blacks || 0),
     contrast: Number(adj.contrast || 0),
     temperature: Number(wb.temperature || adj.temperature || 0),
     tint: Number(wb.tint || adj.tint || 0),
+    vibrance: Number(adj.vibrance || 0),
     saturation: Number(adj.saturation || 0),
   };
 }
@@ -575,7 +605,7 @@ function recipeForSave(recipe) {
 
   var vals = adjustmentValues(out);
   var adj = {};
-  ['exposure', 'contrast', 'saturation'].forEach(function(key) {
+  ['exposure', 'highlights', 'shadows', 'whites', 'blacks', 'contrast', 'vibrance', 'saturation'].forEach(function(key) {
     if (Math.abs(Number(vals[key] || 0)) > 0.000001) adj[key] = Number(vals[key]);
   });
   var wb = {};
@@ -627,9 +657,14 @@ function syncControls() {
     if (label) label.textContent = fixed ? Number(value || 0).toFixed(1) : String(Math.round(Number(value || 0)));
   };
   set('exposure', vals.exposure, true);
+  set('highlights', vals.highlights, false);
+  set('shadows', vals.shadows, false);
+  set('whites', vals.whites, false);
+  set('blacks', vals.blacks, false);
   set('contrast', vals.contrast, false);
   set('temperature', vals.temperature, false);
   set('tint', vals.tint, false);
+  set('vibrance', vals.vibrance, false);
   set('saturation', vals.saturation, false);
   var straight = Number(r.straighten || 0);
   document.getElementById('straightenRange').value = String(straight);
@@ -745,7 +780,7 @@ function setAdjustment(key, value) {
   if (key === 'exposure') document.getElementById('exposureValue').textContent = vals[key].toFixed(1);
   else document.getElementById(key + 'Value').textContent = String(Math.round(vals[key]));
   var adj = cloneRecipe(editorState.recipe.adjustments || {});
-  ['exposure', 'contrast', 'saturation'].forEach(function(name) {
+  ['exposure', 'highlights', 'shadows', 'whites', 'blacks', 'contrast', 'vibrance', 'saturation'].forEach(function(name) {
     if (Math.abs(vals[name]) > 0.000001) adj[name] = vals[name];
     else delete adj[name];
   });

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -171,7 +171,7 @@ def test_export_photos_applies_edit_recipe(export_env):
 
 
 def test_export_photos_applies_adjustment_recipe(export_env):
-    """export_photos applies exposure, white balance, contrast, and saturation."""
+    """export_photos applies stored adjustment recipes."""
     env = export_env
     Image.new("RGB", (80, 60), color=(100, 100, 100)).save(
         str(env["src"] / "bird1.jpg"), "JPEG", quality=95,

--- a/vireo/tests/test_image_edits.py
+++ b/vireo/tests/test_image_edits.py
@@ -91,9 +91,37 @@ def test_normalize_recipe_canonicalizes_white_balance():
     }
 
 
+def test_normalize_recipe_accepts_expanded_adjustments():
+    assert normalize_recipe(
+        {
+            "adjustments": {
+                "highlights": -20,
+                "shadows": 35,
+                "whites": 12,
+                "blacks": -8,
+                "vibrance": 25,
+            }
+        }
+    ) == {
+        "version": 1,
+        "adjustments": {
+            "highlights": -20.0,
+            "shadows": 35.0,
+            "whites": 12.0,
+            "blacks": -8.0,
+            "vibrance": 25.0,
+        },
+    }
+
+
 def test_normalize_recipe_rejects_invalid_white_balance():
     with pytest.raises(RecipeError, match="white_balance.temperature"):
         normalize_recipe({"adjustments": {"white_balance": {"temperature": 200}}})
+
+
+def test_normalize_recipe_rejects_invalid_expanded_adjustment():
+    with pytest.raises(RecipeError, match="highlights adjustment"):
+        normalize_recipe({"adjustments": {"highlights": 200}})
 
 
 def test_apply_recipe_rotates_flips_and_crops():
@@ -130,6 +158,36 @@ def test_apply_recipe_adjusts_exposure_white_balance_contrast_and_saturation():
     assert max(r, g, b) > 100
 
 
+def test_apply_recipe_adjusts_expanded_tone_controls():
+    img = Image.fromarray(
+        np.array(
+            [
+                [[35, 35, 35], [128, 110, 96], [230, 230, 230]],
+            ],
+            dtype=np.uint8,
+        ),
+        "RGB",
+    )
+
+    edited = apply_recipe(
+        img,
+        {
+            "adjustments": {
+                "shadows": 60,
+                "highlights": -60,
+                "whites": 30,
+                "blacks": -30,
+                "vibrance": 40,
+            },
+        },
+    )
+
+    dark, mid, bright = [edited.getpixel((x, 0)) for x in range(3)]
+    assert sum(dark) > 35 * 3
+    assert sum(bright) < 230 * 3
+    assert max(mid) - min(mid) > 128 - 96
+
+
 @pytest.mark.parametrize("mode", ["RGB", "RGBA"])
 def test_apply_recipe_tiling_matches_single_pass(mode, monkeypatch):
     """A multi-tile image must be byte-identical to a whole-frame pass.
@@ -149,8 +207,13 @@ def test_apply_recipe_tiling_matches_single_pass(mode, monkeypatch):
     recipe = {
         "adjustments": {
             "exposure": 1.3,
+            "highlights": -30,
+            "shadows": 45,
+            "whites": 15,
+            "blacks": -10,
             "contrast": 15,
             "white_balance": {"temperature": 40, "tint": -20},
+            "vibrance": 35,
             "saturation": 25,
         }
     }
@@ -165,7 +228,12 @@ def test_apply_recipe_tiling_matches_single_pass(mode, monkeypatch):
         arr[..., :3],
         exposure=1.3,
         white_balance={"temperature": 40, "tint": -20},
+        highlights=-30,
+        shadows=45,
+        whites=15,
+        blacks=-10,
         contrast=15,
+        vibrance=35,
         saturation=25,
     )
     ref8 = np.clip(ref_rgb * 255.0 + 0.5, 0, 255).astype(np.uint8)

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -2052,9 +2052,14 @@ def test_edit_recipe_api_stores_adjustments(client_with_photo):
             "recipe": {
                 "adjustments": {
                     "exposure": 0.5,
+                    "highlights": -20,
+                    "shadows": 35,
+                    "whites": 12,
+                    "blacks": -8,
                     "contrast": 12,
                     "temperature": 25,
                     "tint": -8,
+                    "vibrance": 22,
                     "saturation": 18,
                 },
             },
@@ -2065,7 +2070,12 @@ def test_edit_recipe_api_stores_adjustments(client_with_photo):
     stored = db.get_photo_edit_recipe(photo_id)
     assert stored["adjustments"] == {
         "exposure": 0.5,
+        "highlights": -20.0,
+        "shadows": 35.0,
+        "whites": 12.0,
+        "blacks": -8.0,
         "contrast": 12.0,
+        "vibrance": 22.0,
         "saturation": 18.0,
         "white_balance": {
             "temperature": 25.0,

--- a/vireo/tests/test_tone.py
+++ b/vireo/tests/test_tone.py
@@ -8,6 +8,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 from tone import (
     HIGHLIGHT_KNEE,
     apply_adjustments,
+    apply_vibrance,
     highlight_rolloff,
     linear_to_srgb,
     srgb_to_linear,
@@ -106,3 +107,42 @@ def test_saturation_zero_is_grey_and_preserves_luma():
     out = apply_adjustments(rgb, saturation=-100.0)
     r, g, b = out[0, 0]
     assert abs(r - g) < 1e-3 and abs(g - b) < 1e-3  # fully desaturated -> grey
+
+
+def test_shadows_lift_dark_pixels_more_than_midtones():
+    rgb = np.array([[[0.12, 0.12, 0.12], [0.55, 0.55, 0.55]]], dtype=np.float32)
+    out = apply_adjustments(rgb, shadows=80)
+    dark_delta = float(out[0, 0, 0] - rgb[0, 0, 0])
+    mid_delta = float(out[0, 1, 0] - rgb[0, 1, 0])
+    assert dark_delta > mid_delta
+    assert dark_delta > 0
+
+
+def test_highlights_pull_bright_pixels_more_than_midtones():
+    rgb = np.array([[[0.55, 0.55, 0.55], [0.9, 0.9, 0.9]]], dtype=np.float32)
+    out = apply_adjustments(rgb, highlights=-80)
+    mid_delta = float(rgb[0, 0, 0] - out[0, 0, 0])
+    bright_delta = float(rgb[0, 1, 0] - out[0, 1, 0])
+    assert bright_delta > mid_delta
+    assert bright_delta > 0
+
+
+def test_whites_and_blacks_target_extreme_ranges():
+    rgb = np.array(
+        [[[0.05, 0.05, 0.05], [0.30, 0.30, 0.30], [0.85, 0.85, 0.85]]],
+        dtype=np.float32,
+    )
+    out = apply_adjustments(rgb, blacks=-80, whites=80)
+    assert out[0, 0, 0] < rgb[0, 0, 0]
+    assert abs(float(out[0, 1, 0] - rgb[0, 1, 0])) < 0.02
+    assert out[0, 2, 0] > rgb[0, 2, 0]
+
+
+def test_positive_vibrance_prefers_less_saturated_colors():
+    low = np.array([[[0.55, 0.50, 0.48]]], dtype=np.float32)
+    high = np.array([[[0.95, 0.20, 0.10]]], dtype=np.float32)
+    low_out = apply_vibrance(low, 80)
+    high_out = apply_vibrance(high, 80)
+    low_gain = float(np.max(low_out) - np.min(low_out)) / float(np.max(low) - np.min(low))
+    high_gain = float(np.max(high_out) - np.min(high_out)) / float(np.max(high) - np.min(high))
+    assert low_gain > high_gain

--- a/vireo/tests/test_tone_shader_parity.py
+++ b/vireo/tests/test_tone_shader_parity.py
@@ -15,7 +15,7 @@ drift, that case fails.
 
 It can't execute the actual shader headlessly, but it locks the *formula*:
 sRGB<->linear transfer, the highlight-knee rolloff, the white-balance gains and
-push-gate, and the display-space contrast/saturation — in the same order.
+push-gate, and the display-space range/color controls — in the same order.
 """
 
 import os
@@ -47,7 +47,19 @@ def test_shader_knee_constant_matches_tone():
     assert float(match.group(1)) == tone.HIGHLIGHT_KNEE
 
 
-def _shader_mirror(c, exposure, wb_gain, contrast, saturation, rolloff):
+def _shader_mirror(
+    c,
+    exposure,
+    wb_gain,
+    highlights,
+    shadows,
+    whites,
+    blacks,
+    contrast,
+    vibrance,
+    saturation,
+    rolloff,
+):
     """numpy mirror of the GLSL fragment shader in VireoToneGL."""
     def srgb_to_linear(x):
         # GLSL: mix(x/12.92, pow((x+0.055)/1.055, 2.4), step(0.04045, x))
@@ -63,6 +75,26 @@ def _shader_mirror(c, exposure, wb_gain, contrast, saturation, rolloff):
         r = KNEE + h * (o / (o + h))
         return np.where(x > KNEE, r, x)
 
+    def blend_range(rgb, amount, mask):
+        a = amount / 100.0
+        m = abs(a) * mask
+        if a > 0:
+            return rgb + (1.0 - rgb) * m
+        return rgb - rgb * m
+
+    def apply_vibrance(rgb, amount):
+        a = amount / 100.0
+        if abs(a) < 1e-9:
+            return rgb
+        lum = (rgb @ np.array([0.2126, 0.7152, 0.0722]))[..., None]
+        chroma = np.clip(
+            np.max(rgb, axis=-1, keepdims=True) - np.min(rgb, axis=-1, keepdims=True),
+            0.0,
+            1.0,
+        )
+        factor = np.where(a > 0, 1.0 + a * (1.0 - chroma) * 0.85, 1.0 + a * 0.65)
+        return np.clip(lum + (rgb - lum) * factor, 0.0, 1.0)
+
     lin_pre = srgb_to_linear(c)
     lin = lin_pre * (2.0 ** exposure) * np.asarray(wb_gain)
     if rolloff:
@@ -71,7 +103,17 @@ def _shader_mirror(c, exposure, wb_gain, contrast, saturation, rolloff):
         # (unrolled) value — see the monotonicity note in apply_adjustments.
         lin = np.maximum(roll(lin), np.minimum(lin_pre, lin))
     disp = linear_to_srgb(lin)
+    range_luma = disp @ np.array([0.2126, 0.7152, 0.0722])
+    if shadows:
+        disp = blend_range(disp, shadows, (1.0 - tone.smoothstep(0.05, 0.65, range_luma))[..., None] * 0.48)
+    if highlights:
+        disp = blend_range(disp, highlights, tone.smoothstep(0.35, 0.95, range_luma)[..., None] * 0.42)
+    if blacks:
+        disp = blend_range(disp, blacks, (1.0 - tone.smoothstep(0.00, 0.30, range_luma))[..., None] * 0.34)
+    if whites:
+        disp = blend_range(disp, whites, tone.smoothstep(0.70, 1.00, range_luma)[..., None] * 0.34)
     disp = (disp - 0.5) * contrast + 0.5
+    disp = apply_vibrance(disp, vibrance)
     luma = disp @ np.array([0.2126, 0.7152, 0.0722])
     disp = luma[..., None] + (disp - luma[..., None]) * saturation
     return np.clip(disp, 0.0, 1.0)
@@ -81,17 +123,26 @@ def test_shader_matches_tone_for_full_recipe():
     rng = np.random.default_rng(1)
     px = rng.random((256, 3)).astype(np.float32)
     cases = [
-        (0.0, 0, 0, 0, 0),
-        (1.5, 0, 0, 0, 0),
-        (2.0, 60, -30, 10, 20),
-        (-1.0, 0, 0, 40, -50),
-        (0.0, 0, 0, 0, -100),
-        (3.0, -40, 25, -20, 35),
+        (0.0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+        (1.5, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+        (2.0, 60, -30, -25, 35, 10, -15, 10, 20, 20),
+        (-1.0, 0, 0, 20, -30, -25, 18, 40, 0, -50),
+        (0.0, 0, 0, 0, 0, 0, 0, 0, 30, -100),
+        (3.0, -40, 25, -40, 45, 20, -25, -20, 35, 35),
     ]
-    for ev, temp, tint, con, sat in cases:
+    for ev, temp, tint, hi, sh, wh, bl, con, vib, sat in cases:
         wb = {"temperature": temp, "tint": tint} if (temp or tint) else None
         expected = tone.apply_adjustments(
-            px[None, :, :], exposure=ev, white_balance=wb, contrast=con, saturation=sat
+            px[None, :, :],
+            exposure=ev,
+            white_balance=wb,
+            highlights=hi,
+            shadows=sh,
+            whites=wh,
+            blacks=bl,
+            contrast=con,
+            vibrance=vib,
+            saturation=sat,
         )[0]
 
         # The dispatcher (_lbApplyAdjustmentPreview) derives these from a base of
@@ -102,9 +153,14 @@ def test_shader_matches_tone_for_full_recipe():
             px,
             exposure=ev,
             wb_gain=(gr, gg, gb),
+            highlights=hi,
+            shadows=sh,
+            whites=wh,
+            blacks=bl,
             contrast=max(0.0, 1.0 + con / 100.0),
+            vibrance=vib,
             saturation=max(0.0, 1.0 + sat / 100.0),
             rolloff=pushed,
         )
         max_err = float(np.max(np.abs(got - expected)))
-        assert max_err < 2e-4, (ev, temp, tint, con, sat, max_err)
+        assert max_err < 2e-4, (ev, temp, tint, hi, sh, wh, bl, con, vib, sat, max_err)

--- a/vireo/tone.py
+++ b/vireo/tone.py
@@ -1,9 +1,10 @@
 """Scene-referred tone pipeline for non-destructive photo edits.
 
 This module is the single source of truth for how the editable adjustments
-(exposure, white balance, contrast, saturation) map input pixels to output
-pixels. Geometry (rotate/flip/straighten/crop) lives in ``image_edits`` and is
-not part of this pipeline.
+(exposure, white balance, highlights, shadows, whites, blacks, contrast,
+vibrance, saturation) map input pixels to output pixels. Geometry
+(rotate/flip/straighten/crop) lives in ``image_edits`` and is not part of this
+pipeline.
 
 Why this exists
 ---------------
@@ -17,7 +18,7 @@ flat white. This pipeline therefore:
   2. applies the scene-referred ops (exposure, white balance) in linear,
   3. rolls highlights off with a smooth shoulder (no hard clip to 1.0),
   4. re-encodes linear -> sRGB,
-  5. applies the display-referred ops (contrast, saturation) in sRGB.
+  5. applies the display-referred ops (range controls, contrast, color) in sRGB.
 
 Data ceiling: this operates on whatever 8-bit source it is handed. It produces
 a pleasing rolloff but cannot *recover* highlights that were already clipped
@@ -92,6 +93,13 @@ def highlight_rolloff(lin, knee=HIGHLIGHT_KNEE):
     return np.where(lin > knee, rolled, lin)
 
 
+def smoothstep(edge0, edge1, x):
+    """GLSL-compatible smoothstep for scalar or array inputs."""
+    x = np.asarray(x, dtype=np.float32)
+    t = np.clip((x - edge0) / (edge1 - edge0), 0.0, 1.0)
+    return t * t * (3.0 - 2.0 * t)
+
+
 def white_balance_gains(white_balance):
     """Return per-channel linear gains (r, g, b) for a white-balance dict.
 
@@ -107,12 +115,71 @@ def white_balance_gains(white_balance):
     return r, g, b
 
 
+def _luma(rgb):
+    return (
+        LUMA_R * rgb[..., 0]
+        + LUMA_G * rgb[..., 1]
+        + LUMA_B * rgb[..., 2]
+    )[..., None]
+
+
+def _blend_range(rgb, amount, mask):
+    """Move masked pixels toward white or black without hard clipping."""
+    amount = float(amount) / 100.0
+    if abs(amount) < 1e-9:
+        return rgb
+    mask = mask * abs(amount)
+    if amount > 0:
+        return rgb + (1.0 - rgb) * mask
+    return rgb - rgb * mask
+
+
+def apply_range_adjustments(
+    rgb, *, highlights=0.0, shadows=0.0, whites=0.0, blacks=0.0
+):
+    """Apply display-space tonal range controls with smooth luma masks."""
+    out = np.asarray(rgb, dtype=np.float32)
+    lum = _luma(out)
+
+    if shadows:
+        out = _blend_range(out, shadows, (1.0 - smoothstep(0.05, 0.65, lum)) * 0.48)
+    if highlights:
+        out = _blend_range(out, highlights, smoothstep(0.35, 0.95, lum) * 0.42)
+    if blacks:
+        out = _blend_range(out, blacks, (1.0 - smoothstep(0.00, 0.30, lum)) * 0.34)
+    if whites:
+        out = _blend_range(out, whites, smoothstep(0.70, 1.00, lum) * 0.34)
+
+    return np.clip(out, 0.0, 1.0)
+
+
+def apply_vibrance(rgb, vibrance=0.0):
+    """Apply luma-preserving selective saturation."""
+    amount = float(vibrance) / 100.0
+    if abs(amount) < 1e-9:
+        return rgb
+    luma = _luma(rgb)
+    maxc = np.max(rgb, axis=-1, keepdims=True)
+    minc = np.min(rgb, axis=-1, keepdims=True)
+    chroma = np.clip(maxc - minc, 0.0, 1.0)
+    if amount > 0:
+        factor = 1.0 + amount * (1.0 - chroma) * 0.85
+    else:
+        factor = 1.0 + amount * 0.65
+    return np.clip(luma + (rgb - luma) * factor, 0.0, 1.0)
+
+
 def apply_adjustments(
     rgb,
     *,
     exposure=0.0,
     white_balance=None,
+    highlights=0.0,
+    shadows=0.0,
+    whites=0.0,
+    blacks=0.0,
     contrast=0.0,
+    vibrance=0.0,
     saturation=0.0,
 ):
     """Apply tonal adjustments to an sRGB float image and return sRGB float.
@@ -121,7 +188,12 @@ def apply_adjustments(
         rgb: float array shaped ``(..., 3)`` with sRGB-encoded values in [0,1].
         exposure: stops of exposure (linear gain ``2 ** exposure``).
         white_balance: dict with ``temperature``/``tint`` in [-100, 100], or None.
+        highlights: [-100, 100]; display-space highlight range adjustment.
+        shadows: [-100, 100]; display-space shadow range adjustment.
+        whites: [-100, 100]; display-space white point range adjustment.
+        blacks: [-100, 100]; display-space black point range adjustment.
         contrast: [-100, 100]; a linear contrast around mid-grey (0.5).
+        vibrance: [-100, 100]; luma-preserving selective saturation.
         saturation: [-100, 100]; luma-preserving saturation in display space.
 
     Returns:
@@ -159,16 +231,22 @@ def apply_adjustments(
 
     # --- display-referred ops, in sRGB ---
     disp = linear_to_srgb(lin)
+    if highlights or shadows or whites or blacks:
+        disp = apply_range_adjustments(
+            disp,
+            highlights=highlights,
+            shadows=shadows,
+            whites=whites,
+            blacks=blacks,
+        )
     if contrast:
         c = np.float32(1.0 + float(contrast) / 100.0)
         disp = (disp - 0.5) * c + 0.5
+    if vibrance:
+        disp = apply_vibrance(disp, vibrance)
     if saturation:
         s = np.float32(max(0.0, 1.0 + float(saturation) / 100.0))
-        luma = (
-            LUMA_R * disp[..., 0]
-            + LUMA_G * disp[..., 1]
-            + LUMA_B * disp[..., 2]
-        )[..., None]
+        luma = _luma(disp)
         disp = luma + (disp - luma) * s
 
     return np.clip(disp, 0.0, 1.0)


### PR DESCRIPTION
Adds expanded non-destructive tone controls for highlights, shadows, whites, blacks, and vibrance across the recipe schema and renderer. Wires the controls into the full photo editor and lightbox quick adjustment panel, including WebGL preview parity and an edit math cache bump. Updates API storage and rendering coverage for the new recipe fields. Validation: python -m pytest vireo/tests/test_tone.py vireo/tests/test_image_edits.py vireo/tests/test_tone_shader_parity.py vireo/tests/test_photos_api.py::test_edit_recipe_api_stores_adjustments vireo/tests/test_export.py::test_export_photos_applies_adjustment_recipe vireo/tests/test_photos_api.py::test_photo_editor_page_renders vireo/tests/test_app.py::test_browse_page vireo/tests/test_app.py::test_pages_link_base_css vireo/tests/test_app.py::test_pages_include_vireo_utils -q; python -m ruff check vireo/tone.py vireo/image_edits.py vireo/tests/test_tone.py vireo/tests/test_image_edits.py vireo/tests/test_tone_shader_parity.py vireo/tests/test_photos_api.py vireo/tests/test_export.py; git diff --check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new tone controls for Highlights, Shadows, Whites, Blacks, and Vibrance across the editor and live preview.
  * Expanded adjustment handling so these controls are saved, restored, and rendered consistently.

* **Bug Fixes**
  * Improved adjustment processing so tonal changes apply more accurately across dark and bright regions.
  * Updated cached rendering behavior so edited images refresh correctly after tonal changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->