### PR TITLE
[codex] Preserve scoped workspace roots when merging archives

### DIFF
--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -1707,6 +1707,128 @@ def test_archive_merge_new_path_prunes_stale_broad_nonroot_link(db):
     assert future_photo is None
 
 
+def test_archive_merge_prunes_stale_nonroot_ancestor_above_scoped_root(db):
+    """Existing-row merge must prune non-root ancestors of the merge target.
+
+    A restricted scan (see ``scanner.py`` ``_restrict_root_paths``) links the
+    broad scan base as ``is_root=0`` above the user-facing scoped root — for
+    example, ``/archive`` non-root and ``/archive/USA/2026`` as the only
+    root. When a later merge into ``/archive/USA`` prunes non-root links at
+    or below ``/archive/USA`` and then calls
+    ``_materialize_workspace_descendants``, the surviving ``/archive``
+    non-root ancestor would immediately re-insert ``/archive/USA``,
+    ``/archive/USA/2020``, and any newly-merged sibling like
+    ``/archive/USA/2027``, defeating the scoped merge. The prune must also
+    remove uncovered non-root ancestors of the merge target.
+    """
+    ws_id = db.create_workspace("USA2026")
+
+    db.set_active_workspace(None)
+    archive_base_id = db.add_folder("/archive", name="archive")
+    usa_id = db.add_folder(
+        "/archive/USA",
+        name="USA",
+        parent_id=archive_base_id,
+    )
+    year_id = db.add_folder(
+        "/archive/USA/2026",
+        name="2026",
+        parent_id=usa_id,
+    )
+    old_year_id = db.add_folder(
+        "/archive/USA/2020",
+        name="2020",
+        parent_id=usa_id,
+    )
+    db.add_photo(old_year_id, "old.jpg", ".jpg", 1000, 1.0)
+
+    db.set_active_workspace(ws_id)
+    db.add_workspace_folder(ws_id, year_id)
+    # Seed the stale broad non-root ancestor link. This mirrors what a
+    # restricted scan leaves behind on the scan base above the scoped root.
+    db.add_workspace_folder(ws_id, archive_base_id, is_root=False)
+
+    staged_archive_id = db.add_folder(
+        "/staging/job/USA",
+        name="USA",
+        workspace_root=False,
+    )
+    staged_year_id = db.add_folder(
+        "/staging/job/USA/2026",
+        name="2026",
+        parent_id=staged_archive_id,
+        workspace_root=False,
+    )
+    staged_leaf_id = db.add_folder(
+        "/staging/job/USA/2026/2026-07-02",
+        name="2026-07-02",
+        parent_id=staged_year_id,
+        workspace_root=True,
+    )
+    db.add_photo(staged_leaf_id, "new.jpg", ".jpg", 1000, 2.0)
+    staged_other_year_id = db.add_folder(
+        "/staging/job/USA/2027",
+        name="2027",
+        parent_id=staged_archive_id,
+        workspace_root=False,
+    )
+    staged_other_leaf_id = db.add_folder(
+        "/staging/job/USA/2027/2027-01-01",
+        name="2027-01-01",
+        parent_id=staged_other_year_id,
+        workspace_root=True,
+    )
+    db.add_photo(staged_other_leaf_id, "future.jpg", ".jpg", 1000, 3.0)
+
+    db.merge_staged_tree_into_archive(staged_archive_id, "/archive/USA")
+
+    # Scoped root survives untouched.
+    root_paths = {
+        r["path"] for r in db.get_workspace_folder_roots(ws_id)
+    }
+    assert root_paths == {"/archive/USA/2026"}
+
+    # The stale ``/archive`` non-root ancestor link is gone, so a later
+    # ``_materialize_workspace_descendants`` cannot pull the whole archive
+    # subtree back into the workspace.
+    archive_base_link = db.conn.execute(
+        """SELECT 1 FROM workspace_folders
+           WHERE workspace_id = ? AND folder_id = ?""",
+        (ws_id, archive_base_id),
+    ).fetchone()
+    assert archive_base_link is None
+
+    # ``get_workspace_folders`` invokes ``_materialize_workspace_descendants``;
+    # verify neither the broad archive base nor sibling years surface.
+    linked_paths = {
+        r["path"] for r in db.get_workspace_folders(ws_id)
+    }
+    assert "/archive" not in linked_paths
+    assert "/archive/USA" not in linked_paths
+    assert "/archive/USA/2020" not in linked_paths
+    assert "/archive/USA/2027" not in linked_paths
+    assert "/archive/USA/2027/2027-01-01" not in linked_paths
+
+    # Out-of-scope sibling photos stay hidden.
+    old_photo = db.conn.execute(
+        """SELECT p.filename
+           FROM photos p
+           JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+          WHERE wf.workspace_id = ? AND p.filename = ?""",
+        (ws_id, "old.jpg"),
+    ).fetchone()
+    assert old_photo is None
+
+    future_photo = db.conn.execute(
+        """SELECT p.filename
+           FROM photos p
+           JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+          WHERE wf.workspace_id = ? AND p.filename = ?""",
+        (ws_id, "future.jpg"),
+    ).fetchone()
+    assert future_photo is None
+
+
 def test_move_folders_validates_source_workspace(db):
     """Raises ValueError if source workspace doesn't exist."""
     ws = db.create_workspace("A")

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -1547,6 +1547,79 @@ def test_archive_merge_new_path_preserves_narrower_workspace_root(db):
     assert future_photo is None
 
 
