### PR TITLE
Merge local-processing imports into an existing managed archive

### DIFF
--- a/docs/plans/2026-06-30-merge-into-existing-archive-design.md
+++ b/docs/plans/2026-06-30-merge-into-existing-archive-design.md
@@ -1,0 +1,160 @@
+# Merge local-processing imports into an existing managed archive
+
+**Date:** 2026-06-30
+**Branch:** `archive-destination-overlap-error`
+
+## Problem
+
+A local-processing import whose archive destination is a folder Vireo already
+manages fails at run time:
+
+```
+Pipeline failed
+Archive destination /Volumes/Photography/Raw Files/USA overlaps a folder
+Vireo already manages (/Volumes/Photography/Raw Files/USA). Local processing
+imports must land at a new archive folder; pick a different destination or
+import without local processing.
+```
+
+The message reads as nonsense ("X overlaps X") because the destination *is* the
+managed folder. More importantly, importing new shoots into an existing archive
+is the **expected** workflow — the archive is the system of record and new
+shoots accrete into it. Commit #1064 (`d0194dd9`) was built around exactly this
+shape (a templated copy-import into a destination base full of past shoots), but
+the pipeline storage preflight still hard-refuses it.
+
+## Principle
+
+Importing into an already-managed archive is a normal operation, not an error.
+It should seamlessly merge. The merge is safe because the file-copy layer never
+overwrites or deletes a differing file — it only adds missing files and
+recognizes identical ones.
+
+Scope (agreed): full seamless merge, covering
+- new dated subfolders added under an existing base that holds other shoots,
+- a dated subfolder that already exists and already holds photos (new files fold
+  in),
+- re-dropped cards whose photos are already archived (identical files recognized
+  and skipped, no duplicate catalog rows).
+
+Both "destination **is** a managed folder" and "destination is **inside** a
+managed folder" are handled — same user intent, same reconciliation logic.
+
+## What already works (and is NOT changed)
+
+`move_folder`'s file-copy step already does a safe merge:
+- `rsync --ignore-existing` — never overwrites a file already at the destination
+  (`move.py:1695-1697`).
+- Verify every source file is present at the destination before deleting
+  originals (`move.py:1757-1782`).
+- **Content-conflict refusal** — if any same-name destination file differs in
+  content, the move aborts with nothing copied or deleted
+  (`move.py:1583-1629`).
+
+The merge rides on top of these. It changes only (a) which destinations are
+allowed and (b) the catalog reconciliation step.
+
+## §1 — Guard relaxation
+
+Two guards refuse this today; both become conditional via a new opt-in
+parameter `allow_tracked_merge=False` on `move_folder`. Only the pipeline
+archive call passes `True`; every other caller (manual folder-move UI, remote
+moves) keeps today's hard refusal unchanged.
+
+1. **Pipeline storage preflight** — `pipeline_job.py:1062` (overlap) and
+   `:1085` (ancestor). For local-processing archive runs these stop being fatal
+   (no `_bail_storage`); the run proceeds to merge.
+2. **`move_folder`'s own guards** — `move.py:1545` (overlap) and `:1552`
+   (ancestor). When `allow_tracked_merge=True`, the refusal is replaced by the
+   reconciliation path (§2). When `False` (default), unchanged.
+
+## §2 — Catalog reconciliation (core new logic)
+
+After the file copy + verify succeeds, `move_folder` today calls
+`db.move_folder_path(folder_id, catalog_path)`, which rewrites the staging root
+row's path. That collides on `folders.path` UNIQUE when a tracked row already
+sits at the target. The folder hierarchy is purely path-string based (no
+`parent_id`), so a real merge reconciles folder rows.
+
+New `db` method (e.g. `merge_staged_tree_into_archive`), used only on the
+`allow_tracked_merge` path. Walking staged folder rows root-first, for each
+staged folder compute `target = rebase(staged_path, src_path -> catalog_path)`:
+
+- **Target has no folder row** → genuinely new subfolder. Rewrite the staged
+  row's path to `target` (today's behavior). Set `is_root = 0` if any tracked
+  ancestor is already a root, else `1` — preserving the existing archive's root
+  structure and staying consistent with #1064.
+- **Target already has a tracked folder row** → merge into it:
+  - For each staged photo, its post-move path is `target/filename`.
+    - If **no** photo row exists there → reparent it (update `folder_id` +
+      `path`) into the existing folder.
+    - If one **does** exist → it's an identical file the copy layer already
+      recognized (a differing file would have aborted the move upstream). Drop
+      the staged photo row; the existing archived row stays canonical.
+  - Delete the now-empty staged folder row.
+- **Workspace attach:** every folder the merge touched is added to the current
+  workspace's `workspace_folders` so the new photos surface in the active
+  workspace. Invalidate `new_images` caches for affected roots.
+
+With `skip_duplicates` on (the default) files already in the catalog never reach
+staging, so reconciliation mostly reparents genuinely-new photos and folds new
+dates into existing date-folders. The photo-row-collision branch is the safety
+net for `skip_duplicates`-off re-runs.
+
+## §3 — Pre-run transparency
+
+Two honest signals, no new hashing (UI transparency is a hard rule — an existing
+managed archive must not be presented as an empty/new destination):
+
+1. **"Existing managed archive" + size.** Extend `api_import_destination_preview`
+   (`app.py:10458`, already has `db`): run `_tracked_destination_overlap` /
+   `_tracked_destination_ancestor` against the destination; if either hits,
+   return `{managed_archive: {path, photo_count}}` (one indexed query + count,
+   no file I/O). The import dialog renders *"Destination is an existing Vireo
+   archive (/Volumes/.../USA, 9,041 photos). New files will be merged in."*
+2. **"N of your selected files are already archived."** The import UI already
+   runs the `api_import_check_duplicates` SSE scan (`app.py:10344`), which counts
+   selection files whose hash is in the catalog. Reuse that result — when the
+   destination is a managed archive, frame those as *"38 already in this archive
+   (will be skipped), 412 new (will be merged)"* instead of generic "duplicates."
+
+`preview_destination`'s `existing_folders` ("dir exists on disk") stays but is
+subordinate to the explicit, stronger "managed archive" callout.
+
+## §4 — Final summary
+
+`move_folder`'s result gains counts: `merged_new` (staged photos reparented),
+`merged_into_existing_folders` (date-folders folded into pre-existing ones vs.
+created fresh), `already_present` (identical-path staged rows dropped). The
+pipeline archive summary becomes e.g. *"412 photos archived into existing
+archive /Volumes/.../USA — 412 new across 3 folders (2 new, 1 merged into
+existing), 0 already present."* A brand-new destination keeps today's wording.
+
+## §5 — Testing (TDD, written first)
+
+1. `db.merge_staged_tree_into_archive` unit tests: new subfolder under tracked
+   base; new date folded into existing tracked date-folder; identical-path photo
+   collision drops staged row; `is_root` rule (root ancestor → child
+   `is_root=0`); workspace attach.
+2. `move_folder` with `allow_tracked_merge=True` merges into a tracked
+   destination; without it, still refuses (regression guard).
+3. End-to-end pipeline: local-processing import into an already-managed archive
+   base succeeds, files land in date subfolders, catalog has no duplicate rows,
+   no UNIQUE violation. (The exact scenario from the error.)
+4. Preview endpoint returns `managed_archive` for a tracked destination; `null`
+   for a fresh one.
+5. Update existing `test_pipeline_api.py` tests that assert the *old* failure
+   (`:313`, `:353`, `:402`, incl. the ancestor case) to assert the merge
+   succeeds.
+
+## Files touched
+
+- `vireo/move.py` — `allow_tracked_merge` param; reconciliation call.
+- `vireo/db.py` — `merge_staged_tree_into_archive`.
+- `vireo/pipeline_job.py` — drop fatal preflight for archive runs; pass
+  `allow_tracked_merge=True`; merge-aware archive summary.
+- `vireo/ingest.py` / `vireo/app.py` — `managed_archive` signal in destination
+  preview.
+- Templates (import dialog) — render managed-archive callout + new/already-there
+  split.
+- Tests as above.

--- a/docs/plans/2026-06-30-merge-into-existing-archive-design.md
+++ b/docs/plans/2026-06-30-merge-into-existing-archive-design.md
@@ -115,8 +115,14 @@ managed archive must not be presented as an empty/new destination):
 2. **"N of your selected files are already archived."** The import UI already
    runs the `api_import_check_duplicates` SSE scan (`app.py:10344`), which counts
    selection files whose hash is in the catalog. Reuse that result — when the
-   destination is a managed archive, frame those as *"38 already in this archive
+   destination is a managed archive, frame those as *"38 already in your library
    (will be skipped), 412 new (will be merged)"* instead of generic "duplicates."
+   Note: the duplicate check is catalog-global (`SELECT file_hash FROM photos`,
+   no destination/workspace scope), matching ingest's global `skip_duplicates`.
+   So a match may live in a *different* archive — hence "in your library", not
+   "in this archive" — but the count is still correct for the skip/merge framing
+   (a cross-archive dup is skipped, not merged), so it is deliberately not
+   archive-scoped.
 
 `preview_destination`'s `existing_folders` ("dir exists on disk") stays but is
 subordinate to the explicit, stronger "managed archive" callout.

--- a/docs/plans/2026-06-30-merge-into-existing-archive-design.md
+++ b/docs/plans/2026-06-30-merge-into-existing-archive-design.md
@@ -123,12 +123,22 @@ subordinate to the explicit, stronger "managed archive" callout.
 
 ## §4 — Final summary
 
-`move_folder`'s result gains counts: `merged_new` (staged photos reparented),
-`merged_into_existing_folders` (date-folders folded into pre-existing ones vs.
-created fresh), `already_present` (identical-path staged rows dropped). The
-pipeline archive summary becomes e.g. *"412 photos archived into existing
-archive /Volumes/.../USA — 412 new across 3 folders (2 new, 1 merged into
-existing), 0 already present."* A brand-new destination keeps today's wording.
+`move_folder`'s result gains counts (all defined as the user-facing summary
+reads them — a photo count is a photo count):
+- `new_photos` — total staged photos newly placed into the archive, counting
+  BOTH photos reparented into brand-new folders AND photos moved into a
+  pre-existing target folder. The headline number.
+- `new_folders` — folders created under the archive (no pre-existing target).
+- `merged_folders` — staged folders folded into a pre-existing target folder.
+- `already_present` — identical-filename staged photos dropped because the
+  target folder already held that filename.
+
+The pipeline archive summary becomes e.g. *"412 new photos archived into
+existing archive /Volumes/.../USA (2 new folders, 1 merged into existing, 0
+already present)"* — i.e.
+`"{new_photos} new photos archived into existing archive {base} ({new_folders}
+new folders, {merged_folders} merged into existing, {already_present} already
+present)"`. A brand-new destination keeps today's wording.
 
 ## §5 — Testing (TDD, written first)
 

--- a/docs/plans/2026-06-30-merge-into-existing-archive.md
+++ b/docs/plans/2026-06-30-merge-into-existing-archive.md
@@ -404,8 +404,9 @@ merge = move_result.get("merge")
 if merge:
     base = move_result.get("merged_into_existing", final_destination)
     summary = (
-        f"{merge['merged_new']} photos archived into existing archive "
-        f"{base} ({merge['merged_into_existing_folders']} folders merged, "
+        f"{merge['new_photos']} new photos archived into existing archive "
+        f"{base} ({merge['new_folders']} new folders, "
+        f"{merge['merged_folders']} merged into existing, "
         f"{merge['already_present']} already present)"
     )
 else:

