### PR TITLE
Add "Add to Life List" to the lightbox and browse right-click menu

### DIFF
--- a/docs/plans/2026-06-30-lifelist-add-photo-design.md
+++ b/docs/plans/2026-06-30-lifelist-add-photo-design.md
@@ -1,0 +1,120 @@
+# Easier "Add to Life List" — design
+
+**Date:** 2026-06-30
+**Branch:** `lifelist-add-photo`
+
+## Problem
+
+The only way to choose which photo represents a species in the life list is:
+open `/life-list` → click a species card → the lightbox opens → find the shot →
+click "Use as Life List". The action lives only on the life-list page, so
+crowning a lifer means detouring away from wherever you were actually looking at
+photos.
+
+Note: a photo is never "added to the life list" directly. Any photo tagged with a
+species keyword (`is_species = 1` or `type = 'taxonomy'`) is automatically in the
+list. The only manual choice is **which photo represents each species** — stored
+in `photo_preferences` (`purpose = 'life_list'`, keyed by workspace + purpose +
+species).
+
+## Goal
+
+Bring the "choose the representative photo" action to where the user already is:
+
+1. The **shared lightbox** (works on every page via `_navbar.html`).
+2. The **browse right-click context menu**.
+
+Chosen wording: **"Add to Life List"** (matches how the user phrases it), flipping
+to a selected **"★ Life List photo"** state once the shot is the representative, so
+the control still reflects real current state.
+
+## Section 1 — Backend: `life_list` block on `GET /api/photos/{id}`
+
+Add a `life_list` array to the existing per-photo payload the lightbox already
+fetches:
+
+```json
+"life_list": [
+  { "species": "American Robin", "is_current_photo": false },
+  { "species": "Blue Jay",       "is_current_photo": true  }
+]
+```
+
+- **Eligible species** = the photo's keywords matching `is_species = 1 OR
+  type = 'taxonomy'` — the exact rule `get_life_list_candidates` uses — intersected
+  with the active workspace's visible folders (`workspace_folders`). A species in a
+  folder not visible to the active workspace is not in this workspace's list, so it
+  does not appear.
+- **`is_current_photo`** = a `photo_preferences` row exists with
+  `purpose = 'life_list'`, that species, and this `photo_id`.
+- Empty array → no lifelist affordance anywhere for this photo.
+
+Build this from the same eligibility SQL as the list itself so the button and the
+list can't drift on "what counts as a species." One source of truth on the backend,
+not reimplemented in JS on two pages.
+
+## Section 2 — Lightbox action (everywhere)
+
+Move the panel out of `life_list.html` into the shared lightbox in `_navbar.html`,
+driven by the new `life_list` block (not page-local data). Hook the existing
+`lightbox:photochanged` event; append to `#lightboxActions` (same insertion point
+used today).
+
+Behavior, per the current photo's `life_list` array:
+
+- **0 species** → panel hidden.
+- **1 species**, `is_current_photo` false → **"Add to Life List — American Robin"**
+  (primary). True → **"★ Life List photo — American Robin"** (selected/inert).
+- **2+ species** → one row per species, each with its own button + state.
+
+Click → `POST /api/photo-preferences` (`purpose: 'life_list'`, that species, this
+photo) → re-read state → `showToast('Life List photo set for American Robin',
+'success')`.
+
+Then delete the duplicated panel code from `life_list.html`; the life-list page
+keeps working because it uses the same shared lightbox.
+
+## Section 3 — Browse right-click context menu
+
+Add an entry to `buildPhotoContextMenu(photoIds)` in `browse.html`. The local
+`photos` array already carries `species` names per card, so no fetch is needed:
+
+- **Single photo, 0 species** → item hidden.
+- **Single photo, 1 species** → **"Add to Life List — American Robin"**.
+- **Single photo, 2+ species** → parent **"Add to Life List ▸"** with one child per
+  species; if the shared context menu has no submenu support, fall back to one flat
+  item per species. Confirm against the renderer during implementation.
+- **Multi-selection (2+ photos)** → disabled, hint **"Select a single photo"**
+  (matches how "Find Similar" / "View on Map" disable for multi-select).
+
+Fire-and-forget: the menu performs the set and toasts. It does **not** show a ★
+"already the photo" state (the local array lacks that fact, and fetching per
+right-click would delay menu open). The lightbox remains the surface that shows
+current state. Server-side `_photo_can_be_preference` is the backstop against a
+stale menu setting an invalid photo/species pair.
+
+## Section 4 — Testing
+
+**Backend** (`vireo/tests/test_photos_api.py` / `test_app.py`):
+
+- one species keyword → one entry, `is_current_photo` false;
+- after `POST /api/photo-preferences` → that entry flips to true;
+- species keyword in a folder not visible to the active workspace → empty;
+- plain non-species keyword → empty;
+- two species → two entries with independent `is_current_photo`.
+
+**Regression:** keep `_photo_can_be_preference` validation test green after moving
+the panel; it rejects photo/species mismatches so a stale UI can't set an invalid
+pair.
+
+**Frontend (manual, real browser):** lightbox button on a non-life-list page;
+multi-species shows multiple rows; crowning updates the ★ state and the `/life-list`
+grid; right-click single/multi/zero-species behaves; `/life-list` page still works
+after its duplicated panel code is removed.
+
+## Out of scope (YAGNI)
+
+- Tagging a photo with a *new* species from these surfaces (that's the identify/
+  keyword flow, not this change).
+- Unsetting / clearing a representative (no such affordance exists today).
+- A ★ current-state indicator inside the browse context menu.

