### PR TITLE
Fix new-images pipeline snapshot lag

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -7350,7 +7350,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             wdb.set_active_workspace(ws_id)
             try:
                 return count_new_images_for_workspace(
-                    wdb, ws_id, sample_limit=None, progress_callback=progress_callback,
+                    wdb, ws_id, sample_limit=5, progress_callback=progress_callback,
                 )
             except Exception as e:
                 walk_error["exc"] = e

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -7480,6 +7480,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 kickoff_at_dict.pop(kickoff_key, None)
             return jsonify({"error": recent_err}), 500
 
+        # Force the snapshot generation forward before trusting any cache for
+        # a newly-started session. A navbar probe may have begun before the
+        # click but finish after ``request_kickoff_at``; invalidating first
+        # drops that stale write (or makes the in-flight worker stale) before
+        # the cache reuse check below.
+        if started_snapshot_session:
+            cache.invalidate_workspaces(db_path, [ws_id])
+
         # A cached "sample_complete" result may be there because the navbar
         # probe ran recently — but the cache is not invalidated when files
         # are copied into a mapped folder, so ``sample`` can omit images
@@ -7501,14 +7509,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             wdb = Database(db_path)
             wdb.set_active_workspace(ws_id)
             return count_new_images_for_workspace(wdb, ws_id, sample_limit=None)
-
-        # Nothing fresh yet. The first POST in a snapshot session must force
-        # a walk that begins at click time. If a navbar probe is already in
-        # flight, invalidating bumps the cache generation; kickoff_compute
-        # coalesces onto that old event only long enough to queue one fresh
-        # rerun, and the stale write is dropped by the generation guard.
-        if started_snapshot_session:
-            cache.invalidate_workspaces(db_path, [ws_id])
 
         event = cache.kickoff_compute(db_path, ws_id, compute)
         if event.wait(timeout=0.5):

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -7290,13 +7290,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if ws_id is None:
             return jsonify({"workspace_id": None, "new_count": 0, "per_root": [], "sample": []})
 
+        def response_payload(result):
+            """Return a small client payload while keeping full paths in cache."""
+            payload = dict(result)
+            payload["workspace_id"] = ws_id
+            payload["sample"] = list(payload.get("sample") or [])[:5]
+            payload.pop("sample_complete", None)
+            return payload
+
         cache = db._new_images_cache
         db_path = db._db_path
         cached = cache.get(db_path, ws_id)
         if cached is not None:
-            payload = dict(cached)
-            payload["workspace_id"] = ws_id
-            return jsonify(payload)
+            return jsonify(response_payload(cached))
 
         # If a recent compute failed and we're still inside the backoff
         # window, surface the error instead of kicking off another walk.
@@ -7334,7 +7340,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             wdb.set_active_workspace(ws_id)
             try:
                 return count_new_images_for_workspace(
-                    wdb, ws_id, progress_callback=progress_callback,
+                    wdb, ws_id, sample_limit=None, progress_callback=progress_callback,
                 )
             except Exception as e:
                 walk_error["exc"] = e
@@ -7401,9 +7407,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if event.wait(timeout=0.5):
             cached = cache.get(db_path, ws_id)
             if cached is not None:
-                payload = dict(cached)
-                payload["workspace_id"] = ws_id
-                return jsonify(payload)
+                return jsonify(response_payload(cached))
             # Compute finished but produced no cached entry — it must have
             # raised. Surface the error captured by the worker.
             recent_err = cache.get_recent_error(db_path, ws_id)
@@ -7430,16 +7434,41 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         ws_id = db._active_workspace_id
         if ws_id is None:
             return jsonify({"error": "no active workspace"}), 400
+        cache = db._new_images_cache
+        db_path = db._db_path
+
+        def create_snapshot_from_result(result):
+            file_paths = list(result.get("sample") or [])
+            snap_id = db.create_new_images_snapshot(file_paths)
+            folders = sorted({os.path.dirname(p) for p in file_paths})
+            return jsonify({
+                "snapshot_id": snap_id,
+                "file_count": len(file_paths),
+                "folders": folders,
+            })
+
+        cached = cache.get(db_path, ws_id)
+        if cached is not None and cached.get("sample_complete"):
+            return create_snapshot_from_result(cached)
+
         from new_images import count_new_images_for_workspace
-        result = count_new_images_for_workspace(db, ws_id, sample_limit=None)
-        file_paths = list(result["sample"])
-        snap_id = db.create_new_images_snapshot(file_paths)
-        folders = sorted({os.path.dirname(p) for p in file_paths})
-        return jsonify({
-            "snapshot_id": snap_id,
-            "file_count": len(file_paths),
-            "folders": folders,
-        })
+
+        def compute():
+            from db import Database
+            wdb = Database(db_path)
+            wdb.set_active_workspace(ws_id)
+            return count_new_images_for_workspace(wdb, ws_id, sample_limit=None)
+
+        event = cache.kickoff_compute(db_path, ws_id, compute)
+        if event.wait(timeout=0.5):
+            cached = cache.get(db_path, ws_id)
+            if cached is not None and cached.get("sample_complete"):
+                return create_snapshot_from_result(cached)
+            recent_err = cache.get_recent_error(db_path, ws_id)
+            if recent_err is not None:
+                return jsonify({"error": recent_err}), 500
+
+        return jsonify({"pending": True}), 202
 
     @app.route(
         "/api/workspaces/active/new-images/snapshot/<int:snapshot_id>",

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -7461,19 +7461,29 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "folders": folders,
             })
 
