### PR TITLE
Preserve RAW highlights in edit renders

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -18613,16 +18613,21 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             recipe = db.get_photo_edit_recipe(photo_id) or {}
         if not isinstance(recipe, dict):
             return "Invalid recipe", 400
-        display_recipe = dict(recipe)
-        display_recipe.pop("crop", None)
 
         try:
-            from image_edits import RecipeError, apply_recipe_to_loaded_image
+            from image_edits import (
+                RecipeError,
+                apply_recipe_to_loaded_image,
+                normalize_recipe,
+            )
             from image_loader import (
                 RAW_DECODE_PRESERVE_HIGHLIGHTS,
                 RAW_EXTENSIONS,
                 load_image,
             )
+            recipe = normalize_recipe(recipe) or {}
+            display_recipe = dict(recipe)
+            display_recipe.pop("crop", None)
             recipe_json = display_recipe
             vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
             folder_row = db.conn.execute(

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -13195,6 +13195,39 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         {"raw_decode": raw_decode} if raw_decode else {}
                     )
                     img = load_image(canonical, max_size=load_max_size, **load_kwargs)
+                    if (
+                        img is None
+                        and os.path.splitext(canonical)[1].lower() in RAW_EXTENSIONS
+                    ):
+                        # Mirror serve_preview's cache-miss fallback: libraw
+                        # couldn't decode this RAW (unsupported variant, etc.),
+                        # so try the companion JPEG before leaving the cache
+                        # cold. Record the source failure so future
+                        # _recipe_render_source calls (preview, edit-preview,
+                        # original) select the companion directly instead of
+                        # retrying the failed RAW.
+                        companion_rel = detail_photo["companion_path"]
+                        folder_path = folders.get(detail_photo["folder_id"])
+                        if companion_rel and folder_path:
+                            companion_abs = os.path.join(folder_path, companion_rel)
+                            if (
+                                os.path.exists(companion_abs)
+                                and companion_abs != canonical
+                            ):
+                                log.info(
+                                    "RAW decode failed for photo %s preview "
+                                    "warmup at size=%s; falling back to "
+                                    "companion JPEG",
+                                    detail_photo["id"], max_size,
+                                )
+                                _record_working_copy_failure(
+                                    thread_db, detail_photo, canonical,
+                                )
+                                img = load_image(
+                                    companion_abs, max_size=load_max_size,
+                                )
+                                if img is not None:
+                                    canonical = companion_abs
                     if img:
                         if recipe:
                             img = apply_recipe_to_loaded_image(
@@ -18339,6 +18372,25 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             )
             load_kwargs = {"raw_decode": raw_decode} if raw_decode else {}
             img = load_image(canonical, max_size=size, **load_kwargs)
+            if img is None and selected_ext in RAW_EXTENSIONS:
+                # Same companion fallback as serve_preview's cache-miss
+                # path: an unsupported RAW shouldn't kill the in-progress
+                # edit preview when a usable companion JPEG sits next to it.
+                companion_rel = photo["companion_path"]
+                if companion_rel:
+                    companion_abs = os.path.join(folder_row["path"], companion_rel)
+                    if (
+                        os.path.exists(companion_abs)
+                        and companion_abs != canonical
+                    ):
+                        log.info(
+                            "RAW decode failed for photo %s edit-preview; "
+                            "falling back to companion JPEG", photo_id,
+                        )
+                        _record_working_copy_failure(db, photo, canonical)
+                        img = load_image(companion_abs, max_size=size)
+                        if img is not None:
+                            canonical = companion_abs
             if img is None:
                 _record_working_copy_failure(db, photo, canonical)
                 return "Could not load image", 500
@@ -18482,6 +18534,23 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 )
                 image_ext = os.path.splitext(image_path)[1].lower()
                 if companion_source and image_ext not in RAW_EXTENSIONS:
+                    image_path = companion_source
+                elif (
+                    primary_is_raw
+                    and companion_source
+                    and _has_current_working_copy_failure(
+                        photo,
+                        vireo_dir,
+                        trust_existing_working_copy=False,
+                        live_source_path=image_path,
+                        folder_path=folder["path"],
+                    )
+                ):
+                    # Mirror _recipe_render_source: when scanner has marked
+                    # this RAW as failed for the current mtime, route the
+                    # edited render through the companion JPEG so a previous
+                    # request that already succeeded via the companion
+                    # fallback isn't shadowed by the pre-load guard below.
                     image_path = companion_source
             resolved_ext = os.path.splitext(image_path)[1].lower()
             if (

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -9199,6 +9199,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("No photos found", 404)
 
         def _external_edit_recipe_source(photo, recipe, fallback_path):
+            from image_loader import RAW_EXTENSIONS
+
             if recipe.get("crop"):
                 source_path, _using_working_copy = _recipe_render_source(
                     photo, recipe, 0, vireo_dir, folders,
@@ -9217,18 +9219,27 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 ):
                     return wc_path
 
+            # For RAW primaries, never substitute the companion JPEG: its
+            # highlights are already clipped, so the handoff would apply the
+            # recipe to a clipped render even though the RAW would have been
+            # decoded with RAW_DECODE_PRESERVE_HIGHLIGHTS otherwise.
+            primary_is_raw = (
+                os.path.splitext(photo["filename"])[1].lower() in RAW_EXTENSIONS
+            )
+
             folder_path = folders.get(photo["folder_id"])
             if folder_path:
-                companion_path = photo["companion_path"]
-                if companion_path:
-                    companion = os.path.join(folder_path, companion_path)
-                    if (
-                        os.path.exists(companion)
-                        and _path_satisfies_recipe_render(
-                            companion, photo, recipe, 0,
-                        )
-                    ):
-                        return companion
+                if not primary_is_raw:
+                    companion_path = photo["companion_path"]
+                    if companion_path:
+                        companion = os.path.join(folder_path, companion_path)
+                        if (
+                            os.path.exists(companion)
+                            and _path_satisfies_recipe_render(
+                                companion, photo, recipe, 0,
+                            )
+                        ):
+                            return companion
                 original = os.path.join(folder_path, photo["filename"])
                 if os.path.exists(original):
                     return original
@@ -11415,6 +11426,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         return jsonify(result)
 
     def _inat_edit_recipe_source(photo, recipe, fallback_path):
+        from image_loader import RAW_EXTENSIONS
+
         vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
         folders = {photo["folder_id"]: photo["folder_path"]}
         if recipe.get("crop"):
@@ -11434,6 +11447,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 and _path_satisfies_recipe_render(wc_path, photo, recipe, 0)
             ):
                 return wc_path
+
+        # RAW primaries are decoded with RAW_DECODE_PRESERVE_HIGHLIGHTS later;
+        # substituting the camera JPEG companion here would apply the recipe
+        # to a clipped render instead.
+        if os.path.splitext(photo["filename"])[1].lower() in RAW_EXTENSIONS:
+            return fallback_path
 
         companion_path = photo["companion_path"]
         if companion_path:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1871,7 +1871,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def _orientation_swaps_axes(orientation):
         if orientation is None or isinstance(orientation, bool):
             return False
-        if isinstance(orientation, (int, float)):
+        if isinstance(orientation, int | float):
             return int(orientation) in (5, 6, 7, 8)
         text = str(orientation).strip().lower()
         if not text:
@@ -9244,7 +9244,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 apply_recipe,
                 recipe_to_json,
             )
-            from image_loader import load_image
+            from image_loader import (
+                RAW_DECODE_PRESERVE_HIGHLIGHTS,
+                RAW_EXTENSIONS,
+                load_image,
+            )
 
             source_path = _external_edit_recipe_source(
                 photo, recipe, fallback_path,
@@ -9277,7 +9281,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             except (OSError, ValueError, TypeError):
                 pass
 
-            img = load_image(source_path, max_size=None)
+            raw_decode = (
+                RAW_DECODE_PRESERVE_HIGHLIGHTS
+                if os.path.splitext(source_path)[1].lower() in RAW_EXTENSIONS
+                else None
+            )
+            load_kwargs = {"raw_decode": raw_decode} if raw_decode else {}
+            img = load_image(source_path, max_size=None, **load_kwargs)
             if img is None:
                 return None, f"{photo['filename']}: failed to load image"
             rendered = None
@@ -11444,7 +11454,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return fallback_path, None
 
         from image_edits import EDIT_MATH_VERSION, apply_recipe, recipe_to_json
-        from image_loader import load_image
+        from image_loader import (
+            RAW_DECODE_PRESERVE_HIGHLIGHTS,
+            RAW_EXTENSIONS,
+            load_image,
+        )
 
         source_path = _inat_edit_recipe_source(photo, recipe, fallback_path)
         if not source_path or not os.path.isfile(source_path):
@@ -11475,7 +11489,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         except (OSError, ValueError, TypeError):
             pass
 
-        img = load_image(source_path, max_size=None)
+        raw_decode = (
+            RAW_DECODE_PRESERVE_HIGHLIGHTS
+            if os.path.splitext(source_path)[1].lower() in RAW_EXTENSIONS
+            else None
+        )
+        load_kwargs = {"raw_decode": raw_decode} if raw_decode else {}
+        img = load_image(source_path, max_size=None, **load_kwargs)
         if img is None:
             return None, f"{photo['filename']}: failed to load image"
         rendered = None
@@ -17971,7 +17991,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return Response(data, mimetype="image/jpeg")
 
         # Cache miss: generate, insert, evict-if-over-quota, serve.
-        from image_loader import RAW_EXTENSIONS, load_image
+        from image_loader import (
+            RAW_DECODE_PRESERVE_HIGHLIGHTS,
+            RAW_EXTENSIONS,
+            load_image,
+        )
 
         folder_row = db.conn.execute(
             "SELECT id, path FROM folders WHERE id=?", (photo["folder_id"],)
@@ -18002,7 +18026,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             )
             return "Could not load image", 500
         load_max_size = None if recipe and recipe.get("crop") else size
-        img = load_image(canonical, max_size=load_max_size)
+        raw_decode = (
+            RAW_DECODE_PRESERVE_HIGHLIGHTS
+            if recipe and selected_ext in RAW_EXTENSIONS
+            else None
+        )
+        load_kwargs = {"raw_decode": raw_decode} if raw_decode else {}
+        img = load_image(canonical, max_size=load_max_size, **load_kwargs)
         if img is None:
             _record_working_copy_failure(db, photo, canonical)
             return "Could not load image", 500
@@ -18110,7 +18140,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         try:
             from image_edits import RecipeError, apply_recipe_to_loaded_image
-            from image_loader import RAW_EXTENSIONS, load_image
+            from image_loader import (
+                RAW_DECODE_PRESERVE_HIGHLIGHTS,
+                RAW_EXTENSIONS,
+                load_image,
+            )
             recipe_json = display_recipe
             vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
             folder_row = db.conn.execute(
@@ -18139,7 +18173,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     photo_id,
                 )
                 return "Could not load image", 500
-            img = load_image(canonical, max_size=size)
+            raw_decode = (
+                RAW_DECODE_PRESERVE_HIGHLIGHTS
+                if selected_ext in RAW_EXTENSIONS
+                else None
+            )
+            load_kwargs = {"raw_decode": raw_decode} if raw_decode else {}
+            img = load_image(canonical, max_size=size, **load_kwargs)
             if img is None:
                 _record_working_copy_failure(db, photo, canonical)
                 return "Could not load image", 500
@@ -18249,6 +18289,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return None
 
         if recipe:
+            from image_loader import (
+                RAW_DECODE_PRESERVE_HIGHLIGHTS,
+                RAW_EXTENSIONS,
+                load_image,
+            )
+
             folder = db.conn.execute(
                 "SELECT path FROM folders WHERE id=?", (photo["folder_id"],)
             ).fetchone()
@@ -18267,9 +18313,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 companion_source = _full_res_companion_path(
                     folder["path"], using_offline_cache,
                 )
-                if companion_source:
+                image_ext = os.path.splitext(image_path)[1].lower()
+                if companion_source and image_ext not in RAW_EXTENSIONS:
                     image_path = companion_source
-            from image_loader import RAW_EXTENSIONS, load_image
             resolved_ext = os.path.splitext(image_path)[1].lower()
             if (
                 trusted_wc_path is None
@@ -18288,7 +18334,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     photo_id,
                 )
                 return "Could not load image", 500
-            img = load_image(image_path, max_size=None)
+            raw_decode = (
+                RAW_DECODE_PRESERVE_HIGHLIGHTS
+                if resolved_ext in RAW_EXTENSIONS
+                else None
+            )
+            load_kwargs = {"raw_decode": raw_decode} if raw_decode else {}
+            img = load_image(image_path, max_size=None, **load_kwargs)
             if img is None:
                 _record_working_copy_failure(db, photo, image_path)
                 return "Could not load image", 500
@@ -18329,7 +18381,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             {photo["folder_id"]: folder["path"]},
         )
 
-        from image_loader import RAW_EXTENSIONS
+        from image_loader import (
+            RAW_DECODE_PRESERVE_HIGHLIGHTS,
+            RAW_EXTENSIONS,
+        )
         resolved_ext = os.path.splitext(image_path)[1].lower()
         if (
             (not using_offline_cache or resolved_ext in RAW_EXTENSIONS)
@@ -18351,19 +18406,25 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return send_file(image_path)
 
         # Extract full-res working copy (on-demand upgrade)
-        from image_loader import extract_working_copy, load_image
+        from image_loader import (
+            RAW_DECODE_PRESERVE_HIGHLIGHTS,
+            RAW_EXTENSIONS,
+            extract_working_copy,
+            load_image,
+        )
         wc_rel = f"working/{photo_id}.jpg"
         wc_abs = os.path.join(vireo_dir, wc_rel)
         quality = cfg.load().get("working_copy_quality", 92)
 
-        # Prefer companion JPEG as extraction source — avoids slow RAW decode.
-        # Only use it when we can confirm it is full-resolution: its pixel
-        # dimensions must be at least as large as the stored original
-        # dimensions.  If original dimensions are unknown (None) we cannot
-        # make that guarantee, so fall back to decoding from the RAW.
-        source_for_extraction = (
-            _full_res_companion_path(folder["path"], using_offline_cache) or image_path
+        # Prefer companion JPEG only for non-RAW sources. RAW primaries should
+        # be decoded through extract_working_copy's highlight-preserving RAW
+        # path rather than replaced with a camera-rendered JPEG.
+        companion_for_extraction = _full_res_companion_path(
+            folder["path"], using_offline_cache
         )
+        source_for_extraction = image_path
+        if resolved_ext not in RAW_EXTENSIONS and companion_for_extraction:
+            source_for_extraction = companion_for_extraction
 
         if extract_working_copy(source_for_extraction, wc_abs, max_size=0, quality=quality):
             # Update DB so future requests are fast; also backfill
@@ -18385,7 +18446,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return send_file(wc_abs, mimetype="image/jpeg")
 
         # Fallback: serve via load_image
-        img = load_image(image_path, max_size=None)
+        raw_decode = (
+            RAW_DECODE_PRESERVE_HIGHLIGHTS
+            if resolved_ext in RAW_EXTENSIONS
+            else None
+        )
+        load_kwargs = {"raw_decode": raw_decode} if raw_decode else {}
+        img = load_image(image_path, max_size=None, **load_kwargs)
         if img is None:
             _record_working_copy_failure(db, photo, image_path)
             return "Could not load image", 500

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -9367,9 +9367,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         != os.path.abspath(source_path)
                     ):
                         companion_img = load_image(companion_abs, max_size=None)
+                        # Prefer companion when it covers img on both axes —
+                        # a long-edge-only check misses cases like a
+                        # 6000x3376 embedded preview "tying" a 6000x4000
+                        # sidecar and losing the short-edge content.
                         if companion_img is not None and (
                             img is None
-                            or max(companion_img.size) > max(img.size)
+                            or (
+                                companion_img.size[0] >= img.size[0]
+                                and companion_img.size[1] >= img.size[1]
+                                and companion_img.size != img.size
+                            )
                         ):
                             if img is None:
                                 log.info(
@@ -9382,9 +9390,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                                 log.info(
                                     "External-edit RAW decode fell back to "
                                     "undersized embedded JPEG (%dx%d) for "
-                                    "photo %s; using companion JPEG %s",
+                                    "photo %s; using companion JPEG %s "
+                                    "(%dx%d)",
                                     img.size[0], img.size[1], photo["id"],
                                     companion_abs,
+                                    companion_img.size[0],
+                                    companion_img.size[1],
                                 )
                                 img.close()
                             img = companion_img
@@ -11648,9 +11659,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     != os.path.abspath(source_path)
                 ):
                     companion_img = load_image(companion_abs, max_size=None)
+                    # Prefer companion when it covers img on both axes — a
+                    # long-edge-only check misses cases like a 6000x3376
+                    # embedded preview "tying" a 6000x4000 sidecar and
+                    # losing the short-edge content.
                     if companion_img is not None and (
                         img is None
-                        or max(companion_img.size) > max(img.size)
+                        or (
+                            companion_img.size[0] >= img.size[0]
+                            and companion_img.size[1] >= img.size[1]
+                            and companion_img.size != img.size
+                        )
                     ):
                         if img is None:
                             log.info(
@@ -11662,9 +11681,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                             log.info(
                                 "iNat upload RAW decode fell back to "
                                 "undersized embedded JPEG (%dx%d) for "
-                                "photo %s; using companion JPEG %s",
+                                "photo %s; using companion JPEG %s (%dx%d)",
                                 img.size[0], img.size[1], photo["id"],
                                 companion_abs,
+                                companion_img.size[0],
+                                companion_img.size[1],
                             )
                             img.close()
                         img = companion_img

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -9274,14 +9274,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 ):
                     return wc_path
 
-            # For RAW primaries, never substitute the companion JPEG: its
-            # highlights are already clipped, so the handoff would apply the
-            # recipe to a clipped render even though the RAW would have been
-            # decoded with RAW_DECODE_PRESERVE_HIGHLIGHTS otherwise.
-
             folder_path = folders.get(photo["folder_id"])
             if folder_path:
-                if not primary_is_raw:
+                raw_source_available = os.path.exists(fallback_path)
+                # For RAW primaries, skip the companion JPEG while the RAW is
+                # available so edits render from the preserve-highlights decode.
+                # If the RAW volume is offline, a full-size sidecar is the best
+                # remaining local source.
+                if not primary_is_raw or not raw_source_available:
                     companion_path = photo["companion_path"]
                     if companion_path:
                         companion = os.path.join(folder_path, companion_path)
@@ -11586,14 +11586,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             ):
                 return wc_path
 
-        # RAW primaries are decoded with RAW_DECODE_PRESERVE_HIGHLIGHTS later;
-        # substituting the camera JPEG companion here would apply the recipe
-        # to a clipped render instead.
-        if primary_is_raw:
-            return fallback_path
-
         companion_path = photo["companion_path"]
-        if companion_path:
+        raw_source_available = os.path.exists(fallback_path)
+        # RAW primaries are decoded with RAW_DECODE_PRESERVE_HIGHLIGHTS later;
+        # only use the clipped camera JPEG when the RAW source is offline.
+        if companion_path and (not primary_is_raw or not raw_source_available):
             companion = os.path.join(photo["folder_path"], companion_path)
             if (
                 os.path.exists(companion)
@@ -11793,7 +11790,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 )
                 if wc_rel else None
             )
-            if not (recipe and wc_abs and os.path.isfile(wc_abs)):
+            companion_abs = (
+                os.path.join(photo["folder_path"], photo["companion_path"])
+                if photo["companion_path"] else None
+            )
+            if not (
+                recipe
+                and (
+                    (wc_abs and os.path.isfile(wc_abs))
+                    or (companion_abs and os.path.isfile(companion_abs))
+                )
+            ):
                 return json_error("Photo file not found on disk", 404)
 
         upload_path, upload_error = _inat_upload_photo_path(db, photo, photo_path)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1944,7 +1944,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         return _rendered_recipe_long_edge(width, height, recipe) >= required_long
 
     def _recipe_render_source(photo, recipe, max_size, vireo_dir, folders):
-        from image_loader import get_canonical_image_path
+        from image_loader import RAW_EXTENSIONS, get_canonical_image_path
 
         def _is_working_copy_path(path):
             wc_rel = photo["working_copy_path"]
@@ -1957,14 +1957,26 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             canonical = get_canonical_image_path(photo, vireo_dir, folders)
             return canonical, _is_working_copy_path(canonical)
 
-        canonical = get_canonical_image_path(photo, vireo_dir, folders)
-        if not recipe.get("crop") and _is_working_copy_path(canonical):
-            return canonical, True
+        primary_is_raw = (
+            os.path.splitext(photo["filename"])[1].lower() in RAW_EXTENSIONS
+        )
 
-        if recipe.get("crop") and _working_copy_satisfies_recipe_render(
-            photo, recipe, max_size, vireo_dir,
-        ):
-            return canonical, _is_working_copy_path(canonical)
+        canonical = get_canonical_image_path(photo, vireo_dir, folders)
+        # For RAW primaries with a recipe, never short-circuit to the working
+        # copy: legacy working copies predate the highlight-preserving RAW
+        # decode and EDIT_MATH_VERSION's migration only purges preview/thumb
+        # caches, not working copies. Reusing one would apply the recipe to
+        # clipped bytes and bypass RAW_DECODE_PRESERVE_HIGHLIGHTS. Force the
+        # RAW path; the working copy is still the very last fallback below
+        # if the RAW file itself is missing.
+        if not primary_is_raw:
+            if not recipe.get("crop") and _is_working_copy_path(canonical):
+                return canonical, True
+
+            if recipe.get("crop") and _working_copy_satisfies_recipe_render(
+                photo, recipe, max_size, vireo_dir,
+            ):
+                return canonical, _is_working_copy_path(canonical)
 
         folder_path = folders.get(photo["folder_id"])
         if not folder_path:
@@ -1979,10 +1991,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # the RAW is known to fail extraction for this mtime — otherwise edited
         # previews for unsupported RAWs would 500 out even when a full-size
         # companion is available.
