### PR TITLE
[codex] Improve archive conflict diagnostics

### DIFF
--- a/vireo/local_processing.py
+++ b/vireo/local_processing.py
@@ -125,6 +125,26 @@ def conflicting_archive_paths(
     *,
     known_hashes: set[str] | None = None,
 ) -> list[str]:
+    """Return existing archive paths that would block merge-mode archive."""
+    report = archive_conflict_report(
+        path,
+        files,
+        folder_template,
+        known_hashes=known_hashes,
+    )
+    return sorted(
+        report["empty"] + report["partial"] + report["conflicts"]
+    )
+
+
+def archive_conflict_report(
+    path: str,
+    files: list[Path],
+    folder_template: str = "%Y/%Y-%m-%d",
+    *,
+    known_hashes: set[str] | None = None,
+    indexed_paths: set[str] | None = None,
+) -> dict[str, list[str]]:
     """Return existing archive paths that would block merge-mode archive.
 
     ``move_folder(..., merge=True)`` refuses same-relative-path files whose
@@ -152,16 +172,35 @@ def conflicting_archive_paths(
       ``extra_known_hashes`` accumulator so the same card/folder selected
       twice still recognises the second occurrence as an intra-batch
       duplicate that ingest would skip.
+
+    If ``indexed_paths`` is provided, same-path differences are split into:
+
+    * ``empty``: unindexed zero-byte archive files with a non-empty source.
+    * ``partial``: unindexed archive files smaller than the source.
+    * ``conflicts``: everything else that still blocks the merge.
+
+    Empty/partial files are still blocking. They are separated so callers can
+    tell the user this looks like debris from a failed previous archive copy,
+    not a legitimate same-name alternate photo.
     """
     try:
         if not os.path.isdir(path):
-            return []
+            return {"empty": [], "partial": [], "conflicts": []}
     except OSError:
-        return []
+        return {"empty": [], "partial": [], "conflicts": []}
 
     timestamps = _source_file_timestamps(files)
     archive_root = Path(path)
+    empty: set[str] = set()
+    partial: set[str] = set()
     conflicts: set[str] = set()
+    indexed_keys = (
+        {
+            os.path.normcase(os.path.abspath(indexed_path))
+            for indexed_path in indexed_paths
+        }
+        if indexed_paths is not None else None
+    )
     seen_hashes: set[str] | None = (
         set(known_hashes) if known_hashes is not None else None
     )
