### PR TITLE
Handle zero-byte images outside duplicate flow

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -10511,7 +10511,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not paths:
             return json_error("paths required", 400)
 
-        from scanner import compute_file_hash
+        from scanner import EMPTY_FILE_SHA256, compute_file_hash
 
         db = _get_db()
         rows = db.conn.execute(
@@ -10533,6 +10533,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             for checked, path in enumerate(paths, 1):
                 try:
                     file_hash = compute_file_hash(path)
+                    if file_hash == EMPTY_FILE_SHA256 and os.path.getsize(path) == 0:
+                        continue
                     if file_hash in known_hashes or file_hash in seen_hashes:
                         batch_duplicates.append(path)
                         duplicate_count += 1

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -10533,13 +10533,22 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             for checked, path in enumerate(paths, 1):
                 try:
                     file_hash = compute_file_hash(path)
-                    if file_hash == EMPTY_FILE_SHA256 and os.path.getsize(path) == 0:
-                        continue
-                    if file_hash in known_hashes or file_hash in seen_hashes:
-                        batch_duplicates.append(path)
-                        duplicate_count += 1
-                    else:
-                        seen_hashes.add(file_hash)
+                    # Treat zero-byte placeholders as non-duplicates, but fall
+                    # through so the batch-yield block below still runs.
+                    # A `continue` here would swallow any already-queued
+                    # `batch_duplicates` whenever an empty file landed on the
+                    # last path or on a `checked % BATCH_SIZE == 0` boundary,
+                    # leaving the UI unable to deselect those known dupes.
+                    is_empty_placeholder = (
+                        file_hash == EMPTY_FILE_SHA256
+                        and os.path.getsize(path) == 0
+                    )
+                    if not is_empty_placeholder:
+                        if file_hash in known_hashes or file_hash in seen_hashes:
+                            batch_duplicates.append(path)
+                            duplicate_count += 1
+                        else:
+                            seen_hashes.add(file_hash)
                 except OSError:
                     pass  # Skip unreadable/missing files
 

--- a/vireo/audit.py
+++ b/vireo/audit.py
@@ -343,7 +343,7 @@ def verify_hashes(db, progress_cb=None, should_cancel=None):
     Returns stats dict: {checked, ok, baselined, modified, corrupt,
     unreadable, missing, cancelled}
     """
-    from scanner import compute_file_hash
+    from scanner import EMPTY_FILE_SHA256, compute_file_hash
 
     photos = db.get_integrity_photos()
     total = len(photos)
@@ -375,8 +375,16 @@ def verify_hashes(db, progress_cb=None, should_cancel=None):
 
         stats["checked"] += 1
         if not photo["file_hash"]:
-            db.update_photo_hash_check(photo["id"], "ok", file_hash=actual,
-                                       commit=False)
+            # Zero-byte placeholders must NOT have the empty SHA baselined
+            # back in: scanner.py deliberately clears file_hash for empty
+            # files so they don't collide as exact duplicates of every
+            # other zero-byte image in the archive. Mark the row "ok"
+            # without writing file_hash so its NULL state survives audits.
+            if actual == EMPTY_FILE_SHA256:
+                db.update_photo_hash_check(photo["id"], "ok", commit=False)
+            else:
+                db.update_photo_hash_check(photo["id"], "ok", file_hash=actual,
+                                           commit=False)
             stats["baselined"] += 1
         elif actual == photo["file_hash"]:
             db.update_photo_hash_check(photo["id"], "ok", commit=False)

--- a/vireo/audit.py
+++ b/vireo/audit.py
@@ -459,7 +459,7 @@ def accept_current_hash(db, photo_ids):
 
     Returns the number of photos updated.
     """
-    from scanner import compute_file_hash
+    from scanner import EMPTY_FILE_SHA256, compute_file_hash
 
     folders = {f["id"]: f["path"] for f in db.get_folder_tree()}
     accepted = 0
@@ -474,7 +474,22 @@ def accept_current_hash(db, photo_ids):
         except OSError:
             log.warning("Cannot accept hash for unreadable file %s", path)
             continue
-        db.update_photo_hash_check(pid, "ok", file_hash=new_hash)
+        # Zero-byte placeholders must NOT land EMPTY_FILE_SHA256 in
+        # photos.file_hash — mirrors the scanner / verify_hashes rule.
+        # Without this, accepting a flagged zero-byte file reintroduces
+        # the very duplicate identity the rest of the system tries to
+        # keep out, so every empty placeholder would resurface as
+        # exact-duplicate-of-every-other-empty-file until a rescan
+        # repaired it. Clearing the column also drops any pre-truncation
+        # hash that was the original cause of the modified/corrupt flag.
+        try:
+            file_size = os.path.getsize(path)
+        except OSError:
+            file_size = None
+        if new_hash == EMPTY_FILE_SHA256 and file_size == 0:
+            db.update_photo_hash_check(pid, "ok", clear_file_hash=True)
+        else:
+            db.update_photo_hash_check(pid, "ok", file_hash=new_hash)
         accepted += 1
     log.info("Accepted current hash for %d photos", accepted)
     return accepted

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2212,14 +2212,28 @@ class Database:
         }
 
     def update_photo_hash_check(self, photo_id, status, file_hash=None,
-                                commit=True):
+                                commit=True, clear_file_hash=False):
         """Record a hash-verification verdict for one photo.
 
         When ``file_hash`` is given the stored baseline is replaced too
         (first-time baselining, or the user accepting an external edit).
+        Set ``clear_file_hash=True`` to explicitly NULL the stored hash:
+        used for zero-byte files so ``EMPTY_FILE_SHA256`` never lands in
+        the ``file_hash`` column (it would otherwise collide as an exact
+        duplicate of every other empty placeholder).
         """
+        if clear_file_hash and file_hash is not None:
+            raise ValueError(
+                "clear_file_hash and file_hash are mutually exclusive"
+            )
         now = datetime.now().isoformat()
