### PR TITLE
Show full paths in folder preview

### DIFF
--- a/vireo/ingest.py
+++ b/vireo/ingest.py
@@ -175,6 +175,7 @@ def preview_destination(sources, destination, folder_template="%Y/%Y-%m-%d",
         check_path = dest_path if path == "." else dest_path / path
         folders.append({
             "path": path,
+            "full_path": str(check_path),
             "count": folder_counts[path],
             "exists": check_path.is_dir(),
         })

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -2057,18 +2057,18 @@ async function previewDestinationFolders() {
     var parts = [data.total_photos + ' photo' + (data.total_photos !== 1 ? 's' : '')];
     parts.push(data.total_folders + ' folder' + (data.total_folders !== 1 ? 's' : ''));
     var detail = [];
-    if (newCount > 0) detail.push(newCount + ' new');
-    if (existCount > 0) detail.push(existCount + ' existing');
+    if (newCount > 0) detail.push(newCount + ' new folder' + (newCount !== 1 ? 's' : ''));
+    if (existCount > 0) detail.push(existCount + ' existing folder' + (existCount !== 1 ? 's' : ''));
     summaryDiv.textContent = parts.join(' \u2192 ') + (detail.length ? ' (' + detail.join(', ') + ')' : '');
 
     // Render folder list
     listDiv.innerHTML = data.folders.map(function(f) {
       var tag = f.exists
-        ? '<span style="font-size:10px;padding:1px 5px;border-radius:3px;background:var(--accent);color:#fff;margin-left:6px;">exists</span>'
-        : '<span style="font-size:10px;padding:1px 5px;border-radius:3px;background:var(--success,#28a745);color:#fff;margin-left:6px;">new</span>';
-      var label = f.path === '.' ? '(destination root)' : escapeHtml(f.path) + '/';
+        ? '<span style="font-size:10px;padding:1px 5px;border-radius:3px;background:var(--accent);color:#fff;margin-left:6px;white-space:nowrap;">Existing folder</span>'
+        : '<span style="font-size:10px;padding:1px 5px;border-radius:3px;background:var(--success,#28a745);color:#fff;margin-left:6px;white-space:nowrap;">New folder</span>';
+      var fullPath = f.full_path || (f.path === '.' ? destination : destination.replace(/\/$/, '') + '/' + f.path);
       return '<div style="padding:3px 0;display:flex;align-items:center;gap:4px;">'
-        + '<span style="font-family:monospace;color:var(--text-secondary);">' + label + '</span>'
+        + '<span title="' + escapeAttr(fullPath) + '" style="font-family:monospace;color:var(--text-secondary);min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">' + escapeHtml(fullPath) + '</span>'
         + tag
         + '<span style="color:var(--text-dim);margin-left:auto;">' + f.count + ' photo' + (f.count !== 1 ? 's' : '') + '</span>'
         + '</div>';

--- a/vireo/tests/test_ingest.py
+++ b/vireo/tests/test_ingest.py
@@ -1504,6 +1504,7 @@ def test_preview_destination_groups_by_date(tmp_path):
     assert "2026/2026-03-25" in by_path
     assert by_path["2026/2026-03-25"]["count"] == 2
     assert by_path["2026/2026-03-25"]["exists"] is False
+    assert by_path["2026/2026-03-25"]["full_path"] == str(dst / "2026" / "2026-03-25")
     assert "2026/2026-03-26" in by_path
     assert by_path["2026/2026-03-26"]["count"] == 1
 
@@ -1576,6 +1577,7 @@ def test_preview_destination_flat_template(tmp_path):
 
     assert result["total_folders"] == 1
     assert result["folders"][0]["path"] == "."
+    assert result["folders"][0]["full_path"] == str(dst)
     # dst itself exists, so flat folder should show exists=True
     assert result["folders"][0]["exists"] is True
 

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -311,6 +311,7 @@ def test_destination_preview_returns_folder_structure(setup, tmp_path):
         assert data["new_folders"] == 1
         assert len(data["folders"]) == 1
         assert data["folders"][0]["path"] == "2026/2026-03-25"
+        assert data["folders"][0]["full_path"] == str(dst / "2026" / "2026-03-25")
         assert data["folders"][0]["exists"] is False
 
 


### PR DESCRIPTION
## Summary
Show full destination paths in the pipeline folder preview instead of only relative folder names. Label each preview row and summary count as a new folder or existing folder so users can tell what will be created. Add backend and API test coverage for the new full_path field.

## Validation
pytest vireo/tests/test_ingest.py::test_preview_destination_groups_by_date vireo/tests/test_ingest.py::test_preview_destination_flat_template vireo/tests/test_pipeline_api.py::test_destination_preview_returns_folder_structure