@@ -209,10 +248,12 @@ def conflicting_archive_paths(
                 folder_taken.add(chosen_name)
                 continue
 
+            source_size = source_file.stat().st_size
+            dest_size: int | None = None
             if not dest_file.is_symlink() and dest_file.is_file():
-                source_size = source_file.stat().st_size
+                dest_size = dest_file.stat().st_size
                 if (
-                    dest_file.stat().st_size == source_size
+                    dest_size == source_size
                     and filecmp.cmp(source_file, dest_file, shallow=False)
                 ):
                     if _skip_or_record_survivor(source_file):
@@ -229,11 +270,29 @@ def conflicting_archive_paths(
                 # before staging; do not claim a slot either.
                 continue
 
-            conflicts.add(str(dest_file))
+            dest_path = str(dest_file)
+            dest_key = os.path.normcase(os.path.abspath(dest_path))
+            is_unindexed = (
+                indexed_keys is not None
+                and dest_key not in indexed_keys
+            )
+            if is_unindexed and source_size > 0 and dest_size is not None:
+                if dest_size == 0:
+                    empty.add(dest_path)
+                elif dest_size < source_size:
+                    partial.add(dest_path)
+                else:
+                    conflicts.add(dest_path)
+            else:
+                conflicts.add(dest_path)
             folder_taken.add(chosen_name)
         except OSError:
             continue
-    return sorted(conflicts)
+    return {
+        "empty": sorted(empty),
+        "partial": sorted(partial),
+        "conflicts": sorted(conflicts),
+    }
 
 
 def existing_archive_bytes(

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1174,21 +1174,37 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                     )
                                 }
 
+                            from move import _case_insensitive_root
+
                             def _indexed_archive_paths(root: str) -> set[str]:
                                 # Fold symlink/case aliases before deciding a
                                 # cataloged row belongs under this destination:
                                 # the tracked-destination preflight above
-                                # accepts alias-equal roots, so a lexical-only
-                                # is_relative_to would drop indexed rows whose
-                                # stored path uses the canonical spelling while
-                                # the user picked an alias (or vice versa), and
-                                # archive_conflict_report would then label
-                                # zero-byte/truncated indexed archive files as
-                                # unindexed failed-copy debris.
+                                # accepts alias-equal roots via
+                                # _path_equal_or_descends, so anything less here
+                                # would drop indexed rows whose stored path uses
+                                # a different alias than the user-picked
+                                # destination (symlink target vs. link, or a
+                                # case-only twin on case-insensitive POSIX like
+                                # default APFS — os.path.normcase is a no-op on
+                                # POSIX and os.path.realpath preserves the
+                                # supplied spelling, so a lexical
+                                # commonpath/is_relative_to check misses the
+                                # case-only alias). Dropping the row would then
+                                # feed an empty index to
+                                # archive_conflict_report and get a
+                                # zero-byte/truncated indexed archive file
+                                # labelled as unindexed failed-copy debris —
+                                # telling the user to remove a cataloged file.
+                                # Probe the case-insensitive fold root once and
+                                # reuse it per row so
+                                # _path_equal_or_descends' listdir/samefile
+                                # probe doesn't re-run per catalog folder.
                                 root_path = Path(os.path.normpath(root))
                                 root_real = os.path.normcase(
                                     os.path.realpath(root),
                                 )
+                                dest_ci_root = _case_insensitive_root(root)
                                 indexed: set[str] = set()
                                 rows = thread_db.conn.execute(
                                     """SELECT f.path, p.filename
@@ -1196,29 +1212,64 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                          JOIN folders f ON f.id = p.folder_id"""
                                 ).fetchall()
                                 for row in rows:
+                                    folder = row["path"]
+                                    if not _path_equal_or_descends(
+                                        folder, root,
+                                        case_insensitive_root=dest_ci_root,
+                                    ):
+                                        continue
+                                    # Extract the below-root portion of the
+                                    # folder path so we can rebase onto the
+                                    # user-picked root spelling
+                                    # (archive_conflict_report joins
+                                    # `path`/rel_folder/filename to build the
+                                    # dest_key we're matching against). A
+                                    # realpath-based string prefix covers the
+                                    # same-case and symlink-alias cases; the
+                                    # case-fold branch mirrors
+                                    # _path_equal_or_descends' probed-CI-root
+                                    # logic so a POSIX case-only alias still
+                                    # yields the right tail.
                                     folder_real = os.path.normcase(
-                                        os.path.realpath(row["path"]),
+                                        os.path.realpath(folder),
                                     )
-                                    try:
-                                        common = os.path.commonpath(
-                                            [root_real, folder_real],
-                                        )
-                                    except ValueError:
-                                        # Different drives on Windows: no
-                                        # possible overlap.
+                                    rel_suffix: str | None = None
+                                    if folder_real == root_real:
+                                        rel_suffix = ""
+                                    elif folder_real.startswith(
+                                        root_real + os.sep,
+                                    ):
+                                        rel_suffix = folder_real[
+                                            len(root_real) + 1:
+                                        ]
+                                    elif dest_ci_root:
+                                        root_low = root_real.lower()
+                                        folder_low = folder_real.lower()
+                                        if folder_low == root_low:
+                                            rel_suffix = ""
+                                        elif folder_low.startswith(
+                                            root_low + os.sep,
+                                        ):
+                                            rel_suffix = folder_real[
+                                                len(root_real) + 1:
+                                            ]
+                                    if rel_suffix is None:
+                                        # _path_equal_or_descends accepted the
+                                        # row via a samefile walk-up (missing
+                                        # intermediate leaf whose parent aliases
+                                        # to root), so the realpath spelling
+                                        # doesn't line up as a string prefix and
+                                        # we can't safely rebase onto the
+                                        # user-picked spelling. Catalog folders
+                                        # exist on disk by construction — this
+                                        # branch is rare — so drop the row
+                                        # rather than fabricate a spelling.
                                         continue
-                                    if common != root_real:
-                                        continue
-                                    rel = os.path.relpath(
-                                        folder_real, root_real,
-                                    )
-                                    # Rebase the row back onto the user-picked
-                                    # root spelling so the entries here share
-                                    # the same prefix archive_conflict_report
-                                    # uses to build dest_key downstream.
                                     indexed_folder = (
-                                        root_path if rel == "."
-                                        else root_path / rel
+                                        root_path if rel_suffix == ""
+                                        else root_path.joinpath(
+                                            *rel_suffix.split(os.sep),
+                                        )
                                     )
                                     indexed.add(
                                         str(indexed_folder / row["filename"]),

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1013,7 +1013,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
 
                     if params.local_processing:
                         from local_processing import (
-                            conflicting_archive_paths,
+                            archive_conflict_report,
                             existing_archive_bytes,
                             format_bytes,
                             non_duplicate_files,
@@ -1173,18 +1173,74 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                         "WHERE file_hash IS NOT NULL"
                                     )
                                 }
-                            archive_conflicts = conflicting_archive_paths(
+
+                            def _indexed_archive_paths(root: str) -> set[str]:
+                                root_path = Path(os.path.normpath(root))
+                                indexed: set[str] = set()
+                                rows = thread_db.conn.execute(
+                                    """SELECT f.path, p.filename
+                                         FROM photos p
+                                         JOIN folders f ON f.id = p.folder_id"""
+                                ).fetchall()
+                                for row in rows:
+                                    folder = Path(os.path.normpath(row["path"]))
+                                    if (
+                                        folder == root_path
+                                        or folder.is_relative_to(root_path)
+                                    ):
+                                        indexed.add(
+                                            str(Path(row["path"]) / row["filename"])
+                                        )
+                                return indexed
+
+                            archive_report = archive_conflict_report(
                                 final_destination,
                                 selected_files,
                                 params.folder_template,
                                 known_hashes=catalog_hashes,
+                                indexed_paths=_indexed_archive_paths(
+                                    final_destination,
+                                ),
+                            )
+                            archive_conflicts = (
+                                archive_report["empty"]
+                                + archive_report["partial"]
+                                + archive_report["conflicts"]
                             )
                             if archive_conflicts:
+                                incomplete = (
+                                    archive_report["empty"]
+                                    + archive_report["partial"]
+                                )
                                 examples = ", ".join(archive_conflicts[:3])
                                 more = (
                                     f" and {len(archive_conflicts) - 3} more"
                                     if len(archive_conflicts) > 3 else ""
                                 )
+                                if incomplete:
+                                    bits = []
+                                    if archive_report["empty"]:
+                                        bits.append(
+                                            f"{len(archive_report['empty'])} empty"
+                                        )
+                                    if archive_report["partial"]:
+                                        bits.append(
+                                            f"{len(archive_report['partial'])} "
+                                            "partial"
+                                        )
+                                    _bail_storage(
+                                        "Archive destination contains "
+                                        f"{' and '.join(bits)} unindexed file"
+                                        f"{'s' if len(incomplete) != 1 else ''} "
+                                        "at incoming import paths: "
+                                        f"{examples}{more}. This looks like an "
+                                        "interrupted previous archive copy. "
+                                        "Remove or replace those incomplete "
+                                        "files, then retry; Vireo will not "
+                                        "suffix around likely corrupt archive "
+                                        "files."
+                                    )
+                                    return
                                 _bail_storage(
                                     "Archive destination already contains "
                                     "different files at the same import paths: "

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1175,7 +1175,20 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 }
 
                             def _indexed_archive_paths(root: str) -> set[str]:
+                                # Fold symlink/case aliases before deciding a
+                                # cataloged row belongs under this destination:
+                                # the tracked-destination preflight above
+                                # accepts alias-equal roots, so a lexical-only
+                                # is_relative_to would drop indexed rows whose
+                                # stored path uses the canonical spelling while
+                                # the user picked an alias (or vice versa), and
+                                # archive_conflict_report would then label
+                                # zero-byte/truncated indexed archive files as
+                                # unindexed failed-copy debris.
                                 root_path = Path(os.path.normpath(root))
+                                root_real = os.path.normcase(
+                                    os.path.realpath(root),
+                                )
                                 indexed: set[str] = set()
                                 rows = thread_db.conn.execute(
                                     """SELECT f.path, p.filename
@@ -1183,14 +1196,33 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                          JOIN folders f ON f.id = p.folder_id"""
                                 ).fetchall()
                                 for row in rows:
-                                    folder = Path(os.path.normpath(row["path"]))
-                                    if (
-                                        folder == root_path
-                                        or folder.is_relative_to(root_path)
-                                    ):
-                                        indexed.add(
-                                            str(Path(row["path"]) / row["filename"])
+                                    folder_real = os.path.normcase(
+                                        os.path.realpath(row["path"]),
+                                    )
+                                    try:
+                                        common = os.path.commonpath(
+                                            [root_real, folder_real],
                                         )
+                                    except ValueError:
+                                        # Different drives on Windows: no
+                                        # possible overlap.
+                                        continue
+                                    if common != root_real:
+                                        continue
+                                    rel = os.path.relpath(
+                                        folder_real, root_real,
+                                    )
+                                    # Rebase the row back onto the user-picked
+                                    # root spelling so the entries here share
+                                    # the same prefix archive_conflict_report
+                                    # uses to build dest_key downstream.
+                                    indexed_folder = (
+                                        root_path if rel == "."
+                                        else root_path / rel
+                                    )
+                                    indexed.add(
+                                        str(indexed_folder / row["filename"]),
+                                    )
                                 return indexed
 
                             archive_report = archive_conflict_report(
@@ -1212,12 +1244,21 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                     archive_report["empty"]
                                     + archive_report["partial"]
                                 )
-                                examples = ", ".join(archive_conflicts[:3])
-                                more = (
-                                    f" and {len(archive_conflicts) - 3} more"
-                                    if len(archive_conflicts) > 3 else ""
-                                )
                                 if incomplete:
+                                    # Only surface incomplete-file paths in
+                                    # this branch: the message tells the user
+                                    # to remove empty/partial debris, so
+                                    # mixing full-content conflict paths into
+                                    # the example list would point them at
+                                    # files that are neither empty nor
+                                    # truncated.
+                                    incomplete_examples = ", ".join(
+                                        incomplete[:3],
+                                    )
+                                    incomplete_more = (
+                                        f" and {len(incomplete) - 3} more"
+                                        if len(incomplete) > 3 else ""
+                                    )
                                     bits = []
                                     if archive_report["empty"]:
                                         bits.append(
@@ -1233,14 +1274,20 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                         f"{' and '.join(bits)} unindexed file"
                                         f"{'s' if len(incomplete) != 1 else ''} "
                                         "at incoming import paths: "
-                                        f"{examples}{more}. This looks like an "
-                                        "interrupted previous archive copy. "
-                                        "Remove or replace those incomplete "
-                                        "files, then retry; Vireo will not "
-                                        "suffix around likely corrupt archive "
-                                        "files."
+                                        f"{incomplete_examples}"
+                                        f"{incomplete_more}. This looks like "
+                                        "an interrupted previous archive "
+                                        "copy. Remove or replace those "
+                                        "incomplete files, then retry; Vireo "
+                                        "will not suffix around likely "
+                                        "corrupt archive files."
                                     )
                                     return
+                                examples = ", ".join(archive_conflicts[:3])
+                                more = (
+                                    f" and {len(archive_conflicts) - 3} more"
+                                    if len(archive_conflicts) > 3 else ""
+                                )
                                 _bail_storage(
                                     "Archive destination already contains "
                                     "different files at the same import paths: "

--- a/vireo/tests/test_local_processing.py
+++ b/vireo/tests/test_local_processing.py
@@ -328,6 +328,45 @@ def test_conflicting_archive_paths_reports_different_existing_files(tmp_path):
     ) == [str(dest / "conflict.jpg")]
 
 
+def test_archive_conflict_report_classifies_unindexed_incomplete_files(tmp_path):
+    """Unindexed zero-byte and smaller archive files are likely failed-copy
+    debris, so callers can message them separately from real conflicts."""
+    src = tmp_path / "card"
+    src.mkdir()
+    empty_source = src / "empty-conflict.jpg"
+    empty_source.write_bytes(b"source bytes")
+    partial_source = src / "partial-conflict.jpg"
+    partial_source.write_bytes(b"larger source bytes")
+    full_conflict = src / "full-conflict.jpg"
+    full_conflict.write_bytes(b"source")
+
+    dest = tmp_path / "archive"
+    dest.mkdir()
+    (dest / "empty-conflict.jpg").write_bytes(b"")
+    (dest / "partial-conflict.jpg").write_bytes(b"small")
+    (dest / "full-conflict.jpg").write_bytes(b"different but larger")
+
+    report = local_processing.archive_conflict_report(
+        str(dest),
+        [empty_source, partial_source, full_conflict],
+        folder_template="",
+        indexed_paths=set(),
+    )
+
+    assert report["empty"] == [str(dest / "empty-conflict.jpg")]
+    assert report["partial"] == [str(dest / "partial-conflict.jpg")]
+    assert report["conflicts"] == [str(dest / "full-conflict.jpg")]
+
+    indexed_report = local_processing.archive_conflict_report(
+        str(dest),
+        [empty_source],
+        folder_template="",
+        indexed_paths={str(dest / "empty-conflict.jpg")},
+    )
+    assert indexed_report["empty"] == []
+    assert indexed_report["conflicts"] == [str(dest / "empty-conflict.jpg")]
+
+
 def test_conflicting_archive_paths_reports_symlink_even_when_target_matches(tmp_path):
     """A symlink at the archive-relative resume path must be treated as a
     conflict before staging, not as a safe same-content resume hit."""

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -1877,13 +1877,14 @@ def test_pipeline_local_processing_rejects_archive_path_conflicts(
 
     src = tmp_path / "card-conflict"
     src.mkdir()
-    Image.new("RGB", (16, 16), "green").save(src / "fresh.jpg")
+    source_path = src / "fresh.jpg"
+    Image.new("RGB", (16, 16), "green").save(source_path)
 
     final_parent = tmp_path / "archive-conflict-parent"
     final_parent.mkdir()
     final_dest = final_parent / "Archive"
     final_dest.mkdir()
-    (final_dest / "fresh.jpg").write_bytes(b"different existing bytes")
+    (final_dest / "fresh.jpg").write_bytes(b"x" * source_path.stat().st_size)
 
     import local_processing
 
@@ -1906,6 +1907,46 @@ def test_pipeline_local_processing_rejects_archive_path_conflicts(
     assert job["status"] == "failed", job
     error_text = (job.get("error") or "") + str(job.get("result", ""))
     assert "different files at the same import paths" in error_text
+
+
+def test_pipeline_local_processing_reports_incomplete_archive_files(
+    setup, tmp_path, monkeypatch
+):
+    app, _db_path = setup
+
+    src = tmp_path / "card-incomplete"
+    src.mkdir()
+    Image.new("RGB", (16, 16), "green").save(src / "fresh.jpg")
+
+    final_parent = tmp_path / "archive-incomplete-parent"
+    final_parent.mkdir()
+    final_dest = final_parent / "Archive"
+    final_dest.mkdir()
+    (final_dest / "fresh.jpg").write_bytes(b"")
+
+    import local_processing
+
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    monkeypatch.setattr(local_processing, "RESERVED_FREE_BYTES", 0)
+
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json={
+            "sources": [str(src)],
+            "destination": str(final_dest),
+            "local_processing": True,
+            "folder_template": "",
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        assert resp.status_code == 200
+        job = wait_for_job_via_client(c, resp.get_json()["job_id"])
+
+    assert job["status"] == "failed", job
+    error_text = (job.get("error") or "") + str(job.get("result", ""))
+    assert "1 empty unindexed file" in error_text
+    assert "interrupted previous archive copy" in error_text
+    assert "will not suffix around likely corrupt archive files" in error_text
 
 
 def test_pipeline_local_processing_conflict_preflight_skips_known_duplicates(

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -1949,6 +1949,126 @@ def test_pipeline_local_processing_reports_incomplete_archive_files(
     assert "will not suffix around likely corrupt archive files" in error_text
 
 
+def test_pipeline_local_processing_recognises_indexed_archive_via_alias(
+    setup, tmp_path, monkeypatch
+):
+    """When the destination is a symlink alias of a tracked archive folder,
+    the indexed-path lookup must fold the alias so cataloged rows still
+    count as indexed. Otherwise a zero-byte tracked archive file would be
+    mis-reported as unindexed 'interrupted previous archive copy' debris,
+    telling the user to delete a file Vireo already manages."""
+    app, db_path = setup
+
+    src = tmp_path / "card-alias"
+    src.mkdir()
+    Image.new("RGB", (16, 16), "green").save(src / "fresh.jpg")
+
+    real_parent = tmp_path / "archive-alias-real-parent"
+    real_parent.mkdir()
+    real_dest = real_parent / "Archive"
+    real_dest.mkdir()
+    # Zero bytes so it hits the "empty" branch of archive_conflict_report
+    # when it (wrongly) looks unindexed.
+    (real_dest / "fresh.jpg").write_bytes(b"")
+
+    alias_parent = tmp_path / "archive-alias-link-parent"
+    alias_parent.mkdir()
+    alias_dest = alias_parent / "Archive"
+    try:
+        os.symlink(real_dest, alias_dest, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink creation not supported on this platform")
+
+    from db import Database
+    db = Database(db_path)
+    folder_id = db.add_folder(str(real_dest))
+    ws_id = db._active_workspace_id
+    db.add_workspace_folder(ws_id, folder_id)
+    db.add_photo(
+        folder_id=folder_id, filename="fresh.jpg", extension=".jpg",
+        file_size=0, file_mtime=1.0, file_hash=None,
+    )
+    db.close()
+
+    import local_processing
+
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    monkeypatch.setattr(local_processing, "RESERVED_FREE_BYTES", 0)
+
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json={
+            "sources": [str(src)],
+            "destination": str(alias_dest),
+            "local_processing": True,
+            "folder_template": "",
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        assert resp.status_code == 200
+        job = wait_for_job_via_client(c, resp.get_json()["job_id"])
+
+    assert job["status"] == "failed", job
+    error_text = (job.get("error") or "") + str(job.get("result", ""))
+    # The indexed archive row should be recognised through the alias, so
+    # the preflight must not label it as unindexed failed-copy debris.
+    assert "interrupted previous archive copy" not in error_text
+    assert "different files at the same import paths" in error_text
+
+
+def test_pipeline_local_processing_limits_incomplete_examples_to_incomplete(
+    setup, tmp_path, monkeypatch
+):
+    """Mixed incomplete + real-conflict runs must only list the incomplete
+    paths as examples in the 'interrupted previous archive copy' message —
+    the message's wording only describes empty/partial files, so leaking
+    full-content conflict paths into the example list points the user at
+    files that are neither empty nor truncated."""
+    app, _db_path = setup
+
+    src = tmp_path / "card-mixed"
+    src.mkdir()
+    Image.new("RGB", (16, 16), "green").save(src / "incomplete.jpg")
+    Image.new("RGB", (16, 16), "blue").save(src / "conflict.jpg")
+
+    final_parent = tmp_path / "archive-mixed-parent"
+    final_parent.mkdir()
+    final_dest = final_parent / "Archive"
+    final_dest.mkdir()
+    # Empty (incomplete) archive file for the first source.
+    (final_dest / "incomplete.jpg").write_bytes(b"")
+    # Different-content archive file at least as big as the source so
+    # the conflict is a real content mismatch, not partial debris.
+    src_size = (src / "conflict.jpg").stat().st_size
+    (final_dest / "conflict.jpg").write_bytes(b"x" * max(src_size, 1))
+
+    import local_processing
+
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    monkeypatch.setattr(local_processing, "RESERVED_FREE_BYTES", 0)
+
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json={
+            "sources": [str(src)],
+            "destination": str(final_dest),
+            "local_processing": True,
+            "folder_template": "",
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        assert resp.status_code == 200
+        job = wait_for_job_via_client(c, resp.get_json()["job_id"])
+
+    assert job["status"] == "failed", job
+    error_text = (job.get("error") or "") + str(job.get("result", ""))
+    assert "interrupted previous archive copy" in error_text
+    assert "incomplete.jpg" in error_text
+    # The conflict-only file must not appear in the incomplete branch's
+    # example list — the message wording is about empty/partial files.
+    assert "conflict.jpg" not in error_text
+
+
 def test_pipeline_local_processing_conflict_preflight_skips_known_duplicates(
     setup, tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## Summary

- Classify local-processing archive path conflicts into unindexed empty files, unindexed partial files, and real conflicts.
- Surface a clearer storage-stage error when conflicts look like debris from an interrupted archive copy.
- Keep likely corrupt archive files blocking rather than silently suffixing around them.

## Root Cause

The previous preflight collapsed every same-import-path byte mismatch into the same generic conflict message. In practice, zero-byte or smaller unindexed destination files are more likely failed-copy artifacts than legitimate same-name alternate photos.

## Validation

- `ruff check vireo/local_processing.py vireo/pipeline_job.py vireo/tests/test_local_processing.py vireo/tests/test_pipeline_api.py`
- `pytest vireo/tests/test_local_processing.py -q`
- `pytest vireo/tests/test_pipeline_api.py -k local_processing -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved archive conflict detection to distinguish incomplete archive files from true content conflicts.
  * Added clearer preflight messages when an import hits empty or partial existing archive files.

* **Bug Fixes**
  * Import checks now better handle cases where destination files are zero-byte or smaller-than-expected, helping avoid overwriting likely incomplete archives.
  * Conflict handling is more accurate when existing files are already indexed in the destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->