--- a/docs/plans/2026-06-30-merge-into-existing-archive.md
+++ b/docs/plans/2026-06-30-merge-into-existing-archive.md
@@ -1,0 +1,602 @@
+# Merge Into Existing Managed Archive — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Let a local-processing import whose archive destination is already a Vireo-managed folder seamlessly merge into it instead of failing the pipeline.
+
+**Architecture:** The file-copy layer in `move_folder` already merges safely (rsync `--ignore-existing`, verify-before-delete, content-conflict refusal). This plan (a) makes the two tracked-destination guards conditional behind a new `allow_tracked_merge` flag the pipeline passes, (b) replaces `move_folder`'s post-copy `db.move_folder_path` call with a catalog reconciliation that folds staged folder/photo rows into the existing archive rows, and (c) surfaces the existing-archive fact and the already-archived count in the pre-run import preview and the final summary.
+
+**Tech Stack:** Python 3, Flask, SQLite (WAL, FK on), pytest. No frontend framework — Jinja2 + vanilla JS.
+
+**Key facts (verified):**
+- `folders`: `id, path (UNIQUE), parent_id REFERENCES folders(id), name, photo_count, status`.
+- `photos`: identified by `(folder_id, filename)` — **no path column**. Photo collision = same filename in the target folder.
+- `db.check_filename_collisions(photo_ids, target_folder_id)` (`db.py:2722`) returns the colliding `{photo_id, filename}` rows.
+- `db.add_workspace_folder(workspace_id, folder_id, *, is_root=...)` (`db.py:1526`) links a folder subtree to a workspace, sets `workspace_folders.is_root`, and invalidates the new-images cache. `is_root` lives on `workspace_folders`, **not** `folders`.
+- `_tracked_destination_overlap(db, folder_id, dest)` → tracked folder row AT/below `dest`. `_tracked_destination_ancestor(db, folder_id, dest)` → tracked folder row ABOVE `dest` (`move.py:1182`, `:1203`).
+- `db.move_folder_path(folder_id, new_path)` (`db.py:2693`) rewrites a folder's path + path-prefix descendants. It does NOT touch `parent_id`.
+- Pipeline archive call: `move_folder(thread_db, folder["id"], archive_parent, ..., merge=True, reject_tracked_ancestor=True)` at `pipeline_job.py:4606`.
+- Pipeline storage preflight bails via `_bail_storage` at `pipeline_job.py:1062` (overlap) and `:1085` (ancestor).
+
+**Run tests with:**
+```
+python -m pytest vireo/tests/test_db.py vireo/tests/test_move.py vireo/tests/test_pipeline_api.py -q
+```
+
+---
+
+### Task 1: `db.merge_staged_tree_into_archive` — new-subfolder case
+
+Reconciliation method. Start with the simplest case: staged tree maps entirely to **new** target paths (no existing folder rows at the targets) — behaviourally equivalent to `move_folder_path` but also fixes `parent_id` and links the workspace.
+
+**Files:**
+- Modify: `vireo/db.py` (add method near `move_folder_path`, ~`db.py:2720`)
+- Test: `vireo/tests/test_db.py`
+
+**Step 1: Write the failing test**
+
+```python
+def test_merge_staged_tree_new_subfolders(tmp_path):
+    """Staged tree merged under an existing tracked base: new date folders
+    are repointed under the base, parent_id fixed, workspace linked, and the
+    base's existing photos are untouched."""
+    db = Database(str(tmp_path / "t.db"))
+    ws = db.active_workspace_id
+
+    # Existing tracked archive base with one prior shoot.
+    base_id = db.add_folder("/arch/USA")
+    old_id = db.add_folder("/arch/USA/2025/2025-01-01", parent_id=base_id)
+    db.add_photo(old_id, "old.raf")
+    db.add_workspace_folder(ws, base_id, is_root=True)
+
+    # Staged tree (post-rsync the files already live at /arch/USA/...).
+    stage_root = db.add_folder("/stage/USA")
+    stage_leaf = db.add_folder("/stage/USA/2026/2026-06-30", parent_id=stage_root)
+    db.add_photo(stage_leaf, "new.raf")
+
+    db.merge_staged_tree_into_archive(stage_root, "/arch/USA")
+
+    # New leaf now lives under the base, parented correctly.
+    leaf = db.conn.execute(
+        "SELECT id, parent_id FROM folders WHERE path = ?",
+        ("/arch/USA/2026/2026-06-30",),
+    ).fetchone()
+    assert leaf is not None
+    # The staged root row is gone (folded into the existing base).
+    assert db.conn.execute(
+        "SELECT 1 FROM folders WHERE path = ?", ("/stage/USA",)
+    ).fetchone() is None
+    # The new photo moved with the folder; the old photo is untouched.
+    assert db.conn.execute(
+        "SELECT folder_id FROM photos WHERE filename = ?", ("new.raf",)
+    ).fetchone()["folder_id"] == leaf["id"]
+    # New leaf is linked to the workspace as a non-root (base is the root).
+    row = db.conn.execute(
+        "SELECT is_root FROM workspace_folders WHERE workspace_id=? AND folder_id=?",
+        (ws, leaf["id"]),
+    ).fetchone()
+    assert row is not None and row["is_root"] == 0
+```
+
+> Adapt `db.add_folder` / `db.add_photo` / `db.active_workspace_id` to the real
+> helper names used elsewhere in `test_db.py` (grep for how other tests insert
+> folders and photos — e.g. they may use raw `INSERT` or a `_seed` helper).
+
+**Step 2: Run it, expect failure**
+
+Run: `python -m pytest vireo/tests/test_db.py -k merge_staged_tree_new_subfolders -q`
+Expected: FAIL — `AttributeError: 'Database' object has no attribute 'merge_staged_tree_into_archive'`.
+
+**Step 3: Implement**
+
+```python
+def merge_staged_tree_into_archive(self, staged_root_id, archive_path):
+    """Fold a staged folder subtree into an existing tracked archive.
+
+    The on-disk rsync merge has already happened: files that were under the
+    staged root now also live under ``archive_path``. This reconciles the
+    catalog so staged folder/photo rows become rows under the existing
+    archive, with no duplicate ``folders.path`` and correct ``parent_id``.
+
+    For each staged folder (root-first), the target path is the staged path
+    rebased from the staged root onto ``archive_path``:
+
+    * Target has no folder row -> repoint the staged row to the target path,
+      fix its ``parent_id`` to the (now-existing) target-parent folder, and
+      link it to the active workspace as a non-root when a workspace root
+      ancestor exists, else as a root.
+    * Target already has a folder row -> move the staged folder's photos into
+      it (dropping any whose filename already exists there as an identical
+      archived file), then delete the now-empty staged folder row.
+    """
+    staged_root = self.conn.execute(
+        "SELECT path FROM folders WHERE id = ?", (staged_root_id,)
+    ).fetchone()
+    if not staged_root:
+        return {"merged_new": 0, "merged_into_existing_folders": 0,
+                "already_present": 0}
+    staged_root_path = staged_root["path"]
+    ws = self._ws_id()
+
+    # Snapshot staged folders root-first (shallowest path first) so a parent's
+    # target row exists before its children are processed.
+    staged_folders = self.conn.execute(
+        """SELECT id, path FROM folders
+           WHERE path = ? OR substr(REPLACE(path,'\\','/'),1,?) = ?
+           ORDER BY length(path) ASC""",
+        (staged_root_path,
+         len(_subtree_prefix(staged_root_path)),
+         _subtree_prefix(staged_root_path)),
+    ).fetchall()
+
+    counts = {"merged_new": 0, "merged_into_existing_folders": 0,
+              "already_present": 0}
+
+    for sf in staged_folders:
+        rel = _subtree_relative(sf["path"], staged_root_path)
+        target_path = _join_subtree_path(archive_path, rel)
+        target = self.conn.execute(
+            "SELECT id FROM folders WHERE path = ?", (target_path,)
+        ).fetchone()
+        parent_path = os.path.dirname(target_path)
+        parent_row = self.conn.execute(
+            "SELECT id FROM folders WHERE path = ?", (parent_path,)
+        ).fetchone()
+        parent_id = parent_row["id"] if parent_row else None
+
+        if target is None:
+            # New folder under the archive: repoint + reparent + link.
+            self.conn.execute(
+                "UPDATE folders SET path = ?, parent_id = ? WHERE id = ?",
+                (target_path, parent_id, sf["id"]),
+            )
+            # A workspace root ancestor exists iff some ancestor folder is
+            # is_root=1 in this workspace; the base archive normally is.
+            self.add_workspace_folder(ws, sf["id"], is_root=False)
+            counts["merged_new"] += 1
+        else:
+            # Existing folder: move photos in, drop filename-collisions.
+            photo_ids = [r["id"] for r in self.conn.execute(
+                "SELECT id FROM photos WHERE folder_id = ?", (sf["id"],)
+            )]
+            collisions = {c["photo_id"]
+                          for c in self.check_filename_collisions(
+                              photo_ids, target["id"])}
+            for pid in photo_ids:
+                if pid in collisions:
+                    self.conn.execute("DELETE FROM photos WHERE id = ?", (pid,))
+                    counts["already_present"] += 1
+                else:
+                    self.conn.execute(
+                        "UPDATE photos SET folder_id = ? WHERE id = ?",
+                        (target["id"], pid),
+                    )
+            self.conn.execute("DELETE FROM folders WHERE id = ?", (sf["id"],))
+            counts["merged_into_existing_folders"] += 1
+
+    self.conn.commit()
+    self.update_folder_counts()
+    return counts
+```
+
+> Confirm `_subtree_prefix`, `_subtree_relative`, `_join_subtree_path` are the
+> module-level helpers `move_folder_path` uses (`db.py`). Reuse them; do not
+> reimplement path math.
+
+**Step 4: Run it, expect pass**
+
+Run: `python -m pytest vireo/tests/test_db.py -k merge_staged_tree_new_subfolders -q`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "db: merge_staged_tree_into_archive — new-subfolder reconciliation"
+```
+
+---
+
+### Task 2: Reconciliation — existing-folder + collision cases
+
+Cover the date-folder-already-exists and identical-filename branches explicitly with their own test (the implementation from Task 1 already handles them; this locks the behaviour).
+
+**Files:**
+- Test: `vireo/tests/test_db.py`
+
+**Step 1: Write the failing test**
+
+```python
+def test_merge_staged_tree_existing_folder_and_collision(tmp_path):
+    db = Database(str(tmp_path / "t.db"))
+    ws = db.active_workspace_id
+    base_id = db.add_folder("/arch/USA")
+    date_id = db.add_folder("/arch/USA/2026/2026-06-30", parent_id=base_id)
+    db.add_photo(date_id, "dup.raf")      # already archived
+    db.add_photo(date_id, "keep.raf")
+    db.add_workspace_folder(ws, base_id, is_root=True)
+
+    stage_root = db.add_folder("/stage/USA")
+    stage_leaf = db.add_folder("/stage/USA/2026/2026-06-30", parent_id=stage_root)
+    db.add_photo(stage_leaf, "dup.raf")   # same filename -> identical, drop
+    db.add_photo(stage_leaf, "fresh.raf") # genuinely new -> reparent
+
+    counts = db.merge_staged_tree_into_archive(stage_root, "/arch/USA")
+
+    names = {r["filename"] for r in db.conn.execute(
+        "SELECT filename FROM photos WHERE folder_id = ?", (date_id,))}
+    assert names == {"dup.raf", "keep.raf", "fresh.raf"}      # no duplicate row
+    # exactly one dup.raf
+    assert db.conn.execute(
+        "SELECT COUNT(*) c FROM photos WHERE filename='dup.raf'").fetchone()["c"] == 1
+    assert counts["already_present"] == 1
+    assert counts["merged_into_existing_folders"] >= 1
+    # staged rows gone
+    assert db.conn.execute(
+        "SELECT 1 FROM folders WHERE path LIKE '/stage/%'").fetchone() is None
+```
+
+**Step 2: Run it** — Expected: PASS (Task 1 implementation already covers this). If it fails, fix `merge_staged_tree_into_archive`, not the test.
+
+**Step 3: Commit**
+
+```bash
+git add vireo/tests/test_db.py
+git commit -m "test: reconciliation existing-folder + identical-filename collision"
+```
+
+---
+
+### Task 3: `move_folder` gains `allow_tracked_merge`
+
+Make the two tracked-destination guards conditional, and route the post-copy catalog step to the reconciliation when merging into a tracked destination.
+
+**Files:**
+- Modify: `vireo/move.py` — signature at `move.py:1375`; guards at `:1545`/`:1552`; catalog update at `:1802`.
+- Test: `vireo/tests/test_move.py`
+
+**Step 1: Write the failing tests**
+
+```python
+def test_move_folder_refuses_tracked_merge_by_default(move_env):
+    """Default behaviour unchanged: merging into a tracked folder is refused."""
+    # (mirror the existing test at test_move.py that asserts 'already manage';
+    #  assert the same refusal with allow_tracked_merge omitted.)
+    ...
+    assert any("already manage" in e for e in result["errors"])
+
+def test_move_folder_merges_into_tracked_when_allowed(move_env):
+    """With allow_tracked_merge=True the staged tree's files land in the
+    existing archive on disk and the catalog has no duplicate folder rows."""
+    # Build: tracked archive dir with a prior shoot on disk + in catalog;
+    # a staged source dir whose files belong under the archive.
+    result = move_folder(db, staged_id, archive_parent,
+                         merge=True, allow_tracked_merge=True)
+    assert result["errors"] == []
+    assert result["moved"] >= 1
+    # No duplicate folders.path rows; staged rows folded away.
+    assert db.conn.execute(
+        "SELECT 1 FROM folders WHERE path LIKE ?", (staged_prefix + "%",)
+    ).fetchone() is None
+```
+
+> Model `move_env` on the existing fixtures in `test_move.py` (it already has
+> helpers that lay down a source tree on disk and seed catalog rows for the
+> tracked-overlap tests at `:529`, `:549`, `:568`). Reuse them.
+
+**Step 2: Run them, expect failure**
+
+Run: `python -m pytest vireo/tests/test_move.py -k "tracked_merge" -q`
+Expected: FAIL — `move_folder() got an unexpected keyword argument 'allow_tracked_merge'`.
+
+**Step 3: Implement**
+
+In `move_folder`'s signature (`move.py:1375`) add `allow_tracked_merge=False`.
+
+Guard block (`move.py:1544-1558`) — gate both refusals and remember the merge target:
+
+```python
+overlap_check_path = catalog_path if remote else transfer_dest
+merge_into_tracked = None
+tracked = _tracked_destination_overlap(db, folder_id, overlap_check_path)
+if tracked:
+    if not allow_tracked_merge:
+        return {"moved": 0, "errors": [
+            f"Destination overlaps a folder Vireo already manages "
+            f"({tracked['path']}). Merging into or around a tracked folder "
+            f"isn't supported."
+        ]}
+    merge_into_tracked = tracked["path"]
+if reject_tracked_ancestor and merge_into_tracked is None:
+    ancestor = _tracked_destination_ancestor(db, folder_id, overlap_check_path)
+    if ancestor:
+        if not allow_tracked_merge:
+            return {"moved": 0, "errors": [
+                f"Destination is inside a folder Vireo already manages "
+                f"({ancestor['path']}). Pick an untracked archive destination."
+            ]}
+        # Merge into the existing archive root that contains the destination.
+        merge_into_tracked = catalog_path if remote else transfer_dest
+```
+
+> Note: in the ancestor case the staged tree merges at its own resolved
+> `catalog_path` (which sits *inside* the tracked ancestor). The reconciliation
+> rebases staged rows onto that path; the ancestor's own rows are untouched.
+
+Catalog update (`move.py:1800-1803`) — branch:
+
+```python
+if progress_cb:
+    progress_cb(total_files, total_files, "", "Updating catalog")
+if merge_into_tracked is not None:
+    merge_counts = db.merge_staged_tree_into_archive(folder_id, catalog_path)
+else:
+    db.move_folder_path(folder_id, catalog_path)
+db.update_folder_counts()
+```
+
+And thread `merge_counts` into the return dict (default zeros when not a merge):
+
+```python
+result = {"moved": total_photos, "errors": []}
+if merge_into_tracked is not None:
+    result["merge"] = merge_counts
+    result["merged_into_existing"] = merge_into_tracked
+if cleanup_error is not None:
+    result["cleanup_error"] = cleanup_error
+return result
+```
+
+> `developed_dir` rebase block (`move.py:1810-1829`) keys off `move_folder_path`
+> having repointed paths. After a merge the staged paths are gone, so the
+> existing descendant-rebase loop is a no-op for merged rows (they now live at
+> archive paths already). Leave it; verify no crash with `developed_dir=""`
+> (the pipeline passes the configured dir — add a follow-up only if a
+> developed-output merge test surfaces a real gap; YAGNI for now).
+
+**Step 4: Run them, expect pass**
+
+Run: `python -m pytest vireo/tests/test_move.py -k "tracked_merge" -q`
+Expected: PASS. Then run the whole move suite — the existing tracked-overlap refusal tests must still pass:
+Run: `python -m pytest vireo/tests/test_move.py -q`
+
+**Step 5: Commit**
+
+```bash
+git add vireo/move.py vireo/tests/test_move.py
+git commit -m "move_folder: allow_tracked_merge opt-in routes to reconciliation"
+```
+
+---
+
+### Task 4: Pipeline — drop fatal preflight, pass the flag, merge-aware summary
+
+**Files:**
+- Modify: `vireo/pipeline_job.py` — preflight at `:1062`/`:1085`; archive call at `:4606`; summary at `:4635-4650`.
+
+**Step 1: Preflight (`pipeline_job.py:1062-1097`)**
+
+Remove the two `_bail_storage(...)` + `return` blocks for `tracked` and `ancestor`. The downstream `conflicting_archive_paths` check (`:1181`) stays — it's the precise per-file content-conflict guard and is still correct. Leave the import of `_tracked_destination_overlap` / `_tracked_destination_ancestor` only if still referenced; otherwise drop it (ruff F401).
+
+> Keep the `archive_parent` existence + `final_destination`-is-a-file checks
+> (`:1099` onward) — those are unrelated to tracked status.
+
+**Step 2: Archive call (`pipeline_job.py:4606`)**
+
+```python
+move_result = move_folder(
+    thread_db,
+    folder["id"],
+    archive_parent,
+    progress_cb=archive_cb,
+    developed_dir=developed_dir,
+    merge=True,
+    reject_tracked_ancestor=True,
+    allow_tracked_merge=True,
+)
+```
+
+**Step 3: Summary (`pipeline_job.py:4635-4650`)**
+
+```python
+moved = move_result.get("moved", 0)
+merge = move_result.get("merge")
+if merge:
+    base = move_result.get("merged_into_existing", final_destination)
+    summary = (
+        f"{merge['merged_new']} photos archived into existing archive "
+        f"{base} ({merge['merged_into_existing_folders']} folders merged, "
+        f"{merge['already_present']} already present)"
+    )
+else:
+    summary = f"{moved} photos archived"
+if cleanup_error:
+    summary += f" (staging cleanup failed: {cleanup_error})"
+```
+
+Also add `"merge": merge` to `result["archive"]` when present, for the API payload.
+
+**Step 4: Manual sanity**
+
+Run the full pipeline API suite (Task 5 updates these to pass):
+`python -m pytest vireo/tests/test_pipeline_api.py -q`
+
+**Step 5: Commit**
+
+```bash
+git add vireo/pipeline_job.py
+git commit -m "pipeline: merge into existing managed archive instead of failing"
+```
+
+---
+
+### Task 5: Update existing pipeline-API regression tests
+
+The tests at `test_pipeline_api.py:313/353/402` assert the OLD fatal failure. Flip them to assert the merge succeeds.
+
+**Files:**
+- Modify: `vireo/tests/test_pipeline_api.py:300-410` (the overlap and ancestor tests).
+
+**Step 1:** Read those two tests. Rename to reflect new behaviour (e.g. `test_pipeline_merges_into_managed_archive`, `test_pipeline_merges_into_subfolder_of_managed_archive`). Replace the `assert "Vireo already manages" in error_text` assertions with: job completes without a storage failure, files exist at the templated destination, and the catalog has no duplicate `folders.path`.
+
+**Step 2: Run** — `python -m pytest vireo/tests/test_pipeline_api.py -q` → PASS.
+
+**Step 3: Commit**
+
+```bash
+git add vireo/tests/test_pipeline_api.py
+git commit -m "test: pipeline merges into managed archive (was: hard-failed)"
+```
+
+---
+
+### Task 6: End-to-end pipeline merge test
+
+A focused regression for the exact reported scenario: import into an already-managed archive base with a folder template; assert seamless merge.
+
+**Files:**
+- Test: `vireo/tests/test_pipeline_api.py` (new test) — or `vireo/tests/test_pipeline_local_processing.py` if one exists (grep first).
+
+**Step 1: Write the test**
+
+Build a temp archive dir containing a prior shoot, scan it so it's tracked + a workspace root. Run a local-processing pipeline whose `destination` is that archive base, with `folder_template="%Y/%Y-%m-%d"`, sources being a couple of new files with EXIF dates not yet present. Assert: job succeeds; new files land at `<base>/<year>/<date>/`; the prior shoot's files and rows are untouched; no duplicate `folders.path`; the new leaf folder is linked to the active workspace.
+
+> Reuse the pipeline-job test harness the existing overlap tests use (same file)
+> — they already build a runner + thread_db + params. Copy that scaffolding.
+
+**Step 2: Run** — `python -m pytest vireo/tests/test_pipeline_api.py -k merge_e2e -q` → PASS.
+
+**Step 3: Commit**
+
+```bash
+git add vireo/tests/test_pipeline_api.py
+git commit -m "test: end-to-end import merges new shoot into existing archive"
+```
+
+---
+
+### Task 7: Pre-run transparency — `managed_archive` preview signal
+
+**Files:**
+- Modify: `vireo/app.py:10458` (`api_import_destination_preview`).
+- Test: `vireo/tests/test_app.py` (or wherever import-preview is tested — grep `destination-preview`).
+
+**Step 1: Write the failing test**
+
+```python
+def test_destination_preview_flags_managed_archive(client, ...):
+    # Seed a tracked folder at /arch/USA in the catalog.
+    resp = client.post("/api/import/destination-preview", json={
+        "sources": [str(src_dir)],
+        "destination": "/arch/USA",
+        "folder_template": "%Y/%Y-%m-%d",
+    })
+    data = resp.get_json()
+    assert data["managed_archive"]["path"] == "/arch/USA"
+    assert data["managed_archive"]["photo_count"] >= 0
+
+def test_destination_preview_fresh_destination_has_no_managed_archive(client, ...):
+    resp = client.post("/api/import/destination-preview", json={
+        "sources": [str(src_dir)], "destination": str(tmp_path / "fresh"),
+    })
+    assert resp.get_json().get("managed_archive") is None
+```
+
+**Step 2: Run** — Expected: FAIL (`KeyError`/`None`).
+
+**Step 3: Implement**
+
+In `api_import_destination_preview`, after computing `result = preview_destination(...)`, add:
+
+```python
+from move import _tracked_destination_overlap, _tracked_destination_ancestor
+db = _get_db()
+tracked = (_tracked_destination_overlap(db, -1, destination)
+           or _tracked_destination_ancestor(db, -1, destination))
+result["managed_archive"] = None
+if tracked:
+    count = db.conn.execute(
+        """SELECT COUNT(*) c FROM photos p JOIN folders f ON f.id = p.folder_id
+           WHERE f.path = ? OR substr(REPLACE(f.path,'\\','/'),1,?) = ?""",
+        (tracked["path"], len(tracked["path"]) + 1, tracked["path"] + "/"),
+    ).fetchone()["c"]
+    result["managed_archive"] = {"path": tracked["path"], "photo_count": count}
+return jsonify(result)
+```
+
+> Pass `folder_id=-1` so no real folder is excluded from the probe (the preview
+> isn't moving an existing folder). Keep this a pure catalog read — no file I/O.
+
+**Step 4: Run** — `python -m pytest vireo/tests/test_app.py -k managed_archive -q` → PASS.
+
+**Step 5: Commit**
+
+```bash
+git add vireo/app.py vireo/tests/test_app.py
+git commit -m "import preview: flag destination that is an existing managed archive"
+```
+
+---
+
+### Task 8: Import dialog UI — render the merge callout
+
+Surface the `managed_archive` signal and frame duplicates as "already in this archive."
+
+**Files:**
+- Modify: the import dialog template + JS. Grep for the destination-preview fetch:
+  `grep -rn "destination-preview\|check_duplicates\|duplicate_count" vireo/templates/`.
+
+**Step 1:** In the JS that renders the destination-preview response, when
+`data.managed_archive` is non-null, render a prominent line:
+*"Destination is an existing Vireo archive (`<path>`, `<photo_count>` photos). New files will be merged in."*
+
+**Step 2:** Where the duplicate-check (`/api/import/check-duplicates`) result is
+shown, when a managed archive is in play, label the duplicate count as
+*"N already in this archive (will be skipped)"* and the remainder as
+*"K new (will be merged)"* instead of the generic "duplicates" wording.
+
+> No backend change here beyond Task 7. This is presentation only. Match the
+> existing dialog's markup/idiom — do not introduce a framework or new CSS
+> system. Keep copy consistent with `CORE_PHILOSOPHY.md` ("no black boxes").
+
+**Step 3: Manual verification**
+
+Per `@superpowers:verification-before-completion`, drive the real UI
+(Playwright, per the user-first-testing convention): pick an existing archive as
+the destination and confirm the callout renders with the right count; pick a
+fresh folder and confirm no callout.
+
+**Step 4: Commit**
+
+```bash
+git add vireo/templates/
+git commit -m "import dialog: show merge-into-existing-archive callout"
+```
+
+---
+
+### Task 9: Full suite + cleanup
+
+**Step 1:** Run the project's required suite (from `CLAUDE.md`):
+```
+python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py \
+  vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py \
+  vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_move.py \
+  vireo/tests/test_pipeline_api.py -v
+```
+All green (ignore the known pre-existing failures noted in MEMORY.md).
+
+**Step 2:** `ruff check vireo/` clean (drop now-unused imports).
+
+**Step 3:** Open the PR:
+```bash
+gh pr create --base main --title "Merge local-processing imports into an existing managed archive" \
+  --body "<what changed + test results; link the design doc>"
+```
+
+---
+
+## Out of scope (YAGNI)
+- Merging into a tracked folder from the **manual folder-move UI** or **remote moves** — `allow_tracked_merge` stays `False` there.
+- Re-running classification on `skip_duplicates`-off identical re-imports — existing archived photo row wins; predictions on the dropped staged row are not migrated. Revisit only if a real workflow needs it.
+- Developed-output (darktable) directory merge reconciliation beyond the existing rebase — add only if a test surfaces a concrete gap.

--- a/tests/e2e/test_pipeline.py
+++ b/tests/e2e/test_pipeline.py
@@ -193,7 +193,7 @@ def test_pipeline_duplicate_summary_reframed_when_merging(live_server, page):
         "updateDuplicateSummary({done: true, duplicate_count: 2, total: 5});"
     )
     dup = page.locator("#previewSummary .dup-status")
-    expect(dup).to_contain_text("already in this archive")
+    expect(dup).to_contain_text("already in your library")
     expect(dup).to_contain_text("will be skipped")
     expect(dup).to_contain_text("3 new")
     expect(dup).to_contain_text("will be merged")

--- a/tests/e2e/test_pipeline.py
+++ b/tests/e2e/test_pipeline.py
@@ -113,6 +113,105 @@ def test_pipeline_preview_button_disabled_without_source_dest(live_server, page)
     expect(btn).to_be_disabled()
 
 
+def _destination_preview_body(managed_archive):
+    """Minimal destination-preview payload the render path needs, with an
+    optional managed_archive block."""
+    return json.dumps({
+        "total_photos": 3,
+        "total_folders": 1,
+        "new_folders": 0,
+        "existing_folders": 1,
+        "folders": [
+            {"path": "2026/2026-06-30", "count": 3, "exists": True,
+             "full_path": "/arch/USA/2026/2026-06-30"},
+        ],
+        "managed_archive": managed_archive,
+    })
+
+
+def test_pipeline_managed_archive_callout_shown_for_existing_archive(live_server, page):
+    """When destination-preview flags a managed archive, the merge callout
+    renders with the archive path and photo count."""
+    url = live_server["url"]
+    page.goto(f"{url}/pipeline")
+    page.click("#card-destination .stage-header")
+    page.check("[data-testid='copy-photos-toggle']")
+
+    page.route(
+        "**/api/import/destination-preview",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=_destination_preview_body(
+                {"path": "/arch/USA", "photo_count": 1234}
+            ),
+        ),
+    )
+    # Drive the preview directly (no on-disk sources needed — the render path
+    # only consumes the stubbed destination-preview response).
+    page.evaluate("previewDestinationFolders()")
+
+    callout = page.locator("[data-testid='managed-archive-callout']")
+    expect(callout).to_be_visible()
+    expect(callout).to_contain_text("existing Vireo archive")
+    expect(callout).to_contain_text("/arch/USA")
+    expect(callout).to_contain_text("1,234 photos")
+    expect(callout).to_contain_text("merged in")
+
+
+def test_pipeline_no_managed_archive_callout_for_fresh_destination(live_server, page):
+    """A fresh (untracked) destination shows no merge callout."""
+    url = live_server["url"]
+    page.goto(f"{url}/pipeline")
+    page.click("#card-destination .stage-header")
+    page.check("[data-testid='copy-photos-toggle']")
+
+    page.route(
+        "**/api/import/destination-preview",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=_destination_preview_body(None),
+        ),
+    )
+    page.evaluate("previewDestinationFolders()")
+
+    # Results render, but the callout stays hidden.
+    expect(page.locator("[data-testid='folder-preview-results']")).to_be_visible()
+    expect(page.locator("[data-testid='managed-archive-callout']")).to_be_hidden()
+
+
+def test_pipeline_duplicate_summary_reframed_when_merging(live_server, page):
+    """With a managed archive in play, the duplicate summary reads as an
+    archive merge (already-in-archive + new-will-be-merged), not the generic
+    'already imported' wording."""
+    url = live_server["url"]
+    page.goto(f"{url}/pipeline")
+    # Managed-merge framing.
+    page.evaluate(
+        "window._managedArchive = {path: '/arch/USA', photo_count: 10};"
+        "updateDuplicateSummary({done: true, duplicate_count: 2, total: 5});"
+    )
+    dup = page.locator("#previewSummary .dup-status")
+    expect(dup).to_contain_text("already in this archive")
+    expect(dup).to_contain_text("will be skipped")
+    expect(dup).to_contain_text("3 new")
+    expect(dup).to_contain_text("will be merged")
+
+
+def test_pipeline_duplicate_summary_generic_when_fresh(live_server, page):
+    """No managed archive -> today's exact 'already imported' wording."""
+    url = live_server["url"]
+    page.goto(f"{url}/pipeline")
+    page.evaluate(
+        "window._managedArchive = null;"
+        "updateDuplicateSummary({done: true, duplicate_count: 2, total: 5});"
+    )
+    dup = page.locator("#previewSummary .dup-status")
+    expect(dup).to_contain_text("already imported")
+    expect(dup).not_to_contain_text("this archive")
+
+
 def test_pipeline_section_headers_visible(live_server, page):
     url = live_server["url"]
     page.goto(f"{url}/pipeline")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -10497,11 +10497,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if tracked:
             from db import _subtree_prefix
             prefix = _subtree_prefix(tracked["path"])
+            # Count only ok/partial folders — the same set ingest treats as
+            # "the archive" — so the callout's "N photos" matches what the merge
+            # actually considers present. Pure catalog read; no on-disk check.
             count = db.conn.execute(
                 """SELECT COUNT(*) AS c
                      FROM photos p JOIN folders f ON f.id = p.folder_id
-                    WHERE f.path = ?
-                       OR substr(REPLACE(f.path, '\\', '/'), 1, ?) = ?""",
+                    WHERE (f.path = ?
+                           OR substr(REPLACE(f.path, '\\', '/'), 1, ?) = ?)
+                      AND f.status IN ('ok', 'partial')""",
                 (tracked["path"], len(prefix), prefix),
             ).fetchone()["c"]
             result["managed_archive"] = {

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -10484,6 +10484,30 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             )
         except ValueError as e:
             return json_error(str(e), 400)
+
+        # Transparency: if the destination is (or sits inside) a folder Vireo
+        # already manages, surface it as an existing archive so the UI can
+        # frame the import as a merge rather than a fresh copy. Pure catalog
+        # read — no file I/O beyond the tracked-folder probe.
+        from move import _tracked_destination_ancestor, _tracked_destination_overlap
+        db = _get_db()
+        tracked = (_tracked_destination_overlap(db, -1, destination)
+                   or _tracked_destination_ancestor(db, -1, destination))
+        result["managed_archive"] = None
+        if tracked:
+            from db import _subtree_prefix
+            prefix = _subtree_prefix(tracked["path"])
+            count = db.conn.execute(
+                """SELECT COUNT(*) AS c
+                     FROM photos p JOIN folders f ON f.id = p.folder_id
+                    WHERE f.path = ?
+                       OR substr(REPLACE(f.path, '\\', '/'), 1, ?) = ?""",
+                (tracked["path"], len(prefix), prefix),
+            ).fetchone()["c"]
+            result["managed_archive"] = {
+                "path": tracked["path"],
+                "photo_count": count,
+            }
         return jsonify(result)
 
     @app.route("/api/import/folder-preview/thumbnail")

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3156,19 +3156,33 @@ class Database:
                     # bytes into place. By the time we run here rsync has
                     # already finished, so ``os.path.exists`` returns True
                     # in BOTH the real-collision and the phantom-row cases
-                    # and cannot tell them apart. Compare the STAGED photo's
-                    # bytes-identity (file_hash, or file_size fallback) to
-                    # the TARGET row's recorded bytes-identity instead: a
-                    # match means the row correctly describes what is on
-                    # disk (real collision — dropping the staged row is
-                    # safe); a mismatch means rsync just wrote fresh staged
-                    # bytes over a phantom row and the row is stale. In
-                    # the phantom case delete the stale target row and
-                    # reparent the staged photo in its place so the
-                    # surviving catalog row describes the bytes actually on
-                    # disk. This also avoids a UNIQUE(folder_id, filename)
-                    # violation from moving the staged row onto a folder
-                    # that still holds the same basename.
+                    # and cannot tell them apart. Require MATCHING recorded
+                    # ``file_hash`` on both the staged photo and the target
+                    # row to call a collision "real": a hash match means
+                    # the row correctly describes what is on disk (dropping
+                    # the staged row is safe); a hash mismatch means rsync
+                    # replaced a missing file with fresh staged bytes and
+                    # the row is stale. When either recorded hash is
+                    # missing there is no reliable post-copy signal —
+                    # ``file_size`` alone can coincidentally match a
+                    # phantom row's stored size (empty XMP sidecars, small
+                    # metadata files), and hashing the on-disk file to
+                    # compare against the STAGED hash matches trivially in
+                    # BOTH the real-collision case (byte-identical by
+                    # definition) and the phantom case (rsync wrote the
+                    # staged bytes). Default to phantom-replacement below
+                    # when unverifiable: it preserves the freshly-imported
+                    # pipeline output at the cost of any accumulated
+                    # metadata on an unhashed archive row, which is the
+                    # strictly-safer direction — silently dropping the
+                    # newly-imported photo behind a same-size stale row is
+                    # the opposite (and worse) failure. In the phantom
+                    # case delete the stale target row and reparent the
+                    # staged photo in its place so the surviving catalog
+                    # row describes the bytes actually on disk. This also
+                    # avoids a UNIQUE(folder_id, filename) violation from
+                    # moving the staged row onto a folder that still holds
+                    # the same basename.
                     for staged in staged_photos:
                         pid = staged["id"]
                         collision = existing_by_key.get(
@@ -3196,32 +3210,20 @@ class Database:
                             staged_hash = staged["file_hash"]
                             target_hash = collision["file_hash"]
                             if staged_hash and target_hash:
-                                # Byte-identity via hash is the strongest
-                                # signal. Matching hashes → the target
-                                # row's claim matches the file on disk
-                                # (real collision). Mismatch → rsync
+                                # Both hashes present → byte-identity
+                                # comparison is reliable. Match → the
+                                # target row's claim matches the file on
+                                # disk (real collision). Mismatch → rsync
                                 # replaced a missing file with fresh
                                 # bytes; the target row is stale.
                                 real_collision = (staged_hash == target_hash)
-                            else:
-                                # Fall back to file_size when either hash
-                                # is unset (older catalog rows, unhashed
-                                # staged scans). Same principle: the row's
-                                # size matches on-disk → row is accurate;
-                                # differs → row is stale.
-                                target_size = collision["file_size"]
-                                try:
-                                    on_disk_size = os.path.getsize(
-                                        target_disk_path)
-                                except OSError:
-                                    on_disk_size = None
-                                if (target_size is not None
-                                        and on_disk_size is not None):
-                                    real_collision = (
-                                        on_disk_size == target_size)
-                                # else: no signal to verify the row —
-                                # prefer safety and keep the staged photo,
-                                # falling into the phantom branch below.
+                            # else: at least one recorded hash is missing.
+                            # Leave ``real_collision`` False so the
+                            # phantom-replacement branch below runs — see
+                            # the outer comment for why size alone (or a
+                            # freshly-computed on-disk hash) can't safely
+                            # stand in for the recorded-hash comparison
+                            # here.
                         if real_collision:
                             # photo_keywords.photo_id has no ON DELETE CASCADE
                             # (unlike every other photo_id FK), so clear

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2799,7 +2799,12 @@ class Database:
         * ``merged_folders`` — staged folders folded into a pre-existing target
           folder.
         * ``already_present`` — identical-filename staged photos dropped because
-          the target folder already held that filename.
+          the target folder already held that filename AND the target row's
+          recorded bytes-identity (``file_hash``, falling back to ``file_size``)
+          matches what's currently on disk. A filename collision whose target
+          row is stale (its recorded bytes-identity doesn't match the on-disk
+          file that rsync just copied into place) is treated as a phantom
+          replacement instead — see the collision loop below.
         * ``dropped_photo_ids`` — staged photo ids that were deleted during
           the merge (``already_present`` collisions plus phantom target-row
           replacements). The caller passes these to
@@ -3095,7 +3100,8 @@ class Database:
                         (target["id"],),
                     )
                     staged_photos = list(self.conn.execute(
-                        "SELECT id, filename FROM photos WHERE folder_id = ?",
+                        "SELECT id, filename, file_hash, file_size "
+                        "FROM photos WHERE folder_id = ?",
                         (sf["id"],),
                     ))
                     # Detect collisions against the ACTUAL target volume's case
@@ -3121,7 +3127,8 @@ class Database:
                                  else (lambda s: s))
                     existing_by_key = {}
                     for row in self.conn.execute(
-                        "SELECT id, filename FROM photos WHERE folder_id = ?",
+                        "SELECT id, filename, file_hash, file_size "
+                        "FROM photos WHERE folder_id = ?",
                         (target["id"],),
                     ):
                         # First writer wins on the (unlikely) chance two
@@ -3129,47 +3136,92 @@ class Database:
                         # from a pre-fix catalog.
                         existing_by_key.setdefault(
                             normalize(row["filename"]),
-                            {"id": row["id"], "filename": row["filename"]},
+                            {"id": row["id"], "filename": row["filename"],
+                             "file_hash": row["file_hash"],
+                             "file_size": row["file_size"]},
                         )
 
                     # A filename-collision alone is NOT enough to drop the
                     # staged photo as ``already_present``. The drop is only
                     # safe when the collision is REAL on disk — i.e. the
-                    # archived file actually exists at
-                    # ``target_path/filename``, which is the case the rsync
-                    # ``--ignore-existing`` merge relied on (it skipped the
-                    # staged copy because the byte-identical archived file
-                    # was already there; a DIFFERING file would have aborted
-                    # the move upstream in the content-conflict check). If
-                    # the target catalog row is stale — its file missing on
-                    # disk — the upstream check never fired (no dest file to
-                    # compare), rsync COPIED the staged bytes into place, and
-                    # dropping the staged row would leave those fresh bytes
-                    # represented by the old (phantom) row's hash/metadata,
-                    # losing the new photo. So when the target file is
-                    # absent, do NOT drop the staged photo. Instead delete
-                    # the stale target row (its file no longer exists) and
-                    # reparent the staged photo in its place, so the
+                    # target row accurately describes the bytes at
+                    # ``target_path/filename``. rsync ``--ignore-existing``
+                    # skipped the staged copy only when a byte-identical
+                    # archived file was already there (a DIFFERING file
+                    # would have aborted the move upstream in the
+                    # content-conflict check). If the target catalog row is
+                    # stale — its file was MISSING on disk before the
+                    # archive step — the upstream check never fired (no
+                    # dest file to compare) and rsync COPIED the staged
+                    # bytes into place. By the time we run here rsync has
+                    # already finished, so ``os.path.exists`` returns True
+                    # in BOTH the real-collision and the phantom-row cases
+                    # and cannot tell them apart. Compare the STAGED photo's
+                    # bytes-identity (file_hash, or file_size fallback) to
+                    # the TARGET row's recorded bytes-identity instead: a
+                    # match means the row correctly describes what is on
+                    # disk (real collision — dropping the staged row is
+                    # safe); a mismatch means rsync just wrote fresh staged
+                    # bytes over a phantom row and the row is stale. In
+                    # the phantom case delete the stale target row and
+                    # reparent the staged photo in its place so the
                     # surviving catalog row describes the bytes actually on
                     # disk. This also avoids a UNIQUE(folder_id, filename)
-                    # violation from moving the staged row onto a folder that
-                    # still holds the same basename.
+                    # violation from moving the staged row onto a folder
+                    # that still holds the same basename.
                     for staged in staged_photos:
                         pid = staged["id"]
                         collision = existing_by_key.get(
                             normalize(staged["filename"]))
                         # The archived filename may differ in case from the
                         # staged one; probe for the ACTUAL archived name so
-                        # ``os.path.exists`` matches on case-sensitive volumes
-                        # too (where any case-alias check is pointless anyway).
+                        # the on-disk existence check matches on
+                        # case-sensitive volumes too (where any case-alias
+                        # check is pointless anyway).
                         target_filename = (collision["filename"]
                                            if collision else None)
-                        real_collision = (
-                            target_filename is not None
-                            and os.path.exists(
-                                _join_subtree_path(
-                                    target_path, target_filename))
-                        )
+                        target_disk_path = (
+                            _join_subtree_path(target_path, target_filename)
+                            if target_filename is not None else None)
+                        # A missing file on disk is definitely phantom
+                        # (rsync would have written the staged bytes if
+                        # this ever ran in production; the code path
+                        # tolerates the isolated-unit-test case where no
+                        # rsync happened).
+                        target_on_disk = (
+                            target_disk_path is not None
+                            and os.path.exists(target_disk_path))
+                        real_collision = False
+                        if collision is not None and target_on_disk:
+                            staged_hash = staged["file_hash"]
+                            target_hash = collision["file_hash"]
+                            if staged_hash and target_hash:
+                                # Byte-identity via hash is the strongest
+                                # signal. Matching hashes → the target
+                                # row's claim matches the file on disk
+                                # (real collision). Mismatch → rsync
+                                # replaced a missing file with fresh
+                                # bytes; the target row is stale.
+                                real_collision = (staged_hash == target_hash)
+                            else:
+                                # Fall back to file_size when either hash
+                                # is unset (older catalog rows, unhashed
+                                # staged scans). Same principle: the row's
+                                # size matches on-disk → row is accurate;
+                                # differs → row is stale.
+                                target_size = collision["file_size"]
+                                try:
+                                    on_disk_size = os.path.getsize(
+                                        target_disk_path)
+                                except OSError:
+                                    on_disk_size = None
+                                if (target_size is not None
+                                        and on_disk_size is not None):
+                                    real_collision = (
+                                        on_disk_size == target_size)
+                                # else: no signal to verify the row —
+                                # prefer safety and keep the staged photo,
+                                # falling into the phantom branch below.
                         if real_collision:
                             # photo_keywords.photo_id has no ON DELETE CASCADE
                             # (unlike every other photo_id FK), so clear
@@ -3192,10 +3244,16 @@ class Database:
                         else:
                             if collision is not None:
                                 # Filename collided (case-normalized) but the
-                                # archived file is missing on disk: the staged
-                                # bytes were freshly copied and the target
-                                # row is a phantom. Drop the phantom by id so
-                                # the reparent below can take its (folder_id,
+                                # target row is a phantom — either the
+                                # archived file was missing on disk (rsync
+                                # copied the staged bytes into the empty
+                                # slot) or the file is there but its
+                                # bytes-identity (hash/size) doesn't match
+                                # the row's claim (rsync replaced a missing
+                                # file with fresh staged bytes). Either way
+                                # the staged row correctly describes what's
+                                # on disk. Drop the phantom by id so the
+                                # reparent below can take its (folder_id,
                                 # filename) slot and represent the real file.
                                 # Deleting by id (not filename) is required on
                                 # case-insensitive volumes where the staged

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2826,6 +2826,57 @@ class Database:
             self.add_workspace_folder(
                 ws, archive_row["id"], is_root=not has_root_ancestor)
 
+        # Materialize any missing intermediate folder rows between the deepest
+        # existing catalog ancestor and ``archive_path``'s parent (inclusive)
+        # BEFORE the reconciliation loop reads ``parent_id`` by path.
+        #
+        # Nested archive destinations expose this gap: when ``/Photos`` is
+        # tracked and the user imports to ``/Photos/2026/NewShoot``, the
+        # storage preflight materializes ``/Photos/2026`` ON DISK (rsync needs
+        # the transfer parent to exist) but never opens a folder row for it —
+        # the scanner didn't visit that path. Without the row, the loop's
+        # ``WHERE path = ?`` lookup for the staged root's target-parent
+        # returns nothing, and the UPDATE below repoints the staged root to
+        # ``archive_path`` with ``parent_id=NULL`` — floating it outside the
+        # managed archive tree and breaking every parent-based subtree
+        # operation (cascade path renames, ``_folder_subtree_ids_by_path``,
+        # etc.). Walk up from the archive parent until an existing row shows
+        # up (or the filesystem root). When no anchor is found (no tracked
+        # ancestor row in the catalog), the destination is a brand-new
+        # unrelated root — leave the loop's ``parent_id=NULL`` alone, which
+        # is the expected shape for a root. Otherwise insert missing rows
+        # top-down so each child's ``parent_id`` resolves to its freshly-
+        # created parent, and link each to the active workspace non-root
+        # (they sit under an existing tracked root by construction).
+        missing_intermediates = []
+        probe = os.path.dirname(archive_path)
+        anchor_found = False
+        while probe and probe != os.path.dirname(probe):
+            row = self.conn.execute(
+                "SELECT id FROM folders WHERE path = ?", (probe,)
+            ).fetchone()
+            if row is not None:
+                anchor_found = True
+                break
+            missing_intermediates.append(probe)
+            probe = os.path.dirname(probe)
+        if anchor_found:
+            for mid_path in reversed(missing_intermediates):
+                mid_parent = os.path.dirname(mid_path)
+                parent_row = self.conn.execute(
+                    "SELECT id FROM folders WHERE path = ?", (mid_parent,)
+                ).fetchone()
+                parent_id_for_mid = (
+                    parent_row["id"] if parent_row else None)
+                name = os.path.basename(mid_path) or mid_path
+                cur = self.conn.execute(
+                    "INSERT INTO folders (path, name, parent_id) "
+                    "VALUES (?, ?, ?)",
+                    (mid_path, name, parent_id_for_mid),
+                )
+                self.add_workspace_folder(
+                    ws, cur.lastrowid, is_root=False)
+
         # Snapshot staged folders root-first (shallowest path first) so a
         # parent's target row exists before its children are processed.
         prefix = _subtree_prefix(staged_root_path)

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2834,6 +2834,9 @@ class Database:
                 # the tracked-ancestor guard was meant to prevent.
                 # add_workspace_folder's INSERT OR IGNORE can't downgrade an
                 # existing is_root=1 row, so demote it explicitly here.
+                # At merge time the archive base/ancestor is always the
+                # workspace root, so every folded leaf is unconditionally
+                # non-root — no need to check the base's is_root first.
                 self.conn.execute(
                     "UPDATE workspace_folders SET is_root = 0 "
                     "WHERE workspace_id = ? AND folder_id = ?",

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2733,22 +2733,32 @@ class Database:
         * Target has no folder row -> repoint the staged row to the target path,
           fix its ``parent_id`` to the (now-existing) target-parent folder, and
           link it to the active workspace as a non-root (the existing archive
-          base is the workspace root).
+          base is the workspace root). Every staged photo in that folder is a
+          newly-archived photo.
         * Target already has a folder row -> move the staged folder's photos
           into it (dropping any whose filename already exists there as an
           identical archived file), then delete the now-empty staged folder row.
+          Each moved (not dropped) photo is a newly-archived photo.
 
-        Returns a counts dict: ``merged_new`` (folders repointed to new target
-        paths), ``merged_into_existing_folders`` (staged folders folded into an
-        existing target folder), and ``already_present`` (staged photos dropped
-        because the target folder already held that filename).
+        Returns a counts dict (all defined as the user-facing summary reads
+        them):
+
+        * ``new_photos`` — total staged photos newly placed into the archive,
+          counting BOTH photos reparented into brand-new folders AND photos
+          moved into a pre-existing target folder. This is the headline number.
+        * ``new_folders`` — folders created under the archive (the staged folder
+          had no pre-existing target row).
+        * ``merged_folders`` — staged folders folded into a pre-existing target
+          folder.
+        * ``already_present`` — identical-filename staged photos dropped because
+          the target folder already held that filename.
         """
         staged_root = self.conn.execute(
             "SELECT path FROM folders WHERE id = ?", (staged_root_id,)
         ).fetchone()
         if not staged_root:
-            return {"merged_new": 0, "merged_into_existing_folders": 0,
-                    "already_present": 0}
+            return {"new_photos": 0, "new_folders": 0,
+                    "merged_folders": 0, "already_present": 0}
         staged_root_path = staged_root["path"]
         ws = self._ws_id()
 
@@ -2762,13 +2772,17 @@ class Database:
             (staged_root_path, len(prefix), prefix),
         ).fetchall()
 
-        counts = {"merged_new": 0, "merged_into_existing_folders": 0,
-                  "already_present": 0}
+        counts = {"new_photos": 0, "new_folders": 0,
+                  "merged_folders": 0, "already_present": 0}
         # Staged folders that fold into an existing target row are deleted only
         # after every staged folder has been processed. Deleting eagerly would
         # hit a FK violation when a not-yet-reparented staged child still points
         # at the staged parent we are removing.
         to_delete = []
+        # Map of target-path -> folder id for folders already processed in this
+        # run, so a child can fall back to its parent's id (Fix I2) even if the
+        # parent's row isn't yet findable by path lookup.
+        last_target_parent = {}
 
         for sf in staged_folders:
             rel = _subtree_relative(sf["path"], staged_root_path)
@@ -2782,6 +2796,29 @@ class Database:
             ).fetchone()
             parent_id = parent_row["id"] if parent_row else None
 
+            # Defensive: a non-root staged folder whose target-parent row is
+            # missing would silently get parent_id=NULL, breaking the chain.
+            # The scanner normally materializes every intermediate, so this is
+            # an unenforced invariant — log it, and fall back to the last
+            # processed target-parent id when we have one.
+            if (parent_id is None
+                    and target_path != archive_path
+                    and parent_path and parent_path != target_path):
+                fallback = last_target_parent.get(parent_path)
+                if fallback is not None:
+                    log.warning(
+                        "merge_staged_tree_into_archive: no folder row for "
+                        "target parent %r of %r; falling back to id %s",
+                        parent_path, target_path, fallback,
+                    )
+                    parent_id = fallback
+                else:
+                    log.warning(
+                        "merge_staged_tree_into_archive: no folder row for "
+                        "target parent %r of %r; leaving parent_id NULL",
+                        parent_path, target_path,
+                    )
+
             if target is None:
                 # New folder under the archive: repoint + reparent + link.
                 self.conn.execute(
@@ -2789,7 +2826,16 @@ class Database:
                     (target_path, parent_id, sf["id"]),
                 )
                 self.add_workspace_folder(ws, sf["id"], is_root=False)
-                counts["merged_new"] += 1
+                # Every staged photo in a brand-new folder is newly archived.
+                new_count = self.conn.execute(
+                    "SELECT COUNT(*) c FROM photos WHERE folder_id = ?",
+                    (sf["id"],),
+                ).fetchone()["c"]
+                counts["new_photos"] += new_count
+                counts["new_folders"] += 1
+                # Record this folder's id so a child whose path-parent is this
+                # folder can resolve its parent even before counts re-query.
+                last_target_parent[target_path] = sf["id"]
             else:
                 # Existing folder: move photos in, drop filename-collisions.
                 photo_ids = [r["id"] for r in self.conn.execute(
@@ -2800,6 +2846,12 @@ class Database:
                                   photo_ids, target["id"])}
                 for pid in photo_ids:
                     if pid in collisions:
+                        # photo_keywords.photo_id has no ON DELETE CASCADE
+                        # (unlike every other photo_id FK), so clear keyword
+                        # links before deleting the photo or the FK fires.
+                        self.conn.execute(
+                            "DELETE FROM photo_keywords WHERE photo_id = ?",
+                            (pid,))
                         self.conn.execute(
                             "DELETE FROM photos WHERE id = ?", (pid,))
                         counts["already_present"] += 1
@@ -2808,8 +2860,12 @@ class Database:
                             "UPDATE photos SET folder_id = ? WHERE id = ?",
                             (target["id"], pid),
                         )
+                        # A photo moved into a pre-existing archive folder is
+                        # still a newly-archived photo from the user's view.
+                        counts["new_photos"] += 1
                 to_delete.append(sf["id"])
-                counts["merged_into_existing_folders"] += 1
+                counts["merged_folders"] += 1
+                last_target_parent[target_path] = target["id"]
 
         # Delete deepest-first: ``staged_folders`` (hence ``to_delete``) is
         # shallowest-first, so reverse to remove children before parents and

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2826,6 +2826,19 @@ class Database:
                     (target_path, parent_id, sf["id"]),
                 )
                 self.add_workspace_folder(ws, sf["id"], is_root=False)
+                # The staging scan registers each photo-bearing leaf as its
+                # own workspace ROOT (scanner restrict_dirs => is_root=1). Once
+                # that leaf is folded under the existing archive base it must
+                # become a plain descendant, otherwise the merge leaves a stray
+                # second workspace root inside the archive — the exact overlap
+                # the tracked-ancestor guard was meant to prevent.
+                # add_workspace_folder's INSERT OR IGNORE can't downgrade an
+                # existing is_root=1 row, so demote it explicitly here.
+                self.conn.execute(
+                    "UPDATE workspace_folders SET is_root = 0 "
+                    "WHERE workspace_id = ? AND folder_id = ?",
+                    (ws, sf["id"]),
+                )
                 # Every staged photo in a brand-new folder is newly archived.
                 new_count = self.conn.execute(
                     "SELECT COUNT(*) c FROM photos WHERE folder_id = ?",

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2719,6 +2719,112 @@ class Database:
             )
         self.conn.commit()
 
+    def merge_staged_tree_into_archive(self, staged_root_id, archive_path):
+        """Fold a staged folder subtree into an existing tracked archive.
+
+        The on-disk rsync merge has already happened: files that were under the
+        staged root now also live under ``archive_path``. This reconciles the
+        catalog so staged folder/photo rows become rows under the existing
+        archive, with no duplicate ``folders.path`` and correct ``parent_id``.
+
+        For each staged folder (root-first), the target path is the staged path
+        rebased from the staged root onto ``archive_path``:
+
+        * Target has no folder row -> repoint the staged row to the target path,
+          fix its ``parent_id`` to the (now-existing) target-parent folder, and
+          link it to the active workspace as a non-root (the existing archive
+          base is the workspace root).
+        * Target already has a folder row -> move the staged folder's photos
+          into it (dropping any whose filename already exists there as an
+          identical archived file), then delete the now-empty staged folder row.
+
+        Returns a counts dict: ``merged_new`` (folders repointed to new target
+        paths), ``merged_into_existing_folders`` (staged folders folded into an
+        existing target folder), and ``already_present`` (staged photos dropped
+        because the target folder already held that filename).
+        """
+        staged_root = self.conn.execute(
+            "SELECT path FROM folders WHERE id = ?", (staged_root_id,)
+        ).fetchone()
+        if not staged_root:
+            return {"merged_new": 0, "merged_into_existing_folders": 0,
+                    "already_present": 0}
+        staged_root_path = staged_root["path"]
+        ws = self._ws_id()
+
+        # Snapshot staged folders root-first (shallowest path first) so a
+        # parent's target row exists before its children are processed.
+        prefix = _subtree_prefix(staged_root_path)
+        staged_folders = self.conn.execute(
+            """SELECT id, path FROM folders
+               WHERE path = ? OR substr(REPLACE(path, '\\', '/'), 1, ?) = ?
+               ORDER BY length(path) ASC""",
+            (staged_root_path, len(prefix), prefix),
+        ).fetchall()
+
+        counts = {"merged_new": 0, "merged_into_existing_folders": 0,
+                  "already_present": 0}
+        # Staged folders that fold into an existing target row are deleted only
+        # after every staged folder has been processed. Deleting eagerly would
+        # hit a FK violation when a not-yet-reparented staged child still points
+        # at the staged parent we are removing.
+        to_delete = []
+
+        for sf in staged_folders:
+            rel = _subtree_relative(sf["path"], staged_root_path)
+            target_path = _join_subtree_path(archive_path, rel)
+            target = self.conn.execute(
+                "SELECT id FROM folders WHERE path = ?", (target_path,)
+            ).fetchone()
+            parent_path = os.path.dirname(target_path)
+            parent_row = self.conn.execute(
+                "SELECT id FROM folders WHERE path = ?", (parent_path,)
+            ).fetchone()
+            parent_id = parent_row["id"] if parent_row else None
+
+            if target is None:
+                # New folder under the archive: repoint + reparent + link.
+                self.conn.execute(
+                    "UPDATE folders SET path = ?, parent_id = ? WHERE id = ?",
+                    (target_path, parent_id, sf["id"]),
+                )
+                self.add_workspace_folder(ws, sf["id"], is_root=False)
+                counts["merged_new"] += 1
+            else:
+                # Existing folder: move photos in, drop filename-collisions.
+                photo_ids = [r["id"] for r in self.conn.execute(
+                    "SELECT id FROM photos WHERE folder_id = ?", (sf["id"],)
+                )]
+                collisions = {c["photo_id"]
+                              for c in self.check_filename_collisions(
+                                  photo_ids, target["id"])}
+                for pid in photo_ids:
+                    if pid in collisions:
+                        self.conn.execute(
+                            "DELETE FROM photos WHERE id = ?", (pid,))
+                        counts["already_present"] += 1
+                    else:
+                        self.conn.execute(
+                            "UPDATE photos SET folder_id = ? WHERE id = ?",
+                            (target["id"], pid),
+                        )
+                to_delete.append(sf["id"])
+                counts["merged_into_existing_folders"] += 1
+
+        # Delete deepest-first: ``staged_folders`` (hence ``to_delete``) is
+        # shallowest-first, so reverse to remove children before parents and
+        # never orphan a still-referenced ``parent_id``. Drop the folder's
+        # workspace links first — ``workspace_folders.folder_id`` has no
+        # ON DELETE CASCADE, so the folder delete would hit a FK violation.
+        for fid in reversed(to_delete):
+            self.conn.execute(
+                "DELETE FROM workspace_folders WHERE folder_id = ?", (fid,))
+            self.conn.execute("DELETE FROM folders WHERE id = ?", (fid,))
+
+        self.conn.commit()
+        self.update_folder_counts()
+        return counts
+
     def check_filename_collisions(self, photo_ids, target_folder_id):
         """Check if any photo filenames already exist in the target folder.
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1534,8 +1534,18 @@ class Database:
         ids.update(r["id"] for r in rows)
         return list(ids)
 
-    def add_workspace_folder(self, workspace_id, folder_id, *, is_root=True):
-        """Link a folder and its known descendants to a workspace."""
+    def _add_workspace_folder_no_commit(
+            self, workspace_id, folder_id, *, is_root=True):
+        """Link a folder + descendants to a workspace WITHOUT committing.
+
+        Same body as ``add_workspace_folder`` minus the ``commit()`` and cache
+        invalidation. Intended for callers that already run inside a larger
+        try/except+rollback transaction (e.g. ``merge_staged_tree_into_
+        archive``) where a mid-body commit would break rollback safety by
+        persisting a preceding UPDATE that an outer failure was meant to
+        undo. The caller is responsible for committing (and for invalidating
+        the workspace's new-images cache) after its own transaction closes.
+        """
         folder_ids = self._folder_subtree_ids_by_path(folder_id)
         self.conn.executemany(
             """INSERT OR IGNORE INTO workspace_folders
@@ -1551,6 +1561,11 @@ class Database:
                         WHERE workspace_id = ? AND folder_id IN ({placeholders})""",
                     [folder_id, workspace_id] + chunk,
                 )
+
+    def add_workspace_folder(self, workspace_id, folder_id, *, is_root=True):
+        """Link a folder and its known descendants to a workspace."""
+        self._add_workspace_folder_no_commit(
+            workspace_id, folder_id, is_root=is_root)
         self.conn.commit()
         # The folder's untracked files now count toward this workspace's
         # new-images backlog. Drop any stale cached payload so the next read
@@ -2785,13 +2800,20 @@ class Database:
           folder.
         * ``already_present`` — identical-filename staged photos dropped because
           the target folder already held that filename.
+        * ``dropped_photo_ids`` — staged photo ids that were deleted during
+          the merge (``already_present`` collisions plus phantom target-row
+          replacements). The caller passes these to
+          ``cleanup_cached_files_for_deleted_photos`` so orphaned thumbnail /
+          preview / working-copy files can't be inherited by a later import
+          that reuses one of the freed SQLite rowids.
         """
         staged_root = self.conn.execute(
             "SELECT path FROM folders WHERE id = ?", (staged_root_id,)
         ).fetchone()
         if not staged_root:
             return {"new_photos": 0, "new_folders": 0,
-                    "merged_folders": 0, "already_present": 0}
+                    "merged_folders": 0, "already_present": 0,
+                    "dropped_photo_ids": []}
         staged_root_path = staged_root["path"]
         ws = self._ws_id()
 
@@ -2826,7 +2848,7 @@ class Database:
         # behavior to preserve the root flag. Making the "already root" case
         # an explicit skip keeps the merge safe if that invariant ever changes.
         archive_row = self.conn.execute(
-            "SELECT id FROM folders WHERE path = ?", (archive_path,)
+            "SELECT id, status FROM folders WHERE path = ?", (archive_path,)
         ).fetchone()
         if archive_row:
             existing_link = self.conn.execute(
@@ -2845,6 +2867,20 @@ class Database:
                 self.add_workspace_folder(
                     ws, archive_row["id"], is_root=not has_root_ancestor)
             # else: base is already a workspace root — nothing to do.
+            # If the archive base was marked ``missing`` at a previous health
+            # scan (drive unmounted at the time), the storage preflight has
+            # since verified the volume is mounted and the rsync copy landed
+            # files on disk — flip it back to ``ok`` so ws-scoped photo queries
+            # (which filter ``folders.status IN ('ok', 'partial')``) show the
+            # merged photos instead of hiding them until the next health scan
+            # happens to reconcile. Only migrate ``missing`` → ``ok``: leave
+            # ``partial`` alone (the row still has unverified photos) and
+            # ``ok`` unchanged.
+            if archive_row["status"] == "missing":
+                self.conn.execute(
+                    "UPDATE folders SET status = 'ok' WHERE id = ?",
+                    (archive_row["id"],),
+                )
         elif not self._active_ws_root_ancestor_exists(ws, archive_path):
             # ``archive_path`` has no folder row yet — it's a brand-new
             # subfolder inside an already-tracked archive that the staged
@@ -2934,7 +2970,8 @@ class Database:
         ).fetchall()
 
         counts = {"new_photos": 0, "new_folders": 0,
-                  "merged_folders": 0, "already_present": 0}
+                  "merged_folders": 0, "already_present": 0,
+                  "dropped_photo_ids": []}
         # Staged folders that fold into an existing target row are deleted only
         # after every staged folder has been processed. Deleting eagerly would
         # hit a FK violation when a not-yet-reparented staged child still points
@@ -3003,7 +3040,14 @@ class Database:
                         "WHERE id = ?",
                         (target_path, parent_id, sf["id"]),
                     )
-                    self.add_workspace_folder(ws, sf["id"], is_root=False)
+                    # Use the non-committing variant so the folder path/parent_
+                    # id UPDATE just above stays in the outer transaction — the
+                    # public ``add_workspace_folder`` commits, and a mid-loop
+                    # commit would persist a partial reparent that the outer
+                    # rollback (below) could no longer undo if a later staged
+                    # folder raised.
+                    self._add_workspace_folder_no_commit(
+                        ws, sf["id"], is_root=False)
                     # The staging scan registers each photo-bearing leaf as
                     # its own workspace ROOT (scanner restrict_dirs =>
                     # is_root=1). Once that leaf is folded under the existing
@@ -3036,6 +3080,20 @@ class Database:
                     last_target_parent[target_path] = sf["id"]
                 else:
                     # Existing folder: move photos in, drop filename-collisions.
+                    # Restore the target row to visible status if it was marked
+                    # ``missing`` — same rationale as the archive-base status
+                    # flip above. We just verified files exist at
+                    # ``target_path`` (rsync + verify), so a lingering
+                    # ``missing`` from an earlier health scan would hide the
+                    # newly-merged photos from workspace-scoped queries. Only
+                    # migrate ``missing`` → ``ok``; leave ``partial``/``ok``
+                    # alone. Runs inside the outer try/except so a later
+                    # exception still rolls this back.
+                    self.conn.execute(
+                        "UPDATE folders SET status = 'ok' "
+                        "WHERE id = ? AND status = 'missing'",
+                        (target["id"],),
+                    )
                     staged_photos = list(self.conn.execute(
                         "SELECT id, filename FROM photos WHERE folder_id = ?",
                         (sf["id"],),
@@ -3124,6 +3182,13 @@ class Database:
                             self.conn.execute(
                                 "DELETE FROM photos WHERE id = ?", (pid,))
                             counts["already_present"] += 1
+                            # The staged photo id is now free. Thumbnails,
+                            # previews, working copies, and offline cache files
+                            # were keyed off this id, and SQLite reuses freed
+                            # rowids — a later import that lands on this id
+                            # would inherit stale imagery. Report the id up so
+                            # the caller can drop those files.
+                            counts["dropped_photo_ids"].append(pid)
                         else:
                             if collision is not None:
                                 # Filename collided (case-normalized) but the
@@ -3144,6 +3209,11 @@ class Database:
                                 self.conn.execute(
                                     "DELETE FROM photos WHERE id = ?",
                                     (collision["id"],))
+                                # The phantom target-row id is likewise freed —
+                                # its cache files can be reused for a new
+                                # photo. Report it up for cleanup too.
+                                counts["dropped_photo_ids"].append(
+                                    collision["id"])
                             self.conn.execute(
                                 "UPDATE photos SET folder_id = ? "
                                 "WHERE id = ?",

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2762,6 +2762,25 @@ class Database:
         staged_root_path = staged_root["path"]
         ws = self._ws_id()
 
+        # Ensure the existing archive base — and every folder row already
+        # below it — is linked to the active workspace before any staged
+        # photo is reparented onto one of those pre-existing folder rows.
+        # If the archive was scanned only under a different workspace, the
+        # else-branch UPDATE below would move photos onto a ``target["id"]``
+        # that has no ``workspace_folders`` row for ``ws``; workspace-scoped
+        # photo queries join ``workspace_folders`` on ``p.folder_id`` and
+        # would silently drop every merged-in photo. ``add_workspace_folder``
+        # pulls the whole subtree (path-prefix), so a single link on the
+        # archive base covers every existing descendant the reconciliation
+        # can hit. ``is_root=True`` is safe against other workspaces — the
+        # is_root UPDATE is scoped by ``workspace_id`` — and no-ops when the
+        # base was already this workspace's root.
+        archive_row = self.conn.execute(
+            "SELECT id FROM folders WHERE path = ?", (archive_path,)
+        ).fetchone()
+        if archive_row:
+            self.add_workspace_folder(ws, archive_row["id"], is_root=True)
+
         # Snapshot staged folders root-first (shallowest path first) so a
         # parent's target row exists before its children are processed.
         prefix = _subtree_prefix(staged_root_path)

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3203,10 +3203,35 @@ class Database:
                     # avoids a UNIQUE(folder_id, filename) violation from
                     # moving the staged row onto a folder that still holds
                     # the same basename.
+                    #
+                    # ``staged_normalized_claimed`` tracks case-normalized
+                    # filenames already reparented into ``target`` in this
+                    # pass — the intra-staged analogue of
+                    # ``existing_by_key``. On a case-insensitive target
+                    # volume, two staged files whose names differ only in
+                    # case (e.g. staged on a case-sensitive disk archiving
+                    # to APFS/SMB) collide on the same on-disk destination:
+                    # rsync ``--ignore-existing`` writes only the FIRST
+                    # file and silently skips the rest, so any later
+                    # staged row describes bytes that never landed on
+                    # disk. Without this tracker every such row also gets
+                    # reparented into ``target``, leaving multiple catalog
+                    # rows for the same on-disk file (the SQL
+                    # ``UNIQUE(folder_id, filename)`` doesn't fire because
+                    # the recorded filenames differ in case). Drop
+                    # subsequent case-alias staged rows as
+                    # ``already_present`` — the safe direction since their
+                    # bytes are unrepresented on disk. On case-sensitive
+                    # targets ``normalize`` is identity, so different-case
+                    # names have different keys and this tracker never
+                    # triggers.
+                    staged_normalized_claimed = set()
                     for staged in staged_photos:
                         pid = staged["id"]
-                        collision = existing_by_key.get(
-                            normalize(staged["filename"]))
+                        staged_norm = normalize(staged["filename"])
+                        collision = existing_by_key.get(staged_norm)
+                        intra_staged_collision = (
+                            staged_norm in staged_normalized_claimed)
                         # The archived filename may differ in case from the
                         # staged one; probe for the ACTUAL archived name so
                         # the on-disk existence check matches on
@@ -3244,11 +3269,19 @@ class Database:
                             # freshly-computed on-disk hash) can't safely
                             # stand in for the recorded-hash comparison
                             # here.
-                        if real_collision:
+                        if real_collision or intra_staged_collision:
                             # photo_keywords.photo_id has no ON DELETE CASCADE
                             # (unlike every other photo_id FK), so clear
                             # keyword links before deleting the photo or the
                             # FK fires.
+                            #
+                            # ``intra_staged_collision`` shares this branch
+                            # for the same net effect: the staged row's
+                            # bytes are not represented on disk (an earlier
+                            # staged case-alias already claimed the slot,
+                            # rsync ``--ignore-existing`` skipped this
+                            # file), so treating it as ``already_present``
+                            # is correct.
                             self.conn.execute(
                                 "DELETE FROM photo_keywords "
                                 "WHERE photo_id = ?",
@@ -3303,6 +3336,12 @@ class Database:
                             # is still a newly-archived photo from the user's
                             # view.
                             counts["new_photos"] += 1
+                            # Claim the case-normalized slot so a later
+                            # staged row whose filename case-folds to this
+                            # name is dropped as ``already_present``
+                            # instead of adding a second catalog row for
+                            # the same on-disk destination.
+                            staged_normalized_claimed.add(staged_norm)
                     to_delete.append(sf["id"])
                     counts["merged_folders"] += 1
                     last_target_parent[target_path] = target["id"]

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2730,6 +2730,28 @@ class Database:
             )
         self.conn.commit()
 
+    def _active_ws_root_ancestor_exists(self, workspace_id, path):
+        """True if ``workspace_id`` has an ``is_root=1`` folder that equals or
+        is an ancestor of ``path``.
+
+        Used by the merge to decide whether the archive base should itself
+        become a workspace root. Comparison is platform-neutral (``\\`` folded
+        to ``/``, trailing slashes stripped) so a Windows-style stored root
+        still matches a forward-slash archive path.
+        """
+        target = _path_for_subtree_match(path)
+        rows = self.conn.execute(
+            """SELECT f.path FROM workspace_folders wf
+               JOIN folders f ON f.id = wf.folder_id
+               WHERE wf.workspace_id = ? AND wf.is_root = 1""",
+            (workspace_id,),
+        ).fetchall()
+        for r in rows:
+            root = _path_for_subtree_match(r["path"])
+            if target == root or target.startswith(root + "/"):
+                return True
+        return False
+
     def merge_staged_tree_into_archive(self, staged_root_id, archive_path):
         """Fold a staged folder subtree into an existing tracked archive.
 
@@ -2743,9 +2765,9 @@ class Database:
 
         * Target has no folder row -> repoint the staged row to the target path,
           fix its ``parent_id`` to the (now-existing) target-parent folder, and
-          link it to the active workspace as a non-root (the existing archive
-          base is the workspace root). Every staged photo in that folder is a
-          newly-archived photo.
+          link it to the active workspace as a non-root (an existing archive
+          root ancestor already covers it). Every staged photo in that folder is
+          a newly-archived photo.
         * Target already has a folder row -> move the staged folder's photos
           into it (dropping any whose filename already exists there as an
           identical archived file), then delete the now-empty staged folder row.
@@ -2783,14 +2805,26 @@ class Database:
         # would silently drop every merged-in photo. ``add_workspace_folder``
         # pulls the whole subtree (path-prefix), so a single link on the
         # archive base covers every existing descendant the reconciliation
-        # can hit. ``is_root=True`` is safe against other workspaces — the
-        # is_root UPDATE is scoped by ``workspace_id`` — and no-ops when the
-        # base was already this workspace's root.
+        # can hit.
+        #
+        # Root the base ONLY when the active workspace has no existing root
+        # ancestor of it. For an ancestor merge (``/Photos`` is already a
+        # workspace root, base ``/Photos/USA``), rooting the base would create
+        # a SECOND overlapping workspace root inside the first — the exact
+        # duplicate-root state the tracked-overlap guards exist to prevent
+        # (``add_workspace_folder(is_root=True)`` only demotes rows inside the
+        # base's own subtree, so the outer ``/Photos`` root would survive). In
+        # that case just LINK the base non-root; the existing ancestor root
+        # keeps covering it. When there is no root ancestor (the base IS the
+        # archive the user imported into), the base is the natural root.
         archive_row = self.conn.execute(
             "SELECT id FROM folders WHERE path = ?", (archive_path,)
         ).fetchone()
         if archive_row:
-            self.add_workspace_folder(ws, archive_row["id"], is_root=True)
+            has_root_ancestor = self._active_ws_root_ancestor_exists(
+                ws, archive_path)
+            self.add_workspace_folder(
+                ws, archive_row["id"], is_root=not has_root_ancestor)
 
         # Snapshot staged folders root-first (shallowest path first) so a
         # parent's target row exists before its children are processed.
@@ -2864,9 +2898,9 @@ class Database:
                 # the tracked-ancestor guard was meant to prevent.
                 # add_workspace_folder's INSERT OR IGNORE can't downgrade an
                 # existing is_root=1 row, so demote it explicitly here.
-                # At merge time the archive base/ancestor is always the
-                # workspace root, so every folded leaf is unconditionally
-                # non-root — no need to check the base's is_root first.
+                # A folded-in leaf is always a descendant of an existing archive
+                # root (the base itself, or an ancestor root above it), so it is
+                # unconditionally non-root — no need to check the base's is_root.
                 self.conn.execute(
                     "UPDATE workspace_folders SET is_root = 0 "
                     "WHERE workspace_id = ? AND folder_id = ?",
@@ -2887,11 +2921,38 @@ class Database:
                 photo_ids = [r["id"] for r in self.conn.execute(
                     "SELECT id FROM photos WHERE folder_id = ?", (sf["id"],)
                 )]
-                collisions = {c["photo_id"]
+                # ``check_filename_collisions`` is filename-only: it flags a
+                # staged photo whose basename already has a catalog row in the
+                # target folder. That is NOT sufficient to drop the staged
+                # photo as ``already_present``. The drop is only safe when the
+                # collision is REAL on disk — i.e. the archived file actually
+                # exists at ``target_path/filename``, which is the case the
+                # rsync ``--ignore-existing`` merge relied on (it skipped the
+                # staged copy because the byte-identical archived file was
+                # already there; a DIFFERING file would have aborted the move
+                # upstream in the content-conflict check). If the target catalog
+                # row is stale — its file missing on disk — the upstream check
+                # never fired (no dest file to compare), rsync COPIED the staged
+                # bytes into place, and dropping the staged row would leave those
+                # fresh bytes represented by the old (phantom) row's
+                # hash/metadata, losing the new photo. So when the target file is
+                # absent, do NOT drop the staged photo. Instead delete the stale
+                # target row (its file no longer exists) and reparent the staged
+                # photo in its place, so the surviving catalog row describes the
+                # bytes actually on disk. This also avoids a UNIQUE(folder_id,
+                # filename) violation from moving the staged row onto a folder
+                # that still holds the same basename.
+                collisions = {c["photo_id"]: c["filename"]
                               for c in self.check_filename_collisions(
                                   photo_ids, target["id"])}
                 for pid in photo_ids:
-                    if pid in collisions:
+                    filename = collisions.get(pid)
+                    real_collision = (
+                        filename is not None
+                        and os.path.exists(
+                            _join_subtree_path(target_path, filename))
+                    )
+                    if real_collision:
                         # photo_keywords.photo_id has no ON DELETE CASCADE
                         # (unlike every other photo_id FK), so clear keyword
                         # links before deleting the photo or the FK fires.
@@ -2902,6 +2963,24 @@ class Database:
                             "DELETE FROM photos WHERE id = ?", (pid,))
                         counts["already_present"] += 1
                     else:
+                        if filename is not None:
+                            # Filename collided but the archived file is missing
+                            # on disk: the staged bytes were freshly copied and
+                            # the target row is a phantom. Drop the phantom so
+                            # the reparent below can take its (folder_id,
+                            # filename) slot and represent the real file.
+                            stale = self.conn.execute(
+                                "SELECT id FROM photos "
+                                "WHERE folder_id = ? AND filename = ?",
+                                (target["id"], filename),
+                            ).fetchone()
+                            if stale is not None:
+                                self.conn.execute(
+                                    "DELETE FROM photo_keywords "
+                                    "WHERE photo_id = ?", (stale["id"],))
+                                self.conn.execute(
+                                    "DELETE FROM photos WHERE id = ?",
+                                    (stale["id"],))
                         self.conn.execute(
                             "UPDATE photos SET folder_id = ? WHERE id = ?",
                             (target["id"], pid),

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2817,14 +2817,34 @@ class Database:
         # that case just LINK the base non-root; the existing ancestor root
         # keeps covering it. When there is no root ancestor (the base IS the
         # archive the user imported into), the base is the natural root.
+        #
+        # When the base is ALREADY a workspace root for ``ws``, skip the
+        # ``add_workspace_folder`` call entirely instead of passing
+        # ``is_root=False`` — the descendant subtree is already linked from
+        # when the base was rooted, and calling with ``is_root=False`` would
+        # silently rely on ``add_workspace_folder``'s no-op-on-existing-row
+        # behavior to preserve the root flag. Making the "already root" case
+        # an explicit skip keeps the merge safe if that invariant ever changes.
         archive_row = self.conn.execute(
             "SELECT id FROM folders WHERE path = ?", (archive_path,)
         ).fetchone()
         if archive_row:
-            has_root_ancestor = self._active_ws_root_ancestor_exists(
-                ws, archive_path)
-            self.add_workspace_folder(
-                ws, archive_row["id"], is_root=not has_root_ancestor)
+            existing_link = self.conn.execute(
+                "SELECT is_root FROM workspace_folders "
+                "WHERE workspace_id = ? AND folder_id = ?",
+                (ws, archive_row["id"]),
+            ).fetchone()
+            if existing_link is None or existing_link["is_root"] == 0:
+                # Not root of ws (unlinked, or linked non-root): link the
+                # subtree, and root the base only if no strict ancestor is
+                # already a root. ``_active_ws_root_ancestor_exists`` cannot
+                # self-match here because the base is not currently a root
+                # of ws, so the check is a true "ancestor above" question.
+                has_root_ancestor = self._active_ws_root_ancestor_exists(
+                    ws, archive_path)
+                self.add_workspace_folder(
+                    ws, archive_row["id"], is_root=not has_root_ancestor)
+            # else: base is already a workspace root — nothing to do.
 
         # Materialize any missing intermediate folder rows between the deepest
         # existing catalog ancestor and ``archive_path``'s parent (inclusive)
@@ -2899,198 +2919,234 @@ class Database:
         # parent's row isn't yet findable by path lookup.
         last_target_parent = {}
 
-        for sf in staged_folders:
-            rel = _subtree_relative(sf["path"], staged_root_path)
-            target_path = _join_subtree_path(archive_path, rel)
-            target = self.conn.execute(
-                "SELECT id FROM folders WHERE path = ?", (target_path,)
-            ).fetchone()
-            parent_path = os.path.dirname(target_path)
-            parent_row = self.conn.execute(
-                "SELECT id FROM folders WHERE path = ?", (parent_path,)
-            ).fetchone()
-            parent_id = parent_row["id"] if parent_row else None
+        # Wrap the reconciliation body in try/except + rollback so a mid-run
+        # exception (unexpected row shape, raised error from the
+        # case-insensitivity probe, etc.) can't leave a partially-applied
+        # merge sitting on the connection — an unrelated later commit would
+        # otherwise persist half-reparented folders/photos. Matches the
+        # convention used by other multi-step mutation methods in this file
+        # (``delete_folder``, ``move_folders_to_workspace``,
+        # ``_merge_duplicate_keywords_pass``). Archive-base linking and
+        # missing-intermediate materialization above each commit through
+        # their own ``add_workspace_folder`` calls, so their success is
+        # persisted independently — that's the desired shape here: partial
+        # progress on preparing the archive tree is a valid state a retry
+        # can build on, but partial photo/folder reparenting is not.
+        try:
+            for sf in staged_folders:
+                rel = _subtree_relative(sf["path"], staged_root_path)
+                target_path = _join_subtree_path(archive_path, rel)
+                target = self.conn.execute(
+                    "SELECT id FROM folders WHERE path = ?", (target_path,)
+                ).fetchone()
+                parent_path = os.path.dirname(target_path)
+                parent_row = self.conn.execute(
+                    "SELECT id FROM folders WHERE path = ?", (parent_path,)
+                ).fetchone()
+                parent_id = parent_row["id"] if parent_row else None
 
-            # Defensive: a non-root staged folder whose target-parent row is
-            # missing would silently get parent_id=NULL, breaking the chain.
-            # The scanner normally materializes every intermediate, so this is
-            # an unenforced invariant — log it, and fall back to the last
-            # processed target-parent id when we have one.
-            if (parent_id is None
-                    and target_path != archive_path
-                    and parent_path and parent_path != target_path):
-                fallback = last_target_parent.get(parent_path)
-                if fallback is not None:
-                    log.warning(
-                        "merge_staged_tree_into_archive: no folder row for "
-                        "target parent %r of %r; falling back to id %s",
-                        parent_path, target_path, fallback,
-                    )
-                    parent_id = fallback
-                else:
-                    log.warning(
-                        "merge_staged_tree_into_archive: no folder row for "
-                        "target parent %r of %r; leaving parent_id NULL",
-                        parent_path, target_path,
-                    )
-
-            if target is None:
-                # New folder under the archive: repoint + reparent + link.
-                self.conn.execute(
-                    "UPDATE folders SET path = ?, parent_id = ? WHERE id = ?",
-                    (target_path, parent_id, sf["id"]),
-                )
-                self.add_workspace_folder(ws, sf["id"], is_root=False)
-                # The staging scan registers each photo-bearing leaf as its
-                # own workspace ROOT (scanner restrict_dirs => is_root=1). Once
-                # that leaf is folded under the existing archive base it must
-                # become a plain descendant, otherwise the merge leaves a stray
-                # second workspace root inside the archive — the exact overlap
-                # the tracked-ancestor guard was meant to prevent.
-                # add_workspace_folder's INSERT OR IGNORE can't downgrade an
-                # existing is_root=1 row, so demote it explicitly here.
-                # A folded-in leaf is always a descendant of an existing archive
-                # root (the base itself, or an ancestor root above it), so it is
-                # unconditionally non-root — no need to check the base's is_root.
-                self.conn.execute(
-                    "UPDATE workspace_folders SET is_root = 0 "
-                    "WHERE workspace_id = ? AND folder_id = ?",
-                    (ws, sf["id"]),
-                )
-                # Every staged photo in a brand-new folder is newly archived.
-                new_count = self.conn.execute(
-                    "SELECT COUNT(*) c FROM photos WHERE folder_id = ?",
-                    (sf["id"],),
-                ).fetchone()["c"]
-                counts["new_photos"] += new_count
-                counts["new_folders"] += 1
-                # Record this folder's id so a child whose path-parent is this
-                # folder can resolve its parent even before counts re-query.
-                last_target_parent[target_path] = sf["id"]
-            else:
-                # Existing folder: move photos in, drop filename-collisions.
-                staged_photos = list(self.conn.execute(
-                    "SELECT id, filename FROM photos WHERE folder_id = ?",
-                    (sf["id"],),
-                ))
-                # Detect collisions against the ACTUAL target volume's case
-                # rules — not SQLite's default case-sensitive TEXT compare.
-                # On a case-insensitive volume (default macOS APFS, Windows
-                # NTFS), a target row/file named ``IMG.RAF`` and a staged
-                # ``img.raf`` are the same on-disk file: rsync
-                # ``--ignore-existing`` treats them as already present and
-                # skips the copy. A case-sensitive SQL match would miss that,
-                # fall into the else-branch reparent below, and land TWO
-                # catalog rows in one folder pointing at the same on-disk
-                # file (SQLite text-equality is case-sensitive, so
-                # UNIQUE(folder_id, filename) would not fire to catch the
-                # mistake). Build the collision map by normalizing filenames
-                # with the target filesystem's case rules instead. Probes
-                # ``target_path``'s deepest existing ancestor, so a fresh
-                # subfolder inherits its mount's behavior.
-                from move import _case_insensitive_root
-                target_folds_case = _case_insensitive_root(target_path) is not None
-                normalize = (str.casefold if target_folds_case
-                             else (lambda s: s))
-                existing_by_key = {}
-                for row in self.conn.execute(
-                    "SELECT id, filename FROM photos WHERE folder_id = ?",
-                    (target["id"],),
-                ):
-                    # First writer wins on the (unlikely) chance two
-                    # case-alias rows already coexist in the target folder
-                    # from a pre-fix catalog.
-                    existing_by_key.setdefault(
-                        normalize(row["filename"]),
-                        {"id": row["id"], "filename": row["filename"]},
-                    )
-
-                # A filename-collision alone is NOT enough to drop the staged
-                # photo as ``already_present``. The drop is only safe when the
-                # collision is REAL on disk — i.e. the archived file actually
-                # exists at ``target_path/filename``, which is the case the
-                # rsync ``--ignore-existing`` merge relied on (it skipped the
-                # staged copy because the byte-identical archived file was
-                # already there; a DIFFERING file would have aborted the move
-                # upstream in the content-conflict check). If the target
-                # catalog row is stale — its file missing on disk — the
-                # upstream check never fired (no dest file to compare), rsync
-                # COPIED the staged bytes into place, and dropping the staged
-                # row would leave those fresh bytes represented by the old
-                # (phantom) row's hash/metadata, losing the new photo. So
-                # when the target file is absent, do NOT drop the staged
-                # photo. Instead delete the stale target row (its file no
-                # longer exists) and reparent the staged photo in its place,
-                # so the surviving catalog row describes the bytes actually
-                # on disk. This also avoids a UNIQUE(folder_id, filename)
-                # violation from moving the staged row onto a folder that
-                # still holds the same basename.
-                for staged in staged_photos:
-                    pid = staged["id"]
-                    collision = existing_by_key.get(
-                        normalize(staged["filename"]))
-                    # The archived filename may differ in case from the
-                    # staged one; probe for the ACTUAL archived name so
-                    # ``os.path.exists`` matches on case-sensitive volumes
-                    # too (where any case-alias check is pointless anyway).
-                    target_filename = (collision["filename"]
-                                       if collision else None)
-                    real_collision = (
-                        target_filename is not None
-                        and os.path.exists(
-                            _join_subtree_path(target_path, target_filename))
-                    )
-                    if real_collision:
-                        # photo_keywords.photo_id has no ON DELETE CASCADE
-                        # (unlike every other photo_id FK), so clear keyword
-                        # links before deleting the photo or the FK fires.
-                        self.conn.execute(
-                            "DELETE FROM photo_keywords WHERE photo_id = ?",
-                            (pid,))
-                        self.conn.execute(
-                            "DELETE FROM photos WHERE id = ?", (pid,))
-                        counts["already_present"] += 1
+                # Defensive: a non-root staged folder whose target-parent row is
+                # missing would silently get parent_id=NULL, breaking the chain.
+                # The scanner normally materializes every intermediate, so this
+                # is an unenforced invariant — log it, and fall back to the last
+                # processed target-parent id when we have one.
+                if (parent_id is None
+                        and target_path != archive_path
+                        and parent_path and parent_path != target_path):
+                    fallback = last_target_parent.get(parent_path)
+                    if fallback is not None:
+                        log.warning(
+                            "merge_staged_tree_into_archive: no folder row "
+                            "for target parent %r of %r; falling back to "
+                            "id %s",
+                            parent_path, target_path, fallback,
+                        )
+                        parent_id = fallback
                     else:
-                        if collision is not None:
-                            # Filename collided (case-normalized) but the
-                            # archived file is missing on disk: the staged
-                            # bytes were freshly copied and the target row is
-                            # a phantom. Drop the phantom by id so the
-                            # reparent below can take its (folder_id,
-                            # filename) slot and represent the real file.
-                            # Deleting by id (not filename) is required on
-                            # case-insensitive volumes where the staged and
-                            # phantom filenames differ only in case: the SQL
-                            # ``filename = ?`` lookup used earlier would miss
-                            # the stale row and leave both intact.
+                        log.warning(
+                            "merge_staged_tree_into_archive: no folder row "
+                            "for target parent %r of %r; leaving parent_id "
+                            "NULL",
+                            parent_path, target_path,
+                        )
+
+                if target is None:
+                    # New folder under the archive: repoint + reparent + link.
+                    self.conn.execute(
+                        "UPDATE folders SET path = ?, parent_id = ? "
+                        "WHERE id = ?",
+                        (target_path, parent_id, sf["id"]),
+                    )
+                    self.add_workspace_folder(ws, sf["id"], is_root=False)
+                    # The staging scan registers each photo-bearing leaf as
+                    # its own workspace ROOT (scanner restrict_dirs =>
+                    # is_root=1). Once that leaf is folded under the existing
+                    # archive base it must become a plain descendant,
+                    # otherwise the merge leaves a stray second workspace
+                    # root inside the archive — the exact overlap the
+                    # tracked-ancestor guard was meant to prevent.
+                    # add_workspace_folder's INSERT OR IGNORE can't downgrade
+                    # an existing is_root=1 row, so demote it explicitly here.
+                    # A folded-in leaf is always a descendant of an existing
+                    # archive root (the base itself, or an ancestor root
+                    # above it), so it is unconditionally non-root — no need
+                    # to check the base's is_root.
+                    self.conn.execute(
+                        "UPDATE workspace_folders SET is_root = 0 "
+                        "WHERE workspace_id = ? AND folder_id = ?",
+                        (ws, sf["id"]),
+                    )
+                    # Every staged photo in a brand-new folder is newly
+                    # archived.
+                    new_count = self.conn.execute(
+                        "SELECT COUNT(*) c FROM photos WHERE folder_id = ?",
+                        (sf["id"],),
+                    ).fetchone()["c"]
+                    counts["new_photos"] += new_count
+                    counts["new_folders"] += 1
+                    # Record this folder's id so a child whose path-parent is
+                    # this folder can resolve its parent even before counts
+                    # re-query.
+                    last_target_parent[target_path] = sf["id"]
+                else:
+                    # Existing folder: move photos in, drop filename-collisions.
+                    staged_photos = list(self.conn.execute(
+                        "SELECT id, filename FROM photos WHERE folder_id = ?",
+                        (sf["id"],),
+                    ))
+                    # Detect collisions against the ACTUAL target volume's case
+                    # rules — not SQLite's default case-sensitive TEXT compare.
+                    # On a case-insensitive volume (default macOS APFS, Windows
+                    # NTFS), a target row/file named ``IMG.RAF`` and a staged
+                    # ``img.raf`` are the same on-disk file: rsync
+                    # ``--ignore-existing`` treats them as already present and
+                    # skips the copy. A case-sensitive SQL match would miss
+                    # that, fall into the else-branch reparent below, and land
+                    # TWO catalog rows in one folder pointing at the same
+                    # on-disk file (SQLite text-equality is case-sensitive, so
+                    # UNIQUE(folder_id, filename) would not fire to catch the
+                    # mistake). Build the collision map by normalizing
+                    # filenames with the target filesystem's case rules
+                    # instead. Probes ``target_path``'s deepest existing
+                    # ancestor, so a fresh subfolder inherits its mount's
+                    # behavior.
+                    from move import _case_insensitive_root
+                    target_folds_case = (
+                        _case_insensitive_root(target_path) is not None)
+                    normalize = (str.casefold if target_folds_case
+                                 else (lambda s: s))
+                    existing_by_key = {}
+                    for row in self.conn.execute(
+                        "SELECT id, filename FROM photos WHERE folder_id = ?",
+                        (target["id"],),
+                    ):
+                        # First writer wins on the (unlikely) chance two
+                        # case-alias rows already coexist in the target folder
+                        # from a pre-fix catalog.
+                        existing_by_key.setdefault(
+                            normalize(row["filename"]),
+                            {"id": row["id"], "filename": row["filename"]},
+                        )
+
+                    # A filename-collision alone is NOT enough to drop the
+                    # staged photo as ``already_present``. The drop is only
+                    # safe when the collision is REAL on disk — i.e. the
+                    # archived file actually exists at
+                    # ``target_path/filename``, which is the case the rsync
+                    # ``--ignore-existing`` merge relied on (it skipped the
+                    # staged copy because the byte-identical archived file
+                    # was already there; a DIFFERING file would have aborted
+                    # the move upstream in the content-conflict check). If
+                    # the target catalog row is stale — its file missing on
+                    # disk — the upstream check never fired (no dest file to
+                    # compare), rsync COPIED the staged bytes into place, and
+                    # dropping the staged row would leave those fresh bytes
+                    # represented by the old (phantom) row's hash/metadata,
+                    # losing the new photo. So when the target file is
+                    # absent, do NOT drop the staged photo. Instead delete
+                    # the stale target row (its file no longer exists) and
+                    # reparent the staged photo in its place, so the
+                    # surviving catalog row describes the bytes actually on
+                    # disk. This also avoids a UNIQUE(folder_id, filename)
+                    # violation from moving the staged row onto a folder that
+                    # still holds the same basename.
+                    for staged in staged_photos:
+                        pid = staged["id"]
+                        collision = existing_by_key.get(
+                            normalize(staged["filename"]))
+                        # The archived filename may differ in case from the
+                        # staged one; probe for the ACTUAL archived name so
+                        # ``os.path.exists`` matches on case-sensitive volumes
+                        # too (where any case-alias check is pointless anyway).
+                        target_filename = (collision["filename"]
+                                           if collision else None)
+                        real_collision = (
+                            target_filename is not None
+                            and os.path.exists(
+                                _join_subtree_path(
+                                    target_path, target_filename))
+                        )
+                        if real_collision:
+                            # photo_keywords.photo_id has no ON DELETE CASCADE
+                            # (unlike every other photo_id FK), so clear
+                            # keyword links before deleting the photo or the
+                            # FK fires.
                             self.conn.execute(
                                 "DELETE FROM photo_keywords "
-                                "WHERE photo_id = ?", (collision["id"],))
+                                "WHERE photo_id = ?",
+                                (pid,))
                             self.conn.execute(
-                                "DELETE FROM photos WHERE id = ?",
-                                (collision["id"],))
-                        self.conn.execute(
-                            "UPDATE photos SET folder_id = ? WHERE id = ?",
-                            (target["id"], pid),
-                        )
-                        # A photo moved into a pre-existing archive folder is
-                        # still a newly-archived photo from the user's view.
-                        counts["new_photos"] += 1
-                to_delete.append(sf["id"])
-                counts["merged_folders"] += 1
-                last_target_parent[target_path] = target["id"]
+                                "DELETE FROM photos WHERE id = ?", (pid,))
+                            counts["already_present"] += 1
+                        else:
+                            if collision is not None:
+                                # Filename collided (case-normalized) but the
+                                # archived file is missing on disk: the staged
+                                # bytes were freshly copied and the target
+                                # row is a phantom. Drop the phantom by id so
+                                # the reparent below can take its (folder_id,
+                                # filename) slot and represent the real file.
+                                # Deleting by id (not filename) is required on
+                                # case-insensitive volumes where the staged
+                                # and phantom filenames differ only in case:
+                                # the SQL ``filename = ?`` lookup used earlier
+                                # would miss the stale row and leave both
+                                # intact.
+                                self.conn.execute(
+                                    "DELETE FROM photo_keywords "
+                                    "WHERE photo_id = ?", (collision["id"],))
+                                self.conn.execute(
+                                    "DELETE FROM photos WHERE id = ?",
+                                    (collision["id"],))
+                            self.conn.execute(
+                                "UPDATE photos SET folder_id = ? "
+                                "WHERE id = ?",
+                                (target["id"], pid),
+                            )
+                            # A photo moved into a pre-existing archive folder
+                            # is still a newly-archived photo from the user's
+                            # view.
+                            counts["new_photos"] += 1
+                    to_delete.append(sf["id"])
+                    counts["merged_folders"] += 1
+                    last_target_parent[target_path] = target["id"]
 
-        # Delete deepest-first: ``staged_folders`` (hence ``to_delete``) is
-        # shallowest-first, so reverse to remove children before parents and
-        # never orphan a still-referenced ``parent_id``. Drop the folder's
-        # workspace links first — ``workspace_folders.folder_id`` has no
-        # ON DELETE CASCADE, so the folder delete would hit a FK violation.
-        for fid in reversed(to_delete):
-            self.conn.execute(
-                "DELETE FROM workspace_folders WHERE folder_id = ?", (fid,))
-            self.conn.execute("DELETE FROM folders WHERE id = ?", (fid,))
+            # Delete deepest-first: ``staged_folders`` (hence ``to_delete``)
+            # is shallowest-first, so reverse to remove children before
+            # parents and never orphan a still-referenced ``parent_id``.
+            # Drop the folder's workspace links first —
+            # ``workspace_folders.folder_id`` has no ON DELETE CASCADE, so
+            # the folder delete would hit a FK violation.
+            for fid in reversed(to_delete):
+                self.conn.execute(
+                    "DELETE FROM workspace_folders WHERE folder_id = ?",
+                    (fid,))
+                self.conn.execute("DELETE FROM folders WHERE id = ?", (fid,))
 
-        self.conn.commit()
+            self.conn.commit()
+        except Exception:
+            self.conn.rollback()
+            raise
         self.update_folder_counts()
         return counts
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2845,6 +2845,32 @@ class Database:
                 self.add_workspace_folder(
                     ws, archive_row["id"], is_root=not has_root_ancestor)
             # else: base is already a workspace root — nothing to do.
+        elif not self._active_ws_root_ancestor_exists(ws, archive_path):
+            # ``archive_path`` has no folder row yet — it's a brand-new
+            # subfolder inside an already-tracked archive that the staged
+            # root will be repointed onto below. When the tracked archive
+            # was scanned only under a DIFFERENT workspace, the active
+            # workspace has no link to any of it, no root ancestor covers
+            # ``archive_path``, and the staged-root demotion further down
+            # (``UPDATE workspace_folders SET is_root = 0``) leaves ``ws``
+            # with no ``is_root=1`` row for the merged tree at all —
+            # ``get_workspace_folder_roots()`` filters on ``is_root=1``, so
+            # the merged archive silently disappears from the active ws
+            # even though the import reports success. Walk up to find the
+            # deepest tracked ancestor and root it in ``ws`` so the merged
+            # tree has a visible anchor. The intermediate-materialization
+            # block below then links each freshly-created intermediate as a
+            # non-root descendant under this new root.
+            probe = os.path.dirname(archive_path)
+            while probe and probe != os.path.dirname(probe):
+                ancestor_row = self.conn.execute(
+                    "SELECT id FROM folders WHERE path = ?", (probe,)
+                ).fetchone()
+                if ancestor_row is not None:
+                    self.add_workspace_folder(
+                        ws, ancestor_row["id"], is_root=True)
+                    break
+                probe = os.path.dirname(probe)
 
         # Materialize any missing intermediate folder rows between the deepest
         # existing catalog ancestor and ``archive_path``'s parent (inclusive)

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2956,13 +2956,33 @@ class Database:
                 parent_id_for_mid = (
                     parent_row["id"] if parent_row else None)
                 name = os.path.basename(mid_path) or mid_path
+                # Two concurrent local-processing jobs targeting siblings
+                # inside the same tracked archive (e.g. ``/Photos/2026/A`` and
+                # ``/Photos/2026/B`` while only ``/Photos`` is tracked) can
+                # each snapshot the shared intermediate (``/Photos/2026``)
+                # as missing above, then race to insert its ``folders`` row
+                # here. The final archive paths don't overlap, so the
+                # storage-destination reservation doesn't serialize them; the
+                # loser's plain INSERT would hit the ``folders.path`` UNIQUE
+                # constraint AFTER all staging/processing work is done.
+                # ``INSERT OR IGNORE`` + re-query keeps the loser's merge
+                # progressing against whichever row won the race — the same
+                # intermediate is folder-idempotent (same path, same tracked
+                # ancestor parent). ``cur.lastrowid`` is 0 on an ignored
+                # insert, so read the id back via ``WHERE path = ?``.
                 cur = self.conn.execute(
-                    "INSERT INTO folders (path, name, parent_id) "
+                    "INSERT OR IGNORE INTO folders (path, name, parent_id) "
                     "VALUES (?, ?, ?)",
                     (mid_path, name, parent_id_for_mid),
                 )
+                if cur.rowcount:
+                    mid_id = cur.lastrowid
+                else:
+                    mid_id = self.conn.execute(
+                        "SELECT id FROM folders WHERE path = ?", (mid_path,)
+                    ).fetchone()["id"]
                 self.add_workspace_folder(
-                    ws, cur.lastrowid, is_root=False)
+                    ws, mid_id, is_root=False)
 
         # Snapshot staged folders root-first (shallowest path first) so a
         # parent's target row exists before its children are processed.

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -133,7 +133,18 @@ def _subtree_relative(child_path: str, root_path: str) -> str:
 
 def _join_subtree_path(root_path: str, relative_path: str) -> str:
     parts = [p for p in relative_path.split("/") if p]
-    return os.path.join(root_path, *parts) if parts else root_path
+    if not parts:
+        return root_path
+    # Preserve ``root_path``'s separator convention. ``os.path.join`` on
+    # Windows always inserts ``\``, which mixes separators when the root is
+    # forward-slash — breaking equality lookups (``WHERE path = ?``) against
+    # existing folder rows stored with matching separators. Subtree LIKE
+    # queries normalize with REPLACE, but equality queries do not.
+    sep = "\\" if ("\\" in root_path and "/" not in root_path) else "/"
+    stripped = root_path.rstrip("/\\")
+    if not stripped:
+        return root_path + sep.join(parts)
+    return stripped + sep + sep.join(parts)
 
 
 def _chunks(values, size=_SQLITE_PARAM_CHUNK_SIZE):

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2918,39 +2918,76 @@ class Database:
                 last_target_parent[target_path] = sf["id"]
             else:
                 # Existing folder: move photos in, drop filename-collisions.
