### PR TITLE
Add "Rescan Folders" menu action (folder or whole workspace)

### DIFF
--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -66,6 +66,7 @@ pub mod ids {
 
     pub const TOOLS_RUN_PIPELINE: &str = "tools_run_pipeline";
     pub const TOOLS_SCAN_LIBRARY: &str = "tools_scan_library";
+    pub const TOOLS_RESCAN: &str = "tools_rescan";
     pub const TOOLS_FIND_DUPLICATES: &str = "tools_find_duplicates";
     pub const TOOLS_BUILD_PREVIEWS: &str = "tools_build_previews";
     pub const TOOLS_SYNC_METADATA: &str = "tools_sync_metadata";
@@ -145,6 +146,7 @@ pub fn command_for_id(id: &str) -> Option<&'static str> {
         ids::REVIEW_EXCLUDE_WILDLIFE => Some("review_exclude_wildlife"),
         ids::TOOLS_RUN_PIPELINE => Some("tools_run_pipeline"),
         ids::TOOLS_SCAN_LIBRARY => Some("tools_scan_library"),
+        ids::TOOLS_RESCAN => Some("tools_rescan"),
         ids::TOOLS_FIND_DUPLICATES => Some("tools_find_duplicates"),
         ids::TOOLS_BUILD_PREVIEWS => Some("tools_build_previews"),
         ids::TOOLS_SYNC_METADATA => Some("tools_sync_metadata"),
@@ -461,6 +463,7 @@ pub fn build_menu(app: &AppHandle) -> tauri::Result<tauri::menu::Menu<tauri::Wry
         .item(&MenuItemBuilder::with_id(ids::TOOLS_REVIEW_PIPELINE, "Review Pipeline Results").build(app)?)
         .separator()
         .item(&MenuItemBuilder::with_id(ids::TOOLS_SCAN_LIBRARY, "Scan Library...").build(app)?)
+        .item(&MenuItemBuilder::with_id(ids::TOOLS_RESCAN, "Rescan Folders...").build(app)?)
         .item(&MenuItemBuilder::with_id(ids::TOOLS_FIND_DUPLICATES, "Find Duplicates").build(app)?)
         .item(&MenuItemBuilder::with_id(ids::TOOLS_BUILD_PREVIEWS, "Build/Refresh Previews").build(app)?)
         .separator()

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2843,8 +2843,26 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         For each ghost row we report what cached/sidecar artifacts still exist
         (thumb, preview, working copy, XMP) so the user can decide whether
         anything is worth keeping before deleting the row.
+
+        Optional ``?folder_id=N`` scopes the check to that folder and its
+        descendants — the "rescan a specific folder" flow. The id must be
+        linked to the active workspace (same guard as folder rescan); an
+        unknown or foreign id returns 404 rather than silently widening to
+        the whole library.
         """
         db = _get_db()
+        folder_id = request.args.get("folder_id")
+        if folder_id is not None:
+            try:
+                folder_id = int(folder_id)
+            except (TypeError, ValueError):
+                return json_error("folder_id must be an integer")
+            linked = db.conn.execute(
+                "SELECT 1 FROM workspace_folders WHERE workspace_id = ? AND folder_id = ?",
+                (db._active_workspace_id, folder_id),
+            ).fetchone()
+            if not linked:
+                return json_error("folder not found", 404)
         thumb_dir = app.config["THUMB_CACHE_DIR"]
         vireo_dir = os.path.dirname(thumb_dir)
         preview_dir = os.path.join(vireo_dir, "previews")
@@ -2869,7 +2887,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             pass  # cache dir hasn't been created yet — no previews
 
         out = []
-        for row in db.get_missing_photos():
+        for row in db.get_missing_photos(folder_id=folder_id):
             pid = row["id"]
             src = os.path.join(row["folder_path"], row["filename"])
             stem, _ext = os.path.splitext(src)
@@ -12057,6 +12075,40 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             workspace_id=active_ws,
         )
         return jsonify({"job_id": job_id})
+
+    @app.route("/api/jobs/scan-workspace", methods=["POST"])
+    def api_job_scan_workspace():
+        """Queue an incremental scan across every root folder of the active
+        workspace.
+
+        Powers the "Rescan entire workspace" option. Roots that no longer
+        resolve on disk are skipped (they're surfaced separately by the
+        missing-folders flow) and reported back in ``skipped`` so the UI can
+        be honest about what actually ran. Returns 400 with a message when no
+        root is currently reachable, so the caller never shows "rescan
+        started" for a no-op.
+        """
+        body = request.get_json(silent=True) or {}
+        incremental = bool(body.get("incremental", True))
+        db = _get_db()
+        active_ws = db._active_workspace_id
+        roots = [r["path"] for r in db.get_workspace_folder_roots(active_ws)]
+        existing = [r for r in roots if os.path.isdir(r)]
+        skipped = [r for r in roots if not os.path.isdir(r)]
+        if not existing:
+            if roots:
+                return json_error("no workspace folders are currently on disk")
+            return json_error("this workspace has no folders to rescan")
+
+        runner = app._job_runner
+        work = _build_scan_work(existing, incremental, active_ws)
+        job_config = {"roots": existing, "incremental": incremental}
+        if len(existing) == 1:
+            job_config["root"] = existing[0]
+        job_id = runner.start(
+            "scan", work, config=job_config, workspace_id=active_ws,
+        )
+        return jsonify({"job_id": job_id, "roots": existing, "skipped": skipped})
 
     @app.route("/api/jobs/thumbnails", methods=["POST"])
     def api_job_thumbnails():

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2190,12 +2190,14 @@ class Database:
         ``'missing'`` — those are surfaced by ``get_missing_folders`` and
         listing them per-photo would just duplicate that signal at high cost.
 
-        When ``folder_id`` is given, the result is further restricted to that
-        folder and every folder beneath it in the tree (a recursive walk over
-        ``parent_id``). This backs the "rescan a specific folder" flow — the
-        user asked about one folder, so the deleted-original review must not
-        surface ghosts from unrelated parts of the library. ``None`` (the
-        default) keeps the whole-workspace behavior.
+        When ``folder_id`` is given, the result is further restricted to
+        that folder and every folder beneath it in the tree. This backs the
+        "rescan a specific folder" flow — the user asked about one folder,
+        so the deleted-original review must not surface ghosts from unrelated
+        parts of the library. Descendant discovery goes through
+        ``_folder_subtree_ids_by_path`` so legacy rows whose ``parent_id`` is
+        NULL still count as descendants of their path-prefixed root. ``None``
+        (the default) keeps the whole-workspace behavior.
 
         Folder DB ``status`` is updated asynchronously by a 10-minute health
         loop, so a freshly unmounted volume can still show ``status='ok'``
@@ -2213,20 +2215,16 @@ class Database:
         params = [self._ws_id()]
         subtree_clause = ""
         if folder_id is not None:
-            # Restrict to the folder subtree. The CTE seeds on the requested
-            # folder id and walks children via parent_id, so a photo in any
-            # descendant folder is included but nothing outside the branch is.
-            subtree_clause = """
-               AND f.id IN (
-                   WITH RECURSIVE subtree(id) AS (
-                       SELECT id FROM folders WHERE id = ?
-                       UNION ALL
-                       SELECT c.id FROM folders c
-                       JOIN subtree s ON c.parent_id = s.id
-                   )
-                   SELECT id FROM subtree
-               )"""
-            params.append(folder_id)
+            # Restrict to the folder subtree. Path-prefix expansion (the same
+            # helper used by add_workspace_folder etc.) covers legacy rows
+            # whose parent_id is NULL — a plain recursive walk over parent_id
+            # would silently drop those subfolders.
+            subtree_ids = self._folder_subtree_ids_by_path(folder_id)
+            if not subtree_ids:
+                return []
+            placeholders = ",".join("?" for _ in subtree_ids)
+            subtree_clause = f" AND f.id IN ({placeholders})"
+            params.extend(subtree_ids)
         rows = self.conn.execute(
             f"""SELECT p.id, p.filename, p.extension, p.file_size,
                       p.timestamp, p.working_copy_path,

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2222,9 +2222,27 @@ class Database:
             subtree_ids = self._folder_subtree_ids_by_path(folder_id)
             if not subtree_ids:
                 return []
-            placeholders = ",".join("?" for _ in subtree_ids)
-            subtree_clause = f" AND f.id IN ({placeholders})"
-            params.extend(subtree_ids)
+            if len(subtree_ids) <= _SQLITE_PARAM_CHUNK_SIZE:
+                placeholders = ",".join("?" for _ in subtree_ids)
+                subtree_clause = f" AND f.id IN ({placeholders})"
+                params.extend(subtree_ids)
+            else:
+                # A workspace root with thousands of descendant folders would
+                # overflow SQLITE_MAX_VARIABLE_NUMBER (999 on legacy builds)
+                # in a single IN(...) clause. Stage the ids in a
+                # connection-local temp table and join through that instead.
+                self.conn.execute(
+                    "CREATE TEMP TABLE IF NOT EXISTS missing_subtree_ids "
+                    "(id INTEGER PRIMARY KEY)"
+                )
+                self.conn.execute("DELETE FROM missing_subtree_ids")
+                self.conn.executemany(
+                    "INSERT OR IGNORE INTO missing_subtree_ids (id) VALUES (?)",
+                    [(i,) for i in subtree_ids],
+                )
+                subtree_clause = (
+                    " AND f.id IN (SELECT id FROM missing_subtree_ids)"
+                )
         rows = self.conn.execute(
             f"""SELECT p.id, p.filename, p.extension, p.file_size,
                       p.timestamp, p.working_copy_path,

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2183,12 +2183,19 @@ class Database:
             (self._ws_id(),),
         ).fetchall()
 
-    def get_missing_photos(self):
+    def get_missing_photos(self, folder_id=None):
         """Return photos whose source file is missing from disk.
 
         Scoped to the active workspace. Skips photos in folders flagged
         ``'missing'`` — those are surfaced by ``get_missing_folders`` and
         listing them per-photo would just duplicate that signal at high cost.
+
+        When ``folder_id`` is given, the result is further restricted to that
+        folder and every folder beneath it in the tree (a recursive walk over
+        ``parent_id``). This backs the "rescan a specific folder" flow — the
+        user asked about one folder, so the deleted-original review must not
+        surface ghosts from unrelated parts of the library. ``None`` (the
+        default) keeps the whole-workspace behavior.
 
         Folder DB ``status`` is updated asynchronously by a 10-minute health
         loop, so a freshly unmounted volume can still show ``status='ok'``
@@ -2203,16 +2210,33 @@ class Database:
         ``working_copy_path`` so the caller can render rich UI without
         joining again.
         """
+        params = [self._ws_id()]
+        subtree_clause = ""
+        if folder_id is not None:
+            # Restrict to the folder subtree. The CTE seeds on the requested
+            # folder id and walks children via parent_id, so a photo in any
+            # descendant folder is included but nothing outside the branch is.
+            subtree_clause = """
+               AND f.id IN (
+                   WITH RECURSIVE subtree(id) AS (
+                       SELECT id FROM folders WHERE id = ?
+                       UNION ALL
+                       SELECT c.id FROM folders c
+                       JOIN subtree s ON c.parent_id = s.id
+                   )
+                   SELECT id FROM subtree
+               )"""
+            params.append(folder_id)
         rows = self.conn.execute(
-            """SELECT p.id, p.filename, p.extension, p.file_size,
+            f"""SELECT p.id, p.filename, p.extension, p.file_size,
                       p.timestamp, p.working_copy_path,
                       f.id AS folder_id, f.path AS folder_path
                FROM photos p
                JOIN folders f ON p.folder_id = f.id
                JOIN workspace_folders wf ON wf.folder_id = f.id
-               WHERE wf.workspace_id = ? AND f.status != 'missing'
+               WHERE wf.workspace_id = ? AND f.status != 'missing'{subtree_clause}
                ORDER BY f.path, p.filename""",
-            (self._ws_id(),),
+            params,
         ).fetchall()
         # One readdir per folder instead of one stat per photo. On a 50k-photo
         # library across a network volume the per-photo `os.path.exists` was

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1738,6 +1738,7 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
       <div id="wsMenuList"></div>
       <div class="ws-menu-divider"></div>
       <button class="ws-menu-action" onclick="showCreateWorkspaceModal()">+ New Workspace</button>
+      <button class="ws-menu-action" onclick="openRescanModal()">⟳ Rescan folders…</button>
     </div>
   </div>
   <span class="nav-cmd-hint" title="Open command palette (⌘K)" onclick="openCommandPalette()">⌘K</span>
@@ -2091,6 +2092,7 @@ function sendReport() {
 <div class="modal-overlay" id="missingPhotosModal">
   <div class="modal" style="max-width:780px;width:92%;max-height:80vh;display:flex;flex-direction:column;">
     <h3>Missing Originals</h3>
+    <div id="missingPhotosScopeNote" style="display:none;font-size:12px;color:var(--accent);margin-bottom:6px;"></div>
     <p style="color:var(--text-secondary);font-size:13px;margin-bottom:8px;">
       These photos' original files can't be found on disk. Vireo may still have a cached thumbnail, preview, working copy, or XMP sidecar — review what's left, then remove the ones you no longer want in your library.
     </p>
@@ -2105,6 +2107,36 @@ function sendReport() {
       <button class="modal-btn danger" id="missingPhotosRemoveBtn" onclick="removeSelectedMissingPhotos()" disabled>Remove selected</button>
       <button class="modal-btn" onclick="loadMissingPhotos()">Check Again</button>
       <button class="modal-btn modal-btn-cancel" onclick="closeMissingPhotosModal()">Close</button>
+    </div>
+  </div>
+</div>
+
+<!-- Rescan Folders Modal -->
+<div class="modal-overlay" id="rescanModal">
+  <div class="modal" style="max-width:560px;width:90%;">
+    <h3>Rescan Folders</h3>
+    <p style="color:var(--text-secondary);font-size:13px;margin-bottom:12px;">
+      Re-reads your folders and reconciles Vireo with what's on disk: it picks up
+      photos added or changed outside Vireo, and finds photos whose original files
+      were deleted so you can remove them from your library.
+    </p>
+    <div style="display:flex;flex-direction:column;gap:10px;margin-bottom:14px;">
+      <label style="display:flex;align-items:center;gap:8px;cursor:pointer;">
+        <input type="radio" name="rescanScope" value="workspace" checked onchange="onRescanScopeChange()">
+        <span>Entire workspace <span style="color:var(--text-secondary);">— every folder in this workspace</span></span>
+      </label>
+      <label style="display:flex;align-items:center;gap:8px;cursor:pointer;">
+        <input type="radio" name="rescanScope" value="folder" onchange="onRescanScopeChange()">
+        <span>A specific folder</span>
+      </label>
+      <select id="rescanFolderSelect" style="margin-left:26px;max-width:100%;padding:6px 8px;" disabled></select>
+    </div>
+    <div id="rescanEmptyNote" style="display:none;color:var(--text-secondary);font-size:13px;margin-bottom:10px;">
+      This workspace has no folders yet. Add one from the Workspace page first.
+    </div>
+    <div class="modal-actions">
+      <button class="modal-btn" id="rescanRunBtn" onclick="runRescan()">Rescan</button>
+      <button class="modal-btn modal-btn-cancel" onclick="closeRescanModal()">Cancel</button>
     </div>
   </div>
 </div>
@@ -7861,6 +7893,10 @@ window.handleNativeMenuCommand = async function(command) {
         nativeMenuRoute('/workspace');
         nativeMenuInfo('Choose a folder or workspace root to scan.');
         break;
+      case 'tools_rescan':
+        if (typeof openRescanModal === 'function') openRescanModal();
+        else nativeMenuRoute('/workspace');
+        break;
       case 'tools_find_duplicates':
         if (typeof startScan === 'function') await startScan();
         else nativeMenuRoute('/duplicates');
@@ -9406,7 +9442,25 @@ async function startRemoveFolder(folderId, path, photoCount) {
 /* ---------- Missing Originals Modal ---------- */
 let _missingPhotosSelected = new Set();
 
-function openMissingPhotosModal() {
+// Scope for the Missing Originals modal. null folderId = whole workspace.
+// The banner poll (checkMissingPhotos) is always workspace-wide; only the
+// modal honors scope so a "rescan this folder" review can't offer to delete
+// ghosts from folders the user didn't ask about.
+let _missingPhotosScope = { folderId: null, label: '' };
+
+function openMissingPhotosModal(folderId, label) {
+  _missingPhotosScope = {
+    folderId: (folderId == null ? null : folderId),
+    label: label || '',
+  };
+  const note = document.getElementById('missingPhotosScopeNote');
+  if (_missingPhotosScope.folderId != null) {
+    note.textContent = 'Showing only: ' + (_missingPhotosScope.label || 'selected folder');
+    note.style.display = 'block';
+  } else {
+    note.style.display = 'none';
+    note.textContent = '';
+  }
   document.getElementById('missingPhotosDeleteSidecars').checked = true;
   document.getElementById('missingPhotosModal').classList.add('open');
   loadMissingPhotos();
@@ -9415,6 +9469,126 @@ function openMissingPhotosModal() {
 function closeMissingPhotosModal() {
   document.getElementById('missingPhotosModal').classList.remove('open');
   checkMissingPhotos();  // refresh banner
+}
+
+/* ---------- Rescan Folders ---------- */
+// Opens the Rescan modal. Scope defaults to the whole workspace; the folder
+// dropdown is populated from the active workspace's root folders.
+async function openRescanModal() {
+  // Close the workspace dropdown if this was triggered from its menu.
+  const wsMenu = document.getElementById('wsMenu');
+  if (wsMenu) wsMenu.classList.remove('open');
+  if (typeof _wsDropdownOpen !== 'undefined') { try { _wsDropdownOpen = false; } catch (e) {} }
+  const wsRadio = document.querySelector('input[name="rescanScope"][value="workspace"]');
+  const folderRadio = document.querySelector('input[name="rescanScope"][value="folder"]');
+  if (wsRadio) { wsRadio.checked = true; wsRadio.disabled = false; }
+  if (folderRadio) folderRadio.disabled = false;
+  const sel = document.getElementById('rescanFolderSelect');
+  sel.innerHTML = '';
+  sel.disabled = true;
+  const emptyNote = document.getElementById('rescanEmptyNote');
+  emptyNote.style.display = 'none';
+  document.getElementById('rescanRunBtn').disabled = false;
+  document.getElementById('rescanModal').classList.add('open');
+  try {
+    const active = await safeFetch('/api/workspaces/active', {}, { toast: false });
+    const folders = await safeFetch('/api/workspaces/' + active.id + '/folders', {}, { toast: false });
+    if (!folders || folders.length === 0) {
+      emptyNote.textContent = 'This workspace has no folders yet. Add one from the Workspace page first.';
+      emptyNote.style.display = 'block';
+      if (folderRadio) folderRadio.disabled = true;
+      return;
+    }
+    folders.forEach(function(f) {
+      const opt = document.createElement('option');
+      opt.value = f.id;
+      opt.textContent = f.name || f.path;
+      opt.title = f.path;
+      sel.appendChild(opt);
+    });
+  } catch (e) {
+    emptyNote.textContent = 'Could not load this workspace’s folders.';
+    emptyNote.style.display = 'block';
+    if (folderRadio) folderRadio.disabled = true;
+  }
+}
+window.openRescanModal = openRescanModal;
+
+function onRescanScopeChange() {
+  const scopeEl = document.querySelector('input[name="rescanScope"]:checked');
+  const isFolder = !!(scopeEl && scopeEl.value === 'folder');
+  document.getElementById('rescanFolderSelect').disabled = !isFolder;
+}
+
+function closeRescanModal() {
+  document.getElementById('rescanModal').classList.remove('open');
+}
+
+async function runRescan() {
+  const scopeEl = document.querySelector('input[name="rescanScope"]:checked');
+  const scope = scopeEl ? scopeEl.value : 'workspace';
+  const btn = document.getElementById('rescanRunBtn');
+  btn.disabled = true;
+  try {
+    if (scope === 'folder') {
+      const sel = document.getElementById('rescanFolderSelect');
+      const fid = parseInt(sel.value, 10);
+      if (isNaN(fid)) {
+        showToast('Pick a folder to rescan.', 'error');
+        btn.disabled = false;
+        return;
+      }
+      const label = sel.options[sel.selectedIndex]
+        ? sel.options[sel.selectedIndex].textContent : '';
+      await safeFetch('/api/folders/' + fid + '/rescan', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ incremental: true }),
+      });
+      closeRescanModal();
+      showToast('Rescanning “' + label + '” for new and changed photos…', 'info');
+      await reviewDeletedAfterRescan(fid, label);
+    } else {
+      const res = await safeFetch('/api/jobs/scan-workspace', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ incremental: true }),
+      });
+      closeRescanModal();
+      let msg = 'Rescanning the workspace for new and changed photos…';
+      if (res && res.skipped && res.skipped.length) {
+        const n = res.skipped.length;
+        msg += ' (' + n + ' offline folder' + (n === 1 ? '' : 's') + ' skipped)';
+      }
+      showToast(msg, 'info');
+      await reviewDeletedAfterRescan(null, '');
+    }
+  } catch (e) {
+    // safeFetch already surfaced the error; leave the modal open to retry.
+    btn.disabled = false;
+    return;
+  }
+  btn.disabled = false;
+}
+
+// The scan job (incremental) only adds/updates — it never removes rows for
+// files deleted on disk. So immediately after kicking it off, check for
+// missing originals in the same scope and open the review modal if any exist.
+async function reviewDeletedAfterRescan(folderId, label) {
+  try {
+    const url = folderId != null
+      ? '/api/photos/missing?folder_id=' + encodeURIComponent(folderId)
+      : '/api/photos/missing';
+    const photos = await safeFetch(url, {}, { toast: false });
+    if (photos && photos.length) {
+      openMissingPhotosModal(folderId, label);
+    } else {
+      showToast('No deleted photos found' + (label ? ' in “' + label + '”' : '') + '.', 'info');
+    }
+  } catch (e) {
+    // Non-fatal: the background scan still runs; the banner will catch
+    // deletions on its next poll.
+  }
 }
 
 function _escapeAttr(s) {
@@ -9431,12 +9605,18 @@ async function loadMissingPhotos() {
   const cacheId = ++_missingPhotosCacheFetchId;
   const myId = ++_missingPhotosModalFetchId;
   try {
-    const resp = await fetch('/api/photos/missing');
+    const scoped = _missingPhotosScope.folderId != null;
+    const url = scoped
+      ? '/api/photos/missing?folder_id=' + encodeURIComponent(_missingPhotosScope.folderId)
+      : '/api/photos/missing';
+    const resp = await fetch(url);
     if (!resp.ok) throw new Error('check failed');
     if (myId !== _missingPhotosModalFetchId) return;  // superseded by a newer modal load
     const photos = await resp.json();
     if (myId !== _missingPhotosModalFetchId) return;
-    if (cacheId === _missingPhotosCacheFetchId) _missingPhotosCache = photos;
+    // A folder-scoped load is a subset — don't overwrite the workspace-wide
+    // banner cache with it, or the banner's dismissed-count math goes stale.
+    if (!scoped && cacheId === _missingPhotosCacheFetchId) _missingPhotosCache = photos;
     if (photos.length === 0) {
       container.innerHTML = '<p style="color:var(--text-secondary);">No photos with missing originals.</p>';
       checkMissingPhotos();

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -9003,6 +9003,13 @@ setInterval(checkMissingFolders, 600000);
 
 /* ---------- Missing Originals Banner ---------- */
 let _missingPhotosCache = [];
+// Whatever rows the currently open Missing Originals modal is showing,
+// keyed by photo id. Populated by every modal load — including scoped
+// ones that intentionally skip _missingPhotosCache to keep the banner's
+// dismissed-count math honest — so sidecar cleanup can still look up
+// has_xmp_sidecar for a freshly discovered ghost that only exists in a
+// folder-scoped view.
+let _missingPhotosModalRows = new Map();
 let _missingPhotosBannerDismissedCount = 0;
 // Both the banner poll and the modal load hit /api/photos/missing and write
 // to _missingPhotosCache. A slow earlier fetch returning after a newer one
@@ -9617,6 +9624,9 @@ async function loadMissingPhotos() {
     // A folder-scoped load is a subset — don't overwrite the workspace-wide
     // banner cache with it, or the banner's dismissed-count math goes stale.
     if (!scoped && cacheId === _missingPhotosCacheFetchId) _missingPhotosCache = photos;
+    // Sidecar cleanup consults this map (see _deleteMissingPhotoIds) so a
+    // freshly discovered ghost in a scoped load still gets its .xmp removed.
+    _missingPhotosModalRows = new Map(photos.map(p => [p.id, p]));
     if (photos.length === 0) {
       container.innerHTML = '<p style="color:var(--text-secondary);">No photos with missing originals.</p>';
       checkMissingPhotos();
@@ -9709,9 +9719,20 @@ async function _deleteMissingPhotoIds(ids, deleteSidecars) {
   // sidecar paths from the photo row's folder + filename, so once the row
   // is gone the lookup returns nothing and the .xmp would be left behind.
   if (deleteSidecars) {
-    const sidecarIds = _missingPhotosCache
-      .filter(p => ids.includes(p.id) && p.has_xmp_sidecar)
-      .map(p => p.id);
+    // Prefer the modal's own rows: they cover ghosts that only appeared in
+    // a folder-scoped load and therefore aren't in the workspace-wide
+    // cache. Fall back to the cache for the removeOneMissingPhoto path
+    // when the modal isn't open.
+    const idSet = new Set(ids);
+    const seen = new Set();
+    const sidecarIds = [];
+    const consider = (p) => {
+      if (!p || seen.has(p.id)) return;
+      seen.add(p.id);
+      if (idSet.has(p.id) && p.has_xmp_sidecar) sidecarIds.push(p.id);
+    };
+    for (const id of ids) consider(_missingPhotosModalRows.get(id));
+    for (const p of _missingPhotosCache) consider(p);
     if (sidecarIds.length > 0) {
       await safeFetch('/api/photos/missing/delete-sidecars', {
         method: 'POST',

--- a/vireo/tests/test_rescan_scope.py
+++ b/vireo/tests/test_rescan_scope.py
@@ -68,6 +68,29 @@ def test_get_missing_photos_scope_includes_subtree(tmp_path):
     db.close()
 
 
+def test_get_missing_photos_scope_includes_legacy_null_parent_descendants(tmp_path):
+    """Legacy DBs can have descendant folders with parent_id=NULL.
+
+    A recursive walk over parent_id would silently skip them; the path-prefix
+    fallback (shared with _folder_subtree_ids_by_path) keeps the scoped
+    Missing Originals review honest on those older workspaces.
+    """
+    db = _db_with_active_ws(tmp_path)
+    root = tmp_path / "root"
+    root.mkdir()
+    sub = root / "sub"
+    sub.mkdir()
+    froot = db.add_folder(str(root), name="root")
+    # Simulate a legacy row: descendant path under root, but no parent_id link.
+    fsub = db.add_folder(str(sub), name="sub", parent_id=None)
+    ps = _add_photo_file(db, sub, fsub, "s1.jpg")
+
+    (sub / "s1.jpg").unlink()
+
+    assert [r["id"] for r in db.get_missing_photos(folder_id=froot)] == [ps]
+    db.close()
+
+
 # ---- App layer: /api/photos/missing?folder_id= and /api/jobs/scan-workspace
 
 @pytest.fixture

--- a/vireo/tests/test_rescan_scope.py
+++ b/vireo/tests/test_rescan_scope.py
@@ -1,0 +1,164 @@
+"""Tests for folder-scoped deleted-photo detection and workspace rescan.
+
+Backs the "Rescan folders" feature: the user can rescan a single folder or
+the whole workspace, and the deleted-original review must be scoped to match
+so a folder rescan never surfaces ghosts from unrelated folders.
+"""
+
+import os
+
+import pytest
+from db import Database
+
+
+def _db_with_active_ws(tmp_path):
+    db = Database(str(tmp_path / "test.db"))
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    return db
+
+
+def _add_photo_file(db, folder_dir, folder_id, name):
+    (folder_dir / name).write_bytes(b"jpegbytes")
+    return db.add_photo(
+        folder_id=folder_id, filename=name, extension=".jpg",
+        file_size=9, file_mtime=1.0,
+    )
+
+
+# ---- DB layer: get_missing_photos(folder_id=...) -------------------------
+
+def test_get_missing_photos_scoped_to_folder(tmp_path):
+    db = _db_with_active_ws(tmp_path)
+    a = tmp_path / "A"
+    a.mkdir()
+    b = tmp_path / "B"
+    b.mkdir()
+    fa = db.add_folder(str(a), name="A")
+    fb = db.add_folder(str(b), name="B")
+    pa = _add_photo_file(db, a, fa, "a1.jpg")
+    _add_photo_file(db, b, fb, "b1.jpg")
+
+    # Delete A's original outside Vireo -> it becomes a ghost.
+    (a / "a1.jpg").unlink()
+
+    # Whole-workspace check finds A's ghost.
+    assert [r["id"] for r in db.get_missing_photos()] == [pa]
+    # Scoped to B (whose file still exists) finds nothing.
+    assert db.get_missing_photos(folder_id=fb) == []
+    # Scoped to A finds only A's ghost.
+    assert [r["id"] for r in db.get_missing_photos(folder_id=fa)] == [pa]
+    db.close()
+
+
+def test_get_missing_photos_scope_includes_subtree(tmp_path):
+    db = _db_with_active_ws(tmp_path)
+    root = tmp_path / "root"
+    root.mkdir()
+    sub = root / "sub"
+    sub.mkdir()
+    froot = db.add_folder(str(root), name="root")
+    fsub = db.add_folder(str(sub), name="sub", parent_id=froot)
+    ps = _add_photo_file(db, sub, fsub, "s1.jpg")
+
+    (sub / "s1.jpg").unlink()
+
+    # Scoping by the root catches ghosts in descendant folders too.
+    assert [r["id"] for r in db.get_missing_photos(folder_id=froot)] == [ps]
+    db.close()
+
+
+# ---- App layer: /api/photos/missing?folder_id= and /api/jobs/scan-workspace
+
+@pytest.fixture
+def app_with_real_folders(tmp_path, monkeypatch):
+    """create_app backed by two on-disk workspace root folders."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import config as cfg
+    import models
+    from app import create_app
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setattr(models, "DEFAULT_MODELS_DIR", str(tmp_path / "vireo-models"))
+    monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
+
+    db_path = str(tmp_path / "test.db")
+    thumb_dir = str(tmp_path / "thumbs")
+    os.makedirs(thumb_dir)
+
+    db = Database(db_path)
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+
+    a = tmp_path / "A"
+    a.mkdir()
+    b = tmp_path / "B"
+    b.mkdir()
+    fa = db.add_folder(str(a), name="A")
+    fb = db.add_folder(str(b), name="B")
+    pa = _add_photo_file(db, a, fa, "a1.jpg")
+    _add_photo_file(db, b, fb, "b1.jpg")
+    (a / "a1.jpg").unlink()  # A's original is gone
+
+    app = create_app(db_path=db_path, thumb_cache_dir=thumb_dir, api_token="t")
+    yield app, db, {"fa": fa, "fb": fb, "pa": pa}
+    db.close()
+
+
+def test_missing_endpoint_scoped_by_folder(app_with_real_folders):
+    app, _db, ids = app_with_real_folders
+    client = app.test_client()
+
+    # Whole-workspace: the one ghost.
+    allm = client.get("/api/photos/missing").get_json()
+    assert [p["id"] for p in allm] == [ids["pa"]]
+
+    # Scoped to A: the ghost.
+    scoped_a = client.get(f"/api/photos/missing?folder_id={ids['fa']}").get_json()
+    assert [p["id"] for p in scoped_a] == [ids["pa"]]
+
+    # Scoped to B: empty.
+    scoped_b = client.get(f"/api/photos/missing?folder_id={ids['fb']}").get_json()
+    assert scoped_b == []
+
+
+def test_missing_endpoint_rejects_unknown_folder(app_with_real_folders):
+    app, _db, _ids = app_with_real_folders
+    client = app.test_client()
+    assert client.get("/api/photos/missing?folder_id=999999").status_code == 404
+    assert client.get("/api/photos/missing?folder_id=abc").status_code == 400
+
+
+def test_scan_workspace_queues_job(app_with_real_folders):
+    app, _db, _ids = app_with_real_folders
+    client = app.test_client()
+    resp = client.post("/api/jobs/scan-workspace", json={})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["job_id"]
+    # Both real roots scheduled; none skipped.
+    assert len(data["roots"]) == 2
+    assert data["skipped"] == []
+
+
+def test_scan_workspace_empty_workspace(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import config as cfg
+    import models
+    from app import create_app
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setattr(models, "DEFAULT_MODELS_DIR", str(tmp_path / "vireo-models"))
+    monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
+
+    db_path = str(tmp_path / "test.db")
+    thumb_dir = str(tmp_path / "thumbs")
+    os.makedirs(thumb_dir)
+    db = Database(db_path)
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    app = create_app(db_path=db_path, thumb_cache_dir=thumb_dir, api_token="t")
+
+    resp = app.test_client().post("/api/jobs/scan-workspace", json={})
+    assert resp.status_code == 400
+    db.close()

--- a/vireo/tests/test_rescan_scope.py
+++ b/vireo/tests/test_rescan_scope.py
@@ -68,6 +68,39 @@ def test_get_missing_photos_scope_includes_subtree(tmp_path):
     db.close()
 
 
+def test_get_missing_photos_scope_uses_temp_table_over_variable_cap(tmp_path, monkeypatch):
+    """Large workspace roots must not overflow SQLITE_MAX_VARIABLE_NUMBER.
+
+    Legacy SQLite builds cap bound-variable count at 999. A workspace root
+    with thousands of descendant folders would blow past that in a single
+    IN(...) clause; the scoped Missing Originals query stages the ids in a
+    connection-local temp table once the subtree exceeds the chunk size.
+    Force the chunk size down to a handful and verify the query still
+    returns the right ghosts via the temp-table branch.
+    """
+    import db as db_module
+
+    monkeypatch.setattr(db_module, "_SQLITE_PARAM_CHUNK_SIZE", 3)
+
+    db = _db_with_active_ws(tmp_path)
+    root = tmp_path / "root"
+    root.mkdir()
+    froot = db.add_folder(str(root), name="root")
+    ghost_ids = []
+    # Enough subfolders to exceed the patched chunk size several times over.
+    for i in range(10):
+        sub = root / f"sub{i}"
+        sub.mkdir()
+        fsub = db.add_folder(str(sub), name=f"sub{i}", parent_id=froot)
+        pid = _add_photo_file(db, sub, fsub, f"g{i}.jpg")
+        (sub / f"g{i}.jpg").unlink()
+        ghost_ids.append(pid)
+
+    got = sorted(r["id"] for r in db.get_missing_photos(folder_id=froot))
+    assert got == sorted(ghost_ids)
+    db.close()
+
+
 def test_get_missing_photos_scope_includes_legacy_null_parent_descendants(tmp_path):
     """Legacy DBs can have descendant folders with parent_id=NULL.
 


### PR DESCRIPTION
## What & why

Adds a discoverable way to reconcile Vireo with what's on disk after photos are **added or deleted outside the app**. Motivated by: *"if I delete a bunch of photos outside Vireo, how do I ask it to rescan that folder?"*

Key insight this addresses: a scan only ever **adds/updates** rows — it never prunes originals deleted on disk (that's the separate *Missing Originals* flow, previously only reachable via a banner that re-checks every 30 min). So a plain "rescan" wouldn't catch deletions. This ties both halves — new/changed **and** deleted — behind one honest **Rescan** action.

## How to use

Open **Rescan folders…** from either "dropdown at the top":
- **Workspace switcher dropdown** — `⟳ Rescan folders…` (works in browser *and* desktop).
- **Native Tools menu** → *Rescan Folders…* (desktop; cross-platform Tauri).

Pick scope — **entire workspace** or **a specific folder**. Running it starts an incremental scan for new/changed photos, then checks the same scope for deleted originals and opens the *Missing Originals* review (scoped, with a "Showing only: <folder>" note) so you can remove the ghosts. If none are deleted, you get a toast instead.

## Changes

**Backend**
- `db.get_missing_photos(folder_id=…)` — scopes to a folder subtree via a recursive CTE on `parent_id`.
- `GET /api/photos/missing?folder_id=` — workspace-link validated (404 unknown / 400 invalid id).
- `POST /api/jobs/scan-workspace` — scans all reachable workspace roots, reports any offline roots it `skipped`, 400s when there's nothing to scan.

**Frontend / native**
- Rescan modal + scoped Missing Originals modal in `_navbar.html`.
- Workspace-dropdown action + native Tools menu item (`src-tauri/src/menu.rs`).

**Tests** — `vireo/tests/test_rescan_scope.py`: folder scoping incl. subtree, endpoint validation, scan-workspace queueing, empty-workspace 400.

## Verification
- Full Python suite: **1168 passed, 1 pre-existing skip**.
- Live endpoint checks + a **Playwright end-to-end run** of the modal flow (dropdown → modal → folder-scoped review shows only the right ghost; workspace scope unscoped) — no JS console errors.

## Notes
- The desktop **Tools menu** item appears after a Tauri rebuild; the **workspace-dropdown** entry works immediately in the browser. (`cargo check` couldn't run in this environment — it fails on a pre-existing missing bundled sidecar under `src-tauri/binaries/`, before reaching the 3-line menu change, which is pattern-identical to the adjacent `TOOLS_SCAN_LIBRARY` lines.)
- The folder picker lists workspace **root** folders; picking a root rescans its whole subtree. Arbitrary sub-folders remain available via the sidebar right-click "Rescan this Folder."

🤖 Generated with [Claude Code](https://claude.com/claude-code)