### PR TITLE
[codex] Run BioCLIP embedding precompute in background

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -11168,7 +11168,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             thread_db.set_active_workspace(active_ws)
             thread_db.set_workspace_active_labels([labels_path])
 
-            # Auto-compute embeddings for the active model
+            precompute = None
             from models import get_active_model
 
             active_model = get_active_model()
@@ -11181,32 +11181,31 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 try:
                     from classifier import _embedding_cache_path, _resolve_model_dir
 
+                    with open(labels_path) as f:
+                        labels = [line.strip() for line in f if line.strip()]
                     model_dir = _resolve_model_dir(
                         active_model["model_str"], active_model.get("weights_path")
                     )
                     cache_path = _embedding_cache_path(
-                        list(set(species)), active_model["model_str"], model_dir
+                        labels, active_model["model_str"], model_dir
                     )
                     if not os.path.exists(cache_path):
-                        progress_cb(
-                            f'Pre-computing embeddings for {active_model["name"]}...',
-                            0,
-                            0,
-                        )
-                        from classifier import Classifier
-
-                        Classifier(
-                            labels=list(set(species)),
-                            model_str=active_model["model_str"],
-                            pretrained_str=active_model["weights_path"],
-                        )
-                        progress_cb("Embeddings cached!", 0, 0)
+                        precompute = {
+                            "model_id": active_model["id"],
+                            "model_name": active_model["name"],
+                            "labels_file": labels_path,
+                        }
                 except Exception:
                     log.warning(
-                        "Auto-compute embeddings failed (non-fatal)", exc_info=True
+                        "Could not inspect embedding cache after label download",
+                        exc_info=True,
                     )
 
-            return {"species_count": len(set(species)), "labels_file": labels_path}
+            return {
+                "species_count": len(set(species)),
+                "labels_file": labels_path,
+                "embedding_precompute": precompute,
+            }
 
         job_id = runner.start(
             "fetch-labels",

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -3803,6 +3803,38 @@ function selectPipelinePlace(id, name) {
   resetPipelineLabelsStatus();
 }
 
+async function startPipelineLabelEmbeddingPrecompute(precompute) {
+  if (!precompute || !precompute.model_id || !precompute.labels_file) return;
+  var modelName = precompute.model_name || 'active model';
+  try {
+    var data = await safeFetch('/api/jobs/precompute-embeddings', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({
+        model_id: precompute.model_id,
+        labels_file: precompute.labels_file
+      }),
+    }, { toast: false });
+    showToast('Pre-computing embeddings for ' + modelName + ' in background', 'info');
+    safeEventSource('/api/jobs/' + data.job_id + '/stream', {
+      onComplete: function(result) {
+        if (result.status === 'completed') {
+          showToast('Embeddings cached for ' + modelName, 'success');
+          updateReadiness();
+          schedulePlanRefresh();
+        } else {
+          showToast('Embedding precompute failed; classification can compute them later', 'warning');
+        }
+      },
+      onError: function() {
+        updateReadiness();
+      }
+    });
+  } catch(e) {
+    showToast('Species list downloaded; embedding precompute did not start', 'warning');
+  }
+}
+
 async function fetchPipelineLabels() {
   if (!pipelineSelectedPlaceId) return;
   var groups = [];
@@ -3858,6 +3890,7 @@ async function fetchPipelineLabels() {
             status.style.color = 'var(--accent)';
           }
           if (fill) fill.style.width = '100%';
+          var precompute = result.result.embedding_precompute;
           var selectFiles = getSelectedLabelFiles();
           if (newFile && selectFiles.indexOf(newFile) === -1) selectFiles.push(newFile);
           var saveSelectionFailed = false;
@@ -3877,6 +3910,7 @@ async function fetchPipelineLabels() {
             updateLabelsPickerState();
             updateReadiness();
             schedulePlanRefresh();
+            if (precompute) startPipelineLabelEmbeddingPrecompute(precompute);
             if (!saveSelectionFailed) setTimeout(closePipelineLabelsModal, 900);
           });
         } else {

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -2584,13 +2584,24 @@ async function fetchLabels() {
           status.textContent = 'Done! ' + result.result.species_count + ' species downloaded.';
           status.style.color = 'var(--accent)';
           progressFill.style.width = '100%';
+          var precompute = result.result.embedding_precompute;
+          if (precompute) {
+            startBackgroundEmbeddingPrecompute(precompute, {
+              status: status,
+              progressDiv: progressDiv,
+              progressFill: progressFill
+            });
+          }
         } else {
           status.textContent = 'Failed: ' + (result.errors || []).join(', ');
           status.style.color = 'var(--danger)';
         }
         btn.disabled = false;
         loadLabels();
-        setTimeout(function() { progressDiv.style.display = 'none'; }, 3000);
+        loadEmbeddingMatrix();
+        if (!(result.status === 'completed' && result.result && result.result.embedding_precompute)) {
+          setTimeout(function() { progressDiv.style.display = 'none'; }, 3000);
+        }
       },
       onError: function() {
         status.textContent = 'Connection lost';
@@ -2600,6 +2611,69 @@ async function fetchLabels() {
   } catch(e) {
     status.textContent = 'Error: ' + e.message;
     btn.disabled = false;
+  }
+}
+
+async function startBackgroundEmbeddingPrecompute(precompute, opts) {
+  if (!precompute || !precompute.model_id || !precompute.labels_file) return;
+  opts = opts || {};
+  var status = opts.status;
+  var progressDiv = opts.progressDiv;
+  var progressFill = opts.progressFill;
+  var modelName = precompute.model_name || 'active model';
+  if (status) {
+    status.textContent = 'Pre-computing embeddings for ' + modelName + ' in background...';
+    status.style.color = 'var(--text-dim)';
+  }
+  if (progressDiv) progressDiv.style.display = '';
+  if (progressFill) progressFill.style.width = '0%';
+
+  try {
+    var data = await safeFetch('/api/jobs/precompute-embeddings', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({
+        model_id: precompute.model_id,
+        labels_file: precompute.labels_file
+      }),
+    }, { toast: false });
+
+    safeEventSource('/api/jobs/' + data.job_id + '/stream', {
+      onProgress: function(p) {
+        if (status && p.current_file) {
+          status.textContent = p.current_file.replace(/^Computing embeddings/, 'Pre-computing embeddings');
+        }
+        if (progressFill && p.total > 0) {
+          progressFill.style.width = Math.round((p.current / p.total) * 100) + '%';
+        }
+      },
+      onComplete: function(result) {
+        if (result.status === 'completed') {
+          if (status) {
+            status.textContent = 'Embeddings cached for ' + modelName + '.';
+            status.style.color = 'var(--accent)';
+          }
+          if (progressFill) progressFill.style.width = '100%';
+        } else if (status) {
+          status.textContent = 'Species list downloaded; embedding precompute failed.';
+          status.style.color = 'var(--warning)';
+        }
+        loadEmbeddingMatrix();
+        if (progressDiv) setTimeout(function() { progressDiv.style.display = 'none'; }, 3000);
+      },
+      onError: function() {
+        if (status) {
+          status.textContent = 'Species list downloaded; embedding precompute is still listed in Jobs.';
+          status.style.color = 'var(--warning)';
+        }
+      }
+    });
+  } catch(e) {
+    if (status) {
+      status.textContent = 'Species list downloaded; embedding precompute did not start: ' + e.message;
+      status.style.color = 'var(--warning)';
+    }
+    if (progressDiv) setTimeout(function() { progressDiv.style.display = 'none'; }, 3000);
   }
 }
 

