### PR TITLE
Add app reload shortcut

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -44,6 +44,19 @@ fn dispatch_menu_command(app: &tauri::AppHandle, command: &str) {
     }
 }
 
+fn reload_main_window(app: &tauri::AppHandle) {
+    if tray::is_browser_mode(app) {
+        log::warn!("Native reload ignored because Vireo is running in browser mode");
+        return;
+    }
+
+    if let Some(window) = app.get_webview_window("main") {
+        if let Err(e) = window.eval("window.location.reload()") {
+            log::error!("Failed to reload main window: {}", e);
+        }
+    }
+}
+
 #[tauri::command]
 fn get_server_port(state: tauri::State<'_, SidecarState>) -> u16 {
     state.port
@@ -267,6 +280,11 @@ pub fn run() {
             // also route to the browser.
             if id == menu::ids::OPEN_IN_BROWSER {
                 tray::open_ui_in_browser(app);
+                return;
+            }
+
+            if id == menu::ids::VIEW_RELOAD {
+                reload_main_window(app);
                 return;
             }
 

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -29,6 +29,7 @@ pub mod ids {
     pub const REPORT_ISSUE: &str = "report_issue";
     pub const CHECK_FOR_UPDATES: &str = "check_for_updates";
     pub const OPEN_IN_BROWSER: &str = "open_in_browser_now";
+    pub const VIEW_RELOAD: &str = "view_reload";
 
     pub const FILE_NEW_WORKSPACE: &str = "file_new_workspace";
     pub const FILE_OPEN_WORKSPACE: &str = "file_open_workspace";
@@ -349,6 +350,12 @@ pub fn build_menu(app: &AppHandle) -> tauri::Result<tauri::menu::Menu<tauri::Wry
     }
 
     view_builder = view_builder.separator().item(
+        &MenuItemBuilder::with_id(ids::VIEW_RELOAD, "Reload")
+            .accelerator("CmdOrCtrl+R")
+            .build(app)?,
+    );
+
+    view_builder = view_builder.item(
         &MenuItemBuilder::with_id(ids::OPEN_IN_BROWSER, "Open in Browser")
             .accelerator("CmdOrCtrl+Shift+B")
             .build(app)?,
@@ -375,7 +382,6 @@ pub fn build_menu(app: &AppHandle) -> tauri::Result<tauri::menu::Menu<tauri::Wry
         )
         .item(
             &MenuItemBuilder::with_id(ids::PHOTO_REVEAL, reveal_label)
-                .accelerator("CmdOrCtrl+R")
                 .build(app)?,
         )
         .item(


### PR DESCRIPTION
Adds a native View > Reload command to refresh the embedded Vireo webview with Cmd+R. This fixes stale in-app pages by calling window.location.reload() from the Tauri menu handler. It also removes the Cmd+R conflict from Photo > Reveal in Finder so the shortcut has one clear behavior. Validation: cargo check was attempted but blocked because src-tauri/binaries/vireo-server-aarch64-apple-darwin is missing in this workspace; cargo fmt --check also reports pre-existing formatting diffs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **Reload** option in the app’s **View** menu.
  * Added a keyboard shortcut (**Cmd/Ctrl+R**) to reload the main app window.

* **Bug Fixes**
  * The reload action now only affects the main app view and is skipped in browser mode.
  * Improved handling so the reload command doesn’t trigger other menu actions by mistake.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->