### PR TITLE
Add local processing staging for imports

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -16080,11 +16080,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # photos and then fail in archive_stage with "local staging folder
         # was not indexed". Snapshot-scoped runs are likewise rejected: they
         # also bypass ingest because the snapshot's existing files drive
-        # scan_roots directly. Fail fast so the user gets the actual reason.
+        # scan_roots directly. Reject whenever collection_id or
+        # source_snapshot_id is set — a stale source/sources field in the
+        # same request must not slip past, because run_pipeline_job keys
+        # skip_scan off collection_id alone and would still skip ingest.
+        if local_processing and (
+            collection_id is not None or source_snapshot_id is not None
+        ):
+            return json_error(
+                "local_processing cannot be combined with collection_id or "
+                "source_snapshot_id — it requires source or sources"
+            )
         if local_processing and not source and not sources:
             return json_error(
-                "local_processing requires source or sources — it cannot be "
-                "combined with collection_id or source_snapshot_id"
+                "local_processing requires source or sources"
             )
 
         folder_template = body.get("folder_template", "%Y/%Y-%m-%d")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -16073,6 +16073,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("destination must be an absolute path")
         if local_processing and not destination:
             return json_error("local_processing requires a destination")
+        # Local processing only makes sense for import pipelines (source or
+        # sources). Collection pipelines set skip_scan and never run the
+        # ingest stage, so the staging folder is never created or indexed —
+        # the job would burn through every processing stage on the existing
+        # photos and then fail in archive_stage with "local staging folder
+        # was not indexed". Snapshot-scoped runs are likewise rejected: they
+        # also bypass ingest because the snapshot's existing files drive
+        # scan_roots directly. Fail fast so the user gets the actual reason.
+        if local_processing and not source and not sources:
+            return json_error(
+                "local_processing requires source or sources — it cannot be "
+                "combined with collection_id or source_snapshot_id"
+            )
 
         folder_template = body.get("folder_template", "%Y/%Y-%m-%d")
         if destination and folder_template:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -16060,6 +16060,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     return json_error(f"source directory not found: {source}")
 
         destination = body.get("destination")
+        local_processing = bool(body.get("local_processing"))
         # Copy-ingest ("destination") is incompatible with snapshot runs:
         # ingest would copy entire source folders, then snapshot filtering
         # would drop the destination-scanned photo ids, producing empty
@@ -16070,6 +16071,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             )
         if destination and not os.path.isabs(destination):
             return json_error("destination must be an absolute path")
+        if local_processing and not destination:
+            return json_error("local_processing requires a destination")
 
         folder_template = body.get("folder_template", "%Y/%Y-%m-%d")
         if destination and folder_template:
@@ -16083,6 +16086,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             sources=sources,
             source_snapshot_id=source_snapshot_id,
             destination=destination,
+            local_processing=local_processing,
             file_types=body.get("file_types", "both"),
             folder_template=folder_template,
             skip_duplicates=body.get("skip_duplicates", True),
@@ -16199,6 +16203,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "source": source,
                 "sources": sources,
                 "collection_id": collection_id,
+                "destination": destination,
+                "local_processing": local_processing,
                 "skip_classify": params.skip_classify,
                 "skip_extract_masks": params.skip_extract_masks,
                 "skip_regroup": params.skip_regroup,

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2133,69 +2133,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             db.conn.close()
 
     def _cleanup_cached_files_for_deleted_photos(files):
-        """Remove thumbnail, preview, and working-copy files for deleted photos.
-
-        ``files`` is the list returned by ``db.delete_photos`` /
-        ``db.delete_folder``. The FK cascade drops preview_cache rows when
-        photos are deleted, but the on-disk files stay unless we unlink
-        them here — otherwise they leak into untracked bytes that eviction
-        can't see.
-
-        Note: if an unlink fails (e.g. file locked on Windows), the file
-        remains on disk as an orphan because the cascade has already removed
-        the preview_cache row. "Clear cache" in Settings recovers by
-        globbing the directory.
-        """
-        import glob as _glob
-        thumb_dir = app.config["THUMB_CACHE_DIR"]
-        vireo_dir = os.path.dirname(thumb_dir)
-        preview_dir = os.path.join(vireo_dir, "previews")
-        working_dir = os.path.join(vireo_dir, "working")
-        # Offline-cache layout: offline/{originals,xmp,companions}/{pid}{ext}.
-        # The FK cascade drops the offline_originals row when the photo is
-        # deleted, so we lose the exact stored paths — glob by photo id to
-        # cover any source extension and any sidecar/companion that was
-        # copied alongside it.
-        offline_dirs = [
-            os.path.join(vireo_dir, "offline", "originals"),
-            os.path.join(vireo_dir, "offline", "xmp"),
-            os.path.join(vireo_dir, "offline", "companions"),
-        ]
-        for f in files:
-            pid = f["photo_id"]
-            # {id}.jpg lives in all three dirs (legacy full preview, thumb,
-            # working copy). {id}_{size}.jpg is sized preview variants.
-            for d in [thumb_dir, preview_dir, working_dir]:
-                cached = os.path.join(d, f"{pid}.jpg")
-                if os.path.isfile(cached):
-                    try:
-                        os.remove(cached)
-                    except OSError as e:
-                        log.warning(
-                            "Failed to remove cached file %s after photo "
-                            "delete — will be reclaimed by Clear Cache: %s",
-                            cached, e,
-                        )
-            for variant in _glob.glob(os.path.join(preview_dir, f"{pid}_*.jpg")):
-                try:
-                    os.remove(variant)
-                except OSError as e:
-                    log.warning(
-                        "Failed to remove preview variant %s after photo "
-                        "delete — will be reclaimed by Clear Cache: %s",
-                        variant, e,
-                    )
-            for d in offline_dirs:
-                for orphan in _glob.glob(os.path.join(d, f"{pid}.*")):
-                    try:
-                        os.remove(orphan)
-                    except OSError as e:
-                        log.warning(
-                            "Failed to remove offline cache file %s after "
-                            "photo delete — will be reclaimed by Clear "
-                            "Cache: %s",
-                            orphan, e,
-                        )
+        from preview_cache import cleanup_cached_files_for_deleted_photos
+        cleanup_cached_files_for_deleted_photos(
+            app.config["THUMB_CACHE_DIR"], files,
+        )
 
     @app.before_request
     def _enforce_api_v1_token():

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -14080,10 +14080,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     result["ok"] = False
                     result["summary"] = f"Move failed — {errors[0]}"
                 else:
+                    cleanup_error = result.get("cleanup_error")
                     result["ok"] = True
                     result["summary"] = (
                         f"Moved {moved} photo{'s' if moved != 1 else ''}"
                         + (f", {len(errors)} error(s)" if errors else "")
+                        + (
+                            f"; cleanup failed: {cleanup_error}"
+                            if cleanup_error else ""
+                        )
                     )
             return result
 
@@ -16450,6 +16455,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("destination must be an absolute path")
         if local_processing and not destination:
             return json_error("local_processing requires a destination")
+        if local_processing and destination:
+            from local_processing import final_destination_name
+
+            try:
+                final_destination_name(destination)
+            except ValueError:
+                return json_error(
+                    "local_processing destination cannot be a filesystem root"
+                )
         # Local processing only makes sense for import pipelines (source or
         # sources). Collection pipelines set skip_scan and never run the
         # ingest stage, so the staging folder is never created or indexed —

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -1012,6 +1012,19 @@ class JobRunner:
         with self._lock:
             return job_id in self._cancelled
 
+    def clear_cancellation(self, job_id):
+        """Consume any pending cancellation flag for ``job_id``.
+
+        Used by stages that have entered an uninterruptible commit step
+        (e.g. the local-processing archive move) where a Stop press
+        cannot be honored without leaving a partial published artifact.
+        Without consuming the flag, ``_run_job``'s atomic terminal check
+        would record the job as "cancelled" even though the commit
+        succeeded — confusing the user about whether the archive landed.
+        """
+        with self._lock:
+            self._cancelled.discard(job_id)
+
 
 class LogBroadcaster(logging.Handler):
     """Captures log records and broadcasts to SSE subscribers.

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -40,6 +40,14 @@ class JobRunner:
         self._subscribers = {}  # job_id -> list of queues
         self._lock = threading.Lock()
         self._cancelled = set()  # job ids that have been cancelled
+        # job ids past an uninterruptible commit point (e.g. the
+        # local-processing archive move). Once a job is in here, any
+        # late ``cancel_job`` call is a no-op so the terminal status can
+        # no longer be flipped to "cancelled" by a Stop press that
+        # landed after the commit finished but before _run_job recorded
+        # the result. Cleared by _prune_finished_jobs alongside
+        # _cancelled.
+        self._uncancellable = set()
         self._db_path = None
         # Pending pipeline work, keyed by job_id. Populated by
         # ``enqueue_pipeline`` and consumed by ``_try_promote_queued``
@@ -442,6 +450,7 @@ class JobRunner:
             self._events.pop(jid, None)
             self._subscribers.pop(jid, None)
             self._cancelled.discard(jid)
+            self._uncancellable.discard(jid)
 
     def _run_job(self, job, work_fn):
         start_time = time.time()
@@ -915,6 +924,15 @@ class JobRunner:
             if job is not None and job["status"] == "running":
                 if expected_status and expected_status != "running":
                     return False
+                # Stop is a no-op once the job has entered an
+                # uninterruptible commit step (e.g. the local-processing
+                # archive move). Without this guard a Stop landing after
+                # clear_cancellation() but before _run_job's terminal
+                # check would re-add the job to _cancelled and record
+                # the run as "cancelled" even though the archive
+                # already committed to disk.
+                if job_id in self._uncancellable:
+                    return False
                 self._cancelled.add(job_id)
                 return True
             if job is not None:
@@ -954,6 +972,12 @@ class JobRunner:
                     and job["status"] == "running"
                     and (expected_status is None or expected_status == "running")
                 ):
+                    # Same uncancellable guard as the first running-job
+                    # branch above; the post-commit Stop race exists on
+                    # this path too when promotion beat the queued
+                    # cancel.
+                    if job_id in self._uncancellable:
+                        return False
                     self._cancelled.add(job_id)
                     return True
                 if self._queued_pipelines.get(job_id) is queued_cancel:
@@ -1013,7 +1037,8 @@ class JobRunner:
             return job_id in self._cancelled
 
     def clear_cancellation(self, job_id):
-        """Consume any pending cancellation flag for ``job_id``.
+        """Consume any pending cancellation flag for ``job_id`` and
+        mark the job uncancellable.
 
         Used by stages that have entered an uninterruptible commit step
         (e.g. the local-processing archive move) where a Stop press
@@ -1021,9 +1046,15 @@ class JobRunner:
         Without consuming the flag, ``_run_job``'s atomic terminal check
         would record the job as "cancelled" even though the commit
         succeeded — confusing the user about whether the archive landed.
+
+        The flag is consumed AND the job is added to ``_uncancellable``
+        so a Stop press that lands after this call but before
+        ``_run_job`` flips to a terminal status can't re-add the
+        cancellation flag and override the committed result.
         """
         with self._lock:
             self._cancelled.discard(job_id)
+            self._uncancellable.add(job_id)
 
 
 class LogBroadcaster(logging.Handler):

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -1036,6 +1036,20 @@ class JobRunner:
         with self._lock:
             return job_id in self._cancelled
 
+    def begin_uncancellable(self, job_id):
+        """Atomically enter an uninterruptible phase if not cancelled.
+
+        Returns False when a cancellation is already pending, leaving that flag
+        intact so ``_run_job`` can record the job as cancelled. Once this
+        returns True, later ``cancel_job`` calls are ignored until the job
+        reaches a terminal state.
+        """
+        with self._lock:
+            if job_id in self._cancelled:
+                return False
+            self._uncancellable.add(job_id)
+            return True
+
     def clear_cancellation(self, job_id):
         """Consume any pending cancellation flag for ``job_id`` and
         mark the job uncancellable.

--- a/vireo/local_processing.py
+++ b/vireo/local_processing.py
@@ -138,25 +138,20 @@ def conflicting_archive_paths(
       already known to the catalog are treated as ingest skips — they never
       reach staging, so they cannot conflict at the final archive step.
       Callers normally pass the catalog hash set when ``skip_duplicates``
-      is enabled. Hashing only happens for sources whose unsuffixed
-      archive path has a same-name collision; common imports with no
-      archive overlap pay no extra hash cost.
+      is enabled. Duplicate identity is checked before a source claims
+      an archive filename so skipped duplicates cannot shift later
+      survivors onto suffixed paths that ingest would not use.
     * When two surviving sources land in the same archive subfolder under
       the same filename, ingest stages the first at the unsuffixed name
       and the second under ``name_1.ext`` (then ``name_2.ext`` ...). The
       preflight tracks per-folder occupied names so the existing archive's
       same-name file is only compared to the first survivor's content,
       not also (incorrectly) to the second survivor's.
-    * When ``known_hashes`` is in use, the hashes of earlier survivors are
-      folded into ``seen_hashes`` before a later source's conflict check.
-      Mirrors ingest()'s ``extra_known_hashes`` accumulator so the same
-      card/folder selected twice still recognises the second occurrence as
-      an intra-batch duplicate that ingest would skip — without that, a
-      later same-hash source whose archive path collides with an unrelated
-      file would be reported as a fresh conflict and the run would abort.
-      Survivor hashes are computed lazily, only when an actual conflict
-      needs resolving, so the common no-overlap case still pays no hash
-      cost.
+    * When ``known_hashes`` is in use, earlier survivors are added to
+      ``seen_hashes`` as they claim names. Mirrors ingest()'s
+      ``extra_known_hashes`` accumulator so the same card/folder selected
+      twice still recognises the second occurrence as an intra-batch
+      duplicate that ingest would skip.
     """
     try:
         if not os.path.isdir(path):
@@ -173,30 +168,27 @@ def conflicting_archive_paths(
     # Per-archive-subfolder name slots already claimed by earlier survivors
     # in this iteration. Mirrors the per-batch staging tree ingest builds.
     occupied: dict[str, set[str]] = {}
-    # Survivors (sources that ingest would stage) whose hash hasn't been
-    # computed yet. When ``seen_hashes`` is in use and a later source hits
-    # a same-path conflict that needs hash resolution, these get hashed
-    # first so ``seen_hashes`` matches ingest()'s known-hash set at that
-    # point in the source iteration. Stays empty when ``known_hashes`` is
-    # ``None``, so callers without skip_duplicates pay no extra cost.
-    pending_survivor_hashes: list[Path] = []
 
-    def _flush_pending() -> None:
-        if seen_hashes is None or not pending_survivor_hashes:
-            return
-        while pending_survivor_hashes:
-            survivor = pending_survivor_hashes.pop(0)
-            try:
-                file_hash = _duplicate_identity(survivor)
-            except OSError:
-                continue
-            # Zero-byte survivors carry no duplicate identity in
-            # ingest, so don't pollute ``seen_hashes`` with
-            # ``EMPTY_FILE_SHA256`` — that would cause a later
-            # zero-byte source's same-path conflict to be falsely
-            # skipped as an intra-batch duplicate.
-            if file_hash is not None:
-                seen_hashes.add(file_hash)
+    def _skip_or_record_survivor(source_file: Path) -> bool:
+        """Return True when ingest would skip ``source_file`` as a duplicate."""
+        if seen_hashes is None:
+            return False
+        try:
+            file_hash = _duplicate_identity(source_file)
+        except OSError:
+            # ingest() treats hash failures as per-file failures before copy,
+            # so they do not claim destination names.
+            return True
+        # Zero-byte survivors carry no duplicate identity in ingest, so
+        # don't pollute ``seen_hashes`` with ``EMPTY_FILE_SHA256`` — that
+        # would cause a later zero-byte source's same-path conflict to be
+        # falsely skipped as an intra-batch duplicate.
+        if file_hash is None:
+            return False
+        if file_hash in seen_hashes:
+            return True
+        seen_hashes.add(file_hash)
+        return False
 
     for source_file in files:
         try:
@@ -212,9 +204,9 @@ def conflicting_archive_paths(
 
             dest_file = dest_folder / chosen_name
             if not os.path.lexists(dest_file):
+                if _skip_or_record_survivor(source_file):
+                    continue
                 folder_taken.add(chosen_name)
-                if seen_hashes is not None:
-                    pending_survivor_hashes.append(source_file)
                 continue
 
             if not dest_file.is_symlink() and dest_file.is_file():
@@ -223,41 +215,19 @@ def conflicting_archive_paths(
                     dest_file.stat().st_size == source_size
                     and filecmp.cmp(source_file, dest_file, shallow=False)
                 ):
+                    if _skip_or_record_survivor(source_file):
+                        continue
                     folder_taken.add(chosen_name)
-                    if seen_hashes is not None:
-                        pending_survivor_hashes.append(source_file)
                     continue
 
             # Same-path archive file with different content. If ingest
             # would skip this source as a known duplicate, it never
             # reaches staging and so cannot conflict — confirm before
-            # rejecting the run. Hashing is deferred to this branch so
-            # the common no-overlap case stays cheap.
-            if seen_hashes is not None:
-                # Bring ``seen_hashes`` up to date with every earlier
-                # survivor's hash before checking the current source,
-                # mirroring ingest()'s known-hash accumulator order.
-                _flush_pending()
-                try:
-                    file_hash = _duplicate_identity(source_file)
-                except OSError:
-                    continue
-                # Zero-byte sources have no duplicate identity in
-                # ingest (``EMPTY_FILE_SHA256`` is cleared to ``None``
-                # before the dup check), so don't treat them as
-                # intra-batch duplicates of an earlier empty source
-                # and don't pollute ``seen_hashes`` with their hash.
-                if file_hash is not None:
-                    if file_hash in seen_hashes:
-                        # ingest's skip_duplicates branch drops this
-                        # source before staging; do not claim a slot
-                        # either.
-                        continue
-                    # Track the hash so a same-hash sibling later in
-                    # ``files`` is treated as an intra-batch duplicate
-                    # too, the way ingest()'s pass-2 ``known_hashes``
-                    # set does.
-                    seen_hashes.add(file_hash)
+            # rejecting the run.
+            if _skip_or_record_survivor(source_file):
+                # ingest's skip_duplicates branch drops this source
+                # before staging; do not claim a slot either.
+                continue
 
             conflicts.add(str(dest_file))
             folder_taken.add(chosen_name)

--- a/vireo/local_processing.py
+++ b/vireo/local_processing.py
@@ -120,21 +120,31 @@ def existing_archive_bytes(
     return total
 
 
-def non_duplicate_bytes(files: list[Path], known_hashes: set[str]) -> int:
-    """Sum bytes of ``files`` whose content hash isn't already known.
+def non_duplicate_files(
+    files: list[Path], known_hashes: set[str],
+) -> list[Path]:
+    """Return ``files`` minus any whose content hash is already known.
 
     Mirrors the duplicate gate ingest() applies with skip_duplicates=True so
     the local-storage preflight estimate matches what ingest will actually
     copy. ``known_hashes`` covers files already in the catalog; this also
     tracks hashes seen earlier in ``files`` so intra-run duplicates (the
     same card folder selected twice, or two source folders sharing a file)
-    are counted once — ingest() likewise copies the first occurrence and
+    yield only the first occurrence — ingest() likewise copies the first and
     skips later matches via its ``extra_known_hashes`` accumulator.
+
+    Returning the file list (not just a byte sum) lets callers feed the
+    survivor set back into ``existing_archive_bytes`` so the destination
+    credit on a duplicate-filtered retry reflects only files ingest will
+    actually copy. Crediting the destination for a large duplicate that
+    ingest will skip would zero out the archive delta and let the run pass
+    the destination-space preflight even when the fresh files still need
+    room at the archive.
     """
     from scanner import compute_file_hash
 
     seen = set(known_hashes)
-    total = 0
+    survivors: list[Path] = []
     for path in files:
         try:
             file_hash = compute_file_hash(str(path))
@@ -142,13 +152,14 @@ def non_duplicate_bytes(files: list[Path], known_hashes: set[str]) -> int:
             continue
         if file_hash in seen:
             continue
-        try:
-            size = path.stat().st_size
-        except OSError:
-            continue
-        total += size
+        survivors.append(path)
         seen.add(file_hash)
-    return total
+    return survivors
+
+
+def non_duplicate_bytes(files: list[Path], known_hashes: set[str]) -> int:
+    """Sum bytes of ``files`` whose content hash isn't already known."""
+    return total_file_bytes(non_duplicate_files(files, known_hashes))
 
 
 def estimate_required_bytes(source_bytes: int) -> int:

--- a/vireo/local_processing.py
+++ b/vireo/local_processing.py
@@ -75,6 +75,34 @@ def total_file_bytes(files: list[Path]) -> int:
     return total
 
 
+def _duplicate_identity(path: Path) -> str | None:
+    """Return ``path``'s duplicate-identity hash, or ``None`` if it has
+    none.
+
+    Mirrors ingest()'s zero-byte rule: a zero-byte source clears its
+    hash to ``None`` before duplicate checks so ``EMPTY_FILE_SHA256``
+    never enters the identity index. Every empty file is bit-identical
+    to every other, so treating them as duplicates by hash would either
+    drop legitimate placeholders or, in the same-name-collision branch,
+    mint endless ``name_1.ext`` siblings on retry. The preflight callers
+    here must skip empty files for the same reason: an earlier zero-byte
+    source must not poison ``seen_hashes`` and cause a later zero-byte
+    source's same-path conflict to be falsely skipped, and the
+    duplicate-filter survivor list must not collapse two empty sources
+    into one when ingest would copy both.
+    """
+    from scanner import EMPTY_FILE_SHA256, compute_file_hash
+
+    file_hash = compute_file_hash(str(path))
+    if file_hash == EMPTY_FILE_SHA256:
+        try:
+            if path.stat().st_size == 0:
+                return None
+        except OSError:
+            return None
+    return file_hash
+
+
 def _suffix_against(folder_taken: set[str], name: str) -> str:
     """Pick the next free slot for ``name`` given the per-folder set
     ``folder_taken``. Mirrors ingest()'s name-collision rule: the first
@@ -156,13 +184,19 @@ def conflicting_archive_paths(
     def _flush_pending() -> None:
         if seen_hashes is None or not pending_survivor_hashes:
             return
-        from scanner import compute_file_hash
         while pending_survivor_hashes:
             survivor = pending_survivor_hashes.pop(0)
             try:
-                seen_hashes.add(compute_file_hash(str(survivor)))
+                file_hash = _duplicate_identity(survivor)
             except OSError:
                 continue
+            # Zero-byte survivors carry no duplicate identity in
+            # ingest, so don't pollute ``seen_hashes`` with
+            # ``EMPTY_FILE_SHA256`` — that would cause a later
+            # zero-byte source's same-path conflict to be falsely
+            # skipped as an intra-batch duplicate.
+            if file_hash is not None:
+                seen_hashes.add(file_hash)
 
     for source_file in files:
         try:
@@ -204,19 +238,26 @@ def conflicting_archive_paths(
                 # survivor's hash before checking the current source,
                 # mirroring ingest()'s known-hash accumulator order.
                 _flush_pending()
-                from scanner import compute_file_hash
                 try:
-                    file_hash = compute_file_hash(str(source_file))
+                    file_hash = _duplicate_identity(source_file)
                 except OSError:
                     continue
-                if file_hash in seen_hashes:
-                    # ingest's skip_duplicates branch drops this source
-                    # before staging; do not claim a slot either.
-                    continue
-                # Track the hash so a same-hash sibling later in
-                # ``files`` is treated as an intra-batch duplicate too,
-                # the way ingest()'s pass-2 ``known_hashes`` set does.
-                seen_hashes.add(file_hash)
+                # Zero-byte sources have no duplicate identity in
+                # ingest (``EMPTY_FILE_SHA256`` is cleared to ``None``
+                # before the dup check), so don't treat them as
+                # intra-batch duplicates of an earlier empty source
+                # and don't pollute ``seen_hashes`` with their hash.
+                if file_hash is not None:
+                    if file_hash in seen_hashes:
+                        # ingest's skip_duplicates branch drops this
+                        # source before staging; do not claim a slot
+                        # either.
+                        continue
+                    # Track the hash so a same-hash sibling later in
+                    # ``files`` is treated as an intra-batch duplicate
+                    # too, the way ingest()'s pass-2 ``known_hashes``
+                    # set does.
+                    seen_hashes.add(file_hash)
 
             conflicts.add(str(dest_file))
             folder_taken.add(chosen_name)
@@ -310,14 +351,20 @@ def non_duplicate_files(
     the destination-space preflight even when the fresh files still need
     room at the archive.
     """
-    from scanner import compute_file_hash
-
     seen = set(known_hashes)
     survivors: list[Path] = []
     for path in files:
         try:
-            file_hash = compute_file_hash(str(path))
+            file_hash = _duplicate_identity(path)
         except OSError:
+            continue
+        # Zero-byte sources have no duplicate identity in ingest, so
+        # every empty file is a survivor and contributes nothing to
+        # ``seen`` — matching ingest's behavior where two empty sources
+        # both get copied (the second as ``name_1.ext`` if the
+        # destination already has the unsuffixed slot).
+        if file_hash is None:
+            survivors.append(path)
             continue
         if file_hash in seen:
             continue

--- a/vireo/local_processing.py
+++ b/vireo/local_processing.py
@@ -70,6 +70,34 @@ def total_file_bytes(files: list[Path]) -> int:
     return total
 
 
+def existing_archive_bytes(path: str) -> int:
+    """Sum the bytes already present under ``path`` for resume calculations.
+
+    When a previous archive attempt left a partial untracked
+    ``final_destination``, ``move_folder(..., merge=True)`` rsyncs only the
+    files that aren't already there. The storage preflight can therefore
+    credit the bytes already on the archive volume against the required
+    space; otherwise a retry would be rejected for needing room for the
+    full source even though most of it is already published.
+    """
+    try:
+        if not os.path.isdir(path):
+            return 0
+    except OSError:
+        return 0
+    total = 0
+    try:
+        for root, _dirs, files in os.walk(path):
+            for name in files:
+                try:
+                    total += os.path.getsize(os.path.join(root, name))
+                except OSError:
+                    continue
+    except OSError:
+        return 0
+    return total
+
+
 def non_duplicate_bytes(files: list[Path], known_hashes: set[str]) -> int:
     """Sum bytes of ``files`` whose content hash isn't already known.
 
@@ -115,6 +143,7 @@ def storage_plan(
     source_bytes: int,
     *,
     archive_parent: str | None = None,
+    archive_existing_bytes: int = 0,
     reserved_free_bytes: int | None = None,
 ) -> dict:
     """Return local-storage availability and whether batching is required.
@@ -132,9 +161,23 @@ def storage_plan(
     and then fail in the final move with ENOSPC. When they live on
     different devices, the destination volume gets an independent free
     space check.
+
+    When ``archive_existing_bytes`` is non-zero it tells the planner that a
+    previous archive attempt already left that many bytes at the
+    destination. ``move_folder(..., merge=True)`` skips files that are
+    already present, so a retry only needs space for the remaining bytes —
+    capped at ``source_bytes`` so unrelated content at the destination
+    can't extend an unbounded credit. Without this credit a retry whose
+    delta would fit gets rejected as batching-required and the user has
+    to delete the partial archive by hand before resuming.
     """
     if reserved_free_bytes is None:
         reserved_free_bytes = RESERVED_FREE_BYTES
+
+    # Cap at source_bytes so an oversized or unrelated destination tree
+    # doesn't inflate the credit beyond what merge-mode can actually skip.
+    existing_credit = max(0, min(archive_existing_bytes, source_bytes))
+    archive_delta = max(0, source_bytes - existing_credit)
 
     same_device = False
     if archive_parent:
@@ -150,9 +193,10 @@ def storage_plan(
     if same_device:
         # Both staging copy and destination copy land on this volume; the
         # destination copy is taken from staging before the staging files
-        # are deleted, so the peak working set is staging + derived +
-        # destination = required + source_bytes.
-        required += source_bytes
+        # are deleted. In merge-mode resumes, only the delta is rewritten
+        # at the destination, so the peak working set on this volume is
+        # staging + derived + delta.
+        required += archive_delta
     usable = max(0, usage.free - reserved_free_bytes)
     staging_enough = required <= usable
 
@@ -161,7 +205,7 @@ def storage_plan(
     archive_usable = None
     archive_enough = True
     if archive_parent and not same_device:
-        archive_required = source_bytes
+        archive_required = archive_delta
         try:
             archive_usage = shutil.disk_usage(archive_parent)
         except OSError:
@@ -196,6 +240,7 @@ def storage_plan(
         "usable_bytes": usable,
         "staging_enough": staging_enough,
         "archive_required_bytes": archive_required,
+        "archive_existing_bytes": existing_credit,
         "archive_free_bytes": archive_free,
         "archive_usable_bytes": archive_usable,
         "archive_enough": archive_enough,

--- a/vireo/local_processing.py
+++ b/vireo/local_processing.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+import ntpath
 import os
 import shutil
 from pathlib import Path
@@ -15,6 +16,22 @@ MIN_DERIVED_OVERHEAD_BYTES = 5 * GIB
 RESERVED_FREE_BYTES = 10 * GIB
 
 
+def final_destination_name(final_destination: str) -> str:
+    """Return the folder name that must land exactly at ``final_destination``."""
+    nt_normalized = ntpath.normpath(final_destination)
+    nt_drive, nt_tail = ntpath.splitdrive(nt_normalized)
+    if nt_drive:
+        final_name = ntpath.basename(nt_normalized)
+        if not final_name or nt_tail in ("", "\\", "/"):
+            raise ValueError("final_destination must not be a filesystem root")
+        return final_name
+
+    final_name = os.path.basename(os.path.normpath(final_destination))
+    if not final_name:
+        raise ValueError("final_destination must not be a filesystem root")
+    return final_name
+
+
 def staging_root(vireo_dir: str, job_id: str, final_destination: str) -> str:
     """Return the local root whose move target is ``final_destination``.
 
@@ -23,7 +40,7 @@ def staging_root(vireo_dir: str, job_id: str, final_destination: str) -> str:
     the final destination's basename lets the verified archive step land at
     exactly the user-selected path.
     """
-    final_name = os.path.basename(os.path.normpath(final_destination)) or "archive"
+    final_name = final_destination_name(final_destination)
     return str(Path(vireo_dir) / "staging" / job_id / final_name)
 
 

--- a/vireo/local_processing.py
+++ b/vireo/local_processing.py
@@ -1,0 +1,108 @@
+"""Local staging helpers for import-then-archive pipeline runs."""
+
+from __future__ import annotations
+
+import math
+import os
+import shutil
+from pathlib import Path
+
+from ingest import discover_source_files
+
+GIB = 1024 ** 3
+DERIVED_OVERHEAD_RATIO = 0.25
+MIN_DERIVED_OVERHEAD_BYTES = 5 * GIB
+RESERVED_FREE_BYTES = 10 * GIB
+
+
+def staging_root(vireo_dir: str, job_id: str, final_destination: str) -> str:
+    """Return the local root whose move target is ``final_destination``.
+
+    ``move_folder`` always places the source folder inside the destination
+    parent, preserving the source folder's name. Naming the staging root after
+    the final destination's basename lets the verified archive step land at
+    exactly the user-selected path.
+    """
+    final_name = os.path.basename(os.path.normpath(final_destination)) or "archive"
+    return str(Path(vireo_dir) / "staging" / job_id / final_name)
+
+
+def selected_source_files(
+    sources: list[str],
+    file_types: str = "both",
+    recursive: bool = True,
+    exclude_paths: set[str] | None = None,
+) -> list[Path]:
+    """Resolve the exact files a copy-mode pipeline import will consider."""
+    excluded = exclude_paths or set()
+    files: list[Path] = []
+    for source in sources:
+        for path in discover_source_files(source, file_types, recursive=recursive):
+            if str(path) not in excluded:
+                files.append(path)
+    return files
+
+
+def total_file_bytes(files: list[Path]) -> int:
+    total = 0
+    for path in files:
+        try:
+            total += path.stat().st_size
+        except OSError:
+            continue
+    return total
+
+
+def estimate_required_bytes(source_bytes: int) -> int:
+    """Estimate local working-set size for originals plus derived files."""
+    derived = max(
+        int(math.ceil(source_bytes * DERIVED_OVERHEAD_RATIO)),
+        MIN_DERIVED_OVERHEAD_BYTES if source_bytes else 0,
+    )
+    return source_bytes + derived
+
+
+def storage_plan(
+    staging_dir: str,
+    source_bytes: int,
+    *,
+    reserved_free_bytes: int = RESERVED_FREE_BYTES,
+) -> dict:
+    """Return local-storage availability and whether batching is required."""
+    usage = shutil.disk_usage(staging_dir)
+    required = estimate_required_bytes(source_bytes)
+    usable = max(0, usage.free - reserved_free_bytes)
+    if required <= usable:
+        batch_count = 1
+        batch_bytes = source_bytes
+    else:
+        # Estimate how many source-byte batches fit after reserving room for
+        # derived files. The caller can use this for user-facing messaging even
+        # before full batch execution is available.
+        per_batch_source = max(
+            1,
+            int(usable / (1 + DERIVED_OVERHEAD_RATIO)),
+        )
+        batch_count = math.ceil(source_bytes / per_batch_source) if source_bytes else 1
+        batch_bytes = per_batch_source
+    return {
+        "source_bytes": source_bytes,
+        "required_bytes": required,
+        "free_bytes": usage.free,
+        "reserved_free_bytes": reserved_free_bytes,
+        "usable_bytes": usable,
+        "enough": required <= usable,
+        "batching_required": required > usable,
+        "batch_count": int(batch_count),
+        "estimated_batch_source_bytes": int(batch_bytes),
+    }
+
+
+def format_bytes(n: int) -> str:
+    value = float(n)
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if value < 1024 or unit == "TB":
+            if unit == "B":
+                return f"{int(value)} {unit}"
+            return f"{value:.1f} {unit}"
+        value /= 1024

--- a/vireo/local_processing.py
+++ b/vireo/local_processing.py
@@ -120,21 +120,21 @@ def existing_archive_bytes(
     return total
 
 
-def non_duplicate_bytes(files: list[Path], known_hashes: set[str]) -> int:
-    """Sum bytes of ``files`` whose content hash isn't already known.
+def non_duplicate_files(files: list[Path], known_hashes: set[str]) -> list[Path]:
+    """Return files whose content hash isn't already known.
 
     Mirrors the duplicate gate ingest() applies with skip_duplicates=True so
-    the local-storage preflight estimate matches what ingest will actually
-    copy. ``known_hashes`` covers files already in the catalog; this also
-    tracks hashes seen earlier in ``files`` so intra-run duplicates (the
-    same card folder selected twice, or two source folders sharing a file)
-    are counted once — ingest() likewise copies the first occurrence and
-    skips later matches via its ``extra_known_hashes`` accumulator.
+    local-storage preflight decisions use the same source set that ingest
+    will actually copy. ``known_hashes`` covers files already in the catalog;
+    this also tracks hashes seen earlier in ``files`` so intra-run duplicates
+    (the same card folder selected twice, or two source folders sharing a
+    file) are counted once — ingest() likewise copies the first occurrence
+    and skips later matches via its ``extra_known_hashes`` accumulator.
     """
     from scanner import compute_file_hash
 
     seen = set(known_hashes)
-    total = 0
+    survivors = []
     for path in files:
         try:
             file_hash = compute_file_hash(str(path))
@@ -143,11 +143,22 @@ def non_duplicate_bytes(files: list[Path], known_hashes: set[str]) -> int:
         if file_hash in seen:
             continue
         try:
-            size = path.stat().st_size
+            path.stat()
         except OSError:
             continue
-        total += size
+        survivors.append(path)
         seen.add(file_hash)
+    return survivors
+
+
+def non_duplicate_bytes(files: list[Path], known_hashes: set[str]) -> int:
+    """Sum bytes of ``files`` whose content hash isn't already known."""
+    total = 0
+    for path in non_duplicate_files(files, known_hashes):
+        try:
+            total += path.stat().st_size
+        except OSError:
+            continue
     return total
 
 

--- a/vireo/local_processing.py
+++ b/vireo/local_processing.py
@@ -97,19 +97,68 @@ def storage_plan(
     staging_dir: str,
     source_bytes: int,
     *,
+    archive_parent: str | None = None,
     reserved_free_bytes: int | None = None,
 ) -> dict:
     """Return local-storage availability and whether batching is required.
 
     ``reserved_free_bytes`` defaults to the module-level constant, looked up
     at call time so monkeypatching it in tests actually takes effect.
+
+    When ``archive_parent`` is supplied the plan also accounts for the
+    destination volume: archive runs copy-verify-delete via ``move_folder``,
+    so the staged originals must briefly coexist at the destination before
+    staging is removed. When both paths live on the same device, the
+    staging volume must hold the originals once for staging, the derived
+    files, AND a second copy for the destination — without doubling
+    ``source_bytes`` the run could pass the preflight, process for hours,
+    and then fail in the final move with ENOSPC. When they live on
+    different devices, the destination volume gets an independent free
+    space check.
     """
     if reserved_free_bytes is None:
         reserved_free_bytes = RESERVED_FREE_BYTES
+
+    same_device = False
+    if archive_parent:
+        try:
+            same_device = (
+                os.stat(staging_dir).st_dev == os.stat(archive_parent).st_dev
+            )
+        except OSError:
+            same_device = False
+
     usage = shutil.disk_usage(staging_dir)
     required = estimate_required_bytes(source_bytes)
+    if same_device:
+        # Both staging copy and destination copy land on this volume; the
+        # destination copy is taken from staging before the staging files
+        # are deleted, so the peak working set is staging + derived +
+        # destination = required + source_bytes.
+        required += source_bytes
     usable = max(0, usage.free - reserved_free_bytes)
-    if required <= usable:
+    staging_enough = required <= usable
+
+    archive_required = 0
+    archive_free = None
+    archive_usable = None
+    archive_enough = True
+    if archive_parent and not same_device:
+        archive_required = source_bytes
+        try:
+            archive_usage = shutil.disk_usage(archive_parent)
+        except OSError:
+            # Can't probe the destination volume — let the eventual
+            # move_folder surface ENOSPC rather than guess. Leave
+            # archive_enough True so the preflight doesn't false-positive.
+            pass
+        else:
+            archive_free = archive_usage.free
+            archive_usable = max(0, archive_usage.free - reserved_free_bytes)
+            archive_enough = archive_required <= archive_usable
+
+    enough = staging_enough and archive_enough
+    if enough:
         batch_count = 1
         batch_bytes = source_bytes
     else:
@@ -118,7 +167,7 @@ def storage_plan(
         # before full batch execution is available.
         per_batch_source = max(
             1,
-            int(usable / (1 + DERIVED_OVERHEAD_RATIO)),
+            int(usable / (1 + DERIVED_OVERHEAD_RATIO + (1 if same_device else 0))),
         )
         batch_count = math.ceil(source_bytes / per_batch_source) if source_bytes else 1
         batch_bytes = per_batch_source
@@ -128,8 +177,14 @@ def storage_plan(
         "free_bytes": usage.free,
         "reserved_free_bytes": reserved_free_bytes,
         "usable_bytes": usable,
-        "enough": required <= usable,
-        "batching_required": required > usable,
+        "staging_enough": staging_enough,
+        "archive_required_bytes": archive_required,
+        "archive_free_bytes": archive_free,
+        "archive_usable_bytes": archive_usable,
+        "archive_enough": archive_enough,
+        "same_device": same_device,
+        "enough": enough,
+        "batching_required": not enough,
         "batch_count": int(batch_count),
         "estimated_batch_source_bytes": int(batch_bytes),
     }

--- a/vireo/local_processing.py
+++ b/vireo/local_processing.py
@@ -53,6 +53,32 @@ def total_file_bytes(files: list[Path]) -> int:
     return total
 
 
+def non_duplicate_bytes(files: list[Path], known_hashes: set[str]) -> int:
+    """Sum bytes of ``files`` whose content hash isn't in ``known_hashes``.
+
+    Mirrors the duplicate gate ingest() applies with skip_duplicates=True so
+    the local-storage preflight estimate matches what ingest will actually
+    copy. Without this filter a card that's mostly already-imported photos
+    would set ``batching_required`` and abort even though the staging copy
+    would fit (or be zero bytes).
+    """
+    from scanner import compute_file_hash
+
+    total = 0
+    for path in files:
+        try:
+            file_hash = compute_file_hash(str(path))
+        except OSError:
+            continue
+        if file_hash in known_hashes:
+            continue
+        try:
+            total += path.stat().st_size
+        except OSError:
+            continue
+    return total
+
+
 def estimate_required_bytes(source_bytes: int) -> int:
     """Estimate local working-set size for originals plus derived files."""
     derived = max(
@@ -66,9 +92,15 @@ def storage_plan(
     staging_dir: str,
     source_bytes: int,
     *,
-    reserved_free_bytes: int = RESERVED_FREE_BYTES,
+    reserved_free_bytes: int | None = None,
 ) -> dict:
-    """Return local-storage availability and whether batching is required."""
+    """Return local-storage availability and whether batching is required.
+
+    ``reserved_free_bytes`` defaults to the module-level constant, looked up
+    at call time so monkeypatching it in tests actually takes effect.
+    """
+    if reserved_free_bytes is None:
+        reserved_free_bytes = RESERVED_FREE_BYTES
     usage = shutil.disk_usage(staging_dir)
     required = estimate_required_bytes(source_bytes)
     usable = max(0, usage.free - reserved_free_bytes)

--- a/vireo/local_processing.py
+++ b/vireo/local_processing.py
@@ -2,13 +2,18 @@
 
 from __future__ import annotations
 
+import filecmp
 import math
 import ntpath
 import os
 import shutil
 from pathlib import Path
 
-from ingest import discover_source_files
+from ingest import (
+    _source_file_timestamps,
+    build_destination_path,
+    discover_source_files,
+)
 
 GIB = 1024 ** 3
 DERIVED_OVERHEAD_RATIO = 0.25
@@ -70,31 +75,48 @@ def total_file_bytes(files: list[Path]) -> int:
     return total
 
 
-def existing_archive_bytes(path: str) -> int:
-    """Sum the bytes already present under ``path`` for resume calculations.
+def existing_archive_bytes(
+    path: str,
+    files: list[Path],
+    folder_template: str = "%Y/%Y-%m-%d",
+) -> int:
+    """Sum source bytes already present under ``path`` for resume calculations.
 
     When a previous archive attempt left a partial untracked
     ``final_destination``, ``move_folder(..., merge=True)`` rsyncs only the
-    files that aren't already there. The storage preflight can therefore
-    credit the bytes already on the archive volume against the required
-    space; otherwise a retry would be rejected for needing room for the
-    full source even though most of it is already published.
+    files that aren't already there. Credit only destination files that match
+    the selected sources at the same relative import path. Unrelated files in
+    an existing NAS folder do not reduce the bytes the archive will write.
     """
     try:
         if not os.path.isdir(path):
             return 0
     except OSError:
         return 0
+
+    timestamps = _source_file_timestamps(files)
     total = 0
-    try:
-        for root, _dirs, files in os.walk(path):
-            for name in files:
-                try:
-                    total += os.path.getsize(os.path.join(root, name))
-                except OSError:
-                    continue
-    except OSError:
-        return 0
+    credited: set[str] = set()
+    archive_root = Path(path)
+    for source_file in files:
+        try:
+            rel_folder = build_destination_path(
+                timestamps.get(source_file),
+                folder_template,
+            )
+            dest_file = archive_root / rel_folder / source_file.name
+            key = os.path.normcase(os.path.abspath(dest_file))
+            if key in credited or not dest_file.is_file():
+                continue
+            source_size = source_file.stat().st_size
+            if dest_file.stat().st_size != source_size:
+                continue
+            if not filecmp.cmp(source_file, dest_file, shallow=False):
+                continue
+            total += source_size
+            credited.add(key)
+        except OSError:
+            continue
     return total
 
 

--- a/vireo/local_processing.py
+++ b/vireo/local_processing.py
@@ -92,12 +92,31 @@ def conflicting_archive_paths(
     path: str,
     files: list[Path],
     folder_template: str = "%Y/%Y-%m-%d",
+    *,
+    known_hashes: set[str] | None = None,
 ) -> list[str]:
     """Return existing archive paths that would block merge-mode archive.
 
     ``move_folder(..., merge=True)`` refuses same-relative-path files whose
     contents differ. Detect those conflicts before the expensive staging and
     processing work begins.
+
+    The check mirrors ``ingest()``'s staging behavior so it only flags real
+    archive conflicts:
+
+    * When ``known_hashes`` is provided, sources whose content hash is
+      already known to the catalog are treated as ingest skips — they never
+      reach staging, so they cannot conflict at the final archive step.
+      Callers normally pass the catalog hash set when ``skip_duplicates``
+      is enabled. Hashing only happens for sources whose unsuffixed
+      archive path has a same-name collision; common imports with no
+      archive overlap pay no extra hash cost.
+    * When two surviving sources land in the same archive subfolder under
+      the same filename, ingest stages the first at the unsuffixed name
+      and the second under ``name_1.ext`` (then ``name_2.ext`` ...). The
+      preflight tracks per-folder occupied names so the existing archive's
+      same-name file is only compared to the first survivor's content,
+      not also (incorrectly) to the second survivor's.
     """
     try:
         if not os.path.isdir(path):
@@ -108,24 +127,67 @@ def conflicting_archive_paths(
     timestamps = _source_file_timestamps(files)
     archive_root = Path(path)
     conflicts: set[str] = set()
+    seen_hashes: set[str] | None = (
+        set(known_hashes) if known_hashes is not None else None
+    )
+    # Per-archive-subfolder name slots already claimed by earlier survivors
+    # in this iteration. Mirrors the per-batch staging tree ingest builds.
+    occupied: dict[str, set[str]] = {}
+
     for source_file in files:
         try:
-            dest_file = _archive_destination_for_source(
-                archive_root,
-                source_file,
-                timestamps,
+            rel_folder = build_destination_path(
+                timestamps.get(source_file),
                 folder_template,
             )
+            dest_folder = archive_root / rel_folder
+            folder_key = os.path.normcase(os.path.abspath(dest_folder))
+            folder_taken = occupied.setdefault(folder_key, set())
+
+            chosen_name = source_file.name
+            if chosen_name in folder_taken:
+                stem, suffix_ext = os.path.splitext(source_file.name)
+                counter = 1
+                while f"{stem}_{counter}{suffix_ext}" in folder_taken:
+                    counter += 1
+                chosen_name = f"{stem}_{counter}{suffix_ext}"
+
+            dest_file = dest_folder / chosen_name
             if not dest_file.exists():
+                folder_taken.add(chosen_name)
                 continue
+
             if dest_file.is_file():
                 source_size = source_file.stat().st_size
                 if (
                     dest_file.stat().st_size == source_size
                     and filecmp.cmp(source_file, dest_file, shallow=False)
                 ):
+                    folder_taken.add(chosen_name)
                     continue
+
+            # Same-path archive file with different content. If ingest
+            # would skip this source as a known duplicate, it never
+            # reaches staging and so cannot conflict — confirm before
+            # rejecting the run. Hashing is deferred to this branch so
+            # the common no-overlap case stays cheap.
+            if seen_hashes is not None:
+                from scanner import compute_file_hash
+                try:
+                    file_hash = compute_file_hash(str(source_file))
+                except OSError:
+                    continue
+                if file_hash in seen_hashes:
+                    # ingest's skip_duplicates branch drops this source
+                    # before staging; do not claim a slot either.
+                    continue
+                # Track the hash so a same-hash sibling later in
+                # ``files`` is treated as an intra-batch duplicate too,
+                # the way ingest()'s pass-2 ``known_hashes`` set does.
+                seen_hashes.add(file_hash)
+
             conflicts.add(str(dest_file))
+            folder_taken.add(chosen_name)
         except OSError:
             continue
     return sorted(conflicts)

--- a/vireo/local_processing.py
+++ b/vireo/local_processing.py
@@ -75,6 +75,62 @@ def total_file_bytes(files: list[Path]) -> int:
     return total
 
 
+def _archive_destination_for_source(
+    archive_root: Path,
+    source_file: Path,
+    timestamps: dict[Path, object],
+    folder_template: str,
+) -> Path:
+    rel_folder = build_destination_path(
+        timestamps.get(source_file),
+        folder_template,
+    )
+    return archive_root / rel_folder / source_file.name
+
+
+def conflicting_archive_paths(
+    path: str,
+    files: list[Path],
+    folder_template: str = "%Y/%Y-%m-%d",
+) -> list[str]:
+    """Return existing archive paths that would block merge-mode archive.
+
+    ``move_folder(..., merge=True)`` refuses same-relative-path files whose
+    contents differ. Detect those conflicts before the expensive staging and
+    processing work begins.
+    """
+    try:
+        if not os.path.isdir(path):
+            return []
+    except OSError:
+        return []
+
+    timestamps = _source_file_timestamps(files)
+    archive_root = Path(path)
+    conflicts: set[str] = set()
+    for source_file in files:
+        try:
+            dest_file = _archive_destination_for_source(
+                archive_root,
+                source_file,
+                timestamps,
+                folder_template,
+            )
+            if not dest_file.exists():
+                continue
+            if dest_file.is_file():
+                source_size = source_file.stat().st_size
+                if (
+                    dest_file.stat().st_size == source_size
+                    and filecmp.cmp(source_file, dest_file, shallow=False)
+                ):
+                    continue
+            conflicts.add(str(dest_file))
+        except OSError:
+            continue
+    return sorted(conflicts)
+
+
 def existing_archive_bytes(
     path: str,
     files: list[Path],
@@ -100,11 +156,12 @@ def existing_archive_bytes(
     archive_root = Path(path)
     for source_file in files:
         try:
-            rel_folder = build_destination_path(
-                timestamps.get(source_file),
+            dest_file = _archive_destination_for_source(
+                archive_root,
+                source_file,
+                timestamps,
                 folder_template,
             )
-            dest_file = archive_root / rel_folder / source_file.name
             key = os.path.normcase(os.path.abspath(dest_file))
             if key in credited or not dest_file.is_file():
                 continue

--- a/vireo/local_processing.py
+++ b/vireo/local_processing.py
@@ -211,13 +211,13 @@ def conflicting_archive_paths(
             chosen_name = _suffix_against(folder_taken, source_file.name)
 
             dest_file = dest_folder / chosen_name
-            if not dest_file.exists():
+            if not os.path.lexists(dest_file):
                 folder_taken.add(chosen_name)
                 if seen_hashes is not None:
                     pending_survivor_hashes.append(source_file)
                 continue
 
-            if dest_file.is_file():
+            if not dest_file.is_symlink() and dest_file.is_file():
                 source_size = source_file.stat().st_size
                 if (
                     dest_file.stat().st_size == source_size
@@ -316,7 +316,7 @@ def existing_archive_bytes(
             folder_taken.add(chosen_name)
             dest_file = dest_folder / chosen_name
             key = os.path.normcase(os.path.abspath(dest_file))
-            if key in credited or not dest_file.is_file():
+            if key in credited or dest_file.is_symlink() or not dest_file.is_file():
                 continue
             source_size = source_file.stat().st_size
             if dest_file.stat().st_size != source_size:

--- a/vireo/local_processing.py
+++ b/vireo/local_processing.py
@@ -75,17 +75,19 @@ def total_file_bytes(files: list[Path]) -> int:
     return total
 
 
-def _archive_destination_for_source(
-    archive_root: Path,
-    source_file: Path,
-    timestamps: dict[Path, object],
-    folder_template: str,
-) -> Path:
-    rel_folder = build_destination_path(
-        timestamps.get(source_file),
-        folder_template,
-    )
-    return archive_root / rel_folder / source_file.name
+def _suffix_against(folder_taken: set[str], name: str) -> str:
+    """Pick the next free slot for ``name`` given the per-folder set
+    ``folder_taken``. Mirrors ingest()'s name-collision rule: the first
+    source claims the unsuffixed name, then ``name_1.ext``, ``name_2.ext``,
+    and so on for subsequent collisions in the same archive folder.
+    """
+    if name not in folder_taken:
+        return name
+    stem, suffix_ext = os.path.splitext(name)
+    counter = 1
+    while f"{stem}_{counter}{suffix_ext}" in folder_taken:
+        counter += 1
+    return f"{stem}_{counter}{suffix_ext}"
 
 
 def conflicting_archive_paths(
@@ -117,6 +119,16 @@ def conflicting_archive_paths(
       preflight tracks per-folder occupied names so the existing archive's
       same-name file is only compared to the first survivor's content,
       not also (incorrectly) to the second survivor's.
+    * When ``known_hashes`` is in use, the hashes of earlier survivors are
+      folded into ``seen_hashes`` before a later source's conflict check.
+      Mirrors ingest()'s ``extra_known_hashes`` accumulator so the same
+      card/folder selected twice still recognises the second occurrence as
+      an intra-batch duplicate that ingest would skip — without that, a
+      later same-hash source whose archive path collides with an unrelated
+      file would be reported as a fresh conflict and the run would abort.
+      Survivor hashes are computed lazily, only when an actual conflict
+      needs resolving, so the common no-overlap case still pays no hash
+      cost.
     """
     try:
         if not os.path.isdir(path):
@@ -133,6 +145,24 @@ def conflicting_archive_paths(
     # Per-archive-subfolder name slots already claimed by earlier survivors
     # in this iteration. Mirrors the per-batch staging tree ingest builds.
     occupied: dict[str, set[str]] = {}
+    # Survivors (sources that ingest would stage) whose hash hasn't been
+    # computed yet. When ``seen_hashes`` is in use and a later source hits
+    # a same-path conflict that needs hash resolution, these get hashed
+    # first so ``seen_hashes`` matches ingest()'s known-hash set at that
+    # point in the source iteration. Stays empty when ``known_hashes`` is
+    # ``None``, so callers without skip_duplicates pay no extra cost.
+    pending_survivor_hashes: list[Path] = []
+
+    def _flush_pending() -> None:
+        if seen_hashes is None or not pending_survivor_hashes:
+            return
+        from scanner import compute_file_hash
+        while pending_survivor_hashes:
+            survivor = pending_survivor_hashes.pop(0)
+            try:
+                seen_hashes.add(compute_file_hash(str(survivor)))
+            except OSError:
+                continue
 
     for source_file in files:
         try:
@@ -144,17 +174,13 @@ def conflicting_archive_paths(
             folder_key = os.path.normcase(os.path.abspath(dest_folder))
             folder_taken = occupied.setdefault(folder_key, set())
 
-            chosen_name = source_file.name
-            if chosen_name in folder_taken:
-                stem, suffix_ext = os.path.splitext(source_file.name)
-                counter = 1
-                while f"{stem}_{counter}{suffix_ext}" in folder_taken:
-                    counter += 1
-                chosen_name = f"{stem}_{counter}{suffix_ext}"
+            chosen_name = _suffix_against(folder_taken, source_file.name)
 
             dest_file = dest_folder / chosen_name
             if not dest_file.exists():
                 folder_taken.add(chosen_name)
+                if seen_hashes is not None:
+                    pending_survivor_hashes.append(source_file)
                 continue
 
             if dest_file.is_file():
@@ -164,6 +190,8 @@ def conflicting_archive_paths(
                     and filecmp.cmp(source_file, dest_file, shallow=False)
                 ):
                     folder_taken.add(chosen_name)
+                    if seen_hashes is not None:
+                        pending_survivor_hashes.append(source_file)
                     continue
 
             # Same-path archive file with different content. If ingest
@@ -172,6 +200,10 @@ def conflicting_archive_paths(
             # rejecting the run. Hashing is deferred to this branch so
             # the common no-overlap case stays cheap.
             if seen_hashes is not None:
+                # Bring ``seen_hashes`` up to date with every earlier
+                # survivor's hash before checking the current source,
+                # mirroring ingest()'s known-hash accumulator order.
+                _flush_pending()
                 from scanner import compute_file_hash
                 try:
                     file_hash = compute_file_hash(str(source_file))
@@ -205,6 +237,15 @@ def existing_archive_bytes(
     files that aren't already there. Credit only destination files that match
     the selected sources at the same relative import path. Unrelated files in
     an existing NAS folder do not reduce the bytes the archive will write.
+
+    When two selected files land in the same archive folder under the same
+    basename, ingest() stages the first as ``name.ext`` and the second as
+    ``name_1.ext``. A previous partial archive that already contains the
+    suffixed file from a prior interrupted run must still earn resume credit
+    for the second source — without mirroring ingest's suffix logic the
+    second source always points back at the first's already-credited
+    unsuffixed slot and the run can be batching-rejected even though the
+    delta would fit.
     """
     try:
         if not os.path.isdir(path):
@@ -216,14 +257,23 @@ def existing_archive_bytes(
     total = 0
     credited: set[str] = set()
     archive_root = Path(path)
+    # Per-archive-subfolder slots claimed by earlier sources in this
+    # iteration. Mirrors the same per-folder accounting in
+    # ``conflicting_archive_paths`` so both preflight checks agree on
+    # which archive path a same-basename second source maps to.
+    occupied: dict[str, set[str]] = {}
     for source_file in files:
         try:
-            dest_file = _archive_destination_for_source(
-                archive_root,
-                source_file,
-                timestamps,
+            rel_folder = build_destination_path(
+                timestamps.get(source_file),
                 folder_template,
             )
+            dest_folder = archive_root / rel_folder
+            folder_key = os.path.normcase(os.path.abspath(dest_folder))
+            folder_taken = occupied.setdefault(folder_key, set())
+            chosen_name = _suffix_against(folder_taken, source_file.name)
+            folder_taken.add(chosen_name)
+            dest_file = dest_folder / chosen_name
             key = os.path.normcase(os.path.abspath(dest_file))
             if key in credited or not dest_file.is_file():
                 continue

--- a/vireo/local_processing.py
+++ b/vireo/local_processing.py
@@ -54,28 +54,33 @@ def total_file_bytes(files: list[Path]) -> int:
 
 
 def non_duplicate_bytes(files: list[Path], known_hashes: set[str]) -> int:
-    """Sum bytes of ``files`` whose content hash isn't in ``known_hashes``.
+    """Sum bytes of ``files`` whose content hash isn't already known.
 
     Mirrors the duplicate gate ingest() applies with skip_duplicates=True so
     the local-storage preflight estimate matches what ingest will actually
-    copy. Without this filter a card that's mostly already-imported photos
-    would set ``batching_required`` and abort even though the staging copy
-    would fit (or be zero bytes).
+    copy. ``known_hashes`` covers files already in the catalog; this also
+    tracks hashes seen earlier in ``files`` so intra-run duplicates (the
+    same card folder selected twice, or two source folders sharing a file)
+    are counted once — ingest() likewise copies the first occurrence and
+    skips later matches via its ``extra_known_hashes`` accumulator.
     """
     from scanner import compute_file_hash
 
+    seen = set(known_hashes)
     total = 0
     for path in files:
         try:
             file_hash = compute_file_hash(str(path))
         except OSError:
             continue
-        if file_hash in known_hashes:
+        if file_hash in seen:
             continue
         try:
-            total += path.stat().st_size
+            size = path.stat().st_size
         except OSError:
             continue
+        total += size
+        seen.add(file_hash)
     return total
 
 

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -1200,6 +1200,43 @@ def _tracked_destination_overlap(db, folder_id, dest_path):
     return None
 
 
+def _tracked_destination_ancestor(db, folder_id, dest_path):
+    """Return a tracked folder that is an ancestor of dest_path, if any.
+
+    The complement of ``_tracked_destination_overlap``: that one catches
+    tracked folders AT or BELOW ``dest_path``; this one catches tracked
+    folders ABOVE it on the path tree.
+
+    The pipeline's local-processing archive step uses ``db.move_folder_path``
+    to repoint the catalog after rsync, but ``move_folder_path`` only rewrites
+    the moved folder's own path (and cascades to its tracked children). It
+    does NOT reparent the moved row under a tracked ancestor of the new path.
+    If the user picks an archive destination inside an already-tracked root
+    (catalog manages ``/Photos`` and they pick ``/Photos/NewShoot``), the
+    archive move succeeds on disk but leaves the catalog with two unrelated
+    workspace roots whose path strings overlap — a permanently confusing
+    folder tree that breaks future scans of the ancestor root. Reject
+    upfront so the user picks a different archive folder before the pipeline
+    spends time staging and processing.
+
+    Passes ``case_insensitive_root=None`` to skip the per-row case-fold
+    probe; the realpath/normcase comparison at the top of
+    ``_path_equal_or_descends`` already catches every same-case ancestor,
+    which is the only practical case for archive destinations (the user is
+    typing a fresh subfolder name into a UI, not chasing a stale catalog row
+    that differs only by case).
+    """
+    for row in db.conn.execute(
+        "SELECT id, path FROM folders WHERE id != ?", (folder_id,)
+    ):
+        if _path_equal_or_descends(
+            dest_path, row["path"],
+            case_insensitive_root=None,
+        ):
+            return row
+    return None
+
+
 def move_photos(db, photo_ids, destination, progress_cb=None):
     """Move individual photos to a destination directory.
 

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -1540,6 +1540,12 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
             f"({tracked['path']}). Merging into or around a tracked folder "
             f"isn't supported."
         ]}
+    ancestor = _tracked_destination_ancestor(db, folder_id, overlap_check_path)
+    if ancestor:
+        return {"moved": 0, "errors": [
+            f"Destination is inside a folder Vireo already manages "
+            f"({ancestor['path']}). Pick an untracked archive destination."
+        ]}
 
     if remote:
         probe = _remote_dir_exists(remote, transfer_dest)

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -1410,7 +1410,11 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
             succeeds, so the photos stay in the library and resolve whenever
             the NAS is mounted.
 
-    Returns dict with keys: moved (int), errors (list of str)
+    Returns dict with keys: moved (int), errors (list of str). When the
+    catalog has already been repointed at the new destination but deleting
+    the source originals afterwards fails, an extra ``cleanup_error`` (str)
+    is included — the archive is committed and ``errors`` stays empty, but
+    callers should still surface the leftover originals to the user.
     """
     folder = db.conn.execute(
         "SELECT id, path, name FROM folders WHERE id = ?", (folder_id,)
@@ -1808,13 +1812,26 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
             old_child = src_path + new_child[len(catalog_path):]
             relocate_developed_dir(developed_dir, old_child, new_child)
 
-    # Delete originals
+    # Delete originals. The catalog already points at the new destination,
+    # so anything that goes wrong from here is post-commit: the archive is
+    # already published. Return a ``cleanup_error`` so the caller can warn
+    # the user about leftover originals without misreporting the move as
+    # failed (which would also leave the archive's tracked row in place
+    # while telling the user their data is still in staging).
     if progress_cb:
         progress_cb(total_files, total_files, "", "Removing originals")
     log.info("Verification passed, deleting originals: %s", src_path)
-    shutil.rmtree(src_path)
+    cleanup_error = None
+    try:
+        shutil.rmtree(src_path)
+    except OSError as e:
+        log.exception("Post-commit cleanup of %s failed", src_path)
+        cleanup_error = str(e)
 
     if progress_cb:
         progress_cb(total_files, total_files, folder_name, "Done")
 
-    return {"moved": total_photos, "errors": []}
+    result = {"moved": total_photos, "errors": []}
+    if cleanup_error is not None:
+        result["cleanup_error"] = cleanup_error
+    return result

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -1370,7 +1370,7 @@ def move_photos(db, photo_ids, destination, progress_cb=None):
 
 
 def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
-                merge=False, remote=None):
+                merge=False, remote=None, reject_tracked_ancestor=False):
     """Move an entire folder (and subfolders) to a destination.
 
     The folder is placed inside the destination, preserving its name.
@@ -1409,6 +1409,12 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
             path; the catalog is repointed at the mount path once the move
             succeeds, so the photos stay in the library and resolve whenever
             the NAS is mounted.
+        reject_tracked_ancestor: when True, also reject a destination inside
+            another tracked folder. Normal user-initiated moves can validly
+            move into a tracked destination parent; local-processing archive
+            commits opt into this stricter guard because they create a new
+            top-level archive root and cannot be reparented under the
+            existing catalog row.
 
     Returns dict with keys: moved (int), errors (list of str). When the
     catalog has already been repointed at the new destination but deleting
@@ -1540,12 +1546,13 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
             f"({tracked['path']}). Merging into or around a tracked folder "
             f"isn't supported."
         ]}
-    ancestor = _tracked_destination_ancestor(db, folder_id, overlap_check_path)
-    if ancestor:
-        return {"moved": 0, "errors": [
-            f"Destination is inside a folder Vireo already manages "
-            f"({ancestor['path']}). Pick an untracked archive destination."
-        ]}
+    if reject_tracked_ancestor:
+        ancestor = _tracked_destination_ancestor(db, folder_id, overlap_check_path)
+        if ancestor:
+            return {"moved": 0, "errors": [
+                f"Destination is inside a folder Vireo already manages "
+                f"({ancestor['path']}). Pick an untracked archive destination."
+            ]}
 
     if remote:
         probe = _remote_dir_exists(remote, transfer_dest)

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -4284,7 +4284,38 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
         """Move a local-processing staging folder to the final destination."""
         if not params.local_processing:
             return
+
+        def _deindex_staging():
+            # scanner_stage may have already registered the staging folder
+            # and its photos' hashes before we got here. Without removing
+            # those rows a retry of the same source would hit ingest()'s
+            # known-hash skip and copy nothing — the user would then
+            # "successfully" archive an empty destination while the
+            # original files only ever existed in the abandoned staging
+            # tree. Leave the on-disk staging files in place so the user
+            # can still recover them.
+            try:
+                thread_db = Database(db_path)
+                thread_db.set_active_workspace(workspace_id)
+                folder = thread_db.conn.execute(
+                    "SELECT id FROM folders WHERE path = ?",
+                    (params.destination,),
+                ).fetchone()
+                if folder:
+                    thread_db.delete_folder(folder["id"])
+            except Exception:
+                log.exception(
+                    "Failed to deindex local staging folder on archive skip",
+                )
+
         if abort.is_set() or runner.is_cancelled(job["id"]):
+            # Fatal upstream stages (partial scan, thumbnail setup, model
+            # load, detect, classify) set abort and fall through to here
+            # without populating stages[*]["status"] == "failed", so the
+            # already_failed branch below would miss them. Deindex here too
+            # — otherwise the next retry of the same source would treat
+            # every file as a duplicate and publish an empty archive.
+            _deindex_staging()
             stages["archive"]["status"] = "skipped"
             runner.update_step(
                 job["id"], "archive", status="completed", summary="Skipped",
@@ -4310,27 +4341,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
             name for name, s in stages.items() if s.get("status") == "failed"
         ]
         if already_failed:
-            # Before bailing, deindex the local staging folder. scanner_stage
-            # may have already registered it (and its photos' hashes) before
-            # the downstream failure surfaced. Without removing those rows,
-            # a retry of the same source would hit ingest()'s known-hash
-            # skip and copy nothing — the user would then "successfully"
-            # archive an empty destination while the original files only
-            # ever existed in the abandoned staging tree. Leave the on-disk
-            # staging files in place so the user can still recover them.
-            try:
-                thread_db = Database(db_path)
-                thread_db.set_active_workspace(workspace_id)
-                folder = thread_db.conn.execute(
-                    "SELECT id FROM folders WHERE path = ?",
-                    (params.destination,),
-                ).fetchone()
-                if folder:
-                    thread_db.delete_folder(folder["id"])
-            except Exception:
-                log.exception(
-                    "Failed to deindex local staging folder on archive skip",
-                )
+            _deindex_staging()
             stages["archive"]["status"] = "skipped"
             runner.update_step(
                 job["id"], "archive",

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1149,6 +1149,28 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             )
                             return
 
+                        # Make sure the archive parent exists NOW. Otherwise
+                        # the pipeline would stage and process everything,
+                        # then fail at the final move_folder call when rsync
+                        # tries to write to a missing parent — leaving the
+                        # staged copy stranded under ~/.vireo/staging with no
+                        # archive at the final destination. Nested archive
+                        # targets like /mnt/nas/NewShoot/Photos are the
+                        # common case: the parent /mnt/nas/NewShoot may not
+                        # have been created yet by the user.
+                        archive_parent = os.path.dirname(
+                            os.path.normpath(final_destination),
+                        )
+                        try:
+                            os.makedirs(archive_parent, exist_ok=True)
+                        except OSError as exc:
+                            _bail_storage(
+                                f"Archive parent {archive_parent} could "
+                                f"not be created: {exc}. Check that the "
+                                "destination drive is mounted and writable."
+                            )
+                            return
+
                         os.makedirs(params.destination, exist_ok=True)
                         selected_files = selected_source_files(
                             sources,
@@ -4221,6 +4243,26 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
             stages["archive"]["status"] = "skipped"
             runner.update_step(
                 job["id"], "archive", status="completed", summary="Skipped",
+            )
+            _update_stages(runner, job["id"], stages)
+            return
+        # Don't publish partial results: previews, extract_masks,
+        # eye_keypoints, regroup, and miss can all fail without setting
+        # abort, and run_pipeline_job marks the whole job failed at the
+        # end whenever any stage status is "failed". If we ran the archive
+        # in between, the staged folder would have already moved to
+        # final_destination by the time that failure was raised — leaving
+        # the user with a published archive whose pipeline never finished.
+        # Skip instead so staging stays intact and the failure is visible.
+        already_failed = [
+            name for name, s in stages.items() if s.get("status") == "failed"
+        ]
+        if already_failed:
+            stages["archive"]["status"] = "skipped"
+            runner.update_step(
+                job["id"], "archive",
+                status="completed",
+                summary=f"Skipped ({already_failed[0]} failed)",
             )
             _update_stages(runner, job["id"], stages)
             return

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -4441,6 +4441,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 # abandoned staging photo IDs would treat the stale cache file
                 # as a valid thumbnail and skip regenerating it.
                 try:
+                    from pipeline import _results_cache_path
                     from preview_cache import (
                         cleanup_cached_files_for_deleted_photos,
                     )
@@ -4457,6 +4458,17 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             effective_thumb_cache_dir,
                             result.get("files", []),
                         )
+                        thread_db.set_workspace_group_state(
+                            workspace_id=workspace_id,
+                            fingerprint=None,
+                            when_ts=None,
+                        )
+                        with contextlib.suppress(OSError):
+                            os.unlink(
+                                _results_cache_path(
+                                    os.path.dirname(db_path), workspace_id,
+                                )
+                            )
                 except Exception:
                     log.exception(
                         "Failed to deindex local staging folder on archive skip",

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1179,7 +1179,10 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             exclude_paths=params.exclude_paths,
                         )
                         source_bytes = total_file_bytes(selected_files)
-                        plan = storage_plan(params.destination, source_bytes)
+                        plan = storage_plan(
+                            params.destination, source_bytes,
+                            archive_parent=archive_parent,
+                        )
                         # When skip_duplicates is on, ingest() will hash and
                         # skip files whose hash is already in the catalog
                         # OR already seen earlier in this same run before
@@ -1209,6 +1212,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             if filtered_bytes < source_bytes:
                                 plan = storage_plan(
                                     params.destination, filtered_bytes,
+                                    archive_parent=archive_parent,
                                 )
                         result["local_processing"] = {
                             **plan,
@@ -1216,16 +1220,33 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             "final_destination": final_destination,
                         }
                         if plan["batching_required"]:
-                            _bail_storage(
-                                "Local processing needs about "
-                                f"{format_bytes(plan['required_bytes'])}, but "
-                                f"only {format_bytes(plan['usable_bytes'])} is "
-                                "available after keeping local free-space "
-                                "reserve. This import needs "
-                                f"{plan['batch_count']} local-processing "
-                                "batches; automatic batch execution is not "
-                                "available in this build yet."
-                            )
+                            # Tell the user which volume came up short — the
+                            # destination running out of room reads as a
+                            # different problem (pick a bigger archive
+                            # drive) than the staging volume running out
+                            # (free space on ~/.vireo or batch later).
+                            if not plan.get("archive_enough", True):
+                                _bail_storage(
+                                    "Archive destination needs about "
+                                    f"{format_bytes(plan['archive_required_bytes'])}, "
+                                    "but only "
+                                    f"{format_bytes(plan['archive_usable_bytes'] or 0)} "
+                                    f"is free under {archive_parent} after "
+                                    "the free-space reserve. Free space at "
+                                    "the destination or pick a different "
+                                    "archive folder."
+                                )
+                            else:
+                                _bail_storage(
+                                    "Local processing needs about "
+                                    f"{format_bytes(plan['required_bytes'])}, but "
+                                    f"only {format_bytes(plan['usable_bytes'])} is "
+                                    "available after keeping local free-space "
+                                    "reserve. This import needs "
+                                    f"{plan['batch_count']} local-processing "
+                                    "batches; automatic batch execution is not "
+                                    "available in this build yet."
+                                )
                             return
                         summary = (
                             f"{format_bytes(plan['required_bytes'])} needed, "
@@ -4289,6 +4310,27 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
             name for name, s in stages.items() if s.get("status") == "failed"
         ]
         if already_failed:
+            # Before bailing, deindex the local staging folder. scanner_stage
+            # may have already registered it (and its photos' hashes) before
+            # the downstream failure surfaced. Without removing those rows,
+            # a retry of the same source would hit ingest()'s known-hash
+            # skip and copy nothing — the user would then "successfully"
+            # archive an empty destination while the original files only
+            # ever existed in the abandoned staging tree. Leave the on-disk
+            # staging files in place so the user can still recover them.
+            try:
+                thread_db = Database(db_path)
+                thread_db.set_active_workspace(workspace_id)
+                folder = thread_db.conn.execute(
+                    "SELECT id FROM folders WHERE path = ?",
+                    (params.destination,),
+                ).fetchone()
+                if folder:
+                    thread_db.delete_folder(folder["id"])
+            except Exception:
+                log.exception(
+                    "Failed to deindex local staging folder on archive skip",
+                )
             stages["archive"]["status"] = "skipped"
             runner.update_step(
                 job["id"], "archive",

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -40,6 +40,7 @@ class PipelineParams:
     sources: list | None = None
     source_snapshot_id: int | None = None
     destination: str | None = None
+    local_processing: bool = False
     file_types: str = "both"
     folder_template: str = "%Y/%Y-%m-%d"
     skip_duplicates: bool = True
@@ -672,6 +673,15 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
         if thumb_cache_dir
         else os.path.dirname(db_path)
     )
+    final_destination = params.destination if params.local_processing else None
+    staging_parent = None
+    if params.local_processing and params.destination:
+        from local_processing import staging_root
+
+        staging_parent = os.path.join(effective_vireo_dir, "staging", job["id"])
+        params.destination = staging_root(
+            effective_vireo_dir, job["id"], params.destination,
+        )
 
     # Snapshot-scoped pipelines: load the snapshot up front so scan targets
     # are derived from the captured file paths (not a folder the user picked
@@ -717,6 +727,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
     cancel_watcher.start()
 
     stages = {
+        "storage": {"status": "pending", "label": "Checking local storage"},
         "ingest": {"status": "pending", "count": 0, "label": "Importing photos"},
         "scan": {"status": "pending", "count": 0, "label": "Scanning photos"},
         "thumbnails": {"status": "pending", "count": 0, "label": "Generating thumbnails"},
@@ -728,6 +739,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
         "eye_keypoints": {"status": "pending", "count": 0, "label": "Detecting eye keypoints"},
         "regroup": {"status": "pending", "label": "Grouping encounters"},
         "misses": {"status": "pending", "count": 0, "label": "Flagging missed shots"},
+        "archive": {"status": "pending", "count": 0, "label": "Archiving photos"},
     }
 
     # Normalize model_ids: prefer the explicit list, fall back to the legacy
@@ -775,6 +787,8 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
     # Define step tracking for the jobs page
     step_defs = []
     if params.destination:
+        if params.local_processing:
+            step_defs.append({"id": "storage", "label": "Check local storage"})
         step_defs.append({"id": "ingest", "label": "Import photos"})
     step_defs.extend([
         {"id": "scan", "label": "Scan photos"},
@@ -825,6 +839,8 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
     if not params.skip_regroup:
         step_defs.append({"id": "regroup", "label": "Group encounters"})
         step_defs.append({"id": "misses", "label": "Flag missed shots"})
+    if params.local_processing:
+        step_defs.append({"id": "archive", "label": "Archive to destination"})
     runner.set_steps(job["id"], step_defs)
 
     result = {"stages": {}}
@@ -854,6 +870,9 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
     # don't show a perpetually-pending stage.
     if not params.destination:
         stages["ingest"]["status"] = "skipped"
+    if not params.local_processing:
+        stages["storage"]["status"] = "skipped"
+        stages["archive"]["status"] = "skipped"
 
     # --- Stage functions ---
 
@@ -1072,6 +1091,75 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 from pathlib import Path
 
                 from ingest import ingest as do_ingest
+
+                if params.local_processing:
+                    from local_processing import (
+                        format_bytes,
+                        selected_source_files,
+                        storage_plan,
+                        total_file_bytes,
+                    )
+
+                    stages["storage"]["status"] = "running"
+                    runner.update_step(job["id"], "storage", status="running")
+                    _update_stages(runner, job["id"], stages)
+
+                    try:
+                        os.makedirs(params.destination, exist_ok=True)
+                        selected_files = selected_source_files(
+                            sources,
+                            params.file_types,
+                            recursive=params.recursive,
+                            exclude_paths=params.exclude_paths,
+                        )
+                        plan = storage_plan(
+                            params.destination,
+                            total_file_bytes(selected_files),
+                        )
+                        result["local_processing"] = {
+                            **plan,
+                            "staging_destination": params.destination,
+                            "final_destination": final_destination,
+                        }
+                        if plan["batching_required"]:
+                            msg = (
+                                "Local processing needs about "
+                                f"{format_bytes(plan['required_bytes'])}, but "
+                                f"only {format_bytes(plan['usable_bytes'])} is "
+                                "available after keeping local free-space "
+                                "reserve. This import needs "
+                                f"{plan['batch_count']} local-processing "
+                                "batches; automatic batch execution is not "
+                                "available in this build yet."
+                            )
+                            errors.append(f"[storage] Fatal: {msg}")
+                            stages["storage"]["status"] = "failed"
+                            runner.update_step(
+                                job["id"], "storage", status="failed", error=msg,
+                            )
+                            abort.set()
+                            scan_to_thumb.put(_SENTINEL)
+                            return
+                        summary = (
+                            f"{format_bytes(plan['required_bytes'])} needed, "
+                            f"{format_bytes(plan['usable_bytes'])} available"
+                        )
+                        stages["storage"]["status"] = "completed"
+                        runner.update_step(
+                            job["id"], "storage",
+                            status="completed",
+                            summary=summary,
+                        )
+                    except Exception as e:
+                        errors.append(f"[storage] Fatal: {e}")
+                        log.exception("Pipeline local-storage preflight failed")
+                        stages["storage"]["status"] = "failed"
+                        runner.update_step(
+                            job["id"], "storage", status="failed", error=str(e),
+                        )
+                        abort.set()
+                        scan_to_thumb.put(_SENTINEL)
+                        return
 
                 # Same accumulator pattern as scan_acc: do_ingest() is called
                 # once per source folder, with (current, total) local to each
@@ -4059,6 +4147,101 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
 
         _update_stages(runner, job["id"], stages)
 
+    def archive_stage():
+        """Move a local-processing staging folder to the final destination."""
+        if not params.local_processing:
+            return
+        if abort.is_set() or runner.is_cancelled(job["id"]):
+            stages["archive"]["status"] = "skipped"
+            runner.update_step(
+                job["id"], "archive", status="completed", summary="Skipped",
+            )
+            _update_stages(runner, job["id"], stages)
+            return
+        if not final_destination:
+            stages["archive"]["status"] = "skipped"
+            runner.update_step(
+                job["id"], "archive", status="completed", summary="Skipped",
+            )
+            _update_stages(runner, job["id"], stages)
+            return
+
+        stages["archive"]["status"] = "running"
+        runner.update_step(job["id"], "archive", status="running")
+        _update_stages(runner, job["id"], stages)
+
+        try:
+            import config as cfg
+            from move import move_folder
+
+            thread_db = Database(db_path)
+            thread_db.set_active_workspace(workspace_id)
+            folder = thread_db.conn.execute(
+                "SELECT id FROM folders WHERE path = ?", (params.destination,)
+            ).fetchone()
+            if not folder:
+                raise RuntimeError(
+                    f"local staging folder was not indexed: {params.destination}"
+                )
+
+            effective_cfg = thread_db.get_effective_config(cfg.load())
+            developed_dir = effective_cfg.get("darktable_output_dir", "") or ""
+            archive_parent = os.path.dirname(os.path.normpath(final_destination))
+            total_files = {"value": 0}
+
+            def archive_cb(current, total, filename, phase=None):
+                total_files["value"] = max(total_files["value"], total or 0)
+                stages["archive"]["count"] = current
+                stages["archive"]["total"] = total
+                runner.update_step(
+                    job["id"], "archive",
+                    current_file=filename,
+                    progress={"current": current, "total": total},
+                )
+                _emit_progress(
+                    runner, job["id"], stages, "archive",
+                    phase or "Archiving photos",
+                    current_file=filename,
+                )
+
+            move_result = move_folder(
+                thread_db,
+                folder["id"],
+                archive_parent,
+                progress_cb=archive_cb,
+                developed_dir=developed_dir,
+                merge=True,
+            )
+            if move_result.get("errors"):
+                raise RuntimeError("; ".join(move_result["errors"]))
+
+            if staging_parent:
+                with contextlib.suppress(OSError):
+                    os.rmdir(staging_parent)
+
+            stages["archive"]["status"] = "completed"
+            summary = f"{move_result.get('moved', 0)} photos archived"
+            runner.update_step(
+                job["id"], "archive", status="completed", summary=summary,
+            )
+            result["archive"] = {
+                "final_destination": final_destination,
+                "moved": move_result.get("moved", 0),
+            }
+        except Exception as e:
+            msg = (
+                f"{e}. Processing results remain in local staging: "
+                f"{params.destination}"
+            )
+            errors.append(f"[archive] Fatal: {msg}")
+            log.exception("Pipeline archive stage failed")
+            stages["archive"]["status"] = "failed"
+            runner.update_step(
+                job["id"], "archive", status="failed", error=msg,
+            )
+
+        _update_stages(runner, job["id"], stages)
+
     # --- Launch threads ---
 
     threads = {}
@@ -4135,6 +4318,8 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
         with acquire_workspace_regroup(workspace_id):
             regroup_stage()
             miss_stage()
+
+    archive_stage()
 
     cancel_watcher_stop.set()
 

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1231,7 +1231,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         from local_processing import (
                             existing_archive_bytes,
                             format_bytes,
-                            non_duplicate_bytes,
+                            non_duplicate_files,
                             selected_source_files,
                             storage_plan,
                             total_file_bytes,
@@ -1396,14 +1396,20 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                         "WHERE file_hash IS NOT NULL"
                                     )
                                 }
-                                filtered_bytes = non_duplicate_bytes(
+                                filtered_files = non_duplicate_files(
                                     selected_files, known_hashes,
                                 )
+                                filtered_bytes = total_file_bytes(filtered_files)
                                 if filtered_bytes < source_bytes:
+                                    filtered_existing_bytes = existing_archive_bytes(
+                                        final_destination,
+                                        filtered_files,
+                                        params.folder_template,
+                                    )
                                     plan = storage_plan(
                                         params.destination, filtered_bytes,
                                         archive_parent=archive_space_path,
-                                        archive_existing_bytes=existing_bytes,
+                                        archive_existing_bytes=filtered_existing_bytes,
                                     )
                             result["local_processing"] = {
                                 **plan,

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1231,7 +1231,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         from local_processing import (
                             existing_archive_bytes,
                             format_bytes,
-                            non_duplicate_bytes,
+                            non_duplicate_files,
                             selected_source_files,
                             storage_plan,
                             total_file_bytes,
@@ -1396,14 +1396,32 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                         "WHERE file_hash IS NOT NULL"
                                     )
                                 }
-                                filtered_bytes = non_duplicate_bytes(
+                                filtered_files = non_duplicate_files(
                                     selected_files, known_hashes,
                                 )
+                                filtered_bytes = total_file_bytes(filtered_files)
                                 if filtered_bytes < source_bytes:
+                                    # Recompute the destination credit against
+                                    # the survivor set. The first existing_bytes
+                                    # call counts every selected file that's
+                                    # already at final_destination, including
+                                    # known duplicates ingest will SKIP. If a
+                                    # large skipped file is present at the
+                                    # destination and a smaller fresh file is
+                                    # not, that credit would cap to filtered_
+                                    # bytes and drive archive_delta to zero —
+                                    # passing the destination-space preflight
+                                    # for a run that still has to write the
+                                    # fresh file at the archive.
+                                    filtered_existing_bytes = existing_archive_bytes(
+                                        final_destination,
+                                        filtered_files,
+                                        params.folder_template,
+                                    )
                                     plan = storage_plan(
                                         params.destination, filtered_bytes,
                                         archive_parent=archive_space_path,
-                                        archive_existing_bytes=existing_bytes,
+                                        archive_existing_bytes=filtered_existing_bytes,
                                     )
                             result["local_processing"] = {
                                 **plan,

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1386,6 +1386,30 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             error=msg,
                             summary=summary,
                         )
+                        # Stop the run here. Without abort, scanner/previews/
+                        # classify/regroup would all execute against the
+                        # partial subset ingest did manage to copy — regroup
+                        # in particular overwrites the workspace pipeline
+                        # results with photo IDs that archive_stage's
+                        # deindex_staging is then going to delete, leaving
+                        # the workspace pointing at rows that no longer
+                        # exist. archive_stage already gates on abort and
+                        # any earlier-stage failure, so this also publishes
+                        # nothing. Finalize the remaining step rows as
+                        # skipped so the SSE clients don't see perpetually
+                        # pending stages.
+                        abort.set()
+                        stages["scan"]["status"] = "skipped"
+                        runner.update_step(
+                            job["id"], "scan",
+                            status="completed",
+                            summary="Skipped (ingest failed)",
+                        )
+                        _update_stages(runner, job["id"], stages)
+                        # The finally clause at the bottom of scanner_stage
+                        # puts the sentinel on scan_to_thumb so the
+                        # thumbnail consumer drains and exits.
+                        return
                     else:
                         stages["ingest"]["status"] = "completed"
                         runner.update_step(

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1229,6 +1229,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
 
                     if params.local_processing:
                         from local_processing import (
+                            existing_archive_bytes,
                             format_bytes,
                             non_duplicate_bytes,
                             selected_source_files,
@@ -1356,9 +1357,17 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 exclude_paths=params.exclude_paths,
                             )
                             source_bytes = total_file_bytes(selected_files)
+                            # When a previous archive attempt left a partial
+                            # untracked directory at final_destination, the
+                            # retry uses move_folder(..., merge=True), which
+                            # rsyncs only the missing files. Credit the bytes
+                            # already published so the preflight doesn't
+                            # reject a retry whose remaining delta would fit.
+                            existing_bytes = existing_archive_bytes(final_destination)
                             plan = storage_plan(
                                 params.destination, source_bytes,
                                 archive_parent=archive_space_path,
+                                archive_existing_bytes=existing_bytes,
                             )
                             # When skip_duplicates is on, ingest() will hash and
                             # skip files whose hash is already in the catalog
@@ -1390,6 +1399,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                     plan = storage_plan(
                                         params.destination, filtered_bytes,
                                         archive_parent=archive_space_path,
+                                        archive_existing_bytes=existing_bytes,
                                     )
                             result["local_processing"] = {
                                 **plan,

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -993,6 +993,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
 
                     if params.local_processing:
                         from local_processing import (
+                            conflicting_archive_paths,
                             existing_archive_bytes,
                             format_bytes,
                             non_duplicate_files,
@@ -1120,6 +1121,25 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 recursive=params.recursive,
                                 exclude_paths=params.exclude_paths,
                             )
+                            archive_conflicts = conflicting_archive_paths(
+                                final_destination,
+                                selected_files,
+                                params.folder_template,
+                            )
+                            if archive_conflicts:
+                                examples = ", ".join(archive_conflicts[:3])
+                                more = (
+                                    f" and {len(archive_conflicts) - 3} more"
+                                    if len(archive_conflicts) > 3 else ""
+                                )
+                                _bail_storage(
+                                    "Archive destination already contains "
+                                    "different files at the same import paths: "
+                                    f"{examples}{more}. Pick an empty archive "
+                                    "folder, remove the conflicting files, or "
+                                    "import without local processing."
+                                )
+                                return
                             source_bytes = total_file_bytes(selected_files)
                             # When a previous archive attempt left a partial
                             # untracked directory at final_destination, the
@@ -4508,20 +4528,22 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         current_file=filename,
                     )
 
-                # Consume any pending cancellation and lock the job uncancellable
-                # BEFORE the move begins. move_folder is an uninterruptible commit
-                # step (copy → verify → repoint catalog → delete originals); we
-                # can't tear it down mid-flight without leaving partial state.
-                # Clearing AFTER move_folder returns leaves a window where a Stop
-                # press landing during the move would survive into the failure
-                # path: if move_folder raises (ENOSPC, rsync error, verify
-                # mismatch), runner.is_cancelled(job_id) would still be True at
-                # the outer job-terminalization check, JobRunner would record
-                # "cancelled", and the user would never see the archive failure.
-                # Consume up front so a successful commit reports "completed" AND
-                # a failed commit reports "failed" — both win against the racing
-                # Stop press, which couldn't have been honored anyway.
-                runner.clear_cancellation(job["id"])
+                # Atomically lock the job uncancellable BEFORE the move begins,
+                # but only if Stop is not already pending. move_folder is an
+                # uninterruptible commit step (copy -> verify -> repoint catalog
+                # -> delete originals); once it starts, a Stop press cannot be
+                # honored without leaving partial state. If Stop landed just
+                # before this transition, skip archive and let the outer runner
+                # record the job as cancelled.
+                if not runner.begin_uncancellable(job["id"]):
+                    _deindex_staging()
+                    stages["archive"]["status"] = "skipped"
+                    runner.update_step(
+                        job["id"], "archive",
+                        status="completed", summary="Skipped",
+                    )
+                    _update_stages(runner, job["id"], stages)
+                    return
 
                 move_result = move_folder(
                     thread_db,

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -4734,6 +4734,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     progress_cb=archive_cb,
                     developed_dir=developed_dir,
                     merge=True,
+                    reject_tracked_ancestor=True,
                 )
                 if move_result.get("errors"):
                     raise RuntimeError("; ".join(move_result["errors"]))

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1100,7 +1100,10 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         storage_plan,
                         total_file_bytes,
                     )
-                    from move import _tracked_destination_overlap
+                    from move import (
+                        _tracked_destination_ancestor,
+                        _tracked_destination_overlap,
+                    )
 
                     stages["storage"]["status"] = "running"
                     runner.update_step(job["id"], "storage", status="running")
@@ -1146,6 +1149,29 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 "imports must land at a new archive folder; "
                                 "pick a different destination or import "
                                 "without local processing."
+                            )
+                            return
+
+                        # Also reject when the archive destination would land
+                        # INSIDE an already-tracked folder. db.move_folder_path
+                        # (called by move_folder during archive) only rewrites
+                        # the moved row's path string — it does NOT reparent the
+                        # row under the tracked ancestor. The catalog would end
+                        # up with two unrelated workspace roots whose path
+                        # strings overlap, e.g. /Photos and /Photos/NewShoot,
+                        # silently confusing the folder tree and breaking
+                        # future scans of the ancestor root.
+                        ancestor = _tracked_destination_ancestor(
+                            thread_db, -1, final_destination,
+                        )
+                        if ancestor:
+                            _bail_storage(
+                                f"Archive destination {final_destination} "
+                                f"is inside a folder Vireo already manages "
+                                f"({ancestor['path']}). Pick an archive "
+                                f"folder outside {ancestor['path']}, or "
+                                "import without local processing so the "
+                                "scan can attach to the existing folder."
                             )
                             return
 
@@ -4389,6 +4415,21 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     current_file=filename,
                 )
 
+            # Consume any pending cancellation and lock the job uncancellable
+            # BEFORE the move begins. move_folder is an uninterruptible commit
+            # step (copy → verify → repoint catalog → delete originals); we
+            # can't tear it down mid-flight without leaving partial state.
+            # Clearing AFTER move_folder returns leaves a window where a Stop
+            # press landing during the move would survive into the failure
+            # path: if move_folder raises (ENOSPC, rsync error, verify
+            # mismatch), runner.is_cancelled(job_id) would still be True at
+            # the outer job-terminalization check, JobRunner would record
+            # "cancelled", and the user would never see the archive failure.
+            # Consume up front so a successful commit reports "completed" AND
+            # a failed commit reports "failed" — both win against the racing
+            # Stop press, which couldn't have been honored anyway.
+            runner.clear_cancellation(job["id"])
+
             move_result = move_folder(
                 thread_db,
                 folder["id"],
@@ -4403,17 +4444,6 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
             if staging_parent:
                 with contextlib.suppress(OSError):
                     os.rmdir(staging_parent)
-
-            # The archive has been published and originals removed. A Stop
-            # pressed during the move cannot be honored here: move_folder
-            # doesn't accept a cancellation signal, and tearing it down
-            # mid-flight would either leave files in both staging and
-            # destination or wipe staging before verification completes.
-            # Consume any cancellation that landed during the commit so
-            # JobRunner records the run as "completed" rather than
-            # "cancelled" — the archive is on disk and the user should
-            # see that, not a misleading cancelled-status pill.
-            runner.clear_cancellation(job["id"])
 
             stages["archive"]["status"] = "completed"
             summary = f"{move_result.get('moved', 0)} photos archived"

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1133,8 +1133,9 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 if os.path.exists(final_destination)
                                 else archive_parent
                             )
-                            missing_mount_root = _missing_archive_mount_root(
-                                archive_parent,
+                            missing_mount_root = (
+                                _missing_archive_mount_root(final_destination)
+                                or _missing_archive_mount_root(archive_parent)
                             )
                             if missing_mount_root:
                                 _bail_storage(

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1088,8 +1088,17 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             archive_parent = os.path.dirname(
                                 os.path.normpath(final_destination),
                             )
+                            # Use lexists so a broken/dangling symlink at
+                            # final_destination is caught here too. os.path
+                            # .exists returns False for a broken symlink, so
+                            # a stale link left by an unmounted or moved
+                            # archive root would slip through, let the
+                            # pipeline stage and process everything, and
+                            # only fail when move_folder/rsync tried to
+                            # create a directory at a path already occupied
+                            # by that symlink entry.
                             if (
-                                os.path.exists(final_destination)
+                                os.path.lexists(final_destination)
                                 and not os.path.isdir(final_destination)
                             ):
                                 _bail_storage(

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1322,6 +1322,13 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             archive_parent = os.path.dirname(
                                 os.path.normpath(final_destination),
                             )
+                            # Existing archive roots can be mounted volumes; new
+                            # archive leaves have to probe the existing parent.
+                            archive_space_path = (
+                                final_destination
+                                if os.path.exists(final_destination)
+                                else archive_parent
+                            )
                             try:
                                 os.makedirs(archive_parent, exist_ok=True)
                             except OSError as exc:
@@ -1342,7 +1349,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             source_bytes = total_file_bytes(selected_files)
                             plan = storage_plan(
                                 params.destination, source_bytes,
-                                archive_parent=archive_parent,
+                                archive_parent=archive_space_path,
                             )
                             # When skip_duplicates is on, ingest() will hash and
                             # skip files whose hash is already in the catalog
@@ -1373,7 +1380,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 if filtered_bytes < source_bytes:
                                     plan = storage_plan(
                                         params.destination, filtered_bytes,
-                                        archive_parent=archive_parent,
+                                        archive_parent=archive_space_path,
                                     )
                             result["local_processing"] = {
                                 **plan,

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1121,10 +1121,28 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 recursive=params.recursive,
                                 exclude_paths=params.exclude_paths,
                             )
+                            # When skip_duplicates is on, ingest() will skip
+                            # sources whose content hash is already in the
+                            # catalog before they ever reach staging. Pass
+                            # those known hashes to the conflict preflight so
+                            # a duplicate-source that happens to share an
+                            # archive path with an unrelated file does not
+                            # falsely abort the run — ingest will not copy
+                            # it, so it cannot conflict at archive time.
+                            catalog_hashes: set[str] | None = None
+                            if params.skip_duplicates:
+                                catalog_hashes = {
+                                    row["file_hash"]
+                                    for row in thread_db.conn.execute(
+                                        "SELECT file_hash FROM photos "
+                                        "WHERE file_hash IS NOT NULL"
+                                    )
+                                }
                             archive_conflicts = conflicting_archive_paths(
                                 final_destination,
                                 selected_files,
                                 params.folder_template,
+                                known_hashes=catalog_hashes,
                             )
                             if archive_conflicts:
                                 examples = ", ".join(archive_conflicts[:3])
@@ -1174,12 +1192,15 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 and params.skip_duplicates
                                 and selected_files
                             ):
-                                known_hashes = {
-                                    row["file_hash"] for row in thread_db.conn.execute(
-                                        "SELECT file_hash FROM photos "
-                                        "WHERE file_hash IS NOT NULL"
-                                    )
-                                }
+                                # ``catalog_hashes`` was already fetched
+                                # above for the conflict preflight when
+                                # skip_duplicates is on; reuse it instead
+                                # of re-querying the photos table.
+                                known_hashes = (
+                                    catalog_hashes
+                                    if catalog_hashes is not None
+                                    else set()
+                                )
                                 filtered_files = non_duplicate_files(
                                     selected_files, known_hashes,
                                 )

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1095,16 +1095,60 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 if params.local_processing:
                     from local_processing import (
                         format_bytes,
+                        non_duplicate_bytes,
                         selected_source_files,
                         storage_plan,
                         total_file_bytes,
                     )
+                    from move import _tracked_destination_overlap
 
                     stages["storage"]["status"] = "running"
                     runner.update_step(job["id"], "storage", status="running")
                     _update_stages(runner, job["id"], stages)
 
+                    def _bail_storage(msg):
+                        # collection_stage spins on stages["scan"]["status"]
+                        # until it reaches a terminal value, so a storage
+                        # failure that skips scan and ingest entirely must
+                        # mark both as skipped here — otherwise its join()
+                        # blocks the whole pipeline forever.
+                        errors.append(f"[storage] Fatal: {msg}")
+                        stages["storage"]["status"] = "failed"
+                        runner.update_step(
+                            job["id"], "storage",
+                            status="failed", error=msg,
+                        )
+                        for skipped in ("ingest", "scan"):
+                            stages[skipped]["status"] = "skipped"
+                            runner.update_step(
+                                job["id"], skipped,
+                                status="completed", summary="Skipped",
+                            )
+                        abort.set()
+                        scan_to_thumb.put(_SENTINEL)
+
                     try:
+                        # Reject up front if the archive destination is already
+                        # a Vireo-managed folder (e.g., a repeat import to the
+                        # same archive root). Without this check the pipeline
+                        # would stage everything, complete every processing
+                        # step, and then fail in move_folder's tracked-overlap
+                        # guard — leaving the staged copy stranded under
+                        # ~/.vireo/staging with no way to resume.
+                        tracked = _tracked_destination_overlap(
+                            thread_db, -1, final_destination,
+                        )
+                        if tracked:
+                            _bail_storage(
+                                f"Archive destination {final_destination} "
+                                f"overlaps a folder Vireo already manages "
+                                f"({tracked['path']}). Local processing "
+                                "imports must land at a new archive folder; "
+                                "pick a different destination or import "
+                                "without local processing."
+                            )
+                            return
+
                         os.makedirs(params.destination, exist_ok=True)
                         selected_files = selected_source_files(
                             sources,
@@ -1112,17 +1156,42 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             recursive=params.recursive,
                             exclude_paths=params.exclude_paths,
                         )
-                        plan = storage_plan(
-                            params.destination,
-                            total_file_bytes(selected_files),
-                        )
+                        source_bytes = total_file_bytes(selected_files)
+                        plan = storage_plan(params.destination, source_bytes)
+                        # When skip_duplicates is on, ingest() will hash and
+                        # skip files whose hash is already in the catalog
+                        # before writing to staging. The naive byte sum above
+                        # would mark a mostly-duplicate card as batching-
+                        # required even though the staging copy would fit.
+                        # Re-check using the duplicate-filtered set, but only
+                        # when the optimistic check failed — otherwise we'd
+                        # hash the entire source set on every import.
+                        if (
+                            plan["batching_required"]
+                            and params.skip_duplicates
+                            and selected_files
+                        ):
+                            known_hashes = {
+                                row["file_hash"] for row in thread_db.conn.execute(
+                                    "SELECT file_hash FROM photos "
+                                    "WHERE file_hash IS NOT NULL"
+                                )
+                            }
+                            if known_hashes:
+                                filtered_bytes = non_duplicate_bytes(
+                                    selected_files, known_hashes,
+                                )
+                                if filtered_bytes < source_bytes:
+                                    plan = storage_plan(
+                                        params.destination, filtered_bytes,
+                                    )
                         result["local_processing"] = {
                             **plan,
                             "staging_destination": params.destination,
                             "final_destination": final_destination,
                         }
                         if plan["batching_required"]:
-                            msg = (
+                            _bail_storage(
                                 "Local processing needs about "
                                 f"{format_bytes(plan['required_bytes'])}, but "
                                 f"only {format_bytes(plan['usable_bytes'])} is "
@@ -1132,13 +1201,6 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 "batches; automatic batch execution is not "
                                 "available in this build yet."
                             )
-                            errors.append(f"[storage] Fatal: {msg}")
-                            stages["storage"]["status"] = "failed"
-                            runner.update_step(
-                                job["id"], "storage", status="failed", error=msg,
-                            )
-                            abort.set()
-                            scan_to_thumb.put(_SENTINEL)
                             return
                         summary = (
                             f"{format_bytes(plan['required_bytes'])} needed, "
@@ -1151,14 +1213,8 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             summary=summary,
                         )
                     except Exception as e:
-                        errors.append(f"[storage] Fatal: {e}")
                         log.exception("Pipeline local-storage preflight failed")
-                        stages["storage"]["status"] = "failed"
-                        runner.update_step(
-                            job["id"], "storage", status="failed", error=str(e),
-                        )
-                        abort.set()
-                        scan_to_thumb.put(_SENTINEL)
+                        _bail_storage(str(e))
                         return
 
                 # Same accumulator pattern as scan_acc: do_ingest() is called

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1160,12 +1160,16 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         plan = storage_plan(params.destination, source_bytes)
                         # When skip_duplicates is on, ingest() will hash and
                         # skip files whose hash is already in the catalog
-                        # before writing to staging. The naive byte sum above
-                        # would mark a mostly-duplicate card as batching-
-                        # required even though the staging copy would fit.
-                        # Re-check using the duplicate-filtered set, but only
-                        # when the optimistic check failed — otherwise we'd
-                        # hash the entire source set on every import.
+                        # OR already seen earlier in this same run before
+                        # writing to staging. The naive byte sum above would
+                        # mark a mostly-duplicate card — or one where the
+                        # same folder appears in `sources` twice — as
+                        # batching-required even though the staging copy
+                        # would fit. Re-check using the duplicate-filtered
+                        # set, but only when the optimistic check failed —
+                        # otherwise we'd hash the entire source set on every
+                        # import. The filter runs even when the catalog is
+                        # empty so intra-run duplicates still collapse.
                         if (
                             plan["batching_required"]
                             and params.skip_duplicates
@@ -1177,14 +1181,13 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                     "WHERE file_hash IS NOT NULL"
                                 )
                             }
-                            if known_hashes:
-                                filtered_bytes = non_duplicate_bytes(
-                                    selected_files, known_hashes,
+                            filtered_bytes = non_duplicate_bytes(
+                                selected_files, known_hashes,
+                            )
+                            if filtered_bytes < source_bytes:
+                                plan = storage_plan(
+                                    params.destination, filtered_bytes,
                                 )
-                                if filtered_bytes < source_bytes:
-                                    plan = storage_plan(
-                                        params.destination, filtered_bytes,
-                                    )
                         result["local_processing"] = {
                             **plan,
                             "staging_destination": params.destination,

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -23,7 +23,12 @@ from datetime import UTC, datetime
 import numpy as np
 from db import Database, commit_with_retry
 from model_cache import get_default_cache
-from pipeline_locks import acquire_photo_mask, acquire_workspace_regroup
+from pipeline_locks import (
+    acquire_photo_mask,
+    acquire_workspace_regroup,
+    release_archive_destination,
+    try_reserve_archive_destination,
+)
 
 log = logging.getLogger(__name__)
 
@@ -675,1147 +680,1079 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
     )
     final_destination = params.destination if params.local_processing else None
     staging_parent = None
+    archive_destination_reserved = False
     if params.local_processing and params.destination:
         from local_processing import staging_root
+
+        # Reserve the final destination across the whole process BEFORE any
+        # staging or scanning starts. SLOT_CAP=2 in JobRunner means two
+        # local-processing pipelines can race past the storage stage's
+        # DB-only overlap check; without this reservation the second one
+        # would only fail inside ``move_folder`` after staging and
+        # processing everything. ``release_archive_destination`` runs in
+        # the finally below so retries can re-claim once this run ends.
+        if not try_reserve_archive_destination(final_destination):
+            raise RuntimeError(
+                f"Archive destination {final_destination} is already "
+                "being used by another local-processing pipeline. Wait "
+                "for that job to finish, or pick a different destination."
+            )
+        archive_destination_reserved = True
 
         staging_parent = os.path.join(effective_vireo_dir, "staging", job["id"])
         params.destination = staging_root(
             effective_vireo_dir, job["id"], params.destination,
         )
 
-    # Snapshot-scoped pipelines: load the snapshot up front so scan targets
-    # are derived from the captured file paths (not a folder the user picked
-    # later). Raises if the snapshot has been garbage-collected — the API
-    # layer is expected to return 404 before this job ever runs, but we fail
-    # loud here to avoid silently running an unbounded scan.
-    snapshot_paths: list[str] | None = None
-    if params.source_snapshot_id is not None:
-        db_ro = Database(db_path)
-        db_ro.set_active_workspace(workspace_id)
-        snap = db_ro.get_new_images_snapshot(params.source_snapshot_id)
-        if snap is None:
-            raise ValueError(
-                f"snapshot {params.source_snapshot_id} not found"
+    try:
+        # Snapshot-scoped pipelines: load the snapshot up front so scan targets
+        # are derived from the captured file paths (not a folder the user picked
+        # later). Raises if the snapshot has been garbage-collected — the API
+        # layer is expected to return 404 before this job ever runs, but we fail
+        # loud here to avoid silently running an unbounded scan.
+        snapshot_paths: list[str] | None = None
+        if params.source_snapshot_id is not None:
+            db_ro = Database(db_path)
+            db_ro.set_active_workspace(workspace_id)
+            snap = db_ro.get_new_images_snapshot(params.source_snapshot_id)
+            if snap is None:
+                raise ValueError(
+                    f"snapshot {params.source_snapshot_id} not found"
+                )
+            snapshot_paths = list(snap["file_paths"])
+            # Collapse to the minimal non-overlapping ancestor set: if the
+            # snapshot has files at both /root/a.jpg and /root/sub/b.jpg the
+            # naive derived roots (/root, /root/sub) would make the scanner walk
+            # /root/sub twice — once on its own, once as a descendant of /root.
+            scan_roots = _collapse_scan_roots(
+                [os.path.dirname(p) for p in snapshot_paths]
             )
-        snapshot_paths = list(snap["file_paths"])
-        # Collapse to the minimal non-overlapping ancestor set: if the
-        # snapshot has files at both /root/a.jpg and /root/sub/b.jpg the
-        # naive derived roots (/root, /root/sub) would make the scanner walk
-        # /root/sub twice — once on its own, once as a descendant of /root.
-        scan_roots = _collapse_scan_roots(
-            [os.path.dirname(p) for p in snapshot_paths]
-        )
-        # Override any source/sources/collection_id the caller passed; the
-        # snapshot is the single source of truth for what to scan.
-        params.sources = scan_roots
-        params.source = None
-        params.collection_id = None
+            # Override any source/sources/collection_id the caller passed; the
+            # snapshot is the single source of truth for what to scan.
+            params.sources = scan_roots
+            params.source = None
+            params.collection_id = None
 
-    # Bridge user-initiated cancellation (runner.cancel_job) to the local
-    # abort Event so all stages that already honor `abort` stop promptly.
-    cancel_watcher_stop = threading.Event()
+        # Bridge user-initiated cancellation (runner.cancel_job) to the local
+        # abort Event so all stages that already honor `abort` stop promptly.
+        cancel_watcher_stop = threading.Event()
 
-    def _cancel_watcher():
-        while not cancel_watcher_stop.is_set():
-            if runner.is_cancelled(job["id"]):
-                abort.set()
-                return
-            if cancel_watcher_stop.wait(0.25):
-                return
+        def _cancel_watcher():
+            while not cancel_watcher_stop.is_set():
+                if runner.is_cancelled(job["id"]):
+                    abort.set()
+                    return
+                if cancel_watcher_stop.wait(0.25):
+                    return
 
-    cancel_watcher = threading.Thread(target=_cancel_watcher, daemon=True)
-    cancel_watcher.start()
+        cancel_watcher = threading.Thread(target=_cancel_watcher, daemon=True)
+        cancel_watcher.start()
 
-    stages = {
-        "storage": {"status": "pending", "label": "Checking local storage"},
-        "ingest": {"status": "pending", "count": 0, "label": "Importing photos"},
-        "scan": {"status": "pending", "count": 0, "label": "Scanning photos"},
-        "thumbnails": {"status": "pending", "count": 0, "label": "Generating thumbnails"},
-        "previews": {"status": "pending", "count": 0, "label": "Generating previews"},
-        "model_loader": {"status": "pending", "label": "Loading models"},
-        "detect": {"status": "pending", "count": 0, "label": "Detecting subjects"},
-        "classify": {"status": "pending", "count": 0, "cached": 0, "seen": 0, "label": "Classifying species"},
-        "extract_masks": {"status": "pending", "count": 0, "label": "Extracting features"},
-        "eye_keypoints": {"status": "pending", "count": 0, "label": "Detecting eye keypoints"},
-        "regroup": {"status": "pending", "label": "Grouping encounters"},
-        "misses": {"status": "pending", "count": 0, "label": "Flagging missed shots"},
-        "archive": {"status": "pending", "count": 0, "label": "Archiving photos"},
-    }
+        stages = {
+            "storage": {"status": "pending", "label": "Checking local storage"},
+            "ingest": {"status": "pending", "count": 0, "label": "Importing photos"},
+            "scan": {"status": "pending", "count": 0, "label": "Scanning photos"},
+            "thumbnails": {"status": "pending", "count": 0, "label": "Generating thumbnails"},
+            "previews": {"status": "pending", "count": 0, "label": "Generating previews"},
+            "model_loader": {"status": "pending", "label": "Loading models"},
+            "detect": {"status": "pending", "count": 0, "label": "Detecting subjects"},
+            "classify": {"status": "pending", "count": 0, "cached": 0, "seen": 0, "label": "Classifying species"},
+            "extract_masks": {"status": "pending", "count": 0, "label": "Extracting features"},
+            "eye_keypoints": {"status": "pending", "count": 0, "label": "Detecting eye keypoints"},
+            "regroup": {"status": "pending", "label": "Grouping encounters"},
+            "misses": {"status": "pending", "count": 0, "label": "Flagging missed shots"},
+            "archive": {"status": "pending", "count": 0, "label": "Archiving photos"},
+        }
 
-    # Normalize model_ids: prefer the explicit list, fall back to the legacy
-    # single `model_id`, and finally to `[]` which means "use the active model
-    # from config." This is the knob the multi-model fix hangs off of.
-    if params.model_ids:
-        effective_model_ids = list(params.model_ids)
-    elif params.model_id:
-        effective_model_ids = [params.model_id]
-    else:
-        effective_model_ids = []
+        # Normalize model_ids: prefer the explicit list, fall back to the legacy
+        # single `model_id`, and finally to `[]` which means "use the active model
+        # from config." This is the knob the multi-model fix hangs off of.
+        if params.model_ids:
+            effective_model_ids = list(params.model_ids)
+        elif params.model_id:
+            effective_model_ids = [params.model_id]
+        else:
+            effective_model_ids = []
 
-    # Resolve model specs EARLY so per-model `classify:<id>` step_defs can
-    # carry the model's display name as their label. Labels are immutable
-    # after set_steps, so we cannot defer this to model_loader_stage.
-    #
-    # Resolution failures are captured (not raised) so the job still sets up
-    # its step tree and the model_loader stage can surface a clean error.
-    # For any id we fail to resolve we still emit a per-model step — labeled
-    # with the id — so the user sees exactly which model broke.
-    resolved_specs: list = []
-    resolution_error: str | None = None
-    if not params.skip_classify:
-        try:
-            from models import get_active_model, get_models
-            if effective_model_ids:
-                by_id = {m["id"]: m for m in get_models()}
-                for mid in effective_model_ids:
-                    spec = by_id.get(mid)
-                    if not spec or not spec.get("downloaded"):
+        # Resolve model specs EARLY so per-model `classify:<id>` step_defs can
+        # carry the model's display name as their label. Labels are immutable
+        # after set_steps, so we cannot defer this to model_loader_stage.
+        #
+        # Resolution failures are captured (not raised) so the job still sets up
+        # its step tree and the model_loader stage can surface a clean error.
+        # For any id we fail to resolve we still emit a per-model step — labeled
+        # with the id — so the user sees exactly which model broke.
+        resolved_specs: list = []
+        resolution_error: str | None = None
+        if not params.skip_classify:
+            try:
+                from models import get_active_model, get_models
+                if effective_model_ids:
+                    by_id = {m["id"]: m for m in get_models()}
+                    for mid in effective_model_ids:
+                        spec = by_id.get(mid)
+                        if not spec or not spec.get("downloaded"):
+                            raise RuntimeError(
+                                f"Model '{mid}' not found or not downloaded."
+                            )
+                        resolved_specs.append(spec)
+                else:
+                    spec = get_active_model()
+                    if not spec:
                         raise RuntimeError(
-                            f"Model '{mid}' not found or not downloaded."
+                            "No model available. Download one in Settings."
                         )
                     resolved_specs.append(spec)
-            else:
-                spec = get_active_model()
-                if not spec:
-                    raise RuntimeError(
-                        "No model available. Download one in Settings."
+            except Exception as e:
+                resolution_error = str(e)
+
+        # Define step tracking for the jobs page
+        step_defs = []
+        if params.destination:
+            if params.local_processing:
+                step_defs.append({"id": "storage", "label": "Check local storage"})
+            step_defs.append({"id": "ingest", "label": "Import photos"})
+        step_defs.extend([
+            {"id": "scan", "label": "Scan photos"},
+            {"id": "thumbnails", "label": "Generate thumbnails"},
+            {"id": "previews", "label": "Generate previews"},
+        ])
+        if not params.skip_classify:
+            step_defs.append({"id": "model_loader", "label": "Load models"})
+            step_defs.append({"id": "detect", "label": "Detect subjects"})
+            # One row per model — label = model display name, id = classify:<mid>.
+            # When resolution partially failed (e.g. 3 ids requested, 2nd not
+            # downloaded), resolved_specs is a non-empty prefix of the requested
+            # list. Emitting rows from resolved_specs alone would hide the later
+            # failed ids — their "failed" update_step calls would then no-op
+            # silently. Drive row creation off effective_model_ids whenever
+            # resolution reported an error, so every requested model has a visible
+            # step the model_loader stage can mark 'failed'.
+            if resolved_specs and not resolution_error:
+                for spec in resolved_specs:
+                    step_defs.append({
+                        "id": f"classify:{spec['id']}",
+                        "label": f"Classify with {spec['name']}",
+                    })
+            elif effective_model_ids:
+                # Partial or total resolution failure: use display names from any
+                # resolved specs we did get, fall back to the raw id otherwise.
+                by_id = {s["id"]: s for s in resolved_specs}
+                for mid in effective_model_ids:
+                    spec = by_id.get(mid)
+                    label = (
+                        f"Classify with {spec['name']}" if spec
+                        else f"Classify with {mid}"
                     )
-                resolved_specs.append(spec)
-        except Exception as e:
-            resolution_error = str(e)
-
-    # Define step tracking for the jobs page
-    step_defs = []
-    if params.destination:
+                    step_defs.append({
+                        "id": f"classify:{mid}",
+                        "label": label,
+                    })
+            else:
+                # No ids, no resolved spec (active-model resolution failed).
+                # One placeholder row keeps the step tree consistent.
+                step_defs.append({
+                    "id": "classify:__unresolved__",
+                    "label": "Classify species",
+                })
+        if not params.skip_extract_masks:
+            step_defs.append({"id": "extract_masks", "label": "Extract features"})
+            step_defs.append({"id": "eye_keypoints", "label": "Detect eye keypoints"})
+        if not params.skip_regroup:
+            step_defs.append({"id": "regroup", "label": "Group encounters"})
+            step_defs.append({"id": "misses", "label": "Flag missed shots"})
         if params.local_processing:
-            step_defs.append({"id": "storage", "label": "Check local storage"})
-        step_defs.append({"id": "ingest", "label": "Import photos"})
-    step_defs.extend([
-        {"id": "scan", "label": "Scan photos"},
-        {"id": "thumbnails", "label": "Generate thumbnails"},
-        {"id": "previews", "label": "Generate previews"},
-    ])
-    if not params.skip_classify:
-        step_defs.append({"id": "model_loader", "label": "Load models"})
-        step_defs.append({"id": "detect", "label": "Detect subjects"})
-        # One row per model — label = model display name, id = classify:<mid>.
-        # When resolution partially failed (e.g. 3 ids requested, 2nd not
-        # downloaded), resolved_specs is a non-empty prefix of the requested
-        # list. Emitting rows from resolved_specs alone would hide the later
-        # failed ids — their "failed" update_step calls would then no-op
-        # silently. Drive row creation off effective_model_ids whenever
-        # resolution reported an error, so every requested model has a visible
-        # step the model_loader stage can mark 'failed'.
-        if resolved_specs and not resolution_error:
-            for spec in resolved_specs:
-                step_defs.append({
-                    "id": f"classify:{spec['id']}",
-                    "label": f"Classify with {spec['name']}",
-                })
-        elif effective_model_ids:
-            # Partial or total resolution failure: use display names from any
-            # resolved specs we did get, fall back to the raw id otherwise.
-            by_id = {s["id"]: s for s in resolved_specs}
-            for mid in effective_model_ids:
-                spec = by_id.get(mid)
-                label = (
-                    f"Classify with {spec['name']}" if spec
-                    else f"Classify with {mid}"
-                )
-                step_defs.append({
-                    "id": f"classify:{mid}",
-                    "label": label,
-                })
-        else:
-            # No ids, no resolved spec (active-model resolution failed).
-            # One placeholder row keeps the step tree consistent.
-            step_defs.append({
-                "id": "classify:__unresolved__",
-                "label": "Classify species",
-            })
-    if not params.skip_extract_masks:
-        step_defs.append({"id": "extract_masks", "label": "Extract features"})
-        step_defs.append({"id": "eye_keypoints", "label": "Detect eye keypoints"})
-    if not params.skip_regroup:
-        step_defs.append({"id": "regroup", "label": "Group encounters"})
-        step_defs.append({"id": "misses", "label": "Flag missed shots"})
-    if params.local_processing:
-        step_defs.append({"id": "archive", "label": "Archive to destination"})
-    runner.set_steps(job["id"], step_defs)
+            step_defs.append({"id": "archive", "label": "Archive to destination"})
+        runner.set_steps(job["id"], step_defs)
 
-    result = {"stages": {}}
-    collection_id = params.collection_id
-    scan_to_thumb = queue.Queue(maxsize=200)
-    collected_photo_ids = []
-    collection_ready = threading.Event()
-    models_ready = threading.Event()
-    loaded_models = {}  # populated by model_loader thread
-    # Resolved in collection_stage once the scanner has committed photo rows.
-    # When set (i.e. snapshot-scoped runs), the collection is trimmed to this
-    # set so every downstream stage (classify, extract_masks, eye_keypoints,
-    # regroup) operates only on the files captured in the snapshot — files
-    # that landed in the folder after the snapshot are scanned (we walk the
-    # folder) but not further processed.
-    snapshot_photo_ids: set[int] | None = None
+        result = {"stages": {}}
+        collection_id = params.collection_id
+        scan_to_thumb = queue.Queue(maxsize=200)
+        collected_photo_ids = []
+        collection_ready = threading.Event()
+        models_ready = threading.Event()
+        loaded_models = {}  # populated by model_loader thread
+        # Resolved in collection_stage once the scanner has committed photo rows.
+        # When set (i.e. snapshot-scoped runs), the collection is trimmed to this
+        # set so every downstream stage (classify, extract_masks, eye_keypoints,
+        # regroup) operates only on the files captured in the snapshot — files
+        # that landed in the folder after the snapshot are scanned (we walk the
+        # folder) but not further processed.
+        snapshot_photo_ids: set[int] | None = None
 
-    skip_scan = collection_id is not None
+        skip_scan = collection_id is not None
 
-    def _filter_excluded(photos):
-        """Remove photos excluded by user selection in preview."""
-        if not params.exclude_photo_ids:
-            return photos
-        return [p for p in photos if p["id"] not in params.exclude_photo_ids]
+        def _filter_excluded(photos):
+            """Remove photos excluded by user selection in preview."""
+            if not params.exclude_photo_ids:
+                return photos
+            return [p for p in photos if p["id"] not in params.exclude_photo_ids]
 
-    # Mark ingest as skipped when not in copy mode so SSE events
-    # don't show a perpetually-pending stage.
-    if not params.destination:
-        stages["ingest"]["status"] = "skipped"
-    if not params.local_processing:
-        stages["storage"]["status"] = "skipped"
-        stages["archive"]["status"] = "skipped"
+        # Mark ingest as skipped when not in copy mode so SSE events
+        # don't show a perpetually-pending stage.
+        if not params.destination:
+            stages["ingest"]["status"] = "skipped"
+        if not params.local_processing:
+            stages["storage"]["status"] = "skipped"
+            stages["archive"]["status"] = "skipped"
 
-    # --- Stage functions ---
+        # --- Stage functions ---
 
-    def scanner_stage():
-        nonlocal collection_id
+        def scanner_stage():
+            nonlocal collection_id
 
-        # Note: stages["scan"]["status"] is NOT set to "running" here. It is
-        # flipped to "running" just before each do_scan() call below, so
-        # numScan doesn't pulse during the ingest sub-phase.
-        # Collect the scan roots actually fed to do_scan so the finally clause
-        # can invalidate the new-images cache for each one, matching the
-        # try/finally pattern used by api_job_scan / api_job_import_full in
-        # vireo/app.py. scanner.scan commits photo rows incrementally, so even
-        # a mid-scan failure needs invalidation.
-        scanned_roots: list[str] = []
-        thread_db = None
-        try:
-            import config as cfg
-            from scanner import scan as do_scan
+            # Note: stages["scan"]["status"] is NOT set to "running" here. It is
+            # flipped to "running" just before each do_scan() call below, so
+            # numScan doesn't pulse during the ingest sub-phase.
+            # Collect the scan roots actually fed to do_scan so the finally clause
+            # can invalidate the new-images cache for each one, matching the
+            # try/finally pattern used by api_job_scan / api_job_import_full in
+            # vireo/app.py. scanner.scan commits photo rows incrementally, so even
+            # a mid-scan failure needs invalidation.
+            scanned_roots: list[str] = []
+            thread_db = None
+            try:
+                import config as cfg
+                from scanner import scan as do_scan
 
-            thread_db = Database(db_path)
-            thread_db.set_active_workspace(workspace_id)
+                thread_db = Database(db_path)
+                thread_db.set_active_workspace(workspace_id)
 
-            effective_cfg = thread_db.get_effective_config(cfg.load())
-            pipeline_cfg = effective_cfg.get("pipeline", {})
+                effective_cfg = thread_db.get_effective_config(cfg.load())
+                pipeline_cfg = effective_cfg.get("pipeline", {})
 
-            def photo_cb(photo_id, path):
-                collected_photo_ids.append(photo_id)
-                # Abort-aware put: a blocking no-timeout put would wedge the
-                # scanner forever if the thumbnail consumer died with a full
-                # queue (its setup can fail before its drain loop starts).
-                # On abort the item is dropped — the consumer is gone and the
-                # pipeline is tearing down anyway.
-                while not _should_abort(abort):
-                    try:
-                        scan_to_thumb.put((photo_id, path), timeout=0.5)
-                        break
-                    except queue.Full:
-                        continue
-                stages["scan"]["count"] = len(collected_photo_ids)
-                runner.update_step(job["id"], "scan",
-                                   current_file=os.path.basename(path))
+                def photo_cb(photo_id, path):
+                    collected_photo_ids.append(photo_id)
+                    # Abort-aware put: a blocking no-timeout put would wedge the
+                    # scanner forever if the thumbnail consumer died with a full
+                    # queue (its setup can fail before its drain loop starts).
+                    # On abort the item is dropped — the consumer is gone and the
+                    # pipeline is tearing down anyway.
+                    while not _should_abort(abort):
+                        try:
+                            scan_to_thumb.put((photo_id, path), timeout=0.5)
+                            break
+                        except queue.Full:
+                            continue
+                    stages["scan"]["count"] = len(collected_photo_ids)
+                    runner.update_step(job["id"], "scan",
+                                       current_file=os.path.basename(path))
 
-            def status_cb(message):
-                runner.update_step(job["id"], "scan", current_file=message)
-                _emit_progress(
-                    runner, job["id"], stages, "scan", message,
-                )
+                def status_cb(message):
+                    runner.update_step(job["id"], "scan", current_file=message)
+                    _emit_progress(
+                        runner, job["id"], stages, "scan", message,
+                    )
 
-            def cancel_check():
-                return _should_abort(abort) or runner.is_cancelled(job["id"])
+                def cancel_check():
+                    return _should_abort(abort) or runner.is_cancelled(job["id"])
 
-            # Accumulator so multi-folder scans (repair loop, scan-in-place
-            # with sources=[...]) don't rewind the overall progress at each
-            # folder boundary. scan() reports (current, total) local to the
-            # invocation; we fold those into cumulative counters that the
-            # weighted overall bar reads via stages["scan"].
-            scan_acc = {"prior": 0, "last_total": 0}
+                # Accumulator so multi-folder scans (repair loop, scan-in-place
+                # with sources=[...]) don't rewind the overall progress at each
+                # folder boundary. scan() reports (current, total) local to the
+                # invocation; we fold those into cumulative counters that the
+                # weighted overall bar reads via stages["scan"].
+                scan_acc = {"prior": 0, "last_total": 0}
 
-            def progress_cb(current, total):
-                scan_acc["last_total"] = total
-                cum_current = scan_acc["prior"] + current
-                cum_total = scan_acc["prior"] + total
-                stages["scan"]["count"] = cum_current
-                stages["scan"]["total"] = cum_total
-                elapsed = time.time() - job["_start_time"]
-                rate = round(cum_current / max(elapsed, 0.01) * 60, 1)  # files/min
-                remaining = cum_total - cum_current
-                rate_per_sec = cum_current / max(elapsed, 0.01)
-                eta = round(remaining / rate_per_sec) if rate_per_sec > 0 and cum_current >= 10 else None
-                runner.update_step(job["id"], "scan",
-                                   progress={"current": cum_current, "total": cum_total})
-                _emit_progress(
-                    runner, job["id"], stages, "scan", "Scanning photos",
-                    rate=rate,
-                    eta_seconds=eta,
-                )
+                def progress_cb(current, total):
+                    scan_acc["last_total"] = total
+                    cum_current = scan_acc["prior"] + current
+                    cum_total = scan_acc["prior"] + total
+                    stages["scan"]["count"] = cum_current
+                    stages["scan"]["total"] = cum_total
+                    elapsed = time.time() - job["_start_time"]
+                    rate = round(cum_current / max(elapsed, 0.01) * 60, 1)  # files/min
+                    remaining = cum_total - cum_current
+                    rate_per_sec = cum_current / max(elapsed, 0.01)
+                    eta = round(remaining / rate_per_sec) if rate_per_sec > 0 and cum_current >= 10 else None
+                    runner.update_step(job["id"], "scan",
+                                       progress={"current": cum_current, "total": cum_total})
+                    _emit_progress(
+                        runner, job["id"], stages, "scan", "Scanning photos",
+                        rate=rate,
+                        eta_seconds=eta,
+                    )
 
-            def advance_scan_acc():
-                scan_acc["prior"] += scan_acc["last_total"]
-                scan_acc["last_total"] = 0
+                def advance_scan_acc():
+                    scan_acc["prior"] += scan_acc["last_total"]
+                    scan_acc["last_total"] = 0
 
-            # Collection mode: no scan targets, but check whether any
-            # photos in the collection have broken metadata (NULL timestamp
-            # or RAW thumbnail-sized dimensions) that would poison
-            # downstream stages. If so, run a targeted repair scan on just
-            # the affected folders. This is the self-healing path — when
-            # nothing's broken, we keep the historical "Skipped" summary.
-            if skip_scan:
-                coll_photos = thread_db.get_collection_photos(
-                    collection_id, per_page=999999,
-                )
-                # Respect the user's preview-time exclusions: photos removed
-                # from this run must not be rescanned or have their metadata
-                # rewritten as a side effect of repair.
-                in_scope_photos = _filter_excluded(coll_photos)
-                broken = _find_broken_metadata_folders(
-                    thread_db, [p["id"] for p in in_scope_photos],
-                )
-                if not broken:
-                    stages["scan"]["status"] = "skipped"
+                # Collection mode: no scan targets, but check whether any
+                # photos in the collection have broken metadata (NULL timestamp
+                # or RAW thumbnail-sized dimensions) that would poison
+                # downstream stages. If so, run a targeted repair scan on just
+                # the affected folders. This is the self-healing path — when
+                # nothing's broken, we keep the historical "Skipped" summary.
+                if skip_scan:
+                    coll_photos = thread_db.get_collection_photos(
+                        collection_id, per_page=999999,
+                    )
+                    # Respect the user's preview-time exclusions: photos removed
+                    # from this run must not be rescanned or have their metadata
+                    # rewritten as a side effect of repair.
+                    in_scope_photos = _filter_excluded(coll_photos)
+                    broken = _find_broken_metadata_folders(
+                        thread_db, [p["id"] for p in in_scope_photos],
+                    )
+                    if not broken:
+                        stages["scan"]["status"] = "skipped"
+                        runner.update_step(
+                            job["id"], "scan", status="completed",
+                            summary="Skipped (using collection)",
+                        )
+                        _update_stages(runner, job["id"], stages)
+                        scan_to_thumb.put(_SENTINEL)
+                        return
+
+                    total_broken = sum(len(paths) for _, paths in broken)
+                    stages["scan"]["label"] = (
+                        f"Repair metadata ({total_broken} photos)"
+                    )
+                    stages["scan"]["status"] = "running"
                     runner.update_step(
-                        job["id"], "scan", status="completed",
-                        summary="Skipped (using collection)",
+                        job["id"], "scan", status="running",
+                        summary=(f"Repairing {total_broken} photos in "
+                                 f"{len(broken)} folder"
+                                 f"{'s' if len(broken) != 1 else ''}"),
                     )
                     _update_stages(runner, job["id"], stages)
+
+                    # Display-only callback for the repair path: updates the
+                    # scan step's current_file indicator but does NOT enqueue
+                    # into scan_to_thumb. In collection mode thumbnail_stage
+                    # already replays the full collection against the thumb
+                    # cache, so enqueueing here would double-process every
+                    # repaired photo and inflate the thumbnail totals.
+                    def repair_photo_cb(photo_id, path):
+                        runner.update_step(
+                            job["id"], "scan",
+                            current_file=os.path.basename(path),
+                        )
+
+                    unreachable = 0
+                    for folder_path, file_paths in broken:
+                        if not os.path.isdir(folder_path):
+                            log.warning(
+                                "Repair scan skipped for missing folder: %s",
+                                folder_path,
+                            )
+                            unreachable += 1
+                            continue
+                        try:
+                            # restrict_files limits discovery to the known
+                            # broken photos in this folder. Without it, new
+                            # untracked files in the same folder would get
+                            # ingested as a side effect of the repair.
+                            do_scan(
+                                folder_path, thread_db,
+                                progress_callback=progress_cb,
+                                incremental=True,
+                                extract_full_metadata=pipeline_cfg.get(
+                                    "extract_full_metadata", True,
+                                ),
+                                photo_callback=repair_photo_cb,
+                                status_callback=status_cb,
+                                restrict_dirs=[folder_path],
+                                restrict_files=set(file_paths),
+                                vireo_dir=effective_vireo_dir,
+                                thumb_cache_dir=effective_thumb_cache_dir,
+                                cancel_check=cancel_check,
+                            )
+                        except (OSError, RuntimeError) as e:
+                            if str(e) == "scan cancelled" and (
+                                _should_abort(abort) or runner.is_cancelled(job["id"])
+                            ):
+                                abort.set()
+                                stages["scan"]["status"] = "skipped"
+                                runner.update_step(
+                                    job["id"], "scan",
+                                    status="completed",
+                                    summary="Cancelled",
+                                )
+                                break
+                            log.warning(
+                                "Repair scan failed for %s: %s", folder_path, e,
+                            )
+                            unreachable += 1
+                        finally:
+                            advance_scan_acc()
+
+                    if _should_abort(abort) or runner.is_cancelled(job["id"]):
+                        stages["scan"]["status"] = "skipped"
+                        runner.update_step(
+                            job["id"], "scan",
+                            status="completed",
+                            summary="Cancelled",
+                        )
+                        scan_to_thumb.put(_SENTINEL)
+                        return
+
+                    from metadata import scan_metadata_warning
+
+                    summary = f"{total_broken} photos repaired"
+                    if unreachable:
+                        summary += (f", {unreachable} folder"
+                                    f"{'s' if unreachable != 1 else ''} unreachable")
+                    # Mirror the standalone scan/import paths in app.py: append
+                    # the missing-exiftool warning so a repair scan that lost
+                    # metadata reads as degraded, not as a clean success.
+                    metadata_warning = scan_metadata_warning()
+                    if metadata_warning:
+                        summary += f" — {metadata_warning}"
+                    stages["scan"]["status"] = "completed"
+                    runner.update_step(
+                        job["id"], "scan", status="completed", summary=summary,
+                    )
                     scan_to_thumb.put(_SENTINEL)
                     return
 
-                total_broken = sum(len(paths) for _, paths in broken)
-                stages["scan"]["label"] = (
-                    f"Repair metadata ({total_broken} photos)"
-                )
-                stages["scan"]["status"] = "running"
-                runner.update_step(
-                    job["id"], "scan", status="running",
-                    summary=(f"Repairing {total_broken} photos in "
-                             f"{len(broken)} folder"
-                             f"{'s' if len(broken) != 1 else ''}"),
-                )
-                _update_stages(runner, job["id"], stages)
+                # Determine source folder(s)
+                sources = params.sources or ([params.source] if params.source else [])
 
-                # Display-only callback for the repair path: updates the
-                # scan step's current_file indicator but does NOT enqueue
-                # into scan_to_thumb. In collection mode thumbnail_stage
-                # already replays the full collection against the thumb
-                # cache, so enqueueing here would double-process every
-                # repaired photo and inflate the thumbnail totals.
-                def repair_photo_cb(photo_id, path):
-                    runner.update_step(
-                        job["id"], "scan",
-                        current_file=os.path.basename(path),
-                    )
+                if params.destination:
+                    from pathlib import Path
 
-                unreachable = 0
-                for folder_path, file_paths in broken:
-                    if not os.path.isdir(folder_path):
-                        log.warning(
-                            "Repair scan skipped for missing folder: %s",
-                            folder_path,
+                    from ingest import ingest as do_ingest
+
+                    if params.local_processing:
+                        from local_processing import (
+                            format_bytes,
+                            non_duplicate_bytes,
+                            selected_source_files,
+                            storage_plan,
+                            total_file_bytes,
                         )
-                        unreachable += 1
-                        continue
-                    try:
-                        # restrict_files limits discovery to the known
-                        # broken photos in this folder. Without it, new
-                        # untracked files in the same folder would get
-                        # ingested as a side effect of the repair.
-                        do_scan(
-                            folder_path, thread_db,
-                            progress_callback=progress_cb,
-                            incremental=True,
-                            extract_full_metadata=pipeline_cfg.get(
-                                "extract_full_metadata", True,
-                            ),
-                            photo_callback=repair_photo_cb,
-                            status_callback=status_cb,
-                            restrict_dirs=[folder_path],
-                            restrict_files=set(file_paths),
-                            vireo_dir=effective_vireo_dir,
-                            thumb_cache_dir=effective_thumb_cache_dir,
-                            cancel_check=cancel_check,
+                        from move import (
+                            _tracked_destination_ancestor,
+                            _tracked_destination_overlap,
                         )
-                    except (OSError, RuntimeError) as e:
-                        if str(e) == "scan cancelled" and (
-                            _should_abort(abort) or runner.is_cancelled(job["id"])
-                        ):
-                            abort.set()
-                            stages["scan"]["status"] = "skipped"
+
+                        stages["storage"]["status"] = "running"
+                        runner.update_step(job["id"], "storage", status="running")
+                        _update_stages(runner, job["id"], stages)
+
+                        def _bail_storage(msg):
+                            # collection_stage spins on stages["scan"]["status"]
+                            # until it reaches a terminal value, so a storage
+                            # failure that skips scan and ingest entirely must
+                            # mark both as skipped here — otherwise its join()
+                            # blocks the whole pipeline forever.
+                            errors.append(f"[storage] Fatal: {msg}")
+                            stages["storage"]["status"] = "failed"
                             runner.update_step(
-                                job["id"], "scan",
-                                status="completed",
-                                summary="Cancelled",
+                                job["id"], "storage",
+                                status="failed", error=msg,
                             )
-                            break
-                        log.warning(
-                            "Repair scan failed for %s: %s", folder_path, e,
-                        )
-                        unreachable += 1
-                    finally:
-                        advance_scan_acc()
+                            for skipped in ("ingest", "scan"):
+                                stages[skipped]["status"] = "skipped"
+                                runner.update_step(
+                                    job["id"], skipped,
+                                    status="completed", summary="Skipped",
+                                )
+                            abort.set()
+                            scan_to_thumb.put(_SENTINEL)
 
+                        try:
+                            # Reject up front if the archive destination is already
+                            # a Vireo-managed folder (e.g., a repeat import to the
+                            # same archive root). Without this check the pipeline
+                            # would stage everything, complete every processing
+                            # step, and then fail in move_folder's tracked-overlap
+                            # guard — leaving the staged copy stranded under
+                            # ~/.vireo/staging with no way to resume.
+                            tracked = _tracked_destination_overlap(
+                                thread_db, -1, final_destination,
+                            )
+                            if tracked:
+                                _bail_storage(
+                                    f"Archive destination {final_destination} "
+                                    f"overlaps a folder Vireo already manages "
+                                    f"({tracked['path']}). Local processing "
+                                    "imports must land at a new archive folder; "
+                                    "pick a different destination or import "
+                                    "without local processing."
+                                )
+                                return
+
+                            # Also reject when the archive destination would land
+                            # INSIDE an already-tracked folder. db.move_folder_path
+                            # (called by move_folder during archive) only rewrites
+                            # the moved row's path string — it does NOT reparent the
+                            # row under the tracked ancestor. The catalog would end
+                            # up with two unrelated workspace roots whose path
+                            # strings overlap, e.g. /Photos and /Photos/NewShoot,
+                            # silently confusing the folder tree and breaking
+                            # future scans of the ancestor root.
+                            ancestor = _tracked_destination_ancestor(
+                                thread_db, -1, final_destination,
+                            )
+                            if ancestor:
+                                _bail_storage(
+                                    f"Archive destination {final_destination} "
+                                    f"is inside a folder Vireo already manages "
+                                    f"({ancestor['path']}). Pick an archive "
+                                    f"folder outside {ancestor['path']}, or "
+                                    "import without local processing so the "
+                                    "scan can attach to the existing folder."
+                                )
+                                return
+
+                            # Make sure the archive parent exists NOW. Otherwise
+                            # the pipeline would stage and process everything,
+                            # then fail at the final move_folder call when rsync
+                            # tries to write to a missing parent — leaving the
+                            # staged copy stranded under ~/.vireo/staging with no
+                            # archive at the final destination. Nested archive
+                            # targets like /mnt/nas/NewShoot/Photos are the
+                            # common case: the parent /mnt/nas/NewShoot may not
+                            # have been created yet by the user.
+                            archive_parent = os.path.dirname(
+                                os.path.normpath(final_destination),
+                            )
+                            try:
+                                os.makedirs(archive_parent, exist_ok=True)
+                            except OSError as exc:
+                                _bail_storage(
+                                    f"Archive parent {archive_parent} could "
+                                    f"not be created: {exc}. Check that the "
+                                    "destination drive is mounted and writable."
+                                )
+                                return
+
+                            os.makedirs(params.destination, exist_ok=True)
+                            selected_files = selected_source_files(
+                                sources,
+                                params.file_types,
+                                recursive=params.recursive,
+                                exclude_paths=params.exclude_paths,
+                            )
+                            source_bytes = total_file_bytes(selected_files)
+                            plan = storage_plan(
+                                params.destination, source_bytes,
+                                archive_parent=archive_parent,
+                            )
+                            # When skip_duplicates is on, ingest() will hash and
+                            # skip files whose hash is already in the catalog
+                            # OR already seen earlier in this same run before
+                            # writing to staging. The naive byte sum above would
+                            # mark a mostly-duplicate card — or one where the
+                            # same folder appears in `sources` twice — as
+                            # batching-required even though the staging copy
+                            # would fit. Re-check using the duplicate-filtered
+                            # set, but only when the optimistic check failed —
+                            # otherwise we'd hash the entire source set on every
+                            # import. The filter runs even when the catalog is
+                            # empty so intra-run duplicates still collapse.
+                            if (
+                                plan["batching_required"]
+                                and params.skip_duplicates
+                                and selected_files
+                            ):
+                                known_hashes = {
+                                    row["file_hash"] for row in thread_db.conn.execute(
+                                        "SELECT file_hash FROM photos "
+                                        "WHERE file_hash IS NOT NULL"
+                                    )
+                                }
+                                filtered_bytes = non_duplicate_bytes(
+                                    selected_files, known_hashes,
+                                )
+                                if filtered_bytes < source_bytes:
+                                    plan = storage_plan(
+                                        params.destination, filtered_bytes,
+                                        archive_parent=archive_parent,
+                                    )
+                            result["local_processing"] = {
+                                **plan,
+                                "staging_destination": params.destination,
+                                "final_destination": final_destination,
+                            }
+                            if plan["batching_required"]:
+                                # Tell the user which volume came up short — the
+                                # destination running out of room reads as a
+                                # different problem (pick a bigger archive
+                                # drive) than the staging volume running out
+                                # (free space on ~/.vireo or batch later).
+                                if not plan.get("archive_enough", True):
+                                    _bail_storage(
+                                        "Archive destination needs about "
+                                        f"{format_bytes(plan['archive_required_bytes'])}, "
+                                        "but only "
+                                        f"{format_bytes(plan['archive_usable_bytes'] or 0)} "
+                                        f"is free under {archive_parent} after "
+                                        "the free-space reserve. Free space at "
+                                        "the destination or pick a different "
+                                        "archive folder."
+                                    )
+                                else:
+                                    _bail_storage(
+                                        "Local processing needs about "
+                                        f"{format_bytes(plan['required_bytes'])}, but "
+                                        f"only {format_bytes(plan['usable_bytes'])} is "
+                                        "available after keeping local free-space "
+                                        "reserve. This import needs "
+                                        f"{plan['batch_count']} local-processing "
+                                        "batches; automatic batch execution is not "
+                                        "available in this build yet."
+                                    )
+                                return
+                            summary = (
+                                f"{format_bytes(plan['required_bytes'])} needed, "
+                                f"{format_bytes(plan['usable_bytes'])} available"
+                            )
+                            stages["storage"]["status"] = "completed"
+                            runner.update_step(
+                                job["id"], "storage",
+                                status="completed",
+                                summary=summary,
+                            )
+                        except Exception as e:
+                            log.exception("Pipeline local-storage preflight failed")
+                            _bail_storage(str(e))
+                            return
+
+                    # Same accumulator pattern as scan_acc: do_ingest() is called
+                    # once per source folder, with (current, total) local to each
+                    # call. Without accumulation, overall progress rewinds at each
+                    # source boundary.
+                    ingest_acc = {"prior": 0, "last_total": 0}
+
+                    def ingest_cb(current, total, filename):
+                        ingest_acc["last_total"] = total
+                        cum_current = ingest_acc["prior"] + current
+                        cum_total = ingest_acc["prior"] + total
+                        stages["ingest"]["count"] = cum_current
+                        stages["ingest"]["total"] = cum_total
+                        runner.update_step(job["id"], "ingest",
+                                           current_file=filename,
+                                           progress={"current": cum_current, "total": cum_total})
+                        _emit_progress(
+                            runner, job["id"], stages, "ingest", "Importing photos",
+                            current_file=filename,
+                        )
+
+                    def advance_ingest_acc():
+                        ingest_acc["prior"] += ingest_acc["last_total"]
+                        ingest_acc["last_total"] = 0
+
+                if params.destination:
+                    # Copy mode: ingest all sources first, then scan destination
+                    # subfolders that received files.
+                    stages["ingest"]["status"] = "running"
+                    runner.update_step(job["id"], "ingest", status="running")
+                    _update_stages(runner, job["id"], stages)
+
+                    accumulated_hashes: set = set()
+                    all_copied_paths: list = []
+                    all_duplicate_folders: set = set()
+                    total_copied = 0
+                    total_skipped = 0
+                    total_failed = 0
+                    for src_folder in sources:
+                        try:
+                            result_info = do_ingest(
+                                source_dir=src_folder,
+                                destination_dir=params.destination,
+                                db=thread_db,
+                                file_types=params.file_types,
+                                folder_template=params.folder_template,
+                                skip_duplicates=params.skip_duplicates,
+                                progress_callback=ingest_cb,
+                                extra_known_hashes=accumulated_hashes,
+                                skip_paths=params.exclude_paths,
+                                recursive=params.recursive,
+                            )
+                        finally:
+                            advance_ingest_acc()
+                        all_copied_paths.extend(result_info.get("copied_paths", []))
+                        all_duplicate_folders.update(result_info.get("duplicate_folders", []))
+                        total_copied += result_info.get("copied", 0)
+                        total_skipped += result_info.get("skipped_duplicate", 0)
+                        total_failed += result_info.get("failed", 0)
+                        # Collect hashes of files just copied so the next source
+                        # iteration treats them as known even before the DB scan.
+                        if params.skip_duplicates:
+                            import contextlib
+
+                            from scanner import compute_file_hash
+                            for path in result_info.get("copied_paths", []):
+                                with contextlib.suppress(OSError):
+                                    accumulated_hashes.add(compute_file_hash(path))
+
+                    # In local-processing mode, ingest failures must fail the
+                    # ingest stage so archive_stage's "any earlier stage failed"
+                    # gate skips publishing. ingest() catches per-file copy
+                    # errors (unreadable source, disk full mid-card) and returns
+                    # a non-zero ``failed`` count without raising. Without
+                    # propagating that here the archive step would happily move
+                    # the partial staging tree to the user's final destination
+                    # — publishing a partial result that the rest of the
+                    # pipeline would otherwise treat as a successful import.
+                    parts = []
+                    if total_copied:
+                        parts.append(f"{total_copied} copied")
+                    if total_skipped:
+                        parts.append(f"{total_skipped} skipped")
+                    if total_failed:
+                        parts.append(f"{total_failed} failed")
+                    summary = ", ".join(parts) or "0 files"
+                    if params.local_processing and total_failed:
+                        msg = (
+                            f"{total_failed} file"
+                            f"{'s' if total_failed != 1 else ''} failed to copy "
+                            f"during ingest; archive skipped to avoid publishing "
+                            f"a partial result"
+                        )
+                        errors.append(f"[ingest] Fatal: {msg}")
+                        stages["ingest"]["status"] = "failed"
+                        runner.update_step(
+                            job["id"], "ingest",
+                            status="failed",
+                            error=msg,
+                            summary=summary,
+                        )
+                    else:
+                        stages["ingest"]["status"] = "completed"
+                        runner.update_step(
+                            job["id"], "ingest", status="completed",
+                            summary=summary,
+                        )
+                    _update_stages(runner, job["id"], stages)
+
+                    # Scan only the destination subfolders that actually contain
+                    # files we care about, not the entire destination tree. Use
+                    # restrict_dirs so the scanner still roots the folder hierarchy
+                    # at the destination, preserving parent folder links. Include
+                    # folders that received copies AND folders that already hold
+                    # duplicates of the source files — both need to be linked to
+                    # the active workspace. Guard every candidate at this seam:
+                    # scanner._ensure_folder recurses parents until it equals the
+                    # scan root; a non-descendant path would recurse all the way
+                    # to '/', so restrict_dirs must contain only descendants of
+                    # params.destination. ingest() already enforces this, but
+                    # we re-check here to keep the invariant local and obvious.
+                    # Both sides are lexically normalized via os.path.normpath so
+                    # a stored path containing ``..`` can't defeat the check.
+                    import os as _os
+                    dest_p = Path(_os.path.normpath(params.destination))
+
+                    def _under_destination(path: str) -> bool:
+                        return Path(_os.path.normpath(path)).is_relative_to(dest_p)
+
+                    restrict_set: set[str] = set()
+                    if all_copied_paths:
+                        restrict_set.update(
+                            str(Path(p).parent) for p in all_copied_paths
+                            if _under_destination(str(Path(p).parent))
+                        )
+                    restrict_set.update(
+                        f for f in all_duplicate_folders if _under_destination(f)
+                    )
+                    restrict = sorted(restrict_set) if restrict_set else None
+                    # Flip scan to running and reset job progress so status
+                    # events during enumeration don't carry ingest's numbers.
+                    stages["scan"]["status"] = "running"
+                    runner.update_step(job["id"], "scan", status="running")
+                    job["progress"]["current"] = 0
+                    job["progress"]["total"] = 0
+                    _update_stages(runner, job["id"], stages)
+                    # Surface kernel-level enumeration denials (macOS TCC EPERM,
+                    # POSIX EACCES) into job["errors"]. Without this, scanner.scan
+                    # silently skipped the subtree and the scan stage finished as
+                    # "completed" with 0 photos — a black-box outcome the user
+                    # reads as "no photos found here" when the truth is "Vireo
+                    # was denied access". Dedup per path because the walk may
+                    # signal the same dir more than once.
+                    denied_seen: set[str] = set()
+                    def _on_denied(path: str) -> None:
+                        if path in denied_seen:
+                            return
+                        denied_seen.add(path)
+                        errors.append(
+                            f"[scan] PERMISSION_DENIED: {path} — macOS or "
+                            f"filesystem refused enumeration. On macOS open "
+                            f"System Settings → Privacy & Security → Files "
+                            f"and Folders (or Removable/Network Volumes) and "
+                            f"grant Vireo access."
+                        )
+                    scanned_roots.append(params.destination)
+                    do_scan(
+                        params.destination, thread_db,
+                        progress_callback=progress_cb,
+                        incremental=True,
+                        extract_full_metadata=pipeline_cfg.get("extract_full_metadata", True),
+                        photo_callback=photo_cb,
+                        status_callback=status_cb,
+                        restrict_dirs=restrict,
+                        vireo_dir=effective_vireo_dir,
+                        thumb_cache_dir=effective_thumb_cache_dir,
+                        permission_error_callback=_on_denied,
+                        cancel_check=cancel_check,
+                    )
+                else:
+                    # Scan-in-place: scan each source folder independently.
+                    stages["scan"]["status"] = "running"
+                    runner.update_step(job["id"], "scan", status="running")
+                    job["progress"]["current"] = 0
+                    job["progress"]["total"] = 0
+                    _update_stages(runner, job["id"], stages)
+                    # See ingest branch above — same denial-surfacing rationale.
+                    denied_seen: set[str] = set()
+                    def _on_denied(path: str) -> None:
+                        if path in denied_seen:
+                            return
+                        denied_seen.add(path)
+                        errors.append(
+                            f"[scan] PERMISSION_DENIED: {path} — macOS or "
+                            f"filesystem refused enumeration. On macOS open "
+                            f"System Settings → Privacy & Security → Files "
+                            f"and Folders (or Removable/Network Volumes) and "
+                            f"grant Vireo access."
+                        )
+                    for src_folder in sources:
+                        scanned_roots.append(src_folder)
+                        try:
+                            do_scan(
+                                src_folder, thread_db,
+                                progress_callback=progress_cb,
+                                incremental=True,
+                                extract_full_metadata=pipeline_cfg.get("extract_full_metadata", True),
+                                photo_callback=photo_cb,
+                                skip_paths=params.exclude_paths,
+                                status_callback=status_cb,
+                                recursive=params.recursive,
+                                vireo_dir=effective_vireo_dir,
+                                thumb_cache_dir=effective_thumb_cache_dir,
+                                permission_error_callback=_on_denied,
+                                cancel_check=cancel_check,
+                            )
+                        finally:
+                            advance_scan_acc()
                 if _should_abort(abort) or runner.is_cancelled(job["id"]):
                     stages["scan"]["status"] = "skipped"
                     runner.update_step(
-                        job["id"], "scan",
-                        status="completed",
-                        summary="Cancelled",
-                    )
-                    scan_to_thumb.put(_SENTINEL)
-                    return
-
-                from metadata import scan_metadata_warning
-
-                summary = f"{total_broken} photos repaired"
-                if unreachable:
-                    summary += (f", {unreachable} folder"
-                                f"{'s' if unreachable != 1 else ''} unreachable")
-                # Mirror the standalone scan/import paths in app.py: append
-                # the missing-exiftool warning so a repair scan that lost
-                # metadata reads as degraded, not as a clean success.
-                metadata_warning = scan_metadata_warning()
-                if metadata_warning:
-                    summary += f" — {metadata_warning}"
-                stages["scan"]["status"] = "completed"
-                runner.update_step(
-                    job["id"], "scan", status="completed", summary=summary,
-                )
-                scan_to_thumb.put(_SENTINEL)
-                return
-
-            # Determine source folder(s)
-            sources = params.sources or ([params.source] if params.source else [])
-
-            if params.destination:
-                from pathlib import Path
-
-                from ingest import ingest as do_ingest
-
-                if params.local_processing:
-                    from local_processing import (
-                        format_bytes,
-                        non_duplicate_bytes,
-                        selected_source_files,
-                        storage_plan,
-                        total_file_bytes,
-                    )
-                    from move import (
-                        _tracked_destination_ancestor,
-                        _tracked_destination_overlap,
-                    )
-
-                    stages["storage"]["status"] = "running"
-                    runner.update_step(job["id"], "storage", status="running")
-                    _update_stages(runner, job["id"], stages)
-
-                    def _bail_storage(msg):
-                        # collection_stage spins on stages["scan"]["status"]
-                        # until it reaches a terminal value, so a storage
-                        # failure that skips scan and ingest entirely must
-                        # mark both as skipped here — otherwise its join()
-                        # blocks the whole pipeline forever.
-                        errors.append(f"[storage] Fatal: {msg}")
-                        stages["storage"]["status"] = "failed"
-                        runner.update_step(
-                            job["id"], "storage",
-                            status="failed", error=msg,
-                        )
-                        for skipped in ("ingest", "scan"):
-                            stages[skipped]["status"] = "skipped"
-                            runner.update_step(
-                                job["id"], skipped,
-                                status="completed", summary="Skipped",
-                            )
-                        abort.set()
-                        scan_to_thumb.put(_SENTINEL)
-
-                    try:
-                        # Reject up front if the archive destination is already
-                        # a Vireo-managed folder (e.g., a repeat import to the
-                        # same archive root). Without this check the pipeline
-                        # would stage everything, complete every processing
-                        # step, and then fail in move_folder's tracked-overlap
-                        # guard — leaving the staged copy stranded under
-                        # ~/.vireo/staging with no way to resume.
-                        tracked = _tracked_destination_overlap(
-                            thread_db, -1, final_destination,
-                        )
-                        if tracked:
-                            _bail_storage(
-                                f"Archive destination {final_destination} "
-                                f"overlaps a folder Vireo already manages "
-                                f"({tracked['path']}). Local processing "
-                                "imports must land at a new archive folder; "
-                                "pick a different destination or import "
-                                "without local processing."
-                            )
-                            return
-
-                        # Also reject when the archive destination would land
-                        # INSIDE an already-tracked folder. db.move_folder_path
-                        # (called by move_folder during archive) only rewrites
-                        # the moved row's path string — it does NOT reparent the
-                        # row under the tracked ancestor. The catalog would end
-                        # up with two unrelated workspace roots whose path
-                        # strings overlap, e.g. /Photos and /Photos/NewShoot,
-                        # silently confusing the folder tree and breaking
-                        # future scans of the ancestor root.
-                        ancestor = _tracked_destination_ancestor(
-                            thread_db, -1, final_destination,
-                        )
-                        if ancestor:
-                            _bail_storage(
-                                f"Archive destination {final_destination} "
-                                f"is inside a folder Vireo already manages "
-                                f"({ancestor['path']}). Pick an archive "
-                                f"folder outside {ancestor['path']}, or "
-                                "import without local processing so the "
-                                "scan can attach to the existing folder."
-                            )
-                            return
-
-                        # Make sure the archive parent exists NOW. Otherwise
-                        # the pipeline would stage and process everything,
-                        # then fail at the final move_folder call when rsync
-                        # tries to write to a missing parent — leaving the
-                        # staged copy stranded under ~/.vireo/staging with no
-                        # archive at the final destination. Nested archive
-                        # targets like /mnt/nas/NewShoot/Photos are the
-                        # common case: the parent /mnt/nas/NewShoot may not
-                        # have been created yet by the user.
-                        archive_parent = os.path.dirname(
-                            os.path.normpath(final_destination),
-                        )
-                        try:
-                            os.makedirs(archive_parent, exist_ok=True)
-                        except OSError as exc:
-                            _bail_storage(
-                                f"Archive parent {archive_parent} could "
-                                f"not be created: {exc}. Check that the "
-                                "destination drive is mounted and writable."
-                            )
-                            return
-
-                        os.makedirs(params.destination, exist_ok=True)
-                        selected_files = selected_source_files(
-                            sources,
-                            params.file_types,
-                            recursive=params.recursive,
-                            exclude_paths=params.exclude_paths,
-                        )
-                        source_bytes = total_file_bytes(selected_files)
-                        plan = storage_plan(
-                            params.destination, source_bytes,
-                            archive_parent=archive_parent,
-                        )
-                        # When skip_duplicates is on, ingest() will hash and
-                        # skip files whose hash is already in the catalog
-                        # OR already seen earlier in this same run before
-                        # writing to staging. The naive byte sum above would
-                        # mark a mostly-duplicate card — or one where the
-                        # same folder appears in `sources` twice — as
-                        # batching-required even though the staging copy
-                        # would fit. Re-check using the duplicate-filtered
-                        # set, but only when the optimistic check failed —
-                        # otherwise we'd hash the entire source set on every
-                        # import. The filter runs even when the catalog is
-                        # empty so intra-run duplicates still collapse.
-                        if (
-                            plan["batching_required"]
-                            and params.skip_duplicates
-                            and selected_files
-                        ):
-                            known_hashes = {
-                                row["file_hash"] for row in thread_db.conn.execute(
-                                    "SELECT file_hash FROM photos "
-                                    "WHERE file_hash IS NOT NULL"
-                                )
-                            }
-                            filtered_bytes = non_duplicate_bytes(
-                                selected_files, known_hashes,
-                            )
-                            if filtered_bytes < source_bytes:
-                                plan = storage_plan(
-                                    params.destination, filtered_bytes,
-                                    archive_parent=archive_parent,
-                                )
-                        result["local_processing"] = {
-                            **plan,
-                            "staging_destination": params.destination,
-                            "final_destination": final_destination,
-                        }
-                        if plan["batching_required"]:
-                            # Tell the user which volume came up short — the
-                            # destination running out of room reads as a
-                            # different problem (pick a bigger archive
-                            # drive) than the staging volume running out
-                            # (free space on ~/.vireo or batch later).
-                            if not plan.get("archive_enough", True):
-                                _bail_storage(
-                                    "Archive destination needs about "
-                                    f"{format_bytes(plan['archive_required_bytes'])}, "
-                                    "but only "
-                                    f"{format_bytes(plan['archive_usable_bytes'] or 0)} "
-                                    f"is free under {archive_parent} after "
-                                    "the free-space reserve. Free space at "
-                                    "the destination or pick a different "
-                                    "archive folder."
-                                )
-                            else:
-                                _bail_storage(
-                                    "Local processing needs about "
-                                    f"{format_bytes(plan['required_bytes'])}, but "
-                                    f"only {format_bytes(plan['usable_bytes'])} is "
-                                    "available after keeping local free-space "
-                                    "reserve. This import needs "
-                                    f"{plan['batch_count']} local-processing "
-                                    "batches; automatic batch execution is not "
-                                    "available in this build yet."
-                                )
-                            return
-                        summary = (
-                            f"{format_bytes(plan['required_bytes'])} needed, "
-                            f"{format_bytes(plan['usable_bytes'])} available"
-                        )
-                        stages["storage"]["status"] = "completed"
-                        runner.update_step(
-                            job["id"], "storage",
-                            status="completed",
-                            summary=summary,
-                        )
-                    except Exception as e:
-                        log.exception("Pipeline local-storage preflight failed")
-                        _bail_storage(str(e))
-                        return
-
-                # Same accumulator pattern as scan_acc: do_ingest() is called
-                # once per source folder, with (current, total) local to each
-                # call. Without accumulation, overall progress rewinds at each
-                # source boundary.
-                ingest_acc = {"prior": 0, "last_total": 0}
-
-                def ingest_cb(current, total, filename):
-                    ingest_acc["last_total"] = total
-                    cum_current = ingest_acc["prior"] + current
-                    cum_total = ingest_acc["prior"] + total
-                    stages["ingest"]["count"] = cum_current
-                    stages["ingest"]["total"] = cum_total
-                    runner.update_step(job["id"], "ingest",
-                                       current_file=filename,
-                                       progress={"current": cum_current, "total": cum_total})
-                    _emit_progress(
-                        runner, job["id"], stages, "ingest", "Importing photos",
-                        current_file=filename,
-                    )
-
-                def advance_ingest_acc():
-                    ingest_acc["prior"] += ingest_acc["last_total"]
-                    ingest_acc["last_total"] = 0
-
-            if params.destination:
-                # Copy mode: ingest all sources first, then scan destination
-                # subfolders that received files.
-                stages["ingest"]["status"] = "running"
-                runner.update_step(job["id"], "ingest", status="running")
-                _update_stages(runner, job["id"], stages)
-
-                accumulated_hashes: set = set()
-                all_copied_paths: list = []
-                all_duplicate_folders: set = set()
-                total_copied = 0
-                total_skipped = 0
-                total_failed = 0
-                for src_folder in sources:
-                    try:
-                        result_info = do_ingest(
-                            source_dir=src_folder,
-                            destination_dir=params.destination,
-                            db=thread_db,
-                            file_types=params.file_types,
-                            folder_template=params.folder_template,
-                            skip_duplicates=params.skip_duplicates,
-                            progress_callback=ingest_cb,
-                            extra_known_hashes=accumulated_hashes,
-                            skip_paths=params.exclude_paths,
-                            recursive=params.recursive,
-                        )
-                    finally:
-                        advance_ingest_acc()
-                    all_copied_paths.extend(result_info.get("copied_paths", []))
-                    all_duplicate_folders.update(result_info.get("duplicate_folders", []))
-                    total_copied += result_info.get("copied", 0)
-                    total_skipped += result_info.get("skipped_duplicate", 0)
-                    total_failed += result_info.get("failed", 0)
-                    # Collect hashes of files just copied so the next source
-                    # iteration treats them as known even before the DB scan.
-                    if params.skip_duplicates:
-                        import contextlib
-
-                        from scanner import compute_file_hash
-                        for path in result_info.get("copied_paths", []):
-                            with contextlib.suppress(OSError):
-                                accumulated_hashes.add(compute_file_hash(path))
-
-                # In local-processing mode, ingest failures must fail the
-                # ingest stage so archive_stage's "any earlier stage failed"
-                # gate skips publishing. ingest() catches per-file copy
-                # errors (unreadable source, disk full mid-card) and returns
-                # a non-zero ``failed`` count without raising. Without
-                # propagating that here the archive step would happily move
-                # the partial staging tree to the user's final destination
-                # — publishing a partial result that the rest of the
-                # pipeline would otherwise treat as a successful import.
-                parts = []
-                if total_copied:
-                    parts.append(f"{total_copied} copied")
-                if total_skipped:
-                    parts.append(f"{total_skipped} skipped")
-                if total_failed:
-                    parts.append(f"{total_failed} failed")
-                summary = ", ".join(parts) or "0 files"
-                if params.local_processing and total_failed:
-                    msg = (
-                        f"{total_failed} file"
-                        f"{'s' if total_failed != 1 else ''} failed to copy "
-                        f"during ingest; archive skipped to avoid publishing "
-                        f"a partial result"
-                    )
-                    errors.append(f"[ingest] Fatal: {msg}")
-                    stages["ingest"]["status"] = "failed"
-                    runner.update_step(
-                        job["id"], "ingest",
-                        status="failed",
-                        error=msg,
-                        summary=summary,
+                        job["id"], "scan", status="completed", summary="Cancelled",
                     )
                 else:
-                    stages["ingest"]["status"] = "completed"
+                    from metadata import scan_metadata_warning
+
+                    stages["scan"]["status"] = "completed"
+                    # Pipeline scans use scanner.scan exactly like the standalone
+                    # /api/jobs/scan path, so a missing exiftool silently strips
+                    # capture dates, GPS, and camera info here too. Append the
+                    # same warning the standalone path appends.
+                    scan_summary = f"{stages['scan']['count']} photos"
+                    metadata_warning = scan_metadata_warning()
+                    if metadata_warning:
+                        scan_summary += f" — {metadata_warning}"
+                    runner.update_step(job["id"], "scan", status="completed",
+                                       summary=scan_summary)
+            except Exception as e:
+                if str(e) == "scan cancelled" and (
+                    _should_abort(abort) or runner.is_cancelled(job["id"])
+                ):
+                    abort.set()
+                    stages["scan"]["status"] = "skipped"
                     runner.update_step(
-                        job["id"], "ingest", status="completed",
-                        summary=summary,
+                        job["id"], "scan", status="completed", summary="Cancelled",
                     )
+                else:
+                    errors.append(f"[scan] Fatal: {e}")
+                    log.exception("Pipeline scan stage failed")
+                    abort.set()
+                    stages["scan"]["status"] = "failed"
+                    runner.update_step(job["id"], "scan", status="failed", error=str(e))
+            finally:
+                # Invalidate the new-images cache for every root fed to do_scan,
+                # on both success and exception paths. scanner.scan commits photo
+                # rows incrementally, so even a mid-scan failure can leave DB
+                # state that invalidates cached new-image counts. Mirrors the
+                # try/finally in api_job_scan and api_job_import_full.
+                if thread_db is not None and scanned_roots:
+                    from new_images import invalidate_new_images_after_scan
+                    for scanned_root in scanned_roots:
+                        try:
+                            invalidate_new_images_after_scan(thread_db, scanned_root)
+                        except Exception:
+                            log.exception(
+                                "Failed to invalidate new-images cache for %s",
+                                scanned_root,
+                            )
+                scan_to_thumb.put(_SENTINEL)
                 _update_stages(runner, job["id"], stages)
 
-                # Scan only the destination subfolders that actually contain
-                # files we care about, not the entire destination tree. Use
-                # restrict_dirs so the scanner still roots the folder hierarchy
-                # at the destination, preserving parent folder links. Include
-                # folders that received copies AND folders that already hold
-                # duplicates of the source files — both need to be linked to
-                # the active workspace. Guard every candidate at this seam:
-                # scanner._ensure_folder recurses parents until it equals the
-                # scan root; a non-descendant path would recurse all the way
-                # to '/', so restrict_dirs must contain only descendants of
-                # params.destination. ingest() already enforces this, but
-                # we re-check here to keep the invariant local and obvious.
-                # Both sides are lexically normalized via os.path.normpath so
-                # a stored path containing ``..`` can't defeat the check.
-                import os as _os
-                dest_p = Path(_os.path.normpath(params.destination))
+        def collection_stage():
+            """Wait for scan to finish, build collection, signal classifier."""
+            nonlocal collection_id, snapshot_photo_ids
 
-                def _under_destination(path: str) -> bool:
-                    return Path(_os.path.normpath(path)).is_relative_to(dest_p)
+            if skip_scan:
+                collection_ready.set()
+                return
 
-                restrict_set: set[str] = set()
-                if all_copied_paths:
-                    restrict_set.update(
-                        str(Path(p).parent) for p in all_copied_paths
-                        if _under_destination(str(Path(p).parent))
-                    )
-                restrict_set.update(
-                    f for f in all_duplicate_folders if _under_destination(f)
-                )
-                restrict = sorted(restrict_set) if restrict_set else None
-                # Flip scan to running and reset job progress so status
-                # events during enumeration don't carry ingest's numbers.
-                stages["scan"]["status"] = "running"
-                runner.update_step(job["id"], "scan", status="running")
-                job["progress"]["current"] = 0
-                job["progress"]["total"] = 0
-                _update_stages(runner, job["id"], stages)
-                # Surface kernel-level enumeration denials (macOS TCC EPERM,
-                # POSIX EACCES) into job["errors"]. Without this, scanner.scan
-                # silently skipped the subtree and the scan stage finished as
-                # "completed" with 0 photos — a black-box outcome the user
-                # reads as "no photos found here" when the truth is "Vireo
-                # was denied access". Dedup per path because the walk may
-                # signal the same dir more than once.
-                denied_seen: set[str] = set()
-                def _on_denied(path: str) -> None:
-                    if path in denied_seen:
-                        return
-                    denied_seen.add(path)
-                    errors.append(
-                        f"[scan] PERMISSION_DENIED: {path} — macOS or "
-                        f"filesystem refused enumeration. On macOS open "
-                        f"System Settings → Privacy & Security → Files "
-                        f"and Folders (or Removable/Network Volumes) and "
-                        f"grant Vireo access."
-                    )
-                scanned_roots.append(params.destination)
-                do_scan(
-                    params.destination, thread_db,
-                    progress_callback=progress_cb,
-                    incremental=True,
-                    extract_full_metadata=pipeline_cfg.get("extract_full_metadata", True),
-                    photo_callback=photo_cb,
-                    status_callback=status_cb,
-                    restrict_dirs=restrict,
-                    vireo_dir=effective_vireo_dir,
-                    thumb_cache_dir=effective_thumb_cache_dir,
-                    permission_error_callback=_on_denied,
-                    cancel_check=cancel_check,
-                )
-            else:
-                # Scan-in-place: scan each source folder independently.
-                stages["scan"]["status"] = "running"
-                runner.update_step(job["id"], "scan", status="running")
-                job["progress"]["current"] = 0
-                job["progress"]["total"] = 0
-                _update_stages(runner, job["id"], stages)
-                # See ingest branch above — same denial-surfacing rationale.
-                denied_seen: set[str] = set()
-                def _on_denied(path: str) -> None:
-                    if path in denied_seen:
-                        return
-                    denied_seen.add(path)
-                    errors.append(
-                        f"[scan] PERMISSION_DENIED: {path} — macOS or "
-                        f"filesystem refused enumeration. On macOS open "
-                        f"System Settings → Privacy & Security → Files "
-                        f"and Folders (or Removable/Network Volumes) and "
-                        f"grant Vireo access."
-                    )
-                for src_folder in sources:
-                    scanned_roots.append(src_folder)
-                    try:
-                        do_scan(
-                            src_folder, thread_db,
-                            progress_callback=progress_cb,
-                            incremental=True,
-                            extract_full_metadata=pipeline_cfg.get("extract_full_metadata", True),
-                            photo_callback=photo_cb,
-                            skip_paths=params.exclude_paths,
-                            status_callback=status_cb,
-                            recursive=params.recursive,
-                            vireo_dir=effective_vireo_dir,
-                            thumb_cache_dir=effective_thumb_cache_dir,
-                            permission_error_callback=_on_denied,
-                            cancel_check=cancel_check,
-                        )
-                    finally:
-                        advance_scan_acc()
-            if _should_abort(abort) or runner.is_cancelled(job["id"]):
-                stages["scan"]["status"] = "skipped"
-                runner.update_step(
-                    job["id"], "scan", status="completed", summary="Cancelled",
-                )
-            else:
-                from metadata import scan_metadata_warning
-
-                stages["scan"]["status"] = "completed"
-                # Pipeline scans use scanner.scan exactly like the standalone
-                # /api/jobs/scan path, so a missing exiftool silently strips
-                # capture dates, GPS, and camera info here too. Append the
-                # same warning the standalone path appends.
-                scan_summary = f"{stages['scan']['count']} photos"
-                metadata_warning = scan_metadata_warning()
-                if metadata_warning:
-                    scan_summary += f" — {metadata_warning}"
-                runner.update_step(job["id"], "scan", status="completed",
-                                   summary=scan_summary)
-        except Exception as e:
-            if str(e) == "scan cancelled" and (
-                _should_abort(abort) or runner.is_cancelled(job["id"])
-            ):
-                abort.set()
-                stages["scan"]["status"] = "skipped"
-                runner.update_step(
-                    job["id"], "scan", status="completed", summary="Cancelled",
-                )
-            else:
-                errors.append(f"[scan] Fatal: {e}")
-                log.exception("Pipeline scan stage failed")
-                abort.set()
-                stages["scan"]["status"] = "failed"
-                runner.update_step(job["id"], "scan", status="failed", error=str(e))
-        finally:
-            # Invalidate the new-images cache for every root fed to do_scan,
-            # on both success and exception paths. scanner.scan commits photo
-            # rows incrementally, so even a mid-scan failure can leave DB
-            # state that invalidates cached new-image counts. Mirrors the
-            # try/finally in api_job_scan and api_job_import_full.
-            if thread_db is not None and scanned_roots:
-                from new_images import invalidate_new_images_after_scan
-                for scanned_root in scanned_roots:
-                    try:
-                        invalidate_new_images_after_scan(thread_db, scanned_root)
-                    except Exception:
-                        log.exception(
-                            "Failed to invalidate new-images cache for %s",
-                            scanned_root,
-                        )
-            scan_to_thumb.put(_SENTINEL)
-            _update_stages(runner, job["id"], stages)
-
-    def collection_stage():
-        """Wait for scan to finish, build collection, signal classifier."""
-        nonlocal collection_id, snapshot_photo_ids
-
-        if skip_scan:
-            collection_ready.set()
-            return
-
-        # Wait for scanner to complete (don't check abort -- we want the
-        # collection regardless so the user can see scanned photos)
-        while True:
-            if stages["scan"]["status"] in ("completed", "failed", "skipped"):
-                break
-            time.sleep(0.1)
-
-        # Snapshot-scoped runs: resolve the captured file paths to photo IDs
-        # now that the scanner has committed rows, and trim the collection
-        # to exactly that set. A late-arriving file (landed in the folder
-        # after the snapshot) was still scanned — we walk the whole folder —
-        # but must not be classified or scored. Any snapshot path that never
-        # resolved (file was moved/deleted between snapshot and pipeline
-        # run) is logged so an unexpectedly small collection is auditable.
-        if snapshot_paths is not None:
-            resolver_db = Database(db_path)
-            resolver_db.set_active_workspace(workspace_id)
-            # Split each snapshot path into (dirname, basename) and match on
-            # the two columns directly. Concatenating with a hardcoded '/'
-            # would mismatch Windows paths captured via os.path.join, where
-            # both the snapshot and folders.path use backslash separators.
-            pairs = [os.path.split(p) for p in snapshot_paths]
-            resolved: set[int] = set()
-            # 2 placeholders per pair; cap below SQLite's default 999-param
-            # limit (pre-3.32) with headroom.
-            _CHUNK = 400
-            for i in range(0, len(pairs), _CHUNK):
-                chunk = pairs[i : i + _CHUNK]
-                values = ",".join("(?, ?)" for _ in chunk)
-                flat_params = tuple(v for pair in chunk for v in pair)
-                rows = resolver_db.conn.execute(
-                    f"""SELECT p.id
-                          FROM photos p
-                          JOIN folders f ON f.id = p.folder_id
-                         WHERE (f.path, p.filename) IN (VALUES {values})""",
-                    flat_params,
-                ).fetchall()
-                resolved.update(r["id"] for r in rows)
-            snapshot_photo_ids = resolved
-
-            missing = len(snapshot_paths) - len(snapshot_photo_ids)
-            log.info(
-                "pipeline: snapshot %s had %d files, %d ingested, %d missing on disk",
-                params.source_snapshot_id,
-                len(snapshot_paths),
-                len(snapshot_photo_ids),
-                missing,
-            )
-
-            # Filter collected_photo_ids to the snapshot set. collected_photo_ids
-            # is only read by this stage (to build the collection); the thumbnail
-            # queue has already drained it independently.
-            collected_photo_ids[:] = [
-                pid for pid in collected_photo_ids if pid in snapshot_photo_ids
-            ]
-
-        if not collected_photo_ids:
-            collection_ready.set()
-            return
-
-        try:
-            thread_db = Database(db_path)
-            thread_db.set_active_workspace(workspace_id)
-            from datetime import datetime as dt
-
-            name = "Pipeline " + dt.now().strftime("%Y-%m-%d %H:%M")
-            collection_id = thread_db.add_collection(
-                name,
-                json.dumps([{"field": "photo_ids", "value": collected_photo_ids}]),
-            )
-            result["collection_id"] = collection_id
-        except Exception as e:
-            errors.append(f"[collection] Fatal: {e}")
-            log.exception("Pipeline collection stage failed")
-            abort.set()
-        finally:
-            collection_ready.set()
-
-    def thumbnail_stage():
-        stages["thumbnails"]["status"] = "running"
-        runner.update_step(job["id"], "thumbnails", status="running")
-        _update_stages(runner, job["id"], stages)
-        try:
-            from thumbnails import generate_thumbnail
-
-            thread_db = Database(db_path)
-            thread_db.set_active_workspace(workspace_id)
-
-            import config as cfg
-            effective_cfg = thread_db.get_effective_config(cfg.load())
-            thumb_size = effective_cfg.get("display", {}).get("thumbnail_size", 300)
-
-            # Write thumbnails to the configured cache dir so custom
-            # --thumb-dir layouts receive the files the Flask serve
-            # route (reading from app.config["THUMB_CACHE_DIR"]) will
-            # look for. Falls back to <db_dir>/thumbnails only when the
-            # caller passed no explicit override.
-            cache_dir = effective_thumb_cache_dir
-            os.makedirs(cache_dir, exist_ok=True)
-
-            generated = 0
-            skipped = 0
-            failed = 0
-
-            # Mark photos.thumb_path so the dashboard's coverage query
-            # (`thumb_path IS NOT NULL`) reflects each freshly-generated or
-            # already-cached thumbnail. Batched so the writer lock isn't held
-            # per-row under sustained scan throughput.
-            THUMB_PATH_BATCH = 25
-            pending_thumb_paths = []
-
-            def _flush_thumb_paths():
-                if pending_thumb_paths:
-                    thread_db.conn.executemany(
-                        "UPDATE photos SET thumb_path=? WHERE id=?",
-                        pending_thumb_paths,
-                    )
-                    commit_with_retry(thread_db.conn)
-                    pending_thumb_paths.clear()
-
+            # Wait for scanner to complete (don't check abort -- we want the
+            # collection regardless so the user can see scanned photos)
             while True:
-                try:
-                    item = scan_to_thumb.get(timeout=1.0)
-                except queue.Empty:
-                    # Keep draining even if abort is set -- we want thumbnails
-                    # for any photos already scanned. Only stop on sentinel.
-                    if _should_abort(abort) and scan_to_thumb.empty():
-                        break
-                    continue
-                if item is _SENTINEL:
+                if stages["scan"]["status"] in ("completed", "failed", "skipped"):
                     break
-                photo_id, photo_path = item
-                try:
-                    thumb_path = os.path.join(cache_dir, f"{photo_id}.jpg")
-                    already_exists = os.path.exists(thumb_path)
-                    recipe = thread_db.get_photo_edit_recipe(photo_id)
-                    detail_photo = None
-                    if recipe:
-                        detail_photo = thread_db.get_photo(photo_id)
-                        if detail_photo:
-                            folder_row = thread_db.get_folder(detail_photo["folder_id"])
-                            folders = (
-                                {folder_row["id"]: folder_row["path"]}
-                                if folder_row else {}
-                            )
-                            photo_path = _recipe_render_source(
-                                detail_photo,
-                                recipe,
-                                thumb_size,
-                                effective_vireo_dir,
-                                folders,
-                            )
-                            if (
-                                os.path.splitext(photo_path)[1].lower() in _RAW_EXTENSIONS
-                                and _has_current_working_copy_failure(
-                                    detail_photo,
-                                    effective_vireo_dir,
-                                    trust_existing_working_copy=False,
-                                    live_source_path=photo_path,
-                                    folder_path=folders.get(detail_photo["folder_id"]),
-                                )
-                            ):
-                                skipped += 1
-                                continue
-                    recipe_kwargs = {"recipe": recipe} if recipe else {}
-                    result_path = generate_thumbnail(
-                        photo_id,
-                        photo_path,
-                        cache_dir,
-                        size=thumb_size,
-                        **recipe_kwargs,
-                    )
-                    if result_path is None:
-                        failed += 1
-                    elif already_exists:
-                        skipped += 1
-                        pending_thumb_paths.append((f"{photo_id}.jpg", photo_id))
-                    else:
-                        generated += 1
-                        pending_thumb_paths.append((f"{photo_id}.jpg", photo_id))
-                    if len(pending_thumb_paths) >= THUMB_PATH_BATCH:
-                        _flush_thumb_paths()
-                except Exception:
-                    failed += 1
-                    log.debug("Thumbnail failed for photo %s", photo_id)
-                # Include failed in the progress counter so the dashboard
-                # reflects all work attempted, not just successes. Mixed
-                # success/failure must not hide behind a 0/N progress bar.
-                stages["thumbnails"]["count"] = generated + skipped + failed
-                processed = generated + skipped + failed
-                # Use scan count directly regardless of whether scan has
-                # completed yet — this avoids the total staying at 0/? when
-                # the thumbnail worker catches up with scan before scan's
-                # status flips to "completed".
-                scan_total = stages["scan"].get("count", 0)
-                stages["thumbnails"]["total"] = scan_total
-                runner.update_step(job["id"], "thumbnails",
-                                   current_file=os.path.basename(photo_path),
-                                   progress={"current": processed, "total": scan_total})
-                elapsed = time.time() - job["_start_time"]
-                rate = round(processed / max(elapsed, 0.01) * 60, 1)
-                _emit_progress(
-                    runner, job["id"], stages, "thumbnails", "Generating thumbnails",
-                    current_file=os.path.basename(photo_path),
-                    rate=rate,
+                time.sleep(0.1)
+
+            # Snapshot-scoped runs: resolve the captured file paths to photo IDs
+            # now that the scanner has committed rows, and trim the collection
+            # to exactly that set. A late-arriving file (landed in the folder
+            # after the snapshot) was still scanned — we walk the whole folder —
+            # but must not be classified or scored. Any snapshot path that never
+            # resolved (file was moved/deleted between snapshot and pipeline
+            # run) is logged so an unexpectedly small collection is auditable.
+            if snapshot_paths is not None:
+                resolver_db = Database(db_path)
+                resolver_db.set_active_workspace(workspace_id)
+                # Split each snapshot path into (dirname, basename) and match on
+                # the two columns directly. Concatenating with a hardcoded '/'
+                # would mismatch Windows paths captured via os.path.join, where
+                # both the snapshot and folders.path use backslash separators.
+                pairs = [os.path.split(p) for p in snapshot_paths]
+                resolved: set[int] = set()
+                # 2 placeholders per pair; cap below SQLite's default 999-param
+                # limit (pre-3.32) with headroom.
+                _CHUNK = 400
+                for i in range(0, len(pairs), _CHUNK):
+                    chunk = pairs[i : i + _CHUNK]
+                    values = ",".join("(?, ?)" for _ in chunk)
+                    flat_params = tuple(v for pair in chunk for v in pair)
+                    rows = resolver_db.conn.execute(
+                        f"""SELECT p.id
+                              FROM photos p
+                              JOIN folders f ON f.id = p.folder_id
+                             WHERE (f.path, p.filename) IN (VALUES {values})""",
+                        flat_params,
+                    ).fetchall()
+                    resolved.update(r["id"] for r in rows)
+                snapshot_photo_ids = resolved
+
+                missing = len(snapshot_paths) - len(snapshot_photo_ids)
+                log.info(
+                    "pipeline: snapshot %s had %d files, %d ingested, %d missing on disk",
+                    params.source_snapshot_id,
+                    len(snapshot_paths),
+                    len(snapshot_photo_ids),
+                    missing,
                 )
 
-            # Collection mode: the scanner is skipped so the queue above was
-            # empty. Iterate the collection's photos directly — mirrors the
-            # pattern used by previews_stage — so replays against an existing
-            # collection still regenerate any missing thumbs.
-            if skip_scan and collection_id:
-                coll_photos = _filter_excluded(
-                    thread_db.get_collection_photos(collection_id, per_page=999999)
+                # Filter collected_photo_ids to the snapshot set. collected_photo_ids
+                # is only read by this stage (to build the collection); the thumbnail
+                # queue has already drained it independently.
+                collected_photo_ids[:] = [
+                    pid for pid in collected_photo_ids if pid in snapshot_photo_ids
+                ]
+
+            if not collected_photo_ids:
+                collection_ready.set()
+                return
+
+            try:
+                thread_db = Database(db_path)
+                thread_db.set_active_workspace(workspace_id)
+                from datetime import datetime as dt
+
+                name = "Pipeline " + dt.now().strftime("%Y-%m-%d %H:%M")
+                collection_id = thread_db.add_collection(
+                    name,
+                    json.dumps([{"field": "photo_ids", "value": collected_photo_ids}]),
                 )
-                folders = {f["id"]: f["path"] for f in thread_db.get_folder_tree()}
-                total = len(coll_photos)
-                for photo in coll_photos:
-                    if _should_abort(abort):
-                        break
-                    photo_id = photo["id"]
-                    folder_path = folders.get(photo["folder_id"], "")
-                    photo_path = os.path.join(folder_path, photo["filename"])
-                    thumb_path = os.path.join(cache_dir, f"{photo_id}.jpg")
-                    already_exists = os.path.exists(thumb_path)
+                result["collection_id"] = collection_id
+            except Exception as e:
+                errors.append(f"[collection] Fatal: {e}")
+                log.exception("Pipeline collection stage failed")
+                abort.set()
+            finally:
+                collection_ready.set()
+
+        def thumbnail_stage():
+            stages["thumbnails"]["status"] = "running"
+            runner.update_step(job["id"], "thumbnails", status="running")
+            _update_stages(runner, job["id"], stages)
+            try:
+                from thumbnails import generate_thumbnail
+
+                thread_db = Database(db_path)
+                thread_db.set_active_workspace(workspace_id)
+
+                import config as cfg
+                effective_cfg = thread_db.get_effective_config(cfg.load())
+                thumb_size = effective_cfg.get("display", {}).get("thumbnail_size", 300)
+
+                # Write thumbnails to the configured cache dir so custom
+                # --thumb-dir layouts receive the files the Flask serve
+                # route (reading from app.config["THUMB_CACHE_DIR"]) will
+                # look for. Falls back to <db_dir>/thumbnails only when the
+                # caller passed no explicit override.
+                cache_dir = effective_thumb_cache_dir
+                os.makedirs(cache_dir, exist_ok=True)
+
+                generated = 0
+                skipped = 0
+                failed = 0
+
+                # Mark photos.thumb_path so the dashboard's coverage query
+                # (`thumb_path IS NOT NULL`) reflects each freshly-generated or
+                # already-cached thumbnail. Batched so the writer lock isn't held
+                # per-row under sustained scan throughput.
+                THUMB_PATH_BATCH = 25
+                pending_thumb_paths = []
+
+                def _flush_thumb_paths():
+                    if pending_thumb_paths:
+                        thread_db.conn.executemany(
+                            "UPDATE photos SET thumb_path=? WHERE id=?",
+                            pending_thumb_paths,
+                        )
+                        commit_with_retry(thread_db.conn)
+                        pending_thumb_paths.clear()
+
+                while True:
                     try:
+                        item = scan_to_thumb.get(timeout=1.0)
+                    except queue.Empty:
+                        # Keep draining even if abort is set -- we want thumbnails
+                        # for any photos already scanned. Only stop on sentinel.
+                        if _should_abort(abort) and scan_to_thumb.empty():
+                            break
+                        continue
+                    if item is _SENTINEL:
+                        break
+                    photo_id, photo_path = item
+                    try:
+                        thumb_path = os.path.join(cache_dir, f"{photo_id}.jpg")
+                        already_exists = os.path.exists(thumb_path)
                         recipe = thread_db.get_photo_edit_recipe(photo_id)
                         detail_photo = None
                         if recipe:
-                            detail_photo = thread_db.get_photo(photo_id) or photo
-                            photo_path = _recipe_render_source(
-                                detail_photo,
-                                recipe,
-                                thumb_size,
-                                effective_vireo_dir,
-                                folders,
-                            )
-                            if (
-                                os.path.splitext(photo_path)[1].lower() in _RAW_EXTENSIONS
-                                and _has_current_working_copy_failure(
-                                    detail_photo,
-                                    effective_vireo_dir,
-                                    trust_existing_working_copy=False,
-                                    live_source_path=photo_path,
-                                    folder_path=folders.get(detail_photo["folder_id"]),
+                            detail_photo = thread_db.get_photo(photo_id)
+                            if detail_photo:
+                                folder_row = thread_db.get_folder(detail_photo["folder_id"])
+                                folders = (
+                                    {folder_row["id"]: folder_row["path"]}
+                                    if folder_row else {}
                                 )
-                            ):
-                                skipped += 1
-                                continue
+                                photo_path = _recipe_render_source(
+                                    detail_photo,
+                                    recipe,
+                                    thumb_size,
+                                    effective_vireo_dir,
+                                    folders,
+                                )
+                                if (
+                                    os.path.splitext(photo_path)[1].lower() in _RAW_EXTENSIONS
+                                    and _has_current_working_copy_failure(
+                                        detail_photo,
+                                        effective_vireo_dir,
+                                        trust_existing_working_copy=False,
+                                        live_source_path=photo_path,
+                                        folder_path=folders.get(detail_photo["folder_id"]),
+                                    )
+                                ):
+                                    skipped += 1
+                                    continue
                         recipe_kwargs = {"recipe": recipe} if recipe else {}
                         result_path = generate_thumbnail(
                             photo_id,
@@ -1837,14 +1774,20 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     except Exception:
                         failed += 1
                         log.debug("Thumbnail failed for photo %s", photo_id)
+                    # Include failed in the progress counter so the dashboard
+                    # reflects all work attempted, not just successes. Mixed
+                    # success/failure must not hide behind a 0/N progress bar.
                     stages["thumbnails"]["count"] = generated + skipped + failed
-                    stages["thumbnails"]["total"] = total
                     processed = generated + skipped + failed
-                    runner.update_step(
-                        job["id"], "thumbnails",
-                        current_file=os.path.basename(photo_path),
-                        progress={"current": processed, "total": total},
-                    )
+                    # Use scan count directly regardless of whether scan has
+                    # completed yet — this avoids the total staying at 0/? when
+                    # the thumbnail worker catches up with scan before scan's
+                    # status flips to "completed".
+                    scan_total = stages["scan"].get("count", 0)
+                    stages["thumbnails"]["total"] = scan_total
+                    runner.update_step(job["id"], "thumbnails",
+                                       current_file=os.path.basename(photo_path),
+                                       progress={"current": processed, "total": scan_total})
                     elapsed = time.time() - job["_start_time"]
                     rate = round(processed / max(elapsed, 0.01) * 60, 1)
                     _emit_progress(
@@ -1853,1646 +1796,1786 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         rate=rate,
                     )
 
-            # Flush any thumb_path updates from the final partial batch.
-            _flush_thumb_paths()
+                # Collection mode: the scanner is skipped so the queue above was
+                # empty. Iterate the collection's photos directly — mirrors the
+                # pattern used by previews_stage — so replays against an existing
+                # collection still regenerate any missing thumbs.
+                if skip_scan and collection_id:
+                    coll_photos = _filter_excluded(
+                        thread_db.get_collection_photos(collection_id, per_page=999999)
+                    )
+                    folders = {f["id"]: f["path"] for f in thread_db.get_folder_tree()}
+                    total = len(coll_photos)
+                    for photo in coll_photos:
+                        if _should_abort(abort):
+                            break
+                        photo_id = photo["id"]
+                        folder_path = folders.get(photo["folder_id"], "")
+                        photo_path = os.path.join(folder_path, photo["filename"])
+                        thumb_path = os.path.join(cache_dir, f"{photo_id}.jpg")
+                        already_exists = os.path.exists(thumb_path)
+                        try:
+                            recipe = thread_db.get_photo_edit_recipe(photo_id)
+                            detail_photo = None
+                            if recipe:
+                                detail_photo = thread_db.get_photo(photo_id) or photo
+                                photo_path = _recipe_render_source(
+                                    detail_photo,
+                                    recipe,
+                                    thumb_size,
+                                    effective_vireo_dir,
+                                    folders,
+                                )
+                                if (
+                                    os.path.splitext(photo_path)[1].lower() in _RAW_EXTENSIONS
+                                    and _has_current_working_copy_failure(
+                                        detail_photo,
+                                        effective_vireo_dir,
+                                        trust_existing_working_copy=False,
+                                        live_source_path=photo_path,
+                                        folder_path=folders.get(detail_photo["folder_id"]),
+                                    )
+                                ):
+                                    skipped += 1
+                                    continue
+                            recipe_kwargs = {"recipe": recipe} if recipe else {}
+                            result_path = generate_thumbnail(
+                                photo_id,
+                                photo_path,
+                                cache_dir,
+                                size=thumb_size,
+                                **recipe_kwargs,
+                            )
+                            if result_path is None:
+                                failed += 1
+                            elif already_exists:
+                                skipped += 1
+                                pending_thumb_paths.append((f"{photo_id}.jpg", photo_id))
+                            else:
+                                generated += 1
+                                pending_thumb_paths.append((f"{photo_id}.jpg", photo_id))
+                            if len(pending_thumb_paths) >= THUMB_PATH_BATCH:
+                                _flush_thumb_paths()
+                        except Exception:
+                            failed += 1
+                            log.debug("Thumbnail failed for photo %s", photo_id)
+                        stages["thumbnails"]["count"] = generated + skipped + failed
+                        stages["thumbnails"]["total"] = total
+                        processed = generated + skipped + failed
+                        runner.update_step(
+                            job["id"], "thumbnails",
+                            current_file=os.path.basename(photo_path),
+                            progress={"current": processed, "total": total},
+                        )
+                        elapsed = time.time() - job["_start_time"]
+                        rate = round(processed / max(elapsed, 0.01) * 60, 1)
+                        _emit_progress(
+                            runner, job["id"], stages, "thumbnails", "Generating thumbnails",
+                            current_file=os.path.basename(photo_path),
+                            rate=rate,
+                        )
 
-            from thumbnails import format_summary as thumb_summary
-            thumb_result = {"generated": generated, "skipped": skipped, "failed": failed}
-            processed = generated + skipped + failed
-            # Mixed-outcome rollup: any failure flips status to 'failed'.
-            # The summary still shows both counts so partial success is visible,
-            # but status surfaces the problem on the job history list.
-            final_status = "failed" if failed > 0 else "completed"
-            stages["thumbnails"]["status"] = final_status
-            thumb_rollup = (
-                f"[thumbnails] {failed} of {processed} thumbnails failed to generate"
-                if failed > 0 else None
-            )
-            if thumb_rollup:
-                errors.append(thumb_rollup)
-            runner.update_step(job["id"], "thumbnails", status=final_status,
-                               summary=thumb_summary(thumb_result),
-                               error_count=failed,
-                               error=thumb_rollup,
-                               progress={"current": processed, "total": processed})
-            result["stages"]["thumbnails"] = thumb_result
-        except Exception as e:
-            errors.append(f"[thumbnails] Fatal: {e}")
-            log.exception("Pipeline thumbnail stage failed")
-            stages["thumbnails"]["status"] = "failed"
-            runner.update_step(job["id"], "thumbnails", status="failed", error=str(e))
-            # This stage is the sole consumer of scan_to_thumb. Anything
-            # above can raise BEFORE the drain loop (import, Database(),
-            # cfg.load(), os.makedirs) — if we just returned, the scanner
-            # would eventually block forever in put() once the queue fills,
-            # wedging threads["scanner"].join() and leaking a pipeline slot
-            # until restart. Set abort so the scanner stops producing, then
-            # drain whatever is already queued. Stop at the sentinel, or
-            # when the queue stays empty (the sentinel may already have
-            # been consumed by the main loop before a late failure; with
-            # abort set, photo_cb no longer blocks, so breaking on Empty
-            # is safe).
-            abort.set()
-            while True:
-                try:
-                    item = scan_to_thumb.get(timeout=1.0)
-                except queue.Empty:
-                    break
-                if item is _SENTINEL:
-                    break
-        _update_stages(runner, job["id"], stages)
+                # Flush any thumb_path updates from the final partial batch.
+                _flush_thumb_paths()
 
-    def previews_stage():
-        """Generate preview images for browsed photos."""
-        if abort.is_set():
-            stages["previews"]["status"] = "skipped"
-            runner.update_step(job["id"], "previews", status="completed",
-                               summary="Skipped")
-            return
-
-        stages["previews"]["status"] = "running"
-        runner.update_step(job["id"], "previews", status="running")
-        _update_stages(runner, job["id"], stages)
-
-        try:
-            import config as cfg
-            from image_edits import apply_recipe_to_loaded_image
-            from image_loader import load_image
-
-            thread_db = Database(db_path)
-            thread_db.set_active_workspace(workspace_id)
-
-            effective = thread_db.get_effective_config(cfg.load())
-            raw_size = (
-                params.preview_max_size
-                if params.preview_max_size is not None
-                else effective.get("preview_max_size", 1920)
-            )
-            if raw_size == 0:
-                # "Full resolution" — /full redirects to /original, so
-                # there's no size-suffixed file to warm. Skip rather
-                # than produce untracked {id}.jpg files.
-                runner.update_step(
-                    job["id"], "previews", status="completed",
-                    summary="Skipped (preview_max_size=0 → serves originals)",
+                from thumbnails import format_summary as thumb_summary
+                thumb_result = {"generated": generated, "skipped": skipped, "failed": failed}
+                processed = generated + skipped + failed
+                # Mixed-outcome rollup: any failure flips status to 'failed'.
+                # The summary still shows both counts so partial success is visible,
+                # but status surfaces the problem on the job history list.
+                final_status = "failed" if failed > 0 else "completed"
+                stages["thumbnails"]["status"] = final_status
+                thumb_rollup = (
+                    f"[thumbnails] {failed} of {processed} thumbnails failed to generate"
+                    if failed > 0 else None
                 )
-                stages["previews"]["status"] = "completed"
-                return
-            max_size = int(raw_size or 1920)
-            preview_quality = effective.get("preview_quality", 90)
-            # Must match the Flask serve convention — app.py reads, reaps,
-            # and evicts previews under dirname(THUMB_CACHE_DIR)/previews.
-            # Using dirname(db_path) here would, with a custom --thumb-dir,
-            # warm previews (and preview_cache rows) under a root the app
-            # never serves from.
-            base_dir = effective_vireo_dir
-            preview_dir = os.path.join(base_dir, "previews")
-            os.makedirs(preview_dir, exist_ok=True)
+                if thumb_rollup:
+                    errors.append(thumb_rollup)
+                runner.update_step(job["id"], "thumbnails", status=final_status,
+                                   summary=thumb_summary(thumb_result),
+                                   error_count=failed,
+                                   error=thumb_rollup,
+                                   progress={"current": processed, "total": processed})
+                result["stages"]["thumbnails"] = thumb_result
+            except Exception as e:
+                errors.append(f"[thumbnails] Fatal: {e}")
+                log.exception("Pipeline thumbnail stage failed")
+                stages["thumbnails"]["status"] = "failed"
+                runner.update_step(job["id"], "thumbnails", status="failed", error=str(e))
+                # This stage is the sole consumer of scan_to_thumb. Anything
+                # above can raise BEFORE the drain loop (import, Database(),
+                # cfg.load(), os.makedirs) — if we just returned, the scanner
+                # would eventually block forever in put() once the queue fills,
+                # wedging threads["scanner"].join() and leaking a pipeline slot
+                # until restart. Set abort so the scanner stops producing, then
+                # drain whatever is already queued. Stop at the sentinel, or
+                # when the queue stays empty (the sentinel may already have
+                # been consumed by the main loop before a late failure; with
+                # abort set, photo_cb no longer blocks, so breaking on Empty
+                # is safe).
+                abort.set()
+                while True:
+                    try:
+                        item = scan_to_thumb.get(timeout=1.0)
+                    except queue.Empty:
+                        break
+                    if item is _SENTINEL:
+                        break
+            _update_stages(runner, job["id"], stages)
 
-            if collection_id:
-                photos = _filter_excluded(thread_db.get_collection_photos(collection_id, per_page=999999))
-            elif not skip_scan:
-                # Scan ran but produced no photos — skip previews to avoid
-                # unexpectedly processing the entire workspace.
+        def previews_stage():
+            """Generate preview images for browsed photos."""
+            if abort.is_set():
+                stages["previews"]["status"] = "skipped"
                 runner.update_step(job["id"], "previews", status="completed",
-                                   summary="Skipped (no photos scanned)")
-                stages["previews"]["status"] = "completed"
+                                   summary="Skipped")
                 return
-            else:
-                photos = thread_db.get_photos(per_page=999999)
 
-            folders = {f["id"]: f["path"] for f in thread_db.get_folder_tree()}
-            total = len(photos)
-            generated = 0
-            skipped = 0
-            failed = 0
+            stages["previews"]["status"] = "running"
+            runner.update_step(job["id"], "previews", status="running")
+            _update_stages(runner, job["id"], stages)
 
-            for i, photo in enumerate(photos):
-                if _should_abort(abort):
-                    break
-                detail_photo = thread_db.get_photo(photo["id"]) or photo
-                cache_path = os.path.join(preview_dir, f'{photo["id"]}_{max_size}.jpg')
-                recipe = thread_db.get_photo_edit_recipe(photo["id"])
-                if os.path.exists(cache_path):
-                    cache_row = None
-                    with contextlib.suppress(Exception):
-                        cache_row = thread_db.preview_cache_get(photo["id"], max_size)
-                    if recipe and cache_row is None:
-                        with contextlib.suppress(OSError):
-                            os.remove(cache_path)
-                        if os.path.exists(cache_path):
+            try:
+                import config as cfg
+                from image_edits import apply_recipe_to_loaded_image
+                from image_loader import load_image
+
+                thread_db = Database(db_path)
+                thread_db.set_active_workspace(workspace_id)
+
+                effective = thread_db.get_effective_config(cfg.load())
+                raw_size = (
+                    params.preview_max_size
+                    if params.preview_max_size is not None
+                    else effective.get("preview_max_size", 1920)
+                )
+                if raw_size == 0:
+                    # "Full resolution" — /full redirects to /original, so
+                    # there's no size-suffixed file to warm. Skip rather
+                    # than produce untracked {id}.jpg files.
+                    runner.update_step(
+                        job["id"], "previews", status="completed",
+                        summary="Skipped (preview_max_size=0 → serves originals)",
+                    )
+                    stages["previews"]["status"] = "completed"
+                    return
+                max_size = int(raw_size or 1920)
+                preview_quality = effective.get("preview_quality", 90)
+                # Must match the Flask serve convention — app.py reads, reaps,
+                # and evicts previews under dirname(THUMB_CACHE_DIR)/previews.
+                # Using dirname(db_path) here would, with a custom --thumb-dir,
+                # warm previews (and preview_cache rows) under a root the app
+                # never serves from.
+                base_dir = effective_vireo_dir
+                preview_dir = os.path.join(base_dir, "previews")
+                os.makedirs(preview_dir, exist_ok=True)
+
+                if collection_id:
+                    photos = _filter_excluded(thread_db.get_collection_photos(collection_id, per_page=999999))
+                elif not skip_scan:
+                    # Scan ran but produced no photos — skip previews to avoid
+                    # unexpectedly processing the entire workspace.
+                    runner.update_step(job["id"], "previews", status="completed",
+                                       summary="Skipped (no photos scanned)")
+                    stages["previews"]["status"] = "completed"
+                    return
+                else:
+                    photos = thread_db.get_photos(per_page=999999)
+
+                folders = {f["id"]: f["path"] for f in thread_db.get_folder_tree()}
+                total = len(photos)
+                generated = 0
+                skipped = 0
+                failed = 0
+
+                for i, photo in enumerate(photos):
+                    if _should_abort(abort):
+                        break
+                    detail_photo = thread_db.get_photo(photo["id"]) or photo
+                    cache_path = os.path.join(preview_dir, f'{photo["id"]}_{max_size}.jpg')
+                    recipe = thread_db.get_photo_edit_recipe(photo["id"])
+                    if os.path.exists(cache_path):
+                        cache_row = None
+                        with contextlib.suppress(Exception):
+                            cache_row = thread_db.preview_cache_get(photo["id"], max_size)
+                        if recipe and cache_row is None:
+                            with contextlib.suppress(OSError):
+                                os.remove(cache_path)
+                            if os.path.exists(cache_path):
+                                skipped += 1
+                                log.info(
+                                    "Skipping untracked edited preview for photo %s; "
+                                    "existing cache file could not be removed",
+                                    photo["id"],
+                                )
+                                continue
+                        else:
+                            skipped += 1
+                            try:
+                                if cache_row is None:
+                                    thread_db.preview_cache_insert(
+                                        photo["id"],
+                                        max_size,
+                                        os.path.getsize(cache_path),
+                                    )
+                            except Exception:
+                                pass  # photo may have been deleted mid-pipeline
+                            continue
+                    if not os.path.exists(cache_path):
+                        canonical = _recipe_render_source(
+                            detail_photo, recipe, max_size, base_dir, folders,
+                        )
+                        if (
+                            os.path.splitext(canonical)[1].lower() in _RAW_EXTENSIONS
+                            and _has_current_working_copy_failure(
+                                detail_photo,
+                                base_dir,
+                                trust_existing_working_copy=False,
+                                live_source_path=canonical,
+                                folder_path=folders.get(detail_photo["folder_id"]),
+                            )
+                        ):
                             skipped += 1
                             log.info(
-                                "Skipping untracked edited preview for photo %s; "
-                                "existing cache file could not be removed",
+                                "Skipping pipeline preview for photo %s; RAW "
+                                "working-copy extraction already failed for "
+                                "current source mtime",
                                 photo["id"],
                             )
                             continue
-                    else:
-                        skipped += 1
-                        try:
-                            if cache_row is None:
-                                thread_db.preview_cache_insert(
-                                    photo["id"],
-                                    max_size,
-                                    os.path.getsize(cache_path),
+                        load_max_size = (
+                            None if recipe and recipe.get("crop") else max_size
+                        )
+                        img = load_image(canonical, max_size=load_max_size)
+                        if img:
+                            if recipe:
+                                img = apply_recipe_to_loaded_image(
+                                    img, recipe, max_size=max_size,
                                 )
-                        except Exception:
-                            pass  # photo may have been deleted mid-pipeline
-                        continue
-                if not os.path.exists(cache_path):
-                    canonical = _recipe_render_source(
-                        detail_photo, recipe, max_size, base_dir, folders,
-                    )
-                    if (
-                        os.path.splitext(canonical)[1].lower() in _RAW_EXTENSIONS
-                        and _has_current_working_copy_failure(
-                            detail_photo,
-                            base_dir,
-                            trust_existing_working_copy=False,
-                            live_source_path=canonical,
-                            folder_path=folders.get(detail_photo["folder_id"]),
-                        )
-                    ):
-                        skipped += 1
-                        log.info(
-                            "Skipping pipeline preview for photo %s; RAW "
-                            "working-copy extraction already failed for "
-                            "current source mtime",
-                            photo["id"],
-                        )
-                        continue
-                    load_max_size = (
-                        None if recipe and recipe.get("crop") else max_size
-                    )
-                    img = load_image(canonical, max_size=load_max_size)
-                    if img:
-                        if recipe:
-                            img = apply_recipe_to_loaded_image(
-                                img, recipe, max_size=max_size,
+                            # Atomic write: with SLOT_CAP > 1 two pipelines
+                            # processing the same photo can both miss the
+                            # os.path.exists() check above and race here on the
+                            # deterministic {id}_{max_size}.jpg path. A direct
+                            # img.save(cache_path) would interleave/truncate the
+                            # JPEG bytes; tempfile + os.replace makes the visible
+                            # file flip atomically (same pattern as
+                            # thumbnails.generate_thumbnail).
+                            fd, tmp_path = tempfile.mkstemp(
+                                prefix=f'.{photo["id"]}.', suffix=".jpg.tmp",
+                                dir=preview_dir,
                             )
-                        # Atomic write: with SLOT_CAP > 1 two pipelines
-                        # processing the same photo can both miss the
-                        # os.path.exists() check above and race here on the
-                        # deterministic {id}_{max_size}.jpg path. A direct
-                        # img.save(cache_path) would interleave/truncate the
-                        # JPEG bytes; tempfile + os.replace makes the visible
-                        # file flip atomically (same pattern as
-                        # thumbnails.generate_thumbnail).
-                        fd, tmp_path = tempfile.mkstemp(
-                            prefix=f'.{photo["id"]}.', suffix=".jpg.tmp",
-                            dir=preview_dir,
-                        )
-                        os.close(fd)
-                        try:
-                            img.save(tmp_path, format="JPEG", quality=preview_quality)
-                            os.replace(tmp_path, cache_path)
-                        except Exception:
-                            with contextlib.suppress(OSError):
-                                os.unlink(tmp_path)
-                            raise
-                        with contextlib.suppress(Exception):
-                            thread_db.preview_cache_insert(
-                                photo["id"], max_size, os.path.getsize(cache_path),
-                            )
-                        generated += 1
-                    else:
-                        # image_loader already logged the failure at WARNING;
-                        # count it here so it surfaces in the rollup.
-                        failed += 1
+                            os.close(fd)
+                            try:
+                                img.save(tmp_path, format="JPEG", quality=preview_quality)
+                                os.replace(tmp_path, cache_path)
+                            except Exception:
+                                with contextlib.suppress(OSError):
+                                    os.unlink(tmp_path)
+                                raise
+                            with contextlib.suppress(Exception):
+                                thread_db.preview_cache_insert(
+                                    photo["id"], max_size, os.path.getsize(cache_path),
+                                )
+                            generated += 1
+                        else:
+                            # image_loader already logged the failure at WARNING;
+                            # count it here so it surfaces in the rollup.
+                            failed += 1
 
-                stages["previews"]["count"] = i + 1
-                stages["previews"]["total"] = total
-                runner.update_step(job["id"], "previews",
-                                   current_file=photo["filename"],
-                                   progress={"current": i + 1, "total": total})
-                _emit_progress(
-                    runner, job["id"], stages, "previews", "Generating previews",
-                    current_file=photo["filename"],
-                    rate=round(
-                        (i + 1) / max(time.time() - job["_start_time"], 0.01) * 60, 1
-                    ),
+                    stages["previews"]["count"] = i + 1
+                    stages["previews"]["total"] = total
+                    runner.update_step(job["id"], "previews",
+                                       current_file=photo["filename"],
+                                       progress={"current": i + 1, "total": total})
+                    _emit_progress(
+                        runner, job["id"], stages, "previews", "Generating previews",
+                        current_file=photo["filename"],
+                        rate=round(
+                            (i + 1) / max(time.time() - job["_start_time"], 0.01) * 60, 1
+                        ),
+                    )
+
+                # One eviction pass after the stage so preview_cache_max_mb is
+                # enforced even when the pipeline is the only producer (e.g.
+                # first-run ingest). Writes happen per-photo above to avoid
+                # per-row fsyncs.
+                from preview_cache import evict_if_over_quota
+                evict_if_over_quota(thread_db, base_dir)
+
+                result["stages"]["previews"] = {
+                    "generated": generated, "skipped": skipped, "failed": failed, "total": total
+                }
+                final_status = "failed" if failed > 0 else "completed"
+                stages["previews"]["status"] = final_status
+                previews_rollup = (
+                    f"[previews] {failed} of {total} previews failed to generate"
+                    if failed > 0 else None
                 )
+                if previews_rollup:
+                    errors.append(previews_rollup)
+                summary_parts = [f"{generated} generated"]
+                if skipped:
+                    summary_parts.append(f"{skipped} cached")
+                if failed:
+                    summary_parts.append(f"{failed} failed")
+                runner.update_step(job["id"], "previews", status=final_status,
+                                   summary=", ".join(summary_parts),
+                                   error_count=failed,
+                                   error=previews_rollup)
+            except Exception as e:
+                errors.append(f"[previews] Fatal: {e}")
+                log.exception("Pipeline previews stage failed")
+                stages["previews"]["status"] = "failed"
+                runner.update_step(job["id"], "previews", status="failed", error=str(e))
 
-            # One eviction pass after the stage so preview_cache_max_mb is
-            # enforced even when the pipeline is the only producer (e.g.
-            # first-run ingest). Writes happen per-photo above to avoid
-            # per-row fsyncs.
-            from preview_cache import evict_if_over_quota
-            evict_if_over_quota(thread_db, base_dir)
+            _update_stages(runner, job["id"], stages)
 
-            result["stages"]["previews"] = {
-                "generated": generated, "skipped": skipped, "failed": failed, "total": total
-            }
-            final_status = "failed" if failed > 0 else "completed"
-            stages["previews"]["status"] = final_status
-            previews_rollup = (
-                f"[previews] {failed} of {total} previews failed to generate"
-                if failed > 0 else None
+        def _load_model_bundle(active_model, tax, thread_db):
+            """Turn a resolved model spec into a ready-to-use classifier bundle.
+
+            Loads labels for the model and constructs the Classifier/TimmClassifier,
+            translating ONNXRuntime's cryptic missing-weights errors into an
+            actionable "Repair" hint. Called by both the model_loader stage (for
+            the first model) and the classify stage (for each subsequent model in
+            a multi-model run).
+            """
+            from classify_job import (
+                _load_labels,
+                _record_labels_fingerprint,
+                _resolve_label_sources,
             )
-            if previews_rollup:
-                errors.append(previews_rollup)
-            summary_parts = [f"{generated} generated"]
-            if skipped:
-                summary_parts.append(f"{skipped} cached")
-            if failed:
-                summary_parts.append(f"{failed} failed")
-            runner.update_step(job["id"], "previews", status=final_status,
-                               summary=", ".join(summary_parts),
-                               error_count=failed,
-                               error=previews_rollup)
-        except Exception as e:
-            errors.append(f"[previews] Fatal: {e}")
-            log.exception("Pipeline previews stage failed")
-            stages["previews"]["status"] = "failed"
-            runner.update_step(job["id"], "previews", status="failed", error=str(e))
+            from labels_fingerprint import compute_fingerprint
+            from models import _classify_model_state
 
-        _update_stages(runner, job["id"], stages)
+            model_str = active_model["model_str"]
+            weights_path = active_model["weights_path"]
+            model_type = active_model.get("model_type", "bioclip")
+            model_name = active_model["name"]
+            model_is_custom = active_model.get("source") == "custom"
 
-    def _load_model_bundle(active_model, tax, thread_db):
-        """Turn a resolved model spec into a ready-to-use classifier bundle.
-
-        Loads labels for the model and constructs the Classifier/TimmClassifier,
-        translating ONNXRuntime's cryptic missing-weights errors into an
-        actionable "Repair" hint. Called by both the model_loader stage (for
-        the first model) and the classify stage (for each subsequent model in
-        a multi-model run).
-        """
-        from classify_job import (
-            _load_labels,
-            _record_labels_fingerprint,
-            _resolve_label_sources,
-        )
-        from labels_fingerprint import compute_fingerprint
-        from models import _classify_model_state
-
-        model_str = active_model["model_str"]
-        weights_path = active_model["weights_path"]
-        model_type = active_model.get("model_type", "bioclip")
-        model_name = active_model["name"]
-        model_is_custom = active_model.get("source") == "custom"
-
-        labels, use_tol = _load_labels(
-            model_type=model_type,
-            model_str=model_str,
-            labels_file=params.labels_file,
-            labels_files=params.labels_files,
-            db=thread_db,
-        )
-        # Compute a content-addressable fingerprint for the active label set
-        # and record it in the labels_fingerprints sidecar. Kept on the bundle
-        # so classify_stage can pass it to record_classifier_run for each
-        # (detection, model, fingerprint) triple.
-        fp = compute_fingerprint(labels)
-        label_sources = _resolve_label_sources(params, thread_db)
-        _record_labels_fingerprint(thread_db, fp, labels, sources=label_sources)
-
-        # Preflight: validate the on-disk model before handing it to
-        # ONNXRuntime. A stale _check_onnx_downloaded result (e.g. after
-        # the user deleted a .onnx.data file, or the download manifest
-        # changed) would otherwise surface as an opaque ONNXRuntime crash.
-        # "unverified" is accepted here: all files are present, only the
-        # SHA256 cross-check with HuggingFace was skipped (transient network
-        # issue). The lazy verify_if_needed call below will retry the hash
-        # check, and get_models() already treats these as downloaded, so
-        # rejecting them here turns a warning into a hard pipeline failure.
-        files = active_model.get("files", [])
-        if files and weights_path:
-            state = _classify_model_state(weights_path, files)
-            if state not in ("ok", "unverified"):
-                raise RuntimeError(
-                    _incomplete_model_message(model_name, model_is_custom)
-                )
-
-        # Lazy SHA256 verification: for known models (those with an
-        # hf_subdir), hash every LFS file on first load in this process
-        # and compare against HuggingFace's reported SHA256. Catches
-        # silent corruption and truncated downloads that slipped past
-        # hf_hub_download. Result is cached in-process so subsequent
-        # pipeline runs pay zero cost.
-        hf_subdir = active_model.get("hf_subdir")
-        if hf_subdir and not model_is_custom and weights_path:
-            import model_verify
-            try:
-                model_verify.verify_if_needed(
-                    active_model["id"], weights_path, hf_subdir
-                )
-            except model_verify.ModelCorruptError as verify_err:
-                log.warning(
-                    "Lazy verification failed for %s: %s",
-                    active_model["id"], verify_err,
-                )
-                raise RuntimeError(
-                    _incomplete_model_message(model_name, model_is_custom)
-                ) from verify_err
-            except model_verify.VerifyError as verify_err:
-                # Can't reach HF to fetch expected hashes — log and
-                # proceed. This keeps offline pipeline runs working
-                # when the model is already on disk.
-                log.warning(
-                    "Skipping verification for %s (could not fetch "
-                    "expected hashes): %s",
-                    active_model["id"], verify_err,
-                )
-
-        def _construct_classifier():
-            if model_type == "timm":
-                from timm_classifier import TimmClassifier
-                return TimmClassifier(model_str, taxonomy=tax)
-            from classifier import Classifier
-            return Classifier(
-                labels=None if use_tol else labels,
+            labels, use_tol = _load_labels(
+                model_type=model_type,
                 model_str=model_str,
-                pretrained_str=weights_path,
+                labels_file=params.labels_file,
+                labels_files=params.labels_files,
+                db=thread_db,
             )
+            # Compute a content-addressable fingerprint for the active label set
+            # and record it in the labels_fingerprints sidecar. Kept on the bundle
+            # so classify_stage can pass it to record_classifier_run for each
+            # (detection, model, fingerprint) triple.
+            fp = compute_fingerprint(labels)
+            label_sources = _resolve_label_sources(params, thread_db)
+            _record_labels_fingerprint(thread_db, fp, labels, sources=label_sources)
 
-        # Cache key includes the labels fingerprint when use_tol=False because
-        # the Classifier pre-computes text embeddings for the provided labels
-        # at construction time. Two pipelines with the same model but
-        # different labels must NOT share a session. Tree-of-Life mode
-        # (use_tol=True) reads precomputed embeddings from disk and is
-        # label-independent, so the key collapses to a constant.
-        #
-        # The timm key also varies by taxonomy fingerprint: TimmClassifier
-        # captures the taxonomy at construction and resolves common names /
-        # hierarchy from it on every prediction. Reusing a classifier loaded
-        # against a stale taxonomy (or no taxonomy) after a later run
-        # downloads or refreshes one would silently emit predictions
-        # missing the enrichment, so a change in taxonomy must miss the
-        # cache and rebuild.
-        #
-        # The weights fingerprint catches in-place model replacement
-        # (Repair, custom re-register). Without it, a pipeline started
-        # before the old session's idle timer fires would reuse the
-        # stale ONNX session on the new bytes.
-        tax_fp = _taxonomy_fingerprint(tax) if model_type == "timm" else None
-        files = active_model.get("files")
+            # Preflight: validate the on-disk model before handing it to
+            # ONNXRuntime. A stale _check_onnx_downloaded result (e.g. after
+            # the user deleted a .onnx.data file, or the download manifest
+            # changed) would otherwise surface as an opaque ONNXRuntime crash.
+            # "unverified" is accepted here: all files are present, only the
+            # SHA256 cross-check with HuggingFace was skipped (transient network
+            # issue). The lazy verify_if_needed call below will retry the hash
+            # check, and get_models() already treats these as downloaded, so
+            # rejecting them here turns a warning into a hard pipeline failure.
+            files = active_model.get("files", [])
+            if files and weights_path:
+                state = _classify_model_state(weights_path, files)
+                if state not in ("ok", "unverified"):
+                    raise RuntimeError(
+                        _incomplete_model_message(model_name, model_is_custom)
+                    )
 
-        def _build_cache_key(weights_fp):
-            return (
-                "timm" if model_type == "timm" else "bioclip",
-                active_model["id"],
-                model_str,
-                weights_path,
-                "__tol__" if use_tol else fp,
-                tax_fp,
-                weights_fp,
-            )
-
-        cache_key = _build_cache_key(_weights_fingerprint(weights_path, files))
-
-        # _construct_classifier may trigger the ONNX self-heal path
-        # (create_session_with_self_heal) which deletes corrupt weights
-        # and redownloads them inside the factory. That bumps the file
-        # mtime/size, so the pre-load fingerprint baked into ``cache_key``
-        # no longer matches what the *next* pipeline will compute. Rekey
-        # to the post-load fingerprint so the second pipeline hits this
-        # entry instead of loading a duplicate session against the freshly
-        # written bytes.
-        def _post_load_key(_value):
-            return _build_cache_key(_weights_fingerprint(weights_path, files))
-
-        cache_handle = None
-        try:
-            cache_handle = get_default_cache().acquire(
-                cache_key, _construct_classifier,
-                post_load_key=_post_load_key,
-            )
-            clf = cache_handle.__enter__()
-        except Exception as load_err:
-            # ONNXRuntime signals missing external-data with a
-            # "model_path must not be empty" / "Initializer" error. Treat
-            # any load failure as an incomplete-model hint for the user —
-            # but only when we can confirm the on-disk files are actually
-            # bad. A transient ONNX failure (memory pressure, mmap race,
-            # test-suite monkeypatches from another process) should not
-            # permanently mark a healthy install as "Incomplete".
-            if _looks_like_missing_external_data(load_err):
+            # Lazy SHA256 verification: for known models (those with an
+            # hf_subdir), hash every LFS file on first load in this process
+            # and compare against HuggingFace's reported SHA256. Catches
+            # silent corruption and truncated downloads that slipped past
+            # hf_hub_download. Result is cached in-process so subsequent
+            # pipeline runs pay zero cost.
+            hf_subdir = active_model.get("hf_subdir")
+            if hf_subdir and not model_is_custom and weights_path:
                 import model_verify
-
-                files_ok = False
-                hf_subdir = active_model.get("hf_subdir")
-                if (
-                    weights_path
-                    and hf_subdir
-                    and not model_is_custom
-                ):
-                    try:
-                        result = model_verify.verify_model(
-                            weights_path, hf_subdir
-                        )
-                        files_ok = result.ok
-                    except model_verify.VerifyError:
-                        # Network unavailable — can't confirm either way.
-                        # Fall through to the conservative path that writes
-                        # the sentinel so the user sees Repair.
-                        files_ok = False
-
-                if files_ok:
-                    # Files match HF hashes exactly — the ONNX error is
-                    # transient, not corruption. Do NOT write
-                    # .verify_failed; do NOT tell the user to Repair. Just
-                    # re-raise with a retry hint.
+                try:
+                    model_verify.verify_if_needed(
+                        active_model["id"], weights_path, hf_subdir
+                    )
+                except model_verify.ModelCorruptError as verify_err:
                     log.warning(
-                        "ONNXRuntime load failed for %s but on-disk files "
-                        "pass SHA256 verification — treating as transient.",
-                        active_model.get("id", "<unknown>"),
+                        "Lazy verification failed for %s: %s",
+                        active_model["id"], verify_err,
                     )
                     raise RuntimeError(
-                        f"Model '{model_name}' failed to load "
-                        f"(transient ONNXRuntime error). Retry the "
-                        f"pipeline. If this keeps happening, restart Vireo."
-                    ) from load_err
-
-                # Files are bad or unverifiable — write the sentinel so
-                # Settings surfaces the Repair button.
-                if weights_path:
-                    sentinel_path = os.path.join(
-                        weights_path,
-                        model_verify.VERIFY_FAILED_SENTINEL,
-                    )
-                    try:
-                        with open(sentinel_path, "w") as f:
-                            f.write(f"onnx-load-failure: {load_err}\n")
-                    except OSError:
-                        pass
-                raise RuntimeError(
-                    _incomplete_model_message(model_name, model_is_custom)
-                ) from load_err
-            raise
-
-        return {
-            "clf": clf,
-            "_cache_handle": cache_handle,
-            "model_type": model_type,
-            "model_name": model_name,
-            "model_str": model_str,
-            "labels": labels,
-            "labels_fingerprint": fp,
-            "use_tol": use_tol,
-            "active_model": active_model,
-        }
-
-    def model_loader_stage():
-        if params.skip_classify:
-            stages["model_loader"]["status"] = "skipped"
-            runner.update_step(job["id"], "model_loader", status="completed",
-                               summary="Skipped")
-            _update_stages(runner, job["id"], stages)
-            models_ready.set()
-            return
-        stages["model_loader"]["status"] = "running"
-        runner.update_step(job["id"], "model_loader", status="running",
-                           current_file="Resolving model...")
-        _update_stages(runner, job["id"], stages)
-        try:
-
-            thread_db = Database(db_path)
-            thread_db.set_active_workspace(workspace_id)
-
-            if collection_id:
-                candidate_photos = _filter_excluded(
-                    thread_db.get_collection_photos(collection_id, per_page=999999)
-                )
-                photo_ids = [p["id"] for p in candidate_photos]
-                candidate_ids = thread_db.filter_out_wildlife_excluded(photo_ids)
-                if candidate_photos and not candidate_ids:
-                    stages["model_loader"]["status"] = "skipped"
-                    runner.update_step(
-                        job["id"], "model_loader", status="completed",
-                        summary="Skipped (all photos marked not wildlife)",
-                    )
-                    _update_stages(runner, job["id"], stages)
-                    models_ready.set()
-                    return
-
-            # Specs were pre-resolved at job start so step_defs could carry
-            # the model's display name on each `classify:<id>` row. If that
-            # resolution raised, surface the same error here — model_loader
-            # is the stage that owns "no model / bad id" failures.
-            if resolution_error:
-                raise RuntimeError(resolution_error)
-
-            first_name = resolved_specs[0]["name"]
-            runner.update_step(job["id"], "model_loader", current_file=first_name)
-
-            # Download taxonomy if missing/unusable and requested. Mirrors the
-            # availability check used by /api/pipeline/page-init: a 0-byte stub
-            # from an interrupted download "exists" but is not a usable
-            # taxonomy, and the user opted into a download to recover from
-            # exactly that state.
-            from models import get_taxonomy_info
-            from taxonomy import TAXONOMY_JSON_PATH, find_taxonomy_json
-            taxonomy_path = find_taxonomy_json()
-            if params.download_taxonomy and not get_taxonomy_info().get("available"):
-                try:
-                    from taxonomy import download_taxonomy
-                    _emit_progress(
-                        runner, job["id"], stages, "model_loader", "Downloading taxonomy...",
-                    )
-                    # Always write new downloads to the persistent path.
-                    taxonomy_path = TAXONOMY_JSON_PATH
-                    download_taxonomy(taxonomy_path, progress_callback=lambda msg:
-                        _emit_progress(
-                            runner, job["id"], stages, "model_loader", msg,
-                        )
-                    )
-                except Exception as e:
-                    log.warning("Taxonomy download failed, continuing without: %s", e)
-
-            # Taxonomy is shared across every classifier in the run.
-            # Use load_local_taxonomy() so a corrupt persistent file
-            # falls back to the legacy package-dir copy.
-            from taxonomy import load_local_taxonomy
-            tax = load_local_taxonomy()
-            loaded_models["tax"] = tax
-            loaded_models["resolved_specs"] = resolved_specs
-
-            # Load the first classifier so classify_stage can start as soon
-            # as scan completes; any remaining specs are loaded inside
-            # classify_stage so we never hold more than one model in memory.
-            _emit_progress(
-                runner, job["id"], stages, "model_loader", f"Loading {first_name}...",
-            )
-
-            try:
-                bundle = _load_model_bundle(resolved_specs[0], tax, thread_db)
-                loaded_models.update(bundle)
-            except Exception as preload_err:
-                if len(resolved_specs) > 1:
-                    # Other models remain — don't abort the whole pipeline.
+                        _incomplete_model_message(model_name, model_is_custom)
+                    ) from verify_err
+                except model_verify.VerifyError as verify_err:
+                    # Can't reach HF to fetch expected hashes — log and
+                    # proceed. This keeps offline pipeline runs working
+                    # when the model is already on disk.
                     log.warning(
-                        "First model %s failed to load, %d remaining: %s",
-                        first_name, len(resolved_specs) - 1, preload_err,
-                    )
-                    loaded_models["preload_error"] = str(preload_err)
-                else:
-                    # Single model — fatal, let the outer handler abort.
-                    raise
-
-            loaded_models["pending_specs"] = resolved_specs[1:]
-
-            stages["model_loader"]["status"] = "completed"
-            summary = ", ".join(s["name"] for s in resolved_specs)
-            if "preload_error" in loaded_models:
-                summary += f" ({first_name} failed to preload)"
-            runner.update_step(job["id"], "model_loader", status="completed",
-                               summary=summary)
-        except Exception as e:
-            errors.append(f"[model_loader] Fatal: {e}")
-            log.exception("Pipeline model loader stage failed")
-            abort.set()
-            stages["model_loader"]["status"] = "failed"
-            runner.update_step(job["id"], "model_loader", status="failed", error=str(e))
-        finally:
-            models_ready.set()
-            _update_stages(runner, job["id"], stages)
-
-    # Shared state between detect_stage and classify_stage. Written by
-    # detect_stage, consumed by classify_stage. Populated even on early
-    # exit so classify_stage can reason about "detection ran but produced
-    # nothing" vs. "detection never executed".
-    detect_state = {
-        "photos": [],        # list of photo dicts for the collection
-        "folders": {},       # {folder_id: path}
-        "detections": {},    # {photo_id: [detection_dict, ...]}
-        "processed_ids": set(),  # photo_ids whose _detect_batch iteration completed
-        "pre_run_det_ids": {},   # snapshot for reclassify purge
-        "total_detected": 0,
-        "ran": False,        # True once detect_stage's body executed (even if no-op)
-    }
-
-    def detect_stage():
-        """Run MegaDetector across every collection photo once, ahead of any
-        classification. Populates detect_state so each per-model classify
-        step can pull cached detections rather than re-running MegaDetector.
-
-        Splitting detect out (it used to run interleaved with model 1's
-        classify loop) lets users see detection as its own row in the jobs
-        view, and lets a multi-model run amortize one detection pass across
-        every classifier.
-        """
-        collection_ready.wait()
-        models_ready.wait()
-
-        has_models_to_try = (
-            "clf" in loaded_models
-            or loaded_models.get("resolved_specs")
-        )
-        if (
-            params.skip_classify
-            or abort.is_set()
-            or not collection_id
-            or not has_models_to_try
-        ):
-            stages["detect"]["status"] = "skipped"
-            runner.update_step(job["id"], "detect", status="completed",
-                               summary="Skipped")
-            _update_stages(runner, job["id"], stages)
-            return
-
-        stages["detect"]["status"] = "running"
-        # Also mark the aggregate classify stage as running so the pipeline
-        # wizard's "Classify" card (which predates the detect/classify split)
-        # shows activity during the detect pre-pass instead of waiting for
-        # the first per-model classify step to start.
-        stages["classify"]["status"] = "running"
-        runner.update_step(job["id"], "detect", status="running")
-        _update_stages(runner, job["id"], stages)
-
-        try:
-            from classify_job import _BATCH_SIZE, _detect_batch
-
-            thread_db = Database(db_path)
-            thread_db.set_active_workspace(workspace_id)
-
-            photos = _filter_excluded(
-                thread_db.get_collection_photos(collection_id, per_page=999999)
-            )
-            photo_ids = [p["id"] for p in photos]
-            kept_ids = set(thread_db.filter_out_wildlife_excluded(photo_ids))
-            skipped_wildlife = len(photos) - len(kept_ids)
-            if skipped_wildlife:
-                log.info(
-                    "Skipping %d photo(s) marked not wildlife",
-                    skipped_wildlife,
-                )
-            photos = [p for p in photos if p["id"] in kept_ids]
-            folders = {f["id"]: f["path"] for f in thread_db.get_folder_tree()}
-            total = len(photos)
-            detect_state["photos"] = photos
-            detect_state["folders"] = folders
-            detect_state["ran"] = True
-
-            # Reclassify semantics (see prior interleaved implementation for
-            # history): start with an empty already_detected so EVERY photo
-            # is re-detected; snapshot pre-run detection IDs so we can purge
-            # them after this detect pass completes. On a non-reclassify run,
-            # pre-seed already_detected from detector_runs so _detect_batch
-            # reuses rows instead of re-invoking MegaDetector — including
-            # empty-scene photos (box_count=0) which would otherwise be
-            # re-detected forever by a legacy detections-only seed.
-            if params.reclassify:
-                already_detected: set = set()
-                photo_ids_list = [p["id"] for p in photos]
-                pre_run_det_ids: dict = getattr(
-                    thread_db, "get_detection_ids_for_photos", lambda _: {}
-                )(photo_ids_list)
-            else:
-                already_detected = set(
-                    thread_db.get_detector_run_photo_ids("megadetector-v6")
-                )
-                pre_run_det_ids = {}
-            detect_state["pre_run_det_ids"] = pre_run_det_ids
-
-            # Ensure MegaDetector weights only when we actually need fresh
-            # detection work — an offline rerun over already-detected photos
-            # should not trigger a ~300 MB download.
-            needs_fresh_detection = bool(photos) and (
-                params.reclassify
-                or any(p["id"] not in already_detected for p in photos)
-            )
-            if needs_fresh_detection:
-                from detector import ensure_megadetector_weights
-
-                def _dl_progress(phase, current, total_steps):
-                    # Weight download is a sub-phase of detect; don't treat
-                    # its bytes as detect's stage-level counter or the bar
-                    # jumps ahead before any photo has been detected.
-                    _emit_progress(
-                        runner, job["id"], stages, "detect", phase,
+                        "Skipping verification for %s (could not fetch "
+                        "expected hashes): %s",
+                        active_model["id"], verify_err,
                     )
 
-                ensure_megadetector_weights(progress_callback=_dl_progress)
-
-            this_run_detections: dict = detect_state["detections"]
-            processed_ids: set = detect_state["processed_ids"]
-            total_detected = 0
-            start_time = time.time()
-
-            for batch_start in range(0, total, _BATCH_SIZE):
-                if _should_abort(abort):
-                    break
-                batch = photos[batch_start:batch_start + _BATCH_SIZE]
-                batch_idx = batch_start + len(batch)
-
-                stages["detect"]["count"] = batch_idx
-                stages["detect"]["total"] = total
-                _emit_progress(
-                    runner, job["id"], stages, "detect", "Detecting subjects",
-                    rate=round(
-                        batch_idx / max(time.time() - start_time, 0.01) * 60,
-                        1,
-                    ),
-                )
-                runner.update_step(
-                    job["id"], "detect",
-                    progress={"current": batch_idx, "total": total},
+            def _construct_classifier():
+                if model_type == "timm":
+                    from timm_classifier import TimmClassifier
+                    return TimmClassifier(model_str, taxonomy=tax)
+                from classifier import Classifier
+                return Classifier(
+                    labels=None if use_tol else labels,
+                    model_str=model_str,
+                    pretrained_str=weights_path,
                 )
 
-                # GPU serialisation lives inside detector.detect_animals()
-                # — wrapping the whole batch here would hold the semaphore
-                # across DB writes and CPU sharpness/quality work, blocking
-                # a concurrent pipeline's GPU stages on this pipeline's
-                # non-GPU work.
-                det_map, det_count, det_processed = _detect_batch(
-                    batch, folders, runner, job,
-                    params.reclassify, thread_db,
-                    already_detected_ids=already_detected,
-                    cached_detections=None,
+            # Cache key includes the labels fingerprint when use_tol=False because
+            # the Classifier pre-computes text embeddings for the provided labels
+            # at construction time. Two pipelines with the same model but
+            # different labels must NOT share a session. Tree-of-Life mode
+            # (use_tol=True) reads precomputed embeddings from disk and is
+            # label-independent, so the key collapses to a constant.
+            #
+            # The timm key also varies by taxonomy fingerprint: TimmClassifier
+            # captures the taxonomy at construction and resolves common names /
+            # hierarchy from it on every prediction. Reusing a classifier loaded
+            # against a stale taxonomy (or no taxonomy) after a later run
+            # downloads or refreshes one would silently emit predictions
+            # missing the enrichment, so a change in taxonomy must miss the
+            # cache and rebuild.
+            #
+            # The weights fingerprint catches in-place model replacement
+            # (Repair, custom re-register). Without it, a pipeline started
+            # before the old session's idle timer fires would reuse the
+            # stale ONNX session on the new bytes.
+            tax_fp = _taxonomy_fingerprint(tax) if model_type == "timm" else None
+            files = active_model.get("files")
+
+            def _build_cache_key(weights_fp):
+                return (
+                    "timm" if model_type == "timm" else "bioclip",
+                    active_model["id"],
+                    model_str,
+                    weights_path,
+                    "__tol__" if use_tol else fp,
+                    tax_fp,
+                    weights_fp,
                 )
-                total_detected += det_count
-                already_detected.update(det_processed)
-                for pid, dets in det_map.items():
-                    this_run_detections.setdefault(pid, dets)
-                for pid in det_processed:
-                    this_run_detections.setdefault(pid, [])
-                processed_ids.update(det_processed)
 
-            detect_state["total_detected"] = total_detected
-            # The stale-detection purge is DEFERRED to classify_stage and
-            # only fires after the first model successfully classifies.
-            # Deleting the pre-run detection rows here would cascade through
-            # the predictions FK and destroy prior results in the case where
-            # every classifier ends up failing to load — leaving the user
-            # with no detections AND no predictions. See classify_stage for
-            # the actual delete.
+            cache_key = _build_cache_key(_weights_fingerprint(weights_path, files))
 
-            stages["detect"]["status"] = "completed"
-            runner.update_step(
-                job["id"], "detect", status="completed",
-                summary=(
-                    f"{total_detected} animals detected in {total} photos"
-                    if total else "No photos to detect"
-                ),
-            )
-            result["stages"]["detect"] = {
-                "total": total,
-                "detected": total_detected,
-                "processed": len(processed_ids),
-            }
-        except Exception as e:
-            errors.append(f"[detect] Fatal: {e}")
-            log.exception("Pipeline detect stage failed")
-            abort.set()
-            stages["detect"]["status"] = "failed"
-            runner.update_step(job["id"], "detect", status="failed",
-                               error=str(e))
+            # _construct_classifier may trigger the ONNX self-heal path
+            # (create_session_with_self_heal) which deletes corrupt weights
+            # and redownloads them inside the factory. That bumps the file
+            # mtime/size, so the pre-load fingerprint baked into ``cache_key``
+            # no longer matches what the *next* pipeline will compute. Rekey
+            # to the post-load fingerprint so the second pipeline hits this
+            # entry instead of loading a duplicate session against the freshly
+            # written bytes.
+            def _post_load_key(_value):
+                return _build_cache_key(_weights_fingerprint(weights_path, files))
 
-        _update_stages(runner, job["id"], stages)
+            cache_handle = None
+            try:
+                cache_handle = get_default_cache().acquire(
+                    cache_key, _construct_classifier,
+                    post_load_key=_post_load_key,
+                )
+                clf = cache_handle.__enter__()
+            except Exception as load_err:
+                # ONNXRuntime signals missing external-data with a
+                # "model_path must not be empty" / "Initializer" error. Treat
+                # any load failure as an incomplete-model hint for the user —
+                # but only when we can confirm the on-disk files are actually
+                # bad. A transient ONNX failure (memory pressure, mmap race,
+                # test-suite monkeypatches from another process) should not
+                # permanently mark a healthy install as "Incomplete".
+                if _looks_like_missing_external_data(load_err):
+                    import model_verify
 
-    def classify_stage():
-        """Run one classifier per model against the pre-computed detections.
+                    files_ok = False
+                    hf_subdir = active_model.get("hf_subdir")
+                    if (
+                        weights_path
+                        and hf_subdir
+                        and not model_is_custom
+                    ):
+                        try:
+                            result = model_verify.verify_model(
+                                weights_path, hf_subdir
+                            )
+                            files_ok = result.ok
+                        except model_verify.VerifyError:
+                            # Network unavailable — can't confirm either way.
+                            # Fall through to the conservative path that writes
+                            # the sentinel so the user sees Repair.
+                            files_ok = False
 
-        Each model drives its own `classify:<model_id>` step so users see
-        per-model progress, duration, and summary instead of an aggregate.
-        A model that fails to load is marked `failed` on its own row — the
-        run continues with remaining models.
-        """
-        has_models_to_try = (
-            "clf" in loaded_models
-            or loaded_models.get("resolved_specs")
-        )
-        if (
-            params.skip_classify
-            or abort.is_set()
-            or not collection_id
-            or not has_models_to_try
-        ):
-            # Distinguish loader-driven abort (model resolution or preload
-            # failure) from benign skips (skip_classify, user cancellation,
-            # missing collection): rows for the former must surface as
-            # 'failed' so the per-model failure is visible on the job tree
-            # — the whole point of splitting classify into per-model rows.
-            loader_failed = stages["model_loader"]["status"] == "failed"
-            loader_err = next(
-                (e for e in errors if e.startswith("[model_loader] Fatal:")),
-                None,
-            )
-            row_status = "failed" if loader_failed else "completed"
-            row_summary = (
-                "Model load failed" if loader_failed else "Skipped"
-            )
-            stages["classify"]["status"] = (
-                "failed" if loader_failed else "skipped"
-            )
-
-            specs_for_step_ids = loaded_models.get("resolved_specs") or []
-            if specs_for_step_ids:
-                for spec in specs_for_step_ids:
-                    runner.update_step(
-                        job["id"], f"classify:{spec['id']}",
-                        status=row_status, summary=row_summary,
-                        error=loader_err if loader_failed else None,
-                    )
-            else:
-                for mid in (effective_model_ids or ["__unresolved__"]):
-                    runner.update_step(
-                        job["id"], f"classify:{mid}",
-                        status=row_status, summary=row_summary,
-                        error=loader_err if loader_failed else None,
-                    )
-            # model_loader may have already loaded the first classifier
-            # before this early-return path was hit (e.g. abort.is_set()).
-            # Release its cache handle so a same-key reload can be a hit
-            # and idle eviction can reclaim VRAM.
-            _release_classifier_cache_handle(loaded_models)
-            _update_stages(runner, job["id"], stages)
-            return
-
-        stages["classify"]["status"] = "running"
-        _update_stages(runner, job["id"], stages)
-
-        # Track which per-model rows have reached a terminal state so a
-        # fatal error raised by one model doesn't overwrite the status of
-        # already-completed models (P2 from the Codex review). Defined
-        # outside the try so the except handler can read them.
-        completed_step_ids: set = set()
-        failed_step_ids: set = set()
-
-        try:
-            import config as cfg
-            from classify_job import (
-                _BATCH_SIZE,
-                _flush_batch,
-                _prepare_image,
-                _record_batch_classifier_runs,
-                _store_grouped_predictions,
-            )
-
-            thread_db = Database(db_path)
-            thread_db.set_active_workspace(workspace_id)
-
-            user_cfg = thread_db.get_effective_config(cfg.load())
-            grouping_window = user_cfg.get("grouping_window_seconds", 5)
-            similarity_threshold = user_cfg.get("similarity_threshold", 0.85)
-
-            tax = loaded_models["tax"]
-            # Fingerprint for the FIRST model is preloaded by model_loader_stage.
-            # Each subsequent iteration reloads its own bundle (with its own fp)
-            # inside the loop, so we read loaded_models["labels_fingerprint"]
-            # per-spec below rather than capturing a single value here.
-            resolved_specs_local = loaded_models.get("resolved_specs") or [
-                loaded_models["active_model"]
-            ]
-
-            photos = detect_state["photos"]
-            folders = detect_state["folders"]
-            cached_detections = detect_state["detections"]
-            total = len(photos)
-
-            total_predictions_stored = 0
-            total_failed = 0
-            total_skipped_existing = 0
-            # Track unique photo IDs that failed in any model so the rollup
-            # message always produces a valid X-of-N ratio. total_failed sums
-            # per-model failures and can exceed total in multi-model runs.
-            failed_photo_ids: set = set()
-
-            skipped_model_names: list = []
-            models_succeeded = 0
-            # Track photo IDs actually processed by the first successful
-            # model's classify loop so the stale-detection purge is scoped
-            # to reclassified photos only. Using detect_state["processed_ids"]
-            # (all detected photos) would incorrectly delete detections for
-            # photos that weren't reached if the job was aborted mid-classify.
-            first_model_photo_ids: set = set()
-
-            from datetime import datetime as dt
-
-            for spec_idx, active_spec in enumerate(resolved_specs_local):
-                step_id = f"classify:{active_spec['id']}"
-                if _should_abort(abort):
-                    # Anything not yet touched stays pending; mark it skipped
-                    # so the job tree finalizes cleanly.
-                    runner.update_step(job["id"], step_id,
-                                       status="completed",
-                                       summary="Skipped (cancelled)")
-                    continue
-
-                runner.update_step(job["id"], step_id, status="running")
-
-                if spec_idx == 0 and "clf" in loaded_models:
-                    # First model preloaded by model_loader_stage.
-                    clf = loaded_models["clf"]
-                    model_type = loaded_models["model_type"]
-                    model_name = loaded_models["model_name"]
-                else:
-                    # Don't reset stages["classify"]["count"] here — it now
-                    # accumulates real inferences per-photo (Task 3); jumping
-                    # it to spec_idx * total would silently double-count the
-                    # cached hits from prior specs.  total is left at its
-                    # multi-spec value (set by the batch-end push of the
-                    # previous spec, or unchanged on first entry); explicitly
-                    # restate it so the "Loading next model..." event always
-                    # carries the multi-spec total.
-                    stages["classify"]["total"] = total * len(resolved_specs_local)
-                    _emit_progress(
-                        runner, job["id"], stages, "classify", f"Loading {active_spec['name']}...",
-                        step_id=step_id,
-                    )
-                    # Drop the prior model's per-photo payload BEFORE loading
-                    # the next bundle so we don't hold old results + new model
-                    # weights concurrently. Without this, multi-model runs on
-                    # large collections can hit transient OOMs.
-                    with contextlib.suppress(NameError, UnboundLocalError):
-                        raw_results.clear()  # noqa: F821 — bound in prior iter
-                    # Release the previous spec's cache handle so its
-                    # refcount drops and a same-cache-key reload below (or
-                    # in another pipeline) can be a hit. Must happen
-                    # BEFORE popping ``clf`` so we don't lose the only
-                    # reference to the bundle that owns the handle.
-                    _release_classifier_cache_handle(loaded_models)
-                    for k in ("clf", "model_type", "model_name", "model_str",
-                              "labels", "use_tol", "active_model"):
-                        loaded_models.pop(k, None)
-                    clf = None
-                    try:
-                        bundle = _load_model_bundle(active_spec, tax, thread_db)
-                    except Exception as model_err:
+                    if files_ok:
+                        # Files match HF hashes exactly — the ONNX error is
+                        # transient, not corruption. Do NOT write
+                        # .verify_failed; do NOT tell the user to Repair. Just
+                        # re-raise with a retry hint.
                         log.warning(
-                            "Skipping model %s: %s",
-                            active_spec["name"], model_err,
+                            "ONNXRuntime load failed for %s but on-disk files "
+                            "pass SHA256 verification — treating as transient.",
+                            active_model.get("id", "<unknown>"),
                         )
-                        skipped_model_names.append(active_spec["name"])
+                        raise RuntimeError(
+                            f"Model '{model_name}' failed to load "
+                            f"(transient ONNXRuntime error). Retry the "
+                            f"pipeline. If this keeps happening, restart Vireo."
+                        ) from load_err
+
+                    # Files are bad or unverifiable — write the sentinel so
+                    # Settings surfaces the Repair button.
+                    if weights_path:
+                        sentinel_path = os.path.join(
+                            weights_path,
+                            model_verify.VERIFY_FAILED_SENTINEL,
+                        )
+                        try:
+                            with open(sentinel_path, "w") as f:
+                                f.write(f"onnx-load-failure: {load_err}\n")
+                        except OSError:
+                            pass
+                    raise RuntimeError(
+                        _incomplete_model_message(model_name, model_is_custom)
+                    ) from load_err
+                raise
+
+            return {
+                "clf": clf,
+                "_cache_handle": cache_handle,
+                "model_type": model_type,
+                "model_name": model_name,
+                "model_str": model_str,
+                "labels": labels,
+                "labels_fingerprint": fp,
+                "use_tol": use_tol,
+                "active_model": active_model,
+            }
+
+        def model_loader_stage():
+            if params.skip_classify:
+                stages["model_loader"]["status"] = "skipped"
+                runner.update_step(job["id"], "model_loader", status="completed",
+                                   summary="Skipped")
+                _update_stages(runner, job["id"], stages)
+                models_ready.set()
+                return
+            stages["model_loader"]["status"] = "running"
+            runner.update_step(job["id"], "model_loader", status="running",
+                               current_file="Resolving model...")
+            _update_stages(runner, job["id"], stages)
+            try:
+
+                thread_db = Database(db_path)
+                thread_db.set_active_workspace(workspace_id)
+
+                if collection_id:
+                    candidate_photos = _filter_excluded(
+                        thread_db.get_collection_photos(collection_id, per_page=999999)
+                    )
+                    photo_ids = [p["id"] for p in candidate_photos]
+                    candidate_ids = thread_db.filter_out_wildlife_excluded(photo_ids)
+                    if candidate_photos and not candidate_ids:
+                        stages["model_loader"]["status"] = "skipped"
                         runner.update_step(
-                            job["id"], step_id,
-                            status="failed",
-                            error=str(model_err),
-                            summary=f"Failed to load: {model_err}",
+                            job["id"], "model_loader", status="completed",
+                            summary="Skipped (all photos marked not wildlife)",
                         )
-                        failed_step_ids.add(step_id)
-                        continue
-                    loaded_models.update(bundle)
-                    clf = bundle["clf"]
-                    model_type = bundle["model_type"]
-                    model_name = bundle["model_name"]
-
-                # The fingerprint for THIS model's label set — pinned by
-                # model_loader_stage for the first model and by _load_model_bundle
-                # for subsequent ones. Used to key the classifier_runs gate so
-                # a repeat pass over the same (detection, model, fingerprint)
-                # skips work instead of re-running inference. Hoisted above
-                # the reclassify clear so the clear can scope by fingerprint.
-                spec_fp = loaded_models.get("labels_fingerprint", "legacy")
-
-                # The reclassify clear (wipes prior predictions for this
-                # model+fingerprint) is intentionally deferred to just before
-                # _store_grouped_predictions below — clearing here and then
-                # cancelling mid-classify would leave the predictions table
-                # empty for this model with no replacement, erasing the
-                # user's prior classifications instead of preserving them.
-
-                # No photo-level short-circuit: it would hide detections
-                # that newly cross the workspace's detector_confidence
-                # threshold on photos that already had a cached prediction
-                # for some other detection. The per-detection
-                # classifier_runs gate below handles skipping correctly
-                # and still surfaces cached results into raw_results so
-                # grouping sees them.
-                # Pre-flight cache estimate. One indexed query so the UI
-                # can display "~M cached, ~K to classify" before the first
-                # inference runs and ETAs are honest from the start. The
-                # estimate may overcount if a run-key exists but no cached
-                # predictions do (see lines ~2000-2004); the live `cached`
-                # counter reflects actual skips.
-                #
-                # Skipped on reclassify runs (the gate below is bypassed
-                # so every photo is re-inferred regardless of cache state)
-                # and on multi-spec runs (the estimate would only cover
-                # the current spec while ``total`` already spans every
-                # spec, producing a banner that undercounts cache and
-                # overstates remaining work — and since the UI hides the
-                # banner once any photo lands, there's no correction
-                # window). The single-spec case is the common one.
-                if (
-                    not params.reclassify
-                    and len(resolved_specs_local) == 1
-                ):
-                    cached_est = thread_db.count_classifier_runs(
-                        [p["id"] for p in photos],
-                        model_name,
-                        spec_fp,
-                    )
-                    stages["classify"]["cached_estimate"] = (
-                        stages["classify"].get("cached_estimate", 0) + cached_est
-                    )
-                # Set total BEFORE the pre-flight event so the UI's
-                # ``stageTotal - stageCachedEst`` subtraction renders the
-                # real "to classify" count on the first event the user
-                # sees, not 0.
-                stages["classify"]["total"] = total * len(resolved_specs_local)
-                _emit_progress(
-                    runner, job["id"], stages, "classify",
-                    f"Classifying with {active_spec['name']}",
-                    step_id=step_id,
-                )
-                raw_results: list = []
-                failed = 0
-                skipped_existing = 0
-                stages["classify"].setdefault("cached", 0)
-                stages["classify"].setdefault("seen", 0)
-                # Photos that iterated past the inner abort check IN THIS spec.
-                # Used for the per-spec ``runner.update_step`` progress (which
-                # is bounded by ``total``, not the multi-spec stage total) and
-                # for the batch-end rate calc.  Captures every branch — cache
-                # hit, successful inference, no-detection, image decode fail,
-                # inference fail — so spec-level progress reaches ``total`` at
-                # the end of the spec regardless of outcome mix.
-                processed_in_spec = 0
-                start_time = time.time()
-                batch_size = 32  # classification batch granularity
-                inference_batch_size = _BATCH_SIZE
-                inference_batch: list = []
-                has_flushed_in_spec = False
-
-                def _close_pending_inference(inference_batch=inference_batch):
-                    for entry in inference_batch:
-                        with contextlib.suppress(Exception):
-                            entry["img"].close()
-                    inference_batch.clear()
-
-                def _flush_pending_inference(
-                    inference_batch=inference_batch,
-                    raw_results=raw_results,
-                    clf=clf,
-                    model_type=model_type,
-                    model_name=model_name,
-                    spec_fp=spec_fp,
-                ):
-                    nonlocal failed, has_flushed_in_spec
-                    if not inference_batch:
+                        _update_stages(runner, job["id"], stages)
+                        models_ready.set()
                         return
 
-                    pending = list(inference_batch)
-                    inference_batch.clear()
-                    has_flushed_in_spec = True
-                    pre_len = len(raw_results)
-                    # GPU serialisation lives inside _flush_batch around the
-                    # inference call so the DB upserts/result-building afterward
-                    # don't hold the semaphore while the GPU is idle.
-                    n_batch_failed = _flush_batch(
-                        pending, clf, model_type, model_name,
-                        thread_db, raw_results,
+                # Specs were pre-resolved at job start so step_defs could carry
+                # the model's display name on each `classify:<id>` row. If that
+                # resolution raised, surface the same error here — model_loader
+                # is the stage that owns "no model / bad id" failures.
+                if resolution_error:
+                    raise RuntimeError(resolution_error)
+
+                first_name = resolved_specs[0]["name"]
+                runner.update_step(job["id"], "model_loader", current_file=first_name)
+
+                # Download taxonomy if missing/unusable and requested. Mirrors the
+                # availability check used by /api/pipeline/page-init: a 0-byte stub
+                # from an interrupted download "exists" but is not a usable
+                # taxonomy, and the user opted into a download to recover from
+                # exactly that state.
+                from models import get_taxonomy_info
+                from taxonomy import TAXONOMY_JSON_PATH, find_taxonomy_json
+                taxonomy_path = find_taxonomy_json()
+                if params.download_taxonomy and not get_taxonomy_info().get("available"):
+                    try:
+                        from taxonomy import download_taxonomy
+                        _emit_progress(
+                            runner, job["id"], stages, "model_loader", "Downloading taxonomy...",
+                        )
+                        # Always write new downloads to the persistent path.
+                        taxonomy_path = TAXONOMY_JSON_PATH
+                        download_taxonomy(taxonomy_path, progress_callback=lambda msg:
+                            _emit_progress(
+                                runner, job["id"], stages, "model_loader", msg,
+                            )
+                        )
+                    except Exception as e:
+                        log.warning("Taxonomy download failed, continuing without: %s", e)
+
+                # Taxonomy is shared across every classifier in the run.
+                # Use load_local_taxonomy() so a corrupt persistent file
+                # falls back to the legacy package-dir copy.
+                from taxonomy import load_local_taxonomy
+                tax = load_local_taxonomy()
+                loaded_models["tax"] = tax
+                loaded_models["resolved_specs"] = resolved_specs
+
+                # Load the first classifier so classify_stage can start as soon
+                # as scan completes; any remaining specs are loaded inside
+                # classify_stage so we never hold more than one model in memory.
+                _emit_progress(
+                    runner, job["id"], stages, "model_loader", f"Loading {first_name}...",
+                )
+
+                try:
+                    bundle = _load_model_bundle(resolved_specs[0], tax, thread_db)
+                    loaded_models.update(bundle)
+                except Exception as preload_err:
+                    if len(resolved_specs) > 1:
+                        # Other models remain — don't abort the whole pipeline.
+                        log.warning(
+                            "First model %s failed to load, %d remaining: %s",
+                            first_name, len(resolved_specs) - 1, preload_err,
+                        )
+                        loaded_models["preload_error"] = str(preload_err)
+                    else:
+                        # Single model — fatal, let the outer handler abort.
+                        raise
+
+                loaded_models["pending_specs"] = resolved_specs[1:]
+
+                stages["model_loader"]["status"] = "completed"
+                summary = ", ".join(s["name"] for s in resolved_specs)
+                if "preload_error" in loaded_models:
+                    summary += f" ({first_name} failed to preload)"
+                runner.update_step(job["id"], "model_loader", status="completed",
+                                   summary=summary)
+            except Exception as e:
+                errors.append(f"[model_loader] Fatal: {e}")
+                log.exception("Pipeline model loader stage failed")
+                abort.set()
+                stages["model_loader"]["status"] = "failed"
+                runner.update_step(job["id"], "model_loader", status="failed", error=str(e))
+            finally:
+                models_ready.set()
+                _update_stages(runner, job["id"], stages)
+
+        # Shared state between detect_stage and classify_stage. Written by
+        # detect_stage, consumed by classify_stage. Populated even on early
+        # exit so classify_stage can reason about "detection ran but produced
+        # nothing" vs. "detection never executed".
+        detect_state = {
+            "photos": [],        # list of photo dicts for the collection
+            "folders": {},       # {folder_id: path}
+            "detections": {},    # {photo_id: [detection_dict, ...]}
+            "processed_ids": set(),  # photo_ids whose _detect_batch iteration completed
+            "pre_run_det_ids": {},   # snapshot for reclassify purge
+            "total_detected": 0,
+            "ran": False,        # True once detect_stage's body executed (even if no-op)
+        }
+
+        def detect_stage():
+            """Run MegaDetector across every collection photo once, ahead of any
+            classification. Populates detect_state so each per-model classify
+            step can pull cached detections rather than re-running MegaDetector.
+
+            Splitting detect out (it used to run interleaved with model 1's
+            classify loop) lets users see detection as its own row in the jobs
+            view, and lets a multi-model run amortize one detection pass across
+            every classifier.
+            """
+            collection_ready.wait()
+            models_ready.wait()
+
+            has_models_to_try = (
+                "clf" in loaded_models
+                or loaded_models.get("resolved_specs")
+            )
+            if (
+                params.skip_classify
+                or abort.is_set()
+                or not collection_id
+                or not has_models_to_try
+            ):
+                stages["detect"]["status"] = "skipped"
+                runner.update_step(job["id"], "detect", status="completed",
+                                   summary="Skipped")
+                _update_stages(runner, job["id"], stages)
+                return
+
+            stages["detect"]["status"] = "running"
+            # Also mark the aggregate classify stage as running so the pipeline
+            # wizard's "Classify" card (which predates the detect/classify split)
+            # shows activity during the detect pre-pass instead of waiting for
+            # the first per-model classify step to start.
+            stages["classify"]["status"] = "running"
+            runner.update_step(job["id"], "detect", status="running")
+            _update_stages(runner, job["id"], stages)
+
+            try:
+                from classify_job import _BATCH_SIZE, _detect_batch
+
+                thread_db = Database(db_path)
+                thread_db.set_active_workspace(workspace_id)
+
+                photos = _filter_excluded(
+                    thread_db.get_collection_photos(collection_id, per_page=999999)
+                )
+                photo_ids = [p["id"] for p in photos]
+                kept_ids = set(thread_db.filter_out_wildlife_excluded(photo_ids))
+                skipped_wildlife = len(photos) - len(kept_ids)
+                if skipped_wildlife:
+                    log.info(
+                        "Skipping %d photo(s) marked not wildlife",
+                        skipped_wildlife,
                     )
-                    failed += n_batch_failed
+                photos = [p for p in photos if p["id"] in kept_ids]
+                folders = {f["id"]: f["path"] for f in thread_db.get_folder_tree()}
+                total = len(photos)
+                detect_state["photos"] = photos
+                detect_state["folders"] = folders
+                detect_state["ran"] = True
 
-                    successful_det_ids = {
-                        r.get("detection_id") for r in raw_results[pre_len:]
-                    }
-                    if n_batch_failed:
-                        for entry in pending:
-                            if entry.get("detection_id") not in successful_det_ids:
-                                failed_photo_ids.add(entry["photo"]["id"])
-
-                    _record_batch_classifier_runs(
-                        thread_db, pending, model_name, spec_fp, raw_results,
-                        pre_len,
+                # Reclassify semantics (see prior interleaved implementation for
+                # history): start with an empty already_detected so EVERY photo
+                # is re-detected; snapshot pre-run detection IDs so we can purge
+                # them after this detect pass completes. On a non-reclassify run,
+                # pre-seed already_detected from detector_runs so _detect_batch
+                # reuses rows instead of re-invoking MegaDetector — including
+                # empty-scene photos (box_count=0) which would otherwise be
+                # re-detected forever by a legacy detections-only seed.
+                if params.reclassify:
+                    already_detected: set = set()
+                    photo_ids_list = [p["id"] for p in photos]
+                    pre_run_det_ids: dict = getattr(
+                        thread_db, "get_detection_ids_for_photos", lambda _: {}
+                    )(photo_ids_list)
+                else:
+                    already_detected = set(
+                        thread_db.get_detector_run_photo_ids("megadetector-v6")
                     )
+                    pre_run_det_ids = {}
+                detect_state["pre_run_det_ids"] = pre_run_det_ids
 
-                    new_count = len(raw_results) - pre_len
-                    if new_count > 0:
-                        stages["classify"]["count"] = (
-                            stages["classify"].get("count", 0) + new_count
+                # Ensure MegaDetector weights only when we actually need fresh
+                # detection work — an offline rerun over already-detected photos
+                # should not trigger a ~300 MB download.
+                needs_fresh_detection = bool(photos) and (
+                    params.reclassify
+                    or any(p["id"] not in already_detected for p in photos)
+                )
+                if needs_fresh_detection:
+                    from detector import ensure_megadetector_weights
+
+                    def _dl_progress(phase, current, total_steps):
+                        # Weight download is a sub-phase of detect; don't treat
+                        # its bytes as detect's stage-level counter or the bar
+                        # jumps ahead before any photo has been detected.
+                        _emit_progress(
+                            runner, job["id"], stages, "detect", phase,
                         )
 
-                for batch_start in range(0, total, batch_size):
+                    ensure_megadetector_weights(progress_callback=_dl_progress)
+
+                this_run_detections: dict = detect_state["detections"]
+                processed_ids: set = detect_state["processed_ids"]
+                total_detected = 0
+                start_time = time.time()
+
+                for batch_start in range(0, total, _BATCH_SIZE):
                     if _should_abort(abort):
                         break
-                    batch = photos[batch_start:batch_start + batch_size]
+                    batch = photos[batch_start:batch_start + _BATCH_SIZE]
+                    batch_idx = batch_start + len(batch)
 
-                    for photo in batch:
-                        # Per-photo abort check so cancel takes effect within
-                        # one inference (~seconds) instead of waiting for the
-                        # next batch boundary (~32 photos). The outer batch
-                        # loop's check at the top of the next iteration will
-                        # then break out of the batch loop entirely.
+                    stages["detect"]["count"] = batch_idx
+                    stages["detect"]["total"] = total
+                    _emit_progress(
+                        runner, job["id"], stages, "detect", "Detecting subjects",
+                        rate=round(
+                            batch_idx / max(time.time() - start_time, 0.01) * 60,
+                            1,
+                        ),
+                    )
+                    runner.update_step(
+                        job["id"], "detect",
+                        progress={"current": batch_idx, "total": total},
+                    )
+
+                    # GPU serialisation lives inside detector.detect_animals()
+                    # — wrapping the whole batch here would hold the semaphore
+                    # across DB writes and CPU sharpness/quality work, blocking
+                    # a concurrent pipeline's GPU stages on this pipeline's
+                    # non-GPU work.
+                    det_map, det_count, det_processed = _detect_batch(
+                        batch, folders, runner, job,
+                        params.reclassify, thread_db,
+                        already_detected_ids=already_detected,
+                        cached_detections=None,
+                    )
+                    total_detected += det_count
+                    already_detected.update(det_processed)
+                    for pid, dets in det_map.items():
+                        this_run_detections.setdefault(pid, dets)
+                    for pid in det_processed:
+                        this_run_detections.setdefault(pid, [])
+                    processed_ids.update(det_processed)
+
+                detect_state["total_detected"] = total_detected
+                # The stale-detection purge is DEFERRED to classify_stage and
+                # only fires after the first model successfully classifies.
+                # Deleting the pre-run detection rows here would cascade through
+                # the predictions FK and destroy prior results in the case where
+                # every classifier ends up failing to load — leaving the user
+                # with no detections AND no predictions. See classify_stage for
+                # the actual delete.
+
+                stages["detect"]["status"] = "completed"
+                runner.update_step(
+                    job["id"], "detect", status="completed",
+                    summary=(
+                        f"{total_detected} animals detected in {total} photos"
+                        if total else "No photos to detect"
+                    ),
+                )
+                result["stages"]["detect"] = {
+                    "total": total,
+                    "detected": total_detected,
+                    "processed": len(processed_ids),
+                }
+            except Exception as e:
+                errors.append(f"[detect] Fatal: {e}")
+                log.exception("Pipeline detect stage failed")
+                abort.set()
+                stages["detect"]["status"] = "failed"
+                runner.update_step(job["id"], "detect", status="failed",
+                                   error=str(e))
+
+            _update_stages(runner, job["id"], stages)
+
+        def classify_stage():
+            """Run one classifier per model against the pre-computed detections.
+
+            Each model drives its own `classify:<model_id>` step so users see
+            per-model progress, duration, and summary instead of an aggregate.
+            A model that fails to load is marked `failed` on its own row — the
+            run continues with remaining models.
+            """
+            has_models_to_try = (
+                "clf" in loaded_models
+                or loaded_models.get("resolved_specs")
+            )
+            if (
+                params.skip_classify
+                or abort.is_set()
+                or not collection_id
+                or not has_models_to_try
+            ):
+                # Distinguish loader-driven abort (model resolution or preload
+                # failure) from benign skips (skip_classify, user cancellation,
+                # missing collection): rows for the former must surface as
+                # 'failed' so the per-model failure is visible on the job tree
+                # — the whole point of splitting classify into per-model rows.
+                loader_failed = stages["model_loader"]["status"] == "failed"
+                loader_err = next(
+                    (e for e in errors if e.startswith("[model_loader] Fatal:")),
+                    None,
+                )
+                row_status = "failed" if loader_failed else "completed"
+                row_summary = (
+                    "Model load failed" if loader_failed else "Skipped"
+                )
+                stages["classify"]["status"] = (
+                    "failed" if loader_failed else "skipped"
+                )
+
+                specs_for_step_ids = loaded_models.get("resolved_specs") or []
+                if specs_for_step_ids:
+                    for spec in specs_for_step_ids:
+                        runner.update_step(
+                            job["id"], f"classify:{spec['id']}",
+                            status=row_status, summary=row_summary,
+                            error=loader_err if loader_failed else None,
+                        )
+                else:
+                    for mid in (effective_model_ids or ["__unresolved__"]):
+                        runner.update_step(
+                            job["id"], f"classify:{mid}",
+                            status=row_status, summary=row_summary,
+                            error=loader_err if loader_failed else None,
+                        )
+                # model_loader may have already loaded the first classifier
+                # before this early-return path was hit (e.g. abort.is_set()).
+                # Release its cache handle so a same-key reload can be a hit
+                # and idle eviction can reclaim VRAM.
+                _release_classifier_cache_handle(loaded_models)
+                _update_stages(runner, job["id"], stages)
+                return
+
+            stages["classify"]["status"] = "running"
+            _update_stages(runner, job["id"], stages)
+
+            # Track which per-model rows have reached a terminal state so a
+            # fatal error raised by one model doesn't overwrite the status of
+            # already-completed models (P2 from the Codex review). Defined
+            # outside the try so the except handler can read them.
+            completed_step_ids: set = set()
+            failed_step_ids: set = set()
+
+            try:
+                import config as cfg
+                from classify_job import (
+                    _BATCH_SIZE,
+                    _flush_batch,
+                    _prepare_image,
+                    _record_batch_classifier_runs,
+                    _store_grouped_predictions,
+                )
+
+                thread_db = Database(db_path)
+                thread_db.set_active_workspace(workspace_id)
+
+                user_cfg = thread_db.get_effective_config(cfg.load())
+                grouping_window = user_cfg.get("grouping_window_seconds", 5)
+                similarity_threshold = user_cfg.get("similarity_threshold", 0.85)
+
+                tax = loaded_models["tax"]
+                # Fingerprint for the FIRST model is preloaded by model_loader_stage.
+                # Each subsequent iteration reloads its own bundle (with its own fp)
+                # inside the loop, so we read loaded_models["labels_fingerprint"]
+                # per-spec below rather than capturing a single value here.
+                resolved_specs_local = loaded_models.get("resolved_specs") or [
+                    loaded_models["active_model"]
+                ]
+
+                photos = detect_state["photos"]
+                folders = detect_state["folders"]
+                cached_detections = detect_state["detections"]
+                total = len(photos)
+
+                total_predictions_stored = 0
+                total_failed = 0
+                total_skipped_existing = 0
+                # Track unique photo IDs that failed in any model so the rollup
+                # message always produces a valid X-of-N ratio. total_failed sums
+                # per-model failures and can exceed total in multi-model runs.
+                failed_photo_ids: set = set()
+
+                skipped_model_names: list = []
+                models_succeeded = 0
+                # Track photo IDs actually processed by the first successful
+                # model's classify loop so the stale-detection purge is scoped
+                # to reclassified photos only. Using detect_state["processed_ids"]
+                # (all detected photos) would incorrectly delete detections for
+                # photos that weren't reached if the job was aborted mid-classify.
+                first_model_photo_ids: set = set()
+
+                from datetime import datetime as dt
+
+                for spec_idx, active_spec in enumerate(resolved_specs_local):
+                    step_id = f"classify:{active_spec['id']}"
+                    if _should_abort(abort):
+                        # Anything not yet touched stays pending; mark it skipped
+                        # so the job tree finalizes cleanly.
+                        runner.update_step(job["id"], step_id,
+                                           status="completed",
+                                           summary="Skipped (cancelled)")
+                        continue
+
+                    runner.update_step(job["id"], step_id, status="running")
+
+                    if spec_idx == 0 and "clf" in loaded_models:
+                        # First model preloaded by model_loader_stage.
+                        clf = loaded_models["clf"]
+                        model_type = loaded_models["model_type"]
+                        model_name = loaded_models["model_name"]
+                    else:
+                        # Don't reset stages["classify"]["count"] here — it now
+                        # accumulates real inferences per-photo (Task 3); jumping
+                        # it to spec_idx * total would silently double-count the
+                        # cached hits from prior specs.  total is left at its
+                        # multi-spec value (set by the batch-end push of the
+                        # previous spec, or unchanged on first entry); explicitly
+                        # restate it so the "Loading next model..." event always
+                        # carries the multi-spec total.
+                        stages["classify"]["total"] = total * len(resolved_specs_local)
+                        _emit_progress(
+                            runner, job["id"], stages, "classify", f"Loading {active_spec['name']}...",
+                            step_id=step_id,
+                        )
+                        # Drop the prior model's per-photo payload BEFORE loading
+                        # the next bundle so we don't hold old results + new model
+                        # weights concurrently. Without this, multi-model runs on
+                        # large collections can hit transient OOMs.
+                        with contextlib.suppress(NameError, UnboundLocalError):
+                            raw_results.clear()  # noqa: F821 — bound in prior iter
+                        # Release the previous spec's cache handle so its
+                        # refcount drops and a same-cache-key reload below (or
+                        # in another pipeline) can be a hit. Must happen
+                        # BEFORE popping ``clf`` so we don't lose the only
+                        # reference to the bundle that owns the handle.
+                        _release_classifier_cache_handle(loaded_models)
+                        for k in ("clf", "model_type", "model_name", "model_str",
+                                  "labels", "use_tol", "active_model"):
+                            loaded_models.pop(k, None)
+                        clf = None
+                        try:
+                            bundle = _load_model_bundle(active_spec, tax, thread_db)
+                        except Exception as model_err:
+                            log.warning(
+                                "Skipping model %s: %s",
+                                active_spec["name"], model_err,
+                            )
+                            skipped_model_names.append(active_spec["name"])
+                            runner.update_step(
+                                job["id"], step_id,
+                                status="failed",
+                                error=str(model_err),
+                                summary=f"Failed to load: {model_err}",
+                            )
+                            failed_step_ids.add(step_id)
+                            continue
+                        loaded_models.update(bundle)
+                        clf = bundle["clf"]
+                        model_type = bundle["model_type"]
+                        model_name = bundle["model_name"]
+
+                    # The fingerprint for THIS model's label set — pinned by
+                    # model_loader_stage for the first model and by _load_model_bundle
+                    # for subsequent ones. Used to key the classifier_runs gate so
+                    # a repeat pass over the same (detection, model, fingerprint)
+                    # skips work instead of re-running inference. Hoisted above
+                    # the reclassify clear so the clear can scope by fingerprint.
+                    spec_fp = loaded_models.get("labels_fingerprint", "legacy")
+
+                    # The reclassify clear (wipes prior predictions for this
+                    # model+fingerprint) is intentionally deferred to just before
+                    # _store_grouped_predictions below — clearing here and then
+                    # cancelling mid-classify would leave the predictions table
+                    # empty for this model with no replacement, erasing the
+                    # user's prior classifications instead of preserving them.
+
+                    # No photo-level short-circuit: it would hide detections
+                    # that newly cross the workspace's detector_confidence
+                    # threshold on photos that already had a cached prediction
+                    # for some other detection. The per-detection
+                    # classifier_runs gate below handles skipping correctly
+                    # and still surfaces cached results into raw_results so
+                    # grouping sees them.
+                    # Pre-flight cache estimate. One indexed query so the UI
+                    # can display "~M cached, ~K to classify" before the first
+                    # inference runs and ETAs are honest from the start. The
+                    # estimate may overcount if a run-key exists but no cached
+                    # predictions do (see lines ~2000-2004); the live `cached`
+                    # counter reflects actual skips.
+                    #
+                    # Skipped on reclassify runs (the gate below is bypassed
+                    # so every photo is re-inferred regardless of cache state)
+                    # and on multi-spec runs (the estimate would only cover
+                    # the current spec while ``total`` already spans every
+                    # spec, producing a banner that undercounts cache and
+                    # overstates remaining work — and since the UI hides the
+                    # banner once any photo lands, there's no correction
+                    # window). The single-spec case is the common one.
+                    if (
+                        not params.reclassify
+                        and len(resolved_specs_local) == 1
+                    ):
+                        cached_est = thread_db.count_classifier_runs(
+                            [p["id"] for p in photos],
+                            model_name,
+                            spec_fp,
+                        )
+                        stages["classify"]["cached_estimate"] = (
+                            stages["classify"].get("cached_estimate", 0) + cached_est
+                        )
+                    # Set total BEFORE the pre-flight event so the UI's
+                    # ``stageTotal - stageCachedEst`` subtraction renders the
+                    # real "to classify" count on the first event the user
+                    # sees, not 0.
+                    stages["classify"]["total"] = total * len(resolved_specs_local)
+                    _emit_progress(
+                        runner, job["id"], stages, "classify",
+                        f"Classifying with {active_spec['name']}",
+                        step_id=step_id,
+                    )
+                    raw_results: list = []
+                    failed = 0
+                    skipped_existing = 0
+                    stages["classify"].setdefault("cached", 0)
+                    stages["classify"].setdefault("seen", 0)
+                    # Photos that iterated past the inner abort check IN THIS spec.
+                    # Used for the per-spec ``runner.update_step`` progress (which
+                    # is bounded by ``total``, not the multi-spec stage total) and
+                    # for the batch-end rate calc.  Captures every branch — cache
+                    # hit, successful inference, no-detection, image decode fail,
+                    # inference fail — so spec-level progress reaches ``total`` at
+                    # the end of the spec regardless of outcome mix.
+                    processed_in_spec = 0
+                    start_time = time.time()
+                    batch_size = 32  # classification batch granularity
+                    inference_batch_size = _BATCH_SIZE
+                    inference_batch: list = []
+                    has_flushed_in_spec = False
+
+                    def _close_pending_inference(inference_batch=inference_batch):
+                        for entry in inference_batch:
+                            with contextlib.suppress(Exception):
+                                entry["img"].close()
+                        inference_batch.clear()
+
+                    def _flush_pending_inference(
+                        inference_batch=inference_batch,
+                        raw_results=raw_results,
+                        clf=clf,
+                        model_type=model_type,
+                        model_name=model_name,
+                        spec_fp=spec_fp,
+                    ):
+                        nonlocal failed, has_flushed_in_spec
+                        if not inference_batch:
+                            return
+
+                        pending = list(inference_batch)
+                        inference_batch.clear()
+                        has_flushed_in_spec = True
+                        pre_len = len(raw_results)
+                        # GPU serialisation lives inside _flush_batch around the
+                        # inference call so the DB upserts/result-building afterward
+                        # don't hold the semaphore while the GPU is idle.
+                        n_batch_failed = _flush_batch(
+                            pending, clf, model_type, model_name,
+                            thread_db, raw_results,
+                        )
+                        failed += n_batch_failed
+
+                        successful_det_ids = {
+                            r.get("detection_id") for r in raw_results[pre_len:]
+                        }
+                        if n_batch_failed:
+                            for entry in pending:
+                                if entry.get("detection_id") not in successful_det_ids:
+                                    failed_photo_ids.add(entry["photo"]["id"])
+
+                        _record_batch_classifier_runs(
+                            thread_db, pending, model_name, spec_fp, raw_results,
+                            pre_len,
+                        )
+
+                        new_count = len(raw_results) - pre_len
+                        if new_count > 0:
+                            stages["classify"]["count"] = (
+                                stages["classify"].get("count", 0) + new_count
+                            )
+
+                    for batch_start in range(0, total, batch_size):
                         if _should_abort(abort):
                             break
-                        processed_in_spec += 1
-                        stages["classify"]["seen"] = (
-                            stages["classify"].get("seen", 0) + 1
-                        )
-                        # Record this photo as classify-processed for the first
-                        # successful model. Used by the stale-detection purge to
-                        # restrict deletions to photos actually reclassified.
-                        if models_succeeded == 0:
-                            first_model_photo_ids.add(photo["id"])
+                        batch = photos[batch_start:batch_start + batch_size]
 
-                        # Pull the primary detection for this photo from the
-                        # detect-stage cache. Fall back to db.get_detections()
-                        # only for photos whose per-photo detect iteration
-                        # never completed (e.g. mid-batch exception, or the
-                        # detect stage was skipped for an already-detected
-                        # non-reclassify run — in which case the DB holds the
-                        # authoritative rows). Photos with no detections get
-                        # skipped entirely; pipeline classify is detection-
-                        # driven and won't synthesize full-image boxes.
-                        if photo["id"] in cached_detections:
-                            # cached_detections from _detect_batch can include
-                            # full-image rows when an earlier pass synthesized
-                            # them (legacy db state); filter to match the
-                            # fallback-query branch below so primary_det never
-                            # lands on a full-image box. Pipeline classify is
-                            # detection-driven and won't classify full-image.
-                            photo_dets = [
-                                d for d in cached_detections[photo["id"]]
-                                if d.get("detector_model") != "full-image"
-                            ]
-                        else:
-                            photo_dets = [
-                                {
-                                    "id": d["id"],
-                                    "box_x": d["box_x"],
-                                    "box_y": d["box_y"],
-                                    "box_w": d["box_w"],
-                                    "box_h": d["box_h"],
-                                    "confidence": d["detector_confidence"],
-                                    "category": d["category"],
-                                }
-                                for d in thread_db.get_detections(photo["id"])
-                                if d["detector_model"] != "full-image"
-                            ]
-                        primary_det = photo_dets[0] if photo_dets else None
-                        if primary_det is None:
-                            continue
-
-                        # Classifier-run gate: skip work when this exact
-                        # (detection, classifier_model, labels_fingerprint)
-                        # triple was already classified. Reclassify bypasses
-                        # the gate so users can force a fresh pass. When
-                        # gated, surface the cached top-1 prediction into
-                        # raw_results so downstream grouping/storage sees
-                        # it — otherwise the cached detection would silently
-                        # drop out of the grouping pipeline.
-                        if not params.reclassify:
-                            run_keys = thread_db.get_classifier_run_keys(
-                                primary_det["id"]
+                        for photo in batch:
+                            # Per-photo abort check so cancel takes effect within
+                            # one inference (~seconds) instead of waiting for the
+                            # next batch boundary (~32 photos). The outer batch
+                            # loop's check at the top of the next iteration will
+                            # then break out of the batch loop entirely.
+                            if _should_abort(abort):
+                                break
+                            processed_in_spec += 1
+                            stages["classify"]["seen"] = (
+                                stages["classify"].get("seen", 0) + 1
                             )
-                            if (model_name, spec_fp) in run_keys:
-                                cached = thread_db.get_predictions_for_detection(
-                                    primary_det["id"],
-                                    classifier_model=model_name,
-                                    labels_fingerprint=spec_fp,
-                                    min_classifier_conf=0,
+                            # Record this photo as classify-processed for the first
+                            # successful model. Used by the stale-detection purge to
+                            # restrict deletions to photos actually reclassified.
+                            if models_succeeded == 0:
+                                first_model_photo_ids.add(photo["id"])
+
+                            # Pull the primary detection for this photo from the
+                            # detect-stage cache. Fall back to db.get_detections()
+                            # only for photos whose per-photo detect iteration
+                            # never completed (e.g. mid-batch exception, or the
+                            # detect stage was skipped for an already-detected
+                            # non-reclassify run — in which case the DB holds the
+                            # authoritative rows). Photos with no detections get
+                            # skipped entirely; pipeline classify is detection-
+                            # driven and won't synthesize full-image boxes.
+                            if photo["id"] in cached_detections:
+                                # cached_detections from _detect_batch can include
+                                # full-image rows when an earlier pass synthesized
+                                # them (legacy db state); filter to match the
+                                # fallback-query branch below so primary_det never
+                                # lands on a full-image box. Pipeline classify is
+                                # detection-driven and won't classify full-image.
+                                photo_dets = [
+                                    d for d in cached_detections[photo["id"]]
+                                    if d.get("detector_model") != "full-image"
+                                ]
+                            else:
+                                photo_dets = [
+                                    {
+                                        "id": d["id"],
+                                        "box_x": d["box_x"],
+                                        "box_y": d["box_y"],
+                                        "box_w": d["box_w"],
+                                        "box_h": d["box_h"],
+                                        "confidence": d["detector_confidence"],
+                                        "category": d["category"],
+                                    }
+                                    for d in thread_db.get_detections(photo["id"])
+                                    if d["detector_model"] != "full-image"
+                                ]
+                            primary_det = photo_dets[0] if photo_dets else None
+                            if primary_det is None:
+                                continue
+
+                            # Classifier-run gate: skip work when this exact
+                            # (detection, classifier_model, labels_fingerprint)
+                            # triple was already classified. Reclassify bypasses
+                            # the gate so users can force a fresh pass. When
+                            # gated, surface the cached top-1 prediction into
+                            # raw_results so downstream grouping/storage sees
+                            # it — otherwise the cached detection would silently
+                            # drop out of the grouping pipeline.
+                            if not params.reclassify:
+                                run_keys = thread_db.get_classifier_run_keys(
+                                    primary_det["id"]
                                 )
-                                if cached:
-                                    skipped_existing += 1
-                                    stages["classify"]["cached"] += 1
-                                    top = cached[0]
-                                    folder_path = folders.get(photo["folder_id"], "")
-                                    image_path = os.path.join(
-                                        folder_path, photo["filename"],
+                                if (model_name, spec_fp) in run_keys:
+                                    cached = thread_db.get_predictions_for_detection(
+                                        primary_det["id"],
+                                        classifier_model=model_name,
+                                        labels_fingerprint=spec_fp,
+                                        min_classifier_conf=0,
                                     )
-                                    timestamp = None
-                                    if photo["timestamp"]:
-                                        with contextlib.suppress(ValueError, TypeError):
-                                            timestamp = dt.fromisoformat(
-                                                photo["timestamp"]
-                                            )
-                                    embedding = None
-                                    if model_type != "timm":
-                                        emb_blob = thread_db.get_photo_embedding(
-                                            photo["id"], model_name,
+                                    if cached:
+                                        skipped_existing += 1
+                                        stages["classify"]["cached"] += 1
+                                        top = cached[0]
+                                        folder_path = folders.get(photo["folder_id"], "")
+                                        image_path = os.path.join(
+                                            folder_path, photo["filename"],
                                         )
-                                        if emb_blob:
-                                            embedding = np.frombuffer(
-                                                emb_blob, dtype=np.float32,
+                                        timestamp = None
+                                        if photo["timestamp"]:
+                                            with contextlib.suppress(ValueError, TypeError):
+                                                timestamp = dt.fromisoformat(
+                                                    photo["timestamp"]
+                                                )
+                                        embedding = None
+                                        if model_type != "timm":
+                                            emb_blob = thread_db.get_photo_embedding(
+                                                photo["id"], model_name,
                                             )
-                                    raw_results.append({
-                                        "photo": photo,
-                                        "detection_id": primary_det["id"],
-                                        "folder_path": folder_path,
-                                        "image_path": image_path,
-                                        "prediction": top["species"],
-                                        "confidence": top["confidence"],
-                                        "timestamp": timestamp,
-                                        "filename": photo["filename"],
-                                        "embedding": embedding,
-                                        "taxonomy": None,
-                                        "_existing": True,
-                                    })
-                                    continue
-                                # Run key with no cached rows (e.g.
-                                # prior pass stored `category == 'match'`
-                                # so the prediction was intentionally not
-                                # written). Fall through to re-classify
-                                # instead of stranding the detection.
+                                            if emb_blob:
+                                                embedding = np.frombuffer(
+                                                    emb_blob, dtype=np.float32,
+                                                )
+                                        raw_results.append({
+                                            "photo": photo,
+                                            "detection_id": primary_det["id"],
+                                            "folder_path": folder_path,
+                                            "image_path": image_path,
+                                            "prediction": top["species"],
+                                            "confidence": top["confidence"],
+                                            "timestamp": timestamp,
+                                            "filename": photo["filename"],
+                                            "embedding": embedding,
+                                            "taxonomy": None,
+                                            "_existing": True,
+                                        })
+                                        continue
+                                    # Run key with no cached rows (e.g.
+                                    # prior pass stored `category == 'match'`
+                                    # so the prediction was intentionally not
+                                    # written). Fall through to re-classify
+                                    # instead of stranding the detection.
 
-                        img, folder_path, image_path = _prepare_image(
-                            photo, folders, primary_det,
-                        )
-                        if img is None:
-                            failed += 1
-                            failed_photo_ids.add(photo["id"])
-                            continue
-                        inference_batch.append({
-                            "photo": photo,
-                            "detection_id": primary_det["id"],
-                            "folder_path": folder_path,
-                            "image_path": image_path,
-                            "img": img,
-                        })
-                        # Flush the first real inference immediately. That
-                        # preserves the existing cancel checkpoint after model
-                        # warm-up, then later images batch normally for GPU
-                        # throughput.
-                        if (
-                            not has_flushed_in_spec
-                            or len(inference_batch) >= inference_batch_size
-                        ):
+                            img, folder_path, image_path = _prepare_image(
+                                photo, folders, primary_det,
+                            )
+                            if img is None:
+                                failed += 1
+                                failed_photo_ids.add(photo["id"])
+                                continue
+                            inference_batch.append({
+                                "photo": photo,
+                                "detection_id": primary_det["id"],
+                                "folder_path": folder_path,
+                                "image_path": image_path,
+                                "img": img,
+                            })
+                            # Flush the first real inference immediately. That
+                            # preserves the existing cancel checkpoint after model
+                            # warm-up, then later images batch normally for GPU
+                            # throughput.
+                            if (
+                                not has_flushed_in_spec
+                                or len(inference_batch) >= inference_batch_size
+                            ):
+                                _flush_pending_inference()
+
+                        # Batch boundary: surface the per-photo accumulated
+                        # count + cached to the UI. Replaces the old per-batch
+                        # pre-advance which lied about progress when batches
+                        # contained cache hits.
+                        if _should_abort(abort):
+                            _close_pending_inference()
+                        else:
                             _flush_pending_inference()
+                        stages["classify"]["total"] = total * len(resolved_specs_local)
+                        elapsed = max(time.time() - start_time, 0.01)
+                        _emit_progress(
+                            runner, job["id"], stages, "classify",
+                            f"Classifying with {active_spec['name']}"
+                            + (
+                                f" ({spec_idx + 1}/{len(resolved_specs_local)})"
+                                if len(resolved_specs_local) > 1 else ""
+                            ),
+                            step_id=step_id,
+                            rate=round(processed_in_spec / elapsed * 60, 1),
+                        )
+                        runner.update_step(
+                            job["id"], step_id,
+                            progress={
+                                "current": processed_in_spec,
+                                "total": total,
+                            },
+                        )
 
-                    # Batch boundary: surface the per-photo accumulated
-                    # count + cached to the UI. Replaces the old per-batch
-                    # pre-advance which lied about progress when batches
-                    # contained cache hits.
                     if _should_abort(abort):
                         _close_pending_inference()
                     else:
                         _flush_pending_inference()
-                    stages["classify"]["total"] = total * len(resolved_specs_local)
-                    elapsed = max(time.time() - start_time, 0.01)
-                    _emit_progress(
-                        runner, job["id"], stages, "classify",
-                        f"Classifying with {active_spec['name']}"
-                        + (
-                            f" ({spec_idx + 1}/{len(resolved_specs_local)})"
-                            if len(resolved_specs_local) > 1 else ""
-                        ),
-                        step_id=step_id,
-                        rate=round(processed_in_spec / elapsed * 60, 1),
-                    )
-                    runner.update_step(
-                        job["id"], step_id,
-                        progress={
-                            "current": processed_in_spec,
-                            "total": total,
-                        },
-                    )
 
-                if _should_abort(abort):
-                    _close_pending_inference()
-                else:
-                    _flush_pending_inference()
+                    # Skip the grouping/storage finalization on cancel — it can
+                    # take a minute on large collections and the user has already
+                    # asked us to stop. Per-photo counters are accurate, no
+                    # corrective fixup needed.
+                    if _should_abort(abort):
+                        _emit_progress(
+                            runner, job["id"], stages, "classify",
+                            f"Cancelled — {processed_in_spec} of "
+                            f"{total} processed",
+                            step_id=step_id,
+                        )
+                        runner.update_step(
+                            job["id"], step_id,
+                            status="completed",
+                            progress={
+                                "current": processed_in_spec,
+                                "total": total,
+                            },
+                            summary=(
+                                f"Cancelled "
+                                f"({processed_in_spec} of {total} processed)"
+                            ),
+                        )
+                        continue
 
-                # Skip the grouping/storage finalization on cancel — it can
-                # take a minute on large collections and the user has already
-                # asked us to stop. Per-photo counters are accurate, no
-                # corrective fixup needed.
-                if _should_abort(abort):
-                    _emit_progress(
-                        runner, job["id"], stages, "classify",
-                        f"Cancelled — {processed_in_spec} of "
-                        f"{total} processed",
-                        step_id=step_id,
-                    )
-                    runner.update_step(
-                        job["id"], step_id,
-                        status="completed",
-                        progress={
-                            "current": processed_in_spec,
-                            "total": total,
-                        },
-                        summary=(
-                            f"Cancelled "
-                            f"({processed_in_spec} of {total} processed)"
-                        ),
-                    )
-                    continue
-
-                # Reclassify clear, deferred from the top of the per-spec body
-                # so a mid-batch cancel above leaves the user's prior
-                # predictions intact (Codex P1 review on #710).  Scope by
-                # labels_fingerprint so reclassifying one workspace's label
-                # set doesn't wipe another workspace's cached predictions on
-                # the same photos under its own fingerprint (shared-folder
-                # setups).  ``clear_run_keys=False`` because the per-photo
-                # ``record_classifier_run`` calls inside the loop above
-                # already wrote fresh classifier_runs rows for processed
-                # detections — wiping them here would strand the gate and
-                # force the next non-reclassify pass to re-infer everything.
-                if params.reclassify:
-                    thread_db.clear_predictions(
-                        model=model_name,
-                        collection_photo_ids=[p["id"] for p in photos],
-                        labels_fingerprint=spec_fp,
-                        clear_run_keys=False,
-                    )
-
-                group_result = _store_grouped_predictions(
-                    raw_results, job["id"], model_name,
-                    grouping_window, similarity_threshold, tax, thread_db,
-                    labels_fingerprint=spec_fp,
-                )
-                preds = group_result["predictions_stored"]
-                total_predictions_stored += preds
-                total_failed += failed
-                total_skipped_existing += skipped_existing
-                models_succeeded += 1
-                completed_step_ids.add(step_id)
-
-                # Reclassify stale-row purge: only fires after the FIRST
-                # successful model has written fresh predictions, so a run
-                # where every model fails to load leaves prior detections
-                # (and their cascaded predictions) intact. Photos whose
-                # detect iteration never completed keep their old rows.
-                if (
-                    params.reclassify
-                    and models_succeeded == 1
-                    and detect_state["pre_run_det_ids"]
-                ):
-                    pre_ids = detect_state["pre_run_det_ids"]
-                    # Scope the purge to photos whose detect AND classify
-                    # iterations both completed in this run. Using only
-                    # classify coverage would delete rows for photos that
-                    # hit the db.get_detections() fallback (i.e. never got
-                    # a fresh detect). Using only detect coverage would
-                    # delete rows for photos the classifier never reached.
-                    # The intersection guarantees there's a replacement
-                    # detection AND that the classifier considered it.
-                    purge_ids = (
-                        first_model_photo_ids
-                        & detect_state["processed_ids"]
-                    )
-                    # Delete only pre-run ids the current run did NOT
-                    # re-produce. Detection ids are content-addressed
-                    # (vireo/detection_id.py), so re-detecting the same boxes
-                    # yields the SAME ids as the pre-run snapshot, and
-                    # write_detection_batch UPSERTs them with the freshly
-                    # written predictions now hanging off them. Deleting every
-                    # pre-run id unconditionally would cascade-delete those
-                    # predictions (and the live detection rows) for every photo
-                    # whose boxes didn't change — the common reclassify case.
-                    # Compare against the ids THIS run actually re-detected
-                    # (detect_state["detections"] is the in-memory map
-                    # _detect_batch built); a photo that came back empty has
-                    # no entry, so its pre-run rows are all stale and get
-                    # purged (write_detection_batch([]) already cleared them at
-                    # the data layer — this is the belt-and-suspenders pass and
-                    # cross-model cleanup). A photo re-detected with the same
-                    # boxes has its ids in the fresh set, so they survive.
-                    fresh_by_photo = detect_state["detections"]
-                    stale_ids = [
-                        det_id
-                        for photo_id, id_set in pre_ids.items()
-                        if photo_id in purge_ids
-                        for det_id in id_set
-                        if det_id not in {
-                            d["id"]
-                            for d in fresh_by_photo.get(photo_id, [])
-                        }
-                    ]
-                    if stale_ids:
-                        getattr(
-                            thread_db,
-                            "delete_detections_by_ids",
-                            lambda _: None,
-                        )(stale_ids)
-                        log.debug(
-                            "reclassify: purged %d stale detection rows for "
-                            "%d photos (%d not in purge scope, rows preserved)",
-                            len(stale_ids),
-                            len(purge_ids & pre_ids.keys()),
-                            len(pre_ids) - len(purge_ids & pre_ids.keys()),
+                    # Reclassify clear, deferred from the top of the per-spec body
+                    # so a mid-batch cancel above leaves the user's prior
+                    # predictions intact (Codex P1 review on #710).  Scope by
+                    # labels_fingerprint so reclassifying one workspace's label
+                    # set doesn't wipe another workspace's cached predictions on
+                    # the same photos under its own fingerprint (shared-folder
+                    # setups).  ``clear_run_keys=False`` because the per-photo
+                    # ``record_classifier_run`` calls inside the loop above
+                    # already wrote fresh classifier_runs rows for processed
+                    # detections — wiping them here would strand the gate and
+                    # force the next non-reclassify pass to re-infer everything.
+                    if params.reclassify:
+                        thread_db.clear_predictions(
+                            model=model_name,
+                            collection_photo_ids=[p["id"] for p in photos],
+                            labels_fingerprint=spec_fp,
+                            clear_run_keys=False,
                         )
 
-                parts = [f"{preds} predictions"]
-                if skipped_existing:
-                    parts.append(f"{skipped_existing} cached")
-                if failed:
-                    parts.append(f"{failed} failed")
-                runner.update_step(
-                    job["id"], step_id, status="completed",
-                    summary=", ".join(parts),
-                )
-
-            # Cancellation takes precedence over the all-models-failed-to-load
-            # signal: if the user cancelled mid-classify after a prior model
-            # had already been added to skipped_model_names, raising here
-            # would misclassify the cancel as a fatal load failure and
-            # overwrite the per-model 'Cancelled' summary in the exception
-            # handler.
-            if (
-                models_succeeded == 0
-                and skipped_model_names
-                and not _should_abort(abort)
-            ):
-                raise RuntimeError(
-                    f"All {len(skipped_model_names)} model(s) failed to load: "
-                    + ", ".join(skipped_model_names)
-                )
-
-            # Roll up per-photo failures into a single classify stage status
-            # + errors[] entry, matching the pattern in #562. Per-model step
-            # rows already carry their own summary; the stage status reflects
-            # the whole classify pass.  error_count uses unique failed photo
-            # IDs (not per-model attempt count) so the badge can never
-            # exceed total photos.
-            n_failed_photos = len(failed_photo_ids)
-            stages["classify"]["status"] = (
-                "failed" if total_failed > 0 else "completed"
-            )
-            if total_failed > 0:
-                errors.append(
-                    f"[classify] {n_failed_photos} of {total} photos "
-                    "failed to classify"
-                )
-            result["stages"]["classify"] = {
-                "total": total,
-                "predictions_stored": total_predictions_stored,
-                "detected": detect_state["total_detected"],
-                "failed": total_failed,
-                "already_classified": total_skipped_existing,
-                "model_count": len(resolved_specs_local),
-                "models_succeeded": models_succeeded,
-                "models_skipped": len(skipped_model_names),
-                "skipped_model_names": skipped_model_names,
-            }
-        except Exception as e:
-            errors.append(f"[classify] Fatal: {e}")
-            log.exception("Pipeline classify stage failed")
-            abort.set()
-            stages["classify"]["status"] = "failed"
-            # Only surface the fatal error on rows that haven't already
-            # reached a terminal state. Without this, a late-loop exception
-            # would overwrite the 'completed' status of earlier models that
-            # finished successfully, misreporting per-model outcomes.
-            specs_for_step_ids = loaded_models.get("resolved_specs") or []
-            for spec in specs_for_step_ids:
-                sid = f"classify:{spec['id']}"
-                if sid in completed_step_ids or sid in failed_step_ids:
-                    continue
-                runner.update_step(
-                    job["id"], sid,
-                    status="failed", error=str(e),
-                )
-        finally:
-            # Release the held classifier so subsequent pipelines can reuse
-            # the cached session (or the idle timer can reclaim VRAM). Runs
-            # whether classify completed cleanly, errored mid-loop, or hit
-            # the fatal-exception path above.
-            _release_classifier_cache_handle(loaded_models)
-
-        _update_stages(runner, job["id"], stages)
-
-    def extract_masks_stage():
-        """Run SAM2 mask extraction + DINOv2 embeddings after classify."""
-        if params.skip_extract_masks or abort.is_set() or not collection_id:
-            stages["extract_masks"]["status"] = "skipped"
-            runner.update_step(job["id"], "extract_masks", status="completed",
-                               summary="Skipped")
-            return
-
-        stages["extract_masks"]["status"] = "running"
-        runner.update_step(job["id"], "extract_masks", status="running")
-        _update_stages(runner, job["id"], stages)
-
-        try:
-            import config as cfg
-            from dino_embed import embed, embed_batch, embedding_to_blob
-            from masking import (
-                crop_completeness,
-                crop_subject,
-                generate_mask,
-                render_proxy,
-                save_mask,
-            )
-            from quality import compute_all_quality_features
-
-            thread_db = Database(db_path)
-            thread_db.set_active_workspace(workspace_id)
-
-            effective_cfg = thread_db.get_effective_config(cfg.load())
-            pipeline_cfg = effective_cfg.get("pipeline", {})
-            sam2_variant = pipeline_cfg.get("sam2_variant")
-            dinov2_variant = pipeline_cfg.get("dinov2_variant")
-            proxy_longest_edge = pipeline_cfg.get("proxy_longest_edge")
-
-            masks_dir = os.path.join(os.path.dirname(db_path), "masks")
-            os.makedirs(masks_dir, exist_ok=True)
-
-            photos = _filter_excluded(thread_db.get_collection_photos(collection_id, per_page=999999))
-
-            # Build a map of photo_id -> primary detection (highest confidence)
-            # from the detections table. Only photos with detections and without
-            # masks need processing.
-            #
-            # Skip synthetic full-image detections (detector_model='full-image').
-            # Those rows exist only to give classify predictions a non-NULL FK
-            # anchor for photos where MegaDetector found no animals — they are
-            # not real subject boxes and should not drive mask extraction or
-            # count toward the photos_with_detections safeguard below (which
-            # surfaces the "weights missing / no detections" diagnostic).
-            # Note: we intentionally do NOT short-circuit when the photo
-            # already has *some* mask in the photos table — that legacy
-            # check ignored which SAM variant produced the mask, so a
-            # config change to a different variant would never re-run.
-            # The per-photo cache check happens inside the loop below
-            # against photo_masks(photo_id, sam2_variant).
-            #
-            # Track sub-threshold-only photos separately so the silent-
-            # completion guard can distinguish "no detection rows at all"
-            # from "rows exist but every confidence is below
-            # detector_confidence" — the user's remediation differs
-            # (download weights vs lower the threshold).
-            detector_confidence = effective_cfg.get("detector_confidence", 0.2)
-            photo_det_map = {}
-            photos_with_detections = 0
-            photos_subthreshold_only = 0
-            for p in photos:
-                # Pass the captured detector_confidence explicitly so the
-                # floor matches effective_cfg (and the standalone
-                # /api/jobs/extract-masks path), not whatever cfg.load()
-                # would re-read from disk inside get_detections. With the
-                # legacy `mask_path IS NULL` prefilter gone, sub-threshold-
-                # only photos would otherwise enter SAM extraction on
-                # variant cache misses.
-                dets = [
-                    d for d in thread_db.get_detections(
-                        p["id"], min_conf=detector_confidence,
+                    group_result = _store_grouped_predictions(
+                        raw_results, job["id"], model_name,
+                        grouping_window, similarity_threshold, tax, thread_db,
+                        labels_fingerprint=spec_fp,
                     )
-                    if d["detector_model"] != "full-image"
-                ]
-                if dets:
-                    photos_with_detections += 1
-                    primary = dets[0]  # already ordered by confidence DESC
-                    photo_det_map[p["id"]] = {
-                        "photo": p,
-                        "det_box": {
-                            "x": primary["box_x"],
-                            "y": primary["box_y"],
-                            "w": primary["box_w"],
-                            "h": primary["box_h"],
-                        },
-                        "detector_model": primary["detector_model"],
-                        # Stored prompt provenance: full-precision bbox
-                        # tuple. detections.box_* are normalized REAL
-                        # values in [0, 1], so int()-truncating would
-                        # collapse every prompt to (0, 0, 0, 0) and the
-                        # cache/staleness check would never invalidate
-                        # on bbox change. SQLite's column type affinity
-                        # accepts REAL into the INTEGER-declared
-                        # columns and stores them verbatim.
-                        "prompt": (
-                            primary["box_x"],
-                            primary["box_y"],
-                            primary["box_w"],
-                            primary["box_h"],
-                        ),
-                    }
-                else:
-                    # No qualifying detection — but check whether sub-
-                    # threshold rows exist so the silent-completion guard
-                    # can distinguish "weights never ran" from "threshold
-                    # too high". This counter only matters for photos
-                    # that haven't been masked yet (an already-masked
-                    # photo isn't in the "what got skipped silently"
-                    # diagnostic regardless of threshold).
-                    raw_dets = [
-                        d for d in thread_db.get_detections(p["id"], min_conf=0)
+                    preds = group_result["predictions_stored"]
+                    total_predictions_stored += preds
+                    total_failed += failed
+                    total_skipped_existing += skipped_existing
+                    models_succeeded += 1
+                    completed_step_ids.add(step_id)
+
+                    # Reclassify stale-row purge: only fires after the FIRST
+                    # successful model has written fresh predictions, so a run
+                    # where every model fails to load leaves prior detections
+                    # (and their cascaded predictions) intact. Photos whose
+                    # detect iteration never completed keep their old rows.
+                    if (
+                        params.reclassify
+                        and models_succeeded == 1
+                        and detect_state["pre_run_det_ids"]
+                    ):
+                        pre_ids = detect_state["pre_run_det_ids"]
+                        # Scope the purge to photos whose detect AND classify
+                        # iterations both completed in this run. Using only
+                        # classify coverage would delete rows for photos that
+                        # hit the db.get_detections() fallback (i.e. never got
+                        # a fresh detect). Using only detect coverage would
+                        # delete rows for photos the classifier never reached.
+                        # The intersection guarantees there's a replacement
+                        # detection AND that the classifier considered it.
+                        purge_ids = (
+                            first_model_photo_ids
+                            & detect_state["processed_ids"]
+                        )
+                        # Delete only pre-run ids the current run did NOT
+                        # re-produce. Detection ids are content-addressed
+                        # (vireo/detection_id.py), so re-detecting the same boxes
+                        # yields the SAME ids as the pre-run snapshot, and
+                        # write_detection_batch UPSERTs them with the freshly
+                        # written predictions now hanging off them. Deleting every
+                        # pre-run id unconditionally would cascade-delete those
+                        # predictions (and the live detection rows) for every photo
+                        # whose boxes didn't change — the common reclassify case.
+                        # Compare against the ids THIS run actually re-detected
+                        # (detect_state["detections"] is the in-memory map
+                        # _detect_batch built); a photo that came back empty has
+                        # no entry, so its pre-run rows are all stale and get
+                        # purged (write_detection_batch([]) already cleared them at
+                        # the data layer — this is the belt-and-suspenders pass and
+                        # cross-model cleanup). A photo re-detected with the same
+                        # boxes has its ids in the fresh set, so they survive.
+                        fresh_by_photo = detect_state["detections"]
+                        stale_ids = [
+                            det_id
+                            for photo_id, id_set in pre_ids.items()
+                            if photo_id in purge_ids
+                            for det_id in id_set
+                            if det_id not in {
+                                d["id"]
+                                for d in fresh_by_photo.get(photo_id, [])
+                            }
+                        ]
+                        if stale_ids:
+                            getattr(
+                                thread_db,
+                                "delete_detections_by_ids",
+                                lambda _: None,
+                            )(stale_ids)
+                            log.debug(
+                                "reclassify: purged %d stale detection rows for "
+                                "%d photos (%d not in purge scope, rows preserved)",
+                                len(stale_ids),
+                                len(purge_ids & pre_ids.keys()),
+                                len(pre_ids) - len(purge_ids & pre_ids.keys()),
+                            )
+
+                    parts = [f"{preds} predictions"]
+                    if skipped_existing:
+                        parts.append(f"{skipped_existing} cached")
+                    if failed:
+                        parts.append(f"{failed} failed")
+                    runner.update_step(
+                        job["id"], step_id, status="completed",
+                        summary=", ".join(parts),
+                    )
+
+                # Cancellation takes precedence over the all-models-failed-to-load
+                # signal: if the user cancelled mid-classify after a prior model
+                # had already been added to skipped_model_names, raising here
+                # would misclassify the cancel as a fatal load failure and
+                # overwrite the per-model 'Cancelled' summary in the exception
+                # handler.
+                if (
+                    models_succeeded == 0
+                    and skipped_model_names
+                    and not _should_abort(abort)
+                ):
+                    raise RuntimeError(
+                        f"All {len(skipped_model_names)} model(s) failed to load: "
+                        + ", ".join(skipped_model_names)
+                    )
+
+                # Roll up per-photo failures into a single classify stage status
+                # + errors[] entry, matching the pattern in #562. Per-model step
+                # rows already carry their own summary; the stage status reflects
+                # the whole classify pass.  error_count uses unique failed photo
+                # IDs (not per-model attempt count) so the badge can never
+                # exceed total photos.
+                n_failed_photos = len(failed_photo_ids)
+                stages["classify"]["status"] = (
+                    "failed" if total_failed > 0 else "completed"
+                )
+                if total_failed > 0:
+                    errors.append(
+                        f"[classify] {n_failed_photos} of {total} photos "
+                        "failed to classify"
+                    )
+                result["stages"]["classify"] = {
+                    "total": total,
+                    "predictions_stored": total_predictions_stored,
+                    "detected": detect_state["total_detected"],
+                    "failed": total_failed,
+                    "already_classified": total_skipped_existing,
+                    "model_count": len(resolved_specs_local),
+                    "models_succeeded": models_succeeded,
+                    "models_skipped": len(skipped_model_names),
+                    "skipped_model_names": skipped_model_names,
+                }
+            except Exception as e:
+                errors.append(f"[classify] Fatal: {e}")
+                log.exception("Pipeline classify stage failed")
+                abort.set()
+                stages["classify"]["status"] = "failed"
+                # Only surface the fatal error on rows that haven't already
+                # reached a terminal state. Without this, a late-loop exception
+                # would overwrite the 'completed' status of earlier models that
+                # finished successfully, misreporting per-model outcomes.
+                specs_for_step_ids = loaded_models.get("resolved_specs") or []
+                for spec in specs_for_step_ids:
+                    sid = f"classify:{spec['id']}"
+                    if sid in completed_step_ids or sid in failed_step_ids:
+                        continue
+                    runner.update_step(
+                        job["id"], sid,
+                        status="failed", error=str(e),
+                    )
+            finally:
+                # Release the held classifier so subsequent pipelines can reuse
+                # the cached session (or the idle timer can reclaim VRAM). Runs
+                # whether classify completed cleanly, errored mid-loop, or hit
+                # the fatal-exception path above.
+                _release_classifier_cache_handle(loaded_models)
+
+            _update_stages(runner, job["id"], stages)
+
+        def extract_masks_stage():
+            """Run SAM2 mask extraction + DINOv2 embeddings after classify."""
+            if params.skip_extract_masks or abort.is_set() or not collection_id:
+                stages["extract_masks"]["status"] = "skipped"
+                runner.update_step(job["id"], "extract_masks", status="completed",
+                                   summary="Skipped")
+                return
+
+            stages["extract_masks"]["status"] = "running"
+            runner.update_step(job["id"], "extract_masks", status="running")
+            _update_stages(runner, job["id"], stages)
+
+            try:
+                import config as cfg
+                from dino_embed import embed, embed_batch, embedding_to_blob
+                from masking import (
+                    crop_completeness,
+                    crop_subject,
+                    generate_mask,
+                    render_proxy,
+                    save_mask,
+                )
+                from quality import compute_all_quality_features
+
+                thread_db = Database(db_path)
+                thread_db.set_active_workspace(workspace_id)
+
+                effective_cfg = thread_db.get_effective_config(cfg.load())
+                pipeline_cfg = effective_cfg.get("pipeline", {})
+                sam2_variant = pipeline_cfg.get("sam2_variant")
+                dinov2_variant = pipeline_cfg.get("dinov2_variant")
+                proxy_longest_edge = pipeline_cfg.get("proxy_longest_edge")
+
+                masks_dir = os.path.join(os.path.dirname(db_path), "masks")
+                os.makedirs(masks_dir, exist_ok=True)
+
+                photos = _filter_excluded(thread_db.get_collection_photos(collection_id, per_page=999999))
+
+                # Build a map of photo_id -> primary detection (highest confidence)
+                # from the detections table. Only photos with detections and without
+                # masks need processing.
+                #
+                # Skip synthetic full-image detections (detector_model='full-image').
+                # Those rows exist only to give classify predictions a non-NULL FK
+                # anchor for photos where MegaDetector found no animals — they are
+                # not real subject boxes and should not drive mask extraction or
+                # count toward the photos_with_detections safeguard below (which
+                # surfaces the "weights missing / no detections" diagnostic).
+                # Note: we intentionally do NOT short-circuit when the photo
+                # already has *some* mask in the photos table — that legacy
+                # check ignored which SAM variant produced the mask, so a
+                # config change to a different variant would never re-run.
+                # The per-photo cache check happens inside the loop below
+                # against photo_masks(photo_id, sam2_variant).
+                #
+                # Track sub-threshold-only photos separately so the silent-
+                # completion guard can distinguish "no detection rows at all"
+                # from "rows exist but every confidence is below
+                # detector_confidence" — the user's remediation differs
+                # (download weights vs lower the threshold).
+                detector_confidence = effective_cfg.get("detector_confidence", 0.2)
+                photo_det_map = {}
+                photos_with_detections = 0
+                photos_subthreshold_only = 0
+                for p in photos:
+                    # Pass the captured detector_confidence explicitly so the
+                    # floor matches effective_cfg (and the standalone
+                    # /api/jobs/extract-masks path), not whatever cfg.load()
+                    # would re-read from disk inside get_detections. With the
+                    # legacy `mask_path IS NULL` prefilter gone, sub-threshold-
+                    # only photos would otherwise enter SAM extraction on
+                    # variant cache misses.
+                    dets = [
+                        d for d in thread_db.get_detections(
+                            p["id"], min_conf=detector_confidence,
+                        )
                         if d["detector_model"] != "full-image"
                     ]
-                    if raw_dets:
-                        has_mask = thread_db.conn.execute(
-                            "SELECT mask_path FROM photos WHERE id=?", (p["id"],)
-                        ).fetchone()[0]
-                        if not has_mask:
-                            photos_subthreshold_only += 1
+                    if dets:
+                        photos_with_detections += 1
+                        primary = dets[0]  # already ordered by confidence DESC
+                        photo_det_map[p["id"]] = {
+                            "photo": p,
+                            "det_box": {
+                                "x": primary["box_x"],
+                                "y": primary["box_y"],
+                                "w": primary["box_w"],
+                                "h": primary["box_h"],
+                            },
+                            "detector_model": primary["detector_model"],
+                            # Stored prompt provenance: full-precision bbox
+                            # tuple. detections.box_* are normalized REAL
+                            # values in [0, 1], so int()-truncating would
+                            # collapse every prompt to (0, 0, 0, 0) and the
+                            # cache/staleness check would never invalidate
+                            # on bbox change. SQLite's column type affinity
+                            # accepts REAL into the INTEGER-declared
+                            # columns and stores them verbatim.
+                            "prompt": (
+                                primary["box_x"],
+                                primary["box_y"],
+                                primary["box_w"],
+                                primary["box_h"],
+                            ),
+                        }
+                    else:
+                        # No qualifying detection — but check whether sub-
+                        # threshold rows exist so the silent-completion guard
+                        # can distinguish "weights never ran" from "threshold
+                        # too high". This counter only matters for photos
+                        # that haven't been masked yet (an already-masked
+                        # photo isn't in the "what got skipped silently"
+                        # diagnostic regardless of threshold).
+                        raw_dets = [
+                            d for d in thread_db.get_detections(p["id"], min_conf=0)
+                            if d["detector_model"] != "full-image"
+                        ]
+                        if raw_dets:
+                            has_mask = thread_db.conn.execute(
+                                "SELECT mask_path FROM photos WHERE id=?", (p["id"],)
+                            ).fetchone()[0]
+                            if not has_mask:
+                                photos_subthreshold_only += 1
 
-            photos_to_process = [
-                photo_det_map[pid] for pid in photo_det_map
-            ]
+                photos_to_process = [
+                    photo_det_map[pid] for pid in photo_det_map
+                ]
 
-            folders = {f["id"]: f["path"] for f in thread_db.get_folder_tree()}
-            total = len(photos_to_process)
-            masked = 0
-            skipped = 0
-            em_failed = 0
-            start_time = time.time()
+                folders = {f["id"]: f["path"] for f in thread_db.get_folder_tree()}
+                total = len(photos_to_process)
+                masked = 0
+                skipped = 0
+                em_failed = 0
+                start_time = time.time()
 
-            # If the input collection has photos but none carry detections,
-            # surface a clear status instead of silently completing with
-            # masked=0 — otherwise the pipeline rejects every photo with
-            # no_subject_mask without explaining why masks were never made.
-            # Distinguish two cases:
-            #   (a) weights missing → actionable remediation
-            #   (b) weights present → legitimate outcome (empty scenes,
-            #       strict confidence threshold, non-wildlife photos)
-            # Only fire this diagnostic when classify actually ran in this
-            # invocation.  If classify was skipped (skip_classify=True, no
-            # models available, abort, etc.) zero detections is expected and
-            # appending an extract_masks error would be factually incorrect.
-            classify_ran = stages["classify"]["status"] not in ("skipped", "pending")
-            if photos_with_detections == 0 and len(photos) > 0 and classify_ran:
-                weights_present = False
-                try:
-                    from detector import MEGADETECTOR_ONNX_PATH
-                    weights_present = os.path.isfile(MEGADETECTOR_ONNX_PATH)
-                except ImportError:
+                # If the input collection has photos but none carry detections,
+                # surface a clear status instead of silently completing with
+                # masked=0 — otherwise the pipeline rejects every photo with
+                # no_subject_mask without explaining why masks were never made.
+                # Distinguish two cases:
+                #   (a) weights missing → actionable remediation
+                #   (b) weights present → legitimate outcome (empty scenes,
+                #       strict confidence threshold, non-wildlife photos)
+                # Only fire this diagnostic when classify actually ran in this
+                # invocation.  If classify was skipped (skip_classify=True, no
+                # models available, abort, etc.) zero detections is expected and
+                # appending an extract_masks error would be factually incorrect.
+                classify_ran = stages["classify"]["status"] not in ("skipped", "pending")
+                if photos_with_detections == 0 and len(photos) > 0 and classify_ran:
                     weights_present = False
+                    try:
+                        from detector import MEGADETECTOR_ONNX_PATH
+                        weights_present = os.path.isfile(MEGADETECTOR_ONNX_PATH)
+                    except ImportError:
+                        weights_present = False
 
-                if photos_subthreshold_only > 0:
+                    if photos_subthreshold_only > 0:
+                        reason = (
+                            f"{photos_subthreshold_only} photo(s) have detections but every "
+                            f"detection is below the current detector_confidence threshold "
+                            f"({detector_confidence}). The pipeline will reject these photos "
+                            "with `no_subject_mask`. Lower `detector_confidence` in workspace "
+                            "settings to extract masks for them."
+                        )
+                        summary = (
+                            f"Skipped — {photos_subthreshold_only} photo(s) below "
+                            f"detector_confidence threshold ({detector_confidence})"
+                        )
+                    elif weights_present:
+                        reason = (
+                            f"No detections produced for {len(photos)} photo(s). MegaDetector ran but "
+                            "found no animals meeting the confidence threshold. The pipeline will "
+                            "reject every photo with `no_subject_mask`. Lower `detector_confidence` "
+                            "in settings or rerun classify with a different threshold if detections "
+                            "were expected."
+                        )
+                        summary = "Skipped — MegaDetector produced no detections"
+                    else:
+                        reason = (
+                            f"No detections available for {len(photos)} photo(s). MegaDetector "
+                            "weights are not downloaded, so the classify stage ran on full images "
+                            "and stored no detections. Without detections the mask extraction stage "
+                            "has nothing to process, and the pipeline will reject every photo with "
+                            "`no_subject_mask`. Download MegaDetector V6 from the pipeline models "
+                            "page and rerun the pipeline."
+                        )
+                        summary = "Skipped — MegaDetector weights not downloaded"
+
+                    log.warning("Pipeline extract-masks: %s", reason)
+                    errors.append(f"[extract_masks] {reason}")
+                    stages["extract_masks"]["status"] = "skipped"
+                    runner.update_step(
+                        job["id"], "extract_masks", status="completed",
+                        summary=summary,
+                    )
+                    if photos_subthreshold_only > 0:
+                        em_reason = "all_subthreshold"
+                    elif weights_present:
+                        em_reason = "no_detections"
+                    else:
+                        em_reason = "weights_missing"
+                    result["stages"]["extract_masks"] = {
+                        "masked": 0, "skipped": 0, "failed": 0, "total": 0,
+                        "subthreshold": photos_subthreshold_only,
+                        "reason": em_reason,
+                    }
+                    _update_stages(runner, job["id"], stages)
+                    return
+
+                # Mixed-state guard: photos_with_detections > 0 (some photos have
+                # qualifying detections — already masked from a prior run) but
+                # there are also unmasked photos whose only detections are below
+                # the threshold. Without this branch the stage completes silently
+                # with "0 masked, 0 skipped" and the user has no way to discover
+                # why the unmasked photos were never processed. Production hit
+                # this when 4166 of 5054 photos were already masked and the
+                # remaining 727 had only sub-threshold detections.
+                if total == 0 and photos_subthreshold_only > 0 and classify_ran:
                     reason = (
                         f"{photos_subthreshold_only} photo(s) have detections but every "
                         f"detection is below the current detector_confidence threshold "
@@ -3504,1095 +3587,1052 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         f"Skipped — {photos_subthreshold_only} photo(s) below "
                         f"detector_confidence threshold ({detector_confidence})"
                     )
-                elif weights_present:
-                    reason = (
-                        f"No detections produced for {len(photos)} photo(s). MegaDetector ran but "
-                        "found no animals meeting the confidence threshold. The pipeline will "
-                        "reject every photo with `no_subject_mask`. Lower `detector_confidence` "
-                        "in settings or rerun classify with a different threshold if detections "
-                        "were expected."
-                    )
-                    summary = "Skipped — MegaDetector produced no detections"
-                else:
-                    reason = (
-                        f"No detections available for {len(photos)} photo(s). MegaDetector "
-                        "weights are not downloaded, so the classify stage ran on full images "
-                        "and stored no detections. Without detections the mask extraction stage "
-                        "has nothing to process, and the pipeline will reject every photo with "
-                        "`no_subject_mask`. Download MegaDetector V6 from the pipeline models "
-                        "page and rerun the pipeline."
-                    )
-                    summary = "Skipped — MegaDetector weights not downloaded"
-
-                log.warning("Pipeline extract-masks: %s", reason)
-                errors.append(f"[extract_masks] {reason}")
-                stages["extract_masks"]["status"] = "skipped"
-                runner.update_step(
-                    job["id"], "extract_masks", status="completed",
-                    summary=summary,
-                )
-                if photos_subthreshold_only > 0:
-                    em_reason = "all_subthreshold"
-                elif weights_present:
-                    em_reason = "no_detections"
-                else:
-                    em_reason = "weights_missing"
-                result["stages"]["extract_masks"] = {
-                    "masked": 0, "skipped": 0, "failed": 0, "total": 0,
-                    "subthreshold": photos_subthreshold_only,
-                    "reason": em_reason,
-                }
-                _update_stages(runner, job["id"], stages)
-                return
-
-            # Mixed-state guard: photos_with_detections > 0 (some photos have
-            # qualifying detections — already masked from a prior run) but
-            # there are also unmasked photos whose only detections are below
-            # the threshold. Without this branch the stage completes silently
-            # with "0 masked, 0 skipped" and the user has no way to discover
-            # why the unmasked photos were never processed. Production hit
-            # this when 4166 of 5054 photos were already masked and the
-            # remaining 727 had only sub-threshold detections.
-            if total == 0 and photos_subthreshold_only > 0 and classify_ran:
-                reason = (
-                    f"{photos_subthreshold_only} photo(s) have detections but every "
-                    f"detection is below the current detector_confidence threshold "
-                    f"({detector_confidence}). The pipeline will reject these photos "
-                    "with `no_subject_mask`. Lower `detector_confidence` in workspace "
-                    "settings to extract masks for them."
-                )
-                summary = (
-                    f"Skipped — {photos_subthreshold_only} photo(s) below "
-                    f"detector_confidence threshold ({detector_confidence})"
-                )
-                log.warning("Pipeline extract-masks: %s", reason)
-                errors.append(f"[extract_masks] {reason}")
-                stages["extract_masks"]["status"] = "skipped"
-                runner.update_step(
-                    job["id"], "extract_masks", status="completed",
-                    summary=summary,
-                )
-                result["stages"]["extract_masks"] = {
-                    "masked": 0, "skipped": 0, "failed": 0, "total": 0,
-                    "subthreshold": photos_subthreshold_only,
-                    "reason": "all_subthreshold",
-                }
-                _update_stages(runner, job["id"], stages)
-                return
-
-            # Auto-download SAM2 + DINOv2 weights on first pipeline run.
-            # Mirrors the MegaDetector auto-download pattern (commit 90cd0f9):
-            # without this, first-time users hit 1 FileNotFoundError per
-            # photo instead of either getting the weights automatically
-            # or seeing one actionable message.
-            #
-            # The download is deferred until the loop hits the first true
-            # cache miss. With per-variant photo_masks, the worklist now
-            # includes every photo with a detection (cache hits are
-            # filtered inside the loop, not by a `mask_path IS NULL`
-            # prefilter), so gating on ``total > 0`` would force a
-            # multi-hundred-MB download even on a fully-cached rerun in
-            # an offline / fresh-checkout environment. ``_ensure_weights``
-            # is idempotent and a no-op on second invocation.
-            from dino_embed import ensure_dinov2_weights
-            from masking import ensure_sam2_weights
-
-            def _dl_progress(phase, current, total_steps):
-                _emit_progress(
-                    runner, job["id"], stages, "extract_masks", phase,
-                )
-
-            _weights_ensured = [False]
-
-            def _ensure_weights():
-                if _weights_ensured[0]:
-                    return
-                ensure_sam2_weights(
-                    variant=sam2_variant, progress_callback=_dl_progress,
-                )
-                ensure_dinov2_weights(
-                    variant=dinov2_variant, progress_callback=_dl_progress,
-                )
-                _weights_ensured[0] = True
-
-            processed = 0
-            for i, entry in enumerate(photos_to_process):
-                if _should_abort(abort):
-                    break
-
-                photo = entry["photo"]
-                det_box = entry["det_box"]
-                photo_id = photo["id"]
-                folder_path = folders.get(photo["folder_id"], "")
-                image_path = os.path.join(folder_path, photo["filename"])
-
-                try:
-                    # Per-photo serialisation. Two pipelines whose
-                    # collections overlap can both reach this photo.
-                    # Without this lock:
-                    #
-                    #   - Same variant: both write the same
-                    #     ``masks/{photo_id}.{variant}.png`` file and
-                    #     can corrupt each other's bytes mid-write.
-                    #   - Different variants (e.g. two workspaces
-                    #     sharing folders but configured with sam2-small
-                    #     vs sam2-large): the per-variant mask files
-                    #     don't collide, BUT both runs denormalise into
-                    #     the same ``photos`` row via
-                    #     ``set_active_mask_variant`` and
-                    #     ``update_photo_embeddings``. Their writes can
-                    #     interleave, leaving photos.active_mask_variant
-                    #     pointing at one variant while photos.dino_*
-                    #     embeddings were cropped from the other's mask.
-                    #     regroup reads these denormalised columns, so
-                    #     the corruption would silently flow into
-                    #     grouping.
-                    #
-                    # Keyed by photo_id alone — not (photo_id, variant) —
-                    # so the cross-variant collision in (2) is covered.
-                    # Workspace isn't part of the key because photos are
-                    # global in Vireo.
-                    with acquire_photo_mask(photo_id):
-                        # Cache hit: a row already exists for (photo, variant)
-                        # AND its stored prompt + detector still match the
-                        # current primary detection AND the file is on disk.
-                        # In that case the SAM result is unchanged, so we
-                        # only re-activate the mask (cheap denormalize) and
-                        # skip the heavy SAM + DINOv2 work.
-                        existing = thread_db.get_photo_mask(
-                            photo_id, sam2_variant,
-                        )
-                        if existing is not None:
-                            cached_prompt = (
-                                existing["prompt_x"], existing["prompt_y"],
-                                existing["prompt_w"], existing["prompt_h"],
-                            )
-                            if (existing["detector_model"]
-                                    == entry["detector_model"]
-                                    and cached_prompt == entry["prompt"]
-                                    and existing["path"]
-                                    and os.path.isfile(existing["path"])):
-                                # The cheap skip (re-activate only) is correct
-                                # ONLY when the photos row is already fully
-                                # consistent for this variant. set_active_mask_
-                                # variant denormalises this variant's mask
-                                # features, but it does NOT touch the
-                                # dino_* embeddings — those still describe
-                                # whatever mask was active when they were last
-                                # computed. If the row is currently active on a
-                                # different SAM variant (e.g. two workspaces
-                                # share a folder but use sam2-small vs -large),
-                                # re-activating would leave the denormalised
-                                # mask features describing this variant while
-                                # the subject embedding was cropped from the
-                                # other variant's mask. regroup reads both off
-                                # the photos row, so it would mix them. Only
-                                # skip when active_mask_variant AND
-                                # dino_embedding_variant already match; else
-                                # fall through to the full recompute, which
-                                # writes set_active_mask_variant +
-                                # update_photo_embeddings together.
-                                state = thread_db.conn.execute(
-                                    "SELECT active_mask_variant, "
-                                    "dino_embedding_variant FROM photos "
-                                    "WHERE id = ?",
-                                    (photo_id,),
-                                ).fetchone()
-                                if (state is not None
-                                        and state["active_mask_variant"]
-                                        == sam2_variant
-                                        and state["dino_embedding_variant"]
-                                        == dinov2_variant):
-                                    masked += 1
-                                    processed = i + 1
-                                    continue
-
-                        # First true cache miss: ensure SAM2 + DINOv2 weights
-                        # are present before render_proxy/generate_mask runs.
-                        # No-op on subsequent iterations.
-                        _ensure_weights()
-
-                        proxy = render_proxy(image_path, longest_edge=proxy_longest_edge)
-                        if proxy is None:
-                            skipped += 1
-                            processed = i + 1
-                            continue
-                        if _should_abort(abort):
-                            break
-
-                        # GPU serialisation lives inside masking.generate_mask
-                        # (around the encoder/decoder session.run calls). The
-                        # wider wrap previously here held the semaphore through
-                        # SAM weight load + image preprocessing + prompt-coord
-                        # math, blocking other pipelines' GPU work for CPU-only
-                        # phases.
-                        mask = generate_mask(proxy, det_box, variant=sam2_variant)
-                        if mask is None:
-                            skipped += 1
-                            processed = i + 1
-                            continue
-                        if _should_abort(abort):
-                            break
-
-                        mask_path = save_mask(
-                            mask, masks_dir, photo_id, sam2_variant,
-                        )
-                        completeness = crop_completeness(mask)
-                        features = compute_all_quality_features(proxy, mask)
-                        if _should_abort(abort):
-                            break
-
-                        # Per-mask features (move from photos row into
-                        # photo_masks; set_active_mask_variant denormalizes
-                        # them back into photos for downstream readers).
-                        mask_subject_tenengrad = features.pop(
-                            "subject_tenengrad", None,
-                        )
-                        mask_bg_tenengrad = features.pop("bg_tenengrad", None)
-                        # Mask-derived subject_size: fraction of frame
-                        # covered by the boolean mask. Replaces the
-                        # detection-bbox approximation classify uses.
-                        total_pixels = float(mask.size)
-                        if total_pixels > 0:
-                            mask_subject_size = float(
-                                np.count_nonzero(mask) / total_pixels
-                            )
-                        else:
-                            mask_subject_size = None
-
-                        # GPU serialisation lives inside dino_embed.embed /
-                        # embed_batch (around the session.run call). The wider
-                        # wrap previously here held the semaphore through
-                        # per-image resize/normalize preprocessing.
-                        subject_crop = crop_subject(proxy, mask, margin=0.15)
-                        if subject_crop is not None:
-                            embs = embed_batch(
-                                [subject_crop, proxy], variant=dinov2_variant,
-                            )
-                            subj_emb_blob = embedding_to_blob(embs[0])
-                            global_emb_blob = embedding_to_blob(embs[1])
-                        else:
-                            subj_emb_blob = None
-                            global_emb_blob = embedding_to_blob(
-                                embed(proxy, variant=dinov2_variant),
-                            )
-
-                        thread_db.upsert_photo_mask(
-                            photo_id=photo_id,
-                            variant=sam2_variant,
-                            path=mask_path,
-                            detector_model=entry["detector_model"],
-                            prompt_x=entry["prompt"][0],
-                            prompt_y=entry["prompt"][1],
-                            prompt_w=entry["prompt"][2],
-                            prompt_h=entry["prompt"][3],
-                            subject_size=mask_subject_size,
-                            subject_tenengrad=mask_subject_tenengrad,
-                            bg_tenengrad=mask_bg_tenengrad,
-                            crop_complete=completeness,
-                        )
-                        thread_db.set_active_mask_variant(
-                            photo_id, sam2_variant,
-                        )
-                        # Remaining (non-mask) per-photo features still land
-                        # on the photos row.  mask_path / crop_complete /
-                        # subject_tenengrad / bg_tenengrad now flow via
-                        # set_active_mask_variant above, so they are
-                        # intentionally NOT passed here.
-                        if features:
-                            thread_db.update_photo_pipeline_features(
-                                photo_id, **features,
-                            )
-                        thread_db.update_photo_embeddings(
-                            photo_id,
-                            dino_subject_embedding=subj_emb_blob,
-                            dino_global_embedding=global_emb_blob,
-                            variant=dinov2_variant,
-                        )
-                        masked += 1
-                except Exception:
-                    em_failed += 1
-                    log.warning("Mask extraction failed for photo %s", photo_id, exc_info=True)
-
-                processed = i + 1
-                stages["extract_masks"]["count"] = processed
-                stages["extract_masks"]["total"] = total
-                runner.update_step(job["id"], "extract_masks",
-                                   progress={"current": processed, "total": total},
-                                   error_count=em_failed)
-                _emit_progress(
-                    runner, job["id"], stages, "extract_masks",
-                    "Extracting features (SAM2 + DINOv2)",
-                    rate=round(processed / max(time.time() - start_time, 0.01) * 60, 1),
-                )
-
-            if _should_abort(abort):
-                # Distinguish a user cancel from a clean completion: pin a
-                # "Cancelled" summary on the final step update so the job
-                # tree doesn't report a half-done stage as if it ran to
-                # term. Mirrors the classify-cancel path PR #710 added.
-                stages["extract_masks"]["status"] = "completed"
-                em_summary = (
-                    f"Cancelled ({processed} of {total} processed)"
-                    if total else "Cancelled"
-                )
-                runner.update_step(
-                    job["id"], "extract_masks", status="completed",
-                    progress={"current": processed, "total": total},
-                    summary=em_summary,
-                    error_count=em_failed,
-                )
-                result["stages"]["extract_masks"] = {
-                    "masked": masked, "skipped": skipped, "failed": em_failed,
-                    "total": total, "cancelled": True,
-                }
-            else:
-                final_status = "failed" if em_failed > 0 else "completed"
-                stages["extract_masks"]["status"] = final_status
-                em_rollup = (
-                    f"[extract_masks] {em_failed} of {total} photos failed mask extraction"
-                    if em_failed > 0 else None
-                )
-                if em_rollup:
-                    errors.append(em_rollup)
-                em_summary_parts = [f"{masked} masked", f"{skipped} skipped"]
-                if em_failed:
-                    em_summary_parts.append(f"{em_failed} failed")
-                if photos_subthreshold_only > 0:
-                    em_summary_parts.append(
-                        f"{photos_subthreshold_only} below detector_confidence "
-                        f"({detector_confidence})"
-                    )
-                runner.update_step(job["id"], "extract_masks", status=final_status,
-                                   summary=", ".join(em_summary_parts),
-                                   error_count=em_failed,
-                                   error=em_rollup)
-                result["stages"]["extract_masks"] = {
-                    "masked": masked, "skipped": skipped, "failed": em_failed,
-                    "total": total, "subthreshold": photos_subthreshold_only,
-                }
-        except Exception as e:
-            errors.append(f"[extract_masks] Fatal: {e}")
-            log.exception("Pipeline extract-masks stage failed")
-            stages["extract_masks"]["status"] = "failed"
-            runner.update_step(job["id"], "extract_masks", status="failed", error=str(e))
-
-        _update_stages(runner, job["id"], stages)
-
-    def eye_keypoints_stage():
-        """Run per-photo eye keypoint detection between mask extraction and scoring.
-
-        No-op when the stage is disabled by config, when no SuperAnimal
-        weights are on disk (users opt-in via the pipeline models card),
-        or when no eligible photos remain. Per-photo failures are logged
-        and do not abort the stage.
-        """
-        if (
-            params.skip_eye_keypoints
-            or params.skip_extract_masks
-            or abort.is_set()
-            or not collection_id
-        ):
-            stages["eye_keypoints"]["status"] = "skipped"
-            runner.update_step(
-                job["id"], "eye_keypoints", status="completed", summary="Skipped",
-            )
-            return
-
-        stages["eye_keypoints"]["status"] = "running"
-        runner.update_step(job["id"], "eye_keypoints", status="running")
-        _update_stages(runner, job["id"], stages)
-
-        try:
-            import config as cfg
-            from pipeline import (
-                _resolve_collection_photo_ids,
-                detect_eye_keypoints_stage,
-                eye_keypoint_stage_preflight,
-            )
-
-            thread_db = Database(db_path)
-            thread_db.set_active_workspace(workspace_id)
-            effective_cfg = thread_db.get_effective_config(cfg.load())
-            pipeline_cfg = effective_cfg.get("pipeline", {})
-
-            # Mirror the stage-level preflight so a no-op run doesn't pay the
-            # O(N) eligibility join cost or report a misleading
-            # "0 of N processed" summary on large libraries.
-            skip_reason = eye_keypoint_stage_preflight(pipeline_cfg)
-            if skip_reason is not None:
-                stages["eye_keypoints"]["status"] = "skipped"
-                runner.update_step(
-                    job["id"], "eye_keypoints",
-                    status="completed", summary=f"Skipped — {skip_reason}",
-                )
-                result["stages"]["eye_keypoints"] = {
-                    "processed": 0, "total": 0, "skipped": skip_reason,
-                }
-                _update_stages(runner, job["id"], stages)
-                return
-
-            collection_photo_ids = (
-                _resolve_collection_photo_ids(thread_db, collection_id)
-                if collection_id is not None else None
-            )
-            # Honor preview-deselection so the eye stage matches the set of
-            # photos extract/regroup will act on. Without this the stage
-            # mutates eye_* for unchecked photos and those values are locked
-            # in by the eye_tenengrad IS NULL idempotency guard on reruns.
-            if params.exclude_photo_ids and collection_photo_ids is not None:
-                collection_photo_ids = {
-                    pid for pid in collection_photo_ids
-                    if pid not in params.exclude_photo_ids
-                }
-            photos_for_stage = thread_db.list_photos_for_eye_keypoint_stage(
-                photo_ids=collection_photo_ids,
-            )
-            # Defensive second filter: when collection_photo_ids is None
-            # (whole-workspace path) the DB query above returned every
-            # eligible row, so excluded IDs would otherwise still influence
-            # the download planner below and trigger weights for variants no
-            # included photo routes to.
-            if params.exclude_photo_ids:
-                photos_for_stage = [
-                    p for p in photos_for_stage
-                    if p["id"] not in params.exclude_photo_ids
-                ]
-            total = len(photos_for_stage)
-            start_time = time.time()
-            processed = {"count": 0}
-
-            def _progress(phase, current, total_steps):
-                processed["count"] = current
-                stages["eye_keypoints"]["count"] = current
-                stages["eye_keypoints"]["total"] = total_steps
-                runner.update_step(
-                    job["id"], "eye_keypoints",
-                    progress={"current": current, "total": total_steps},
-                )
-                _emit_progress(
-                    runner, job["id"], stages, "eye_keypoints", phase,
-                    rate=round(
-                        current / max(time.time() - start_time, 0.01) * 60, 1
-                    ),
-                )
-
-            # Auto-download SuperAnimal weights on first pipeline run.
-            # Mirrors the SAM2/DINOv2 auto-download pattern in extract_masks
-            # (commit 90cd0f9): without this, every photo silently skips on
-            # a fresh install. Only fetch variants the per-photo router
-            # would actually pick — a collection of out-of-scope classes
-            # (fish/reptiles/invertebrates) shouldn't pay the bandwidth
-            # cost for weights that will never be used.
-            if total > 0:
-                import keypoints as kp
-                from pipeline import _resolve_keypoint_model
-
-                # Mirror Gate 1 in _process_photo_for_eye: rows whose
-                # classifier confidence is below eye_classifier_conf_gate
-                # get skipped at run time, so they shouldn't influence
-                # which variants get downloaded — otherwise an all-low-
-                # confidence collection still pays the bandwidth cost
-                # for weights no photo can reach.
-                conf_gate = pipeline_cfg.get(
-                    "eye_classifier_conf_gate", 0.5,
-                )
-                needed_models = []
-                for row in photos_for_stage:
-                    if (row.get("species_conf") or 0.0) < conf_gate:
-                        continue
-                    model_name = _resolve_keypoint_model(thread_db, row)
-                    if model_name and model_name not in needed_models:
-                        needed_models.append(model_name)
-
-                # Use a separate download-progress callback so a cancel
-                # during/just after weight download doesn't leak the
-                # download counter into `processed['count']` (which would
-                # surface as e.g. "Cancelled (1 of N processed)" before any
-                # photo has actually been touched).
-                def _dl_progress(phase, current, total_steps):
-                    _emit_progress(
-                        runner, job["id"], stages, "eye_keypoints", phase,
-                    )
-
-                # Preserve a stable order (quadruped, bird) for tests and
-                # log readability when both variants are needed. Re-check
-                # abort between models so a cancel that arrives after the
-                # first weights download can short-circuit the second
-                # multi-hundred-MB fetch instead of forcing the user to
-                # wait through it.
-                #
-                # Eye Keypoints is an optional stage: a transient HF /
-                # network failure must degrade to a skipped stage, not a
-                # hard pipeline failure. Without this guard the RuntimeError
-                # raised by ensure_keypoint_weights bubbles to the outer
-                # except, marks the stage 'failed', and tanks the whole
-                # run for a first-run/offline user who never opted into
-                # eye keypoints in the first place.
-                try:
-                    for kp_model in (
-                        "superanimal-quadruped", "superanimal-bird",
-                    ):
-                        if _should_abort(abort):
-                            break
-                        if kp_model in needed_models:
-                            kp.ensure_keypoint_weights(
-                                kp_model, progress_callback=_dl_progress,
-                            )
-                except Exception as dl_err:
-                    log.warning(
-                        "Eye keypoints stage skipped — weight download "
-                        "failed: %s", dl_err,
-                    )
-                    errors.append(f"[eye_keypoints] {dl_err}")
-                    stages["eye_keypoints"]["status"] = "skipped"
+                    log.warning("Pipeline extract-masks: %s", reason)
+                    errors.append(f"[extract_masks] {reason}")
+                    stages["extract_masks"]["status"] = "skipped"
                     runner.update_step(
-                        job["id"], "eye_keypoints",
-                        status="completed",
-                        summary=(
-                            f"Skipped — failed to download keypoint "
-                            f"weights: {dl_err}"
-                        ),
+                        job["id"], "extract_masks", status="completed",
+                        summary=summary,
                     )
-                    result["stages"]["eye_keypoints"] = {
-                        "processed": 0, "total": total,
-                        "skipped": "weight_download_failed",
+                    result["stages"]["extract_masks"] = {
+                        "masked": 0, "skipped": 0, "failed": 0, "total": 0,
+                        "subthreshold": photos_subthreshold_only,
+                        "reason": "all_subthreshold",
                     }
                     _update_stages(runner, job["id"], stages)
                     return
 
-            detect_eye_keypoints_stage(
-                thread_db, config=pipeline_cfg, progress_callback=_progress,
-                collection_id=collection_id,
-                exclude_photo_ids=params.exclude_photo_ids,
-                abort_check=lambda: _should_abort(abort),
-            )
-
-            stages["eye_keypoints"]["status"] = "completed"
-            if _should_abort(abort):
-                # Match the classify- and extract_masks-cancel summaries so
-                # the job tree distinguishes a user cancel from a clean
-                # finish that happened to process the same count.
-                summary = (
-                    f"Cancelled ({processed['count']} of {total} processed)"
-                    if total else "Cancelled"
-                )
-                runner.update_step(
-                    job["id"], "eye_keypoints",
-                    status="completed", summary=summary,
-                )
-                result["stages"]["eye_keypoints"] = {
-                    "processed": processed["count"], "total": total,
-                    "cancelled": True,
-                }
-            else:
-                summary = (
-                    f"{processed['count']} of {total} photos processed"
-                    if total else "No eligible photos"
-                )
-                runner.update_step(
-                    job["id"], "eye_keypoints",
-                    status="completed", summary=summary,
-                )
-                result["stages"]["eye_keypoints"] = {
-                    "processed": processed["count"], "total": total,
-                }
-        except Exception as e:
-            errors.append(f"[eye_keypoints] Fatal: {e}")
-            log.exception("Pipeline eye-keypoints stage failed")
-            stages["eye_keypoints"]["status"] = "failed"
-            runner.update_step(
-                job["id"], "eye_keypoints", status="failed", error=str(e),
-            )
-
-        _update_stages(runner, job["id"], stages)
-
-    def regroup_stage():
-        """Run pipeline grouping + scoring + triage from cached features."""
-        if params.skip_regroup or abort.is_set() or not collection_id:
-            stages["regroup"]["status"] = "skipped"
-            runner.update_step(job["id"], "regroup", status="completed",
-                               summary="Skipped")
-            return
-
-        stages["regroup"]["status"] = "running"
-        runner.update_step(job["id"], "regroup", status="running")
-        _update_stages(runner, job["id"], stages)
-
-        # The per-workspace regroup lock is now acquired by the
-        # orchestrator (see run_pipeline_job body) so it spans BOTH
-        # regroup_stage and miss_stage atomically — the inner lock
-        # that used to live here would deadlock against the outer one
-        # (Python locks aren't reentrant). The deferred-update pattern
-        # likewise goes away: runner.update_step is fine to call here
-        # because nothing under JobRunner._lock acquires the workspace
-        # regroup lock, so there's no cycle to invert.
-        try:
-            import config as cfg
-            from pipeline import load_photo_features, run_full_pipeline, save_results
-
-            thread_db = Database(db_path)
-            thread_db.set_active_workspace(workspace_id)
-
-            effective_cfg = thread_db.get_effective_config(cfg.load())
-            pipeline_cfg = effective_cfg.get("pipeline", {})
-
-            photos = load_photo_features(thread_db, collection_id=collection_id, config=effective_cfg)
-            if params.exclude_photo_ids:
-                photos = [p for p in photos if p["id"] not in params.exclude_photo_ids]
-            if not photos:
-                result["stages"]["regroup"] = {"error": "No photos with pipeline features found."}
-                stages["regroup"]["status"] = "completed"
-                runner.update_step(
-                    job["id"], "regroup",
-                    status="completed", summary="No photos to group",
-                )
-            else:
-                results = run_full_pipeline(photos, config=pipeline_cfg, emit_trace=True)
-                cache_dir = os.path.dirname(db_path)
-                save_results(results, cache_dir, workspace_id)
-
-                # Stamp the grouping fingerprint + timestamp BEFORE marking
-                # the step completed, so a partial regroup that crashes
-                # between here and update_step doesn't end up labeled "fresh"
-                # with a stale fp.
+                # Auto-download SAM2 + DINOv2 weights on first pipeline run.
+                # Mirrors the MegaDetector auto-download pattern (commit 90cd0f9):
+                # without this, first-time users hit 1 FileNotFoundError per
+                # photo instead of either getting the weights automatically
+                # or seeing one actionable message.
                 #
-                # Only stamp when the regroup actually covered the whole
-                # workspace — if it ran on a filtered subset (a
-                # sub-collection, or with exclude_photo_ids set) some
-                # workspace photos were intentionally not regrouped, so
-                # claiming workspace-level freshness would let the pipeline
-                # page hide a real stale state.
+                # The download is deferred until the loop hits the first true
+                # cache miss. With per-variant photo_masks, the worklist now
+                # includes every photo with a detection (cache hits are
+                # filtered inside the loop, not by a `mask_path IS NULL`
+                # prefilter), so gating on ``total > 0`` would force a
+                # multi-hundred-MB download even on a fully-cached rerun in
+                # an offline / fresh-checkout environment. ``_ensure_weights``
+                # is idempotent and a no-op on second invocation.
+                from dino_embed import ensure_dinov2_weights
+                from masking import ensure_sam2_weights
+
+                def _dl_progress(phase, current, total_steps):
+                    _emit_progress(
+                        runner, job["id"], stages, "extract_masks", phase,
+                    )
+
+                _weights_ensured = [False]
+
+                def _ensure_weights():
+                    if _weights_ensured[0]:
+                        return
+                    ensure_sam2_weights(
+                        variant=sam2_variant, progress_callback=_dl_progress,
+                    )
+                    ensure_dinov2_weights(
+                        variant=dinov2_variant, progress_callback=_dl_progress,
+                    )
+                    _weights_ensured[0] = True
+
+                processed = 0
+                for i, entry in enumerate(photos_to_process):
+                    if _should_abort(abort):
+                        break
+
+                    photo = entry["photo"]
+                    det_box = entry["det_box"]
+                    photo_id = photo["id"]
+                    folder_path = folders.get(photo["folder_id"], "")
+                    image_path = os.path.join(folder_path, photo["filename"])
+
+                    try:
+                        # Per-photo serialisation. Two pipelines whose
+                        # collections overlap can both reach this photo.
+                        # Without this lock:
+                        #
+                        #   - Same variant: both write the same
+                        #     ``masks/{photo_id}.{variant}.png`` file and
+                        #     can corrupt each other's bytes mid-write.
+                        #   - Different variants (e.g. two workspaces
+                        #     sharing folders but configured with sam2-small
+                        #     vs sam2-large): the per-variant mask files
+                        #     don't collide, BUT both runs denormalise into
+                        #     the same ``photos`` row via
+                        #     ``set_active_mask_variant`` and
+                        #     ``update_photo_embeddings``. Their writes can
+                        #     interleave, leaving photos.active_mask_variant
+                        #     pointing at one variant while photos.dino_*
+                        #     embeddings were cropped from the other's mask.
+                        #     regroup reads these denormalised columns, so
+                        #     the corruption would silently flow into
+                        #     grouping.
+                        #
+                        # Keyed by photo_id alone — not (photo_id, variant) —
+                        # so the cross-variant collision in (2) is covered.
+                        # Workspace isn't part of the key because photos are
+                        # global in Vireo.
+                        with acquire_photo_mask(photo_id):
+                            # Cache hit: a row already exists for (photo, variant)
+                            # AND its stored prompt + detector still match the
+                            # current primary detection AND the file is on disk.
+                            # In that case the SAM result is unchanged, so we
+                            # only re-activate the mask (cheap denormalize) and
+                            # skip the heavy SAM + DINOv2 work.
+                            existing = thread_db.get_photo_mask(
+                                photo_id, sam2_variant,
+                            )
+                            if existing is not None:
+                                cached_prompt = (
+                                    existing["prompt_x"], existing["prompt_y"],
+                                    existing["prompt_w"], existing["prompt_h"],
+                                )
+                                if (existing["detector_model"]
+                                        == entry["detector_model"]
+                                        and cached_prompt == entry["prompt"]
+                                        and existing["path"]
+                                        and os.path.isfile(existing["path"])):
+                                    # The cheap skip (re-activate only) is correct
+                                    # ONLY when the photos row is already fully
+                                    # consistent for this variant. set_active_mask_
+                                    # variant denormalises this variant's mask
+                                    # features, but it does NOT touch the
+                                    # dino_* embeddings — those still describe
+                                    # whatever mask was active when they were last
+                                    # computed. If the row is currently active on a
+                                    # different SAM variant (e.g. two workspaces
+                                    # share a folder but use sam2-small vs -large),
+                                    # re-activating would leave the denormalised
+                                    # mask features describing this variant while
+                                    # the subject embedding was cropped from the
+                                    # other variant's mask. regroup reads both off
+                                    # the photos row, so it would mix them. Only
+                                    # skip when active_mask_variant AND
+                                    # dino_embedding_variant already match; else
+                                    # fall through to the full recompute, which
+                                    # writes set_active_mask_variant +
+                                    # update_photo_embeddings together.
+                                    state = thread_db.conn.execute(
+                                        "SELECT active_mask_variant, "
+                                        "dino_embedding_variant FROM photos "
+                                        "WHERE id = ?",
+                                        (photo_id,),
+                                    ).fetchone()
+                                    if (state is not None
+                                            and state["active_mask_variant"]
+                                            == sam2_variant
+                                            and state["dino_embedding_variant"]
+                                            == dinov2_variant):
+                                        masked += 1
+                                        processed = i + 1
+                                        continue
+
+                            # First true cache miss: ensure SAM2 + DINOv2 weights
+                            # are present before render_proxy/generate_mask runs.
+                            # No-op on subsequent iterations.
+                            _ensure_weights()
+
+                            proxy = render_proxy(image_path, longest_edge=proxy_longest_edge)
+                            if proxy is None:
+                                skipped += 1
+                                processed = i + 1
+                                continue
+                            if _should_abort(abort):
+                                break
+
+                            # GPU serialisation lives inside masking.generate_mask
+                            # (around the encoder/decoder session.run calls). The
+                            # wider wrap previously here held the semaphore through
+                            # SAM weight load + image preprocessing + prompt-coord
+                            # math, blocking other pipelines' GPU work for CPU-only
+                            # phases.
+                            mask = generate_mask(proxy, det_box, variant=sam2_variant)
+                            if mask is None:
+                                skipped += 1
+                                processed = i + 1
+                                continue
+                            if _should_abort(abort):
+                                break
+
+                            mask_path = save_mask(
+                                mask, masks_dir, photo_id, sam2_variant,
+                            )
+                            completeness = crop_completeness(mask)
+                            features = compute_all_quality_features(proxy, mask)
+                            if _should_abort(abort):
+                                break
+
+                            # Per-mask features (move from photos row into
+                            # photo_masks; set_active_mask_variant denormalizes
+                            # them back into photos for downstream readers).
+                            mask_subject_tenengrad = features.pop(
+                                "subject_tenengrad", None,
+                            )
+                            mask_bg_tenengrad = features.pop("bg_tenengrad", None)
+                            # Mask-derived subject_size: fraction of frame
+                            # covered by the boolean mask. Replaces the
+                            # detection-bbox approximation classify uses.
+                            total_pixels = float(mask.size)
+                            if total_pixels > 0:
+                                mask_subject_size = float(
+                                    np.count_nonzero(mask) / total_pixels
+                                )
+                            else:
+                                mask_subject_size = None
+
+                            # GPU serialisation lives inside dino_embed.embed /
+                            # embed_batch (around the session.run call). The wider
+                            # wrap previously here held the semaphore through
+                            # per-image resize/normalize preprocessing.
+                            subject_crop = crop_subject(proxy, mask, margin=0.15)
+                            if subject_crop is not None:
+                                embs = embed_batch(
+                                    [subject_crop, proxy], variant=dinov2_variant,
+                                )
+                                subj_emb_blob = embedding_to_blob(embs[0])
+                                global_emb_blob = embedding_to_blob(embs[1])
+                            else:
+                                subj_emb_blob = None
+                                global_emb_blob = embedding_to_blob(
+                                    embed(proxy, variant=dinov2_variant),
+                                )
+
+                            thread_db.upsert_photo_mask(
+                                photo_id=photo_id,
+                                variant=sam2_variant,
+                                path=mask_path,
+                                detector_model=entry["detector_model"],
+                                prompt_x=entry["prompt"][0],
+                                prompt_y=entry["prompt"][1],
+                                prompt_w=entry["prompt"][2],
+                                prompt_h=entry["prompt"][3],
+                                subject_size=mask_subject_size,
+                                subject_tenengrad=mask_subject_tenengrad,
+                                bg_tenengrad=mask_bg_tenengrad,
+                                crop_complete=completeness,
+                            )
+                            thread_db.set_active_mask_variant(
+                                photo_id, sam2_variant,
+                            )
+                            # Remaining (non-mask) per-photo features still land
+                            # on the photos row.  mask_path / crop_complete /
+                            # subject_tenengrad / bg_tenengrad now flow via
+                            # set_active_mask_variant above, so they are
+                            # intentionally NOT passed here.
+                            if features:
+                                thread_db.update_photo_pipeline_features(
+                                    photo_id, **features,
+                                )
+                            thread_db.update_photo_embeddings(
+                                photo_id,
+                                dino_subject_embedding=subj_emb_blob,
+                                dino_global_embedding=global_emb_blob,
+                                variant=dinov2_variant,
+                            )
+                            masked += 1
+                    except Exception:
+                        em_failed += 1
+                        log.warning("Mask extraction failed for photo %s", photo_id, exc_info=True)
+
+                    processed = i + 1
+                    stages["extract_masks"]["count"] = processed
+                    stages["extract_masks"]["total"] = total
+                    runner.update_step(job["id"], "extract_masks",
+                                       progress={"current": processed, "total": total},
+                                       error_count=em_failed)
+                    _emit_progress(
+                        runner, job["id"], stages, "extract_masks",
+                        "Extracting features (SAM2 + DINOv2)",
+                        rate=round(processed / max(time.time() - start_time, 0.01) * 60, 1),
+                    )
+
+                if _should_abort(abort):
+                    # Distinguish a user cancel from a clean completion: pin a
+                    # "Cancelled" summary on the final step update so the job
+                    # tree doesn't report a half-done stage as if it ran to
+                    # term. Mirrors the classify-cancel path PR #710 added.
+                    stages["extract_masks"]["status"] = "completed"
+                    em_summary = (
+                        f"Cancelled ({processed} of {total} processed)"
+                        if total else "Cancelled"
+                    )
+                    runner.update_step(
+                        job["id"], "extract_masks", status="completed",
+                        progress={"current": processed, "total": total},
+                        summary=em_summary,
+                        error_count=em_failed,
+                    )
+                    result["stages"]["extract_masks"] = {
+                        "masked": masked, "skipped": skipped, "failed": em_failed,
+                        "total": total, "cancelled": True,
+                    }
+                else:
+                    final_status = "failed" if em_failed > 0 else "completed"
+                    stages["extract_masks"]["status"] = final_status
+                    em_rollup = (
+                        f"[extract_masks] {em_failed} of {total} photos failed mask extraction"
+                        if em_failed > 0 else None
+                    )
+                    if em_rollup:
+                        errors.append(em_rollup)
+                    em_summary_parts = [f"{masked} masked", f"{skipped} skipped"]
+                    if em_failed:
+                        em_summary_parts.append(f"{em_failed} failed")
+                    if photos_subthreshold_only > 0:
+                        em_summary_parts.append(
+                            f"{photos_subthreshold_only} below detector_confidence "
+                            f"({detector_confidence})"
+                        )
+                    runner.update_step(job["id"], "extract_masks", status=final_status,
+                                       summary=", ".join(em_summary_parts),
+                                       error_count=em_failed,
+                                       error=em_rollup)
+                    result["stages"]["extract_masks"] = {
+                        "masked": masked, "skipped": skipped, "failed": em_failed,
+                        "total": total, "subthreshold": photos_subthreshold_only,
+                    }
+            except Exception as e:
+                errors.append(f"[extract_masks] Fatal: {e}")
+                log.exception("Pipeline extract-masks stage failed")
+                stages["extract_masks"]["status"] = "failed"
+                runner.update_step(job["id"], "extract_masks", status="failed", error=str(e))
+
+            _update_stages(runner, job["id"], stages)
+
+        def eye_keypoints_stage():
+            """Run per-photo eye keypoint detection between mask extraction and scoring.
+
+            No-op when the stage is disabled by config, when no SuperAnimal
+            weights are on disk (users opt-in via the pipeline models card),
+            or when no eligible photos remain. Per-photo failures are logged
+            and do not abort the stage.
+            """
+            if (
+                params.skip_eye_keypoints
+                or params.skip_extract_masks
+                or abort.is_set()
+                or not collection_id
+            ):
+                stages["eye_keypoints"]["status"] = "skipped"
+                runner.update_step(
+                    job["id"], "eye_keypoints", status="completed", summary="Skipped",
+                )
+                return
+
+            stages["eye_keypoints"]["status"] = "running"
+            runner.update_step(job["id"], "eye_keypoints", status="running")
+            _update_stages(runner, job["id"], stages)
+
+            try:
+                import config as cfg
                 from pipeline import (
                     _resolve_collection_photo_ids,
-                    compute_group_fingerprint,
+                    detect_eye_keypoints_stage,
+                    eye_keypoint_stage_preflight,
                 )
-                collection_photo_ids = _resolve_collection_photo_ids(
-                    thread_db, collection_id,
+
+                thread_db = Database(db_path)
+                thread_db.set_active_workspace(workspace_id)
+                effective_cfg = thread_db.get_effective_config(cfg.load())
+                pipeline_cfg = effective_cfg.get("pipeline", {})
+
+                # Mirror the stage-level preflight so a no-op run doesn't pay the
+                # O(N) eligibility join cost or report a misleading
+                # "0 of N processed" summary on large libraries.
+                skip_reason = eye_keypoint_stage_preflight(pipeline_cfg)
+                if skip_reason is not None:
+                    stages["eye_keypoints"]["status"] = "skipped"
+                    runner.update_step(
+                        job["id"], "eye_keypoints",
+                        status="completed", summary=f"Skipped — {skip_reason}",
+                    )
+                    result["stages"]["eye_keypoints"] = {
+                        "processed": 0, "total": 0, "skipped": skip_reason,
+                    }
+                    _update_stages(runner, job["id"], stages)
+                    return
+
+                collection_photo_ids = (
+                    _resolve_collection_photo_ids(thread_db, collection_id)
+                    if collection_id is not None else None
                 )
-                ws_photo_ids = {
-                    r["id"] for r in thread_db.conn.execute(
-                        """SELECT p.id
-                             FROM photos p
-                             JOIN workspace_folders wf
-                               ON wf.folder_id = p.folder_id
-                            WHERE wf.workspace_id = ?""",
-                        (workspace_id,),
-                    ).fetchall()
-                }
-                covered_full_workspace = (
-                    not params.exclude_photo_ids
-                    and ws_photo_ids.issubset(collection_photo_ids)
+                # Honor preview-deselection so the eye stage matches the set of
+                # photos extract/regroup will act on. Without this the stage
+                # mutates eye_* for unchecked photos and those values are locked
+                # in by the eye_tenengrad IS NULL idempotency guard on reruns.
+                if params.exclude_photo_ids and collection_photo_ids is not None:
+                    collection_photo_ids = {
+                        pid for pid in collection_photo_ids
+                        if pid not in params.exclude_photo_ids
+                    }
+                photos_for_stage = thread_db.list_photos_for_eye_keypoint_stage(
+                    photo_ids=collection_photo_ids,
                 )
-                if covered_full_workspace:
-                    thread_db.set_workspace_group_state(
-                        workspace_id=workspace_id,
-                        fingerprint=compute_group_fingerprint(effective_cfg),
-                        when_ts=int(time.time()),
+                # Defensive second filter: when collection_photo_ids is None
+                # (whole-workspace path) the DB query above returned every
+                # eligible row, so excluded IDs would otherwise still influence
+                # the download planner below and trigger weights for variants no
+                # included photo routes to.
+                if params.exclude_photo_ids:
+                    photos_for_stage = [
+                        p for p in photos_for_stage
+                        if p["id"] not in params.exclude_photo_ids
+                    ]
+                total = len(photos_for_stage)
+                start_time = time.time()
+                processed = {"count": 0}
+
+                def _progress(phase, current, total_steps):
+                    processed["count"] = current
+                    stages["eye_keypoints"]["count"] = current
+                    stages["eye_keypoints"]["total"] = total_steps
+                    runner.update_step(
+                        job["id"], "eye_keypoints",
+                        progress={"current": current, "total": total_steps},
+                    )
+                    _emit_progress(
+                        runner, job["id"], stages, "eye_keypoints", phase,
+                        rate=round(
+                            current / max(time.time() - start_time, 0.01) * 60, 1
+                        ),
+                    )
+
+                # Auto-download SuperAnimal weights on first pipeline run.
+                # Mirrors the SAM2/DINOv2 auto-download pattern in extract_masks
+                # (commit 90cd0f9): without this, every photo silently skips on
+                # a fresh install. Only fetch variants the per-photo router
+                # would actually pick — a collection of out-of-scope classes
+                # (fish/reptiles/invertebrates) shouldn't pay the bandwidth
+                # cost for weights that will never be used.
+                if total > 0:
+                    import keypoints as kp
+                    from pipeline import _resolve_keypoint_model
+
+                    # Mirror Gate 1 in _process_photo_for_eye: rows whose
+                    # classifier confidence is below eye_classifier_conf_gate
+                    # get skipped at run time, so they shouldn't influence
+                    # which variants get downloaded — otherwise an all-low-
+                    # confidence collection still pays the bandwidth cost
+                    # for weights no photo can reach.
+                    conf_gate = pipeline_cfg.get(
+                        "eye_classifier_conf_gate", 0.5,
+                    )
+                    needed_models = []
+                    for row in photos_for_stage:
+                        if (row.get("species_conf") or 0.0) < conf_gate:
+                            continue
+                        model_name = _resolve_keypoint_model(thread_db, row)
+                        if model_name and model_name not in needed_models:
+                            needed_models.append(model_name)
+
+                    # Use a separate download-progress callback so a cancel
+                    # during/just after weight download doesn't leak the
+                    # download counter into `processed['count']` (which would
+                    # surface as e.g. "Cancelled (1 of N processed)" before any
+                    # photo has actually been touched).
+                    def _dl_progress(phase, current, total_steps):
+                        _emit_progress(
+                            runner, job["id"], stages, "eye_keypoints", phase,
+                        )
+
+                    # Preserve a stable order (quadruped, bird) for tests and
+                    # log readability when both variants are needed. Re-check
+                    # abort between models so a cancel that arrives after the
+                    # first weights download can short-circuit the second
+                    # multi-hundred-MB fetch instead of forcing the user to
+                    # wait through it.
+                    #
+                    # Eye Keypoints is an optional stage: a transient HF /
+                    # network failure must degrade to a skipped stage, not a
+                    # hard pipeline failure. Without this guard the RuntimeError
+                    # raised by ensure_keypoint_weights bubbles to the outer
+                    # except, marks the stage 'failed', and tanks the whole
+                    # run for a first-run/offline user who never opted into
+                    # eye keypoints in the first place.
+                    try:
+                        for kp_model in (
+                            "superanimal-quadruped", "superanimal-bird",
+                        ):
+                            if _should_abort(abort):
+                                break
+                            if kp_model in needed_models:
+                                kp.ensure_keypoint_weights(
+                                    kp_model, progress_callback=_dl_progress,
+                                )
+                    except Exception as dl_err:
+                        log.warning(
+                            "Eye keypoints stage skipped — weight download "
+                            "failed: %s", dl_err,
+                        )
+                        errors.append(f"[eye_keypoints] {dl_err}")
+                        stages["eye_keypoints"]["status"] = "skipped"
+                        runner.update_step(
+                            job["id"], "eye_keypoints",
+                            status="completed",
+                            summary=(
+                                f"Skipped — failed to download keypoint "
+                                f"weights: {dl_err}"
+                            ),
+                        )
+                        result["stages"]["eye_keypoints"] = {
+                            "processed": 0, "total": total,
+                            "skipped": "weight_download_failed",
+                        }
+                        _update_stages(runner, job["id"], stages)
+                        return
+
+                detect_eye_keypoints_stage(
+                    thread_db, config=pipeline_cfg, progress_callback=_progress,
+                    collection_id=collection_id,
+                    exclude_photo_ids=params.exclude_photo_ids,
+                    abort_check=lambda: _should_abort(abort),
+                )
+
+                stages["eye_keypoints"]["status"] = "completed"
+                if _should_abort(abort):
+                    # Match the classify- and extract_masks-cancel summaries so
+                    # the job tree distinguishes a user cancel from a clean
+                    # finish that happened to process the same count.
+                    summary = (
+                        f"Cancelled ({processed['count']} of {total} processed)"
+                        if total else "Cancelled"
+                    )
+                    runner.update_step(
+                        job["id"], "eye_keypoints",
+                        status="completed", summary=summary,
+                    )
+                    result["stages"]["eye_keypoints"] = {
+                        "processed": processed["count"], "total": total,
+                        "cancelled": True,
+                    }
+                else:
+                    summary = (
+                        f"{processed['count']} of {total} photos processed"
+                        if total else "No eligible photos"
+                    )
+                    runner.update_step(
+                        job["id"], "eye_keypoints",
+                        status="completed", summary=summary,
+                    )
+                    result["stages"]["eye_keypoints"] = {
+                        "processed": processed["count"], "total": total,
+                    }
+            except Exception as e:
+                errors.append(f"[eye_keypoints] Fatal: {e}")
+                log.exception("Pipeline eye-keypoints stage failed")
+                stages["eye_keypoints"]["status"] = "failed"
+                runner.update_step(
+                    job["id"], "eye_keypoints", status="failed", error=str(e),
+                )
+
+            _update_stages(runner, job["id"], stages)
+
+        def regroup_stage():
+            """Run pipeline grouping + scoring + triage from cached features."""
+            if params.skip_regroup or abort.is_set() or not collection_id:
+                stages["regroup"]["status"] = "skipped"
+                runner.update_step(job["id"], "regroup", status="completed",
+                                   summary="Skipped")
+                return
+
+            stages["regroup"]["status"] = "running"
+            runner.update_step(job["id"], "regroup", status="running")
+            _update_stages(runner, job["id"], stages)
+
+            # The per-workspace regroup lock is now acquired by the
+            # orchestrator (see run_pipeline_job body) so it spans BOTH
+            # regroup_stage and miss_stage atomically — the inner lock
+            # that used to live here would deadlock against the outer one
+            # (Python locks aren't reentrant). The deferred-update pattern
+            # likewise goes away: runner.update_step is fine to call here
+            # because nothing under JobRunner._lock acquires the workspace
+            # regroup lock, so there's no cycle to invert.
+            try:
+                import config as cfg
+                from pipeline import load_photo_features, run_full_pipeline, save_results
+
+                thread_db = Database(db_path)
+                thread_db.set_active_workspace(workspace_id)
+
+                effective_cfg = thread_db.get_effective_config(cfg.load())
+                pipeline_cfg = effective_cfg.get("pipeline", {})
+
+                photos = load_photo_features(thread_db, collection_id=collection_id, config=effective_cfg)
+                if params.exclude_photo_ids:
+                    photos = [p for p in photos if p["id"] not in params.exclude_photo_ids]
+                if not photos:
+                    result["stages"]["regroup"] = {"error": "No photos with pipeline features found."}
+                    stages["regroup"]["status"] = "completed"
+                    runner.update_step(
+                        job["id"], "regroup",
+                        status="completed", summary="No photos to group",
                     )
                 else:
-                    # Partial run — save_results just clobbered
-                    # pipeline_results_ws*.json with subset output, so any
-                    # pre-existing fingerprint now points at a cache that
-                    # no longer reflects the full workspace. Invalidate so
-                    # the pipeline page surfaces the staleness as will-run
-                    # instead of falsely reporting done-prior.
-                    thread_db.set_workspace_group_state(
-                        workspace_id=workspace_id,
-                        fingerprint=None,
-                        when_ts=None,
+                    results = run_full_pipeline(photos, config=pipeline_cfg, emit_trace=True)
+                    cache_dir = os.path.dirname(db_path)
+                    save_results(results, cache_dir, workspace_id)
+
+                    # Stamp the grouping fingerprint + timestamp BEFORE marking
+                    # the step completed, so a partial regroup that crashes
+                    # between here and update_step doesn't end up labeled "fresh"
+                    # with a stale fp.
+                    #
+                    # Only stamp when the regroup actually covered the whole
+                    # workspace — if it ran on a filtered subset (a
+                    # sub-collection, or with exclude_photo_ids set) some
+                    # workspace photos were intentionally not regrouped, so
+                    # claiming workspace-level freshness would let the pipeline
+                    # page hide a real stale state.
+                    from pipeline import (
+                        _resolve_collection_photo_ids,
+                        compute_group_fingerprint,
+                    )
+                    collection_photo_ids = _resolve_collection_photo_ids(
+                        thread_db, collection_id,
+                    )
+                    ws_photo_ids = {
+                        r["id"] for r in thread_db.conn.execute(
+                            """SELECT p.id
+                                 FROM photos p
+                                 JOIN workspace_folders wf
+                                   ON wf.folder_id = p.folder_id
+                                WHERE wf.workspace_id = ?""",
+                            (workspace_id,),
+                        ).fetchall()
+                    }
+                    covered_full_workspace = (
+                        not params.exclude_photo_ids
+                        and ws_photo_ids.issubset(collection_photo_ids)
+                    )
+                    if covered_full_workspace:
+                        thread_db.set_workspace_group_state(
+                            workspace_id=workspace_id,
+                            fingerprint=compute_group_fingerprint(effective_cfg),
+                            when_ts=int(time.time()),
+                        )
+                    else:
+                        # Partial run — save_results just clobbered
+                        # pipeline_results_ws*.json with subset output, so any
+                        # pre-existing fingerprint now points at a cache that
+                        # no longer reflects the full workspace. Invalidate so
+                        # the pipeline page surfaces the staleness as will-run
+                        # instead of falsely reporting done-prior.
+                        thread_db.set_workspace_group_state(
+                            workspace_id=workspace_id,
+                            fingerprint=None,
+                            when_ts=None,
+                        )
+
+                    stages["regroup"]["status"] = "completed"
+                    summary_info = results.get("summary", {})
+                    groups = summary_info.get("groups", "")
+                    runner.update_step(
+                        job["id"], "regroup",
+                        status="completed",
+                        summary=f"{groups} groups" if groups else "Done",
+                    )
+                    result["stages"]["regroup"] = summary_info
+            except Exception as e:
+                errors.append(f"[regroup] Fatal: {e}")
+                log.exception("Pipeline regroup stage failed")
+                stages["regroup"]["status"] = "failed"
+                runner.update_step(
+                    job["id"], "regroup", status="failed", error=str(e),
+                )
+            _update_stages(runner, job["id"], stages)
+
+        def miss_stage():
+            """Compute miss-detection flags for the workspace after regroup.
+
+            Runs last so burst_id is available. Uses only per-photo features
+            already computed by earlier stages — no model inference.
+            """
+            # Skip when classify was skipped: classify_miss depends on fresh
+            # detections/classifications written by the classify stage, and
+            # without them it would mass-flag "no_subject" on photos whose
+            # subjects simply weren't re-evaluated this run.
+            #
+            # Also skip when regroup failed: miss classification depends on
+            # regroup's burst_id output, so running here after a regroup
+            # failure would overwrite miss_* flags with stale context during
+            # an already-failing job. regroup_stage marks itself "failed"
+            # without setting abort, so check the stage status explicitly.
+            if (
+                params.skip_regroup
+                or params.skip_classify
+                or abort.is_set()
+                or not collection_id
+                or stages["regroup"].get("status") == "failed"
+            ):
+                stages["misses"]["status"] = "skipped"
+                runner.update_step(job["id"], "misses", status="completed",
+                                   summary="Skipped")
+                return
+
+            stages["misses"]["status"] = "running"
+            runner.update_step(job["id"], "misses", status="running")
+            _update_stages(runner, job["id"], stages)
+
+            try:
+                from datetime import UTC, datetime
+
+                import config as cfg
+                from misses import compute_misses_for_workspace
+                from pipeline import load_results_raw, save_results_raw
+
+                thread_db = Database(db_path)
+                thread_db.set_active_workspace(workspace_id)
+
+                effective_cfg = thread_db.get_effective_config(cfg.load())
+                pipeline_cfg = effective_cfg.get("pipeline", {})
+
+                # Share one timestamp between the DB write and the saved
+                # pipeline-results cache so pipeline_review's "Review misses"
+                # shortcut can gate on actual recomputation in this run and
+                # scope /misses?since=... to exactly what was just written.
+                now_ts = datetime.now(UTC).isoformat(timespec="microseconds")
+                miss_enabled = pipeline_cfg.get("miss_enabled", True)
+
+                n = compute_misses_for_workspace(
+                    thread_db,
+                    pipeline_cfg,
+                    collection_id=collection_id,
+                    exclude_photo_ids=params.exclude_photo_ids,
+                    now=now_ts,
+                )
+
+                stages["misses"]["status"] = "completed"
+                stages["misses"]["count"] = n
+                runner.update_step(job["id"], "misses", status="completed",
+                                   summary=f"{n} photos evaluated")
+                result["stages"]["misses"] = {"evaluated": n}
+
+                # Mark the cached results so the review UI knows misses
+                # were actually recomputed this run. Without this, the
+                # shortcut would surface stale miss flags from a prior
+                # run as "current-run misses" whenever miss_enabled=False
+                # or the stage was skipped.
+                if miss_enabled:
+                    cache_dir = os.path.dirname(db_path)
+                    cached = load_results_raw(cache_dir, workspace_id)
+                    if cached is not None:
+                        cached["miss_computed_at"] = now_ts
+                        save_results_raw(cached, cache_dir, workspace_id)
+            except Exception as e:
+                errors.append(f"[misses] Fatal: {e}")
+                log.exception("Pipeline miss-detection stage failed")
+                stages["misses"]["status"] = "failed"
+                runner.update_step(job["id"], "misses", status="failed", error=str(e))
+
+            _update_stages(runner, job["id"], stages)
+
+        def archive_stage():
+            """Move a local-processing staging folder to the final destination."""
+            if not params.local_processing:
+                return
+
+            def _deindex_staging():
+                # scanner_stage may have already registered the staging folder
+                # and its photos' hashes before we got here. Without removing
+                # those rows a retry of the same source would hit ingest()'s
+                # known-hash skip and copy nothing — the user would then
+                # "successfully" archive an empty destination while the
+                # original files only ever existed in the abandoned staging
+                # tree. Leave the on-disk staging files in place so the user
+                # can still recover them.
+                #
+                # Cached thumbnails/previews/working copies for the staged
+                # photos also have to go: the FK cascade clears preview_cache
+                # rows but leaves the on-disk ``{photo_id}.jpg`` files. SQLite
+                # reuses freed rowids, so a retry that lands on one of the
+                # abandoned staging photo IDs would treat the stale cache file
+                # as a valid thumbnail and skip regenerating it.
+                try:
+                    from preview_cache import (
+                        cleanup_cached_files_for_deleted_photos,
                     )
 
-                stages["regroup"]["status"] = "completed"
-                summary_info = results.get("summary", {})
-                groups = summary_info.get("groups", "")
+                    thread_db = Database(db_path)
+                    thread_db.set_active_workspace(workspace_id)
+                    folder = thread_db.conn.execute(
+                        "SELECT id FROM folders WHERE path = ?",
+                        (params.destination,),
+                    ).fetchone()
+                    if folder:
+                        result = thread_db.delete_folder(folder["id"])
+                        cleanup_cached_files_for_deleted_photos(
+                            effective_thumb_cache_dir,
+                            result.get("files", []),
+                        )
+                except Exception:
+                    log.exception(
+                        "Failed to deindex local staging folder on archive skip",
+                    )
+
+            if abort.is_set() or runner.is_cancelled(job["id"]):
+                # Fatal upstream stages (partial scan, thumbnail setup, model
+                # load, detect, classify) set abort and fall through to here
+                # without populating stages[*]["status"] == "failed", so the
+                # already_failed branch below would miss them. Deindex here too
+                # — otherwise the next retry of the same source would treat
+                # every file as a duplicate and publish an empty archive.
+                _deindex_staging()
+                stages["archive"]["status"] = "skipped"
                 runner.update_step(
-                    job["id"], "regroup",
-                    status="completed",
-                    summary=f"{groups} groups" if groups else "Done",
+                    job["id"], "archive", status="completed", summary="Skipped",
                 )
-                result["stages"]["regroup"] = summary_info
-        except Exception as e:
-            errors.append(f"[regroup] Fatal: {e}")
-            log.exception("Pipeline regroup stage failed")
-            stages["regroup"]["status"] = "failed"
-            runner.update_step(
-                job["id"], "regroup", status="failed", error=str(e),
-            )
-        _update_stages(runner, job["id"], stages)
+                _update_stages(runner, job["id"], stages)
+                return
+            if not final_destination:
+                stages["archive"]["status"] = "skipped"
+                runner.update_step(
+                    job["id"], "archive", status="completed", summary="Skipped",
+                )
+                _update_stages(runner, job["id"], stages)
+                return
+            # Don't publish partial results: previews, extract_masks,
+            # eye_keypoints, regroup, and miss can all fail without setting
+            # abort, and run_pipeline_job marks the whole job failed at the
+            # end whenever any stage status is "failed". If we ran the archive
+            # in between, the staged folder would have already moved to
+            # final_destination by the time that failure was raised — leaving
+            # the user with a published archive whose pipeline never finished.
+            # Skip instead so staging stays intact and the failure is visible.
+            already_failed = [
+                name for name, s in stages.items() if s.get("status") == "failed"
+            ]
+            if already_failed:
+                _deindex_staging()
+                stages["archive"]["status"] = "skipped"
+                runner.update_step(
+                    job["id"], "archive",
+                    status="completed",
+                    summary=f"Skipped ({already_failed[0]} failed)",
+                )
+                _update_stages(runner, job["id"], stages)
+                return
 
-    def miss_stage():
-        """Compute miss-detection flags for the workspace after regroup.
+            stages["archive"]["status"] = "running"
+            runner.update_step(job["id"], "archive", status="running")
+            _update_stages(runner, job["id"], stages)
 
-        Runs last so burst_id is available. Uses only per-photo features
-        already computed by earlier stages — no model inference.
-        """
-        # Skip when classify was skipped: classify_miss depends on fresh
-        # detections/classifications written by the classify stage, and
-        # without them it would mass-flag "no_subject" on photos whose
-        # subjects simply weren't re-evaluated this run.
-        #
-        # Also skip when regroup failed: miss classification depends on
-        # regroup's burst_id output, so running here after a regroup
-        # failure would overwrite miss_* flags with stale context during
-        # an already-failing job. regroup_stage marks itself "failed"
-        # without setting abort, so check the stage status explicitly.
-        if (
-            params.skip_regroup
-            or params.skip_classify
-            or abort.is_set()
-            or not collection_id
-            or stages["regroup"].get("status") == "failed"
-        ):
-            stages["misses"]["status"] = "skipped"
-            runner.update_step(job["id"], "misses", status="completed",
-                               summary="Skipped")
-            return
-
-        stages["misses"]["status"] = "running"
-        runner.update_step(job["id"], "misses", status="running")
-        _update_stages(runner, job["id"], stages)
-
-        try:
-            from datetime import UTC, datetime
-
-            import config as cfg
-            from misses import compute_misses_for_workspace
-            from pipeline import load_results_raw, save_results_raw
-
-            thread_db = Database(db_path)
-            thread_db.set_active_workspace(workspace_id)
-
-            effective_cfg = thread_db.get_effective_config(cfg.load())
-            pipeline_cfg = effective_cfg.get("pipeline", {})
-
-            # Share one timestamp between the DB write and the saved
-            # pipeline-results cache so pipeline_review's "Review misses"
-            # shortcut can gate on actual recomputation in this run and
-            # scope /misses?since=... to exactly what was just written.
-            now_ts = datetime.now(UTC).isoformat(timespec="microseconds")
-            miss_enabled = pipeline_cfg.get("miss_enabled", True)
-
-            n = compute_misses_for_workspace(
-                thread_db,
-                pipeline_cfg,
-                collection_id=collection_id,
-                exclude_photo_ids=params.exclude_photo_ids,
-                now=now_ts,
-            )
-
-            stages["misses"]["status"] = "completed"
-            stages["misses"]["count"] = n
-            runner.update_step(job["id"], "misses", status="completed",
-                               summary=f"{n} photos evaluated")
-            result["stages"]["misses"] = {"evaluated": n}
-
-            # Mark the cached results so the review UI knows misses
-            # were actually recomputed this run. Without this, the
-            # shortcut would surface stale miss flags from a prior
-            # run as "current-run misses" whenever miss_enabled=False
-            # or the stage was skipped.
-            if miss_enabled:
-                cache_dir = os.path.dirname(db_path)
-                cached = load_results_raw(cache_dir, workspace_id)
-                if cached is not None:
-                    cached["miss_computed_at"] = now_ts
-                    save_results_raw(cached, cache_dir, workspace_id)
-        except Exception as e:
-            errors.append(f"[misses] Fatal: {e}")
-            log.exception("Pipeline miss-detection stage failed")
-            stages["misses"]["status"] = "failed"
-            runner.update_step(job["id"], "misses", status="failed", error=str(e))
-
-        _update_stages(runner, job["id"], stages)
-
-    def archive_stage():
-        """Move a local-processing staging folder to the final destination."""
-        if not params.local_processing:
-            return
-
-        def _deindex_staging():
-            # scanner_stage may have already registered the staging folder
-            # and its photos' hashes before we got here. Without removing
-            # those rows a retry of the same source would hit ingest()'s
-            # known-hash skip and copy nothing — the user would then
-            # "successfully" archive an empty destination while the
-            # original files only ever existed in the abandoned staging
-            # tree. Leave the on-disk staging files in place so the user
-            # can still recover them.
             try:
+                import config as cfg
+                from move import move_folder
+
                 thread_db = Database(db_path)
                 thread_db.set_active_workspace(workspace_id)
                 folder = thread_db.conn.execute(
-                    "SELECT id FROM folders WHERE path = ?",
-                    (params.destination,),
+                    "SELECT id FROM folders WHERE path = ?", (params.destination,)
                 ).fetchone()
-                if folder:
-                    thread_db.delete_folder(folder["id"])
-            except Exception:
-                log.exception(
-                    "Failed to deindex local staging folder on archive skip",
+                if not folder:
+                    raise RuntimeError(
+                        f"local staging folder was not indexed: {params.destination}"
+                    )
+
+                effective_cfg = thread_db.get_effective_config(cfg.load())
+                developed_dir = effective_cfg.get("darktable_output_dir", "") or ""
+                archive_parent = os.path.dirname(os.path.normpath(final_destination))
+                total_files = {"value": 0}
+
+                def archive_cb(current, total, filename, phase=None):
+                    total_files["value"] = max(total_files["value"], total or 0)
+                    stages["archive"]["count"] = current
+                    stages["archive"]["total"] = total
+                    runner.update_step(
+                        job["id"], "archive",
+                        current_file=filename,
+                        progress={"current": current, "total": total},
+                    )
+                    _emit_progress(
+                        runner, job["id"], stages, "archive",
+                        phase or "Archiving photos",
+                        current_file=filename,
+                    )
+
+                # Consume any pending cancellation and lock the job uncancellable
+                # BEFORE the move begins. move_folder is an uninterruptible commit
+                # step (copy → verify → repoint catalog → delete originals); we
+                # can't tear it down mid-flight without leaving partial state.
+                # Clearing AFTER move_folder returns leaves a window where a Stop
+                # press landing during the move would survive into the failure
+                # path: if move_folder raises (ENOSPC, rsync error, verify
+                # mismatch), runner.is_cancelled(job_id) would still be True at
+                # the outer job-terminalization check, JobRunner would record
+                # "cancelled", and the user would never see the archive failure.
+                # Consume up front so a successful commit reports "completed" AND
+                # a failed commit reports "failed" — both win against the racing
+                # Stop press, which couldn't have been honored anyway.
+                runner.clear_cancellation(job["id"])
+
+                move_result = move_folder(
+                    thread_db,
+                    folder["id"],
+                    archive_parent,
+                    progress_cb=archive_cb,
+                    developed_dir=developed_dir,
+                    merge=True,
                 )
+                if move_result.get("errors"):
+                    raise RuntimeError("; ".join(move_result["errors"]))
 
-        if abort.is_set() or runner.is_cancelled(job["id"]):
-            # Fatal upstream stages (partial scan, thumbnail setup, model
-            # load, detect, classify) set abort and fall through to here
-            # without populating stages[*]["status"] == "failed", so the
-            # already_failed branch below would miss them. Deindex here too
-            # — otherwise the next retry of the same source would treat
-            # every file as a duplicate and publish an empty archive.
-            _deindex_staging()
-            stages["archive"]["status"] = "skipped"
-            runner.update_step(
-                job["id"], "archive", status="completed", summary="Skipped",
-            )
-            _update_stages(runner, job["id"], stages)
-            return
-        if not final_destination:
-            stages["archive"]["status"] = "skipped"
-            runner.update_step(
-                job["id"], "archive", status="completed", summary="Skipped",
-            )
-            _update_stages(runner, job["id"], stages)
-            return
-        # Don't publish partial results: previews, extract_masks,
-        # eye_keypoints, regroup, and miss can all fail without setting
-        # abort, and run_pipeline_job marks the whole job failed at the
-        # end whenever any stage status is "failed". If we ran the archive
-        # in between, the staged folder would have already moved to
-        # final_destination by the time that failure was raised — leaving
-        # the user with a published archive whose pipeline never finished.
-        # Skip instead so staging stays intact and the failure is visible.
-        already_failed = [
-            name for name, s in stages.items() if s.get("status") == "failed"
-        ]
-        if already_failed:
-            _deindex_staging()
-            stages["archive"]["status"] = "skipped"
-            runner.update_step(
-                job["id"], "archive",
-                status="completed",
-                summary=f"Skipped ({already_failed[0]} failed)",
-            )
-            _update_stages(runner, job["id"], stages)
-            return
+                if staging_parent:
+                    with contextlib.suppress(OSError):
+                        os.rmdir(staging_parent)
 
-        stages["archive"]["status"] = "running"
-        runner.update_step(job["id"], "archive", status="running")
-        _update_stages(runner, job["id"], stages)
-
-        try:
-            import config as cfg
-            from move import move_folder
-
-            thread_db = Database(db_path)
-            thread_db.set_active_workspace(workspace_id)
-            folder = thread_db.conn.execute(
-                "SELECT id FROM folders WHERE path = ?", (params.destination,)
-            ).fetchone()
-            if not folder:
-                raise RuntimeError(
-                    f"local staging folder was not indexed: {params.destination}"
-                )
-
-            effective_cfg = thread_db.get_effective_config(cfg.load())
-            developed_dir = effective_cfg.get("darktable_output_dir", "") or ""
-            archive_parent = os.path.dirname(os.path.normpath(final_destination))
-            total_files = {"value": 0}
-
-            def archive_cb(current, total, filename, phase=None):
-                total_files["value"] = max(total_files["value"], total or 0)
-                stages["archive"]["count"] = current
-                stages["archive"]["total"] = total
+                stages["archive"]["status"] = "completed"
+                summary = f"{move_result.get('moved', 0)} photos archived"
                 runner.update_step(
-                    job["id"], "archive",
-                    current_file=filename,
-                    progress={"current": current, "total": total},
+                    job["id"], "archive", status="completed", summary=summary,
                 )
-                _emit_progress(
-                    runner, job["id"], stages, "archive",
-                    phase or "Archiving photos",
-                    current_file=filename,
+                result["archive"] = {
+                    "final_destination": final_destination,
+                    "moved": move_result.get("moved", 0),
+                }
+            except Exception as e:
+                msg = (
+                    f"{e}. Processing results remain in local staging: "
+                    f"{params.destination}"
+                )
+                errors.append(f"[archive] Fatal: {msg}")
+                log.exception("Pipeline archive stage failed")
+                # move_folder doesn't repoint the catalog until it has
+                # verified every copied file, so a raise here means the
+                # folders/photos rows still point at the staging tree. If we
+                # leave them indexed, a retry of the same source sees the
+                # staging hashes via ingest()'s global duplicate check, skips
+                # the copy, and "successfully" publishes an empty archive
+                # while the original files remain only under ~/.vireo/staging.
+                # Deindex to match the archive-skip paths above; the on-disk
+                # staging files are left in place per the error message so
+                # the user can still recover them manually.
+                _deindex_staging()
+                stages["archive"]["status"] = "failed"
+                runner.update_step(
+                    job["id"], "archive", status="failed", error=msg,
                 )
 
-            # Consume any pending cancellation and lock the job uncancellable
-            # BEFORE the move begins. move_folder is an uninterruptible commit
-            # step (copy → verify → repoint catalog → delete originals); we
-            # can't tear it down mid-flight without leaving partial state.
-            # Clearing AFTER move_folder returns leaves a window where a Stop
-            # press landing during the move would survive into the failure
-            # path: if move_folder raises (ENOSPC, rsync error, verify
-            # mismatch), runner.is_cancelled(job_id) would still be True at
-            # the outer job-terminalization check, JobRunner would record
-            # "cancelled", and the user would never see the archive failure.
-            # Consume up front so a successful commit reports "completed" AND
-            # a failed commit reports "failed" — both win against the racing
-            # Stop press, which couldn't have been honored anyway.
-            runner.clear_cancellation(job["id"])
+            _update_stages(runner, job["id"], stages)
 
-            move_result = move_folder(
-                thread_db,
-                folder["id"],
-                archive_parent,
-                progress_cb=archive_cb,
-                developed_dir=developed_dir,
-                merge=True,
-            )
-            if move_result.get("errors"):
-                raise RuntimeError("; ".join(move_result["errors"]))
+        # --- Launch threads ---
 
-            if staging_parent:
-                with contextlib.suppress(OSError):
-                    os.rmdir(staging_parent)
+        threads = {}
 
-            stages["archive"]["status"] = "completed"
-            summary = f"{move_result.get('moved', 0)} photos archived"
-            runner.update_step(
-                job["id"], "archive", status="completed", summary=summary,
-            )
-            result["archive"] = {
-                "final_destination": final_destination,
-                "moved": move_result.get("moved", 0),
-            }
-        except Exception as e:
-            msg = (
-                f"{e}. Processing results remain in local staging: "
-                f"{params.destination}"
-            )
-            errors.append(f"[archive] Fatal: {msg}")
-            log.exception("Pipeline archive stage failed")
-            # move_folder doesn't repoint the catalog until it has
-            # verified every copied file, so a raise here means the
-            # folders/photos rows still point at the staging tree. If we
-            # leave them indexed, a retry of the same source sees the
-            # staging hashes via ingest()'s global duplicate check, skips
-            # the copy, and "successfully" publishes an empty archive
-            # while the original files remain only under ~/.vireo/staging.
-            # Deindex to match the archive-skip paths above; the on-disk
-            # staging files are left in place per the error message so
-            # the user can still recover them manually.
-            _deindex_staging()
-            stages["archive"]["status"] = "failed"
-            runner.update_step(
-                job["id"], "archive", status="failed", error=msg,
-            )
+        # Phase 1: scan + thumbnails + model loading (concurrent)
+        threads["scanner"] = threading.Thread(target=scanner_stage, daemon=True)
+        threads["collection"] = threading.Thread(target=collection_stage, daemon=True)
+        threads["thumbnail"] = threading.Thread(target=thumbnail_stage, daemon=True)
+        threads["model_loader"] = threading.Thread(target=model_loader_stage, daemon=True)
 
-        _update_stages(runner, job["id"], stages)
+        for t in threads.values():
+            t.start()
 
-    # --- Launch threads ---
+        # Wait for scan-related threads to finish
+        threads["scanner"].join()
+        threads["collection"].join()
+        threads["thumbnail"].join()
+        threads["model_loader"].join()
 
-    threads = {}
+        # Phase 1.5: previews (needs scan complete, runs before classify).
+        #
+        # This and every later stage are always invoked — even when `abort`
+        # is set — so their step rows reach a terminal status. Gating the
+        # call on abort would leave the runner.set_steps-created rows
+        # persisted as "pending" with no finished_at, forever. Each stage
+        # checks abort internally and marks itself "Skipped".
+        previews_stage()
 
-    # Phase 1: scan + thumbnails + model loading (concurrent)
-    threads["scanner"] = threading.Thread(target=scanner_stage, daemon=True)
-    threads["collection"] = threading.Thread(target=collection_stage, daemon=True)
-    threads["thumbnail"] = threading.Thread(target=thumbnail_stage, daemon=True)
-    threads["model_loader"] = threading.Thread(target=model_loader_stage, daemon=True)
+        # Phase 2: detect (needs collection; runs MegaDetector once across all
+        # photos so each per-model classify step reuses cached detections
+        # instead of re-running the detector).
+        #
+        # Always invoked — even when `abort` is set by an earlier stage — so
+        # the `detect` step row reaches a terminal status. Skipping the call
+        # would leave the row pending forever on a model-loader failure.
+        # detect_stage handles abort internally and marks itself skipped.
+        detect_stage()
 
-    for t in threads.values():
-        t.start()
+        # Phase 3: classify per model (reads cached detections from detect_stage).
+        # Always invoked for the same reason: every `classify:<model_id>` row
+        # must land in a terminal state so the jobs tree finalizes cleanly on
+        # a loader-triggered abort.
+        classify_stage()
 
-    # Wait for scan-related threads to finish
-    threads["scanner"].join()
-    threads["collection"].join()
-    threads["thumbnail"].join()
-    threads["model_loader"].join()
+        # Phase 3: extract-masks (needs classify output)
+        extract_masks_stage()
 
-    # Phase 1.5: previews (needs scan complete, runs before classify).
-    #
-    # This and every later stage are always invoked — even when `abort`
-    # is set — so their step rows reach a terminal status. Gating the
-    # call on abort would leave the runner.set_steps-created rows
-    # persisted as "pending" with no finished_at, forever. Each stage
-    # checks abort internally and marks itself "Skipped".
-    previews_stage()
+        # Phase 3.5: eye keypoints (needs masks + classifier output). No-op when
+        # SuperAnimal weights are absent — users opt in on the pipeline models
+        # card. Per-photo failures log and continue rather than abort the stage.
+        eye_keypoints_stage()
 
-    # Phase 2: detect (needs collection; runs MegaDetector once across all
-    # photos so each per-model classify step reuses cached detections
-    # instead of re-running the detector).
-    #
-    # Always invoked — even when `abort` is set by an earlier stage — so
-    # the `detect` step row reaches a terminal status. Skipping the call
-    # would leave the row pending forever on a model-loader failure.
-    # detect_stage handles abort internally and marks itself skipped.
-    detect_stage()
-
-    # Phase 3: classify per model (reads cached detections from detect_stage).
-    # Always invoked for the same reason: every `classify:<model_id>` row
-    # must land in a terminal state so the jobs tree finalizes cleanly on
-    # a loader-triggered abort.
-    classify_stage()
-
-    # Phase 3: extract-masks (needs classify output)
-    extract_masks_stage()
-
-    # Phase 3.5: eye keypoints (needs masks + classifier output). No-op when
-    # SuperAnimal weights are absent — users opt in on the pipeline models
-    # card. Per-photo failures log and continue rather than abort the stage.
-    eye_keypoints_stage()
-
-    # Phases 4 + 5: regroup and miss detection. Held under the
-    # per-workspace regroup lock TOGETHER so a concurrent same-workspace
-    # pipeline can't slip a regroup_stage in between this run's
-    # regroup_stage and its miss_stage — that would leave the persisted
-    # miss flags + ``miss_computed_at`` paired with a grouping
-    # (burst_id / pipeline_results_ws*.json) the miss computation never
-    # saw. Pipelines targeting different workspaces share neither
-    # stage's state and don't contend here.
-    #
-    # miss_stage's own gate covers the regroup-failed and abort cases, so
-    # both stages can be invoked unconditionally and still reach a
-    # terminal step status.
-    if abort.is_set():
-        # Both stages early-return as "Skipped" without touching grouping
-        # state, so the lock isn't needed — and skipping the calls would
-        # leave their step rows pending forever. Staying outside the lock
-        # also keeps an aborted/cancelled run from blocking behind a
-        # concurrent pipeline's regroup.
-        regroup_stage()
-        miss_stage()
-    else:
-        with acquire_workspace_regroup(workspace_id):
+        # Phases 4 + 5: regroup and miss detection. Held under the
+        # per-workspace regroup lock TOGETHER so a concurrent same-workspace
+        # pipeline can't slip a regroup_stage in between this run's
+        # regroup_stage and its miss_stage — that would leave the persisted
+        # miss flags + ``miss_computed_at`` paired with a grouping
+        # (burst_id / pipeline_results_ws*.json) the miss computation never
+        # saw. Pipelines targeting different workspaces share neither
+        # stage's state and don't contend here.
+        #
+        # miss_stage's own gate covers the regroup-failed and abort cases, so
+        # both stages can be invoked unconditionally and still reach a
+        # terminal step status.
+        if abort.is_set():
+            # Both stages early-return as "Skipped" without touching grouping
+            # state, so the lock isn't needed — and skipping the calls would
+            # leave their step rows pending forever. Staying outside the lock
+            # also keeps an aborted/cancelled run from blocking behind a
+            # concurrent pipeline's regroup.
             regroup_stage()
             miss_stage()
+        else:
+            with acquire_workspace_regroup(workspace_id):
+                regroup_stage()
+                miss_stage()
 
-    archive_stage()
+        archive_stage()
 
-    cancel_watcher_stop.set()
+        cancel_watcher_stop.set()
 
-    elapsed = time.time() - job["_start_time"]
-    result["duration"] = round(elapsed, 1)
-    result["errors"] = list(errors)
+        elapsed = time.time() - job["_start_time"]
+        result["duration"] = round(elapsed, 1)
+        result["errors"] = list(errors)
 
-    # If any stage ended in 'failed' and the job wasn't cancelled, propagate
-    # the failure so JobRunner marks the whole job as failed rather than
-    # silently recording it as completed. Cancellation takes precedence:
-    # a cancelled job stays cancelled even if stages crashed on the way down.
-    failed_stages = [
-        name for name, s in stages.items() if s.get("status") == "failed"
-    ]
-    if failed_stages and not runner.is_cancelled(job["id"]):
-        # Stash the structured result on the job BEFORE raising so the
-        # completion event and job_history still carry per-stage details
-        # (stages dict, errors list). Without this, the pipeline UI loses
-        # the "Failed: [stage_name]" mapping on the card that owned the
-        # failure because it reads result.result.stages / .errors.
-        job["result"] = result
-        # Prefer a "[stage] Fatal: …" error from one of the failed stages
-        # rather than blindly using errors[0], which may be a non-fatal
-        # per-photo warning (e.g. "Photo <id>: mask extraction failed")
-        # logged before the stage-level failure. Falling back to errors[0]
-        # when no stage-fatal entry exists keeps backward compatibility for
-        # any edge case where a stage marks itself failed without appending a
-        # Fatal error; the final fallback covers an empty errors list.
-        first_error = next(
-            (e for e in errors if any(e.startswith(f"[{s}] Fatal:") for s in failed_stages)),
-            errors[0] if errors else f"stage '{failed_stages[0]}' failed",
-        )
-        # Record the fatal error for _persist_job so it can store the stage
-        # failure message rather than job["errors"][0], which may be a
-        # non-fatal per-photo warning that was logged before this failure.
-        job["_fatal_error"] = first_error
-        raise RuntimeError(first_error)
+        # If any stage ended in 'failed' and the job wasn't cancelled, propagate
+        # the failure so JobRunner marks the whole job as failed rather than
+        # silently recording it as completed. Cancellation takes precedence:
+        # a cancelled job stays cancelled even if stages crashed on the way down.
+        failed_stages = [
+            name for name, s in stages.items() if s.get("status") == "failed"
+        ]
+        if failed_stages and not runner.is_cancelled(job["id"]):
+            # Stash the structured result on the job BEFORE raising so the
+            # completion event and job_history still carry per-stage details
+            # (stages dict, errors list). Without this, the pipeline UI loses
+            # the "Failed: [stage_name]" mapping on the card that owned the
+            # failure because it reads result.result.stages / .errors.
+            job["result"] = result
+            # Prefer a "[stage] Fatal: …" error from one of the failed stages
+            # rather than blindly using errors[0], which may be a non-fatal
+            # per-photo warning (e.g. "Photo <id>: mask extraction failed")
+            # logged before the stage-level failure. Falling back to errors[0]
+            # when no stage-fatal entry exists keeps backward compatibility for
+            # any edge case where a stage marks itself failed without appending a
+            # Fatal error; the final fallback covers an empty errors list.
+            first_error = next(
+                (e for e in errors if any(e.startswith(f"[{s}] Fatal:") for s in failed_stages)),
+                errors[0] if errors else f"stage '{failed_stages[0]}' failed",
+            )
+            # Record the fatal error for _persist_job so it can store the stage
+            # failure message rather than job["errors"][0], which may be a
+            # non-fatal per-photo warning that was logged before this failure.
+            job["_fatal_error"] = first_error
+            raise RuntimeError(first_error)
 
-    return result
+        return result
+    finally:
+        if archive_destination_reserved:
+            release_archive_destination(final_destination)

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -4482,15 +4482,42 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     with contextlib.suppress(OSError):
                         os.rmdir(staging_parent)
 
+                # move_folder repointed the catalog at final_destination
+                # before deleting the source originals, so a
+                # ``cleanup_error`` means the archive IS committed — files
+                # are at the destination, but some leftovers remain in
+                # staging (locked file, permission issue, etc.). Report
+                # success with a warning rather than failure: the
+                # alternative ("failed" + "results remain in staging") tells
+                # the user their data is lost when it's actually safe at
+                # final_destination, and would also leave the freshly
+                # created tracked folder row in the catalog while we tried
+                # to deindex a staging row that move_folder_path already
+                # renamed away.
+                cleanup_error = move_result.get("cleanup_error")
                 stages["archive"]["status"] = "completed"
-                summary = f"{move_result.get('moved', 0)} photos archived"
+                moved = move_result.get("moved", 0)
+                if cleanup_error:
+                    summary = (
+                        f"{moved} photos archived "
+                        f"(staging cleanup failed: {cleanup_error})"
+                    )
+                    errors.append(
+                        f"[archive] Warning: staging cleanup failed after "
+                        f"commit — leftover files in {params.destination}: "
+                        f"{cleanup_error}"
+                    )
+                else:
+                    summary = f"{moved} photos archived"
                 runner.update_step(
                     job["id"], "archive", status="completed", summary=summary,
                 )
                 result["archive"] = {
                     "final_destination": final_destination,
-                    "moved": move_result.get("moved", 0),
+                    "moved": moved,
                 }
+                if cleanup_error:
+                    result["archive"]["cleanup_error"] = cleanup_error
             except Exception as e:
                 msg = (
                     f"{e}. Processing results remain in local staging: "

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1322,6 +1322,15 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             archive_parent = os.path.dirname(
                                 os.path.normpath(final_destination),
                             )
+                            if (
+                                os.path.exists(final_destination)
+                                and not os.path.isdir(final_destination)
+                            ):
+                                _bail_storage(
+                                    f"Archive destination {final_destination} "
+                                    "already exists and is not a directory."
+                                )
+                                return
                             # Existing archive roots can be mounted volumes; new
                             # archive leaves have to probe the existing parent.
                             archive_space_path = (

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1278,6 +1278,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 all_duplicate_folders: set = set()
                 total_copied = 0
                 total_skipped = 0
+                total_failed = 0
                 for src_folder in sources:
                     try:
                         result_info = do_ingest(
@@ -1298,6 +1299,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     all_duplicate_folders.update(result_info.get("duplicate_folders", []))
                     total_copied += result_info.get("copied", 0)
                     total_skipped += result_info.get("skipped_duplicate", 0)
+                    total_failed += result_info.get("failed", 0)
                     # Collect hashes of files just copied so the next source
                     # iteration treats them as known even before the DB scan.
                     if params.skip_duplicates:
@@ -1308,15 +1310,44 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             with contextlib.suppress(OSError):
                                 accumulated_hashes.add(compute_file_hash(path))
 
-                # Mark ingest complete
+                # In local-processing mode, ingest failures must fail the
+                # ingest stage so archive_stage's "any earlier stage failed"
+                # gate skips publishing. ingest() catches per-file copy
+                # errors (unreadable source, disk full mid-card) and returns
+                # a non-zero ``failed`` count without raising. Without
+                # propagating that here the archive step would happily move
+                # the partial staging tree to the user's final destination
+                # — publishing a partial result that the rest of the
+                # pipeline would otherwise treat as a successful import.
                 parts = []
                 if total_copied:
                     parts.append(f"{total_copied} copied")
                 if total_skipped:
                     parts.append(f"{total_skipped} skipped")
-                stages["ingest"]["status"] = "completed"
-                runner.update_step(job["id"], "ingest", status="completed",
-                                   summary=", ".join(parts) or "0 files")
+                if total_failed:
+                    parts.append(f"{total_failed} failed")
+                summary = ", ".join(parts) or "0 files"
+                if params.local_processing and total_failed:
+                    msg = (
+                        f"{total_failed} file"
+                        f"{'s' if total_failed != 1 else ''} failed to copy "
+                        f"during ingest; archive skipped to avoid publishing "
+                        f"a partial result"
+                    )
+                    errors.append(f"[ingest] Fatal: {msg}")
+                    stages["ingest"]["status"] = "failed"
+                    runner.update_step(
+                        job["id"], "ingest",
+                        status="failed",
+                        error=msg,
+                        summary=summary,
+                    )
+                else:
+                    stages["ingest"]["status"] = "completed"
+                    runner.update_step(
+                        job["id"], "ingest", status="completed",
+                        summary=summary,
+                    )
                 _update_stages(runner, job["id"], stages)
 
                 # Scan only the destination subfolders that actually contain
@@ -4319,6 +4350,17 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
             if staging_parent:
                 with contextlib.suppress(OSError):
                     os.rmdir(staging_parent)
+
+            # The archive has been published and originals removed. A Stop
+            # pressed during the move cannot be honored here: move_folder
+            # doesn't accept a cancellation signal, and tearing it down
+            # mid-flight would either leave files in both staging and
+            # destination or wipe staging before verification completes.
+            # Consume any cancellation that landed during the commit so
+            # JobRunner records the run as "completed" rather than
+            # "cancelled" — the archive is on disk and the user should
+            # see that, not a misleading cancelled-status pill.
+            runner.clear_cancellation(job["id"])
 
             stages["archive"]["status"] = "completed"
             summary = f"{move_result.get('moved', 0)} photos archived"

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -4608,11 +4608,6 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         f"{moved} photos archived "
                         f"(staging cleanup failed: {cleanup_error})"
                     )
-                    errors.append(
-                        f"[archive] Warning: staging cleanup failed after "
-                        f"commit — leftover files in {params.destination}: "
-                        f"{cleanup_error}"
-                    )
                 else:
                     summary = f"{moved} photos archived"
                 runner.update_step(

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1363,7 +1363,11 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             # rsyncs only the missing files. Credit the bytes
                             # already published so the preflight doesn't
                             # reject a retry whose remaining delta would fit.
-                            existing_bytes = existing_archive_bytes(final_destination)
+                            existing_bytes = existing_archive_bytes(
+                                final_destination,
+                                selected_files,
+                                params.folder_template,
+                            )
                             plan = storage_plan(
                                 params.destination, source_bytes,
                                 archive_parent=archive_space_path,

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -4431,6 +4431,17 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
             )
             errors.append(f"[archive] Fatal: {msg}")
             log.exception("Pipeline archive stage failed")
+            # move_folder doesn't repoint the catalog until it has
+            # verified every copied file, so a raise here means the
+            # folders/photos rows still point at the staging tree. If we
+            # leave them indexed, a retry of the same source sees the
+            # staging hashes via ingest()'s global duplicate check, skips
+            # the copy, and "successfully" publishes an empty archive
+            # while the original files remain only under ~/.vireo/staging.
+            # Deindex to match the archive-skip paths above; the on-disk
+            # staging files are left in place per the error message so
+            # the user can still recover them manually.
+            _deindex_staging()
             stages["archive"]["status"] = "failed"
             runner.update_step(
                 job["id"], "archive", status="failed", error=msg,

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1167,7 +1167,21 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                     "import without local processing."
                                 )
                                 return
-                            source_bytes = total_file_bytes(selected_files)
+                            planning_files = selected_files
+                            if (
+                                params.skip_duplicates
+                                and selected_files
+                                and catalog_hashes is not None
+                            ):
+                                # Plan against the exact files ingest will
+                                # stage, not the full selection. This keeps
+                                # both source_bytes and resume credit aligned
+                                # with skip_duplicates even when the unfiltered
+                                # plan appears to have enough space.
+                                planning_files = non_duplicate_files(
+                                    selected_files, catalog_hashes,
+                                )
+                            source_bytes = total_file_bytes(planning_files)
                             # When a previous archive attempt left a partial
                             # untracked directory at final_destination, the
                             # retry uses move_folder(..., merge=True), which
@@ -1176,7 +1190,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             # reject a retry whose remaining delta would fit.
                             existing_bytes = existing_archive_bytes(
                                 final_destination,
-                                selected_files,
+                                planning_files,
                                 params.folder_template,
                             )
                             plan = storage_plan(
@@ -1184,59 +1198,6 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 archive_parent=archive_space_path,
                                 archive_existing_bytes=existing_bytes,
                             )
-                            # When skip_duplicates is on, ingest() will hash and
-                            # skip files whose hash is already in the catalog
-                            # OR already seen earlier in this same run before
-                            # writing to staging. The naive byte sum above would
-                            # mark a mostly-duplicate card — or one where the
-                            # same folder appears in `sources` twice — as
-                            # batching-required even though the staging copy
-                            # would fit. Re-check using the duplicate-filtered
-                            # set, but only when the optimistic check failed —
-                            # otherwise we'd hash the entire source set on every
-                            # import. The filter runs even when the catalog is
-                            # empty so intra-run duplicates still collapse.
-                            if (
-                                plan["batching_required"]
-                                and params.skip_duplicates
-                                and selected_files
-                            ):
-                                # ``catalog_hashes`` was already fetched
-                                # above for the conflict preflight when
-                                # skip_duplicates is on; reuse it instead
-                                # of re-querying the photos table.
-                                known_hashes = (
-                                    catalog_hashes
-                                    if catalog_hashes is not None
-                                    else set()
-                                )
-                                filtered_files = non_duplicate_files(
-                                    selected_files, known_hashes,
-                                )
-                                filtered_bytes = total_file_bytes(filtered_files)
-                                if filtered_bytes < source_bytes:
-                                    # Recompute the destination credit against
-                                    # the survivor set. The first existing_bytes
-                                    # call counts every selected file that's
-                                    # already at final_destination, including
-                                    # known duplicates ingest will SKIP. If a
-                                    # large skipped file is present at the
-                                    # destination and a smaller fresh file is
-                                    # not, that credit would cap to filtered_
-                                    # bytes and drive archive_delta to zero —
-                                    # passing the destination-space preflight
-                                    # for a run that still has to write the
-                                    # fresh file at the archive.
-                                    filtered_existing_bytes = existing_archive_bytes(
-                                        final_destination,
-                                        filtered_files,
-                                        params.folder_template,
-                                    )
-                                    plan = storage_plan(
-                                        params.destination, filtered_bytes,
-                                        archive_parent=archive_space_path,
-                                        archive_existing_bytes=filtered_existing_bytes,
-                                    )
                             result["local_processing"] = {
                                 **plan,
                                 "staging_destination": params.destination,

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -52,6 +52,26 @@ log = logging.getLogger(__name__)
 _SENTINEL = object()  # unique end-of-stream marker
 
 
+def _missing_archive_mount_root(path: str) -> str | None:
+    """Return a likely missing mount root that must not be auto-created."""
+    def _candidate(posix_path: str) -> str | None:
+        parts = posix_path.split("/")
+        if len(parts) >= 3 and parts[0] == "" and parts[1] in {"Volumes", "mnt"}:
+            return f"/{parts[1]}/{parts[2]}"
+        if len(parts) >= 4 and parts[0] == "" and parts[1] == "media":
+            return f"/media/{parts[2]}/{parts[3]}"
+        return None
+
+    raw_posix = os.path.expanduser(path).replace("\\", "/")
+    normalized = os.path.normpath(os.path.abspath(os.path.expanduser(path)))
+    normalized_posix = normalized.replace("\\", "/")
+
+    for mount_root in (_candidate(raw_posix), _candidate(normalized_posix)):
+        if mount_root and not os.path.lexists(mount_root):
+            return mount_root
+    return None
+
+
 @dataclass
 class PipelineParams:
     """Parameters for a streaming pipeline job."""
@@ -1113,6 +1133,16 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 if os.path.exists(final_destination)
                                 else archive_parent
                             )
+                            missing_mount_root = _missing_archive_mount_root(
+                                archive_parent,
+                            )
+                            if missing_mount_root:
+                                _bail_storage(
+                                    f"Archive mount root {missing_mount_root} "
+                                    "is not available. Check that the "
+                                    "destination drive is mounted and writable."
+                                )
+                                return
                             try:
                                 os.makedirs(archive_parent, exist_ok=True)
                             except OSError as exc:

--- a/vireo/pipeline_locks.py
+++ b/vireo/pipeline_locks.py
@@ -185,3 +185,49 @@ def acquire_photo_mask(photo_id):
 
 def _photo_mask_lock_for_tests(photo_id):
     return acquire_photo_mask(photo_id)
+
+
+# In-flight archive destinations claimed by local-processing pipeline runs.
+# Two pipelines aimed at the same new ``final_destination`` can both pass the
+# DB-only overlap check before either one has created the folder row (jobs.py
+# allows up to SLOT_CAP=2 pipeline jobs concurrently), and the second would
+# only fail inside ``move_folder`` after staging and processing everything.
+# Reserving the destination up front rejects the duplicate run before any
+# expensive work starts.
+_ARCHIVE_DESTINATIONS: set = set()
+_ARCHIVE_DESTINATIONS_GUARD = threading.Lock()
+
+
+def _normalize_archive_destination(path):
+    import os
+
+    return os.path.normpath(os.path.abspath(path))
+
+
+def try_reserve_archive_destination(path):
+    """Claim ``path`` for an in-flight local-processing archive.
+
+    Returns True on first claim, False if another running pipeline already
+    owns the same destination. Paths are normalised to absolute, so
+    ``/Photos/Shoot`` and ``./Photos/Shoot`` collide. Must be paired with
+    ``release_archive_destination`` once the run terminates (success or
+    failure) so retries and follow-on runs can re-acquire.
+    """
+    normalized = _normalize_archive_destination(path)
+    with _ARCHIVE_DESTINATIONS_GUARD:
+        if normalized in _ARCHIVE_DESTINATIONS:
+            return False
+        _ARCHIVE_DESTINATIONS.add(normalized)
+        return True
+
+
+def release_archive_destination(path):
+    """Release a previously reserved archive destination."""
+    normalized = _normalize_archive_destination(path)
+    with _ARCHIVE_DESTINATIONS_GUARD:
+        _ARCHIVE_DESTINATIONS.discard(normalized)
+
+
+def _archive_destinations_for_tests():
+    with _ARCHIVE_DESTINATIONS_GUARD:
+        return set(_ARCHIVE_DESTINATIONS)

--- a/vireo/pipeline_locks.py
+++ b/vireo/pipeline_locks.py
@@ -199,29 +199,45 @@ _ARCHIVE_DESTINATIONS_GUARD = threading.Lock()
 
 
 def _normalize_archive_destination(path):
+    """Absolute, symlink-resolved, case-normalised form of ``path``.
+
+    ``realpath`` resolves symlinks (including partial resolution when the
+    leaf doesn't exist yet — the existing prefix is followed and the
+    missing tail is preserved). ``normcase`` folds case on Windows. Two
+    spellings that point at the same physical destination — a symlink and
+    its real path, a case-only alias on case-insensitive Windows —
+    collapse to the same key, so reservation/release can't drift apart and
+    a reservation lookup hits even when the caller used a different
+    spelling.
+
+    Case-insensitive POSIX (default macOS APFS) needs an FS probe to fold
+    case, which ``_paths_overlap`` does via ``move._path_equal_or_descends``
+    for the comparison itself. Keeping the stored key as
+    ``normcase(realpath(...))`` is enough because reserve/release are
+    paired with the same Python string in pipeline_job.
+    """
     import os
 
-    return os.path.normpath(os.path.abspath(path))
+    return os.path.normcase(os.path.realpath(path))
 
 
 def _paths_overlap(a, b):
     """Return True if ``a`` and ``b`` are equal or one descends from the other.
 
-    Both inputs must already be normalised absolute paths. Uses
-    ``os.path.commonpath`` so prefix-string traps like ``/Photos/Shoot`` vs
-    ``/Photos/ShootSubset`` don't false-positive as overlapping.
+    Defers to ``move._path_equal_or_descends`` so the reservation check
+    folds the same alias surface (symlinks, Windows case folding,
+    case-insensitive POSIX) that ``move_folder``'s own overlap check runs
+    later. Without this, two pipelines targeting the same physical
+    destination via different spellings could both pass the reservation
+    check and race into the same archive root before the move-time guard
+    runs.
     """
-    import os
+    from move import _path_equal_or_descends
 
     if a == b:
         return True
-    try:
-        common = os.path.commonpath([a, b])
-    except ValueError:
-        # Different drives (Windows) or one path isn't absolute. After
-        # normalisation that means the two can't possibly overlap.
-        return False
-    return common in (a, b)
+    return (_path_equal_or_descends(a, b)
+            or _path_equal_or_descends(b, a))
 
 
 def try_reserve_archive_destination(path):

--- a/vireo/pipeline_locks.py
+++ b/vireo/pipeline_locks.py
@@ -204,19 +204,45 @@ def _normalize_archive_destination(path):
     return os.path.normpath(os.path.abspath(path))
 
 
+def _paths_overlap(a, b):
+    """Return True if ``a`` and ``b`` are equal or one descends from the other.
+
+    Both inputs must already be normalised absolute paths. Uses
+    ``os.path.commonpath`` so prefix-string traps like ``/Photos/Shoot`` vs
+    ``/Photos/ShootSubset`` don't false-positive as overlapping.
+    """
+    import os
+
+    if a == b:
+        return True
+    try:
+        common = os.path.commonpath([a, b])
+    except ValueError:
+        # Different drives (Windows) or one path isn't absolute. After
+        # normalisation that means the two can't possibly overlap.
+        return False
+    return common in (a, b)
+
+
 def try_reserve_archive_destination(path):
     """Claim ``path`` for an in-flight local-processing archive.
 
     Returns True on first claim, False if another running pipeline already
-    owns the same destination. Paths are normalised to absolute, so
-    ``/Photos/Shoot`` and ``./Photos/Shoot`` collide. Must be paired with
+    owns an overlapping destination — equal to ``path``, an ancestor of it,
+    or a descendant of it. Equal paths obviously collide; nested paths also
+    collide because ``move_folder`` would either create the parent's tracked
+    row inside its child's archive root, or move a parent into a destination
+    that the child has already claimed, leaving overlapping folder roots in
+    the catalog. Paths are normalised to absolute, so ``/Photos/Shoot`` and
+    ``./Photos/Shoot`` collide. Must be paired with
     ``release_archive_destination`` once the run terminates (success or
     failure) so retries and follow-on runs can re-acquire.
     """
     normalized = _normalize_archive_destination(path)
     with _ARCHIVE_DESTINATIONS_GUARD:
-        if normalized in _ARCHIVE_DESTINATIONS:
-            return False
+        for existing in _ARCHIVE_DESTINATIONS:
+            if _paths_overlap(existing, normalized):
+                return False
         _ARCHIVE_DESTINATIONS.add(normalized)
         return True
 

--- a/vireo/preview_cache.py
+++ b/vireo/preview_cache.py
@@ -7,10 +7,77 @@ pipeline import from ``app`` (which would be circular) or duplicating
 the loop in two modules.
 """
 
+import glob as _glob
 import logging
 import os
 
 log = logging.getLogger(__name__)
+
+
+def cleanup_cached_files_for_deleted_photos(thumb_cache_dir, files):
+    """Remove thumbnail, preview, and working-copy files for deleted photos.
+
+    ``files`` is the list returned by ``db.delete_photos`` /
+    ``db.delete_folder``. The FK cascade drops preview_cache rows when
+    photos are deleted, but the on-disk files stay unless we unlink
+    them here — otherwise they leak into untracked bytes that eviction
+    can't see, and on SQLite a retry that reuses one of the just-freed
+    photo IDs would treat the stale ``{photo_id}.jpg`` as a valid
+    thumbnail and skip regenerating it.
+
+    Note: if an unlink fails (e.g. file locked on Windows), the file
+    remains on disk as an orphan because the cascade has already removed
+    the preview_cache row. "Clear cache" in Settings recovers by globbing
+    the directory.
+    """
+    vireo_dir = os.path.dirname(thumb_cache_dir)
+    preview_dir = os.path.join(vireo_dir, "previews")
+    working_dir = os.path.join(vireo_dir, "working")
+    # Offline-cache layout: offline/{originals,xmp,companions}/{pid}{ext}.
+    # The FK cascade drops the offline_originals row when the photo is
+    # deleted, so we lose the exact stored paths — glob by photo id to
+    # cover any source extension and any sidecar/companion that was
+    # copied alongside it.
+    offline_dirs = [
+        os.path.join(vireo_dir, "offline", "originals"),
+        os.path.join(vireo_dir, "offline", "xmp"),
+        os.path.join(vireo_dir, "offline", "companions"),
+    ]
+    for f in files:
+        pid = f["photo_id"]
+        # {id}.jpg lives in all three dirs (legacy full preview, thumb,
+        # working copy). {id}_{size}.jpg is sized preview variants.
+        for d in [thumb_cache_dir, preview_dir, working_dir]:
+            cached = os.path.join(d, f"{pid}.jpg")
+            if os.path.isfile(cached):
+                try:
+                    os.remove(cached)
+                except OSError as e:
+                    log.warning(
+                        "Failed to remove cached file %s after photo "
+                        "delete — will be reclaimed by Clear Cache: %s",
+                        cached, e,
+                    )
+        for variant in _glob.glob(os.path.join(preview_dir, f"{pid}_*.jpg")):
+            try:
+                os.remove(variant)
+            except OSError as e:
+                log.warning(
+                    "Failed to remove preview variant %s after photo "
+                    "delete — will be reclaimed by Clear Cache: %s",
+                    variant, e,
+                )
+        for d in offline_dirs:
+            for orphan in _glob.glob(os.path.join(d, f"{pid}.*")):
+                try:
+                    os.remove(orphan)
+                except OSError as e:
+                    log.warning(
+                        "Failed to remove offline cache file %s after "
+                        "photo delete — will be reclaimed by Clear "
+                        "Cache: %s",
+                        orphan, e,
+                    )
 
 
 def evict_if_over_quota(db, vireo_dir):

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -828,6 +828,16 @@ body { padding-bottom: 36px; }
               </label>
             </div>
           </div>
+          <div class="setting-row">
+            <div class="setting-item">
+              <label style="font-size:12px;color:var(--text-secondary);cursor:pointer;">
+                <input type="checkbox" id="chkLocalProcessing" style="accent-color:var(--accent);" onchange="updateStartButton()" data-testid="local-processing-toggle"> Use local disk while processing
+              </label>
+              <div style="font-size:11px;color:var(--text-dim);margin-top:4px;line-height:1.4;">
+                Files are staged locally for faster processing, then archived to the destination after verification.
+              </div>
+            </div>
+          </div>
           <!-- Folder Organization -->
           <div style="border-top:1px solid var(--border-primary,#14374E);margin:12px 0;"></div>
           <div class="setting-row">
@@ -2610,6 +2620,8 @@ async function startPipeline() {
       body.destination = document.getElementById('cfgDestination').value.trim();
       body.skip_duplicates = document.getElementById('chkSkipDuplicates').checked;
       body.folder_template = getSelectedFolderTemplate();
+      var localProcessing = document.getElementById('chkLocalProcessing');
+      body.local_processing = !!(localProcessing && localProcessing.checked);
     }
   } else if (_sourceMode === 'new_images') {
     body.source_snapshot_id = newImagesSnapshotId;
@@ -2757,6 +2769,7 @@ async function startPipeline() {
 
 // Map pipeline stage names to UI card element suffixes
 var _stageToCard = {
+  storage: 'Destination',
   ingest: 'Source',
   scan: 'Scan',
   thumbnails: 'Previews',
@@ -2766,6 +2779,7 @@ var _stageToCard = {
   extract_masks: 'Extract',
   eye_keypoints: 'EyeKeypoints',
   regroup: 'Group',
+  archive: 'Destination',
 };
 
 // Reverse of _stageToCard: cardSuffix -> [backend stage names]. Used by
@@ -2995,7 +3009,7 @@ function _onPipelineComplete(result) {
       actionStatus.textContent = 'Pipeline cancelled.';
       actionStatus.className = 'status-msg';
     }
-    ['Source', 'Scan', 'Previews', 'Classify', 'Extract', 'EyeKeypoints', 'Group'].forEach(function(cardSuffix) {
+    ['Source', 'Destination', 'Scan', 'Previews', 'Classify', 'Extract', 'EyeKeypoints', 'Group'].forEach(function(cardSuffix) {
       if (_runningStages[cardSuffix]) {
         delete _runningStages[cardSuffix];
         // Record a real 'cancelled' outcome so later refreshPipelineUI

--- a/vireo/tests/test_local_processing.py
+++ b/vireo/tests/test_local_processing.py
@@ -53,3 +53,29 @@ def test_storage_plan_reports_batching_when_local_space_is_short(
     assert plan["batching_required"] is True
     assert plan["batch_count"] > 1
     assert plan["usable_bytes"] == 150
+
+
+def test_non_duplicate_bytes_excludes_known_hashes(tmp_path):
+    """non_duplicate_bytes mirrors ingest()'s skip_duplicates gate: files whose
+    hash is already in the catalog must not be counted against the staging
+    budget, otherwise a mostly-duplicate card would fail the storage preflight
+    even when the actual copy would fit comfortably."""
+    from scanner import compute_file_hash
+
+    fresh = tmp_path / "fresh.jpg"
+    fresh.write_bytes(b"fresh-bytes-payload")
+    dup = tmp_path / "dup.jpg"
+    dup.write_bytes(b"already-imported-content")
+
+    known = {compute_file_hash(str(dup))}
+    assert local_processing.non_duplicate_bytes([fresh, dup], known) == fresh.stat().st_size
+
+    # All files duplicates → zero bytes to stage.
+    known_all = {compute_file_hash(str(fresh)), compute_file_hash(str(dup))}
+    assert local_processing.non_duplicate_bytes([fresh, dup], known_all) == 0
+
+    # Empty known set → behaves like total_file_bytes.
+    assert (
+        local_processing.non_duplicate_bytes([fresh, dup], set())
+        == local_processing.total_file_bytes([fresh, dup])
+    )

--- a/vireo/tests/test_local_processing.py
+++ b/vireo/tests/test_local_processing.py
@@ -768,3 +768,78 @@ def test_storage_plan_recomputes_archive_credit_for_duplicate_filtered_set(
         reserved_free_bytes=0,
     )
     assert buggy_plan["archive_required_bytes"] == 0
+
+
+def test_conflicting_archive_paths_treats_empty_files_as_no_duplicate_identity(
+    tmp_path,
+):
+    """Zero-byte sources must not poison ``seen_hashes`` with
+    ``EMPTY_FILE_SHA256``. ingest() clears the empty-file hash to None
+    before duplicate checks, so an early empty survivor must not cause a
+    later empty source's same-path conflict to be falsely skipped as an
+    intra-batch duplicate. Without this, a real archive collision on the
+    second empty source would be hidden by the preflight and only
+    surface when ``move_folder(..., merge=True)`` rejected it after
+    every processing stage had already run."""
+    src = tmp_path / "card"
+    src.mkdir()
+    # First empty source: its archive path is missing, so the function
+    # only records it as a pending survivor. Without the fix,
+    # _flush_pending would add EMPTY_FILE_SHA256 to seen_hashes.
+    first = src / "first.jpg"
+    first.write_bytes(b"")
+    # Second empty source: its archive path is occupied by a different
+    # file. Without the fix, the conflict branch would hash `second`,
+    # see EMPTY_FILE_SHA256 in seen_hashes from the flush, and treat
+    # `second` as an intra-batch duplicate skip — so the real conflict
+    # would never reach the caller.
+    second = src / "second.jpg"
+    second.write_bytes(b"")
+
+    dest = tmp_path / "archive"
+    dest.mkdir()
+    (dest / "second.jpg").write_bytes(b"unrelated non-empty content")
+
+    # Empty known_hashes (skip_duplicates on, no catalog matches) still
+    # enables the survivor-tracking branch. With the fix, the empty
+    # files have no duplicate identity, so the conflict on `second` is
+    # reported instead of being silently swallowed.
+    conflicts = local_processing.conflicting_archive_paths(
+        str(dest),
+        [first, second],
+        folder_template="",
+        known_hashes=set(),
+    )
+    assert conflicts == [str(dest / "second.jpg")]
+
+
+def test_non_duplicate_files_keeps_zero_byte_sources(tmp_path):
+    """ingest() doesn't dedupe zero-byte files by hash, so the survivor
+    list mustn't collapse two empty sources into one — that would
+    under-count the staged set and let downstream callers (such as the
+    duplicate-filtered storage retry) credit destination space against
+    the wrong number of bytes."""
+    fresh = tmp_path / "fresh.jpg"
+    fresh.write_bytes(b"fresh-bytes-payload")
+    empty_a = tmp_path / "empty_a.jpg"
+    empty_a.write_bytes(b"")
+    empty_b = tmp_path / "empty_b.jpg"
+    empty_b.write_bytes(b"")
+
+    survivors = local_processing.non_duplicate_files(
+        [fresh, empty_a, empty_b], set(),
+    )
+    # Both empty sources survive, matching ingest's copy-both-as-
+    # placeholders behavior.
+    assert survivors == [fresh, empty_a, empty_b]
+
+    # Even when an empty hash is in known_hashes (which scanner is
+    # careful never to write, but a buggy caller might pass in), the
+    # empty source must still survive — ingest itself ignores
+    # EMPTY_FILE_SHA256 entries when deciding what to skip.
+    from scanner import EMPTY_FILE_SHA256
+
+    survivors_with_poisoned_known = local_processing.non_duplicate_files(
+        [fresh, empty_a, empty_b], {EMPTY_FILE_SHA256},
+    )
+    assert survivors_with_poisoned_known == [fresh, empty_a, empty_b]

--- a/vireo/tests/test_local_processing.py
+++ b/vireo/tests/test_local_processing.py
@@ -342,6 +342,49 @@ def test_conflicting_archive_paths_skips_known_duplicates(tmp_path):
     ) == []
 
 
+def test_conflicting_archive_paths_tracks_survivor_hashes(tmp_path):
+    """When skip_duplicates is enabled and the selected sources contain the
+    same bytes twice (for example the same card folder selected twice),
+    ingest() copies the first occurrence, adds its hash to the known-hash
+    set, and skips later same-hash sources before staging. The preflight
+    must mirror that: a later same-hash source that happens to map to an
+    existing different archive path must not be reported as a conflict,
+    because ingest will skip it before staging.
+
+    The earlier survivor's archive path is missing in this scenario, so
+    the earlier branch never hashes it. The function must therefore fold
+    earlier survivors' hashes into ``seen_hashes`` lazily before checking
+    a later same-hash source against an existing archive collision."""
+    src = tmp_path / "card"
+    src.mkdir()
+    # Two source files with identical bytes (same content hash) but
+    # different names so they map to different archive paths.
+    first = src / "first.jpg"
+    first.write_bytes(b"identical-content")
+    second = src / "second.jpg"
+    second.write_bytes(b"identical-content")
+
+    dest = tmp_path / "archive"
+    dest.mkdir()
+    # The first source's archive path is missing (no conflict — survivor),
+    # so the function never hashes it in the simple branch. The second
+    # source's archive path collides with an unrelated file. Without the
+    # survivor-hash fix, the function would hash `second`, find its hash
+    # missing from seen_hashes (since `first` was never hashed), and
+    # falsely report a conflict — even though ingest would skip `second`
+    # as an intra-batch duplicate of `first`.
+    (dest / "second.jpg").write_bytes(b"unrelated-content")
+
+    # Empty known_hashes (skip_duplicates on, no catalog matches) is
+    # enough to enable the survivor-tracking branch.
+    assert local_processing.conflicting_archive_paths(
+        str(dest),
+        [first, second],
+        folder_template="",
+        known_hashes=set(),
+    ) == []
+
+
 def test_conflicting_archive_paths_mirrors_ingest_filename_suffix(tmp_path):
     """Two sources that share an import folder and filename but differ in
     content are staged as ``name.ext`` and ``name_1.ext``. The preflight
@@ -383,6 +426,39 @@ def test_conflicting_archive_paths_mirrors_ingest_filename_suffix(tmp_path):
         [first, second],
         folder_template="",
     ) == [str(dest / "frame_1.jpg")]
+
+
+def test_existing_archive_bytes_credits_suffixed_resumes(tmp_path):
+    """When two selected files share a basename in the same import folder,
+    ingest() stages the first as ``name.ext`` and the second as
+    ``name_1.ext``. A previous partial archive that already contains both
+    suffixed variants must credit both source files' bytes — otherwise the
+    second source (whose dest path collides with the first's credit) earns
+    zero credit and the retry can be batching-rejected even though the
+    delta would fit."""
+    src = tmp_path / "card"
+    src.mkdir()
+    # Two source files with the same basename but in different subfolders,
+    # so both map to the same archive folder under folder_template="".
+    first = src / "a" / "frame.jpg"
+    first.parent.mkdir()
+    first.write_bytes(b"first-content")
+    second = src / "b" / "frame.jpg"
+    second.parent.mkdir()
+    second.write_bytes(b"second-content-longer")
+
+    dest = tmp_path / "archive"
+    dest.mkdir()
+    # A partial prior archive run already staged both files at their
+    # ingest-assigned paths. The retry must credit both.
+    (dest / "frame.jpg").write_bytes(b"first-content")
+    (dest / "frame_1.jpg").write_bytes(b"second-content-longer")
+
+    assert local_processing.existing_archive_bytes(
+        str(dest),
+        [first, second],
+        folder_template="",
+    ) == len(b"first-content") + len(b"second-content-longer")
 
 
 def test_existing_archive_bytes_returns_zero_for_missing_or_file(tmp_path):

--- a/vireo/tests/test_local_processing.py
+++ b/vireo/tests/test_local_processing.py
@@ -280,6 +280,30 @@ def test_existing_archive_bytes_ignores_unmatched_or_different_files(tmp_path):
     ) == 0
 
 
+def test_conflicting_archive_paths_reports_different_existing_files(tmp_path):
+    """Same archive-relative path with different content must be rejected
+    before the final merge-mode archive step."""
+    src = tmp_path / "card"
+    src.mkdir()
+    matching = src / "matching.jpg"
+    matching.write_bytes(b"same")
+    conflicting = src / "conflict.jpg"
+    conflicting.write_bytes(b"source")
+    missing = src / "missing.jpg"
+    missing.write_bytes(b"new")
+
+    dest = tmp_path / "archive"
+    dest.mkdir()
+    (dest / "matching.jpg").write_bytes(b"same")
+    (dest / "conflict.jpg").write_bytes(b"target")
+
+    assert local_processing.conflicting_archive_paths(
+        str(dest),
+        [matching, conflicting, missing],
+        folder_template="",
+    ) == [str(dest / "conflict.jpg")]
+
+
 def test_existing_archive_bytes_returns_zero_for_missing_or_file(tmp_path):
     """Missing directories and regular files give no credit — the caller
     treats them as a fresh archive run."""

--- a/vireo/tests/test_local_processing.py
+++ b/vireo/tests/test_local_processing.py
@@ -235,6 +235,169 @@ def test_storage_plan_same_device_batching_when_insufficient(
     assert plan["enough"] is False
 
 
+def test_existing_archive_bytes_sums_existing_directory(tmp_path):
+    """existing_archive_bytes() walks the destination so a partial archive
+    contributes a credit for the next preflight."""
+    dest = tmp_path / "archive"
+    dest.mkdir()
+    (dest / "a.jpg").write_bytes(b"x" * 100)
+    nested = dest / "sub"
+    nested.mkdir()
+    (nested / "b.jpg").write_bytes(b"y" * 250)
+
+    assert local_processing.existing_archive_bytes(str(dest)) == 350
+
+
+def test_existing_archive_bytes_returns_zero_for_missing_or_file(tmp_path):
+    """Missing directories and regular files give no credit — the caller
+    treats them as a fresh archive run."""
+    assert local_processing.existing_archive_bytes(
+        str(tmp_path / "does-not-exist")
+    ) == 0
+
+    plain = tmp_path / "plain.txt"
+    plain.write_bytes(b"hello")
+    assert local_processing.existing_archive_bytes(str(plain)) == 0
+
+
+def test_storage_plan_credits_existing_archive_on_resume(monkeypatch, tmp_path):
+    """When a previous archive attempt left bytes at the destination, the
+    preflight credits them: move_folder merge-mode rsyncs only the delta,
+    so a retry whose remaining work fits must not be rejected as
+    batching-required."""
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    archive_parent = tmp_path / "archive_parent"
+    archive_parent.mkdir()
+
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    usage_by_path = {
+        str(staging): Usage(total=10_000, used=0, free=10_000),
+        # Without the credit, archive_required would be 800 and this
+        # destination (free=300) would fail the preflight. With 700 bytes
+        # already archived, the delta is only 100 and the retry fits.
+        str(archive_parent): Usage(total=10_000, used=9_700, free=300),
+    }
+    monkeypatch.setattr(
+        local_processing.shutil,
+        "disk_usage",
+        lambda path: usage_by_path[path],
+    )
+
+    real_stat = local_processing.os.stat
+    class FakeStat:
+        def __init__(self, dev): self.st_dev = dev
+    stat_by_path = {
+        str(staging): FakeStat(1), str(archive_parent): FakeStat(2),
+    }
+    monkeypatch.setattr(
+        local_processing.os, "stat",
+        lambda path: stat_by_path.get(path, real_stat(path)),
+    )
+
+    plan = local_processing.storage_plan(
+        str(staging),
+        source_bytes=800,
+        archive_parent=str(archive_parent),
+        archive_existing_bytes=700,
+        reserved_free_bytes=0,
+    )
+
+    assert plan["archive_existing_bytes"] == 700
+    assert plan["archive_required_bytes"] == 100
+    assert plan["archive_enough"] is True
+    assert plan["enough"] is True
+    assert plan["batching_required"] is False
+
+
+def test_storage_plan_caps_existing_credit_at_source_bytes(monkeypatch, tmp_path):
+    """A destination that contains more bytes than the source — extra
+    unrelated content from a previous run — must not extend the credit
+    past source_bytes, otherwise the preflight would always treat the
+    destination as full enough regardless of the source."""
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    archive_parent = tmp_path / "archive_parent"
+    archive_parent.mkdir()
+
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    usage_by_path = {
+        str(staging): Usage(total=10_000, used=0, free=10_000),
+        str(archive_parent): Usage(total=10_000, used=9_900, free=100),
+    }
+    monkeypatch.setattr(
+        local_processing.shutil,
+        "disk_usage",
+        lambda path: usage_by_path[path],
+    )
+
+    real_stat = local_processing.os.stat
+    class FakeStat:
+        def __init__(self, dev): self.st_dev = dev
+    stat_by_path = {
+        str(staging): FakeStat(1), str(archive_parent): FakeStat(2),
+    }
+    monkeypatch.setattr(
+        local_processing.os, "stat",
+        lambda path: stat_by_path.get(path, real_stat(path)),
+    )
+
+    plan = local_processing.storage_plan(
+        str(staging),
+        source_bytes=500,
+        archive_parent=str(archive_parent),
+        archive_existing_bytes=10_000,  # absurd overshoot
+        reserved_free_bytes=0,
+    )
+
+    assert plan["archive_existing_bytes"] == 500
+    assert plan["archive_required_bytes"] == 0
+    assert plan["archive_enough"] is True
+
+
+def test_storage_plan_same_device_credits_existing_archive(monkeypatch, tmp_path):
+    """On same-device runs the destination copy is the move-folder rewrite,
+    which in merge mode only writes the delta. The same-device extra
+    requirement must shrink to the delta too — otherwise resume runs that
+    fit are rejected even when the destination is already most of the way
+    there."""
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    archive_parent = tmp_path / "archive"
+    archive_parent.mkdir()
+
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    monkeypatch.setattr(
+        local_processing.shutil,
+        "disk_usage",
+        lambda path: Usage(total=10_000, used=0, free=1_400),
+    )
+    real_stat = local_processing.os.stat
+    class FakeStat:
+        def __init__(self, dev): self.st_dev = dev
+    stat_by_path = {
+        str(staging): FakeStat(7), str(archive_parent): FakeStat(7),
+    }
+    monkeypatch.setattr(
+        local_processing.os, "stat",
+        lambda path: stat_by_path.get(path, real_stat(path)),
+    )
+
+    # Without credit: required = 1000 + 250 + 1000 = 2250 → batching.
+    # With 900 already archived: required = 1000 + 250 + 100 = 1350 → fits.
+    plan = local_processing.storage_plan(
+        str(staging),
+        source_bytes=1_000,
+        archive_parent=str(archive_parent),
+        archive_existing_bytes=900,
+        reserved_free_bytes=0,
+    )
+
+    assert plan["same_device"] is True
+    assert plan["required_bytes"] == 1_350
+    assert plan["enough"] is True
+
+
 def test_non_duplicate_bytes_deduplicates_within_pass(tmp_path):
     """Intra-run duplicates — the same file selected twice via overlapping
     sources, or two source folders sharing a file — must collapse the way

--- a/vireo/tests/test_local_processing.py
+++ b/vireo/tests/test_local_processing.py
@@ -280,6 +280,30 @@ def test_existing_archive_bytes_ignores_unmatched_or_different_files(tmp_path):
     ) == 0
 
 
+def test_existing_archive_bytes_ignores_symlink_matches(tmp_path):
+    """Symlinked archive entries are not safe resume credit, even when their
+    target bytes match the source file."""
+    src = tmp_path / "card"
+    src.mkdir()
+    source = src / "linked.jpg"
+    source.write_bytes(b"same")
+
+    dest = tmp_path / "archive"
+    dest.mkdir()
+    target = dest / "target.jpg"
+    target.write_bytes(b"same")
+    try:
+        (dest / "linked.jpg").symlink_to(target)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+    assert local_processing.existing_archive_bytes(
+        str(dest),
+        [source],
+        folder_template="",
+    ) == 0
+
+
 def test_conflicting_archive_paths_reports_different_existing_files(tmp_path):
     """Same archive-relative path with different content must be rejected
     before the final merge-mode archive step."""
@@ -302,6 +326,30 @@ def test_conflicting_archive_paths_reports_different_existing_files(tmp_path):
         [matching, conflicting, missing],
         folder_template="",
     ) == [str(dest / "conflict.jpg")]
+
+
+def test_conflicting_archive_paths_reports_symlink_even_when_target_matches(tmp_path):
+    """A symlink at the archive-relative resume path must be treated as a
+    conflict before staging, not as a safe same-content resume hit."""
+    src = tmp_path / "card"
+    src.mkdir()
+    source = src / "linked.jpg"
+    source.write_bytes(b"same")
+
+    dest = tmp_path / "archive"
+    dest.mkdir()
+    target = dest / "target.jpg"
+    target.write_bytes(b"same")
+    try:
+        (dest / "linked.jpg").symlink_to(target)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+    assert local_processing.conflicting_archive_paths(
+        str(dest),
+        [source],
+        folder_template="",
+    ) == [str(dest / "linked.jpg")]
 
 
 def test_conflicting_archive_paths_skips_known_duplicates(tmp_path):

--- a/vireo/tests/test_local_processing.py
+++ b/vireo/tests/test_local_processing.py
@@ -304,6 +304,87 @@ def test_conflicting_archive_paths_reports_different_existing_files(tmp_path):
     ) == [str(dest / "conflict.jpg")]
 
 
+def test_conflicting_archive_paths_skips_known_duplicates(tmp_path):
+    """When skip_duplicates would skip a source whose hash is already in the
+    catalog, that source never reaches staging and so cannot conflict at
+    archive time. Passing the catalog hash set lets the preflight mirror
+    that behavior instead of falsely aborting the run."""
+    from scanner import compute_file_hash
+
+    src = tmp_path / "card"
+    src.mkdir()
+    already_imported = src / "imported.jpg"
+    already_imported.write_bytes(b"source-bytes")
+    fresh = src / "fresh.jpg"
+    fresh.write_bytes(b"new-bytes")
+
+    dest = tmp_path / "archive"
+    dest.mkdir()
+    # The archive already has a different file at the duplicate source's
+    # path. Without the duplicate filter, the preflight would flag this.
+    (dest / "imported.jpg").write_bytes(b"unrelated-target")
+
+    # Without known_hashes: imported.jpg is reported as a conflict.
+    assert local_processing.conflicting_archive_paths(
+        str(dest),
+        [already_imported, fresh],
+        folder_template="",
+    ) == [str(dest / "imported.jpg")]
+
+    # With imported.jpg's hash in the catalog: ingest will skip it, so
+    # the preflight no longer reports the (irrelevant) archive collision.
+    known = {compute_file_hash(str(already_imported))}
+    assert local_processing.conflicting_archive_paths(
+        str(dest),
+        [already_imported, fresh],
+        folder_template="",
+        known_hashes=known,
+    ) == []
+
+
+def test_conflicting_archive_paths_mirrors_ingest_filename_suffix(tmp_path):
+    """Two sources that share an import folder and filename but differ in
+    content are staged as ``name.ext`` and ``name_1.ext``. The preflight
+    must compare the second source against the suffixed archive path —
+    not also against the unsuffixed one — otherwise a resume where the
+    archive already contains the first exact match incorrectly rejects
+    the second source as a conflict."""
+    src = tmp_path / "card"
+    src.mkdir()
+    first = src / "subdir-a" / "frame.jpg"
+    first.parent.mkdir()
+    first.write_bytes(b"first-content")
+    # Same basename as `first` but in a different source subfolder, so
+    # both map to the same archive-relative path under folder_template="".
+    second = src / "subdir-b" / "frame.jpg"
+    second.parent.mkdir()
+    second.write_bytes(b"second-content")
+
+    dest = tmp_path / "archive"
+    dest.mkdir()
+    # The archive already contains the first source verbatim — the
+    # second source would be staged under the suffixed name, and no
+    # `frame_1.jpg` exists at the archive, so the run must not abort.
+    (dest / "frame.jpg").write_bytes(b"first-content")
+
+    assert local_processing.conflicting_archive_paths(
+        str(dest),
+        [first, second],
+        folder_template="",
+    ) == []
+
+    # If the archive also has the suffixed slot taken by a different
+    # file, the second source genuinely conflicts there and must be
+    # reported — confirming the suffix tracking still surfaces real
+    # archive collisions.
+    (dest / "frame_1.jpg").write_bytes(b"unrelated")
+    assert local_processing.conflicting_archive_paths(
+        str(dest),
+        [first, second],
+        folder_template="",
+    ) == [str(dest / "frame_1.jpg")]
+
+
 def test_existing_archive_bytes_returns_zero_for_missing_or_file(tmp_path):
     """Missing directories and regular files give no credit — the caller
     treats them as a fresh archive run."""

--- a/vireo/tests/test_local_processing.py
+++ b/vireo/tests/test_local_processing.py
@@ -465,3 +465,129 @@ def test_non_duplicate_bytes_deduplicates_within_pass(tmp_path):
         local_processing.non_duplicate_bytes([fresh, fresh], set())
         == fresh.stat().st_size
     )
+
+
+def test_non_duplicate_files_returns_survivor_list(tmp_path):
+    """non_duplicate_files returns the file list ingest will actually copy,
+    not just a byte total. The pipeline preflight feeds that list back into
+    existing_archive_bytes so the destination credit on a duplicate-filtered
+    retry covers only the survivors — without it, a known-duplicate file
+    that's already at the destination would credit against the smaller
+    survivor byte total and zero out the archive delta even though the
+    fresh file still has to be written."""
+    from scanner import compute_file_hash
+
+    fresh = tmp_path / "fresh.jpg"
+    fresh.write_bytes(b"fresh-bytes-payload")
+    dup = tmp_path / "dup.jpg"
+    dup.write_bytes(b"already-imported-content")
+    other = tmp_path / "shared.jpg"
+    other.write_bytes(b"shared-bytes")
+    other_copy = tmp_path / "shared_copy.jpg"
+    other_copy.write_bytes(b"shared-bytes")  # intra-run duplicate of `other`
+
+    known = {compute_file_hash(str(dup))}
+    survivors = local_processing.non_duplicate_files(
+        [fresh, dup, other, other_copy], known,
+    )
+    assert survivors == [fresh, other]
+
+
+def test_storage_plan_recomputes_archive_credit_for_duplicate_filtered_set(
+    monkeypatch, tmp_path,
+):
+    """When skip_duplicates triggers the storage_plan retry, the existing-
+    archive credit must be recomputed against the survivor file list, not
+    reused from the full selection. Otherwise a large known-duplicate file
+    already at the destination would credit against the smaller filtered
+    byte count, drive archive_delta to zero, and pass the destination
+    preflight — even though the fresh survivor still has to be written at
+    the archive."""
+    from scanner import compute_file_hash
+
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    archive_parent = tmp_path / "nas"
+    archive_parent.mkdir()
+    final_destination = archive_parent / "Photos"
+    # Simulate a previous archive attempt: the large duplicate file is
+    # already laid down at the resume-credit-eligible relative path.
+    final_destination.mkdir()
+    archived_dup_subdir = final_destination / "2024" / "2024-05-01"
+    archived_dup_subdir.mkdir(parents=True)
+    big_dup = tmp_path / "big_dup.jpg"
+    big_dup.write_bytes(b"x" * 10_000)  # large duplicate (already cataloged)
+    os.utime(big_dup, (1714521600, 1714521600))  # 2024-05-01
+    (archived_dup_subdir / big_dup.name).write_bytes(b"x" * 10_000)
+
+    fresh = tmp_path / "fresh.jpg"
+    fresh.write_bytes(b"y" * 100)  # small fresh file (no archive copy yet)
+    os.utime(fresh, (1714521600, 1714521600))
+
+    known = {compute_file_hash(str(big_dup))}
+    survivors = local_processing.non_duplicate_files([big_dup, fresh], known)
+    assert survivors == [fresh]
+
+    # The full-set credit (used by the first plan call) covers the big
+    # duplicate that's already at the destination.
+    full_credit = local_processing.existing_archive_bytes(
+        str(final_destination), [big_dup, fresh],
+    )
+    assert full_credit == 10_000
+
+    # The survivor-set credit must cover only `fresh`, which is NOT at the
+    # destination yet. Reusing full_credit on the retry would zero out the
+    # archive delta even though fresh still has to be written.
+    survivor_credit = local_processing.existing_archive_bytes(
+        str(final_destination), survivors,
+    )
+    assert survivor_credit == 0
+
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    monkeypatch.setattr(
+        local_processing.shutil,
+        "disk_usage",
+        lambda path: Usage(total=10_000, used=0, free=10_000),
+    )
+
+    # Force staging and archive onto different fake devices so the
+    # destination-volume check actually runs (same_device skips it). The
+    # bug surfaces precisely when the archive lives on a separate volume
+    # whose free space the planner is responsible for checking.
+    real_stat = os.stat
+
+    def fake_stat(path, *args, **kwargs):
+        result = real_stat(path, *args, **kwargs)
+        if str(path).startswith(str(final_destination)):
+            return os.stat_result(
+                (result.st_mode, result.st_ino, 999) + tuple(result)[3:]
+            )
+        return result
+
+    monkeypatch.setattr(local_processing.os, "stat", fake_stat)
+
+    filtered_bytes = local_processing.total_file_bytes(survivors)
+    plan = local_processing.storage_plan(
+        str(staging),
+        filtered_bytes,
+        archive_parent=str(final_destination),
+        archive_existing_bytes=survivor_credit,
+        reserved_free_bytes=0,
+    )
+    assert plan["same_device"] is False
+    # archive_delta = filtered_bytes (100) - survivor_credit (0) = 100.
+    # Reusing full_credit (10_000) would have capped to filtered_bytes and
+    # driven archive_required_bytes to 0.
+    assert plan["archive_required_bytes"] == filtered_bytes
+
+    # Sanity check the bug we're guarding against: feeding the full-set
+    # credit (10_000) on the filtered retry zeroes out the archive delta,
+    # which is exactly what the pipeline_job retry path must NOT do.
+    buggy_plan = local_processing.storage_plan(
+        str(staging),
+        filtered_bytes,
+        archive_parent=str(final_destination),
+        archive_existing_bytes=full_credit,
+        reserved_free_bytes=0,
+    )
+    assert buggy_plan["archive_required_bytes"] == 0

--- a/vireo/tests/test_local_processing.py
+++ b/vireo/tests/test_local_processing.py
@@ -1,0 +1,55 @@
+import os
+from collections import namedtuple
+
+import local_processing
+
+Usage = namedtuple("Usage", "total used free")
+
+
+def test_staging_root_uses_final_destination_basename(tmp_path):
+    root = local_processing.staging_root(
+        str(tmp_path), "pipeline-123", "/Volumes/NAS/Photos"
+    )
+
+    assert root == os.path.join(str(tmp_path), "staging", "pipeline-123", "Photos")
+
+
+def test_storage_plan_reports_enough_space(monkeypatch, tmp_path):
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    monkeypatch.setattr(
+        local_processing.shutil,
+        "disk_usage",
+        lambda path: Usage(total=500, used=100, free=400),
+    )
+
+    plan = local_processing.storage_plan(
+        str(tmp_path),
+        source_bytes=100,
+        reserved_free_bytes=10,
+    )
+
+    assert plan["enough"] is True
+    assert plan["batching_required"] is False
+    assert plan["batch_count"] == 1
+
+
+def test_storage_plan_reports_batching_when_local_space_is_short(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    monkeypatch.setattr(
+        local_processing.shutil,
+        "disk_usage",
+        lambda path: Usage(total=500, used=100, free=170),
+    )
+
+    plan = local_processing.storage_plan(
+        str(tmp_path),
+        source_bytes=200,
+        reserved_free_bytes=20,
+    )
+
+    assert plan["enough"] is False
+    assert plan["batching_required"] is True
+    assert plan["batch_count"] > 1
+    assert plan["usable_bytes"] == 150

--- a/vireo/tests/test_local_processing.py
+++ b/vireo/tests/test_local_processing.py
@@ -390,6 +390,46 @@ def test_conflicting_archive_paths_skips_known_duplicates(tmp_path):
     ) == []
 
 
+def test_conflicting_archive_paths_skips_duplicates_before_claiming_names(
+    tmp_path,
+):
+    """A catalog duplicate must not reserve a destination filename before a
+    later fresh source with the same basename is evaluated."""
+    from scanner import compute_file_hash
+
+    src = tmp_path / "card"
+    src.mkdir()
+    already_imported = src / "existing" / "frame.jpg"
+    already_imported.parent.mkdir()
+    already_imported.write_bytes(b"already-imported")
+    fresh = src / "fresh" / "frame.jpg"
+    fresh.parent.mkdir()
+    fresh.write_bytes(b"fresh-bytes")
+
+    dest = tmp_path / "archive"
+    dest.mkdir()
+    (dest / "frame_1.jpg").write_bytes(b"unrelated-target")
+
+    # Without duplicate filtering, the first frame.jpg claims the unsuffixed
+    # slot and the fresh frame.jpg is correctly checked against frame_1.jpg.
+    assert local_processing.conflicting_archive_paths(
+        str(dest),
+        [already_imported, fresh],
+        folder_template="",
+    ) == [str(dest / "frame_1.jpg")]
+
+    # With the first source already in the catalog, ingest skips it before
+    # claiming frame.jpg. The fresh source therefore stages as frame.jpg, not
+    # frame_1.jpg, and the unrelated partial frame_1.jpg is irrelevant.
+    known = {compute_file_hash(str(already_imported))}
+    assert local_processing.conflicting_archive_paths(
+        str(dest),
+        [already_imported, fresh],
+        folder_template="",
+        known_hashes=known,
+    ) == []
+
+
 def test_conflicting_archive_paths_tracks_survivor_hashes(tmp_path):
     """When skip_duplicates is enabled and the selected sources contain the
     same bytes twice (for example the same card folder selected twice),

--- a/vireo/tests/test_local_processing.py
+++ b/vireo/tests/test_local_processing.py
@@ -2,6 +2,7 @@ import os
 from collections import namedtuple
 
 import local_processing
+import pytest
 
 Usage = namedtuple("Usage", "total used free")
 
@@ -12,6 +13,14 @@ def test_staging_root_uses_final_destination_basename(tmp_path):
     )
 
     assert root == os.path.join(str(tmp_path), "staging", "pipeline-123", "Photos")
+
+
+def test_staging_root_rejects_filesystem_root(tmp_path):
+    with pytest.raises(ValueError, match="filesystem root"):
+        local_processing.staging_root(str(tmp_path), "pipeline-123", os.sep)
+
+    with pytest.raises(ValueError, match="filesystem root"):
+        local_processing.staging_root(str(tmp_path), "pipeline-123", "C:\\")
 
 
 def test_storage_plan_reports_enough_space(monkeypatch, tmp_path):

--- a/vireo/tests/test_local_processing.py
+++ b/vireo/tests/test_local_processing.py
@@ -74,8 +74,36 @@ def test_non_duplicate_bytes_excludes_known_hashes(tmp_path):
     known_all = {compute_file_hash(str(fresh)), compute_file_hash(str(dup))}
     assert local_processing.non_duplicate_bytes([fresh, dup], known_all) == 0
 
-    # Empty known set → behaves like total_file_bytes.
+    # Empty known set with no intra-run duplicates → equals total_file_bytes.
     assert (
         local_processing.non_duplicate_bytes([fresh, dup], set())
         == local_processing.total_file_bytes([fresh, dup])
+    )
+
+
+def test_non_duplicate_bytes_deduplicates_within_pass(tmp_path):
+    """Intra-run duplicates — the same file selected twice via overlapping
+    sources, or two source folders sharing a file — must collapse the way
+    ingest() does. Without intra-run dedup the estimator would double-count
+    them and falsely trigger batching_required on a card that fits, even
+    when the catalog is empty."""
+    fresh = tmp_path / "fresh.jpg"
+    fresh.write_bytes(b"fresh-bytes-payload")
+    dup_a = tmp_path / "dup_a.jpg"
+    dup_a.write_bytes(b"shared-content")
+    dup_b = tmp_path / "dup_b.jpg"
+    dup_b.write_bytes(b"shared-content")  # same bytes → same hash
+
+    # Empty catalog: intra-run duplicates still collapse, so total equals
+    # the unique-hash bytes (fresh + one copy of the shared content).
+    expected = fresh.stat().st_size + dup_a.stat().st_size
+    assert (
+        local_processing.non_duplicate_bytes([fresh, dup_a, dup_b], set())
+        == expected
+    )
+
+    # The same file listed twice (overlapping sources) counts once.
+    assert (
+        local_processing.non_duplicate_bytes([fresh, fresh], set())
+        == fresh.stat().st_size
     )

--- a/vireo/tests/test_local_processing.py
+++ b/vireo/tests/test_local_processing.py
@@ -235,29 +235,70 @@ def test_storage_plan_same_device_batching_when_insufficient(
     assert plan["enough"] is False
 
 
-def test_existing_archive_bytes_sums_existing_directory(tmp_path):
-    """existing_archive_bytes() walks the destination so a partial archive
-    contributes a credit for the next preflight."""
+def test_existing_archive_bytes_sums_matching_source_files(tmp_path):
+    """existing_archive_bytes() credits only files that match the selected
+    source files at their archive-relative paths."""
+    src = tmp_path / "card"
+    src.mkdir()
+    first = src / "a.jpg"
+    first.write_bytes(b"x" * 100)
+    second = src / "b.jpg"
+    second.write_bytes(b"y" * 250)
+
     dest = tmp_path / "archive"
     dest.mkdir()
     (dest / "a.jpg").write_bytes(b"x" * 100)
-    nested = dest / "sub"
-    nested.mkdir()
-    (nested / "b.jpg").write_bytes(b"y" * 250)
+    (dest / "b.jpg").write_bytes(b"y" * 250)
+    (dest / "unrelated.jpg").write_bytes(b"z" * 500)
 
-    assert local_processing.existing_archive_bytes(str(dest)) == 350
+    assert local_processing.existing_archive_bytes(
+        str(dest),
+        [first, second],
+        folder_template="",
+    ) == 350
+
+
+def test_existing_archive_bytes_ignores_unmatched_or_different_files(tmp_path):
+    """Existing files must not reduce required archive space unless they are
+    exact matches for the source file at the path ingest would create."""
+    src = tmp_path / "card"
+    src.mkdir()
+    first = src / "a.jpg"
+    first.write_bytes(b"x" * 100)
+    same_size_different = src / "same-size.jpg"
+    same_size_different.write_bytes(b"source")
+
+    dest = tmp_path / "archive"
+    dest.mkdir()
+    (dest / "unrelated.jpg").write_bytes(b"x" * 100)
+    (dest / "same-size.jpg").write_bytes(b"target")
+
+    assert local_processing.existing_archive_bytes(
+        str(dest),
+        [first, same_size_different],
+        folder_template="",
+    ) == 0
 
 
 def test_existing_archive_bytes_returns_zero_for_missing_or_file(tmp_path):
     """Missing directories and regular files give no credit — the caller
     treats them as a fresh archive run."""
+    source = tmp_path / "source.jpg"
+    source.write_bytes(b"source")
+
     assert local_processing.existing_archive_bytes(
-        str(tmp_path / "does-not-exist")
+        str(tmp_path / "does-not-exist"),
+        [source],
+        folder_template="",
     ) == 0
 
     plain = tmp_path / "plain.txt"
     plain.write_bytes(b"hello")
-    assert local_processing.existing_archive_bytes(str(plain)) == 0
+    assert local_processing.existing_archive_bytes(
+        str(plain),
+        [source],
+        folder_template="",
+    ) == 0
 
 
 def test_storage_plan_credits_existing_archive_on_resume(monkeypatch, tmp_path):

--- a/vireo/tests/test_local_processing.py
+++ b/vireo/tests/test_local_processing.py
@@ -81,6 +81,151 @@ def test_non_duplicate_bytes_excludes_known_hashes(tmp_path):
     )
 
 
+def test_storage_plan_checks_destination_volume_on_different_device(
+    monkeypatch, tmp_path
+):
+    """When staging and archive_parent are on different devices, the
+    destination volume gets an independent free-space check. A nearly-full
+    archive drive that the staging volume can't see must trip
+    batching_required so the user finds out before the pipeline spends
+    hours staging and processing only to ENOSPC at the final move."""
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    archive_parent = tmp_path / "archive_parent"
+    archive_parent.mkdir()
+
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+
+    usage_by_path = {
+        str(staging): Usage(total=10_000, used=0, free=10_000),
+        str(archive_parent): Usage(total=10_000, used=9_900, free=100),
+    }
+    monkeypatch.setattr(
+        local_processing.shutil,
+        "disk_usage",
+        lambda path: usage_by_path[path],
+    )
+
+    # Force same_device detection to return False so the destination check
+    # runs independently. (On a real filesystem with two tmpfs mounts the
+    # st_dev would already differ; on a single-FS test runner this avoids
+    # depending on that detail.)
+    real_stat = local_processing.os.stat
+    class FakeStat:
+        def __init__(self, dev): self.st_dev = dev
+    stat_by_path = {
+        str(staging): FakeStat(1), str(archive_parent): FakeStat(2),
+    }
+    monkeypatch.setattr(
+        local_processing.os, "stat",
+        lambda path: stat_by_path.get(path, real_stat(path)),
+    )
+
+    plan = local_processing.storage_plan(
+        str(staging),
+        source_bytes=500,
+        archive_parent=str(archive_parent),
+        reserved_free_bytes=0,
+    )
+
+    assert plan["staging_enough"] is True
+    assert plan["archive_enough"] is False
+    assert plan["archive_required_bytes"] == 500
+    assert plan["archive_free_bytes"] == 100
+    assert plan["same_device"] is False
+    assert plan["enough"] is False
+    assert plan["batching_required"] is True
+
+
+def test_storage_plan_doubles_source_bytes_on_same_device(
+    monkeypatch, tmp_path
+):
+    """When staging and archive_parent share a device, the archive's
+    copy-verify-delete needs a second copy of source bytes on the same
+    volume before staging is removed. The plan must add source_bytes to
+    the staging requirement, not just account for it independently —
+    otherwise a volume that barely fits source + derived would pass the
+    preflight and ENOSPC during the move."""
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    archive_parent = tmp_path / "archive"
+    archive_parent.mkdir()
+
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    monkeypatch.setattr(
+        local_processing.shutil,
+        "disk_usage",
+        lambda path: Usage(total=10_000, used=0, free=10_000),
+    )
+
+    real_stat = local_processing.os.stat
+    class FakeStat:
+        def __init__(self, dev): self.st_dev = dev
+    stat_by_path = {
+        str(staging): FakeStat(7), str(archive_parent): FakeStat(7),
+    }
+    monkeypatch.setattr(
+        local_processing.os, "stat",
+        lambda path: stat_by_path.get(path, real_stat(path)),
+    )
+
+    plan = local_processing.storage_plan(
+        str(staging),
+        source_bytes=1_000,
+        archive_parent=str(archive_parent),
+        reserved_free_bytes=0,
+    )
+
+    # required = source + derived(25%) + extra source = 1000 + 250 + 1000
+    assert plan["same_device"] is True
+    assert plan["required_bytes"] == 2_250
+    # The destination doesn't get a separate check when it's the same
+    # device — its bytes are already inside required_bytes.
+    assert plan["archive_required_bytes"] == 0
+    assert plan["enough"] is True
+
+
+def test_storage_plan_same_device_batching_when_insufficient(
+    monkeypatch, tmp_path
+):
+    """Same-device case where the volume isn't big enough for both copies
+    plus derived must report batching_required."""
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    archive_parent = tmp_path / "archive"
+    archive_parent.mkdir()
+
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    # Free space barely fits one copy + derived; can't fit two copies.
+    monkeypatch.setattr(
+        local_processing.shutil,
+        "disk_usage",
+        lambda path: Usage(total=10_000, used=0, free=1_500),
+    )
+    real_stat = local_processing.os.stat
+    class FakeStat:
+        def __init__(self, dev): self.st_dev = dev
+    stat_by_path = {
+        str(staging): FakeStat(7), str(archive_parent): FakeStat(7),
+    }
+    monkeypatch.setattr(
+        local_processing.os, "stat",
+        lambda path: stat_by_path.get(path, real_stat(path)),
+    )
+
+    plan = local_processing.storage_plan(
+        str(staging),
+        source_bytes=1_000,
+        archive_parent=str(archive_parent),
+        reserved_free_bytes=0,
+    )
+
+    assert plan["same_device"] is True
+    assert plan["required_bytes"] == 2_250
+    assert plan["batching_required"] is True
+    assert plan["enough"] is False
+
+
 def test_non_duplicate_bytes_deduplicates_within_pass(tmp_path):
     """Intra-run duplicates — the same file selected twice via overlapping
     sources, or two source folders sharing a file — must collapse the way

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -541,7 +541,10 @@ def test_move_folder_refuses_destination_inside_tracked_ancestor(move_env):
     destination = env["dst"] / "Archive"
 
     result = move_folder(
-        db=env["db"], folder_id=env["fid_src"], destination=str(destination)
+        db=env["db"],
+        folder_id=env["fid_src"],
+        destination=str(destination),
+        reject_tracked_ancestor=True,
     )
 
     assert result["moved"] == 0

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -165,6 +165,58 @@ def test_move_folder_copies_tree(move_env):
     assert folder["path"] == str(env["dst"] / "src")
 
 
+def test_move_folder_reports_cleanup_error_after_commit(move_env, monkeypatch):
+    """Catalog repoints first, so a post-commit rmtree failure is committed.
+
+    If rmtree(src_path) raises after move_folder_path has already pointed
+    the catalog at the destination, the archive IS published — the files
+    exist at the destination and the catalog resolves there. Surfacing
+    that as a normal ``errors`` entry would tell the caller the move
+    failed (the pipeline reports "results remain in staging") even though
+    the data is safely at final_destination and the freshly created
+    tracked folder row is in the catalog. Returning ``cleanup_error``
+    separately lets callers warn about leftover originals without
+    misreporting the move.
+    """
+    import move as move_mod
+
+    env = move_env
+
+    def raise_on_rmtree(path):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(move_mod.shutil, "rmtree", raise_on_rmtree)
+
+    result = move_mod.move_folder(
+        db=env["db"], folder_id=env["fid_src"], destination=str(env["dst"])
+    )
+    assert result["errors"] == []
+    assert result["moved"] >= 1
+    assert result.get("cleanup_error") == "permission denied"
+    # Catalog now points at the new destination (commit step ran before
+    # rmtree) — verifying we don't roll that back on the cleanup failure.
+    folder = env["db"].conn.execute(
+        "SELECT path FROM folders WHERE id = ?", (env["fid_src"],)
+    ).fetchone()
+    assert folder["path"] == str(env["dst"] / "src")
+
+
+def test_move_folder_no_cleanup_error_on_clean_run(move_env):
+    """When rmtree succeeds, ``cleanup_error`` is not present.
+
+    Locks in that the new key is opt-in and the existing happy-path
+    return shape is unchanged for the typical case.
+    """
+    from move import move_folder
+
+    env = move_env
+    result = move_folder(
+        db=env["db"], folder_id=env["fid_src"], destination=str(env["dst"])
+    )
+    assert "cleanup_error" not in result
+    assert result["errors"] == []
+
+
 def test_move_folder_refuses_existing_dest_without_merge(move_env):
     """move_folder refuses an existing destination and preserves originals."""
     from move import move_folder

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -533,6 +533,23 @@ def test_move_folder_merge_refuses_tracked_descendant(move_env):
     assert (env["src"] / "bird1.jpg").exists()
 
 
+def test_move_folder_refuses_destination_inside_tracked_ancestor(move_env):
+    """Moving into a subfolder of a tracked root would create overlapping roots."""
+    from move import move_folder
+
+    env = move_env
+    destination = env["dst"] / "Archive"
+
+    result = move_folder(
+        db=env["db"], folder_id=env["fid_src"], destination=str(destination)
+    )
+
+    assert result["moved"] == 0
+    assert any("inside a folder Vireo already manages" in e for e in result["errors"])
+    assert (env["src"] / "bird1.jpg").exists()
+    assert not destination.exists()
+
+
 def test_move_folder_refuses_missing_tracked_destination_before_copy(move_env):
     """A stale tracked destination row must block the move even when the
     resolved destination does not currently exist on disk."""

--- a/vireo/tests/test_move_api.py
+++ b/vireo/tests/test_move_api.py
@@ -170,6 +170,56 @@ def test_move_folder_failed_move_recorded_as_failed(app_and_db, tmp_path):
     assert row["error_count"] >= 1
 
 
+def test_move_folder_job_surfaces_post_commit_cleanup_warning(
+    app_and_db, tmp_path, monkeypatch
+):
+    import move as move_mod
+    from wait import wait_for_job_via_client
+
+    app, db = app_and_db
+    src = tmp_path / "cleanup_src"
+    src.mkdir()
+    (src / "bird.jpg").write_bytes(b"\xff\xd8" + b"\x00" * 20)
+    fid = db.add_folder(str(src), name="cleanup_src")
+    db.add_photo(
+        folder_id=fid,
+        filename="bird.jpg",
+        extension=".jpg",
+        file_size=22,
+        file_mtime=1.0,
+    )
+    dst = tmp_path / "cleanup_dst"
+    dst.mkdir()
+
+    real_rmtree = move_mod.shutil.rmtree
+
+    def cleanup_fails(path, *args, **kwargs):
+        if os.fspath(path) == str(src):
+            raise OSError("permission denied")
+        return real_rmtree(path, *args, **kwargs)
+
+    monkeypatch.setattr(move_mod.shutil, "rmtree", cleanup_fails)
+
+    client = app.test_client()
+    resp = client.post("/api/jobs/move-folder", json={
+        "folder_id": fid,
+        "destination": str(dst),
+    })
+    assert resp.status_code == 200
+
+    job = wait_for_job_via_client(
+        client, resp.get_json()["job_id"], wait_for_history=True
+    )
+
+    assert job["status"] == "completed", job
+    result = job["result"]
+    assert result["ok"] is True
+    assert result["errors"] == []
+    assert "cleanup_error" in result
+    assert "cleanup failed" in result["summary"]
+    assert "permission denied" in result["summary"]
+
+
 def test_move_folder_merge_param_accepted(app_and_db, tmp_path):
     """POST /api/jobs/move-folder accepts merge=true and starts a job."""
     app, db = app_and_db

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -1142,6 +1142,41 @@ def test_pipeline_local_processing_preflight_probes_existing_final_destination(
     assert set(archive_paths) == {str(final_dest)}
 
 
+def test_pipeline_local_processing_rejects_existing_file_archive_destination(
+    setup, tmp_path, monkeypatch
+):
+    app, _db_path = setup
+
+    src = tmp_path / "card5"
+    src.mkdir()
+    Image.new("RGB", (16, 16), "green").save(src / "fresh.jpg")
+
+    final_dest = tmp_path / "Archive"
+    final_dest.write_text("not a directory")
+
+    import local_processing
+
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    monkeypatch.setattr(local_processing, "RESERVED_FREE_BYTES", 0)
+
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json={
+            "sources": [str(src)],
+            "destination": str(final_dest),
+            "local_processing": True,
+            "folder_template": "",
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        assert resp.status_code == 200
+        job = wait_for_job_via_client(c, resp.get_json()["job_id"])
+
+    assert job["status"] == "failed", job
+    error_text = (job.get("error") or "") + str(job.get("result", ""))
+    assert "not a directory" in error_text
+
+
 def test_import_full_scan_only_returns_job_id(setup):
     """copy=false skips ingest, just scans the source folder."""
     app, db_path = setup

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -673,6 +673,117 @@ def test_pipeline_local_processing_completes_when_cancel_during_archive(
     assert job["result"]["archive"]["final_destination"] == str(final_dest)
 
 
+def test_pipeline_local_processing_deindexes_staging_on_cancel_after_scan(
+    setup, tmp_path, monkeypatch
+):
+    """Regression: when the user clicks Stop after scanner_stage has
+    already indexed the local staging folder but before archive_stage runs,
+    the cancel_watcher sets abort and every downstream stage skips with
+    status "skipped" (not "failed"). archive_stage's abort/cancel
+    early-return must still deindex the staging folder — otherwise the
+    abandoned staging rows would gate ingest()'s known-hash skip on the
+    next retry, letting that retry "successfully" archive an empty
+    destination. The already_failed branch's deindex doesn't help here:
+    cancellation marks stages "skipped", not "failed", so the existing
+    failed-stage cleanup path never runs.
+    """
+    app, db_path = setup
+
+    final_parent = tmp_path / "nas_cancel_pre"
+    final_parent.mkdir()
+    final_dest = final_parent / "Photos"
+
+    src = tmp_path / "card_cancel_pre"
+    src.mkdir()
+    Image.new("RGB", (16, 16), "white").save(src / "kept.jpg")
+
+    import local_processing
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    monkeypatch.setattr(local_processing, "RESERVED_FREE_BYTES", 0)
+
+    # Trigger cancellation in scanner_stage's finally block, after the
+    # staging folder has been scanned and the photo hashes committed. The
+    # pipeline's cancel_watcher polls runner.is_cancelled and sets `abort`
+    # within 0.25s, so by the time archive_stage runs it sees abort.is_set()
+    # and takes the early-return path.
+    import new_images
+    runner = app._job_runner
+    cancelled_once = {"done": False}
+    real_invalidate = new_images.invalidate_new_images_after_scan
+
+    def cancelling_invalidate(db, root):
+        if not cancelled_once["done"]:
+            with runner._lock:
+                running = [
+                    jid for jid, j in runner._jobs.items()
+                    if j.get("status") == "running"
+                    and jid.startswith("pipeline-")
+                ]
+            if running:
+                runner.cancel_job(running[0])
+                cancelled_once["done"] = True
+        return real_invalidate(db, root)
+
+    monkeypatch.setattr(
+        new_images, "invalidate_new_images_after_scan",
+        cancelling_invalidate,
+    )
+
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json={
+            "sources": [str(src)],
+            "destination": str(final_dest),
+            "local_processing": True,
+            "folder_template": "",
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        assert resp.status_code == 200
+        job_id = resp.get_json()["job_id"]
+        job = wait_for_job_via_client(c, job_id)
+
+    # archive must NOT publish files when cancelled before commit.
+    assert not (final_dest / "kept.jpg").exists()
+    # The terminal status reflects the cancellation, not a successful run.
+    assert job["status"] != "completed", job
+
+    # Staging files stay on disk so the user can recover.
+    staging_file = (
+        tmp_path / "staging" / job_id / "Photos" / "kept.jpg"
+    )
+    assert staging_file.is_file(), (
+        f"staging files should remain when archive is skipped, "
+        f"missing at {staging_file}"
+    )
+
+    # The staging folder must be removed from the catalog. Without the
+    # abort branch's deindex, this row would survive and ingest()'s
+    # known-hash gate would skip every file on retry — producing an empty
+    # archive on the next run of the same source.
+    from db import Database
+    check_db = Database(db_path)
+    staging_dir = str(staging_file.parent)
+    folder_row = check_db.conn.execute(
+        "SELECT id FROM folders WHERE path = ?", (staging_dir,),
+    ).fetchone()
+    assert folder_row is None, (
+        f"staging folder must be deindexed when archive is skipped via "
+        f"abort/cancel, still present at {staging_dir}"
+    )
+    photo_rows = check_db.conn.execute(
+        "SELECT id FROM photos WHERE folder_id IN ("
+        "  SELECT id FROM folders WHERE path LIKE ?"
+        ")",
+        (str(tmp_path / "staging" / job_id) + "%",),
+    ).fetchall()
+    assert not photo_rows, (
+        "no photo rows should remain under the abandoned staging tree, "
+        f"got {len(photo_rows)}"
+    )
+    check_db.close()
+
+
 def test_pipeline_local_processing_preflight_filters_duplicates(
     setup, tmp_path, monkeypatch
 ):

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -505,8 +505,10 @@ def test_pipeline_local_processing_rejects_missing_archive_mount_root(
         job = wait_for_job_via_client(c, resp.get_json()["job_id"])
 
     assert job["status"] == "failed", job
-    error_text = (job.get("error") or "") + str(job.get("result", ""))
-    assert f"Archive mount root {missing_mount}" in error_text
+    errors = job.get("result", {}).get("errors", [])
+    assert any(
+        f"Archive mount root {missing_mount}" in error for error in errors
+    ), job
     assert not missing_mount.exists()
 
 

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -745,6 +745,66 @@ def test_pipeline_local_processing_completes_when_cancel_during_archive(
     assert job["result"]["archive"]["final_destination"] == str(final_dest)
 
 
+def test_pipeline_local_processing_cancels_before_archive_commit(
+    setup, tmp_path, monkeypatch
+):
+    """A Stop press that lands just before archive commit begins is still
+    honorably cancellable because nothing has been published yet."""
+    app, db_path = setup
+
+    final_parent = tmp_path / "nas_cancel_before_commit"
+    final_parent.mkdir()
+    final_dest = final_parent / "Photos"
+
+    src = tmp_path / "card_cancel_before_commit"
+    src.mkdir()
+    Image.new("RGB", (16, 16), "white").save(src / "kept.jpg")
+
+    import local_processing
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    monkeypatch.setattr(local_processing, "RESERVED_FREE_BYTES", 0)
+
+    runner = app._job_runner
+    real_begin_uncancellable = runner.begin_uncancellable
+    cancelled_once = {"done": False}
+
+    def cancelling_begin_uncancellable(job_id):
+        if not cancelled_once["done"]:
+            cancelled_once["done"] = True
+            assert runner.cancel_job(job_id) is True
+        return real_begin_uncancellable(job_id)
+
+    monkeypatch.setattr(
+        runner, "begin_uncancellable", cancelling_begin_uncancellable,
+    )
+
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json={
+            "sources": [str(src)],
+            "destination": str(final_dest),
+            "local_processing": True,
+            "folder_template": "",
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        assert resp.status_code == 200
+        job_id = resp.get_json()["job_id"]
+        job = wait_for_job_via_client(c, job_id)
+
+    assert job["status"] == "cancelled", job
+    assert not (final_dest / "kept.jpg").exists()
+
+    from db import Database
+    check_db = Database(db_path)
+    folder_row = check_db.conn.execute(
+        "SELECT id FROM folders WHERE path = ?",
+        (str(tmp_path / "staging" / job_id / "Photos"),),
+    ).fetchone()
+    check_db.close()
+    assert folder_row is None
+
+
 def test_pipeline_local_processing_failed_archive_reports_failed_even_after_cancel(
     setup, tmp_path, monkeypatch
 ):
@@ -1260,6 +1320,44 @@ def test_pipeline_local_processing_rejects_existing_file_archive_destination(
     assert job["status"] == "failed", job
     error_text = (job.get("error") or "") + str(job.get("result", ""))
     assert "not a directory" in error_text
+
+
+def test_pipeline_local_processing_rejects_archive_path_conflicts(
+    setup, tmp_path, monkeypatch
+):
+    app, _db_path = setup
+
+    src = tmp_path / "card-conflict"
+    src.mkdir()
+    Image.new("RGB", (16, 16), "green").save(src / "fresh.jpg")
+
+    final_parent = tmp_path / "archive-conflict-parent"
+    final_parent.mkdir()
+    final_dest = final_parent / "Archive"
+    final_dest.mkdir()
+    (final_dest / "fresh.jpg").write_bytes(b"different existing bytes")
+
+    import local_processing
+
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    monkeypatch.setattr(local_processing, "RESERVED_FREE_BYTES", 0)
+
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json={
+            "sources": [str(src)],
+            "destination": str(final_dest),
+            "local_processing": True,
+            "folder_template": "",
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        assert resp.status_code == 200
+        job = wait_for_job_via_client(c, resp.get_json()["job_id"])
+
+    assert job["status"] == "failed", job
+    error_text = (job.get("error") or "") + str(job.get("result", ""))
+    assert "different files at the same import paths" in error_text
 
 
 def test_pipeline_local_processing_credits_existing_archive_for_resume(

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -235,6 +235,136 @@ def test_pipeline_local_processing_archives_to_final_destination(
     assert job["result"]["archive"]["final_destination"] == str(final_dest)
 
 
+def test_pipeline_local_processing_rejects_already_tracked_destination(
+    setup, tmp_path, monkeypatch
+):
+    """Regression: a second local-processing import to a destination that
+    Vireo already manages must fail fast at the storage preflight. Without
+    the upfront check the pipeline would stage everything, complete every
+    processing step, and only fail in move_folder's tracked-overlap guard —
+    leaving the staged copy stranded under ~/.vireo/staging."""
+    app, db_path = setup
+
+    final_parent = tmp_path / "nas"
+    final_parent.mkdir()
+    final_dest = final_parent / "Photos"
+
+    import local_processing
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    monkeypatch.setattr(local_processing, "RESERVED_FREE_BYTES", 0)
+
+    # Seed the catalog with a tracked folder at the prospective archive path,
+    # matching the post-state of an earlier successful local-processing run.
+    from db import Database
+    db = Database(db_path)
+    db.add_folder(str(final_dest))
+    db.close()
+
+    src = tmp_path / "card2"
+    src.mkdir()
+    Image.new("RGB", (16, 16), "blue").save(src / "again.jpg")
+
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json={
+            "sources": [str(src)],
+            "destination": str(final_dest),
+            "local_processing": True,
+            "folder_template": "",
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        assert resp.status_code == 200
+        job = wait_for_job_via_client(c, resp.get_json()["job_id"])
+
+    assert job["status"] == "failed", job
+    error_text = (job.get("error") or "") + str(job.get("result", ""))
+    assert "Vireo already manages" in error_text, job
+
+
+def test_pipeline_local_processing_preflight_filters_duplicates(
+    setup, tmp_path, monkeypatch
+):
+    """When skip_duplicates is on and the source is mostly already in the
+    catalog, the storage preflight must measure only the bytes ingest would
+    actually copy. Without the duplicate-aware re-check, the naive byte sum
+    would set batching_required and abort an import that would fit in
+    staging."""
+    app, db_path = setup
+
+    final_parent = tmp_path / "nas"
+    final_parent.mkdir()
+    final_dest = final_parent / "Photos"
+
+    src = tmp_path / "card3"
+    src.mkdir()
+    Image.new("RGB", (16, 16), "white").save(src / "dup.jpg")
+    Image.new("RGB", (16, 16), "red").save(src / "fresh.jpg")
+
+    # Insert the dup file's hash into the catalog so skip_duplicates will
+    # treat it as already-known. selected_source_files only walks the source
+    # tree, so the photos table just needs the hash present.
+    from db import Database
+    from scanner import compute_file_hash
+    dup_hash = compute_file_hash(str(src / "dup.jpg"))
+
+    db = Database(db_path)
+    seed_folder = tmp_path / "seed"
+    seed_folder.mkdir()
+    folder_id = db.add_folder(str(seed_folder))
+    ws_id = db._active_workspace_id
+    db.add_workspace_folder(ws_id, folder_id)
+    db.add_photo(
+        folder_id=folder_id, filename="dup.jpg", extension=".jpg",
+        file_size=10, file_mtime=1.0, file_hash=dup_hash,
+    )
+    db.close()
+
+    # Pick a disk_usage and reserve combination so that summing both files
+    # would exceed the usable budget, but the fresh file alone fits.
+    fresh_bytes = (src / "fresh.jpg").stat().st_size
+    dup_bytes = (src / "dup.jpg").stat().st_size
+    total_bytes = fresh_bytes + dup_bytes
+    # required_bytes ≈ source_bytes * 1.25 (overhead ratio) when
+    # MIN_DERIVED_OVERHEAD_BYTES=0. Pick free = roughly fresh_bytes * 2 plus
+    # reserve so the duplicate-filtered plan fits but the naive plan doesn't.
+    reserve = 4
+    free = int(fresh_bytes * 1.5) + reserve + 1
+    assert free < int(total_bytes * 1.25) + reserve, "free must exceed filtered need but not the naive need"
+
+    from collections import namedtuple
+    Usage = namedtuple("Usage", "total used free")
+
+    import local_processing
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    monkeypatch.setattr(local_processing, "RESERVED_FREE_BYTES", reserve)
+    monkeypatch.setattr(
+        local_processing.shutil, "disk_usage",
+        lambda path: Usage(total=free * 10, used=0, free=free),
+    )
+
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json={
+            "sources": [str(src)],
+            "destination": str(final_dest),
+            "local_processing": True,
+            "skip_duplicates": True,
+            "folder_template": "",
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        assert resp.status_code == 200
+        job = wait_for_job_via_client(c, resp.get_json()["job_id"])
+
+    assert job["status"] == "completed", job
+    # Storage plan recorded on the job reflects the filtered bytes, not the
+    # naive sum that would have aborted.
+    plan = job["result"]["local_processing"]
+    assert plan["batching_required"] is False, plan
+    assert plan["source_bytes"] <= fresh_bytes, plan
+
+
 def test_import_full_scan_only_returns_job_id(setup):
     """copy=false skips ingest, just scans the source folder."""
     app, db_path = setup

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -481,6 +481,28 @@ def test_pipeline_local_processing_skips_archive_when_previews_fail(
 
     monkeypatch.setattr(image_loader, "load_image", boom)
 
+    import json
+
+    from db import Database
+    from pipeline import _results_cache_path
+
+    seed_db = Database(db_path)
+    ws_id = seed_db._active_workspace_id
+    seed_db.set_workspace_group_state(
+        ws_id, fingerprint="stale-group-fingerprint", when_ts=1714579200,
+    )
+    seed_db.close()
+    cache_path = _results_cache_path(os.path.dirname(db_path), ws_id)
+    with open(cache_path, "w") as f:
+        json.dump(
+            {
+                "photos": [{"id": 999999}],
+                "encounters": [],
+                "summary": {},
+            },
+            f,
+        )
+
     with app.test_client() as c:
         resp = c.post("/api/jobs/pipeline", json={
             "sources": [str(src)],
@@ -515,7 +537,6 @@ def test_pipeline_local_processing_skips_archive_when_previews_fail(
     # catalog. Otherwise ingest()'s known-hash skip would treat a retry's
     # files as duplicates and stage nothing, letting the next archive
     # publish an empty destination.
-    from db import Database
     check_db = Database(db_path)
     staging_dir = str(staging_file.parent)
     folder_row = check_db.conn.execute(
@@ -535,6 +556,17 @@ def test_pipeline_local_processing_skips_archive_when_previews_fail(
         "no photo rows should remain under the abandoned staging tree, "
         f"got {len(photo_rows)}"
     )
+    assert not os.path.exists(cache_path), (
+        "abandoning staged rows must remove the grouping cache, otherwise "
+        "pipeline review can render deleted photo IDs"
+    )
+    ws_row = check_db.conn.execute(
+        "SELECT last_grouped_at, last_group_fingerprint "
+        "FROM workspaces WHERE id = ?",
+        (ws_id,),
+    ).fetchone()
+    assert ws_row["last_grouped_at"] is None
+    assert ws_row["last_group_fingerprint"] is None
     check_db.close()
 
 

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -1360,6 +1360,69 @@ def test_pipeline_local_processing_rejects_archive_path_conflicts(
     assert "different files at the same import paths" in error_text
 
 
+def test_pipeline_local_processing_conflict_preflight_skips_known_duplicates(
+    setup, tmp_path, monkeypatch
+):
+    """A source whose hash is already in the catalog is skipped by ingest
+    before staging, so a same-name different-content file at the archive
+    must not cause the preflight to abort the run."""
+    app, db_path = setup
+
+    src = tmp_path / "card-dup-conflict"
+    src.mkdir()
+    dup_path = src / "dup.jpg"
+    Image.new("RGB", (16, 16), "white").save(dup_path)
+    fresh_path = src / "fresh.jpg"
+    Image.new("RGB", (16, 16), "red").save(fresh_path)
+
+    from db import Database
+    from scanner import compute_file_hash
+
+    dup_hash = compute_file_hash(str(dup_path))
+
+    db = Database(db_path)
+    seed_folder = tmp_path / "seed"
+    seed_folder.mkdir()
+    folder_id = db.add_folder(str(seed_folder))
+    ws_id = db._active_workspace_id
+    db.add_workspace_folder(ws_id, folder_id)
+    db.add_photo(
+        folder_id=folder_id, filename="dup.jpg", extension=".jpg",
+        file_size=10, file_mtime=1.0, file_hash=dup_hash,
+    )
+    db.close()
+
+    final_parent = tmp_path / "archive-parent"
+    final_parent.mkdir()
+    final_dest = final_parent / "Archive"
+    final_dest.mkdir()
+    # Same archive-relative path as the dup source, different content.
+    # Without the duplicate filter the preflight would reject this run.
+    (final_dest / "dup.jpg").write_bytes(b"different existing bytes")
+
+    import local_processing
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    monkeypatch.setattr(local_processing, "RESERVED_FREE_BYTES", 0)
+
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json={
+            "sources": [str(src)],
+            "destination": str(final_dest),
+            "local_processing": True,
+            "skip_duplicates": True,
+            "folder_template": "",
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        assert resp.status_code == 200
+        job = wait_for_job_via_client(c, resp.get_json()["job_id"])
+
+    error_text = (job.get("error") or "") + str(job.get("result", ""))
+    assert "different files at the same import paths" not in error_text
+    assert job["status"] == "completed", job
+
+
 def test_pipeline_local_processing_credits_existing_archive_for_resume(
     setup, tmp_path, monkeypatch
 ):

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -675,6 +675,90 @@ def test_pipeline_local_processing_fails_ingest_when_files_fail_to_copy(
     assert (staging_root / "good.jpg").is_file()
 
 
+def test_pipeline_local_processing_ingest_failure_short_circuits_pipeline(
+    setup, tmp_path, monkeypatch
+):
+    """Regression: a fatal local-processing ingest failure marked the
+    ingest step "failed" but left ``abort`` clear, so scanner_stage went
+    on to scan the partial staging tree and previews/classify/regroup
+    ran on the photos that did copy. In a normal pipeline run with
+    regroup enabled, that overwrote the workspace pipeline results with
+    photo IDs that archive_stage then deindexed during staging cleanup —
+    the workspace was left pointing at rows that no longer existed,
+    after spending hours processing a partial import. A fatal ingest
+    failure must set ``abort`` so every downstream stage short-circuits.
+    """
+    app, _db_path = setup
+
+    final_parent = tmp_path / "nas_short_circuit"
+    final_parent.mkdir()
+    final_dest = final_parent / "Photos"
+
+    src = tmp_path / "card_short_circuit"
+    src.mkdir()
+    Image.new("RGB", (16, 16), "white").save(src / "good.jpg")
+    Image.new("RGB", (16, 16), "red").save(src / "bad.jpg")
+
+    import local_processing
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    monkeypatch.setattr(local_processing, "RESERVED_FREE_BYTES", 0)
+
+    # ingest() catches per-file copy errors and continues — bad.jpg will
+    # bump ``failed`` while good.jpg still lands in staging.
+    import ingest as ingest_mod
+
+    real_copy2 = ingest_mod.shutil.copy2
+
+    def flaky_copy2(src_path, dest_path, *args, **kwargs):
+        if os.path.basename(str(src_path)) == "bad.jpg":
+            raise OSError("synthetic copy failure")
+        return real_copy2(src_path, dest_path, *args, **kwargs)
+
+    monkeypatch.setattr(ingest_mod.shutil, "copy2", flaky_copy2)
+
+    # Track whether scanner.scan ever ran. If the abort propagation in
+    # the ingest-failure branch is wired correctly the scan stage is
+    # marked skipped without calling do_scan; if it ever fires we know
+    # the scanner/previews/classify/regroup chain executed against the
+    # partial copy.
+    import scanner as scanner_mod
+    scan_calls: list[str] = []
+    real_scan = scanner_mod.scan
+
+    def tracking_scan(root, *args, **kwargs):
+        scan_calls.append(str(root))
+        return real_scan(root, *args, **kwargs)
+
+    with patch.object(scanner_mod, "scan", tracking_scan):
+        with app.test_client() as c:
+            # Deliberately leave skip_regroup unset so a regression here
+            # would actually run the regroup stage against the partial
+            # subset.
+            resp = c.post("/api/jobs/pipeline", json={
+                "sources": [str(src)],
+                "destination": str(final_dest),
+                "local_processing": True,
+                "folder_template": "",
+                "skip_classify": True,
+                "skip_extract_masks": True,
+            })
+            assert resp.status_code == 200
+            job_id = resp.get_json()["job_id"]
+            job = wait_for_job_via_client(c, job_id)
+
+    assert job["status"] == "failed", job
+    assert not scan_calls, (
+        "scanner.scan must not be called after a fatal local-processing "
+        f"ingest failure; called with {scan_calls!r}"
+    )
+    # Nothing publishes at the destination.
+    assert not (final_dest / "good.jpg").exists()
+    # Staging stays intact for recovery.
+    staging_root = tmp_path / "staging" / job_id / "Photos"
+    assert staging_root.is_dir(), staging_root
+    assert (staging_root / "good.jpg").is_file()
+
+
 def test_pipeline_local_processing_completes_when_cancel_during_archive(
     setup, tmp_path, monkeypatch
 ):

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -1240,11 +1240,11 @@ def test_pipeline_local_processing_preflight_filters_duplicates(
     assert plan["source_bytes"] <= fresh_bytes, plan
 
 
-def test_pipeline_local_processing_recomputes_archive_credit_after_duplicate_filter(
+def test_pipeline_local_processing_plans_archive_credit_after_duplicate_filter(
     setup, tmp_path, monkeypatch
 ):
-    """Duplicate-filtered storage retries must recompute archive credit from
-    survivor files, not from skipped duplicates."""
+    """Storage preflight must plan archive credit from survivor files, not from
+    skipped duplicates, before accepting a plan."""
     app, db_path = setup
 
     final_parent = tmp_path / "nas-filtered-credit"
@@ -1318,11 +1318,9 @@ def test_pipeline_local_processing_recomputes_archive_credit_after_duplicate_fil
         job = wait_for_job_via_client(c, resp.get_json()["job_id"])
 
     assert job["status"] == "completed", job
-    assert len(storage_calls) >= 2
-    assert storage_calls[0]["source_bytes"] == total_bytes
-    assert storage_calls[0]["archive_existing_bytes"] == dup_bytes
-    assert storage_calls[-1]["source_bytes"] == fresh_bytes
-    assert storage_calls[-1]["archive_existing_bytes"] == 0
+    assert len(storage_calls) == 1
+    assert storage_calls[0]["source_bytes"] == fresh_bytes
+    assert storage_calls[0]["archive_existing_bytes"] == 0
 
 
 def test_pipeline_local_processing_preflight_probes_existing_final_destination(

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -439,6 +439,102 @@ def test_pipeline_local_processing_skips_archive_when_previews_fail(
         f"missing at {staging_file}"
     )
 
+    # The staging folder and its photo hashes must be removed from the
+    # catalog. Otherwise ingest()'s known-hash skip would treat a retry's
+    # files as duplicates and stage nothing, letting the next archive
+    # publish an empty destination.
+    from db import Database
+    check_db = Database(db_path)
+    staging_dir = str(staging_file.parent)
+    folder_row = check_db.conn.execute(
+        "SELECT id FROM folders WHERE path = ?", (staging_dir,),
+    ).fetchone()
+    assert folder_row is None, (
+        f"staging folder must be deindexed on archive skip, still present "
+        f"at {staging_dir}"
+    )
+    photo_rows = check_db.conn.execute(
+        "SELECT id FROM photos WHERE folder_id IN ("
+        "  SELECT id FROM folders WHERE path LIKE ?"
+        ")",
+        (str(tmp_path / "staging" / job_id) + "%",),
+    ).fetchall()
+    assert not photo_rows, (
+        "no photo rows should remain under the abandoned staging tree, "
+        f"got {len(photo_rows)}"
+    )
+    check_db.close()
+
+
+def test_pipeline_local_processing_retry_after_skip_actually_copies(
+    setup, tmp_path, monkeypatch
+):
+    """End-to-end regression: a local-processing run whose archive was
+    skipped (due to an earlier failed stage) must leave the catalog in a
+    state where the user can retry the same source folder and have ingest
+    actually re-copy the files. Without deindexing the failed staging
+    tree, ingest's known-hash gate would skip every file in the new
+    staging dir and the second run would publish an empty destination."""
+    app, db_path = setup
+
+    src = tmp_path / "card_retry"
+    src.mkdir()
+    Image.new("RGB", (16, 16), "white").save(src / "again.jpg")
+
+    final_parent = tmp_path / "nas_retry"
+    final_parent.mkdir()
+    final_dest = final_parent / "Photos"
+
+    import local_processing
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    monkeypatch.setattr(local_processing, "RESERVED_FREE_BYTES", 0)
+
+    # First run: previews fail, archive is skipped, staging is left on
+    # disk but deindexed from the catalog.
+    import image_loader
+    real_load_image = image_loader.load_image
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("synthetic preview failure")
+
+    monkeypatch.setattr(image_loader, "load_image", boom)
+
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json={
+            "sources": [str(src)],
+            "destination": str(final_dest),
+            "local_processing": True,
+            "folder_template": "",
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        first_job = wait_for_job_via_client(c, resp.get_json()["job_id"])
+    assert first_job["status"] == "failed", first_job
+    assert not (final_dest / "again.jpg").exists()
+
+    # Second run: previews succeed (restore the real loader). The retry
+    # must actually re-stage the file and publish to final_dest — the
+    # previous-run staging hashes must no longer block ingest.
+    monkeypatch.setattr(image_loader, "load_image", real_load_image)
+
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json={
+            "sources": [str(src)],
+            "destination": str(final_dest),
+            "local_processing": True,
+            "folder_template": "",
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        second_job = wait_for_job_via_client(c, resp.get_json()["job_id"])
+    assert second_job["status"] == "completed", second_job
+    assert (final_dest / "again.jpg").is_file(), (
+        "retry must actually copy the file to the archive; deindex on "
+        "archive-skip is what makes that possible"
+    )
+
 
 def test_pipeline_local_processing_fails_ingest_when_files_fail_to_copy(
     setup, tmp_path, monkeypatch
@@ -620,12 +716,15 @@ def test_pipeline_local_processing_preflight_filters_duplicates(
     fresh_bytes = (src / "fresh.jpg").stat().st_size
     dup_bytes = (src / "dup.jpg").stat().st_size
     total_bytes = fresh_bytes + dup_bytes
-    # required_bytes ≈ source_bytes * 1.25 (overhead ratio) when
-    # MIN_DERIVED_OVERHEAD_BYTES=0. Pick free = roughly fresh_bytes * 2 plus
-    # reserve so the duplicate-filtered plan fits but the naive plan doesn't.
+    # required_bytes ≈ source_bytes * 2.25 here: staging and archive_parent
+    # both resolve to tmp_path so storage_plan's same-device branch doubles
+    # the source-byte allotment (originals in staging + originals at the
+    # destination during copy-verify-delete) on top of the 0.25 derived
+    # overhead. Pick free so the duplicate-filtered plan fits but the
+    # naive plan doesn't.
     reserve = 4
-    free = int(fresh_bytes * 1.5) + reserve + 1
-    assert free < int(total_bytes * 1.25) + reserve, "free must exceed filtered need but not the naive need"
+    free = int(fresh_bytes * 2.5) + reserve + 1
+    assert free < int(total_bytes * 2.25) + reserve, "free must exceed filtered need but not the naive need"
 
     from collections import namedtuple
     Usage = namedtuple("Usage", "total used free")

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -1177,6 +1177,56 @@ def test_pipeline_local_processing_rejects_existing_file_archive_destination(
     assert "not a directory" in error_text
 
 
+def test_pipeline_local_processing_credits_existing_archive_for_resume(
+    setup, tmp_path, monkeypatch
+):
+    """When a previous archive attempt left bytes at the destination, the
+    preflight calls storage_plan with archive_existing_bytes set so the
+    delta fits even when the destination volume is tight."""
+    app, _db_path = setup
+
+    src = tmp_path / "card-resume"
+    src.mkdir()
+    Image.new("RGB", (16, 16), "red").save(src / "fresh.jpg")
+
+    final_parent = tmp_path / "archive-parent"
+    final_parent.mkdir()
+    final_dest = final_parent / "Archive"
+    final_dest.mkdir()
+    # Seed the destination with a partial-archive file so the credit > 0.
+    (final_dest / "already-published.jpg").write_bytes(b"existing-payload")
+
+    import local_processing
+
+    real_storage_plan = local_processing.storage_plan
+    credits: list = []
+
+    def recording_storage_plan(staging_dir, source_bytes, **kwargs):
+        credits.append(kwargs.get("archive_existing_bytes"))
+        return real_storage_plan(staging_dir, source_bytes, **kwargs)
+
+    monkeypatch.setattr(local_processing, "storage_plan", recording_storage_plan)
+
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json={
+            "sources": [str(src)],
+            "destination": str(final_dest),
+            "local_processing": True,
+            "folder_template": "",
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        assert resp.status_code == 200
+        job = wait_for_job_via_client(c, resp.get_json()["job_id"])
+
+    assert credits, "storage_plan was not called"
+    assert all(c is not None for c in credits)
+    # Credit equals the bytes already at the destination (one seeded file).
+    assert credits[0] == len(b"existing-payload")
+    assert job["status"] == "completed", job
+
+
 def test_import_full_scan_only_returns_job_id(setup):
     """copy=false skips ingest, just scans the source folder."""
     app, db_path = setup

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -1096,6 +1096,91 @@ def test_pipeline_local_processing_preflight_filters_duplicates(
     assert plan["source_bytes"] <= fresh_bytes, plan
 
 
+def test_pipeline_local_processing_recomputes_archive_credit_after_duplicate_filter(
+    setup, tmp_path, monkeypatch
+):
+    """Duplicate-filtered storage retries must recompute archive credit from
+    survivor files, not from skipped duplicates."""
+    app, db_path = setup
+
+    final_parent = tmp_path / "nas-filtered-credit"
+    final_parent.mkdir()
+    final_dest = final_parent / "Photos"
+    final_dest.mkdir()
+
+    src = tmp_path / "card-filtered-credit"
+    src.mkdir()
+    Image.new("RGB", (16, 16), "white").save(src / "dup.jpg")
+    Image.new("RGB", (16, 16), "red").save(src / "fresh.jpg")
+    shutil.copy2(src / "dup.jpg", final_dest / "dup.jpg")
+
+    from db import Database
+    from scanner import compute_file_hash
+    dup_hash = compute_file_hash(str(src / "dup.jpg"))
+
+    db = Database(db_path)
+    seed_folder = tmp_path / "seed-filtered-credit"
+    seed_folder.mkdir()
+    folder_id = db.add_folder(str(seed_folder))
+    ws_id = db._active_workspace_id
+    db.add_workspace_folder(ws_id, folder_id)
+    db.add_photo(
+        folder_id=folder_id, filename="dup.jpg", extension=".jpg",
+        file_size=10, file_mtime=1.0, file_hash=dup_hash,
+    )
+    db.close()
+
+    fresh_bytes = (src / "fresh.jpg").stat().st_size
+    dup_bytes = (src / "dup.jpg").stat().st_size
+    total_bytes = fresh_bytes + dup_bytes
+    reserve = 4
+    free = int(fresh_bytes * 2.5) + reserve + 1
+    assert free < int(total_bytes * 1.25 + fresh_bytes) + reserve
+
+    from collections import namedtuple
+    Usage = namedtuple("Usage", "total used free")
+
+    import local_processing
+    real_storage_plan = local_processing.storage_plan
+    storage_calls = []
+
+    def recording_storage_plan(staging_dir, source_bytes, **kwargs):
+        storage_calls.append({
+            "source_bytes": source_bytes,
+            "archive_existing_bytes": kwargs.get("archive_existing_bytes"),
+        })
+        return real_storage_plan(staging_dir, source_bytes, **kwargs)
+
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    monkeypatch.setattr(local_processing, "RESERVED_FREE_BYTES", reserve)
+    monkeypatch.setattr(local_processing, "storage_plan", recording_storage_plan)
+    monkeypatch.setattr(
+        local_processing.shutil, "disk_usage",
+        lambda path: Usage(total=free * 10, used=0, free=free),
+    )
+
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json={
+            "sources": [str(src)],
+            "destination": str(final_dest),
+            "local_processing": True,
+            "skip_duplicates": True,
+            "folder_template": "",
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        assert resp.status_code == 200
+        job = wait_for_job_via_client(c, resp.get_json()["job_id"])
+
+    assert job["status"] == "completed", job
+    assert len(storage_calls) >= 2
+    assert storage_calls[0]["source_bytes"] == total_bytes
+    assert storage_calls[0]["archive_existing_bytes"] == dup_bytes
+    assert storage_calls[-1]["source_bytes"] == fresh_bytes
+    assert storage_calls[-1]["archive_existing_bytes"] == 0
+
+
 def test_pipeline_local_processing_preflight_probes_existing_final_destination(
     setup, tmp_path, monkeypatch
 ):

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -282,6 +282,113 @@ def test_pipeline_local_processing_rejects_already_tracked_destination(
     assert "Vireo already manages" in error_text, job
 
 
+def test_pipeline_local_processing_creates_missing_archive_parent(
+    setup, tmp_path, monkeypatch
+):
+    """Regression: a nested archive destination whose parent doesn't yet
+    exist (e.g. /mnt/nas/NewShoot/Photos when NewShoot was never created
+    by the user) must be set up during the storage preflight, not left for
+    move_folder to discover after every processing step finishes. Without
+    the upfront makedirs the run would stage, process, and only fail at
+    the final move, leaving the staged copy stranded."""
+    app, db_path = setup
+
+    nonexistent_parent = tmp_path / "nas" / "NewShoot"
+    assert not nonexistent_parent.exists()
+    final_dest = nonexistent_parent / "Photos"
+
+    src = tmp_path / "card_parent"
+    src.mkdir()
+    Image.new("RGB", (16, 16), "white").save(src / "shot.jpg")
+
+    import local_processing
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    monkeypatch.setattr(local_processing, "RESERVED_FREE_BYTES", 0)
+
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json={
+            "sources": [str(src)],
+            "destination": str(final_dest),
+            "local_processing": True,
+            "folder_template": "",
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        assert resp.status_code == 200
+        job = wait_for_job_via_client(c, resp.get_json()["job_id"])
+
+    assert job["status"] == "completed", job
+    assert (final_dest / "shot.jpg").is_file()
+    assert nonexistent_parent.is_dir()
+
+
+def test_pipeline_local_processing_skips_archive_when_previews_fail(
+    setup, tmp_path, monkeypatch
+):
+    """Regression: previews, extract_masks, eye_keypoints, regroup, and
+    miss can all fail without aborting the run, but run_pipeline_job
+    raises at the end whenever any stage status is "failed". If
+    archive_stage ran anyway, the staged folder would already be moved to
+    the user's archive root by the time that failure surfaced — publishing
+    a partial result from a job marked failed. Skip the archive when an
+    earlier stage failed and leave staging intact instead."""
+    app, db_path = setup
+
+    final_parent = tmp_path / "nas2"
+    final_parent.mkdir()
+    final_dest = final_parent / "Photos"
+
+    src = tmp_path / "card_fail"
+    src.mkdir()
+    Image.new("RGB", (16, 16), "white").save(src / "boom.jpg")
+
+    import local_processing
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    monkeypatch.setattr(local_processing, "RESERVED_FREE_BYTES", 0)
+
+    # Force previews_stage to fail without setting abort. The stage's
+    # outer try/except catches load_image() failures and marks the stage
+    # status "failed"; abort stays clear and the rest of the pipeline
+    # continues toward archive.
+    import image_loader
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("synthetic preview failure")
+
+    monkeypatch.setattr(image_loader, "load_image", boom)
+
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json={
+            "sources": [str(src)],
+            "destination": str(final_dest),
+            "local_processing": True,
+            "folder_template": "",
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        assert resp.status_code == 200
+        job_id = resp.get_json()["job_id"]
+        job = wait_for_job_via_client(c, job_id)
+
+    # The job fails because previews_stage marked itself failed and
+    # run_pipeline_job re-raises at the end for any failed stage.
+    assert job["status"] == "failed", job
+
+    # archive must NOT publish files when an earlier stage failed.
+    assert not (final_dest / "boom.jpg").exists()
+
+    # Staging stays intact so the user can recover or retry.
+    staging_file = (
+        tmp_path / "staging" / job_id / "Photos" / "boom.jpg"
+    )
+    assert staging_file.is_file(), (
+        f"staging file should remain when archive is skipped, "
+        f"missing at {staging_file}"
+    )
+
+
 def test_pipeline_local_processing_preflight_filters_duplicates(
     setup, tmp_path, monkeypatch
 ):

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -804,6 +804,81 @@ def test_pipeline_local_processing_failed_archive_reports_failed_even_after_canc
     assert job["status"] == "failed", job
 
 
+def test_pipeline_local_processing_post_commit_cleanup_error_reports_completed(
+    setup, tmp_path, monkeypatch
+):
+    """Regression: post-commit rmtree failures must not flip the job to failed.
+
+    ``move_folder`` repoints the catalog at ``final_destination`` before
+    deleting the staging originals. If the post-commit rmtree raises (a
+    locked file, a permission glitch in ``~/.vireo/staging``), the archive
+    IS committed: files exist at the destination and the catalog points
+    there. Previously the broad except in archive_stage caught the rmtree
+    exception, marked the stage failed, and told the user "results remain
+    in local staging" — but the files were at ``final_destination`` and a
+    freshly created tracked folder row was now in the catalog. The fix
+    distinguishes the post-commit cleanup error via ``move_folder``'s
+    new ``cleanup_error`` return key and reports the job completed with a
+    warning instead.
+    """
+    app, db_path = setup
+
+    final_parent = tmp_path / "nas_post_commit"
+    final_parent.mkdir()
+    final_dest = final_parent / "Photos"
+
+    src = tmp_path / "card_post_commit"
+    src.mkdir()
+    Image.new("RGB", (16, 16), "white").save(src / "kept.jpg")
+
+    import local_processing
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    monkeypatch.setattr(local_processing, "RESERVED_FREE_BYTES", 0)
+
+    import move as move_mod
+    real_move_folder_fn = move_mod.move_folder
+
+    def cleanup_failing_move_folder(db, folder_id, destination, **kwargs):
+        # Run the real move (it commits) but inject a cleanup error via
+        # rmtree. We do this by patching shutil.rmtree only for the
+        # duration of this call, so the real verify/move_folder_path runs
+        # but the final src delete raises.
+        import shutil
+        orig_rmtree = shutil.rmtree
+
+        def raising_rmtree(path, *a, **k):
+            raise OSError("permission denied: staging file locked")
+
+        shutil.rmtree = raising_rmtree
+        try:
+            return real_move_folder_fn(db, folder_id, destination, **kwargs)
+        finally:
+            shutil.rmtree = orig_rmtree
+
+    monkeypatch.setattr(move_mod, "move_folder", cleanup_failing_move_folder)
+
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json={
+            "sources": [str(src)],
+            "destination": str(final_dest),
+            "local_processing": True,
+            "folder_template": "",
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        assert resp.status_code == 200
+        job_id = resp.get_json()["job_id"]
+        job = wait_for_job_via_client(c, job_id)
+
+    # The archive committed despite the staging cleanup error.
+    assert job["status"] == "completed", job
+    assert (final_dest / "kept.jpg").is_file()
+    archive_result = job["result"]["archive"]
+    assert archive_result["final_destination"] == str(final_dest)
+    assert "cleanup_error" in archive_result
+
+
 def test_pipeline_local_processing_deindexes_staging_on_cancel_after_scan(
     setup, tmp_path, monkeypatch
 ):

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -199,6 +199,28 @@ def test_pipeline_local_processing_requires_destination(setup):
         shutil.rmtree(src, ignore_errors=True)
 
 
+def test_pipeline_local_processing_rejects_collection_id(setup, tmp_path):
+    # Collection pipelines set skip_scan and never run ingest, so the
+    # staging folder is never created/indexed. Without this rejection
+    # the job would burn through every processing stage and then fail
+    # at archive_stage with "local staging folder was not indexed".
+    app, _db_path = setup
+    dest = tmp_path / "archive"
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json={
+            "collection_id": 1,
+            "destination": str(dest),
+            "local_processing": True,
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        assert resp.status_code == 400
+        err = resp.get_json()["error"].lower()
+        assert "local_processing" in err
+        assert "source" in err
+
+
 def test_pipeline_local_processing_archives_to_final_destination(
     setup, tmp_path, monkeypatch
 ):

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -1322,6 +1322,57 @@ def test_pipeline_local_processing_rejects_existing_file_archive_destination(
     assert "not a directory" in error_text
 
 
+def test_pipeline_local_processing_rejects_broken_symlink_archive_destination(
+    setup, tmp_path, monkeypatch
+):
+    """A broken/dangling symlink left at ``final_destination`` — e.g. by an
+    unmounted or moved archive root — must be rejected up front. The
+    earlier ``os.path.exists`` guard followed the symlink and returned
+    False for a dangling target, so the pipeline staged and processed
+    every source before ``move_folder`` ultimately failed trying to
+    create a directory at a pathname already occupied by the symlink
+    entry. The lexists guard catches the entry regardless of whether
+    its target resolves."""
+    app, _db_path = setup
+
+    src = tmp_path / "card-broken-symlink"
+    src.mkdir()
+    Image.new("RGB", (16, 16), "green").save(src / "fresh.jpg")
+
+    archive_parent = tmp_path / "archive-parent"
+    archive_parent.mkdir()
+    final_dest = archive_parent / "Archive"
+    missing_target = tmp_path / "missing-mount-point"
+    try:
+        os.symlink(str(missing_target), str(final_dest))
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported on this filesystem")
+    assert os.path.lexists(str(final_dest))
+    assert not os.path.exists(str(final_dest))
+
+    import local_processing
+
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    monkeypatch.setattr(local_processing, "RESERVED_FREE_BYTES", 0)
+
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json={
+            "sources": [str(src)],
+            "destination": str(final_dest),
+            "local_processing": True,
+            "folder_template": "",
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        assert resp.status_code == 200
+        job = wait_for_job_via_client(c, resp.get_json()["job_id"])
+
+    assert job["status"] == "failed", job
+    error_text = (job.get("error") or "") + str(job.get("result", ""))
+    assert "not a directory" in error_text
+
+
 def test_pipeline_local_processing_rejects_archive_path_conflicts(
     setup, tmp_path, monkeypatch
 ):

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -440,6 +440,143 @@ def test_pipeline_local_processing_skips_archive_when_previews_fail(
     )
 
 
+def test_pipeline_local_processing_fails_ingest_when_files_fail_to_copy(
+    setup, tmp_path, monkeypatch
+):
+    """Regression: ingest() catches per-file copy errors and returns a
+    non-zero ``failed`` count without raising, but the scanner stage was
+    marking ingest as "completed" regardless. archive_stage's "any earlier
+    stage failed" gate then let the partial staging tree publish to the
+    final destination. Local-processing mode must fail the ingest stage
+    when files fail to copy so the archive is skipped and staging is
+    preserved for the user to recover.
+    """
+    app, db_path = setup
+
+    final_parent = tmp_path / "nas_fail_ingest"
+    final_parent.mkdir()
+    final_dest = final_parent / "Photos"
+
+    src = tmp_path / "card_partial"
+    src.mkdir()
+    Image.new("RGB", (16, 16), "white").save(src / "good.jpg")
+    Image.new("RGB", (16, 16), "red").save(src / "bad.jpg")
+
+    import local_processing
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    monkeypatch.setattr(local_processing, "RESERVED_FREE_BYTES", 0)
+
+    # Simulate a partial-card copy failure: ingest() catches the OSError
+    # and bumps `failed` by 1, but returns normally so the run continues.
+    import ingest as ingest_mod
+
+    real_copy2 = ingest_mod.shutil.copy2
+
+    def flaky_copy2(src_path, dest_path, *args, **kwargs):
+        if os.path.basename(str(src_path)) == "bad.jpg":
+            raise OSError("synthetic copy failure")
+        return real_copy2(src_path, dest_path, *args, **kwargs)
+
+    monkeypatch.setattr(ingest_mod.shutil, "copy2", flaky_copy2)
+
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json={
+            "sources": [str(src)],
+            "destination": str(final_dest),
+            "local_processing": True,
+            "folder_template": "",
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        assert resp.status_code == 200
+        job_id = resp.get_json()["job_id"]
+        job = wait_for_job_via_client(c, job_id)
+
+    # Ingest is marked failed and the whole run is recorded as failed.
+    assert job["status"] == "failed", job
+
+    # Nothing is published at the final destination, even though good.jpg
+    # made it into staging.
+    assert not (final_dest / "good.jpg").exists()
+    assert not final_dest.exists() or not any(final_dest.iterdir())
+
+    # The successfully-copied file stays in staging so the user can recover.
+    staging_root = tmp_path / "staging" / job_id / "Photos"
+    assert staging_root.is_dir(), staging_root
+    assert (staging_root / "good.jpg").is_file()
+
+
+def test_pipeline_local_processing_completes_when_cancel_during_archive(
+    setup, tmp_path, monkeypatch
+):
+    """Regression: move_folder does not accept a cancellation signal, and
+    tearing it down mid-flight would leave a partial archive at the
+    destination. A Stop press once the archive begins must therefore be
+    consumed so the job records "completed" rather than recording a
+    "cancelled" status for a run that actually published its output.
+    """
+    app, db_path = setup
+
+    final_parent = tmp_path / "nas_cancel"
+    final_parent.mkdir()
+    final_dest = final_parent / "Photos"
+
+    src = tmp_path / "card_cancel"
+    src.mkdir()
+    Image.new("RGB", (16, 16), "white").save(src / "kept.jpg")
+
+    import local_processing
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    monkeypatch.setattr(local_processing, "RESERVED_FREE_BYTES", 0)
+
+    # Simulate the user clicking Stop while move_folder is mid-copy: wrap
+    # the real move_folder so that, just as it begins, the job is added
+    # to the runner's cancellation set. Without clear_cancellation in
+    # archive_stage, JobRunner._run_job's atomic terminal check would
+    # then record the run as "cancelled" even though the archive
+    # committed and the originals were removed.
+    import move as move_mod
+    real_move_folder_fn = move_mod.move_folder
+
+    runner = app._job_runner
+
+    def cancelling_move_folder(db, folder_id, destination, **kwargs):
+        # Resolve the current job id off the runner — we can't get it
+        # passed in directly. There's exactly one running pipeline job at
+        # this point, so pick it out of the runner's job map.
+        with runner._lock:
+            running = [
+                jid for jid, j in runner._jobs.items()
+                if j.get("status") == "running"
+                and jid.startswith("pipeline-")
+            ]
+        assert len(running) == 1, running
+        runner.cancel_job(running[0])
+        return real_move_folder_fn(db, folder_id, destination, **kwargs)
+
+    monkeypatch.setattr(move_mod, "move_folder", cancelling_move_folder)
+
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json={
+            "sources": [str(src)],
+            "destination": str(final_dest),
+            "local_processing": True,
+            "folder_template": "",
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        assert resp.status_code == 200
+        job_id = resp.get_json()["job_id"]
+        job = wait_for_job_via_client(c, job_id)
+
+    # The archive committed, so the job must NOT record cancelled.
+    assert job["status"] == "completed", job
+    assert (final_dest / "kept.jpg").is_file()
+    assert job["result"]["archive"]["final_destination"] == str(final_dest)
+
+
 def test_pipeline_local_processing_preflight_filters_duplicates(
     setup, tmp_path, monkeypatch
 ):

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import pytest
 from app import create_app
 from PIL import Image
+from wait import wait_for_job_via_client
 
 
 @pytest.fixture
@@ -178,6 +179,60 @@ def test_import_full_rejects_relative_destination(setup):
             assert "absolute" in resp.get_json()["error"].lower()
     finally:
         shutil.rmtree(src, ignore_errors=True)
+
+
+def test_pipeline_local_processing_requires_destination(setup):
+    app, db_path = setup
+    src = tempfile.mkdtemp()
+    try:
+        with app.test_client() as c:
+            resp = c.post("/api/jobs/pipeline", json={
+                "sources": [src],
+                "local_processing": True,
+                "skip_classify": True,
+                "skip_extract_masks": True,
+                "skip_regroup": True,
+            })
+            assert resp.status_code == 400
+            assert "destination" in resp.get_json()["error"].lower()
+    finally:
+        shutil.rmtree(src, ignore_errors=True)
+
+
+def test_pipeline_local_processing_archives_to_final_destination(
+    setup, tmp_path, monkeypatch
+):
+    app, db_path = setup
+    src = tmp_path / "card"
+    src.mkdir()
+    final_parent = tmp_path / "nas"
+    final_parent.mkdir()
+    final_dest = final_parent / "Photos"
+
+    img = Image.new("RGB", (16, 16), "white")
+    img.save(src / "test.jpg")
+
+    import local_processing
+
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    monkeypatch.setattr(local_processing, "RESERVED_FREE_BYTES", 0)
+
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json={
+            "sources": [str(src)],
+            "destination": str(final_dest),
+            "local_processing": True,
+            "folder_template": "",
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        assert resp.status_code == 200
+        job = wait_for_job_via_client(c, resp.get_json()["job_id"])
+
+    assert job["status"] == "completed", job
+    assert (final_dest / "test.jpg").is_file()
+    assert job["result"]["archive"]["final_destination"] == str(final_dest)
 
 
 def test_import_full_scan_only_returns_job_id(setup):

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -333,6 +333,58 @@ def test_pipeline_local_processing_rejects_already_tracked_destination(
     assert "Vireo already manages" in error_text, job
 
 
+def test_pipeline_local_processing_rejects_destination_inside_tracked_root(
+    setup, tmp_path, monkeypatch
+):
+    """Regression: an archive destination INSIDE an already-tracked folder
+    (catalog manages /Photos and the user picks /Photos/NewShoot) must fail
+    fast at the storage preflight. db.move_folder_path only rewrites the
+    moved row's path — it does NOT reparent the row under the tracked
+    ancestor. Without this check the archive would succeed on disk but
+    leave the catalog with two unrelated workspace roots whose path strings
+    overlap (e.g. /Photos and /Photos/NewShoot), confusing the folder tree
+    and breaking future scans of the ancestor root."""
+    app, db_path = setup
+
+    tracked_root = tmp_path / "nas_ancestor" / "Photos"
+    tracked_root.mkdir(parents=True)
+    # Nested archive destination INSIDE the existing tracked root.
+    final_dest = tracked_root / "NewShoot"
+
+    import local_processing
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    monkeypatch.setattr(local_processing, "RESERVED_FREE_BYTES", 0)
+
+    from db import Database
+    db = Database(db_path)
+    db.add_folder(str(tracked_root))
+    db.close()
+
+    src = tmp_path / "card_ancestor"
+    src.mkdir()
+    Image.new("RGB", (16, 16), "red").save(src / "shot.jpg")
+
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json={
+            "sources": [str(src)],
+            "destination": str(final_dest),
+            "local_processing": True,
+            "folder_template": "",
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        assert resp.status_code == 200
+        job = wait_for_job_via_client(c, resp.get_json()["job_id"])
+
+    assert job["status"] == "failed", job
+    error_text = (job.get("error") or "") + str(job.get("result", ""))
+    assert "is inside a folder Vireo already manages" in error_text, job
+    # The pipeline must NOT have archived anything: tracked_root still has
+    # no NewShoot subdirectory and the source files weren't published.
+    assert not final_dest.exists(), final_dest
+
+
 def test_pipeline_local_processing_creates_missing_archive_parent(
     setup, tmp_path, monkeypatch
 ):
@@ -671,6 +723,85 @@ def test_pipeline_local_processing_completes_when_cancel_during_archive(
     assert job["status"] == "completed", job
     assert (final_dest / "kept.jpg").is_file()
     assert job["result"]["archive"]["final_destination"] == str(final_dest)
+
+
+def test_pipeline_local_processing_failed_archive_reports_failed_even_after_cancel(
+    setup, tmp_path, monkeypatch
+):
+    """Regression: clear_cancellation must consume the Stop flag BEFORE
+    move_folder runs, not after. If clear is deferred to after a successful
+    move, a Stop press that landed during a move which then FAILED (ENOSPC,
+    rsync error, verify mismatch) would leave the cancel flag set; the
+    outer JobRunner terminal check would record the run as "cancelled",
+    masking the archive failure from the user. The job must report
+    "failed" so the user sees the real outcome.
+    """
+    app, db_path = setup
+
+    final_parent = tmp_path / "nas_cancel_fail"
+    final_parent.mkdir()
+    final_dest = final_parent / "Photos"
+
+    src = tmp_path / "card_cancel_fail"
+    src.mkdir()
+    Image.new("RGB", (16, 16), "white").save(src / "kept.jpg")
+
+    import local_processing
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    monkeypatch.setattr(local_processing, "RESERVED_FREE_BYTES", 0)
+
+    # Simulate the user clicking Stop while move_folder is mid-copy AND the
+    # move then fails (e.g. verification mismatch). Two requirements:
+    # (1) clear_cancellation must already have run before move_folder is
+    # invoked, so the cancel flag is gone; (2) when move_folder returns a
+    # failure result, the job must report "failed", not "cancelled".
+    import move as move_mod
+
+    runner = app._job_runner
+
+    def cancelling_and_failing_move_folder(db, folder_id, destination, **kwargs):
+        with runner._lock:
+            running = [
+                jid for jid, j in runner._jobs.items()
+                if j.get("status") == "running"
+                and jid.startswith("pipeline-")
+            ]
+        assert len(running) == 1, running
+        # cancel_job must be a no-op here: the archive stage has already
+        # marked the job uncancellable via clear_cancellation. Without that
+        # ordering, the Stop press below would land in _cancelled and
+        # survive into _run_job's terminal check, recording "cancelled".
+        accepted = runner.cancel_job(running[0])
+        assert accepted is False, (
+            "cancel_job accepted after the archive stage started; "
+            "clear_cancellation must run BEFORE move_folder to make the "
+            "job uncancellable for the duration of the commit"
+        )
+        # Now simulate the move itself failing — e.g. an rsync verify
+        # mismatch. archive_stage raises and falls into the except branch.
+        return {"moved": 0, "errors": [
+            "Verification failed: 'kept.jpg' is missing or differs at the "
+            "destination. Originals preserved."
+        ]}
+
+    monkeypatch.setattr(move_mod, "move_folder", cancelling_and_failing_move_folder)
+
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json={
+            "sources": [str(src)],
+            "destination": str(final_dest),
+            "local_processing": True,
+            "folder_template": "",
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        assert resp.status_code == 200
+        job_id = resp.get_json()["job_id"]
+        job = wait_for_job_via_client(c, job_id)
+
+    # The archive raised — the run must report failed, not cancelled.
+    assert job["status"] == "failed", job
 
 
 def test_pipeline_local_processing_deindexes_staging_on_cancel_after_scan(

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -1096,6 +1096,52 @@ def test_pipeline_local_processing_preflight_filters_duplicates(
     assert plan["source_bytes"] <= fresh_bytes, plan
 
 
+def test_pipeline_local_processing_preflight_probes_existing_final_destination(
+    setup, tmp_path, monkeypatch
+):
+    """Existing archive folders may be mount roots and must be probed directly."""
+    app, _db_path = setup
+
+    src = tmp_path / "card4"
+    src.mkdir()
+    Image.new("RGB", (16, 16), "blue").save(src / "fresh.jpg")
+
+    final_parent = tmp_path / "Volumes"
+    final_parent.mkdir()
+    final_dest = final_parent / "Archive"
+    final_dest.mkdir()
+
+    import local_processing
+
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    monkeypatch.setattr(local_processing, "RESERVED_FREE_BYTES", 0)
+    real_storage_plan = local_processing.storage_plan
+    archive_paths = []
+
+    def recording_storage_plan(staging_dir, source_bytes, **kwargs):
+        archive_paths.append(kwargs.get("archive_parent"))
+        return real_storage_plan(staging_dir, source_bytes, **kwargs)
+
+    monkeypatch.setattr(local_processing, "storage_plan", recording_storage_plan)
+
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json={
+            "sources": [str(src)],
+            "destination": str(final_dest),
+            "local_processing": True,
+            "folder_template": "",
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        assert resp.status_code == 200
+        job = wait_for_job_via_client(c, resp.get_json()["job_id"])
+
+    assert job["status"] == "completed", job
+    assert archive_paths
+    assert set(archive_paths) == {str(final_dest)}
+
+
 def test_import_full_scan_only_returns_job_id(setup):
     """copy=false skips ingest, just scans the source folder."""
     app, db_path = setup

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -1187,14 +1187,16 @@ def test_pipeline_local_processing_credits_existing_archive_for_resume(
 
     src = tmp_path / "card-resume"
     src.mkdir()
-    Image.new("RGB", (16, 16), "red").save(src / "fresh.jpg")
+    source_file = src / "fresh.jpg"
+    Image.new("RGB", (16, 16), "red").save(source_file)
 
     final_parent = tmp_path / "archive-parent"
     final_parent.mkdir()
     final_dest = final_parent / "Archive"
     final_dest.mkdir()
-    # Seed the destination with a partial-archive file so the credit > 0.
-    (final_dest / "already-published.jpg").write_bytes(b"existing-payload")
+    # Seed the destination with the exact file that a previous archive
+    # attempt would have left behind so the resume credit is valid.
+    shutil.copy2(source_file, final_dest / "fresh.jpg")
 
     import local_processing
 
@@ -1222,8 +1224,54 @@ def test_pipeline_local_processing_credits_existing_archive_for_resume(
 
     assert credits, "storage_plan was not called"
     assert all(c is not None for c in credits)
-    # Credit equals the bytes already at the destination (one seeded file).
-    assert credits[0] == len(b"existing-payload")
+    # Credit equals the matching source bytes already at the destination.
+    assert credits[0] == source_file.stat().st_size
+    assert job["status"] == "completed", job
+
+
+def test_pipeline_local_processing_does_not_credit_unrelated_archive_content(
+    setup, tmp_path, monkeypatch
+):
+    """Existing destination bytes only count when they match selected source
+    files at the same archive-relative path."""
+    app, _db_path = setup
+
+    src = tmp_path / "card-unrelated"
+    src.mkdir()
+    Image.new("RGB", (16, 16), "red").save(src / "fresh.jpg")
+
+    final_parent = tmp_path / "archive-parent"
+    final_parent.mkdir()
+    final_dest = final_parent / "Archive"
+    final_dest.mkdir()
+    (final_dest / "unrelated.jpg").write_bytes(b"existing-payload")
+
+    import local_processing
+
+    real_storage_plan = local_processing.storage_plan
+    credits: list = []
+
+    def recording_storage_plan(staging_dir, source_bytes, **kwargs):
+        credits.append(kwargs.get("archive_existing_bytes"))
+        return real_storage_plan(staging_dir, source_bytes, **kwargs)
+
+    monkeypatch.setattr(local_processing, "storage_plan", recording_storage_plan)
+
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json={
+            "sources": [str(src)],
+            "destination": str(final_dest),
+            "local_processing": True,
+            "folder_template": "",
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        assert resp.status_code == 200
+        job = wait_for_job_via_client(c, resp.get_json()["job_id"])
+
+    assert credits, "storage_plan was not called"
+    assert credits[0] == 0
     assert job["status"] == "completed", job
 
 

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -446,6 +446,70 @@ def test_pipeline_local_processing_creates_missing_archive_parent(
     assert nonexistent_parent.is_dir()
 
 
+def test_pipeline_local_processing_detects_missing_archive_mount_root(monkeypatch):
+    """Unmounted NAS paths like /Volumes/NAS/Shoot must not be created as
+    local stub directories during archive-parent preflight."""
+    import pipeline_job
+
+    real_lexists = os.path.lexists
+
+    def fake_lexists(path):
+        if path == "/Volumes/NAS":
+            return False
+        return real_lexists(path)
+
+    monkeypatch.setattr(pipeline_job.os.path, "lexists", fake_lexists)
+
+    assert (
+        pipeline_job._missing_archive_mount_root("/Volumes/NAS/Shoot")
+        == "/Volumes/NAS"
+    )
+    assert pipeline_job._missing_archive_mount_root("/Volumes/NAS") == "/Volumes/NAS"
+
+
+def test_pipeline_local_processing_rejects_missing_archive_mount_root(
+    setup, tmp_path, monkeypatch
+):
+    """Regression: storage preflight must fail before makedirs can create a
+    missing mount root and accidentally archive onto the local disk."""
+    app, _db_path = setup
+
+    missing_mount = tmp_path / "missing_mount"
+    final_dest = missing_mount / "Shoot" / "Photos"
+
+    src = tmp_path / "card_mount"
+    src.mkdir()
+    Image.new("RGB", (16, 16), "white").save(src / "shot.jpg")
+
+    import local_processing
+    import pipeline_job
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    monkeypatch.setattr(local_processing, "RESERVED_FREE_BYTES", 0)
+    monkeypatch.setattr(
+        pipeline_job,
+        "_missing_archive_mount_root",
+        lambda _path: str(missing_mount),
+    )
+
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json={
+            "sources": [str(src)],
+            "destination": str(final_dest),
+            "local_processing": True,
+            "folder_template": "",
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        assert resp.status_code == 200
+        job = wait_for_job_via_client(c, resp.get_json()["job_id"])
+
+    assert job["status"] == "failed", job
+    error_text = (job.get("error") or "") + str(job.get("result", ""))
+    assert f"Archive mount root {missing_mount}" in error_text
+    assert not missing_mount.exists()
+
+
 def test_pipeline_local_processing_skips_archive_when_previews_fail(
     setup, tmp_path, monkeypatch
 ):

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -474,8 +474,7 @@ def test_pipeline_local_processing_rejects_missing_archive_mount_root(
     missing mount root and accidentally archive onto the local disk."""
     app, _db_path = setup
 
-    missing_mount = tmp_path / "missing_mount"
-    final_dest = missing_mount / "Shoot" / "Photos"
+    final_dest = tmp_path / "missing_mount"
 
     src = tmp_path / "card_mount"
     src.mkdir()
@@ -488,7 +487,7 @@ def test_pipeline_local_processing_rejects_missing_archive_mount_root(
     monkeypatch.setattr(
         pipeline_job,
         "_missing_archive_mount_root",
-        lambda _path: str(missing_mount),
+        lambda path: str(final_dest) if path == str(final_dest) else None,
     )
 
     with app.test_client() as c:
@@ -507,9 +506,9 @@ def test_pipeline_local_processing_rejects_missing_archive_mount_root(
     assert job["status"] == "failed", job
     errors = job.get("result", {}).get("errors", [])
     assert any(
-        f"Archive mount root {missing_mount}" in error for error in errors
+        f"Archive mount root {final_dest}" in error for error in errors
     ), job
-    assert not missing_mount.exists()
+    assert not final_dest.exists()
 
 
 def test_pipeline_local_processing_skips_archive_when_previews_fail(

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -218,7 +218,36 @@ def test_pipeline_local_processing_rejects_collection_id(setup, tmp_path):
         assert resp.status_code == 400
         err = resp.get_json()["error"].lower()
         assert "local_processing" in err
-        assert "source" in err
+        assert "collection_id" in err
+
+
+def test_pipeline_local_processing_rejects_collection_id_with_stale_sources(
+    setup, tmp_path,
+):
+    # run_pipeline_job sets skip_scan = collection_id is not None, so a
+    # request that mixes collection_id with a stale source/sources field
+    # still skips ingest — the staging folder never gets created or
+    # indexed and archive_stage fails with "local staging folder was not
+    # indexed". The API guard must reject collection_id outright when
+    # local_processing is on, not just the no-source case.
+    app, _db_path = setup
+    src = tmp_path / "card"
+    src.mkdir()
+    dest = tmp_path / "archive"
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json={
+            "collection_id": 1,
+            "sources": [str(src)],
+            "destination": str(dest),
+            "local_processing": True,
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        assert resp.status_code == 400
+        err = resp.get_json()["error"].lower()
+        assert "local_processing" in err
+        assert "collection_id" in err
 
 
 def test_pipeline_local_processing_archives_to_final_destination(

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -1073,6 +1073,7 @@ def test_pipeline_local_processing_post_commit_cleanup_error_reports_completed(
     archive_result = job["result"]["archive"]
     assert archive_result["final_destination"] == str(final_dest)
     assert "cleanup_error" in archive_result
+    assert job["result"]["errors"] == []
 
 
 def test_pipeline_local_processing_deindexes_staging_on_cancel_after_scan(

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -199,6 +199,26 @@ def test_pipeline_local_processing_requires_destination(setup):
         shutil.rmtree(src, ignore_errors=True)
 
 
+def test_pipeline_local_processing_rejects_filesystem_root_destination(
+    setup, tmp_path
+):
+    app, _db_path = setup
+    src = tmp_path / "card"
+    src.mkdir()
+
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json={
+            "sources": [str(src)],
+            "destination": os.path.abspath(os.sep),
+            "local_processing": True,
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        assert resp.status_code == 400
+        assert "filesystem root" in resp.get_json()["error"].lower()
+
+
 def test_pipeline_local_processing_rejects_collection_id(setup, tmp_path):
     # Collection pipelines set skip_scan and never run ingest, so the
     # staging folder is never created/indexed. Without this rejection

--- a/vireo/tests/test_pipeline_locks.py
+++ b/vireo/tests/test_pipeline_locks.py
@@ -376,3 +376,29 @@ def test_archive_destination_reserve_normalises_relative_paths():
         assert try_reserve_archive_destination(abs_path) is False
     finally:
         release_archive_destination("Photos/Shoot")
+
+
+def test_archive_destination_reserve_rejects_symlinked_alias(tmp_path):
+    """A symlink and its real path resolve to the same archive root.
+
+    Without realpath in the normalisation, two jobs choosing the same
+    physical destination via different spellings (a real path and a
+    symlink to it) could both pass the reservation check; with two
+    pipeline slots they would then race into the same archive root before
+    ``move_folder``'s catalog-side guards run.
+    """
+    real_target = tmp_path / "real_dest"
+    real_target.mkdir()
+    symlink = tmp_path / "link_dest"
+    symlink.symlink_to(real_target)
+
+    real_child = str(real_target / "Shoot")
+    aliased_child = str(symlink / "Shoot")
+
+    try:
+        assert try_reserve_archive_destination(real_child) is True
+        # Aliased path resolves through realpath to the same physical
+        # directory — the second reservation must collide.
+        assert try_reserve_archive_destination(aliased_child) is False
+    finally:
+        release_archive_destination(real_child)

--- a/vireo/tests/test_pipeline_locks.py
+++ b/vireo/tests/test_pipeline_locks.py
@@ -13,6 +13,8 @@ from pipeline_locks import (
     acquire_gpu_if_session_uses_it,
     acquire_photo_mask,
     acquire_workspace_regroup,
+    release_archive_destination,
+    try_reserve_archive_destination,
 )
 
 
@@ -296,3 +298,81 @@ def test_photo_mask_lock_reentrant_keys_share_one_lock():
     lock1 = _photo_mask_lock_for_tests(7)
     lock2 = _photo_mask_lock_for_tests(7)
     assert lock1 is lock2
+
+
+def test_archive_destination_reserve_rejects_exact_match():
+    """Two pipelines targeting the same destination cannot both reserve."""
+    try:
+        assert try_reserve_archive_destination("/Photos/Shoot") is True
+        assert try_reserve_archive_destination("/Photos/Shoot") is False
+    finally:
+        release_archive_destination("/Photos/Shoot")
+
+
+def test_archive_destination_reserve_rejects_descendant():
+    """A child of an already-reserved root is rejected before processing starts.
+
+    Without this the parent run can create a tracked folder row that the
+    child later tries to archive into, leaving overlapping folder roots in
+    the catalog after the second job moves staging into the already-claimed
+    tree.
+    """
+    try:
+        assert try_reserve_archive_destination("/Photos/Shoot") is True
+        assert try_reserve_archive_destination("/Photos/Shoot/Subset") is False
+    finally:
+        release_archive_destination("/Photos/Shoot")
+
+
+def test_archive_destination_reserve_rejects_ancestor():
+    """A parent of an already-reserved leaf is rejected too.
+
+    Symmetry matters because either run can land first; once the leaf is
+    in flight, a second pipeline aiming at the enclosing root would later
+    have to reparent the in-flight subtree, which ``move_folder_path``
+    doesn't do.
+    """
+    try:
+        assert try_reserve_archive_destination("/Photos/Shoot/Subset") is True
+        assert try_reserve_archive_destination("/Photos/Shoot") is False
+    finally:
+        release_archive_destination("/Photos/Shoot/Subset")
+
+
+def test_archive_destination_reserve_allows_sibling_prefix_lookalike():
+    """``/Photos/Shoot`` and ``/Photos/ShootSubset`` are siblings, not nested.
+
+    A naive ``startswith`` overlap check would false-positive here and
+    block an unrelated archive. ``commonpath`` correctly returns
+    ``/Photos`` for both, which equals neither leaf.
+    """
+    try:
+        assert try_reserve_archive_destination("/Photos/Shoot") is True
+        assert try_reserve_archive_destination("/Photos/ShootSubset") is True
+    finally:
+        release_archive_destination("/Photos/Shoot")
+        release_archive_destination("/Photos/ShootSubset")
+
+
+def test_archive_destination_release_allows_reacquire():
+    """After release, the same destination (or a nested one) can be claimed."""
+    assert try_reserve_archive_destination("/Photos/Shoot") is True
+    release_archive_destination("/Photos/Shoot")
+    try:
+        # Same path is reusable.
+        assert try_reserve_archive_destination("/Photos/Shoot") is True
+        release_archive_destination("/Photos/Shoot")
+        # And a previously-blocked nested path is also reusable.
+        assert try_reserve_archive_destination("/Photos/Shoot/Subset") is True
+    finally:
+        release_archive_destination("/Photos/Shoot/Subset")
+
+
+def test_archive_destination_reserve_normalises_relative_paths():
+    """Relative and absolute spellings of the same target collide."""
+    abs_path = os.path.abspath("Photos/Shoot")
+    try:
+        assert try_reserve_archive_destination("Photos/Shoot") is True
+        assert try_reserve_archive_destination(abs_path) is False
+    finally:
+        release_archive_destination("Photos/Shoot")

--- a/vireo/tests/test_pipeline_locks.py
+++ b/vireo/tests/test_pipeline_locks.py
@@ -4,6 +4,8 @@ import sys
 import threading
 import time
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 sys.path.insert(0, os.path.dirname(__file__))
 
@@ -390,7 +392,10 @@ def test_archive_destination_reserve_rejects_symlinked_alias(tmp_path):
     real_target = tmp_path / "real_dest"
     real_target.mkdir()
     symlink = tmp_path / "link_dest"
-    symlink.symlink_to(real_target)
+    try:
+        symlink.symlink_to(real_target)
+    except OSError as exc:
+        pytest.skip(f"symlinks not supported on this filesystem: {exc}")
 
     real_child = str(real_target / "Shoot")
     aliased_child = str(symlink / "Shoot")


### PR DESCRIPTION
Adds an optional Pipeline setting to stage copy-mode imports on local disk before archiving to the final destination. The pipeline now performs a local-storage preflight, reports when batching would be required, processes from the staging folder, and archives with the existing verified folder move path while preserving staging on failure. The API accepts the new local_processing flag and the UI maps storage/archive progress to the Destination card. Validation: ruff on touched files plus focused local-processing and pipeline API tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “use local disk while processing” option for pipeline copy jobs, staging results locally before archiving to the chosen destination.
* **Bug Fixes**
  * Improved local-processing validation (destination required/normalized, stronger conflict rules) and failure handling for storage, ingest, and archiving.
  * Added safer archive reservation to prevent concurrent runs targeting the same/overlapping destination.
  * Post-commit cleanup failures now surface as warnings (including preview-cache cleanup for deleted photos).
  * Updated job cancellation behavior to avoid incorrect terminal status changes.
* **Tests**
  * Expanded unit and end-to-end coverage for local planning, duplicates/resume accounting, API validation, cleanup, reservation, and cancellation edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->