### PR TITLE
Add one-click Auto Tone to the photo editor

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -18249,6 +18249,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         try:
             from image_edits import (
+                SCHEMA_VERSION,
                 RecipeError,
                 apply_recipe_to_loaded_image,
                 normalize_recipe,
@@ -18273,8 +18274,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # photo with a legacy JPEG working copy must use the RAW source
             # here too, so the in-progress edit preview matches the saved
             # preview/export bytes from the highlight-preserving decode.
+            # Auto Tone strips tonal adjustments to sample neutral pixels;
+            # for a RAW primary that can leave recipe empty, which would
+            # normally short-circuit _recipe_render_source to the canonical
+            # working copy. Pass a sentinel non-empty recipe in that case so
+            # the same RAW-primary gating applies and analysis reads the
+            # highlight-preserved RAW decode rather than clipped legacy
+            # working-copy bytes.
+            source_recipe = recipe
+            if request.args.get("analysis") == "1" and not recipe:
+                source_recipe = {"version": SCHEMA_VERSION}
             canonical, using_working_copy = _recipe_render_source(
-                photo, recipe, size, vireo_dir,
+                photo, source_recipe, size, vireo_dir,
                 {folder_row["id"]: folder_row["path"]},
             )
             selected_ext = os.path.splitext(canonical)[1].lower()

--- a/vireo/templates/photo_editor.html
+++ b/vireo/templates/photo_editor.html
@@ -1183,12 +1183,20 @@ async function autoTone() {
     // stripped recipe is empty, so RAW primaries decode with highlight
     // preservation instead of returning clipped legacy JPEG working-copy
     // pixels that would skew the exposure/highlight heuristics.
+    // Snapshot the recipe at start: if the user changes crop, geometry, or
+    // sliders while the render is in flight, the analysis is stale — we
+    // built the URL and the sample crop from the old recipe, so applying
+    // the result would overwrite newer edits or compute from mismatched
+    // geometry.
+    var startKey = recipeKey(editorState.recipe);
+    var sampleCrop = cloneRecipe({crop: ensureCrop(editorState.recipe)}).crop;
     var base = previewRecipeFor(editorState.recipe);
     delete base.adjustments;
     var src = '/photos/' + editorState.photoId + '/edit-preview?size=1024&analysis=1&recipe=' +
       encodeURIComponent(JSON.stringify(base));
     var img = await _loadImage(src);
-    var stats = _lumaStats(img, ensureCrop(editorState.recipe));
+    if (recipeKey(editorState.recipe) !== startKey) return;
+    var stats = _lumaStats(img, sampleCrop);
     if (!stats) throw new Error('no canvas context');
     var auto = computeAutoTone(stats);
 

--- a/vireo/templates/photo_editor.html
+++ b/vireo/templates/photo_editor.html
@@ -1044,17 +1044,28 @@ function _smoothstep(e0, e1, x) {
 }
 
 // Sample an image into a 256-bin luma histogram plus shadow/highlight clip counts.
-function _lumaStats(img) {
+function _lumaStats(img, crop) {
+  // The base render is geometry-applied but uncropped, and `crop` (normalized
+  // 0..1) is in that same coordinate space. Sample only the pixels inside the
+  // active crop so Auto Tone's heuristics see the frame the user is keeping.
   var maxSample = 180;
-  var scale = Math.min(1, maxSample / Math.max(img.naturalWidth, img.naturalHeight));
-  var w = Math.max(1, Math.round(img.naturalWidth * scale));
-  var h = Math.max(1, Math.round(img.naturalHeight * scale));
+  var sx = 0, sy = 0;
+  var sW = img.naturalWidth, sH = img.naturalHeight;
+  if (crop && !isFullCrop(crop)) {
+    sx = Math.max(0, Math.round((Number(crop.x) || 0) * img.naturalWidth));
+    sy = Math.max(0, Math.round((Number(crop.y) || 0) * img.naturalHeight));
+    sW = Math.max(1, Math.round((Number(crop.w) || 1) * img.naturalWidth));
+    sH = Math.max(1, Math.round((Number(crop.h) || 1) * img.naturalHeight));
+  }
+  var scale = Math.min(1, maxSample / Math.max(sW, sH));
+  var w = Math.max(1, Math.round(sW * scale));
+  var h = Math.max(1, Math.round(sH * scale));
   var c = document.createElement('canvas');
   c.width = w;
   c.height = h;
   var cx = c.getContext('2d', { willReadFrequently: true });
   if (!cx) return null;
-  cx.drawImage(img, 0, 0, w, h);
+  cx.drawImage(img, sx, sy, sW, sH, 0, 0, w, h);
   var data = cx.getImageData(0, 0, w, h).data;
   var hist = new Array(256).fill(0);
   var clipLow = 0;
@@ -1173,7 +1184,7 @@ async function autoTone() {
     var src = '/photos/' + editorState.photoId + '/edit-preview?size=1024&recipe=' +
       encodeURIComponent(JSON.stringify(base));
     var img = await _loadImage(src);
-    var stats = _lumaStats(img);
+    var stats = _lumaStats(img, ensureCrop(editorState.recipe));
     if (!stats) throw new Error('no canvas context');
     var auto = computeAutoTone(stats);
 

--- a/vireo/templates/photo_editor.html
+++ b/vireo/templates/photo_editor.html
@@ -1179,9 +1179,13 @@ async function autoTone() {
   try {
     // Analyse the photo with current geometry but NO tonal/colour edits, so
     // Auto Tone reads the original pixels and is idempotent across clicks.
+    // ?analysis=1 keeps the server on the recipe-render path even when the
+    // stripped recipe is empty, so RAW primaries decode with highlight
+    // preservation instead of returning clipped legacy JPEG working-copy
+    // pixels that would skew the exposure/highlight heuristics.
     var base = previewRecipeFor(editorState.recipe);
     delete base.adjustments;
-    var src = '/photos/' + editorState.photoId + '/edit-preview?size=1024&recipe=' +
+    var src = '/photos/' + editorState.photoId + '/edit-preview?size=1024&analysis=1&recipe=' +
       encodeURIComponent(JSON.stringify(base));
     var img = await _loadImage(src);
     var stats = _lumaStats(img, ensureCrop(editorState.recipe));

--- a/vireo/templates/photo_editor.html
+++ b/vireo/templates/photo_editor.html
@@ -422,6 +422,9 @@ body {
 
     <div class="panel-band">
       <div class="panel-title">Adjustments</div>
+      <div class="button-row">
+        <button class="editor-btn" type="button" id="autoToneBtn" onclick="autoTone()">Auto Tone</button>
+      </div>
       <div class="control-row">
         <label for="exposureRange">Exposure</label>
         <input id="exposureRange" data-adjustment="exposure" type="range" min="-5" max="5" step="0.1" value="0" oninput="setAdjustment('exposure', this.value)">
@@ -1018,6 +1021,193 @@ function resetAdjustments() {
   delete editorState.recipe.adjustments;
   syncControls();
   markChanged(true);
+}
+
+// --- Auto Tone -------------------------------------------------------------
+// One-click tonal balance derived from the photo's own luminance histogram.
+// These helpers mirror the semantics of tone.py (linear-light exposure,
+// display-space range controls) closely enough to land a sensible starting
+// point; the user fine-tunes from there. Auto Tone intentionally leaves colour
+// (white balance, vibrance, saturation) untouched so it never neutralises a
+// wanted cast such as golden-hour warmth.
+
+function _srgbToLinear(c) {
+  return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+function _linearToSrgb(c) {
+  c = Math.max(0, c);
+  return c <= 0.0031308 ? c * 12.92 : 1.055 * Math.pow(c, 1 / 2.4) - 0.055;
+}
+function _smoothstep(e0, e1, x) {
+  var t = Math.min(1, Math.max(0, (x - e0) / (e1 - e0)));
+  return t * t * (3 - 2 * t);
+}
+
+// Sample an image into a 256-bin luma histogram plus shadow/highlight clip counts.
+function _lumaStats(img) {
+  var maxSample = 180;
+  var scale = Math.min(1, maxSample / Math.max(img.naturalWidth, img.naturalHeight));
+  var w = Math.max(1, Math.round(img.naturalWidth * scale));
+  var h = Math.max(1, Math.round(img.naturalHeight * scale));
+  var c = document.createElement('canvas');
+  c.width = w;
+  c.height = h;
+  var cx = c.getContext('2d', { willReadFrequently: true });
+  if (!cx) return null;
+  cx.drawImage(img, 0, 0, w, h);
+  var data = cx.getImageData(0, 0, w, h).data;
+  var hist = new Array(256).fill(0);
+  var clipLow = 0;
+  var clipHigh = 0;
+  var total = 0;
+  for (var i = 0; i < data.length; i += 4) {
+    var luma = 0.2126 * data[i] + 0.7152 * data[i + 1] + 0.0722 * data[i + 2];
+    var b = Math.min(255, Math.max(0, Math.round(luma)));
+    hist[b] += 1;
+    if (b <= 4) clipLow += 1;
+    if (b >= 250) clipHigh += 1;
+    total += 1;
+  }
+  return { hist: hist, total: Math.max(1, total), clipLow: clipLow, clipHigh: clipHigh };
+}
+
+// Luma value in [0,1] at which the cumulative histogram first reaches `frac`.
+function _percentile(hist, total, frac) {
+  var target = frac * total;
+  var cum = 0;
+  for (var i = 0; i < hist.length; i++) {
+    cum += hist[i];
+    if (cum >= target) return i / 255;
+  }
+  return 1;
+}
+
+function computeAutoTone(stats) {
+  var lo = _percentile(stats.hist, stats.total, 0.005); // shadow end
+  var hi = _percentile(stats.hist, stats.total, 0.995); // highlight end
+  var med = _percentile(stats.hist, stats.total, 0.5);  // midtone
+  var clipHighFrac = stats.clipHigh / stats.total;
+  var clipLowFrac = stats.clipLow / stats.total;
+
+  // Exposure: nudge the median toward a mid-grey target in linear light,
+  // damped and clamped so a legitimately bright or dark scene is not dragged
+  // to a flat grey.
+  var target = 0.45;
+  var ev = Math.log(_srgbToLinear(target) / _srgbToLinear(Math.max(med, 0.004))) / Math.LN2;
+  ev = Math.max(-1.2, Math.min(1.2, ev * 0.8));
+  var gain = Math.pow(2, ev);
+
+  // Predict where the endpoints will sit after the exposure shift.
+  var hiE = _linearToSrgb(_srgbToLinear(hi) * gain);
+  var loE = _linearToSrgb(_srgbToLinear(lo) * gain);
+
+  // Only set white/black points when there is a real tonal range to anchor to;
+  // a near-uniform frame has no meaningful endpoints to stretch.
+  var spread = hi - lo;
+  var hasRange = spread > 0.04;
+
+  // Whites: lift the brightest tones toward white only when the image clearly
+  // lacks brights (a well-exposed frame already near white is left alone).
+  var whites = 0;
+  if (hasRange && hiE < 0.9) {
+    var maskW = _smoothstep(0.70, 1.0, hiE) * 0.34;
+    if (maskW > 0.01) {
+      whites = ((0.97 - hiE) / ((1 - hiE) * maskW)) * 100;
+      whites = Math.max(0, Math.min(35, Math.round(whites)));
+    }
+  }
+
+  // Blacks: deepen the darkest tones only when true blacks are clearly missing
+  // (a low, hazy black point).
+  var blacks = 0;
+  if (hasRange && loE > 0.08) {
+    var maskB = (1 - _smoothstep(0.0, 0.3, loE)) * 0.34;
+    if (maskB > 0.01) {
+      blacks = ((loE - 0.03) / (loE * maskB)) * 100;
+      blacks = -Math.max(0, Math.min(35, Math.round(blacks)));
+    }
+  }
+
+  // Highlights / shadows: recover ends that are already blown or crushed.
+  var highlights = clipHighFrac > 0.02 ? -Math.min(55, Math.round(clipHighFrac * 600)) : 0;
+  var shadows = clipLowFrac > 0.02 ? Math.min(55, Math.round(clipLowFrac * 600)) : 0;
+
+  // Contrast: add some punch only when the original tonal range is genuinely
+  // flat (hazy / low-contrast). Never reduce contrast on a normal full-range
+  // image, which would just mute it.
+  var contrast = spread < 0.55 ? Math.min(25, Math.round((0.55 - spread) * 100)) : 0;
+
+  return {
+    exposure: Math.round(ev * 10) / 10,
+    whites: whites,
+    blacks: blacks,
+    highlights: highlights,
+    shadows: shadows,
+    contrast: contrast,
+  };
+}
+
+function _loadImage(src) {
+  return new Promise(function(resolve, reject) {
+    var im = new Image();
+    im.onload = function() { resolve(im); };
+    im.onerror = function() { reject(new Error('image load failed')); };
+    im.src = src;
+  });
+}
+
+async function autoTone() {
+  if (!editorState.photoId) return;
+  var btn = document.getElementById('autoToneBtn');
+  if (btn && btn.disabled) return;
+  var prevLabel = btn ? btn.textContent : '';
+  if (btn) {
+    btn.disabled = true;
+    btn.textContent = 'Analyzing...';
+  }
+  try {
+    // Analyse the photo with current geometry but NO tonal/colour edits, so
+    // Auto Tone reads the original pixels and is idempotent across clicks.
+    var base = previewRecipeFor(editorState.recipe);
+    delete base.adjustments;
+    var src = '/photos/' + editorState.photoId + '/edit-preview?size=1024&recipe=' +
+      encodeURIComponent(JSON.stringify(base));
+    var img = await _loadImage(src);
+    var stats = _lumaStats(img);
+    if (!stats) throw new Error('no canvas context');
+    var auto = computeAutoTone(stats);
+
+    // Replace the tonal values; preserve any colour choices already made.
+    var vals = adjustmentValues(editorState.recipe);
+    var adj = {};
+    ['exposure', 'highlights', 'shadows', 'whites', 'blacks', 'contrast'].forEach(function(k) {
+      if (Math.abs(auto[k]) > 0.000001) adj[k] = auto[k];
+    });
+    ['vibrance', 'saturation'].forEach(function(k) {
+      if (Math.abs(vals[k]) > 0.000001) adj[k] = vals[k];
+    });
+    var wb = {};
+    if (Math.abs(vals.temperature) > 0.000001) wb.temperature = vals.temperature;
+    if (Math.abs(vals.tint) > 0.000001) wb.tint = vals.tint;
+    if (Object.keys(wb).length) adj.white_balance = wb;
+    if (Object.keys(adj).length) editorState.recipe.adjustments = adj;
+    else delete editorState.recipe.adjustments;
+
+    syncControls();
+    markChanged(true);
+    if (typeof showToast === 'function') {
+      showToast('Auto-balanced tones from the histogram (color left unchanged)', 'success');
+    }
+  } catch (e) {
+    if (typeof showToast === 'function') {
+      showToast('Could not analyze this photo for Auto Tone', 'error');
+    }
+  } finally {
+    if (btn) {
+      btn.disabled = false;
+      btn.textContent = prevLabel || 'Auto Tone';
+    }
+  }
 }
 
 function resetAllEdits() {

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1517,6 +1517,59 @@ def test_edit_preview_skips_recent_failed_raw_before_decode(
     assert called["load"] is False
 
 
+def test_edit_preview_analysis_keeps_raw_on_recipe_render_path(
+    client_with_photo, monkeypatch,
+):
+    """``analysis=1`` must not let an empty recipe drop a RAW primary onto
+    its legacy JPEG working copy. Auto Tone strips tonal adjustments to
+    read neutral pixels; for a RAW with no other geometry the resulting
+    recipe is empty, which would normally short-circuit
+    ``_recipe_render_source`` to the canonical working copy and produce
+    clipped pixels for the highlight/exposure heuristics.
+    """
+    import app as app_module
+
+    app, db, photo_id = client_with_photo
+    db.conn.execute(
+        "UPDATE photos SET filename='neutral.NEF', extension='.nef' WHERE id=?",
+        (photo_id,),
+    )
+    db.conn.commit()
+
+    seen_recipes = []
+    real_render_source = app_module._recipe_render_source
+
+    def spy_render_source(photo, recipe, max_size, vireo_dir, folders):
+        seen_recipes.append(recipe)
+        return real_render_source(photo, recipe, max_size, vireo_dir, folders)
+
+    monkeypatch.setattr(app_module, "_recipe_render_source", spy_render_source)
+
+    client = app.test_client()
+    client.get(
+        f"/photos/{photo_id}/edit-preview",
+        query_string={"size": "1024", "recipe": "{}"},
+    )
+    client.get(
+        f"/photos/{photo_id}/edit-preview",
+        query_string={"size": "1024", "recipe": "{}", "analysis": "1"},
+    )
+    client.get(
+        f"/photos/{photo_id}/edit-preview",
+        query_string={
+            "size": "1024",
+            "recipe": '{"rotation":90}',
+            "analysis": "1",
+        },
+    )
+
+    assert seen_recipes == [
+        {},
+        {"version": 1},
+        {"version": 1, "rotation": 90},
+    ]
+
+
 def test_non_crop_preview_loads_with_requested_size(client_with_photo, monkeypatch):
     import image_loader
 


### PR DESCRIPTION
## What

Adds an **Auto Tone** button to the photo editor's Adjustments panel. One click derives a sensible tonal starting point from the photo's own luminance histogram and sets the exposure / highlights / shadows / whites / blacks / contrast sliders — the user fine-tunes from there.

This implements the "one-click Auto" idea from our editor brainstorm. It fits the product's AI identity, reuses the existing histogram machinery, and is labeled honestly per `CORE_PHILOSOPHY.md`.

## How it works

- Renders the photo with current geometry but **no tonal/colour edits** (via the existing `/edit-preview` endpoint), so the analysis reads the original pixels and is **idempotent** across clicks.
- Samples a downscaled copy into a 256-bin luma histogram (same approach as the live histogram feedback) plus shadow/highlight clip counts.
- Derives slider values with bounded heuristics that **mirror `tone.py` semantics** (linear-light exposure `2**ev`, display-space range controls, contrast around mid-grey):
  - **Exposure** nudges the median toward mid-grey (damped ×0.8, clamped ±1.2 stops).
  - **Whites/Blacks** anchor the end points, but only when there's real headroom (a near-white frame is left alone).
  - **Highlights/Shadows** recover ends that are already blown/crushed.
  - **Contrast** adds punch only to genuinely flat/hazy frames; never mutes a normal full-range image.

## Deliberate scope

- **Leaves colour untouched** (white balance, vibrance, saturation). For wildlife this is the *correct* call — auto-WB would wrongly neutralise wanted casts like golden-hour warmth. Existing colour choices are preserved.
- A **well-exposed image returns all-zeros** — Auto does nothing rather than fiddling, which builds trust.
- Honest toast: *"Auto-balanced tones from the histogram (color left unchanged)"*.

## Testing

- Validated the heuristic numerically against the **real `tone.py` pipeline** across well-exposed / dull / hazy / under / over-exposed synthetic images: correct direction in every case, all values within slider range, balanced image → all zeros.
- JS syntax-checked via `node --check`.
- Full suite: **1200 passed, 1 skipped**.

| Scenario | Auto result |
|---|---|
| well-exposed wide-range | all zeros |
| dull / lacks brights | +exposure, whites +35 / blacks −35 |
| hazy low-contrast | +24 contrast, slight −exposure |
| underexposed | +1.2 exposure, +shadows, +contrast |
| overexposed + clipping | −1.2 exposure, −55 highlights, −35 blacks |

🤖 Generated with [Claude Code](https://claude.com/claude-code)