### PR TITLE
Fix folder tree mis-nesting after relocate/move

### DIFF
--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2343,6 +2343,51 @@ class Database:
                 missing.append(row)
         return missing
 
+    def nearest_ancestor_folder_id(self, path, exclude_id=None):
+        """Return the id of the folder whose stored path is the longest proper
+        ancestor of ``path`` (platform-neutral prefix match), or None if no
+        folder row is an ancestor.
+
+        Used to keep ``parent_id`` consistent with ``path`` after relocations
+        and moves. Those operations rewrite a folder's ``path`` but would
+        otherwise leave ``parent_id`` pinned to the OLD location's parent,
+        which mis-nests the folder in the browse tree (e.g. a date folder
+        moved onto another volume staying linked to its original parent).
+        Folder counts are small, so the linear scan is fine.
+        """
+        target = _path_for_subtree_match(path)
+        best_id = None
+        best_len = -1
+        for row in self.conn.execute("SELECT id, path FROM folders"):
+            if exclude_id is not None and row["id"] == exclude_id:
+                continue
+            cand = _path_for_subtree_match(row["path"])
+            if target == cand or not target.startswith(cand + "/"):
+                continue
+            if len(cand) > best_len:
+                best_id = row["id"]
+                best_len = len(cand)
+        return best_id
+
+    def _relink_parents_by_path(self, folder_ids):
+        """Re-derive ``parent_id`` from the current ``path`` for each folder.
+
+        Relocations and merges rewrite ``path`` but leave ``parent_id``
+        pinned to the pre-move parent, which mis-nests the folder in the
+        browse tree. Call this after path rewrites — all affected paths must
+        already be committed to the rows so ancestor lookup sees them.
+        """
+        for fid in folder_ids:
+            row = self.conn.execute(
+                "SELECT path FROM folders WHERE id = ?", (fid,)
+            ).fetchone()
+            if row is None:
+                continue
+            self.conn.execute(
+                "UPDATE folders SET parent_id = ? WHERE id = ?",
+                (self.nearest_ancestor_folder_id(row["path"], exclude_id=fid), fid),
+            )
+
     def relocate_folder(self, folder_id, new_path):
         """Update folder path and set status to 'ok'.
 
@@ -2423,6 +2468,7 @@ class Database:
                 )
                 cascaded.append({"id": child["id"], "old_path": child["path"], "new_path": candidate})
 
+        self._relink_parents_by_path([folder_id] + [c["id"] for c in cascaded])
         self.conn.commit()
         return cascaded
 
@@ -2548,6 +2594,7 @@ class Database:
                 )
                 cascaded.append({"id": child["id"], "old_path": child["path"], "new_path": candidate})
 
+        self._relink_parents_by_path([c["id"] for c in cascaded])
         self.conn.commit()
         return cascaded
 

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -1221,10 +1221,13 @@ def move_photos(db, photo_ids, destination, progress_cb=None):
     if dest_row:
         dest_folder_id = dest_row["id"]
     else:
-        # Insert folder record without auto-linking to workspace (add_folder would auto-link)
+        # Insert folder record without auto-linking to workspace (add_folder would auto-link).
+        # Set parent_id from the nearest existing ancestor so the destination
+        # nests correctly in the browse tree instead of floating as a root.
         cur = db.conn.execute(
-            "INSERT OR IGNORE INTO folders (path, name) VALUES (?, ?)",
-            (destination, os.path.basename(destination)),
+            "INSERT OR IGNORE INTO folders (path, name, parent_id) VALUES (?, ?, ?)",
+            (destination, os.path.basename(destination),
+             db.nearest_ancestor_folder_id(destination)),
         )
         db.conn.commit()
         if cur.rowcount > 0:

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -6164,6 +6164,53 @@ def test_relocate_folder_cascade(tmp_path):
     assert row["status"] == "ok"
 
 
+def test_nearest_ancestor_folder_id(tmp_path):
+    """nearest_ancestor_folder_id returns the longest proper-ancestor row."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+
+    usa = db.add_folder("/vol/USA", name="USA")
+    usa_2026 = db.add_folder("/vol/USA/2026", name="2026", parent_id=usa)
+
+    # Longest ancestor wins over the shallower one.
+    assert db.nearest_ancestor_folder_id("/vol/USA/2026/2026-05-30") == usa_2026
+    # Falls back to the nearest existing ancestor when the immediate one has
+    # no row.
+    assert db.nearest_ancestor_folder_id("/vol/USA/gap/leaf") == usa
+    # No ancestor row -> None (folder is a root).
+    assert db.nearest_ancestor_folder_id("/elsewhere/x") is None
+    # A row is never its own ancestor.
+    assert db.nearest_ancestor_folder_id("/vol/USA", exclude_id=usa) is None
+
+
+def test_relocate_folder_relinks_parent_by_path(tmp_path):
+    """Relocating a folder re-derives parent_id from its new path so it does
+    not stay nested under its pre-move parent (browse-tree mis-nesting bug)."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+
+    pics_2026 = db.add_folder("/pics/2026", name="2026")
+    usa = db.add_folder("/vol/USA", name="USA")
+    # A date folder that originally lived under /pics/2026.
+    date = db.add_folder("/pics/2026/2026-05-30", name="2026-05-30",
+                         parent_id=pics_2026)
+    db.conn.execute("UPDATE folders SET status = 'missing' WHERE id = ?", (date,))
+    db.conn.commit()
+
+    # User moved it onto the USA volume and re-points Vireo at the new path.
+    db.relocate_folder(date, "/vol/USA/2026-05-30")
+
+    row = db.conn.execute(
+        "SELECT parent_id FROM folders WHERE id = ?", (date,)
+    ).fetchone()
+    # Re-linked to its real new ancestor, not left pointing at /pics/2026.
+    assert row["parent_id"] == usa
+
+
 def test_relocate_folder_merge_into_existing(tmp_path):
     """relocate_folder merges photos into existing folder when paths conflict."""
     from db import Database

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -128,6 +128,23 @@ def test_move_photos_creates_dest_folder_record(move_env):
     assert row is not None
 
 
+def test_move_photos_dest_folder_nests_under_ancestor(move_env):
+    """A new destination under an existing folder gets parent_id set to that
+    ancestor so it nests in the browse tree instead of floating as a root."""
+    from move import move_photos
+
+    env = move_env
+    # Destination is a brand-new subfolder of the existing `dst` folder.
+    sub_dst = env["dst"] / "sub"
+    sub_dst.mkdir()
+
+    move_photos(db=env["db"], photo_ids=[env["p1"]], destination=str(sub_dst))
+    row = env["db"].conn.execute(
+        "SELECT parent_id FROM folders WHERE path = ?", (str(sub_dst),)
+    ).fetchone()
+    assert row["parent_id"] == env["fid_dst"]
+
+
 def test_move_photos_companion_files(move_env):
     """move_photos moves companion (RAW) files alongside the photo."""
     from move import move_photos


### PR DESCRIPTION
## What & why

The browse sidebar's FOLDERS tree was showing folders nested under the wrong parent — e.g. USA date folders (`/Volumes/.../USA/2026/2026-05-30`) displayed under `Pictures → 2026`, and a moved folder floating up as its own root.

Root cause: the tree groups by `folders.parent_id`, but two operations rewrote a folder's `path` without ever updating `parent_id`:

- **`relocate_folder`** (`db.py`) — re-pointing a missing folder to a new location rewrites `path` (and cascades child paths) but left `parent_id` pinned to the *old* location's parent.
- **`move_photos`** (`move.py`) — inserted the destination folder with no `parent_id` at all, so it became a root.

## Changes

- Add `Database.nearest_ancestor_folder_id(path)` — the folder row whose stored path is the longest proper ancestor of a given path.
- `relocate_folder` / `_merge_into_existing` re-derive `parent_id` from the new path for the folder and every cascaded child after rewriting paths (new `_relink_parents_by_path` helper).
- `move_photos` sets `parent_id` from the nearest existing ancestor when inserting a new destination folder.

## Tests

- `test_nearest_ancestor_folder_id` — longest-ancestor / fallback / no-ancestor / self-exclusion.
- `test_relocate_folder_relinks_parent_by_path` — regression for the relocate case.
- `test_move_photos_dest_folder_nests_under_ancestor` — regression for the move case.

Full required suite green: **1198 passed, 1 skipped**.

> Note: existing corrupted rows in a live DB are repaired by re-running this derivation; the recompute also runs naturally on the next relocate/move of an affected folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)