### PR TITLE
Lightbox: default the SAM mask overlay to hidden

### DIFF
--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -5365,7 +5365,7 @@ function _lbPersistBool(key, value) {
 }
 
 var _lbBoxesVisible = _lbStoredBool('vireo.lb.boxesVisible', true);
-var _lbMasksVisible = _lbStoredBool('vireo.lb.masksVisible', true);
+var _lbMasksVisible = _lbStoredBool('vireo.lb.masksVisible', false);
 var _lbEyeVisible = _lbStoredBool('vireo.lb.eyeVisible', true);
 var _lbInfoVisible = _lbStoredBool('vireo.lb.infoVisible', true);
 var _lbChromeVisible = _lbStoredBool('vireo.lb.chromeVisible', true);


### PR DESCRIPTION
## What changed

Flip the first-run default for the lightbox SAM mask overlay from **on** to **off**.

The overlay's visibility is a single global, localStorage-backed preference (`vireo.lb.masksVisible`). Its fallback value — used when the browser has no stored preference yet — was `true`, so any photo that has a generated mask opened with the overlay painted on. This changes the fallback to `false` in `vireo/templates/_navbar.html` so the lightbox opens clean; masks remain one click away via the existing **Show Masks** toggle, and that choice is still persisted per browser.

```js
// before
var _lbMasksVisible = _lbStoredBool('vireo.lb.masksVisible', true);
// after
var _lbMasksVisible = _lbStoredBool('vireo.lb.masksVisible', false);
```

## Note

Only the **no-stored-preference fallback** changes. A browser that has already toggled the mask button holds a stored value (`'1'`/`'0'`) that still wins over this default — so to see the new default take effect there, toggle once or clear the `vireo.lb.masksVisible` localStorage key.

## Tests

`python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py -q` → **1237 passed, 1 skipped**. (Change is a frontend template default; no test covers this JS constant directly.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)