-                photo_ids = [r["id"] for r in self.conn.execute(
-                    "SELECT id FROM photos WHERE folder_id = ?", (sf["id"],)
-                )]
-                # ``check_filename_collisions`` is filename-only: it flags a
-                # staged photo whose basename already has a catalog row in the
-                # target folder. That is NOT sufficient to drop the staged
+                staged_photos = list(self.conn.execute(
+                    "SELECT id, filename FROM photos WHERE folder_id = ?",
+                    (sf["id"],),
+                ))
+                # Detect collisions against the ACTUAL target volume's case
+                # rules — not SQLite's default case-sensitive TEXT compare.
+                # On a case-insensitive volume (default macOS APFS, Windows
+                # NTFS), a target row/file named ``IMG.RAF`` and a staged
+                # ``img.raf`` are the same on-disk file: rsync
+                # ``--ignore-existing`` treats them as already present and
+                # skips the copy. A case-sensitive SQL match would miss that,
+                # fall into the else-branch reparent below, and land TWO
+                # catalog rows in one folder pointing at the same on-disk
+                # file (SQLite text-equality is case-sensitive, so
+                # UNIQUE(folder_id, filename) would not fire to catch the
+                # mistake). Build the collision map by normalizing filenames
+                # with the target filesystem's case rules instead. Probes
+                # ``target_path``'s deepest existing ancestor, so a fresh
+                # subfolder inherits its mount's behavior.
+                from move import _case_insensitive_root
+                target_folds_case = _case_insensitive_root(target_path) is not None
+                normalize = (str.casefold if target_folds_case
+                             else (lambda s: s))
+                existing_by_key = {}
+                for row in self.conn.execute(
+                    "SELECT id, filename FROM photos WHERE folder_id = ?",
+                    (target["id"],),
+                ):
+                    # First writer wins on the (unlikely) chance two
+                    # case-alias rows already coexist in the target folder
+                    # from a pre-fix catalog.
+                    existing_by_key.setdefault(
+                        normalize(row["filename"]),
+                        {"id": row["id"], "filename": row["filename"]},
+                    )
+
+                # A filename-collision alone is NOT enough to drop the staged
                 # photo as ``already_present``. The drop is only safe when the
                 # collision is REAL on disk — i.e. the archived file actually
                 # exists at ``target_path/filename``, which is the case the
                 # rsync ``--ignore-existing`` merge relied on (it skipped the
                 # staged copy because the byte-identical archived file was
                 # already there; a DIFFERING file would have aborted the move