-        from image_loader import RAW_EXTENSIONS
-        primary_is_raw = (
-            os.path.splitext(photo["filename"])[1].lower() in RAW_EXTENSIONS
-        )
         companion_path = photo["companion_path"]
         original_abs = os.path.join(folder_path, photo["filename"])
         allow_companion = not primary_is_raw or _has_current_working_copy_failure(
@@ -9215,14 +9223,21 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         def _external_edit_recipe_source(photo, recipe, fallback_path):
             from image_loader import RAW_EXTENSIONS
 
+            primary_is_raw = (
+                os.path.splitext(photo["filename"])[1].lower() in RAW_EXTENSIONS
+            )
+
             if recipe.get("crop"):
                 source_path, _using_working_copy = _recipe_render_source(
                     photo, recipe, 0, vireo_dir, folders,
                 )
                 return source_path or fallback_path
 
+            # For RAW primaries, skip the working-copy short-circuit: legacy
+            # working copies predate the highlight-preserving RAW decode and
+            # would feed the editor a clipped JPEG to apply the recipe to.
             wc_rel = photo["working_copy_path"]
-            if wc_rel:
+            if wc_rel and not primary_is_raw:
                 wc_path = (
                     wc_rel if os.path.isabs(wc_rel)
                     else os.path.join(vireo_dir, wc_rel)
@@ -9237,9 +9252,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # highlights are already clipped, so the handoff would apply the
             # recipe to a clipped render even though the RAW would have been
             # decoded with RAW_DECODE_PRESERVE_HIGHLIGHTS otherwise.
-            primary_is_raw = (
-                os.path.splitext(photo["filename"])[1].lower() in RAW_EXTENSIONS
-            )
 
             folder_path = folders.get(photo["folder_id"])
             if folder_path:
@@ -11448,14 +11460,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
         folders = {photo["folder_id"]: photo["folder_path"]}
+        primary_is_raw = (
+            os.path.splitext(photo["filename"])[1].lower() in RAW_EXTENSIONS
+        )
         if recipe.get("crop"):
             source_path, _using_working_copy = _recipe_render_source(
                 photo, recipe, 0, vireo_dir, folders,
             )
             return source_path or fallback_path
 
+        # For RAW primaries, skip the working-copy short-circuit: legacy
+        # working copies predate the highlight-preserving RAW decode and
+        # would feed iNat a clipped JPEG to apply the recipe to.
         wc_rel = photo["working_copy_path"]
-        if wc_rel:
+        if wc_rel and not primary_is_raw:
             wc_path = (
                 wc_rel if os.path.isabs(wc_rel)
                 else os.path.join(vireo_dir, wc_rel)
@@ -11469,7 +11487,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # RAW primaries are decoded with RAW_DECODE_PRESERVE_HIGHLIGHTS later;
         # substituting the camera JPEG companion here would apply the recipe
         # to a clipped render instead.
-        if os.path.splitext(photo["filename"])[1].lower() in RAW_EXTENSIONS:
+        if primary_is_raw:
             return fallback_path
 
         companion_path = photo["companion_path"]
@@ -18355,7 +18373,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             ).fetchone()
             if not folder:
                 return "Not found", 404
-            image_path = trusted_wc_path
+            # For edited RAW primaries, a "trusted" working copy can still
+            # predate the highlight-preserving RAW decode (the migration
+            # purges previews and thumbnails but not working copies). Force
+            # the RAW path so the recipe runs over preserve-highlights bytes,
+            # not the older clipped-JPEG working copy.
+            primary_is_raw = (
+                os.path.splitext(photo["filename"])[1].lower() in RAW_EXTENSIONS
+            )
+            image_path = None if primary_is_raw else trusted_wc_path
             using_offline_cache = False
             if image_path is None:
                 from offline_cache import resolve_original_path
@@ -18373,7 +18399,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     image_path = companion_source
             resolved_ext = os.path.splitext(image_path)[1].lower()
             if (
-                trusted_wc_path is None
+                (primary_is_raw or trusted_wc_path is None)
                 and resolved_ext in RAW_EXTENSIONS
                 and _has_current_working_copy_failure(
                     photo,
@@ -18396,6 +18422,23 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             )
             load_kwargs = {"raw_decode": raw_decode} if raw_decode else {}
             img = load_image(image_path, max_size=None, **load_kwargs)
+            if img is None and resolved_ext in RAW_EXTENSIONS:
+                # RAW couldn't decode (unsupported variant, no embedded JPEG).
+                # Fall back to the full-resolution companion JPEG when one
+                # exists so an unsupported-RAW edit doesn't 500 with a usable
+                # sidecar sitting next to the RAW.
+                companion_fallback = _full_res_companion_path(
+                    folder["path"], using_offline_cache,
+                )
+                if companion_fallback and companion_fallback != image_path:
+                    log.info(
+                        "RAW decode failed for photo %s edited original; "
+                        "falling back to companion JPEG", photo_id,
+                    )
+                    _record_working_copy_failure(db, photo, image_path)
+                    img = load_image(companion_fallback, max_size=None)
+                    if img is not None:
+                        image_path = companion_fallback
             if img is None:
                 _record_working_copy_failure(db, photo, image_path)
                 return "Could not load image", 500
@@ -18500,6 +18543,39 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             db.conn.commit()
             return send_file(wc_abs, mimetype="image/jpeg")
 
+        # extract_working_copy failed on a RAW source: try the full-res
+        # companion JPEG as a fallback before giving up. This catches
+        # unsupported RAW variants (libraw can't demosaic, no usable
+        # embedded JPEG) on RAW+JPEG rows — without it, a usable sidecar
+        # JPEG would be ignored and the request would 500.
+        if (
+            resolved_ext in RAW_EXTENSIONS
+            and companion_for_extraction
+            and companion_for_extraction != source_for_extraction
+            and extract_working_copy(
+                companion_for_extraction, wc_abs, max_size=0, quality=quality,
+            )
+        ):
+            from PIL import Image as _PILImage
+            with _PILImage.open(wc_abs) as upgraded:
+                uw, uh = upgraded.size
+            updates = ["working_copy_path=?"]
+            params = [wc_rel]
+            if not photo["width"] or not photo["height"]:
+                updates.extend(["width=?", "height=?"])
+                params.extend([uw, uh])
+            params.append(photo_id)
+            db.conn.execute(
+                f"UPDATE photos SET {', '.join(updates)} WHERE id=?",
+                params,
+            )
+            db.conn.commit()
+            log.info(
+                "RAW extraction failed for photo %s original; served "
+                "companion JPEG instead", photo_id,
+            )
+            return send_file(wc_abs, mimetype="image/jpeg")
+
         # Fallback: serve via load_image
         raw_decode = (
             RAW_DECODE_PRESERVE_HIGHLIGHTS
@@ -18508,6 +18584,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         )
         load_kwargs = {"raw_decode": raw_decode} if raw_decode else {}
         img = load_image(image_path, max_size=None, **load_kwargs)
+        if (
+            img is None
+            and resolved_ext in RAW_EXTENSIONS
+            and companion_for_extraction
+            and companion_for_extraction != image_path
+        ):
+            log.info(
+                "RAW decode failed for photo %s original; falling back to "
+                "companion JPEG", photo_id,
+            )
+            img = load_image(companion_for_extraction, max_size=None)
+            if img is not None:
+                image_path = companion_for_extraction
         if img is None:
             _record_working_copy_failure(db, photo, image_path)
             return "Could not load image", 500

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -18165,6 +18165,27 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         )
         load_kwargs = {"raw_decode": raw_decode} if raw_decode else {}
         img = load_image(canonical, max_size=load_max_size, **load_kwargs)
+        if img is None and selected_ext in RAW_EXTENSIONS:
+            # libraw couldn't decode this RAW (unsupported variant, corrupt
+            # file, no usable embedded JPEG). Try the companion JPEG before
+            # 500ing so a sidecar that can satisfy the preview isn't refused
+            # — mirrors the fallback in serve_original_photo's edited path.
+            companion_rel = photo["companion_path"]
+            if companion_rel:
+                companion_abs = os.path.join(folder_row["path"], companion_rel)
+                if (
+                    os.path.exists(companion_abs)
+                    and companion_abs != canonical
+                ):
+                    log.info(
+                        "RAW decode failed for photo %s preview at size=%s; "
+                        "falling back to companion JPEG",
+                        photo_id, size,
+                    )
+                    _record_working_copy_failure(db, photo, canonical)
+                    img = load_image(companion_abs, max_size=load_max_size)
+                    if img is not None:
+                        canonical = companion_abs
         if img is None:
             _record_working_copy_failure(db, photo, canonical)
             return "Could not load image", 500

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1895,6 +1895,28 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return height, width
         return width, height
 
+    def _scaled_recipe_source_dimensions(photo, max_size=None):
+        width, height = _recipe_source_dimensions(photo)
+        if width <= 0 or height <= 0:
+            return 0, 0
+        if max_size:
+            long_edge = max(width, height)
+            if long_edge > max_size:
+                scale = max_size / long_edge
+                width = round(width * scale)
+                height = round(height * scale)
+        return width, height
+
+    def _image_is_smaller_than_expected(img, expected_w, expected_h):
+        return (
+            expected_w > 0
+            and expected_h > 0
+            and (
+                img.size[0] + 1 < expected_w
+                or img.size[1] + 1 < expected_h
+            )
+        )
+
     def _image_size_after_exif_orientation(img):
         width, height = img.size
         orientation = None
@@ -13299,16 +13321,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         # can still be undersized. Mirror serve_preview's
                         # cache-miss undersized check so we don't bake an
                         # embedded preview into the tracked warmed cache.
-                        expected_long = max(
-                            int(detail_photo["width"]),
-                            int(detail_photo["height"]),
+                        expected_w, expected_h = _scaled_recipe_source_dimensions(
+                            detail_photo, load_max_size,
                         )
-                        if load_max_size is not None:
-                            expected_long = min(expected_long, load_max_size)
-                        loaded_long = max(img.size)
-                        if (
-                            expected_long > 0
-                            and loaded_long < expected_long * 0.9
+                        if _image_is_smaller_than_expected(
+                            img, expected_w, expected_h,
                         ):
                             companion_rel = detail_photo["companion_path"]
                             folder_path = folders.get(
@@ -13326,11 +13343,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                                         "RAW decode for photo %s preview "
                                         "warmup at size=%s returned "
                                         "undersized embedded preview "
-                                        "(%dx%d, expected long edge %d); "
+                                        "(%dx%d, expected %dx%d); "
                                         "falling back to companion JPEG",
                                         detail_photo["id"], max_size,
                                         img.size[0], img.size[1],
-                                        expected_long,
+                                        expected_w, expected_h,
                                     )
                                     img.close()
                                     companion_img = load_image(
@@ -18401,11 +18418,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # companion JPEG could satisfy the requested size, prefer it
             # over caching a downscaled embedded preview that future hits
             # would silently keep serving.
-            expected_long = max(int(photo["width"]), int(photo["height"]))
-            if load_max_size is not None:
-                expected_long = min(expected_long, load_max_size)
-            loaded_long = max(img.size)
-            if expected_long > 0 and loaded_long < expected_long * 0.9:
+            expected_w, expected_h = _scaled_recipe_source_dimensions(
+                photo, load_max_size,
+            )
+            if _image_is_smaller_than_expected(img, expected_w, expected_h):
                 companion_rel = photo["companion_path"]
                 if companion_rel:
                     companion_abs = os.path.join(folder_row["path"], companion_rel)
@@ -18416,10 +18432,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         log.info(
                             "RAW decode for photo %s preview at size=%s "
                             "returned undersized embedded preview (%dx%d, "
-                            "expected long edge %d); falling back to "
+                            "expected %dx%d); falling back to "
                             "companion JPEG",
                             photo_id, size, img.size[0], img.size[1],
-                            expected_long,
+                            expected_w, expected_h,
                         )
                         img.close()
                         companion_img = load_image(
@@ -18622,11 +18638,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 # in-progress editor doesn't render against a clipped
                 # downscaled preview when a full-size companion JPEG is
                 # sitting next to the RAW.
-                expected_long = min(
-                    max(int(photo["width"]), int(photo["height"])), size,
+                expected_w, expected_h = _scaled_recipe_source_dimensions(
+                    photo, size,
                 )
-                loaded_long = max(img.size)
-                if expected_long > 0 and loaded_long < expected_long * 0.9:
+                if _image_is_smaller_than_expected(img, expected_w, expected_h):
                     companion_rel = photo["companion_path"]
                     if companion_rel:
                         companion_abs = os.path.join(
@@ -18639,10 +18654,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                             log.info(
                                 "RAW decode for photo %s edit-preview "
                                 "returned undersized embedded preview "
-                                "(%dx%d, expected long edge %d); falling "
+                                "(%dx%d, expected %dx%d); falling "
                                 "back to companion JPEG",
                                 photo_id, img.size[0], img.size[1],
-                                expected_long,
+                                expected_w, expected_h,
                             )
                             img.close()
                             companion_img = load_image(
@@ -18873,18 +18888,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 # 1:1 edited views that's the wrong file to cache — try
                 # the full-size companion before saving an undersized
                 # originals/<id>.jpg.
-                loaded_long = max(img.size)
-                expected_long = max(int(photo["width"]), int(photo["height"]))
-                if expected_long > 0 and loaded_long < expected_long * 0.9:
+                expected_w, expected_h = _scaled_recipe_source_dimensions(photo)
+                if _image_is_smaller_than_expected(img, expected_w, expected_h):
                     companion_fallback = _full_res_companion_path(
                         folder["path"], using_offline_cache,
                     )
                     if companion_fallback and companion_fallback != image_path:
                         log.info(
                             "RAW decode for photo %s edited original returned "
-                            "undersized embedded preview (%dx%d, expected long "
-                            "edge %d); falling back to companion JPEG",
-                            photo_id, img.size[0], img.size[1], expected_long,
+                            "undersized embedded preview (%dx%d, expected "
+                            "%dx%d); falling back to companion JPEG",
+                            photo_id, img.size[0], img.size[1],
+                            expected_w, expected_h,
                         )
                         img.close()
                         img = load_image(companion_fallback, max_size=None)
@@ -19028,13 +19043,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 and photo["width"]
                 and photo["height"]
             ):
-                expected_long = max(int(photo["width"]), int(photo["height"]))
-                if expected_long > 0 and max(uw, uh) < expected_long * 0.9:
+                expected_w, expected_h = _scaled_recipe_source_dimensions(photo)
+                if (
+                    expected_w > 0
+                    and expected_h > 0
+                    and (
+                        uw + 1 < expected_w
+                        or uh + 1 < expected_h
+                    )
+                ):
                     log.info(
                         "RAW working copy for photo %s is undersized "
-                        "(%dx%d, expected long edge %d); re-extracting "
+                        "(%dx%d, expected %dx%d); re-extracting "
                         "from companion JPEG",
-                        photo_id, uw, uh, expected_long,
+                        photo_id, uw, uh, expected_w, expected_h,
                     )
                     if extract_working_copy(
                         companion_for_extraction, wc_abs,
@@ -19112,14 +19134,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # Same undersized-embedded-JPEG guard as the working-copy path
             # above: if rawpy.postprocess fell back to a small embedded
             # preview, prefer the full-size companion JPEG before caching.
-            loaded_long = max(img.size)
-            expected_long = max(int(photo["width"]), int(photo["height"]))
-            if expected_long > 0 and loaded_long < expected_long * 0.9:
+            expected_w, expected_h = _scaled_recipe_source_dimensions(photo)
+            if _image_is_smaller_than_expected(img, expected_w, expected_h):
                 log.info(
                     "RAW decode for photo %s original returned undersized "
-                    "embedded preview (%dx%d, expected long edge %d); "
+                    "embedded preview (%dx%d, expected %dx%d); "
                     "falling back to companion JPEG",
-                    photo_id, img.size[0], img.size[1], expected_long,
+                    photo_id, img.size[0], img.size[1],
+                    expected_w, expected_h,
                 )
                 img.close()
                 img = load_image(companion_for_extraction, max_size=None)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -15282,6 +15282,39 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 recipe=recipe,
                 raw_decode=raw_decode,
             )
+            if (
+                not result
+                and os.path.splitext(source)[1].lower() in RAW_EXTENSIONS
+            ):
+                # libraw couldn't demosaic the RAW (unsupported variant,
+                # corrupt file, no usable embedded JPEG). Try the companion
+                # JPEG before 404'ing so a RAW+JPEG row whose RAW can't be
+                # decoded still gets a grid thumbnail — mirrors the
+                # companion fallback in serve_preview / serve_original.
+                companion_rel = photo["companion_path"]
+                if companion_rel:
+                    companion_abs = os.path.join(
+                        folder_row["path"], companion_rel,
+                    )
+                    if (
+                        os.path.exists(companion_abs)
+                        and companion_abs != source
+                    ):
+                        log.info(
+                            "Thumbnail self-heal RAW decode failed for "
+                            "photo %s; falling back to companion JPEG",
+                            photo_id,
+                        )
+                        _record_working_copy_failure(db, photo, source)
+                        result = generate_thumbnail(
+                            photo_id,
+                            companion_abs,
+                            thumb_dir,
+                            size=thumb_size,
+                            recipe=recipe,
+                        )
+                        if result:
+                            source = companion_abs
         except Exception:
             log.exception(
                 "Thumbnail self-heal failed for photo %s (source=%s)",
@@ -18198,6 +18231,54 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         )
         load_kwargs = {"raw_decode": raw_decode} if raw_decode else {}
         img = load_image(canonical, max_size=load_max_size, **load_kwargs)
+        if (
+            img is not None
+            and selected_ext in RAW_EXTENSIONS
+            and photo["width"]
+            and photo["height"]
+        ):
+            # _load_raw falls back to the embedded camera JPEG when libraw
+            # can't demosaic the sensor data, even in preserve-highlights
+            # mode. That preview is often a fraction of the sensor's full
+            # resolution, so a "successful" load can still be undersized
+            # relative to what the request asked for. If a full-size
+            # companion JPEG could satisfy the requested size, prefer it
+            # over caching a downscaled embedded preview that future hits
+            # would silently keep serving.
+            expected_long = max(int(photo["width"]), int(photo["height"]))
+            if load_max_size is not None:
+                expected_long = min(expected_long, load_max_size)
+            loaded_long = max(img.size)
+            if expected_long > 0 and loaded_long < expected_long * 0.9:
+                companion_rel = photo["companion_path"]
+                if companion_rel:
+                    companion_abs = os.path.join(folder_row["path"], companion_rel)
+                    if (
+                        os.path.exists(companion_abs)
+                        and companion_abs != canonical
+                    ):
+                        log.info(
+                            "RAW decode for photo %s preview at size=%s "
+                            "returned undersized embedded preview (%dx%d, "
+                            "expected long edge %d); falling back to "
+                            "companion JPEG",
+                            photo_id, size, img.size[0], img.size[1],
+                            expected_long,
+                        )
+                        img.close()
+                        companion_img = load_image(
+                            companion_abs, max_size=load_max_size,
+                        )
+                        if companion_img is not None:
+                            img = companion_img
+                            canonical = companion_abs
+                        else:
+                            # Companion unreadable — recover the embedded
+                            # preview rather than 500ing the request.
+                            img = load_image(
+                                canonical, max_size=load_max_size,
+                                **load_kwargs,
+                            )
         if img is None and selected_ext in RAW_EXTENSIONS:
             # libraw couldn't decode this RAW (unsupported variant, corrupt
             # file, no usable embedded JPEG). Try the companion JPEG before

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -30,6 +30,7 @@ from db import (
     IncompatibleDatabaseError,
     commit_with_retry,
 )
+from exif_orientation import orientation_swaps_axes as _orientation_swaps_axes
 from flask import (
     Flask,
     Response,
@@ -1867,19 +1868,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if isinstance(values, dict) and "Orientation" in values:
                 return values["Orientation"]
         return metadata.get("Orientation")
-
-    def _orientation_swaps_axes(orientation):
-        if orientation is None or isinstance(orientation, bool):
-            return False
-        if isinstance(orientation, int | float):
-            return int(orientation) in (5, 6, 7, 8)
-        text = str(orientation).strip().lower()
-        if not text:
-            return False
-        try:
-            return int(text) in (5, 6, 7, 8)
-        except ValueError:
-            return "90" in text or "270" in text
 
     def _recipe_source_dimensions(photo):
         try:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -18939,23 +18939,25 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         folder["path"], using_offline_cache,
                     )
                     if companion_fallback and companion_fallback != image_path:
-                        log.info(
-                            "RAW decode for photo %s edited original returned "
-                            "undersized embedded preview (%dx%d, expected "
-                            "%dx%d); falling back to companion JPEG",
-                            photo_id, img.size[0], img.size[1],
-                            expected_w, expected_h,
+                        companion_img = load_image(
+                            companion_fallback, max_size=None,
                         )
-                        img.close()
-                        img = load_image(companion_fallback, max_size=None)
-                        if img is not None:
-                            image_path = companion_fallback
-                        else:
-                            # Companion path also unreadable — fall back
-                            # to the embedded preview rather than 500ing.
-                            img = load_image(
-                                image_path, max_size=None, **load_kwargs,
+                        if _companion_image_can_replace_raw_result(
+                            companion_img, img, expected_w, expected_h,
+                        ):
+                            log.info(
+                                "RAW decode for photo %s edited original "
+                                "returned undersized embedded preview "
+                                "(%dx%d, expected %dx%d); falling back to "
+                                "companion JPEG",
+                                photo_id, img.size[0], img.size[1],
+                                expected_w, expected_h,
                             )
+                            img.close()
+                            img = companion_img
+                            image_path = companion_fallback
+                        elif companion_img is not None:
+                            companion_img.close()
             if img is None and resolved_ext in RAW_EXTENSIONS:
                 # RAW couldn't decode (unsupported variant, no embedded JPEG).
                 # Fall back to the full-resolution companion JPEG when one
@@ -19195,19 +19197,24 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # preview, prefer the full-size companion JPEG before caching.
             expected_w, expected_h = _scaled_recipe_source_dimensions(photo)
             if _image_is_smaller_than_expected(img, expected_w, expected_h):
-                log.info(
-                    "RAW decode for photo %s original returned undersized "
-                    "embedded preview (%dx%d, expected %dx%d); "
-                    "falling back to companion JPEG",
-                    photo_id, img.size[0], img.size[1],
-                    expected_w, expected_h,
+                companion_img = load_image(
+                    companion_for_extraction, max_size=None,
                 )
-                img.close()
-                img = load_image(companion_for_extraction, max_size=None)
-                if img is not None:
+                if _companion_image_can_replace_raw_result(
+                    companion_img, img, expected_w, expected_h,
+                ):
+                    log.info(
+                        "RAW decode for photo %s original returned "
+                        "undersized embedded preview (%dx%d, expected "
+                        "%dx%d); falling back to companion JPEG",
+                        photo_id, img.size[0], img.size[1],
+                        expected_w, expected_h,
+                    )
+                    img.close()
+                    img = companion_img
                     image_path = companion_for_extraction
-                else:
-                    img = load_image(image_path, max_size=None, **load_kwargs)
+                elif companion_img is not None:
+                    companion_img.close()
         if (
             img is None
             and resolved_ext in RAW_EXTENSIONS

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -13196,6 +13196,70 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     )
                     img = load_image(canonical, max_size=load_max_size, **load_kwargs)
                     if (
+                        img is not None
+                        and os.path.splitext(canonical)[1].lower() in RAW_EXTENSIONS
+                        and detail_photo["width"]
+                        and detail_photo["height"]
+                    ):
+                        # _load_raw falls back to an embedded JPEG when
+                        # libraw can't demosaic; that preview is often a
+                        # fraction of sensor resolution, so a non-None load
+                        # can still be undersized. Mirror serve_preview's
+                        # cache-miss undersized check so we don't bake an
+                        # embedded preview into the tracked warmed cache.
+                        expected_long = max(
+                            int(detail_photo["width"]),
+                            int(detail_photo["height"]),
+                        )
+                        if load_max_size is not None:
+                            expected_long = min(expected_long, load_max_size)
+                        loaded_long = max(img.size)
+                        if (
+                            expected_long > 0
+                            and loaded_long < expected_long * 0.9
+                        ):
+                            companion_rel = detail_photo["companion_path"]
+                            folder_path = folders.get(
+                                detail_photo["folder_id"]
+                            )
+                            if companion_rel and folder_path:
+                                companion_abs = os.path.join(
+                                    folder_path, companion_rel,
+                                )
+                                if (
+                                    os.path.exists(companion_abs)
+                                    and companion_abs != canonical
+                                ):
+                                    log.info(
+                                        "RAW decode for photo %s preview "
+                                        "warmup at size=%s returned "
+                                        "undersized embedded preview "
+                                        "(%dx%d, expected long edge %d); "
+                                        "falling back to companion JPEG",
+                                        detail_photo["id"], max_size,
+                                        img.size[0], img.size[1],
+                                        expected_long,
+                                    )
+                                    img.close()
+                                    companion_img = load_image(
+                                        companion_abs,
+                                        max_size=load_max_size,
+                                    )
+                                    if companion_img is not None:
+                                        img = companion_img
+                                        canonical = companion_abs
+                                    else:
+                                        # Companion unreadable — recover the
+                                        # embedded preview so the warmer
+                                        # still produces something rather
+                                        # than counting this photo as
+                                        # failed for the size mismatch.
+                                        img = load_image(
+                                            canonical,
+                                            max_size=load_max_size,
+                                            **load_kwargs,
+                                        )
+                    if (
                         img is None
                         and os.path.splitext(canonical)[1].lower() in RAW_EXTENSIONS
                     ):
@@ -18453,6 +18517,52 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             )
             load_kwargs = {"raw_decode": raw_decode} if raw_decode else {}
             img = load_image(canonical, max_size=size, **load_kwargs)
+            if (
+                img is not None
+                and selected_ext in RAW_EXTENSIONS
+                and photo["width"]
+                and photo["height"]
+            ):
+                # _load_raw falls back to an embedded camera JPEG when libraw
+                # can't demosaic; that preview is often a fraction of sensor
+                # resolution, so non-None can still be undersized. Mirror
+                # serve_preview's cache-miss undersized check so the
+                # in-progress editor doesn't render against a clipped
+                # downscaled preview when a full-size companion JPEG is
+                # sitting next to the RAW.
+                expected_long = min(
+                    max(int(photo["width"]), int(photo["height"])), size,
+                )
+                loaded_long = max(img.size)
+                if expected_long > 0 and loaded_long < expected_long * 0.9:
+                    companion_rel = photo["companion_path"]
+                    if companion_rel:
+                        companion_abs = os.path.join(
+                            folder_row["path"], companion_rel,
+                        )
+                        if (
+                            os.path.exists(companion_abs)
+                            and companion_abs != canonical
+                        ):
+                            log.info(
+                                "RAW decode for photo %s edit-preview "
+                                "returned undersized embedded preview "
+                                "(%dx%d, expected long edge %d); falling "
+                                "back to companion JPEG",
+                                photo_id, img.size[0], img.size[1],
+                                expected_long,
+                            )
+                            img.close()
+                            companion_img = load_image(
+                                companion_abs, max_size=size,
+                            )
+                            if companion_img is not None:
+                                img = companion_img
+                                canonical = companion_abs
+                            else:
+                                img = load_image(
+                                    canonical, max_size=size, **load_kwargs,
+                                )
             if img is None and selected_ext in RAW_EXTENSIONS:
                 # Same companion fallback as serve_preview's cache-miss
                 # path: an unsupported RAW shouldn't kill the in-progress

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -15227,12 +15227,27 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     photo_id,
                 )
                 return "", 404
+            # Derive the decode mode from the primary photo's extension
+            # rather than source so a future change to render-source
+            # resolution cannot silently bypass RAW_DECODE_PRESERVE_HIGHLIGHTS
+            # for a RAW primary. Without this, EDIT_MATH_VERSION's cache
+            # purge regenerates edited-RAW thumbnails through the default
+            # JPEG-first decode and grid thumbnails diverge from previews
+            # / exports (which preserve highlights).
+            from image_loader import RAW_DECODE_PRESERVE_HIGHLIGHTS, RAW_EXTENSIONS
+            raw_decode = (
+                RAW_DECODE_PRESERVE_HIGHLIGHTS
+                if recipe
+                and os.path.splitext(photo["filename"])[1].lower() in RAW_EXTENSIONS
+                else None
+            )
             result = generate_thumbnail(
                 photo_id,
                 source,
                 thumb_dir,
                 size=thumb_size,
                 recipe=recipe,
+                raw_decode=raw_decode,
             )
         except Exception:
             log.exception(

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1917,6 +1917,22 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             )
         )
 
+    def _companion_image_can_replace_raw_result(
+        companion_img, current_img, expected_w, expected_h,
+    ):
+        if companion_img is None:
+            return False
+        if expected_w > 0 and expected_h > 0:
+            return not _image_is_smaller_than_expected(
+                companion_img, expected_w, expected_h,
+            )
+        if current_img is None:
+            return True
+        return (
+            companion_img.size[0] >= current_img.size[0]
+            and companion_img.size[1] >= current_img.size[1]
+        )
+
     def _image_size_after_exif_orientation(img):
         width, height = img.size
         orientation = None
@@ -13364,35 +13380,29 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                                     os.path.exists(companion_abs)
                                     and companion_abs != canonical
                                 ):
-                                    log.info(
-                                        "RAW decode for photo %s preview "
-                                        "warmup at size=%s returned "
-                                        "undersized embedded preview "
-                                        "(%dx%d, expected %dx%d); "
-                                        "falling back to companion JPEG",
-                                        detail_photo["id"], max_size,
-                                        img.size[0], img.size[1],
-                                        expected_w, expected_h,
-                                    )
-                                    img.close()
                                     companion_img = load_image(
                                         companion_abs,
                                         max_size=load_max_size,
                                     )
-                                    if companion_img is not None:
+                                    if _companion_image_can_replace_raw_result(
+                                        companion_img, img,
+                                        expected_w, expected_h,
+                                    ):
+                                        log.info(
+                                            "RAW decode for photo %s preview "
+                                            "warmup at size=%s returned "
+                                            "undersized embedded preview "
+                                            "(%dx%d, expected %dx%d); "
+                                            "falling back to companion JPEG",
+                                            detail_photo["id"], max_size,
+                                            img.size[0], img.size[1],
+                                            expected_w, expected_h,
+                                        )
+                                        img.close()
                                         img = companion_img
                                         canonical = companion_abs
-                                    else:
-                                        # Companion unreadable — recover the
-                                        # embedded preview so the warmer
-                                        # still produces something rather
-                                        # than counting this photo as
-                                        # failed for the size mismatch.
-                                        img = load_image(
-                                            canonical,
-                                            max_size=load_max_size,
-                                            **load_kwargs,
-                                        )
+                                    elif companion_img is not None:
+                                        companion_img.close()
                     if (
                         img is None
                         and os.path.splitext(canonical)[1].lower() in RAW_EXTENSIONS
@@ -18461,28 +18471,25 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         os.path.exists(companion_abs)
                         and companion_abs != canonical
                     ):
-                        log.info(
-                            "RAW decode for photo %s preview at size=%s "
-                            "returned undersized embedded preview (%dx%d, "
-                            "expected %dx%d); falling back to "
-                            "companion JPEG",
-                            photo_id, size, img.size[0], img.size[1],
-                            expected_w, expected_h,
-                        )
-                        img.close()
                         companion_img = load_image(
                             companion_abs, max_size=load_max_size,
                         )
-                        if companion_img is not None:
+                        if _companion_image_can_replace_raw_result(
+                            companion_img, img, expected_w, expected_h,
+                        ):
+                            log.info(
+                                "RAW decode for photo %s preview at size=%s "
+                                "returned undersized embedded preview (%dx%d, "
+                                "expected %dx%d); falling back to "
+                                "companion JPEG",
+                                photo_id, size, img.size[0], img.size[1],
+                                expected_w, expected_h,
+                            )
+                            img.close()
                             img = companion_img
                             canonical = companion_abs
-                        else:
-                            # Companion unreadable — recover the embedded
-                            # preview rather than 500ing the request.
-                            img = load_image(
-                                canonical, max_size=load_max_size,
-                                **load_kwargs,
-                            )
+                        elif companion_img is not None:
+                            companion_img.close()
         if img is None and selected_ext in RAW_EXTENSIONS:
             # libraw couldn't decode this RAW (unsupported variant, corrupt
             # file, no usable embedded JPEG). Try the companion JPEG before
@@ -18683,25 +18690,25 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                             os.path.exists(companion_abs)
                             and companion_abs != canonical
                         ):
-                            log.info(
-                                "RAW decode for photo %s edit-preview "
-                                "returned undersized embedded preview "
-                                "(%dx%d, expected %dx%d); falling "
-                                "back to companion JPEG",
-                                photo_id, img.size[0], img.size[1],
-                                expected_w, expected_h,
-                            )
-                            img.close()
                             companion_img = load_image(
                                 companion_abs, max_size=size,
                             )
-                            if companion_img is not None:
+                            if _companion_image_can_replace_raw_result(
+                                companion_img, img, expected_w, expected_h,
+                            ):
+                                log.info(
+                                    "RAW decode for photo %s edit-preview "
+                                    "returned undersized embedded preview "
+                                    "(%dx%d, expected %dx%d); falling "
+                                    "back to companion JPEG",
+                                    photo_id, img.size[0], img.size[1],
+                                    expected_w, expected_h,
+                                )
+                                img.close()
                                 img = companion_img
                                 canonical = companion_abs
-                            else:
-                                img = load_image(
-                                    canonical, max_size=size, **load_kwargs,
-                                )
+                            elif companion_img is not None:
+                                companion_img.close()
             if img is None and selected_ext in RAW_EXTENSIONS:
                 # Same companion fallback as serve_preview's cache-miss
                 # path: an unsupported RAW shouldn't kill the in-progress

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -9322,13 +9322,36 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # than source_path so a future change to source_path resolution
             # (working copy, companion JPEG fallback, etc.) cannot silently
             # bypass RAW_DECODE_PRESERVE_HIGHLIGHTS for a RAW primary.
-            raw_decode = (
-                RAW_DECODE_PRESERVE_HIGHLIGHTS
-                if os.path.splitext(photo["filename"])[1].lower() in RAW_EXTENSIONS
-                else None
+            primary_is_raw = (
+                os.path.splitext(photo["filename"])[1].lower() in RAW_EXTENSIONS
             )
+            raw_decode = RAW_DECODE_PRESERVE_HIGHLIGHTS if primary_is_raw else None
             load_kwargs = {"raw_decode": raw_decode} if raw_decode else {}
             img = load_image(source_path, max_size=None, **load_kwargs)
+            if img is None and primary_is_raw:
+                # libraw can't decode this RAW (unsupported variant, corrupt
+                # sensor data, no usable embedded JPEG). Fall back to the
+                # full-size companion JPEG so Open External still works for
+                # RAW+JPEG pairs that have a usable handoff JPEG. Cache key
+                # stays on the RAW source so a future RAW replacement (mtime
+                # bump) re-tries the RAW; we accept that companion-only edits
+                # won't invalidate this render — matching the cache contract
+                # used elsewhere for RAW-primary photos.
+                folder_path = folders.get(photo["folder_id"])
+                companion_path = photo["companion_path"]
+                if folder_path and companion_path:
+                    companion_abs = os.path.join(folder_path, companion_path)
+                    if (
+                        os.path.exists(companion_abs)
+                        and os.path.abspath(companion_abs)
+                        != os.path.abspath(source_path)
+                    ):
+                        log.info(
+                            "External-edit RAW decode failed for photo %s; "
+                            "falling back to companion JPEG %s",
+                            photo["id"], companion_abs,
+                        )
+                        img = load_image(companion_abs, max_size=None)
             if img is None:
                 return None, f"{photo['filename']}: failed to load image"
             rendered = None
@@ -11548,13 +11571,34 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # than source_path so a future change to source_path resolution
         # (working copy, companion JPEG fallback, etc.) cannot silently
         # bypass RAW_DECODE_PRESERVE_HIGHLIGHTS for a RAW primary.
-        raw_decode = (
-            RAW_DECODE_PRESERVE_HIGHLIGHTS
-            if os.path.splitext(photo["filename"])[1].lower() in RAW_EXTENSIONS
-            else None
+        primary_is_raw = (
+            os.path.splitext(photo["filename"])[1].lower() in RAW_EXTENSIONS
         )
+        raw_decode = RAW_DECODE_PRESERVE_HIGHLIGHTS if primary_is_raw else None
         load_kwargs = {"raw_decode": raw_decode} if raw_decode else {}
         img = load_image(source_path, max_size=None, **load_kwargs)
+        if img is None and primary_is_raw:
+            # Mirror _external_edit_handoff_path: libraw may fail to decode
+            # this RAW variant, but the full-size companion JPEG can still
+            # carry the recipe for iNaturalist. Without this fallback the
+            # upload silently fails for RAW+JPEG pairs whose RAW is
+            # unsupported. Cache key stays on the RAW source — see comment
+            # in _external_edit_handoff_path for the contract trade-off.
+            companion_path = photo["companion_path"]
+            folder_path = photo["folder_path"]
+            if folder_path and companion_path:
+                companion_abs = os.path.join(folder_path, companion_path)
+                if (
+                    os.path.exists(companion_abs)
+                    and os.path.abspath(companion_abs)
+                    != os.path.abspath(source_path)
+                ):
+                    log.info(
+                        "iNat upload RAW decode failed for photo %s; "
+                        "falling back to companion JPEG %s",
+                        photo["id"], companion_abs,
+                    )
+                    img = load_image(companion_abs, max_size=None)
         if img is None:
             return None, f"{photo['filename']}: failed to load image"
         rendered = None

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -15447,6 +15447,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 and os.path.splitext(photo["filename"])[1].lower() in RAW_EXTENSIONS
                 else None
             )
+            min_source_size = None
+            if raw_decode and os.path.splitext(source)[1].lower() in RAW_EXTENSIONS:
+                load_max_size = None if recipe and recipe.get("crop") else thumb_size
+                min_source_size = _scaled_recipe_source_dimensions(
+                    photo, load_max_size,
+                )
             result = generate_thumbnail(
                 photo_id,
                 source,
@@ -15454,6 +15460,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 size=thumb_size,
                 recipe=recipe,
                 raw_decode=raw_decode,
+                min_source_size=min_source_size,
             )
             if (
                 not result

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -18959,16 +18959,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 # RAW couldn't decode (unsupported variant, no embedded JPEG).
                 # Fall back to the full-resolution companion JPEG when one
                 # exists so an unsupported-RAW edit doesn't 500 with a usable
-                # sidecar sitting next to the RAW. Do NOT record a blocking
-                # RAW source-failure marker here when the companion rescues
-                # the render: the marker would make the next request's
-                # pre-load guard above return 500 even though companion
-                # rendering just worked. We accept the cost of retrying the
-                # failing RAW once per request in exchange for never hiding
-                # a usable photo behind a stale marker.
+                # sidecar sitting next to the RAW. When the companion rescues
+                # the render, record the RAW source-failure marker so the
+                # next request's RAW-failure routing branch above sends the
+                # render directly through the companion instead of paying
+                # for the same failing decode every hit. The pre-load guard
+                # at line ~18896 won't shadow it because that routing branch
+                # rewrites image_path to the companion before the guard runs.
                 companion_fallback = _full_res_companion_path(
                     folder["path"], using_offline_cache,
                 )
+                raw_source_path = image_path
                 if companion_fallback and companion_fallback != image_path:
                     log.info(
                         "RAW decode failed for photo %s edited original; "
@@ -18977,11 +18978,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     img = load_image(companion_fallback, max_size=None)
                     if img is not None:
                         image_path = companion_fallback
+                        _record_working_copy_failure(db, photo, raw_source_path)
                     else:
-                        # Companion also failed — now we record the marker so
-                        # repeated requests fail fast instead of retrying both
-                        # sources on every hit.
-                        _record_working_copy_failure(db, photo, image_path)
+                        # Companion also failed — record the marker so repeated
+                        # requests fail fast instead of retrying both sources
+                        # on every hit.
+                        _record_working_copy_failure(db, photo, raw_source_path)
             if img is None:
                 _record_working_copy_failure(db, photo, image_path)
                 return "Could not load image", 500

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -18577,6 +18577,42 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             )
             load_kwargs = {"raw_decode": raw_decode} if raw_decode else {}
             img = load_image(image_path, max_size=None, **load_kwargs)
+            if (
+                img is not None
+                and resolved_ext in RAW_EXTENSIONS
+                and photo["width"]
+                and photo["height"]
+            ):
+                # _load_raw falls back to the embedded JPEG even in
+                # preserve-highlights mode when libraw can't demosaic the
+                # sensor data, so a successful load can still be the small
+                # camera preview rather than full-resolution pixels. For
+                # 1:1 edited views that's the wrong file to cache — try
+                # the full-size companion before saving an undersized
+                # originals/<id>.jpg.
+                loaded_long = max(img.size)
+                expected_long = max(int(photo["width"]), int(photo["height"]))
+                if expected_long > 0 and loaded_long < expected_long * 0.9:
+                    companion_fallback = _full_res_companion_path(
+                        folder["path"], using_offline_cache,
+                    )
+                    if companion_fallback and companion_fallback != image_path:
+                        log.info(
+                            "RAW decode for photo %s edited original returned "
+                            "undersized embedded preview (%dx%d, expected long "
+                            "edge %d); falling back to companion JPEG",
+                            photo_id, img.size[0], img.size[1], expected_long,
+                        )
+                        img.close()
+                        img = load_image(companion_fallback, max_size=None)
+                        if img is not None:
+                            image_path = companion_fallback
+                        else:
+                            # Companion path also unreadable — fall back
+                            # to the embedded preview rather than 500ing.
+                            img = load_image(
+                                image_path, max_size=None, **load_kwargs,
+                            )
             if img is None and resolved_ext in RAW_EXTENSIONS:
                 # RAW couldn't decode (unsupported variant, no embedded JPEG).
                 # Fall back to the full-resolution companion JPEG when one
@@ -18695,6 +18731,39 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             from PIL import Image as _PILImage
             with _PILImage.open(wc_abs) as upgraded:
                 uw, uh = upgraded.size
+            # For RAW sources, extract_working_copy can succeed via the
+            # embedded JPEG fallback when libraw can't demosaic the file.
+            # That preview is often a fraction of the sensor's full
+            # resolution, so persisting it as the working copy would
+            # silently downgrade /original for every later request. Try
+            # the companion JPEG instead when one can satisfy the full
+            # size before recording this wc.
+            if (
+                resolved_ext in RAW_EXTENSIONS
+                and companion_for_extraction
+                and companion_for_extraction != source_for_extraction
+                and photo["width"]
+                and photo["height"]
+            ):
+                expected_long = max(int(photo["width"]), int(photo["height"]))
+                if expected_long > 0 and max(uw, uh) < expected_long * 0.9:
+                    log.info(
+                        "RAW working copy for photo %s is undersized "
+                        "(%dx%d, expected long edge %d); re-extracting "
+                        "from companion JPEG",
+                        photo_id, uw, uh, expected_long,
+                    )
+                    if extract_working_copy(
+                        companion_for_extraction, wc_abs,
+                        max_size=0, quality=quality,
+                    ):
+                        with _PILImage.open(wc_abs) as upgraded:
+                            uw, uh = upgraded.size
+                    else:
+                        log.warning(
+                            "Companion re-extraction failed for photo %s; "
+                            "keeping undersized RAW working copy", photo_id,
+                        )
             updates = ["working_copy_path=?"]
             params = [wc_rel]
             if not photo["width"] or not photo["height"]:
@@ -18749,6 +18818,32 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         )
         load_kwargs = {"raw_decode": raw_decode} if raw_decode else {}
         img = load_image(image_path, max_size=None, **load_kwargs)
+        if (
+            img is not None
+            and resolved_ext in RAW_EXTENSIONS
+            and companion_for_extraction
+            and companion_for_extraction != image_path
+            and photo["width"]
+            and photo["height"]
+        ):
+            # Same undersized-embedded-JPEG guard as the working-copy path
+            # above: if rawpy.postprocess fell back to a small embedded
+            # preview, prefer the full-size companion JPEG before caching.
+            loaded_long = max(img.size)
+            expected_long = max(int(photo["width"]), int(photo["height"]))
+            if expected_long > 0 and loaded_long < expected_long * 0.9:
+                log.info(
+                    "RAW decode for photo %s original returned undersized "
+                    "embedded preview (%dx%d, expected long edge %d); "
+                    "falling back to companion JPEG",
+                    photo_id, img.size[0], img.size[1], expected_long,
+                )
+                img.close()
+                img = load_image(companion_for_extraction, max_size=None)
+                if img is not None:
+                    image_path = companion_for_extraction
+                else:
+                    img = load_image(image_path, max_size=None, **load_kwargs)
         if (
             img is None
             and resolved_ext in RAW_EXTENSIONS

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2031,12 +2031,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # companion is available.
         companion_path = photo["companion_path"]
         original_abs = os.path.join(folder_path, photo["filename"])
-        allow_companion = not primary_is_raw or _has_current_working_copy_failure(
-            photo,
-            vireo_dir,
-            trust_existing_working_copy=False,
-            live_source_path=original_abs,
-            folder_path=folder_path,
+        allow_companion = (
+            not primary_is_raw
+            or not os.path.exists(original_abs)
+            or _has_current_working_copy_failure(
+                photo,
+                vireo_dir,
+                trust_existing_working_copy=False,
+                live_source_path=original_abs,
+                folder_path=folder_path,
+            )
         )
         if companion_path and allow_companion:
             companion = os.path.join(folder_path, companion_path)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -9328,15 +9328,35 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             raw_decode = RAW_DECODE_PRESERVE_HIGHLIGHTS if primary_is_raw else None
             load_kwargs = {"raw_decode": raw_decode} if raw_decode else {}
             img = load_image(source_path, max_size=None, **load_kwargs)
-            if img is None and primary_is_raw:
+            needs_companion = False
+            if primary_is_raw:
+                if img is None:
+                    needs_companion = True
+                else:
+                    # libraw may return the embedded JPEG when it cannot
+                    # demosaic — that preview is typically much smaller
+                    # than the full-size companion JPEG, so the handoff
+                    # would apply the recipe to clipped pixels even when
+                    # a usable sidecar exists. Compare both oriented
+                    # dimensions (with 1px rounding slack) against the
+                    # photo's stored size and trigger the companion
+                    # fallback when the RAW result is undersized.
+                    orig_w, orig_h = _recipe_source_dimensions(photo)
+                    if orig_w > 0 and orig_h > 0 and (
+                        img.size[0] + 1 < orig_w
+                        or img.size[1] + 1 < orig_h
+                    ):
+                        needs_companion = True
+            if needs_companion:
                 # libraw can't decode this RAW (unsupported variant, corrupt
-                # sensor data, no usable embedded JPEG). Fall back to the
-                # full-size companion JPEG so Open External still works for
-                # RAW+JPEG pairs that have a usable handoff JPEG. Cache key
-                # stays on the RAW source so a future RAW replacement (mtime
-                # bump) re-tries the RAW; we accept that companion-only edits
-                # won't invalidate this render — matching the cache contract
-                # used elsewhere for RAW-primary photos.
+                # sensor data, no usable embedded JPEG) or only produced an
+                # undersized embedded preview. Fall back to the full-size
+                # companion JPEG so Open External still works for RAW+JPEG
+                # pairs that have a usable handoff JPEG. Cache key stays on
+                # the RAW source so a future RAW replacement (mtime bump)
+                # re-tries the RAW; we accept that companion-only edits
+                # won't invalidate this render — matching the cache
+                # contract used elsewhere for RAW-primary photos.
                 folder_path = folders.get(photo["folder_id"])
                 companion_path = photo["companion_path"]
                 if folder_path and companion_path:
@@ -9346,12 +9366,30 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         and os.path.abspath(companion_abs)
                         != os.path.abspath(source_path)
                     ):
-                        log.info(
-                            "External-edit RAW decode failed for photo %s; "
-                            "falling back to companion JPEG %s",
-                            photo["id"], companion_abs,
-                        )
-                        img = load_image(companion_abs, max_size=None)
+                        companion_img = load_image(companion_abs, max_size=None)
+                        if companion_img is not None and (
+                            img is None
+                            or max(companion_img.size) > max(img.size)
+                        ):
+                            if img is None:
+                                log.info(
+                                    "External-edit RAW decode failed for "
+                                    "photo %s; falling back to companion "
+                                    "JPEG %s",
+                                    photo["id"], companion_abs,
+                                )
+                            else:
+                                log.info(
+                                    "External-edit RAW decode fell back to "
+                                    "undersized embedded JPEG (%dx%d) for "
+                                    "photo %s; using companion JPEG %s",
+                                    img.size[0], img.size[1], photo["id"],
+                                    companion_abs,
+                                )
+                                img.close()
+                            img = companion_img
+                        elif companion_img is not None:
+                            companion_img.close()
             if img is None:
                 return None, f"{photo['filename']}: failed to load image"
             rendered = None
@@ -11577,7 +11615,23 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         raw_decode = RAW_DECODE_PRESERVE_HIGHLIGHTS if primary_is_raw else None
         load_kwargs = {"raw_decode": raw_decode} if raw_decode else {}
         img = load_image(source_path, max_size=None, **load_kwargs)
-        if img is None and primary_is_raw:
+        needs_companion = False
+        if primary_is_raw:
+            if img is None:
+                needs_companion = True
+            else:
+                # libraw may return the embedded JPEG when demosaic
+                # fails — see _external_edit_handoff_path for the same
+                # gate. Without this an unsupported RAW would upload
+                # clipped/undersized pixels to iNaturalist even when a
+                # usable sidecar JPEG exists.
+                orig_w, orig_h = _recipe_source_dimensions(photo)
+                if orig_w > 0 and orig_h > 0 and (
+                    img.size[0] + 1 < orig_w
+                    or img.size[1] + 1 < orig_h
+                ):
+                    needs_companion = True
+        if needs_companion:
             # Mirror _external_edit_handoff_path: libraw may fail to decode
             # this RAW variant, but the full-size companion JPEG can still
             # carry the recipe for iNaturalist. Without this fallback the
@@ -11593,12 +11647,29 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     and os.path.abspath(companion_abs)
                     != os.path.abspath(source_path)
                 ):
-                    log.info(
-                        "iNat upload RAW decode failed for photo %s; "
-                        "falling back to companion JPEG %s",
-                        photo["id"], companion_abs,
-                    )
-                    img = load_image(companion_abs, max_size=None)
+                    companion_img = load_image(companion_abs, max_size=None)
+                    if companion_img is not None and (
+                        img is None
+                        or max(companion_img.size) > max(img.size)
+                    ):
+                        if img is None:
+                            log.info(
+                                "iNat upload RAW decode failed for photo %s; "
+                                "falling back to companion JPEG %s",
+                                photo["id"], companion_abs,
+                            )
+                        else:
+                            log.info(
+                                "iNat upload RAW decode fell back to "
+                                "undersized embedded JPEG (%dx%d) for "
+                                "photo %s; using companion JPEG %s",
+                                img.size[0], img.size[1], photo["id"],
+                                companion_abs,
+                            )
+                            img.close()
+                        img = companion_img
+                    elif companion_img is not None:
+                        companion_img.close()
         if img is None:
             return None, f"{photo['filename']}: failed to load image"
         rendered = None

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -18305,8 +18305,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             ).fetchone()
             if not folder_row:
                 return "Not found", 404
+            # Resolve the source with the actual recipe (not None) so
+            # _recipe_render_source applies its RAW-primary gating: a RAW
+            # photo with a legacy JPEG working copy must use the RAW source
+            # here too, so the in-progress edit preview matches the saved
+            # preview/export bytes from the highlight-preserving decode.
             canonical, using_working_copy = _recipe_render_source(
-                photo, None, size, vireo_dir, {folder_row["id"]: folder_row["path"]},
+                photo, recipe, size, vireo_dir,
+                {folder_row["id"]: folder_row["path"]},
             )
             selected_ext = os.path.splitext(canonical)[1].lower()
             if (
@@ -18506,7 +18512,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 # RAW couldn't decode (unsupported variant, no embedded JPEG).
                 # Fall back to the full-resolution companion JPEG when one
                 # exists so an unsupported-RAW edit doesn't 500 with a usable
-                # sidecar sitting next to the RAW.
+                # sidecar sitting next to the RAW. Do NOT record a blocking
+                # RAW source-failure marker here when the companion rescues
+                # the render: the marker would make the next request's
+                # pre-load guard above return 500 even though companion
+                # rendering just worked. We accept the cost of retrying the
+                # failing RAW once per request in exchange for never hiding
+                # a usable photo behind a stale marker.
                 companion_fallback = _full_res_companion_path(
                     folder["path"], using_offline_cache,
                 )
@@ -18515,10 +18527,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         "RAW decode failed for photo %s edited original; "
                         "falling back to companion JPEG", photo_id,
                     )
-                    _record_working_copy_failure(db, photo, image_path)
                     img = load_image(companion_fallback, max_size=None)
                     if img is not None:
                         image_path = companion_fallback
+                    else:
+                        # Companion also failed — now we record the marker so
+                        # repeated requests fail fast instead of retrying both
+                        # sources on every hit.
+                        _record_working_copy_failure(db, photo, image_path)
             if img is None:
                 _record_working_copy_failure(db, photo, image_path)
                 return "Could not load image", 500

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1973,23 +1973,37 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 if os.path.exists(wc_path):
                     return wc_path, True
             return "", False
+        # For RAW primaries, prefer the RAW source so the caller can decode it
+        # with highlight preservation rather than serving the camera's already-
+        # clipped companion JPEG. The companion remains a valid fallback when
+        # the RAW is known to fail extraction for this mtime — otherwise edited
+        # previews for unsupported RAWs would 500 out even when a full-size
+        # companion is available.
+        from image_loader import RAW_EXTENSIONS
+        primary_is_raw = (
+            os.path.splitext(photo["filename"])[1].lower() in RAW_EXTENSIONS
+        )
         companion_path = photo["companion_path"]
-        if companion_path:
+        original_abs = os.path.join(folder_path, photo["filename"])
+        allow_companion = not primary_is_raw or _has_current_working_copy_failure(
+            photo,
+            vireo_dir,
+            trust_existing_working_copy=False,
+            live_source_path=original_abs,
+            folder_path=folder_path,
+        )
+        if companion_path and allow_companion:
             companion = os.path.join(folder_path, companion_path)
             if (
                 os.path.exists(companion)
                 and _path_satisfies_recipe_render(companion, photo, recipe, max_size)
             ):
                 return companion, True
-        original = os.path.join(
-            folder_path,
-            photo["filename"],
-        )
-        if not os.path.exists(original) and photo["working_copy_path"]:
+        if not os.path.exists(original_abs) and photo["working_copy_path"]:
             wc_path = os.path.join(vireo_dir, photo["working_copy_path"])
             if os.path.exists(wc_path):
                 return wc_path, True
-        return original, False
+        return original_abs, False
 
     _ACCELERATED_RUNTIME_PROVIDERS = {
         "ACLExecutionProvider",
@@ -9292,9 +9306,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             except (OSError, ValueError, TypeError):
                 pass
 
+            # Derive the decode mode from the primary photo's extension rather
+            # than source_path so a future change to source_path resolution
+            # (working copy, companion JPEG fallback, etc.) cannot silently
+            # bypass RAW_DECODE_PRESERVE_HIGHLIGHTS for a RAW primary.
             raw_decode = (
                 RAW_DECODE_PRESERVE_HIGHLIGHTS
-                if os.path.splitext(source_path)[1].lower() in RAW_EXTENSIONS
+                if os.path.splitext(photo["filename"])[1].lower() in RAW_EXTENSIONS
                 else None
             )
             load_kwargs = {"raw_decode": raw_decode} if raw_decode else {}
@@ -11508,9 +11526,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         except (OSError, ValueError, TypeError):
             pass
 
+        # Derive the decode mode from the primary photo's extension rather
+        # than source_path so a future change to source_path resolution
+        # (working copy, companion JPEG fallback, etc.) cannot silently
+        # bypass RAW_DECODE_PRESERVE_HIGHLIGHTS for a RAW primary.
         raw_decode = (
             RAW_DECODE_PRESERVE_HIGHLIGHTS
-            if os.path.splitext(source_path)[1].lower() in RAW_EXTENSIONS
+            if os.path.splitext(photo["filename"])[1].lower() in RAW_EXTENSIONS
             else None
         )
         load_kwargs = {"raw_decode": raw_decode} if raw_decode else {}
@@ -13001,7 +13023,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
             import config as cfg
             from image_edits import apply_recipe_to_loaded_image
-            from image_loader import load_image
+            from image_loader import RAW_DECODE_PRESERVE_HIGHLIGHTS, load_image
 
             thread_db = Database(db_path)
             thread_db.set_active_workspace(active_ws)
@@ -13096,7 +13118,21 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     load_max_size = (
                         None if recipe and recipe.get("crop") else max_size
                     )
-                    img = load_image(canonical, max_size=load_max_size)
+                    # Match serve_preview's decode mode so warmed bytes equal
+                    # the on-demand render — without this, an edited RAW
+                    # preview written here would still come from the JPEG-first
+                    # path and overwrite serve_preview's highlight-preserving
+                    # cache on first warm.
+                    raw_decode = (
+                        RAW_DECODE_PRESERVE_HIGHLIGHTS
+                        if recipe
+                        and os.path.splitext(canonical)[1].lower() in RAW_EXTENSIONS
+                        else None
+                    )
+                    load_kwargs = (
+                        {"raw_decode": raw_decode} if raw_decode else {}
+                    )
+                    img = load_image(canonical, max_size=load_max_size, **load_kwargs)
                     if img:
                         if recipe:
                             img = apply_recipe_to_loaded_image(

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -9255,11 +9255,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 )
                 return source_path or fallback_path
 
-            # For RAW primaries, skip the working-copy short-circuit: legacy
-            # working copies predate the highlight-preserving RAW decode and
-            # would feed the editor a clipped JPEG to apply the recipe to.
+            # For RAW primaries, skip the working-copy short-circuit while the
+            # RAW source is available: legacy working copies predate the
+            # highlight-preserving RAW decode and would feed the editor a
+            # clipped JPEG to apply the recipe to. If the RAW source is
+            # offline/missing, the working copy is the only local fallback.
             wc_rel = photo["working_copy_path"]
-            if wc_rel and not primary_is_raw:
+            if wc_rel and (
+                not primary_is_raw or not os.path.exists(fallback_path)
+            ):
                 wc_path = (
                     wc_rel if os.path.isabs(wc_rel)
                     else os.path.join(vireo_dir, wc_rel)
@@ -11563,11 +11567,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             )
             return source_path or fallback_path
 
-        # For RAW primaries, skip the working-copy short-circuit: legacy
-        # working copies predate the highlight-preserving RAW decode and
-        # would feed iNat a clipped JPEG to apply the recipe to.
+        # For RAW primaries, skip the working-copy short-circuit while the
+        # RAW source is available: legacy working copies predate the
+        # highlight-preserving RAW decode and would feed iNat a clipped JPEG
+        # to apply the recipe to. If the RAW source is offline/missing, the
+        # working copy is the only local fallback.
         wc_rel = photo["working_copy_path"]
-        if wc_rel and not primary_is_raw:
+        if wc_rel and (
+            not primary_is_raw or not os.path.exists(fallback_path)
+        ):
             wc_path = (
                 wc_rel if os.path.isabs(wc_rel)
                 else os.path.join(vireo_dir, wc_rel)
@@ -11776,7 +11784,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         photo_path = os.path.join(photo["folder_path"], photo["filename"])
         if not os.path.isfile(photo_path):
-            return json_error("Photo file not found on disk", 404)
+            recipe = db.get_photo_edit_recipe(photo_id)
+            wc_rel = photo["working_copy_path"]
+            wc_abs = (
+                wc_rel if wc_rel and os.path.isabs(wc_rel)
+                else os.path.join(
+                    os.path.dirname(app.config["THUMB_CACHE_DIR"]), wc_rel,
+                )
+                if wc_rel else None
+            )
+            if not (recipe and wc_abs and os.path.isfile(wc_abs)):
+                return json_error("Photo file not found on disk", 404)
 
         upload_path, upload_error = _inat_upload_photo_path(db, photo, photo_path)
         if upload_error:
@@ -18838,7 +18856,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     folder["path"], using_offline_cache,
                 )
                 image_ext = os.path.splitext(image_path)[1].lower()
-                if companion_source and image_ext not in RAW_EXTENSIONS:
+                if (
+                    primary_is_raw
+                    and trusted_wc_path
+                    and not os.path.exists(image_path)
+                ):
+                    image_path = trusted_wc_path
+                elif companion_source and image_ext not in RAW_EXTENSIONS:
                     image_path = companion_source
                 elif (
                     primary_is_raw

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -18983,19 +18983,36 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             RAW_EXTENSIONS,
         )
         resolved_ext = os.path.splitext(image_path)[1].lower()
-        if (
+        companion_for_extraction = _full_res_companion_path(
+            folder["path"], using_offline_cache
+        )
+        has_current_raw_failure = (
             (not using_offline_cache or resolved_ext in RAW_EXTENSIONS)
             and _has_current_working_copy_failure(
                 photo, vireo_dir, trust_existing_working_copy=False,
                 live_source_path=image_path, folder_path=folder["path"],
             )
-        ):
-            log.info(
-                "Skipping original-image extraction for photo %s; RAW working-copy "
-                "extraction already failed for current source mtime",
-                photo_id,
-            )
-            return "Could not load image", 500
+        )
+        if has_current_raw_failure:
+            if (
+                resolved_ext in RAW_EXTENSIONS
+                and companion_for_extraction
+                and companion_for_extraction != image_path
+            ):
+                log.info(
+                    "RAW working-copy extraction already failed for photo %s; "
+                    "serving full-size companion JPEG %s for original",
+                    photo_id, companion_for_extraction,
+                )
+                image_path = companion_for_extraction
+                resolved_ext = os.path.splitext(image_path)[1].lower()
+            else:
+                log.info(
+                    "Skipping original-image extraction for photo %s; RAW working-copy "
+                    "extraction already failed for current source mtime",
+                    photo_id,
+                )
+                return "Could not load image", 500
 
         # For browser-native formats without a working copy, serve directly
         ext = resolved_ext
@@ -19016,9 +19033,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # Prefer companion JPEG only for non-RAW sources. RAW primaries should
         # be decoded through extract_working_copy's highlight-preserving RAW
         # path rather than replaced with a camera-rendered JPEG.
-        companion_for_extraction = _full_res_companion_path(
-            folder["path"], using_offline_cache
-        )
         source_for_extraction = image_path
         if resolved_ext not in RAW_EXTENSIONS and companion_for_extraction:
             source_for_extraction = companion_for_extraction

--- a/vireo/exif_orientation.py
+++ b/vireo/exif_orientation.py
@@ -1,0 +1,27 @@
+"""Shared EXIF orientation helpers.
+
+Centralizes the ``Orientation`` tag interpretation used by thumbnails,
+exports, the scanner, the Flask app, and the pipeline. Keeping the
+predicate here prevents the per-file copies from drifting (e.g. accepting
+``int|float`` numerics, swallowing booleans, parsing string variants like
+``"90 cw"``).
+"""
+
+
+def orientation_swaps_axes(orientation):
+    """Return True for EXIF Orientation values that rotate by 90°/270°.
+
+    Accepts integers, floats, and the string forms ExifTool emits.
+    Values 5-8 swap the rendered axes; values 1-4 do not.
+    """
+    if orientation is None or isinstance(orientation, bool):
+        return False
+    if isinstance(orientation, int | float):
+        return int(orientation) in (5, 6, 7, 8)
+    text = str(orientation).strip().lower()
+    if not text:
+        return False
+    try:
+        return int(text) in (5, 6, 7, 8)
+    except ValueError:
+        return "90" in text or "270" in text

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -210,8 +210,19 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
             )
             source_path = None
             if not use_wc:
+                primary_path = (
+                    os.path.join(folder_path, photo["filename"])
+                    if folder_path else ""
+                )
+                primary_is_raw = (
+                    os.path.splitext(photo["filename"])[1].lower()
+                    in RAW_EXTENSIONS
+                )
                 source_path = _companion_can_satisfy_export(
-                    photo, folder_path, recipe, max_size, exif_data=exif_data
+                    photo, folder_path, recipe, max_size, exif_data=exif_data,
+                    skip_raw_primary=(
+                        not primary_is_raw or os.path.isfile(primary_path)
+                    ),
                 )
             if not source_path:
                 source_path = _resolve_source(

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -780,12 +780,13 @@ def _working_copy_can_satisfy_export(
     # Reusing such a copy would silently apply the recipe to clipped bytes.
     # If the RAW source is offline/missing, though, the working copy is the
     # only local fallback for resized exports.
-    if recipe and os.path.splitext(photo["filename"])[1].lower() in RAW_EXTENSIONS:
-        if not folder_path:
-            return False
-        original = os.path.join(folder_path, photo["filename"])
-        if os.path.exists(original):
-            return False
+    if (
+        recipe
+        and os.path.splitext(photo["filename"])[1].lower() in RAW_EXTENSIONS
+        and folder_path
+        and os.path.exists(os.path.join(folder_path, photo["filename"]))
+    ):
+        return False
     wc_rel = photo["working_copy_path"]
     if not wc_rel:
         return False

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -290,20 +290,36 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
                 # demosaic the RAW; that preview can be much smaller than
                 # the full-size companion JPEG, so the export would
                 # quietly produce undersized bytes for unsupported RAW+JPEG
-                # files. Compare the loaded long edge to the source's
-                # expected dimensions (capped by ``load_max_size`` when
-                # set) and prefer the companion when the RAW result is
-                # smaller.
+                # files. Compare *both* loaded dimensions against the
+                # source's expected dimensions (capped by
+                # ``load_max_size`` when set) — a long-edge-only check
+                # accepts e.g. 6000x3376 embedded previews for 6000x4000
+                # photos, dropping short-edge content.
                 needs_companion = img is None
-                expected_long = 0
+                expected_w, expected_h = 0, 0
                 if img is not None:
                     orig_w, orig_h = _recipe_source_dimensions(photo, exif_data)
-                    expected_long = max(orig_w, orig_h)
-                    if load_max_size and (
-                        expected_long == 0 or expected_long > load_max_size
+                    expected_w, expected_h = orig_w, orig_h
+                    if (
+                        load_max_size
+                        and expected_w > 0
+                        and expected_h > 0
                     ):
-                        expected_long = load_max_size
-                    if expected_long > 0 and max(img.size) < expected_long:
+                        long_edge = max(expected_w, expected_h)
+                        if long_edge > load_max_size:
+                            scale = load_max_size / long_edge
+                            expected_w = round(expected_w * scale)
+                            expected_h = round(expected_h * scale)
+                    # Allow a 1px slack for rounding between RAW decoder
+                    # output and stored dimensions.
+                    if (
+                        expected_w > 0
+                        and expected_h > 0
+                        and (
+                            img.size[0] + 1 < expected_w
+                            or img.size[1] + 1 < expected_h
+                        )
+                    ):
                         needs_companion = True
                 if needs_companion:
                     companion_fallback = _companion_can_satisfy_export(
@@ -327,10 +343,10 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
                             else:
                                 log.info(
                                     "RAW decode fell back to undersized "
-                                    "embedded JPEG (%dx%d, expected %d on "
-                                    "long edge) for %s; using companion "
-                                    "JPEG instead",
-                                    img.size[0], img.size[1], expected_long,
+                                    "embedded JPEG (%dx%d, expected %dx%d) "
+                                    "for %s; using companion JPEG instead",
+                                    img.size[0], img.size[1],
+                                    expected_w, expected_h,
                                     photo["filename"],
                                 )
                                 img.close()

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -205,7 +205,8 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
                 break
         if not source_path:
             use_wc = _working_copy_can_satisfy_export(
-                photo, recipe, max_size, wc_max, vireo_dir, exif_data=exif_data
+                photo, recipe, max_size, wc_max, vireo_dir,
+                exif_data=exif_data, folder_path=folder_path,
             )
             source_path = None
             if not use_wc:
@@ -753,22 +754,27 @@ def _find_developed_output(
 
 
 def _working_copy_can_satisfy_export(
-    photo, recipe, max_size, wc_max, vireo_dir, exif_data=None
+    photo, recipe, max_size, wc_max, vireo_dir, exif_data=None, folder_path=None
 ):
     """Return True when the working copy can preserve requested export pixels."""
     if not max_size or max_size <= 0:
         return False
     if max_size > wc_max:
         return False
-    # For RAW primaries with an edit recipe, the working copy is unreliable:
-    # libraries built before the highlight-preserving RAW decode landed
-    # carry working copies derived from clipped sources (camera JPEG or the
-    # JPEG-first RAW path), and EDIT_MATH_VERSION purges previews/thumbnails
-    # but not working copies. Reusing such a copy would silently apply the
-    # recipe to clipped bytes. Force the export path back to the RAW so the
-    # later load_image() call gets RAW_DECODE_PRESERVE_HIGHLIGHTS.
+    # For RAW primaries with an edit recipe, the working copy is unreliable
+    # while the RAW source is available: libraries built before the
+    # highlight-preserving RAW decode landed carry working copies derived
+    # from clipped sources (camera JPEG or the JPEG-first RAW path), and
+    # EDIT_MATH_VERSION purges previews/thumbnails but not working copies.
+    # Reusing such a copy would silently apply the recipe to clipped bytes.
+    # If the RAW source is offline/missing, though, the working copy is the
+    # only local fallback for resized exports.
     if recipe and os.path.splitext(photo["filename"])[1].lower() in RAW_EXTENSIONS:
-        return False
+        if not folder_path:
+            return False
+        original = os.path.join(folder_path, photo["filename"])
+        if os.path.exists(original):
+            return False
     wc_rel = photo["working_copy_path"]
     if not wc_rel:
         return False

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -9,7 +9,7 @@ import re
 import shutil
 
 from image_edits import apply_recipe_to_loaded_image
-from image_loader import load_image
+from image_loader import RAW_DECODE_PRESERVE_HIGHLIGHTS, RAW_EXTENSIONS, load_image
 
 log = logging.getLogger(__name__)
 
@@ -275,7 +275,13 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
             load_max_size = (
                 None if recipe and recipe.get("crop") else (max_size or None)
             )
-            img = load_image(source_path, max_size=load_max_size)
+            raw_decode = (
+                RAW_DECODE_PRESERVE_HIGHLIGHTS
+                if recipe and os.path.splitext(source_path)[1].lower() in RAW_EXTENSIONS
+                else None
+            )
+            load_kwargs = {"raw_decode": raw_decode} if raw_decode else {}
+            img = load_image(source_path, max_size=load_max_size, **load_kwargs)
             if img is None:
                 errors.append(f"{photo['filename']}: failed to load image")
                 if progress_cb:
@@ -378,7 +384,7 @@ def _exif_orientation(exif_data):
 def _orientation_swaps_axes(orientation):
     if orientation is None or isinstance(orientation, bool):
         return False
-    if isinstance(orientation, (int, float)):
+    if isinstance(orientation, int | float):
         return int(orientation) in (5, 6, 7, 8)
     text = str(orientation).strip().lower()
     if not text:

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -717,6 +717,12 @@ def _companion_can_satisfy_export(photo, folder_path, recipe, max_size, exif_dat
     """Return a full-resolution companion path when it can satisfy edited export."""
     if not recipe:
         return None
+    # When the primary is a RAW, decoding the RAW with the highlight-preserving
+    # mode yields better edit results than the in-camera JPEG companion (whose
+    # highlights are already clipped). Skip the substitution so the export
+    # path falls back to the RAW primary and gets RAW_DECODE_PRESERVE_HIGHLIGHTS.
+    if os.path.splitext(photo["filename"])[1].lower() in RAW_EXTENSIONS:
+        return None
     companion_rel = photo["companion_path"]
     if not companion_rel or not folder_path:
         return None

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -275,13 +275,29 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
             load_max_size = (
                 None if recipe and recipe.get("crop") else (max_size or None)
             )
+            source_is_raw = (
+                os.path.splitext(source_path)[1].lower() in RAW_EXTENSIONS
+            )
             raw_decode = (
-                RAW_DECODE_PRESERVE_HIGHLIGHTS
-                if recipe and os.path.splitext(source_path)[1].lower() in RAW_EXTENSIONS
-                else None
+                RAW_DECODE_PRESERVE_HIGHLIGHTS if recipe and source_is_raw else None
             )
             load_kwargs = {"raw_decode": raw_decode} if raw_decode else {}
             img = load_image(source_path, max_size=load_max_size, **load_kwargs)
+            if img is None and source_is_raw:
+                # RAW decode failed (unsupported sensor, corrupt file, etc.).
+                # The previously rejected companion JPEG is still a usable
+                # fallback even though its highlights are clipped — a
+                # rendered camera JPEG beats a failed export.
+                companion_fallback = _companion_can_satisfy_export(
+                    photo, folder_path, recipe, max_size,
+                    exif_data=exif_data, skip_raw_primary=False,
+                )
+                if companion_fallback:
+                    log.info(
+                        "RAW decode failed for %s; falling back to companion JPEG",
+                        photo["filename"],
+                    )
+                    img = load_image(companion_fallback, max_size=load_max_size)
             if img is None:
                 errors.append(f"{photo['filename']}: failed to load image")
                 if progress_cb:
@@ -713,15 +729,24 @@ def _working_copy_can_satisfy_export(
     return wc_render_long >= required_long
 
 
-def _companion_can_satisfy_export(photo, folder_path, recipe, max_size, exif_data=None):
-    """Return a full-resolution companion path when it can satisfy edited export."""
+def _companion_can_satisfy_export(
+    photo, folder_path, recipe, max_size, exif_data=None,
+    *, skip_raw_primary=True,
+):
+    """Return a full-resolution companion path when it can satisfy edited export.
+
+    By default RAW primaries are skipped so the export decodes the RAW with
+    ``RAW_DECODE_PRESERVE_HIGHLIGHTS`` instead of the camera JPEG (whose
+    highlights are already clipped). Pass ``skip_raw_primary=False`` to get
+    the companion path as a fallback when the RAW decode itself fails — a
+    rendered camera JPEG is still better than a failed export.
+    """
     if not recipe:
         return None
-    # When the primary is a RAW, decoding the RAW with the highlight-preserving
-    # mode yields better edit results than the in-camera JPEG companion (whose
-    # highlights are already clipped). Skip the substitution so the export
-    # path falls back to the RAW primary and gets RAW_DECODE_PRESERVE_HIGHLIGHTS.
-    if os.path.splitext(photo["filename"])[1].lower() in RAW_EXTENSIONS:
+    if (
+        skip_raw_primary
+        and os.path.splitext(photo["filename"])[1].lower() in RAW_EXTENSIONS
+    ):
         return None
     companion_rel = photo["companion_path"]
     if not companion_rel or not folder_path:

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -283,21 +283,60 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
             )
             load_kwargs = {"raw_decode": raw_decode} if raw_decode else {}
             img = load_image(source_path, max_size=load_max_size, **load_kwargs)
-            if img is None and source_is_raw:
-                # RAW decode failed (unsupported sensor, corrupt file, etc.).
-                # The previously rejected companion JPEG is still a usable
-                # fallback even though its highlights are clipped — a
-                # rendered camera JPEG beats a failed export.
-                companion_fallback = _companion_can_satisfy_export(
-                    photo, folder_path, recipe, max_size,
-                    exif_data=exif_data, skip_raw_primary=False,
-                )
-                if companion_fallback:
-                    log.info(
-                        "RAW decode failed for %s; falling back to companion JPEG",
-                        photo["filename"],
+            if source_is_raw:
+                # RAW decode either failed outright (`img is None`) or
+                # silently fell back to the embedded JPEG. ``_load_raw``
+                # returns ``raw.extract_thumb()`` when libraw cannot
+                # demosaic the RAW; that preview can be much smaller than
+                # the full-size companion JPEG, so the export would
+                # quietly produce undersized bytes for unsupported RAW+JPEG
+                # files. Compare the loaded long edge to the source's
+                # expected dimensions (capped by ``load_max_size`` when
+                # set) and prefer the companion when the RAW result is
+                # smaller.
+                needs_companion = img is None
+                expected_long = 0
+                if img is not None:
+                    orig_w, orig_h = _recipe_source_dimensions(photo, exif_data)
+                    expected_long = max(orig_w, orig_h)
+                    if load_max_size and (
+                        expected_long == 0 or expected_long > load_max_size
+                    ):
+                        expected_long = load_max_size
+                    if expected_long > 0 and max(img.size) < expected_long:
+                        needs_companion = True
+                if needs_companion:
+                    companion_fallback = _companion_can_satisfy_export(
+                        photo, folder_path, recipe, max_size,
+                        exif_data=exif_data, skip_raw_primary=False,
                     )
-                    img = load_image(companion_fallback, max_size=load_max_size)
+                    if companion_fallback:
+                        companion_img = load_image(
+                            companion_fallback, max_size=load_max_size,
+                        )
+                        if companion_img is not None and (
+                            img is None
+                            or max(companion_img.size) > max(img.size)
+                        ):
+                            if img is None:
+                                log.info(
+                                    "RAW decode failed for %s; falling back "
+                                    "to companion JPEG",
+                                    photo["filename"],
+                                )
+                            else:
+                                log.info(
+                                    "RAW decode fell back to undersized "
+                                    "embedded JPEG (%dx%d, expected %d on "
+                                    "long edge) for %s; using companion "
+                                    "JPEG instead",
+                                    img.size[0], img.size[1], expected_long,
+                                    photo["filename"],
+                                )
+                                img.close()
+                            img = companion_img
+                        elif companion_img is not None:
+                            companion_img.close()
             if img is None:
                 errors.append(f"{photo['filename']}: failed to load image")
                 if progress_cb:

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -8,6 +8,7 @@ import os
 import re
 import shutil
 
+from exif_orientation import orientation_swaps_axes as _orientation_swaps_axes
 from image_edits import apply_recipe_to_loaded_image
 from image_loader import RAW_DECODE_PRESERVE_HIGHLIGHTS, RAW_EXTENSIONS, load_image
 
@@ -474,20 +475,6 @@ def _exif_orientation(exif_data):
         if isinstance(values, dict) and "Orientation" in values:
             return values["Orientation"]
     return metadata.get("Orientation")
-
-
-def _orientation_swaps_axes(orientation):
-    if orientation is None or isinstance(orientation, bool):
-        return False
-    if isinstance(orientation, int | float):
-        return int(orientation) in (5, 6, 7, 8)
-    text = str(orientation).strip().lower()
-    if not text:
-        return False
-    try:
-        return int(text) in (5, 6, 7, 8)
-    except ValueError:
-        return "90" in text or "270" in text
 
 
 def _image_size_after_exif_orientation(img):

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -500,14 +500,32 @@ def _image_size_after_exif_orientation(img):
     return width, height
 
 
-def _recipe_result_long_edge(width, height, recipe):
-    """Return the rendered long edge after right-angle rotation and crop."""
+def _recipe_result_dimensions(width, height, recipe):
+    """Return rendered dimensions after right-angle rotation and crop."""
     rotation = (recipe or {}).get("rotation", 0)
     if rotation in (90, 270):
         width, height = height, width
     crop = (recipe or {}).get("crop") if recipe else None
     if crop:
-        return max(float(crop["w"]) * width, float(crop["h"]) * height)
+        width = float(crop["w"]) * width
+        height = float(crop["h"]) * height
+    return width, height
+
+
+def _scale_dimensions_to_max(width, height, max_size):
+    if max_size is None:
+        return width, height
+    long_edge = max(width, height)
+    if long_edge > max_size:
+        scale = max_size / long_edge
+        width = round(width * scale)
+        height = round(height * scale)
+    return width, height
+
+
+def _recipe_result_long_edge(width, height, recipe):
+    """Return the rendered long edge after right-angle rotation and crop."""
+    width, height = _recipe_result_dimensions(width, height, recipe)
     return max(width, height)
 
 
@@ -858,10 +876,19 @@ def _companion_can_satisfy_export(
     original_w, original_h = _recipe_source_dimensions(photo, exif_data)
     if original_w <= 0 or original_h <= 0:
         return None
-    required_long = _recipe_result_long_edge(original_w, original_h, recipe)
-    if max_size is not None:
-        required_long = min(max_size, required_long)
-    if _recipe_result_long_edge(comp_w, comp_h, recipe) >= required_long:
+    required_w, required_h = _recipe_result_dimensions(
+        original_w, original_h, recipe,
+    )
+    comp_render_w, comp_render_h = _recipe_result_dimensions(
+        comp_w, comp_h, recipe,
+    )
+    required_w, required_h = _scale_dimensions_to_max(
+        required_w, required_h, max_size,
+    )
+    comp_render_w, comp_render_h = _scale_dimensions_to_max(
+        comp_render_w, comp_render_h, max_size,
+    )
+    if comp_render_w + 1 >= required_w and comp_render_h + 1 >= required_h:
         return companion
     return None
 

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -693,6 +693,15 @@ def _working_copy_can_satisfy_export(
         return False
     if max_size > wc_max:
         return False
+    # For RAW primaries with an edit recipe, the working copy is unreliable:
+    # libraries built before the highlight-preserving RAW decode landed
+    # carry working copies derived from clipped sources (camera JPEG or the
+    # JPEG-first RAW path), and EDIT_MATH_VERSION purges previews/thumbnails
+    # but not working copies. Reusing such a copy would silently apply the
+    # recipe to clipped bytes. Force the export path back to the RAW so the
+    # later load_image() call gets RAW_DECODE_PRESERVE_HIGHLIGHTS.
+    if recipe and os.path.splitext(photo["filename"])[1].lower() in RAW_EXTENSIONS:
+        return False
     wc_rel = photo["working_copy_path"]
     if not wc_rel:
         return False

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -330,9 +330,18 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
                         companion_img = load_image(
                             companion_fallback, max_size=load_max_size,
                         )
+                        # Prefer companion when it covers img on both
+                        # axes — a long-edge-only check misses cases
+                        # like a 6000x3376 embedded preview "tying" a
+                        # 6000x4000 sidecar and losing the short-edge
+                        # content.
                         if companion_img is not None and (
                             img is None
-                            or max(companion_img.size) > max(img.size)
+                            or (
+                                companion_img.size[0] >= img.size[0]
+                                and companion_img.size[1] >= img.size[1]
+                                and companion_img.size != img.size
+                            )
                         ):
                             if img is None:
                                 log.info(
@@ -344,10 +353,13 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
                                 log.info(
                                     "RAW decode fell back to undersized "
                                     "embedded JPEG (%dx%d, expected %dx%d) "
-                                    "for %s; using companion JPEG instead",
+                                    "for %s; using companion JPEG (%dx%d) "
+                                    "instead",
                                     img.size[0], img.size[1],
                                     expected_w, expected_h,
                                     photo["filename"],
+                                    companion_img.size[0],
+                                    companion_img.size[1],
                                 )
                                 img.close()
                             img = companion_img

--- a/vireo/image_edits.py
+++ b/vireo/image_edits.py
@@ -22,7 +22,8 @@ SCHEMA_VERSION = 1
 #   1 — original gamma-encoded sRGB multiply with hard clip at white.
 #   2 — linear-light pipeline with gated highlight shoulder.
 #   3 — expanded tone controls: highlights/shadows/whites/blacks/vibrance.
-EDIT_MATH_VERSION = 3
+#   4 — RAW edit renders demosaic with auto-bright off + highlight blending.
+EDIT_MATH_VERSION = 4
 
 _ADJUSTMENT_RANGES = {
     "exposure": (-5.0, 5.0),

--- a/vireo/image_loader.py
+++ b/vireo/image_loader.py
@@ -6,15 +6,19 @@ Performance notes:
 - PIL resize and JPEG encode are negligible (<0.15s)
 - libraw (via rawpy) is already C — Rust/numba won't help here
 
-RAW strategy (JPEG-first):
+RAW strategy:
 - Modern cameras embed a full-resolution JPEG in the RAW file (the same image
   the camera would produce in RAW+JPEG mode). For a photo organizer, that's
   both faster to decode and sufficient in quality.
 - It also works for RAW variants libraw cannot decode. Example: Nikon Z 8
   "High Efficiency*" (HE*) files use TicoRAW compression that libraw 0.22
   cannot decode. The embedded JPEG is our only path for those files.
-- We prefer the embedded JPEG whenever it meets the requested size, and
-  fall back to it when demosaic-based decode raises.
+- Browsing paths use the JPEG-first strategy: prefer the embedded JPEG whenever
+  it meets the requested size, and fall back to it when demosaic-based decode
+  raises.
+- Edit-quality working copies use RAW_DECODE_PRESERVE_HIGHLIGHTS: demosaic the
+  RAW with auto-bright disabled and highlight blending enabled, falling back to
+  the embedded JPEG only when libraw cannot decode the file.
 """
 
 import io
@@ -29,6 +33,9 @@ log = logging.getLogger(__name__)
 RAW_EXTENSIONS = {".nef", ".cr2", ".cr3", ".arw", ".raf", ".dng", ".rw2", ".orf"}
 IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".tiff", ".tif", ".bmp", ".webp"}
 SUPPORTED_EXTENSIONS = IMAGE_EXTENSIONS | RAW_EXTENSIONS
+RAW_DECODE_JPEG_FIRST = "jpeg_first"
+RAW_DECODE_PRESERVE_HIGHLIGHTS = "preserve_highlights"
+_RAW_DECODE_MODES = {RAW_DECODE_JPEG_FIRST, RAW_DECODE_PRESERVE_HIGHLIGHTS}
 
 # macOS "package" directories that hold OTHER apps' managed data. Walking
 # into them triggers Sequoia's "<app> would like to access data from other
@@ -338,12 +345,13 @@ def safe_scan_walk(top, onerror=None):
         yield from safe_scan_walk(os.path.join(top, subdir), onerror=onerror)
 
 
-def load_image(file_path, max_size=1024):
+def load_image(file_path, max_size=1024, raw_decode=RAW_DECODE_JPEG_FIRST):
     """Load an image file and return a PIL Image, resized to max_size.
 
     Supports JPEG, PNG, TIFF, and RAW formats (NEF, CR2, ARW, etc.).
-    For RAW files, prefers the embedded full-res JPEG preview when it meets
-    the requested size; falls back to demosaic-based decode otherwise.
+    For RAW files, ``raw_decode`` controls whether browsing gets the fast
+    JPEG-first path or edit-quality renders demosaic the RAW with highlight
+    preservation settings before falling back to an embedded JPEG.
     Returns None if the file cannot be loaded.
 
     For RAW files we retry once on transient libraw I/O errors. NAS volumes
@@ -355,6 +363,8 @@ def load_image(file_path, max_size=1024):
     Args:
         file_path: Path to the image file
         max_size: Maximum dimension (longest side). None or 0 for full resolution.
+        raw_decode: RAW_DECODE_JPEG_FIRST (default) or
+            RAW_DECODE_PRESERVE_HIGHLIGHTS.
 
     Returns:
         PIL.Image.Image or None
@@ -364,10 +374,12 @@ def load_image(file_path, max_size=1024):
 
     if ext not in SUPPORTED_EXTENSIONS:
         return None
+    if raw_decode not in _RAW_DECODE_MODES:
+        raise ValueError(f"raw_decode must be one of: {', '.join(sorted(_RAW_DECODE_MODES))}")
 
     try:
         if ext in RAW_EXTENSIONS:
-            img = _load_raw_with_retry(path, max_size)
+            img = _load_raw_with_retry(path, max_size, raw_decode=raw_decode)
         else:
             with Image.open(str(path)) as opened:
                 img = ImageOps.exif_transpose(opened)
@@ -385,7 +397,7 @@ def load_image(file_path, max_size=1024):
         return None
 
 
-def _load_raw_with_retry(path, max_size):
+def _load_raw_with_retry(path, max_size, raw_decode=RAW_DECODE_JPEG_FIRST):
     """Wrap _load_raw with a single retry on transient libraw I/O errors.
 
     Only retries on LibRawIOError — other libraw errors (UnsupportedFormat,
@@ -394,7 +406,7 @@ def _load_raw_with_retry(path, max_size):
     contention-related and resolve immediately.
     """
     try:
-        return _load_raw(path, max_size)
+        return _load_raw(path, max_size, raw_decode=raw_decode)
     except Exception as e:
         # Identify libraw I/O errors by class name so we don't have to
         # import rawpy at module scope (it's only present when a RAW
@@ -402,7 +414,7 @@ def _load_raw_with_retry(path, max_size):
         if type(e).__name__ != "LibRawIOError":
             raise
         log.info("Transient libraw I/O error on %s; retrying once", path)
-        return _load_raw(path, max_size)
+        return _load_raw(path, max_size, raw_decode=raw_decode)
 
 
 def _load_standard(path, max_size):
@@ -509,7 +521,11 @@ def extract_working_copy(source_path, output_path, max_size=4096, quality=92):
         True on success, False on failure
     """
     try:
-        img = load_image(source_path, max_size=max_size or None)
+        img = load_image(
+            source_path,
+            max_size=max_size or None,
+            raw_decode=RAW_DECODE_PRESERVE_HIGHLIGHTS,
+        )
         if img is None:
             return False
         os.makedirs(os.path.dirname(output_path), exist_ok=True)
@@ -521,13 +537,18 @@ def extract_working_copy(source_path, output_path, max_size=4096, quality=92):
         return False
 
 
-def _load_raw(path, max_size):
-    """Load a RAW file using JPEG-first strategy.
+def _load_raw(path, max_size, raw_decode=RAW_DECODE_JPEG_FIRST):
+    """Load a RAW file using the requested decode strategy.
 
-    1. Try the embedded JPEG preview; use it if it's big enough for max_size.
-    2. Otherwise demosaic via rawpy.postprocess().
-    3. If postprocess raises (e.g. libraw 0.22 can't decode Nikon HE*/TicoRAW),
-       fall back to the embedded JPEG even if smaller than max_size.
+    JPEG-first:
+      1. Try the embedded JPEG preview; use it if it's big enough for max_size.
+      2. Otherwise demosaic via rawpy.postprocess().
+      3. If postprocess raises (e.g. libraw 0.22 can't decode Nikon HE*/TicoRAW),
+         fall back to the embedded JPEG even if smaller than max_size.
+
+    Preserve-highlights:
+      1. Demosaic the RAW with auto-bright disabled and highlight blending on.
+      2. Fall back to the embedded JPEG only if libraw cannot decode the RAW.
     """
     import rawpy
 
@@ -536,14 +557,23 @@ def _load_raw(path, max_size):
 
         # JPEG-first: if the embedded preview is large enough for the request,
         # use it and skip the slower RAW decode entirely.
-        if (embedded is not None and max_size and max_size > 0
-                and max(embedded.size) >= max_size):
+        if (
+            raw_decode == RAW_DECODE_JPEG_FIRST
+            and embedded is not None
+            and max_size
+            and max_size > 0
+            and max(embedded.size) >= max_size
+        ):
             return embedded
 
         # Otherwise demosaic the sensor data, falling back to the embedded
         # JPEG if libraw can't decode this RAW variant.
         try:
-            return _postprocess_raw(raw, max_size)
+            return _postprocess_raw(
+                raw,
+                max_size,
+                preserve_highlights=raw_decode == RAW_DECODE_PRESERVE_HIGHLIGHTS,
+            )
         except Exception as e:
             if embedded is not None:
                 # Only claim "full camera output" when the embedded JPEG
@@ -592,17 +622,27 @@ def _extract_embedded_jpeg(raw):
         return None
 
 
-def _postprocess_raw(raw, max_size):
+def _postprocess_raw(raw, max_size, preserve_highlights=False):
     """Demosaic raw sensor data into a PIL Image.
 
     Uses half-size decode when the target fits, which is ~3x faster and still
     produces ~4000x2700 for a 45MP sensor.
     """
+    import rawpy
+
     use_half = False
     if max_size and max_size > 0:
         sensor_long = max(raw.sizes.width, raw.sizes.height)
         half_long = sensor_long // 2
         if max_size <= half_long:
             use_half = True
-    rgb = raw.postprocess(half_size=use_half)
+    kwargs = {"half_size": use_half}
+    if preserve_highlights:
+        kwargs.update({
+            "use_camera_wb": True,
+            "no_auto_bright": True,
+            "bright": 1.0,
+            "highlight_mode": rawpy.HighlightMode.Blend,
+        })
+    rgb = raw.postprocess(**kwargs)
     return Image.fromarray(rgb)

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -319,6 +319,20 @@ def _thumb_raw_decode_kwargs(photo, recipe):
     return {"raw_decode": RAW_DECODE_PRESERVE_HIGHLIGHTS}
 
 
+def _thumb_min_source_size_kwargs(photo, recipe, thumb_size, source_path):
+    if not recipe or not photo:
+        return {}
+    filename = _photo_value(photo, "filename") or ""
+    if os.path.splitext(filename)[1].lower() not in _RAW_EXTENSIONS:
+        return {}
+    if os.path.splitext(source_path or "")[1].lower() not in _RAW_EXTENSIONS:
+        return {}
+    load_max_size = None if recipe.get("crop") else thumb_size
+    return {
+        "min_source_size": _scaled_recipe_source_dimensions(photo, load_max_size),
+    }
+
+
 def _has_current_working_copy_failure(
     photo, vireo_dir=None, trust_existing_working_copy=True,
     live_source_path=None, folder_path=None,
@@ -1603,6 +1617,9 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     # to _recipe_render_source cannot silently bypass
                     # RAW_DECODE_PRESERVE_HIGHLIGHTS for a RAW primary.
                     raw_decode_kwargs = _thumb_raw_decode_kwargs(detail_photo, recipe)
+                    min_size_kwargs = _thumb_min_source_size_kwargs(
+                        detail_photo, recipe, thumb_size, photo_path,
+                    )
                     result_path = generate_thumbnail(
                         photo_id,
                         photo_path,
@@ -1610,6 +1627,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         size=thumb_size,
                         **recipe_kwargs,
                         **raw_decode_kwargs,
+                        **min_size_kwargs,
                     )
                     if (
                         result_path is None
@@ -1707,6 +1725,9 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         raw_decode_kwargs = _thumb_raw_decode_kwargs(
                             detail_photo, recipe,
                         )
+                        min_size_kwargs = _thumb_min_source_size_kwargs(
+                            detail_photo, recipe, thumb_size, photo_path,
+                        )
                         result_path = generate_thumbnail(
                             photo_id,
                             photo_path,
@@ -1714,6 +1735,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             size=thumb_size,
                             **recipe_kwargs,
                             **raw_decode_kwargs,
+                            **min_size_kwargs,
                         )
                         if (
                             result_path is None

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -192,16 +192,25 @@ def _recipe_render_source(photo, recipe, max_size, vireo_dir, folders):
 
     if not recipe:
         return get_canonical_image_path(photo, vireo_dir, folders)
+    primary_is_raw = (
+        os.path.splitext(photo["filename"])[1].lower() in _RAW_EXTENSIONS
+    )
     canonical = get_canonical_image_path(photo, vireo_dir, folders)
     wc_rel = photo["working_copy_path"]
-    if not recipe.get("crop") and canonical and wc_rel:
-        wc_path = wc_rel if os.path.isabs(wc_rel) else os.path.join(vireo_dir, wc_rel)
-        if os.path.abspath(canonical) == os.path.abspath(wc_path):
+    # For RAW primaries with a recipe, never short-circuit to the working
+    # copy: legacy working copies predate the highlight-preserving RAW
+    # decode, and EDIT_MATH_VERSION's migration only purges preview/thumb
+    # caches, not working copies. Reusing one would apply the recipe to
+    # clipped bytes and bypass RAW_DECODE_PRESERVE_HIGHLIGHTS.
+    if not primary_is_raw:
+        if not recipe.get("crop") and canonical and wc_rel:
+            wc_path = wc_rel if os.path.isabs(wc_rel) else os.path.join(vireo_dir, wc_rel)
+            if os.path.abspath(canonical) == os.path.abspath(wc_path):
+                return canonical
+        if recipe.get("crop") and _working_copy_satisfies_recipe_render(
+            photo, recipe, max_size, vireo_dir,
+        ):
             return canonical
-    if recipe.get("crop") and _working_copy_satisfies_recipe_render(
-        photo, recipe, max_size, vireo_dir,
-    ):
-        return canonical
 
     folder_path = folders.get(photo["folder_id"])
     if not folder_path:
@@ -216,9 +225,6 @@ def _recipe_render_source(photo, recipe, max_size, vireo_dir, folders):
     # RAW is known to fail extraction for this mtime — otherwise edited
     # previews/exports for unsupported RAWs would 500 out even though a
     # full-size companion JPEG is available.
-    primary_is_raw = (
-        os.path.splitext(photo["filename"])[1].lower() in _RAW_EXTENSIONS
-    )
     companion_path = photo["companion_path"]
     original = os.path.join(folder_path, photo["filename"])
     allow_companion = not primary_is_raw or _has_current_working_copy_failure(

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -275,6 +275,26 @@ _RAW_EXTENSIONS = (".nef", ".cr2", ".cr3", ".arw", ".raf", ".dng", ".rw2", ".orf
 _WORKING_COPY_FAILURE_RETRY_SECONDS = 24 * 60 * 60
 
 
+def _thumb_raw_decode_kwargs(photo, recipe):
+    """Return raw_decode kwargs for generate_thumbnail.
+
+    When the primary photo is a RAW and a recipe is being applied, the
+    thumbnail must demosaic with the same highlight-preserving mode used
+    by preview/export. Otherwise EDIT_MATH_VERSION's cache purge would
+    regenerate grid thumbnails through load_image's default JPEG-first
+    decode and the grid would diverge from the preview/export pipeline.
+    Returns an empty dict for non-RAW primaries or no-recipe paths so
+    the caller's existing behavior is preserved.
+    """
+    if not recipe or not photo:
+        return {}
+    filename = _photo_value(photo, "filename") or ""
+    if os.path.splitext(filename)[1].lower() not in _RAW_EXTENSIONS:
+        return {}
+    from image_loader import RAW_DECODE_PRESERVE_HIGHLIGHTS
+    return {"raw_decode": RAW_DECODE_PRESERVE_HIGHLIGHTS}
+
+
 def _has_current_working_copy_failure(
     photo, vireo_dir=None, trust_existing_working_copy=True,
     live_source_path=None, folder_path=None,
@@ -1504,12 +1524,18 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 skipped += 1
                                 continue
                     recipe_kwargs = {"recipe": recipe} if recipe else {}
+                    # Derive the decode mode from the primary photo's
+                    # extension rather than photo_path so a future change
+                    # to _recipe_render_source cannot silently bypass
+                    # RAW_DECODE_PRESERVE_HIGHLIGHTS for a RAW primary.
+                    raw_decode_kwargs = _thumb_raw_decode_kwargs(detail_photo, recipe)
                     result_path = generate_thumbnail(
                         photo_id,
                         photo_path,
                         cache_dir,
                         size=thumb_size,
                         **recipe_kwargs,
+                        **raw_decode_kwargs,
                     )
                     if result_path is None:
                         failed += 1
@@ -1589,12 +1615,21 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 skipped += 1
                                 continue
                         recipe_kwargs = {"recipe": recipe} if recipe else {}
+                        # Derive the decode mode from the primary photo's
+                        # extension rather than photo_path so a future
+                        # change to _recipe_render_source cannot silently
+                        # bypass RAW_DECODE_PRESERVE_HIGHLIGHTS for a RAW
+                        # primary.
+                        raw_decode_kwargs = _thumb_raw_decode_kwargs(
+                            detail_photo, recipe,
+                        )
                         result_path = generate_thumbnail(
                             photo_id,
                             photo_path,
                             cache_dir,
                             size=thumb_size,
                             **recipe_kwargs,
+                            **raw_decode_kwargs,
                         )
                         if result_path is None:
                             failed += 1

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -22,6 +22,7 @@ from datetime import UTC, datetime
 
 import numpy as np
 from db import Database, commit_with_retry
+from exif_orientation import orientation_swaps_axes as _orientation_swaps_axes
 from model_cache import get_default_cache
 from pipeline_locks import acquire_photo_mask, acquire_workspace_regroup
 
@@ -105,20 +106,6 @@ def _exif_orientation(exif_data):
         if isinstance(values, dict) and "Orientation" in values:
             return values["Orientation"]
     return metadata.get("Orientation")
-
-
-def _orientation_swaps_axes(orientation):
-    if orientation is None or isinstance(orientation, bool):
-        return False
-    if isinstance(orientation, int | float):
-        return int(orientation) in (5, 6, 7, 8)
-    text = str(orientation).strip().lower()
-    if not text:
-        return False
-    try:
-        return int(text) in (5, 6, 7, 8)
-    except ValueError:
-        return "90" in text or "270" in text
 
 
 def _recipe_source_dimensions(photo):

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1850,6 +1850,48 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         {"raw_decode": raw_decode} if raw_decode else {}
                     )
                     img = load_image(canonical, max_size=load_max_size, **load_kwargs)
+                    if (
+                        img is None
+                        and os.path.splitext(canonical)[1].lower() in _RAW_EXTENSIONS
+                    ):
+                        # Mirror serve_preview's cache-miss fallback: libraw
+                        # couldn't decode this RAW, so try the companion JPEG
+                        # before counting the photo as failed and leaving the
+                        # warmed cache cold. Record the source failure so
+                        # future _recipe_render_source calls (preview, edit-
+                        # preview, original) route through the companion
+                        # instead of retrying the failed RAW.
+                        companion_rel = detail_photo["companion_path"]
+                        folder_path = folders.get(detail_photo["folder_id"])
+                        if companion_rel and folder_path:
+                            companion_abs = os.path.join(folder_path, companion_rel)
+                            if (
+                                os.path.exists(companion_abs)
+                                and companion_abs != canonical
+                            ):
+                                log.info(
+                                    "RAW decode failed for photo %s pipeline "
+                                    "preview at size=%s; falling back to "
+                                    "companion JPEG",
+                                    detail_photo["id"], max_size,
+                                )
+                                file_mtime = detail_photo["file_mtime"]
+                                if file_mtime is not None:
+                                    with contextlib.suppress(Exception):
+                                        thread_db.conn.execute(
+                                            "UPDATE photos SET"
+                                            " working_copy_failed_at=datetime('now'),"
+                                            " working_copy_failed_mtime=?,"
+                                            " working_copy_failed_source='source'"
+                                            " WHERE id=?",
+                                            (file_mtime, detail_photo["id"]),
+                                        )
+                                        commit_with_retry(thread_db.conn)
+                                img = load_image(
+                                    companion_abs, max_size=load_max_size,
+                                )
+                                if img is not None:
+                                    canonical = companion_abs
                     if img:
                         if recipe:
                             img = apply_recipe_to_loaded_image(

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -160,6 +160,23 @@ def _image_is_smaller_than_expected(img, expected_w, expected_h):
     )
 
 
+def _companion_image_can_replace_raw_result(
+    companion_img, current_img, expected_w, expected_h,
+):
+    if companion_img is None:
+        return False
+    if expected_w > 0 and expected_h > 0:
+        return not _image_is_smaller_than_expected(
+            companion_img, expected_w, expected_h,
+        )
+    if current_img is None:
+        return True
+    return (
+        companion_img.size[0] >= current_img.size[0]
+        and companion_img.size[1] >= current_img.size[1]
+    )
+
+
 def _image_size_after_exif_orientation(img):
     width, height = img.size
     orientation = None
@@ -1999,35 +2016,30 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                     os.path.exists(companion_abs)
                                     and companion_abs != canonical
                                 ):
-                                    log.info(
-                                        "RAW decode for photo %s pipeline "
-                                        "preview at size=%s returned "
-                                        "undersized embedded preview "
-                                        "(%dx%d, expected %dx%d); "
-                                        "falling back to companion JPEG",
-                                        detail_photo["id"], max_size,
-                                        img.size[0], img.size[1],
-                                        expected_w, expected_h,
-                                    )
-                                    img.close()
                                     companion_img = load_image(
                                         companion_abs,
                                         max_size=load_max_size,
                                     )
-                                    if companion_img is not None:
+                                    if _companion_image_can_replace_raw_result(
+                                        companion_img, img,
+                                        expected_w, expected_h,
+                                    ):
+                                        log.info(
+                                            "RAW decode for photo %s "
+                                            "pipeline preview at size=%s "
+                                            "returned undersized embedded "
+                                            "preview (%dx%d, expected "
+                                            "%dx%d); falling back to "
+                                            "companion JPEG",
+                                            detail_photo["id"], max_size,
+                                            img.size[0], img.size[1],
+                                            expected_w, expected_h,
+                                        )
+                                        img.close()
                                         img = companion_img
                                         canonical = companion_abs
-                                    else:
-                                        # Companion unreadable — recover the
-                                        # embedded preview so the warmer
-                                        # still produces something rather
-                                        # than counting this photo as
-                                        # failed for the size mismatch.
-                                        img = load_image(
-                                            canonical,
-                                            max_size=load_max_size,
-                                            **load_kwargs,
-                                        )
+                                    elif companion_img is not None:
+                                        companion_img.close()
                     if (
                         img is None
                         and os.path.splitext(canonical)[1].lower() in _RAW_EXTENSIONS

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -136,6 +136,30 @@ def _recipe_source_dimensions(photo):
     return width, height
 
 
+def _scaled_recipe_source_dimensions(photo, max_size=None):
+    width, height = _recipe_source_dimensions(photo)
+    if width <= 0 or height <= 0:
+        return 0, 0
+    if max_size:
+        long_edge = max(width, height)
+        if long_edge > max_size:
+            scale = max_size / long_edge
+            width = round(width * scale)
+            height = round(height * scale)
+    return width, height
+
+
+def _image_is_smaller_than_expected(img, expected_w, expected_h):
+    return (
+        expected_w > 0
+        and expected_h > 0
+        and (
+            img.size[0] + 1 < expected_w
+            or img.size[1] + 1 < expected_h
+        )
+    )
+
+
 def _image_size_after_exif_orientation(img):
     width, height = img.size
     orientation = None
@@ -1935,16 +1959,11 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         # still be undersized. Mirror serve_preview's
                         # cache-miss undersized check so we don't bake an
                         # embedded preview into the tracked warmed cache.
-                        expected_long = max(
-                            int(detail_photo["width"]),
-                            int(detail_photo["height"]),
+                        expected_w, expected_h = _scaled_recipe_source_dimensions(
+                            detail_photo, load_max_size,
                         )
-                        if load_max_size is not None:
-                            expected_long = min(expected_long, load_max_size)
-                        loaded_long = max(img.size)
-                        if (
-                            expected_long > 0
-                            and loaded_long < expected_long * 0.9
+                        if _image_is_smaller_than_expected(
+                            img, expected_w, expected_h,
                         ):
                             companion_rel = detail_photo["companion_path"]
                             folder_path = folders.get(
@@ -1962,11 +1981,11 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                         "RAW decode for photo %s pipeline "
                                         "preview at size=%s returned "
                                         "undersized embedded preview "
-                                        "(%dx%d, expected long edge %d); "
+                                        "(%dx%d, expected %dx%d); "
                                         "falling back to companion JPEG",
                                         detail_photo["id"], max_size,
                                         img.size[0], img.size[1],
-                                        expected_long,
+                                        expected_w, expected_h,
                                     )
                                     img.close()
                                     companion_img = load_image(

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -348,6 +348,56 @@ def _has_current_working_copy_failure(
     return age < _WORKING_COPY_FAILURE_RETRY_SECONDS
 
 
+def _retry_thumbnail_with_companion(
+    thread_db, generate_thumbnail, photo, photo_id, raw_source_path,
+    cache_dir, thumb_size, recipe, folder_path,
+):
+    """Mirror serve_thumb's RAW->companion fallback for pipeline jobs.
+
+    When ``generate_thumbnail`` fails on a RAW source, try the companion
+    JPEG before counting the photo as failed and record a source failure
+    marker so future ``_recipe_render_source`` calls route through the
+    companion. Returns the new thumbnail path on success or ``None`` if
+    no usable companion fallback was available.
+    """
+    if not photo or not folder_path:
+        return None
+    companion_rel = _photo_value(photo, "companion_path")
+    if not companion_rel:
+        return None
+    companion_abs = os.path.join(folder_path, companion_rel)
+    if (
+        not os.path.exists(companion_abs)
+        or os.path.abspath(companion_abs) == os.path.abspath(raw_source_path)
+    ):
+        return None
+    log.info(
+        "Pipeline thumbnail RAW decode failed for photo %s; "
+        "falling back to companion JPEG",
+        photo_id,
+    )
+    file_mtime = _photo_value(photo, "file_mtime")
+    if file_mtime is not None:
+        with contextlib.suppress(Exception):
+            thread_db.conn.execute(
+                "UPDATE photos SET"
+                " working_copy_failed_at=datetime('now'),"
+                " working_copy_failed_mtime=?,"
+                " working_copy_failed_source='source'"
+                " WHERE id=?",
+                (file_mtime, photo_id),
+            )
+            commit_with_retry(thread_db.conn)
+    recipe_kwargs = {"recipe": recipe} if recipe else {}
+    return generate_thumbnail(
+        photo_id,
+        companion_abs,
+        cache_dir,
+        size=thumb_size,
+        **recipe_kwargs,
+    )
+
+
 _CLASSIFIER_BUNDLE_FIELDS = (
     "clf", "model_type", "model_name", "model_str",
     "labels", "use_tol", "active_model", "labels_fingerprint",
@@ -1537,6 +1587,16 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         **recipe_kwargs,
                         **raw_decode_kwargs,
                     )
+                    if (
+                        result_path is None
+                        and detail_photo is not None
+                        and os.path.splitext(photo_path)[1].lower() in _RAW_EXTENSIONS
+                    ):
+                        result_path = _retry_thumbnail_with_companion(
+                            thread_db, generate_thumbnail, detail_photo,
+                            photo_id, photo_path, cache_dir, thumb_size,
+                            recipe, folders.get(detail_photo["folder_id"]),
+                        )
                     if result_path is None:
                         failed += 1
                     elif already_exists:
@@ -1631,6 +1691,19 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             **recipe_kwargs,
                             **raw_decode_kwargs,
                         )
+                        if (
+                            result_path is None
+                            and os.path.splitext(photo_path)[1].lower() in _RAW_EXTENSIONS
+                        ):
+                            # detail_photo is set when recipe is set;
+                            # otherwise fall back to the collection's
+                            # `photo` row which carries companion_path.
+                            fallback_photo = detail_photo or photo
+                            result_path = _retry_thumbnail_with_companion(
+                                thread_db, generate_thumbnail, fallback_photo,
+                                photo_id, photo_path, cache_dir, thumb_size,
+                                recipe, folder_path,
+                            )
                         if result_path is None:
                             failed += 1
                         elif already_exists:

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1851,6 +1851,70 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     )
                     img = load_image(canonical, max_size=load_max_size, **load_kwargs)
                     if (
+                        img is not None
+                        and os.path.splitext(canonical)[1].lower() in _RAW_EXTENSIONS
+                        and detail_photo["width"]
+                        and detail_photo["height"]
+                    ):
+                        # _load_raw falls back to an embedded JPEG when
+                        # libraw can't demosaic; that preview is often a
+                        # fraction of sensor resolution, so non-None can
+                        # still be undersized. Mirror serve_preview's
+                        # cache-miss undersized check so we don't bake an
+                        # embedded preview into the tracked warmed cache.
+                        expected_long = max(
+                            int(detail_photo["width"]),
+                            int(detail_photo["height"]),
+                        )
+                        if load_max_size is not None:
+                            expected_long = min(expected_long, load_max_size)
+                        loaded_long = max(img.size)
+                        if (
+                            expected_long > 0
+                            and loaded_long < expected_long * 0.9
+                        ):
+                            companion_rel = detail_photo["companion_path"]
+                            folder_path = folders.get(
+                                detail_photo["folder_id"]
+                            )
+                            if companion_rel and folder_path:
+                                companion_abs = os.path.join(
+                                    folder_path, companion_rel,
+                                )
+                                if (
+                                    os.path.exists(companion_abs)
+                                    and companion_abs != canonical
+                                ):
+                                    log.info(
+                                        "RAW decode for photo %s pipeline "
+                                        "preview at size=%s returned "
+                                        "undersized embedded preview "
+                                        "(%dx%d, expected long edge %d); "
+                                        "falling back to companion JPEG",
+                                        detail_photo["id"], max_size,
+                                        img.size[0], img.size[1],
+                                        expected_long,
+                                    )
+                                    img.close()
+                                    companion_img = load_image(
+                                        companion_abs,
+                                        max_size=load_max_size,
+                                    )
+                                    if companion_img is not None:
+                                        img = companion_img
+                                        canonical = companion_abs
+                                    else:
+                                        # Companion unreadable — recover the
+                                        # embedded preview so the warmer
+                                        # still produces something rather
+                                        # than counting this photo as
+                                        # failed for the size mismatch.
+                                        img = load_image(
+                                            canonical,
+                                            max_size=load_max_size,
+                                            **load_kwargs,
+                                        )
+                    if (
                         img is None
                         and os.path.splitext(canonical)[1].lower() in _RAW_EXTENSIONS
                     ):

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -210,18 +210,31 @@ def _recipe_render_source(photo, recipe, max_size, vireo_dir, folders):
             if os.path.exists(wc_path):
                 return wc_path
         return ""
+    # When the primary is RAW, prefer the RAW source so the caller can decode
+    # with highlight preservation rather than serving the camera's already-
+    # clipped companion JPEG. The companion remains a valid fallback when the
+    # RAW is known to fail extraction for this mtime — otherwise edited
+    # previews/exports for unsupported RAWs would 500 out even though a
+    # full-size companion JPEG is available.
+    primary_is_raw = (
+        os.path.splitext(photo["filename"])[1].lower() in _RAW_EXTENSIONS
+    )
     companion_path = photo["companion_path"]
-    if companion_path:
+    original = os.path.join(folder_path, photo["filename"])
+    allow_companion = not primary_is_raw or _has_current_working_copy_failure(
+        photo,
+        vireo_dir,
+        trust_existing_working_copy=False,
+        live_source_path=original,
+        folder_path=folder_path,
+    )
+    if companion_path and allow_companion:
         companion = os.path.join(folder_path, companion_path)
         if (
             os.path.exists(companion)
             and _path_satisfies_recipe_render(companion, photo, recipe, max_size)
         ):
             return companion
-    original = os.path.join(
-        folder_path,
-        photo["filename"],
-    )
     if not os.path.exists(original) and photo["working_copy_path"]:
         wc_path = os.path.join(vireo_dir, photo["working_copy_path"])
         if os.path.exists(wc_path):
@@ -1670,7 +1683,10 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
         try:
             import config as cfg
             from image_edits import apply_recipe_to_loaded_image
-            from image_loader import load_image
+            from image_loader import (
+                RAW_DECODE_PRESERVE_HIGHLIGHTS,
+                load_image,
+            )
 
             thread_db = Database(db_path)
             thread_db.set_active_workspace(workspace_id)
@@ -1778,7 +1794,21 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     load_max_size = (
                         None if recipe and recipe.get("crop") else max_size
                     )
-                    img = load_image(canonical, max_size=load_max_size)
+                    # Match serve_preview's decode mode so warmed bytes equal
+                    # the on-demand render — without this, an edited RAW
+                    # preview written here would still come from the JPEG-first
+                    # path and overwrite serve_preview's highlight-preserving
+                    # cache on first warm.
+                    raw_decode = (
+                        RAW_DECODE_PRESERVE_HIGHLIGHTS
+                        if recipe
+                        and os.path.splitext(canonical)[1].lower() in _RAW_EXTENSIONS
+                        else None
+                    )
+                    load_kwargs = (
+                        {"raw_decode": raw_decode} if raw_decode else {}
+                    )
+                    img = load_image(canonical, max_size=load_max_size, **load_kwargs)
                     if img:
                         if recipe:
                             img = apply_recipe_to_loaded_image(

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -110,7 +110,7 @@ def _exif_orientation(exif_data):
 def _orientation_swaps_axes(orientation):
     if orientation is None or isinstance(orientation, bool):
         return False
-    if isinstance(orientation, (int, float)):
+    if isinstance(orientation, int | float):
         return int(orientation) in (5, 6, 7, 8)
     text = str(orientation).strip().lower()
     if not text:

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -877,6 +877,7 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
         # extract_working_copy is slow (RAW decode + JPEG encode); run it
         # before any DB write so no transaction is open while it runs.
         ok = extract_working_copy(source, wc_abs, max_size=wc_max_size, quality=wc_quality)
+        raw_failed_then_companion = False
         if not ok and primary_is_raw and companion_path:
             log.info(
                 "RAW working-copy extraction failed for photo %s (%s); "
@@ -892,15 +893,32 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
             ok = extract_working_copy(
                 source, wc_abs, max_size=wc_max_size, quality=wc_quality,
             )
+            raw_failed_then_companion = ok
         if ok:
-            db.conn.execute(
-                "UPDATE photos SET working_copy_path=?,"
-                " working_copy_failed_at=NULL,"
-                " working_copy_failed_mtime=NULL,"
-                " working_copy_failed_source=NULL"
-                " WHERE id=?",
-                (wc_rel, row["id"]),
-            )
+            if raw_failed_then_companion:
+                # The companion-derived working copy is usable, but request
+                # paths still need to know the RAW itself failed: edited RAW
+                # render paths (preview/edit-preview/original/export) gate
+                # companion selection in _recipe_render_source on a present
+                # "source" failure marker. Clearing it here would push those
+                # paths back through the unsupported RAW decode and 500.
+                db.conn.execute(
+                    "UPDATE photos SET working_copy_path=?,"
+                    " working_copy_failed_at=datetime('now'),"
+                    " working_copy_failed_mtime=?,"
+                    " working_copy_failed_source='source'"
+                    " WHERE id=?",
+                    (wc_rel, row["file_mtime"], row["id"]),
+                )
+            else:
+                db.conn.execute(
+                    "UPDATE photos SET working_copy_path=?,"
+                    " working_copy_failed_at=NULL,"
+                    " working_copy_failed_mtime=NULL,"
+                    " working_copy_failed_source=NULL"
+                    " WHERE id=?",
+                    (wc_rel, row["id"]),
+                )
         else:
             # Mark failure gated on current file_mtime so a future content
             # change (mtime bump) clears the gate and we retry. The

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -53,6 +53,23 @@ _SCAN_MP_METHOD = (
 _WINDOWS_MAX_WORKERS = 61
 
 
+def _scaled_dimensions(width, height, max_size):
+    try:
+        width = int(width or 0)
+        height = int(height or 0)
+    except (TypeError, ValueError):
+        return 0, 0
+    if width <= 0 or height <= 0:
+        return 0, 0
+    if max_size and max_size > 0:
+        long_edge = max(width, height)
+        if long_edge > max_size:
+            scale = max_size / long_edge
+            width = round(width * scale)
+            height = round(height * scale)
+    return width, height
+
+
 def compute_file_hash(file_path, chunk_size=65536):
     """Compute SHA-256 hash of a file. Returns hex digest string."""
     h = hashlib.sha256()
@@ -891,13 +908,12 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
             and row["width"]
             and row["height"]
         ):
-            expected_long = max(int(row["width"]), int(row["height"]))
-            if wc_max_size and wc_max_size > 0:
-                expected_long = min(expected_long, wc_max_size)
+            expected_w, expected_h = _scaled_dimensions(
+                row["width"], row["height"], wc_max_size,
+            )
             try:
-                from PIL import Image as _PILImage
-                with _PILImage.open(wc_abs) as _wc:
-                    wc_long = max(_wc.size)
+                with Image.open(wc_abs) as _wc:
+                    wc_w, wc_h = _wc.size
             except Exception:
                 # PIL couldn't open the file: corrupt / truncated /
                 # unsupported. Treat as a failed extraction so the
@@ -909,19 +925,23 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
                     "JPEG %s",
                     row["id"], wc_abs, companion_path,
                 )
-                wc_long = 0
+                wc_w = wc_h = 0
                 ok = False
             if (
                 ok
-                and expected_long > 0
-                and wc_long
-                and wc_long < expected_long * 0.9
+                and expected_w > 0
+                and expected_h > 0
+                and (
+                    wc_w + 1 < expected_w
+                    or wc_h + 1 < expected_h
+                )
             ):
                 log.info(
                     "RAW working-copy extraction for photo %s produced "
-                    "undersized result (%d, expected long edge %d); "
+                    "undersized result (%dx%d, expected %dx%d); "
                     "retrying from companion JPEG %s",
-                    row["id"], wc_long, expected_long, companion_path,
+                    row["id"], wc_w, wc_h, expected_w, expected_h,
+                    companion_path,
                 )
                 ok = False
         if not ok and primary_is_raw and companion_path:

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -899,8 +899,24 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
                 with _PILImage.open(wc_abs) as _wc:
                     wc_long = max(_wc.size)
             except Exception:
+                # PIL couldn't open the file: corrupt / truncated /
+                # unsupported. Treat as a failed extraction so the
+                # companion fallback below runs instead of caching an
+                # unreadable working copy.
+                log.info(
+                    "RAW working-copy extraction for photo %s produced "
+                    "an unreadable file %s; retrying from companion "
+                    "JPEG %s",
+                    row["id"], wc_abs, companion_path,
+                )
                 wc_long = 0
-            if expected_long > 0 and wc_long and wc_long < expected_long * 0.9:
+                ok = False
+            if (
+                ok
+                and expected_long > 0
+                and wc_long
+                and wc_long < expected_long * 0.9
+            ):
                 log.info(
                     "RAW working-copy extraction for photo %s produced "
                     "undersized result (%d, expected long edge %d); "

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -993,8 +993,8 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
                 and expected_w > 0
                 and expected_h > 0
                 and (
-                    wc_w + 1 < expected_w
-                    or wc_h + 1 < expected_h
+                    wc_w < expected_w * 0.99
+                    or wc_h < expected_h * 0.99
                 )
             ):
                 log.info(

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -878,6 +878,36 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
         # before any DB write so no transaction is open while it runs.
         ok = extract_working_copy(source, wc_abs, max_size=wc_max_size, quality=wc_quality)
         raw_failed_then_companion = False
+        # libraw returns an embedded JPEG when it can't demosaic a RAW; that
+        # preview is often a fraction of sensor resolution, so ok=True here
+        # can still produce an undersized working copy. Treat a substantially
+        # undersized RAW extraction the same as a hard failure so the
+        # companion-fallback branch below replaces it instead of caching the
+        # downscaled preview.
+        if (
+            ok
+            and primary_is_raw
+            and companion_path
+            and row["width"]
+            and row["height"]
+        ):
+            expected_long = max(int(row["width"]), int(row["height"]))
+            if wc_max_size and wc_max_size > 0:
+                expected_long = min(expected_long, wc_max_size)
+            try:
+                from PIL import Image as _PILImage
+                with _PILImage.open(wc_abs) as _wc:
+                    wc_long = max(_wc.size)
+            except Exception:
+                wc_long = 0
+            if expected_long > 0 and wc_long and wc_long < expected_long * 0.9:
+                log.info(
+                    "RAW working-copy extraction for photo %s produced "
+                    "undersized result (%d, expected long edge %d); "
+                    "retrying from companion JPEG %s",
+                    row["id"], wc_long, expected_long, companion_path,
+                )
+                ok = False
         if not ok and primary_is_raw and companion_path:
             log.info(
                 "RAW working-copy extraction failed for photo %s (%s); "

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 import imagehash
 from db import commit_with_retry
+from exif_orientation import orientation_swaps_axes as _orientation_swaps_axes
 from image_loader import (
     RAW_EXTENSIONS,
     SUPPORTED_EXTENSIONS,
@@ -91,20 +92,6 @@ def _exif_orientation_from_data(exif_data):
         if isinstance(values, dict) and "Orientation" in values:
             return values["Orientation"]
     return metadata.get("Orientation")
-
-
-def _orientation_swaps_axes(orientation):
-    if orientation is None or isinstance(orientation, bool):
-        return False
-    if isinstance(orientation, int | float):
-        return int(orientation) in (5, 6, 7, 8)
-    text = str(orientation).strip().lower()
-    if not text:
-        return False
-    try:
-        return int(text) in (5, 6, 7, 8)
-    except ValueError:
-        return "90" in text or "270" in text
 
 
 def _oriented_dimensions(width, height, exif_data):

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -850,10 +850,16 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
         wc_rel = f"working/{row['id']}.jpg"
         wc_abs = os.path.join(vireo_dir, wc_rel)
 
-        # Prefer companion JPEG if available
+        # Prefer companion JPEG for non-RAW primaries. For RAW primaries,
+        # working copies are the edit-quality source, so decode the RAW with
+        # image_loader's highlight-preserving settings instead of baking in
+        # a camera JPEG that may already have clipped highlights.
         source = os.path.join(row["folder_path"], row["filename"])
         failure_source = "source"
-        if row["companion_path"]:
+        if (
+            os.path.splitext(row["filename"])[1].lower() not in RAW_EXTENSIONS
+            and row["companion_path"]
+        ):
             companion = os.path.join(row["folder_path"], row["companion_path"])
             if os.path.isfile(companion):
                 source = companion

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -884,7 +884,11 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
                 row["id"], primary_path, companion_path,
             )
             source = companion_path
-            failure_source = "companion"
+            # Keep failure_source = "source": the RAW already failed, and
+            # _has_current_working_copy_failure ignores "companion" markers
+            # while both files exist — overwriting here would silently
+            # un-shield request paths from the known RAW failure if the
+            # companion extraction also fails.
             ok = extract_working_copy(
                 source, wc_abs, max_size=wc_max_size, quality=wc_quality,
             )

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -70,6 +70,60 @@ def _scaled_dimensions(width, height, max_size):
     return width, height
 
 
+def _exif_orientation_from_data(exif_data):
+    # Mirror of vireo.thumbnails._exif_orientation; kept local so the scanner
+    # doesn't take a runtime dependency on the request-path thumbnail module.
+    if not exif_data:
+        return None
+    if isinstance(exif_data, str):
+        try:
+            metadata = json.loads(exif_data)
+        except (TypeError, ValueError):
+            return None
+    elif isinstance(exif_data, dict):
+        metadata = exif_data
+    else:
+        return None
+    if not isinstance(metadata, dict):
+        return None
+    for group in ("EXIF", "IFD0", "TIFF", "File"):
+        values = metadata.get(group)
+        if isinstance(values, dict) and "Orientation" in values:
+            return values["Orientation"]
+    return metadata.get("Orientation")
+
+
+def _orientation_swaps_axes(orientation):
+    if orientation is None or isinstance(orientation, bool):
+        return False
+    if isinstance(orientation, int | float):
+        return int(orientation) in (5, 6, 7, 8)
+    text = str(orientation).strip().lower()
+    if not text:
+        return False
+    try:
+        return int(text) in (5, 6, 7, 8)
+    except ValueError:
+        return "90" in text or "270" in text
+
+
+def _oriented_dimensions(width, height, exif_data):
+    """Return (width, height) rotated to match what extract_working_copy writes.
+
+    Stored ``width``/``height`` come straight from the sensor/file metadata,
+    so for portrait shots taken on a landscape sensor they're the unrotated
+    axes (e.g. 6000x4000 with EXIF Orientation 6). The request-path helpers
+    in thumbnails/app/export/pipeline normalize these to display orientation
+    before comparing against rendered pixels; scanner's RAW-undersize check
+    must do the same or it sees the orientation-normalized JPEG written by
+    ``extract_working_copy`` (4000x6000) as catastrophically undersized vs.
+    the raw 6000x4000 and falls back to the companion JPEG.
+    """
+    if _orientation_swaps_axes(_exif_orientation_from_data(exif_data)):
+        return height, width
+    return width, height
+
+
 def compute_file_hash(file_path, chunk_size=65536):
     """Compute SHA-256 hash of a file. Returns hex digest string."""
     h = hashlib.sha256()
@@ -836,7 +890,7 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
     rows = db.conn.execute(
         f"""
         SELECT p.id, p.filename, p.companion_path, p.working_copy_path,
-               p.extension, p.width, p.height, p.file_mtime,
+               p.extension, p.width, p.height, p.exif_data, p.file_mtime,
                f.path AS folder_path
           FROM photos p
           JOIN folders f ON f.id = p.folder_id
@@ -908,8 +962,15 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
             and row["width"]
             and row["height"]
         ):
+            # Stored width/height are the unrotated sensor axes; swap them
+            # before scaling so portrait files (e.g. 6000x4000 + Orientation 6)
+            # produce the same expected dimensions as the orientation-normalized
+            # JPEG that extract_working_copy actually writes.
+            oriented_w, oriented_h = _oriented_dimensions(
+                row["width"], row["height"], row["exif_data"],
+            )
             expected_w, expected_h = _scaled_dimensions(
-                row["width"], row["height"], wc_max_size,
+                oriented_w, oriented_h, wc_max_size,
             )
             try:
                 with Image.open(wc_abs) as _wc:

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -850,24 +850,44 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
         wc_rel = f"working/{row['id']}.jpg"
         wc_abs = os.path.join(vireo_dir, wc_rel)
 
-        # Prefer companion JPEG for non-RAW primaries. For RAW primaries,
-        # working copies are the edit-quality source, so decode the RAW with
-        # image_loader's highlight-preserving settings instead of baking in
-        # a camera JPEG that may already have clipped highlights.
-        source = os.path.join(row["folder_path"], row["filename"])
-        failure_source = "source"
-        if (
-            os.path.splitext(row["filename"])[1].lower() not in RAW_EXTENSIONS
-            and row["companion_path"]
-        ):
-            companion = os.path.join(row["folder_path"], row["companion_path"])
-            if os.path.isfile(companion):
-                source = companion
-                failure_source = "companion"
+        # Working copies are the edit-quality source. For non-RAW primaries
+        # we still prefer the companion JPEG outright (fast path). For RAW
+        # primaries we decode the RAW with image_loader's highlight-preserving
+        # settings instead of baking in a camera JPEG that may already have
+        # clipped highlights — but if libraw cannot decode this RAW variant
+        # (and the embedded thumb is unusable too) we still fall back to the
+        # companion so an extractable JPEG copy isn't refused outright.
+        primary_path = os.path.join(row["folder_path"], row["filename"])
+        primary_is_raw = (
+            os.path.splitext(row["filename"])[1].lower() in RAW_EXTENSIONS
+        )
+        companion_path = None
+        if row["companion_path"]:
+            candidate = os.path.join(row["folder_path"], row["companion_path"])
+            if os.path.isfile(candidate):
+                companion_path = candidate
+
+        if not primary_is_raw and companion_path:
+            source = companion_path
+            failure_source = "companion"
+        else:
+            source = primary_path
+            failure_source = "source"
 
         # extract_working_copy is slow (RAW decode + JPEG encode); run it
         # before any DB write so no transaction is open while it runs.
         ok = extract_working_copy(source, wc_abs, max_size=wc_max_size, quality=wc_quality)
+        if not ok and primary_is_raw and companion_path:
+            log.info(
+                "RAW working-copy extraction failed for photo %s (%s); "
+                "falling back to companion JPEG %s",
+                row["id"], primary_path, companion_path,
+            )
+            source = companion_path
+            failure_source = "companion"
+            ok = extract_working_copy(
+                source, wc_abs, max_size=wc_max_size, quality=wc_quality,
+            )
         if ok:
             db.conn.execute(
                 "UPDATE photos SET working_copy_path=?,"

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3655,7 +3655,7 @@ function _vireoHashString(s) {
 // seeing the old bytes from their own browser cache until they expire.
 // test_edit_math_version_template_constant_matches_python locks the two
 // constants together.
-var _VIREO_EDIT_MATH_VERSION = 3;
+var _VIREO_EDIT_MATH_VERSION = 4;
 
 function _vireoEditRecipeCacheKey(recipe) {
   var normalized = _lbCloneEditRecipe(recipe);

--- a/vireo/tests/test_config.py
+++ b/vireo/tests/test_config.py
@@ -260,6 +260,10 @@ def test_conftest_autouse_fixture_restores_cfg_path(tmp_path):
             )
     """))
 
+    # Isolate the sub-pytest from the parent's env: drop any inherited
+    # PYTEST_ADDOPTS/PYTEST_CURRENT_TEST and route TMP/TEMP into a fresh
+    # subdir so the nested pytest's own tmp_path_factory doesn't see the
+    # parent's shared Temp tree.
     child_tmp = tmp_path / "subpytest-tmp"
     child_tmp.mkdir()
     child_env = os.environ.copy()
@@ -268,9 +272,20 @@ def test_conftest_autouse_fixture_restores_cfg_path(tmp_path):
     child_env["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
     child_env["TMP"] = str(child_tmp)
     child_env["TEMP"] = str(child_tmp)
+    # ``--rootdir`` + ``--confcutdir`` pin the sub-pytest's collection scope
+    # to ``sub_dir``. Without them, pytest walks ``argpath.parents`` up to the
+    # drive root, and on Windows runners the parent walk through the shared
+    # ``Temp\`` directory triggers ``Session._collect_path`` to iterate sibling
+    # entries — when a sibling like ``Temp\firefox`` (left by an unrelated
+    # process) is removed between scandir and pytest's Windows
+    # ``samefile_nofollow`` lstat, collection dies with a spurious
+    # ``FileNotFoundError`` and this test fails for reasons unrelated to the
+    # autouse fixture under test. The TMP/TEMP override above doesn't help
+    # here because ``sub_dir`` still lives under the parent's Temp.
     result = subprocess.run(
         [sys.executable, "-m", "pytest", str(sub_dir), "-q",
-         "-p", "no:cacheprovider", "-p", "no:xdist", "--no-header"],
+         "-p", "no:cacheprovider", "-p", "no:xdist", "--no-header",
+         "--rootdir", str(sub_dir), "--confcutdir", str(sub_dir)],
         capture_output=True, text=True, timeout=60, env=child_env,
     )
     assert result.returncode == 0, (

--- a/vireo/tests/test_config.py
+++ b/vireo/tests/test_config.py
@@ -260,10 +260,18 @@ def test_conftest_autouse_fixture_restores_cfg_path(tmp_path):
             )
     """))
 
+    child_tmp = tmp_path / "subpytest-tmp"
+    child_tmp.mkdir()
+    child_env = os.environ.copy()
+    child_env.pop("PYTEST_ADDOPTS", None)
+    child_env.pop("PYTEST_CURRENT_TEST", None)
+    child_env["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
+    child_env["TMP"] = str(child_tmp)
+    child_env["TEMP"] = str(child_tmp)
     result = subprocess.run(
         [sys.executable, "-m", "pytest", str(sub_dir), "-q",
          "-p", "no:cacheprovider", "-p", "no:xdist", "--no-header"],
-        capture_output=True, text=True, timeout=60,
+        capture_output=True, text=True, timeout=60, env=child_env,
     )
     assert result.returncode == 0, (
         f"sub-pytest failed (exit {result.returncode}):\n"

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -650,6 +650,58 @@ def test_export_falls_back_to_companion_when_raw_short_edge_is_smaller(
         assert img.size == (3000, 2000)
 
 
+def test_export_rejects_reduced_companion_when_raw_decode_fails(
+    export_env, monkeypatch,
+):
+    """A reduced/aspect-cropped sidecar must not satisfy RAW fallback export."""
+    import export as export_module
+
+    env = export_env
+    db = env["db"]
+    raw_path = env["src"] / "source.NEF"
+    raw_path.write_bytes(b"\x00")
+    Image.new("RGB", (6000, 3376), color="green").save(
+        env["src"] / "source.jpg", "JPEG", quality=95,
+    )
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='source.NEF', extension='.nef',
+               companion_path='source.jpg',
+               working_copy_path=NULL,
+               width=6000, height=4000
+           WHERE id=?""",
+        (env["p1"],),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(env["p1"], {"rotation": 0})
+
+    load_calls = []
+
+    def tracking_load_image(file_path, max_size=1024, **kwargs):
+        load_calls.append(str(file_path))
+        if str(file_path).lower().endswith(".nef"):
+            return None
+        return Image.new("RGB", (3000, 1688), color="green")
+
+    monkeypatch.setattr(export_module, "load_image", tracking_load_image)
+
+    result = export_photos(
+        db=db,
+        vireo_dir=env["vireo_dir"],
+        photo_ids=[env["p1"]],
+        destination=env["dest"],
+        options={
+            "naming_template": "{original}",
+            "max_size": 3000,
+        },
+    )
+
+    assert result["exported"] == 0
+    assert result["errors"] == ["source.NEF: failed to load image"]
+    assert len(load_calls) == 1
+    assert load_calls[0].lower().endswith(".nef")
+
+
 def test_export_keeps_raw_when_decode_succeeds_at_full_size(
     export_env, monkeypatch,
 ):

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -265,10 +265,22 @@ def test_export_cropped_recipe_avoids_undersized_working_copy(export_env):
         assert img.size == (300, 225)
 
 
-def test_export_cropped_recipe_uses_full_res_companion_before_raw(export_env):
-    """Cropped RAW+JPEG exports should use a sufficient companion before RAW."""
+def test_export_edited_raw_skips_companion_jpeg_substitution(
+    export_env, monkeypatch,
+):
+    """Edited RAW+JPEG exports must decode the RAW, not the clipped companion JPEG.
+
+    Companion JPEGs are camera-baked: their highlights are already clipped.
+    Substituting the companion would silently bypass the RAW_DECODE_PRESERVE_HIGHLIGHTS
+    decode mode and apply edits to clipped data.
+    """
+    import export as export_module
+    from image_loader import RAW_DECODE_PRESERVE_HIGHLIGHTS
+
     env = export_env
     db = env["db"]
+    raw_path = env["src"] / "source.NEF"
+    raw_path.write_bytes(b"\x00")
     db.conn.execute(
         """UPDATE photos
            SET filename='source.NEF', extension='.nef',
@@ -284,6 +296,14 @@ def test_export_cropped_recipe_uses_full_res_companion_before_raw(export_env):
         {"crop": {"x": 0, "y": 0, "w": 0.5, "h": 0.5}},
     )
 
+    load_calls = []
+
+    def tracking_load_image(file_path, max_size=1024, **kwargs):
+        load_calls.append((str(file_path), kwargs))
+        return Image.new("RGB", (800, 600), color="red")
+
+    monkeypatch.setattr(export_module, "load_image", tracking_load_image)
+
     result = export_photos(
         db=db,
         vireo_dir=env["vireo_dir"],
@@ -297,105 +317,12 @@ def test_export_cropped_recipe_uses_full_res_companion_before_raw(export_env):
 
     assert result["exported"] == 1
     assert result["errors"] == []
-    with Image.open(os.path.join(env["dest"], "source.jpg")) as img:
-        assert img.size == (300, 225)
-
-
-def test_export_non_crop_recipe_uses_full_res_companion_before_raw(
-    export_env, monkeypatch,
-):
-    """Non-crop RAW+JPEG edits should use a sufficient companion before RAW."""
-    import export as export_module
-
-    env = export_env
-    db = env["db"]
-    companion_path = os.path.join(env["src"], "bird1.jpg")
-    db.conn.execute(
-        """UPDATE photos
-           SET filename='source.NEF', extension='.nef',
-               companion_path='bird1.jpg',
-               working_copy_path=NULL,
-               width=800, height=600
-           WHERE id=?""",
-        (env["p1"],),
+    assert len(load_calls) == 1
+    loaded_path, loaded_kwargs = load_calls[0]
+    assert loaded_path.lower().endswith(".nef"), (
+        f"export should load the RAW primary, got {loaded_path!r}"
     )
-    db.conn.commit()
-    db.set_photo_edit_recipe(env["p1"], {"rotation": 90})
-    original_load_image = export_module.load_image
-    loaded_paths = []
-
-    def tracking_load_image(file_path, max_size=1024):
-        loaded_paths.append(file_path)
-        if str(file_path).lower().endswith(".nef"):
-            raise AssertionError("export decoded RAW before companion")
-        return original_load_image(file_path, max_size=max_size)
-
-    monkeypatch.setattr(export_module, "load_image", tracking_load_image)
-
-    result = export_photos(
-        db=db,
-        vireo_dir=env["vireo_dir"],
-        photo_ids=[env["p1"]],
-        destination=env["dest"],
-        options={
-            "naming_template": "{original}",
-            "max_size": 500,
-        },
-    )
-
-    assert result["exported"] == 1
-    assert result["errors"] == []
-    assert loaded_paths == [companion_path]
-    with Image.open(os.path.join(env["dest"], "source.jpg")) as img:
-        assert img.size == (375, 500)
-
-
-def test_export_cropped_recipe_uses_exif_oriented_companion(export_env):
-    """Companion eligibility must match load_image's EXIF-transposed source."""
-    env = export_env
-    db = env["db"]
-    companion_path = env["src"] / "bird1.jpg"
-    companion = Image.new("RGB", (600, 400), color="red")
-    exif = companion.getexif()
-    exif[0x0112] = 6
-    companion.save(str(companion_path), "JPEG", quality=95, exif=exif.tobytes())
-    db.conn.execute(
-        """UPDATE photos
-           SET filename='source.NEF', extension='.nef',
-               companion_path='bird1.jpg',
-               working_copy_path=NULL,
-               width=?, height=?, exif_data=?
-           WHERE id=?""",
-        (
-            600,
-            400,
-            json.dumps({"EXIF": {"Orientation": 6}}),
-            env["p1"],
-        ),
-    )
-    db.conn.commit()
-    db.set_photo_edit_recipe(
-        env["p1"],
-        {"crop": {"x": 0, "y": 0, "w": 0.5, "h": 1}},
-    )
-
-    result = export_photos(
-        db=db,
-        vireo_dir=env["vireo_dir"],
-        photo_ids=[env["p1"]],
-        destination=env["dest"],
-        options={
-            "naming_template": "{original}",
-            "max_size": 500,
-        },
-    )
-
-    assert result["exported"] == 1
-    assert result["errors"] == []
-    with Image.open(os.path.join(env["dest"], "source.jpg")) as img:
-        assert max(img.size) == 500
-        r, g, b = img.resize((1, 1)).getpixel((0, 0))
-    assert r > g and r > b
+    assert loaded_kwargs.get("raw_decode") == RAW_DECODE_PRESERVE_HIGHLIGHTS
 
 
 def test_export_cropped_recipe_avoids_undersized_developed_output(export_env):

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -364,6 +364,46 @@ def test_export_edited_raw_uses_working_copy_when_source_missing(export_env):
         assert img.size == (300, 400)
 
 
+def test_export_edited_raw_uses_working_copy_when_folder_missing(export_env):
+    """Missing-folder RAW exports may still use a sufficient local working copy."""
+    env = export_env
+    db = env["db"]
+    working_dir = os.path.join(env["vireo_dir"], "working")
+    os.makedirs(working_dir, exist_ok=True)
+    wc_rel = f"working/{env['p1']}.jpg"
+    Image.new("RGB", (800, 600), color="red").save(
+        os.path.join(env["vireo_dir"], wc_rel), "JPEG", quality=95,
+    )
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='offline.NEF', extension='.nef',
+               working_copy_path=?,
+               companion_path=NULL,
+               width=800, height=600
+           WHERE id=?""",
+        (wc_rel, env["p1"]),
+    )
+    db.conn.execute("UPDATE folders SET status='missing' WHERE id=?", (env["fid"],))
+    db.conn.commit()
+    db.set_photo_edit_recipe(env["p1"], {"rotation": 90})
+
+    result = export_photos(
+        db=db,
+        vireo_dir=env["vireo_dir"],
+        photo_ids=[env["p1"]],
+        destination=env["dest"],
+        options={
+            "naming_template": "{original}",
+            "max_size": 400,
+        },
+    )
+
+    assert result["exported"] == 1
+    assert result["errors"] == []
+    with Image.open(os.path.join(env["dest"], "offline.jpg")) as img:
+        assert img.size == (300, 400)
+
+
 def test_export_edited_raw_uses_companion_when_source_missing(export_env):
     """Offline edited RAW+JPEG exports may use a full-size companion."""
     env = export_env

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -325,6 +325,45 @@ def test_export_edited_raw_skips_companion_jpeg_substitution(
     assert loaded_kwargs.get("raw_decode") == RAW_DECODE_PRESERVE_HIGHLIGHTS
 
 
+def test_export_edited_raw_uses_working_copy_when_source_missing(export_env):
+    """Resized edited RAW exports may use a sufficient working copy offline."""
+    env = export_env
+    db = env["db"]
+    working_dir = os.path.join(env["vireo_dir"], "working")
+    os.makedirs(working_dir, exist_ok=True)
+    wc_rel = f"working/{env['p1']}.jpg"
+    Image.new("RGB", (800, 600), color="red").save(
+        os.path.join(env["vireo_dir"], wc_rel), "JPEG", quality=95,
+    )
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='offline.NEF', extension='.nef',
+               working_copy_path=?,
+               companion_path=NULL,
+               width=800, height=600
+           WHERE id=?""",
+        (wc_rel, env["p1"]),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(env["p1"], {"rotation": 90})
+
+    result = export_photos(
+        db=db,
+        vireo_dir=env["vireo_dir"],
+        photo_ids=[env["p1"]],
+        destination=env["dest"],
+        options={
+            "naming_template": "{original}",
+            "max_size": 400,
+        },
+    )
+
+    assert result["exported"] == 1
+    assert result["errors"] == []
+    with Image.open(os.path.join(env["dest"], "offline.jpg")) as img:
+        assert img.size == (300, 400)
+
+
 def test_export_falls_back_to_companion_when_raw_decode_fails(
     export_env, monkeypatch,
 ):

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -470,6 +470,74 @@ def test_export_falls_back_to_companion_when_raw_returns_undersized_image(
         assert img.size == (3000, 2000)
 
 
+def test_export_falls_back_to_companion_when_raw_short_edge_is_smaller(
+    export_env, monkeypatch,
+):
+    """Companion replaces RAW even when long edges tie.
+
+    Codex's regression case: a 6000x3376 embedded preview for a 6000x4000
+    RAW has the same long edge as the companion JPEG. A long-edge-only
+    swap gate (``max(companion.size) > max(img.size)``) would keep the
+    embedded preview and crop from pixels missing short-edge content. The
+    swap must compare both axes.
+    """
+    import export as export_module
+
+    env = export_env
+    db = env["db"]
+    raw_path = env["src"] / "source.NEF"
+    raw_path.write_bytes(b"\x00")
+    Image.new("RGB", (6000, 4000), color="green").save(
+        str(env["src"] / "bird1.jpg"), "JPEG", quality=85,
+    )
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='source.NEF', extension='.nef',
+               companion_path='bird1.jpg',
+               working_copy_path=NULL,
+               width=6000, height=4000
+           WHERE id=?""",
+        (env["p1"],),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(
+        env["p1"],
+        {"crop": {"x": 0, "y": 0, "w": 0.5, "h": 0.5}},
+    )
+
+    load_calls = []
+
+    def fake_load_image(file_path, max_size=1024, **kwargs):
+        load_calls.append((str(file_path), kwargs))
+        if str(file_path).lower().endswith(".nef"):
+            # Long edge ties the companion (6000), but the short edge
+            # falls short of the 4000 sensor height.
+            return Image.new("RGB", (6000, 3376), color="red")
+        return Image.new("RGB", (6000, 4000), color="green")
+
+    monkeypatch.setattr(export_module, "load_image", fake_load_image)
+
+    result = export_photos(
+        db=db,
+        vireo_dir=env["vireo_dir"],
+        photo_ids=[env["p1"]],
+        destination=env["dest"],
+        options={"naming_template": "{original}"},
+    )
+
+    assert result["exported"] == 1
+    assert result["errors"] == []
+    # Both loads happen and the companion wins despite the long-edge tie.
+    assert len(load_calls) == 2
+    assert load_calls[0][0].lower().endswith(".nef")
+    assert load_calls[1][0].lower().endswith(".jpg")
+    with Image.open(os.path.join(env["dest"], "source.jpg")) as img:
+        # 50% crop of full-size companion (6000x4000 -> 3000x2000), not
+        # the undersized embedded preview's crop (6000x3376 -> 3000x1688)
+        # that a long-edge-only gate would have kept.
+        assert img.size == (3000, 2000)
+
+
 def test_export_keeps_raw_when_decode_succeeds_at_full_size(
     export_env, monkeypatch,
 ):

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -325,6 +325,68 @@ def test_export_edited_raw_skips_companion_jpeg_substitution(
     assert loaded_kwargs.get("raw_decode") == RAW_DECODE_PRESERVE_HIGHLIGHTS
 
 
+def test_export_falls_back_to_companion_when_raw_decode_fails(
+    export_env, monkeypatch,
+):
+    """When the RAW primary fails to decode, fall back to the companion JPEG.
+
+    A camera JPEG with clipped highlights still beats a failed export. The
+    unconditional RAW skip in `_companion_can_satisfy_export` would otherwise
+    leave RAW+JPEG photos with no usable source whenever libraw can't
+    demosaic the RAW.
+    """
+    import export as export_module
+
+    env = export_env
+    db = env["db"]
+    raw_path = env["src"] / "source.NEF"
+    raw_path.write_bytes(b"\x00")
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='source.NEF', extension='.nef',
+               companion_path='bird1.jpg',
+               working_copy_path=NULL,
+               width=800, height=600
+           WHERE id=?""",
+        (env["p1"],),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(
+        env["p1"],
+        {"crop": {"x": 0, "y": 0, "w": 0.5, "h": 0.5}},
+    )
+
+    load_calls = []
+
+    def flaky_load_image(file_path, max_size=1024, **kwargs):
+        load_calls.append((str(file_path), kwargs))
+        if str(file_path).lower().endswith(".nef"):
+            return None
+        return Image.new("RGB", (800, 600), color="green")
+
+    monkeypatch.setattr(export_module, "load_image", flaky_load_image)
+
+    result = export_photos(
+        db=db,
+        vireo_dir=env["vireo_dir"],
+        photo_ids=[env["p1"]],
+        destination=env["dest"],
+        options={
+            "naming_template": "{original}",
+            "max_size": 300,
+        },
+    )
+
+    assert result["exported"] == 1
+    assert result["errors"] == []
+    # RAW first (preserve-highlights), then companion as fallback.
+    assert len(load_calls) == 2
+    assert load_calls[0][0].lower().endswith(".nef")
+    assert load_calls[1][0].lower().endswith(".jpg")
+    # The fallback companion load must NOT pass raw_decode (it's a JPEG).
+    assert "raw_decode" not in load_calls[1][1]
+
+
 def test_export_cropped_recipe_avoids_undersized_developed_output(export_env):
     """Cropped resized exports skip developed files that lack source pixels."""
     env = export_env

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -364,6 +364,39 @@ def test_export_edited_raw_uses_working_copy_when_source_missing(export_env):
         assert img.size == (300, 400)
 
 
+def test_export_edited_raw_uses_companion_when_source_missing(export_env):
+    """Offline edited RAW+JPEG exports may use a full-size companion."""
+    env = export_env
+    db = env["db"]
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='offline.NEF', extension='.nef',
+               working_copy_path=NULL,
+               companion_path='bird1.jpg',
+               width=800, height=600
+           WHERE id=?""",
+        (env["p1"],),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(env["p1"], {"rotation": 90})
+
+    result = export_photos(
+        db=db,
+        vireo_dir=env["vireo_dir"],
+        photo_ids=[env["p1"]],
+        destination=env["dest"],
+        options={
+            "naming_template": "{original}",
+            "max_size": 400,
+        },
+    )
+
+    assert result["exported"] == 1
+    assert result["errors"] == []
+    with Image.open(os.path.join(env["dest"], "offline.jpg")) as img:
+        assert img.size == (300, 400)
+
+
 def test_export_falls_back_to_companion_when_raw_decode_fails(
     export_env, monkeypatch,
 ):

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -394,6 +394,134 @@ def test_export_falls_back_to_companion_when_raw_decode_fails(
     assert "raw_decode" not in load_calls[1][1]
 
 
+def test_export_falls_back_to_companion_when_raw_returns_undersized_image(
+    export_env, monkeypatch,
+):
+    """Undersized RAW results (embedded preview) trigger the companion fallback.
+
+    ``image_loader._load_raw`` returns ``raw.extract_thumb()`` when libraw
+    cannot demosaic the RAW. That preview can be much smaller than the
+    full-size companion JPEG, so a non-None ``img`` here would silently
+    produce a downscaled export. Compare against the source's expected
+    long edge and prefer the companion when the RAW result falls short.
+    """
+    import export as export_module
+
+    env = export_env
+    db = env["db"]
+    raw_path = env["src"] / "source.NEF"
+    raw_path.write_bytes(b"\x00")
+    # Overwrite the fixture's 800x600 JPEG with a full-size companion so
+    # _companion_can_satisfy_export accepts it for a crop against the
+    # 6000x4000 source.
+    Image.new("RGB", (6000, 4000), color="green").save(
+        str(env["src"] / "bird1.jpg"), "JPEG", quality=85,
+    )
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='source.NEF', extension='.nef',
+               companion_path='bird1.jpg',
+               working_copy_path=NULL,
+               width=6000, height=4000
+           WHERE id=?""",
+        (env["p1"],),
+    )
+    db.conn.commit()
+    # Crop recipe so load_max_size is None and we ask for the full source.
+    db.set_photo_edit_recipe(
+        env["p1"],
+        {"crop": {"x": 0, "y": 0, "w": 0.5, "h": 0.5}},
+    )
+
+    load_calls = []
+
+    def fake_load_image(file_path, max_size=1024, **kwargs):
+        load_calls.append((str(file_path), kwargs))
+        if str(file_path).lower().endswith(".nef"):
+            # Stand in for _load_raw returning an undersized embedded JPEG
+            # when libraw fails to demosaic the RAW.
+            return Image.new("RGB", (1600, 1067), color="red")
+        # Companion JPEG is the actual full-size source.
+        return Image.new("RGB", (6000, 4000), color="green")
+
+    monkeypatch.setattr(export_module, "load_image", fake_load_image)
+
+    result = export_photos(
+        db=db,
+        vireo_dir=env["vireo_dir"],
+        photo_ids=[env["p1"]],
+        destination=env["dest"],
+        options={
+            "naming_template": "{original}",
+            # No max_size so the recipe's crop runs against the full source.
+        },
+    )
+
+    assert result["exported"] == 1
+    assert result["errors"] == []
+    # RAW first (preserve-highlights), companion as fallback since the RAW
+    # load returned an undersized result.
+    assert len(load_calls) == 2
+    assert load_calls[0][0].lower().endswith(".nef")
+    assert load_calls[1][0].lower().endswith(".jpg")
+    # Final export must be the full-resolution cropped output (3000x2000),
+    # not the downscaled embedded preview's crop (800x533).
+    with Image.open(os.path.join(env["dest"], "source.jpg")) as img:
+        assert img.size == (3000, 2000)
+
+
+def test_export_keeps_raw_when_decode_succeeds_at_full_size(
+    export_env, monkeypatch,
+):
+    """A successful preserve-highlights RAW decode is not replaced by companion."""
+    import export as export_module
+
+    env = export_env
+    db = env["db"]
+    raw_path = env["src"] / "source.NEF"
+    raw_path.write_bytes(b"\x00")
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='source.NEF', extension='.nef',
+               companion_path='bird1.jpg',
+               working_copy_path=NULL,
+               width=6000, height=4000
+           WHERE id=?""",
+        (env["p1"],),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(
+        env["p1"],
+        {"crop": {"x": 0, "y": 0, "w": 0.5, "h": 0.5}},
+    )
+
+    load_calls = []
+
+    def fake_load_image(file_path, max_size=1024, **kwargs):
+        load_calls.append((str(file_path), kwargs))
+        # RAW decode succeeds at full sensor dimensions.
+        return Image.new("RGB", (6000, 4000), color="red")
+
+    monkeypatch.setattr(export_module, "load_image", fake_load_image)
+
+    result = export_photos(
+        db=db,
+        vireo_dir=env["vireo_dir"],
+        photo_ids=[env["p1"]],
+        destination=env["dest"],
+        options={
+            "naming_template": "{original}",
+        },
+    )
+
+    assert result["exported"] == 1
+    assert result["errors"] == []
+    # Only the RAW load; no companion fallback when the RAW result is
+    # already full-size.
+    assert len(load_calls) == 1
+    assert load_calls[0][0].lower().endswith(".nef")
+
+
 def test_export_cropped_recipe_avoids_undersized_developed_output(export_env):
     """Cropped resized exports skip developed files that lack source pixels."""
     env = export_env

--- a/vireo/tests/test_export.py
+++ b/vireo/tests/test_export.py
@@ -336,6 +336,7 @@ def test_export_falls_back_to_companion_when_raw_decode_fails(
     demosaic the RAW.
     """
     import export as export_module
+    from image_loader import RAW_DECODE_PRESERVE_HIGHLIGHTS
 
     env = export_env
     db = env["db"]
@@ -382,6 +383,12 @@ def test_export_falls_back_to_companion_when_raw_decode_fails(
     # RAW first (preserve-highlights), then companion as fallback.
     assert len(load_calls) == 2
     assert load_calls[0][0].lower().endswith(".nef")
+    # The failed RAW attempt must still request preserve-highlights so the
+    # fallback path can't quietly downgrade the RAW-first contract by
+    # passing the default JPEG-first decode mode.
+    assert (
+        load_calls[0][1].get("raw_decode") == RAW_DECODE_PRESERVE_HIGHLIGHTS
+    )
     assert load_calls[1][0].lower().endswith(".jpg")
     # The fallback companion load must NOT pass raw_decode (it's a JPEG).
     assert "raw_decode" not in load_calls[1][1]

--- a/vireo/tests/test_image_loader.py
+++ b/vireo/tests/test_image_loader.py
@@ -44,6 +44,7 @@ class _FakeRaw:
         self._postprocess_size = postprocess_size
         self.sizes = SimpleNamespace(width=sensor_size[0], height=sensor_size[1])
         self.postprocess_calls = 0
+        self.postprocess_kwargs = []
 
     def __enter__(self):
         return self
@@ -58,8 +59,9 @@ class _FakeRaw:
         return SimpleNamespace(format=rawpy.ThumbFormat.JPEG,
                                data=self._embedded_jpeg)
 
-    def postprocess(self, half_size=False):
+    def postprocess(self, half_size=False, **kwargs):
         self.postprocess_calls += 1
+        self.postprocess_kwargs.append({"half_size": half_size, **kwargs})
         if self._postprocess_error is not None:
             raise self._postprocess_error
         import numpy as np
@@ -139,6 +141,36 @@ def test_raw_uses_embedded_jpeg_when_large_enough(tmp_path, monkeypatch):
     assert max(result.size) == 1920  # downscaled from 4000
     assert result.size == (1920, 960)
     assert fake.postprocess_calls == 0, "postprocess should be skipped"
+
+
+def test_raw_preserve_highlights_mode_bypasses_embedded_jpeg(tmp_path, monkeypatch):
+    """Edit-quality RAW loads demosaic instead of using camera-rendered JPEGs."""
+    import rawpy
+    from image_loader import RAW_DECODE_PRESERVE_HIGHLIGHTS, load_image
+
+    nef = tmp_path / "test.nef"
+    nef.write_bytes(b"fake NEF content")
+
+    fake = _install_fake_raw(monkeypatch, _FakeRaw(
+        embedded_jpeg=_jpeg_bytes((4000, 2000)),
+        postprocess_size=(6000, 4000),
+    ))
+
+    result = load_image(
+        str(nef),
+        max_size=1920,
+        raw_decode=RAW_DECODE_PRESERVE_HIGHLIGHTS,
+    )
+
+    assert result is not None
+    assert fake.postprocess_calls == 1
+    assert max(result.size) == 1920
+    kwargs = fake.postprocess_kwargs[-1]
+    assert kwargs["half_size"] is True
+    assert kwargs["use_camera_wb"] is True
+    assert kwargs["no_auto_bright"] is True
+    assert kwargs["bright"] == 1.0
+    assert kwargs["highlight_mode"] == rawpy.HighlightMode.Blend
 
 
 def test_raw_falls_back_to_embedded_on_postprocess_failure(tmp_path, monkeypatch):
@@ -242,6 +274,31 @@ def test_raw_uses_postprocess_when_embedded_too_small(tmp_path, monkeypatch):
     assert max(result.size) == 2048  # downscaled from postprocess output
 
 
+def test_raw_preserve_highlights_falls_back_to_embedded_on_decode_failure(
+    tmp_path, monkeypatch
+):
+    """Unsupported RAWs still use embedded JPEG fallback in edit-quality mode."""
+    import rawpy
+    from image_loader import RAW_DECODE_PRESERVE_HIGHLIGHTS, load_image
+
+    nef = tmp_path / "test.nef"
+    nef.write_bytes(b"fake NEF content")
+
+    _install_fake_raw(monkeypatch, _FakeRaw(
+        embedded_jpeg=_jpeg_bytes((1600, 1067)),
+        postprocess_error=rawpy.LibRawFileUnsupportedError(b'unsupported'),
+    ))
+
+    result = load_image(
+        str(nef),
+        max_size=2048,
+        raw_decode=RAW_DECODE_PRESERVE_HIGHLIGHTS,
+    )
+
+    assert result is not None
+    assert max(result.size) == 1600
+
+
 def test_raw_returns_none_when_no_embedded_and_postprocess_fails(tmp_path, monkeypatch):
     """No embedded JPEG and postprocess fails → return None (current contract)."""
     import rawpy
@@ -330,6 +387,42 @@ def test_extract_working_copy_full_resolution(tmp_path):
     assert result is True
     out_img = Image.open(str(output))
     assert out_img.size == (6000, 4000)
+
+
+def test_extract_working_copy_uses_highlight_preserving_raw_decode(
+    tmp_path, monkeypatch
+):
+    """Working-copy extraction is the edit-quality path for RAW sources."""
+    import image_loader
+    from PIL import Image
+
+    calls = []
+
+    def fake_load_image(source_path, max_size=1024, raw_decode=None):
+        calls.append({
+            "source_path": source_path,
+            "max_size": max_size,
+            "raw_decode": raw_decode,
+        })
+        return Image.new("RGB", (100, 50), color="white")
+
+    monkeypatch.setattr(image_loader, "load_image", fake_load_image)
+
+    output = tmp_path / "working" / "42.jpg"
+    result = image_loader.extract_working_copy(
+        str(tmp_path / "photo.nef"),
+        str(output),
+        max_size=4096,
+        quality=92,
+    )
+
+    assert result is True
+    assert output.exists()
+    assert calls == [{
+        "source_path": str(tmp_path / "photo.nef"),
+        "max_size": 4096,
+        "raw_decode": image_loader.RAW_DECODE_PRESERVE_HIGHLIGHTS,
+    }]
 
 
 def test_extract_working_copy_missing_source_returns_false(tmp_path):

--- a/vireo/tests/test_inat.py
+++ b/vireo/tests/test_inat.py
@@ -343,6 +343,43 @@ def test_api_inat_submit_uses_edited_render(app_and_db):
         assert img.size == (40, 80)
 
 
+def test_api_inat_submit_uses_working_copy_when_raw_source_missing(app_and_db):
+    app, db, pid = app_and_db
+    import config as cfg
+    cfg.save({"inat_token": "fake-token"})
+
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    working_dir = os.path.join(vireo_dir, "working")
+    os.makedirs(working_dir, exist_ok=True)
+    wc_rel = f"working/{pid}.jpg"
+    Image.new("RGB", (80, 40), (220, 30, 20)).save(
+        os.path.join(vireo_dir, wc_rel), "JPEG",
+    )
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='offline.NEF', extension='.nef',
+               working_copy_path=?,
+               width=80, height=40
+           WHERE id=?""",
+        (wc_rel, pid),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(pid, {"rotation": 90})
+
+    client = app.test_client()
+    with patch(
+        "inat.submit_observation",
+        return_value=(12345, "https://www.inaturalist.org/observations/12345"),
+    ) as mock_submit:
+        resp = client.post("/api/inat/submit", json={"photo_id": pid})
+
+    assert resp.status_code == 200
+    upload_path = mock_submit.call_args.kwargs["photo_path"]
+    assert os.path.basename(os.path.dirname(upload_path)) == "inat-uploads"
+    with Image.open(upload_path) as img:
+        assert img.size == (40, 80)
+
+
 def test_inat_upload_handoff_meta_includes_math_version(app_and_db):
     """The iNat upload render reuses inat-uploads/<id>.jpg only when its
     cached metadata matches. That metadata must carry EDIT_MATH_VERSION so a

--- a/vireo/tests/test_inat.py
+++ b/vireo/tests/test_inat.py
@@ -417,6 +417,43 @@ def test_api_inat_submit_uses_companion_when_raw_source_missing(app_and_db):
         assert img.size == (40, 80)
 
 
+def test_api_inat_submit_uses_companion_for_cropped_raw_source_missing(app_and_db):
+    app, db, pid = app_and_db
+    import config as cfg
+    cfg.save({"inat_token": "fake-token"})
+
+    folder = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id = p.folder_id WHERE p.id = ?",
+        (pid,),
+    ).fetchone()
+    companion_path = os.path.join(folder["path"], "bird.jpg")
+    Image.new("RGB", (80, 40), (220, 30, 20)).save(companion_path)
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='offline.NEF', extension='.nef',
+               working_copy_path=NULL,
+               companion_path='bird.jpg',
+               width=80, height=40
+           WHERE id=?""",
+        (pid,),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(pid, {"crop": {"x": 0, "y": 0, "w": 0.5, "h": 1}})
+
+    client = app.test_client()
+    with patch(
+        "inat.submit_observation",
+        return_value=(12345, "https://www.inaturalist.org/observations/12345"),
+    ) as mock_submit:
+        resp = client.post("/api/inat/submit", json={"photo_id": pid})
+
+    assert resp.status_code == 200, resp.get_json()
+    upload_path = mock_submit.call_args.kwargs["photo_path"]
+    assert os.path.basename(os.path.dirname(upload_path)) == "inat-uploads"
+    with Image.open(upload_path) as img:
+        assert img.size == (40, 40)
+
+
 def test_inat_upload_handoff_meta_includes_math_version(app_and_db):
     """The iNat upload render reuses inat-uploads/<id>.jpg only when its
     cached metadata matches. That metadata must carry EDIT_MATH_VERSION so a

--- a/vireo/tests/test_inat.py
+++ b/vireo/tests/test_inat.py
@@ -380,6 +380,43 @@ def test_api_inat_submit_uses_working_copy_when_raw_source_missing(app_and_db):
         assert img.size == (40, 80)
 
 
+def test_api_inat_submit_uses_companion_when_raw_source_missing(app_and_db):
+    app, db, pid = app_and_db
+    import config as cfg
+    cfg.save({"inat_token": "fake-token"})
+
+    folder = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id = p.folder_id WHERE p.id = ?",
+        (pid,),
+    ).fetchone()
+    companion_path = os.path.join(folder["path"], "bird.jpg")
+    Image.new("RGB", (80, 40), (220, 30, 20)).save(companion_path)
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='offline.NEF', extension='.nef',
+               working_copy_path=NULL,
+               companion_path='bird.jpg',
+               width=80, height=40
+           WHERE id=?""",
+        (pid,),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(pid, {"rotation": 90})
+
+    client = app.test_client()
+    with patch(
+        "inat.submit_observation",
+        return_value=(12345, "https://www.inaturalist.org/observations/12345"),
+    ) as mock_submit:
+        resp = client.post("/api/inat/submit", json={"photo_id": pid})
+
+    assert resp.status_code == 200, resp.get_json()
+    upload_path = mock_submit.call_args.kwargs["photo_path"]
+    assert os.path.basename(os.path.dirname(upload_path)) == "inat-uploads"
+    with Image.open(upload_path) as img:
+        assert img.size == (40, 80)
+
+
 def test_inat_upload_handoff_meta_includes_math_version(app_and_db):
     """The iNat upload render reuses inat-uploads/<id>.jpg only when its
     cached metadata matches. That metadata must carry EDIT_MATH_VERSION so a

--- a/vireo/tests/test_open_external.py
+++ b/vireo/tests/test_open_external.py
@@ -149,6 +149,76 @@ def test_open_external_edit_recipe_avoids_capped_working_copy(
         assert img.size == (600, 800)
 
 
+def test_open_external_falls_back_to_companion_when_raw_decode_fails(
+    app_and_db, monkeypatch, tmp_path,
+):
+    """For edited RAW+JPEG pairs, the handoff render must fall back to the
+    full-size companion JPEG when libraw can't decode the RAW. Without the
+    fallback, Open External fails for any RAW variant the system can't decode
+    even though a usable JPEG handoff sits right next to it.
+    """
+    import image_loader
+    from PIL import Image
+
+    app, db = app_and_db
+    client = app.test_client()
+
+    source_dir = tmp_path / "ext-raw"
+    source_dir.mkdir()
+    raw_path = source_dir / "bird.NEF"
+    raw_path.write_bytes(b"unsupported raw")
+    jpg_path = source_dir / "bird.JPG"
+    Image.new("RGB", (1200, 800), (60, 120, 200)).save(
+        str(jpg_path), "JPEG", quality=85,
+    )
+
+    fid = db.add_folder(str(source_dir), name="ext-raw")
+    pid = db.add_photo(
+        folder_id=fid, filename="bird.NEF", extension=".nef",
+        file_size=raw_path.stat().st_size,
+        file_mtime=raw_path.stat().st_mtime,
+        width=1200, height=800,
+    )
+    db.conn.execute(
+        "UPDATE photos SET companion_path=? WHERE id=?",
+        ("bird.JPG", pid),
+    )
+    db.set_photo_edit_recipe(pid, {"adjustments": {"exposure": 0.5}})
+    db.conn.commit()
+
+    real_load_image = image_loader.load_image
+    load_calls = []
+
+    def fake_load_image(path, *args, **kwargs):
+        load_calls.append(path)
+        # Simulate libraw refusing the RAW variant.
+        if path.lower().endswith(".nef"):
+            return None
+        return real_load_image(path, *args, **kwargs)
+
+    monkeypatch.setattr(image_loader, "load_image", fake_load_image)
+
+    client.post(
+        '/api/config',
+        data=json.dumps({"external_editor": "/usr/bin/gimp"}),
+        content_type='application/json',
+    )
+    launched = _patch_launchers(monkeypatch)
+
+    resp = client.post(
+        '/api/photos/open-external',
+        data=json.dumps({"photo_ids": [pid]}),
+        content_type='application/json',
+    )
+    assert resp.status_code == 200, resp.get_json()
+    # RAW was tried first, then the companion fallback succeeded.
+    assert any(p.lower().endswith(".nef") for p in load_calls), load_calls
+    assert any(p.lower().endswith(".jpg") for p in load_calls), load_calls
+    opened_path = launched[0][1][1]
+    assert os.path.exists(opened_path)
+    assert os.path.basename(os.path.dirname(opened_path)) == "external-edits"
+
+
 def test_open_external_returns_500_on_launch_failure(app_and_db, monkeypatch):
     """POST /api/photos/open-external returns 500 when launcher raises."""
     app, _ = app_and_db

--- a/vireo/tests/test_open_external.py
+++ b/vireo/tests/test_open_external.py
@@ -149,6 +149,45 @@ def test_open_external_edit_recipe_avoids_capped_working_copy(
         assert img.size == (600, 800)
 
 
+def test_open_external_uses_working_copy_when_raw_source_missing(
+    client_with_photo, monkeypatch,
+):
+    """RAW-first handoff should still work when the RAW volume is offline."""
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    working_dir = os.path.join(vireo_dir, "working")
+    os.makedirs(working_dir, exist_ok=True)
+    working_path = os.path.join(working_dir, f"{photo_id}.jpg")
+    Image.new("RGB", (800, 600), (10, 20, 30)).save(working_path, "JPEG")
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='offline.NEF', extension='.nef',
+               working_copy_path=?,
+               width=800, height=600
+           WHERE id=?""",
+        (f"working/{photo_id}.jpg", photo_id),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(photo_id, {"rotation": 90})
+    client.post('/api/config',
+                data=json.dumps({"external_editor": "/usr/bin/gimp"}),
+                content_type='application/json')
+    launched = _patch_launchers(monkeypatch)
+
+    resp = client.post('/api/photos/open-external',
+                       data=json.dumps({"photo_ids": [photo_id]}),
+                       content_type='application/json')
+
+    assert resp.status_code == 200, resp.get_json()
+    opened_path = launched[0][1][1]
+    assert os.path.basename(os.path.dirname(opened_path)) == "external-edits"
+    with Image.open(opened_path) as img:
+        assert img.size == (600, 800)
+
+
 def test_open_external_falls_back_to_companion_when_raw_decode_fails(
     app_and_db, monkeypatch, tmp_path,
 ):

--- a/vireo/tests/test_open_external.py
+++ b/vireo/tests/test_open_external.py
@@ -188,6 +188,41 @@ def test_open_external_uses_working_copy_when_raw_source_missing(
         assert img.size == (600, 800)
 
 
+def test_open_external_uses_companion_when_raw_source_missing(
+    client_with_photo, monkeypatch,
+):
+    """Offline RAW+JPEG handoff should use a full-size sidecar if no wc exists."""
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='offline.NEF', extension='.nef',
+               working_copy_path=NULL,
+               companion_path='test.jpg',
+               width=800, height=600
+           WHERE id=?""",
+        (photo_id,),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(photo_id, {"rotation": 90})
+    client.post('/api/config',
+                data=json.dumps({"external_editor": "/usr/bin/gimp"}),
+                content_type='application/json')
+    launched = _patch_launchers(monkeypatch)
+
+    resp = client.post('/api/photos/open-external',
+                       data=json.dumps({"photo_ids": [photo_id]}),
+                       content_type='application/json')
+
+    assert resp.status_code == 200, resp.get_json()
+    opened_path = launched[0][1][1]
+    assert os.path.basename(os.path.dirname(opened_path)) == "external-edits"
+    with Image.open(opened_path) as img:
+        assert img.size == (600, 800)
+
+
 def test_open_external_falls_back_to_companion_when_raw_decode_fails(
     app_and_db, monkeypatch, tmp_path,
 ):

--- a/vireo/tests/test_open_external.py
+++ b/vireo/tests/test_open_external.py
@@ -223,6 +223,44 @@ def test_open_external_uses_companion_when_raw_source_missing(
         assert img.size == (600, 800)
 
 
+def test_open_external_uses_companion_for_cropped_raw_source_missing(
+    client_with_photo, monkeypatch,
+):
+    """Offline cropped RAW+JPEG handoff should use a satisfying sidecar."""
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='offline.NEF', extension='.nef',
+               working_copy_path=NULL,
+               companion_path='test.jpg',
+               width=800, height=600
+           WHERE id=?""",
+        (photo_id,),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(
+        photo_id,
+        {"crop": {"x": 0, "y": 0, "w": 0.5, "h": 1}},
+    )
+    client.post('/api/config',
+                data=json.dumps({"external_editor": "/usr/bin/gimp"}),
+                content_type='application/json')
+    launched = _patch_launchers(monkeypatch)
+
+    resp = client.post('/api/photos/open-external',
+                       data=json.dumps({"photo_ids": [photo_id]}),
+                       content_type='application/json')
+
+    assert resp.status_code == 200, resp.get_json()
+    opened_path = launched[0][1][1]
+    assert os.path.basename(os.path.dirname(opened_path)) == "external-edits"
+    with Image.open(opened_path) as img:
+        assert img.size == (400, 600)
+
+
 def test_open_external_falls_back_to_companion_when_raw_decode_fails(
     app_and_db, monkeypatch, tmp_path,
 ):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -3108,6 +3108,162 @@ def test_original_falls_back_to_companion_when_raw_extraction_fails(
     assert resp.mimetype == "image/jpeg"
 
 
+def test_original_uses_companion_when_raw_extract_returns_undersized(
+    client_with_photo, monkeypatch,
+):
+    """``extract_working_copy`` returns True even when ``_load_raw`` falls
+    back to a small embedded JPEG, so a successful extract can still
+    produce a working copy that's a fraction of the sensor's full
+    resolution. /photos/<id>/original must detect that fallback and
+    re-extract from the companion JPEG before caching it as the
+    working copy — otherwise every later 1:1 request silently serves
+    the downscaled preview even though a full-size sidecar exists.
+    """
+    import io
+    import os
+
+    import image_loader
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    folder_row = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (photo_id,),
+    ).fetchone()
+    folder_path = folder_row["path"]
+
+    raw_path = os.path.join(folder_path, "source.NEF")
+    with open(raw_path, "wb") as f:
+        f.write(b"unsupported raw")
+    companion_path = os.path.join(folder_path, "source.JPG")
+    Image.new("RGB", (6000, 4000), (90, 140, 180)).save(
+        companion_path, "JPEG", quality=85,
+    )
+
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='source.NEF', extension='.nef',
+               companion_path='source.JPG',
+               working_copy_path=NULL,
+               working_copy_failed_at=NULL,
+               working_copy_failed_mtime=NULL,
+               working_copy_failed_source=NULL,
+               width=6000, height=4000
+           WHERE id=?""",
+        (photo_id,),
+    )
+    db.conn.commit()
+
+    real_extract = image_loader.extract_working_copy
+    extract_calls = []
+
+    def extract_with_size_fallback(source, output, *args, **kwargs):
+        extract_calls.append(str(source))
+        if str(source).lower().endswith(".nef"):
+            # Stand in for `_load_raw` returning the embedded JPEG when
+            # libraw can't demosaic the RAW: write an undersized JPEG
+            # and return True (matches the current contract).
+            os.makedirs(os.path.dirname(output), exist_ok=True)
+            Image.new("RGB", (1600, 1067), (200, 50, 50)).save(
+                output, "JPEG", quality=85,
+            )
+            return True
+        return real_extract(source, output, *args, **kwargs)
+
+    monkeypatch.setattr(image_loader, "extract_working_copy", extract_with_size_fallback)
+
+    client = app.test_client()
+    resp = client.get(f"/photos/{photo_id}/original")
+
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    assert resp.mimetype == "image/jpeg"
+    # Both sources must be tried — RAW first, then companion after the
+    # undersized output is detected.
+    assert len(extract_calls) == 2
+    assert extract_calls[0].lower().endswith(".nef")
+    assert extract_calls[1].lower().endswith(".jpg")
+    # The persisted working copy must be the full-size companion render.
+    with Image.open(io.BytesIO(resp.data)) as img:
+        assert max(img.size) >= 5400
+
+
+def test_edited_original_uses_companion_when_raw_returns_undersized(
+    client_with_photo, monkeypatch,
+):
+    """For edited RAW originals, ``load_image`` can return a small
+    embedded JPEG when ``rawpy.postprocess`` fails — the
+    ``preserve_highlights`` mode still falls back to the embedded
+    thumb. The endpoint must compare the loaded dimensions against
+    the photo's stored full-resolution dimensions and try the
+    companion JPEG before caching an undersized originals/<id>.jpg.
+    """
+    import io
+    import os
+
+    import image_loader
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    folder_row = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (photo_id,),
+    ).fetchone()
+    folder_path = folder_row["path"]
+
+    raw_path = os.path.join(folder_path, "edit.NEF")
+    with open(raw_path, "wb") as f:
+        f.write(b"unsupported raw")
+    companion_path = os.path.join(folder_path, "edit.JPG")
+    Image.new("RGB", (6000, 4000), (90, 140, 180)).save(
+        companion_path, "JPEG", quality=85,
+    )
+
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='edit.NEF', extension='.nef',
+               companion_path='edit.JPG',
+               working_copy_path=NULL,
+               working_copy_failed_at=NULL,
+               working_copy_failed_mtime=NULL,
+               working_copy_failed_source=NULL,
+               width=6000, height=4000
+           WHERE id=?""",
+        (photo_id,),
+    )
+    db.conn.commit()
+    # An edit recipe routes the request through the highlight-preserving
+    # decode path that the new size-validation guards.
+    db.set_photo_edit_recipe(photo_id, {"rotation": 0})
+
+    load_calls = []
+
+    def fake_load_image(file_path, max_size=1024, **kwargs):
+        load_calls.append((str(file_path), kwargs))
+        if str(file_path).lower().endswith(".nef"):
+            # Stand in for `_load_raw` returning an undersized embedded
+            # preview when libraw can't demosaic the sensor data.
+            return Image.new("RGB", (1600, 1067), (200, 50, 50))
+        return Image.new("RGB", (6000, 4000), (90, 140, 180))
+
+    monkeypatch.setattr(image_loader, "load_image", fake_load_image)
+    # The endpoint imports load_image into the local module namespace too.
+    import app as app_module
+    monkeypatch.setattr(app_module, "load_image", fake_load_image, raising=False)
+
+    client = app.test_client()
+    resp = client.get(f"/photos/{photo_id}/original")
+
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    # The RAW was attempted first, then the companion JPEG after the
+    # undersized result was detected.
+    paths = [str(p[0]).lower() for p in load_calls]
+    assert any(p.endswith(".nef") for p in paths)
+    assert any(p.endswith(".jpg") for p in paths)
+    # The cached original must be the full-size companion render.
+    with Image.open(io.BytesIO(resp.data)) as img:
+        assert max(img.size) >= 5400
+
+
 def test_eviction_removes_oldest_files_when_over_quota(tmp_path, monkeypatch):
     """When writes push cache over quota, oldest-accessed entries are evicted."""
     import os

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -3038,6 +3038,66 @@ def test_preview_falls_back_to_companion_when_raw_short_edge_is_smaller(
         assert img.size == (1920, 1280)
 
 
+def test_preview_keeps_raw_result_when_companion_is_smaller(
+    client_with_photo, monkeypatch,
+):
+    """Do not replace an undersized RAW preview with a still-smaller sidecar."""
+    import io
+    import os
+
+    import image_loader
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    folder = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (photo_id,),
+    ).fetchone()
+
+    raw_path = os.path.join(folder["path"], "wide.NEF")
+    with open(raw_path, "wb") as f:
+        f.write(b"unsupported raw")
+    companion_abs = os.path.join(folder["path"], "wide-small.jpg")
+    Image.new("RGB", (1000, 667), (40, 90, 180)).save(
+        companion_abs, "JPEG", quality=85,
+    )
+
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='wide.NEF', extension='.nef',
+               companion_path='wide-small.jpg',
+               working_copy_path=NULL,
+               width=6000, height=4000,
+               working_copy_failed_at=NULL,
+               working_copy_failed_mtime=NULL,
+               working_copy_failed_source=NULL
+           WHERE id=?""",
+        (photo_id,),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(photo_id, {"rotation": 0})
+
+    original_load_image = image_loader.load_image
+    loaded_paths = []
+
+    def tracking_load_image(file_path, max_size=1024, **kwargs):
+        loaded_paths.append(str(file_path))
+        if str(file_path).lower().endswith(".nef"):
+            return Image.new("RGB", (1920, 1080), (200, 50, 50))
+        return original_load_image(file_path, max_size=max_size, **kwargs)
+
+    monkeypatch.setattr(image_loader, "load_image", tracking_load_image)
+
+    client = app.test_client()
+    resp = client.get(f"/photos/{photo_id}/preview?size=1920")
+
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    assert loaded_paths[0] == raw_path
+    assert loaded_paths[1] == companion_abs
+    with Image.open(io.BytesIO(resp.data)) as img:
+        assert img.size == (1920, 1080)
+
+
 def test_original_skips_recent_failed_raw_working_copy(
     client_with_photo, monkeypatch,
 ):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -2873,6 +2873,68 @@ def test_preview_falls_back_to_companion_on_first_raw_decode_failure(
     assert row["working_copy_failed_source"] == "source"
 
 
+def test_preview_falls_back_to_companion_when_raw_short_edge_is_smaller(
+    client_with_photo, monkeypatch,
+):
+    """Preview caching must compare both RAW result axes before accepting it."""
+    import io
+    import os
+
+    import image_loader
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    folder = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (photo_id,),
+    ).fetchone()
+
+    raw_path = os.path.join(folder["path"], "wide.NEF")
+    with open(raw_path, "wb") as f:
+        f.write(b"unsupported raw")
+    companion_abs = os.path.join(folder["path"], "wide.jpg")
+    Image.new("RGB", (6000, 4000), (40, 90, 180)).save(
+        companion_abs, "JPEG", quality=85,
+    )
+
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='wide.NEF', extension='.nef',
+               companion_path='wide.jpg',
+               working_copy_path=NULL,
+               width=6000, height=4000,
+               working_copy_failed_at=NULL,
+               working_copy_failed_mtime=NULL,
+               working_copy_failed_source=NULL
+           WHERE id=?""",
+        (photo_id,),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(photo_id, {"rotation": 0})
+
+    original_load_image = image_loader.load_image
+    loaded_paths = []
+
+    def tracking_load_image(file_path, max_size=1024, **kwargs):
+        loaded_paths.append(str(file_path))
+        if str(file_path).lower().endswith(".nef"):
+            # Same requested long edge as the 1920px preview, but the expected
+            # 3:2 short edge is 1280. A long-edge-only check would accept this.
+            return Image.new("RGB", (1920, 1080), (200, 50, 50))
+        return original_load_image(file_path, max_size=max_size, **kwargs)
+
+    monkeypatch.setattr(image_loader, "load_image", tracking_load_image)
+
+    client = app.test_client()
+    resp = client.get(f"/photos/{photo_id}/preview?size=1920")
+
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    assert loaded_paths[0] == raw_path
+    assert loaded_paths[1] == companion_abs
+    with Image.open(io.BytesIO(resp.data)) as img:
+        assert img.size == (1920, 1280)
+
+
 def test_original_skips_recent_failed_raw_working_copy(
     client_with_photo, monkeypatch,
 ):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1891,9 +1891,15 @@ def test_edited_original_uses_trusted_working_copy_when_source_missing(
         assert img.size == (600, 800)
 
 
-def test_edited_original_does_not_use_companion_after_raw_failure_marker(
+def test_edited_original_uses_companion_after_raw_failure_marker(
     client_with_photo, monkeypatch,
 ):
+    """When the scanner has marked the RAW as failed for the current mtime,
+    the edited original endpoint must route through the full-resolution
+    companion JPEG instead of returning 500. Otherwise the same photo
+    that already rendered via the companion fallback once would stop
+    serving on every subsequent request until the marker expires —
+    exactly what _recipe_render_source already prevents for previews."""
     import image_loader
 
     app, db, photo_id = client_with_photo
@@ -1921,16 +1927,18 @@ def test_edited_original_does_not_use_companion_after_raw_failure_marker(
     original_load_image = image_loader.load_image
     loaded_paths = []
 
-    def tracking_load_image(file_path, max_size=1024):
-        loaded_paths.append(file_path)
-        return original_load_image(file_path, max_size=max_size)
+    def tracking_load_image(file_path, max_size=1024, **kwargs):
+        loaded_paths.append(str(file_path))
+        return original_load_image(file_path, max_size=max_size, **kwargs)
 
     monkeypatch.setattr(image_loader, "load_image", tracking_load_image)
 
     rendered = client.get(f"/photos/{photo_id}/original")
 
-    assert rendered.status_code == 500
-    assert loaded_paths == []
+    assert rendered.status_code == 200, rendered.data
+    # The endpoint must skip the failed RAW and load the companion JPEG.
+    assert len(loaded_paths) == 1
+    assert loaded_paths[0].lower().endswith(".jpg")
 
 
 def test_edited_original_decodes_raw_with_highlight_preservation(

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1953,6 +1953,47 @@ def test_edited_original_uses_trusted_working_copy_when_source_missing(
         assert img.size == (600, 800)
 
 
+def test_edited_raw_original_uses_trusted_working_copy_when_source_missing(
+    client_with_photo,
+):
+    import io
+    import os
+
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    working_dir = os.path.join(vireo_dir, "working")
+    os.makedirs(working_dir, exist_ok=True)
+    wc_rel = f"working/{photo_id}.jpg"
+    Image.new("RGB", (800, 600), (30, 120, 200)).save(
+        os.path.join(vireo_dir, wc_rel), "JPEG",
+    )
+    folder = db.conn.execute(
+        "SELECT f.path, p.filename FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (photo_id,),
+    ).fetchone()
+    os.remove(os.path.join(folder["path"], folder["filename"]))
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='offline.NEF', extension='.nef',
+               working_copy_path=?,
+               companion_path=NULL,
+               width=800, height=600
+           WHERE id=?""",
+        (wc_rel, photo_id),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(photo_id, {"rotation": 90})
+
+    rendered = client.get(f"/photos/{photo_id}/original")
+
+    assert rendered.status_code == 200, rendered.get_data(as_text=True)
+    with Image.open(io.BytesIO(rendered.data)) as img:
+        assert img.size == (600, 800)
+
+
 def test_edited_original_uses_companion_after_raw_failure_marker(
     client_with_photo, monkeypatch,
 ):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1853,6 +1853,68 @@ def test_cropped_thumbnail_uses_companion_before_raw_failure_marker(
         assert img.size == (267, 400)
 
 
+def test_thumbnail_falls_back_when_raw_short_edge_is_smaller(
+    client_with_photo, monkeypatch,
+):
+    """A RAW embedded preview with the requested long edge is still too small
+    when its short edge does not match the expected aspect. The thumbnail
+    self-heal path should reject it and retry the companion before caching.
+    """
+    import io
+    import os
+
+    import thumbnails
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    folder = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (photo_id,),
+    ).fetchone()
+    raw_path = os.path.join(folder["path"], "thumb.NEF")
+    with open(raw_path, "wb") as f:
+        f.write(b"unsupported raw")
+    companion_path = os.path.join(folder["path"], "thumb.jpg")
+    Image.new("RGB", (6000, 4000), (40, 90, 180)).save(
+        companion_path, "JPEG", quality=85,
+    )
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='thumb.NEF', extension='.nef',
+               companion_path='thumb.jpg',
+               working_copy_path=NULL,
+               width=6000, height=4000,
+               working_copy_failed_at=NULL,
+               working_copy_failed_mtime=NULL,
+               working_copy_failed_source=NULL
+           WHERE id=?""",
+        (photo_id,),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(photo_id, {"rotation": 90})
+
+    original_load_image = thumbnails.load_image
+    loaded_paths = []
+
+    def tracking_load_image(file_path, max_size=1024, **kwargs):
+        loaded_paths.append(str(file_path))
+        if str(file_path).lower().endswith(".nef"):
+            # Long edge ties the requested thumbnail size (400), but a 3:2
+            # source should load as 400x267 before recipe application.
+            return Image.new("RGB", (400, 225), (200, 50, 50))
+        return original_load_image(file_path, max_size=max_size, **kwargs)
+
+    monkeypatch.setattr(thumbnails, "load_image", tracking_load_image)
+
+    rendered = client.get(f"/thumbnails/{photo_id}.jpg")
+
+    assert rendered.status_code == 200
+    assert loaded_paths == [raw_path, companion_path]
+    with Image.open(io.BytesIO(rendered.data)) as img:
+        assert img.size == (267, 400)
+
+
 def test_edited_original_uses_trusted_working_copy_when_source_missing(
     client_with_photo,
 ):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1881,14 +1881,10 @@ def test_edited_original_uses_trusted_working_copy_when_source_missing(
         assert img.size == (600, 800)
 
 
-def test_edited_original_prefers_full_res_companion_before_raw_decode(
+def test_edited_original_does_not_use_companion_after_raw_failure_marker(
     client_with_photo, monkeypatch,
 ):
-    import io
-    import os
-
     import image_loader
-    from PIL import Image
 
     app, db, photo_id = client_with_photo
     client = app.test_client()
@@ -1896,7 +1892,6 @@ def test_edited_original_prefers_full_res_companion_before_raw_decode(
         "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
         (photo_id,),
     ).fetchone()
-    companion_path = os.path.join(folder["path"], "test.jpg")
     db.conn.execute(
         """UPDATE photos
            SET filename='source.NEF', extension='.nef',
@@ -1918,18 +1913,14 @@ def test_edited_original_prefers_full_res_companion_before_raw_decode(
 
     def tracking_load_image(file_path, max_size=1024):
         loaded_paths.append(file_path)
-        if str(file_path).lower().endswith(".nef"):
-            raise AssertionError("edited original decoded RAW before companion")
         return original_load_image(file_path, max_size=max_size)
 
     monkeypatch.setattr(image_loader, "load_image", tracking_load_image)
 
     rendered = client.get(f"/photos/{photo_id}/original")
 
-    assert rendered.status_code == 200
-    assert loaded_paths == [companion_path]
-    with Image.open(io.BytesIO(rendered.data)) as img:
-        assert img.size == (600, 800)
+    assert rendered.status_code == 500
+    assert loaded_paths == []
 
 
 def test_edited_original_cache_write_is_atomic(client_with_photo, monkeypatch):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1923,6 +1923,68 @@ def test_edited_original_does_not_use_companion_after_raw_failure_marker(
     assert loaded_paths == []
 
 
+def test_edited_original_decodes_raw_with_highlight_preservation(
+    client_with_photo, monkeypatch,
+):
+    """Edited RAW+JPEG originals must decode the RAW, not substitute the JPEG.
+
+    The companion JPEG is the camera-baked render with highlights already
+    clipped; substituting it bypasses RAW_DECODE_PRESERVE_HIGHLIGHTS and applies
+    the user's edits to clipped data.
+    """
+    import io
+    import os
+
+    import app as app_module
+    import image_loader
+    from image_loader import RAW_DECODE_PRESERVE_HIGHLIGHTS
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    folder = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (photo_id,),
+    ).fetchone()
+    raw_path = os.path.join(folder["path"], "source.NEF")
+    with open(raw_path, "wb") as f:
+        f.write(b"\x00")
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='source.NEF', extension='.nef',
+               companion_path='test.jpg',
+               working_copy_path=NULL,
+               width=800, height=600,
+               file_mtime=1234.0
+           WHERE id=?""",
+        (photo_id,),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(photo_id, {"rotation": 90})
+
+    load_calls = []
+
+    def tracking_load_image(file_path, max_size=1024, **kwargs):
+        load_calls.append((str(file_path), kwargs))
+        return Image.new("RGB", (800, 600), color="red")
+
+    monkeypatch.setattr(image_loader, "load_image", tracking_load_image)
+    if hasattr(app_module, "load_image"):
+        monkeypatch.setattr(app_module, "load_image", tracking_load_image)
+
+    rendered = client.get(f"/photos/{photo_id}/original")
+
+    assert rendered.status_code == 200, rendered.data
+    assert len(load_calls) == 1
+    loaded_path, loaded_kwargs = load_calls[0]
+    assert loaded_path.lower().endswith(".nef"), (
+        f"endpoint should load RAW primary, got {loaded_path!r}"
+    )
+    assert loaded_kwargs.get("raw_decode") == RAW_DECODE_PRESERVE_HIGHLIGHTS
+    with Image.open(io.BytesIO(rendered.data)) as img:
+        assert img.size == (600, 800)
+
+
 def test_edited_original_cache_write_is_atomic(client_with_photo, monkeypatch):
     import os
 

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -2073,6 +2073,68 @@ def test_edited_original_uses_companion_after_raw_failure_marker(
     assert loaded_paths[0].lower().endswith(".jpg")
 
 
+def test_edited_original_records_raw_marker_when_companion_rescues_decode(
+    client_with_photo, monkeypatch,
+):
+    """When the RAW decode fails on an edited RAW+JPEG with no current
+    failure marker, the companion-fallback path must stamp
+    working_copy_failed_source='source' so the next request routes
+    directly through the companion via the marker-aware branch instead
+    of retrying the slow failing RAW decode each hit."""
+    import os
+
+    import app as app_module
+    import image_loader
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    folder = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (photo_id,),
+    ).fetchone()
+    raw_path = os.path.join(folder["path"], "unsupported.NEF")
+    with open(raw_path, "wb") as f:
+        f.write(b"\x00")
+    companion_path = os.path.join(folder["path"], "unsupported.JPG")
+    Image.new("RGB", (800, 600), (40, 80, 120)).save(companion_path, "JPEG")
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='unsupported.NEF', extension='.nef',
+               companion_path='unsupported.JPG',
+               working_copy_path=NULL,
+               working_copy_failed_at=NULL,
+               working_copy_failed_mtime=NULL,
+               working_copy_failed_source=NULL,
+               width=800, height=600,
+               file_mtime=1234.0
+           WHERE id=?""",
+        (photo_id,),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(photo_id, {"rotation": 90})
+
+    def fake_load_image(file_path, max_size=1024, **kwargs):
+        if str(file_path).lower().endswith(".nef"):
+            return None
+        return Image.new("RGB", (800, 600), (40, 80, 120))
+
+    monkeypatch.setattr(image_loader, "load_image", fake_load_image)
+    if hasattr(app_module, "load_image"):
+        monkeypatch.setattr(app_module, "load_image", fake_load_image, raising=False)
+
+    resp = client.get(f"/photos/{photo_id}/original")
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+
+    row = db.conn.execute(
+        "SELECT working_copy_failed_source, working_copy_failed_mtime"
+        " FROM photos WHERE id=?",
+        (photo_id,),
+    ).fetchone()
+    assert row["working_copy_failed_source"] == "source"
+    assert row["working_copy_failed_mtime"] == 1234.0
+
+
 def test_edited_original_decodes_raw_with_highlight_preservation(
     client_with_photo, monkeypatch,
 ):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -2954,6 +2954,64 @@ def test_original_refreshes_failure_marker_when_stale_retry_fails(
     assert row["age_seconds"] is not None and row["age_seconds"] < 60
 
 
+def test_original_falls_back_to_companion_when_raw_extraction_fails(
+    client_with_photo, monkeypatch,
+):
+    """For a RAW+JPEG row whose RAW libraw can't decode, /photos/<id>/original
+    must use the full-size companion JPEG instead of returning 500.
+    _full_res_companion_path() already confirms a usable sidecar; bailing out
+    when the RAW alone fails throws away a request the system can satisfy.
+    """
+    import os
+
+    import image_loader
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    folder_row = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (photo_id,),
+    ).fetchone()
+    folder_path = folder_row["path"]
+
+    # Replace the JPEG with a RAW+JPEG pair so the row looks like RAW+companion.
+    raw_path = os.path.join(folder_path, "bad.NEF")
+    with open(raw_path, "wb") as f:
+        f.write(b"unsupported raw")
+    companion_path = os.path.join(folder_path, "bad.JPG")
+    Image.new("RGB", (1600, 1200), (90, 140, 180)).save(
+        companion_path, "JPEG", quality=85,
+    )
+
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='bad.NEF', extension='.nef',
+               companion_path=?,
+               working_copy_path=NULL,
+               working_copy_failed_at=NULL,
+               working_copy_failed_mtime=NULL,
+               working_copy_failed_source=NULL
+           WHERE id=?""",
+        ("bad.JPG", photo_id),
+    )
+    db.conn.commit()
+
+    real_extract = image_loader.extract_working_copy
+
+    def extract_only_companion(source, output, *args, **kwargs):
+        if source.lower().endswith(".nef"):
+            return False
+        return real_extract(source, output, *args, **kwargs)
+
+    monkeypatch.setattr(image_loader, "extract_working_copy", extract_only_companion)
+
+    client = app.test_client()
+    resp = client.get(f"/photos/{photo_id}/original")
+
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    assert resp.mimetype == "image/jpeg"
+
+
 def test_eviction_removes_oldest_files_when_over_quota(tmp_path, monkeypatch):
     """When writes push cache over quota, oldest-accessed entries are evicted."""
     import os

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1824,21 +1824,31 @@ def test_cropped_thumbnail_uses_companion_before_raw_failure_marker(
         photo_id,
         {"crop": {"x": 0, "y": 0, "w": 0.5, "h": 1}},
     )
+    from image_loader import RAW_DECODE_PRESERVE_HIGHLIGHTS
     original_load_image = thumbnails.load_image
-    loaded_paths = []
+    loaded = []
 
-    def tracking_load_image(file_path, max_size=1024):
-        loaded_paths.append(file_path)
+    def tracking_load_image(file_path, max_size=1024, **kwargs):
+        loaded.append((file_path, kwargs))
         if str(file_path).lower().endswith(".nef"):
             raise AssertionError("thumbnail retried RAW before companion")
-        return original_load_image(file_path, max_size=max_size)
+        return original_load_image(file_path, max_size=max_size, **kwargs)
 
     monkeypatch.setattr(thumbnails, "load_image", tracking_load_image)
 
     rendered = client.get(f"/thumbnails/{photo_id}.jpg")
 
     assert rendered.status_code == 200
+    loaded_paths = [path for path, _ in loaded]
     assert loaded_paths == [companion_path]
+    # Even though the resolved source is the companion JPEG, the
+    # thumbnail self-heal must request RAW_DECODE_PRESERVE_HIGHLIGHTS so
+    # the call would demosaic the RAW with highlight preservation if
+    # _recipe_render_source had returned the RAW path instead. Keying
+    # the decode mode off the photo's primary extension (not the
+    # resolved source) keeps thumbnails in sync with previews/exports.
+    _, loaded_kwargs = loaded[0]
+    assert loaded_kwargs.get("raw_decode") == RAW_DECODE_PRESERVE_HIGHLIGHTS
     with Image.open(io.BytesIO(rendered.data)) as img:
         assert img.size == (267, 400)
 

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -2606,7 +2606,10 @@ def test_preview_honors_raw_marker_after_companion_bypass_retry_fails(
 
     assert first.status_code == 500
     assert second.status_code == 500
-    assert calls["count"] == 1
+    # First request: RAW load fails → companion fallback attempted → also
+    # fails → source marker stamped. Second request: the source marker
+    # short-circuits before any load_image call.
+    assert calls["count"] == 2
     row = db.conn.execute(
         """SELECT working_copy_failed_mtime, working_copy_failed_source
            FROM photos WHERE id=?""",
@@ -2785,6 +2788,81 @@ def test_preview_does_not_refresh_failure_marker_when_working_copy_jpeg_is_corru
         (photo_id,),
     ).fetchone()
     assert row["age_seconds"] is not None and row["age_seconds"] > 24 * 60 * 60
+
+
+def test_preview_falls_back_to_companion_on_first_raw_decode_failure(
+    client_with_photo, monkeypatch,
+):
+    """When an edited RAW+JPEG preview has no failure marker yet,
+    ``_recipe_render_source`` returns the RAW for highlight-preserving
+    decode. If libraw can't decode that RAW, the preview must try the
+    companion JPEG before 500ing — otherwise an unsupported RAW edit fails
+    even though a usable sidecar exists. Mirrors
+    serve_original_photo's edited-path companion fallback.
+    """
+    import os
+
+    import image_loader
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    folder = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (photo_id,),
+    ).fetchone()
+
+    raw_path = os.path.join(folder["path"], "bad.NEF")
+    with open(raw_path, "wb") as f:
+        f.write(b"unsupported raw")
+    companion_abs = os.path.join(folder["path"], "bad.jpg")
+    Image.new("RGB", (1600, 1200), (40, 90, 180)).save(
+        companion_abs, "JPEG", quality=85,
+    )
+
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='bad.NEF', extension='.nef',
+               companion_path='bad.jpg',
+               working_copy_path=NULL,
+               width=1600, height=1200,
+               working_copy_failed_at=NULL,
+               working_copy_failed_mtime=NULL,
+               working_copy_failed_source=NULL
+           WHERE id=?""",
+        (photo_id,),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(photo_id, {"rotation": 90})
+
+    original_load_image = image_loader.load_image
+    loaded_paths = []
+
+    def tracking_load_image(file_path, max_size=1024, **kwargs):
+        loaded_paths.append(file_path)
+        if str(file_path).lower().endswith(".nef"):
+            return None
+        return original_load_image(file_path, max_size=max_size, **kwargs)
+
+    monkeypatch.setattr(image_loader, "load_image", tracking_load_image)
+
+    client = app.test_client()
+    resp = client.get(f"/photos/{photo_id}/preview?size=1920")
+
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    assert resp.mimetype == "image/jpeg"
+    # RAW first (preserve-highlights), then companion as fallback.
+    assert len(loaded_paths) == 2
+    assert str(loaded_paths[0]).lower().endswith(".nef")
+    assert str(loaded_paths[1]) == companion_abs
+
+    # The failed RAW decode must stamp the source marker so subsequent
+    # requests skip the slow RAW retry and _recipe_render_source selects
+    # the companion directly.
+    row = db.conn.execute(
+        "SELECT working_copy_failed_source FROM photos WHERE id=?",
+        (photo_id,),
+    ).fetchone()
+    assert row["working_copy_failed_source"] == "source"
 
 
 def test_original_skips_recent_failed_raw_working_copy(

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -3064,6 +3064,78 @@ def test_original_skips_recent_failed_raw_after_rejecting_small_working_copy(
     assert called["extract"] is False
 
 
+def test_original_uses_companion_after_raw_marker_and_small_working_copy(
+    client_with_photo, monkeypatch,
+):
+    """A source RAW failure marker should not block a full-size sidecar.
+
+    Scanner can preserve ``working_copy_failed_source='source'`` after creating
+    a capped companion working copy. When /original rejects that capped working
+    copy, it must upgrade from the sidecar instead of failing fast on the RAW
+    marker before companion fallback is considered.
+    """
+    import io
+    import os
+
+    import image_loader
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    folder = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (photo_id,),
+    ).fetchone()
+    folder_path = folder["path"]
+
+    raw_path = os.path.join(folder_path, "marked.NEF")
+    with open(raw_path, "wb") as f:
+        f.write(b"unsupported raw")
+    companion_path = os.path.join(folder_path, "marked.JPG")
+    Image.new("RGB", (6000, 4000), (90, 140, 180)).save(
+        companion_path, "JPEG", quality=85,
+    )
+    working_dir = os.path.join(vireo_dir, "working")
+    os.makedirs(working_dir, exist_ok=True)
+    capped_wc_rel = f"working/{photo_id}.jpg"
+    Image.new("RGB", (1000, 667), (20, 40, 60)).save(
+        os.path.join(vireo_dir, capped_wc_rel), "JPEG", quality=85,
+    )
+
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='marked.NEF', extension='.nef',
+               companion_path='marked.JPG',
+               working_copy_path=?,
+               working_copy_failed_at=datetime('now'),
+               working_copy_failed_mtime=file_mtime,
+               working_copy_failed_source='source',
+               width=6000, height=4000
+           WHERE id=?""",
+        (capped_wc_rel, photo_id),
+    )
+    db.conn.commit()
+
+    real_extract = image_loader.extract_working_copy
+    extracted_sources = []
+
+    def tracking_extract(source, output, *args, **kwargs):
+        extracted_sources.append(str(source))
+        if str(source).lower().endswith(".nef"):
+            raise AssertionError("original route retried source-failed RAW")
+        return real_extract(source, output, *args, **kwargs)
+
+    monkeypatch.setattr(image_loader, "extract_working_copy", tracking_extract)
+
+    client = app.test_client()
+    resp = client.get(f"/photos/{photo_id}/original")
+
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    assert extracted_sources == [companion_path]
+    with Image.open(io.BytesIO(resp.data)) as img:
+        assert img.size == (6000, 4000)
+
+
 def test_original_refreshes_failure_marker_when_stale_retry_fails(
     client_with_photo, monkeypatch,
 ):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1450,6 +1450,35 @@ def test_edit_preview_renders_uncommitted_recipe_without_storing(client_with_pho
         assert img.size == (600, 800)
 
 
+def test_edit_preview_returns_400_for_malformed_crop(client_with_photo):
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    working_dir = os.path.join(vireo_dir, "working")
+    os.makedirs(working_dir, exist_ok=True)
+    wc_rel = f"working/{photo_id}.jpg"
+    Image.new("RGB", (800, 600), (180, 90, 40)).save(
+        os.path.join(vireo_dir, wc_rel), "JPEG", quality=85,
+    )
+    db.conn.execute(
+        "UPDATE photos SET working_copy_path=? WHERE id=?",
+        (wc_rel, photo_id),
+    )
+    db.conn.commit()
+
+    rendered = app.test_client().get(
+        f"/photos/{photo_id}/edit-preview",
+        query_string={
+            "size": "1920",
+            "recipe": '{"crop":{"x":0}}',
+        },
+    )
+
+    assert rendered.status_code == 400
+    assert "crop must include" in rendered.get_data(as_text=True)
+
+
 def test_edit_preview_skips_recent_failed_raw_before_decode(
     client_with_photo, monkeypatch,
 ):

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -1720,6 +1720,56 @@ def test_scan_falls_back_when_raw_working_copy_short_edge_is_smaller(
         assert img.size == (4096, 2731)
 
 
+def test_scan_accepts_near_full_raw_working_copy(tmp_path, monkeypatch):
+    """Tiny RAW active-area differences should not force companion fallback."""
+    import config as cfg
+    import scanner
+    from db import Database
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+
+    photo_dir = tmp_path / "photos"
+    photo_dir.mkdir()
+
+    nef_file = photo_dir / "IMG_006.nef"
+    nef_file.write_bytes(b"fake raw data")
+    jpg_file = photo_dir / "IMG_006.jpg"
+    Image.new("RGB", (6000, 4000), color=(0, 255, 0)).save(str(jpg_file), "JPEG")
+
+    monkeypatch.setattr(scanner, "extract_metadata", lambda paths: {})
+
+    sources_used = []
+
+    def fake_extract(source, output, max_size=4096, quality=92):
+        sources_used.append(source)
+        os.makedirs(os.path.dirname(output), exist_ok=True)
+        # Expected scaled dimensions are 4096x2731. This is within 1% of
+        # the expected short edge and should be accepted as a RAW decode.
+        Image.new("RGB", (4096, 2705)).save(output, "JPEG")
+        return True
+
+    monkeypatch.setattr(scanner, "extract_working_copy", fake_extract)
+
+    db = Database(str(vireo_dir / "test.db"))
+    scanner.scan(str(photo_dir), db, vireo_dir=str(vireo_dir))
+
+    assert len(sources_used) == 1
+    assert sources_used[0].endswith("IMG_006.nef")
+
+    raw_row = db.conn.execute(
+        "SELECT working_copy_path, working_copy_failed_source"
+        " FROM photos WHERE extension = '.nef'"
+    ).fetchone()
+    assert raw_row["working_copy_path"] is not None
+    assert raw_row["working_copy_failed_source"] is None
+
+    with Image.open(vireo_dir / raw_row["working_copy_path"]) as img:
+        assert img.size == (4096, 2705)
+
+
 def test_scan_accepts_portrait_raw_working_copy_with_exif_orientation(
     tmp_path, monkeypatch,
 ):

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -1645,6 +1645,21 @@ def test_scan_falls_back_to_companion_when_raw_extraction_fails(
     assert sources_used[0].endswith("IMG_002.nef")
     assert sources_used[1].endswith("IMG_002.jpg")
 
+    # The companion-derived working copy is set, but the source failure marker
+    # must remain so _recipe_render_source still allows companion selection for
+    # edited RAW renders. Without this, _has_current_working_copy_failure
+    # returns False, allow_companion stays False for the RAW primary, and the
+    # render paths retry the unsupported RAW and 500.
+    raw_row = db.conn.execute(
+        "SELECT working_copy_path, working_copy_failed_source,"
+        " working_copy_failed_at, working_copy_failed_mtime, file_mtime"
+        " FROM photos WHERE extension = '.nef'"
+    ).fetchone()
+    assert raw_row["working_copy_path"] is not None
+    assert raw_row["working_copy_failed_source"] == "source"
+    assert raw_row["working_copy_failed_at"] is not None
+    assert float(raw_row["working_copy_failed_mtime"]) == float(raw_row["file_mtime"])
+
 
 def test_scan_marks_source_failure_when_raw_and_companion_both_fail(
     tmp_path, monkeypatch,

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -1590,6 +1590,62 @@ def test_scan_uses_raw_primary_for_raw_working_copy(tmp_path, monkeypatch):
     )
 
 
+def test_scan_falls_back_to_companion_when_raw_extraction_fails(
+    tmp_path, monkeypatch,
+):
+    """RAW+JPEG pairs still get a working copy from the companion when the
+    RAW decode itself fails (e.g. libraw cannot decode the RAW variant and
+    the embedded preview is unusable). Without the fallback the row would
+    be marked as a working-copy failure even though a full-size JPEG copy
+    is sitting right next to it.
+    """
+    import config as cfg
+    import scanner
+    from db import Database
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+
+    photo_dir = tmp_path / "photos"
+    photo_dir.mkdir()
+
+    nef_file = photo_dir / "IMG_002.nef"
+    nef_file.write_bytes(b"fake raw data")
+    jpg_file = photo_dir / "IMG_002.jpg"
+    Image.new("RGB", (6000, 4000), color=(0, 255, 0)).save(str(jpg_file), "JPEG")
+
+    monkeypatch.setattr(scanner, "extract_metadata", lambda paths: {})
+
+    sources_used = []
+
+    def fake_extract(source, output, max_size=4096, quality=92):
+        sources_used.append(source)
+        # Simulate libraw failure on the RAW; succeed when called with the
+        # companion JPEG.
+        if source.endswith(".nef"):
+            return False
+        os.makedirs(os.path.dirname(output), exist_ok=True)
+        Image.new("RGB", (4096, 2731)).save(output, "JPEG")
+        return True
+
+    monkeypatch.setattr(scanner, "extract_working_copy", fake_extract)
+
+    db = Database(str(vireo_dir / "test.db"))
+    scanner.scan(str(photo_dir), db, vireo_dir=str(vireo_dir))
+
+    photos = db.get_photos(per_page=999999)
+    raw_photos = [p for p in photos if p["extension"] == ".nef"]
+    assert len(raw_photos) == 1
+    assert raw_photos[0]["working_copy_path"] is not None
+
+    # Both calls should have happened: RAW first (failed), then companion.
+    assert len(sources_used) == 2
+    assert sources_used[0].endswith("IMG_002.nef")
+    assert sources_used[1].endswith("IMG_002.jpg")
+
+
 # --- _extract_timestamp tests ---
 
 def test_extract_timestamp_subsec():

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -1661,6 +1661,65 @@ def test_scan_falls_back_to_companion_when_raw_extraction_fails(
     assert float(raw_row["working_copy_failed_mtime"]) == float(raw_row["file_mtime"])
 
 
+def test_scan_falls_back_when_raw_working_copy_short_edge_is_smaller(
+    tmp_path, monkeypatch,
+):
+    """A RAW embedded preview can tie the expected long edge while missing
+    short-edge pixels. Scanner must compare both axes before accepting the
+    RAW-derived working copy, otherwise the companion fallback never runs.
+    """
+    import config as cfg
+    import scanner
+    from db import Database
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+
+    photo_dir = tmp_path / "photos"
+    photo_dir.mkdir()
+
+    nef_file = photo_dir / "IMG_004.nef"
+    nef_file.write_bytes(b"fake raw data")
+    jpg_file = photo_dir / "IMG_004.jpg"
+    Image.new("RGB", (6000, 4000), color=(0, 255, 0)).save(str(jpg_file), "JPEG")
+
+    monkeypatch.setattr(scanner, "extract_metadata", lambda paths: {})
+
+    sources_used = []
+
+    def fake_extract(source, output, max_size=4096, quality=92):
+        sources_used.append(source)
+        os.makedirs(os.path.dirname(output), exist_ok=True)
+        if source.endswith(".nef"):
+            # Same expected long edge after scaling (4096), but short edge is
+            # too small for a 6000x4000 source scaled to 4096x2731.
+            Image.new("RGB", (4096, 2305)).save(output, "JPEG")
+        else:
+            Image.new("RGB", (4096, 2731)).save(output, "JPEG")
+        return True
+
+    monkeypatch.setattr(scanner, "extract_working_copy", fake_extract)
+
+    db = Database(str(vireo_dir / "test.db"))
+    scanner.scan(str(photo_dir), db, vireo_dir=str(vireo_dir))
+
+    assert len(sources_used) == 2
+    assert sources_used[0].endswith("IMG_004.nef")
+    assert sources_used[1].endswith("IMG_004.jpg")
+
+    raw_row = db.conn.execute(
+        "SELECT working_copy_path, working_copy_failed_source"
+        " FROM photos WHERE extension = '.nef'"
+    ).fetchone()
+    assert raw_row["working_copy_path"] is not None
+    assert raw_row["working_copy_failed_source"] == "source"
+
+    with Image.open(vireo_dir / raw_row["working_copy_path"]) as img:
+        assert img.size == (4096, 2731)
+
+
 def test_scan_marks_source_failure_when_raw_and_companion_both_fail(
     tmp_path, monkeypatch,
 ):

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -1720,6 +1720,85 @@ def test_scan_falls_back_when_raw_working_copy_short_edge_is_smaller(
         assert img.size == (4096, 2731)
 
 
+def test_scan_accepts_portrait_raw_working_copy_with_exif_orientation(
+    tmp_path, monkeypatch,
+):
+    """Stored width/height are the unrotated sensor axes, so a portrait shot
+    on a landscape sensor is e.g. 6000x4000 with EXIF Orientation 6.
+    ``extract_working_copy`` writes the orientation-normalized JPEG (4000x6000
+    scaled to 4096). The scanner's RAW-undersize check must apply the same
+    orientation swap that the request-path helpers use; otherwise it sees
+    4096-on-the-short-edge as catastrophically undersized vs. an expected
+    4096-on-the-long-edge and falls back to the companion JPEG, leaving
+    ``working_copy_failed_source='source'`` so edited renders bypass the
+    preserve-highlights RAW path for every portrait photo.
+    """
+    import config as cfg
+    import scanner
+    from db import Database
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+
+    photo_dir = tmp_path / "photos"
+    photo_dir.mkdir()
+
+    nef_file = photo_dir / "IMG_005.nef"
+    nef_file.write_bytes(b"fake raw data")
+    jpg_file = photo_dir / "IMG_005.jpg"
+    # Companion JPEG written with sensor-axis dimensions; the orientation
+    # flag below is what tells consumers it should display as portrait.
+    Image.new("RGB", (6000, 4000), color=(255, 0, 255)).save(str(jpg_file), "JPEG")
+
+    portrait_meta = {
+        "File": {"ImageWidth": 6000, "ImageHeight": 4000},
+        "EXIF": {
+            "ImageWidth": 6000,
+            "ImageHeight": 4000,
+            "Orientation": 6,
+        },
+    }
+
+    def fake_metadata(paths):
+        return {str(p): portrait_meta for p in paths}
+
+    monkeypatch.setattr(scanner, "extract_metadata", fake_metadata)
+
+    sources_used = []
+
+    def fake_extract(source, output, max_size=4096, quality=92):
+        sources_used.append(source)
+        os.makedirs(os.path.dirname(output), exist_ok=True)
+        # libraw + image_loader normalize EXIF orientation: a 6000x4000 sensor
+        # readout with Orientation 6 is written as a portrait 4000x6000 JPEG,
+        # which here scales to 2731x4096 to fit max_size=4096.
+        Image.new("RGB", (2731, 4096)).save(output, "JPEG")
+        return True
+
+    monkeypatch.setattr(scanner, "extract_working_copy", fake_extract)
+
+    db = Database(str(vireo_dir / "test.db"))
+    scanner.scan(str(photo_dir), db, vireo_dir=str(vireo_dir))
+
+    # Only the RAW should have been extracted — no companion fallback.
+    assert len(sources_used) == 1, sources_used
+    assert sources_used[0].endswith("IMG_005.nef")
+
+    raw_row = db.conn.execute(
+        "SELECT working_copy_path, working_copy_failed_source"
+        " FROM photos WHERE extension = '.nef'"
+    ).fetchone()
+    assert raw_row is not None
+    assert raw_row["working_copy_path"] is not None
+    assert raw_row["working_copy_failed_source"] is None, (
+        "Portrait RAW with orientation-normalized working copy must not be "
+        "marked as a source failure; got "
+        f"{raw_row['working_copy_failed_source']!r}"
+    )
+
+
 def test_scan_marks_source_failure_when_raw_and_companion_both_fail(
     tmp_path, monkeypatch,
 ):

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -1536,8 +1536,8 @@ def test_scan_skips_working_copy_for_jpeg(tmp_path, monkeypatch):
     assert len(calls) == 0
 
 
-def test_scan_uses_companion_jpeg_for_working_copy(tmp_path, monkeypatch):
-    """When RAW+JPEG pair exists, working copy is extracted from the companion JPEG."""
+def test_scan_uses_raw_primary_for_raw_working_copy(tmp_path, monkeypatch):
+    """RAW working copies decode the RAW primary, not the companion JPEG."""
     import config as cfg
     import scanner
     from db import Database
@@ -1581,10 +1581,12 @@ def test_scan_uses_companion_jpeg_for_working_copy(tmp_path, monkeypatch):
     assert len(raw_photos) == 1
     assert raw_photos[0]["working_copy_path"] is not None
 
-    # Verify the companion JPEG was used as the source, not the RAW file
+    # Verify the RAW primary was used as the source, not the companion JPEG.
+    # Working copies are the edit-quality path, so they must preserve the RAW
+    # highlight headroom that a camera JPEG may have already clipped.
     assert len(sources_used) == 1
-    assert sources_used[0].endswith("IMG_001.jpg"), (
-        f"Expected companion JPEG as source, got: {sources_used[0]}"
+    assert sources_used[0].endswith("IMG_001.nef"), (
+        f"Expected RAW primary as source, got: {sources_used[0]}"
     )
 
 

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -1646,6 +1646,58 @@ def test_scan_falls_back_to_companion_when_raw_extraction_fails(
     assert sources_used[1].endswith("IMG_002.jpg")
 
 
+def test_scan_marks_source_failure_when_raw_and_companion_both_fail(
+    tmp_path, monkeypatch,
+):
+    """When the RAW fails AND the companion fallback also fails, the failure
+    marker must stay 'source' so request paths
+    (_has_current_working_copy_failure) skip the slow RAW retry. Marking
+    'companion' here would silently un-shield request paths from the known
+    RAW failure: that helper explicitly ignores companion markers while both
+    files exist.
+    """
+    import config as cfg
+    import scanner
+    from db import Database
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+
+    photo_dir = tmp_path / "photos"
+    photo_dir.mkdir()
+
+    nef_file = photo_dir / "IMG_003.nef"
+    nef_file.write_bytes(b"fake raw data")
+    jpg_file = photo_dir / "IMG_003.jpg"
+    Image.new("RGB", (6000, 4000), color=(0, 0, 255)).save(str(jpg_file), "JPEG")
+
+    monkeypatch.setattr(scanner, "extract_metadata", lambda paths: {})
+
+    def fake_extract(source, output, max_size=4096, quality=92):
+        # Both RAW and companion fail (e.g. RAW unsupported + companion
+        # write-locked or corrupt).
+        return False
+
+    monkeypatch.setattr(scanner, "extract_working_copy", fake_extract)
+
+    db = Database(str(vireo_dir / "test.db"))
+    scanner.scan(str(photo_dir), db, vireo_dir=str(vireo_dir))
+
+    raw_row = db.conn.execute(
+        "SELECT working_copy_path, working_copy_failed_source"
+        " FROM photos WHERE extension = '.nef'"
+    ).fetchone()
+    assert raw_row is not None
+    assert raw_row["working_copy_path"] is None
+    assert raw_row["working_copy_failed_source"] == "source", (
+        "RAW failure marker must remain 'source' so "
+        "_has_current_working_copy_failure honors it; got "
+        f"{raw_row['working_copy_failed_source']!r}"
+    )
+
+
 # --- _extract_timestamp tests ---
 
 def test_extract_timestamp_subsec():

--- a/vireo/tests/test_thumbnails.py
+++ b/vireo/tests/test_thumbnails.py
@@ -56,6 +56,45 @@ def test_generate_thumbnail_bounds_non_crop_recipe_load(tmp_path, monkeypatch):
     assert seen_max_sizes == [400]
 
 
+def test_generate_thumbnail_forwards_raw_decode(tmp_path, monkeypatch):
+    """generate_thumbnail must forward raw_decode to load_image so an
+    edited RAW thumbnail demosaics with highlight preservation. Without
+    the override, the EDIT_MATH_VERSION cache purge would regenerate the
+    thumb through the default JPEG-first decode and diverge from the
+    preview / export pipeline.
+    """
+    import thumbnails
+    from image_loader import RAW_DECODE_PRESERVE_HIGHLIGHTS
+    from thumbnails import generate_thumbnail
+
+    src = str(tmp_path / "source.jpg")
+    Image.new("RGB", (400, 300), color="red").save(src)
+    cache_dir = str(tmp_path / "thumbs")
+    os.makedirs(cache_dir)
+
+    seen_raw_decode = []
+    original_load_image = thumbnails.load_image
+
+    def tracking_load_image(file_path, max_size=1024, raw_decode=None):
+        seen_raw_decode.append(raw_decode)
+        return original_load_image(file_path, max_size=max_size)
+
+    monkeypatch.setattr(thumbnails, "load_image", tracking_load_image)
+
+    # Caller passes raw_decode through.
+    result = generate_thumbnail(
+        1, src, cache_dir, raw_decode=RAW_DECODE_PRESERVE_HIGHLIGHTS,
+    )
+    assert result is not None
+    assert seen_raw_decode == [RAW_DECODE_PRESERVE_HIGHLIGHTS]
+
+    # Caller omits raw_decode → load_image gets its default.
+    seen_raw_decode.clear()
+    os.remove(result)
+    assert generate_thumbnail(1, src, cache_dir) is not None
+    assert seen_raw_decode == [None]
+
+
 def test_recipe_source_path_uses_exif_oriented_dimensions(tmp_path):
     import json
 

--- a/vireo/tests/test_thumbnails.py
+++ b/vireo/tests/test_thumbnails.py
@@ -317,6 +317,60 @@ def test_generate_all_retries_edited_raw_thumbnail_with_companion(
     assert row["working_copy_failed_source"] == "source"
 
 
+def test_generate_all_retries_when_raw_thumbnail_short_edge_is_smaller(
+    tmp_path, monkeypatch,
+):
+    import thumbnails
+    from db import Database
+
+    photos_dir = tmp_path / "photos"
+    photos_dir.mkdir()
+    raw_path = photos_dir / "source.NEF"
+    raw_path.write_bytes(b"unsupported raw")
+    companion_path = photos_dir / "source.jpg"
+    Image.new("RGB", (6000, 4000), "green").save(companion_path, "JPEG")
+
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    db = Database(str(vireo_dir / "test.db"))
+    folder_id = db.add_folder(str(photos_dir), name="photos")
+    photo_id = db.add_photo(
+        folder_id,
+        "source.NEF",
+        ".nef",
+        file_size=raw_path.stat().st_size,
+        file_mtime=1234.0,
+        width=6000,
+        height=4000,
+    )
+    db.conn.execute(
+        "UPDATE photos SET companion_path='source.jpg' WHERE id=?",
+        (photo_id,),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(photo_id, {"rotation": 90})
+
+    loaded_paths = []
+    original_load_image = thumbnails.load_image
+
+    def tracking_load_image(file_path, max_size=1024, **kwargs):
+        loaded_paths.append(str(file_path))
+        if str(file_path).lower().endswith(".nef"):
+            return Image.new("RGB", (400, 225), "red")
+        return original_load_image(file_path, max_size=max_size, **kwargs)
+
+    monkeypatch.setattr(thumbnails, "load_image", tracking_load_image)
+
+    thumb_dir = vireo_dir / "thumbs"
+    result = thumbnails.generate_all(db, str(thumb_dir), vireo_dir=str(vireo_dir))
+
+    assert result["generated"] == 1
+    assert result["failed"] == 0
+    assert loaded_paths == [str(raw_path), str(companion_path)]
+    with Image.open(thumb_dir / f"{photo_id}.jpg") as img:
+        assert img.size == (267, 400)
+
+
 def test_generate_all_creates_missing(tmp_path):
     """generate_all generates thumbnails for photos without them."""
     from db import Database
@@ -387,7 +441,8 @@ def test_generate_all_does_not_record_thumb_path_on_failure(tmp_path, monkeypatc
 
     monkeypatch.setattr(
         thumbnails_mod, "generate_thumbnail",
-        lambda photo_id, src, cache_dir, size=400, quality=85, recipe=None: None,
+        lambda photo_id, src, cache_dir, size=400, quality=85,
+        recipe=None, **kwargs: None,
     )
 
     cache_dir = str(tmp_path / "thumbs")

--- a/vireo/tests/test_thumbnails.py
+++ b/vireo/tests/test_thumbnails.py
@@ -252,6 +252,71 @@ def test_generate_all_routes_through_canonical_helper(tmp_path, monkeypatch):
         "generate_all should route source-path resolution through get_canonical_image_path"
 
 
+def test_generate_all_retries_edited_raw_thumbnail_with_companion(
+    tmp_path, monkeypatch,
+):
+    """Standalone thumbnail generation should mirror app/pipeline fallback.
+
+    Edited RAW thumbnails try the RAW first for highlight preservation. If that
+    decode fails, a usable sidecar JPEG should still generate the grid thumb and
+    stamp the source failure marker for later source selection.
+    """
+    import thumbnails
+    from db import Database
+
+    photos_dir = tmp_path / "photos"
+    photos_dir.mkdir()
+    raw_path = photos_dir / "source.NEF"
+    raw_path.write_bytes(b"unsupported raw")
+    companion_path = photos_dir / "source.jpg"
+    Image.new("RGB", (800, 600), "green").save(companion_path, "JPEG")
+
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    db = Database(str(vireo_dir / "test.db"))
+    folder_id = db.add_folder(str(photos_dir), name="photos")
+    photo_id = db.add_photo(
+        folder_id,
+        "source.NEF",
+        ".nef",
+        file_size=raw_path.stat().st_size,
+        file_mtime=1234.0,
+        width=800,
+        height=600,
+    )
+    db.conn.execute(
+        "UPDATE photos SET companion_path='source.jpg' WHERE id=?",
+        (photo_id,),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(photo_id, {"rotation": 90})
+
+    loaded_paths = []
+    original_load_image = thumbnails.load_image
+
+    def tracking_load_image(file_path, max_size=1024, **kwargs):
+        loaded_paths.append(str(file_path))
+        if str(file_path).lower().endswith(".nef"):
+            return None
+        return original_load_image(file_path, max_size=max_size, **kwargs)
+
+    monkeypatch.setattr(thumbnails, "load_image", tracking_load_image)
+
+    thumb_dir = vireo_dir / "thumbs"
+    result = thumbnails.generate_all(db, str(thumb_dir), vireo_dir=str(vireo_dir))
+
+    assert result["generated"] == 1
+    assert result["failed"] == 0
+    assert loaded_paths[0] == str(raw_path)
+    assert loaded_paths[1] == str(companion_path)
+    assert os.path.exists(thumb_dir / f"{photo_id}.jpg")
+    row = db.conn.execute(
+        "SELECT working_copy_failed_source FROM photos WHERE id=?",
+        (photo_id,),
+    ).fetchone()
+    assert row["working_copy_failed_source"] == "source"
+
+
 def test_generate_all_creates_missing(tmp_path):
     """generate_all generates thumbnails for photos without them."""
     from db import Database

--- a/vireo/thumbnails.py
+++ b/vireo/thumbnails.py
@@ -123,19 +123,30 @@ def _recipe_source_path(photo, recipe, max_size, vireo_dir, folders):
             return get_canonical_image_path(photo, vireo_dir, folders)
         return os.path.join(folders.get(photo["folder_id"], ""), photo["filename"])
 
+    primary_is_raw = (
+        os.path.splitext(photo["filename"])[1].lower() in RAW_EXTENSIONS
+    )
+
     canonical = get_canonical_image_path(photo, vireo_dir, folders)
     wc_rel = photo["working_copy_path"]
-    if not recipe.get("crop") and canonical and wc_rel:
-        wc_path = wc_rel if os.path.isabs(wc_rel) else os.path.join(vireo_dir, wc_rel)
-        if os.path.abspath(canonical) == os.path.abspath(wc_path):
-            return canonical
-    if recipe.get("crop") and wc_rel:
-        wc_path = os.path.join(vireo_dir, wc_rel)
-        if (
-            os.path.exists(wc_path)
-            and _path_satisfies_recipe_render(wc_path, photo, recipe, max_size)
-        ):
-            return canonical
+    # For RAW primaries, never short-circuit to a JPEG working copy or
+    # camera JPEG companion: legacy working copies predate the highlight-
+    # preserving RAW decode (and EDIT_MATH_VERSION's migration only purges
+    # preview/thumbnail caches, not working copies), and the companion JPEG
+    # is already clipped. Apply the recipe to the RAW so the thumbnail
+    # matches preview/export bytes.
+    if not primary_is_raw:
+        if not recipe.get("crop") and canonical and wc_rel:
+            wc_path = wc_rel if os.path.isabs(wc_rel) else os.path.join(vireo_dir, wc_rel)
+            if os.path.abspath(canonical) == os.path.abspath(wc_path):
+                return canonical
+        if recipe.get("crop") and wc_rel:
+            wc_path = os.path.join(vireo_dir, wc_rel)
+            if (
+                os.path.exists(wc_path)
+                and _path_satisfies_recipe_render(wc_path, photo, recipe, max_size)
+            ):
+                return canonical
 
     folder_path = folders.get(photo["folder_id"])
     if not folder_path:
@@ -145,19 +156,26 @@ def _recipe_source_path(photo, recipe, max_size, vireo_dir, folders):
                 return wc_path
         return ""
     companion_path = photo["companion_path"]
-    if companion_path:
+    original_abs = os.path.join(folder_path, photo["filename"])
+    # Allow companion substitution only for non-RAW primaries, or when the
+    # RAW source is known to fail extraction at its current mtime — same
+    # gate as app._recipe_render_source so the thumbnail/preview/export
+    # paths stay in sync.
+    allow_companion = not primary_is_raw or _has_current_raw_failure(
+        photo, original_abs,
+    )
+    if companion_path and allow_companion:
         companion = os.path.join(folder_path, companion_path)
         if (
             os.path.exists(companion)
             and _path_satisfies_recipe_render(companion, photo, recipe, max_size)
         ):
             return companion
-    original = os.path.join(folder_path, photo["filename"])
-    if not os.path.exists(original) and wc_rel:
+    if not os.path.exists(original_abs) and wc_rel:
         wc_path = os.path.join(vireo_dir, wc_rel)
         if os.path.exists(wc_path):
             return wc_path
-    return original
+    return original_abs
 
 
 def _has_current_raw_failure(photo, source_path):

--- a/vireo/thumbnails.py
+++ b/vireo/thumbnails.py
@@ -90,6 +90,19 @@ def _recipe_source_dimensions(photo):
     return width, height
 
 
+def _scaled_recipe_source_dimensions(photo, max_size=None):
+    width, height = _recipe_source_dimensions(photo)
+    if width <= 0 or height <= 0:
+        return 0, 0
+    if max_size:
+        long_edge = max(width, height)
+        if long_edge > max_size:
+            scale = max_size / long_edge
+            width = round(width * scale)
+            height = round(height * scale)
+    return width, height
+
+
 def _image_size_after_exif_orientation(img):
     width, height = img.size
     orientation = None
@@ -263,7 +276,7 @@ def _retry_thumbnail_with_companion(
 
 def generate_thumbnail(
     photo_id, source_path, cache_dir, size=THUMB_SIZE, quality=85, recipe=None,
-    raw_decode=None,
+    raw_decode=None, min_source_size=None,
 ):
     """Generate a JPEG thumbnail for a photo.
 
@@ -280,6 +293,10 @@ def generate_thumbnail(
             edited RAW thumbnail so the demosaic matches the preview /
             export pipeline instead of falling back to the embedded
             camera JPEG's clipped highlights.
+        min_source_size: optional ``(width, height)`` for the image loaded
+            before applying ``recipe``. If the RAW loader falls back to an
+            embedded preview smaller than either axis, generation returns
+            ``None`` so callers can retry a full-size companion JPEG.
 
     Returns:
         path to the thumbnail file, or None on failure
@@ -295,6 +312,24 @@ def generate_thumbnail(
     if img is None:
         log.warning("Could not load image for thumbnail: %s", source_path)
         return None
+    if min_source_size:
+        expected_w, expected_h = min_source_size
+        if (
+            expected_w > 0
+            and expected_h > 0
+            and (
+                img.size[0] + 1 < expected_w
+                or img.size[1] + 1 < expected_h
+            )
+        ):
+            log.info(
+                "Thumbnail source for photo %s is undersized (%dx%d, "
+                "expected %dx%d): %s",
+                photo_id, img.size[0], img.size[1],
+                expected_w, expected_h, source_path,
+            )
+            img.close()
+            return None
     if recipe:
         from image_edits import apply_recipe_to_loaded_image
         img = apply_recipe_to_loaded_image(img, recipe, max_size=size)
@@ -398,12 +433,22 @@ def generate_all(db, cache_dir, progress_callback=None, config=None, vireo_dir=N
             source_photo["filename"]
         )[1].lower() in RAW_EXTENSIONS:
             raw_decode_kwargs["raw_decode"] = RAW_DECODE_PRESERVE_HIGHLIGHTS
+        min_source_size = None
+        if (
+            recipe
+            and os.path.splitext(source_path)[1].lower() in RAW_EXTENSIONS
+        ):
+            load_max_size = None if recipe.get("crop") else thumb_size
+            min_source_size = _scaled_recipe_source_dimensions(
+                source_photo, load_max_size,
+            )
         result_path = generate_thumbnail(
             photo["id"],
             source_path,
             cache_dir,
             size=thumb_size,
             quality=thumb_quality,
+            min_source_size=min_source_size,
             **recipe_kwargs,
             **raw_decode_kwargs,
         )

--- a/vireo/thumbnails.py
+++ b/vireo/thumbnails.py
@@ -7,6 +7,7 @@ import os
 import tempfile
 from datetime import UTC, datetime
 
+from exif_orientation import orientation_swaps_axes as _orientation_swaps_axes
 from image_loader import (
     RAW_DECODE_PRESERVE_HIGHLIGHTS,
     RAW_EXTENSIONS,
@@ -59,20 +60,6 @@ def _exif_orientation(exif_data):
         if isinstance(values, dict) and "Orientation" in values:
             return values["Orientation"]
     return metadata.get("Orientation")
-
-
-def _orientation_swaps_axes(orientation):
-    if orientation is None or isinstance(orientation, bool):
-        return False
-    if isinstance(orientation, int | float):
-        return int(orientation) in (5, 6, 7, 8)
-    text = str(orientation).strip().lower()
-    if not text:
-        return False
-    try:
-        return int(text) in (5, 6, 7, 8)
-    except ValueError:
-        return "90" in text or "270" in text
 
 
 def _recipe_source_dimensions(photo):

--- a/vireo/thumbnails.py
+++ b/vireo/thumbnails.py
@@ -7,7 +7,12 @@ import os
 import tempfile
 from datetime import UTC, datetime
 
-from image_loader import RAW_EXTENSIONS, get_canonical_image_path, load_image
+from image_loader import (
+    RAW_DECODE_PRESERVE_HIGHLIGHTS,
+    RAW_EXTENSIONS,
+    get_canonical_image_path,
+    load_image,
+)
 
 log = logging.getLogger(__name__)
 
@@ -187,6 +192,7 @@ def _has_current_raw_failure(photo, source_path):
 
 def generate_thumbnail(
     photo_id, source_path, cache_dir, size=THUMB_SIZE, quality=85, recipe=None,
+    raw_decode=None,
 ):
     """Generate a JPEG thumbnail for a photo.
 
@@ -196,6 +202,13 @@ def generate_thumbnail(
         cache_dir: directory to store thumbnails
         size: max dimension in pixels
         quality: JPEG quality (1-95)
+        raw_decode: optional RAW decode mode forwarded to ``load_image``.
+            Defaults to ``None``, which uses ``load_image``'s default
+            (RAW_DECODE_JPEG_FIRST). Pass
+            ``RAW_DECODE_PRESERVE_HIGHLIGHTS`` when regenerating an
+            edited RAW thumbnail so the demosaic matches the preview /
+            export pipeline instead of falling back to the embedded
+            camera JPEG's clipped highlights.
 
     Returns:
         path to the thumbnail file, or None on failure
@@ -206,7 +219,8 @@ def generate_thumbnail(
         return thumb_path
 
     load_max_size = None if recipe and recipe.get("crop") else size
-    img = load_image(source_path, max_size=load_max_size)
+    load_kwargs = {"raw_decode": raw_decode} if raw_decode else {}
+    img = load_image(source_path, max_size=load_max_size, **load_kwargs)
     if img is None:
         log.warning("Could not load image for thumbnail: %s", source_path)
         return None
@@ -304,6 +318,15 @@ def generate_all(db, cache_dir, progress_callback=None, config=None, vireo_dir=N
         # iterations and avoid blocking concurrent jobs (a parallel scan's
         # add_photo INSERT) past the 30s busy_timeout.
         recipe_kwargs = {"recipe": recipe} if recipe else {}
+        # Derive the decode mode from the primary photo's extension so
+        # edited RAWs that fall through to the original source path are
+        # demosaiced with highlight preservation, matching the preview /
+        # export pipeline rather than the default JPEG-first decode.
+        raw_decode_kwargs = {}
+        if recipe and os.path.splitext(
+            source_photo["filename"]
+        )[1].lower() in RAW_EXTENSIONS:
+            raw_decode_kwargs["raw_decode"] = RAW_DECODE_PRESERVE_HIGHLIGHTS
         if generate_thumbnail(
             photo["id"],
             source_path,
@@ -311,6 +334,7 @@ def generate_all(db, cache_dir, progress_callback=None, config=None, vireo_dir=N
             size=thumb_size,
             quality=thumb_quality,
             **recipe_kwargs,
+            **raw_decode_kwargs,
         ) is not None:
             generated += 1
             # Record on-disk presence in the photos table so the dashboard's

--- a/vireo/thumbnails.py
+++ b/vireo/thumbnails.py
@@ -129,12 +129,13 @@ def _recipe_source_path(photo, recipe, max_size, vireo_dir, folders):
 
     canonical = get_canonical_image_path(photo, vireo_dir, folders)
     wc_rel = photo["working_copy_path"]
-    # For RAW primaries, never short-circuit to a JPEG working copy or
-    # camera JPEG companion: legacy working copies predate the highlight-
-    # preserving RAW decode (and EDIT_MATH_VERSION's migration only purges
-    # preview/thumbnail caches, not working copies), and the companion JPEG
-    # is already clipped. Apply the recipe to the RAW so the thumbnail
-    # matches preview/export bytes.
+    # For RAW primaries with a recipe, never short-circuit to the JPEG
+    # working copy or companion: legacy working copies predate the
+    # highlight-preserving RAW decode (EDIT_MATH_VERSION's purge only
+    # touches preview/thumb caches, not working copies). Reusing them
+    # here would feed the recipe a clipped JPEG and silently bypass
+    # generate_thumbnail's RAW_DECODE_PRESERVE_HIGHLIGHTS request — the
+    # raw_decode kwarg is a no-op when load_image gets a JPEG path.
     if not primary_is_raw:
         if not recipe.get("crop") and canonical and wc_rel:
             wc_path = wc_rel if os.path.isabs(wc_rel) else os.path.join(vireo_dir, wc_rel)
@@ -156,13 +157,14 @@ def _recipe_source_path(photo, recipe, max_size, vireo_dir, folders):
                 return wc_path
         return ""
     companion_path = photo["companion_path"]
-    original_abs = os.path.join(folder_path, photo["filename"])
-    # Allow companion substitution only for non-RAW primaries, or when the
-    # RAW source is known to fail extraction at its current mtime — same
-    # gate as app._recipe_render_source so the thumbnail/preview/export
-    # paths stay in sync.
+    original = os.path.join(folder_path, photo["filename"])
+    # Allow the companion JPEG only for non-RAW primaries, OR for RAW
+    # primaries whose RAW is known to fail for the current source mtime —
+    # mirrors the gate in app/pipeline _recipe_render_source so edited
+    # RAW thumbnails decode the highlight-preserving RAW unless we've
+    # already proven it can't be demosaiced.
     allow_companion = not primary_is_raw or _has_current_raw_failure(
-        photo, original_abs,
+        photo, original,
     )
     if companion_path and allow_companion:
         companion = os.path.join(folder_path, companion_path)
@@ -171,11 +173,11 @@ def _recipe_source_path(photo, recipe, max_size, vireo_dir, folders):
             and _path_satisfies_recipe_render(companion, photo, recipe, max_size)
         ):
             return companion
-    if not os.path.exists(original_abs) and wc_rel:
+    if not os.path.exists(original) and wc_rel:
         wc_path = os.path.join(vireo_dir, wc_rel)
         if os.path.exists(wc_path):
             return wc_path
-    return original_abs
+    return original
 
 
 def _has_current_raw_failure(photo, source_path):

--- a/vireo/thumbnails.py
+++ b/vireo/thumbnails.py
@@ -219,6 +219,48 @@ def _has_current_raw_failure(photo, source_path):
     return age < 24 * 60 * 60
 
 
+def _retry_thumbnail_with_companion(
+    db, photo, source_path, cache_dir, size, quality, recipe, folder_path,
+):
+    if not photo or not folder_path:
+        return None
+    companion_rel = _photo_value(photo, "companion_path")
+    if not companion_rel:
+        return None
+    companion_abs = os.path.join(folder_path, companion_rel)
+    if (
+        not os.path.exists(companion_abs)
+        or os.path.abspath(companion_abs) == os.path.abspath(source_path)
+    ):
+        return None
+    photo_id = _photo_value(photo, "id")
+    log.info(
+        "Thumbnail RAW decode failed for photo %s; falling back to companion JPEG",
+        photo_id,
+    )
+    file_mtime = _photo_value(photo, "file_mtime")
+    if file_mtime is not None and photo_id is not None and hasattr(db, "conn"):
+        with contextlib.suppress(Exception):
+            db.conn.execute(
+                "UPDATE photos SET"
+                " working_copy_failed_at=datetime('now'),"
+                " working_copy_failed_mtime=?,"
+                " working_copy_failed_source='source'"
+                " WHERE id=?",
+                (file_mtime, photo_id),
+            )
+            db.conn.commit()
+    recipe_kwargs = {"recipe": recipe} if recipe else {}
+    return generate_thumbnail(
+        photo_id,
+        companion_abs,
+        cache_dir,
+        size=size,
+        quality=quality,
+        **recipe_kwargs,
+    )
+
+
 def generate_thumbnail(
     photo_id, source_path, cache_dir, size=THUMB_SIZE, quality=85, recipe=None,
     raw_decode=None,
@@ -356,7 +398,7 @@ def generate_all(db, cache_dir, progress_callback=None, config=None, vireo_dir=N
             source_photo["filename"]
         )[1].lower() in RAW_EXTENSIONS:
             raw_decode_kwargs["raw_decode"] = RAW_DECODE_PRESERVE_HIGHLIGHTS
-        if generate_thumbnail(
+        result_path = generate_thumbnail(
             photo["id"],
             source_path,
             cache_dir,
@@ -364,7 +406,23 @@ def generate_all(db, cache_dir, progress_callback=None, config=None, vireo_dir=N
             quality=thumb_quality,
             **recipe_kwargs,
             **raw_decode_kwargs,
-        ) is not None:
+        )
+        if (
+            result_path is None
+            and recipe
+            and os.path.splitext(source_path)[1].lower() in RAW_EXTENSIONS
+        ):
+            result_path = _retry_thumbnail_with_companion(
+                db,
+                source_photo,
+                source_path,
+                cache_dir,
+                thumb_size,
+                thumb_quality,
+                recipe,
+                folders.get(source_photo["folder_id"]),
+            )
+        if result_path is not None:
             generated += 1
             # Record on-disk presence in the photos table so the dashboard's
             # coverage query (`thumb_path IS NOT NULL`) reflects this run.

--- a/vireo/thumbnails.py
+++ b/vireo/thumbnails.py
@@ -181,11 +181,20 @@ def _recipe_source_path(photo, recipe, max_size, vireo_dir, folders):
 
 
 def _has_current_raw_failure(photo, source_path):
+    """Whether this RAW row carries an explicit `source` failure marker.
+
+    Only an explicit ``working_copy_failed_source == "source"`` marker
+    routes RAW thumbnails to the companion JPEG. Treating legacy NULL
+    markers the same way as an explicit source failure made thumbnail
+    selection diverge from preview/export, which use only the explicit
+    semantics (see ``_has_current_working_copy_failure`` in ``app.py``
+    and ``pipeline_job.py``).
+    """
     if os.path.splitext(source_path or "")[1].lower() not in RAW_EXTENSIONS:
         return False
     if os.path.splitext(_photo_value(photo, "filename") or "")[1].lower() not in RAW_EXTENSIONS:
         return False
-    if _photo_value(photo, "working_copy_failed_source") not in (None, "source"):
+    if _photo_value(photo, "working_copy_failed_source") != "source":
         return False
     failed_at = _photo_value(photo, "working_copy_failed_at")
     failed_mtime = _photo_value(photo, "working_copy_failed_mtime")

--- a/vireo/thumbnails.py
+++ b/vireo/thumbnails.py
@@ -59,7 +59,7 @@ def _exif_orientation(exif_data):
 def _orientation_swaps_axes(orientation):
     if orientation is None or isinstance(orientation, bool):
         return False
-    if isinstance(orientation, (int, float)):
+    if isinstance(orientation, int | float):
         return int(orientation) in (5, 6, 7, 8)
     text = str(orientation).strip().lower()
     if not text:

--- a/vireo/tone.py
+++ b/vireo/tone.py
@@ -20,11 +20,13 @@ flat white. This pipeline therefore:
   4. re-encodes linear -> sRGB,
   5. applies the display-referred ops (range controls, contrast, color) in sRGB.
 
-Data ceiling: this operates on whatever 8-bit source it is handed. It produces
-a pleasing rolloff but cannot *recover* highlights that were already clipped
-upstream (e.g. in a camera JPEG or an auto-brightened RAW decode). Recovering
-real highlight detail requires decoding RAW to linear with auto-bright off
-(a separate, larger change).
+Data ceiling: this operates on whatever RGB source it is handed. JPEGs and
+legacy working copies are still 8-bit and cannot *recover* highlights that were
+already clipped upstream. New RAW working copies and edited RAW renders ask
+``image_loader`` to demosaic with auto-bright disabled and highlight blending
+enabled before quantizing to the JPEG working/render cache. That preserves more
+RAW highlight headroom for this tone curve, but it is still not a full
+scene-linear 16-bit editing pipeline.
 
 Keep-in-sync contract (Tier 3 / live preview)
 ---------------------------------------------


### PR DESCRIPTION
## Summary
Add an explicit RAW decode mode that demosaics with auto-bright disabled and highlight blending for edit-quality working copies and edited RAW renders.
Keep browsing and thumbnail paths JPEG-first for speed, while preventing RAW primaries from being replaced by companion JPEGs in working-copy generation.
Update tone documentation and tests to cover the new RAW-aware behavior and fallback path.

## Tests
- pytest -q vireo/tests/test_image_loader.py
- pytest -q vireo/tests/test_export.py vireo/tests/test_thumbnails.py vireo/tests/test_scanner.py vireo/tests/test_app.py -k "working_copy or raw or original or edit_recipe or inat or external"
- pytest -q vireo/tests/test_tone.py vireo/tests/test_tone_shader_parity.py
- python -m py_compile vireo/image_loader.py vireo/scanner.py vireo/export.py vireo/app.py vireo/tone.py vireo/tests/test_image_loader.py vireo/tests/test_scanner.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Edited RAW photos now render with improved highlight preservation across previews, thumbnails, and exports.
* **Bug Fixes**
  * RAW decode failures and undersized RAW-derived previews now more consistently fall back to the best available companion JPEG.
  * Improved RAW routing for serve/original, thumbnail retries, and original extraction when RAW sources are missing or working-copy extraction fails.
  * Updated edit preview/original selection logic to use the correct RAW decode mode and correct orientation handling; improved edited image cache invalidation when edit math changes.
* **Documentation**
  * Tone pipeline notes updated to clarify RAW-vs-JPEG behavior and highlight handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->