### PR TITLE
Rename the Pipeline page to Process

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -86,9 +86,10 @@ _WIN_ERROR_MODE_LOCK = threading.Lock()
 # The `id` is the nav-id used in `tabs`; `href` is the canonical
 # route. Labels match what the navbar showed before the unification.
 ALL_PAGES = [
-    {"id": "pipeline",        "label": "Pipeline",        "href": "/pipeline"},
+    {"id": "pipeline",        "label": "Process",         "href": "/pipeline",
+     "keywords": "import add photos ingest scan process new"},
     {"id": "jobs",            "label": "Jobs",            "href": "/jobs"},
-    {"id": "pipeline_review", "label": "Pipeline Review", "href": "/pipeline/review"},
+    {"id": "pipeline_review", "label": "Process Review",  "href": "/pipeline/review"},
     {"id": "pipeline_rapid_review", "label": "Rapid Review", "href": "/pipeline/rapid-review"},
     {"id": "review",          "label": "Review",          "href": "/review"},
     {"id": "cull",            "label": "Cull",            "href": "/cull"},

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -2253,9 +2253,10 @@ window.NAV_DEFAULT_TABS = [
   'highlights', 'misses', 'settings'
 ];
 window.NAV_ALL_PAGES = [
-  {id: 'pipeline',        label: 'Pipeline',        href: '/pipeline'},
+  {id: 'pipeline',        label: 'Process',         href: '/pipeline',
+   keywords: 'import add photos ingest scan process new'},
   {id: 'jobs',            label: 'Jobs',            href: '/jobs'},
-  {id: 'pipeline_review', label: 'Pipeline Review', href: '/pipeline/review'},
+  {id: 'pipeline_review', label: 'Process Review',  href: '/pipeline/review'},
   {id: 'pipeline_rapid_review', label: 'Rapid Review', href: '/pipeline/rapid-review'},
   {id: 'review',          label: 'Review',          href: '/review'},
   {id: 'cull',            label: 'Cull',            href: '/cull'},
@@ -2913,7 +2914,7 @@ window.NAV_ALL_PAGES = [
     },
     navigation: {
       _title: 'Navigation',
-      import: 'Import', pipeline: 'Pipeline', pipeline_review: 'Pipeline Review',
+      import: 'Import', pipeline: 'Process', pipeline_review: 'Process Review',
       review: 'Review', cull: 'Cull', browse: 'Browse', map: 'Map',
       variants: 'Variants', dashboard: 'Dashboard', audit: 'Audit',
       compare: 'Compare', workspace: 'Workspace', keywords: 'Keywords',
@@ -9222,8 +9223,8 @@ function formatDuration(seconds) {
     // the running-job render path below.
     if (running.length === 0) {
       summary.textContent = waiting.length === 1
-        ? 'Pipeline queued'
-        : waiting.length + ' pipelines queued';
+        ? 'Processing queued'
+        : waiting.length + ' processing jobs queued';
       return;
     }
 
@@ -10053,8 +10054,9 @@ async function _deleteMissingPhotoIds(ids, deleteSidecars) {
     if (window.Fuse) {
       fuse = new Fuse(allPages, {
         keys: [
-          {name: 'label', weight: 0.7},
-          {name: 'id',    weight: 0.3},
+          {name: 'label',    weight: 0.6},
+          {name: 'keywords', weight: 0.3},
+          {name: 'id',       weight: 0.1},
         ],
         threshold: 0.4,
         ignoreLocation: true,
@@ -10109,7 +10111,9 @@ async function _deleteMissingPhotoIds(ids, deleteSidecars) {
     } else {
       const q = query.toLowerCase();
       results = allPages.filter(p =>
-        p.label.toLowerCase().includes(q) || p.id.includes(q)
+        p.label.toLowerCase().includes(q) ||
+        p.id.includes(q) ||
+        (p.keywords || '').toLowerCase().includes(q)
       );
     }
     if (selectedIndex >= results.length) selectedIndex = 0;

--- a/vireo/templates/audit.html
+++ b/vireo/templates/audit.html
@@ -138,7 +138,7 @@
       <div class="action-bar">
         <button class="btn btn-primary" id="btnUntracked" onclick="runUntrackedCheck()">Check for Untracked</button>
         <button class="btn btn-secondary" onclick="importAllUntracked()">Import All</button>
-        <button class="btn btn-secondary" id="sendToPipelineBtn" onclick="sendToPipeline()" style="display:none;">Send to Pipeline</button>
+        <button class="btn btn-secondary" id="sendToPipelineBtn" onclick="sendToPipeline()" style="display:none;">Send to Process</button>
         <span class="status-msg" id="untrackedStatus"></span>
       </div>
       <div id="untrackedContent"><div class="empty-msg">Click "Check for Untracked" to scan.</div></div>

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -786,7 +786,7 @@ function render() {
     root.innerHTML =
       '<div class="misses-empty-page">' +
       '<p>No misses detected — either you nailed every shot, or detection hasn\'t run yet.</p>' +
-      '<p><a href="/pipeline">Go to Pipeline</a> to run miss detection on your folders.</p>' +
+      '<p><a href="/pipeline">Go to Process</a> to run miss detection on your folders.</p>' +
       '</div>';
     focusedCategory = null;
     focusedIndex = -1;

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -6,7 +6,7 @@
 <link rel="icon" type="image/png" href="/favicon.ico">
 <link rel="apple-touch-icon" href="/static/apple-touch-icon.png">
 <link rel="stylesheet" href="/static/vireo-base.css">
-<title>Vireo - Pipeline</title>
+<title>Vireo - Process</title>
 <style>
 /* Page overrides */
 body { padding-bottom: 36px; }
@@ -633,7 +633,7 @@ body { padding-bottom: 36px; }
 
 <div class="pipeline-layout">
 <div class="pipeline-left">
-  <h2 style="margin-bottom:20px;font-size:20px;">Pipeline</h2>
+  <h2 style="margin-bottom:20px;font-size:20px;">Process</h2>
 
   <div class="stage-section-header">Setup</div>
 
@@ -1137,7 +1137,7 @@ body { padding-bottom: 36px; }
   </div>
   <div id="pipelineErrorBanner" data-testid="pipeline-error-banner" style="display:none;background:var(--danger,#e5484d);color:#fff;padding:10px 14px;border-radius:6px;margin:8px 0;font-size:13px;">
     <button onclick="this.parentElement.style.display='none'" style="float:right;background:none;border:none;color:#fff;cursor:pointer;font-size:16px;line-height:1;padding:0 4px;">&times;</button>
-    <strong>Pipeline failed</strong>
+    <strong>Processing failed</strong>
     <div id="pipelineErrorText" style="margin-top:4px;white-space:pre-line;"></div>
   </div>
 </div><!-- end pipeline-left -->

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -6,7 +6,7 @@
 <link rel="icon" type="image/png" href="/favicon.ico">
 <link rel="apple-touch-icon" href="/static/apple-touch-icon.png">
 <link rel="stylesheet" href="/static/vireo-base.css">
-<title>Vireo - Pipeline Review</title>
+<title>Vireo - Process Review</title>
 <style>
 /* Layout: sidebar + main */
 .pipeline-layout {
@@ -1411,7 +1411,7 @@ input[type="range"]::-moz-range-thumb {
       <div class="summary-group" aria-label="Inventory counts">
         <div class="summary-group-title">Inventory</div>
         <div class="summary-group-stats">
-          <div class="summary-stat" title="Total photos included in this pipeline review result">
+          <div class="summary-stat" title="Total photos included in this process review result">
             <div class="num" id="statTotalPhotos">0</div>
             <div class="label">Photos</div>
           </div>
@@ -1510,7 +1510,7 @@ input[type="range"]::-moz-range-thumb {
     <div id="encountersContainer"></div>
 
     <div class="empty-state" id="emptyState" style="display:none;">
-      <h2 id="emptyStateHeading">No pipeline results yet</h2>
+      <h2 id="emptyStateHeading">No results yet</h2>
       <p id="emptyStateBody"></p>
       <div class="readiness-stages" id="readinessStages"></div>
       <div class="readiness-actions" id="readinessActions"></div>
@@ -3041,10 +3041,10 @@ function renderEmptyState(readiness) {
 
   if (readiness.state === 'insufficient') {
     heading.textContent = 'Not enough features to compute results yet';
-    body.textContent = 'Run mask extraction on the Pipeline page first '
+    body.textContent = 'Run mask extraction on the Process page first '
       + '— the review page needs masks to score photo quality.';
     actions.innerHTML = '<a href="/pipeline" class="compute-btn" '
-      + 'style="text-decoration:none;display:inline-block;">Open Pipeline</a>';
+      + 'style="text-decoration:none;display:inline-block;">Open Process</a>';
     return;
   }
 

--- a/vireo/templates/shortcuts.html
+++ b/vireo/templates/shortcuts.html
@@ -69,8 +69,8 @@ var SHORTCUT_LABELS = {
   navigation: {
     _title: 'Navigation',
     import: 'Go to Import',
-    pipeline: 'Go to Pipeline',
-    pipeline_review: 'Go to Pipeline Review',
+    pipeline: 'Go to Process',
+    pipeline_review: 'Go to Process Review',
     review: 'Go to Review',
     cull: 'Go to Cull',
     browse: 'Go to Browse',

--- a/vireo/templates/workspace.html
+++ b/vireo/templates/workspace.html
@@ -31,7 +31,7 @@
     <div id="wsFoldersContent"><span style="color:var(--text-ghost);font-size:13px;">Loading...</span></div>
     <div style="margin-top:12px;border-top:1px solid var(--border-primary);padding-top:12px;">
       <a href="/pipeline" class="btn btn-secondary" style="text-decoration:none;display:inline-block;">+ Add Folder</a>
-      <div style="font-size:11px;color:var(--text-dim);margin-top:4px;">Opens Pipeline to add and scan a folder</div>
+      <div style="font-size:11px;color:var(--text-dim);margin-top:4px;">Opens the Process page to add and scan a folder</div>
     </div>
   </div>
 

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -2114,7 +2114,7 @@ def test_navbar_js_fallbacks_match_python_constants():
     def js_to_json(s):
         s = s.rstrip(';').strip()
         s = s.replace("'", '"')
-        s = re.sub(r'(\b)(id|label|href)(\s*:)', r'\1"\2"\3', s)
+        s = re.sub(r'(\b)(id|label|href|keywords)(\s*:)', r'\1"\2"\3', s)
         return s
 
     js_tabs = json.loads(js_to_json(tabs_match.group(1)))


### PR DESCRIPTION
## What & why

The **Pipeline** nav page is engineer-speak — it names the implementation (a chain of stages) rather than what the user is there to do: bring photos in and process them. This renames the user-facing label to **Process**.

The page does *two* jobs — import new photos **and** re-run AI on an existing collection — so a plain "Import" label would undersell it. Instead the page stays **Process** and the "people look for import" concern is solved by **search**: the ⌘K command palette now matches a `keywords` field, so typing **import** / **add photos** / **scan** surfaces Process. The existing empty-state "Import Photos" button on Browse is unchanged.

## Changes (labels/text only)

- Nav registries (`app.py:ALL_PAGES` + `_navbar.html:NAV_ALL_PAGES`): `Pipeline` → `Process`, `Pipeline Review` → `Process Review` (`Review` is already taken by `/review`).
- Page `<title>`s, the `pipeline.html` `<h2>`, error banner ("Processing failed"), and the review empty-state heading ("No results yet").
- Cross-references to the page: shortcuts help, workspace "+ Add Folder" hint, `misses.html` link, `audit.html` "Send to Process" button, `pipeline_review.html` readiness panel ("Open Process"), and the bottom-panel job status ("Processing queued").
- **Discoverability:** added `keywords: "import add photos ingest scan process new"` to the Process page, wired into the palette (Fuse keys + substring fallback).

## Deliberately untouched

Every internal identifier — routes, nav `id`s, job `type=="pipeline"`, config keys, CSS classes, JS functions — plus the separate per-photo **Pipeline Inspector** feature and the Settings **Pipeline Tuning/Models** sections.

## Tests

Extended `test_navbar_js_fallbacks_match_python_constants` to recognize the new `keywords` key when reconciling the JS and Python page registries.

Recommended suite: **1232 passed, 1 skipped**.
\`\`\`
python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py tests/e2e/test_pipeline_rapid_review.py tests/e2e/test_navigation.py -q
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the app’s “Pipeline” naming to “Process” across navigation, page titles, and key call-to-action text.
  * Improved search and shortcut help so Process-related pages are easier to find and access.
* **Bug Fixes**
  * Refined status and empty-state messages to match the new Process terminology, including queued and failed states.
  * Updated related guidance and links in review and audit flows for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->