### PR TITLE
Scope new-images detection to imported folders, not the destination base

### DIFF
--- a/vireo/new_images.py
+++ b/vireo/new_images.py
@@ -52,38 +52,49 @@ def _known_raw_stems_for_workspace(db, workspace_id):
 
 
 def mapped_roots(db, workspace_id):
-    """Return the workspace's mapped roots — linked folders whose ancestor chain
-    contains no other linked folder. Skips folders marked 'missing'. Folders
-    flagged ``'partial'`` from an interrupted scan are kept so a rescan can
-    pick up where the previous one stopped.
+    """Return the workspace's user-facing roots — folders linked to the
+    workspace with ``is_root = 1`` and no ``is_root = 1`` ancestor also linked
+    here. Skips folders marked 'missing'. Folders flagged ``'partial'`` from an
+    interrupted scan are kept so a rescan can pick up where it stopped.
 
-    Checking only the immediate parent would over-include when an intermediate
-    folder was unlinked but a deeper descendant is still linked (e.g. /A linked,
-    /A/B unlinked, /A/B/C linked — both /A and /A/B/C would otherwise be roots
-    and the walk would double-count files under /A/B/C).
+    Scoping by ``is_root`` (the canonical "user-facing root" flag, same as
+    ``get_workspace_folder_roots``) rather than by mere linkage is what keeps
+    the new-images walk aligned with what the user actually imported. A
+    templated copy-import records its leaf destination subfolders as roots and
+    links the destination *base* as a non-root parent (is_root=0) so photo
+    queries and the folder tree still work. Walking by linkage would treat that
+    base as a root and surface every un-imported sibling under it — a whole
+    archive of past shoots — as "new". The is_root migration backfills
+    is_root=1 for exactly the topmost-linked folder of each chain, so this is
+    behaviour-identical to the old topology walk for every pre-existing
+    workspace; it only diverges for the import-container case above.
+
+    The ancestor check still guards against double-counting when two folders in
+    one chain are both marked roots (e.g. /A and /A/B/C with /A/B unlinked):
+    os.walk'ing both would count files under /A/B/C twice.
     """
     rows = db.conn.execute(
-        """SELECT f.id, f.path, f.parent_id
+        """SELECT f.id, f.path, f.parent_id, wf.is_root
            FROM folders f
            JOIN workspace_folders wf ON wf.folder_id = f.id
            WHERE wf.workspace_id = ? AND f.status IN ('ok', 'partial')""",
         (workspace_id,),
     ).fetchall()
-    linked_ids = {r["id"] for r in rows}
-    if not linked_ids:
+    root_ids = {r["id"] for r in rows if r["is_root"]}
+    if not root_ids:
         return []
 
     # Load parent_id for every folder — needed to walk arbitrary-depth ancestor
-    # chains where intermediate folders may not be linked.
+    # chains where intermediate folders may not themselves be roots.
     parent_of = {
         r["id"]: r["parent_id"]
         for r in db.conn.execute("SELECT id, parent_id FROM folders").fetchall()
     }
 
-    def has_linked_ancestor(folder_id):
+    def has_root_ancestor(folder_id):
         parent = parent_of.get(folder_id)
         while parent is not None:
-            if parent in linked_ids:
+            if parent in root_ids:
                 return True
             parent = parent_of.get(parent)
         return False
@@ -91,7 +102,7 @@ def mapped_roots(db, workspace_id):
     return [
         {"id": r["id"], "path": r["path"]}
         for r in rows
-        if not has_linked_ancestor(r["id"])
+        if r["is_root"] and not has_root_ancestor(r["id"])
     ]
 
 

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -1339,6 +1339,23 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
     # Build folder cache: path -> folder_id
     folder_cache = {}
 
+    # When the scan is restricted to specific subfolders, those subfolders —
+    # not the broad scan root — are the user-facing workspace roots. A
+    # templated copy-import lands files in ``<destination>/<template>/...``
+    # dirs and passes those leaf dirs as ``restrict_dirs`` while keeping the
+    # destination base as ``root`` only for parent-chain creation. Promoting
+    # the base to a workspace root would make the new-images walk treat every
+    # un-imported sibling under it as "new" (e.g. a whole archive of past
+    # shoots sharing the destination). Mark the restricted dirs as roots
+    # instead; the base stays linked but is_root=0. See
+    # ``new_images.mapped_roots``. ``effective_restrict_dirs`` (bundle-filtered)
+    # is the set actually enumerated, so root marking matches what was scanned.
+    _restrict_root_paths = None
+    if restrict_dirs is not None:
+        _restrict_root_paths = {
+            os.path.normpath(str(d)) for d in effective_restrict_dirs
+        }
+
     def _ensure_folder(folder_path):
         """Ensure a folder and all its parents exist in the DB. Returns folder_id."""
         folder_str = str(folder_path)