-        if file_hash is not None:
+        if clear_file_hash:
+            self.conn.execute(
+                "UPDATE photos SET hash_status = ?, hash_checked_at = ?, "
+                "file_hash = NULL WHERE id = ?",
+                (status, now, photo_id),
+            )
+        elif file_hash is not None:
             self.conn.execute(
                 "UPDATE photos SET hash_status = ?, hash_checked_at = ?, "
                 "file_hash = ? WHERE id = ?",

--- a/vireo/duplicate_scan.py
+++ b/vireo/duplicate_scan.py
@@ -8,6 +8,8 @@ import os
 from duplicate_buckets import bucket_unresolved_proposals
 from duplicates import DupCandidate, resolve_duplicates
 
+_EMPTY_FILE_SHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
 # SQLite's legacy ``SQLITE_MAX_VARIABLE_NUMBER`` cap is 999 on older builds.
 # An auto-resolved group can exceed that when many `-2` copies of one
 # file accumulate over repeated scans, so any single-statement IN-clause
@@ -80,6 +82,14 @@ def _attach_edit_recipes(db, proposals):
     return proposals
 
 
+def _is_empty_file_group(file_hash, infos):
+    return (
+        file_hash == _EMPTY_FILE_SHA256
+        and infos
+        and all((info.get("file_size") or 0) == 0 for info in infos)
+    )
+
+
 def _build_unresolved_proposal(db, group):
     """Return a proposal dict for an unresolved group, or None on race."""
     rows = _fetch_photo_rows(
@@ -107,12 +117,16 @@ def _build_unresolved_proposal(db, group):
         linfo["reason"] = reason
         losers.append(linfo)
     all_missing = not any(info["exists"] for info in info_by_id.values())
+    empty_file_group = _is_empty_file_group(
+        group["file_hash"], info_by_id.values(),
+    )
     return {
         "file_hash": group["file_hash"],
         "status": "unresolved",
         "winner": info_by_id[winner_id],
         "losers": losers,
         "all_missing": all_missing,
+        "empty_file_group": empty_file_group,
     }
 
 
@@ -173,12 +187,19 @@ def _build_resolved_proposal(db, group):
         linfo["rejected"] = True
         losers.append(linfo)
     all_missing = not any(info["exists"] for info in info_by_id.values())
+    empty_file_group = _is_empty_file_group(
+        group["file_hash"], info_by_id.values(),
+    )
+    if empty_file_group:
+        for loser in losers:
+            loser["reason"] = "empty file"
     return {
         "file_hash": group["file_hash"],
         "status": "resolved",
         "winner": info_by_id[kept[0]["id"]],
         "losers": losers,
         "all_missing": all_missing,
+        "empty_file_group": empty_file_group,
     }
 
 

--- a/vireo/ingest.py
+++ b/vireo/ingest.py
@@ -607,6 +607,31 @@ def ingest(
 
             # Handle filename collision (different file, same name)
             if dest_file.exists():
+                # Zero-byte ↔ zero-byte at the same destination path IS
+                # the same file (every empty file is bit-identical to
+                # every other), but pass 1 cleared ``file_hash`` to
+                # ``None`` for zero-byte sources so EMPTY_FILE_SHA256
+                # doesn't carry duplicate identity. The hash-based
+                # exact-match branch below therefore can't recognise
+                # this collision, and a ``skip_duplicates`` retry of an
+                # interrupted card import would otherwise fall through
+                # to the numeric-suffix branch and start creating
+                # ``name_1.ext``, ``name_2.ext`` placeholder copies of
+                # the same empty file forever. ``known_hashes`` /
+                # ``batch_dest_folders`` are deliberately NOT updated —
+                # zero-byte files are kept out of the duplicate-identity
+                # index everywhere else, and this skip mirrors that.
+                src_is_empty = (
+                    file_hash is None
+                    and source_file.stat().st_size == 0
+                )
+                if src_is_empty and dest_file.stat().st_size == 0:
+                    skipped_duplicate += 1
+                    duplicate_folders.add(str(dest_folder))
+                    emitted += 1
+                    if progress_callback:
+                        progress_callback(emitted, total, source_file.name)
+                    continue
                 dest_hash = compute_file_hash(str(dest_file))
                 if file_hash is not None and file_hash == dest_hash:
                     # Exact same file already there

--- a/vireo/ingest.py
+++ b/vireo/ingest.py
@@ -19,7 +19,7 @@ from image_loader import (
     safe_iter_dir,
     safe_scan_walk,
 )
-from scanner import compute_file_hash
+from scanner import EMPTY_FILE_SHA256, compute_file_hash
 
 log = logging.getLogger(__name__)
 
@@ -538,6 +538,8 @@ def ingest(
     for source_file in files:
         try:
             file_hash = compute_file_hash(str(source_file))
+            if file_hash == EMPTY_FILE_SHA256 and source_file.stat().st_size == 0:
+                file_hash = None
         except Exception as e:
             log.warning("Failed to ingest %s: %s", source_file, e)
             failed += 1
@@ -546,7 +548,7 @@ def ingest(
                 progress_callback(emitted, total, source_file.name)
             continue
 
-        if skip_duplicates and file_hash in known_hashes:
+        if skip_duplicates and file_hash is not None and file_hash in known_hashes:
             skipped_duplicate += 1
             # Record every destination folder that holds a copy of
             # this file, not just one. The pipeline uses this set
@@ -584,7 +586,7 @@ def ingest(
         # if the primary's copy fails (e.g. the destination filename
         # collides with a directory of the same name), the sibling
         # still gets a chance to import the bytes.
-        if skip_duplicates and file_hash in known_hashes:
+        if skip_duplicates and file_hash is not None and file_hash in known_hashes:
             skipped_duplicate += 1
             dest = batch_dest_folders.get(file_hash)
             if dest is not None:
@@ -606,7 +608,7 @@ def ingest(
             # Handle filename collision (different file, same name)
             if dest_file.exists():
                 dest_hash = compute_file_hash(str(dest_file))
-                if file_hash == dest_hash:
+                if file_hash is not None and file_hash == dest_hash:
                     # Exact same file already there
                     skipped_duplicate += 1
                     known_hashes.add(file_hash)
@@ -625,8 +627,9 @@ def ingest(
                     counter += 1
 
             shutil.copy2(str(source_file), str(dest_file))
-            known_hashes.add(file_hash)
-            batch_dest_folders[file_hash] = str(dest_folder)
+            if file_hash is not None:
+                known_hashes.add(file_hash)
+                batch_dest_folders[file_hash] = str(dest_folder)
             copied_paths.append(str(dest_file))
             copied += 1
 

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -28,6 +28,7 @@ from PIL import Image
 from xmp import read_hierarchical_keywords, read_keywords
 
 log = logging.getLogger(__name__)
+EMPTY_FILE_SHA256 = hashlib.sha256(b"").hexdigest()
 
 # scan() runs inside JobRunner/pipeline_job background threads, so the
 # default POSIX "fork" start method is unsafe here: forking a
@@ -1324,8 +1325,26 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                         (existing["timestamp"] is None or dims_suspect)
                         and existing["id"] not in exif_extracted
                     )
+                    if "file_hash" in existing.keys():
+                        existing_file_hash = existing["file_hash"]
+                    else:
+                        hash_row = db.conn.execute(
+                            "SELECT file_hash FROM photos WHERE id = ?",
+                            (existing["id"],),
+                        ).fetchone()
+                        existing_file_hash = (
+                            hash_row["file_hash"] if hash_row else None
+                        )
+                    empty_hash_needs_repair = (
+                        existing["file_size"] == 0
+                        and existing_file_hash == EMPTY_FILE_SHA256
+                    )
 
-                    if file_unchanged and xmp_unchanged and not metadata_missing:
+                    if (
+                        file_unchanged and xmp_unchanged
+                        and not metadata_missing
+                        and not empty_hash_needs_repair
+                    ):
                         processed_count += 1
                         if photo_callback:
                             photo_callback(existing["id"], full_path_str)
@@ -1352,7 +1371,11 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                         )
                         commit_with_retry(db.conn)
 
-                    if file_unchanged and not metadata_missing:
+                    if (
+                        file_unchanged
+                        and not metadata_missing
+                        and not empty_hash_needs_repair
+                    ):
                         processed_count += 1
                         if photo_callback:
                             photo_callback(existing["id"], full_path_str)
@@ -1456,6 +1479,12 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
             touched_folder_ids.add(folder_id)
             file_size = stat.st_size
             file_mtime = stat.st_mtime
+            if file_size == 0 and file_hash == EMPTY_FILE_SHA256:
+                log.warning(
+                    "Empty image file detected; skipping duplicate identity hash: %s",
+                    image_path,
+                )
+                file_hash = None
 
             # XMP sidecar
             xmp_path = image_path.with_suffix(".xmp")
@@ -1519,7 +1548,7 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
             # for them avoids O(N) wasted UPDATE + commit round-trips on
             # large initial scans.
             existing_row = db.conn.execute(
-                "SELECT file_hash FROM photos WHERE folder_id = ? AND filename = ?",
+                "SELECT file_hash, flag FROM photos WHERE folder_id = ? AND filename = ?",
                 (folder_id, image_path.name),
             ).fetchone()
             row_already_existed = existing_row is not None
@@ -1575,6 +1604,13 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                     # that recomputes the same hash leaves coverage intact.
                     updates.append("hash_checked_at=NULL")
                     updates.append("hash_status=NULL")
+            elif file_size == 0:
+                updates.append("file_hash=NULL")
+                if row_already_existed and prev_file_hash is not None:
+                    updates.append("hash_checked_at=NULL")
+                    updates.append("hash_status=NULL")
+                if row_already_existed and prev_file_hash == EMPTY_FILE_SHA256:
+                    updates.append("flag=CASE WHEN flag='rejected' THEN 'none' ELSE flag END")
             if file_meta and extract_full_metadata:
                 updates.append("exif_data=?")
                 update_params.append(json.dumps(file_meta))
@@ -1595,7 +1631,7 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                 # such a file's mtime current would make the next incremental
                 # scan skip it forever with a stale hash and stale derived
                 # caches; leaving the old mtime in place retries it instead.
-                if file_hash is not None:
+                if file_hash is not None or file_size == 0:
                     updates.extend(["file_mtime=?", "file_size=?"])
                     update_params.extend([file_mtime, file_size])
                 # xmp_mtime stays unconditional — the sidecar is a separate

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -1657,14 +1657,20 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
             # stale. Includes the NULL → concrete transition for legacy
             # rows that predate hash tracking — we can't prove their
             # caches match current bytes, so safer to flush and
-            # regenerate. Also fires when a previously-hashed file is
-            # truncated to zero bytes: file_hash is None in that branch
-            # (empty files don't carry duplicate identity), so the plain
+            # regenerate. Also fires when a file is truncated to zero
+            # bytes: file_hash is None in that branch (empty files don't
+            # carry duplicate identity), so the plain
             # ``file_hash is not None`` guard would otherwise leave
             # thumbnails and working copies from the old bytes in place.
-            # Skips the empty → empty repair case (prev was already the
-            # empty SHA) because the bytes didn't actually change.
-            # Gated on ``row_already_existed`` so brand-new inserts
+            # The zero-byte clause covers BOTH non-empty → empty and
+            # legacy NULL → empty: a pre-hash row whose file is now
+            # truncated still has thumbnails rendered from its old
+            # non-empty bytes, and before this fix the previous code
+            # path (which stored the concrete empty SHA) would have
+            # invalidated it via the NULL → concrete branch. Skips the
+            # empty → empty repair case (prev was already the empty SHA)
+            # because the bytes didn't actually change. Gated on
+            # ``row_already_existed`` so brand-new inserts
             # (prev_file_hash is always NULL there) don't trigger
             # pointless UPDATE + commit round-trips on large initial
             # scans. Requires explicit vireo_dir; callers must pass it
@@ -1674,7 +1680,6 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                 file_hash is not None and prev_file_hash != file_hash
             ) or (
                 file_size == 0
-                and prev_file_hash is not None
                 and prev_file_hash != EMPTY_FILE_SHA256
             )
             if (row_already_existed

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -1606,8 +1606,15 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                 if row_already_existed and prev_file_hash is not None:
                     updates.append("hash_checked_at=NULL")
                     updates.append("hash_status=NULL")
-                if row_already_existed and prev_file_hash == EMPTY_FILE_SHA256:
-                    updates.append("flag=CASE WHEN flag='rejected' THEN 'none' ELSE flag END")
+                # Historical rows where the empty SHA leaked in are repaired
+                # here by clearing file_hash above. We deliberately leave the
+                # ``flag`` column untouched: a 'rejected' value could come
+                # from the user (Browse / culling) just as easily as from
+                # past duplicate auto-resolution, and we have no marker that
+                # distinguishes them. Silently un-rejecting a user's
+                # placeholder would be worse than leaving it as-is; the
+                # duplicates page already flags empty-byte groups for
+                # manual review.
             if file_meta and extract_full_metadata:
                 updates.append("exif_data=?")
                 update_params.append(json.dumps(file_meta))

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -1651,15 +1651,28 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
             # stale. Includes the NULL → concrete transition for legacy
             # rows that predate hash tracking — we can't prove their
             # caches match current bytes, so safer to flush and
-            # regenerate. Gated on ``row_already_existed`` so brand-new
-            # inserts (prev_file_hash is always NULL there) don't
-            # trigger pointless UPDATE + commit round-trips on large
-            # initial scans. Requires explicit vireo_dir; callers must
-            # pass it (scan can't guess because --db and --thumb-dir
-            # are independently configurable).
+            # regenerate. Also fires when a previously-hashed file is
+            # truncated to zero bytes: file_hash is None in that branch
+            # (empty files don't carry duplicate identity), so the plain
+            # ``file_hash is not None`` guard would otherwise leave
+            # thumbnails and working copies from the old bytes in place.
+            # Skips the empty → empty repair case (prev was already the
+            # empty SHA) because the bytes didn't actually change.
+            # Gated on ``row_already_existed`` so brand-new inserts
+            # (prev_file_hash is always NULL there) don't trigger
+            # pointless UPDATE + commit round-trips on large initial
+            # scans. Requires explicit vireo_dir; callers must pass it
+            # (scan can't guess because --db and --thumb-dir are
+            # independently configurable).
+            content_identity_changed = (
+                file_hash is not None and prev_file_hash != file_hash
+            ) or (
+                file_size == 0
+                and prev_file_hash is not None
+                and prev_file_hash != EMPTY_FILE_SHA256
+            )
             if (row_already_existed
-                    and file_hash is not None
-                    and prev_file_hash != file_hash
+                    and content_identity_changed
                     and vireo_dir):
                 _invalidate_derived_caches(
                     db, vireo_dir, photo_id, thumb_cache_dir=thumb_cache_dir,

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -1325,16 +1325,13 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                         (existing["timestamp"] is None or dims_suspect)
                         and existing["id"] not in exif_extracted
                     )
-                    if "file_hash" in existing.keys():
-                        existing_file_hash = existing["file_hash"]
-                    else:
-                        hash_row = db.conn.execute(
-                            "SELECT file_hash FROM photos WHERE id = ?",
-                            (existing["id"],),
-                        ).fetchone()
-                        existing_file_hash = (
-                            hash_row["file_hash"] if hash_row else None
-                        )
+                    hash_row = db.conn.execute(
+                        "SELECT file_hash FROM photos WHERE id = ?",
+                        (existing["id"],),
+                    ).fetchone()
+                    existing_file_hash = (
+                        hash_row["file_hash"] if hash_row else None
+                    )
                     empty_hash_needs_repair = (
                         existing["file_size"] == 0
                         and existing_file_hash == EMPTY_FILE_SHA256

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -1174,12 +1174,17 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
 
     # Build existing photo lookup for incremental mode
     existing_photos = {}
+    existing_file_hashes = {}
     exif_extracted = set()  # photo IDs where ExifTool has already run
     if incremental:
         all_photos = db.get_photos(per_page=999999)
         for p in all_photos:
             # Key by folder_id + filename won't work easily, so use a second lookup
             existing_photos[p["id"]] = p
+        existing_file_hashes = {
+            row["id"]: row["file_hash"]
+            for row in db.conn.execute("SELECT id, file_hash FROM photos")
+        }
         # Build a path-based lookup: we need folder path + filename
         existing_by_path = {}
         folders = {f["id"]: f["path"] for f in db.get_folder_tree()}
@@ -1325,13 +1330,7 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                         (existing["timestamp"] is None or dims_suspect)
                         and existing["id"] not in exif_extracted
                     )
-                    hash_row = db.conn.execute(
-                        "SELECT file_hash FROM photos WHERE id = ?",
-                        (existing["id"],),
-                    ).fetchone()
-                    existing_file_hash = (
-                        hash_row["file_hash"] if hash_row else None
-                    )
+                    existing_file_hash = existing_file_hashes.get(existing["id"])
                     empty_hash_needs_repair = (
                         existing["file_size"] == 0
                         and existing_file_hash == EMPTY_FILE_SHA256

--- a/vireo/templates/duplicates.html
+++ b/vireo/templates/duplicates.html
@@ -462,6 +462,9 @@
     var resolvedGroupCount = result.resolved_group_count || resolved.length;
     var resolvedLoserCount = result.resolved_loser_count ||
       resolved.reduce(function(n, p) { return n + (p.losers || []).length; }, 0);
+    var emptyFileGroupCount = resolved.reduce(function(n, p) {
+      return n + (p.empty_file_group ? 1 : 0);
+    }, 0);
     var resolvedBytes = 0;
     resolved.forEach(function(p) {
       (p.losers || []).forEach(function(l) {
@@ -490,6 +493,12 @@
           '<div class="label">Cleanup pending</div></div>' +
         '<div class="summary-stat"><div class="num">' + formatBytes(resolvedBytes) + '</div>' +
           '<div class="label">Extra files on disk</div></div>';
+      if (emptyFileGroupCount > 0) {
+        summaryHtml +=
+          '<div class="summary-stat"><div class="num" style="color:var(--warning, #d69e2e);">' +
+            emptyFileGroupCount + '</div>' +
+            '<div class="label">Empty-file groups</div></div>';
+      }
     }
     summaryHtml += '</div>';
     summary.innerHTML = summaryHtml;
@@ -542,10 +551,14 @@
           '<h2 class="' + toggleClass + '" id="resolvedToggle" onclick="toggleResolvedSection()">' +
             '<span class="chev">&#9656;</span> Resolved — cleanup pending' +
           '</h2>' +
-          '<div class="section-sub">Vireo already picked which copy to keep for ' +
-          resolvedGroupCount + ' group' + (resolvedGroupCount === 1 ? '' : 's') +
-          ', but the extra copies (' + formatBytes(resolvedBytes) +
-          ') are still on disk. Move them to Trash to finish cleanup.</div>' +
+          '<div class="section-sub">' +
+          (emptyFileGroupCount === resolvedGroupCount
+            ? 'These groups are zero-byte files, usually from an interrupted copy or storage problem. Check the original source or backup before deleting anything.'
+            : 'Vireo already picked which copy to keep for ' +
+              resolvedGroupCount + ' group' + (resolvedGroupCount === 1 ? '' : 's') +
+              ', but the extra copies (' + formatBytes(resolvedBytes) +
+              ') are still on disk. Empty-file groups need source or backup checks before cleanup.') +
+          '</div>' +
         '</div>';
       // Hide the bulk button entirely when every remaining resolved group is
       // protected — otherwise it sticks around as a no-op that always toasts
@@ -588,6 +601,14 @@
     var losers = group.losers || [];
     var winnerMissing = winner.exists === false;
     var anyLoserMissing = losers.some(function(l) { return l.exists === false; });
+    if (group.empty_file_group) {
+      return '<div class="group-warning severe">' +
+        '<b>Zero-byte image files detected.</b> These are not real duplicate photos; ' +
+        'they are empty placeholders, usually from an interrupted copy, failed import, ' +
+        'or storage issue. Check the camera card, original source, or backup before ' +
+        'moving files to Trash. After restoring or deleting them, rescan this folder.' +
+        '</div>';
+    }
     if (allMissing) {
       return '<div class="group-warning severe">' +
         '<b>All files in this group are missing on disk.</b> ' +
@@ -881,10 +902,15 @@
     var html = '<div class="dup-group" data-hash="' + escapeHtml(hash) + '"' +
                (winnerMissing ? ' data-protected="winner-missing"' : '') + '>';
     html += '<div class="dup-group-header">';
-    html += '<label style="cursor:default;">' +
-            losers.length + ' extra ' +
-            (losers.length === 1 ? 'copy' : 'copies') +
-            ' rejected during scan</label>';
+    if (group.empty_file_group) {
+      html += '<label style="cursor:default;">' +
+              (losers.length + 1) + ' zero-byte files detected</label>';
+    } else {
+      html += '<label style="cursor:default;">' +
+              losers.length + ' extra ' +
+              (losers.length === 1 ? 'copy' : 'copies') +
+              ' rejected during scan</label>';
+    }
     html += '<span class="hash">' + escapeHtml(hash.substring(0, 16)) + '...</span>';
     html += '</div>';
     html += renderGroupWarning(group);

--- a/vireo/tests/test_audit.py
+++ b/vireo/tests/test_audit.py
@@ -558,6 +558,61 @@ def test_accept_current_hash_clears_flag(tmp_path):
     assert stats['ok'] == 1 and stats['modified'] == 0
 
 
+def test_accept_current_hash_does_not_store_empty_sha_for_zero_byte_file(tmp_path):
+    """Accepting a flagged zero-byte file must NOT write EMPTY_FILE_SHA256
+    back into ``photos.file_hash``.
+
+    A photo that legitimately had bytes (and a real hash) gets truncated
+    to zero on disk; verify_hashes() flags it modified/corrupt because
+    the recomputed empty SHA doesn't match the stored hash. If the user
+    accepts the current state as the new truth, the prior code path
+    would store ``EMPTY_FILE_SHA256`` as the baseline, re-introducing
+    the exact duplicate identity this PR removes — every accepted empty
+    file would resurface as duplicate-of-every-other-empty-file.
+    """
+    from audit import accept_current_hash
+    from db import Database
+    from scanner import EMPTY_FILE_SHA256
+
+    root = tmp_path / "photos"
+    root.mkdir()
+    path = root / "DSC_0001.NEF"
+    # Legitimate prior content that produced a real hash.
+    path.write_bytes(b"original raw bytes")
+
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder(str(root), name="photos")
+    pid = db.add_photo(
+        folder_id=folder_id,
+        filename=path.name,
+        extension=path.suffix.lower(),
+        file_size=path.stat().st_size,
+        file_mtime=path.stat().st_mtime,
+        file_hash="deadbeef" * 8,
+    )
+    # Now the file is truncated to zero bytes externally and the user
+    # decides to accept the new state.
+    path.write_bytes(b"")
+    db.conn.execute(
+        "UPDATE photos SET hash_status = 'modified' WHERE id = ?", (pid,)
+    )
+    db.conn.commit()
+
+    accepted = accept_current_hash(db, [pid])
+
+    assert accepted == 1
+    row = db.conn.execute(
+        "SELECT file_hash, hash_status FROM photos WHERE id = ?", (pid,)
+    ).fetchone()
+    assert row["file_hash"] is None, (
+        "accept_current_hash must clear file_hash for zero-byte files; "
+        f"got {row['file_hash']!r} which is the empty-file SHA "
+        f"({EMPTY_FILE_SHA256!r})" if row["file_hash"] == EMPTY_FILE_SHA256
+        else f"accept_current_hash left a stale baseline: {row['file_hash']!r}"
+    )
+    assert row["hash_status"] == "ok"
+
+
 def test_rescan_resets_hash_coverage_after_external_edit(tmp_path):
     """When a rescan replaces the stored baseline hash, the verification
     markers must be cleared: 'checked' means THIS baseline was verified,

--- a/vireo/tests/test_audit.py
+++ b/vireo/tests/test_audit.py
@@ -422,6 +422,48 @@ def test_verify_hashes_ok_and_baseline(tmp_path):
     assert runs['integrity']['problem_count'] == 0
 
 
+def test_verify_hashes_does_not_baseline_empty_files_back_to_empty_hash(tmp_path):
+    """Zero-byte placeholders that scanner cleared to file_hash=NULL must
+    stay NULL after a Verify Hashes run — otherwise the audit would
+    silently re-introduce ``EMPTY_FILE_SHA256`` and resurrect every empty
+    file as duplicate-of-every-other-empty-file in the duplicates view.
+    """
+    from audit import verify_hashes
+    from db import Database
+    from scanner import EMPTY_FILE_SHA256
+
+    root = tmp_path / "photos"
+    root.mkdir()
+    empty_path = root / "DSC_0001.NEF"
+    empty_path.write_bytes(b"")
+
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder(str(root), name="photos")
+    db.add_photo(
+        folder_id=folder_id,
+        filename=empty_path.name,
+        extension=empty_path.suffix.lower(),
+        file_size=0,
+        file_mtime=os.path.getmtime(empty_path),
+    )
+
+    stats = verify_hashes(db)
+
+    assert stats["baselined"] == 1
+    row = db.conn.execute(
+        "SELECT file_hash, hash_status FROM photos WHERE filename = ?",
+        (empty_path.name,),
+    ).fetchone()
+    assert row["file_hash"] is None, (
+        "verify_hashes must not write EMPTY_FILE_SHA256 onto a zero-byte row"
+    )
+    assert row["hash_status"] == "ok"
+    # Sanity: confirm the constant we're guarding against is what hashing
+    # an empty file actually returns.
+    import hashlib
+    assert hashlib.sha256(b"").hexdigest() == EMPTY_FILE_SHA256
+
+
 def test_verify_hashes_flags_corruption_when_mtime_unchanged(tmp_path):
     """Content change with the original mtime is the bit-rot signature."""
     from audit import verify_hashes

--- a/vireo/tests/test_check_duplicates.py
+++ b/vireo/tests/test_check_duplicates.py
@@ -158,3 +158,50 @@ def test_check_duplicates_missing_file_skipped(app_and_db, tmp_path):
     done = [e for e in events if e.get("done")]
     assert len(done) == 1
     assert done[0]["checked"] == 2  # Both counted as checked
+
+
+def test_check_duplicates_zero_byte_file_does_not_swallow_pending_batch(
+    app_and_db, tmp_path
+):
+    """A zero-byte path at end-of-list (or on a BATCH_SIZE boundary) must
+    not eat already-queued ``batch_duplicates``. The pipeline UI only
+    learns about duplicates from emitted ``data.duplicates`` events; if
+    the end-of-list yield is skipped, ``duplicate_count`` reports the
+    duplicate but the UI never deselects it.
+    """
+    app, db, fid = app_and_db
+
+    library_dir = tmp_path / "library"
+    library_dir.mkdir(exist_ok=True)
+    img = Image.new("RGB", (50, 50), color="red")
+    img.save(str(library_dir / "existing.jpg"))
+
+    from scanner import scan
+    scan(str(library_dir), db)
+
+    source = tmp_path / "source"
+    source.mkdir()
+    img.save(str(source / "duplicate.jpg"))  # Will match the library hash.
+    (source / "empty.NEF").write_bytes(b"")
+
+    client = app.test_client()
+    # Order matters: empty file is LAST, so the only opportunity to emit
+    # the queued duplicate is the ``checked == total`` branch.
+    resp = client.post("/api/import/check-duplicates", json={
+        "paths": [str(source / "duplicate.jpg"), str(source / "empty.NEF")],
+    })
+
+    events = parse_sse_events(resp.data)
+    done = [e for e in events if e.get("done")]
+    assert len(done) == 1
+    assert done[0]["duplicate_count"] == 1
+
+    all_duplicates = []
+    for e in events:
+        if "duplicates" in e:
+            all_duplicates.extend(e["duplicates"])
+    assert str(source / "duplicate.jpg") in all_duplicates, (
+        "Zero-byte trailing path must not skip the final batch emit; "
+        "the duplicate.jpg path needs to surface in a data.duplicates "
+        "event so the import UI can deselect it."
+    )

--- a/vireo/tests/test_check_duplicates.py
+++ b/vireo/tests/test_check_duplicates.py
@@ -109,6 +109,37 @@ def test_check_duplicates_all_new(app_and_db, tmp_path):
     assert done[0]["duplicate_count"] == 0
 
 
+def test_check_duplicates_ignores_zero_byte_images(app_and_db, tmp_path):
+    """Empty image placeholders should not be reported as duplicate photos."""
+    app, db, fid = app_and_db
+    from scanner import EMPTY_FILE_SHA256
+
+    # Historical DB state: older scans could store the empty-file hash.
+    db.add_photo(
+        folder_id=fid,
+        filename="empty.NEF",
+        extension=".nef",
+        file_size=0,
+        file_mtime=1.0,
+        file_hash=EMPTY_FILE_SHA256,
+    )
+
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "DSC_0001.NEF").write_bytes(b"")
+    (source / "DSC_0002.NEF").write_bytes(b"")
+
+    client = app.test_client()
+    resp = client.post("/api/import/check-duplicates", json={
+        "paths": [str(source / "DSC_0001.NEF"), str(source / "DSC_0002.NEF")],
+    })
+
+    events = parse_sse_events(resp.data)
+    done = [e for e in events if e.get("done")]
+    assert len(done) == 1
+    assert done[0]["duplicate_count"] == 0
+
+
 def test_check_duplicates_missing_file_skipped(app_and_db, tmp_path):
     """Missing files are skipped without crashing."""
     app, db, fid = app_and_db

--- a/vireo/tests/test_duplicates_db.py
+++ b/vireo/tests/test_duplicates_db.py
@@ -419,6 +419,28 @@ def test_run_duplicate_scan_emits_resolved_proposal(tmp_path):
     assert result["loser_count"] == 0
 
 
+def test_run_duplicate_scan_marks_empty_file_groups(tmp_path):
+    """Historical empty-file duplicate groups are called out for the UI."""
+    from duplicate_scan import run_duplicate_scan
+
+    empty_hash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    db = Database(str(tmp_path / "t.db"))
+    fid = db.add_folder(str(tmp_path))
+    _add(db, fid, "DSC_0001.NEF", file_hash=empty_hash)
+    _add(db, fid, "DSC_0002.NEF", file_hash=empty_hash)
+    db.conn.execute(
+        "UPDATE photos SET file_size = 0 WHERE file_hash = ?", (empty_hash,)
+    )
+    db.conn.commit()
+
+    result = run_duplicate_scan({"progress": {}}, db, include_resolved=True)
+
+    prop = result["proposals"][0]
+    assert prop["status"] == "resolved"
+    assert prop["empty_file_group"] is True
+    assert prop["losers"][0]["reason"] == "empty file"
+
+
 def test_run_duplicate_scan_attaches_edit_recipes(tmp_path):
     """Fresh scan results seed thumbnail edit cache keys immediately."""
     from duplicate_scan import run_duplicate_scan

--- a/vireo/tests/test_ingest.py
+++ b/vireo/tests/test_ingest.py
@@ -574,6 +574,51 @@ def test_ingest_custom_folder_template(tmp_path):
     assert (dst / "2026" / "03" / "photo.jpg").exists()
 
 
+def test_ingest_skip_duplicates_zero_byte_destination_collision(tmp_path):
+    """A zero-byte source that finds a zero-byte file at the exact
+    destination path must be treated as a duplicate skip — not as a
+    name collision needing ``name_1.ext``.
+
+    Pass 1 deliberately clears ``file_hash`` to ``None`` for zero-byte
+    sources so ``EMPTY_FILE_SHA256`` doesn't enter the global
+    duplicate-identity index. Pass 2's hash-based exact-match check
+    therefore can't recognise the collision; without an explicit
+    zero-byte branch a ``skip_duplicates`` retry of an interrupted card
+    import would fall through to the numeric-suffix branch and keep
+    minting empty placeholders forever.
+    """
+    src = tmp_path / "card"
+    dst = tmp_path / "nas"
+    src.mkdir()
+    dst.mkdir()
+
+    empty = src / "DSC_0001.NEF"
+    empty.write_bytes(b"")
+    mtime = datetime(2026, 3, 28).timestamp()
+    os.utime(str(empty), (mtime, mtime))
+
+    db = Database(str(tmp_path / "test.db"))
+    first = ingest(str(src), str(dst), db=db, skip_duplicates=True)
+    assert first["copied"] == 1
+    assert first["skipped_duplicate"] == 0
+
+    date_folder = dst / "2026" / "2026-03-28"
+    assert sorted(p.name for p in date_folder.iterdir()) == ["DSC_0001.NEF"]
+
+    # Retry the same card: the destination already holds a zero-byte
+    # file at the exact path. The retry must skip it, not create
+    # ``DSC_0001_1.NEF``.
+    second = ingest(str(src), str(dst), db=db, skip_duplicates=True)
+    assert second["copied"] == 0, (
+        f"retry created an extra placeholder: {second!r}"
+    )
+    assert second["skipped_duplicate"] == 1
+    assert sorted(p.name for p in date_folder.iterdir()) == ["DSC_0001.NEF"], (
+        "retry produced a name_1 sibling instead of skipping the existing "
+        "zero-byte file"
+    )
+
+
 def test_ingest_filename_collision(tmp_path):
     """Same filename from different source gets a suffix."""
     src1 = tmp_path / "card1"

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -318,6 +318,46 @@ def test_scan_discovers_photos(tmp_path):
     assert filenames == {'img1.jpg', 'img2.jpg', 'img3.jpg'}
 
 
+def test_scan_zero_byte_images_are_not_duplicate_photos(tmp_path):
+    """Empty image files are corruption/placeholders, not duplicate photos."""
+    from db import Database
+    from scanner import EMPTY_FILE_SHA256, scan
+
+    root = tmp_path / "photos"
+    root.mkdir()
+    (root / "DSC_0001.NEF").write_bytes(b"")
+    (root / "DSC_0002.NEF").write_bytes(b"")
+
+    db = Database(str(tmp_path / "test.db"))
+    scan(str(root), db)
+
+    rows = db.conn.execute(
+        "SELECT filename, file_size, file_hash, flag FROM photos ORDER BY filename"
+    ).fetchall()
+    assert [r["filename"] for r in rows] == ["DSC_0001.NEF", "DSC_0002.NEF"]
+    assert all(r["file_size"] == 0 for r in rows)
+    assert all(r["file_hash"] is None for r in rows)
+    assert all(r["flag"] != "rejected" for r in rows)
+
+    # Historical repair: older scans stored the SHA-256 of empty bytes, which
+    # made unrelated empty files look like exact duplicates and auto-rejected
+    # all but one. A rescan should clear that duplicate identity and undo only
+    # those empty-hash auto-rejections.
+    db.conn.execute(
+        "UPDATE photos SET file_hash = ?, flag = 'rejected'",
+        (EMPTY_FILE_SHA256,),
+    )
+    db.conn.commit()
+
+    scan(str(root), db, incremental=True)
+
+    repaired = db.conn.execute(
+        "SELECT file_hash, flag FROM photos ORDER BY filename"
+    ).fetchall()
+    assert all(r["file_hash"] is None for r in repaired)
+    assert all(r["flag"] == "none" for r in repaired)
+
+
 def test_scan_cancel_check_aborts_before_discovery(tmp_path):
     """scan() honors cancel_check before doing scan work."""
     from db import Database

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -2862,6 +2862,72 @@ def test_rescan_invalidates_caches_when_file_truncated_to_zero(tmp_path):
     )
 
 
+def test_rescan_invalidates_caches_on_null_to_empty_transition(tmp_path):
+    """Legacy/pre-hash rows have ``file_hash = NULL`` but may still carry
+    thumbnails or working copies rendered from their old non-empty bytes.
+    When such a file is later truncated to zero, the scanner clears
+    ``file_hash`` (the empty SHA must not collide as a duplicate
+    identity), so the prior ``prev_file_hash != file_hash`` guard alone
+    couldn't see the transition (None → None). Cache invalidation must
+    still fire in this case — otherwise the stale thumbnail rendered
+    from the original non-empty bytes survives forever.
+    """
+    from db import Database
+    from scanner import scan
+    from thumbnails import generate_thumbnail
+
+    root = str(tmp_path / "photos")
+    os.makedirs(root)
+    img_path = os.path.join(root, "shot.jpg")
+    Image.new("RGB", (800, 600), color=(0, 255, 0)).save(img_path, "JPEG")
+
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    cache_dir = vireo_dir / "thumbnails"
+    cache_dir.mkdir()
+
+    db = Database(str(vireo_dir / "test.db"))
+    scan(root, db, vireo_dir=str(vireo_dir))
+    photo_id = db.get_photos(per_page=100)[0]["id"]
+
+    thumb_path = str(cache_dir / f"{photo_id}.jpg")
+    generate_thumbnail(photo_id, img_path, str(cache_dir))
+    assert os.path.exists(thumb_path)
+
+    # Simulate a legacy pre-hash row whose file_hash was never recorded.
+    # The actual on-disk bytes are still the original non-empty image,
+    # but the DB has no hash baseline to compare against.
+    db.conn.execute(
+        "UPDATE photos SET file_hash = NULL WHERE id = ?", (photo_id,),
+    )
+    db.conn.commit()
+
+    # Replace with a zero-byte file and force the incremental scan to
+    # reprocess by clearing the stored mtime.
+    os.truncate(img_path, 0)
+    db.conn.execute(
+        "UPDATE photos SET file_mtime = 0 WHERE id = ?", (photo_id,)
+    )
+    db.conn.commit()
+
+    scan(root, db, incremental=True, vireo_dir=str(vireo_dir),
+         thumb_cache_dir=str(cache_dir))
+
+    row = db.conn.execute(
+        "SELECT file_hash, file_size FROM photos WHERE id = ?", (photo_id,)
+    ).fetchone()
+    assert row["file_hash"] is None, (
+        "sanity: zero-byte file must not carry an empty-SHA duplicate identity"
+    )
+    assert row["file_size"] == 0
+
+    assert not os.path.exists(thumb_path), (
+        "NULL → empty transition must invalidate derived caches; "
+        "otherwise legacy rows keep the thumbnail rendered from their "
+        "old non-empty bytes after the source file is truncated."
+    )
+
+
 def test_rescan_regenerates_working_copy_when_file_content_changes(tmp_path):
     """When a large JPEG's content changes, re-scan must invalidate the stale
     working copy so the subsequent extraction reflects current pixels."""

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -2801,6 +2801,64 @@ def test_rescan_invalidates_when_prev_file_hash_was_null(tmp_path):
     )
 
 
+def test_rescan_invalidates_caches_when_file_truncated_to_zero(tmp_path):
+    """Truncating a previously-hashed photo to zero bytes is a content
+    change — derived thumbnails and working copies were rendered from
+    the old non-empty bytes and no longer match what's on disk. The
+    zero-byte branch clears ``file_hash`` (so the empty SHA never
+    becomes a duplicate identity) which must NOT bypass the
+    invalidation: otherwise the old thumbnail and working copy stay
+    cached forever, even though the source file is empty.
+    """
+    from db import Database
+    from scanner import scan
+    from thumbnails import generate_thumbnail
+
+    root = str(tmp_path / "photos")
+    os.makedirs(root)
+    img_path = os.path.join(root, "shot.jpg")
+    Image.new("RGB", (800, 600), color=(255, 0, 0)).save(img_path, "JPEG")
+
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    cache_dir = vireo_dir / "thumbnails"
+    cache_dir.mkdir()
+
+    db = Database(str(vireo_dir / "test.db"))
+    scan(root, db, vireo_dir=str(vireo_dir))
+    photo_id = db.get_photos(per_page=100)[0]["id"]
+
+    thumb_path = str(cache_dir / f"{photo_id}.jpg")
+    generate_thumbnail(photo_id, img_path, str(cache_dir))
+    assert os.path.exists(thumb_path)
+
+    # Replace with a zero-byte file. Bump mtime backwards so the
+    # incremental scan actually reprocesses the row instead of taking
+    # the file_unchanged fast path.
+    os.truncate(img_path, 0)
+    db.conn.execute(
+        "UPDATE photos SET file_mtime = 0 WHERE id = ?", (photo_id,)
+    )
+    db.conn.commit()
+
+    scan(root, db, incremental=True, vireo_dir=str(vireo_dir),
+         thumb_cache_dir=str(cache_dir))
+
+    new_hash = db.conn.execute(
+        "SELECT file_hash, file_size FROM photos WHERE id = ?", (photo_id,)
+    ).fetchone()
+    assert new_hash["file_hash"] is None, (
+        "sanity: zero-byte file must not carry an empty-SHA duplicate identity"
+    )
+    assert new_hash["file_size"] == 0
+
+    assert not os.path.exists(thumb_path), (
+        "Invalidation must fire on the truncate-to-zero transition; "
+        "otherwise the thumbnail rendered from the original (non-empty) "
+        "bytes stays cached even though the source file is now empty."
+    )
+
+
 def test_rescan_regenerates_working_copy_when_file_content_changes(tmp_path):
     """When a large JPEG's content changes, re-scan must invalidate the stale
     working copy so the subsequent extraction reflects current pixels."""

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -340,9 +340,12 @@ def test_scan_zero_byte_images_are_not_duplicate_photos(tmp_path):
     assert all(r["flag"] != "rejected" for r in rows)
 
     # Historical repair: older scans stored the SHA-256 of empty bytes, which
-    # made unrelated empty files look like exact duplicates and auto-rejected
-    # all but one. A rescan should clear that duplicate identity and undo only
-    # those empty-hash auto-rejections.
+    # made unrelated empty files look like exact duplicates. A rescan should
+    # clear that duplicate identity. The ``flag`` column is left as-is
+    # because a 'rejected' value could come from the user (Browse / culling)
+    # just as easily as from past duplicate auto-resolution — silently
+    # un-rejecting a manually rejected placeholder would be worse than
+    # leaving it; the duplicates page calls out empty groups for review.
     db.conn.execute(
         "UPDATE photos SET file_hash = ?, flag = 'rejected'",
         (EMPTY_FILE_SHA256,),
@@ -355,7 +358,7 @@ def test_scan_zero_byte_images_are_not_duplicate_photos(tmp_path):
         "SELECT file_hash, flag FROM photos ORDER BY filename"
     ).fetchall()
     assert all(r["file_hash"] is None for r in repaired)
-    assert all(r["flag"] == "none" for r in repaired)
+    assert all(r["flag"] == "rejected" for r in repaired)
 
 
 def test_scan_cancel_check_aborts_before_discovery(tmp_path):


### PR DESCRIPTION
Treat zero-byte image files as empty placeholders instead of exact duplicate photos. The scanner now avoids storing the empty-file SHA-256 as duplicate identity and repairs historical empty-hash rows on rescan, while import duplicate checks ignore zero-byte matches. The duplicates page now calls out zero-byte groups and directs users to check source media or backups before cleanup. Validated with focused scanner/import tests, the duplicate DB suite, and Python compile checks.