+def test_archive_merge_nested_new_path_does_not_link_out_of_scope_intermediate(db):
+    """A missing intermediate under a broad archive must not leak siblings.
+
+    Workspace root ``/archive/USA/2026`` is scoped narrower than the archive
+    base ``/archive/USA``. Merging into a nested new path ``/archive/USA/2027/
+    Trip`` requires materializing ``/archive/USA/2027`` as a folder row for
+    ``parent_id`` chaining. That intermediate must not be linked to the
+    workspace: no workspace root covers it, and any non-root link would let
+    ``_materialize_workspace_descendants`` (called by ``get_workspace_folders``)
+    pull the merged ``/archive/USA/2027/Trip`` subtree into the workspace.
+    """
+    ws_id = db.create_workspace("USA2026")
+
+    db.set_active_workspace(None)
+    archive_id = db.add_folder("/archive/USA", name="USA")
+    year_id = db.add_folder(
+        "/archive/USA/2026",
+        name="2026",
+        parent_id=archive_id,
+    )
+
+    db.set_active_workspace(ws_id)
+    db.add_workspace_folder(ws_id, year_id)
+
+    staged_trip_id = db.add_folder(
+        "/staging/job/Trip",
+        name="Trip",
+        workspace_root=True,
+    )
+    db.add_photo(staged_trip_id, "future.jpg", ".jpg", 1000, 3.0)
+
+    result = db.merge_staged_tree_into_archive(
+        staged_trip_id,
+        "/archive/USA/2027/Trip",
+    )
+
+    assert result["new_photos"] == 1
+
+    root_paths = {
+        r["path"] for r in db.get_workspace_folder_roots(ws_id)
+    }
+    assert root_paths == {"/archive/USA/2026"}
+
+    intermediate_row = db.conn.execute(
+        "SELECT id FROM folders WHERE path = ?",
+        ("/archive/USA/2027",),
+    ).fetchone()
+    assert intermediate_row is not None
+    intermediate_link = db.conn.execute(
+        """SELECT 1 FROM workspace_folders
+           WHERE workspace_id = ? AND folder_id = ?""",
+        (ws_id, intermediate_row["id"]),
+    ).fetchone()
+    assert intermediate_link is None
+
+    # get_workspace_folders() runs _materialize_workspace_descendants; the
+    # merged Trip subtree must remain invisible to this scoped workspace.
+    linked_paths = {
+        r["path"] for r in db.get_workspace_folders(ws_id)
+    }
+    assert "/archive/USA/2027" not in linked_paths
+    assert "/archive/USA/2027/Trip" not in linked_paths
+
+    future_photo = db.conn.execute(
+        """SELECT p.filename
+           FROM photos p
+           JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+          WHERE wf.workspace_id = ? AND p.filename = ?""",
+        (ws_id, "future.jpg"),
+    ).fetchone()
+    assert future_photo is None
+
+
 def test_move_folders_validates_source_workspace(db):
     """Raises ValueError if source workspace doesn't exist."""
     ws = db.create_workspace("A")

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -1377,10 +1377,16 @@ def test_archive_merge_preserves_narrower_workspace_root(db):
         workspace_root=True,
     )
     db.add_photo(staged_other_leaf_id, "future.jpg", ".jpg", 1000, 3.0)
+    db._new_images_cache.set(
+        db._db_path,
+        ws_id,
+        {"new_count": 99, "files": []},
+    )
 
     result = db.merge_staged_tree_into_archive(staged_archive_id, "/archive/USA")
 
     assert result["new_photos"] == 2
+    assert db._new_images_cache.get(db._db_path, ws_id) is None
     root_paths = {
         r["path"] for r in db.get_workspace_folder_roots(ws_id)
     }

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -1336,6 +1336,12 @@ def test_archive_merge_preserves_narrower_workspace_root(db):
 
     db.set_active_workspace(ws_id)
     db.add_workspace_folder(ws_id, year_id)