-                # upstream in the content-conflict check). If the target catalog
-                # row is stale — its file missing on disk — the upstream check
-                # never fired (no dest file to compare), rsync COPIED the staged
-                # bytes into place, and dropping the staged row would leave those
-                # fresh bytes represented by the old (phantom) row's
-                # hash/metadata, losing the new photo. So when the target file is
-                # absent, do NOT drop the staged photo. Instead delete the stale
-                # target row (its file no longer exists) and reparent the staged
-                # photo in its place, so the surviving catalog row describes the
-                # bytes actually on disk. This also avoids a UNIQUE(folder_id,
-                # filename) violation from moving the staged row onto a folder
-                # that still holds the same basename.
-                collisions = {c["photo_id"]: c["filename"]
-                              for c in self.check_filename_collisions(
-                                  photo_ids, target["id"])}
-                for pid in photo_ids:
-                    filename = collisions.get(pid)
+                # upstream in the content-conflict check). If the target
+                # catalog row is stale — its file missing on disk — the
+                # upstream check never fired (no dest file to compare), rsync
+                # COPIED the staged bytes into place, and dropping the staged
+                # row would leave those fresh bytes represented by the old
+                # (phantom) row's hash/metadata, losing the new photo. So
+                # when the target file is absent, do NOT drop the staged
+                # photo. Instead delete the stale target row (its file no
+                # longer exists) and reparent the staged photo in its place,
+                # so the surviving catalog row describes the bytes actually
+                # on disk. This also avoids a UNIQUE(folder_id, filename)
+                # violation from moving the staged row onto a folder that
+                # still holds the same basename.
+                for staged in staged_photos:
+                    pid = staged["id"]
+                    collision = existing_by_key.get(
+                        normalize(staged["filename"]))
+                    # The archived filename may differ in case from the
+                    # staged one; probe for the ACTUAL archived name so
+                    # ``os.path.exists`` matches on case-sensitive volumes
+                    # too (where any case-alias check is pointless anyway).
+                    target_filename = (collision["filename"]
+                                       if collision else None)
                     real_collision = (
-                        filename is not None
+                        target_filename is not None
                         and os.path.exists(
-                            _join_subtree_path(target_path, filename))
+                            _join_subtree_path(target_path, target_filename))
                     )
                     if real_collision:
                         # photo_keywords.photo_id has no ON DELETE CASCADE
@@ -2963,24 +3000,24 @@ class Database:
                             "DELETE FROM photos WHERE id = ?", (pid,))
                         counts["already_present"] += 1
                     else:
-                        if filename is not None:
-                            # Filename collided but the archived file is missing
-                            # on disk: the staged bytes were freshly copied and
-                            # the target row is a phantom. Drop the phantom so
-                            # the reparent below can take its (folder_id,
+                        if collision is not None:
+                            # Filename collided (case-normalized) but the
+                            # archived file is missing on disk: the staged
+                            # bytes were freshly copied and the target row is
+                            # a phantom. Drop the phantom by id so the
+                            # reparent below can take its (folder_id,
                             # filename) slot and represent the real file.
-                            stale = self.conn.execute(
-                                "SELECT id FROM photos "
-                                "WHERE folder_id = ? AND filename = ?",
-                                (target["id"], filename),
-                            ).fetchone()
-                            if stale is not None:
-                                self.conn.execute(
-                                    "DELETE FROM photo_keywords "
-                                    "WHERE photo_id = ?", (stale["id"],))
-                                self.conn.execute(
-                                    "DELETE FROM photos WHERE id = ?",
-                                    (stale["id"],))
+                            # Deleting by id (not filename) is required on
+                            # case-insensitive volumes where the staged and
+                            # phantom filenames differ only in case: the SQL
+                            # ``filename = ?`` lookup used earlier would miss
+                            # the stale row and leave both intact.
+                            self.conn.execute(
+                                "DELETE FROM photo_keywords "
+                                "WHERE photo_id = ?", (collision["id"],))
+                            self.conn.execute(
+                                "DELETE FROM photos WHERE id = ?",
+                                (collision["id"],))
                         self.conn.execute(
                             "UPDATE photos SET folder_id = ? WHERE id = ?",
                             (target["id"], pid),

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -1562,6 +1562,16 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
     # byte-for-byte unchanged: both tracked-destination cases refuse the move.
     overlap_check_path = catalog_path if remote else transfer_dest
     merge_into_tracked = None
+    # The catalog path the staged tree is reconciled ONTO. Distinct from
+    # ``merge_into_tracked`` (the user-facing "existing archive" label): for an
+    # exact overlap the reconciliation base must be the STORED tracked path, not
+    # ``catalog_path``, because ``catalog_path`` may be an alias (symlink /
+    # case-only fold) of the tracked folder. The files rsync to the same on-disk
+    # location either way, but ``merge_staged_tree_into_archive`` does exact
+    # ``WHERE path = ?`` catalog lookups that only match the row stored under the
+    # tracked path — rebasing onto the alias would miss it and create a second
+    # folder row for the same archive.
+    merge_reconcile_base = None
     tracked = _tracked_destination_overlap(db, folder_id, overlap_check_path)
     if tracked:
         # ``_tracked_destination_overlap`` returns any tracked row at-or-below
@@ -1587,6 +1597,10 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
                 f"isn't supported."
             ]}
         merge_into_tracked = tracked["path"]
+        # Reconcile onto the STORED tracked path (not the possibly-aliased
+        # ``catalog_path``) so the existing archive rows are found, not
+        # duplicated. See the ``merge_reconcile_base`` note above.
+        merge_reconcile_base = tracked["path"]
     if reject_tracked_ancestor and merge_into_tracked is None:
         ancestor = _tracked_destination_ancestor(db, folder_id, overlap_check_path)
         if ancestor:
@@ -1602,8 +1616,12 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
             # rows untouched. The reconciliation still uses ``catalog_path`` as
             # the rebase target (below), but the user-facing "existing archive"
             # base we report is the managed-archive root (``ancestor["path"]``),
-            # not the staged landing path inside it.
+            # not the staged landing path inside it. Here the staged tree lands
+            # at its own ``catalog_path`` (a genuinely-new subpath inside the
+            # ancestor), so ``catalog_path`` IS the correct reconciliation base
+            # — unlike the exact-overlap case above.
             merge_into_tracked = ancestor["path"]
+            merge_reconcile_base = catalog_path
 
     if remote:
         probe = _remote_dir_exists(remote, transfer_dest)
@@ -1855,7 +1873,11 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
         # Destination is a tracked archive and the caller opted into merging:
         # fold the staged folder/photo rows into the existing archive rows
         # instead of a path cascade (which would collide on folders.path).
-        merge_counts = db.merge_staged_tree_into_archive(folder_id, catalog_path)
+        # ``merge_reconcile_base`` is the STORED tracked path for an exact
+        # overlap (so alias/case-fold destinations still match the existing
+        # rows) and ``catalog_path`` for the ancestor case; see where it is set.
+        merge_counts = db.merge_staged_tree_into_archive(
+            folder_id, merge_reconcile_base)
     else:
         db.move_folder_path(folder_id, catalog_path)
     db.update_folder_counts()

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -1200,6 +1200,72 @@ def _tracked_destination_overlap(db, folder_id, dest_path):
     return None
 
 
+def _rebase_under_stored_ancestor(catalog_path, ancestor_path):
+    """Return ``catalog_path`` with any alias-prefix folded to STORED
+    ``ancestor_path``.
+
+    ``catalog_path`` is at or below ``ancestor_path`` per
+    ``_tracked_destination_ancestor``, but the match may have been via
+    ``_path_equal_or_descends``' alias surface (symlink resolution, Windows
+    case-fold via ``normcase``, POSIX case-insensitive ``samefile``). In those
+    cases ``catalog_path``'s leading components differ character-for-character
+    from ``ancestor_path`` even though they resolve to the same on-disk
+    directory. ``merge_staged_tree_into_archive`` reads parent rows by exact
+    ``WHERE path = ?`` — an alias-prefixed base would miss the tracked rows and
+    create a parallel alias-path row set outside the managed archive tree
+    (with ``parent_id=NULL``), so re-root the base on the stored form here.
+
+    The exact-overlap branch of ``move_folder`` passes ``tracked["path"]`` as
+    the reconcile base directly (there IS no suffix — the destination IS the
+    tracked folder); this helper is for the ancestor case where a real
+    relative suffix has to be reattached below the stored ancestor.
+    """
+    if catalog_path == ancestor_path:
+        return ancestor_path
+    prefix = ancestor_path + os.sep
+    if catalog_path.startswith(prefix):
+        return catalog_path
+    # Symlink alias: realpath collapses the link. On POSIX ``normcase`` is a
+    # no-op so the raw realpath is enough; on Windows ``normcase`` also
+    # folds case so the ``normcase(realpath(...))`` compare handles both.
+    real_ancestor = os.path.realpath(ancestor_path)
+    real_catalog = os.path.realpath(catalog_path)
+    if real_catalog == real_ancestor:
+        return ancestor_path
+    real_prefix = real_ancestor + os.sep
+    if real_catalog.startswith(real_prefix):
+        return ancestor_path + real_catalog[len(real_ancestor):]
+    norm_ancestor = os.path.normcase(real_ancestor)
+    norm_catalog = os.path.normcase(real_catalog)
+    if norm_catalog == norm_ancestor:
+        return ancestor_path
+    if norm_catalog.startswith(os.path.normcase(real_prefix)):
+        return ancestor_path + real_catalog[len(real_ancestor):]
+    # Case-only POSIX alias: neither ``realpath`` nor ``normcase`` folds it,
+    # so walk up ``catalog_path`` looking for an existing ancestor whose inode
+    # matches ``ancestor_path`` — the same samefile fallback
+    # ``_path_equal_or_descends`` uses to accept the destination in the first
+    # place. Then join the remaining components onto ``ancestor_path``.
+    parts = []
+    cur = catalog_path
+    while cur:
+        parent = os.path.dirname(cur)
+        if parent == cur:
+            break
+        if os.path.exists(cur) and _samefile_or_false(cur, ancestor_path):
+            if not parts:
+                return ancestor_path
+            return os.path.join(ancestor_path, *parts)
+        parts.insert(0, os.path.basename(cur))
+        cur = parent
+    # No alias match after all. ``_tracked_destination_ancestor`` already
+    # matched via one of the surfaces above, so this shouldn't happen — if
+    # something in the alias surface changes and the walk falls through,
+    # keep today's behaviour (catalog_path unchanged) rather than silently
+    # corrupting the reconcile base.
+    return catalog_path
+
+
 def _tracked_destination_ancestor(db, folder_id, dest_path):
     """Return a tracked folder that is an ancestor of dest_path, if any.
 
@@ -1613,15 +1679,25 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
             # destination. The staged tree lands at its own resolved
             # catalog_path (inside the tracked ancestor); the reconciliation
             # rebases staged rows onto that path and leaves the ancestor's own
-            # rows untouched. The reconciliation still uses ``catalog_path`` as
-            # the rebase target (below), but the user-facing "existing archive"
-            # base we report is the managed-archive root (``ancestor["path"]``),
-            # not the staged landing path inside it. Here the staged tree lands
-            # at its own ``catalog_path`` (a genuinely-new subpath inside the
-            # ancestor), so ``catalog_path`` IS the correct reconciliation base
-            # — unlike the exact-overlap case above.
+            # rows untouched. The user-facing "existing archive" base we
+            # report is the managed-archive root (``ancestor["path"]``), not
+            # the staged landing path inside it.
+            #
+            # The reconciliation base is the STORED ancestor's path with the
+            # relative-below-ancestor suffix appended, NOT the user-entered
+            # ``catalog_path`` — those two only agree when the ancestor probe
+            # matched by pure string prefix. When it matched via a symlink,
+            # Windows case-fold, or POSIX case-only alias (catalog stores
+            # ``/Photos``, user selects ``/photos/NewShoot``),
+            # ``catalog_path`` has an alias prefix that ``merge_staged_tree_
+            # into_archive``'s exact ``WHERE path = ?`` parent lookups miss.
+            # That would land the staged root with ``parent_id=NULL`` under an
+            # alias-prefixed path, spawning a parallel row set outside the
+            # managed archive tree. Fold the alias prefix to the stored form
+            # here.
             merge_into_tracked = ancestor["path"]
-            merge_reconcile_base = catalog_path
+            merge_reconcile_base = _rebase_under_stored_ancestor(
+                catalog_path, ancestor["path"])
 
     if remote:
         probe = _remote_dir_exists(remote, transfer_dest)
@@ -1887,9 +1963,23 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
     # path, so the DB update above just invalidated the old subdir's
     # implicit key — rename it on disk to match the new path, and cascade
     # to any descendant folders whose paths also shifted.
+    #
+    # On the merge path the catalog was reparented onto
+    # ``merge_reconcile_base``, not ``catalog_path`` — those two only
+    # differ when the tracked destination was reached via a symlink or
+    # case-alias (see where ``merge_reconcile_base`` is set), but when they
+    # do differ the developed-dir key is derived from the STORED path, not
+    # the alias. Relocating from ``src_path`` to the aliased
+    # ``catalog_path`` would move renders under the alias-path hash and
+    # exports (which read the catalog's stored path) would look under the
+    # stored-path hash, miss them, and fall back to RAW. Use the same
+    # reconciled base the catalog uses.
+    developed_base = (merge_reconcile_base
+                      if merge_into_tracked is not None
+                      else catalog_path)
     if developed_dir:
         from export import relocate_developed_dir
-        relocate_developed_dir(developed_dir, src_path, catalog_path)
+        relocate_developed_dir(developed_dir, src_path, developed_base)
         # SQL LIKE treats `_` and `%` (and the escape char) as wildcards,
         # all of which are valid POSIX path characters. Without a strict
         # prefix guard, an unrelated folder like `/dXst/birds/fake` would
@@ -1898,14 +1988,14 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
         # developed subdir. Filter results by a literal prefix check.
         descendant_rows = db.conn.execute(
             "SELECT path FROM folders WHERE path LIKE ?",
-            (catalog_path + "/%",),
+            (developed_base + "/%",),
         ).fetchall()
-        prefix = catalog_path + "/"
+        prefix = developed_base + "/"
         for row in descendant_rows:
             new_child = row["path"]
             if not new_child.startswith(prefix):
                 continue
-            old_child = src_path + new_child[len(catalog_path):]
+            old_child = src_path + new_child[len(developed_base):]
             relocate_developed_dir(developed_dir, old_child, new_child)
 
     # Delete originals. The catalog already points at the new destination,

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -2039,12 +2039,20 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
 
     result = {"moved": total_photos, "errors": []}
     if merge_into_tracked is not None:
+        # ``dropped_photo_ids`` is a cleanup handle for the caller (thumbnails,
+        # previews, offline copies of the deleted staged photos), not a
+        # user-facing count. Lift it off ``merge_counts`` so ``result["merge"]``
+        # stays a stable dict of display numbers that gets serialized straight
+        # into the archive-stage summary/API payload.
+        dropped = merge_counts.pop("dropped_photo_ids", None) or []
         result["merge"] = merge_counts
         result["merged_into_existing"] = merge_into_tracked
         # On the merge path ``total_photos`` counts every staged source photo,
         # including identical ones that were dropped as ``already_present``.
         # Report ``moved`` as the photos actually added to the archive.
         result["moved"] = merge_counts["new_photos"]
+        if dropped:
+            result["dropped_photo_ids"] = dropped
     if cleanup_error is not None:
         result["cleanup_error"] = cleanup_error
     return result

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -1583,8 +1583,11 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
             # destination. The staged tree lands at its own resolved
             # catalog_path (inside the tracked ancestor); the reconciliation
             # rebases staged rows onto that path and leaves the ancestor's own
-            # rows untouched.
-            merge_into_tracked = catalog_path if remote else transfer_dest
+            # rows untouched. The reconciliation still uses ``catalog_path`` as
+            # the rebase target (below), but the user-facing "existing archive"
+            # base we report is the managed-archive root (``ancestor["path"]``),
+            # not the staged landing path inside it.
+            merge_into_tracked = ancestor["path"]
 
     if remote:
         probe = _remote_dir_exists(remote, transfer_dest)
@@ -1890,6 +1893,10 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
     if merge_into_tracked is not None:
         result["merge"] = merge_counts
         result["merged_into_existing"] = merge_into_tracked
+        # On the merge path ``total_photos`` counts every staged source photo,
+        # including identical ones that were dropped as ``already_present``.
+        # Report ``moved`` as the photos actually added to the archive.
+        result["moved"] = merge_counts["new_photos"]
     if cleanup_error is not None:
         result["cleanup_error"] = cleanup_error
     return result

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -1564,7 +1564,23 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
     merge_into_tracked = None
     tracked = _tracked_destination_overlap(db, folder_id, overlap_check_path)
     if tracked:
-        if not allow_tracked_merge:
+        # ``_tracked_destination_overlap`` returns any tracked row at-or-below
+        # ``overlap_check_path``. The opt-in merge only covers the "into an
+        # existing archive" case where the tracked row IS the destination;
+        # a tracked row STRICTLY BELOW the destination is the "wrap a fresh
+        # parent around an existing tracked subtree" case (e.g. /Photos/USA
+        # tracked, destination /Photos). The reconciliation would rebase the
+        # staged tree onto the wrapper path and leave the pre-existing tracked
+        # descendant with unchanged parentage — two overlapping catalog
+        # subtrees managing the same on-disk area. Refuse even when
+        # ``allow_tracked_merge`` is set. Uses the same alias-folding surface
+        # as the overlap probe (symlinks, Windows case-fold, case-insensitive
+        # POSIX) so a case-only alias of the destination still counts as the
+        # tracked row itself, not a wrapping parent.
+        tracked_is_destination = _path_equal_or_descends(
+            overlap_check_path, tracked["path"],
+        )
+        if not allow_tracked_merge or not tracked_is_destination:
             return {"moved": 0, "errors": [
                 f"Destination overlaps a folder Vireo already manages "
                 f"({tracked['path']}). Merging into or around a tracked folder "

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -1373,7 +1373,8 @@ def move_photos(db, photo_ids, destination, progress_cb=None):
 
 
 def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
-                merge=False, remote=None, reject_tracked_ancestor=False):
+                merge=False, remote=None, reject_tracked_ancestor=False,
+                allow_tracked_merge=False):
     """Move an entire folder (and subfolders) to a destination.
 
     The folder is placed inside the destination, preserving its name.
@@ -1418,6 +1419,16 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
             commits opt into this stricter guard because they create a new
             top-level archive root and cannot be reparented under the
             existing catalog row.
+        allow_tracked_merge: when True, a tracked destination (overlap or, with
+            ``reject_tracked_ancestor``, ancestor) is no longer an error.
+            Instead, after the verified file copy, the staged folder/photo rows
+            are folded into the existing archive rows via
+            ``db.merge_staged_tree_into_archive`` (new folders repointed,
+            identical-filename photos dropped) rather than a path cascade. Only
+            the local-processing archive commit opts in; manual and remote
+            moves keep the default refusal. The result then carries ``merge``
+            (the reconciliation counts) and ``merged_into_existing`` (the
+            tracked archive path).
 
     Returns dict with keys: moved (int), errors (list of str). When the
     catalog has already been repointed at the new destination but deleting
@@ -1541,21 +1552,39 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
     # (default macOS APFS) all collapse to the same tracked row — otherwise
     # a destination reached via any of those would slip past and leave two
     # folder rows managing the same on-disk tree.
+    #
+    # When ``allow_tracked_merge`` is set (the local-processing archive commit
+    # opts in), a tracked destination is NOT an error: instead we remember the
+    # tracked path in ``merge_into_tracked`` and, after the verified file copy,
+    # reconcile the catalog by folding the staged folder/photo rows into the
+    # existing archive rows rather than calling ``db.move_folder_path`` (which
+    # would collide on folders.path UNIQUE). Default (flag off) behaviour is
+    # byte-for-byte unchanged: both tracked-destination cases refuse the move.
     overlap_check_path = catalog_path if remote else transfer_dest
+    merge_into_tracked = None
     tracked = _tracked_destination_overlap(db, folder_id, overlap_check_path)
     if tracked:
-        return {"moved": 0, "errors": [
-            f"Destination overlaps a folder Vireo already manages "
-            f"({tracked['path']}). Merging into or around a tracked folder "
-            f"isn't supported."
-        ]}
-    if reject_tracked_ancestor:
+        if not allow_tracked_merge:
+            return {"moved": 0, "errors": [
+                f"Destination overlaps a folder Vireo already manages "
+                f"({tracked['path']}). Merging into or around a tracked folder "
+                f"isn't supported."
+            ]}
+        merge_into_tracked = tracked["path"]
+    if reject_tracked_ancestor and merge_into_tracked is None:
         ancestor = _tracked_destination_ancestor(db, folder_id, overlap_check_path)
         if ancestor:
-            return {"moved": 0, "errors": [
-                f"Destination is inside a folder Vireo already manages "
-                f"({ancestor['path']}). Pick an untracked archive destination."
-            ]}
+            if not allow_tracked_merge:
+                return {"moved": 0, "errors": [
+                    f"Destination is inside a folder Vireo already manages "
+                    f"({ancestor['path']}). Pick an untracked archive destination."
+                ]}
+            # Merge into the existing archive root that contains the
+            # destination. The staged tree lands at its own resolved
+            # catalog_path (inside the tracked ancestor); the reconciliation
+            # rebases staged rows onto that path and leaves the ancestor's own
+            # rows untouched.
+            merge_into_tracked = catalog_path if remote else transfer_dest
 
     if remote:
         probe = _remote_dir_exists(remote, transfer_dest)
@@ -1792,14 +1821,24 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
 
     # Update DB first: cascade folder paths (safer — if rmtree fails, the old
     # folder becomes an orphan on disk rather than the DB pointing to deleted
-    # paths). A merge into an already-tracked destination is refused above, so
-    # catalog_path is never a different existing folder row here and this
-    # cascade (root + all descendants) cannot collide with folders.path UNIQUE.
+    # paths). Unless the caller opted into merging (``merge_into_tracked``), a
+    # merge into an already-tracked destination is refused above, so
+    # catalog_path is never a different existing folder row in the cascade
+    # branch and that cascade (root + all descendants) cannot collide with
+    # folders.path UNIQUE. When merging into a tracked archive we instead
+    # reconcile the staged rows into the existing archive rows below.
     # For a remote move catalog_path is the local mount path, so the catalog
     # keeps resolving to the photos whenever the NAS is mounted.
     if progress_cb:
         progress_cb(total_files, total_files, "", "Updating catalog")
-    db.move_folder_path(folder_id, catalog_path)
+    merge_counts = None
+    if merge_into_tracked is not None:
+        # Destination is a tracked archive and the caller opted into merging:
+        # fold the staged folder/photo rows into the existing archive rows
+        # instead of a path cascade (which would collide on folders.path).
+        merge_counts = db.merge_staged_tree_into_archive(folder_id, catalog_path)
+    else:
+        db.move_folder_path(folder_id, catalog_path)
     db.update_folder_counts()
 
     # Rebase any developed-output subdirs nested under the configured
@@ -1848,6 +1887,9 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
         progress_cb(total_files, total_files, folder_name, "Done")
 
     result = {"moved": total_photos, "errors": []}
+    if merge_into_tracked is not None:
+        result["merge"] = merge_counts
+        result["merged_into_existing"] = merge_into_tracked
     if cleanup_error is not None:
         result["cleanup_error"] = cleanup_error
     return result

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -1182,6 +1182,15 @@ def _destination_overlaps_source(src_path, dest_path):
 def _tracked_destination_overlap(db, folder_id, dest_path):
     """Return another tracked folder at or below dest_path, if one exists.
 
+    When both an exact-match row (a tracked folder alias-equal to
+    ``dest_path``) AND a strict-descendant row exist, the exact-match row
+    is returned. Otherwise the caller's exact-vs-descendant branch would
+    fire non-deterministically based on the arbitrary order SQLite happened
+    to return the rows in (e.g. ``/Photos/USA`` inserted before its later-
+    scanned parent ``/Photos``): selecting the exact tracked parent would
+    get rejected as the unsupported "wrap around a tracked subfolder" case
+    just because the child row was seen first.
+
     The case-insensitive root of `dest_path` is probed once and reused for
     every row — otherwise the probe (an os.listdir of the deepest existing
     ancestor, plus samefile of two child paths) re-runs per non-matching row,
@@ -1189,6 +1198,7 @@ def _tracked_destination_overlap(db, folder_id, dest_path):
     large catalogs or network-backed destinations.
     """
     dest_ci_root = _case_insensitive_root(dest_path)
+    descendant = None
     for row in db.conn.execute(
         "SELECT id, path FROM folders WHERE id != ?", (folder_id,)
     ):
@@ -1196,8 +1206,18 @@ def _tracked_destination_overlap(db, folder_id, dest_path):
             row["path"], dest_path,
             case_insensitive_root=dest_ci_root,
         ):
-            return row
-    return None
+            # Prefer an exact (alias-folded) match: ``row["path"]`` is
+            # at-or-below ``dest_path``, so if ``dest_path`` is ALSO
+            # at-or-below ``row["path"]`` the two paths alias-fold to the
+            # same directory and this row IS the destination the caller
+            # can accept as a merge. Otherwise the row is a strict
+            # descendant (the "wrap around" case); remember it as a
+            # fallback in case no exact-match row turns up later.
+            if _path_equal_or_descends(dest_path, row["path"]):
+                return row
+            if descendant is None:
+                descendant = row
+    return descendant
 
 
 def _rebase_under_stored_ancestor(catalog_path, ancestor_path):

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -4611,6 +4611,24 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 if move_result.get("errors"):
                     raise RuntimeError("; ".join(move_result["errors"]))
 
+                # Merge-into-existing-archive dropped some staged photo rows
+                # (identical filename already archived, or a phantom target
+                # row was replaced). SQLite reuses freed rowids, so any
+                # thumbnail / preview / working-copy / offline-cache file
+                # keyed off one of those ids would silently become a stale
+                # asset for whichever future photo lands on the same id.
+                # Mirror the archive-skip cleanup path so no orphaned cache
+                # files can survive the merge.
+                dropped_ids = move_result.get("dropped_photo_ids") or []
+                if dropped_ids:
+                    from preview_cache import (
+                        cleanup_cached_files_for_deleted_photos,
+                    )
+                    cleanup_cached_files_for_deleted_photos(
+                        effective_thumb_cache_dir,
+                        [{"photo_id": pid} for pid in dropped_ids],
+                    )
+
                 if staging_parent:
                     with contextlib.suppress(OSError):
                         os.rmdir(staging_parent)

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1021,11 +1021,6 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             storage_plan,
                             total_file_bytes,
                         )
-                        from move import (
-                            _tracked_destination_ancestor,
-                            _tracked_destination_overlap,
-                        )
-
                         stages["storage"]["status"] = "running"
                         runner.update_step(job["id"], "storage", status="running")
                         _update_stages(runner, job["id"], stages)
@@ -1052,49 +1047,14 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             scan_to_thumb.put(_SENTINEL)
 
                         try:
-                            # Reject up front if the archive destination is already
-                            # a Vireo-managed folder (e.g., a repeat import to the
-                            # same archive root). Without this check the pipeline
-                            # would stage everything, complete every processing
-                            # step, and then fail in move_folder's tracked-overlap
-                            # guard — leaving the staged copy stranded under
-                            # ~/.vireo/staging with no way to resume.
-                            tracked = _tracked_destination_overlap(
-                                thread_db, -1, final_destination,
-                            )
-                            if tracked:
-                                _bail_storage(
-                                    f"Archive destination {final_destination} "
-                                    f"overlaps a folder Vireo already manages "
-                                    f"({tracked['path']}). Local processing "
-                                    "imports must land at a new archive folder; "
-                                    "pick a different destination or import "
-                                    "without local processing."
-                                )
-                                return
-
-                            # Also reject when the archive destination would land
-                            # INSIDE an already-tracked folder. db.move_folder_path
-                            # (called by move_folder during archive) only rewrites
-                            # the moved row's path string — it does NOT reparent the
-                            # row under the tracked ancestor. The catalog would end
-                            # up with two unrelated workspace roots whose path
-                            # strings overlap, e.g. /Photos and /Photos/NewShoot,
-                            # silently confusing the folder tree and breaking
-                            # future scans of the ancestor root.
-                            ancestor = _tracked_destination_ancestor(
-                                thread_db, -1, final_destination,
-                            )
-                            if ancestor:
-                                _bail_storage(
-                                    f"Archive destination {final_destination} "
-                                    f"is inside a folder Vireo already manages "
-                                    f"({ancestor['path']}). Pick an archive "
-                                    f"folder outside {ancestor['path']}, or "
-                                    "import without local processing so the "
-                                    "scan can attach to the existing folder."
-                                )
-                                return
+                            # A tracked archive destination (the import lands at
+                            # or inside a folder Vireo already manages) is no
+                            # longer a hard failure: the archive move opts into
+                            # merging (allow_tracked_merge=True) and folds the
+                            # staged tree into the existing archive. The precise
+                            # per-file content-conflict guard below
+                            # (conflicting_archive_paths) still refuses any
+                            # same-path file whose bytes differ.
 
                             # Make sure the archive parent exists NOW. Otherwise
                             # the pipeline would stage and process everything,