+        with kickoff_at_lock:
+            request_kickoff_at = kickoff_at_dict.get(kickoff_key)
+            started_snapshot_session = request_kickoff_at is None
+            if started_snapshot_session:
+                request_kickoff_at = time.monotonic()
+                kickoff_at_dict[kickoff_key] = request_kickoff_at
+
+        recent_err = cache.get_recent_error(db_path, ws_id)
+        if recent_err is not None:
+            with kickoff_at_lock:
+                kickoff_at_dict.pop(kickoff_key, None)
+            return jsonify({"error": recent_err}), 500
+
         # A cached "sample_complete" result may be there because the navbar
         # probe ran recently — but the cache is not invalidated when files
         # are copied into a mapped folder, so ``sample`` can omit images
         # that arrived after that probe. Only trust the cached sample if
         # this request's snapshot session already forced a fresh walk and
         # the entry was written *after* that invalidation.
-        with kickoff_at_lock:
-            request_kickoff_at = kickoff_at_dict.get(kickoff_key)
         cached = cache.get(db_path, ws_id)
         entry_set_at = cache.get_entry_set_at(db_path, ws_id)
         if (cached is not None
                 and cached.get("sample_complete")
-                and request_kickoff_at is not None
                 and entry_set_at is not None
                 and entry_set_at >= request_kickoff_at):
             return create_snapshot_from_result(cached)
@@ -7486,18 +7496,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             wdb.set_active_workspace(ws_id)
             return count_new_images_for_workspace(wdb, ws_id, sample_limit=None)
 
-        # Nothing fresh yet. If a background walk is already running for
-        # this workspace it was almost certainly kicked off by an earlier
-        # poll in this same snapshot session — coalesce onto it rather than
-        # invalidating it out from under itself and starting a redundant
-        # walk. Only when no walk is in flight do we mark the request's
-        # kickoff time and drop the cached entry, so a fresh walk starts
-        # and reflects disk state at click time.
-        if not cache.has_inflight(db_path, ws_id):
-            with kickoff_at_lock:
-                kickoff_at_dict[kickoff_key] = time.monotonic()
+        # Nothing fresh yet. The first POST in a snapshot session must force
+        # a walk that begins at click time. If a navbar probe is already in
+        # flight, invalidating bumps the cache generation; kickoff_compute
+        # coalesces onto that old event only long enough to queue one fresh
+        # rerun, and the stale write is dropped by the generation guard.
+        if started_snapshot_session:
             cache.invalidate_workspaces(db_path, [ws_id])
-            request_kickoff_at = kickoff_at_dict[kickoff_key]
 
         event = cache.kickoff_compute(db_path, ws_id, compute)
         if event.wait(timeout=0.5):
@@ -7505,9 +7510,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             entry_set_at = cache.get_entry_set_at(db_path, ws_id)
             if (cached is not None
                     and cached.get("sample_complete")
-                    and (request_kickoff_at is None
-                         or (entry_set_at is not None
-                             and entry_set_at >= request_kickoff_at))):
+                    and entry_set_at is not None
+                    and entry_set_at >= request_kickoff_at):
                 return create_snapshot_from_result(cached)
             recent_err = cache.get_recent_error(db_path, ws_id)
             if recent_err is not None:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2138,6 +2138,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     app._log_broadcaster = LogBroadcaster(buffer_size=500)
     app._log_broadcaster.install()
 
+    # Per-workspace monotonic timestamp recording when the current snapshot
+    # POST forced a fresh recompute. Subsequent polls on the same request
+    # compare the cache entry's set_at to this value: if the entry was
+    # written after we invalidated, it's the fresh walk's result and can be
+    # reused; if it predates our invalidation, it's a stale navbar probe and
+    # must be re-walked. Cleared when a snapshot is successfully returned.
+    app._new_images_snapshot_kickoff_at = {}
+    app._new_images_snapshot_kickoff_lock = threading.Lock()
+
     # Self-healing background backfill of missing working copies. RAW (and
     # oversized JPEG) imports need a JPEG working copy at
     # ``~/.vireo/working/{photo_id}.jpg`` so /photos/<id>/original can serve
@@ -7436,19 +7445,37 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return jsonify({"error": "no active workspace"}), 400
         cache = db._new_images_cache
         db_path = db._db_path
+        kickoff_key = (db_path, ws_id)
+        kickoff_at_dict = app._new_images_snapshot_kickoff_at
+        kickoff_at_lock = app._new_images_snapshot_kickoff_lock
 
         def create_snapshot_from_result(result):
             file_paths = list(result.get("sample") or [])
             snap_id = db.create_new_images_snapshot(file_paths)
             folders = sorted({os.path.dirname(p) for p in file_paths})
+            with kickoff_at_lock:
+                kickoff_at_dict.pop(kickoff_key, None)
             return jsonify({
                 "snapshot_id": snap_id,
                 "file_count": len(file_paths),
                 "folders": folders,
             })
 
+        # A cached "sample_complete" result may be there because the navbar
+        # probe ran recently — but the cache is not invalidated when files
+        # are copied into a mapped folder, so ``sample`` can omit images
+        # that arrived after that probe. Only trust the cached sample if
+        # this request's snapshot session already forced a fresh walk and
+        # the entry was written *after* that invalidation.
+        with kickoff_at_lock:
+            request_kickoff_at = kickoff_at_dict.get(kickoff_key)
         cached = cache.get(db_path, ws_id)
-        if cached is not None and cached.get("sample_complete"):
+        entry_set_at = cache.get_entry_set_at(db_path, ws_id)
+        if (cached is not None
+                and cached.get("sample_complete")
+                and request_kickoff_at is not None
+                and entry_set_at is not None
+                and entry_set_at >= request_kickoff_at):
             return create_snapshot_from_result(cached)
 
         from new_images import count_new_images_for_workspace
@@ -7459,13 +7486,33 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             wdb.set_active_workspace(ws_id)
             return count_new_images_for_workspace(wdb, ws_id, sample_limit=None)
 