+    db.conn.executemany(
+        """INSERT INTO workspace_folders (workspace_id, folder_id, is_root)
+           VALUES (?, ?, 0)""",
+        [(ws_id, archive_id), (ws_id, old_year_id)],
+    )
+    db.conn.commit()
 
     # Staging mirrors local-processing imports: the broad staging folder is
     # just the archive shell; the touched dated leaf is the user-facing import
@@ -1358,15 +1364,29 @@ def test_archive_merge_preserves_narrower_workspace_root(db):
         workspace_root=True,
     )
     db.add_photo(staged_leaf_id, "new.jpg", ".jpg", 1000, 2.0)
+    staged_other_year_id = db.add_folder(
+        "/staging/job/USA/2027",
+        name="2027",
+        parent_id=staged_archive_id,
+        workspace_root=False,
+    )
+    staged_other_leaf_id = db.add_folder(
+        "/staging/job/USA/2027/2027-01-01",
+        name="2027-01-01",
+        parent_id=staged_other_year_id,
+        workspace_root=True,
+    )
+    db.add_photo(staged_other_leaf_id, "future.jpg", ".jpg", 1000, 3.0)
 
     result = db.merge_staged_tree_into_archive(staged_archive_id, "/archive/USA")
 
-    assert result["new_photos"] == 1
+    assert result["new_photos"] == 2
     root_paths = {
         r["path"] for r in db.get_workspace_folder_roots(ws_id)
     }
     assert "/archive/USA/2026" in root_paths
     assert "/archive/USA" not in root_paths
