### PR TITLE
Unify RAW render-source selection into one resolver

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -30,7 +30,16 @@ from db import (
     IncompatibleDatabaseError,
     commit_with_retry,
 )
-from exif_orientation import orientation_swaps_axes as _orientation_swaps_axes
+from render_source import (
+    companion_image_can_replace_raw_result as _companion_image_can_replace_raw_result,
+    has_current_working_copy_failure as _has_current_working_copy_failure,
+    image_is_smaller_than_expected as _image_is_smaller_than_expected,
+    recipe_render_source as _recipe_render_source,
+    recipe_source_dimensions as _recipe_source_dimensions,
+    record_working_copy_failure as _record_working_copy_failure,
+    scaled_recipe_source_dimensions as _scaled_recipe_source_dimensions,
+)
+from render_source import path_satisfies_recipe_render as _path_satisfies_recipe_render
 from flask import (
     Flask,
     Response,
@@ -54,7 +63,6 @@ from werkzeug.exceptions import BadRequest
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 log = logging.getLogger(__name__)
-_EXIF_ORIENTATION_TAG = 274
 
 # Serializes Windows SetErrorMode calls. SetErrorMode is process-wide, so
 # concurrent /api/volumes requests could otherwise interleave save/restore
@@ -442,7 +450,6 @@ def _collect_highlight_buckets(
 # SQLite versions. Sized below 999 to leave headroom for additional bound
 # parameters in joined statements.
 _SQL_PARAM_CHUNK = 900
-_WORKING_COPY_FAILURE_RETRY_SECONDS = 24 * 60 * 60
 
 
 def _chunked(seq, size=_SQL_PARAM_CHUNK):
@@ -787,147 +794,6 @@ def _build_best_batch_response(db, seed_photo_id, rows):
         "alternate_ids": alternate_ids,
         "suggested_reject_ids": reject_ids,
     }, None
-
-
-def _has_current_working_copy_failure(
-    photo, vireo_dir=None, trust_existing_working_copy=True,
-    live_source_path=None, folder_path=None,
-):
-    """Return True when this RAW already failed working-copy extraction.
-
-    Missing thumbnail/preview requests normally self-heal by decoding the
-    source. For RAW rows whose working-copy extraction already failed at the
-    same source mtime, retrying that decode in a request thread can block the
-    UI for minutes and then fail the same way. A present working copy is still
-    authoritative for thumbnail/preview routes, but callers that have already
-    rejected that copy as insufficient can opt into honoring the marker anyway.
-    A stale ``working_copy_path`` whose file was deleted should not bypass a
-    fresh failure marker. If a RAW+JPEG companion pair has a companion-source
-    marker while both the companion and RAW source are currently available, allow
-    request paths to try the RAW: scanner.py prefers companions for working-copy
-    extraction, so that marker may not describe a RAW failure. Match scanner.py's
-    stale-failure contract: a file replacement changes ``file_mtime`` and
-    failures older than 24 hours are allowed to retry.
-    """
-    def _get(key):
-        try:
-            return photo[key]
-        except (KeyError, IndexError, TypeError):
-            return None
-
-    working_copy_path = _get("working_copy_path")
-    if working_copy_path and trust_existing_working_copy:
-        if not vireo_dir:
-            return False
-        wc_abs = (
-            working_copy_path if os.path.isabs(working_copy_path)
-            else os.path.join(vireo_dir, working_copy_path)
-        )
-        if os.path.exists(wc_abs):
-            return False
-
-    filename = _get("filename") or ""
-    try:
-        from image_loader import RAW_EXTENSIONS
-    except Exception:
-        RAW_EXTENSIONS = {
-            ".nef", ".cr2", ".cr3", ".arw", ".raf", ".dng", ".rw2", ".orf",
-        }
-    if os.path.splitext(filename)[1].lower() not in RAW_EXTENSIONS:
-        return False
-
-    companion_path = _get("companion_path")
-    if companion_path and live_source_path and folder_path:
-        companion_abs = os.path.join(folder_path, companion_path)
-        failed_source = _get("working_copy_failed_source")
-        if (
-            failed_source != "source"
-            and os.path.exists(live_source_path)
-            and os.path.exists(companion_abs)
-        ):
-            return False
-
-    failed_at = _get("working_copy_failed_at")
-    failed_mtime = _get("working_copy_failed_mtime")
-    file_mtime = _get("file_mtime")
-    if not failed_at or failed_mtime is None or file_mtime is None:
-        return False
-    try:
-        if float(failed_mtime) != float(file_mtime):
-            return False
-    except (TypeError, ValueError):
-        return False
-    try:
-        failed_s = str(failed_at).strip()
-        if failed_s.endswith("Z"):
-            failed_s = failed_s[:-1] + "+00:00"
-        failed_dt = datetime.fromisoformat(failed_s)
-        if failed_dt.tzinfo is None:
-            failed_dt = failed_dt.replace(tzinfo=UTC)
-    except (TypeError, ValueError):
-        return False
-    age = (datetime.now(UTC) - failed_dt.astimezone(UTC)).total_seconds()
-    return age < _WORKING_COPY_FAILURE_RETRY_SECONDS
-
-
-def _record_working_copy_failure(db, photo, source_path=None):
-    """Persist a RAW extraction failure marker after a request-time retry.
-
-    When ``_has_current_working_copy_failure`` returns False because the stored
-    marker is older than ``_WORKING_COPY_FAILURE_RETRY_SECONDS``, the request
-    paths are allowed to retry the slow RAW decode. If that retry still fails,
-    we refresh ``working_copy_failed_at``/``working_copy_failed_mtime`` so the
-    next thumbnail/preview/original request fails fast again instead of
-    repeating the expensive decode until the scanner runs. Mirrors the SQL the
-    scanner writes on failure (scanner.py around the working-copy backfill).
-    No-op for non-RAW rows, rows without a recorded ``file_mtime``/``id``,
-    source paths that are currently unavailable/offline, or source paths that
-    aren't the original RAW (e.g. a corrupt working-copy JPEG returned by
-    ``get_canonical_image_path``) — a non-RAW decode failure isn't a RAW
-    extraction failure and must not stamp the RAW marker. Request-time RAW
-    failures are recorded with ``working_copy_failed_source='source'`` so
-    companion-source bypasses do not ignore fresh RAW failures.
-    """
-    def _get(key):
-        try:
-            return photo[key]
-        except (KeyError, IndexError, TypeError):
-            return None
-
-    filename = _get("filename") or ""
-    try:
-        from image_loader import RAW_EXTENSIONS
-    except Exception:
-        RAW_EXTENSIONS = {
-            ".nef", ".cr2", ".cr3", ".arw", ".raf", ".dng", ".rw2", ".orf",
-        }
-    if os.path.splitext(filename)[1].lower() not in RAW_EXTENSIONS:
-        return
-    if source_path is not None:
-        if os.path.splitext(source_path)[1].lower() not in RAW_EXTENSIONS:
-            return
-        if not os.path.exists(source_path):
-            return
-
-    file_mtime = _get("file_mtime")
-    photo_id = _get("id")
-    if file_mtime is None or photo_id is None:
-        return
-
-    try:
-        db.conn.execute(
-            "UPDATE photos SET working_copy_failed_at=datetime('now'),"
-            " working_copy_failed_mtime=?,"
-            " working_copy_failed_source='source'"
-            " WHERE id=?",
-            (file_mtime, photo_id),
-        )
-        db.conn.commit()
-    except Exception:
-        log.debug(
-            "Could not refresh working_copy_failed marker for photo %s",
-            photo_id, exc_info=True,
-        )
 
 
 def _file_manager_labels():
@@ -1831,217 +1697,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             workspace_id=db._ws_id(), _commit=False,
         )
         db.conn.commit()