@@ -1349,11 +1366,16 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
         if folder_path != root_path:
             parent_id = _ensure_folder(folder_path.parent)
 
+        if _restrict_root_paths is not None:
+            is_ws_root = os.path.normpath(folder_str) in _restrict_root_paths
+        else:
+            is_ws_root = (folder_path == root_path)
+
         folder_id = db.add_folder(
             path=folder_str,
             name=folder_path.name,
             parent_id=parent_id,
-            workspace_root=(folder_path == root_path),
+            workspace_root=is_ws_root,
         )
         folder_cache[folder_str] = folder_id
         return folder_id

--- a/vireo/tests/test_new_images.py
+++ b/vireo/tests/test_new_images.py
@@ -242,8 +242,8 @@ def test_import_into_archive_base_does_not_surface_siblings_as_new(db_with_works
     and reported the whole archive as "new". After scoping roots to the
     imported leaf folders, only genuinely-new files inside those leaves count.
     """
-    from scanner import scan
     from new_images import count_new_images_for_workspace
+    from scanner import scan
 
     db, ws_id, tmp_path = db_with_workspace
     base = tmp_path / "USA"

--- a/vireo/tests/test_new_images.py
+++ b/vireo/tests/test_new_images.py
@@ -233,6 +233,51 @@ def test_mapped_roots_excludes_folder_with_any_linked_ancestor(db_with_workspace
     )
 
 
+def test_import_into_archive_base_does_not_surface_siblings_as_new(db_with_workspace):
+    """End-to-end regression for the archive-base over-scope bug.
+
+    Importing into a destination base that already holds a large archive
+    (``USA/`` with many shoot folders) used to promote ``USA`` to a workspace
+    root, so the new-images detector walked every un-imported shoot under it
+    and reported the whole archive as "new". After scoping roots to the
+    imported leaf folders, only genuinely-new files inside those leaves count.
+    """
+    from scanner import scan
+    from new_images import count_new_images_for_workspace
+
+    db, ws_id, tmp_path = db_with_workspace
+    base = tmp_path / "USA"
+    imported = base / "2026-06-22"
+    sibling = base / "2026-01-01"          # pre-existing, never imported
+    _touch_image(str(imported / "IMG_0001.JPG"))
+    _touch_image(str(imported / "IMG_0002.JPG"))
+    _touch_image(str(sibling / "OLD_0001.JPG"))
+
+    # Mirror a templated copy-import: scan the base but restrict ingestion to
+    # the one subfolder the import wrote into.
+    scan(str(base), db, restrict_dirs=[str(imported)])
+
+    # Nothing on disk is unaccounted for within the imported root.
+    result = count_new_images_for_workspace(db, ws_id)
+    assert result["new_count"] == 0, (
+        f"The un-imported sibling shoot must NOT be surfaced as new; "
+        f"got {result['new_count']}. per_root={result['per_root']}"
+    )
+    assert [r["path"] for r in result["per_root"]] == [str(imported)], (
+        f"Only the imported leaf should be walked; per_root={result['per_root']}"
+    )
+
+    # A genuinely new file dropped into the imported root is still detected,
+    # while a new file in the un-imported sibling is correctly ignored.
+    _touch_image(str(imported / "IMG_0003.JPG"))
+    _touch_image(str(sibling / "OLD_0002.JPG"))
+    result2 = count_new_images_for_workspace(db, ws_id)
+    assert result2["new_count"] == 1, (
+        f"Only the new file inside the imported root should count; "
+        f"got {result2['new_count']}. per_root={result2['per_root']}"
+    )
+
+
 def test_progress_callback_fires_during_walk_and_on_completion(db_with_workspace):
     """count_new_images_for_workspace must invoke an optional progress_callback
     while walking and once at the end, so the new-images job entry can stream

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -3419,6 +3419,50 @@ def test_scan_promotes_top_level_target_to_workspace_root(tmp_path):
     assert root_paths == [root]
 
 
+def test_restricted_scan_roots_subfolders_not_destination_base(tmp_path):
+    """A templated import scans the destination *base* but only ingests the
+    leaf subfolders it wrote into (passed as restrict_dirs). Those leaves —
+    not the base — must become the workspace roots, so the new-images walk
+    doesn't later treat un-imported siblings under the base as "new".
+
+    Regression: importing into ``/Volumes/.../USA`` (a whole archive root)
+    promoted ``USA`` to a workspace root, and the new-images detector then
+    walked every un-imported shoot in the archive.
+    """
+    from db import Database
+    from scanner import scan
+
+    base = str(tmp_path / "USA")
+    _create_test_images(base, {
+        "2026-06-22": ["a.jpg", "b.jpg"],   # the import
+        "2026-01-01": ["old.jpg"],          # a pre-existing sibling, NOT imported
+    })
+    imported = os.path.join(base, "2026-06-22")
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db._active_workspace_id
+
+    scan(base, db, restrict_dirs=[imported])
+
+    root_paths = [f["path"] for f in db.get_workspace_folder_roots(ws_id)]
+    linked_paths = {f["path"] for f in db.get_workspace_folders(ws_id)}
+    # The imported leaf is the user-facing root; the archive base is linked
+    # (for the folder hierarchy) but is NOT a root.
+    assert root_paths == [imported]
+    assert base in linked_paths
+    # Ingestion stayed scoped to the restricted dir — the sibling shoot's
+    # files were never pulled in.
+    photo_paths = {
+        os.path.join(r["folder_path"], r["filename"])
+        for r in db.conn.execute(
+            "SELECT f.path AS folder_path, p.filename "
+            "FROM photos p JOIN folders f ON f.id = p.folder_id"
+        ).fetchall()
+    }
+    assert os.path.join(imported, "a.jpg") in photo_paths
+    assert os.path.join(base, "2026-01-01", "old.jpg") not in photo_paths
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX permissions required")
 def test_scan_surfaces_permission_denied_subdirs(tmp_path):
     """A subdir the kernel won't let us enter must surface as a denied path,


### PR DESCRIPTION
## Problem

The pipeline readiness panel reported thousands of "new images to classify" even though the user had only imported a handful of shoot dates. Investigation against a live DB showed the workspace's only mapped root was the **destination base** `/Volumes/Photography/Raw Files/USA` — a whole RAW archive (2016→2026). Only 4 date folders had been imported (5,190 photos), but the new-images detector was walking the entire archive and reporting every un-imported sibling shoot as "new."

## Root cause

A templated copy-import calls `scanner.scan(destination, restrict_dirs=[leaf folders])`:
- Ingestion is correctly scoped to the leaf folders via `restrict_dirs`.
- **But** `_ensure_folder` promoted the scan root (the destination base) to a user-facing workspace root (`is_root=1`).
- `new_images.mapped_roots` defined "roots" as *any linked folder with no linked ancestor*, so it returned the base and `os.walk`'d the whole tree.

The two scopes (what import ingests vs. what new-images watches) disagreed.

## Fix

- **`scanner.scan`** — when `restrict_dirs` is set, mark the restricted leaf dirs as the workspace roots instead of the broad scan base. The base stays linked (`is_root=0`) so the folder hierarchy and workspace-scoped photo queries are unchanged. Single-folder cases where `restrict_dirs == [root]` (pipeline repair/regroup scans) keep identical behavior.
- **`new_images.mapped_roots`** — scope the walk to `is_root=1` folders (the canonical user-facing-root flag, already used by `get_workspace_folder_roots`) rather than topology over all linked folders. The `is_root` migration backfills `is_root=1` for exactly the topmost-linked folder of each chain, so this is **behaviour-identical for every pre-existing workspace**; it only diverges for the import-container case above. The arbitrary-depth ancestor check is retained to prevent double-counting when two folders in one chain are both roots.

## Tests

- `test_restricted_scan_roots_subfolders_not_destination_base` (scanner): a restricted scan roots the imported subfolder, not the base, and does not ingest un-imported siblings.
- `test_import_into_archive_base_does_not_surface_siblings_as_new` (new_images, end-to-end): un-imported siblings under the base are not surfaced; a genuinely-new file dropped into the imported folder still is.

Full suite run locally: **1,395 passed, 1 skipped** (CLAUDE.md suite + `test_scanner`, `test_new_images`, `test_new_images_api`, `test_audit`, and the e2e new-images pipeline test).

## Caveat (existing databases)

This corrects behaviour going forward. A DB that already flagged a destination base as a root needs a one-time workspace re-scope to point at the imported leaf folders. The migration deliberately does **not** auto-demote roots, since "imported into an archive base" can't be safely distinguished from "user genuinely wants the whole folder watched."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted scans now correctly treat the selected subfolder as the workspace root instead of the broader parent folder.
  * New image counts now stay scoped to the intended imported folder, avoiding accidental inclusion of sibling content.
  * Scanning behavior is more accurate for archive/template import flows, especially when only part of a directory tree is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->