### PR TITLE
Photo editor: sharpening + noise reduction (detail pass)

### DIFF
--- a/docs/plans/2026-07-03-detail-pass-design.md
+++ b/docs/plans/2026-07-03-detail-pass-design.md
@@ -1,0 +1,144 @@
+# Detail pass: sharpening + noise reduction for edit recipes
+
+## Motivation
+
+Wildlife photos are frequently high-ISO, and exports already render edit
+recipes into output files — so today every exported keeper goes out with raw
+sensor noise and zero output sharpening. The non-destructive editor covers
+geometry and tone but has no detail controls, which is the biggest gap between
+Vireo's editor and a Lightroom pass.
+
+## Recipe schema
+
+Three new keys inside `adjustments` (schema version stays 1 — old recipes are
+unaffected, new keys default to no-op):
+
+| Key | Range | Default | Meaning |
+|---|---|---|---|
+| `sharpen` | 0..100 | 0 (absent) | Luminance unsharp-mask amount |
+| `sharpen_radius` | 0.5..3.0 | 1.0 (absent) | USM radius, in **native photo pixels** |
+| `noise_reduction` | 0..100 | 0 (absent) | Luminance bilateral NR + mild chroma smoothing |
+
+Normalization rules:
+- `sharpen` and `noise_reduction` join `_ADJUSTMENT_RANGES`; a value of 0 is
+  normalized away like every other adjustment.
+- `sharpen_radius` is only stored when `sharpen` is present, and is normalized
+  away when it equals the 1.0 default. It never appears alone.
+
+## Semantics: radius is in native pixels, applied at output resolution
+
+Detail ops are neighborhood operations — unlike the tone pipeline they are
+**not** scale-invariant, and Vireo renders the same recipe at many sizes
+(edit-preview at 1920, preview cache, thumbnails, full-res export). The
+contract:
+
+> A recipe's detail settings describe the effect on the **full-resolution
+> render**. Smaller renders approximate that full-res result downscaled.
+
+Implementation: the detail pass runs **last**, after geometry, tone, and the
+final long-edge resize, at output resolution, with the spatial parameters
+multiplied by the render scale:
+
+```
+scale = output_long_edge / rendered_long_edge_at_native_res(photo, recipe)
+```
+
+`rendered_long_edge_at_native_res` accounts for rotation and crop (straighten
+keeps dimensions), so a tight crop rendered at 1920 correctly gets a larger
+scale than an uncropped 1920 render. This matches how per-pixel ops already
+behave (tone at 1920 == tone at full res, downscaled) and mirrors what a
+photographer expects from every RAW editor: sharpening is subtle at fit zoom
+and judged at 1:1.
+
+Running the pass after the downscale (instead of inside `apply_recipe` before
+`thumbnail()`) is also the cheap order: previews NR a ≤4MP image instead of a
+45MP one.
+
+When the caller can't supply native dimensions, scale falls back to 1.0
+(apply-as-authored). All photo-backed call sites can supply them via
+`render_source.recipe_source_dimensions`.
+
+## Rendering implementation
+
+New module `vireo/detail.py` (neighborhood counterpart to the strictly
+per-pixel `tone.py` — the per-pixel contract of `tone.py` is untouched):
+
+- **Order:** noise reduction first, then sharpening.
+- **Noise reduction:** bilateral filter on the luma channel (fixed small
+  window, spatial sigma scaled by render scale, range sigma and blend derived
+  from the amount), plus a mild Gaussian on the chroma channels (chroma noise
+  is a large fraction of perceived high-ISO noise). Uses the PIL YCbCr
+  conversion for channel separation.
+- **Sharpening:** luminance-only unsharp mask (sharpening Y and adding the
+  delta back to RGB avoids the color fringing of naive RGB USM), Gaussian
+  implemented as a separable numpy convolution — no new dependencies.
+- **Tiling:** like `_apply_adjustments`, the pass processes row bands with a
+  halo of overlap pixels (halo = max kernel radius) so peak memory stays
+  bounded on 45MP exports and tiled output is numerically identical to a
+  whole-frame pass.
+- Alpha passes through unchanged; identity (both amounts 0) is byte-exact
+  because the pass is skipped entirely.
+
+`apply_recipe_to_loaded_image(img, recipe, max_size=None)` gains a
+`native_size=(w, h)` keyword; it computes the scale and runs the detail pass
+after the resize. `apply_recipe` itself does not apply detail ops.
+
+### Call sites to update (pass `native_size`)
+
+- `app.py serve_photo_edit_preview` (in-progress editor preview)
+- `app.py` saved-recipe preview path (~18439)
+- `export.py _render_exported_photo`
+- `thumbnails.py` recipe branch
+- `pipeline_job.py` recipe branches
+
+### No `EDIT_MATH_VERSION` bump
+
+The bump exists to purge cached renders when existing recipes would produce
+different bytes. No existing recipe contains detail keys, and recipes without
+them render byte-identically, so no purge is needed. (The preview cache is
+already invalidated per-photo when a recipe changes.)
+
+## Editor UI (`photo_editor.html`)
+
+- New **Detail** section after Adjustments: `Sharpen` (0–100, step 1),
+  `Radius` (0.5–3.0, step 0.1, shown only meaningful with sharpen > 0),
+  `Noise reduction` (0–100, step 1). Wired through the existing
+  `setAdjustment`/`adjustmentValues`/`recipeForSave`/`syncControls` lists,
+  with the radius-only-with-sharpen rule mirrored in `recipeForSave` so
+  dirty-state comparison stays stable against server normalization.
+- **100% zoom gets a bigger render:** `updatePreview` requests
+  `size=3840` (the endpoint max) when `zoomMode === 'actual'`, 1920 otherwise.
+  Today 100% zoom displays the 1920 render at natural size, which would make
+  detail settings impossible to judge. 3840 is still below native for
+  most bodies — an honest "Preview at 3840px" note appears in the status line
+  in 100% mode. A true region-render 1:1 preview is a possible follow-up.
+- Copy Settings / batch apply / undo / history / XMP sync all carry the
+  whole `adjustments` object and need no changes.
+
+## Live-preview transparency
+
+The lightbox WebGL preview (`VireoToneGL`) transcribes the per-pixel tone
+pipeline and cannot express neighborhood ops. As with re-edits today, its
+live preview is an approximation that snaps to the exact server render after
+save; detail ops simply don't participate in the live delta. The editor page
+— where detail is actually authored — uses exact server renders, so the
+transparency rule ("the preview you judge is the render you get") holds where
+it matters. `test_tone_shader_parity.py` is unaffected because `tone.py` is
+unchanged.
+
+## Auto Tone
+
+Auto Tone only writes tonal keys and continues to leave detail (like color)
+untouched. The `analysis=1` sampling path strips tonal adjustments client-side
+before requesting the analysis render; detail keys are stripped the same way
+(they would perturb neutral-pixel sampling slightly via NR).
+
+## Testing
+
+- `test_image_edits.py`: normalization/validation of the three keys,
+  radius-requires-sharpen, defaults normalized away, range errors.
+- `test_detail.py` (new): byte-exact identity at zero amounts; sharpening
+  increases edge acutance; NR reduces flat-region noise while preserving a
+  step edge; scale < 1 weakens the effect; alpha preserved; tiled == untiled.
+- Integration: `apply_recipe_to_loaded_image` with `native_size` matches the
+  direct detail pass at scale 1; recipe PUT round-trips detail keys.

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -9145,7 +9145,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
             from image_edits import (
                 EDIT_MATH_VERSION,
-                apply_recipe,
+                apply_recipe_to_loaded_image,
                 recipe_to_json,
             )
             from image_loader import (
@@ -9263,7 +9263,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             tmp_path = None
             fd = None
             try:
-                rendered = apply_recipe(img, recipe)
+                rendered = apply_recipe_to_loaded_image(
+                    img, recipe,
+                    native_size=_recipe_source_dimensions(photo),
+                )
                 quality = cfg.load().get("working_copy_quality", 92)
                 fd, tmp_path = tempfile.mkstemp(
                     prefix=f".{photo['id']}.", suffix=".jpg.tmp", dir=out_dir,
@@ -11476,7 +11479,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not recipe:
             return fallback_path, None
 
-        from image_edits import EDIT_MATH_VERSION, apply_recipe, recipe_to_json
+        from image_edits import (
+            EDIT_MATH_VERSION,
+            apply_recipe_to_loaded_image,
+            recipe_to_json,
+        )
         from image_loader import (
             RAW_DECODE_PRESERVE_HIGHLIGHTS,
             RAW_EXTENSIONS,
@@ -11584,7 +11591,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         tmp_path = None
         fd = None
         try:
-            rendered = apply_recipe(img, recipe)
+            rendered = apply_recipe_to_loaded_image(
+                img, recipe,
+                native_size=_recipe_source_dimensions(photo),
+            )
             quality = cfg.load().get("working_copy_quality", 92)
             fd, tmp_path = tempfile.mkstemp(
                 prefix=f".{photo['id']}.", suffix=".jpg.tmp", dir=out_dir,
@@ -13318,6 +13328,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         if recipe:
                             img = apply_recipe_to_loaded_image(
                                 img, recipe, max_size=max_size,
+                                native_size=_recipe_source_dimensions(
+                                    detail_photo
+                                ),
                             )
                         img.save(cache_path, format="JPEG", quality=preview_quality)
                         with contextlib.suppress(Exception):
@@ -15379,6 +15392,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 recipe=recipe,
                 raw_decode=raw_decode,
                 min_source_size=min_source_size,
+                native_size=(
+                    _recipe_source_dimensions(photo) if recipe else None
+                ),
             )
             if (
                 not result
@@ -15410,6 +15426,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                             thumb_dir,
                             size=thumb_size,
                             recipe=recipe,
+                            native_size=(
+                                _recipe_source_dimensions(photo)
+                                if recipe else None
+                            ),
                         )
                         if result:
                             source = companion_abs
@@ -18436,7 +18456,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return "Could not load image", 500
         if recipe:
             from image_edits import apply_recipe_to_loaded_image
-            img = apply_recipe_to_loaded_image(img, recipe, max_size=size)
+            img = apply_recipe_to_loaded_image(
+                img, recipe, max_size=size,
+                native_size=_recipe_source_dimensions(photo),
+            )
 
         preview_quality = cfg.load().get("preview_quality", 90)
 
@@ -18667,7 +18690,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if img is None:
                 _record_working_copy_failure(db, photo, canonical)
                 return "Could not load image", 500
-            img = apply_recipe_to_loaded_image(img, recipe_json, max_size=size)
+            img = apply_recipe_to_loaded_image(
+                img, recipe_json, max_size=size,
+                native_size=_recipe_source_dimensions(photo),
+            )
         except RecipeError as e:
             return str(e), 400
 
@@ -18926,8 +18952,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if img is None:
                 _record_working_copy_failure(db, photo, image_path)
                 return "Could not load image", 500
-            from image_edits import apply_recipe
-            img = apply_recipe(img, recipe)
+            from image_edits import apply_recipe_to_loaded_image
+            img = apply_recipe_to_loaded_image(
+                img, recipe,
+                native_size=_recipe_source_dimensions(photo),
+            )
             originals_dir = os.path.join(vireo_dir, "originals")
             cache_path = os.path.join(originals_dir, f"{photo_id}.jpg")
             os.makedirs(originals_dir, exist_ok=True)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -18562,6 +18562,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 SCHEMA_VERSION,
                 RecipeError,
                 apply_recipe_to_loaded_image,
+                detail_render_scale,
                 normalize_recipe,
             )
             from image_loader import (
@@ -18569,6 +18570,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 RAW_EXTENSIONS,
                 load_image,
             )
+            from render_source import rendered_recipe_long_edge
             recipe = normalize_recipe(recipe) or {}
             display_recipe = dict(recipe)
             display_recipe.pop("crop", None)
@@ -18690,9 +18692,30 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if img is None:
                 _record_working_copy_failure(db, photo, canonical)
                 return "Could not load image", 500
+            native_dims = _recipe_source_dimensions(photo)
+            # Detail scale must reflect the SAVED (cropped) render even though
+            # we render the preview uncropped — otherwise a tighter crop makes
+            # the saved output's sharpen/NR visibly stronger than the preview
+            # showed, and cropped detail edits look wrong. Simulate what the
+            # saved render's max long edge would be (bounded by the endpoint
+            # size, like /full's crop-aware preview), then compute the scale
+            # from the original recipe (with crop).
+            preview_detail_scale = None
+            if native_dims and native_dims[0] and native_dims[1]:
+                saved_native_long = float(rendered_recipe_long_edge(
+                    native_dims[0], native_dims[1], recipe,
+                ))
+                if saved_native_long > 0:
+                    saved_rendered_long = min(float(size), saved_native_long)
+                    preview_detail_scale = detail_render_scale(
+                        (saved_rendered_long, saved_rendered_long),
+                        native_dims,
+                        recipe,
+                    )
             img = apply_recipe_to_loaded_image(
                 img, recipe_json, max_size=size,
-                native_size=_recipe_source_dimensions(photo),
+                native_size=native_dims,
+                detail_scale=preview_detail_scale,
             )
         except RecipeError as e:
             return str(e), 400

--- a/vireo/detail.py
+++ b/vireo/detail.py
@@ -1,0 +1,223 @@
+"""Neighborhood detail pass (noise reduction + sharpening) for edit recipes.
+
+This is the spatial counterpart to :mod:`tone`: where the tone pipeline is
+strictly per-pixel (and therefore scale-invariant and shader-transcribable),
+these ops read pixel neighborhoods and are **not** scale-invariant. The
+contract, from the detail-pass design doc: a recipe's detail settings describe
+the effect on the full-resolution render, spatial parameters are authored in
+native photo pixels, and callers rendering at a reduced size pass ``scale``
+(output pixels per native pixel) so kernels shrink proportionally. The pass
+runs last, in display space, after geometry, tone, and the final resize.
+
+Because the ops are neighborhood reads, they cannot join the lightbox WebGL
+live preview (per-pixel shader); the editor page judges them through exact
+server renders instead.
+
+Ordering inside the pass follows RAW-editor convention: noise reduction first
+(luminance bilateral plus mild chroma smoothing), then luminance-only unsharp
+masking — sharpening Y and adding the delta back to RGB avoids the color
+fringing of naive per-channel USM.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+from PIL import Image
+
+try:
+    from .tone import LUMA_B, LUMA_G, LUMA_R
+except ImportError:
+    from tone import LUMA_B, LUMA_G, LUMA_R
+
+# Row-tile budget in pixels, like image_edits._ADJUST_TILE_PIXELS: bounds peak
+# memory on full-resolution exports. Tiles overlap by a halo wide enough that
+# every written pixel sees only real neighbors, so tiled output is numerically
+# identical to a whole-frame pass. Overridable in tests to force many tiles.
+_DETAIL_TILE_PIXELS = 4_000_000
+
+# Unsharp-mask strength at amount=100: delta gain of 1.5 is a strong but not
+# cartoonish ceiling for high-ISO wildlife detail.
+_SHARPEN_GAIN = 1.5
+
+# Bilateral spatial sigma at scale 1.0, and its floor so the filter stays a
+# real neighborhood op even for tiny preview scales (the downscale itself has
+# already averaged most noise away by then).
+_NR_SIGMA_SPATIAL = 1.6
+_NR_SIGMA_SPATIAL_MIN = 0.5
+
+# Bilateral range sigma in [0,1] luma units: from ~8 8-bit levels at amount 0+
+# to ~31 levels at amount 100. Edges larger than a few sigmas pass through.
+_NR_SIGMA_RANGE_BASE = 0.03
+_NR_SIGMA_RANGE_SPAN = 0.09
+
+# Chroma noise is smoothed with a plain Gaussian; chroma resolution loss is
+# far less visible than luma blur, so the sigma runs a bit larger.
+_NR_SIGMA_CHROMA = 1.5
+_NR_SIGMA_CHROMA_MIN = 0.5
+
+# Sharpening below this effective sigma would be sub-pixel noise shaping.
+_SHARPEN_SIGMA_MIN = 0.3
+
+_BILATERAL_MAX_RADIUS = 3
+
+
+def _gaussian_kernel(sigma):
+    radius = max(1, int(math.ceil(3.0 * sigma)))
+    x = np.arange(-radius, radius + 1, dtype=np.float32)
+    kernel = np.exp(-(x * x) / np.float32(2.0 * sigma * sigma))
+    return kernel / kernel.sum()
+
+
+def _blur_axis(arr, kernel, axis):
+    radius = len(kernel) // 2
+    pad = [(0, 0)] * arr.ndim
+    pad[axis] = (radius, radius)
+    padded = np.pad(arr, pad, mode="reflect")
+    out = np.zeros(arr.shape, dtype=np.float32)
+    length = arr.shape[axis]
+    for i, weight in enumerate(kernel):
+        window = [slice(None)] * arr.ndim
+        window[axis] = slice(i, i + length)
+        out += padded[tuple(window)] * weight
+    return out
+
+
+def _gaussian_blur(arr, sigma):
+    """Separable Gaussian over the two spatial axes (2D or HxWxC arrays)."""
+    kernel = _gaussian_kernel(sigma)
+    return _blur_axis(_blur_axis(arr, kernel, 0), kernel, 1)
+
+
+def _bilateral(y, sigma_spatial, sigma_range, radius):
+    """Fixed-window bilateral filter on a 2D luma plane."""
+    height, width = y.shape
+    padded = np.pad(y, radius, mode="reflect")
+    acc = np.zeros_like(y, dtype=np.float32)
+    weights = np.zeros_like(y, dtype=np.float32)
+    inv_2ss = np.float32(1.0 / (2.0 * sigma_spatial * sigma_spatial))
+    inv_2sr = np.float32(1.0 / (2.0 * sigma_range * sigma_range))
+    for dy in range(-radius, radius + 1):
+        for dx in range(-radius, radius + 1):
+            shifted = padded[
+                radius + dy : radius + dy + height,
+                radius + dx : radius + dx + width,
+            ]
+            diff = shifted - y
+            weight = np.exp(
+                -np.float32(dy * dy + dx * dx) * inv_2ss - diff * diff * inv_2sr
+            )
+            acc += shifted * weight
+            weights += weight
+    return acc / weights
+
+
+def _luma(rgb):
+    return LUMA_R * rgb[..., 0] + LUMA_G * rgb[..., 1] + LUMA_B * rgb[..., 2]
+
+
+def _detail_params(sharpen, sharpen_radius, noise_reduction, scale):
+    """Resolve slider values + render scale into concrete filter parameters.
+
+    Returns None when the pass is a no-op. ``halo`` is the number of overlap
+    rows a tile needs so every written pixel's (sequential NR -> sharpen)
+    neighborhood contains only real image data.
+    """
+    sharpen_k = max(0.0, float(sharpen or 0.0)) / 100.0
+    nr_k = max(0.0, float(noise_reduction or 0.0)) / 100.0
+    if sharpen_k <= 0.0 and nr_k <= 0.0:
+        return None
+    scale = float(scale or 1.0)
+    if not math.isfinite(scale) or scale <= 0.0:
+        scale = 1.0
+
+    params = {"nr": None, "sharpen": None}
+    nr_halo = 0
+    sharpen_halo = 0
+    if nr_k > 0.0:
+        sigma_spatial = max(_NR_SIGMA_SPATIAL_MIN, _NR_SIGMA_SPATIAL * scale)
+        bilateral_radius = min(
+            _BILATERAL_MAX_RADIUS, max(1, int(math.ceil(2.0 * sigma_spatial)))
+        )
+        sigma_chroma = max(_NR_SIGMA_CHROMA_MIN, _NR_SIGMA_CHROMA * scale)
+        chroma_radius = max(1, int(math.ceil(3.0 * sigma_chroma)))
+        params["nr"] = {
+            "blend": nr_k,
+            "sigma_spatial": sigma_spatial,
+            "sigma_range": _NR_SIGMA_RANGE_BASE + _NR_SIGMA_RANGE_SPAN * nr_k,
+            "radius": bilateral_radius,
+            "sigma_chroma": sigma_chroma,
+        }
+        nr_halo = max(bilateral_radius, chroma_radius)
+    if sharpen_k > 0.0:
+        sigma = max(_SHARPEN_SIGMA_MIN, float(sharpen_radius) * scale)
+        params["sharpen"] = {"gain": sharpen_k * _SHARPEN_GAIN, "sigma": sigma}
+        sharpen_halo = max(1, int(math.ceil(3.0 * sigma)))
+    params["halo"] = nr_halo + sharpen_halo
+    return params
+
+
+def _run_detail(rgb, params):
+    """Run the detail pass on a float32 (H, W, 3) array in [0, 1]."""
+    out = rgb
+    nr = params["nr"]
+    if nr:
+        y = _luma(out)
+        chroma = out - y[..., None]
+        y_filtered = _bilateral(
+            y, nr["sigma_spatial"], nr["sigma_range"], nr["radius"]
+        )
+        y = y + (y_filtered - y) * np.float32(nr["blend"])
+        chroma_filtered = _gaussian_blur(chroma, nr["sigma_chroma"])
+        chroma = chroma + (chroma_filtered - chroma) * np.float32(nr["blend"])
+        out = np.clip(y[..., None] + chroma, 0.0, 1.0)
+    sharpen = params["sharpen"]
+    if sharpen:
+        y = _luma(out)
+        delta = (y - _gaussian_blur(y, sharpen["sigma"])) * np.float32(
+            sharpen["gain"]
+        )
+        out = np.clip(out + delta[..., None], 0.0, 1.0)
+    return out
+
+
+def apply_detail(img, *, sharpen=0.0, sharpen_radius=1.0, noise_reduction=0.0,
+                 scale=1.0):
+    """Apply the detail pass to a PIL image and return a PIL image.
+
+    ``sharpen`` and ``noise_reduction`` are recipe amounts in [0, 100];
+    ``sharpen_radius`` is in native photo pixels and ``scale`` converts it to
+    this render's pixels. A no-op returns the input image unchanged.
+    """
+    params = _detail_params(sharpen, sharpen_radius, noise_reduction, scale)
+    if params is None:
+        return img
+
+    has_alpha = "A" in img.getbands() or "transparency" in img.info
+    if img.mode not in ("RGB", "RGBA"):
+        img = img.convert("RGBA" if has_alpha else "RGB")
+    elif img.mode == "RGB" and "transparency" in img.info:
+        img = img.convert("RGBA")
+
+    src = np.asarray(img)
+    height, width = src.shape[:2]
+    channels = src.shape[2]
+    out8 = np.empty((height, width, channels), dtype=np.uint8)
+
+    halo = params["halo"]
+    rows_per_tile = max(1, _DETAIL_TILE_PIXELS // max(1, width))
+    for top in range(0, height, rows_per_tile):
+        bottom = min(top + rows_per_tile, height)
+        ext_top = max(0, top - halo)
+        ext_bottom = min(height, bottom + halo)
+        tile = src[ext_top:ext_bottom, :, :3].astype(np.float32) / 255.0
+        result = _run_detail(tile, params)
+        result = result[top - ext_top : bottom - ext_top]
+        out8[top:bottom, :, :3] = np.clip(result * 255.0 + 0.5, 0, 255).astype(
+            np.uint8
+        )
+        if channels == 4:
+            out8[top:bottom, :, 3] = src[top:bottom, :, 3]
+
+    return Image.fromarray(out8, "RGBA" if channels == 4 else "RGB")

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -369,7 +369,10 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
                     progress_cb(i + 1, len(photo_ids), photo["filename"])
                 continue
             if recipe:
-                img = apply_recipe_to_loaded_image(img, recipe, max_size=max_size)
+                img = apply_recipe_to_loaded_image(
+                    img, recipe, max_size=max_size,
+                    native_size=_recipe_source_dimensions(photo, exif_data),
+                )
             _save_export_image(img, out_path, format_info, quality)
             img.close()
             exported += 1

--- a/vireo/image_edits.py
+++ b/vireo/image_edits.py
@@ -34,7 +34,19 @@ _ADJUSTMENT_RANGES = {
     "contrast": (-100.0, 100.0),
     "vibrance": (-100.0, 100.0),
     "saturation": (-100.0, 100.0),
+    # Detail ops (see detail.py). Zero is a no-op like every other adjustment;
+    # sharpen_radius is validated separately because its no-op is absence, not 0.
+    "sharpen": (0.0, 100.0),
+    "noise_reduction": (0.0, 100.0),
 }
+
+SHARPEN_RADIUS_RANGE = (0.5, 3.0)
+SHARPEN_RADIUS_DEFAULT = 1.0
+
+# Adjustment keys handled by the neighborhood pass in detail.py, not the
+# per-pixel tone pipeline. A recipe containing only these must not run the
+# tone pass at all (so a detail-only edit stays byte-exact outside detail).
+_DETAIL_KEYS = frozenset({"sharpen", "sharpen_radius", "noise_reduction"})
 
 _WHITE_BALANCE_RANGES = {
     "temperature": (-100.0, 100.0),
@@ -160,6 +172,25 @@ def normalize_recipe(recipe):
             raise RecipeError(f"{name} adjustment must be between {lo:g} and {hi:g}")
         if abs(val) > 1e-9:
             normalized_adjustments[name] = round(val, 6)
+
+    # The USM radius only means something while sharpening is on, and its
+    # default (1.0) is canonicalized to absence so an untouched radius slider
+    # never dirties a recipe.
+    if normalized_adjustments.get("sharpen"):
+        raw_radius = adjustments.get("sharpen_radius")
+        if raw_radius not in (None, ""):
+            if isinstance(raw_radius, bool) or not isinstance(
+                raw_radius, int | float
+            ):
+                raise RecipeError("sharpen_radius adjustment must be numeric")
+            radius = float(raw_radius)
+            lo, hi = SHARPEN_RADIUS_RANGE
+            if not math.isfinite(radius) or radius < lo or radius > hi:
+                raise RecipeError(
+                    f"sharpen_radius adjustment must be between {lo:g} and {hi:g}"
+                )
+            if abs(radius - SHARPEN_RADIUS_DEFAULT) > 1e-9:
+                normalized_adjustments["sharpen_radius"] = round(radius, 6)
 
     white_balance = adjustments.get("white_balance")
     if white_balance is None:
@@ -317,17 +348,79 @@ def apply_recipe(img, recipe):
         result = result.crop((left, top, right, bottom))
 
     adjustments = normalized.get("adjustments") or {}
-    if adjustments:
-        result = _apply_adjustments(result, adjustments)
+    tone_adjustments = {
+        k: v for k, v in adjustments.items() if k not in _DETAIL_KEYS
+    }
+    if tone_adjustments:
+        result = _apply_adjustments(result, tone_adjustments)
 
     return result
 
 
-def apply_recipe_to_loaded_image(img, recipe, max_size=None):
-    """Apply edits, then optionally constrain the long edge."""
-    result = apply_recipe(img, recipe)
+def detail_render_scale(rendered_size, native_size, recipe):
+    """Return output pixels per native pixel for a recipe render.
+
+    ``rendered_size`` is the final image's (width, height); ``native_size`` is
+    the photo's orientation-corrected native (width, height), or None when
+    unknown (scale falls back to 1.0 — apply detail as authored). The scale
+    compares long edges against what the recipe would render at native
+    resolution: right-angle rotation swaps the axes a crop applies to, crop
+    shrinks them, and straighten keeps dimensions.
+    """
+    if not native_size:
+        return 1.0
+    try:
+        native_w, native_h = (float(v) for v in native_size)
+    except (TypeError, ValueError):
+        return 1.0
+    if native_w <= 0 or native_h <= 0:
+        return 1.0
+    if (recipe or {}).get("rotation") in (90, 270):
+        native_w, native_h = native_h, native_w
+    crop = (recipe or {}).get("crop")
+    if crop:
+        native_long = max(
+            float(crop["w"]) * native_w, float(crop["h"]) * native_h
+        )
+    else:
+        native_long = max(native_w, native_h)
+    if native_long <= 0:
+        return 1.0
+    return max(rendered_size) / native_long
+
+
+def apply_recipe_to_loaded_image(img, recipe, max_size=None, native_size=None):
+    """Apply edits, constrain the long edge, then run the detail pass.
+
+    Detail ops (sharpen/NR) are neighborhood filters authored in native
+    pixels, so they run last — at output resolution, with kernels scaled by
+    ``detail_render_scale`` — approximating the full-resolution render
+    downscaled. Callers that know the photo's native dimensions pass them via
+    ``native_size`` (see render_source.recipe_source_dimensions).
+    """
+    normalized = normalize_recipe(recipe)
+    result = apply_recipe(img, normalized)
     if max_size and max_size > 0 and max(result.size) > max_size:
         result.thumbnail((max_size, max_size), resample=Image.Resampling.LANCZOS)
+
+    adjustments = (normalized or {}).get("adjustments") or {}
+    sharpen = adjustments.get("sharpen", 0.0)
+    noise_reduction = adjustments.get("noise_reduction", 0.0)
+    if sharpen or noise_reduction:
+        try:
+            from .detail import apply_detail
+        except ImportError:
+            from detail import apply_detail
+
+        result = apply_detail(
+            result,
+            sharpen=sharpen,
+            sharpen_radius=adjustments.get(
+                "sharpen_radius", SHARPEN_RADIUS_DEFAULT
+            ),
+            noise_reduction=noise_reduction,
+            scale=detail_render_scale(result.size, native_size, normalized),
+        )
     return result
 
 

--- a/vireo/image_edits.py
+++ b/vireo/image_edits.py
@@ -389,7 +389,9 @@ def detail_render_scale(rendered_size, native_size, recipe):
     return max(rendered_size) / native_long
 
 
-def apply_recipe_to_loaded_image(img, recipe, max_size=None, native_size=None):
+def apply_recipe_to_loaded_image(
+    img, recipe, max_size=None, native_size=None, detail_scale=None,
+):
     """Apply edits, constrain the long edge, then run the detail pass.
 
     Detail ops (sharpen/NR) are neighborhood filters authored in native
@@ -397,6 +399,13 @@ def apply_recipe_to_loaded_image(img, recipe, max_size=None, native_size=None):
     ``detail_render_scale`` — approximating the full-resolution render
     downscaled. Callers that know the photo's native dimensions pass them via
     ``native_size`` (see render_source.recipe_source_dimensions).
+
+    ``detail_scale`` overrides the scale computed from this call's recipe.
+    Use it when rendering a modified recipe (e.g. the edit-preview endpoint
+    strips crop to show the whole frame) so the detail pass still matches
+    what the unmodified recipe's saved render would produce — otherwise a
+    tighter crop scales sharpen/NR up in the saved output but not in the
+    preview, and the two disagree for cropped detail edits.
     """
     normalized = normalize_recipe(recipe)
     result = apply_recipe(img, normalized)
@@ -412,6 +421,11 @@ def apply_recipe_to_loaded_image(img, recipe, max_size=None, native_size=None):
         except ImportError:
             from detail import apply_detail
 
+        scale = (
+            detail_scale
+            if detail_scale is not None
+            else detail_render_scale(result.size, native_size, normalized)
+        )
         result = apply_detail(
             result,
             sharpen=sharpen,
@@ -419,7 +433,7 @@ def apply_recipe_to_loaded_image(img, recipe, max_size=None, native_size=None):
                 "sharpen_radius", SHARPEN_RADIUS_DEFAULT
             ),
             noise_reduction=noise_reduction,
-            scale=detail_render_scale(result.size, native_size, normalized),
+            scale=scale,
         )
     return result
 

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -44,6 +44,9 @@ from render_source import (
     recipe_render_source,
 )
 from render_source import (
+    recipe_source_dimensions as _recipe_source_dimensions,
+)
+from render_source import (
     scaled_recipe_source_dimensions as _scaled_recipe_source_dimensions,
 )
 
@@ -203,6 +206,10 @@ def _retry_thumbnail_with_companion(
             )
             commit_with_retry(thread_db.conn)
     recipe_kwargs = {"recipe": recipe} if recipe else {}
+    if recipe:
+        recipe_kwargs["native_size"] = (
+            _recipe_source_dimensions(photo)
+        )
     return generate_thumbnail(
         photo_id,
         companion_abs,
@@ -1894,6 +1901,10 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                     skipped += 1
                                     continue
                         recipe_kwargs = {"recipe": recipe} if recipe else {}
+                        if recipe:
+                            recipe_kwargs["native_size"] = (
+                                _recipe_source_dimensions(detail_photo)
+                            )
                         raw_decode_kwargs = _thumb_raw_decode_kwargs(
                             detail_photo, recipe,
                         )
@@ -1997,6 +2008,10 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                     skipped += 1
                                     continue
                             recipe_kwargs = {"recipe": recipe} if recipe else {}
+                            if recipe:
+                                recipe_kwargs["native_size"] = (
+                                    _recipe_source_dimensions(detail_photo)
+                                )
                             raw_decode_kwargs = _thumb_raw_decode_kwargs(
                                 detail_photo, recipe,
                             )
@@ -2323,6 +2338,9 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             if recipe:
                                 img = apply_recipe_to_loaded_image(
                                     img, recipe, max_size=max_size,
+                                    native_size=_recipe_source_dimensions(
+                                        detail_photo
+                                    ),
                                 )
                             # Atomic write: with SLOT_CAP > 1 two pipelines
                             # processing the same photo can both miss the

--- a/vireo/templates/photo_editor.html
+++ b/vireo/templates/photo_editor.html
@@ -495,6 +495,28 @@ body {
         <button class="editor-btn" type="button" onclick="resetAdjustments()">Reset Adjustments</button>
       </div>
     </div>
+
+    <div class="panel-band">
+      <div class="panel-title">Detail</div>
+      <div class="control-row">
+        <label for="sharpenRange">Sharpen</label>
+        <input id="sharpenRange" data-adjustment="sharpen" type="range" min="0" max="100" step="1" value="0" oninput="setAdjustment('sharpen', this.value)">
+        <span class="control-value" id="sharpenValue">0</span>
+      </div>
+      <div class="control-row">
+        <label for="sharpen_radiusRange">Radius</label>
+        <input id="sharpen_radiusRange" data-adjustment="sharpen_radius" type="range" min="0.5" max="3" step="0.1" value="1" oninput="setAdjustment('sharpen_radius', this.value)">
+        <span class="control-value" id="sharpen_radiusValue">1.0</span>
+      </div>
+      <div class="control-row">
+        <label for="noise_reductionRange">Denoise</label>
+        <input id="noise_reductionRange" data-adjustment="noise_reduction" type="range" min="0" max="100" step="1" value="0" oninput="setAdjustment('noise_reduction', this.value)">
+        <span class="control-value" id="noise_reductionValue">0</span>
+      </div>
+      <div class="button-row">
+        <button class="editor-btn" type="button" onclick="resetDetail()">Reset Detail</button>
+      </div>
+    </div>
   </aside>
 
   <aside class="history-panel">
@@ -575,11 +597,15 @@ function updateFeedbackControls() {
 }
 
 function setZoomMode(mode) {
-  editorState.zoomMode = mode === 'actual' ? 'actual' : 'fit';
+  var next = mode === 'actual' ? 'actual' : 'fit';
+  var changed = next !== editorState.zoomMode;
+  editorState.zoomMode = next;
   var wrap = document.getElementById('editorCanvasWrap');
   if (wrap) wrap.classList.toggle('zoom-actual', editorState.zoomMode === 'actual');
   updateFeedbackControls();
   renderCropBox();
+  // The two zoom modes request different render sizes.
+  if (changed && editorState.photoId && !editorState.loading) schedulePreview();
 }
 
 function toggleBeforePreview() {
@@ -720,6 +746,9 @@ function adjustmentValues(recipe) {
     tint: Number(wb.tint || adj.tint || 0),
     vibrance: Number(adj.vibrance || 0),
     saturation: Number(adj.saturation || 0),
+    sharpen: Number(adj.sharpen || 0),
+    sharpen_radius: Number(adj.sharpen_radius || 1),
+    noise_reduction: Number(adj.noise_reduction || 0),
   };
 }
 
@@ -754,9 +783,15 @@ function recipeForSave(recipe) {
 
   var vals = adjustmentValues(out);
   var adj = {};
-  ['exposure', 'highlights', 'shadows', 'whites', 'blacks', 'contrast', 'vibrance', 'saturation'].forEach(function(key) {
+  ['exposure', 'highlights', 'shadows', 'whites', 'blacks', 'contrast', 'vibrance', 'saturation', 'sharpen', 'noise_reduction'].forEach(function(key) {
     if (Math.abs(Number(vals[key] || 0)) > 0.000001) adj[key] = Number(vals[key]);
   });
+  // Radius only rides along with active sharpening, and its 1.0 default is
+  // canonicalized to absence — mirrors normalize_recipe so dirty-state
+  // comparison stays stable against the server's canonical form.
+  if (adj.sharpen && Math.abs(Number(vals.sharpen_radius) - 1) > 0.000001) {
+    adj.sharpen_radius = Number(vals.sharpen_radius);
+  }
   var wb = {};
   ['temperature', 'tint'].forEach(function(key) {
     if (Math.abs(Number(vals[key] || 0)) > 0.000001) wb[key] = Number(vals[key]);
@@ -790,6 +825,8 @@ function updateRecipeSummary() {
   if (r.adjustments) {
     Object.keys(r.adjustments).forEach(function(key) {
       if (key === 'white_balance') parts.push('white balance');
+      else if (key === 'sharpen_radius') return; // folded into "sharpen"
+      else if (key === 'noise_reduction') parts.push('noise reduction');
       else parts.push(key);
     });
   }
@@ -815,6 +852,9 @@ function syncControls() {
   set('tint', vals.tint, false);
   set('vibrance', vals.vibrance, false);
   set('saturation', vals.saturation, false);
+  set('sharpen', vals.sharpen, false);
+  set('sharpen_radius', vals.sharpen_radius, true);
+  set('noise_reduction', vals.noise_reduction, false);
   var straight = Number(r.straighten || 0);
   document.getElementById('straightenRange').value = String(straight);
   document.getElementById('straightenValue').textContent = straight.toFixed(1);
@@ -934,11 +974,15 @@ function updatePreview() {
   var seq = ++editorState.previewSeq;
   document.getElementById('previewStatus').textContent = 'Rendering preview...';
   updateFeedbackControls();
+  // 100% zoom asks for the endpoint's max render so detail (sharpen/NR) is
+  // judgeable near native pixels; fit zoom keeps the cheaper 1920 render.
+  var size = editorState.zoomMode === 'actual' ? 3840 : 1920;
   img.onload = function() {
     if (seq !== editorState.previewSeq) return;
-    document.getElementById('previewStatus').textContent = editorState.showBefore
+    var suffix = size === 3840 ? ' (3840px render)' : '';
+    document.getElementById('previewStatus').textContent = (editorState.showBefore
       ? 'Preview is showing the saved recipe'
-      : 'Preview uses the current unsaved recipe';
+      : 'Preview uses the current unsaved recipe') + suffix;
     renderCropBox();
     updateHistogramFeedback();
   };
@@ -948,7 +992,7 @@ function updatePreview() {
     clearHistogramFeedback();
   };
   var recipe = editorState.showBefore ? previewRecipeFor(editorState.savedRecipe) : previewRecipe();
-  img.src = '/photos/' + editorState.photoId + '/edit-preview?size=1920&recipe=' +
+  img.src = '/photos/' + editorState.photoId + '/edit-preview?size=' + size + '&recipe=' +
     encodeURIComponent(JSON.stringify(recipe)) + '&v=' + seq;
 }
 
@@ -1038,13 +1082,15 @@ function setAspect(aspect) {
 function setAdjustment(key, value) {
   var vals = adjustmentValues(editorState.recipe);
   vals[key] = Number(value) || 0;
-  if (key === 'exposure') document.getElementById('exposureValue').textContent = vals[key].toFixed(1);
+  if (key === 'exposure' || key === 'sharpen_radius') document.getElementById(key + 'Value').textContent = vals[key].toFixed(1);
   else document.getElementById(key + 'Value').textContent = String(Math.round(vals[key]));
   var adj = cloneRecipe(editorState.recipe.adjustments || {});
-  ['exposure', 'highlights', 'shadows', 'whites', 'blacks', 'contrast', 'vibrance', 'saturation'].forEach(function(name) {
+  ['exposure', 'highlights', 'shadows', 'whites', 'blacks', 'contrast', 'vibrance', 'saturation', 'sharpen', 'noise_reduction'].forEach(function(name) {
     if (Math.abs(vals[name]) > 0.000001) adj[name] = vals[name];
     else delete adj[name];
   });
+  if (adj.sharpen && Math.abs(vals.sharpen_radius - 1) > 0.000001) adj.sharpen_radius = vals.sharpen_radius;
+  else delete adj.sharpen_radius;
   var wb = {};
   if (Math.abs(vals.temperature) > 0.000001) wb.temperature = vals.temperature;
   if (Math.abs(vals.tint) > 0.000001) wb.tint = vals.tint;
@@ -1056,7 +1102,25 @@ function setAdjustment(key, value) {
 }
 
 function resetAdjustments() {
-  delete editorState.recipe.adjustments;
+  // Detail lives in its own panel band; only clear the tone/color keys.
+  var adj = cloneRecipe(editorState.recipe.adjustments || {});
+  var kept = {};
+  ['sharpen', 'sharpen_radius', 'noise_reduction'].forEach(function(key) {
+    if (adj[key]) kept[key] = adj[key];
+  });
+  if (Object.keys(kept).length) editorState.recipe.adjustments = kept;
+  else delete editorState.recipe.adjustments;
+  syncControls();
+  markChanged(true);
+}
+
+function resetDetail() {
+  var adj = cloneRecipe(editorState.recipe.adjustments || {});
+  delete adj.sharpen;
+  delete adj.sharpen_radius;
+  delete adj.noise_reduction;
+  if (Object.keys(adj).length) editorState.recipe.adjustments = adj;
+  else delete editorState.recipe.adjustments;
   syncControls();
   markChanged(true);
 }
@@ -1244,9 +1308,12 @@ async function autoTone() {
     ['exposure', 'highlights', 'shadows', 'whites', 'blacks', 'contrast'].forEach(function(k) {
       if (Math.abs(auto[k]) > 0.000001) adj[k] = auto[k];
     });
-    ['vibrance', 'saturation'].forEach(function(k) {
+    ['vibrance', 'saturation', 'sharpen', 'noise_reduction'].forEach(function(k) {
       if (Math.abs(vals[k]) > 0.000001) adj[k] = vals[k];
     });
+    if (adj.sharpen && Math.abs(vals.sharpen_radius - 1) > 0.000001) {
+      adj.sharpen_radius = vals.sharpen_radius;
+    }
     var wb = {};
     if (Math.abs(vals.temperature) > 0.000001) wb.temperature = vals.temperature;
     if (Math.abs(vals.tint) > 0.000001) wb.tint = vals.tint;

--- a/vireo/tests/test_detail.py
+++ b/vireo/tests/test_detail.py
@@ -1,0 +1,239 @@
+"""Tests for the neighborhood detail pass (noise reduction + sharpening).
+
+Unlike the per-pixel tone pipeline, detail ops depend on pixel neighborhoods,
+so these tests exercise spatial behavior: edge acutance, noise statistics,
+render-scale weakening, and tiling equivalence.
+"""
+
+import os
+import sys
+
+import numpy as np
+import pytest
+from PIL import Image, ImageFilter
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import detail
+from detail import apply_detail
+
+
+def _luma(arr):
+    rgb = arr[..., :3].astype(np.float32)
+    return 0.2126 * rgb[..., 0] + 0.7152 * rgb[..., 1] + 0.0722 * rgb[..., 2]
+
+
+def _soft_edge_image(width=64, height=32, blur=1.2):
+    """A vertical dark->light step edge softened by a Gaussian blur.
+
+    The default softness sits in the band a ~1px-radius unsharp mask acts on;
+    pass a larger ``blur`` to test how reduced render scales weaken the
+    (proportionally smaller) kernel.
+    """
+    arr = np.zeros((height, width, 3), dtype=np.uint8)
+    arr[:, width // 2:, :] = 200
+    arr[:, : width // 2, :] = 55
+    img = Image.fromarray(arr, "RGB")
+    return img.filter(ImageFilter.GaussianBlur(blur))
+
+
+def _noisy_flat_image(width=96, height=96, level=120, sigma=14, seed=7):
+    rng = np.random.default_rng(seed)
+    base = np.full((height, width, 3), level, dtype=np.float32)
+    noisy = base + rng.normal(0.0, sigma, size=base.shape)
+    return Image.fromarray(
+        np.clip(noisy, 0, 255).astype(np.uint8), "RGB"
+    )
+
+
+def _max_horizontal_luma_step(img):
+    y = _luma(np.asarray(img))
+    return float(np.max(np.abs(np.diff(y, axis=1))))
+
+
+def test_apply_detail_zero_amounts_is_identity():
+    rng = np.random.default_rng(3)
+    src = rng.integers(0, 256, size=(20, 30, 3), dtype=np.uint8)
+    img = Image.fromarray(src, "RGB")
+
+    out = apply_detail(img, sharpen=0, noise_reduction=0)
+
+    assert np.array_equal(np.asarray(out), src)
+
+
+def test_sharpen_increases_edge_acutance():
+    img = _soft_edge_image()
+
+    sharpened = apply_detail(img, sharpen=60)
+
+    assert _max_horizontal_luma_step(sharpened) > _max_horizontal_luma_step(img) * 1.15
+
+
+def test_sharpen_amount_is_monotone():
+    img = _soft_edge_image()
+
+    mild = apply_detail(img, sharpen=25)
+    strong = apply_detail(img, sharpen=90)
+
+    assert _max_horizontal_luma_step(strong) > _max_horizontal_luma_step(mild)
+
+
+def test_sharpen_effect_weakens_at_reduced_render_scale():
+    """Radius is defined in native pixels; a downscaled render must apply a
+    proportionally smaller kernel, extracting less contrast from the same
+    (already softened) edge."""
+    img = _soft_edge_image(blur=4.0)
+
+    full = apply_detail(img, sharpen=60, sharpen_radius=2.0, scale=1.0)
+    reduced = apply_detail(img, sharpen=60, sharpen_radius=2.0, scale=0.25)
+
+    delta_full = np.mean(np.abs(_luma(np.asarray(full)) - _luma(np.asarray(img))))
+    delta_reduced = np.mean(
+        np.abs(_luma(np.asarray(reduced)) - _luma(np.asarray(img)))
+    )
+    assert delta_full > delta_reduced * 1.5
+
+
+def test_noise_reduction_smooths_flat_regions():
+    img = _noisy_flat_image()
+
+    smoothed = apply_detail(img, noise_reduction=80)
+
+    # Compare interior noise (avoid border effects).
+    before = np.std(_luma(np.asarray(img))[8:-8, 8:-8])
+    after = np.std(_luma(np.asarray(smoothed))[8:-8, 8:-8])
+    assert after < before * 0.75
+
+
+def test_noise_reduction_preserves_step_edges():
+    arr = np.zeros((48, 48, 3), dtype=np.float32)
+    arr[:, 24:, :] = 200.0
+    arr[:, :24, :] = 40.0
+    rng = np.random.default_rng(11)
+    arr += rng.normal(0.0, 10.0, size=arr.shape)
+    img = Image.fromarray(np.clip(arr, 0, 255).astype(np.uint8), "RGB")
+
+    smoothed = apply_detail(img, noise_reduction=80)
+
+    y = _luma(np.asarray(smoothed))
+    left = float(np.mean(y[:, 18:22]))
+    right = float(np.mean(y[:, 26:30]))
+    # The 160-level step must survive strong NR nearly intact.
+    assert right - left > 130
+
+
+def test_apply_detail_preserves_alpha():
+    rng = np.random.default_rng(5)
+    src = rng.integers(0, 256, size=(24, 24, 4), dtype=np.uint8)
+    img = Image.fromarray(src, "RGBA")
+
+    out = apply_detail(img, sharpen=50, noise_reduction=50)
+
+    assert out.mode == "RGBA"
+    assert np.array_equal(np.asarray(out)[..., 3], src[..., 3])
+
+
+@pytest.mark.parametrize("mode", ["RGB", "RGBA"])
+def test_apply_detail_tiling_matches_single_pass(mode, monkeypatch):
+    """Row-band tiling with halo overlap must be byte-identical to a
+    whole-frame pass."""
+    rng = np.random.default_rng(42)
+    channels = 4 if mode == "RGBA" else 3
+    src = rng.integers(0, 256, size=(90, 17, channels), dtype=np.uint8)
+    img = Image.fromarray(src, mode)
+    kwargs = {"sharpen": 55, "sharpen_radius": 1.8, "noise_reduction": 45}
+
+    whole = np.asarray(apply_detail(img, **kwargs))
+
+    monkeypatch.setattr(detail, "_DETAIL_TILE_PIXELS", 17 * 4)
+    tiled = np.asarray(apply_detail(img, **kwargs))
+
+    assert np.array_equal(whole, tiled)
+
+
+def test_apply_recipe_to_loaded_image_runs_detail_pass():
+    from image_edits import apply_recipe_to_loaded_image
+
+    img = _soft_edge_image()
+    recipe = {"adjustments": {"sharpen": 60}}
+
+    plain = apply_recipe_to_loaded_image(img, None)
+    edited = apply_recipe_to_loaded_image(img, recipe)
+
+    assert _max_horizontal_luma_step(edited) > _max_horizontal_luma_step(plain) * 1.15
+
+
+def test_apply_recipe_to_loaded_image_scales_detail_to_native_size():
+    """A render at 1/4 of native resolution must apply a ~1/4-size kernel:
+    weaker effect than the same recipe rendered as if the image were native."""
+    from image_edits import apply_recipe_to_loaded_image
+
+    img = _soft_edge_image(blur=4.0)
+    recipe = {"adjustments": {"sharpen": 60, "sharpen_radius": 2.0}}
+
+    at_native = apply_recipe_to_loaded_image(
+        img, recipe, native_size=(img.size[0], img.size[1])
+    )
+    at_quarter = apply_recipe_to_loaded_image(
+        img, recipe, native_size=(img.size[0] * 4, img.size[1] * 4)
+    )
+
+    base = _luma(np.asarray(img))
+    delta_native = np.mean(np.abs(_luma(np.asarray(at_native)) - base))
+    delta_quarter = np.mean(np.abs(_luma(np.asarray(at_quarter)) - base))
+    assert delta_native > delta_quarter * 1.5
+
+
+def test_detail_render_scale_accounts_for_crop_and_rotation():
+    """Scale = output pixels per native pixel along the long edge, using the
+    long edge the recipe would render at native resolution (rotation swaps
+    axes, crop shrinks them; straighten keeps dimensions)."""
+    from image_edits import detail_render_scale, normalize_recipe
+
+    # Uncropped: 2000-wide render of an 8000-wide native photo.
+    plain = normalize_recipe({"adjustments": {"sharpen": 50}})
+    assert detail_render_scale((2000, 1500), (8000, 6000), plain) == pytest.approx(
+        0.25
+    )
+
+    # Half-frame crop: the same 2000-wide output now covers 4000 native
+    # pixels, so the scale doubles.
+    cropped = normalize_recipe(
+        {
+            "crop": {"x": 0.25, "y": 0.25, "w": 0.5, "h": 0.5},
+            "adjustments": {"sharpen": 50},
+        }
+    )
+    assert detail_render_scale((2000, 1500), (8000, 6000), cropped) == pytest.approx(
+        0.5
+    )
+
+    # Rotation swaps the axes a crop applies to: a 0.5-wide crop of a rotated
+    # 8000x6000 photo spans 0.5 * 6000 horizontally and the full 8000
+    # vertically.
+    rotated = normalize_recipe(
+        {
+            "rotation": 90,
+            "crop": {"x": 0.25, "y": 0.0, "w": 0.5, "h": 1.0},
+            "adjustments": {"sharpen": 50},
+        }
+    )
+    assert detail_render_scale((750, 2000), (8000, 6000), rotated) == pytest.approx(
+        0.25
+    )
+
+    # Unknown native size falls back to apply-as-authored.
+    assert detail_render_scale((2000, 1500), None, plain) == 1.0
+    assert detail_render_scale((2000, 1500), (0, 0), plain) == 1.0
+
+
+def test_apply_recipe_detail_only_recipe_does_not_run_tone_pipeline():
+    """A detail-only recipe must leave non-detail pixels' tone untouched:
+    sharpening a perfectly flat image is a no-op, byte-exact."""
+    from image_edits import apply_recipe
+
+    img = Image.new("RGB", (32, 32), (137, 141, 129))
+
+    out = apply_recipe(img, {"adjustments": {"sharpen": 80, "noise_reduction": 0}})
+
+    assert np.array_equal(np.asarray(out), np.asarray(img))

--- a/vireo/tests/test_image_edits.py
+++ b/vireo/tests/test_image_edits.py
@@ -114,6 +114,64 @@ def test_normalize_recipe_accepts_expanded_adjustments():
     }
 
 
+def test_normalize_recipe_accepts_detail_adjustments():
+    assert normalize_recipe(
+        {
+            "adjustments": {
+                "sharpen": 40,
+                "sharpen_radius": 1.5,
+                "noise_reduction": 25,
+            }
+        }
+    ) == {
+        "version": 1,
+        "adjustments": {
+            "sharpen": 40.0,
+            "sharpen_radius": 1.5,
+            "noise_reduction": 25.0,
+        },
+    }
+
+
+def test_normalize_recipe_drops_default_sharpen_radius():
+    assert normalize_recipe(
+        {"adjustments": {"sharpen": 40, "sharpen_radius": 1.0}}
+    ) == {
+        "version": 1,
+        "adjustments": {"sharpen": 40.0},
+    }
+
+
+def test_normalize_recipe_drops_radius_without_sharpen():
+    assert normalize_recipe({"adjustments": {"sharpen_radius": 2.0}}) is None
+    assert normalize_recipe(
+        {"adjustments": {"sharpen": 0, "sharpen_radius": 2.0}}
+    ) is None
+
+
+def test_normalize_recipe_drops_zero_detail_amounts():
+    assert normalize_recipe(
+        {"adjustments": {"sharpen": 0, "noise_reduction": 0}}
+    ) is None
+
+
+@pytest.mark.parametrize(
+    ("adjustments", "message"),
+    [
+        ({"sharpen": -1}, "sharpen adjustment"),
+        ({"sharpen": 101}, "sharpen adjustment"),
+        ({"noise_reduction": 150}, "noise_reduction adjustment"),
+        ({"sharpen": 40, "sharpen_radius": 0.4}, "sharpen_radius"),
+        ({"sharpen": 40, "sharpen_radius": 3.5}, "sharpen_radius"),
+        ({"sharpen": 40, "sharpen_radius": "wide"}, "sharpen_radius"),
+        ({"sharpen": 40, "sharpen_radius": True}, "sharpen_radius"),
+    ],
+)
+def test_normalize_recipe_rejects_invalid_detail_adjustments(adjustments, message):
+    with pytest.raises(RecipeError, match=message):
+        normalize_recipe({"adjustments": adjustments})
+
+
 def test_normalize_recipe_rejects_invalid_white_balance():
     with pytest.raises(RecipeError, match="white_balance.temperature"):
         normalize_recipe({"adjustments": {"white_balance": {"temperature": 200}}})

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1709,6 +1709,79 @@ def test_edit_preview_scales_detail_to_native_resolution(client_with_photo):
     assert dist_scaled < dist_unscaled
 
 
+def test_edit_preview_detail_scale_matches_saved_cropped_render(
+    client_with_photo,
+):
+    """When the in-progress recipe has both a crop and a detail adjustment,
+    the uncropped edit-preview must scale sharpen/NR as the saved (cropped)
+    render would — using the recipe's crop for the native long edge, not the
+    full uncropped native. Otherwise a tighter crop makes the saved render
+    visibly sharper than the preview showed."""
+    import io
+    import json as jsonlib
+
+    import numpy as np
+    from image_edits import apply_recipe_to_loaded_image, detail_render_scale
+    from image_loader import load_image
+    from PIL import Image, ImageFilter
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+
+    # Soft vertical edge so sharpening has something to bite on.
+    folder = db.conn.execute("SELECT path FROM folders").fetchone()
+    src_path = os.path.join(folder["path"], "test.jpg")
+    arr = np.zeros((600, 800, 3), dtype=np.uint8)
+    arr[:, 400:, :] = 200
+    arr[:, :400, :] = 55
+    edge = Image.fromarray(arr, "RGB").filter(ImageFilter.GaussianBlur(4.0))
+    edge.save(src_path, "JPEG", quality=95)
+
+    recipe = {
+        "crop": {"x": 0.25, "y": 0.25, "w": 0.5, "h": 0.5},
+        "adjustments": {"sharpen": 100, "sharpen_radius": 3.0},
+    }
+    resp = client.get(
+        f"/photos/{photo_id}/edit-preview",
+        query_string={"size": "256", "recipe": jsonlib.dumps(recipe)},
+    )
+    assert resp.status_code == 200
+    with Image.open(io.BytesIO(resp.data)) as img:
+        served = np.asarray(img.convert("RGB")).astype(np.float32)
+
+    # "As-saved" reference: render the uncropped preview but scale detail by
+    # what the saved cropped render's scale would be (source is 800 wide, size
+    # cap is 256, so both scales bound to size=256).
+    display_recipe = dict(recipe)
+    display_recipe.pop("crop")
+    saved_scale = detail_render_scale((256, 256), (800, 600), recipe)
+    matched = np.asarray(
+        apply_recipe_to_loaded_image(
+            load_image(src_path, max_size=256),
+            display_recipe,
+            max_size=256,
+            native_size=(800, 600),
+            detail_scale=saved_scale,
+        )
+    ).astype(np.float32)
+    # "As-uncropped" (buggy) reference: crop stripped from the scale too.
+    unmatched = np.asarray(
+        apply_recipe_to_loaded_image(
+            load_image(src_path, max_size=256),
+            display_recipe,
+            max_size=256,
+            native_size=(800, 600),
+        )
+    ).astype(np.float32)
+
+    dist_matched = float(np.mean(np.abs(served - matched)))
+    dist_unmatched = float(np.mean(np.abs(served - unmatched)))
+    # The crop shrinks native_long by ~2x, so the crop-aware detail scale is
+    # roughly 2x the crop-stripped one; the two reference renders differ enough
+    # that the served bytes should clearly track the crop-aware one.
+    assert dist_matched < dist_unmatched
+
+
 def test_edit_preview_returns_400_for_malformed_crop(client_with_photo):
     from PIL import Image
 

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1660,6 +1660,55 @@ def test_edit_preview_renders_uncommitted_recipe_without_storing(client_with_pho
         assert img.size == (600, 800)
 
 
+def test_edit_preview_scales_detail_to_native_resolution(client_with_photo):
+    """A downscaled edit-preview of a sharpen recipe must shrink the USM
+    kernel by the render scale (output px per native px): the served bytes
+    should match a scale-aware detail pass, not an as-authored (scale 1.0)
+    pass on the small render."""
+    import io
+    import json as jsonlib
+
+    import numpy as np
+    from image_edits import apply_recipe_to_loaded_image
+    from image_loader import load_image
+    from PIL import Image, ImageFilter
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+
+    # Re-draw the 800x600 source as a soft vertical edge so sharpening has
+    # something to bite on (the fixture default is a flat color).
+    folder = db.conn.execute("SELECT path FROM folders").fetchone()
+    src_path = os.path.join(folder["path"], "test.jpg")
+    arr = np.zeros((600, 800, 3), dtype=np.uint8)
+    arr[:, 400:, :] = 200
+    arr[:, :400, :] = 55
+    edge = Image.fromarray(arr, "RGB").filter(ImageFilter.GaussianBlur(4.0))
+    edge.save(src_path, "JPEG", quality=95)
+
+    recipe = {"adjustments": {"sharpen": 100, "sharpen_radius": 3.0}}
+    resp = client.get(
+        f"/photos/{photo_id}/edit-preview",
+        query_string={"size": "256", "recipe": jsonlib.dumps(recipe)},
+    )
+    assert resp.status_code == 200
+    with Image.open(io.BytesIO(resp.data)) as img:
+        served = np.asarray(img.convert("RGB")).astype(np.float32)
+
+    scaled = np.asarray(
+        apply_recipe_to_loaded_image(
+            load_image(src_path, max_size=256), recipe, native_size=(800, 600)
+        )
+    ).astype(np.float32)
+    unscaled = np.asarray(
+        apply_recipe_to_loaded_image(load_image(src_path, max_size=256), recipe)
+    ).astype(np.float32)
+
+    dist_scaled = float(np.mean(np.abs(served - scaled)))
+    dist_unscaled = float(np.mean(np.abs(served - unscaled)))
+    assert dist_scaled < dist_unscaled
+
+
 def test_edit_preview_returns_400_for_malformed_crop(client_with_photo):
     from PIL import Image
 

--- a/vireo/thumbnails.py
+++ b/vireo/thumbnails.py
@@ -19,6 +19,9 @@ from render_source import (
     photo_value as _photo_value,
 )
 from render_source import (
+    recipe_source_dimensions as _recipe_source_dimensions,
+)
+from render_source import (
     scaled_recipe_source_dimensions as _scaled_recipe_source_dimensions,
 )
 
@@ -106,6 +109,8 @@ def _retry_thumbnail_with_companion(
             )
             db.conn.commit()
     recipe_kwargs = {"recipe": recipe} if recipe else {}
+    if recipe:
+        recipe_kwargs["native_size"] = _recipe_source_dimensions(photo)
     return generate_thumbnail(
         photo_id,
         companion_abs,
@@ -118,7 +123,7 @@ def _retry_thumbnail_with_companion(
 
 def generate_thumbnail(
     photo_id, source_path, cache_dir, size=THUMB_SIZE, quality=85, recipe=None,
-    raw_decode=None, min_source_size=None,
+    raw_decode=None, min_source_size=None, native_size=None,
 ):
     """Generate a JPEG thumbnail for a photo.
 
@@ -139,6 +144,10 @@ def generate_thumbnail(
             before applying ``recipe``. If the RAW loader falls back to an
             embedded preview smaller than either axis, generation returns
             ``None`` so callers can retry a full-size companion JPEG.
+        native_size: optional orientation-corrected native ``(width, height)``
+            of the photo (see ``render_source.recipe_source_dimensions``),
+            used to scale the recipe's detail pass (sharpen/NR kernels) to
+            this render's resolution.
 
     Returns:
         path to the thumbnail file, or None on failure
@@ -167,7 +176,9 @@ def generate_thumbnail(
             return None
     if recipe:
         from image_edits import apply_recipe_to_loaded_image
-        img = apply_recipe_to_loaded_image(img, recipe, max_size=size)
+        img = apply_recipe_to_loaded_image(
+            img, recipe, max_size=size, native_size=native_size,
+        )
 
     os.makedirs(cache_dir, exist_ok=True)
     # Atomic write: two concurrent jobs (or two iterations of the same job
@@ -259,6 +270,10 @@ def generate_all(db, cache_dir, progress_callback=None, config=None, vireo_dir=N
         # iterations and avoid blocking concurrent jobs (a parallel scan's
         # add_photo INSERT) past the 30s busy_timeout.
         recipe_kwargs = {"recipe": recipe} if recipe else {}
+        if recipe:
+            recipe_kwargs["native_size"] = _recipe_source_dimensions(
+                source_photo
+            )
         # Derive the decode mode from the primary photo's extension so
         # edited RAWs that fall through to the original source path are
         # demosaiced with highlight preservation, matching the preview /


### PR DESCRIPTION
## What

Adds the first neighborhood (non-per-pixel) ops to the non-destructive edit pipeline: **Sharpen** (luminance unsharp mask, amount 0–100 + radius 0.5–3.0) and **Denoise** (luma bilateral + mild chroma smoothing, 0–100). Design doc: `docs/plans/2026-07-03-detail-pass-design.md`.

## How it works

- **Schema**: three new `adjustments` keys — `sharpen`, `sharpen_radius`, `noise_reduction`. Schema version unchanged; zero values and the 1.0 default radius normalize away, and radius never appears without sharpen. Old recipes render byte-identically, so no `EDIT_MATH_VERSION` bump / cache purge.
- **Semantics**: detail settings describe the **full-resolution render**; radius is authored in native photo pixels. The pass runs last (after geometry, tone, and the final resize) at output resolution with kernels scaled by `detail_render_scale` = output px / native px (rotation- and crop-aware). Smaller renders approximate the full-res result downscaled — same contract every RAW editor uses (sharpening is judged at 1:1, subtle at fit zoom).
- **New module `vireo/detail.py`**: NR first (fixed-window bilateral on luma, Gaussian on chroma), then luminance-only USM (no color fringing). Separable numpy convolutions, no new dependencies. Row-band tiling with halo overlap keeps memory bounded on 45MP exports and is byte-identical to a whole-frame pass (tested).
- **Call sites**: `native_size` plumbed through edit-preview, preview cache + warmup, thumbnails, exports, external-edit/iNat/original renders (`render_source.recipe_source_dimensions`).
- **Editor UI**: new Detail panel band (Sharpen / Radius / Denoise + Reset Detail; Reset Adjustments now leaves detail alone). At 100% zoom the preview requests the endpoint max (3840px) instead of 1920 and says so in the status line, so detail is judgeable near native pixels. Auto Tone continues to leave detail (like color) untouched.
- **Live preview transparency**: the lightbox WebGL tone shader is per-pixel and can't express these ops — as with re-edits today, its live approximation snaps to the exact server render on save. The editor page (where detail is authored) uses exact server renders throughout. `tone.py` and the shader-parity test are untouched.

## Tests

- `1403 passed, 3 skipped` — workspaces, db, app, photos/edits/jobs/darktable/config APIs, image_edits, tone + shader parity, thumbnails, export, new `test_detail.py` (identity, acutance, monotonicity, scale weakening, noise stats, edge preservation, alpha, tiling equivalence, scale math).
- `491 passed` — full pipeline suites (pipeline_job/thumbnail-warm paths touched).
- End-to-end: real app on a temp DB — editor page + detail previews render; Playwright drive of the new sliders, radius canonicalization, Reset behaviors, 3840px zoom render, and save round-trip through the server normalizer.
- Perf: 24MP export render is ~0.6s sharpen-only, ~6s with NR; previews use scaled (smaller) kernels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)