-
-    def _rendered_recipe_long_edge(width, height, recipe):
-        rotation = (recipe or {}).get("rotation", 0)
-        if rotation in (90, 270):
-            width, height = height, width
-        crop = (recipe or {}).get("crop") if recipe else None
-        if crop:
-            return max(float(crop["w"]) * width, float(crop["h"]) * height)
-        return max(width, height)
-
-    def _photo_value(photo, key):
-        try:
-            return photo[key]
-        except (KeyError, IndexError, TypeError):
-            if hasattr(photo, "get"):
-                return photo.get(key)
-        return None
-
-    def _exif_orientation(exif_data):
-        if not exif_data:
-            return None
-        if isinstance(exif_data, str):
-            try:
-                metadata = json.loads(exif_data)
-            except (TypeError, ValueError):
-                return None
-        elif isinstance(exif_data, dict):
-            metadata = exif_data
-        else:
-            return None
-        if not isinstance(metadata, dict):
-            return None
-        for group in ("EXIF", "IFD0", "TIFF", "File"):
-            values = metadata.get(group)
-            if isinstance(values, dict) and "Orientation" in values:
-                return values["Orientation"]
-        return metadata.get("Orientation")
-
-    def _recipe_source_dimensions(photo):
-        try:
-            width = int(_photo_value(photo, "width") or 0)
-            height = int(_photo_value(photo, "height") or 0)
-        except (TypeError, ValueError):
-            return 0, 0
-        if (
-            width > 0
-            and height > 0
-            and _orientation_swaps_axes(_exif_orientation(_photo_value(photo, "exif_data")))
-        ):
-            return height, width
-        return width, height
-
-    def _scaled_recipe_source_dimensions(photo, max_size=None):
-        width, height = _recipe_source_dimensions(photo)
-        if width <= 0 or height <= 0:
-            return 0, 0
-        if max_size:
-            long_edge = max(width, height)
-            if long_edge > max_size:
-                scale = max_size / long_edge
-                width = round(width * scale)
-                height = round(height * scale)
-        return width, height
-
-    def _image_is_smaller_than_expected(img, expected_w, expected_h):
-        return (
-            expected_w > 0
-            and expected_h > 0
-            and (
-                img.size[0] + 1 < expected_w
-                or img.size[1] + 1 < expected_h
-            )
-        )
-
-    def _companion_image_can_replace_raw_result(
-        companion_img, current_img, expected_w, expected_h,
-    ):
-        if companion_img is None:
-            return False
-        if expected_w > 0 and expected_h > 0:
-            return not _image_is_smaller_than_expected(
-                companion_img, expected_w, expected_h,
-            )
-        if current_img is None:
-            return True
-        return (
-            companion_img.size[0] >= current_img.size[0]
-            and companion_img.size[1] >= current_img.size[1]
-        )
-
-    def _image_size_after_exif_orientation(img):
-        width, height = img.size
-        orientation = None
-        with contextlib.suppress(Exception):
-            orientation = img.getexif().get(_EXIF_ORIENTATION_TAG)
-        if _orientation_swaps_axes(orientation):
-            return height, width
-        return width, height
-
-    def _working_copy_satisfies_recipe_render(photo, recipe, max_size, vireo_dir):
-        if not recipe or not recipe.get("crop"):
-            return True
-        wc_rel = photo["working_copy_path"]
-        if not wc_rel:
-            return False
-        wc_path = os.path.join(vireo_dir, wc_rel)
-        if not os.path.exists(wc_path):
-            return False
-        try:
-            from PIL import Image as _PILImage
-            with _PILImage.open(wc_path) as wc_img:
-                wc_w, wc_h = _image_size_after_exif_orientation(wc_img)
-        except Exception:
-            return False
-        original_w, original_h = _recipe_source_dimensions(photo)
-        if original_w <= 0 or original_h <= 0:
-            return False
-        original_render_long = _rendered_recipe_long_edge(original_w, original_h, recipe)
-        required_long = min(max_size, original_render_long) if max_size else original_render_long
-        wc_render_long = _rendered_recipe_long_edge(wc_w, wc_h, recipe)
-        return wc_render_long >= required_long
-
-    def _path_satisfies_recipe_render(path, photo, recipe, max_size):
-        original_w, original_h = _recipe_source_dimensions(photo)
-        if original_w <= 0 or original_h <= 0:
-            return False
-        try:
-            from PIL import Image as _PILImage
-            with _PILImage.open(path) as img:
-                width, height = _image_size_after_exif_orientation(img)
-        except Exception:
-            return False
-        original_render_long = _rendered_recipe_long_edge(
-            original_w, original_h, recipe,
-        )
-        required_long = min(max_size, original_render_long) if max_size else original_render_long
-        return _rendered_recipe_long_edge(width, height, recipe) >= required_long
-
-    def _recipe_render_source(photo, recipe, max_size, vireo_dir, folders):
-        from image_loader import RAW_EXTENSIONS, get_canonical_image_path
-
-        def _is_working_copy_path(path):
-            wc_rel = photo["working_copy_path"]
-            if not path or not wc_rel:
-                return False
-            wc_path = wc_rel if os.path.isabs(wc_rel) else os.path.join(vireo_dir, wc_rel)
-            return os.path.abspath(path) == os.path.abspath(wc_path)
-
-        if not recipe:
-            canonical = get_canonical_image_path(photo, vireo_dir, folders)
-            return canonical, _is_working_copy_path(canonical)
-
-        primary_is_raw = (
-            os.path.splitext(photo["filename"])[1].lower() in RAW_EXTENSIONS
-        )
-
-        canonical = get_canonical_image_path(photo, vireo_dir, folders)
-        # For RAW primaries with a recipe, never short-circuit to the working
-        # copy: legacy working copies predate the highlight-preserving RAW
-        # decode and EDIT_MATH_VERSION's migration only purges preview/thumb
-        # caches, not working copies. Reusing one would apply the recipe to
-        # clipped bytes and bypass RAW_DECODE_PRESERVE_HIGHLIGHTS. Force the
-        # RAW path; the working copy is still the very last fallback below
-        # if the RAW file itself is missing.
-        if not primary_is_raw:
-            if not recipe.get("crop") and _is_working_copy_path(canonical):
-                return canonical, True
-
-            if recipe.get("crop") and _working_copy_satisfies_recipe_render(
-                photo, recipe, max_size, vireo_dir,
-            ):
-                return canonical, _is_working_copy_path(canonical)
-
-        folder_path = folders.get(photo["folder_id"])
-        if not folder_path:
-            if photo["working_copy_path"]:
-                wc_path = os.path.join(vireo_dir, photo["working_copy_path"])
-                if os.path.exists(wc_path):
-                    return wc_path, True
-            return "", False
-        # For RAW primaries, prefer the RAW source so the caller can decode it
-        # with highlight preservation rather than serving the camera's already-
-        # clipped companion JPEG. The companion remains a valid fallback when
-        # the RAW is known to fail extraction for this mtime — otherwise edited
-        # previews for unsupported RAWs would 500 out even when a full-size
-        # companion is available.
-        companion_path = photo["companion_path"]
-        original_abs = os.path.join(folder_path, photo["filename"])
-        allow_companion = (
-            not primary_is_raw
-            or not os.path.exists(original_abs)
-            or _has_current_working_copy_failure(
-                photo,
-                vireo_dir,
-                trust_existing_working_copy=False,
-                live_source_path=original_abs,
-                folder_path=folder_path,
-            )
-        )
-        if companion_path and allow_companion:
-            companion = os.path.join(folder_path, companion_path)
-            if (
-                os.path.exists(companion)
-                and _path_satisfies_recipe_render(companion, photo, recipe, max_size)
-            ):
-                return companion, True
-        if not os.path.exists(original_abs) and photo["working_copy_path"]:
-            wc_path = os.path.join(vireo_dir, photo["working_copy_path"])
-            if os.path.exists(wc_path):
-                return wc_path, True
-        return original_abs, False
 
     _ACCELERATED_RUNTIME_PROVIDERS = {
         "ACLExecutionProvider",
@@ -9362,25 +9017,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             raw_decode = RAW_DECODE_PRESERVE_HIGHLIGHTS if primary_is_raw else None
             load_kwargs = {"raw_decode": raw_decode} if raw_decode else {}
             img = load_image(source_path, max_size=None, **load_kwargs)
+            expected_w, expected_h = 0, 0
             needs_companion = False
             if primary_is_raw:
-                if img is None:
-                    needs_companion = True
-                else:
-                    # libraw may return the embedded JPEG when it cannot
-                    # demosaic — that preview is typically much smaller
-                    # than the full-size companion JPEG, so the handoff
-                    # would apply the recipe to clipped pixels even when
-                    # a usable sidecar exists. Compare both oriented
-                    # dimensions (with 1px rounding slack) against the
-                    # photo's stored size and trigger the companion
-                    # fallback when the RAW result is undersized.
-                    orig_w, orig_h = _recipe_source_dimensions(photo)
-                    if orig_w > 0 and orig_h > 0 and (
-                        img.size[0] + 1 < orig_w
-                        or img.size[1] + 1 < orig_h
-                    ):
-                        needs_companion = True
+                # libraw may return the embedded JPEG when it cannot
+                # demosaic — that preview is typically much smaller than the
+                # full-size companion JPEG, so the handoff would apply the
+                # recipe to clipped pixels even when a usable sidecar exists.
+                # Trigger the companion fallback when the RAW failed outright
+                # or came back undersized (both axes checked, shared helper).
+                expected_w, expected_h = _recipe_source_dimensions(photo)
+                needs_companion = img is None or _image_is_smaller_than_expected(
+                    img, expected_w, expected_h,
+                )
             if needs_companion:
                 # libraw can't decode this RAW (unsupported variant, corrupt
                 # sensor data, no usable embedded JPEG) or only produced an
@@ -9401,17 +9050,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         != os.path.abspath(source_path)
                     ):
                         companion_img = load_image(companion_abs, max_size=None)
-                        # Prefer companion when it covers img on both axes —
-                        # a long-edge-only check misses cases like a
-                        # 6000x3376 embedded preview "tying" a 6000x4000
+                        # Prefer companion when it covers the expected size on
+                        # both axes — a long-edge-only check misses cases like
+                        # a 6000x3376 embedded preview "tying" a 6000x4000
                         # sidecar and losing the short-edge content.
