### PR TITLE
Make BioCLIP-2.5 the default model

### DIFF
--- a/vireo/models.py
+++ b/vireo/models.py
@@ -82,6 +82,14 @@ def tree_of_life_ready(model_str, model_dir):
         for f in TOL_ARTIFACT_FILES
     )
 
+
+# The model a fresh install downloads and classifies with by default (the
+# welcome flow downloads this, and get_active_model() prefers it when the user
+# hasn't chosen one). BioCLIP-2.5 is the strongest variant and ships Tree of
+# Life embeddings, so it classifies label-free out of the box — no regional
+# species list required for a new user to get results.
+DEFAULT_MODEL_ID = "bioclip-2.5-vith14"
+
 # Known models that can be downloaded.
 # Each entry specifies which ONNX files are needed and the subdirectory
 # within the HF repo where they live.
@@ -387,7 +395,11 @@ def build_self_heal_redownloader(model_dir):
 
 
 def get_active_model():
-    """Return the currently active model config, or the first downloaded one."""
+    """Return the currently active model config, or the default when unset.
+
+    Priority: the explicitly-selected active_model, then DEFAULT_MODEL_ID if
+    downloaded, then any downloaded model (KNOWN_MODELS order).
+    """
     config = _load_config()
     models = get_models()
     active_id = config.get("active_model")
@@ -397,7 +409,12 @@ def get_active_model():
             if m["id"] == active_id and m["downloaded"]:
                 return m
 
-    # Fall back to first downloaded model
+    # No explicit choice: prefer the default model if it's downloaded.
+    for m in models:
+        if m["id"] == DEFAULT_MODEL_ID and m["downloaded"]:
+            return m
+
+    # Otherwise fall back to the first downloaded model.
     for m in models:
         if m["downloaded"]:
             return m

--- a/vireo/models.py
+++ b/vireo/models.py
@@ -397,8 +397,19 @@ def build_self_heal_redownloader(model_dir):
 def get_active_model():
     """Return the currently active model config, or the default when unset.
 
-    Priority: the explicitly-selected active_model, then DEFAULT_MODEL_ID if
-    downloaded, then any downloaded model (KNOWN_MODELS order).
+    Priority: the explicitly-selected active_model, then DEFAULT_MODEL_ID
+    when downloaded AND label-free-ready (Tree of Life artifacts on disk),
+    then any downloaded model (KNOWN_MODELS order).
+
+    The ToL-ready gate on the default matters because bioclip-2.5's ToL
+    artifacts are declared as `optional_files`: an install can succeed
+    without them and stay usable for label-list mode. In that partial
+    state, overriding a fully-ready ToL model (e.g. bioclip-2, which
+    carries its ToL files as required) with 2.5 would flip the welcome
+    flow to "setup blocked" and make label-free classification raise in
+    Classifier's label loader. Only take over the fallback when the
+    default can actually classify on its own; otherwise fall through so a
+    ToL-ready model already on disk still wins.
     """
     config = _load_config()
     models = get_models()
@@ -409,9 +420,14 @@ def get_active_model():
             if m["id"] == active_id and m["downloaded"]:
                 return m
 
-    # No explicit choice: prefer the default model if it's downloaded.
     for m in models:
-        if m["id"] == DEFAULT_MODEL_ID and m["downloaded"]:
+        if (
+            m["id"] == DEFAULT_MODEL_ID
+            and m["downloaded"]
+            and tree_of_life_ready(
+                m.get("model_str", ""), m.get("weights_path")
+            )
+        ):
             return m
 
     # Otherwise fall back to the first downloaded model.

--- a/vireo/templates/welcome.html
+++ b/vireo/templates/welcome.html
@@ -285,7 +285,7 @@ if (typeof safeEventSource === 'undefined') {
   };
 }
 
-var MODEL_ID = 'bioclip-vit-b-16';
+var MODEL_ID = 'bioclip-2.5-vith14';
 var modelAlreadyDownloaded = false;
 var classificationReady = false;
 
@@ -363,11 +363,12 @@ async function getStarted() {
   }
 }
 
