### PR TITLE
Missing folders: green check on the all-clear state

### DIFF
--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -9716,7 +9716,14 @@ async function loadMissingFolders() {
     const data = await resp.json();
     const folders = data.missing;
     if (folders.length === 0) {
-      container.innerHTML = '<p style="color:var(--text-secondary);">All folders are accounted for.</p>';
+      container.textContent = '';
+      const ok = document.createElement('p');
+      ok.style.cssText = 'color:#4caf50;display:flex;align-items:center;gap:8px;font-weight:500;';
+      const check = document.createElement('span');
+      check.textContent = '✓';
+      check.style.cssText = 'font-size:18px;line-height:1;';
+      ok.append(check, document.createTextNode('All folders are accounted for.'));
+      container.appendChild(ok);
       checkMissingFolders();  // update banner
       return;
     }


### PR DESCRIPTION
## What changed

When the Missing Folders modal has nothing to report, it now shows a green ✓ with green text — **✓ All folders are accounted for.** — instead of the previous muted grey line, so the resolved state reads unambiguously as "all good."

This came out of a design gut-check: the **Check Again** button stays (it's a re-poll / re-verify affordance, most useful right after remounting a drive), and we make the success state clearer rather than removing controls.

## Details

- Uses the existing `#4caf50` success-green convention (see `.report-status.success` at `_navbar.html:252`).
- Built with safe DOM methods rather than `innerHTML`, matching the surrounding `loadMissingFolders()` function's pattern.
- Renders both when the modal opens with no missing folders and right after a "Check Again" resolves everything.

## Testing

Frontend-only cosmetic change (single empty-state branch in `loadMissingFolders()`); no backend or test surface affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the empty-state message shown when all folders are accounted for, while keeping the same visible behavior and clearing prior content before display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->