-                        if companion_img is not None and (
-                            img is None
-                            or (
-                                companion_img.size[0] >= img.size[0]
-                                and companion_img.size[1] >= img.size[1]
-                                and companion_img.size != img.size
-                            )
+                        if _companion_image_can_replace_raw_result(
+                            companion_img, img, expected_w, expected_h,
                         ):
                             if img is None:
                                 log.info(
@@ -11672,22 +11316,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         raw_decode = RAW_DECODE_PRESERVE_HIGHLIGHTS if primary_is_raw else None
         load_kwargs = {"raw_decode": raw_decode} if raw_decode else {}
         img = load_image(source_path, max_size=None, **load_kwargs)
+        expected_w, expected_h = 0, 0
         needs_companion = False
         if primary_is_raw:
-            if img is None:
-                needs_companion = True
-            else:
-                # libraw may return the embedded JPEG when demosaic
-                # fails — see _external_edit_handoff_path for the same
-                # gate. Without this an unsupported RAW would upload
-                # clipped/undersized pixels to iNaturalist even when a
-                # usable sidecar JPEG exists.
-                orig_w, orig_h = _recipe_source_dimensions(photo)
-                if orig_w > 0 and orig_h > 0 and (
-                    img.size[0] + 1 < orig_w
-                    or img.size[1] + 1 < orig_h
-                ):
-                    needs_companion = True
+            # libraw may return the embedded JPEG when demosaic fails — see
+            # _external_edit_handoff_path for the same gate. Without this an
+            # unsupported RAW would upload clipped/undersized pixels to
+            # iNaturalist even when a usable sidecar JPEG exists. Both axes
+            # checked via the shared helper.
+            expected_w, expected_h = _recipe_source_dimensions(photo)
+            needs_companion = img is None or _image_is_smaller_than_expected(
+                img, expected_w, expected_h,
+            )
         if needs_companion:
             # Mirror _external_edit_handoff_path: libraw may fail to decode
             # this RAW variant, but the full-size companion JPEG can still
@@ -11705,17 +11345,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     != os.path.abspath(source_path)
                 ):
                     companion_img = load_image(companion_abs, max_size=None)
-                    # Prefer companion when it covers img on both axes — a
-                    # long-edge-only check misses cases like a 6000x3376
-                    # embedded preview "tying" a 6000x4000 sidecar and
-                    # losing the short-edge content.
-                    if companion_img is not None and (
-                        img is None
-                        or (
-                            companion_img.size[0] >= img.size[0]
-                            and companion_img.size[1] >= img.size[1]
-                            and companion_img.size != img.size
-                        )
+                    # Prefer companion when it covers the expected size on
+                    # both axes — a long-edge-only check misses cases like a
+                    # 6000x3376 embedded preview "tying" a 6000x4000 sidecar
+                    # and losing the short-edge content.
+                    if _companion_image_can_replace_raw_result(
+                        companion_img, img, expected_w, expected_h,
                     ):
                         if img is None:
                             log.info(

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -30,16 +30,6 @@ from db import (
     IncompatibleDatabaseError,
     commit_with_retry,
 )
-from render_source import (
-    companion_image_can_replace_raw_result as _companion_image_can_replace_raw_result,
-    has_current_working_copy_failure as _has_current_working_copy_failure,
-    image_is_smaller_than_expected as _image_is_smaller_than_expected,
-    recipe_render_source as _recipe_render_source,
-    recipe_source_dimensions as _recipe_source_dimensions,
-    record_working_copy_failure as _record_working_copy_failure,
-    scaled_recipe_source_dimensions as _scaled_recipe_source_dimensions,
-)
-from render_source import path_satisfies_recipe_render as _path_satisfies_recipe_render
 from flask import (
     Flask,
     Response,
@@ -58,6 +48,28 @@ from preview_cache import (
 )
 from preview_cache import (
     reconcile_preview_cache,
+)
+from render_source import (
+    companion_image_can_replace_raw_result as _companion_image_can_replace_raw_result,
+)
+from render_source import (
+    has_current_working_copy_failure as _has_current_working_copy_failure,
+)
+from render_source import (
+    image_is_smaller_than_expected as _image_is_smaller_than_expected,
+)
+from render_source import path_satisfies_recipe_render as _path_satisfies_recipe_render
+from render_source import (
+    recipe_render_source as _recipe_render_source,
+)
+from render_source import (
+    recipe_source_dimensions as _recipe_source_dimensions,
+)
+from render_source import (
+    record_working_copy_failure as _record_working_copy_failure,
+)
+from render_source import (
+    scaled_recipe_source_dimensions as _scaled_recipe_source_dimensions,
 )
 from werkzeug.exceptions import BadRequest
 

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -1,6 +1,5 @@
 """Photo export with resize, quality control, and template-based naming."""
 
-import contextlib
 import hashlib
 import logging
 import os
@@ -12,10 +11,14 @@ from image_loader import RAW_DECODE_PRESERVE_HIGHLIGHTS, RAW_EXTENSIONS, load_im
 from render_source import (
     companion_image_can_replace_raw_result,
     image_is_smaller_than_expected,
-    image_size_after_exif_orientation as _image_size_after_exif_orientation,
-    recipe_source_dimensions as _recipe_source_dimensions,
     rendered_recipe_long_edge,
     scaled_recipe_source_dimensions,
+)
+from render_source import (
+    image_size_after_exif_orientation as _image_size_after_exif_orientation,
+)
+from render_source import (
+    recipe_source_dimensions as _recipe_source_dimensions,
 )
 
 log = logging.getLogger(__name__)

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -2,21 +2,26 @@
 
 import contextlib
 import hashlib
-import json
 import logging
 import os
 import re
 import shutil
 
-from exif_orientation import orientation_swaps_axes as _orientation_swaps_axes
 from image_edits import apply_recipe_to_loaded_image
 from image_loader import RAW_DECODE_PRESERVE_HIGHLIGHTS, RAW_EXTENSIONS, load_image
+from render_source import (
+    companion_image_can_replace_raw_result,
+    image_is_smaller_than_expected,
+    image_size_after_exif_orientation as _image_size_after_exif_orientation,
+    recipe_source_dimensions as _recipe_source_dimensions,
+    rendered_recipe_long_edge,
+    scaled_recipe_source_dimensions,
+)
 
 log = logging.getLogger(__name__)
 
 # Characters not allowed in filenames (covers Windows + macOS + Linux)
 _UNSAFE_RE = re.compile(r'[<>:"/|?*\\]')
-_EXIF_ORIENTATION_TAG = 274
 _OUTPUT_FORMATS = {
     "jpg": {"extension": "jpg", "pil_format": "JPEG", "quality": True},
     "jpeg": {"extension": "jpg", "pil_format": "JPEG", "quality": True},
@@ -311,28 +316,10 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
                 needs_companion = img is None
                 expected_w, expected_h = 0, 0
                 if img is not None:
-                    orig_w, orig_h = _recipe_source_dimensions(photo, exif_data)
-                    expected_w, expected_h = orig_w, orig_h
-                    if (
-                        load_max_size
-                        and expected_w > 0
-                        and expected_h > 0
-                    ):
-                        long_edge = max(expected_w, expected_h)
-                        if long_edge > load_max_size:
-                            scale = load_max_size / long_edge
-                            expected_w = round(expected_w * scale)
-                            expected_h = round(expected_h * scale)
-                    # Allow a 1px slack for rounding between RAW decoder
-                    # output and stored dimensions.
-                    if (
-                        expected_w > 0
-                        and expected_h > 0
-                        and (
-                            img.size[0] + 1 < expected_w
-                            or img.size[1] + 1 < expected_h
-                        )
-                    ):
+                    expected_w, expected_h = scaled_recipe_source_dimensions(
+                        photo, load_max_size, exif_data,
+                    )
+                    if image_is_smaller_than_expected(img, expected_w, expected_h):
                         needs_companion = True
                 if needs_companion:
                     companion_fallback = _companion_can_satisfy_export(
@@ -348,13 +335,8 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
                         # like a 6000x3376 embedded preview "tying" a
                         # 6000x4000 sidecar and losing the short-edge
                         # content.
-                        if companion_img is not None and (
-                            img is None
-                            or (
-                                companion_img.size[0] >= img.size[0]
-                                and companion_img.size[1] >= img.size[1]
-                                and companion_img.size != img.size
-                            )
+                        if companion_image_can_replace_raw_result(
+                            companion_img, img, expected_w, expected_h,
                         ):
                             if img is None:
                                 log.info(
@@ -444,49 +426,6 @@ def _get_photo_exif_data(db, photo_ids):
     return out
 
 
-def _recipe_source_dimensions(photo, exif_data=None):
-    """Return original dimensions as load_image sees them after EXIF transpose."""
-    try:
-        width = int(photo["width"] or 0)
-        height = int(photo["height"] or 0)
-    except (KeyError, IndexError, TypeError, ValueError):
-        return 0, 0
-    if width > 0 and height > 0 and _orientation_swaps_axes(_exif_orientation(exif_data)):
-        return height, width
-    return width, height
-
-
-def _exif_orientation(exif_data):
-    if not exif_data:
-        return None
-    if isinstance(exif_data, str):
-        try:
-            metadata = json.loads(exif_data)
-        except (TypeError, ValueError):
-            return None
-    elif isinstance(exif_data, dict):
-        metadata = exif_data
-    else:
-        return None
-    if not isinstance(metadata, dict):
-        return None
-    for group in ("EXIF", "IFD0", "TIFF", "File"):
-        values = metadata.get(group)
-        if isinstance(values, dict) and "Orientation" in values:
-            return values["Orientation"]
-    return metadata.get("Orientation")
-
-
-def _image_size_after_exif_orientation(img):
-    width, height = img.size
-    orientation = None
-    with contextlib.suppress(Exception):
-        orientation = img.getexif().get(_EXIF_ORIENTATION_TAG)
-    if _orientation_swaps_axes(orientation):
-        return height, width
-    return width, height
-
-
 def _recipe_result_dimensions(width, height, recipe):
     """Return rendered dimensions after right-angle rotation and crop."""
     rotation = (recipe or {}).get("rotation", 0)
@@ -512,8 +451,7 @@ def _scale_dimensions_to_max(width, height, max_size):
 
 def _recipe_result_long_edge(width, height, recipe):
     """Return the rendered long edge after right-angle rotation and crop."""
-    width, height = _recipe_result_dimensions(width, height, recipe)
-    return max(width, height)
+    return rendered_recipe_long_edge(width, height, recipe)
 
 
 def _developed_can_satisfy_size(dev_path, photo, max_size, recipe=None, exif_data=None):

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -18,7 +18,6 @@ import tempfile
 import threading
 import time
 from dataclasses import dataclass
-from datetime import UTC, datetime
 
 import numpy as np
 from db import Database, commit_with_retry
@@ -26,13 +25,22 @@ from model_cache import get_default_cache
 from pipeline_locks import acquire_photo_mask, acquire_workspace_regroup
 from render_source import (
     companion_image_can_replace_raw_result as _companion_image_can_replace_raw_result,
+)
+from render_source import (
     has_current_working_copy_failure as _has_current_working_copy_failure,
+)
+from render_source import (
     image_is_smaller_than_expected as _image_is_smaller_than_expected,
+)
+from render_source import (
     photo_value as _photo_value,
+)
+from render_source import (
     recipe_render_source,
+)
+from render_source import (
     scaled_recipe_source_dimensions as _scaled_recipe_source_dimensions,
 )
-from render_source import path_satisfies_recipe_render as _path_satisfies_recipe_render
 
 log = logging.getLogger(__name__)
 

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -22,14 +22,21 @@ from datetime import UTC, datetime
 
 import numpy as np
 from db import Database, commit_with_retry
-from exif_orientation import orientation_swaps_axes as _orientation_swaps_axes
 from model_cache import get_default_cache
 from pipeline_locks import acquire_photo_mask, acquire_workspace_regroup
+from render_source import (
+    companion_image_can_replace_raw_result as _companion_image_can_replace_raw_result,
+    has_current_working_copy_failure as _has_current_working_copy_failure,
+    image_is_smaller_than_expected as _image_is_smaller_than_expected,
+    photo_value as _photo_value,
+    recipe_render_source,
+    scaled_recipe_source_dimensions as _scaled_recipe_source_dimensions,
+)
+from render_source import path_satisfies_recipe_render as _path_satisfies_recipe_render
 
 log = logging.getLogger(__name__)
 
 _SENTINEL = object()  # unique end-of-stream marker
-_EXIF_ORIENTATION_TAG = 274
 
 
 @dataclass
@@ -68,212 +75,13 @@ def _should_abort(abort_event):
     return abort_event.is_set()
 
 
-def _rendered_recipe_long_edge(width, height, recipe):
-    rotation = (recipe or {}).get("rotation", 0)
-    if rotation in (90, 270):
-        width, height = height, width
-    crop = (recipe or {}).get("crop") if recipe else None
-    if crop:
-        return max(float(crop["w"]) * width, float(crop["h"]) * height)
-    return max(width, height)
-
-
-def _photo_value(photo, key):
-    try:
-        return photo[key]
-    except (KeyError, IndexError, TypeError):
-        if hasattr(photo, "get"):
-            return photo.get(key)
-    return None
-
-
-def _exif_orientation(exif_data):
-    if not exif_data:
-        return None
-    if isinstance(exif_data, str):
-        try:
-            metadata = json.loads(exif_data)
-        except (TypeError, ValueError):
-            return None
-    elif isinstance(exif_data, dict):
-        metadata = exif_data
-    else:
-        return None
-    if not isinstance(metadata, dict):
-        return None
-    for group in ("EXIF", "IFD0", "TIFF", "File"):
-        values = metadata.get(group)
-        if isinstance(values, dict) and "Orientation" in values:
-            return values["Orientation"]
-    return metadata.get("Orientation")
-
-
-def _recipe_source_dimensions(photo):
-    try:
-        width = int(_photo_value(photo, "width") or 0)
-        height = int(_photo_value(photo, "height") or 0)
-    except (TypeError, ValueError):
-        return 0, 0
-    if (
-        width > 0
-        and height > 0
-        and _orientation_swaps_axes(_exif_orientation(_photo_value(photo, "exif_data")))
-    ):
-        return height, width
-    return width, height
-
-
-def _scaled_recipe_source_dimensions(photo, max_size=None):
-    width, height = _recipe_source_dimensions(photo)
-    if width <= 0 or height <= 0:
-        return 0, 0
-    if max_size:
-        long_edge = max(width, height)
-        if long_edge > max_size:
-            scale = max_size / long_edge
-            width = round(width * scale)
-            height = round(height * scale)
-    return width, height
-
-
-def _image_is_smaller_than_expected(img, expected_w, expected_h):
-    return (
-        expected_w > 0
-        and expected_h > 0
-        and (
-            img.size[0] + 1 < expected_w
-            or img.size[1] + 1 < expected_h
-        )
-    )
-
-
-def _companion_image_can_replace_raw_result(
-    companion_img, current_img, expected_w, expected_h,
-):
-    if companion_img is None:
-        return False
-    if expected_w > 0 and expected_h > 0:
-        return not _image_is_smaller_than_expected(
-            companion_img, expected_w, expected_h,
-        )
-    if current_img is None:
-        return True
-    return (
-        companion_img.size[0] >= current_img.size[0]
-        and companion_img.size[1] >= current_img.size[1]
-    )
-
-
-def _image_size_after_exif_orientation(img):
-    width, height = img.size
-    orientation = None
-    with contextlib.suppress(Exception):
-        orientation = img.getexif().get(_EXIF_ORIENTATION_TAG)
-    if _orientation_swaps_axes(orientation):
-        return height, width
-    return width, height
-
-
-def _working_copy_satisfies_recipe_render(photo, recipe, max_size, vireo_dir):
-    if not recipe or not recipe.get("crop"):
-        return True
-    wc_rel = photo["working_copy_path"]
-    if not wc_rel:
-        return False
-    wc_path = os.path.join(vireo_dir, wc_rel)
-    if not os.path.exists(wc_path):
-        return False
-    try:
-        from PIL import Image as _PILImage
-        with _PILImage.open(wc_path) as wc_img:
-            wc_w, wc_h = _image_size_after_exif_orientation(wc_img)
-    except Exception:
-        return False
-    original_w, original_h = _recipe_source_dimensions(photo)
-    if original_w <= 0 or original_h <= 0:
-        return False
-    original_render_long = _rendered_recipe_long_edge(original_w, original_h, recipe)
-    required_long = min(max_size, original_render_long) if max_size else original_render_long
-    wc_render_long = _rendered_recipe_long_edge(wc_w, wc_h, recipe)
-    return wc_render_long >= required_long
-
-
-def _path_satisfies_recipe_render(path, photo, recipe, max_size):
-    original_w, original_h = _recipe_source_dimensions(photo)
-    if original_w <= 0 or original_h <= 0:
-        return False
-    try:
-        from PIL import Image as _PILImage
-        with _PILImage.open(path) as img:
-            width, height = _image_size_after_exif_orientation(img)
-    except Exception:
-        return False
-    original_render_long = _rendered_recipe_long_edge(
-        original_w, original_h, recipe,
-    )
-    required_long = min(max_size, original_render_long) if max_size else original_render_long
-    return _rendered_recipe_long_edge(width, height, recipe) >= required_long
-
-
 def _recipe_render_source(photo, recipe, max_size, vireo_dir, folders):
-    from image_loader import get_canonical_image_path
+    """Thin wrapper around the shared resolver, returning just the path.
 
-    if not recipe:
-        return get_canonical_image_path(photo, vireo_dir, folders)
-    primary_is_raw = (
-        os.path.splitext(photo["filename"])[1].lower() in _RAW_EXTENSIONS
-    )
-    canonical = get_canonical_image_path(photo, vireo_dir, folders)
-    wc_rel = photo["working_copy_path"]
-    # For RAW primaries with a recipe, never short-circuit to the working
-    # copy: legacy working copies predate the highlight-preserving RAW
-    # decode, and EDIT_MATH_VERSION's migration only purges preview/thumb
-    # caches, not working copies. Reusing one would apply the recipe to
-    # clipped bytes and bypass RAW_DECODE_PRESERVE_HIGHLIGHTS.
-    if not primary_is_raw:
-        if not recipe.get("crop") and canonical and wc_rel:
-            wc_path = wc_rel if os.path.isabs(wc_rel) else os.path.join(vireo_dir, wc_rel)
-            if os.path.abspath(canonical) == os.path.abspath(wc_path):
-                return canonical
-        if recipe.get("crop") and _working_copy_satisfies_recipe_render(
-            photo, recipe, max_size, vireo_dir,
-        ):
-            return canonical
-
-    folder_path = folders.get(photo["folder_id"])
-    if not folder_path:
-        if photo["working_copy_path"]:
-            wc_path = os.path.join(vireo_dir, photo["working_copy_path"])
-            if os.path.exists(wc_path):
-                return wc_path
-        return ""
-    # When the primary is RAW, prefer the RAW source so the caller can decode
-    # with highlight preservation rather than serving the camera's already-
-    # clipped companion JPEG. The companion remains a valid fallback when the
-    # RAW is known to fail extraction for this mtime — otherwise edited
-    # previews/exports for unsupported RAWs would 500 out even though a
-    # full-size companion JPEG is available.
-    companion_path = photo["companion_path"]
-    original = os.path.join(folder_path, photo["filename"])
-    allow_companion = not primary_is_raw or _has_current_working_copy_failure(
-        photo,
-        vireo_dir,
-        trust_existing_working_copy=False,
-        live_source_path=original,
-        folder_path=folder_path,
-    )
-    if companion_path and allow_companion:
-        companion = os.path.join(folder_path, companion_path)
-        if (
-            os.path.exists(companion)
-            and _path_satisfies_recipe_render(companion, photo, recipe, max_size)
-        ):
-            return companion
-    if not os.path.exists(original) and photo["working_copy_path"]:
-        wc_path = os.path.join(vireo_dir, photo["working_copy_path"])
-        if os.path.exists(wc_path):
-            return wc_path
-    return original
+    Pipeline callers don't need the ``using_working_copy`` flag, so the second
+    element of :func:`render_source.recipe_render_source` is dropped.
+    """
+    return recipe_render_source(photo, recipe, max_size, vireo_dir, folders)[0]
 
 
 def _incomplete_model_message(model_name, is_custom=False):
@@ -300,7 +108,6 @@ def _looks_like_missing_external_data(err):
 
 
 _RAW_EXTENSIONS = (".nef", ".cr2", ".cr3", ".arw", ".raf", ".dng", ".rw2", ".orf")
-_WORKING_COPY_FAILURE_RETRY_SECONDS = 24 * 60 * 60
 
 
 def _thumb_raw_decode_kwargs(photo, recipe):
@@ -335,59 +142,6 @@ def _thumb_min_source_size_kwargs(photo, recipe, thumb_size, source_path):
     return {
         "min_source_size": _scaled_recipe_source_dimensions(photo, load_max_size),
     }
-
-
-def _has_current_working_copy_failure(
-    photo, vireo_dir=None, trust_existing_working_copy=True,
-    live_source_path=None, folder_path=None,
-):
-    working_copy_path = _photo_value(photo, "working_copy_path")
-    if working_copy_path and trust_existing_working_copy:
-        if not vireo_dir:
-            return False
-        wc_abs = (
-            working_copy_path if os.path.isabs(working_copy_path)
-            else os.path.join(vireo_dir, working_copy_path)
-        )
-        if os.path.exists(wc_abs):
-            return False
-
-    filename = _photo_value(photo, "filename") or ""
-    if os.path.splitext(filename)[1].lower() not in _RAW_EXTENSIONS:
-        return False
-
-    companion_path = _photo_value(photo, "companion_path")
-    if companion_path and live_source_path and folder_path:
-        companion_abs = os.path.join(folder_path, companion_path)
-        failed_source = _photo_value(photo, "working_copy_failed_source")
-        if (
-            failed_source != "source"
-            and os.path.exists(live_source_path)
-            and os.path.exists(companion_abs)
-        ):
-            return False
-
-    failed_at = _photo_value(photo, "working_copy_failed_at")
-    failed_mtime = _photo_value(photo, "working_copy_failed_mtime")
-    file_mtime = _photo_value(photo, "file_mtime")
-    if not failed_at or failed_mtime is None or file_mtime is None:
-        return False
-    try:
-        if float(failed_mtime) != float(file_mtime):
-            return False
-    except (TypeError, ValueError):
-        return False
-    try:
-        failed_s = str(failed_at).strip()
-        if failed_s.endswith("Z"):
-            failed_s = failed_s[:-1] + "+00:00"
-        failed_dt = datetime.fromisoformat(failed_s)
-        if failed_dt.tzinfo is None:
-            failed_dt = failed_dt.replace(tzinfo=UTC)
-    except (TypeError, ValueError):
-        return False
-    age = (datetime.now(UTC) - failed_dt.astimezone(UTC)).total_seconds()
-    return age < _WORKING_COPY_FAILURE_RETRY_SECONDS
 
 
 def _retry_thumbnail_with_companion(

--- a/vireo/render_source.py
+++ b/vireo/render_source.py
@@ -1,0 +1,450 @@
+"""Single source of truth for edit-render source selection.
+
+For an edited photo, several flows (preview, preview-warmer, edit-preview,
+edited-original serving, thumbnail self-heal, export, external-editor and
+iNaturalist hand-off, and the scanner's working-copy extraction) must answer
+the same questions:
+
+* Which file do we actually decode — the RAW primary, the companion JPEG, the
+  working copy, or the original? (:func:`recipe_render_source`)
+* After decoding, is the result big enough, or did libraw hand us a small
+  embedded preview that a full-size companion JPEG should replace?
+  (:func:`is_undersized` / :func:`companion_image_can_replace_raw_result`)
+* Has this RAW already failed extraction for the current source mtime, so a
+  request thread should not block on the same slow decode again?
+  (:func:`has_current_working_copy_failure` / :func:`record_working_copy_failure`)
+
+Historically each flow carried its own copy of these helpers across
+``app.py``, ``pipeline_job.py``, ``thumbnails.py``, ``export.py`` and
+``scanner.py``. The copies drifted (long-edge-only vs both-axis dimension
+checks, ``+1px`` vs ``*0.99`` tolerances, EXIF-orientation axis swaps applied
+in some copies but not others), so a fix in one flow never reached the
+others. This module holds the canonical implementations; the per-flow modules
+import them so a single change covers every flow.
+"""
+
+import contextlib
+import json
+import logging
+import os
+from datetime import UTC, datetime
+
+from exif_orientation import orientation_swaps_axes
+from image_loader import RAW_EXTENSIONS, get_canonical_image_path
+
+log = logging.getLogger(__name__)
+
+# Stored failure markers expire after this long so transient I/O / environment
+# failures recover even when the source file itself is unchanged. Must match
+# scanner.py's ``_FAILURE_RETRY_AFTER`` window.
+WORKING_COPY_FAILURE_RETRY_SECONDS = 24 * 60 * 60
+
+# PIL's numeric tag id for EXIF ``Orientation``.
+EXIF_ORIENTATION_TAG = 274
+
+# Sentinel so ``recipe_source_dimensions`` can distinguish "read exif_data from
+# the photo row" from an explicit ``exif_data=None`` passed by export.py.
+_UNSET = object()
+
+
+def photo_value(photo, key):
+    """Read ``key`` from a sqlite Row or a plain dict, returning None if absent."""
+    try:
+        return photo[key]
+    except (KeyError, IndexError, TypeError):
+        if hasattr(photo, "get"):
+            return photo.get(key)
+    return None
+
+
+def exif_orientation(exif_data):
+    """Return the EXIF ``Orientation`` value from stored metadata, or None.
+
+    ``exif_data`` may be a JSON string (as stored on the photo row) or an
+    already-parsed dict. Looks in the common metadata groups ExifTool emits
+    before falling back to a top-level ``Orientation`` key.
+    """
+    if not exif_data:
+        return None
+    if isinstance(exif_data, str):
+        try:
+            metadata = json.loads(exif_data)
+        except (TypeError, ValueError):
+            return None
+    elif isinstance(exif_data, dict):
+        metadata = exif_data
+    else:
+        return None
+    if not isinstance(metadata, dict):
+        return None
+    for group in ("EXIF", "IFD0", "TIFF", "File"):
+        values = metadata.get(group)
+        if isinstance(values, dict) and "Orientation" in values:
+            return values["Orientation"]
+    return metadata.get("Orientation")
+
+
+def recipe_source_dimensions(photo, exif_data=_UNSET):
+    """Return the photo's (width, height) as ``load_image`` sees them.
+
+    Stored width/height are the unrotated sensor axes; this normalizes them to
+    display orientation (swapping for EXIF orientations 5-8) so callers compare
+    against the orientation-corrected pixels ``load_image`` returns. Pass
+    ``exif_data`` explicitly when it isn't on the photo row (export.py loads it
+    separately); otherwise it's read from ``photo['exif_data']``.
+    """
+    try:
+        width = int(photo_value(photo, "width") or 0)
+        height = int(photo_value(photo, "height") or 0)
+    except (TypeError, ValueError):
+        return 0, 0
+    if width <= 0 or height <= 0:
+        return 0, 0
+    if exif_data is _UNSET:
+        exif_data = photo_value(photo, "exif_data")
+    if orientation_swaps_axes(exif_orientation(exif_data)):
+        return height, width
+    return width, height
+
+
+def scaled_recipe_source_dimensions(photo, max_size=None, exif_data=_UNSET):
+    """Like :func:`recipe_source_dimensions` but scaled down to ``max_size``.
+
+    Mirrors ``load_image``'s long-edge downscale so callers can compare a
+    loaded image against the dimensions a same-``max_size`` decode would yield.
+    """
+    width, height = recipe_source_dimensions(photo, exif_data)
+    if width <= 0 or height <= 0:
+        return 0, 0
+    if max_size:
+        long_edge = max(width, height)
+        if long_edge > max_size:
+            scale = max_size / long_edge
+            width = round(width * scale)
+            height = round(height * scale)
+    return width, height
+
+
+def rendered_recipe_long_edge(width, height, recipe):
+    """Return the rendered long edge after right-angle rotation and crop."""
+    rotation = (recipe or {}).get("rotation", 0)
+    if rotation in (90, 270):
+        width, height = height, width
+    crop = (recipe or {}).get("crop") if recipe else None
+    if crop:
+        return max(float(crop["w"]) * width, float(crop["h"]) * height)
+    return max(width, height)
+
+
+def image_size_after_exif_orientation(img):
+    """Return an opened image's (width, height) after EXIF transpose."""
+    width, height = img.size
+    orientation = None
+    with contextlib.suppress(Exception):
+        orientation = img.getexif().get(EXIF_ORIENTATION_TAG)
+    if orientation_swaps_axes(orientation):
+        return height, width
+    return width, height
+
+
+def is_undersized(width, height, expected_w, expected_h, *, abs_slack=1, rel_slack=0.0):
+    """Return True when (width, height) falls short of the expected size.
+
+    Compares *both* axes — a long-edge-only check accepts e.g. a 6000x3376
+    embedded preview for a 6000x4000 source and silently drops short-edge
+    content. The tolerance is explicit so callers can pick the slack their
+    comparison needs without forking the logic:
+
+    * ``abs_slack`` (default 1px) absorbs rounding between a RAW decoder's
+      output and the stored dimensions — used by the request-path checks that
+      compare a decoded preview against a full-size companion.
+    * ``rel_slack`` (e.g. 0.01) absorbs libraw emitting the active image area a
+      few pixels narrower than the full sensor — used by the scanner's
+      RAW working-copy size gate so a valid extraction isn't marked failed.
+
+    The more lenient (smaller) of the two thresholds wins so passing both is
+    safe. Returns False when the expected size is unknown (<= 0).
+    """
+    if expected_w <= 0 or expected_h <= 0:
+        return False
+    thr_w = min(expected_w - abs_slack, expected_w * (1.0 - rel_slack))
+    thr_h = min(expected_h - abs_slack, expected_h * (1.0 - rel_slack))
+    return width < thr_w or height < thr_h
+
+
+def image_is_smaller_than_expected(img, expected_w, expected_h, *, abs_slack=1, rel_slack=0.0):
+    """:func:`is_undersized` applied to an opened image's size."""
+    return is_undersized(
+        img.size[0], img.size[1], expected_w, expected_h,
+        abs_slack=abs_slack, rel_slack=rel_slack,
+    )
+
+
+def companion_image_can_replace_raw_result(
+    companion_img, current_img, expected_w, expected_h,
+):
+    """Return True when the companion JPEG should replace a RAW decode result.
+
+    When the expected size is known, the companion qualifies if it meets that
+    size on both axes. Otherwise it must cover the current decode on both axes.
+    """
+    if companion_img is None:
+        return False
+    if expected_w > 0 and expected_h > 0:
+        return not image_is_smaller_than_expected(
+            companion_img, expected_w, expected_h,
+        )
+    if current_img is None:
+        return True
+    return (
+        companion_img.size[0] >= current_img.size[0]
+        and companion_img.size[1] >= current_img.size[1]
+    )
+
+
+def working_copy_satisfies_recipe_render(photo, recipe, max_size, vireo_dir):
+    """Return True when the working copy is large enough for this recipe render.
+
+    Uncropped renders are always satisfiable by the working copy; cropped ones
+    must keep enough rendered long edge after the crop.
+    """
+    if not recipe or not recipe.get("crop"):
+        return True
+    wc_rel = photo_value(photo, "working_copy_path")
+    if not wc_rel:
+        return False
+    wc_path = os.path.join(vireo_dir, wc_rel)
+    if not os.path.exists(wc_path):
+        return False
+    try:
+        from PIL import Image as _PILImage
+        with _PILImage.open(wc_path) as wc_img:
+            wc_w, wc_h = image_size_after_exif_orientation(wc_img)
+    except Exception:
+        return False
+    original_w, original_h = recipe_source_dimensions(photo)
+    if original_w <= 0 or original_h <= 0:
+        return False
+    original_render_long = rendered_recipe_long_edge(original_w, original_h, recipe)
+    required_long = (
+        min(max_size, original_render_long) if max_size else original_render_long
+    )
+    wc_render_long = rendered_recipe_long_edge(wc_w, wc_h, recipe)
+    return wc_render_long >= required_long
+
+
+def path_satisfies_recipe_render(path, photo, recipe, max_size):
+    """Return True when the file at ``path`` is large enough for this render."""
+    original_w, original_h = recipe_source_dimensions(photo)
+    if original_w <= 0 or original_h <= 0:
+        return False
+    try:
+        from PIL import Image as _PILImage
+        with _PILImage.open(path) as img:
+            width, height = image_size_after_exif_orientation(img)
+    except Exception:
+        return False
+    original_render_long = rendered_recipe_long_edge(original_w, original_h, recipe)
+    required_long = (
+        min(max_size, original_render_long) if max_size else original_render_long
+    )
+    return rendered_recipe_long_edge(width, height, recipe) >= required_long
+
+
+def recipe_render_source(photo, recipe, max_size, vireo_dir, folders):
+    """Pick the file to decode for an edited render. Returns (path, using_wc).
+
+    ``using_wc`` is True when the returned path is the photo's working copy —
+    callers use it to skip the RAW-failure gate (a working copy is already a
+    decoded JPEG, not a fresh RAW decode that could block).
+
+    Selection rules:
+
+    * No recipe: the canonical path (working copy if present, else original).
+    * RAW primaries with a recipe never short-circuit to the working copy —
+      legacy working copies predate the highlight-preserving RAW decode and
+      ``EDIT_MATH_VERSION``'s migration only purges preview/thumb caches, not
+      working copies, so reusing one would apply the recipe to clipped bytes.
+    * Non-RAW primaries may use the working copy when it satisfies the render.
+    * The companion JPEG is used for a RAW primary only when the RAW source is
+      offline or already marked failed for the current mtime; otherwise the RAW
+      is decoded with highlight preservation.
+    * The working copy is the last fallback when the original is offline.
+    """
+    if not vireo_dir:
+        folder_path = folders.get(photo_value(photo, "folder_id"), "")
+        return os.path.join(folder_path, photo_value(photo, "filename") or ""), False
+
+    def _is_working_copy_path(path):
+        wc_rel = photo_value(photo, "working_copy_path")
+        if not path or not wc_rel:
+            return False
+        wc_path = (
+            wc_rel if os.path.isabs(wc_rel) else os.path.join(vireo_dir, wc_rel)
+        )
+        return os.path.abspath(path) == os.path.abspath(wc_path)
+
+    canonical = get_canonical_image_path(photo, vireo_dir, folders)
+    if not recipe:
+        return canonical, _is_working_copy_path(canonical)
+
+    primary_is_raw = (
+        os.path.splitext(photo_value(photo, "filename"))[1].lower() in RAW_EXTENSIONS
+    )
+
+    if not primary_is_raw:
+        if not recipe.get("crop") and _is_working_copy_path(canonical):
+            return canonical, True
+        if recipe.get("crop") and working_copy_satisfies_recipe_render(
+            photo, recipe, max_size, vireo_dir,
+        ):
+            return canonical, _is_working_copy_path(canonical)
+
+    folder_path = folders.get(photo_value(photo, "folder_id"))
+    wc_rel = photo_value(photo, "working_copy_path")
+    if not folder_path:
+        if wc_rel:
+            wc_path = os.path.join(vireo_dir, wc_rel)
+            if os.path.exists(wc_path):
+                return wc_path, True
+        return "", False
+
+    companion_path = photo_value(photo, "companion_path")
+    original_abs = os.path.join(folder_path, photo_value(photo, "filename"))
+    allow_companion = (
+        not primary_is_raw
+        or not os.path.exists(original_abs)
+        or has_current_working_copy_failure(
+            photo,
+            vireo_dir,
+            trust_existing_working_copy=False,
+            live_source_path=original_abs,
+            folder_path=folder_path,
+        )
+    )
+    if companion_path and allow_companion:
+        companion = os.path.join(folder_path, companion_path)
+        if os.path.exists(companion) and path_satisfies_recipe_render(
+            companion, photo, recipe, max_size,
+        ):
+            return companion, True
+    if not os.path.exists(original_abs) and wc_rel:
+        wc_path = os.path.join(vireo_dir, wc_rel)
+        if os.path.exists(wc_path):
+            return wc_path, True
+    return original_abs, False
+
+
+def has_current_working_copy_failure(
+    photo, vireo_dir=None, trust_existing_working_copy=True,
+    live_source_path=None, folder_path=None,
+):
+    """Return True when this RAW already failed working-copy extraction.
+
+    Missing thumbnail/preview requests normally self-heal by decoding the
+    source. For RAW rows whose working-copy extraction already failed at the
+    same source mtime, retrying that decode in a request thread can block the
+    UI for minutes and then fail the same way. A present working copy is still
+    authoritative for thumbnail/preview routes, but callers that have already
+    rejected that copy as insufficient can opt into honoring the marker anyway.
+    A stale ``working_copy_path`` whose file was deleted should not bypass a
+    fresh failure marker. If a RAW+JPEG companion pair has a companion-source
+    marker while both the companion and RAW source are currently available,
+    allow request paths to try the RAW: scanner.py prefers companions for
+    working-copy extraction, so that marker may not describe a RAW failure.
+    Match scanner.py's stale-failure contract: a file replacement changes
+    ``file_mtime`` and failures older than 24 hours are allowed to retry.
+    """
+    working_copy_path = photo_value(photo, "working_copy_path")
+    if working_copy_path and trust_existing_working_copy:
+        if not vireo_dir:
+            return False
+        wc_abs = (
+            working_copy_path if os.path.isabs(working_copy_path)
+            else os.path.join(vireo_dir, working_copy_path)
+        )
+        if os.path.exists(wc_abs):
+            return False
+
+    filename = photo_value(photo, "filename") or ""
+    if os.path.splitext(filename)[1].lower() not in RAW_EXTENSIONS:
+        return False
+
+    companion_path = photo_value(photo, "companion_path")
+    if companion_path and live_source_path and folder_path:
+        companion_abs = os.path.join(folder_path, companion_path)
+        failed_source = photo_value(photo, "working_copy_failed_source")
+        if (
+            failed_source != "source"
+            and os.path.exists(live_source_path)
+            and os.path.exists(companion_abs)
+        ):
+            return False
+
+    failed_at = photo_value(photo, "working_copy_failed_at")
+    failed_mtime = photo_value(photo, "working_copy_failed_mtime")
+    file_mtime = photo_value(photo, "file_mtime")
+    if not failed_at or failed_mtime is None or file_mtime is None:
+        return False
+    try:
+        if float(failed_mtime) != float(file_mtime):
+            return False
+    except (TypeError, ValueError):
+        return False
+    try:
+        failed_s = str(failed_at).strip()
+        if failed_s.endswith("Z"):
+            failed_s = failed_s[:-1] + "+00:00"
+        failed_dt = datetime.fromisoformat(failed_s)
+        if failed_dt.tzinfo is None:
+            failed_dt = failed_dt.replace(tzinfo=UTC)
+    except (TypeError, ValueError):
+        return False
+    age = (datetime.now(UTC) - failed_dt.astimezone(UTC)).total_seconds()
+    return age < WORKING_COPY_FAILURE_RETRY_SECONDS
+
+
+def record_working_copy_failure(db, photo, source_path=None):
+    """Persist a RAW extraction failure marker after a request-time retry.
+
+    When :func:`has_current_working_copy_failure` returns False because the
+    stored marker is older than ``WORKING_COPY_FAILURE_RETRY_SECONDS``, request
+    paths are allowed to retry the slow RAW decode. If that retry still fails,
+    refresh ``working_copy_failed_at``/``working_copy_failed_mtime`` so the next
+    thumbnail/preview/original request fails fast again instead of repeating the
+    expensive decode until the scanner runs. Mirrors the SQL the scanner writes
+    on failure. No-op for non-RAW rows, rows without a recorded
+    ``file_mtime``/``id``, source paths that are currently unavailable/offline,
+    or source paths that aren't the original RAW (e.g. a corrupt working-copy
+    JPEG) — a non-RAW decode failure isn't a RAW extraction failure and must not
+    stamp the RAW marker. Recorded with ``working_copy_failed_source='source'``
+    so companion-source bypasses do not ignore fresh RAW failures.
+    """
+    filename = photo_value(photo, "filename") or ""
+    if os.path.splitext(filename)[1].lower() not in RAW_EXTENSIONS:
+        return
+    if source_path is not None:
+        if os.path.splitext(source_path)[1].lower() not in RAW_EXTENSIONS:
+            return
+        if not os.path.exists(source_path):
+            return
+
+    file_mtime = photo_value(photo, "file_mtime")
+    photo_id = photo_value(photo, "id")
+    if file_mtime is None or photo_id is None:
+        return
+
+    try:
+        db.conn.execute(
+            "UPDATE photos SET working_copy_failed_at=datetime('now'),"
+            " working_copy_failed_mtime=?,"
+            " working_copy_failed_source='source'"
+            " WHERE id=?",
+            (file_mtime, photo_id),
+        )
+        db.conn.commit()
+    except Exception:
+        log.debug(
+            "Could not refresh working_copy_failed marker for photo %s",
+            photo_id, exc_info=True,
+        )

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -16,8 +16,6 @@ from pathlib import Path
 import imagehash
 from db import commit_with_retry
 from exif_orientation import orientation_swaps_axes as _orientation_swaps_axes
-from render_source import exif_orientation as _exif_orientation_from_data
-from render_source import is_undersized
 from image_loader import (
     RAW_EXTENSIONS,
     SUPPORTED_EXTENSIONS,
@@ -28,6 +26,8 @@ from image_loader import (
 )
 from metadata import extract_metadata
 from PIL import Image
+from render_source import exif_orientation as _exif_orientation_from_data
+from render_source import is_undersized
 from xmp import read_hierarchical_keywords, read_keywords
 
 log = logging.getLogger(__name__)

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -16,6 +16,8 @@ from pathlib import Path
 import imagehash
 from db import commit_with_retry
 from exif_orientation import orientation_swaps_axes as _orientation_swaps_axes
+from render_source import exif_orientation as _exif_orientation_from_data
+from render_source import is_undersized
 from image_loader import (
     RAW_EXTENSIONS,
     SUPPORTED_EXTENSIONS,
@@ -70,29 +72,6 @@ def _scaled_dimensions(width, height, max_size):
             width = round(width * scale)
             height = round(height * scale)
     return width, height
-
-
-def _exif_orientation_from_data(exif_data):
-    # Mirror of vireo.thumbnails._exif_orientation; kept local so the scanner
-    # doesn't take a runtime dependency on the request-path thumbnail module.
-    if not exif_data:
-        return None
-    if isinstance(exif_data, str):
-        try:
-            metadata = json.loads(exif_data)
-        except (TypeError, ValueError):
-            return None
-    elif isinstance(exif_data, dict):
-        metadata = exif_data
-    else:
-        return None
-    if not isinstance(metadata, dict):
-        return None
-    for group in ("EXIF", "IFD0", "TIFF", "File"):
-        values = metadata.get(group)
-        if isinstance(values, dict) and "Orientation" in values:
-            return values["Orientation"]
-    return metadata.get("Orientation")
 
 
 def _oriented_dimensions(width, height, exif_data):
@@ -976,14 +955,12 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
                 )
                 wc_w = wc_h = 0
                 ok = False
-            if (
-                ok
-                and expected_w > 0
-                and expected_h > 0
-                and (
-                    wc_w < expected_w * 0.99
-                    or wc_h < expected_h * 0.99
-                )
+            # Use a 1% relative tolerance (not the request paths' 1px slack):
+            # libraw can emit the active image area a few pixels narrower than
+            # the full sensor, and a strict check would mark a valid extraction
+            # as failed and route every edited render away from the RAW.
+            if ok and is_undersized(
+                wc_w, wc_h, expected_w, expected_h, abs_slack=0, rel_slack=0.01,
             ):
                 log.info(
                     "RAW working-copy extraction for photo %s produced "

--- a/vireo/tests/test_render_source.py
+++ b/vireo/tests/test_render_source.py
@@ -1,0 +1,118 @@
+"""Lock the canonical render-source primitives shared across flows.
+
+These encode the exact edge cases that previously drifted between per-flow
+copies in app.py, pipeline_job.py, thumbnails.py, export.py and scanner.py:
+both-axis (not long-edge-only) dimension checks, the embedded-preview "tie"
+case, EXIF-orientation axis swaps, and the request-path (1px) vs scanner (1%)
+undersize tolerances.
+"""
+
+import json
+import os
+import sys
+
+from PIL import Image
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import render_source as rs
+
+
+def _img(w, h):
+    return Image.new("RGB", (w, h), "gray")
+
+
+def test_is_undersized_checks_both_axes():
+    # A 6000x3376 embedded preview for a 6000x4000 source matches on the long
+    # edge but loses short-edge content — a long-edge-only check would miss it.
+    assert rs.is_undersized(6000, 3376, 6000, 4000) is True
+    assert rs.is_undersized(6000, 4000, 6000, 4000) is False
+
+
+def test_is_undersized_unknown_expected_is_never_undersized():
+    assert rs.is_undersized(10, 10, 0, 0) is False
+    assert rs.is_undersized(10, 10, 6000, 0) is False
+
+
+def test_is_undersized_default_abs_slack_absorbs_one_px():
+    # Request paths tolerate 1px of rounding between decoder output and stored
+    # dimensions, but not more.
+    assert rs.is_undersized(5999, 3999, 6000, 4000) is False
+    assert rs.is_undersized(5998, 4000, 6000, 4000) is True
+
+
+def test_is_undersized_relative_tolerance_for_scanner():
+    # Scanner uses a 1% relative tolerance (abs_slack=0): libraw can emit the
+    # active image area a few px narrower than the full sensor.
+    assert rs.is_undersized(
+        5940, 3960, 6000, 4000, abs_slack=0, rel_slack=0.01,
+    ) is False
+    assert rs.is_undersized(
+        5939, 3960, 6000, 4000, abs_slack=0, rel_slack=0.01,
+    ) is True
+
+
+def test_companion_replaces_undersized_decode_on_tie():
+    # img tied the source on the long edge but is short on the other axis; a
+    # full-size companion should replace it.
+    img = _img(6000, 3376)
+    companion = _img(6000, 4000)
+    assert rs.companion_image_can_replace_raw_result(
+        companion, img, 6000, 4000,
+    ) is True
+
+
+def test_companion_rejected_when_also_undersized():
+    img = _img(6000, 3376)
+    companion = _img(4000, 3000)  # bigger than img but still < expected
+    assert rs.companion_image_can_replace_raw_result(
+        companion, img, 6000, 4000,
+    ) is False
+
+
+def test_companion_none_never_replaces():
+    assert rs.companion_image_can_replace_raw_result(
+        None, _img(10, 10), 6000, 4000,
+    ) is False
+
+
+def test_companion_with_unknown_expected_covers_current():
+    # When expected dims are unknown, the companion must cover the current
+    # decode on both axes; a None current decode is always replaceable.
+    assert rs.companion_image_can_replace_raw_result(
+        _img(800, 600), None, 0, 0,
+    ) is True
+    assert rs.companion_image_can_replace_raw_result(
+        _img(800, 600), _img(800, 600), 0, 0,
+    ) is True
+    assert rs.companion_image_can_replace_raw_result(
+        _img(799, 600), _img(800, 600), 0, 0,
+    ) is False
+
+
+def test_recipe_source_dimensions_swaps_for_orientation():
+    photo = {
+        "width": 6000,
+        "height": 4000,
+        "exif_data": json.dumps({"EXIF": {"Orientation": 6}}),
+    }
+    assert rs.recipe_source_dimensions(photo) == (4000, 6000)
+
+
+def test_recipe_source_dimensions_no_swap_without_orientation():
+    photo = {"width": 6000, "height": 4000, "exif_data": None}
+    assert rs.recipe_source_dimensions(photo) == (6000, 4000)
+
+
+def test_recipe_source_dimensions_explicit_exif_overrides_row():
+    # export.py passes exif_data separately rather than from the row.
+    photo = {"width": 6000, "height": 4000}
+    assert rs.recipe_source_dimensions(
+        photo, json.dumps({"EXIF": {"Orientation": 6}}),
+    ) == (4000, 6000)
+
+
+def test_scaled_recipe_source_dimensions_scales_long_edge():
+    photo = {"width": 6000, "height": 4000, "exif_data": None}
+    assert rs.scaled_recipe_source_dimensions(photo, 3000) == (3000, 2000)
+    assert rs.scaled_recipe_source_dimensions(photo, None) == (6000, 4000)

--- a/vireo/tests/test_thumbnails.py
+++ b/vireo/tests/test_thumbnails.py
@@ -99,6 +99,7 @@ def test_recipe_source_path_uses_exif_oriented_dimensions(tmp_path):
     import json
 
     import pipeline_job
+    import render_source
     import thumbnails
 
     folder = tmp_path / "photos"
@@ -125,6 +126,8 @@ def test_recipe_source_path_uses_exif_oriented_dimensions(tmp_path):
     folders = {10: str(folder)}
     recipe = {"crop": {"x": 0.0, "y": 0.0, "w": 0.5, "h": 1.0}}
 
+    # thumbnails / pipeline source selection both delegate to the shared
+    # resolver, which returns just the path here.
     assert thumbnails._recipe_source_path(
         photo, recipe, 500, str(vireo_dir), folders,
     ) == str(original)
@@ -137,10 +140,8 @@ def test_recipe_source_path_uses_exif_oriented_dimensions(tmp_path):
     oriented_working = working_dir / "2.jpg"
     Image.new("RGB", (600, 400), color="blue").save(oriented_working, exif=exif)
 
-    assert thumbnails._path_satisfies_recipe_render(
-        str(oriented_working), photo, recipe, 500,
-    )
-    assert pipeline_job._path_satisfies_recipe_render(
+    # Orientation-aware render-size check lives in render_source now.
+    assert render_source.path_satisfies_recipe_render(
         str(oriented_working), photo, recipe, 500,
     )
 

--- a/vireo/tests/test_thumbnails.py
+++ b/vireo/tests/test_thumbnails.py
@@ -242,8 +242,11 @@ def test_generate_all_routes_through_canonical_helper(tmp_path, monkeypatch):
         width=200, height=150,
     )
 
+    # Source resolution routes through render_source (shared by thumbnails,
+    # app, pipeline and export); patch it there.
+    import render_source
     mock_helper = MagicMock(return_value=str(src))
-    monkeypatch.setattr(thumbnails, "get_canonical_image_path", mock_helper)
+    monkeypatch.setattr(render_source, "get_canonical_image_path", mock_helper)
 
     thumb_dir = vireo_dir / "thumbs"
     thumbnails.generate_all(db, str(thumb_dir), vireo_dir=str(vireo_dir))

--- a/vireo/thumbnails.py
+++ b/vireo/thumbnails.py
@@ -13,11 +13,14 @@ from image_loader import (
 )
 from render_source import (
     image_is_smaller_than_expected,
-    photo_value as _photo_value,
     recipe_render_source,
+)
+from render_source import (
+    photo_value as _photo_value,
+)
+from render_source import (
     scaled_recipe_source_dimensions as _scaled_recipe_source_dimensions,
 )
-from render_source import path_satisfies_recipe_render as _path_satisfies_recipe_render
 
 log = logging.getLogger(__name__)
 

--- a/vireo/thumbnails.py
+++ b/vireo/thumbnails.py
@@ -1,183 +1,35 @@
 """Generate and manage local thumbnail cache for the photo browser."""
 
 import contextlib
-import json
 import logging
 import os
 import tempfile
 from datetime import UTC, datetime
 
-from exif_orientation import orientation_swaps_axes as _orientation_swaps_axes
 from image_loader import (
     RAW_DECODE_PRESERVE_HIGHLIGHTS,
     RAW_EXTENSIONS,
-    get_canonical_image_path,
     load_image,
 )
+from render_source import (
+    image_is_smaller_than_expected,
+    photo_value as _photo_value,
+    recipe_render_source,
+    scaled_recipe_source_dimensions as _scaled_recipe_source_dimensions,
+)
+from render_source import path_satisfies_recipe_render as _path_satisfies_recipe_render
 
 log = logging.getLogger(__name__)
 
 DEFAULT_CACHE_DIR = os.path.expanduser("~/.vireo/thumbnails")
 THUMB_SIZE = 400
-_EXIF_ORIENTATION_TAG = 274
-
-
-def _rendered_recipe_long_edge(width, height, recipe):
-    rotation = (recipe or {}).get("rotation", 0)
-    if rotation in (90, 270):
-        width, height = height, width
-    crop = (recipe or {}).get("crop") if recipe else None
-    if crop:
-        return max(float(crop["w"]) * width, float(crop["h"]) * height)
-    return max(width, height)
-
-
-def _photo_value(photo, key):
-    try:
-        return photo[key]
-    except (KeyError, IndexError, TypeError):
-        if hasattr(photo, "get"):
-            return photo.get(key)
-    return None
-
-
-def _exif_orientation(exif_data):
-    if not exif_data:
-        return None
-    if isinstance(exif_data, str):
-        try:
-            metadata = json.loads(exif_data)
-        except (TypeError, ValueError):
-            return None
-    elif isinstance(exif_data, dict):
-        metadata = exif_data
-    else:
-        return None
-    if not isinstance(metadata, dict):
-        return None
-    for group in ("EXIF", "IFD0", "TIFF", "File"):
-        values = metadata.get(group)
-        if isinstance(values, dict) and "Orientation" in values:
-            return values["Orientation"]
-    return metadata.get("Orientation")
-
-
-def _recipe_source_dimensions(photo):
-    try:
-        width = int(_photo_value(photo, "width") or 0)
-        height = int(_photo_value(photo, "height") or 0)
-    except (TypeError, ValueError):
-        return 0, 0
-    if (
-        width > 0
-        and height > 0
-        and _orientation_swaps_axes(_exif_orientation(_photo_value(photo, "exif_data")))
-    ):
-        return height, width
-    return width, height
-
-
-def _scaled_recipe_source_dimensions(photo, max_size=None):
-    width, height = _recipe_source_dimensions(photo)
-    if width <= 0 or height <= 0:
-        return 0, 0
-    if max_size:
-        long_edge = max(width, height)
-        if long_edge > max_size:
-            scale = max_size / long_edge
-            width = round(width * scale)
-            height = round(height * scale)
-    return width, height
-
-
-def _image_size_after_exif_orientation(img):
-    width, height = img.size
-    orientation = None
-    with contextlib.suppress(Exception):
-        orientation = img.getexif().get(_EXIF_ORIENTATION_TAG)
-    if _orientation_swaps_axes(orientation):
-        return height, width
-    return width, height
-
-
-def _path_satisfies_recipe_render(path, photo, recipe, max_size):
-    original_w, original_h = _recipe_source_dimensions(photo)
-    if original_w <= 0 or original_h <= 0:
-        return False
-    try:
-        from PIL import Image as _PILImage
-        with _PILImage.open(path) as img:
-            width, height = _image_size_after_exif_orientation(img)
-    except Exception:
-        return False
-    original_render_long = _rendered_recipe_long_edge(
-        original_w, original_h, recipe,
-    )
-    required_long = min(max_size, original_render_long) if max_size else original_render_long
-    return _rendered_recipe_long_edge(width, height, recipe) >= required_long
-
-
 def _recipe_source_path(photo, recipe, max_size, vireo_dir, folders):
-    if not vireo_dir or not recipe:
-        if vireo_dir:
-            return get_canonical_image_path(photo, vireo_dir, folders)
-        return os.path.join(folders.get(photo["folder_id"], ""), photo["filename"])
+    """Thin wrapper around the shared resolver, returning just the path.
 
-    primary_is_raw = (
-        os.path.splitext(photo["filename"])[1].lower() in RAW_EXTENSIONS
-    )
-
-    canonical = get_canonical_image_path(photo, vireo_dir, folders)
-    wc_rel = photo["working_copy_path"]
-    # For RAW primaries with a recipe, never short-circuit to the JPEG
-    # working copy or companion: legacy working copies predate the
-    # highlight-preserving RAW decode (EDIT_MATH_VERSION's purge only
-    # touches preview/thumb caches, not working copies). Reusing them
-    # here would feed the recipe a clipped JPEG and silently bypass
-    # generate_thumbnail's RAW_DECODE_PRESERVE_HIGHLIGHTS request — the
-    # raw_decode kwarg is a no-op when load_image gets a JPEG path.
-    if not primary_is_raw:
-        if not recipe.get("crop") and canonical and wc_rel:
-            wc_path = wc_rel if os.path.isabs(wc_rel) else os.path.join(vireo_dir, wc_rel)
-            if os.path.abspath(canonical) == os.path.abspath(wc_path):
-                return canonical
-        if recipe.get("crop") and wc_rel:
-            wc_path = os.path.join(vireo_dir, wc_rel)
-            if (
-                os.path.exists(wc_path)
-                and _path_satisfies_recipe_render(wc_path, photo, recipe, max_size)
-            ):
-                return canonical
-
-    folder_path = folders.get(photo["folder_id"])
-    if not folder_path:
-        if wc_rel:
-            wc_path = os.path.join(vireo_dir, wc_rel)
-            if os.path.exists(wc_path):
-                return wc_path
-        return ""
-    companion_path = photo["companion_path"]
-    original = os.path.join(folder_path, photo["filename"])
-    # Allow the companion JPEG only for non-RAW primaries, OR for RAW
-    # primaries whose RAW is known to fail for the current source mtime —
-    # mirrors the gate in app/pipeline _recipe_render_source so edited
-    # RAW thumbnails decode the highlight-preserving RAW unless we've
-    # already proven it can't be demosaiced.
-    allow_companion = not primary_is_raw or _has_current_raw_failure(
-        photo, original,
-    )
-    if companion_path and allow_companion:
-        companion = os.path.join(folder_path, companion_path)
-        if (
-            os.path.exists(companion)
-            and _path_satisfies_recipe_render(companion, photo, recipe, max_size)
-        ):
-            return companion
-    if not os.path.exists(original) and wc_rel:
-        wc_path = os.path.join(vireo_dir, wc_rel)
-        if os.path.exists(wc_path):
-            return wc_path
-    return original
+    Thumbnail callers don't need the ``using_working_copy`` flag, so the
+    second element of :func:`render_source.recipe_render_source` is dropped.
+    """
+    return recipe_render_source(photo, recipe, max_size, vireo_dir, folders)[0]
 
 
 def _has_current_raw_failure(photo, source_path):
@@ -301,14 +153,7 @@ def generate_thumbnail(
         return None
     if min_source_size:
         expected_w, expected_h = min_source_size
-        if (
-            expected_w > 0
-            and expected_h > 0
-            and (
-                img.size[0] + 1 < expected_w
-                or img.size[1] + 1 < expected_h
-            )
-        ):
+        if image_is_smaller_than_expected(img, expected_w, expected_h):
             log.info(
                 "Thumbnail source for photo %s is undersized (%dx%d, "
                 "expected %dx%d): %s",


### PR DESCRIPTION
## Summary
The RAW edit-render source decision — pick the file to decode (RAW primary / companion JPEG / working copy / original), validate dimensions on both axes with EXIF orientation, fall back to the companion on RAW failure or undersize, and read/write the `working_copy_failed` marker — was duplicated across `app.py`, `pipeline_job.py`, `thumbnails.py`, `export.py` and `scanner.py`, and the copies had drifted (long-edge vs both-axis checks, `+1px` vs `*0.99` tolerances, orientation swaps in some copies but not others, three source-selectors with different return types), which is why PR #1047's review loop kept finding the same class of edge case in a new place and never converged. This PR adds `vireo/render_source.py` as the single source of truth and routes every flow through it (local names kept as thin wrappers, so call sites are unchanged), makes the undersize tolerance an explicit parameter (request paths 1px, scanner 1%) instead of an accidental fork, and replaces the last inline both-axis copies in the external-editor and iNat handoffs with the shared helper. Net **−944 / +96** across the five existing files, plus a new module and tests pinning the both-axis / tie / orientation / tolerance edge cases.

## Tests
Full suite green for everything touched: `3765 passed` (the only 5 failures — `test_grouping` exifread `ModuleNotFoundError` and one live-server sweep integration test — reproduce on the pre-change tree and are unrelated). New `vireo/tests/test_render_source.py` (12 tests) locks the canonical primitives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)