@@ -4611,6 +4571,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     developed_dir=developed_dir,
                     merge=True,
                     reject_tracked_ancestor=True,
+                    allow_tracked_merge=True,
                 )
                 if move_result.get("errors"):
                     raise RuntimeError("; ".join(move_result["errors"]))
@@ -4634,13 +4595,22 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 cleanup_error = move_result.get("cleanup_error")
                 stages["archive"]["status"] = "completed"
                 moved = move_result.get("moved", 0)
-                if cleanup_error:
+                merge = move_result.get("merge")
+                if merge:
+                    base = move_result.get(
+                        "merged_into_existing", final_destination,
+                    )
                     summary = (
-                        f"{moved} photos archived "
-                        f"(staging cleanup failed: {cleanup_error})"
+                        f"{merge['new_photos']} new photos archived into "
+                        f"existing archive {base} "
+                        f"({merge['new_folders']} new folders, "
+                        f"{merge['merged_folders']} merged into existing, "
+                        f"{merge['already_present']} already present)"
                     )
                 else:
                     summary = f"{moved} photos archived"
+                if cleanup_error:
+                    summary += f" (staging cleanup failed: {cleanup_error})"
                 runner.update_step(
                     job["id"], "archive", status="completed", summary=summary,
                 )
@@ -4648,6 +4618,8 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     "final_destination": final_destination,
                     "moved": moved,
                 }
+                if merge:
+                    result["archive"]["merge"] = merge
                 if cleanup_error:
                     result["archive"]["cleanup_error"] = cleanup_error
             except Exception as e:

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1055,6 +1055,41 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             # per-file content-conflict guard below
                             # (conflicting_archive_paths) still refuses any
                             # same-path file whose bytes differ.
+                            #
+                            # BUT — the merge only supports the "exact overlap"
+                            # (destination IS a tracked folder) and the "ancestor
+                            # overlap" (destination is INSIDE a tracked folder)
+                            # cases. A tracked row STRICTLY BELOW the destination
+                            # (e.g. /Photos/USA already tracked and the user
+                            # picks /Photos) is the "wrap a fresh parent around
+                            # an existing tracked subtree" case which
+                            # move_folder refuses even with allow_tracked_merge.
+                            # Without an early refuse here the pipeline would
+                            # stage and process everything, then fail only at
+                            # the archive step and leave processed results
+                            # stranded under staging. Mirror move_folder's
+                            # alias-folded check so a symlink or case-only alias
+                            # of the tracked path is treated as the exact-match
+                            # case, not a descendant.
+                            from move import (
+                                _path_equal_or_descends,
+                                _tracked_destination_overlap,
+                            )
+                            preflight_tracked = _tracked_destination_overlap(
+                                thread_db, -1, final_destination,
+                            )
+                            if preflight_tracked and not _path_equal_or_descends(
+                                final_destination, preflight_tracked["path"],
+                            ):
+                                _bail_storage(
+                                    f"Archive destination {final_destination} "
+                                    "sits above a folder Vireo already manages "
+                                    f"({preflight_tracked['path']}). Merging "
+                                    "around a tracked subfolder isn't "
+                                    "supported. Pick the tracked folder itself "
+                                    "or a location outside it."
+                                )
+                                return
 
                             # Make sure the archive parent exists NOW. Otherwise
                             # the pipeline would stage and process everything,

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -877,6 +877,7 @@ body { padding-bottom: 36px; }
             </div>
           </div>
           <div id="folderPreviewResults" style="display:none;margin-top:8px;" data-testid="folder-preview-results">
+            <div id="folderPreviewManagedArchive" style="display:none;font-size:12px;line-height:1.4;margin-bottom:8px;padding:6px 8px;border-radius:4px;background:var(--bg-tertiary,#0d2436);border:1px solid var(--accent,#24E5CA);" data-testid="managed-archive-callout"></div>
             <div id="folderPreviewSummary" style="font-size:12px;font-weight:600;margin-bottom:6px;"></div>
             <div id="folderPreviewList" style="font-size:12px;max-height:200px;overflow-y:auto;"></div>
             <div id="folderPreviewStale" style="display:none;font-size:11px;color:var(--warning,#f0ad4e);margin-top:4px;">
@@ -1435,6 +1436,11 @@ var _previewLoading = false;   // true while import/new-images preview scope is 
 var _previewAbort = null;      // AbortController for in-flight request
 var _duplicateResults = {};    // path -> true for duplicates (cache)
 var _duplicateCheckAbort = null;  // AbortController for in-flight check
