### PR TITLE
[codex] Fix rapid review hotkey readiness

### DIFF
--- a/vireo/templates/pipeline_rapid_review.html
+++ b/vireo/templates/pipeline_rapid_review.html
@@ -1480,6 +1480,19 @@ function renderCurrent() {
   var img = document.getElementById('currentPhoto');
   var empty = document.getElementById('stageEmpty');
   var pill = document.getElementById('statusPill');
+  if (p && !rapid.seeded && !rapid.loadError) {
+    img.removeAttribute('src');
+    img.style.display = 'none';
+    empty.style.display = '';
+    empty.textContent = 'Loading burst state...';
+    pill.style.display = 'none';
+    document.getElementById('filename').textContent = 'Loading burst state...';
+    document.getElementById('metricQuality').textContent = '-';
+    document.getElementById('metricSharpness').textContent = '-';
+    document.getElementById('metricLabel').textContent = '-';
+    document.getElementById('metricReviewed').textContent = rapid.reviewed.size + '/' + rapid.items.length;
+    return;
+  }
   if (!p) {
     resetRapidZoom();
     img.removeAttribute('src');


### PR DESCRIPTION
## Summary
- Show a loading placeholder while Rapid Review is waiting for burst state seeding.
- Keep filenames and active photo content hidden until decision hotkeys are actually enabled.

## Root Cause
Rapid Review rendered the first filename before `/api/pipeline/group/state` finished. The decision guard correctly ignored hotkeys until seeding completed, so a fast first `x`/`p` keypress could be dropped while `a.jpg` was already visible.

## Impact
Once a filename is visible, page-local decision shortcuts are ready. Failed state loads still keep apply/decision actions disabled.

## Validation
- `pytest tests/e2e/test_pipeline_rapid_review.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the review screen’s handling of images while burst data is still loading.
  * During this loading state, the app now shows a clear loading message, temporarily hides image-specific details, and updates progress counters accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->