+    assert "/archive/USA/2027/2027-01-01" not in root_paths
 
     archive_link = db.conn.execute(
         """SELECT is_root FROM workspace_folders
@@ -1400,6 +1420,15 @@ def test_archive_merge_preserves_narrower_workspace_root(db):
         (ws_id, "old.jpg"),
     ).fetchone()
     assert old_photo is None
+
+    future_photo = db.conn.execute(
+        """SELECT p.filename
+           FROM photos p
+           JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+          WHERE wf.workspace_id = ? AND p.filename = ?""",
+        (ws_id, "future.jpg"),
+    ).fetchone()
+    assert future_photo is None
 
 
 def test_move_folders_validates_source_workspace(db):

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -1318,6 +1318,90 @@ def test_move_folders_blocks_descendant_when_source_root_remains(db):
     assert db.get_workspace_folders(ws2) == []
 
 
+def test_archive_merge_preserves_narrower_workspace_root(db):
+    """Merging into a broad archive must not widen an already-scoped workspace."""
+    ws_id = db.create_workspace("USA2026")
+
+    # Existing archive rows are globally known from another workspace/history,
+    # but this workspace is intentionally rooted only at the 2026 subtree.
+    db.set_active_workspace(None)
+    archive_id = db.add_folder("/archive/USA", name="USA")
+    year_id = db.add_folder("/archive/USA/2026", name="2026")
+    old_year_id = db.add_folder(
+        "/archive/USA/2020",
+        name="2020",
+        parent_id=archive_id,
+    )
+    db.add_photo(old_year_id, "old.jpg", ".jpg", 1000, 1.0)
+
+    db.set_active_workspace(ws_id)
+    db.add_workspace_folder(ws_id, year_id)
+
+    # Staging mirrors local-processing imports: the broad staging folder is
+    # just the archive shell; the touched dated leaf is the user-facing import
+    # root while it is still in staging.
+    staged_archive_id = db.add_folder(
+        "/staging/job/USA",
+        name="USA",
+        workspace_root=False,
+    )
+    staged_year_id = db.add_folder(
+        "/staging/job/USA/2026",
+        name="2026",
+        parent_id=staged_archive_id,
+        workspace_root=False,
+    )
+    staged_leaf_id = db.add_folder(
+        "/staging/job/USA/2026/2026-07-02",
+        name="2026-07-02",
+        parent_id=staged_year_id,
+        workspace_root=True,
+    )
+    db.add_photo(staged_leaf_id, "new.jpg", ".jpg", 1000, 2.0)
+
+    result = db.merge_staged_tree_into_archive(staged_archive_id, "/archive/USA")
+
+    assert result["new_photos"] == 1
+    root_paths = {
+        r["path"] for r in db.get_workspace_folder_roots(ws_id)
+    }
+    assert "/archive/USA/2026" in root_paths
+    assert "/archive/USA" not in root_paths
+
+    archive_link = db.conn.execute(
+        """SELECT is_root FROM workspace_folders
+           WHERE workspace_id = ? AND folder_id = ?""",
+        (ws_id, archive_id),
+    ).fetchone()
+    assert archive_link is None
+
+    old_year_link = db.conn.execute(
+        """SELECT 1 FROM workspace_folders
+           WHERE workspace_id = ? AND folder_id = ?""",
+        (ws_id, old_year_id),
+    ).fetchone()
+    assert old_year_link is None
+
+    new_photo = db.conn.execute(
+        """SELECT p.filename
+           FROM photos p
+           JOIN folders f ON f.id = p.folder_id
+           JOIN workspace_folders wf ON wf.folder_id = f.id
+          WHERE wf.workspace_id = ? AND f.path = ?""",
+        (ws_id, "/archive/USA/2026/2026-07-02"),
+    ).fetchone()
+    assert new_photo["filename"] == "new.jpg"
+
+    old_photo = db.conn.execute(
+        """SELECT p.filename
+           FROM photos p
+           JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+          WHERE wf.workspace_id = ? AND p.filename = ?""",
+        (ws_id, "old.jpg"),
+    ).fetchone()
+    assert old_photo is None
+
+
 def test_move_folders_validates_source_workspace(db):
     """Raises ValueError if source workspace doesn't exist."""
     ws = db.create_workspace("A")

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -1486,6 +1486,67 @@ def test_archive_merge_scoped_root_invalidates_new_images_cache(db):
     assert db._new_images_cache.get(db._db_path, ws_id) is None
 
 
+def test_archive_merge_new_path_preserves_narrower_workspace_root(db):
+    """Merging to a new archive path must not root a broader known ancestor."""
+    ws_id = db.create_workspace("USA2026")
+
+    db.set_active_workspace(None)
+    archive_id = db.add_folder("/archive/USA", name="USA")
+    year_id = db.add_folder(
+        "/archive/USA/2026",
+        name="2026",
+        parent_id=archive_id,
+    )
+    db.add_folder(
+        "/archive/USA/2020",
+        name="2020",
+        parent_id=archive_id,
+    )
+
+    db.set_active_workspace(ws_id)
+    db.add_workspace_folder(ws_id, year_id)
+
+    staged_year_id = db.add_folder(
+        "/staging/job/2027",
+        name="2027",
+        workspace_root=False,
+    )
+    staged_leaf_id = db.add_folder(
+        "/staging/job/2027/2027-01-01",
+        name="2027-01-01",
+        parent_id=staged_year_id,
+        workspace_root=True,
+    )
+    db.add_photo(staged_leaf_id, "future.jpg", ".jpg", 1000, 3.0)
+
+    result = db.merge_staged_tree_into_archive(
+        staged_year_id,
+        "/archive/USA/2027",
+    )
+
+    assert result["new_photos"] == 1
+    root_paths = {
+        r["path"] for r in db.get_workspace_folder_roots(ws_id)
+    }
+    assert root_paths == {"/archive/USA/2026"}
+
+    archive_link = db.conn.execute(
+        """SELECT 1 FROM workspace_folders
+           WHERE workspace_id = ? AND folder_id = ?""",
+        (ws_id, archive_id),
+    ).fetchone()
+    assert archive_link is None
+
+    future_photo = db.conn.execute(
+        """SELECT p.filename
+           FROM photos p
+           JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+          WHERE wf.workspace_id = ? AND p.filename = ?""",
+        (ws_id, "future.jpg"),
+    ).fetchone()
+    assert future_photo is None
+
+
 def test_move_folders_validates_source_workspace(db):
     """Raises ValueError if source workspace doesn't exist."""
     ws = db.create_workspace("A")

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -1437,6 +1437,55 @@ def test_archive_merge_preserves_narrower_workspace_root(db):
     assert future_photo is None
 
 
+def test_archive_merge_scoped_root_invalidates_new_images_cache(db):
+    """Scoped-root merges must flush a stale new-images cache after commit.
+
+    The scoped-root branch skips ``add_workspace_folder`` for the broad
+    archive base; ``_prune_...`` and ``_materialize_...`` only invalidate
+    when they actually change rows. In the shape below both are no-ops, so
+    the only workspace-membership writes come from the reconciliation
+    loop's ``_add_workspace_folder_no_commit`` — which does not invalidate.
+    Without the post-commit invalidation a cache entry set between the
+    rsync copy and reconciliation would keep reporting the just-imported
+    files as "new" until the TTL expired.
+    """
+    ws_id = db.create_workspace("USA2026")
+
+    db.set_active_workspace(None)
+    archive_id = db.add_folder("/archive/USA", name="USA")
+    year_id = db.add_folder("/archive/USA/2026", name="2026")
+
+    db.set_active_workspace(ws_id)
+    db.add_workspace_folder(ws_id, year_id)
+
+    staged_archive_id = db.add_folder(
+        "/staging/job/USA",
+        name="USA",
+        workspace_root=False,
+    )
+    staged_year_id = db.add_folder(
+        "/staging/job/USA/2026",
+        name="2026",
+        parent_id=staged_archive_id,
+        workspace_root=False,
+    )
+    staged_leaf_id = db.add_folder(
+        "/staging/job/USA/2026/2026-07-02",
+        name="2026-07-02",
+        parent_id=staged_year_id,
+        workspace_root=True,
+    )
+    db.add_photo(staged_leaf_id, "new.jpg", ".jpg", 1000, 2.0)
+
+    db._new_images_cache.set(
+        db._db_path, ws_id, {"new_count": 0, "per_root": [], "sample": []}
+    )
+
+    db.merge_staged_tree_into_archive(staged_archive_id, "/archive/USA")
+
+    assert db._new_images_cache.get(db._db_path, ws_id) is None
+
+
 def test_move_folders_validates_source_workspace(db):
     """Raises ValueError if source workspace doesn't exist."""
     ws = db.create_workspace("A")

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -1620,6 +1620,93 @@ def test_archive_merge_nested_new_path_does_not_link_out_of_scope_intermediate(d
     assert future_photo is None
 
 
+def test_archive_merge_new_path_prunes_stale_broad_nonroot_link(db):
+    """No-row merge must prune a stale broad ``is_root=0`` ancestor link.
+
+    Workspace root ``/archive/USA/2026`` is scoped narrower than the archive
+    base ``/archive/USA``. If the workspace already carries a stale
+    ``is_root=0`` link on ``/archive/USA`` (e.g. from a prior broader merge
+    or a legacy layout), merging into a brand-new sibling like
+    ``/archive/USA/2027/Trip`` (no folder row for the archive destination
+    yet) walks up to ``/archive/USA``, hits the descendant-root guard, and
+    skips rooting it. Without also pruning that stale non-root link the
+    next ``get_workspace_folders()`` runs
+    ``_materialize_workspace_descendants`` from ``/archive/USA`` and pulls
+    the freshly-inserted ``/archive/USA/2027`` (and its ``Trip`` subtree)
+    into the workspace, defeating the scoped merge. The elif branch must
+    prune uncovered non-root links matching the existing-row cleanup.
+    """
+    ws_id = db.create_workspace("USA2026")
+
+    db.set_active_workspace(None)
+    archive_id = db.add_folder("/archive/USA", name="USA")
+    year_id = db.add_folder(
+        "/archive/USA/2026",
+        name="2026",
+        parent_id=archive_id,
+    )
+
+    db.set_active_workspace(ws_id)
+    db.add_workspace_folder(ws_id, year_id)
+    # Seed the stale broad non-root link that this fix must clean up.
+    db.add_workspace_folder(ws_id, archive_id, is_root=False)
+
+    archive_link_before = db.conn.execute(
+        """SELECT is_root FROM workspace_folders
+           WHERE workspace_id = ? AND folder_id = ?""",
+        (ws_id, archive_id),
+    ).fetchone()
+    assert archive_link_before is not None
+    assert archive_link_before["is_root"] == 0
+
+    staged_trip_id = db.add_folder(
+        "/staging/job/Trip",
+        name="Trip",
+        workspace_root=True,
+    )
+    db.add_photo(staged_trip_id, "future.jpg", ".jpg", 1000, 3.0)
+
+    result = db.merge_staged_tree_into_archive(
+        staged_trip_id,
+        "/archive/USA/2027/Trip",
+    )
+
+    assert result["new_photos"] == 1
+
+    # The narrower root survives untouched.
+    root_paths = {
+        r["path"] for r in db.get_workspace_folder_roots(ws_id)
+    }
+    assert root_paths == {"/archive/USA/2026"}
+
+    # The stale ``/archive/USA`` non-root link is gone.
+    archive_link_after = db.conn.execute(
+        """SELECT 1 FROM workspace_folders
+           WHERE workspace_id = ? AND folder_id = ?""",
+        (ws_id, archive_id),
+    ).fetchone()
+    assert archive_link_after is None
+
+    # ``get_workspace_folders`` runs ``_materialize_workspace_descendants``;
+    # the merged Trip subtree and the new 2027 intermediate must remain
+    # invisible to this scoped workspace.
+    linked_paths = {
+        r["path"] for r in db.get_workspace_folders(ws_id)
+    }
+    assert "/archive/USA" not in linked_paths
+    assert "/archive/USA/2027" not in linked_paths
+    assert "/archive/USA/2027/Trip" not in linked_paths
+
+    future_photo = db.conn.execute(
+        """SELECT p.filename
+           FROM photos p
+           JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+          WHERE wf.workspace_id = ? AND p.filename = ?""",
+        (ws_id, "future.jpg"),
+    ).fetchone()
+    assert future_photo is None
+
+
 def test_move_folders_validates_source_workspace(db):
     """Raises ValueError if source workspace doesn't exist."""
     ws = db.create_workspace("A")

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3045,7 +3045,15 @@ class Database:
         # is the expected shape for a root. Otherwise insert missing rows
         # top-down so each child's ``parent_id`` resolves to its freshly-
         # created parent, and link each to the active workspace non-root
-        # (they sit under an existing tracked root by construction).
+        # ONLY when an existing workspace root actually covers the
+        # intermediate. Linking non-root unconditionally would leak: if the
+        # workspace is scoped to a narrower root (e.g. ``/archive/USA/2026``)
+        # and the merge target is a sibling like ``/archive/USA/2027/Trip``,
+        # the descendant-root guard above suppresses rooting ``/archive/USA``,
+        # so no workspace root covers the ``/archive/USA/2027`` intermediate.
+        # A non-root link there still makes 2027's subtree visible via
+        # ``_materialize_workspace_descendants`` (called by
+        # ``get_workspace_folders``), defeating the scoped-merge behavior.
         missing_intermediates = []
         probe = os.path.dirname(archive_path)
         anchor_found = False
@@ -3092,8 +3100,9 @@ class Database:
                     mid_id = self.conn.execute(
                         "SELECT id FROM folders WHERE path = ?", (mid_path,)
                     ).fetchone()["id"]
-                self.add_workspace_folder(
-                    ws, mid_id, is_root=False)
+                if self._active_ws_root_ancestor_exists(ws, mid_path):
+                    self.add_workspace_folder(
+                        ws, mid_id, is_root=False)
 
         # Snapshot staged folders root-first (shallowest path first) so a
         # parent's target row exists before its children are processed.

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3474,6 +3474,7 @@ class Database:
                 self.conn.execute("DELETE FROM folders WHERE id = ?", (fid,))
 
             self.conn.commit()
+            self._new_images_cache.invalidate_workspaces(self._db_path, [ws])
         except Exception:
             self.conn.rollback()
             raise

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2824,7 +2824,18 @@ class Database:
         return False
 
     def _prune_ws_nonroot_links_outside_roots(self, workspace_id, path):
-        """Drop non-root links below ``path`` that no root still covers."""
+        """Drop non-root links that could re-materialize ``path``'s subtree.
+
+        Prunes uncovered non-root links that are ``path`` itself, strict
+        descendants of ``path``, OR strict ancestors of ``path``. Ancestors
+        matter because ``_materialize_workspace_descendants`` walks the whole
+        subtree below every linked folder — a surviving non-root ancestor
+        like ``/archive`` (left over from a restricted scan; see
+        ``scanner.py`` ``_restrict_root_paths``) would immediately re-insert
+        ``/archive/USA`` and any sibling like ``/archive/USA/2027`` after
+        the caller pruned them, defeating a scoped merge into a workspace
+        rooted at ``/archive/USA/2026``.
+        """
         target = _path_for_subtree_match(path)
         roots = [
             _path_for_subtree_match(r["path"])
@@ -2845,7 +2856,10 @@ class Database:
         prune_ids = []
         for row in rows:
             current = _path_for_subtree_match(row["path"])
-            if current != target and not current.startswith(target_prefix):
+            current_prefix = current + "/"
+            if (current != target
+                    and not current.startswith(target_prefix)
+                    and not target.startswith(current_prefix)):
                 continue
             if any(current == root or current.startswith(root + "/")
                    for root in roots):

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2823,6 +2823,47 @@ class Database:
                 return True
         return False
 
+    def _prune_ws_nonroot_links_outside_roots(self, workspace_id, path):
+        """Drop non-root links below ``path`` that no root still covers."""
+        target = _path_for_subtree_match(path)
+        roots = [
+            _path_for_subtree_match(r["path"])
+            for r in self.conn.execute(
+                """SELECT f.path FROM workspace_folders wf
+                   JOIN folders f ON f.id = wf.folder_id
+                   WHERE wf.workspace_id = ? AND wf.is_root = 1""",
+                (workspace_id,),
+            ).fetchall()
+        ]
+        rows = self.conn.execute(
+            """SELECT wf.folder_id, f.path FROM workspace_folders wf
+               JOIN folders f ON f.id = wf.folder_id
+               WHERE wf.workspace_id = ? AND wf.is_root = 0""",
+            (workspace_id,),
+        ).fetchall()
+        target_prefix = target + "/"
+        prune_ids = []
+        for row in rows:
+            current = _path_for_subtree_match(row["path"])
+            if current != target and not current.startswith(target_prefix):
+                continue
+            if any(current == root or current.startswith(root + "/")
+                   for root in roots):
+                continue
+            prune_ids.append(row["folder_id"])
+
+        for chunk in _chunks(prune_ids):
+            placeholders = ",".join("?" for _ in chunk)
+            self.conn.execute(
+                f"""DELETE FROM workspace_folders
+                    WHERE workspace_id = ? AND folder_id IN ({placeholders})""",
+                [workspace_id] + chunk,
+            )
+        if prune_ids:
+            self.conn.commit()
+            self._new_images_cache.invalidate_workspaces(
+                self._db_path, [workspace_id])
+
     def merge_staged_tree_into_archive(self, staged_root_id, archive_path):
         """Fold a staged folder subtree into an existing tracked archive.
 
@@ -2931,6 +2972,8 @@ class Database:
                 has_root_descendant = self._active_ws_root_descendant_exists(
                     ws, archive_path)
                 if has_root_descendant and not has_root_ancestor:
+                    self._prune_ws_nonroot_links_outside_roots(
+                        ws, archive_path)
                     self._materialize_workspace_descendants(ws)
                 else:
                     self.add_workspace_folder(
@@ -3126,6 +3169,8 @@ class Database:
                         )
 
                 if target is None:
+                    target_in_workspace = self._active_ws_root_ancestor_exists(
+                        ws, target_path)
                     # New folder under the archive: repoint + reparent + link.
                     self.conn.execute(
                         "UPDATE folders SET path = ?, parent_id = ? "
@@ -3138,26 +3183,29 @@ class Database:
                     # commit would persist a partial reparent that the outer
                     # rollback (below) could no longer undo if a later staged
                     # folder raised.
-                    self._add_workspace_folder_no_commit(
-                        ws, sf["id"], is_root=False)
-                    # The staging scan registers each photo-bearing leaf as
-                    # its own workspace ROOT (scanner restrict_dirs =>
-                    # is_root=1). Once that leaf is folded under the existing
-                    # archive base it must become a plain descendant,
-                    # otherwise the merge leaves a stray second workspace
-                    # root inside the archive — the exact overlap the
-                    # tracked-ancestor guard was meant to prevent.
-                    # add_workspace_folder's INSERT OR IGNORE can't downgrade
-                    # an existing is_root=1 row, so demote it explicitly here.
-                    # A folded-in leaf is always a descendant of an existing
-                    # archive root (the base itself, or an ancestor root
-                    # above it), so it is unconditionally non-root — no need
-                    # to check the base's is_root.
-                    self.conn.execute(
-                        "UPDATE workspace_folders SET is_root = 0 "
-                        "WHERE workspace_id = ? AND folder_id = ?",
-                        (ws, sf["id"]),
-                    )
+                    if target_in_workspace:
+                        self._add_workspace_folder_no_commit(
+                            ws, sf["id"], is_root=False)
+                        # The staging scan registers each photo-bearing leaf as
+                        # its own workspace ROOT (scanner restrict_dirs =>
+                        # is_root=1). Once that leaf is folded under the existing
+                        # archive base it must become a plain descendant,
+                        # otherwise the merge leaves a stray second workspace
+                        # root inside the archive — the exact overlap the
+                        # tracked-ancestor guard was meant to prevent.
+                        # add_workspace_folder's INSERT OR IGNORE can't downgrade
+                        # an existing is_root=1 row, so demote it explicitly here.
+                        self.conn.execute(
+                            "UPDATE workspace_folders SET is_root = 0 "
+                            "WHERE workspace_id = ? AND folder_id = ?",
+                            (ws, sf["id"]),
+                        )
+                    else:
+                        self.conn.execute(
+                            "DELETE FROM workspace_folders "
+                            "WHERE workspace_id = ? AND folder_id = ?",
+                            (ws, sf["id"]),
+                        )
                     # Every staged photo in a brand-new folder is newly
                     # archived.
                     new_count = self.conn.execute(

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3018,8 +3018,9 @@ class Database:
                     "SELECT id FROM folders WHERE path = ?", (probe,)
                 ).fetchone()
                 if ancestor_row is not None:
-                    self.add_workspace_folder(
-                        ws, ancestor_row["id"], is_root=True)
+                    if not self._active_ws_root_descendant_exists(ws, probe):
+                        self.add_workspace_folder(
+                            ws, ancestor_row["id"], is_root=True)
                     break
                 probe = os.path.dirname(probe)
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3021,6 +3021,23 @@ class Database:
                     if not self._active_ws_root_descendant_exists(ws, probe):
                         self.add_workspace_folder(
                             ws, ancestor_row["id"], is_root=True)
+                    else:
+                        # Descendant-root guard fires: the workspace is
+                        # scoped narrower than this ancestor, so rooting
+                        # it would widen the scope past the intended root.
+                        # But any pre-existing ``is_root=0`` link on this
+                        # ancestor (or on descendants below it that no
+                        # root still covers) would let
+                        # ``_materialize_workspace_descendants`` — called
+                        # by later ``get_workspace_folders()`` reads —
+                        # pull the broader subtree back into the workspace
+                        # and defeat the scoped merge. Prune those
+                        # uncovered non-root links now, matching the
+                        # cleanup the ``existing_link is None or
+                        # is_root == 0`` branch above already performs
+                        # via ``_prune_ws_nonroot_links_outside_roots``.
+                        self._prune_ws_nonroot_links_outside_roots(
+                            ws, probe)
                     break
                 probe = os.path.dirname(probe)
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2807,6 +2807,22 @@ class Database:
                 return True
         return False
 
+    def _active_ws_root_descendant_exists(self, workspace_id, path):
+        """True if ``workspace_id`` has a strict root descendant of ``path``."""
+        target = _path_for_subtree_match(path)
+        rows = self.conn.execute(
+            """SELECT f.path FROM workspace_folders wf
+               JOIN folders f ON f.id = wf.folder_id
+               WHERE wf.workspace_id = ? AND wf.is_root = 1""",
+            (workspace_id,),
+        ).fetchall()
+        prefix = target + "/"
+        for r in rows:
+            root = _path_for_subtree_match(r["path"])
+            if root.startswith(prefix):
+                return True
+        return False
+
     def merge_staged_tree_into_archive(self, staged_root_id, archive_path):
         """Fold a staged folder subtree into an existing tracked archive.
 
@@ -2903,14 +2919,25 @@ class Database:
             ).fetchone()
             if existing_link is None or existing_link["is_root"] == 0:
                 # Not root of ws (unlinked, or linked non-root): link the
-                # subtree, and root the base only if no strict ancestor is
-                # already a root. ``_active_ws_root_ancestor_exists`` cannot
-                # self-match here because the base is not currently a root
-                # of ws, so the check is a true "ancestor above" question.
+                # subtree, and root the base only if it would not replace an
+                # existing narrower or broader root. A strict descendant root
+                # means the workspace is intentionally scoped inside this
+                # archive (e.g. ``/Photos/USA/2026`` while importing into
+                # ``/Photos/USA``). In that shape, do not link the broad base
+                # at all: even a non-root link materializes every descendant
+                # and would make archive siblings part of workspace queries.
                 has_root_ancestor = self._active_ws_root_ancestor_exists(
                     ws, archive_path)
-                self.add_workspace_folder(
-                    ws, archive_row["id"], is_root=not has_root_ancestor)
+                has_root_descendant = self._active_ws_root_descendant_exists(
+                    ws, archive_path)
+                if has_root_descendant and not has_root_ancestor:
+                    self._materialize_workspace_descendants(ws)
+                else:
+                    self.add_workspace_folder(
+                        ws,
+                        archive_row["id"],
+                        is_root=not has_root_ancestor,
+                    )
             # else: base is already a workspace root — nothing to do.
             # If the archive base was marked ``missing`` at a previous health
             # scan (drive unmounted at the time), the storage preflight has

--- a/vireo/tests/test_new_images_api.py
+++ b/vireo/tests/test_new_images_api.py
@@ -56,6 +56,8 @@ def test_api_new_images_reports_unscanned_files(app_and_db):
 
 
 def test_api_new_images_zero_when_fully_ingested(app_and_db):
+    import time
+
     app, db, ws_id, tmp_path = app_and_db
     root = tmp_path / "shoot"
     _touch_image(str(root / "IMG.JPG"))
@@ -66,6 +68,16 @@ def test_api_new_images_zero_when_fully_ingested(app_and_db):
     client = app.test_client()
     resp = client.get("/api/workspaces/active/new-images")
     data = resp.get_json()
+    # The endpoint waits ~500ms for the background walk before returning
+    # ``pending``. On loaded CI runners the walk can slip past that window,
+    # so tolerate the pending state and re-poll until the cache populates.
+    if data.get("pending"):
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            time.sleep(0.05)
+            data = client.get("/api/workspaces/active/new-images").get_json()
+            if not data.get("pending"):
+                break
     assert data["new_count"] == 0
     assert data["workspace_id"] == ws_id
 


### PR DESCRIPTION
## Summary
- Avoid linking a broad archive base into a workspace when that workspace already has a narrower root inside the archive.
- Add a regression test covering a USA 2026 workspace rooted under a broader USA archive import.

## Impact
This keeps workspace queries scoped to the intended subtree during staged archive merges, so sibling archive content does not become visible in a narrower workspace.

## Validation
- `pytest tests/test_workspaces.py::test_archive_merge_preserves_narrower_workspace_root`
- `pytest tests/test_workspaces.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workspace archive merging so folder access stays limited to the originally scoped area.
  * Prevented broader archive roots from appearing after a merge when only a narrower workspace path should be visible.
  * Ensured merged items remain accessible through the correct workspace path, while out-of-scope older items stay hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->