### PR TITLE
Fix flaky highlights lightbox zoom-carryover e2e test

### DIFF
--- a/tests/e2e/test_highlights_initial_scope.py
+++ b/tests/e2e/test_highlights_initial_scope.py
@@ -234,7 +234,18 @@ def test_highlights_lightbox_next_preserves_pending_one_to_one_zoom(live_server,
     expect(page.locator("#lightboxOverlay")).to_have_class("lightbox-overlay active")
     expect(page.locator("#lightboxCounter")).to_contain_text("1 /")
 
-    page.evaluate(
+    # Leave the first photo at a true 1:1 zoom, and pre-seed the *next* photo's
+    # cached viewport as un-zoomed (fit). Navigation must override that cache and
+    # carry the 1:1 intent forward, not honor the stale fit state.
+    #
+    # The 1:1 handoff is established synchronously by lightboxNav -> openLightbox;
+    # only the later async /api/photos + image-load callbacks settle it (and, for
+    # a real high-res photo, resolve the pending flag into an actual 1:1 zoom).
+    # The seeded photos have no on-disk file or dimensions, so that settling is
+    # degenerate and timing-dependent. Trigger the nav and read the handoff state
+    # in the same synchronous tick — before any async callback runs — so we test
+    # exactly the guarantee (intent carried across navigation) deterministically.
+    handoff = page.evaluate(
         """() => {
             const next = window._lightboxPhotoList[1];
             window._lbNativeZoom = 2;
@@ -247,14 +258,20 @@ def test_highlights_lightbox_next_preserves_pending_one_to_one_zoom(live_server,
                 oneToOne: false,
                 pending1To1: false,
             };
+            lightboxNav(1);
+            return {
+                counter: document.getElementById('lightboxCounter').textContent,
+                pending1To1: window._lbPending1To1,
+                zoom: window._lbZoom,
+                srcKey: window._lbCurrentSrcKey,
+            };
         }"""
     )
 
-    page.locator("[title='Next (→)']").click()
-    expect(page.locator("#lightboxCounter")).to_contain_text("2 /")
-    assert page.evaluate("window._lbPending1To1") is True
-    assert page.evaluate("window._lbZoom > 1.001") is True
-    assert page.evaluate("window._lbCurrentSrcKey") == "original"
+    assert "2 /" in handoff["counter"]
+    assert handoff["pending1To1"] is True
+    assert handoff["zoom"] > 1.001
+    assert handoff["srcKey"] == "original"
 
 
 def test_highlights_api_limits_initial_bucket_and_loads_more(live_server):


### PR DESCRIPTION
## What

`test_highlights_lightbox_next_preserves_pending_one_to_one_zoom` was flaky — it passed on the first run of a fresh process, then failed consistently afterward.

## Why it flaked

The test asserted the **settled** lightbox state after clicking Next, but that state is established *synchronously* by `lightboxNav` → `openLightbox`; it's only mutated afterward by async `/api/photos` + image-load callbacks. The seeded e2e photos have no on-disk file and no dimensions, so once those callbacks fired:

- `/photos/<id>/original` 500s → the error handler downgrades `_lbCurrentSrcKey` from `'original'` to `'full'` (so `assert ... == "original"` flaked).
- Once an image establishes `nativeZoom`, the *pending* 1:1 intent resolves into an *actual* 1:1 zoom and `_lbPending1To1` clears (so `assert ... is True` flaked).

Whether those async callbacks beat the assertions was pure timing — hence pass-then-fail as the response cache warmed.

## Fix

Read the handoff state in the **same synchronous tick** as the navigation: `lightboxNav(1)` plus the state read happen in one `page.evaluate`, before any async callback runs. This tests exactly the feature's guarantee — the 1:1 zoom intent is carried across navigation, overriding the next photo's cached fit viewport — with no dependence on image load timing or dimensions.

## Testing

- 8/8 consecutive runs pass (was: pass once, then fail every time).
- Confirmed the test still **fails** when the carryover is broken (forcing `preserveOneToOne: false` in `lightboxNav`), so it still guards the behavior.
- Full file: `tests/e2e/test_highlights_initial_scope.py` — 6 passed.
- Broader suite (per CLAUDE.md): 1196 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved an end-to-end highlight/lightbox test to verify the next-photo transition more reliably.
  * Added stronger checks for the lightbox counter, zoom state, and pending 1:1 handoff behavior during navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->