### PR TITLE
Add "Edit Photo" right-click entry to open the editor from the grid

### DIFF
--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -6423,6 +6423,17 @@ function refreshCardSelectionVisuals() {
   });
 }
 
+// Open a single grid photo straight in the in-app editor, skipping the
+// lightbox. Hand off the current grid's ordered list so the editor can offer
+// Prev/Next, mirroring the lightbox "Edit Photo" handoff.
+function openPhotoEditor(photoId) {
+  if (window.vireoEditNav) {
+    window.vireoEditNav.setList(photos, photoId);
+    window.vireoEditNav.setLastPhoto(photoId);
+  }
+  window.location.href = '/edit/' + photoId;
+}
+
 function buildPhotoContextMenu(photoIds) {
   var one = photoIds.length === 1;
   var hint = one ? undefined : 'Select a single photo';
@@ -6479,6 +6490,9 @@ function buildPhotoContextMenu(photoIds) {
       onClick: function() { openBestBatchForIds(photoIds, photoIds[0]); } },
     { label: 'Review Burst', disabled: photoIds.length < 2, disabledHint: 'Select at least two photos',
       onClick: function() { openSelectedInBurstReview(); } },
+    { separator: true },
+    { label: 'Edit Photo', disabled: !one, disabledHint: hint,
+      onClick: function() { openPhotoEditor(photoIds[0]); } },
   ].concat(buildOpenInEditorMenuItems(photoIds)).concat([
     { label: window.VIREO_REVEAL_LABEL, disabled: !one, disabledHint: hint,
       onClick: function() { revealPhoto(photoIds[0]); } },

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1567,7 +1567,17 @@ function buildBurstGroupContextMenu(photoId, filename) {
             _grmVisibleItems().map(function(it) { return it.photo_id; }), photoId);
           window.vireoEditNav.setLastPhoto(photoId);
         }
-        window.location.href = '/edit/' + photoId;
+        // Open in a new tab in a real browser so the modal stays alive with
+        // any pending pick/reject/remove decisions — navigating in place
+        // would tear it down and drop that unsaved work. Tauri has no tabs
+        // and ignores window.open(_, '_blank'); navigate in place there,
+        // same tradeoff as Open in Browse Mode.
+        var url = '/edit/' + photoId;
+        if (typeof isTauri === 'function' && isTauri()) {
+          window.location.href = url;
+        } else {
+          window.open(url, '_blank', 'noopener');
+        }
       } },
   ].concat(
     typeof window.buildOpenInEditorMenuItems === 'function'

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1556,6 +1556,17 @@ function buildBurstGroupContextMenu(photoId, filename) {
       onClick: function() {
         if (typeof window.submitToInat === 'function') window.submitToInat(photoId);
       } },
+    { label: 'Edit Photo',
+      onClick: function() {
+        // Hand the group's ordered photo list to the editor for Prev/Next,
+        // mirroring the lightbox "Edit Photo" handoff.
+        if (window.vireoEditNav) {
+          window.vireoEditNav.setList(
+            grmState.items.map(function(it) { return it.photo_id; }), photoId);
+          window.vireoEditNav.setLastPhoto(photoId);
+        }
+        window.location.href = '/edit/' + photoId;
+      } },
   ].concat(
     typeof window.buildOpenInEditorMenuItems === 'function'
       ? window.buildOpenInEditorMenuItems([photoId])

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1559,10 +1559,12 @@ function buildBurstGroupContextMenu(photoId, filename) {
     { label: 'Edit Photo',
       onClick: function() {
         // Hand the group's ordered photo list to the editor for Prev/Next,
-        // mirroring the lightbox "Edit Photo" handoff.
+        // mirroring the lightbox "Edit Photo" handoff. Use the visible
+        // (non-removed) items so the editor can't navigate into frames the
+        // user has already removed from the group.
         if (window.vireoEditNav) {
           window.vireoEditNav.setList(
-            grmState.items.map(function(it) { return it.photo_id; }), photoId);
+            _grmVisibleItems().map(function(it) { return it.photo_id; }), photoId);
           window.vireoEditNav.setLastPhoto(photoId);
         }
         window.location.href = '/edit/' + photoId;


### PR DESCRIPTION
## What

Adds an **Edit Photo** item to the right-click context menu on both photo grids, so you can open a specific photo straight in the in-app editor (`/edit/<id>`) without going through the lightbox first.

Before this, the editor became a first-class page in #1061, but the only ways to open a *specific* photo were:
- the lightbox's "Edit Photo" button (requires opening the lightbox), or
- the navbar "Edit" link (opens the *last-viewed* photo, not the one you're pointing at).

## Changes

- **Browse** (`browse.html`): new `Edit Photo` item in `buildPhotoContextMenu`, single-photo only (disabled with a "Select a single photo" hint on multi-select). A small `openPhotoEditor()` helper hands off the grid's ordered `photos` list so the editor offers Prev/Next — mirroring the lightbox handoff.
- **Review burst modal** (`review.html`): same `Edit Photo` item, handing off `grmState.items` order.

Both reuse the existing `vireoEditNav` cursors (`vireo:lastPhoto`, `vireo:editNav`), so Prev/Next and last-viewed resolution behave identically to the lightbox path.

## Testing

- Required suite green: **1207 passed, 1 skipped**.
- Manually verified with Playwright against a copy of the real DB (isolated instance, no interference with the live app): right-click a browse card → **Edit Photo** navigates to `/edit/<id>`, writes both `vireo:lastPhoto` and `vireo:editNav`, and the editor renders with the exposure slider. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an **Edit Photo** option to photo context menus in both browse and review views.
  * You can now open a selected photo directly in the editor from the grid or burst-group menus.
  * When available, the app preserves the photo order and last-selected photo for a smoother editing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->