### PR TITLE
Pipeline: drop redundant "Add" button on source path input

### DIFF
--- a/tests/e2e/test_pipeline.py
+++ b/tests/e2e/test_pipeline.py
@@ -159,7 +159,7 @@ def test_pipeline_import_plan_waits_for_folder_preview_scope(live_server, page):
     folder_preview_route = []
     page.route("**/api/import/folder-preview", lambda route: folder_preview_route.append(route))
     page.fill("#cfgSourceInput", "/Volumes/Photography/Raw Files/USA/2026/2026-05-30")
-    page.locator("#card-source button", has_text="Add").click()
+    page.press("#cfgSourceInput", "Enter")
     stale_plan_route[0].fulfill(
         status=200,
         content_type="application/json",

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -660,13 +660,10 @@ body { padding-bottom: 36px; }
                 <div class="setting-label" id="lblFolder">Folders</div>
                 <div style="display:flex;flex-direction:column;gap:6px;">
                   <button onclick="browseForFolder()" class="btn btn-primary" style="white-space:nowrap;align-self:flex-start;">Browse&hellip;</button>
-                  <div style="display:flex;gap:6px;">
-                    <input type="text" class="setting-select" id="cfgSourceInput" list="volumeDatalist"
-                           placeholder="or type a path" style="font-family:inherit;flex:1;"
-                           onkeydown="if(event.key==='Enter'){event.preventDefault();addSourceFolder();}">
-                    <datalist id="volumeDatalist"></datalist>
-                    <button onclick="addSourceFolder()" class="btn btn-secondary" style="white-space:nowrap;">Add</button>
-                  </div>
+                  <input type="text" class="setting-select" id="cfgSourceInput" list="volumeDatalist"
+                         placeholder="or type a path and press Enter" style="font-family:inherit;"
+                         onkeydown="if(event.key==='Enter'){event.preventDefault();addSourceFolder();}">
+                  <datalist id="volumeDatalist"></datalist>
                 </div>
                 <div id="sourceFolderList" style="margin-top:6px;"></div>
                 <label style="font-size:12px;color:var(--text-secondary);cursor:pointer;margin-top:6px;display:inline-flex;align-items:center;gap:4px;">


### PR DESCRIPTION
## What changed

The source folder section in the pipeline stacked a `Browse…` button above a "type a path" input with its own **Add** button. Because the two controls share one column, the Add button read as "step 2 of Browse" — even though `Browse…` already commits its selection on its own, and the typed-path input already commits on **Enter**.

The result: people clicked **Add** after browsing (where it does nothing), not really knowing what the flow was.

This removes the redundant Add button:

- Drop the `Add` button; rely on the existing Enter-to-commit handler.
- Placeholder updated `or type a path` → `or type a path and press Enter` so the commit gesture stays discoverable.
- Keeps the type-a-path escape hatch (useful for pasting deep/NAS paths) — just de-clutters it.

Only the source side is affected; the destination input was already direct-bound with no Add button.

Before:
```
[ Browse… ]
[ or type a path        ] [ Add ]
```
After:
```
[ Browse… ]
[ or type a path and press Enter        ]
```

## Tests

- `tests/e2e/test_pipeline.py` updated to press Enter instead of clicking Add — **29 passed**.
- `vireo/tests/test_app.py` + `test_jobs_api.py` — **314 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streamlined source path entry in the pipeline flow so users add a folder by pressing Enter, with updated guidance in the input field.
  * Improved consistency between the interface and automated tests for the folder selection step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->