+        # Nothing fresh yet. If a background walk is already running for
+        # this workspace it was almost certainly kicked off by an earlier
+        # poll in this same snapshot session — coalesce onto it rather than
+        # invalidating it out from under itself and starting a redundant
+        # walk. Only when no walk is in flight do we mark the request's
+        # kickoff time and drop the cached entry, so a fresh walk starts
+        # and reflects disk state at click time.
+        if not cache.has_inflight(db_path, ws_id):
+            with kickoff_at_lock:
+                kickoff_at_dict[kickoff_key] = time.monotonic()
+            cache.invalidate_workspaces(db_path, [ws_id])
+            request_kickoff_at = kickoff_at_dict[kickoff_key]
+
         event = cache.kickoff_compute(db_path, ws_id, compute)
         if event.wait(timeout=0.5):
             cached = cache.get(db_path, ws_id)
-            if cached is not None and cached.get("sample_complete"):
+            entry_set_at = cache.get_entry_set_at(db_path, ws_id)
+            if (cached is not None
+                    and cached.get("sample_complete")
+                    and (request_kickoff_at is None
+                         or (entry_set_at is not None
+                             and entry_set_at >= request_kickoff_at))):
                 return create_snapshot_from_result(cached)
             recent_err = cache.get_recent_error(db_path, ws_id)
             if recent_err is not None:
+                with kickoff_at_lock:
+                    kickoff_at_dict.pop(kickoff_key, None)
                 return jsonify({"error": recent_err}), 500
 
         return jsonify({"pending": True}), 202

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -7303,7 +7303,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             """Return a small client payload while keeping full paths in cache."""
             payload = dict(result)
             payload["workspace_id"] = ws_id
-            payload["sample"] = list(payload.get("sample") or [])[:5]
+            sample = payload.get("sample") or []
+            payload["sample"] = sample[:5]
             payload.pop("sample_complete", None)
             return payload
 
@@ -7461,11 +7462,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "folders": folders,
             })
 
+        session_ttl_seconds = 120
+        now = time.monotonic()
         with kickoff_at_lock:
             request_kickoff_at = kickoff_at_dict.get(kickoff_key)
-            started_snapshot_session = request_kickoff_at is None
+            started_snapshot_session = (
+                request_kickoff_at is None
+                or now - request_kickoff_at > session_ttl_seconds
+            )
             if started_snapshot_session:
-                request_kickoff_at = time.monotonic()
+                request_kickoff_at = now
                 kickoff_at_dict[kickoff_key] = request_kickoff_at
 
         recent_err = cache.get_recent_error(db_path, ws_id)

--- a/vireo/new_images.py
+++ b/vireo/new_images.py
@@ -278,6 +278,33 @@ class NewImagesCache:
                 return None
             return result
 
+    def get_entry_set_at(self, db_path, workspace_id):
+        """Return the monotonic timestamp at which the current cache entry was
+        written, or ``None`` if there is no live entry. Callers use this to
+        distinguish a cache write that happened *before* their request from
+        one that happened *after*, so that a snapshot POST can tell whether
+        the cached sample reflects disk state at click time or was left over
+        from an earlier navbar probe."""
+        key = (db_path, workspace_id)
+        with self._lock:
+            entry = self._entries.get(key)
+            if entry is None:
+                return None
+            _result, set_at = entry
+            if time.monotonic() - set_at > self._ttl:
+                del self._entries[key]
+                return None
+            return set_at
+
+    def has_inflight(self, db_path, workspace_id):
+        """Return True if a background compute is currently running for
+        ``(db_path, workspace_id)``. Callers use this to coalesce onto an
+        existing walk instead of tearing it down with a fresh invalidation.
+        """
+        key = (db_path, workspace_id)
+        with self._lock:
+            return key in self._inflight
+
     def get_generation(self, db_path, workspace_id):
         """Return the current generation for ``(db_path, workspace_id)`` (0 if unseen)."""
         key = (db_path, workspace_id)