--- a/vireo/templates/welcome.html
+++ b/vireo/templates/welcome.html
@@ -502,6 +502,22 @@ function selectPlace(id, name) {
   document.getElementById('fetchLabelsBtn').disabled = false;
 }
 
+async function startWelcomeEmbeddingPrecompute(precompute) {
+  if (!precompute || !precompute.model_id || !precompute.labels_file) return;
+  try {
+    await safeFetch('/api/jobs/precompute-embeddings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model_id: precompute.model_id,
+        labels_file: precompute.labels_file,
+      }),
+    }, { toast: false });
+  } catch(e) {
+    /* Non-fatal: the first classification run can still compute embeddings. */
+  }
+}
+
 async function fetchLabels() {
   if (!selectedPlaceId) return;
   var groups = [];
@@ -553,9 +569,12 @@ async function fetchLabels() {
         if (result.status === 'completed' && result.result) {
           bar.style.width = '100%';
           status.style.color = 'var(--accent)';
+          var precompute = result.result.embedding_precompute;
           status.textContent = 'Done! ' + result.result.species_count +
-            ' species downloaded. Finishing setup…';
-          setTimeout(finishSetup, 800);
+            ' species downloaded.' + (precompute ? ' Pre-computing embeddings in background…' : ' Finishing setup…');
+          Promise.resolve(startWelcomeEmbeddingPrecompute(precompute)).then(function() {
+            setTimeout(finishSetup, 500);
+          });
         } else {
           status.style.color = 'var(--danger)';
           status.textContent = 'Failed: ' + ((result.errors || []).join(', ') || 'unknown error');

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -1832,6 +1832,76 @@ def test_pipeline_exposes_inline_label_download_modal(app_and_db):
     assert 'id="pipelineFetchLabelsBtn"' in html
 
 
+def test_fetch_labels_returns_embedding_precompute_metadata_without_inline_compute(
+    app_and_db, monkeypatch, tmp_path,
+):
+    """Species-list download should finish before label embeddings compute."""
+    import classifier
+    import labels
+    import models
+
+    labels_dir = tmp_path / "labels"
+    monkeypatch.setattr(labels, "LABELS_DIR", str(labels_dir))
+    monkeypatch.setattr(
+        labels,
+        "fetch_species_list",
+        lambda *args, **kwargs: ["Blue Jay", "American Robin", "Blue Jay"],
+    )
+    monkeypatch.setattr(
+        models,
+        "get_active_model",
+        lambda: {
+            "id": "bioclip-2.5-vith14",
+            "name": "BioCLIP-2.5",
+            "downloaded": True,
+            "model_type": "bioclip",
+            "model_str": "hf-hub:imageomics/bioclip-2.5-vith14",
+            "weights_path": str(tmp_path / "model"),
+        },
+    )
+    monkeypatch.setattr(
+        classifier,
+        "_resolve_model_dir",
+        lambda *args, **kwargs: str(tmp_path / "model"),
+    )
+    monkeypatch.setattr(
+        classifier,
+        "_embedding_cache_path",
+        lambda *args, **kwargs: str(tmp_path / "missing-cache.npy"),
+    )
+
+    classifier_calls = []
+
+    def fail_if_classifier_constructed(*args, **kwargs):
+        classifier_calls.append((args, kwargs))
+        raise AssertionError("fetch-labels must not compute embeddings inline")
+
+    monkeypatch.setattr(classifier, "Classifier", fail_if_classifier_constructed)
+
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post(
+        "/api/jobs/fetch-labels",
+        json={
+            "place_id": 1,
+            "place_name": "Test Place",
+            "taxon_groups": ["birds"],
+        },
+    )
+
+    assert resp.status_code == 200
+    job = wait_for_job_via_client(client, resp.get_json()["job_id"])
+
+    assert job["status"] == "completed"
+    assert classifier_calls == []
+    assert job["result"]["species_count"] == 2
+    assert job["result"]["embedding_precompute"] == {
+        "model_id": "bioclip-2.5-vith14",
+        "model_name": "BioCLIP-2.5",
+        "labels_file": job["result"]["labels_file"],
+    }
+
+
 def test_cull_page_uses_pipeline_controls(app_and_db):
     """Cull exposes the same threshold sliders as pipeline review."""
     app, _ = app_and_db

--- a/vireo/tests/test_welcome.py
+++ b/vireo/tests/test_welcome.py
@@ -17,6 +17,20 @@ def test_models_status_endpoint(app_and_db):
     assert isinstance(data["needs_setup"], bool)
 
 
+def test_welcome_starts_embedding_precompute_after_label_download(app_and_db):
+    """Onboarding label downloads should warm embeddings in the background."""
+    app, _ = app_and_db
+    client = app.test_client()
+
+    resp = client.get("/welcome")
+
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert "startWelcomeEmbeddingPrecompute" in html
+    assert "/api/jobs/precompute-embeddings" in html
+    assert "embedding_precompute" in html
+
+
 def test_models_status_no_models_needs_setup(app_and_db, monkeypatch):
     """When no classification model is downloaded, needs_setup is True."""
     import models


### PR DESCRIPTION
## Summary

- stop the species-list download job from computing BioCLIP label embeddings inline
- return precompute metadata from the label fetch job so callers can launch the existing background precompute job
- update Settings and the pipeline label modal to start embedding precompute in the background after labels download
- add a regression test that verifies label download completes without constructing the classifier inline

## Root Cause

`/api/jobs/fetch-labels` saved the downloaded labels and then synchronously constructed `Classifier(...)` for the active BioCLIP model. That meant the species-list job stayed busy in the "Pre-computing embeddings" phase, leaving the user with a blocking-looking progress state and cancel as the obvious action.

## Validation

- `pytest -q vireo/tests/test_app.py::test_fetch_labels_returns_embedding_precompute_metadata_without_inline_compute vireo/tests/test_app.py::test_precompute_embeddings_rejects_timm_models vireo/tests/test_job_submission_api.py::test_precompute_embedding_warning_sizing_ignores_decode_errors`
- `python -m py_compile vireo/app.py`
- `pytest -q vireo/tests/test_app.py::test_pipeline_exposes_inline_label_download_modal vireo/tests/test_app.py::test_fetch_labels_returns_embedding_precompute_metadata_without_inline_compute`