-/* The model is ready. The default model (BioCLIP ViT-B-16) classifies by
-   matching against a regional species list, so without labels the pipeline
-   would fail at the classify stage. Route the user to the labels step unless
-   classification is already usable (a Tree-of-Life model or labels already
-   present), in which case finish setup straight away. */
+/* The model is ready. The default model (BioCLIP-2.5) ships Tree of Life
+   embeddings, so it classifies label-free and setup can finish straight away.
+   The status endpoint reports classification usable when the active model is
+   label-free (Tree of Life or timm) OR a non-empty label list is present;
+   otherwise route the user to the labels step so the pipeline won't fail at
+   the classify stage. */
 async function proceedAfterModel() {
   var ready = false;
   try {

--- a/vireo/tests/test_models.py
+++ b/vireo/tests/test_models.py
@@ -282,32 +282,78 @@ def test_get_active_model_fallback(tmp_path, monkeypatch):
     assert active["id"] == "bioclip-vit-b-16"
 
 
+def _install_known_model(tmp_path, models, model_id, *, include_optional=False):
+    """Materialize a KNOWN_MODELS entry on disk with `.data` sidecars and
+    JSON stubs so `get_models()` sees it as downloaded. When
+    `include_optional` is True, also drop stubs for `optional_files` —
+    used to simulate a bioclip-2.5 install that has (or doesn't have)
+    its Tree of Life artifacts on disk."""
+    km = next(m for m in models.KNOWN_MODELS if m["id"] == model_id)
+    d = tmp_path / "models" / model_id
+    d.mkdir(parents=True)
+    for fn in km["files"]:
+        if fn.endswith(".data"):
+            _make_fake_data_file(d / fn)
+        else:
+            (d / fn).write_text("{}")
+    if include_optional:
+        for fn in km.get("optional_files", []):
+            (d / fn).write_text("{}")
+
+
 def test_get_active_model_prefers_default(tmp_path, monkeypatch):
     """With no active_model set, prefer DEFAULT_MODEL_ID over the first
-    downloaded model, even though it isn't first in KNOWN_MODELS order."""
+    downloaded model — but only when the default's Tree of Life artifacts
+    are on disk so it's actually label-free-ready."""
     import models
 
     monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
     monkeypatch.setattr(models, "DEFAULT_MODELS_DIR", str(tmp_path / "models"))
 
-    def _make_model(model_id):
-        km = next(m for m in models.KNOWN_MODELS if m["id"] == model_id)
-        d = tmp_path / "models" / model_id
-        d.mkdir(parents=True)
-        for fn in km["files"]:
-            if fn.endswith(".data"):
-                _make_fake_data_file(d / fn)
-            else:
-                (d / fn).write_text("{}")
-
-    # Both v1 (first in KNOWN_MODELS) and the default 2.5 are downloaded.
-    _make_model("bioclip-vit-b-16")
-    _make_model(models.DEFAULT_MODEL_ID)
+    # Both v1 (first in KNOWN_MODELS) and the default 2.5 are downloaded,
+    # with 2.5's ToL artifacts present so it is label-free-ready.
+    _install_known_model(tmp_path, models, "bioclip-vit-b-16")
+    _install_known_model(
+        tmp_path, models, models.DEFAULT_MODEL_ID, include_optional=True,
+    )
     models._save_config({"models": [], "active_model": None})
 
     active = models.get_active_model()
     assert active is not None
     assert active["id"] == models.DEFAULT_MODEL_ID
+
+
+def test_get_active_model_skips_default_when_tol_missing(tmp_path, monkeypatch):
+    """Prefer the default only when it's actually label-free-ready.
+
+    bioclip-2.5 declares its ToL artifacts as `optional_files`, so an
+    install can succeed without them and be usable only for label-list
+    classification. If we blindly preferred 2.5 anyway, an install where
+    bioclip-2 is fully ToL-ready would get overridden by a 2.5 that can't
+    classify without labels — the status endpoint would report setup
+    blocked and Classifier(labels=None) would raise in _load_labels.
+    Instead, fall through so the ToL-ready bioclip-2 wins.
+    """
+    import models
+
+    monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
+    monkeypatch.setattr(models, "DEFAULT_MODELS_DIR", str(tmp_path / "models"))
+
+    # 2.5 installed WITHOUT its optional ToL artifacts; bioclip-2 fully
+    # installed (its ToL files are required, so they land automatically).
+    _install_known_model(
+        tmp_path, models, models.DEFAULT_MODEL_ID, include_optional=False,
+    )
+    _install_known_model(tmp_path, models, "bioclip-2")
+    models._save_config({"models": [], "active_model": None})
+
+    active = models.get_active_model()
+    assert active is not None
+    assert active["id"] != models.DEFAULT_MODEL_ID
+    # Fall-through walks KNOWN_MODELS order; v1 isn't downloaded, so
+    # bioclip-2 is the first downloaded entry — and it's the one we want,
+    # since it's the ToL-ready model.
+    assert active["id"] == "bioclip-2"
 
 
 # ---------------------------------------------------------------------------

--- a/vireo/tests/test_models.py
+++ b/vireo/tests/test_models.py
@@ -282,6 +282,34 @@ def test_get_active_model_fallback(tmp_path, monkeypatch):
     assert active["id"] == "bioclip-vit-b-16"
 
 
+def test_get_active_model_prefers_default(tmp_path, monkeypatch):
+    """With no active_model set, prefer DEFAULT_MODEL_ID over the first
+    downloaded model, even though it isn't first in KNOWN_MODELS order."""
+    import models
+
+    monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
+    monkeypatch.setattr(models, "DEFAULT_MODELS_DIR", str(tmp_path / "models"))
+
+    def _make_model(model_id):
+        km = next(m for m in models.KNOWN_MODELS if m["id"] == model_id)
+        d = tmp_path / "models" / model_id
+        d.mkdir(parents=True)
+        for fn in km["files"]:
+            if fn.endswith(".data"):
+                _make_fake_data_file(d / fn)
+            else:
+                (d / fn).write_text("{}")
+
+    # Both v1 (first in KNOWN_MODELS) and the default 2.5 are downloaded.
+    _make_model("bioclip-vit-b-16")
+    _make_model(models.DEFAULT_MODEL_ID)
+    models._save_config({"models": [], "active_model": None})
+
+    active = models.get_active_model()
+    assert active is not None
+    assert active["id"] == models.DEFAULT_MODEL_ID
+
+
 # ---------------------------------------------------------------------------
 # register_model
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #1077 (now merged). Now that BioCLIP-2.5 ships Tree of Life embeddings, it classifies **label-free out of the box**, making it a strictly better default than v1 for a new user — no regional species list required to get results.

## Changes

- **`vireo/models.py`** — add explicit `DEFAULT_MODEL_ID = "bioclip-2.5-vith14"`. `get_active_model()` now prefers it (when downloaded) ahead of the "first downloaded in KNOWN_MODELS order" fallback, so an install with no explicit choice lands on 2.5. No list reorder — Models page order unchanged.
- **`vireo/templates/welcome.html`** — first-run download target → `bioclip-2.5-vith14`; updated the stale comment. Because 2.5 is label-free (ToL) once its artifacts are on disk (`optional_files`, downloaded best-effort by `download_model`), the status endpoint reports classification usable via `tree_of_life_ready(...)` and the welcome flow finishes setup **without** the labels step.
- **`vireo/tests/test_models.py`** — `test_get_active_model_prefers_default`.

## Intentional tradeoff (flagging for review)

First-run download grows from **~400 MB (v1)** to **~7.5 GB** (2.5 weights 3.9 GB + `tol_embeddings.npy` 3.5 GB + classes 147 MB), and ViT-H/14 CPU inference is slower than v1 — in exchange for higher accuracy and a **zero-config, label-free** first-run experience. This is the product call from the original discussion; easy to revert or gate behind a smaller default if download size is a concern.

## Tests

`vireo/tests/test_models.py` green (69 passed), incl. the new default-preference test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app now has a new default model selection when no model has been explicitly chosen.
  * The welcome/onboarding flow now points to a newer default classification model.

* **Bug Fixes**
  * Active model selection now prefers the recommended default model when it’s available, instead of simply choosing the first downloaded model.
  * Onboarding guidance was updated to better match the model’s readiness behavior during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->