+// Set from the last destination-preview when the destination is (or sits
+// inside) an existing Vireo-managed archive: { path, photo_count }. null
+// otherwise. Used to reframe the destination preview + duplicate summary as
+// a merge into an existing archive rather than a fresh copy.
+var _managedArchive = null;
 var _thumbSchedulerCancel = null; // cancels the current thumbnail pump on re-render
 
 function fetchFolderPreview() {
@@ -1789,7 +1795,20 @@ function updateDuplicateSummary(data) {
   span.className = 'stat dup-status';
   if (data.done) {
     if (data.duplicate_count > 0) {
-      span.innerHTML = '<span class="stat-value">' + data.duplicate_count + '</span> already imported';
+      if (_managedArchive) {
+        // Merging into an existing archive: frame duplicates as already
+        // living in that archive (they'll be skipped), and \u2014 when we can
+        // reliably derive it \u2014 how many are genuinely new (will be merged).
+        span.innerHTML = '<span class="stat-value">' + data.duplicate_count
+          + '</span> already in this archive (will be skipped)';
+        if (typeof data.total === 'number' && data.total >= data.duplicate_count) {
+          var newCount = data.total - data.duplicate_count;
+          span.innerHTML += ', <span class="stat-value">' + newCount
+            + '</span> new (will be merged)';
+        }
+      } else {
+        span.innerHTML = '<span class="stat-value">' + data.duplicate_count + '</span> already imported';
+      }
     }
     // If 0 duplicates, show nothing
   } else {
@@ -1818,7 +1837,9 @@ function onSkipDuplicatesToggle() {
     if (dupCount > 0) {
       var span = document.createElement('span');
       span.className = 'stat dup-status';
-      span.innerHTML = '<span class="stat-value">' + dupCount + '</span> already imported';
+      span.innerHTML = _managedArchive
+        ? '<span class="stat-value">' + dupCount + '</span> already in this archive (will be skipped)'
+        : '<span class="stat-value">' + dupCount + '</span> already imported';
       summary.appendChild(span);
     }
   } else {
@@ -2084,6 +2105,12 @@ async function previewDestinationFolders() {
         + '</div>';
     }).join('');
 
+    // Managed-archive callout: when the destination is (or sits inside) an
+    // existing Vireo-managed archive, say so plainly so the dialog never
+    // presents an existing archive as an empty/new destination.
+    _managedArchive = data.managed_archive || null;
+    renderManagedArchiveCallout();
+
     resultsDiv.style.display = '';
     _folderPreviewShown = true;
     btn.textContent = 'Refresh preview';
@@ -2096,8 +2123,44 @@ async function previewDestinationFolders() {
   }
 }
 
+// Render (or hide) the "destination is an existing managed archive" callout
+// based on _managedArchive. Built with textContent so the archive path is
+// never interpreted as HTML.
+function renderManagedArchiveCallout() {
+  var el = document.getElementById('folderPreviewManagedArchive');
+  if (!el) return;
+  if (!_managedArchive || !_managedArchive.path) {
+    el.textContent = '';
+    el.style.display = 'none';
+    return;
+  }
+  var count = _managedArchive.photo_count || 0;
+  el.textContent = '';
+
+  var lead = document.createElement('span');
+  lead.textContent = 'Destination is an existing Vireo archive (';
+  el.appendChild(lead);
+
+  var pathEl = document.createElement('code');
+  pathEl.style.fontFamily = 'monospace';
+  pathEl.textContent = _managedArchive.path;
+  el.appendChild(pathEl);
+
+  var mid = document.createElement('span');
+  mid.textContent = ', ' + count.toLocaleString() + ' photo' + (count === 1 ? '' : 's')
+    + '). New files will be merged in.';
+  el.appendChild(mid);
+
+  el.style.display = '';
+}
+
 function markFolderPreviewStale() {
   if (!_folderPreviewShown) return;
+  // A source/destination change invalidates the managed-archive verdict — drop
+  // it so the duplicate summary doesn't keep merge-framing against a stale
+  // destination. The callout stays visible (with the stale banner below it)
+  // until the user refreshes, at which point it's recomputed.
+  _managedArchive = null;
   document.getElementById('folderPreviewStale').style.display = '';
   var btn = document.getElementById('btnPreviewFolders');
   btn.textContent = 'Refresh preview';

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1797,10 +1797,14 @@ function updateDuplicateSummary(data) {
     if (data.duplicate_count > 0) {
       if (_managedArchive) {
         // Merging into an existing archive: frame duplicates as already
-        // living in that archive (they'll be skipped), and \u2014 when we can
+        // living in the catalog (they'll be skipped), and \u2014 when we can
         // reliably derive it \u2014 how many are genuinely new (will be merged).
+        // The duplicate check is catalog-global (matches ingest's global
+        // skip), so a match may live in a different archive \u2014 hence
+        // "in your library", not "in this archive". The count is still
+        // correct for the skip/merge framing.
         span.innerHTML = '<span class="stat-value">' + data.duplicate_count
-          + '</span> already in this archive (will be skipped)';
+          + '</span> already in your library (will be skipped)';
         if (typeof data.total === 'number' && data.total >= data.duplicate_count) {
           var newCount = data.total - data.duplicate_count;
           span.innerHTML += ', <span class="stat-value">' + newCount
@@ -1838,7 +1842,7 @@ function onSkipDuplicatesToggle() {
       var span = document.createElement('span');
       span.className = 'stat dup-status';
       span.innerHTML = _managedArchive
-        ? '<span class="stat-value">' + dupCount + '</span> already in this archive (will be skipped)'
+        ? '<span class="stat-value">' + dupCount + '</span> already in your library (will be skipped)'
         : '<span class="stat-value">' + dupCount + '</span> already imported';
       summary.appendChild(span);
     }
@@ -2158,9 +2162,11 @@ function markFolderPreviewStale() {
   if (!_folderPreviewShown) return;
   // A source/destination change invalidates the managed-archive verdict — drop
   // it so the duplicate summary doesn't keep merge-framing against a stale
-  // destination. The callout stays visible (with the stale banner below it)
-  // until the user refreshes, at which point it's recomputed.
+  // destination, and hide the callout so it never asserts an "existing archive"
+  // for a path that may no longer be the destination. The amber "click Refresh"
+  // banner below still prompts the user; the callout is recomputed on refresh.
   _managedArchive = null;
+  renderManagedArchiveCallout();
   document.getElementById('folderPreviewStale').style.display = '';
   var btn = document.getElementById('btnPreviewFolders');
   btn.textContent = 'Refresh preview';

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -7810,6 +7810,87 @@ def test_merge_staged_tree_materializes_missing_intermediate_parent(db):
     assert mid_link is not None and mid_link["is_root"] == 0
 
 
+def test_merge_staged_tree_intermediate_insert_survives_race(db):
+    """Regression: two concurrent local-processing jobs targeting siblings
+    inside the same tracked archive (e.g. ``/Photos/2026/A`` and
+    ``/Photos/2026/B`` while only ``/Photos`` is tracked) can both snapshot
+    the shared intermediate ``/Photos/2026`` as missing during walk-up, then
+    race to insert it. The archive-destination reservation lets them run
+    because the leaf paths don't overlap. Without ``INSERT OR IGNORE`` +
+    requery, the loser would raise ``IntegrityError`` on the intermediate's
+    ``folders.path`` UNIQUE constraint AFTER all staging/processing work is
+    already done, stranding the merge. The reconciliation must instead fall
+    back to the winner's row and finish parenting the staged tree under it.
+    """
+    ws = db._active_workspace_id
+
+    # Tracked archive root; the shared intermediate /Photos/2026 has never
+    # been scanned (no folder row for it yet).
+    root_id = db.add_folder("/Photos", name="Photos")
+    db.add_workspace_folder(ws, root_id, is_root=True)
+
+    # Staged tree that will land at /Photos/2026/A after rsync.
+    stage_root = db.add_folder("/stage/A", name="A", workspace_root=False)
+    db.add_photo(folder_id=stage_root, filename="a.raf", extension=".raf",
+                 file_size=100, file_mtime=1.0)
+
+    # Simulate the race: the walk-up probe above has already snapshotted
+    # /Photos/2026 as missing; here we sneak in a competing insert JUST
+    # before the reconciliation's own INSERT fires, standing in for the
+    # winning concurrent job's commit. Without INSERT OR IGNORE the loser's
+    # plain INSERT would raise here. Wrap the connection (sqlite3.Connection
+    # is C-implemented and doesn't allow assigning to .execute directly).
+    real_conn = db.conn
+
+    class _RacingConn:
+        race_inserted = False
+
+        def execute(self_wrap, sql, params=()):
+            if (not _RacingConn.race_inserted
+                    and isinstance(sql, str)
+                    and sql.startswith("INSERT OR IGNORE INTO folders")):
+                real_conn.execute(
+                    "INSERT INTO folders (path, name, parent_id) "
+                    "VALUES (?, ?, ?)",
+                    ("/Photos/2026", "2026", root_id),
+                )
+                _RacingConn.race_inserted = True
+            return real_conn.execute(sql, params)
+
+        def __getattr__(self_wrap, name):
+            return getattr(real_conn, name)
+
+    db.conn = _RacingConn()
+    try:
+        db.merge_staged_tree_into_archive(stage_root, "/Photos/2026/A")
+    finally:
+        db.conn = real_conn
+
+    # The race was actually triggered (guards against a future refactor that
+    # renames the INSERT and silently no-ops this simulation).
+    assert _RacingConn.race_inserted, (
+        "expected the reconciliation to run INSERT OR IGNORE for the missing "
+        "intermediate row — the simulation didn't fire, so the race is no "
+        "longer exercised"
+    )
+
+    # Exactly one /Photos/2026 row survives (the winner's), and the staged
+    # tree ended up parented under it — no duplicates, no NULL parent, no
+    # UNIQUE-constraint crash.
+    mid_rows = db.conn.execute(
+        "SELECT id, parent_id FROM folders WHERE path = ?",
+        ("/Photos/2026",),
+    ).fetchall()
+    assert len(mid_rows) == 1
+    mid_id = mid_rows[0]["id"]
+    assert mid_rows[0]["parent_id"] == root_id
+    dest = db.conn.execute(
+        "SELECT parent_id FROM folders WHERE path = ?",
+        ("/Photos/2026/A",),
+    ).fetchone()
+    assert dest is not None and dest["parent_id"] == mid_id
+
+
 def test_merge_staged_tree_missing_target_file_keeps_new_photo(db, tmp_path):
     """Defensive: a filename collision against a STALE target row whose file is
     missing on disk must NOT drop the staged photo as ``already_present``. The

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -7864,6 +7864,103 @@ def test_merge_staged_tree_case_alias_collision_on_case_insensitive_volume(
     assert counts["new_photos"] == 0
 
 
+def test_merge_staged_tree_rolls_back_on_error(db, monkeypatch):
+    """Regression: ``merge_staged_tree_into_archive`` runs a long sequence of
+    UPDATE/DELETE statements before a single final commit. An exception
+    partway through the reconciliation loop must ``rollback()`` — otherwise
+    the pending mutations sit on the connection and a later unrelated commit
+    silently persists a half-merged catalog. Matches the pattern used by
+    ``delete_folder``, ``move_folders_to_workspace``, and
+    ``_merge_duplicate_keywords_pass``.
+
+    The concrete pending-mutation this test forces is a photo reparent from
+    a staged else-branch iteration (existing target folder). The else-branch
+    contains no ``add_workspace_folder`` call, so its ``UPDATE photos SET
+    folder_id`` is genuinely pending until the end-of-body commit — a raise
+    before that commit must roll it back."""
+    ws = db._active_workspace_id
+
+    # Existing tracked archive base + a pre-existing date folder so the
+    # first staged-folder iteration hits the else-branch (target exists),
+    # not the if-branch (which would commit mid-loop through
+    # ``add_workspace_folder`` and defeat the rollback demonstration).
+    base_id = db.add_folder("/arch/USA", name="USA")
+    existing_date_id = db.add_folder("/arch/USA/2025-12-25",
+                                     name="2025-12-25", parent_id=base_id)
+    db.add_photo(folder_id=existing_date_id, filename="old.raf",
+                 extension=".raf", file_size=100, file_mtime=1.0)
+    db.add_workspace_folder(ws, base_id, is_root=True)
+
+    # Staged tree with two else-branch iterations. The stage_root maps to
+    # ``/arch/USA`` (base_id, exists), and the stage_leaf maps to
+    # ``/arch/USA/2025-12-25`` (existing_date_id, exists). We seed the
+    # stage_leaf photo so iteration 1 does its pending
+    # ``UPDATE photos SET folder_id`` first, then iteration 2 blows up on
+    # the ``_case_insensitive_root`` probe.
+    stage_root = db.add_folder("/stage/USA", name="USA",
+                               workspace_root=False)
+    staged_root_pid = db.add_photo(
+        folder_id=stage_root, filename="root_new.raf",
+        extension=".raf", file_size=150, file_mtime=1.5,
+    )
+    stage_leaf = db.add_folder("/stage/USA/2025-12-25",
+                               name="2025-12-25", parent_id=stage_root,
+                               workspace_root=False)
+    staged_leaf_pid = db.add_photo(
+        folder_id=stage_leaf, filename="leaf_new.raf",
+        extension=".raf", file_size=200, file_mtime=2.0,
+    )
+
+    # Poison ``_case_insensitive_root`` to succeed on the FIRST call (so
+    # iteration 1 completes its pending photo reparent) and raise on the
+    # SECOND (so iteration 2 crashes AFTER iteration 1's pending
+    # ``UPDATE photos SET folder_id`` is queued but before the end-of-body
+    # commit).
+    import move as move_mod
+    real_ci_root = move_mod._case_insensitive_root
+    call_count = {"n": 0}
+
+    def _flaky(path):
+        call_count["n"] += 1
+        if call_count["n"] >= 2:
+            raise RuntimeError("case-fold probe blew up mid-merge")
+        return real_ci_root(path)
+
+    monkeypatch.setattr(move_mod, "_case_insensitive_root", _flaky)
+
+    import pytest as _pytest
+    with _pytest.raises(RuntimeError, match="case-fold probe blew up"):
+        db.merge_staged_tree_into_archive(stage_root, "/arch/USA")
+
+    # Iteration 1's pending ``UPDATE photos SET folder_id = base_id`` was
+    # rolled back: the staged photo is still on stage_root, NOT on base_id.
+    # Without the try/except + rollback, the pending UPDATE would sit on the
+    # connection and any later commit on the same connection would persist
+    # it — a silent half-merge.
+    assert db.conn.execute(
+        "SELECT folder_id FROM photos WHERE id = ?", (staged_root_pid,)
+    ).fetchone()["folder_id"] == stage_root
+    # Iteration 2's staged photo is untouched (the raise fired before its
+    # photo loop even ran).
+    assert db.conn.execute(
+        "SELECT folder_id FROM photos WHERE id = ?", (staged_leaf_pid,)
+    ).fetchone()["folder_id"] == stage_leaf
+    # Neither staged folder was folded into the archive — stage_root's row
+    # still lives under its staging path, not deleted or reparented.
+    assert db.conn.execute(
+        "SELECT id FROM folders WHERE path = ?", ("/stage/USA",)
+    ).fetchone()["id"] == stage_root
+    # The pre-existing archived photo is untouched.
+    old_photo = db.conn.execute(
+        "SELECT folder_id FROM photos WHERE filename = ?", ("old.raf",)
+    ).fetchone()
+    assert old_photo["folder_id"] == existing_date_id
+    # Confirm the poison actually fired twice (i.e. we did reach the raise
+    # via iteration 2, so iteration 1's pending mutation genuinely happened
+    # and the rollback is what returned staged_root_pid to stage_root).
+    assert call_count["n"] == 2
+
+
 def test_folder_under_rule_excludes_siblings_and_escapes_wildcards(tmp_path, monkeypatch):
     """'folder under /photos/2023' must match that folder and its
     descendants only — not the sibling /photos/2023-trip — and a _ in the

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -7541,6 +7541,80 @@ def test_merge_staged_tree_existing_folder_and_collision(db):
     ).fetchone() is None
 
 
+def test_merge_staged_tree_links_archive_to_active_workspace(db):
+    """Regression: when the pre-existing archive base is linked only to a
+    DIFFERENT workspace, merging staged photos into it must link the base
+    (and its subtree) to the active workspace too. Workspace-scoped photo
+    queries join ``workspace_folders`` on ``p.folder_id``; without the link,
+    the else-branch UPDATE moves photos onto a ``target["id"]`` that has no
+    ``workspace_folders`` row for the active ws, and every merged-in photo
+    silently vanishes from ws-scoped views even though the import reports
+    success. Reproduces via two workspaces: the archive lives under ``other``
+    only, and ``active`` runs the merge."""
+    # Archive lives under the default workspace; ``active`` never scans it.
+    other_ws = db._active_workspace_id
+    base_id = db.add_folder("/arch/USA", name="USA")
+    date_id = db.add_folder("/arch/USA/2025-06-30", name="2025-06-30",
+                            parent_id=base_id, workspace_root=False)
+    db.add_photo(folder_id=date_id, filename="prior.raf", extension=".raf",
+                 file_size=100, file_mtime=1.0)
+
+    # Switch to a fresh workspace — the one running the pipeline.
+    active_ws = db.create_workspace("Active")
+    db.set_active_workspace(active_ws)
+
+    # Precondition: the active ws cannot see the archive yet.
+    assert db.conn.execute(
+        "SELECT 1 FROM workspace_folders "
+        "WHERE workspace_id=? AND folder_id=?",
+        (active_ws, base_id),
+    ).fetchone() is None
+
+    # Staged tree post-rsync; a real scan restrict_dirs registers the leaf
+    # as its own root, but the base_id-invisible visibility bug reproduces
+    # regardless of that flag, so keep the setup minimal.
+    stage_root = db.add_folder("/stage/USA", name="USA", workspace_root=False)
+    stage_leaf = db.add_folder("/stage/USA/2025-06-30", name="2025-06-30",
+                               parent_id=stage_root, workspace_root=False)
+    new_pid = db.add_photo(folder_id=stage_leaf, filename="new.raf",
+                           extension=".raf", file_size=200, file_mtime=2.0)
+
+    db.merge_staged_tree_into_archive(stage_root, "/arch/USA")
+
+    # Archive base is now the active workspace's root; the subtree pull in
+    # add_workspace_folder linked the existing date folder along with it.
+    base_link = db.conn.execute(
+        "SELECT is_root FROM workspace_folders "
+        "WHERE workspace_id=? AND folder_id=?",
+        (active_ws, base_id),
+    ).fetchone()
+    assert base_link is not None and base_link["is_root"] == 1
+    assert db.conn.execute(
+        "SELECT 1 FROM workspace_folders "
+        "WHERE workspace_id=? AND folder_id=?",
+        (active_ws, date_id),
+    ).fetchone() is not None
+
+    # The other workspace's link on the archive base is preserved — the
+    # is_root UPDATE in add_workspace_folder is scoped by workspace_id.
+    other_link = db.conn.execute(
+        "SELECT is_root FROM workspace_folders "
+        "WHERE workspace_id=? AND folder_id=?",
+        (other_ws, base_id),
+    ).fetchone()
+    assert other_link is not None and other_link["is_root"] == 1
+
+    # The merged-in photo landed on the existing date folder and is now
+    # visible via the exact workspace_folders join every scoped query uses.
+    row = db.conn.execute(
+        """SELECT p.filename FROM photos p
+           JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+           WHERE p.id = ? AND wf.workspace_id = ?""",
+        (new_pid, active_ws),
+    ).fetchone()
+    assert row is not None and row["filename"] == "new.raf"
+
+
 def test_folder_under_rule_excludes_siblings_and_escapes_wildcards(tmp_path, monkeypatch):
     """'folder under /photos/2023' must match that folder and its
     descendants only — not the sibling /photos/2023-trip — and a _ in the

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -7418,6 +7418,65 @@ def test_merge_staged_tree_new_subfolders(db):
     assert row is not None and row["is_root"] == 0
 
 
+def test_merge_staged_tree_downgrades_staged_root_leaf(db):
+    """Regression: a staged photo-bearing leaf that the scanner registered as
+    its OWN workspace root (workspace_folders.is_root=1) must be demoted to a
+    plain descendant when it is folded under the existing archive base.
+
+    This reproduces the real trigger: the staging scan restricts to the leaf
+    dir, so add_folder links it as a root. add_workspace_folder's INSERT OR
+    IGNORE cannot downgrade that pre-existing is_root=1 row, so the merge must
+    UPDATE it to 0 explicitly — otherwise a stray second workspace root is left
+    inside the archive. The prior new-subfolders test seeds the staged rows with
+    workspace_root=False, so it would pass even with the fix removed; this one
+    genuinely exercises the downgrade."""
+    ws = db._active_workspace_id
+
+    # Existing tracked archive base, linked as the workspace root.
+    base_id = db.add_folder("/arch/USA", name="USA")
+    db.add_workspace_folder(ws, base_id, is_root=True)
+
+    # Staged tree post-rsync. The leaf is registered as its OWN root, exactly as
+    # the staging scanner does (restrict_dirs => is_root=1 on the scanned leaf).
+    stage_root = db.add_folder("/stage/USA", name="USA", workspace_root=False)
+    stage_year = db.add_folder("/stage/USA/2026", name="2026",
+                               parent_id=stage_root, workspace_root=False)
+    stage_leaf = db.add_folder("/stage/USA/2026/2026-06-30", name="2026-06-30",
+                               parent_id=stage_year, workspace_root=True)
+    db.add_photo(folder_id=stage_leaf, filename="new.raf", extension=".raf",
+                 file_size=200, file_mtime=2.0)
+
+    # Precondition: the staged leaf really IS a workspace root before the merge,
+    # so this test genuinely exercises the downgrade path.
+    pre = db.conn.execute(
+        "SELECT is_root FROM workspace_folders WHERE workspace_id=? AND folder_id=?",
+        (ws, stage_leaf),
+    ).fetchone()
+    assert pre is not None and pre["is_root"] == 1
+
+    db.merge_staged_tree_into_archive(stage_root, "/arch/USA")
+
+    # The folded leaf now lives under the archive as a NON-root descendant.
+    leaf = db.conn.execute(
+        "SELECT id FROM folders WHERE path = ?",
+        ("/arch/USA/2026/2026-06-30",),
+    ).fetchone()
+    assert leaf is not None
+    leaf_link = db.conn.execute(
+        "SELECT is_root FROM workspace_folders WHERE workspace_id=? AND folder_id=?",
+        (ws, leaf["id"]),
+    ).fetchone()
+    assert leaf_link is not None and leaf_link["is_root"] == 0
+
+    # The archive base is the single remaining workspace root.
+    roots = db.conn.execute(
+        "SELECT folder_id FROM workspace_folders "
+        "WHERE workspace_id=? AND is_root=1",
+        (ws,),
+    ).fetchall()
+    assert [r["folder_id"] for r in roots] == [base_id]
+
+
 def test_merge_staged_tree_existing_folder_and_collision(db):
     """Staged folder folds into a pre-existing target date-folder: a
     same-filename staged photo (even one carrying keyword links) is dropped as

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -8157,6 +8157,120 @@ def test_merge_staged_tree_case_alias_collision_on_case_insensitive_volume(
     assert counts["new_photos"] == 0
 
 
+def test_merge_staged_tree_intra_staged_case_alias_collision(
+    db, tmp_path, monkeypatch,
+):
+    """Regression: two staged files whose filenames differ only in case
+    land in the same staged folder (e.g. staged on a case-sensitive disk,
+    archiving to a case-insensitive volume like APFS/SMB). rsync
+    ``--ignore-existing`` writes the FIRST file and silently skips the
+    second, so the second row's bytes never land on disk. Without an
+    intra-staged claim tracker, both rows get reparented into the target
+    folder — SQLite text-equality is case-sensitive so UNIQUE(folder_id,
+    filename) doesn't fire, and the catalog ends up with two rows for one
+    on-disk file (losing the second image). The second staged row must be
+    dropped as ``already_present`` instead of reparented.
+    """
+    ws = db._active_workspace_id
+
+    arch = tmp_path / "arch" / "USA"
+    date_dir = arch / "2026-06-30"
+    date_dir.mkdir(parents=True)
+    # Empty target folder — no pre-existing catalog rows and (initially)
+    # no on-disk photos. The archive-side folder rows exist but the merge
+    # tracker must catch the intra-staged collision itself.
+    base_id = db.add_folder(str(arch), name="USA")
+    date_id = db.add_folder(str(date_dir), name="2026-06-30",
+                            parent_id=base_id)
+    db.add_workspace_folder(ws, base_id, is_root=True)
+
+    stage = tmp_path / "stage" / "USA"
+    stage_root = db.add_folder(str(stage), name="USA", workspace_root=False)
+    stage_leaf = db.add_folder(str(stage / "2026-06-30"), name="2026-06-30",
+                               parent_id=stage_root, workspace_root=False)
+    # Two staged photos with case-differing filenames. Different hashes
+    # model the realistic case where the two source files have DIFFERENT
+    # bytes — rsync writes only one of them to disk and the other row
+    # describes bytes that never landed. Even if the file hashes matched,
+    # only one on-disk file can exist on a case-insensitive volume so a
+    # second catalog row is still wrong.
+    first_pid = db.add_photo(folder_id=stage_leaf, filename="IMG.RAF",
+                             extension=".raf", file_size=100,
+                             file_mtime=1.0, file_hash="FIRSTBYTES")
+    second_pid = db.add_photo(folder_id=stage_leaf, filename="img.raf",
+                              extension=".raf", file_size=200,
+                              file_mtime=2.0, file_hash="OTHERBYTES")
+
+    # Force the merge to treat the target volume as case-insensitive
+    # regardless of the CI host's actual filesystem behavior.
+    import move
+    monkeypatch.setattr(move, "_case_insensitive_root", lambda p: "/")
+
+    counts = db.merge_staged_tree_into_archive(stage_root, str(arch))
+
+    # Exactly one photo row ends up in the target folder — the first
+    # staged row was reparented, the second was dropped as
+    # ``already_present`` (and its id reported for cache cleanup).
+    rows = db.conn.execute(
+        "SELECT id, filename FROM photos WHERE folder_id = ?", (date_id,),
+    ).fetchall()
+    assert len(rows) == 1
+    assert rows[0]["id"] == first_pid
+    assert rows[0]["filename"] == "IMG.RAF"
+    assert db.conn.execute(
+        "SELECT 1 FROM photos WHERE id = ?", (second_pid,)
+    ).fetchone() is None
+    assert counts["already_present"] == 1
+    assert counts["new_photos"] == 1
+    assert second_pid in counts["dropped_photo_ids"]
+
+
+def test_merge_staged_tree_intra_staged_case_alias_case_sensitive_volume(
+    db, tmp_path, monkeypatch,
+):
+    """On a case-sensitive archive volume (Linux ext4), two staged files
+    ``IMG.RAF`` and ``img.raf`` are distinct on-disk files and both should
+    be reparented into the target folder — the intra-staged claim tracker
+    must NOT trigger. Guards against a regression where the tracker
+    normalizes with ``str.casefold`` unconditionally and drops legitimate
+    distinct files on case-sensitive targets.
+    """
+    ws = db._active_workspace_id
+
+    arch = tmp_path / "arch" / "USA"
+    date_dir = arch / "2026-06-30"
+    date_dir.mkdir(parents=True)
+    base_id = db.add_folder(str(arch), name="USA")
+    date_id = db.add_folder(str(date_dir), name="2026-06-30",
+                            parent_id=base_id)
+    db.add_workspace_folder(ws, base_id, is_root=True)
+
+    stage = tmp_path / "stage" / "USA"
+    stage_root = db.add_folder(str(stage), name="USA", workspace_root=False)
+    stage_leaf = db.add_folder(str(stage / "2026-06-30"), name="2026-06-30",
+                               parent_id=stage_root, workspace_root=False)
+    upper_pid = db.add_photo(folder_id=stage_leaf, filename="IMG.RAF",
+                             extension=".raf", file_size=100,
+                             file_mtime=1.0, file_hash="UPPERBYTES")
+    lower_pid = db.add_photo(folder_id=stage_leaf, filename="img.raf",
+                             extension=".raf", file_size=200,
+                             file_mtime=2.0, file_hash="LOWERBYTES")
+
+    # Case-sensitive target: ``_case_insensitive_root`` returns None.
+    import move
+    monkeypatch.setattr(move, "_case_insensitive_root", lambda p: None)
+
+    counts = db.merge_staged_tree_into_archive(stage_root, str(arch))
+
+    rows = {r["filename"]: r["id"] for r in db.conn.execute(
+        "SELECT id, filename FROM photos WHERE folder_id = ? ORDER BY filename",
+        (date_id,),
+    ).fetchall()}
+    assert rows == {"IMG.RAF": upper_pid, "img.raf": lower_pid}
+    assert counts["already_present"] == 0
+    assert counts["new_photos"] == 2
+
+
 def test_merge_staged_tree_rolls_back_on_error(db, monkeypatch):
     """Regression: ``merge_staged_tree_into_archive`` runs a long sequence of
     UPDATE/DELETE statements before a single final commit. An exception

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -7927,31 +7927,37 @@ def test_merge_staged_tree_phantom_row_replaces_when_file_on_disk_after_rsync(
     assert phantom_pid in counts["dropped_photo_ids"]
 
 
-def test_merge_staged_tree_phantom_row_replaces_via_file_size_when_hashes_null(
+def test_merge_staged_tree_defaults_to_phantom_when_hashes_missing(
     db, tmp_path,
 ):
     """When either row's ``file_hash`` is unset (older catalog rows, or a
-    scan that failed to hash), the phantom detection falls back to
-    comparing the target row's recorded ``file_size`` to the actual file
-    on disk. Mismatch → phantom (rsync wrote fresh bytes over a missing
-    file), match → real collision."""
+    scan that failed to hash), the collision guard has no safe post-copy
+    signal — ``file_size`` alone can coincidentally match a phantom row's
+    stored size (empty XMP sidecars, small metadata files), and rehashing
+    the on-disk file always matches the staged hash in the phantom case
+    (rsync wrote the staged bytes). Default to phantom-replacement so the
+    freshly-imported pipeline output survives; the alternative (silently
+    dropping the new photo behind a same-size stale row) is the worse
+    failure mode. Regression for the Codex finding at db.py:3221."""
     ws = db._active_workspace_id
 
     arch = tmp_path / "arch" / "USA"
     date_dir = arch / "2026-06-30"
     date_dir.mkdir(parents=True)
-    # The staged file is 100 bytes; rsync just landed it in the archive
-    # slot after the archived file went missing.
+    # The archived file IS on disk (rsync landed the staged bytes there),
+    # and its size EQUALS the phantom row's recorded size — the exact
+    # coincidence the old size-fallback would have false-flagged as a
+    # real collision, silently dropping the newly-imported photo.
     (date_dir / "collide.raf").write_bytes(b"x" * 100)
 
     base_id = db.add_folder(str(arch), name="USA")
     date_id = db.add_folder(str(date_dir), name="2026-06-30",
                             parent_id=base_id)
-    # Phantom row records the OLD (missing) archived file's size (42B),
-    # not the freshly-copied 100B bytes now on disk. No file_hash on the
-    # row exercises the size fallback.
+    # Phantom row: no file_hash (older catalog row that pre-dates
+    # hashing) and a recorded size that HAPPENS to equal the freshly-
+    # copied staged file's size.
     phantom_pid = db.add_photo(folder_id=date_id, filename="collide.raf",
-                               extension=".raf", file_size=42,
+                               extension=".raf", file_size=100,
                                file_mtime=1.0)
     db.add_workspace_folder(ws, base_id, is_root=True)
 
@@ -7959,12 +7965,16 @@ def test_merge_staged_tree_phantom_row_replaces_via_file_size_when_hashes_null(
     stage_root = db.add_folder(str(stage), name="USA", workspace_root=False)
     stage_leaf = db.add_folder(str(stage / "2026-06-30"), name="2026-06-30",
                                parent_id=stage_root, workspace_root=False)
+    # Staged photo also lacks a recorded hash (the unhashed-scan case).
     new_pid = db.add_photo(folder_id=stage_leaf, filename="collide.raf",
                            extension=".raf", file_size=100,
                            file_mtime=2.0)
 
     counts = db.merge_staged_tree_into_archive(stage_root, str(arch))
 
+    # Without hash-based verification the guard defaults to phantom, so
+    # the staged (newly-imported) photo is preserved and the unverifiable
+    # target row is dropped.
     assert counts["already_present"] == 0
     assert counts["new_photos"] == 1
     surviving = db.conn.execute(
@@ -7975,6 +7985,9 @@ def test_merge_staged_tree_phantom_row_replaces_via_file_size_when_hashes_null(
     assert db.conn.execute(
         "SELECT 1 FROM photos WHERE id = ?", (phantom_pid,)
     ).fetchone() is None
+    # The phantom's cache files must still be reported for cleanup so a
+    # rowid re-use can't inherit stale imagery.
+    assert phantom_pid in counts["dropped_photo_ids"]
 
 
 def test_merge_staged_tree_case_alias_collision_on_case_insensitive_volume(
@@ -8355,8 +8368,13 @@ def test_merge_staged_tree_reports_dropped_photo_ids_for_collisions(
     base_id = db.add_folder(str(arch), name="USA")
     date_id = db.add_folder(str(date_dir), name="2026-01-01",
                             parent_id=base_id)
+    # Matching ``file_hash`` on both sides is required for the collision
+    # guard to treat this as a real collision — the row's byte-identity
+    # claim (hash) has to match the staged photo's for the drop to be
+    # safe in the post-copy path. See merge_staged_tree_into_archive's
+    # hash-only invariant.
     db.add_photo(folder_id=date_id, filename="dup.raf", extension=".raf",
-                 file_size=8, file_mtime=1.0)
+                 file_size=8, file_mtime=1.0, file_hash="DUPHASH")
     db.add_workspace_folder(ws, base_id, is_root=True)
 
     stage = tmp_path / "stage" / "USA"
@@ -8365,7 +8383,8 @@ def test_merge_staged_tree_reports_dropped_photo_ids_for_collisions(
     stage_leaf = db.add_folder(str(stage / "2026-01-01"), name="2026-01-01",
                                parent_id=stage_root, workspace_root=False)
     dup_pid = db.add_photo(folder_id=stage_leaf, filename="dup.raf",
-                           extension=".raf", file_size=8, file_mtime=2.0)
+                           extension=".raf", file_size=8, file_mtime=2.0,
+                           file_hash="DUPHASH")
 
     counts = db.merge_staged_tree_into_archive(stage_root, str(arch))
 

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -8032,6 +8032,258 @@ def test_merge_staged_tree_rolls_back_on_error(db, monkeypatch):
     assert call_count["n"] == 2
 
 
+def test_merge_staged_tree_new_folder_reparent_rolls_back_on_later_error(
+        db, monkeypatch):
+    """Regression: the new-folder branch (``target is None``) used to call
+    ``self.add_workspace_folder(...)`` — which commits the connection — so
+    a later exception's ``rollback()`` could not undo the preceding
+    ``UPDATE folders SET path = ?, parent_id = ?`` on the same staged row.
+    That left a half-merged catalog: the staged folder's path pointed at
+    the archive even though the merge as a whole was rolled back.
+
+    The fix is a non-committing helper (``_add_workspace_folder_no_commit``)
+    used inside the loop. This test exercises specifically the mid-loop
+    new-folder path followed by a later else-branch crash and verifies the
+    new-folder iteration's UPDATE is fully rolled back — a companion to
+    ``test_merge_staged_tree_rolls_back_on_error`` (which covers the
+    else-branch photo reparent)."""
+    ws = db._active_workspace_id
+
+    # Existing tracked archive base + one pre-existing descendant so the
+    # deepest staged iteration hits the else-branch (crash point).
+    base_id = db.add_folder("/arch/USA", name="USA")
+    existing_id = db.add_folder("/arch/USA/existing_leaf",
+                                name="existing_leaf", parent_id=base_id)
+    db.add_workspace_folder(ws, base_id, is_root=True)
+
+    # Three staged folders ordered by length so iteration order is:
+    #   1. stage_root       → target=/arch/USA (EXISTS, else)
+    #   2. stage_new        → target=/arch/USA/new_leaf (NEW, if-branch — the
+    #                          iteration whose rollback we're verifying)
+    #   3. stage_existing   → target=/arch/USA/existing_leaf (EXISTS, else —
+    #                          the iteration we poison to force the raise)
+    stage_root = db.add_folder("/stage/USA", name="USA",
+                               workspace_root=False)
+    stage_new = db.add_folder("/stage/USA/new_leaf", name="new_leaf",
+                              parent_id=stage_root, workspace_root=False)
+    stage_new_pid = db.add_photo(folder_id=stage_new, filename="new.raf",
+                                 extension=".raf",
+                                 file_size=100, file_mtime=1.0)
+    stage_existing = db.add_folder("/stage/USA/existing_leaf",
+                                   name="existing_leaf",
+                                   parent_id=stage_root, workspace_root=False)
+    db.add_photo(folder_id=stage_existing, filename="dup.raf",
+                 extension=".raf", file_size=100, file_mtime=1.0)
+
+    # Poison ``_case_insensitive_root`` to succeed on the first call (else
+    # iteration 1, stage_root → base) and raise on the second call
+    # (else iteration 3, stage_existing → existing_leaf). Iteration 2
+    # (if-branch, stage_new → new target) queues an UPDATE folders SET
+    # path/parent_id + a workspace-folder link BETWEEN those two calls — the
+    # raise fires with iteration 2's mutations still uncommitted, so a
+    # correct rollback must revert stage_new's path.
+    import move as move_mod
+    real_ci_root = move_mod._case_insensitive_root
+    calls = {"n": 0}
+
+    def _flaky(path):
+        calls["n"] += 1
+        if calls["n"] >= 2:
+            raise RuntimeError("case-fold probe blew up mid-merge")
+        return real_ci_root(path)
+
+    monkeypatch.setattr(move_mod, "_case_insensitive_root", _flaky)
+
+    import pytest as _pytest
+    with _pytest.raises(RuntimeError, match="case-fold probe blew up"):
+        db.merge_staged_tree_into_archive(stage_root, "/arch/USA")
+
+    # Poison actually fired on iteration 3 (2nd call) — confirms iteration 2
+    # completed BEFORE the raise, so its UPDATE is exactly what should have
+    # rolled back.
+    assert calls["n"] == 2
+
+    # stage_new's path UPDATE + parent_id UPDATE was rolled back: still
+    # ``/stage/USA/new_leaf``, parented to stage_root, not to base_id.
+    # Without the fix, the mid-loop commit inside ``add_workspace_folder``
+    # would have persisted the path change and this row would sit at
+    # ``/arch/USA/new_leaf`` with base_id as parent.
+    row = db.conn.execute(
+        "SELECT path, parent_id FROM folders WHERE id = ?", (stage_new,)
+    ).fetchone()
+    assert row["path"] == "/stage/USA/new_leaf"
+    assert row["parent_id"] == stage_root
+    # No archive row at the target path was left behind.
+    assert db.conn.execute(
+        "SELECT 1 FROM folders WHERE path = ?", ("/arch/USA/new_leaf",)
+    ).fetchone() is None
+    # The staged photo still lives under stage_new.
+    assert db.conn.execute(
+        "SELECT folder_id FROM photos WHERE id = ?", (stage_new_pid,)
+    ).fetchone()["folder_id"] == stage_new
+
+
+def test_merge_staged_tree_restores_missing_archive_base_status(db):
+    """Regression: an existing archive row marked ``status='missing'`` (e.g.
+    a health scan ran while the drive was unmounted) must be flipped back to
+    ``ok`` when the merge succeeds, otherwise the ws-scoped photo queries
+    (which filter ``status IN ('ok', 'partial')``) hide the newly-merged
+    photos even though the import reported success."""
+    ws = db._active_workspace_id
+    base_id = db.add_folder("/arch/USA", name="USA")
+    db.add_workspace_folder(ws, base_id, is_root=True)
+    # Simulate a prior health scan that saw the drive unmounted.
+    db.conn.execute(
+        "UPDATE folders SET status = 'missing' WHERE id = ?", (base_id,))
+    db.conn.commit()
+
+    stage_root = db.add_folder("/stage/USA", name="USA",
+                               workspace_root=False)
+    db.add_photo(folder_id=stage_root, filename="new.raf",
+                 extension=".raf", file_size=100, file_mtime=1.0)
+
+    db.merge_staged_tree_into_archive(stage_root, "/arch/USA")
+
+    assert db.conn.execute(
+        "SELECT status FROM folders WHERE id = ?", (base_id,)
+    ).fetchone()["status"] == "ok"
+
+
+def test_merge_staged_tree_restores_missing_target_folder_status(
+        db, tmp_path):
+    """Regression: same as ``restores_missing_archive_base_status`` but for
+    an existing DESCENDANT target folder that the merge folds staged photos
+    into. Any lingering ``missing`` from an older health scan must flip to
+    ``ok`` after the merge so photos aren't hidden."""
+    ws = db._active_workspace_id
+    arch = tmp_path / "arch" / "USA"
+    date_dir = arch / "2026-01-01"
+    date_dir.mkdir(parents=True)
+
+    base_id = db.add_folder(str(arch), name="USA")
+    date_id = db.add_folder(str(date_dir), name="2026-01-01",
+                            parent_id=base_id)
+    db.add_workspace_folder(ws, base_id, is_root=True)
+    # Mark the DESCENDANT folder as missing.
+    db.conn.execute(
+        "UPDATE folders SET status = 'missing' WHERE id = ?", (date_id,))
+    db.conn.commit()
+
+    stage = tmp_path / "stage" / "USA"
+    stage_root = db.add_folder(str(stage), name="USA",
+                               workspace_root=False)
+    stage_leaf = db.add_folder(str(stage / "2026-01-01"), name="2026-01-01",
+                               parent_id=stage_root, workspace_root=False)
+    db.add_photo(folder_id=stage_leaf, filename="fresh.raf",
+                 extension=".raf", file_size=100, file_mtime=1.0)
+
+    db.merge_staged_tree_into_archive(stage_root, str(arch))
+
+    assert db.conn.execute(
+        "SELECT status FROM folders WHERE id = ?", (date_id,)
+    ).fetchone()["status"] == "ok"
+
+
+def test_merge_staged_tree_partial_archive_base_status_preserved(db):
+    """The status restore only migrates ``missing`` → ``ok``. A folder
+    marked ``partial`` (some verified photos missing on disk) still has
+    unverified state and should remain ``partial`` after the merge — the
+    merge only proves the newly-added files exist, not the earlier ones."""
+    ws = db._active_workspace_id
+    base_id = db.add_folder("/arch/USA", name="USA")
+    db.add_workspace_folder(ws, base_id, is_root=True)
+    db.conn.execute(
+        "UPDATE folders SET status = 'partial' WHERE id = ?", (base_id,))
+    db.conn.commit()
+
+    stage_root = db.add_folder("/stage/USA", name="USA",
+                               workspace_root=False)
+    db.add_photo(folder_id=stage_root, filename="new.raf",
+                 extension=".raf", file_size=100, file_mtime=1.0)
+
+    db.merge_staged_tree_into_archive(stage_root, "/arch/USA")
+
+    assert db.conn.execute(
+        "SELECT status FROM folders WHERE id = ?", (base_id,)
+    ).fetchone()["status"] == "partial"
+
+
+def test_merge_staged_tree_reports_dropped_photo_ids_for_collisions(
+        db, tmp_path):
+    """Regression: cached thumbnails/previews/working copies are keyed off
+    ``photos.id``. When the merge drops a staged photo as ``already_present``
+    (identical file already archived), the freed photo id would leave orphan
+    cache files on disk; SQLite reuses freed rowids so a later import that
+    lands on the same id would inherit stale imagery. The merge must report
+    the dropped ids up to the caller so it can clean the on-disk cache."""
+    ws = db._active_workspace_id
+    arch = tmp_path / "arch" / "USA"
+    date_dir = arch / "2026-01-01"
+    date_dir.mkdir(parents=True)
+    # The archived file must exist on disk for the collision to be treated
+    # as ``already_present`` (a phantom target row is instead REPLACED).
+    (date_dir / "dup.raf").write_bytes(b"archived")
+
+    base_id = db.add_folder(str(arch), name="USA")
+    date_id = db.add_folder(str(date_dir), name="2026-01-01",
+                            parent_id=base_id)
+    db.add_photo(folder_id=date_id, filename="dup.raf", extension=".raf",
+                 file_size=8, file_mtime=1.0)
+    db.add_workspace_folder(ws, base_id, is_root=True)
+
+    stage = tmp_path / "stage" / "USA"
+    stage_root = db.add_folder(str(stage), name="USA",
+                               workspace_root=False)
+    stage_leaf = db.add_folder(str(stage / "2026-01-01"), name="2026-01-01",
+                               parent_id=stage_root, workspace_root=False)
+    dup_pid = db.add_photo(folder_id=stage_leaf, filename="dup.raf",
+                           extension=".raf", file_size=8, file_mtime=2.0)
+
+    counts = db.merge_staged_tree_into_archive(stage_root, str(arch))
+
+    assert counts["already_present"] == 1
+    assert dup_pid in counts["dropped_photo_ids"]
+
+
+def test_merge_staged_tree_reports_dropped_photo_ids_for_phantom_target(
+        db, tmp_path):
+    """Regression: when the target folder has a filename-collision row whose
+    on-disk file is MISSING (a phantom row from a prior stale state), the
+    merge deletes the phantom and reparents the staged photo. The phantom's
+    freed photo id must also be reported as dropped so its cache files get
+    cleaned."""
+    ws = db._active_workspace_id
+    arch = tmp_path / "arch" / "USA"
+    date_dir = arch / "2026-01-01"
+    date_dir.mkdir(parents=True)
+    # NOTE: don't create dup.raf — the phantom target row points at a
+    # non-existent archived file.
+
+    base_id = db.add_folder(str(arch), name="USA")
+    date_id = db.add_folder(str(date_dir), name="2026-01-01",
+                            parent_id=base_id)
+    phantom_pid = db.add_photo(folder_id=date_id, filename="dup.raf",
+                               extension=".raf",
+                               file_size=8, file_mtime=1.0)
+    db.add_workspace_folder(ws, base_id, is_root=True)
+
+    stage = tmp_path / "stage" / "USA"
+    stage_root = db.add_folder(str(stage), name="USA",
+                               workspace_root=False)
+    stage_leaf = db.add_folder(str(stage / "2026-01-01"), name="2026-01-01",
+                               parent_id=stage_root, workspace_root=False)
+    db.add_photo(folder_id=stage_leaf, filename="dup.raf",
+                 extension=".raf", file_size=8, file_mtime=2.0)
+
+    counts = db.merge_staged_tree_into_archive(stage_root, str(arch))
+
+    # No ``already_present`` this time (the collision was a phantom, and the
+    # staged bytes represent the surviving row).
+    assert counts["already_present"] == 0
+    # The phantom id was freed and must be reported for cache cleanup.
+    assert phantom_pid in counts["dropped_photo_ids"]
+
+
 def test_folder_under_rule_excludes_siblings_and_escapes_wildcards(tmp_path, monkeypatch):
     """'folder under /photos/2023' must match that folder and its
     descendants only — not the sibling /photos/2023-trip — and a _ in the

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -7488,7 +7488,11 @@ def test_merge_staged_tree_existing_folder_and_collision(db, tmp_path):
     ws = db._active_workspace_id
 
     # Real on-disk archive so the collision drop's "archived file exists" check
-    # sees the byte-identical file rsync --ignore-existing preserved.
+    # sees the byte-identical file rsync --ignore-existing preserved. Both the
+    # staged and archived rows carry the SAME file_hash — a real collision (as
+    # opposed to a phantom-row replacement) only reaches the merge when the
+    # bytes on both sides are identical, because the upstream content-conflict
+    # check would abort the whole move otherwise.
     arch = tmp_path / "arch" / "USA"
     date_dir = arch / "2026" / "2026-06-30"
     date_dir.mkdir(parents=True)
@@ -7499,9 +7503,9 @@ def test_merge_staged_tree_existing_folder_and_collision(db, tmp_path):
     year_id = db.add_folder(str(arch / "2026"), name="2026", parent_id=base_id)
     date_id = db.add_folder(str(date_dir), name="2026-06-30", parent_id=year_id)
     db.add_photo(folder_id=date_id, filename="dup.raf", extension=".raf",
-                 file_size=100, file_mtime=1.0)
+                 file_size=12, file_mtime=1.0, file_hash="DUPHASH")
     db.add_photo(folder_id=date_id, filename="keep.raf", extension=".raf",
-                 file_size=100, file_mtime=1.0)
+                 file_size=13, file_mtime=1.0, file_hash="KEEPHASH")
     db.add_workspace_folder(ws, base_id, is_root=True)
 
     # Staged tree post-rsync. The intermediate year folder is a real row so the
@@ -7514,9 +7518,10 @@ def test_merge_staged_tree_existing_folder_and_collision(db, tmp_path):
                                name="2026-06-30",
                                parent_id=stage_year, workspace_root=False)
     dup_pid = db.add_photo(folder_id=stage_leaf, filename="dup.raf",
-                           extension=".raf", file_size=200, file_mtime=2.0)
+                           extension=".raf", file_size=12, file_mtime=2.0,
+                           file_hash="DUPHASH")
     db.add_photo(folder_id=stage_leaf, filename="fresh.raf", extension=".raf",
-                 file_size=200, file_mtime=2.0)
+                 file_size=200, file_mtime=2.0, file_hash="FRESHHASH")
 
     # Attach a keyword to the COLLIDED staged photo so the delete must clear
     # photo_keywords first; without the fix this raises a FK error.
@@ -7856,6 +7861,122 @@ def test_merge_staged_tree_missing_target_file_keeps_new_photo(db, tmp_path):
     ).fetchone() is None
 
 
+def test_merge_staged_tree_phantom_row_replaces_when_file_on_disk_after_rsync(
+    db, tmp_path,
+):
+    """Regression for the exact production ordering: ``move_folder`` runs
+    rsync ``--ignore-existing`` FIRST, then calls
+    ``merge_staged_tree_into_archive``. If the target row was a phantom
+    (its file missing before rsync), rsync creates the file at the target
+    path from the staged bytes — so by the time the merge's collision
+    check runs, ``os.path.exists`` returns True in the phantom case too
+    and can't tell it apart from a real byte-identical collision. Left
+    unfixed, the staged photo would be dropped as ``already_present`` and
+    the freshly-copied bytes would be represented by the phantom row's
+    stale hash/metadata — the newly-imported photo silently disappears
+    behind the stale row.
+
+    Distinguish real collision from phantom by the target row's
+    bytes-identity (``file_hash``) instead of raw file existence.
+    """
+    ws = db._active_workspace_id
+
+    arch = tmp_path / "arch" / "USA"
+    date_dir = arch / "2026-06-30"
+    date_dir.mkdir(parents=True)
+    # The archived file IS on disk — but only because rsync just copied it
+    # in from staging over an empty slot. Its bytes are the STAGED bytes;
+    # the target catalog row was a phantom that had lost track of the
+    # deleted original.
+    (date_dir / "collide.raf").write_bytes(b"fresh-staged-bytes")
+
+    base_id = db.add_folder(str(arch), name="USA")
+    date_id = db.add_folder(str(date_dir), name="2026-06-30",
+                            parent_id=base_id)
+    phantom_pid = db.add_photo(folder_id=date_id, filename="collide.raf",
+                               extension=".raf", file_size=100,
+                               file_mtime=1.0, file_hash="STALEHASH")
+    db.add_workspace_folder(ws, base_id, is_root=True)
+
+    stage = tmp_path / "stage" / "USA"
+    stage_root = db.add_folder(str(stage), name="USA", workspace_root=False)
+    stage_leaf = db.add_folder(str(stage / "2026-06-30"), name="2026-06-30",
+                               parent_id=stage_root, workspace_root=False)
+    new_pid = db.add_photo(folder_id=stage_leaf, filename="collide.raf",
+                           extension=".raf", file_size=200, file_mtime=2.0,
+                           file_hash="NEWHASH")
+
+    counts = db.merge_staged_tree_into_archive(stage_root, str(arch))
+
+    # The freshly-copied bytes are represented by the STAGED row (which
+    # accurately describes them), not the stale phantom row.
+    assert counts["already_present"] == 0
+    assert counts["new_photos"] == 1
+    surviving = db.conn.execute(
+        "SELECT id, folder_id, file_hash FROM photos "
+        "WHERE filename='collide.raf'"
+    ).fetchall()
+    assert len(surviving) == 1
+    assert surviving[0]["id"] == new_pid
+    assert surviving[0]["folder_id"] == date_id
+    assert surviving[0]["file_hash"] == "NEWHASH"
+    # The phantom row is gone; its cache files are reported for cleanup.
+    assert db.conn.execute(
+        "SELECT 1 FROM photos WHERE id = ?", (phantom_pid,)
+    ).fetchone() is None
+    assert phantom_pid in counts["dropped_photo_ids"]
+
+
+def test_merge_staged_tree_phantom_row_replaces_via_file_size_when_hashes_null(
+    db, tmp_path,
+):
+    """When either row's ``file_hash`` is unset (older catalog rows, or a
+    scan that failed to hash), the phantom detection falls back to
+    comparing the target row's recorded ``file_size`` to the actual file
+    on disk. Mismatch → phantom (rsync wrote fresh bytes over a missing
+    file), match → real collision."""
+    ws = db._active_workspace_id
+
+    arch = tmp_path / "arch" / "USA"
+    date_dir = arch / "2026-06-30"
+    date_dir.mkdir(parents=True)
+    # The staged file is 100 bytes; rsync just landed it in the archive
+    # slot after the archived file went missing.
+    (date_dir / "collide.raf").write_bytes(b"x" * 100)
+
+    base_id = db.add_folder(str(arch), name="USA")
+    date_id = db.add_folder(str(date_dir), name="2026-06-30",
+                            parent_id=base_id)
+    # Phantom row records the OLD (missing) archived file's size (42B),
+    # not the freshly-copied 100B bytes now on disk. No file_hash on the
+    # row exercises the size fallback.
+    phantom_pid = db.add_photo(folder_id=date_id, filename="collide.raf",
+                               extension=".raf", file_size=42,
+                               file_mtime=1.0)
+    db.add_workspace_folder(ws, base_id, is_root=True)
+
+    stage = tmp_path / "stage" / "USA"
+    stage_root = db.add_folder(str(stage), name="USA", workspace_root=False)
+    stage_leaf = db.add_folder(str(stage / "2026-06-30"), name="2026-06-30",
+                               parent_id=stage_root, workspace_root=False)
+    new_pid = db.add_photo(folder_id=stage_leaf, filename="collide.raf",
+                           extension=".raf", file_size=100,
+                           file_mtime=2.0)
+
+    counts = db.merge_staged_tree_into_archive(stage_root, str(arch))
+
+    assert counts["already_present"] == 0
+    assert counts["new_photos"] == 1
+    surviving = db.conn.execute(
+        "SELECT id FROM photos WHERE filename='collide.raf'"
+    ).fetchall()
+    assert len(surviving) == 1
+    assert surviving[0]["id"] == new_pid
+    assert db.conn.execute(
+        "SELECT 1 FROM photos WHERE id = ?", (phantom_pid,)
+    ).fetchone() is None
+
+
 def test_merge_staged_tree_case_alias_collision_on_case_insensitive_volume(
     db, tmp_path, monkeypatch,
 ):
@@ -7883,16 +8004,23 @@ def test_merge_staged_tree_case_alias_collision_on_case_insensitive_volume(
                             parent_id=base_id)
     archived_pid = db.add_photo(folder_id=date_id, filename="IMG.RAF",
                                 extension=".raf", file_size=100,
-                                file_mtime=1.0, file_hash="ARCH")
+                                file_mtime=1.0, file_hash="SAMEBYTES")
     db.add_workspace_folder(ws, base_id, is_root=True)
 
     stage = tmp_path / "stage" / "USA"
     stage_root = db.add_folder(str(stage), name="USA", workspace_root=False)
     stage_leaf = db.add_folder(str(stage / "2026-06-30"), name="2026-06-30",
                                parent_id=stage_root, workspace_root=False)
+    # A real case-alias collision only reaches the merge step when the bytes
+    # are identical (the upstream content-conflict check aborts the whole
+    # move otherwise), so the two rows describe the same bytes and share a
+    # hash. Modelling that here keeps the collision check's hash comparison
+    # honest: mismatched hashes would (correctly) be treated as a phantom
+    # row now, so a case-alias test with fake mismatching hashes would not
+    # represent the production invariant it's asserting.
     staged_pid = db.add_photo(folder_id=stage_leaf, filename="img.raf",
                               extension=".raf", file_size=100,
-                              file_mtime=2.0, file_hash="STAGED")
+                              file_mtime=2.0, file_hash="SAMEBYTES")
 
     # Force the merge to treat the target volume as case-insensitive
     # regardless of the CI host's actual filesystem behavior (Linux ext4

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -7418,6 +7418,70 @@ def test_merge_staged_tree_new_subfolders(db):
     assert row is not None and row["is_root"] == 0
 
 
+def test_merge_staged_tree_existing_folder_and_collision(db):
+    """Staged folder folds into a pre-existing target date-folder: a
+    same-filename staged photo (even one carrying keyword links) is dropped as
+    already-archived, a genuinely-new one is reparented, and the counts use the
+    settled photo-count names. Regression guard for the photo_keywords FK that
+    has no ON DELETE CASCADE — deleting the collided photo without first
+    clearing its keyword rows would raise FOREIGN KEY constraint failed."""
+    ws = db._active_workspace_id
+
+    base_id = db.add_folder("/arch/USA", name="USA")
+    year_id = db.add_folder("/arch/USA/2026", name="2026", parent_id=base_id)
+    date_id = db.add_folder("/arch/USA/2026/2026-06-30", name="2026-06-30",
+                            parent_id=year_id)
+    db.add_photo(folder_id=date_id, filename="dup.raf", extension=".raf",
+                 file_size=100, file_mtime=1.0)
+    db.add_photo(folder_id=date_id, filename="keep.raf", extension=".raf",
+                 file_size=100, file_mtime=1.0)
+    db.add_workspace_folder(ws, base_id, is_root=True)
+
+    # Staged tree post-rsync. The intermediate year folder is a real row so the
+    # reparent chain is exercised; the leaf already exists at the target.
+    stage_root = db.add_folder("/stage/USA", name="USA", workspace_root=False)
+    stage_year = db.add_folder("/stage/USA/2026", name="2026",
+                               parent_id=stage_root, workspace_root=False)
+    stage_leaf = db.add_folder("/stage/USA/2026/2026-06-30", name="2026-06-30",
+                               parent_id=stage_year, workspace_root=False)
+    dup_pid = db.add_photo(folder_id=stage_leaf, filename="dup.raf",
+                           extension=".raf", file_size=200, file_mtime=2.0)
+    db.add_photo(folder_id=stage_leaf, filename="fresh.raf", extension=".raf",
+                 file_size=200, file_mtime=2.0)
+
+    # Attach a keyword to the COLLIDED staged photo so the delete must clear
+    # photo_keywords first; without the fix this raises a FK error.
+    kw = db.add_keyword("Osprey")
+    db.tag_photo(dup_pid, kw)
+
+    counts = db.merge_staged_tree_into_archive(stage_root, "/arch/USA")
+
+    # No duplicate dup.raf row; fresh.raf reparented into the existing folder.
+    names = {r["filename"] for r in db.conn.execute(
+        "SELECT filename FROM photos WHERE folder_id = ?", (date_id,))}
+    assert names == {"dup.raf", "keep.raf", "fresh.raf"}
+    assert db.conn.execute(
+        "SELECT COUNT(*) c FROM photos WHERE filename='dup.raf'"
+    ).fetchone()["c"] == 1
+    # The dropped staged photo's keyword links are gone too.
+    assert db.conn.execute(
+        "SELECT 1 FROM photo_keywords WHERE photo_id = ?", (dup_pid,)
+    ).fetchone() is None
+
+    # Settled count names with correct values: 1 new photo (fresh.raf), no new
+    # folders (every staged folder mapped to an existing target — root, year,
+    # and leaf all pre-exist under /arch/USA), 3 merged folders, 1 dropped.
+    assert counts["new_photos"] == 1
+    assert counts["new_folders"] == 0
+    assert counts["merged_folders"] == 3
+    assert counts["already_present"] == 1
+
+    # All staged rows folded away.
+    assert db.conn.execute(
+        "SELECT 1 FROM folders WHERE path LIKE '/stage/%'"
+    ).fetchone() is None
+
+
 def test_folder_under_rule_excludes_siblings_and_escapes_wildcards(tmp_path, monkeypatch):
     """'folder under /photos/2023' must match that folder and its
     descendants only — not the sibling /photos/2023-trip — and a _ in the

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -7662,6 +7662,78 @@ def test_merge_staged_tree_ancestor_base_stays_non_root(db):
     assert roots == [root_id]
 
 
+def test_merge_staged_tree_materializes_missing_intermediate_parent(db):
+    """Regression: when the archive destination is nested inside a tracked
+    root but an intermediate archive folder has never been scanned (e.g.
+    ``/Photos`` tracked and the user imports to ``/Photos/2026/NewShoot``),
+    the storage preflight creates ``/Photos/2026`` on disk via rsync's
+    parent-dir setup but never opens a folder row for it. Without the fix
+    the reconciliation repoints the staged root to ``/Photos/2026/NewShoot``
+    with ``parent_id=NULL`` — floating it outside the managed archive tree
+    and breaking every parent-based subtree operation (cascade path
+    renames, ``_folder_subtree_ids_by_path``, tree UI). The merge must
+    materialize the missing intermediate rows top-down so the staged
+    root's ``parent_id`` resolves to the freshly-created ``/Photos/2026``
+    row, and each intermediate must be linked to the active workspace as
+    a non-root (they sit under the existing tracked root).
+    """
+    ws = db._active_workspace_id
+
+    # Existing tracked archive root — a single folder row, no descendants
+    # under it in the catalog. The intermediate ``/Photos/2026`` was
+    # never scanned.
+    root_id = db.add_folder("/Photos", name="Photos")
+    db.add_workspace_folder(ws, root_id, is_root=True)
+
+    # Staged tree that will land at /Photos/2026/NewShoot after rsync.
+    stage_root = db.add_folder("/stage/NewShoot", name="NewShoot",
+                               workspace_root=False)
+    stage_leaf = db.add_folder("/stage/NewShoot/2026-06-30",
+                               name="2026-06-30",
+                               parent_id=stage_root, workspace_root=False)
+    db.add_photo(folder_id=stage_leaf, filename="new.raf", extension=".raf",
+                 file_size=100, file_mtime=1.0)
+
+    db.merge_staged_tree_into_archive(stage_root, "/Photos/2026/NewShoot")
+
+    # The intermediate archive folder now has a real folder row parented
+    # under the tracked root — not floating with parent_id=NULL.
+    mid = db.conn.execute(
+        "SELECT id, parent_id FROM folders WHERE path = ?",
+        ("/Photos/2026",),
+    ).fetchone()
+    assert mid is not None, (
+        "missing intermediate /Photos/2026 should be materialized so the "
+        "reparented staged root has a real parent row to point at"
+    )
+    assert mid["parent_id"] == root_id
+
+    # The staged root, now repointed to the archive destination, is
+    # correctly parented under the freshly-created intermediate.
+    dest = db.conn.execute(
+        "SELECT parent_id FROM folders WHERE path = ?",
+        ("/Photos/2026/NewShoot",),
+    ).fetchone()
+    assert dest is not None
+    assert dest["parent_id"] == mid["id"]
+
+    # /Photos remains the SOLE workspace root — no duplicate overlapping
+    # root created by the materialized intermediates or the reparented
+    # staged root.
+    roots = [r["folder_id"] for r in db.conn.execute(
+        "SELECT folder_id FROM workspace_folders "
+        "WHERE workspace_id=? AND is_root=1", (ws,))]
+    assert roots == [root_id]
+
+    # The intermediate is linked to the active workspace as a non-root so
+    # workspace-scoped queries over the tree include it.
+    mid_link = db.conn.execute(
+        "SELECT is_root FROM workspace_folders "
+        "WHERE workspace_id=? AND folder_id=?", (ws, mid["id"]),
+    ).fetchone()
+    assert mid_link is not None and mid_link["is_root"] == 0
+
+
 def test_merge_staged_tree_missing_target_file_keeps_new_photo(db, tmp_path):
     """Defensive: a filename collision against a STALE target row whose file is
     missing on disk must NOT drop the staged photo as ``already_present``. The

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -7477,19 +7477,27 @@ def test_merge_staged_tree_downgrades_staged_root_leaf(db):
     assert [r["folder_id"] for r in roots] == [base_id]
 
 
-def test_merge_staged_tree_existing_folder_and_collision(db):
+def test_merge_staged_tree_existing_folder_and_collision(db, tmp_path):
     """Staged folder folds into a pre-existing target date-folder: a
-    same-filename staged photo (even one carrying keyword links) is dropped as
-    already-archived, a genuinely-new one is reparented, and the counts use the
-    settled photo-count names. Regression guard for the photo_keywords FK that
-    has no ON DELETE CASCADE — deleting the collided photo without first
-    clearing its keyword rows would raise FOREIGN KEY constraint failed."""
+    same-filename staged photo (even one carrying keyword links) whose archived
+    file REALLY exists on disk is dropped as already-archived, a genuinely-new
+    one is reparented, and the counts use the settled photo-count names.
+    Regression guard for the photo_keywords FK that has no ON DELETE CASCADE —
+    deleting the collided photo without first clearing its keyword rows would
+    raise FOREIGN KEY constraint failed."""
     ws = db._active_workspace_id
 
-    base_id = db.add_folder("/arch/USA", name="USA")
-    year_id = db.add_folder("/arch/USA/2026", name="2026", parent_id=base_id)
-    date_id = db.add_folder("/arch/USA/2026/2026-06-30", name="2026-06-30",
-                            parent_id=year_id)
+    # Real on-disk archive so the collision drop's "archived file exists" check
+    # sees the byte-identical file rsync --ignore-existing preserved.
+    arch = tmp_path / "arch" / "USA"
+    date_dir = arch / "2026" / "2026-06-30"
+    date_dir.mkdir(parents=True)
+    (date_dir / "dup.raf").write_bytes(b"archived-dup")
+    (date_dir / "keep.raf").write_bytes(b"archived-keep")
+
+    base_id = db.add_folder(str(arch), name="USA")
+    year_id = db.add_folder(str(arch / "2026"), name="2026", parent_id=base_id)
+    date_id = db.add_folder(str(date_dir), name="2026-06-30", parent_id=year_id)
     db.add_photo(folder_id=date_id, filename="dup.raf", extension=".raf",
                  file_size=100, file_mtime=1.0)
     db.add_photo(folder_id=date_id, filename="keep.raf", extension=".raf",
@@ -7498,10 +7506,12 @@ def test_merge_staged_tree_existing_folder_and_collision(db):
 
     # Staged tree post-rsync. The intermediate year folder is a real row so the
     # reparent chain is exercised; the leaf already exists at the target.
-    stage_root = db.add_folder("/stage/USA", name="USA", workspace_root=False)
-    stage_year = db.add_folder("/stage/USA/2026", name="2026",
+    stage = tmp_path / "stage" / "USA"
+    stage_root = db.add_folder(str(stage), name="USA", workspace_root=False)
+    stage_year = db.add_folder(str(stage / "2026"), name="2026",
                                parent_id=stage_root, workspace_root=False)
-    stage_leaf = db.add_folder("/stage/USA/2026/2026-06-30", name="2026-06-30",
+    stage_leaf = db.add_folder(str(stage / "2026" / "2026-06-30"),
+                               name="2026-06-30",
                                parent_id=stage_year, workspace_root=False)
     dup_pid = db.add_photo(folder_id=stage_leaf, filename="dup.raf",
                            extension=".raf", file_size=200, file_mtime=2.0)
@@ -7513,7 +7523,7 @@ def test_merge_staged_tree_existing_folder_and_collision(db):
     kw = db.add_keyword("Osprey")
     db.tag_photo(dup_pid, kw)
 
-    counts = db.merge_staged_tree_into_archive(stage_root, "/arch/USA")
+    counts = db.merge_staged_tree_into_archive(stage_root, str(arch))
 
     # No duplicate dup.raf row; fresh.raf reparented into the existing folder.
     names = {r["filename"] for r in db.conn.execute(
@@ -7529,7 +7539,7 @@ def test_merge_staged_tree_existing_folder_and_collision(db):
 
     # Settled count names with correct values: 1 new photo (fresh.raf), no new
     # folders (every staged folder mapped to an existing target — root, year,
-    # and leaf all pre-exist under /arch/USA), 3 merged folders, 1 dropped.
+    # and leaf all pre-exist under the archive), 3 merged folders, 1 dropped.
     assert counts["new_photos"] == 1
     assert counts["new_folders"] == 0
     assert counts["merged_folders"] == 3
@@ -7537,7 +7547,7 @@ def test_merge_staged_tree_existing_folder_and_collision(db):
 
     # All staged rows folded away.
     assert db.conn.execute(
-        "SELECT 1 FROM folders WHERE path LIKE '/stage/%'"
+        "SELECT 1 FROM folders WHERE path LIKE ?", (str(stage) + "%",)
     ).fetchone() is None
 
 
@@ -7613,6 +7623,94 @@ def test_merge_staged_tree_links_archive_to_active_workspace(db):
         (new_pid, active_ws),
     ).fetchone()
     assert row is not None and row["filename"] == "new.raf"
+
+
+def test_merge_staged_tree_ancestor_base_stays_non_root(db):
+    """Regression: when the active workspace already has a managed root ANCESTOR
+    of the archive base (import into an existing subfolder — root ``/Photos``,
+    base ``/Photos/USA``), the merge must LINK the base to the workspace but NOT
+    root it. Rooting it would leave ``/Photos`` and ``/Photos/USA`` as two
+    overlapping workspace roots. When there is no root ancestor the base IS the
+    root (covered by the other merge tests)."""
+    ws = db._active_workspace_id
+
+    # Existing workspace root ancestor.
+    root_id = db.add_folder("/Photos", name="Photos")
+    base_id = db.add_folder("/Photos/USA", name="USA", parent_id=root_id)
+    db.add_workspace_folder(ws, root_id, is_root=True)
+
+    # Staged tree lands at a genuinely-new date subfolder inside the base.
+    stage_root = db.add_folder("/stage/USA", name="USA", workspace_root=False)
+    stage_leaf = db.add_folder("/stage/USA/2026-06-30", name="2026-06-30",
+                               parent_id=stage_root, workspace_root=False)
+    db.add_photo(folder_id=stage_leaf, filename="new.raf", extension=".raf",
+                 file_size=200, file_mtime=2.0)
+
+    db.merge_staged_tree_into_archive(stage_root, "/Photos/USA")
+
+    # The base is linked to the workspace but as a NON-root.
+    base_link = db.conn.execute(
+        "SELECT is_root FROM workspace_folders "
+        "WHERE workspace_id=? AND folder_id=?", (ws, base_id),
+    ).fetchone()
+    assert base_link is not None and base_link["is_root"] == 0
+
+    # /Photos remains the SOLE workspace root — no duplicate overlapping root.
+    roots = [r["folder_id"] for r in db.conn.execute(
+        "SELECT folder_id FROM workspace_folders "
+        "WHERE workspace_id=? AND is_root=1", (ws,))]
+    assert roots == [root_id]
+
+
+def test_merge_staged_tree_missing_target_file_keeps_new_photo(db, tmp_path):
+    """Defensive: a filename collision against a STALE target row whose file is
+    missing on disk must NOT drop the staged photo as ``already_present``. The
+    upstream content-conflict check couldn't fire (no dest file), so rsync
+    copied the new staged bytes; dropping the staged row would leave those bytes
+    represented by the phantom row's hash/metadata and lose the new photo.
+    Instead the phantom row is removed and the staged photo reparented in its
+    place, so the surviving row describes the real on-disk file."""
+    ws = db._active_workspace_id
+
+    # Real on-disk archive, but the archived file is ABSENT (stale catalog row).
+    arch = tmp_path / "arch" / "USA"
+    date_dir = arch / "2026-06-30"
+    date_dir.mkdir(parents=True)
+    # NOTE: no missing.raf written to date_dir — the row is stale.
+
+    base_id = db.add_folder(str(arch), name="USA")
+    date_id = db.add_folder(str(date_dir), name="2026-06-30", parent_id=base_id)
+    stale_pid = db.add_photo(folder_id=date_id, filename="missing.raf",
+                             extension=".raf", file_size=100, file_mtime=1.0,
+                             file_hash="STALEHASH")
+    db.add_workspace_folder(ws, base_id, is_root=True)
+
+    # Staged photo shares the basename but is the freshly-copied real file.
+    stage = tmp_path / "stage" / "USA"
+    stage_root = db.add_folder(str(stage), name="USA", workspace_root=False)
+    stage_leaf = db.add_folder(str(stage / "2026-06-30"), name="2026-06-30",
+                               parent_id=stage_root, workspace_root=False)
+    new_pid = db.add_photo(folder_id=stage_leaf, filename="missing.raf",
+                           extension=".raf", file_size=200, file_mtime=2.0,
+                           file_hash="NEWHASH")
+
+    counts = db.merge_staged_tree_into_archive(stage_root, str(arch))
+
+    # The staged photo survived and now lives on the archive date folder — it
+    # was NOT dropped as already_present.
+    assert counts["already_present"] == 0
+    assert counts["new_photos"] == 1
+    surviving = db.conn.execute(
+        "SELECT id, folder_id, file_hash FROM photos WHERE filename='missing.raf'"
+    ).fetchall()
+    assert len(surviving) == 1
+    assert surviving[0]["id"] == new_pid
+    assert surviving[0]["folder_id"] == date_id
+    assert surviving[0]["file_hash"] == "NEWHASH"
+    # The stale phantom row is gone (replaced by the real bytes' row).
+    assert db.conn.execute(
+        "SELECT 1 FROM photos WHERE id = ?", (stale_pid,)
+    ).fetchone() is None
 
 
 def test_folder_under_rule_excludes_siblings_and_escapes_wildcards(tmp_path, monkeypatch):

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -7354,6 +7354,70 @@ def test_move_folder_path_is_case_sensitive(db):
     assert sibling_child["path"] == "/photos/2024/sibling"
 
 
+def test_merge_staged_tree_new_subfolders(db):
+    """Staged tree merged under an existing tracked base: new date folders
+    are repointed under the base, parent_id fixed, workspace linked, and the
+    base's existing photos are untouched."""
+    ws = db._active_workspace_id
+
+    # Existing tracked archive base with one prior shoot, linked as a root.
+    base_id = db.add_folder("/arch/USA", name="USA")
+    old_id = db.add_folder("/arch/USA/2025/2025-01-01", name="2025-01-01",
+                           parent_id=base_id)
+    db.add_photo(folder_id=old_id, filename="old.raf", extension=".raf",
+                 file_size=100, file_mtime=1.0)
+    db.add_workspace_folder(ws, base_id, is_root=True)
+
+    # Staged tree (post-rsync the files already live at /arch/USA/...). Created
+    # with workspace_root=False so the staged rows are NOT pre-linked as roots.
+    # The intermediate year folder is a real catalog row (a scan would create
+    # it) so the reparenting chain is exercised end to end.
+    stage_root = db.add_folder("/stage/USA", name="USA", workspace_root=False)
+    stage_year = db.add_folder("/stage/USA/2026", name="2026",
+                               parent_id=stage_root, workspace_root=False)
+    stage_leaf = db.add_folder("/stage/USA/2026/2026-06-30", name="2026-06-30",
+                               parent_id=stage_year, workspace_root=False)
+    db.add_photo(folder_id=stage_leaf, filename="new.raf", extension=".raf",
+                 file_size=200, file_mtime=2.0)
+
+    db.merge_staged_tree_into_archive(stage_root, "/arch/USA")
+
+    # New leaf now lives under the base, parented to its (new) target parent.
+    leaf = db.conn.execute(
+        "SELECT id, parent_id FROM folders WHERE path = ?",
+        ("/arch/USA/2026/2026-06-30",),
+    ).fetchone()
+    assert leaf is not None
+    year = db.conn.execute(
+        "SELECT id FROM folders WHERE path = ?", ("/arch/USA/2026",),
+    ).fetchone()
+    assert year is not None
+    assert leaf["parent_id"] == year["id"]
+
+    # The staged root and leaf rows are gone (folded into the existing base).
+    assert db.conn.execute(
+        "SELECT 1 FROM folders WHERE path = ?", ("/stage/USA",)
+    ).fetchone() is None
+    assert db.conn.execute(
+        "SELECT 1 FROM folders WHERE path LIKE '/stage/%'"
+    ).fetchone() is None
+
+    # The new photo moved with the folder; the old photo is untouched.
+    assert db.conn.execute(
+        "SELECT folder_id FROM photos WHERE filename = ?", ("new.raf",)
+    ).fetchone()["folder_id"] == leaf["id"]
+    assert db.conn.execute(
+        "SELECT folder_id FROM photos WHERE filename = ?", ("old.raf",)
+    ).fetchone()["folder_id"] == old_id
+
+    # New leaf is linked to the workspace as a non-root (base is the root).
+    row = db.conn.execute(
+        "SELECT is_root FROM workspace_folders WHERE workspace_id=? AND folder_id=?",
+        (ws, leaf["id"]),
+    ).fetchone()
+    assert row is not None and row["is_root"] == 0
+
+
 def test_folder_under_rule_excludes_siblings_and_escapes_wildcards(tmp_path, monkeypatch):
     """'folder under /photos/2023' must match that folder and its
     descendants only — not the sibling /photos/2023-trip — and a _ in the

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -7625,6 +7625,77 @@ def test_merge_staged_tree_links_archive_to_active_workspace(db):
     assert row is not None and row["filename"] == "new.raf"
 
 
+def test_merge_staged_tree_new_descendant_roots_tracked_ancestor_for_active_ws(
+        db):
+    """Regression: when the archive destination is a BRAND-NEW subfolder
+    inside a tracked archive that belongs only to a DIFFERENT workspace,
+    the merge used to skip the ``if archive_row:`` linking block (the new
+    subfolder has no folder row yet), then the reconciliation loop
+    reparented the staged root onto the new archive path and explicitly
+    demoted it to ``is_root=0``. The active workspace was left with NO
+    ``is_root=1`` row covering the merged tree, and
+    ``get_workspace_folder_roots()`` (which filters on ``is_root=1``)
+    returned nothing — the newly-archived photos silently disappeared from
+    the active workspace even though the import reported success.
+
+    The fix roots the deepest tracked ancestor in the active workspace
+    when no root ancestor is present, so the merged tree has a visible
+    anchor."""
+    # Archive tracked only under the default ws.
+    other_ws = db._active_workspace_id
+    tracked_id = db.add_folder("/arch", name="arch")
+    db.add_workspace_folder(other_ws, tracked_id, is_root=True)
+
+    # Switch to a fresh workspace with NO link to /arch and NO root
+    # ancestor above it.
+    active_ws = db.create_workspace("Active")
+    db.set_active_workspace(active_ws)
+    assert db.conn.execute(
+        "SELECT 1 FROM workspace_folders "
+        "WHERE workspace_id=? AND folder_id=?",
+        (active_ws, tracked_id),
+    ).fetchone() is None
+
+    # Staged tree destined for a NEW subfolder inside /arch — no folder row
+    # for /arch/NewShoot exists yet.
+    stage_root = db.add_folder("/stage/NewShoot", name="NewShoot",
+                               workspace_root=False)
+    stage_leaf = db.add_folder("/stage/NewShoot/2026-06-30", name="2026-06-30",
+                               parent_id=stage_root, workspace_root=False)
+    new_pid = db.add_photo(folder_id=stage_leaf, filename="new.raf",
+                           extension=".raf", file_size=200, file_mtime=2.0)
+
+    db.merge_staged_tree_into_archive(stage_root, "/arch/NewShoot")
+
+    # The tracked ancestor /arch is now a root of the active workspace, so
+    # get_workspace_folder_roots() has an anchor for the merged tree.
+    ancestor_link = db.conn.execute(
+        "SELECT is_root FROM workspace_folders "
+        "WHERE workspace_id=? AND folder_id=?",
+        (active_ws, tracked_id),
+    ).fetchone()
+    assert ancestor_link is not None and ancestor_link["is_root"] == 1
+
+    # The merged photo is visible via the workspace_folders join every
+    # ws-scoped query uses.
+    row = db.conn.execute(
+        """SELECT p.filename FROM photos p
+           JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+           WHERE p.id = ? AND wf.workspace_id = ?""",
+        (new_pid, active_ws),
+    ).fetchone()
+    assert row is not None and row["filename"] == "new.raf"
+
+    # The other workspace's root on /arch is preserved (is_root scoping in
+    # add_workspace_folder is per-workspace).
+    other_link = db.conn.execute(
+        "SELECT is_root FROM workspace_folders "
+        "WHERE workspace_id=? AND folder_id=?",
+        (other_ws, tracked_id),
+    ).fetchone()
+    assert other_link is not None and other_link["is_root"] == 1
+
+
 def test_merge_staged_tree_ancestor_base_stays_non_root(db):
     """Regression: when the active workspace already has a managed root ANCESTOR
     of the archive base (import into an existing subfolder — root ``/Photos``,

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -7713,6 +7713,85 @@ def test_merge_staged_tree_missing_target_file_keeps_new_photo(db, tmp_path):
     ).fetchone() is None
 
 
+def test_merge_staged_tree_case_alias_collision_on_case_insensitive_volume(
+    db, tmp_path, monkeypatch,
+):
+    """On a case-insensitive archive volume (default macOS APFS, Windows
+    NTFS) an existing catalog row ``IMG.RAF`` and a staged ``img.raf`` are
+    the same on-disk file: rsync ``--ignore-existing`` treats them as a
+    match and skips the staged copy. Without a case-aware collision check
+    the staged row would be reparented onto the target folder, leaving TWO
+    catalog rows in one folder for the same file (SQLite text-equality is
+    case-sensitive so UNIQUE(folder_id, filename) doesn't fire to catch
+    the mistake). The staged row must be dropped as ``already_present``.
+    """
+    ws = db._active_workspace_id
+
+    arch = tmp_path / "arch" / "USA"
+    date_dir = arch / "2026-06-30"
+    date_dir.mkdir(parents=True)
+    # Only the upper-case archived file exists on disk. The staged
+    # lower-case name would resolve to this same file on a case-folding
+    # volume.
+    (date_dir / "IMG.RAF").write_bytes(b"archived-bytes")
+
+    base_id = db.add_folder(str(arch), name="USA")
+    date_id = db.add_folder(str(date_dir), name="2026-06-30",
+                            parent_id=base_id)
+    archived_pid = db.add_photo(folder_id=date_id, filename="IMG.RAF",
+                                extension=".raf", file_size=100,
+                                file_mtime=1.0, file_hash="ARCH")
+    db.add_workspace_folder(ws, base_id, is_root=True)
+
+    stage = tmp_path / "stage" / "USA"
+    stage_root = db.add_folder(str(stage), name="USA", workspace_root=False)
+    stage_leaf = db.add_folder(str(stage / "2026-06-30"), name="2026-06-30",
+                               parent_id=stage_root, workspace_root=False)
+    staged_pid = db.add_photo(folder_id=stage_leaf, filename="img.raf",
+                              extension=".raf", file_size=100,
+                              file_mtime=2.0, file_hash="STAGED")
+
+    # Force the merge to treat the target volume as case-insensitive
+    # regardless of the CI host's actual filesystem behavior (Linux ext4
+    # is case-sensitive, so the underlying ``_case_insensitive_root``
+    # probe would otherwise return None and the fix wouldn't be exercised
+    # in this test environment).
+    import move
+    monkeypatch.setattr(move, "_case_insensitive_root", lambda p: "/")
+    # And make ``os.path.exists`` treat the case-alias lookup as present,
+    # since a real case-insensitive volume would resolve
+    # ``.../IMG.raf`` / ``.../img.raf`` back to the same on-disk file.
+    real_exists = os.path.exists
+    def case_insensitive_exists(p):
+        if real_exists(p):
+            return True
+        # Fall back to a case-insensitive directory listing.
+        parent = os.path.dirname(p)
+        base = os.path.basename(p).lower()
+        try:
+            entries = os.listdir(parent)
+        except OSError:
+            return False
+        return any(e.lower() == base for e in entries)
+    monkeypatch.setattr("db.os.path.exists", case_insensitive_exists)
+
+    counts = db.merge_staged_tree_into_archive(stage_root, str(arch))
+
+    # The staged row was dropped, not reparented — one row remains for the
+    # archived file.
+    rows = db.conn.execute(
+        "SELECT id, filename FROM photos WHERE folder_id = ?", (date_id,),
+    ).fetchall()
+    assert len(rows) == 1
+    assert rows[0]["id"] == archived_pid
+    assert rows[0]["filename"] == "IMG.RAF"
+    assert db.conn.execute(
+        "SELECT 1 FROM photos WHERE id = ?", (staged_pid,)
+    ).fetchone() is None
+    assert counts["already_present"] == 1
+    assert counts["new_photos"] == 0
+
+
 def test_folder_under_rule_excludes_siblings_and_escapes_wildcards(tmp_path, monkeypatch):
     """'folder under /photos/2023' must match that folder and its
     descendants only — not the sibling /photos/2023-trip — and a _ in the

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -1001,6 +1001,51 @@ def test_move_folder_merge_moved_excludes_already_present(move_env):
     ).fetchone()["c"] == 1
 
 
+def test_move_folder_merge_reports_dropped_ids_for_cache_cleanup(move_env):
+    """Regression: cached thumbnails/previews/working copies are keyed by
+    ``photos.id``. When the merge drops a staged photo as
+    ``already_present``, the freed rowid would leave orphan cache files on
+    disk (SQLite reuses rowids, so a future import that lands on the same
+    id inherits stale imagery). ``move_folder`` must surface the freed
+    staged ids at ``result['dropped_photo_ids']`` so the pipeline archive
+    stage can hand them to ``cleanup_cached_files_for_deleted_photos``.
+
+    Kept OFF ``result['merge']`` — that dict is serialized into the
+    archive-stage summary/API payload, and internal photo ids are not
+    part of the user-facing shape."""
+    from move import move_folder
+
+    env = move_env
+    db = env["db"]
+
+    # Same setup as ``moved_excludes_already_present`` — bird1.jpg is
+    # byte-identical between staged src and pre-seeded archive landing, so
+    # the merge drops the staged bird1.jpg row.
+    landing = env["dst"] / "src"
+    landing.mkdir()
+    identical_bytes = (env["src"] / "bird1.jpg").read_bytes()
+    (landing / "bird1.jpg").write_bytes(identical_bytes)
+    fid_archive = db.add_folder(str(landing), name="src")
+    db.add_photo(folder_id=fid_archive, filename="bird1.jpg",
+                 extension=".jpg",
+                 file_size=len(identical_bytes), file_mtime=3.0)
+
+    staged_bird1_pid = db.conn.execute(
+        "SELECT id FROM photos WHERE folder_id = ? AND filename = ?",
+        (env["fid_src"], "bird1.jpg"),
+    ).fetchone()["id"]
+
+    result = move_folder(
+        db=db, folder_id=env["fid_src"], destination=str(env["dst"]),
+        merge=True, allow_tracked_merge=True,
+    )
+
+    assert result["errors"] == []
+    assert staged_bird1_pid in result.get("dropped_photo_ids", [])
+    # The user-facing merge dict stays clean of internal ids.
+    assert "dropped_photo_ids" not in result["merge"]
+
+
 def test_move_folder_refuses_missing_tracked_destination_before_copy(move_env):
     """A stale tracked destination row must block the move even when the
     resolved destination does not currently exist on disk."""

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -979,8 +979,20 @@ def test_move_folder_merge_moved_excludes_already_present(move_env):
     identical_bytes = (env["src"] / "bird1.jpg").read_bytes()
     (landing / "bird1.jpg").write_bytes(identical_bytes)
     fid_archive = db.add_folder(str(landing), name="src")
+    # Matching ``file_hash`` on both sides is required for the merge to
+    # treat the collision as real (see merge_staged_tree_into_archive's
+    # hash-only invariant — size alone can't distinguish a real collision
+    # from a rsync-copied phantom in the post-copy path). Pre-seed both
+    # rows with the same hash, and stamp the staged fixture row with it
+    # too so the drop path fires.
     db.add_photo(folder_id=fid_archive, filename="bird1.jpg", extension=".jpg",
-                 file_size=len(identical_bytes), file_mtime=3.0)
+                 file_size=len(identical_bytes), file_mtime=3.0,
+                 file_hash="BIRD1HASH")
+    db.conn.execute(
+        "UPDATE photos SET file_hash = ? WHERE folder_id = ? AND filename = ?",
+        ("BIRD1HASH", env["fid_src"], "bird1.jpg"),
+    )
+    db.conn.commit()
 
     result = move_folder(
         db=db, folder_id=env["fid_src"], destination=str(env["dst"]),
@@ -1026,9 +1038,17 @@ def test_move_folder_merge_reports_dropped_ids_for_cache_cleanup(move_env):
     identical_bytes = (env["src"] / "bird1.jpg").read_bytes()
     (landing / "bird1.jpg").write_bytes(identical_bytes)
     fid_archive = db.add_folder(str(landing), name="src")
+    # Matching ``file_hash`` on both rows exercises the real-collision
+    # drop path (see merge_staged_tree_into_archive's hash-only invariant).
     db.add_photo(folder_id=fid_archive, filename="bird1.jpg",
                  extension=".jpg",
-                 file_size=len(identical_bytes), file_mtime=3.0)
+                 file_size=len(identical_bytes), file_mtime=3.0,
+                 file_hash="BIRD1HASH")
+    db.conn.execute(
+        "UPDATE photos SET file_hash = ? WHERE folder_id = ? AND filename = ?",
+        ("BIRD1HASH", env["fid_src"], "bird1.jpg"),
+    )
+    db.conn.commit()
 
     staged_bird1_pid = db.conn.execute(
         "SELECT id FROM photos WHERE folder_id = ? AND filename = ?",

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -647,6 +647,49 @@ def test_move_folder_merges_into_tracked_when_allowed(move_env):
     assert names == {"prior.jpg", "bird1.jpg", "bird2.jpg"}
 
 
+def test_move_folder_refuses_descendant_tracked_overlap_even_when_merging(move_env):
+    """Regression: ``allow_tracked_merge`` must only accept the "tracked row
+    IS the destination" case, not a tracked row that sits STRICTLY BELOW the
+    resolved destination. The descendant case is "wrap a fresh parent around
+    an existing tracked subtree" (e.g. ``/Photos/USA/2024`` scanned as its
+    own workspace root, then a fresh staged tree lands at ``/Photos/USA``);
+    the reconciliation would rebase the staged tree onto the wrapper path
+    while leaving the pre-existing tracked descendant's parentage untouched,
+    creating two overlapping catalog subtrees managing the same on-disk area.
+    Refuse before any copy — same guard as the default-off case."""
+    from move import move_folder
+
+    env = move_env
+    db = env["db"]
+
+    # Landing resolves to <dst>/src. Register a tracked row STRICTLY BELOW
+    # that landing so ``_tracked_destination_overlap`` returns a descendant
+    # (not an exact match). The row doesn't need to exist on disk — the
+    # overlap probe is folder-row based.
+    landing = env["dst"] / "src"
+    inner = landing / "existing-shoot"
+    inner_fid = db.add_folder(str(inner), name="existing-shoot")
+
+    result = move_folder(
+        db=db, folder_id=env["fid_src"], destination=str(env["dst"]),
+        merge=True, allow_tracked_merge=True,
+    )
+    assert result["moved"] == 0
+    assert any("already manage" in e for e in result["errors"])
+    # Source intact — the guard fires before any copy or delete.
+    assert (env["src"] / "bird1.jpg").exists()
+    assert (env["src"] / "bird2.jpg").exists()
+    # Landing was never materialized and no wrapper folder row was created
+    # for it. The pre-existing tracked descendant row is untouched.
+    assert not landing.exists()
+    assert db.conn.execute(
+        "SELECT 1 FROM folders WHERE path = ?", (str(landing),)
+    ).fetchone() is None
+    assert db.conn.execute(
+        "SELECT id FROM folders WHERE path = ?", (str(inner),)
+    ).fetchone()["id"] == inner_fid
+
+
 def test_move_folder_merge_moved_excludes_already_present(move_env):
     """On the merge path, identical-filename collisions are dropped as
     ``already_present`` and must NOT be counted in ``result['moved']``.

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -891,6 +891,74 @@ def test_move_folder_refuses_descendant_tracked_overlap_even_when_merging(move_e
     ).fetchone()["id"] == inner_fid
 
 
+def test_tracked_destination_overlap_prefers_exact_match_over_descendant(move_env):
+    """Regression: when both an exact-match tracked row (destination itself)
+    and a strict-descendant tracked row exist, ``_tracked_destination_overlap``
+    must return the EXACT match. Without the preference, SQLite returns rows in
+    arbitrary order (insertion / rowid by default); a descendant row inserted
+    BEFORE its later-scanned parent would come back first, and the caller's
+    ``tracked_is_destination`` check would then reject the exact-match merge as
+    the unsupported "wrap around a tracked subfolder" case."""
+    from move import _tracked_destination_overlap
+
+    env = move_env
+    db = env["db"]
+    landing = env["dst"] / "src"
+
+    # Insert the DESCENDANT row first so a plain unordered scan returns it
+    # before the exact-match row that arrives later. Neither row needs to
+    # exist on disk — the overlap probe is folder-row based.
+    desc_fid = db.add_folder(str(landing / "existing-shoot"),
+                             name="existing-shoot")
+    exact_fid = db.add_folder(str(landing), name="src")
+    # Confirm the intended insertion order (descendant has the lower rowid,
+    # so a naive SELECT would hit it first).
+    assert desc_fid < exact_fid
+
+    row = _tracked_destination_overlap(db, env["fid_src"], str(landing))
+    assert row is not None
+    assert row["id"] == exact_fid
+    assert row["path"] == str(landing)
+
+
+def test_move_folder_accepts_exact_tracked_merge_despite_descendant_row(move_env):
+    """End-to-end regression for the ordering fix: ``move_folder`` with
+    ``allow_tracked_merge=True`` must accept an EXACT tracked destination
+    (destination IS the tracked row) even when a strict-descendant tracked row
+    also exists and was inserted first. Before the exact-match preference in
+    ``_tracked_destination_overlap`` the descendant row could be returned first
+    and get treated as the unsupported "wrap" case, refusing the merge."""
+    from move import move_folder
+
+    env = move_env
+    db = env["db"]
+    landing = env["dst"] / "src"
+    landing.mkdir()
+
+    # Descendant tracked row first (lower rowid than the exact-match row),
+    # then the exact-match row for the landing path itself.
+    db.add_folder(str(landing / "existing-shoot"), name="existing-shoot")
+    fid_archive = db.add_folder(str(landing), name="src")
+
+    result = move_folder(
+        db=db, folder_id=env["fid_src"], destination=str(env["dst"]),
+        merge=True, allow_tracked_merge=True,
+    )
+    # The exact-match tracked row means this is the accept-as-merge case, NOT
+    # the descendant-only "wrap" case. Merge succeeds, no errors.
+    assert result["errors"] == []
+    merge = result.get("merge")
+    assert merge is not None
+    # Two staged photos, neither collides with anything in the empty archive:
+    # both become newly-archived rows.
+    assert merge["new_photos"] == 2
+    # The two staged photos are now catalog-parented on the archive folder.
+    assert db.conn.execute(
+        "SELECT COUNT(*) c FROM photos WHERE folder_id = ?",
+        (fid_archive,),
+    ).fetchone()["c"] == 2
+
+
 def test_move_folder_merge_moved_excludes_already_present(move_env):
     """On the merge path, identical-filename collisions are dropped as
     ``already_present`` and must NOT be counted in ``result['moved']``.

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -570,6 +570,83 @@ def test_move_folder_refuses_destination_inside_tracked_ancestor(move_env):
     assert not destination.exists()
 
 
+def test_move_folder_refuses_tracked_merge_by_default(move_env):
+    """Regression guard: without allow_tracked_merge, merging into a tracked
+    destination is still refused (default behaviour byte-for-byte unchanged)."""
+    from move import move_folder
+
+    env = move_env
+    landing = env["dst"] / "src"
+    landing.mkdir()
+    for fn in ("bird1.jpg", "bird1.xmp", "bird2.jpg"):
+        (landing / fn).write_bytes((env["src"] / fn).read_bytes())
+    # Destination already exists as its own folder row in the DB.
+    env["db"].add_folder(str(landing), name="src")
+
+    result = move_folder(
+        db=env["db"], folder_id=env["fid_src"], destination=str(env["dst"]),
+        merge=True,
+    )
+    assert result["moved"] == 0
+    assert any("already manage" in e for e in result["errors"])
+    # Source intact — nothing merged.
+    assert (env["src"] / "bird1.jpg").exists()
+
+
+def test_move_folder_merges_into_tracked_when_allowed(move_env):
+    """With allow_tracked_merge=True the staged tree's files land in the
+    existing archive on disk, the result reports merge counts, and the catalog
+    has no leftover staged folder rows (they fold into the archive)."""
+    from move import move_folder
+
+    env = move_env
+    db = env["db"]
+
+    # The archive destination is the path the staged 'src' folder lands at when
+    # placed inside 'dst' (move_folder preserves the source folder name).
+    landing = env["dst"] / "src"
+    landing.mkdir()
+    # Prior shoot already in the archive on disk + in the catalog as a tracked
+    # workspace-root folder.
+    (landing / "prior.jpg").write_bytes(b"\xff\xd8" + b"\x00" * 50)
+    fid_archive = db.add_folder(str(landing), name="src")
+    db.add_photo(folder_id=fid_archive, filename="prior.jpg", extension=".jpg",
+                 file_size=52, file_mtime=3.0)
+
+    staged_prefix = str(env["src"])
+
+    result = move_folder(
+        db=db, folder_id=env["fid_src"], destination=str(env["dst"]),
+        merge=True, allow_tracked_merge=True,
+    )
+
+    assert result["errors"] == []
+    assert result["moved"] >= 1
+    # Staged files merged onto disk into the existing archive.
+    assert (landing / "bird1.jpg").exists()
+    assert (landing / "bird2.jpg").exists()
+    assert (landing / "prior.jpg").exists()
+    # Staging cleaned up.
+    assert not env["src"].exists()
+
+    # Merge counts surfaced. The two staged photos fold into the existing
+    # archive folder; the prior photo is untouched.
+    assert result["merged_into_existing"] == str(landing)
+    merge = result["merge"]
+    assert merge["new_photos"] == 2
+    assert merge["merged_folders"] >= 1
+    assert merge["already_present"] == 0
+
+    # No leftover staged folder rows — the staged tree folded into the archive.
+    assert db.conn.execute(
+        "SELECT 1 FROM folders WHERE path LIKE ?", (staged_prefix + "%",)
+    ).fetchone() is None
+    # The archive folder now holds all three photos under one row.
+    names = {r["filename"] for r in db.conn.execute(
+        "SELECT filename FROM photos WHERE folder_id = ?", (fid_archive,))}
+    assert names == {"prior.jpg", "bird1.jpg", "bird2.jpg"}
+
+
 def test_move_folder_refuses_missing_tracked_destination_before_copy(move_env):
     """A stale tracked destination row must block the move even when the
     resolved destination does not currently exist on disk."""

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -647,6 +647,73 @@ def test_move_folder_merges_into_tracked_when_allowed(move_env):
     assert names == {"prior.jpg", "bird1.jpg", "bird2.jpg"}
 
 
+def test_move_folder_merge_alias_destination_uses_stored_tracked_path(
+        move_env, monkeypatch):
+    """Regression: when the archive destination is a symlink/case-only alias of
+    an already-tracked folder, the exact-overlap merge must reconcile onto the
+    STORED tracked path, not the aliased ``catalog_path``. Otherwise
+    ``merge_staged_tree_into_archive``'s exact ``WHERE path = ?`` lookups miss
+    the existing row and create a SECOND folder row for the same on-disk
+    archive.
+
+    Simulated on Linux the same way as the case-alias refusal tests:
+      1. Symlink so two distinct path strings share an inode.
+      2. realpath/normcase patched to no-ops so the string-based tracked check
+         misses and the samefile fallback in ``_path_equal_or_descends`` folds
+         the alias to the tracked row.
+    """
+    from move import move_folder
+
+    env = move_env
+    db = env["db"]
+
+    # The real archive folder, tracked at its real path with a prior shoot.
+    real_dst = env["tmp_path"] / "realdst"
+    landing = real_dst / "src"
+    landing.mkdir(parents=True)
+    (landing / "prior.jpg").write_bytes(b"\xff\xd8" + b"\x00" * 50)
+    fid_archive = db.add_folder(str(landing), name="src")
+    db.add_photo(folder_id=fid_archive, filename="prior.jpg", extension=".jpg",
+                 file_size=52, file_mtime=3.0)
+
+    alias_dst = env["tmp_path"] / "alias_dst"
+    try:
+        os.symlink(str(real_dst), str(alias_dst))
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported on this platform")
+
+    monkeypatch.setattr(os.path, "realpath", lambda p: p)
+    monkeypatch.setattr(os.path, "normcase", lambda p: p)
+
+    # destination=alias_dst → resolved dest = alias_dst/src, an alias of the
+    # tracked realdst/src. The merge is accepted (exact overlap via samefile)
+    # and must fold into the existing row, not create a second one.
+    result = move_folder(
+        db=db, folder_id=env["fid_src"], destination=str(alias_dst),
+        merge=True, allow_tracked_merge=True,
+    )
+
+    assert result["errors"] == []
+    # The reconciliation base is the STORED tracked path, so the existing
+    # archive row absorbs the staged photos — exactly ONE folder row for the
+    # on-disk archive, no alias-path duplicate.
+    archive_rows = db.conn.execute(
+        "SELECT id FROM folders WHERE path = ?", (str(landing),)
+    ).fetchall()
+    assert len(archive_rows) == 1
+    assert archive_rows[0]["id"] == fid_archive
+    # No folder row was created under the alias path.
+    assert db.conn.execute(
+        "SELECT 1 FROM folders WHERE path = ?", (str(alias_dst / "src"),)
+    ).fetchone() is None
+    # All three photos live under the single archive row.
+    names = {r["filename"] for r in db.conn.execute(
+        "SELECT filename FROM photos WHERE folder_id = ?", (fid_archive,))}
+    assert names == {"prior.jpg", "bird1.jpg", "bird2.jpg"}
+    # Staging folded away.
+    assert not env["src"].exists()
+
+
 def test_move_folder_refuses_descendant_tracked_overlap_even_when_merging(move_env):
     """Regression: ``allow_tracked_merge`` must only accept the "tracked row
     IS the destination" case, not a tracked row that sits STRICTLY BELOW the

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -714,6 +714,140 @@ def test_move_folder_merge_alias_destination_uses_stored_tracked_path(
     assert not env["src"].exists()
 
 
+def test_move_folder_ancestor_merge_reconciles_onto_stored_ancestor(
+        move_env, monkeypatch):
+    """Regression: when the destination sits INSIDE a tracked folder that was
+    matched via a symlink or case-only alias, the ancestor-merge branch must
+    rebase the reconciliation onto the STORED ancestor path, not the
+    aliased ``catalog_path``. Otherwise ``merge_staged_tree_into_archive``'s
+    exact ``WHERE path = ?`` parent lookups miss the stored ancestor row and
+    land the staged root under an alias-prefixed path with ``parent_id=NULL``,
+    spawning a parallel row set outside the managed archive tree.
+
+    Simulated on Linux the same way as
+    ``test_move_folder_merge_alias_destination_uses_stored_tracked_path``:
+    a symlink so two path strings share an inode, plus ``realpath``/
+    ``normcase`` patched to no-ops so ``_tracked_destination_ancestor`` misses
+    the string-prefix check and falls into the samefile walk-up.
+    """
+    from move import move_folder
+
+    env = move_env
+    db = env["db"]
+
+    # Real tracked ancestor archive with no rows below it yet.
+    real_archive = env["tmp_path"] / "realarch"
+    real_archive.mkdir()
+    fid_ancestor = db.add_folder(str(real_archive), name="realarch")
+
+    # Alias destination pointing at the same on-disk directory.
+    alias_archive = env["tmp_path"] / "aliasarch"
+    try:
+        os.symlink(str(real_archive), str(alias_archive))
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported on this platform")
+
+    monkeypatch.setattr(os.path, "realpath", lambda p: p)
+    monkeypatch.setattr(os.path, "normcase", lambda p: p)
+
+    # destination=alias_archive -> resolved dest = alias_archive/src. The
+    # ancestor probe only matches ``real_archive`` via the samefile walk-up,
+    # so ``catalog_path`` is the alias-prefixed ``alias_archive/src``.
+    result = move_folder(
+        db=db, folder_id=env["fid_src"], destination=str(alias_archive),
+        reject_tracked_ancestor=True, allow_tracked_merge=True,
+    )
+
+    assert result["errors"] == []
+    assert result["merged_into_existing"] == str(real_archive)
+
+    # The staged folder was reconciled onto STORED ancestor + "src", NOT the
+    # alias-prefixed ``aliasarch/src``.
+    stored_landing = str(real_archive / "src")
+    alias_landing = str(alias_archive / "src")
+    stored_row = db.conn.execute(
+        "SELECT id, parent_id FROM folders WHERE path = ?", (stored_landing,)
+    ).fetchone()
+    assert stored_row is not None
+    # Parent resolves to the stored ancestor row — not NULL (which would
+    # mean an alias-prefixed row floating outside the managed tree).
+    assert stored_row["parent_id"] == fid_ancestor
+    # No alias-prefixed row was created.
+    assert db.conn.execute(
+        "SELECT 1 FROM folders WHERE path = ?", (alias_landing,)
+    ).fetchone() is None
+    # Files land on disk under the real archive (same inode either way).
+    assert (real_archive / "src" / "bird1.jpg").exists()
+    assert (real_archive / "src" / "bird2.jpg").exists()
+
+
+def test_move_folder_merge_relocates_developed_dir_onto_reconciled_base(
+        move_env, monkeypatch):
+    """Regression: on the exact-overlap merge path with a symlink/case-only
+    alias destination, ``developed_folder_key`` hashes the STORED tracked
+    path (that's what the catalog stores after reconciliation), so the
+    developed-dir relocation must move outputs onto the same reconciled
+    base. Relocating onto the aliased ``catalog_path`` would leave renders
+    under a hash exports never read from, silently falling back to RAW
+    after import.
+    """
+    from export import developed_folder_key
+    from move import move_folder
+
+    env = move_env
+    db = env["db"]
+
+    # Real archive folder, tracked at its real path.
+    real_dst = env["tmp_path"] / "realdst2"
+    landing = real_dst / "src"
+    landing.mkdir(parents=True)
+    fid_archive = db.add_folder(str(landing), name="src")
+
+    alias_dst = env["tmp_path"] / "alias_dst2"
+    try:
+        os.symlink(str(real_dst), str(alias_dst))
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported on this platform")
+
+    # Pre-existing developed subdir keyed off the STAGED source path (that's
+    # where renders lived before this move ran). Also pre-create the target
+    # keyed off the ALIAS so a bug that relocates onto the alias would look
+    # correct on disk but rot the export path — force the assertion to
+    # distinguish "moved to alias key" from "moved to stored key".
+    developed = env["tmp_path"] / "developed"
+    developed.mkdir()
+    old_key = developed_folder_key(str(env["src"]))
+    (developed / old_key).mkdir()
+    (developed / old_key / "bird1.jpg").write_bytes(b"developed-bytes")
+
+    monkeypatch.setattr(os.path, "realpath", lambda p: p)
+    monkeypatch.setattr(os.path, "normcase", lambda p: p)
+
+    result = move_folder(
+        db=db, folder_id=env["fid_src"], destination=str(alias_dst),
+        merge=True, allow_tracked_merge=True,
+        developed_dir=str(developed),
+    )
+    assert result["errors"] == []
+
+    # The developed subdir moved to the STORED-path key (what export reads
+    # from the catalog after reconciliation), not the alias-path key.
+    stored_key = developed_folder_key(str(landing))
+    alias_key = developed_folder_key(str(alias_dst / "src"))
+    assert stored_key != alias_key
+    assert (developed / stored_key / "bird1.jpg").read_bytes() == b"developed-bytes"
+    assert not (developed / alias_key).exists()
+    # Old (staged-path) key is gone.
+    assert not (developed / old_key).exists()
+    # Catalog still has one archive row — the stored one.
+    assert db.conn.execute(
+        "SELECT COUNT(*) c FROM folders WHERE path = ?", (str(landing),)
+    ).fetchone()["c"] == 1
+    assert db.conn.execute(
+        "SELECT id FROM folders WHERE path = ?", (str(landing),)
+    ).fetchone()["id"] == fid_archive
+
+
 def test_move_folder_refuses_descendant_tracked_overlap_even_when_merging(move_env):
     """Regression: ``allow_tracked_merge`` must only accept the "tracked row
     IS the destination" case, not a tracked row that sits STRICTLY BELOW the

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -647,6 +647,48 @@ def test_move_folder_merges_into_tracked_when_allowed(move_env):
     assert names == {"prior.jpg", "bird1.jpg", "bird2.jpg"}
 
 
+def test_move_folder_merge_moved_excludes_already_present(move_env):
+    """On the merge path, identical-filename collisions are dropped as
+    ``already_present`` and must NOT be counted in ``result['moved']``.
+    ``moved`` reflects photos actually added to the archive
+    (== merge['new_photos']), not every staged source photo."""
+    from move import move_folder
+
+    env = move_env
+    db = env["db"]
+
+    # The staged 'src' folder lands at <dst>/src. Pre-seed that archive folder
+    # with a byte-identical copy of one staged photo (bird1.jpg) so it collides
+    # by filename AND content -> dropped as already_present (rsync
+    # --ignore-existing keeps the archive copy; the catalog drops the staged
+    # row). bird1.jpg in the fixture is b"\xff\xd8" + b"\x00"*100.
+    landing = env["dst"] / "src"
+    landing.mkdir()
+    identical_bytes = (env["src"] / "bird1.jpg").read_bytes()
+    (landing / "bird1.jpg").write_bytes(identical_bytes)
+    fid_archive = db.add_folder(str(landing), name="src")
+    db.add_photo(folder_id=fid_archive, filename="bird1.jpg", extension=".jpg",
+                 file_size=len(identical_bytes), file_mtime=3.0)
+
+    result = move_folder(
+        db=db, folder_id=env["fid_src"], destination=str(env["dst"]),
+        merge=True, allow_tracked_merge=True,
+    )
+
+    assert result["errors"] == []
+    merge = result["merge"]
+    # bird1.jpg collides (identical) -> already_present; bird2.jpg is new.
+    assert merge["already_present"] >= 1
+    assert merge["new_photos"] == 1
+    # moved must exclude the already_present photo.
+    assert result["moved"] == merge["new_photos"]
+    # The archive still has exactly one bird1.jpg row (no duplicate).
+    assert db.conn.execute(
+        "SELECT COUNT(*) c FROM photos WHERE folder_id = ? AND filename = ?",
+        (fid_archive, "bird1.jpg"),
+    ).fetchone()["c"] == 1
+
+
 def test_move_folder_refuses_missing_tracked_destination_before_copy(move_env):
     """A stale tracked destination row must block the move even when the
     resolved destination does not currently exist on disk."""

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -2169,12 +2169,27 @@ def test_destination_preview_flags_managed_archive(setup, tmp_path):
     Image.new("RGB", (16, 16), "green").save(p1)
     Image.new("RGB", (16, 16), "olive").save(p2)
 
+    # A second date subfolder under the same base whose folder row is
+    # 'missing' (e.g. its files went offline). Ingest treats the archive as
+    # status IN ('ok','partial'), so these photos must NOT count toward the
+    # callout's "N photos" even though their rows exist in the catalog.
+    gone = archive / "2024" / "2024-01-01"
+    gone.mkdir(parents=True)
+    g1 = gone / "gone-1.jpg"
+    Image.new("RGB", (16, 16), "gray").save(g1)
+
     from db import Database
     seed = Database(db_path)
     base_id = seed.add_folder(str(archive))
     prior_id = seed.add_folder(str(prior), parent_id=base_id, workspace_root=False)
     for f in (p1, p2):
         seed.add_photo(prior_id, f.name, ".jpg", f.stat().st_size, f.stat().st_mtime)
+    gone_id = seed.add_folder(str(gone), parent_id=base_id, workspace_root=False)
+    seed.add_photo(gone_id, g1.name, ".jpg", g1.stat().st_size, g1.stat().st_mtime)
+    seed.conn.execute(
+        "UPDATE folders SET status = 'missing' WHERE id = ?", (gone_id,)
+    )
+    seed.conn.commit()
     seed.close()
 
     # A fresh source card whose files aren't in the archive yet.
@@ -2195,6 +2210,8 @@ def test_destination_preview_flags_managed_archive(setup, tmp_path):
         data = resp.get_json()
         assert data["managed_archive"] is not None
         assert data["managed_archive"]["path"] == str(archive)
+        # Only the two ok-status photos count; the missing folder's photo is
+        # excluded (matches what ingest considers "the archive").
         assert data["managed_archive"]["photo_count"] == 2
 
 

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -493,6 +493,89 @@ def test_pipeline_local_processing_merges_into_subfolder_of_tracked_root(
         db.close()
 
 
+def test_pipeline_refuses_destination_that_wraps_tracked_subfolder(
+    setup, tmp_path, monkeypatch,
+):
+    """Regression: ``move_folder(..., allow_tracked_merge=True)`` refuses a
+    destination that sits STRICTLY ABOVE an already-tracked folder (e.g.
+    ``/Photos/USA`` tracked and the user picks ``/Photos``) — merging would
+    wrap a fresh parent around the existing tracked subtree. Without the
+    matching preflight check in the pipeline the job would stage and
+    process everything, then fail only at the final archive step and leave
+    the processed results stranded under ``~/.vireo/staging``. The
+    preflight must bail in the storage stage before any staging work
+    happens, marking scan and ingest as skipped so the pipeline actually
+    terminates.
+    """
+    app, db_path = setup
+
+    parent_dest = tmp_path / "nas" / "Photos"
+    tracked_child = parent_dest / "USA"
+    tracked_child.mkdir(parents=True)
+
+    import local_processing
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    monkeypatch.setattr(local_processing, "RESERVED_FREE_BYTES", 0)
+
+    # Only the child is tracked in the catalog; the parent is NOT.
+    from db import Database
+    db = Database(db_path)
+    db.add_folder(str(tracked_child))
+    db.close()
+
+    src = tmp_path / "card_wrap"
+    src.mkdir()
+    photo = src / "shot.jpg"
+    Image.new("RGB", (16, 16), "purple").save(photo)
+
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json={
+            "sources": [str(src)],
+            "destination": str(parent_dest),
+            "local_processing": True,
+            "folder_template": "%Y/%Y-%m-%d",
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        assert resp.status_code == 200
+        job = wait_for_job_via_client(c, resp.get_json()["job_id"])
+
+    # Job terminated — did not hang waiting for a scan that never runs.
+    assert job["status"] == "failed", job
+    error_text = " ".join([
+        str(job.get("error") or ""),
+        str(job.get("result", "")),
+        " ".join(str(s) for s in (job.get("steps") or [])),
+    ])
+    # The specific PREFLIGHT wording ("sits above") — distinct from the
+    # archive-step ``move_folder`` refusal ("Destination overlaps a folder
+    # Vireo already manages") — proves the storage-stage guard fired
+    # before staging, not the archive step at the very end after
+    # everything was processed.
+    assert "sits above" in error_text, error_text
+    assert str(tracked_child) in error_text, error_text
+
+    # Ingest never ran — no photo rows for the source file made it into
+    # the catalog. Without the preflight the pipeline would stage the
+    # file, scan it, and land a catalog row before failing at the archive
+    # move.
+    from db import Database as _Db
+    db2 = _Db(db_path)
+    try:
+        photo_count = db2.conn.execute(
+            "SELECT COUNT(*) c FROM photos"
+        ).fetchone()["c"]
+    finally:
+        db2.close()
+    assert photo_count == 0, photo_count
+
+    # Nothing was copied to the archive destination — the fresh parent
+    # dir stays empty (aside from the pre-existing tracked child dir).
+    landed = list(parent_dest.rglob("*.jpg"))
+    assert landed == [], landed
+
+
 def test_pipeline_merges_new_shoot_into_existing_archive(
     setup, tmp_path, monkeypatch
 ):

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -543,11 +543,26 @@ def test_pipeline_refuses_destination_that_wraps_tracked_subfolder(
 
     # Job terminated — did not hang waiting for a scan that never runs.
     assert job["status"] == "failed", job
-    error_text = " ".join([
-        str(job.get("error") or ""),
-        str(job.get("result", "")),
-        " ".join(str(s) for s in (job.get("steps") or [])),
-    ])
+
+    def _collect_strings(obj):
+        if isinstance(obj, str):
+            return [obj]
+        if isinstance(obj, dict):
+            out = []
+            for v in obj.values():
+                out.extend(_collect_strings(v))
+            return out
+        if isinstance(obj, (list, tuple)):
+            out = []
+            for v in obj:
+                out.extend(_collect_strings(v))
+            return out
+        return []
+
+    # Collect raw string field values (not ``str(dict)``) so Windows
+    # backslash paths compare cleanly — ``str({"error": "C:\\foo"})``
+    # doubles the backslashes via repr, defeating the substring check.
+    error_text = " ".join(_collect_strings(job))
     # The specific PREFLIGHT wording ("sits above") — distinct from the
     # archive-step ``move_folder`` refusal ("Destination overlaps a folder
     # Vireo already manages") — proves the storage-stage guard fired

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -306,41 +306,58 @@ def test_pipeline_local_processing_archives_to_final_destination(
     assert job["result"]["archive"]["final_destination"] == str(final_dest)
 
 
-def test_pipeline_local_processing_rejects_already_tracked_destination(
+def test_pipeline_local_processing_merges_into_tracked_destination(
     setup, tmp_path, monkeypatch
 ):
-    """Regression: a second local-processing import to a destination that
-    Vireo already manages must fail fast at the storage preflight. Without
-    the upfront check the pipeline would stage everything, complete every
-    processing step, and only fail in move_folder's tracked-overlap guard —
-    leaving the staged copy stranded under ~/.vireo/staging."""
+    """A second local-processing import whose archive destination IS an
+    already-managed folder MERGES into it instead of failing. The new files
+    land at the templated date subfolder under the existing base, the prior
+    shoot is untouched, and the catalog gains no duplicate folders.path row."""
     app, db_path = setup
 
     final_parent = tmp_path / "nas"
     final_parent.mkdir()
     final_dest = final_parent / "Photos"
+    final_dest.mkdir()
 
     import local_processing
     monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
     monkeypatch.setattr(local_processing, "RESERVED_FREE_BYTES", 0)
 
-    # Seed the catalog with a tracked folder at the prospective archive path,
-    # matching the post-state of an earlier successful local-processing run.
+    # Seed an existing managed archive: a prior shoot on disk + in the
+    # catalog, with the base linked to the active workspace as a root. This
+    # matches the post-state of an earlier successful local-processing run.
+    prior_dir = final_dest / "2025" / "2025-01-01"
+    prior_dir.mkdir(parents=True)
+    prior_file = prior_dir / "old.jpg"
+    Image.new("RGB", (16, 16), "green").save(prior_file)
+
     from db import Database
     db = Database(db_path)
-    db.add_folder(str(final_dest))
+    base_id = db.add_folder(str(final_dest))
+    prior_id = db.add_folder(
+        str(prior_dir), parent_id=base_id, workspace_root=False
+    )
+    db.add_photo(
+        prior_id, "old.jpg", ".jpg",
+        prior_file.stat().st_size, prior_file.stat().st_mtime,
+    )
     db.close()
 
+    # New shoot whose mtime puts it in a date subfolder not yet present.
     src = tmp_path / "card2"
     src.mkdir()
-    Image.new("RGB", (16, 16), "blue").save(src / "again.jpg")
+    new_file = src / "again.jpg"
+    Image.new("RGB", (16, 16), "blue").save(new_file)
+    new_mtime = datetime(2026, 6, 30, 12, 0, 0).timestamp()
+    os.utime(str(new_file), (new_mtime, new_mtime))
 
     with app.test_client() as c:
         resp = c.post("/api/jobs/pipeline", json={
             "sources": [str(src)],
             "destination": str(final_dest),
             "local_processing": True,
-            "folder_template": "",
+            "folder_template": "%Y/%Y-%m-%d",
             "skip_classify": True,
             "skip_extract_masks": True,
             "skip_regroup": True,
@@ -348,22 +365,55 @@ def test_pipeline_local_processing_rejects_already_tracked_destination(
         assert resp.status_code == 200
         job = wait_for_job_via_client(c, resp.get_json()["job_id"])
 
-    assert job["status"] == "failed", job
+    # Job merged successfully (no storage failure, no tracked-overlap error).
+    assert job["status"] == "completed", job
     error_text = (job.get("error") or "") + str(job.get("result", ""))
-    assert "Vireo already manages" in error_text, job
+    assert "Vireo already manages" not in error_text, job
+
+    # New file landed at the templated destination, merged alongside the
+    # pre-existing prior shoot which is untouched.
+    new_landed = final_dest / "2026" / "2026-06-30" / "again.jpg"
+    assert new_landed.is_file(), list(final_dest.rglob("*"))
+    assert prior_file.is_file()
+
+    # Merge breakdown surfaced on the archive payload.
+    merge = job["result"]["archive"]["merge"]
+    assert merge["new_photos"] >= 1, merge
+    assert merge["new_folders"] >= 1, merge
+
+    # No duplicate folders.path: exactly one row each for the base and the
+    # new leaf, and the new photo is attached under the new leaf.
+    db = Database(db_path)
+    try:
+        for path in (str(final_dest), str(final_dest / "2026" / "2026-06-30")):
+            rows = db.conn.execute(
+                "SELECT id FROM folders WHERE path = ?", (path,)
+            ).fetchall()
+            assert len(rows) == 1, (path, rows)
+        leaf_id = db.conn.execute(
+            "SELECT id FROM folders WHERE path = ?",
+            (str(final_dest / "2026" / "2026-06-30"),),
+        ).fetchone()["id"]
+        attached = db.conn.execute(
+            "SELECT filename FROM photos WHERE folder_id = ?", (leaf_id,)
+        ).fetchall()
+        assert {r["filename"] for r in attached} == {"again.jpg"}, attached
+        # Prior shoot row + photo untouched.
+        assert db.conn.execute(
+            "SELECT 1 FROM photos WHERE filename = ?", ("old.jpg",)
+        ).fetchone() is not None
+    finally:
+        db.close()
 
 
-def test_pipeline_local_processing_rejects_destination_inside_tracked_root(
+def test_pipeline_local_processing_merges_into_subfolder_of_tracked_root(
     setup, tmp_path, monkeypatch
 ):
-    """Regression: an archive destination INSIDE an already-tracked folder
-    (catalog manages /Photos and the user picks /Photos/NewShoot) must fail
-    fast at the storage preflight. db.move_folder_path only rewrites the
-    moved row's path — it does NOT reparent the row under the tracked
-    ancestor. Without this check the archive would succeed on disk but
-    leave the catalog with two unrelated workspace roots whose path strings
-    overlap (e.g. /Photos and /Photos/NewShoot), confusing the folder tree
-    and breaking future scans of the ancestor root."""
+    """An archive destination INSIDE an already-tracked folder (catalog
+    manages /Photos and the user picks /Photos/NewShoot) MERGES into the
+    existing managed tree instead of failing. The staged tree is rebased onto
+    the destination, parented under the tracked ancestor, with no duplicate
+    folders.path row and no stray second workspace root."""
     app, db_path = setup
 
     tracked_root = tmp_path / "nas_ancestor" / "Photos"
@@ -382,14 +432,17 @@ def test_pipeline_local_processing_rejects_destination_inside_tracked_root(
 
     src = tmp_path / "card_ancestor"
     src.mkdir()
-    Image.new("RGB", (16, 16), "red").save(src / "shot.jpg")
+    new_file = src / "shot.jpg"
+    Image.new("RGB", (16, 16), "red").save(new_file)
+    new_mtime = datetime(2026, 6, 30, 12, 0, 0).timestamp()
+    os.utime(str(new_file), (new_mtime, new_mtime))
 
     with app.test_client() as c:
         resp = c.post("/api/jobs/pipeline", json={
             "sources": [str(src)],
             "destination": str(final_dest),
             "local_processing": True,
-            "folder_template": "",
+            "folder_template": "%Y/%Y-%m-%d",
             "skip_classify": True,
             "skip_extract_masks": True,
             "skip_regroup": True,
@@ -397,12 +450,178 @@ def test_pipeline_local_processing_rejects_destination_inside_tracked_root(
         assert resp.status_code == 200
         job = wait_for_job_via_client(c, resp.get_json()["job_id"])
 
-    assert job["status"] == "failed", job
+    assert job["status"] == "completed", job
     error_text = (job.get("error") or "") + str(job.get("result", ""))
-    assert "is inside a folder Vireo already manages" in error_text, job
-    # The pipeline must NOT have archived anything: tracked_root still has
-    # no NewShoot subdirectory and the source files weren't published.
-    assert not final_dest.exists(), final_dest
+    assert "Vireo already manages" not in error_text, job
+
+    # New file landed at the templated destination INSIDE the tracked root.
+    landed = final_dest / "2026" / "2026-06-30" / "shot.jpg"
+    assert landed.is_file(), list(tracked_root.rglob("*"))
+
+    db = Database(db_path)
+    try:
+        # No duplicate folders.path for the leaf or the destination base.
+        for path in (str(final_dest),
+                     str(final_dest / "2026" / "2026-06-30")):
+            rows = db.conn.execute(
+                "SELECT id FROM folders WHERE path = ?", (path,)
+            ).fetchall()
+            assert len(rows) == 1, (path, rows)
+        # The tracked ancestor remains the single workspace root; the merged
+        # subtree is NOT a second root.
+        ws = db._active_workspace_id
+        root_paths = {
+            r["path"] for r in db.conn.execute(
+                """SELECT f.path FROM workspace_folders wf
+                   JOIN folders f ON f.id = wf.folder_id
+                   WHERE wf.workspace_id = ? AND wf.is_root = 1""",
+                (ws,),
+            )
+        }
+        assert str(tracked_root) in root_paths, root_paths
+        assert str(final_dest / "2026" / "2026-06-30") not in root_paths
+        # The new photo is queryable under the new leaf.
+        leaf_id = db.conn.execute(
+            "SELECT id FROM folders WHERE path = ?",
+            (str(final_dest / "2026" / "2026-06-30"),),
+        ).fetchone()["id"]
+        attached = db.conn.execute(
+            "SELECT filename FROM photos WHERE folder_id = ?", (leaf_id,)
+        ).fetchall()
+        assert {r["filename"] for r in attached} == {"shot.jpg"}, attached
+    finally:
+        db.close()
+
+
+def test_pipeline_merges_new_shoot_into_existing_archive(
+    setup, tmp_path, monkeypatch
+):
+    """End-to-end regression for the reported scenario: importing a brand-new
+    shoot into an already-managed archive base seamlessly merges. The prior
+    shoot's files and catalog rows stay untouched, the new files land at the
+    templated date subfolder, no duplicate folders.path is created, and the
+    new leaf is linked to the active workspace (queryable in it)."""
+    app, db_path = setup
+
+    archive_parent = tmp_path / "nas"
+    archive_parent.mkdir()
+    archive_base = archive_parent / "USA"
+    archive_base.mkdir()
+
+    import local_processing
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    monkeypatch.setattr(local_processing, "RESERVED_FREE_BYTES", 0)
+
+    # Existing tracked archive holding a prior shoot — real files on disk and
+    # catalog rows, base linked as a workspace root.
+    prior_dir = archive_base / "2025" / "2025-01-01"
+    prior_dir.mkdir(parents=True)
+    prior_a = prior_dir / "prior-1.jpg"
+    prior_b = prior_dir / "prior-2.jpg"
+    Image.new("RGB", (16, 16), "green").save(prior_a)
+    Image.new("RGB", (16, 16), "olive").save(prior_b)
+
+    from db import Database
+    db = Database(db_path)
+    base_id = db.add_folder(str(archive_base))
+    prior_id = db.add_folder(
+        str(prior_dir), parent_id=base_id, workspace_root=False
+    )
+    for f in (prior_a, prior_b):
+        db.add_photo(
+            prior_id, f.name, ".jpg",
+            f.stat().st_size, f.stat().st_mtime,
+        )
+    prior_photo_ids = {
+        r["id"] for r in db.conn.execute(
+            "SELECT id FROM photos WHERE folder_id = ?", (prior_id,)
+        )
+    }
+    db.close()
+
+    prior_a_bytes = prior_a.read_bytes()
+    prior_b_bytes = prior_b.read_bytes()
+
+    # Two NEW source files whose mtime produces a date subfolder NOT yet
+    # present in the archive.
+    src = tmp_path / "card"
+    src.mkdir()
+    new_a = src / "new-1.jpg"
+    new_b = src / "new-2.jpg"
+    Image.new("RGB", (16, 16), "blue").save(new_a)
+    Image.new("RGB", (16, 16), "navy").save(new_b)
+    new_mtime = datetime(2026, 6, 30, 9, 30, 0).timestamp()
+    for f in (new_a, new_b):
+        os.utime(str(f), (new_mtime, new_mtime))
+
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json={
+            "sources": [str(src)],
+            "destination": str(archive_base),
+            "local_processing": True,
+            "folder_template": "%Y/%Y-%m-%d",
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        assert resp.status_code == 200
+        job = wait_for_job_via_client(c, resp.get_json()["job_id"])
+
+    assert job["status"] == "completed", job
+
+    # New files landed at <base>/<year>/<date>/.
+    new_leaf = archive_base / "2026" / "2026-06-30"
+    assert (new_leaf / "new-1.jpg").is_file(), list(archive_base.rglob("*"))
+    assert (new_leaf / "new-2.jpg").is_file()
+
+    # Prior shoot files untouched on disk (same bytes, same paths).
+    assert prior_a.read_bytes() == prior_a_bytes
+    assert prior_b.read_bytes() == prior_b_bytes
+
+    db = Database(db_path)
+    try:
+        # No duplicate folders.path anywhere.
+        dup = db.conn.execute(
+            "SELECT path, COUNT(*) c FROM folders GROUP BY path HAVING c > 1"
+        ).fetchall()
+        assert dup == [], dup
+        # Exactly one row for the new leaf.
+        leaf_rows = db.conn.execute(
+            "SELECT id FROM folders WHERE path = ?", (str(new_leaf),)
+        ).fetchall()
+        assert len(leaf_rows) == 1, leaf_rows
+        leaf_id = leaf_rows[0]["id"]
+
+        # The new leaf is linked to the active workspace; new photos are
+        # queryable there.
+        ws = db._active_workspace_id
+        linked = db.conn.execute(
+            "SELECT is_root FROM workspace_folders "
+            "WHERE workspace_id = ? AND folder_id = ?",
+            (ws, leaf_id),
+        ).fetchone()
+        assert linked is not None, "new leaf not linked to workspace"
+        assert linked["is_root"] == 0, "new leaf should not be a root"
+        new_names = {
+            r["filename"] for r in db.conn.execute(
+                "SELECT filename FROM photos WHERE folder_id = ?", (leaf_id,)
+            )
+        }
+        assert new_names == {"new-1.jpg", "new-2.jpg"}, new_names
+
+        # Prior shoot rows untouched: same folder id, same photo ids.
+        prior_row = db.conn.execute(
+            "SELECT id FROM folders WHERE path = ?", (str(prior_dir),)
+        ).fetchone()
+        assert prior_row is not None and prior_row["id"] == prior_id
+        still = {
+            r["id"] for r in db.conn.execute(
+                "SELECT id FROM photos WHERE folder_id = ?", (prior_id,)
+            )
+        }
+        assert still == prior_photo_ids, (still, prior_photo_ids)
+    finally:
+        db.close()
 
 
 def test_pipeline_local_processing_creates_missing_archive_parent(

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -2153,6 +2153,113 @@ def test_destination_preview_rejects_absolute_template(setup, tmp_path):
         assert resp.status_code == 400
 
 
+def test_destination_preview_flags_managed_archive(setup, tmp_path):
+    """When the destination is an already-tracked Vireo folder, the preview
+    surfaces it as an existing managed archive with its catalog photo count,
+    so the UI can frame the import as a merge instead of a fresh copy."""
+    app, db_path = setup
+
+    # A real on-disk archive base that the catalog already manages, with a
+    # prior shoot under a date subfolder.
+    archive = tmp_path / "arch" / "USA"
+    prior = archive / "2025" / "2025-01-01"
+    prior.mkdir(parents=True)
+    p1 = prior / "old-1.jpg"
+    p2 = prior / "old-2.jpg"
+    Image.new("RGB", (16, 16), "green").save(p1)
+    Image.new("RGB", (16, 16), "olive").save(p2)
+
+    from db import Database
+    seed = Database(db_path)
+    base_id = seed.add_folder(str(archive))
+    prior_id = seed.add_folder(str(prior), parent_id=base_id, workspace_root=False)
+    for f in (p1, p2):
+        seed.add_photo(prior_id, f.name, ".jpg", f.stat().st_size, f.stat().st_mtime)
+    seed.close()
+
+    # A fresh source card whose files aren't in the archive yet.
+    src = tmp_path / "card"
+    src.mkdir()
+    new = src / "new.jpg"
+    Image.new("RGB", (16, 16), "blue").save(new)
+    mtime = datetime(2026, 6, 30, 9, 30, 0).timestamp()
+    os.utime(str(new), (mtime, mtime))
+
+    with app.test_client() as c:
+        resp = c.post("/api/import/destination-preview", json={
+            "sources": [str(src)],
+            "destination": str(archive),
+            "folder_template": "%Y/%Y-%m-%d",
+        })
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["managed_archive"] is not None
+        assert data["managed_archive"]["path"] == str(archive)
+        assert data["managed_archive"]["photo_count"] == 2
+
+
+def test_destination_preview_fresh_destination_has_no_managed_archive(setup, tmp_path):
+    """A destination that isn't at/inside any tracked folder reports no
+    managed archive, so the UI presents it as a fresh copy target."""
+    app, _ = setup
+    src = tmp_path / "card"
+    src.mkdir()
+    new = src / "new.jpg"
+    Image.new("RGB", (16, 16), "blue").save(new)
+    mtime = datetime(2026, 6, 30, 9, 30, 0).timestamp()
+    os.utime(str(new), (mtime, mtime))
+
+    with app.test_client() as c:
+        resp = c.post("/api/import/destination-preview", json={
+            "sources": [str(src)],
+            "destination": str(tmp_path / "fresh"),
+            "folder_template": "%Y/%Y-%m-%d",
+        })
+        assert resp.status_code == 200
+        assert resp.get_json()["managed_archive"] is None
+
+
+def test_destination_preview_inside_managed_archive_flags_ancestor(setup, tmp_path):
+    """A destination NESTED inside a tracked root surfaces the ancestor archive
+    (and its full photo count), not the nested path — so importing into a new
+    subfolder of a managed root is still flagged as a merge."""
+    app, db_path = setup
+
+    archive = tmp_path / "arch" / "USA"
+    prior = archive / "2025" / "2025-01-01"
+    prior.mkdir(parents=True)
+    p1 = prior / "old-1.jpg"
+    Image.new("RGB", (16, 16), "green").save(p1)
+
+    from db import Database
+    seed = Database(db_path)
+    base_id = seed.add_folder(str(archive))
+    prior_id = seed.add_folder(str(prior), parent_id=base_id, workspace_root=False)
+    seed.add_photo(prior_id, p1.name, ".jpg", p1.stat().st_size, p1.stat().st_mtime)
+    seed.close()
+
+    src = tmp_path / "card"
+    src.mkdir()
+    new = src / "new.jpg"
+    Image.new("RGB", (16, 16), "blue").save(new)
+    mtime = datetime(2026, 6, 30, 9, 30, 0).timestamp()
+    os.utime(str(new), (mtime, mtime))
+
+    nested = archive / "NewShoot"
+
+    with app.test_client() as c:
+        resp = c.post("/api/import/destination-preview", json={
+            "sources": [str(src)],
+            "destination": str(nested),
+            "folder_template": "%Y/%Y-%m-%d",
+        })
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["managed_archive"] is not None
+        assert data["managed_archive"]["path"] == str(archive)
+        assert data["managed_archive"]["photo_count"] == 1
+
+
 def _wait_for_job(client, job_id, timeout=30.0):
     """Poll the job-status endpoint until the job completes or fails."""
     deadline = time.time() + timeout


### PR DESCRIPTION
## Problem

A local-processing import whose archive destination was already a Vireo-managed folder failed the pipeline with a confusing message:

```
Pipeline failed
Archive destination /Volumes/Photography/Raw Files/USA overlaps a folder
Vireo already manages (/Volumes/Photography/Raw Files/USA). ...
```

The "X overlaps X" text reads as nonsense because the destination *is* the managed folder. But importing new shoots into an existing archive is the **expected** workflow — the archive is the system of record and shoots accrete into it (the same shape #1064 was built around). The storage preflight just hard-refused it.

## What this does

Importing into an already-managed archive now **seamlessly merges** instead of failing — for both "destination *is* a managed folder" and "destination *inside* a managed folder".

- **Guard relaxation (opt-in).** `move_folder` gains `allow_tracked_merge=False`; only the pipeline archive passes `True`. Manual folder-move UI and remote moves keep today's hard refusal.
- **Catalog reconciliation.** New `db.merge_staged_tree_into_archive` folds staged folder/photo rows into the existing archive: new subfolders reparent under the base, new dates fold into existing date-folders, identical-filename files are dropped in favor of the archived row, and the workspace is attached. FK-safe (clears `photo_keywords`, deferred deepest-first folder deletes) and downgrades staged leaves so no stray second workspace root is left inside the archive.
- **Pre-run transparency** (`CORE_PHILOSOPHY.md` "no black boxes"). The import dialog now flags *"Destination is an existing Vireo archive (path, N photos). New files will be merged in."* and reframes duplicates as *"N already in your library (will be skipped) / K new (will be merged)"*. (The duplicate check is catalog-global, matching ingest's global `skip_duplicates`, so the wording says "your library", not "this archive".)
- **Final summary** reports the merge breakdown: *"N new photos archived into existing archive <base> (A new folders, B merged into existing, C already present)"*.

## Safety — unchanged

The merge rides on top of `move_folder`'s existing file-copy safety, none of which was touched: rsync `--ignore-existing` (never overwrites), verify-every-source-present before any delete, content-conflict refusal (aborts with nothing copied/deleted), and catalog-updated-before-`rmtree`. Only *which destinations are allowed* and the *catalog step* changed.

## Tests

- **db unit:** new-subfolder reconciliation, existing-folder + identical-filename collision (incl. `photo_keywords` FK), `is_root` downgrade regression, count semantics.
- **move:** opt-in merge into a tracked destination, default-still-refuses regression, `moved` excludes `already_present`.
- **pipeline e2e:** flipped the two old hard-fail tests to assert merge success (overlap + ancestor), plus a new-shoot-into-existing-archive regression (the exact reported scenario).
- **preview endpoint:** `managed_archive` signal (overlap, fresh, ancestor, missing-status exclusion).
- **frontend e2e (Playwright):** callout render/hide + duplicate wording branches.

Full required suite: **1345 passed, 5 skipped** (serial); `ruff` clean. Known pre-existing xdist-only flakes (thumbnail/timeout) are unrelated.

## Follow-up (non-blocking)

`merge_staged_tree_into_archive` has a defensive `parent_id`-NULL fallback for a missing intermediate folder row; the scanner materializes intermediates so it's currently unreachable. Left as a noted follow-up rather than testing an impossible state.

Design + plan: `docs/plans/2026-06-30-merge-into-existing-archive-design.md`, `docs/plans/2026-06-30-merge-into-existing-archive.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local-processing imports can merge into an existing managed archive destination instead of failing on tracked overlaps.
  * Destination preview and the import UI now show a “managed archive” callout (archive path + photo count) and reword duplicate handling as “will be merged” vs “will be skipped.”
  * Pipeline reporting now includes merge-aware counts and summaries when merges occur.
* **Bug Fixes**
  * Improved reconciliation for overlapping/nested tracked destinations, including correct placement, collision handling, and consistent catalog updates.
  * Cached preview artifacts are cleaned up for items dropped during merge.
* **Tests**
  * Added/updated regression coverage for merge behavior and the managed-archive UI/payload wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->