--- a/tests/e2e/test_lifelist_add_verify.py
+++ b/tests/e2e/test_lifelist_add_verify.py
@@ -1,0 +1,90 @@
+"""E2E verification for the "Add to Life List" surfaces (lightbox + browse menu).
+
+Seed (from conftest.seed_e2e_data): photos[0]=hawk1 tagged "Red-tailed Hawk",
+photos[3]=robin1 tagged "American Robin"; the other three carry predictions but
+no accepted species keyword, so they are the zero-species cases.
+"""
+import re
+
+from playwright.sync_api import expect
+
+
+def test_browse_menu_add_to_life_list_sets_representative(live_server, page):
+    url = live_server["url"]
+    hawk = live_server["data"]["photos"][0]
+    page.goto(f"{url}/browse")
+
+    card = page.locator(f'.grid-card[data-id="{hawk}"]')
+    card.wait_for(state="visible")
+    card.click(button="right")
+
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+    item = menu.locator(".vireo-ctx-item", has_text="Add to Life List — Red-tailed Hawk")
+    expect(item).to_be_visible()
+    item.click()
+
+    # End-to-end: the click hit the real API and set THIS photo as the rep.
+    life_list = page.evaluate(
+        """async (pid) => {
+            const r = await fetch('/api/photos/' + pid);
+            const d = await r.json();
+            return d.life_list;
+        }""",
+        hawk,
+    )
+    assert life_list == [{"species": "Red-tailed Hawk", "is_current_photo": True}], life_list
+
+
+def test_browse_menu_hidden_for_photo_without_species(live_server, page):
+    url = live_server["url"]
+    no_species = live_server["data"]["photos"][1]  # hawk2 — no accepted keyword
+    page.goto(f"{url}/browse")
+
+    card = page.locator(f'.grid-card[data-id="{no_species}"]')
+    card.wait_for(state="visible")
+    card.click(button="right")
+
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+    expect(menu.locator(".vireo-ctx-item", has_text="Add to Life List")).to_have_count(0)
+
+
+def test_browse_menu_disabled_for_multi_select(live_server, page):
+    url = live_server["url"]
+    hawk = live_server["data"]["photos"][0]
+    other = live_server["data"]["photos"][1]
+    page.goto(f"{url}/browse")
+
+    hawk_card = page.locator(f'.grid-card[data-id="{hawk}"]')
+    hawk_card.wait_for(state="visible")
+    hawk_card.click(modifiers=["Meta"])
+    page.locator(f'.grid-card[data-id="{other}"]').click(modifiers=["Meta"])
+    assert page.evaluate("selectedPhotos.size") == 2
+
+    hawk_card.click(button="right")
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+    item = menu.locator(".vireo-ctx-item", has_text="Add to Life List")
+    expect(item).to_be_visible()
+    assert "vireo-ctx-disabled" in (item.get_attribute("class") or "")
+    assert item.get_attribute("title") == "Select a single photo"
+
+
+def test_lightbox_panel_add_and_flip_to_selected(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/life-list")
+
+    card = page.locator(".species-card").first
+    card.wait_for(state="visible")
+    card.click()
+
+    panel = page.locator("#lifeListLightboxPanel")
+    expect(panel).to_be_visible()
+    add_btn = panel.locator("button", has_text="Add to Life List")
+    expect(add_btn).to_be_visible()
+    add_btn.click()
+
+    selected = panel.locator("button", has_text="Life List photo")
+    expect(selected).to_be_visible()
+    assert re.search(r"\bprimary\b", selected.get_attribute("class") or "")

--- a/tests/e2e/test_lifelist_add_verify.py
+++ b/tests/e2e/test_lifelist_add_verify.py
@@ -22,7 +22,14 @@ def test_browse_menu_add_to_life_list_sets_representative(live_server, page):
     expect(menu).to_be_visible()
     item = menu.locator(".vireo-ctx-item", has_text="Add to Life List — Red-tailed Hawk")
     expect(item).to_be_visible()
-    item.click()
+
+    # The menu handler is fire-and-forget (safeFetch(...).then(...)); wait for
+    # the POST to settle before reading state, or the /api/photos read races
+    # the write and intermittently sees is_current_photo: false.
+    with page.expect_response(
+        lambda r: "/api/photo-preferences" in r.url and r.status == 200
+    ):
+        item.click()
 
     # End-to-end: the click hit the real API and set THIS photo as the rep.
     life_list = page.evaluate(

--- a/tests/e2e/test_lifelist_add_verify.py
+++ b/tests/e2e/test_lifelist_add_verify.py
@@ -50,6 +50,38 @@ def test_browse_menu_hidden_for_photo_without_species(live_server, page):
     expect(menu.locator(".vireo-ctx-item", has_text="Add to Life List")).to_have_count(0)
 
 
+def test_browse_menu_hidden_for_rejected_photo(live_server, page):
+    """A species-tagged photo that has been rejected must not surface an
+    "Add to Life List" menu item — the server backstop
+    (_photo_can_be_life_list_preference) rejects flag='rejected', so offering
+    it in the menu would only ever produce an error toast."""
+    url = live_server["url"]
+    hawk = live_server["data"]["photos"][0]
+    page.goto(f"{url}/browse")
+
+    # Flag the species-tagged hawk photo as rejected via the same API the
+    # browse UI uses, then reload so the local `photos` array reflects it.
+    page.evaluate(
+        """async (pid) => {
+            await fetch('/api/batch/flag', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ photo_ids: [pid], flag: 'rejected' }),
+            });
+        }""",
+        hawk,
+    )
+    page.reload()
+
+    card = page.locator(f'.grid-card[data-id="{hawk}"]')
+    card.wait_for(state="visible")
+    card.click(button="right")
+
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+    expect(menu.locator(".vireo-ctx-item", has_text="Add to Life List")).to_have_count(0)
+
+
 def test_browse_menu_disabled_for_multi_select(live_server, page):
     url = live_server["url"]
     hawk = live_server["data"]["photos"][0]

--- a/tests/e2e/test_lifelist_add_verify.py
+++ b/tests/e2e/test_lifelist_add_verify.py
@@ -120,3 +120,27 @@ def test_lightbox_panel_add_and_flip_to_selected(live_server, page):
     selected = panel.locator("button", has_text="Life List photo")
     expect(selected).to_be_visible()
     assert re.search(r"\bprimary\b", selected.get_attribute("class") or "")
+
+
+def test_lightbox_panel_hides_after_current_photo_rejected(live_server, page):
+    """When the currently-open photo is rejected via lightbox flag controls,
+    _photo_can_be_life_list_preference stops accepting it on the server. The
+    panel must refresh so "Add to Life List" stops offering clicks that would
+    be guaranteed 4xxs."""
+    url = live_server["url"]
+    page.goto(f"{url}/life-list")
+
+    card = page.locator(".species-card").first
+    card.wait_for(state="visible")
+    card.click()
+
+    panel = page.locator("#lifeListLightboxPanel")
+    expect(panel).to_be_visible()
+    expect(panel.locator("button", has_text="Add to Life List")).to_be_visible()
+
+    # Reject via the same code path the lightbox flag chips call.
+    page.evaluate("() => _lbApplyFlag(_lightboxCurrentId, 'rejected')")
+
+    # After the flag write settles and the listener refetches, the panel
+    # should hide (backend returns empty life_list for rejected photos).
+    expect(panel).to_be_hidden()

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3222,6 +3222,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         keywords = db.get_photo_keywords(photo_id)
         result["keywords"] = [dict(k) for k in keywords]
 
+        # Life-list block: the photo's eligible species plus whether this photo
+        # is the current representative for each, so the shared lightbox and
+        # browse context menu can offer "Add to Life List" and show the honest
+        # selected state without page-local data. Empty when the photo has no
+        # lifelist species (built from the same eligibility rule as the list).
+        life_list_prefs = db.get_photo_preferences("life_list")
+        result["life_list"] = [
+            {"species": s, "is_current_photo": life_list_prefs.get(s) == photo_id}
+            for s in db.get_photo_life_list_species(photo_id)
+        ]
+
         # Location section: pre-resolved leaf + parent chain so the photo
         # detail panel can render the filled state without a second roundtrip.
         result["location"] = _serialize_photo_location(db, photo_id)

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -7949,6 +7949,35 @@ class Database:
             (ws,),
         ).fetchall()
 
+    def get_photo_life_list_species(self, photo_id):
+        """Return this photo's lifelist-eligible species names in the active
+        workspace, ordered by name.
+
+        Same eligibility rule as :meth:`get_life_list_candidates`: an accepted
+        species keyword (``is_species = 1`` or ``type = 'taxonomy'``) on a
+        non-rejected photo in a workspace-visible folder. Returns ``[]`` when
+        the photo carries no such species (or is rejected / outside the
+        workspace), which is exactly when no "Add to Life List" affordance
+        should appear.
+        """
+        ws = self._ws_id()
+        rows = self.conn.execute(
+            """SELECT DISTINCT k.name AS species
+               FROM photo_keywords pk
+               JOIN keywords k ON k.id = pk.keyword_id
+                AND (k.is_species = 1 OR k.type = 'taxonomy')
+               JOIN photos p ON p.id = pk.photo_id
+                AND COALESCE(p.flag, 'none') != 'rejected'
+               JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+                AND wf.workspace_id = ?
+               JOIN folders f ON f.id = p.folder_id
+                AND f.status IN ('ok', 'partial')
+               WHERE pk.photo_id = ?
+               ORDER BY k.name""",
+            (ws, photo_id),
+        ).fetchall()
+        return [r["species"] for r in rows]
+
     def get_life_list_locations(self):
         """Return {species name: [location keyword names]} for the life list.
 

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3469,6 +3469,23 @@ document.addEventListener('lightbox:photochanged', function(event) {
   if (pid != null) _lbRenderLifeListPanel(pid);
 });
 
+// A photo's flag decides its life-list eligibility (a rejected photo can't be a
+// Life List photo, per _photo_can_be_life_list_preference). The cached
+// `life_list` block goes stale the moment the user changes the flag from the
+// lightbox, so re-fetch it and re-render — this hides the panel when the photo
+// becomes rejected and re-shows it when the flag is cleared again.
+document.addEventListener('lightbox:flagchanged', async function(event) {
+  var pid = event.detail ? event.detail.photoId : null;
+  if (pid == null || _lightboxCurrentId !== pid) return;
+  try {
+    var fresh = await window.safeFetch('/api/photos/' + pid, {}, { toast: false });
+    // Guard against a stale fetch clobbering the panel after navigation.
+    if (!fresh || _lightboxCurrentId !== pid) return;
+    _lbPhotoDataByPhoto[String(pid)] = fresh;
+    _lbRenderLifeListPanel(pid);
+  } catch (e) { /* leave the last-rendered panel in place if the refresh fails */ }
+});
+
 var _lbEditRecipe = null;
 var _lbEditRecipeLoaded = false;
 var _lbRenderedAdjustmentValues = null;

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -543,6 +543,13 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
 }
+.lifelist-lb-panel { display:flex; flex-direction:column; gap:6px; align-items:stretch; padding:4px 8px; border-radius:4px; background:rgba(12,14,16,0.88); border:1px solid rgba(255,255,255,0.42); color:#f4f7f8; font-size:12px; font-weight:650; text-shadow:0 1px 1px rgba(0,0,0,0.75); }
+.lifelist-lb-row { display:flex; align-items:center; gap:8px; justify-content:space-between; }
+.lifelist-lb-row .lifelist-lb-species { white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:180px; }
+.lifelist-lb-panel button { min-height:24px; border:1px solid rgba(255,255,255,0.42); background:rgba(255,255,255,0.12); color:#fff; border-radius:4px; padding:4px 9px; cursor:pointer; font-size:12px; font-weight:650; }
+.lifelist-lb-panel button:hover { background:rgba(255,255,255,0.2); border-color:rgba(255,255,255,0.72); }
+.lifelist-lb-panel button:disabled { cursor:default; }
+.lifelist-lb-panel button.primary { border-color:rgba(255,224,102,0.84); color:#ffe066; background:rgba(255,224,102,0.10); }
 .lightbox-adjust-panel {
   display: none;
   position: absolute;
@@ -3371,6 +3378,97 @@ var _lbEditRecipeWriteSeq = 0;
 var _lbEditRecipeWriteSeqByPhoto = {};
 var _lbPhotoDataByPhoto = {};
 var _lbRenderVersionByPhoto = {};
+
+// --- Life List: "Add to Life List" panel, shared across every page's lightbox.
+// Driven by the `life_list` block on GET /api/photos/<id> (cached in
+// _lbPhotoDataByPhoto), so the action works wherever a photo is opened — not
+// just on the /life-list page. Each eligible species gets its own row; the
+// button reflects real state (representative → selected, disabled star).
+function _lbEnsureLifeListPanel() {
+  var actions = document.getElementById('lightboxActions');
+  if (!actions) return null;
+  var panel = document.getElementById('lifeListLightboxPanel');
+  if (!panel) {
+    panel = document.createElement('div');
+    panel.id = 'lifeListLightboxPanel';
+    panel.className = 'lifelist-lb-panel';
+    actions.insertBefore(panel, actions.firstChild);
+  }
+  return panel;
+}
+
+function _lbRenderLifeListPanel(photoId) {
+  var panel = _lbEnsureLifeListPanel();
+  if (!panel) return;
+  var data = _lbPhotoDataByPhoto[String(photoId)];
+  var entries = (data && data.life_list) || [];
+  if (!entries.length) {
+    panel.style.display = 'none';
+    panel.innerHTML = '';
+    return;
+  }
+  panel.style.display = '';
+  panel.innerHTML = '';
+  entries.forEach(function(entry) {
+    var row = document.createElement('div');
+    row.className = 'lifelist-lb-row';
+    var label = document.createElement('span');
+    label.className = 'lifelist-lb-species';
+    label.textContent = entry.species;
+    var btn = document.createElement('button');
+    btn.type = 'button';
+    if (entry.is_current_photo) {
+      btn.className = 'primary';
+      btn.disabled = true;
+      btn.textContent = '★ Life List photo';
+    } else {
+      btn.textContent = 'Add to Life List';
+    }
+    btn.addEventListener('click', function(event) {
+      event.stopPropagation();
+      setLifeListPhoto(entry.species, photoId, btn);
+    });
+    row.appendChild(label);
+    row.appendChild(btn);
+    panel.appendChild(row);
+  });
+}
+
+async function setLifeListPhoto(species, photoId, button) {
+  if (!species || !photoId) return;
+  if (button) button.disabled = true;
+  try {
+    await window.safeFetch('/api/photo-preferences', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ purpose: 'life_list', species: species, photo_id: photoId }),
+    });
+    // Re-read this photo's block so the panel shows the honest new state, and
+    // refresh the lightbox's cache so re-renders stay consistent.
+    try {
+      var fresh = await window.safeFetch('/api/photos/' + photoId, {}, { toast: false });
+      if (fresh) _lbPhotoDataByPhoto[String(photoId)] = fresh;
+    } catch (e) { /* keep the panel usable even if the refresh fails */ }
+    if (_lightboxCurrentId === photoId) _lbRenderLifeListPanel(photoId);
+    // Let the /life-list page (or any listener) refresh its grid + ribbons.
+    document.dispatchEvent(new CustomEvent('lifelist:changed', {
+      detail: { species: species, photoId: photoId },
+    }));
+    if (typeof showToast === 'function') {
+      showToast('Life List photo set for ' + species, 'success');
+    }
+  } finally {
+    if (button) button.disabled = false;
+  }
+}
+
+document.addEventListener('lightbox:photochanged', function(event) {
+  var pid = event.detail ? event.detail.photoId : null;
+  // Render from cache now (instant when revisiting a loaded photo); the panel
+  // re-renders again once the fresh /api/photos fetch resolves.
+  if (pid != null) _lbRenderLifeListPanel(pid);
+});
+
 var _lbEditRecipe = null;
 var _lbEditRecipeLoaded = false;
 var _lbRenderedAdjustmentValues = null;
@@ -5706,6 +5804,7 @@ function openLightbox(photoId, filename, photoList, options) {
         data.edit_recipe = _lbRecipeHasEdits(currentRecipe) ? _lbCloneEditRecipe(currentRecipe) : null;
       }
       _lbPhotoDataByPhoto[String(photoId)] = data;
+      _lbRenderLifeListPanel(photoId);
       if (editRecipeFresh) {
         _lbRememberEditRecipe(photoId, data.edit_recipe);
         if (_vireoEditRecipeCacheKey(data.edit_recipe) !== recipeKeyBefore) {

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -6418,10 +6418,49 @@ function buildPhotoContextMenu(photoIds) {
     { separator: true },
     { label: 'Add Keyword\u2026', onClick: function() { batchAddKeyword(); } },
     { label: 'Add to Collection\u2026', onClick: function() { addToCollection(); } },
+  ]).concat(buildLifeListMenuItems(photoIds)).concat([
     { label: 'Adjust Capture Time\u2026', onClick: function() { openCaptureTimeModal(); } },
     { separator: true },
     { label: 'Delete', onClick: function() { batchDelete(); } },
   ]);
+}
+
+// "Add to Life List" context-menu items. A photo is a lifelist representative
+// per species keyword, so one item per eligible species (the same species
+// names shown on the card). Fire-and-forget: it sets the representative and
+// toasts; the server (_photo_can_be_life_list_preference) is the backstop for
+// a stale menu. Disabled for a multi-selection because crowning one shot from
+// many is ambiguous; hidden entirely when nothing selected has a species.
+function buildLifeListMenuItems(photoIds) {
+  var hasSpecies = photoIds.some(function(id) {
+    var p = photos.find(function(x) { return x.id === id; });
+    return p && p.species && p.species.length;
+  });
+  if (!hasSpecies) return [];
+  if (photoIds.length !== 1) {
+    return [{ label: 'Add to Life List', disabled: true,
+              disabledHint: 'Select a single photo' }];
+  }
+  var photo = photos.find(function(p) { return p.id === photoIds[0]; });
+  return (photo.species || []).map(function(sp) {
+    return {
+      label: 'Add to Life List \u2014 ' + sp,
+      onClick: function() { addPhotoToLifeList(sp, photoIds[0]); },
+    };
+  });
+}
+
+function addPhotoToLifeList(species, photoId) {
+  if (!species || !photoId) return;
+  safeFetch('/api/photo-preferences', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ purpose: 'life_list', species: species, photo_id: photoId }),
+  }).then(function() {
+    if (typeof showToast === 'function') {
+      showToast('Life List photo set for ' + species, 'success');
+    }
+  });
 }
 
 // Document-level delegation: grids re-render on sort/filter/scroll, so

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -6431,17 +6431,23 @@ function buildPhotoContextMenu(photoIds) {
 // toasts; the server (_photo_can_be_life_list_preference) is the backstop for
 // a stale menu. Disabled for a multi-selection because crowning one shot from
 // many is ambiguous; hidden entirely when nothing selected has a species.
+// Rejected photos are excluded here too \u2014 they'd fail the server backstop
+// (`_photo_can_be_life_list_preference` rejects `flag = 'rejected'`) and only
+// produce an error toast, so don't offer the action in the first place.
+function _lifeListEligibleClient(p) {
+  return !!(p && p.species && p.species.length && p.flag !== 'rejected');
+}
 function buildLifeListMenuItems(photoIds) {
-  var hasSpecies = photoIds.some(function(id) {
-    var p = photos.find(function(x) { return x.id === id; });
-    return p && p.species && p.species.length;
+  var anyEligible = photoIds.some(function(id) {
+    return _lifeListEligibleClient(photos.find(function(x) { return x.id === id; }));
   });
-  if (!hasSpecies) return [];
+  if (!anyEligible) return [];
   if (photoIds.length !== 1) {
     return [{ label: 'Add to Life List', disabled: true,
               disabledHint: 'Select a single photo' }];
   }
   var photo = photos.find(function(p) { return p.id === photoIds[0]; });
+  if (!_lifeListEligibleClient(photo)) return [];
   return (photo.species || []).map(function(sp) {
     return {
       label: 'Add to Life List \u2014 ' + sp,

--- a/vireo/templates/life_list.html
+++ b/vireo/templates/life_list.html
@@ -37,11 +37,8 @@
 
   .lifelist-empty { text-align:center; padding:80px 24px; color:var(--text-secondary); }
   .lifelist-empty a { color:var(--accent); }
-  .lifelist-lb-panel { display:flex; align-items:center; gap:8px; flex-wrap:wrap; min-height:32px; padding:4px 8px; border-radius:4px; background:rgba(12,14,16,0.88); border:1px solid rgba(255,255,255,0.42); color:#f4f7f8; font-size:12px; font-weight:650; text-shadow:0 1px 1px rgba(0,0,0,0.75); }
-  .lifelist-lb-panel button { min-height:24px; border:1px solid rgba(255,255,255,0.42); background:rgba(255,255,255,0.12); color:#fff; border-radius:4px; padding:4px 9px; cursor:pointer; font-size:12px; font-weight:650; }
-  .lifelist-lb-panel button:hover { background:rgba(255,255,255,0.2); border-color:rgba(255,255,255,0.72); }
-  .lifelist-lb-panel button:disabled { color:rgba(255,255,255,0.48); border-color:rgba(255,255,255,0.22); background:rgba(255,255,255,0.06); cursor:default; }
-  .lifelist-lb-panel button.primary { border-color:rgba(255,224,102,0.84); color:#ffe066; }
+  /* .lifelist-lb-panel styles now live in _navbar.html — the "Add to Life
+     List" lightbox panel is shared across every page's lightbox. */
 </style>
 </head>
 <body>
@@ -111,7 +108,6 @@
 <script>
 var currentData = null;
 var debounceTimer = null;
-var activeLightboxPhotoId = null;
 
 // All dynamic values rendered into card HTML pass through escapeAttr —
 // same escaping convention as highlights.html.
@@ -235,13 +231,12 @@ function render() {
       var entry = (currentData.species || []).find(function(e) { return e.species === sp; });
       if (entry && entry.best && window.openLightbox) {
         // The lightbox set is this species' top photos so the user can
-        // flip through their best shots of the lifer.
-        activeLightboxPhotoId = entry.best.id;
+        // flip through their best shots of the lifer. The shared lightbox
+        // panel (see _navbar.html) renders its own "Add to Life List" control.
         openLightbox(entry.best.id, entry.best.filename, entry.photos || [entry.best]);
       }
     });
   });
-  updateLifeListLightboxControls(activeLightboxPhotoId);
 }
 
 function debounceRender() {
@@ -307,71 +302,11 @@ async function startPublishSite() {
   }
 }
 
-function findLifeListEntryForPhoto(photoId) {
-  if (!currentData || photoId == null) return null;
-  var entries = currentData.species || [];
-  for (var i = 0; i < entries.length; i++) {
-    var match = (entries[i].photos || []).find(function(p) { return p.id === photoId; });
-    if (match) return { entry: entries[i], photo: match };
-  }
-  return null;
-}
-
-function ensureLifeListLightboxPanel() {
-  var actions = document.getElementById('lightboxActions');
-  if (!actions) return null;
-  var panel = document.getElementById('lifeListLightboxPanel');
-  if (!panel) {
-    panel = document.createElement('div');
-    panel.id = 'lifeListLightboxPanel';
-    panel.className = 'lifelist-lb-panel';
-    actions.insertBefore(panel, actions.firstChild);
-  }
-  return panel;
-}
-
-async function setLifeListPhoto(species, photoId, button) {
-  if (!species || !photoId) return;
-  if (button) button.disabled = true;
-  try {
-    await safeFetch('/api/photo-preferences', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ purpose: 'life_list', species: species, photo_id: photoId }),
-    });
-    await loadLifeList();
-    updateLifeListLightboxControls(activeLightboxPhotoId);
-    if (typeof showToast === 'function') showToast('Life List photo set', 'success');
-  } finally {
-    if (button) button.disabled = false;
-  }
-}
-
-function updateLifeListLightboxControls(photoId) {
-  var panel = ensureLifeListLightboxPanel();
-  if (!panel) return;
-  var match = findLifeListEntryForPhoto(photoId);
-  if (!match) {
-    panel.style.display = 'none';
-    panel.innerHTML = '';
-    return;
-  }
-  panel.style.display = '';
-  var selected = !!match.photo.is_life_list_photo;
-  panel.innerHTML = '<span>' + escapeAttr(match.entry.species) + '</span>'
-    + '<button data-lb-action="set-life-list"'
-    + (selected ? ' class="primary"' : '') + '>'
-    + (selected ? 'Life List Photo' : 'Use as Life List') + '</button>';
-  var btn = panel.querySelector('button');
-  btn.addEventListener('click', function(event) {
-    event.stopPropagation();
-    setLifeListPhoto(match.entry.species, match.photo.id, btn);
-  });
-}
-
-document.addEventListener('lightbox:photochanged', function(event) {
-  activeLightboxPhotoId = event.detail ? event.detail.photoId : null;
-  updateLifeListLightboxControls(activeLightboxPhotoId);
+// The "Add to Life List" lightbox panel is shared (see _navbar.html) and
+// works on every page. When it changes a representative photo, it dispatches
+// `lifelist:changed`; refresh this page's grid + ribbons in response.
+document.addEventListener('lifelist:changed', function() {
+  loadLifeList();
 });
 
 loadLifeList();

--- a/vireo/tests/test_jobs.py
+++ b/vireo/tests/test_jobs.py
@@ -475,8 +475,6 @@ def test_job_history_persists_steps_tree(tmp_path):
 
 def test_job_history_prunes_to_100(tmp_path):
     """Job history prunes entries beyond 100 per workspace."""
-    import time
-
     from db import Database
     from jobs import JobRunner
 
@@ -498,9 +496,12 @@ def test_job_history_prunes_to_100(tmp_path):
     def work(job):
         return {}
 
+    # Pruning happens inside _persist_job (INSERT + retention DELETE), and
+    # _persisted flips true only after both commit. A fixed sleep raced the
+    # worker thread on slower Windows I/O; wait_for_history is the exact
+    # sync point.
     job_id = runner.start("test", work, workspace_id=ws_id)
-    wait_for_job_via_runner(runner, job_id)
-    time.sleep(0.5)
+    wait_for_job_via_runner(runner, job_id, wait_for_history=True)
 
     count = db.conn.execute(
         "SELECT COUNT(*) FROM job_history WHERE workspace_id = ?", (ws_id,)

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -496,6 +496,116 @@ def test_api_photo_detail_includes_on_disk_path(app_and_db):
     assert data['path'] == expected_path
 
 
+def test_photo_detail_life_list_lists_eligible_species(app_and_db):
+    """GET /api/photos/<id> exposes a life_list block naming the photo's
+    lifelist-eligible species so the shared lightbox / browse menu can offer
+    an 'Add to Life List' action without page-local data."""
+    app, db = app_and_db
+    client = app.test_client()
+    pid = db.get_photos()[0]["id"]
+    kid = db.add_keyword("American Robin", is_species=True)
+    db.tag_photo(pid, kid)
+
+    data = client.get(f"/api/photos/{pid}").get_json()
+    assert data["life_list"] == [
+        {"species": "American Robin", "is_current_photo": False}
+    ]
+
+
+def test_photo_detail_life_list_marks_current_representative(app_and_db):
+    """is_current_photo is true once this photo is the species' representative."""
+    app, db = app_and_db
+    client = app.test_client()
+    pid = db.get_photos()[0]["id"]
+    kid = db.add_keyword("American Robin", is_species=True)
+    db.tag_photo(pid, kid)
+    db.set_photo_preference("life_list", "American Robin", pid)
+
+    data = client.get(f"/api/photos/{pid}").get_json()
+    assert data["life_list"] == [
+        {"species": "American Robin", "is_current_photo": True}
+    ]
+
+
+def test_photo_detail_life_list_current_false_when_other_photo_is_rep(app_and_db):
+    """A species can be on the list with a different representative photo; this
+    photo then reports is_current_photo false (button, not selected star)."""
+    app, db = app_and_db
+    client = app.test_client()
+    photos = db.get_photos()
+    p1, p2 = photos[0]["id"], photos[1]["id"]
+    kid = db.add_keyword("American Robin", is_species=True)
+    db.tag_photo(p1, kid)
+    db.tag_photo(p2, kid)
+    db.set_photo_preference("life_list", "American Robin", p2)
+
+    data = client.get(f"/api/photos/{p1}").get_json()
+    assert data["life_list"] == [
+        {"species": "American Robin", "is_current_photo": False}
+    ]
+
+
+def test_photo_detail_life_list_excludes_non_species_keyword(app_and_db):
+    """Plain (non-species) keywords never produce a lifelist entry."""
+    app, db = app_and_db
+    client = app.test_client()
+    pid = db.get_photos()[0]["id"]
+    kid = db.add_keyword("Central Park", kw_type="location")
+    db.tag_photo(pid, kid)
+
+    data = client.get(f"/api/photos/{pid}").get_json()
+    assert data["life_list"] == []
+
+
+def test_photo_detail_life_list_includes_taxonomy_type_keyword(app_and_db):
+    """type='taxonomy' keywords count even when is_species is 0 — same rule as
+    get_life_list_candidates, so the button and the list can't drift."""
+    app, db = app_and_db
+    client = app.test_client()
+    pid = db.get_photos()[0]["id"]
+    db.conn.execute(
+        "INSERT INTO keywords (name, type, is_species) VALUES ('Bald Eagle', 'taxonomy', 0)"
+    )
+    kid = db.conn.execute(
+        "SELECT id FROM keywords WHERE name='Bald Eagle'"
+    ).fetchone()["id"]
+    db.tag_photo(pid, kid)
+    db.conn.commit()
+
+    data = client.get(f"/api/photos/{pid}").get_json()
+    assert data["life_list"] == [
+        {"species": "Bald Eagle", "is_current_photo": False}
+    ]
+
+
+def test_photo_detail_life_list_multiple_species_independent_state(app_and_db):
+    """A photo with two species gets two entries, each with its own state."""
+    app, db = app_and_db
+    client = app.test_client()
+    pid = db.get_photos()[0]["id"]
+    db.tag_photo(pid, db.add_keyword("American Robin", is_species=True))
+    db.tag_photo(pid, db.add_keyword("Blue Jay", is_species=True))
+    db.set_photo_preference("life_list", "Blue Jay", pid)
+
+    data = client.get(f"/api/photos/{pid}").get_json()
+    by_species = {e["species"]: e["is_current_photo"] for e in data["life_list"]}
+    assert by_species == {"American Robin": False, "Blue Jay": True}
+
+
+def test_photo_detail_life_list_empty_for_rejected_photo(app_and_db):
+    """Rejected photos are excluded from the life list, so their block is empty
+    — matches _photo_can_be_life_list_preference, the POST-time backstop."""
+    app, db = app_and_db
+    client = app.test_client()
+    pid = db.get_photos()[0]["id"]
+    kid = db.add_keyword("American Robin", is_species=True)
+    db.tag_photo(pid, kid)
+    db.update_photo_flag(pid, "rejected")
+
+    data = client.get(f"/api/photos/{pid}").get_json()
+    assert data["life_list"] == []
+
+
 def test_api_photos_by_ids_preserves_selection_order(app_and_db):
     """POST /api/photos/by-ids returns active-workspace photos in caller order."""
     app, db = app_and_db


### PR DESCRIPTION
## What & why

Choosing which photo represents a species in the life list used to be reachable **only** from the `/life-list` page: open the page → click a species card → lightbox opens → click "Use as Life List". This brings that action to where photos are already being viewed.

Note: a photo is never "added" to the life list directly — any species-tagged photo is automatically on the list. The only manual choice is *which photo represents each species*, and this makes that choice reachable everywhere.

## Changes

- **Backend** — `GET /api/photos/<id>` gains a `life_list` block: the photo's eligible species plus `is_current_photo` for each. Built from the same `is_species = 1 OR type = 'taxonomy'` rule the list itself uses (new `db.get_photo_life_list_species`), so the button and the list can't drift. Empty for non-species / rejected photos.
- **Lightbox (shared, every page)** — the "Add to Life List" panel moves out of `life_list.html` into the shared lightbox in `_navbar.html`, driven by the new block. One row per species; the button reads **"Add to Life List"** and flips to a selected, disabled **"★ Life List photo"** once this shot is the representative. Setting a photo dispatches a `lifelist:changed` event so the `/life-list` page refreshes its grid + ribbons.
- **Browse right-click menu** — adds **"Add to Life List — &lt;species&gt;"** (one item per eligible species) between "Add to Collection…" and "Adjust Capture Time…". Disabled for a multi-selection ("Select a single photo"), hidden when nothing selected has a species. Fire-and-forget; the existing `_photo_can_be_life_list_preference` check is the server-side backstop.

Wording is "Add to Life List" per request; the lightbox keeps an honest selected state.

## Testing

- **7 new backend tests** (`test_photos_api.py`): eligibility, current-photo flip, other-photo-is-rep, non-species exclusion, taxonomy-type keyword, multi-species independent state, rejected-photo empty.
- **New Playwright e2e** (`tests/e2e/test_lifelist_add_verify.py`): browse menu sets the rep end-to-end, hidden for zero-species, disabled for multi-select, and the lightbox panel flips to "★ Life List photo".
- Full suite: **1169 passed, 1 skipped** (pre-existing). Verified in a real browser — lightbox panel, browse menu, success toast, and the life-list ribbon all confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared “Add to Life List” control in the lightbox, letting you set a representative photo for eligible species.
  * Added a browse context-menu action for quickly adding a photo to the Life List.
  * Photo details now include Life List eligibility and current-representative status for each species.

* **Bug Fixes**
  * Improved handling of multi-select and species-eligibility cases in the browse menu.
  * Life List updates now refresh the grid and lightbox state consistently after changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->