### PR TITLE
Fix import date folder planning

### DIFF
--- a/vireo/ingest.py
+++ b/vireo/ingest.py
@@ -527,27 +527,49 @@ def ingest(
     failed = 0
     copied_paths = []
     duplicate_folders: set[str] = set()
-    timestamps = _source_file_timestamps(files)
+    emitted = 0
 
-    for i, source_file in enumerate(files):
+    # Pass 1: hash each file and partition into duplicates vs. survivors.
+    # Timestamp resolution is deferred to Pass 2 so a duplicate-only
+    # re-import of a large card does not run the EXIF/ExifTool prepass on
+    # files we already have — the duplicate gate short-circuits first.
+    to_copy: list[tuple[Path, str]] = []
+    for source_file in files:
         try:
-            # Compute hash for duplicate detection
             file_hash = compute_file_hash(str(source_file))
+        except Exception as e:
+            log.warning("Failed to ingest %s: %s", source_file, e)
+            failed += 1
+            emitted += 1
+            if progress_callback:
+                progress_callback(emitted, total, source_file.name)
+            continue
 
-            if skip_duplicates and file_hash in known_hashes:
-                skipped_duplicate += 1
-                # Record every destination folder that holds a copy of
-                # this file, not just one. The pipeline uses this set
-                # verbatim as restrict_dirs, so if we only report one
-                # folder the others never get linked to the active
-                # workspace.
-                duplicate_folders.update(
-                    known_hash_folders.get(file_hash, ())
-                )
-                if progress_callback:
-                    progress_callback(i + 1, total, source_file.name)
-                continue
+        if skip_duplicates and file_hash in known_hashes:
+            skipped_duplicate += 1
+            # Record every destination folder that holds a copy of
+            # this file, not just one. The pipeline uses this set
+            # verbatim as restrict_dirs, so if we only report one
+            # folder the others never get linked to the active
+            # workspace.
+            duplicate_folders.update(
+                known_hash_folders.get(file_hash, ())
+            )
+            emitted += 1
+            if progress_callback:
+                progress_callback(emitted, total, source_file.name)
+            continue
 
+        to_copy.append((source_file, file_hash))
+
+    # Pass 2: resolve timestamps only for survivors and copy. Batching
+    # ExifTool across survivors keeps the fresh-card import fast for
+    # formats that lack lightweight EXIF (HEIC, video) without paying
+    # that cost for files the duplicate gate already rejected.
+    timestamps = _source_file_timestamps([s for s, _ in to_copy])
+
+    for source_file, file_hash in to_copy:
+        try:
             rel_folder = build_destination_path(
                 timestamps.get(source_file), folder_template
             )
@@ -564,8 +586,9 @@ def ingest(
                     skipped_duplicate += 1
                     known_hashes.add(file_hash)
                     duplicate_folders.add(str(dest_folder))
+                    emitted += 1
                     if progress_callback:
-                        progress_callback(i + 1, total, source_file.name)
+                        progress_callback(emitted, total, source_file.name)
                     continue
                 # Different file, same name — add numeric suffix
                 stem = dest_file.stem
@@ -584,8 +607,9 @@ def ingest(
             log.warning("Failed to ingest %s: %s", source_file, e)
             failed += 1
 
+        emitted += 1
         if progress_callback:
-            progress_callback(i + 1, total, source_file.name)
+            progress_callback(emitted, total, source_file.name)
 
     return {
         "copied": copied,

--- a/vireo/ingest.py
+++ b/vireo/ingest.py
@@ -4,6 +4,7 @@ import contextlib
 import logging
 import os
 import posixpath
+import re
 import shutil
 import sys
 from datetime import datetime
@@ -137,6 +138,103 @@ def build_destination_path(exif_timestamp, template="%Y/%Y-%m-%d"):
     return result
 
 
+_EXIFTOOL_DT_RE = re.compile(
+    r"(\d{4}):(\d{2}):(\d{2})[ T](\d{2}):(\d{2}):(\d{2})"
+)
+
+
+def _parse_metadata_timestamp(value):
+    if not value:
+        return None
+    match = _EXIFTOOL_DT_RE.search(str(value))
+    if not match:
+        return None
+    try:
+        return datetime(
+            int(match.group(1)),
+            int(match.group(2)),
+            int(match.group(3)),
+            int(match.group(4)),
+            int(match.group(5)),
+            int(match.group(6)),
+        )
+    except ValueError:
+        return None
+
+
+def _metadata_capture_timestamp(metadata):
+    for group_name in ("EXIF", "XMP", "QuickTime", "Composite"):
+        group = metadata.get(group_name)
+        if not isinstance(group, dict):
+            continue
+        for key in (
+            "DateTimeOriginal",
+            "CreateDate",
+            "DateTimeDigitized",
+            "SubSecDateTimeOriginal",
+            "MediaCreateDate",
+            "TrackCreateDate",
+        ):
+            dt = _parse_metadata_timestamp(group.get(key))
+            if dt is not None:
+                return dt
+    return None
+
+
+def _source_file_timestamps(files):
+    """Resolve capture timestamps for source files.
+
+    Use the existing lightweight EXIF reader first. For files it cannot parse,
+    ask ExifTool in batches via metadata.extract_metadata, then fall back to
+    file modification time. This keeps date-folder planning aligned with the
+    richer metadata path used elsewhere in Vireo without requiring ExifTool
+    for the common JPEG/RAW fast path.
+    """
+    timestamps = {}
+    missing = []
+
+    for source_file in files:
+        exif_dt = None
+        with contextlib.suppress(OSError, ValueError):
+            exif_dt = read_exif_timestamp(str(source_file))
+        if exif_dt is None:
+            missing.append(source_file)
+        else:
+            timestamps[source_file] = exif_dt
+
+    if missing:
+        try:
+            from metadata import extract_metadata
+
+            metadata_by_path = extract_metadata(
+                [str(path) for path in missing],
+                restricted_tags=[
+                    "-DateTimeOriginal",
+                    "-CreateDate",
+                    "-DateTimeDigitized",
+                    "-SubSecDateTimeOriginal",
+                    "-MediaCreateDate",
+                    "-TrackCreateDate",
+                ],
+            )
+        except Exception:
+            log.debug(
+                "Could not read ExifTool metadata for import timestamps",
+                exc_info=True,
+            )
+            metadata_by_path = {}
+
+        for source_file in missing:
+            metadata = metadata_by_path.get(str(source_file), {})
+            exif_dt = _metadata_capture_timestamp(metadata)
+            if exif_dt is None:
+                with contextlib.suppress(OSError, ValueError, OverflowError):
+                    exif_dt = datetime.fromtimestamp(source_file.stat().st_mtime)
+            timestamps[source_file] = exif_dt
+
+    return timestamps
+
+
 def preview_destination(sources, destination, folder_template="%Y/%Y-%m-%d",
                         file_types="both", recursive=True, exclude_paths=None):
     """Dry-run preview of destination folder structure.
@@ -155,16 +253,10 @@ def preview_destination(sources, destination, folder_template="%Y/%Y-%m-%d",
         skip = set(exclude_paths)
         all_files = [f for f in all_files if str(f) not in skip]
 
+    timestamps = _source_file_timestamps(all_files)
     folder_counts = {}
     for source_file in all_files:
-        exif_dt = None
-        with contextlib.suppress(OSError, ValueError):
-            exif_dt = read_exif_timestamp(str(source_file))
-        if exif_dt is None:
-            with contextlib.suppress(OSError, ValueError, OverflowError):
-                exif_dt = datetime.fromtimestamp(source_file.stat().st_mtime)
-
-        rel_folder = build_destination_path(exif_dt, folder_template)
+        rel_folder = build_destination_path(timestamps.get(source_file), folder_template)
         if not rel_folder:
             rel_folder = "."
         folder_counts[rel_folder] = folder_counts.get(rel_folder, 0) + 1
@@ -435,6 +527,7 @@ def ingest(
     failed = 0
     copied_paths = []
     duplicate_folders: set[str] = set()
+    timestamps = _source_file_timestamps(files)
 
     for i, source_file in enumerate(files):
         try:
@@ -455,18 +548,9 @@ def ingest(
                     progress_callback(i + 1, total, source_file.name)
                 continue
 
-            # Determine destination folder from EXIF date
-            exif_dt = None
-            try:
-                exif_dt = read_exif_timestamp(str(source_file))
-            except (OSError, ValueError):
-                log.debug("Could not read EXIF timestamp from %s", source_file)
-            if exif_dt is None:
-                # Fall back to file modification time
-                with contextlib.suppress(OSError, ValueError, OverflowError):
-                    exif_dt = datetime.fromtimestamp(source_file.stat().st_mtime)
-
-            rel_folder = build_destination_path(exif_dt, folder_template)
+            rel_folder = build_destination_path(
+                timestamps.get(source_file), folder_template
+            )
             dest_folder = Path(destination_dir) / rel_folder
             dest_folder.mkdir(parents=True, exist_ok=True)
 

--- a/vireo/ingest.py
+++ b/vireo/ingest.py
@@ -561,6 +561,14 @@ def ingest(
             continue
 
         to_copy.append((source_file, file_hash))
+        # Mark the survivor as known so a later byte-identical file in
+        # the same import (different name, or destined for a different
+        # subfolder) is caught by the duplicate gate above. The previous
+        # single-pass loop got this for free because it added each
+        # copied hash before processing the next file; the two-pass
+        # split must do it explicitly. Pass 2 also adds the hash on
+        # successful copy — the dual-write is harmless.
+        known_hashes.add(file_hash)
 
     # Pass 2: resolve timestamps only for survivors and copy. Batching
     # ExifTool across survivors keeps the fresh-card import fast for

--- a/vireo/ingest.py
+++ b/vireo/ingest.py
@@ -561,14 +561,6 @@ def ingest(
             continue
 
         to_copy.append((source_file, file_hash))
-        # Mark the survivor as known so a later byte-identical file in
-        # the same import (different name, or destined for a different
-        # subfolder) is caught by the duplicate gate above. The previous
-        # single-pass loop got this for free because it added each
-        # copied hash before processing the next file; the two-pass
-        # split must do it explicitly. Pass 2 also adds the hash on
-        # successful copy — the dual-write is harmless.
-        known_hashes.add(file_hash)
 
     # Pass 2: resolve timestamps only for survivors and copy. Batching
     # ExifTool across survivors keeps the fresh-card import fast for
@@ -576,7 +568,31 @@ def ingest(
     # that cost for files the duplicate gate already rejected.
     timestamps = _source_file_timestamps([s for s, _ in to_copy])
 
+    # Records the destination folder where each hash actually landed
+    # during this batch. Populated only when pass 2 marks a hash as
+    # known (successful copy or exact-match destination collision) so
+    # an intra-batch duplicate can report the correct post-import scan
+    # folder.
+    batch_dest_folders: dict[str, str] = {}
+
     for source_file, file_hash in to_copy:
+        # Intra-batch dedup: a byte-identical sibling earlier in this
+        # batch already landed (or matched an existing destination
+        # file). Skip without re-copying. We intentionally defer this
+        # mark to pass 2 success rather than recording it in pass 1 —
+        # if the primary's copy fails (e.g. the destination filename
+        # collides with a directory of the same name), the sibling
+        # still gets a chance to import the bytes.
+        if skip_duplicates and file_hash in known_hashes:
+            skipped_duplicate += 1
+            dest = batch_dest_folders.get(file_hash)
+            if dest is not None:
+                duplicate_folders.add(dest)
+            emitted += 1
+            if progress_callback:
+                progress_callback(emitted, total, source_file.name)
+            continue
+
         try:
             rel_folder = build_destination_path(
                 timestamps.get(source_file), folder_template
@@ -593,6 +609,7 @@ def ingest(
                     # Exact same file already there
                     skipped_duplicate += 1
                     known_hashes.add(file_hash)
+                    batch_dest_folders[file_hash] = str(dest_folder)
                     duplicate_folders.add(str(dest_folder))
                     emitted += 1
                     if progress_callback:
@@ -608,6 +625,7 @@ def ingest(
 
             shutil.copy2(str(source_file), str(dest_file))
             known_hashes.add(file_hash)
+            batch_dest_folders[file_hash] = str(dest_folder)
             copied_paths.append(str(dest_file))
             copied += 1
 

--- a/vireo/tests/test_ingest.py
+++ b/vireo/tests/test_ingest.py
@@ -511,6 +511,50 @@ def test_ingest_skip_duplicates_within_single_batch(tmp_path):
     assert len(on_disk) == 1
 
 
+def test_ingest_intra_batch_dup_retries_after_primary_failure(tmp_path):
+    """If the primary copy of a hash fails in pass 2, a byte-identical
+    sibling in the same batch still gets a chance to import the bytes.
+
+    Regression: when intra-batch dedup was eagerly marked in pass 1, a
+    failed primary copy left every byte-identical sibling permanently
+    skipped — no copy ever landed for that hash even though the user
+    asked for ``skip_duplicates=True`` (which only means "don't import
+    bytes I already have", not "give up if the first try fails").
+    """
+    import shutil
+
+    src = tmp_path / "sd_card"
+    dst = tmp_path / "nas"
+    src.mkdir()
+    dst.mkdir()
+
+    # Two byte-identical files; same mtime so they target the same date folder.
+    Image.new("RGB", (100, 100), color="green").save(str(src / "IMG_001.jpg"))
+    shutil.copyfile(str(src / "IMG_001.jpg"), str(src / "IMG_002.jpg"))
+    mtime = datetime(2026, 3, 28).timestamp()
+    os.utime(str(src / "IMG_001.jpg"), (mtime, mtime))
+    os.utime(str(src / "IMG_002.jpg"), (mtime, mtime))
+
+    # Squat the primary's destination path with a directory of the same
+    # name. shutil.copy2 (and compute_file_hash on the "dest_file")
+    # then raise IsADirectoryError, so the primary fails in pass 2.
+    dest_folder = dst / "2026" / "2026-03-28"
+    dest_folder.mkdir(parents=True)
+    (dest_folder / "IMG_001.jpg").mkdir()
+
+    db = Database(str(tmp_path / "test.db"))
+    result = ingest(str(src), str(dst), db=db, skip_duplicates=True)
+
+    assert result["failed"] == 1, result
+    assert result["copied"] == 1, result
+    assert result["skipped_duplicate"] == 0, result
+    # The sibling should have landed under the date folder.
+    files_on_disk = sorted(
+        p.name for p in dest_folder.iterdir() if p.is_file()
+    )
+    assert "IMG_002.jpg" in files_on_disk, files_on_disk
+
+
 def test_ingest_custom_folder_template(tmp_path):
     """Custom folder template is used for organization."""
     src = tmp_path / "sd_card"

--- a/vireo/tests/test_ingest.py
+++ b/vireo/tests/test_ingest.py
@@ -381,6 +381,58 @@ def test_ingest_uses_metadata_dates_when_lightweight_exif_fails(
     assert not (dst / "2026" / "2026-03-30" / "a.jpg").exists()
 
 
+def test_ingest_skips_timestamp_resolution_for_duplicates(
+    tmp_path, monkeypatch
+):
+    """Duplicate-only re-imports must not trigger EXIF or ExifTool work."""
+    import ingest as ingest_module
+    import metadata as metadata_module
+    from scanner import compute_file_hash
+
+    src = tmp_path / "sd_card"
+    dst = tmp_path / "nas"
+    src.mkdir()
+    dst.mkdir()
+
+    files = ["a.jpg", "b.jpg"]
+    hashes = set()
+    for i, name in enumerate(files):
+        Image.new("RGB", (100, 100), color=(i * 80, 0, 0)).save(str(src / name))
+        hashes.add(compute_file_hash(str(src / name)))
+
+    exif_calls: list[str] = []
+    extract_calls: list[list[str]] = []
+
+    def tracking_read_exif(path):
+        exif_calls.append(path)
+        return None
+
+    def tracking_extract_metadata(paths, restricted_tags=None):
+        extract_calls.append(list(paths))
+        return {}
+
+    monkeypatch.setattr(ingest_module, "read_exif_timestamp", tracking_read_exif)
+    monkeypatch.setattr(
+        metadata_module, "extract_metadata", tracking_extract_metadata
+    )
+
+    db = Database(str(tmp_path / "test.db"))
+    result = ingest(
+        str(src),
+        str(dst),
+        db=db,
+        skip_duplicates=True,
+        extra_known_hashes=hashes,
+    )
+
+    assert result["copied"] == 0
+    assert result["skipped_duplicate"] == 2
+    # The duplicate gate short-circuits before any timestamp work runs,
+    # so neither the lightweight EXIF reader nor ExifTool is touched.
+    assert exif_calls == []
+    assert extract_calls == []
+
+
 def test_ingest_unsorted_fallback(tmp_path):
     """Files with no EXIF and no readable mtime go to unsorted/."""
     src = tmp_path / "sd_card"

--- a/vireo/tests/test_ingest.py
+++ b/vireo/tests/test_ingest.py
@@ -477,6 +477,40 @@ def test_ingest_skip_duplicates(tmp_path):
     assert result2["skipped_duplicate"] == 1
 
 
+def test_ingest_skip_duplicates_within_single_batch(tmp_path):
+    """Two byte-identical source files (different names) in one import are deduped.
+
+    Regression: the two-pass ingest (hash → partition → copy) must still
+    suppress intra-batch duplicates the way the prior single-pass loop
+    did, where each copied hash was visible to subsequent iterations.
+    """
+    import shutil
+
+    src = tmp_path / "sd_card"
+    dst = tmp_path / "nas"
+    src.mkdir()
+    dst.mkdir()
+
+    # Same bytes, two filenames. Different mtimes so a naive
+    # "different timestamp → different destination folder" path
+    # would copy both — only the hash check catches it.
+    Image.new("RGB", (100, 100), color="blue").save(str(src / "IMG_001.jpg"))
+    shutil.copyfile(str(src / "IMG_001.jpg"), str(src / "IMG_002.jpg"))
+    mtime_a = datetime(2026, 3, 28).timestamp()
+    mtime_b = datetime(2026, 4, 15).timestamp()
+    os.utime(str(src / "IMG_001.jpg"), (mtime_a, mtime_a))
+    os.utime(str(src / "IMG_002.jpg"), (mtime_b, mtime_b))
+
+    db = Database(str(tmp_path / "test.db"))
+    result = ingest(str(src), str(dst), db=db, skip_duplicates=True)
+
+    assert result["copied"] == 1
+    assert result["skipped_duplicate"] == 1
+    # Exactly one file on disk under dst.
+    on_disk = [p for p in dst.rglob("*") if p.is_file()]
+    assert len(on_disk) == 1
+
+
 def test_ingest_custom_folder_template(tmp_path):
     """Custom folder template is used for organization."""
     src = tmp_path / "sd_card"

--- a/vireo/tests/test_ingest.py
+++ b/vireo/tests/test_ingest.py
@@ -344,6 +344,43 @@ def test_ingest_copies_files_to_date_folders(tmp_path):
     assert (dst / "2026" / "2026-03-28" / "photo.jpg").exists()
 
 
+def test_ingest_uses_metadata_dates_when_lightweight_exif_fails(
+    tmp_path, monkeypatch
+):
+    """ExifTool metadata keeps copied files split by capture date."""
+    import ingest as ingest_module
+    import metadata as metadata_module
+
+    src = tmp_path / "sd_card"
+    dst = tmp_path / "nas"
+    src.mkdir()
+    dst.mkdir()
+
+    files = ["a.jpg", "b.jpg"]
+    for i, name in enumerate(files):
+        Image.new("RGB", (100, 100), color=(i * 80, 0, 0)).save(str(src / name))
+        mtime = datetime(2026, 3, 30, 12, 0, 0).timestamp()
+        os.utime(str(src / name), (mtime, mtime))
+
+    monkeypatch.setattr(ingest_module, "read_exif_timestamp", lambda _path: None)
+
+    def fake_extract_metadata(paths, restricted_tags=None):
+        return {
+            str(src / "a.jpg"): {"EXIF": {"DateTimeOriginal": "2026:03:25 10:00:00"}},
+            str(src / "b.jpg"): {"EXIF": {"DateTimeOriginal": "2026:03:26 10:00:00"}},
+        }
+
+    monkeypatch.setattr(metadata_module, "extract_metadata", fake_extract_metadata)
+
+    db = Database(str(tmp_path / "test.db"))
+    result = ingest(str(src), str(dst), db=db)
+
+    assert result["copied"] == 2
+    assert (dst / "2026" / "2026-03-25" / "a.jpg").exists()
+    assert (dst / "2026" / "2026-03-26" / "b.jpg").exists()
+    assert not (dst / "2026" / "2026-03-30" / "a.jpg").exists()
+
+
 def test_ingest_unsorted_fallback(tmp_path):
     """Files with no EXIF and no readable mtime go to unsorted/."""
     src = tmp_path / "sd_card"
@@ -1506,6 +1543,46 @@ def test_preview_destination_groups_by_date(tmp_path):
     assert by_path["2026/2026-03-25"]["exists"] is False
     assert "2026/2026-03-26" in by_path
     assert by_path["2026/2026-03-26"]["count"] == 1
+
+
+def test_preview_destination_uses_metadata_dates_when_lightweight_exif_fails(
+    tmp_path, monkeypatch
+):
+    """Preview keeps capture-date folders when ExifTool has the date."""
+    import ingest as ingest_module
+    import metadata as metadata_module
+
+    src = tmp_path / "sd_card"
+    dst = tmp_path / "nas"
+    src.mkdir()
+    dst.mkdir()
+
+    for name in ("a.jpg", "b.jpg"):
+        Image.new("RGB", (100, 100)).save(str(src / name))
+        mtime = datetime(2026, 3, 30, 12, 0, 0).timestamp()
+        os.utime(str(src / name), (mtime, mtime))
+
+    monkeypatch.setattr(ingest_module, "read_exif_timestamp", lambda _path: None)
+
+    def fake_extract_metadata(paths, restricted_tags=None):
+        return {
+            str(src / "a.jpg"): {"EXIF": {"DateTimeOriginal": "2026:03:25 10:00:00"}},
+            str(src / "b.jpg"): {"EXIF": {"DateTimeOriginal": "2026:03:26 10:00:00"}},
+        }
+
+    monkeypatch.setattr(metadata_module, "extract_metadata", fake_extract_metadata)
+
+    result = preview_destination(
+        sources=[str(src)],
+        destination=str(dst),
+        folder_template="%Y/%Y-%m-%d",
+    )
+
+    by_path = {f["path"]: f for f in result["folders"]}
+    assert result["total_folders"] == 2
+    assert by_path["2026/2026-03-25"]["count"] == 1
+    assert by_path["2026/2026-03-26"]["count"] == 1
+    assert "2026/2026-03-30" not in by_path
 
 
 def test_preview_destination_detects_existing_folders(tmp_path):


### PR DESCRIPTION
## Summary
- Use richer metadata extraction for import destination timestamps when lightweight EXIF parsing misses capture dates.
- Share that timestamp resolution between folder preview and actual ingest so both paths split copied files by capture date before falling back to file modification time.
- Add regression coverage for preview and copy behavior when files share one modification date but have different metadata capture dates.

## Tests
- pytest vireo/tests/test_ingest.py -q
- pytest vireo/tests/test_pipeline_api.py -q -k 'destination_preview or import_full_copy_restricts_scan_to_new_subfolders'
- ruff check vireo/ingest.py vireo/tests/test_ingest.py


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved destination folder planning by using richer timestamp detection when basic date reading is unavailable.
  * Ingest now batches timestamp resolution for surviving files, making duplicate handling more efficient and consistent.

* **Bug Fixes**
  * Fixed duplicate handling so skipped files no longer trigger unnecessary timestamp work.
  * Resolved edge cases where identical files in the same batch could be copied or grouped incorrectly.
  * Improved fallback behavior to use file modification time when no metadata timestamp is found.

* **Tests**
  * Added coverage for metadata-based date selection, duplicate short-circuiting, and same-batch retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->