--- a/vireo/new_images.py
+++ b/vireo/new_images.py
@@ -208,7 +208,12 @@ def count_new_images_for_workspace(db, workspace_id, sample_limit=5,
     if progress_callback is not None:
         progress_callback(files_checked, total)
 
-    return {"new_count": total, "per_root": per_root, "sample": sample}
+    return {
+        "new_count": total,
+        "per_root": per_root,
+        "sample": sample,
+        "sample_complete": sample_limit is None or len(sample) >= total,
+    }
 
 
 class NewImagesCache:

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -2145,7 +2145,7 @@ function sendReport() {
 <!-- New Images Banner -->
 <div class="new-images-banner" id="newImagesBanner" style="display:none;">
   <span id="newImagesMsg"></span>
-  <button type="button" class="banner-cta" onclick="createPipelineFromNewImages()">Create a pipeline</button>
+  <button type="button" class="banner-cta" onclick="createPipelineFromNewImages(this)">Create a pipeline</button>
   <button class="banner-dismiss" onclick="dismissNewImagesBanner()">&times;</button>
 </div>
 
@@ -9763,15 +9763,39 @@ function dismissNewImagesBanner() {
   }
 }
 
-async function createPipelineFromNewImages() {
+function _sleepNewImages(ms) {
+  return new Promise(function(resolve) { setTimeout(resolve, ms); });
+}
+
+async function createPipelineFromNewImages(btn) {
+  if (btn && btn.disabled) return;
+  const originalText = btn ? btn.textContent : '';
+  if (btn) {
+    btn.disabled = true;
+    btn.textContent = 'Preparing...';
+  }
   try {
-    const r = await fetch('/api/workspaces/active/new-images/snapshot', {method: 'POST'});
-    if (!r.ok) throw new Error('snapshot failed');
-    const data = await r.json();
-    window.location.href = `/pipeline?new_images=${data.snapshot_id}`;
+    while (true) {
+      const r = await fetch('/api/workspaces/active/new-images/snapshot', {method: 'POST'});
+      if (r.status === 202) {
+        if (btn) btn.textContent = 'Still preparing...';
+        await _sleepNewImages(3000);
+        continue;
+      }
+      if (!r.ok) throw new Error('snapshot failed');
+      const data = await r.json();
+      if (!data || data.snapshot_id == null) throw new Error('snapshot missing');
+      window.location.href = `/pipeline?new_images=${data.snapshot_id}`;
+      return;
+    }
   } catch (e) {
     // Fall back to the existing behavior — blank pipeline wizard.
     window.location.href = '/pipeline';
+  } finally {
+    if (btn) {
+      btn.disabled = false;
+      btn.textContent = originalText || 'Create a pipeline';
+    }
   }
 }
 

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -9775,7 +9775,8 @@ async function createPipelineFromNewImages(btn) {
     btn.textContent = 'Preparing...';
   }
   try {
-    while (true) {
+    const maxAttempts = 20;  // About one minute at 3s intervals.
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
       const r = await fetch('/api/workspaces/active/new-images/snapshot', {method: 'POST'});
       if (r.status === 202) {
         if (btn) btn.textContent = 'Still preparing...';
@@ -9788,6 +9789,7 @@ async function createPipelineFromNewImages(btn) {
       window.location.href = `/pipeline?new_images=${data.snapshot_id}`;
       return;
     }
+    throw new Error('snapshot timed out');
   } catch (e) {
     // Fall back to the existing behavior — blank pipeline wizard.
     window.location.href = '/pipeline';

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1429,6 +1429,27 @@ document.addEventListener('DOMContentLoaded', refreshPipelineUI);
 // -- New images (Stage 1 third option) --
 var newImagesSnapshotId = null;
 
+function sleepNewImagesSnapshot(ms) {
+  return new Promise(function(resolve) { setTimeout(resolve, ms); });
+}
+
+async function createNewImagesSnapshotWithRetry(onPending) {
+  var maxAttempts = 20;  // About one minute at 3s intervals.
+  for (var attempt = 0; attempt < maxAttempts; attempt++) {
+    var resp = await fetch('/api/workspaces/active/new-images/snapshot', {method: 'POST'});
+    if (resp.status === 202) {
+      if (typeof onPending === 'function') onPending(attempt);
+      await sleepNewImagesSnapshot(3000);
+      continue;
+    }
+    if (!resp.ok) throw new Error('snapshot failed');
+    var data = await resp.json();
+    if (!data || data.snapshot_id == null) throw new Error('snapshot missing');
+    return data.snapshot_id;
+  }
+  throw new Error('snapshot timed out');
+}
+
 async function initNewImagesCard() {
   var params = new URLSearchParams(window.location.search);
   var deepLinkId = params.get('new_images');
@@ -2355,17 +2376,28 @@ async function selectSourceMode(mode) {
 
   if (mode === 'new_images' && newImagesSnapshotId === null) {
     // User is selecting the card directly (no deep-link) — freeze the list now.
+    var actionStatus = document.getElementById('pipelineActionStatus');
+    var snapshotError = null;
     try {
-      var resp = await fetch('/api/workspaces/active/new-images/snapshot', {method: 'POST'});
-      if (resp.ok) {
-        var data = await resp.json();
-        newImagesSnapshotId = data.snapshot_id;
+      if (actionStatus) {
+        actionStatus.textContent = 'Preparing new-images snapshot...';
+        actionStatus.className = 'status-msg';
       }
+      newImagesSnapshotId = await createNewImagesSnapshotWithRetry(function() {
+        if (actionStatus) {
+          actionStatus.textContent = 'Still preparing new-images snapshot...';
+        }
+      });
     } catch (e) {
       // Leave snapshot id null; submit will fail validation via updateStartButton.
+      snapshotError = 'New-images snapshot is still being prepared. Try again in a moment.';
     }
     // Snapshot resolved (or failed) — refresh start-button state.
     updateStartButton();
+    if (snapshotError && actionStatus) {
+      actionStatus.textContent = snapshotError;
+      actionStatus.className = 'status-msg error';
+    }
   }
 
   fetchFolderPreview();

--- a/vireo/tests/test_new_images_api.py
+++ b/vireo/tests/test_new_images_api.py
@@ -606,6 +606,154 @@ def test_post_snapshot_reuses_walk_across_polls(app_and_db, monkeypatch):
         release.set()
 
 
+def test_post_snapshot_queues_fresh_walk_when_navbar_walk_inflight(
+        app_and_db, monkeypatch):
+    """A snapshot click must not accept an already-running navbar probe as
+    the snapshot source. That probe began before the click, so files copied
+    while it was walking could be missing. The POST should invalidate the
+    generation, wait for the stale walk only as a queueing point, then return
+    a snapshot from the fresh rerun it owns."""
+    import threading
+    import time
+
+    import new_images as new_images_module
+    from new_images import get_shared_cache
+
+    app, db, ws_id, tmp_path = app_and_db
+    folder = tmp_path / "photos"
+    folder.mkdir()
+    db.add_folder(str(folder))
+    old_path = str(folder / "IMG_001.JPG")
+    fresh_path = str(folder / "IMG_002.JPG")
+    _touch_image(old_path)
+    _touch_image(fresh_path)
+
+    old_started = threading.Event()
+    old_release = threading.Event()
+    fresh_calls = {"n": 0}
+
+    def old_navbar_compute():
+        old_started.set()
+        old_release.wait(timeout=5)
+        return {
+            "new_count": 1,
+            "per_root": [{"folder_id": 1, "path": str(folder), "new_count": 1}],
+            "sample": [old_path],
+            "sample_complete": True,
+        }
+
+    def fresh_snapshot_count(*args, **kwargs):
+        fresh_calls["n"] += 1
+        return {
+            "new_count": 2,
+            "per_root": [{"folder_id": 1, "path": str(folder), "new_count": 2}],
+            "sample": [old_path, fresh_path],
+            "sample_complete": True,
+        }
+
+    cache = get_shared_cache()
+    cache.kickoff_compute(db._db_path, ws_id, old_navbar_compute)
+    assert old_started.wait(timeout=2), "navbar walk never started"
+    monkeypatch.setattr(
+        new_images_module, "count_new_images_for_workspace",
+        fresh_snapshot_count,
+    )
+
+    try:
+        with app.test_client() as client:
+            first = client.post("/api/workspaces/active/new-images/snapshot")
+            assert first.status_code == 202
+            assert first.get_json() == {"pending": True}
+            assert fresh_calls["n"] == 0, (
+                "fresh rerun should be queued behind the existing walk, not "
+                "started in parallel"
+            )
+
+            old_release.set()
+            deadline = time.monotonic() + 2.0
+            resp = None
+            while time.monotonic() < deadline:
+                resp = client.post("/api/workspaces/active/new-images/snapshot")
+                if resp.status_code == 200:
+                    break
+                time.sleep(0.05)
+
+            assert resp is not None and resp.status_code == 200, (
+                f"snapshot never converged after queued rerun; "
+                f"last={resp and resp.status_code}"
+            )
+            data = resp.get_json()
+            assert data["file_count"] == 2
+            assert fresh_calls["n"] == 1
+
+        snap = db.get_new_images_snapshot(data["snapshot_id"])
+        assert snap["file_paths"] == [old_path, fresh_path]
+    finally:
+        old_release.set()
+
+
+def test_post_snapshot_surfaces_async_error_without_retry_loop(
+        app_and_db, monkeypatch):
+    """If a snapshot-owned async walk fails after returning 202, the next poll
+    should surface that error and stop the snapshot session. It must not clear
+    the failure by invalidating again and start a new full walk every poll."""
+    import threading
+    import time
+
+    import new_images as new_images_module
+
+    app, db, ws_id, tmp_path = app_and_db
+    folder = tmp_path / "photos"
+    _touch_image(str(folder / "IMG_001.JPG"))
+    db.add_folder(str(folder))
+
+    call_count = {"n": 0}
+    started = threading.Event()
+    release = threading.Event()
+
+    def slow_boom(*args, **kwargs):
+        call_count["n"] += 1
+        started.set()
+        release.wait(timeout=5)
+        raise RuntimeError("disk unreachable")
+
+    monkeypatch.setattr(
+        new_images_module, "count_new_images_for_workspace", slow_boom,
+    )
+
+    try:
+        with app.test_client() as client:
+            first = client.post("/api/workspaces/active/new-images/snapshot")
+            assert first.status_code == 202
+            assert started.is_set()
+            assert call_count["n"] == 1
+
+            release.set()
+            deadline = time.monotonic() + 2.0
+            error_resp = None
+            while time.monotonic() < deadline:
+                error_resp = client.post(
+                    "/api/workspaces/active/new-images/snapshot",
+                )
+                if error_resp.status_code == 500:
+                    break
+                time.sleep(0.05)
+
+            assert error_resp is not None and error_resp.status_code == 500
+            assert "disk unreachable" in error_resp.get_json()["error"]
+
+            for _ in range(3):
+                retry = client.post("/api/workspaces/active/new-images/snapshot")
+                assert retry.status_code == 500
+            time.sleep(0.1)
+            assert call_count["n"] == 1, (
+                f"snapshot polls should not restart failed walks inside "
+                f"backoff; got {call_count['n']} calls"
+            )
+    finally:
+        release.set()
+
+
 def test_post_snapshot_next_click_after_success_forces_fresh_walk(app_and_db, monkeypatch):
     """After a snapshot returns successfully, a fresh click (e.g. the user
     dismissed the pipeline and clicked "Create a pipeline" again after

--- a/vireo/tests/test_new_images_api.py
+++ b/vireo/tests/test_new_images_api.py
@@ -183,6 +183,41 @@ def test_api_new_images_response_trims_full_cached_sample(app_and_db):
     assert len(cached["sample"]) == 8
 
 
+def test_api_new_images_cached_response_slices_without_full_copy(app_and_db):
+    """Cached full snapshots may contain tens of thousands of paths. The
+    navbar response should copy only the five paths it returns, not materialize
+    the entire cached sequence before slicing."""
+    from new_images import get_shared_cache
+
+    class SampleOnlySlice:
+        def __bool__(self):
+            return True
+
+        def __iter__(self):
+            raise AssertionError("sample should be sliced directly")
+
+        def __getitem__(self, key):
+            assert isinstance(key, slice), f"unexpected key: {key!r}"
+            assert key.start is None
+            assert key.stop == 5
+            return [f"/tmp/IMG_{i:03d}.JPG" for i in range(5)]
+
+    app, db, ws_id, tmp_path = app_and_db
+    get_shared_cache().set(db._db_path, ws_id, {
+        "new_count": 100000,
+        "per_root": [],
+        "sample": SampleOnlySlice(),
+        "sample_complete": True,
+    })
+
+    client = app.test_client()
+    resp = client.get("/api/workspaces/active/new-images")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data["sample"]) == 5
+    assert "sample_complete" not in data
+
+
 def test_api_new_images_returns_error_when_compute_fails(app_and_db, monkeypatch):
     """If the background walk raises (e.g. unavailable volume, DB error), the
     endpoint must surface an error instead of looping forever on pending.
@@ -690,6 +725,47 @@ def test_post_snapshot_queues_fresh_walk_when_navbar_walk_inflight(
         assert snap["file_paths"] == [old_path, fresh_path]
     finally:
         old_release.set()
+
+
+def test_post_snapshot_expires_abandoned_session_before_reuse(app_and_db):
+    """If a client abandons a 202 snapshot session, its kickoff marker must
+    not let a later click reuse that old session's cached sample. Once the
+    marker is older than the client retry window, a new POST must invalidate
+    and recompute from current disk state."""
+    import time
+
+    from new_images import get_shared_cache
+
+    app, db, ws_id, tmp_path = app_and_db
+    folder = tmp_path / "photos"
+    folder.mkdir()
+    db.add_folder(str(folder))
+    old_path = str(folder / "IMG_001.JPG")
+    fresh_path = str(folder / "IMG_002.JPG")
+    _touch_image(old_path)
+
+    cache = get_shared_cache()
+    with app._new_images_snapshot_kickoff_lock:
+        app._new_images_snapshot_kickoff_at[(db._db_path, ws_id)] = (
+            time.monotonic() - 121
+        )
+    cache.set(db._db_path, ws_id, {
+        "new_count": 1,
+        "per_root": [{"folder_id": 1, "path": str(folder), "new_count": 1}],
+        "sample": [old_path],
+        "sample_complete": True,
+    })
+
+    _touch_image(fresh_path)
+
+    with app.test_client() as client:
+        resp = client.post("/api/workspaces/active/new-images/snapshot")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["file_count"] == 2
+
+    snap = db.get_new_images_snapshot(data["snapshot_id"])
+    assert fresh_path in snap["file_paths"]
 
 
 def test_post_snapshot_surfaces_async_error_without_retry_loop(

--- a/vireo/tests/test_new_images_api.py
+++ b/vireo/tests/test_new_images_api.py
@@ -149,9 +149,9 @@ def test_api_new_images_returns_cached_after_background_compute_finishes(app_and
     assert data["new_count"] == 1
 
 
-def test_api_new_images_response_trims_full_cached_sample(app_and_db):
-    """The navbar only needs a tiny sample, but the server cache keeps the full
-    path list so "Create a pipeline" can snapshot without a second full walk."""
+def test_api_new_images_response_keeps_navbar_cache_bounded(app_and_db):
+    """The navbar only needs a tiny sample. Keep that probe's cache bounded;
+    the snapshot POST performs its own full walk when the user clicks."""
     import time
 
     from new_images import get_shared_cache
@@ -179,8 +179,8 @@ def test_api_new_images_response_trims_full_cached_sample(app_and_db):
             break
         time.sleep(0.01)
     assert cached is not None
-    assert cached["sample_complete"] is True
-    assert len(cached["sample"]) == 8
+    assert cached["sample_complete"] is False
+    assert len(cached["sample"]) == 5
 
 
 def test_api_new_images_cached_response_slices_without_full_copy(app_and_db):

--- a/vireo/tests/test_new_images_api.py
+++ b/vireo/tests/test_new_images_api.py
@@ -568,6 +568,49 @@ def test_post_snapshot_recomputes_over_navbar_populated_cache(app_and_db):
     assert fresh_path in snap["file_paths"]
 
 
+def test_post_snapshot_invalidates_before_trusting_newer_navbar_cache(
+        app_and_db, monkeypatch):
+    """A navbar walk can begin before the click but write its cache after the
+    snapshot session timestamp. The first snapshot POST must invalidate before
+    checking cache freshness, so that pre-click walk cannot masquerade as the
+    snapshot-owned result."""
+    import app as app_module
+    from new_images import get_shared_cache
+
+    fake_now = {"value": 200.0}
+    monkeypatch.setattr(
+        app_module.time, "monotonic", lambda: fake_now["value"],
+    )
+
+    app, db, ws_id, tmp_path = app_and_db
+    folder = tmp_path / "photos"
+    folder.mkdir()
+    db.add_folder(str(folder))
+    old_path = str(folder / "IMG_001.JPG")
+    fresh_path = str(folder / "IMG_002.JPG")
+    _touch_image(old_path)
+    _touch_image(fresh_path)
+
+    # Simulate a navbar worker that started before the click but wrote cache
+    # just after the snapshot session's kickoff timestamp.
+    get_shared_cache().set(db._db_path, ws_id, {
+        "new_count": 1,
+        "per_root": [{"folder_id": 1, "path": str(folder), "new_count": 1}],
+        "sample": [old_path],
+        "sample_complete": True,
+    })
+    fake_now["value"] = 100.0
+
+    with app.test_client() as client:
+        resp = client.post("/api/workspaces/active/new-images/snapshot")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["file_count"] == 2
+
+    snap = db.get_new_images_snapshot(data["snapshot_id"])
+    assert fresh_path in snap["file_paths"]
+
+
 def test_post_snapshot_reuses_walk_across_polls(app_and_db, monkeypatch):
     """The client polls the snapshot endpoint on 202 responses. Once the
     fresh walk this session kicked off populates the cache, subsequent

--- a/vireo/tests/test_new_images_api.py
+++ b/vireo/tests/test_new_images_api.py
@@ -149,6 +149,40 @@ def test_api_new_images_returns_cached_after_background_compute_finishes(app_and
     assert data["new_count"] == 1
 
 
+def test_api_new_images_response_trims_full_cached_sample(app_and_db):
+    """The navbar only needs a tiny sample, but the server cache keeps the full
+    path list so "Create a pipeline" can snapshot without a second full walk."""
+    import time
+
+    from new_images import get_shared_cache
+
+    app, db, ws_id, tmp_path = app_and_db
+    root = tmp_path / "shoot"
+    for i in range(8):
+        _touch_image(str(root / f"IMG_{i:03d}.JPG"))
+    db.add_folder(str(root), name="shoot")
+
+    client = app.test_client()
+    resp = client.get("/api/workspaces/active/new-images")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["new_count"] == 8
+    assert len(data["sample"]) == 5
+    assert "sample_complete" not in data
+
+    cache = get_shared_cache()
+    deadline = time.monotonic() + 2.0
+    cached = None
+    while time.monotonic() < deadline:
+        cached = cache.get(db._db_path, ws_id)
+        if cached is not None:
+            break
+        time.sleep(0.01)
+    assert cached is not None
+    assert cached["sample_complete"] is True
+    assert len(cached["sample"]) == 8
+
+
 def test_api_new_images_returns_error_when_compute_fails(app_and_db, monkeypatch):
     """If the background walk raises (e.g. unavailable volume, DB error), the
     endpoint must surface an error instead of looping forever on pending.
@@ -451,6 +485,43 @@ def test_post_snapshot_creates_row_with_current_new_images(app_and_db):
 
     snap = db.get_new_images_snapshot(data["snapshot_id"])
     assert snap["file_count"] == 2
+
+
+def test_post_snapshot_uses_complete_cache_without_rewalk(app_and_db, monkeypatch):
+    import new_images as new_images_module
+    from new_images import get_shared_cache
+
+    app, db, ws_id, tmp_path = app_and_db
+    folder = tmp_path / "photos"
+    paths = []
+    for i in range(7):
+        path = folder / f"IMG_{i:03d}.JPG"
+        _touch_image(str(path))
+        paths.append(str(path))
+    db.add_folder(str(folder))
+
+    get_shared_cache().set(db._db_path, ws_id, {
+        "new_count": len(paths),
+        "per_root": [{"folder_id": 1, "path": str(folder), "new_count": len(paths)}],
+        "sample": paths,
+        "sample_complete": True,
+    })
+
+    def boom(*args, **kwargs):
+        raise AssertionError("snapshot endpoint should not re-walk complete cache")
+
+    monkeypatch.setattr(
+        new_images_module, "count_new_images_for_workspace", boom,
+    )
+
+    with app.test_client() as client:
+        resp = client.post("/api/workspaces/active/new-images/snapshot")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["file_count"] == 7
+
+    snap = db.get_new_images_snapshot(data["snapshot_id"])
+    assert snap["file_count"] == 7
 
 
 def test_post_snapshot_zero_new_images_returns_200(app_and_db):

--- a/vireo/tests/test_new_images_api.py
+++ b/vireo/tests/test_new_images_api.py
@@ -524,6 +524,39 @@ def test_post_snapshot_uses_complete_cache_without_rewalk(app_and_db, monkeypatc
     assert snap["file_count"] == 7
 
 
+def test_post_snapshot_returns_pending_when_cache_is_incomplete(app_and_db, monkeypatch):
+    import threading
+
+    import new_images as new_images_module
+
+    app, db, ws_id, tmp_path = app_and_db
+    folder = tmp_path / "photos"
+    _touch_image(str(folder / "IMG_001.JPG"))
+    db.add_folder(str(folder))
+
+    release = threading.Event()
+    started = threading.Event()
+    real_count = new_images_module.count_new_images_for_workspace
+
+    def slow_count(*args, **kwargs):
+        started.set()
+        release.wait(timeout=5)
+        return real_count(*args, **kwargs)
+
+    monkeypatch.setattr(
+        new_images_module, "count_new_images_for_workspace", slow_count,
+    )
+
+    try:
+        with app.test_client() as client:
+            resp = client.post("/api/workspaces/active/new-images/snapshot")
+            assert resp.status_code == 202
+            assert resp.get_json() == {"pending": True}
+            assert started.is_set()
+    finally:
+        release.set()
+
+
 def test_post_snapshot_zero_new_images_returns_200(app_and_db):
     app, db, ws_id, tmp_path = app_and_db
     with app.test_client() as client:

--- a/vireo/tests/test_new_images_api.py
+++ b/vireo/tests/test_new_images_api.py
@@ -487,41 +487,166 @@ def test_post_snapshot_creates_row_with_current_new_images(app_and_db):
     assert snap["file_count"] == 2
 
 
-def test_post_snapshot_uses_complete_cache_without_rewalk(app_and_db, monkeypatch):
-    import new_images as new_images_module
+def test_post_snapshot_recomputes_over_navbar_populated_cache(app_and_db):
+    """The navbar probe populates the shared new-images cache and holds it
+    for the ``NewImagesCache`` TTL. Ordinary file copies into a mapped folder
+    do not invalidate it, so a user who gets a banner count, drops more
+    images into the folder, and then clicks "Create a pipeline" must not
+    receive a snapshot built from the stale cached sample — the endpoint
+    must re-walk the disk at click time. Verifies the fix for the Codex
+    review comment on the async-snapshot PR."""
     from new_images import get_shared_cache
 
     app, db, ws_id, tmp_path = app_and_db
     folder = tmp_path / "photos"
-    paths = []
-    for i in range(7):
-        path = folder / f"IMG_{i:03d}.JPG"
-        _touch_image(str(path))
-        paths.append(str(path))
+    folder.mkdir()
     db.add_folder(str(folder))
 
+    # Simulate the navbar's cache after an earlier probe: two images were
+    # on disk and captured in the sample.
+    old_paths = [str(folder / "IMG_001.JPG"), str(folder / "IMG_002.JPG")]
+    for p in old_paths:
+        _touch_image(p)
     get_shared_cache().set(db._db_path, ws_id, {
-        "new_count": len(paths),
-        "per_root": [{"folder_id": 1, "path": str(folder), "new_count": len(paths)}],
-        "sample": paths,
+        "new_count": len(old_paths),
+        "per_root": [{"folder_id": 1, "path": str(folder), "new_count": len(old_paths)}],
+        "sample": list(old_paths),
         "sample_complete": True,
     })
 
-    def boom(*args, **kwargs):
-        raise AssertionError("snapshot endpoint should not re-walk complete cache")
-
-    monkeypatch.setattr(
-        new_images_module, "count_new_images_for_workspace", boom,
-    )
+    # A third image lands on disk between the navbar probe and the click.
+    fresh_path = str(folder / "IMG_003.JPG")
+    _touch_image(fresh_path)
 
     with app.test_client() as client:
         resp = client.post("/api/workspaces/active/new-images/snapshot")
         assert resp.status_code == 200
         data = resp.get_json()
-        assert data["file_count"] == 7
+        # The endpoint must have re-walked and picked up the third file,
+        # not returned the two-file navbar cache.
+        assert data["file_count"] == 3, (
+            f"expected fresh walk to include new file, got {data!r}"
+        )
 
     snap = db.get_new_images_snapshot(data["snapshot_id"])
-    assert snap["file_count"] == 7
+    assert snap["file_count"] == 3
+    assert fresh_path in snap["file_paths"]
+
+
+def test_post_snapshot_reuses_walk_across_polls(app_and_db, monkeypatch):
+    """The client polls the snapshot endpoint on 202 responses. Once the
+    fresh walk this session kicked off populates the cache, subsequent
+    polls must reuse that result rather than tearing it down and starting
+    yet another walk — otherwise polling would livelock, never converging
+    on a snapshot."""
+    import threading
+
+    import new_images as new_images_module
+
+    app, db, ws_id, tmp_path = app_and_db
+    folder = tmp_path / "photos"
+    _touch_image(str(folder / "IMG_001.JPG"))
+    db.add_folder(str(folder))
+
+    call_count = {"n": 0}
+    started = threading.Event()
+    release = threading.Event()
+    lock = threading.Lock()
+    real_count = new_images_module.count_new_images_for_workspace
+
+    def counting_slow(*args, **kwargs):
+        with lock:
+            call_count["n"] += 1
+        started.set()
+        release.wait(timeout=5)
+        return real_count(*args, **kwargs)
+
+    monkeypatch.setattr(
+        new_images_module, "count_new_images_for_workspace", counting_slow,
+    )
+
+    try:
+        with app.test_client() as client:
+            # First POST kicks off the walk; walk is blocked in-flight.
+            first = client.post("/api/workspaces/active/new-images/snapshot")
+            assert first.status_code == 202
+            assert started.is_set()
+            calls_after_first = call_count["n"]
+
+            # A poll arriving before the walk finishes must coalesce, not
+            # spawn a second walk.
+            second = client.post("/api/workspaces/active/new-images/snapshot")
+            assert second.status_code == 202
+            assert call_count["n"] == calls_after_first, (
+                "poll during in-flight walk must not spawn another compute"
+            )
+
+            # Let the walk finish, then poll again — this time the endpoint
+            # should reuse the fresh cache and return the snapshot without
+            # walking a third time.
+            release.set()
+
+            import time as _time
+            deadline = _time.monotonic() + 2.0
+            resp = None
+            while _time.monotonic() < deadline:
+                resp = client.post("/api/workspaces/active/new-images/snapshot")
+                if resp.status_code == 200:
+                    break
+                _time.sleep(0.05)
+            assert resp is not None and resp.status_code == 200, (
+                f"snapshot never converged after walk; last status {resp and resp.status_code}"
+            )
+            assert resp.get_json()["file_count"] == 1
+            assert call_count["n"] == calls_after_first, (
+                f"post-walk poll must not spawn another compute; "
+                f"call_count={call_count['n']} vs baseline {calls_after_first}"
+            )
+    finally:
+        release.set()
+
+
+def test_post_snapshot_next_click_after_success_forces_fresh_walk(app_and_db, monkeypatch):
+    """After a snapshot returns successfully, a fresh click (e.g. the user
+    dismissed the pipeline and clicked "Create a pipeline" again after
+    dropping more files) must trigger a new walk — the previous snapshot
+    session's cache reuse must not linger and mask new arrivals."""
+    import new_images as new_images_module
+
+    app, db, ws_id, tmp_path = app_and_db
+    folder = tmp_path / "photos"
+    _touch_image(str(folder / "IMG_001.JPG"))
+    db.add_folder(str(folder))
+
+    call_count = {"n": 0}
+    real_count = new_images_module.count_new_images_for_workspace
+
+    def counting(*args, **kwargs):
+        call_count["n"] += 1
+        return real_count(*args, **kwargs)
+
+    monkeypatch.setattr(
+        new_images_module, "count_new_images_for_workspace", counting,
+    )
+
+    with app.test_client() as client:
+        first = client.post("/api/workspaces/active/new-images/snapshot")
+        assert first.status_code == 200
+        assert first.get_json()["file_count"] == 1
+        calls_after_first = call_count["n"]
+        assert calls_after_first >= 1
+
+        # User copies another image, then clicks again.
+        _touch_image(str(folder / "IMG_002.JPG"))
+        second = client.post("/api/workspaces/active/new-images/snapshot")
+        assert second.status_code == 200
+        assert second.get_json()["file_count"] == 2, (
+            "second click must recompute and pick up newly-copied file"
+        )
+        assert call_count["n"] > calls_after_first, (
+            f"second click must trigger a fresh walk; "
+            f"call_count went {calls_after_first} -> {call_count['n']}"
+        )
 
 
 def test_post_snapshot_returns_pending_when_cache_is_incomplete(app_and_db, monkeypatch):


### PR DESCRIPTION
## Summary
- Cache complete new-image paths server-side while keeping navbar responses small.
- Let snapshot creation reuse that complete cache, returning pending instead of blocking when preparation is still running.
- Add immediate button feedback and retry behavior for the banner CTA.

## Validation
- pytest -q vireo/tests/test_new_images_api.py tests/e2e/test_new_images_pipeline.py
- pytest -q vireo/tests/test_new_images.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the “New Images” flow to support background snapshot preparation with automatic polling and a smoother transition into pipeline creation.
  * Snapshot results can now be reused from cached data when available, reducing repeated work.

* **Bug Fixes**
  * New image responses now return a shorter preview list while preserving the full cached result behind the scenes.
  * Pipeline creation now handles pending snapshot generation and errors more gracefully, with the button state restored after completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->