### PR TITLE
Photo editor: presets library (save/apply reusable looks)

### DIFF
--- a/docs/plans/2026-07-03-edit-presets-design.md
+++ b/docs/plans/2026-07-03-edit-presets-design.md
@@ -1,0 +1,64 @@
+# Edit presets
+
+## Motivation
+
+Recurring shooting situations ("high-ISO forest", "backlit water", "overcast
+plumage") get re-dialed by hand for every photo. Copy Settings already moves a
+recipe between photos in one session; presets make that vocabulary persistent
+and one click from the editor.
+
+## Decisions
+
+- **Adjustments-only.** A preset stores the `adjustments` object (tone, white
+  balance, detail) and never geometry — rotation, flip, straighten, and crop
+  are facts about one photo, not a look. The server strips geometry on save.
+- **Global, not workspace-scoped.** Presets are the photographer's vocabulary,
+  like photos and keywords; a look is the same look in every workspace.
+- **Upsert by name.** Saving a preset under an existing name overwrites it —
+  the natural "tweak and re-save" loop, no versioning ceremony.
+- **Apply replaces the whole adjustments object** (geometry untouched). The
+  mental model is "make the sliders look exactly like when I saved this",
+  which is transparent and idempotent, rather than a per-key merge whose
+  result depends on the photo's current state.
+- Applying only edits the in-editor working recipe (marks dirty, re-renders
+  preview); nothing persists until Save. Batch application rides the existing
+  Copy Settings / bulk-apply flows.
+
+## Storage
+
+```sql
+CREATE TABLE IF NOT EXISTS edit_presets (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    name        TEXT NOT NULL UNIQUE,
+    recipe_json TEXT NOT NULL,           -- canonical {"version":1,"adjustments":{...}}
+    created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+```
+
+`recipe_json` is validated and canonicalized through `normalize_recipe` (same
+path as photo recipes), restricted to the adjustments section. A preset that
+normalizes to no adjustments is rejected, not stored empty.
+
+## API
+
+- `GET /api/edit-presets` → `{presets: [{id, name, recipe, updated_at}, ...]}`
+  sorted by name.
+- `POST /api/edit-presets` `{name, recipe}` → upsert by trimmed name; strips
+  geometry, 400 on invalid/empty adjustments or blank/overlong name.
+- `DELETE /api/edit-presets/<id>` → 404 if unknown.
+
+No rename endpoint in v1 — save under the new name and delete the old one.
+
+## Editor UI
+
+A **Presets** band above Adjustments in `photo_editor.html`: a `<select>` of
+saved presets plus Apply / Save… / Delete buttons. Save prompts for a name
+(prefilled with the current selection) and captures the current adjustments
+(both the Adjustments and Detail bands). Apply overwrites the working
+recipe's adjustments, syncs sliders, and re-renders the preview.
+
+## Follow-ups (out of scope)
+
+- Grid right-click "Apply preset" batch action (merge-with-geometry endpoint).
+- Preset preview thumbnails.

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4103,6 +4103,35 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "recipe": db.get_photo_edit_recipe(applied[0]) if applied else None,
         })
 
+    @app.route("/api/edit-presets", methods=["GET", "POST"])
+    def api_edit_presets():
+        """List or save (upsert by name) global edit presets.
+
+        Presets store an adjustments-only recipe — a reusable look. Geometry
+        is stripped on save; see db.save_edit_preset.
+        """
+        db = _get_db()
+        if request.method == "GET":
+            return jsonify({"presets": db.list_edit_presets()})
+        body = request.get_json(silent=True)
+        if not isinstance(body, dict):
+            return json_error("request body must be a JSON object")
+        recipe = body.get("recipe")
+        if not isinstance(recipe, dict):
+            return json_error("recipe must be a JSON object")
+        try:
+            preset = db.save_edit_preset(body.get("name"), recipe)
+        except ValueError as e:  # includes RecipeError
+            return json_error(str(e))
+        return jsonify({"ok": True, "preset": preset})
+
+    @app.route("/api/edit-presets/<int:preset_id>", methods=["DELETE"])
+    def api_delete_edit_preset(preset_id):
+        db = _get_db()
+        if not db.delete_edit_preset(preset_id):
+            return json_error("preset not found", 404)
+        return jsonify({"ok": True})
+
     @app.route("/api/photos/<int:photo_id>/edit-history")
     def api_photo_edit_history(photo_id):
         db = _get_db()

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -727,6 +727,14 @@ class Database:
                 updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
             );
 
+            CREATE TABLE IF NOT EXISTS edit_presets (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                name        TEXT NOT NULL UNIQUE,
+                recipe_json TEXT NOT NULL,
+                created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+                updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+
             CREATE TABLE IF NOT EXISTS photo_preferences (
                 workspace_id  INTEGER NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
                 purpose       TEXT NOT NULL,
@@ -6570,6 +6578,105 @@ class Database:
         cur = self.conn.execute(
             "DELETE FROM photo_edit_recipes WHERE photo_id = ?",
             (photo_id,),
+        )
+        self.conn.commit()
+        return cur.rowcount > 0
+
+    # --- edit presets (global, adjustments-only looks) ----------------------
+
+    EDIT_PRESET_NAME_MAX = 80
+
+    def list_edit_presets(self):
+        """Return all edit presets, sorted case-insensitively by name.
+
+        Presets are global (not workspace-scoped): they capture a look, and a
+        look is the same look in every workspace.
+        """
+        from image_edits import copy_recipe
+
+        rows = self.conn.execute(
+            "SELECT id, name, recipe_json, updated_at FROM edit_presets"
+        ).fetchall()
+        out = []
+        for row in rows:
+            try:
+                recipe = copy_recipe(row["recipe_json"])
+            except Exception:
+                log.warning(
+                    "Invalid stored edit preset %s (%r)",
+                    row["id"], row["name"], exc_info=True,
+                )
+                continue
+            out.append({
+                "id": row["id"],
+                "name": row["name"],
+                "recipe": recipe,
+                "updated_at": row["updated_at"],
+            })
+        out.sort(key=lambda p: p["name"].casefold())
+        return out
+
+    def save_edit_preset(self, name, recipe):
+        """Create or overwrite (by trimmed name) a global edit preset.
+
+        Only the recipe's ``adjustments`` section is kept — geometry
+        (rotation/flip/straighten/crop) describes one photo, not a look.
+        Raises ValueError (or RecipeError, its subclass) for a blank or
+        overlong name, a malformed recipe, or one with no effective
+        adjustments. Returns the stored preset dict.
+        """
+        from image_edits import (
+            RecipeError,
+            copy_recipe,
+            normalize_recipe,
+            recipe_to_json,
+        )
+
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError("preset name must not be blank")
+        name = name.strip()
+        if len(name) > self.EDIT_PRESET_NAME_MAX:
+            raise ValueError(
+                f"preset name must be {self.EDIT_PRESET_NAME_MAX} "
+                "characters or fewer"
+            )
+
+        if isinstance(recipe, str):
+            recipe = normalize_recipe(recipe) or {}
+        if not isinstance(recipe, dict):
+            raise RecipeError("recipe must be an object")
+        normalized = normalize_recipe(
+            {"adjustments": recipe.get("adjustments") or {}}
+        )
+        if not (normalized or {}).get("adjustments"):
+            raise ValueError("preset must include at least one adjustment")
+        recipe_json = recipe_to_json(normalized)
+
+        self.conn.execute(
+            """INSERT INTO edit_presets (name, recipe_json, updated_at)
+               VALUES (?, ?, datetime('now'))
+               ON CONFLICT(name) DO UPDATE SET
+                   recipe_json = excluded.recipe_json,
+                   updated_at = excluded.updated_at""",
+            (name, recipe_json),
+        )
+        self.conn.commit()
+        row = self.conn.execute(
+            "SELECT id, name, recipe_json, updated_at FROM edit_presets "
+            "WHERE name = ?",
+            (name,),
+        ).fetchone()
+        return {
+            "id": row["id"],
+            "name": row["name"],
+            "recipe": copy_recipe(row["recipe_json"]),
+            "updated_at": row["updated_at"],
+        }
+
+    def delete_edit_preset(self, preset_id):
+        """Delete an edit preset. Returns True if a row was removed."""
+        cur = self.conn.execute(
+            "DELETE FROM edit_presets WHERE id = ?", (preset_id,)
         )
         self.conn.commit()
         return cur.rowcount > 0

--- a/vireo/templates/photo_editor.html
+++ b/vireo/templates/photo_editor.html
@@ -218,6 +218,22 @@ body {
   font-size: 12px;
 }
 .control-row input[type="range"] { width: 100%; }
+.preset-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 8px;
+  margin: 10px 0;
+}
+.preset-row select,
+.preset-row input[type="text"] {
+  width: 100%;
+  padding: 6px 8px;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-primary);
+  border-radius: 4px;
+  font-size: 12px;
+}
 .control-value {
   color: var(--text-muted);
   font-size: 12px;
@@ -437,6 +453,21 @@ body {
     </div>
 
     <div class="panel-band">
+      <div class="panel-title">Presets</div>
+      <div class="preset-row">
+        <select id="presetSelect" onchange="onPresetSelected()">
+          <option value="">Select a preset...</option>
+        </select>
+        <input id="presetNameInput" type="text" maxlength="80" placeholder="Preset name" aria-label="Preset name">
+      </div>
+      <div class="button-row">
+        <button class="editor-btn" type="button" id="applyPresetBtn" onclick="applySelectedPreset()" disabled>Apply</button>
+        <button class="editor-btn" type="button" id="savePresetBtn" onclick="saveCurrentAsPreset()">Save</button>
+        <button class="editor-btn" type="button" id="deletePresetBtn" onclick="deleteSelectedPreset()" disabled>Delete</button>
+      </div>
+    </div>
+
+    <div class="panel-band">
       <div class="panel-title">Adjustments</div>
       <div class="button-row">
         <button class="editor-btn" type="button" id="autoToneBtn" onclick="autoTone()">Auto Tone</button>
@@ -536,6 +567,7 @@ var editorState = {
   photo: null,
   savedRecipe: {},
   recipe: {},
+  presets: [],
   previewSeq: 0,
   previewTimer: null,
   drag: null,
@@ -1114,6 +1146,122 @@ function resetAdjustments() {
   markChanged(true);
 }
 
+// --- Presets ---------------------------------------------------------------
+// Reusable adjustments-only looks (tone + white balance + detail). Applying a
+// preset replaces the working recipe's adjustments and leaves geometry alone;
+// nothing persists until the user saves the photo. See
+// docs/plans/2026-07-03-edit-presets-design.md.
+
+async function loadPresets(selectId) {
+  try {
+    var data = await safeFetch('/api/edit-presets', {}, {toast: false});
+    editorState.presets = data.presets || [];
+  } catch (e) {
+    editorState.presets = [];
+  }
+  renderPresetOptions(selectId);
+}
+
+function renderPresetOptions(selectId) {
+  var sel = document.getElementById('presetSelect');
+  if (!sel) return;
+  var current = selectId != null ? String(selectId) : sel.value;
+  sel.innerHTML = '';
+  var placeholder = document.createElement('option');
+  placeholder.value = '';
+  placeholder.textContent = editorState.presets.length
+    ? 'Select a preset...'
+    : 'No presets saved yet';
+  sel.appendChild(placeholder);
+  editorState.presets.forEach(function(p) {
+    var opt = document.createElement('option');
+    opt.value = String(p.id);
+    opt.textContent = p.name;
+    sel.appendChild(opt);
+  });
+  sel.value = current;
+  if (sel.value !== current) sel.value = '';
+  onPresetSelected();
+}
+
+function selectedPreset() {
+  var sel = document.getElementById('presetSelect');
+  var id = sel ? Number(sel.value) : NaN;
+  return editorState.presets.find(function(p) { return p.id === id; }) || null;
+}
+
+function onPresetSelected() {
+  var preset = selectedPreset();
+  document.getElementById('applyPresetBtn').disabled = !preset;
+  document.getElementById('deletePresetBtn').disabled = !preset;
+  if (preset) document.getElementById('presetNameInput').value = preset.name;
+}
+
+function applySelectedPreset() {
+  var preset = selectedPreset();
+  if (!preset || editorState.loading) return;
+  var adj = cloneRecipe((preset.recipe || {}).adjustments || {});
+  if (Object.keys(adj).length) editorState.recipe.adjustments = adj;
+  else delete editorState.recipe.adjustments;
+  syncControls();
+  markChanged(true);
+  if (typeof showToast === 'function') {
+    showToast('Applied preset "' + preset.name + '" (not saved yet)', 'success');
+  }
+}
+
+async function saveCurrentAsPreset() {
+  var current = recipeForSave(editorState.recipe);
+  if (!current.adjustments) {
+    if (typeof showToast === 'function') {
+      showToast('No adjustments to save as a preset', 'error');
+    }
+    return;
+  }
+  var name = document.getElementById('presetNameInput').value.trim();
+  if (!name) {
+    if (typeof showToast === 'function') {
+      showToast('Enter a preset name first', 'error');
+    }
+    return;
+  }
+  try {
+    var data = await safeFetch('/api/edit-presets', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({
+        name: name,
+        recipe: {adjustments: current.adjustments},
+      }),
+    }, {toast: false});
+    await loadPresets(data.preset && data.preset.id);
+    if (typeof showToast === 'function') {
+      showToast('Saved preset "' + data.preset.name + '"', 'success');
+    }
+  } catch (e) {
+    if (typeof showToast === 'function') {
+      showToast(e.message || 'Could not save preset', 'error');
+    }
+  }
+}
+
+async function deleteSelectedPreset() {
+  var preset = selectedPreset();
+  if (!preset) return;
+  try {
+    await safeFetch('/api/edit-presets/' + preset.id, {method: 'DELETE'}, {toast: false});
+    document.getElementById('presetNameInput').value = '';
+    await loadPresets('');
+    if (typeof showToast === 'function') {
+      showToast('Deleted preset "' + preset.name + '"', 'success');
+    }
+  } catch (e) {
+    if (typeof showToast === 'function') {
+      showToast(e.message || 'Could not delete preset', 'error');
+    }
+  }
+}
+
 function resetDetail() {
   var adj = cloneRecipe(editorState.recipe.adjustments || {});
   delete adj.sharpen;
@@ -1658,6 +1806,7 @@ async function initEditor() {
   initEditorKeyboard();
   clearHistogramFeedback();
   setZoomMode('fit');
+  loadPresets();
   if (window.vireoEditNav) editorState.navIds = window.vireoEditNav.getList() || [];
   var match = window.location.pathname.match(/\/edit\/(\d+)/);
   var photoId = match

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -14614,3 +14614,89 @@ def test_workspace_active_labels_survive_non_dict_overrides(tmp_path):
         # Setter must replace the junk rather than crash on item assignment.
         db.set_workspace_active_labels(["birds.txt"])
         assert db.get_workspace_active_labels() == ["birds.txt"]
+
+
+def test_edit_presets_crud_strips_geometry(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    assert db.list_edit_presets() == []
+
+    preset = db.save_edit_preset(
+        "High-ISO forest",
+        {
+            "rotation": 90,
+            "crop": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+            "adjustments": {"exposure": 0.5, "noise_reduction": 40},
+        },
+    )
+    assert preset["name"] == "High-ISO forest"
+    assert preset["recipe"] == {
+        "version": 1,
+        "adjustments": {"exposure": 0.5, "noise_reduction": 40.0},
+    }
+
+    listed = db.list_edit_presets()
+    assert len(listed) == 1
+    assert listed[0]["id"] == preset["id"]
+    assert listed[0]["recipe"]["adjustments"]["noise_reduction"] == 40.0
+
+
+def test_edit_preset_upserts_by_trimmed_name(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+
+    first = db.save_edit_preset("Backlit  ", {"adjustments": {"exposure": 1}})
+    second = db.save_edit_preset(
+        " Backlit", {"adjustments": {"shadows": 30}}
+    )
+
+    assert first["name"] == "Backlit"
+    assert second["id"] == first["id"]
+    listed = db.list_edit_presets()
+    assert len(listed) == 1
+    assert listed[0]["recipe"]["adjustments"] == {"shadows": 30.0}
+
+
+def test_edit_presets_list_sorted_by_name(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    for name in ("zebra dusk", "Backlit", "high-ISO forest"):
+        db.save_edit_preset(name, {"adjustments": {"contrast": 10}})
+
+    names = [p["name"] for p in db.list_edit_presets()]
+    assert names == sorted(names, key=str.casefold)
+
+
+def test_edit_preset_rejects_empty_or_geometry_only(tmp_path):
+    import pytest
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+
+    with pytest.raises(ValueError):
+        db.save_edit_preset("Nothing", {})
+    with pytest.raises(ValueError):
+        db.save_edit_preset("Geometry only", {"rotation": 90})
+    with pytest.raises(ValueError):
+        db.save_edit_preset("Zeroed", {"adjustments": {"exposure": 0}})
+    assert db.list_edit_presets() == []
+
+
+def test_edit_preset_rejects_blank_or_overlong_name(tmp_path):
+    import pytest
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+
+    with pytest.raises(ValueError):
+        db.save_edit_preset("   ", {"adjustments": {"exposure": 1}})
+    with pytest.raises(ValueError):
+        db.save_edit_preset("x" * 200, {"adjustments": {"exposure": 1}})
+
+
+def test_delete_edit_preset(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    preset = db.save_edit_preset("Doomed", {"adjustments": {"exposure": 1}})
+
+    assert db.delete_edit_preset(preset["id"]) is True
+    assert db.delete_edit_preset(preset["id"]) is False
+    assert db.list_edit_presets() == []

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -7625,3 +7625,71 @@ def test_collection_add_photos_rejects_non_integer_ids(app_and_db):
                        json={'photo_ids': [pid]})
     assert resp.status_code == 200
     assert resp.get_json()["total"] == 1
+
+
+def test_edit_presets_api_crud(app_and_db):
+    app, db = app_and_db
+    client = app.test_client()
+
+    assert client.get("/api/edit-presets").get_json() == {"presets": []}
+
+    resp = client.post(
+        "/api/edit-presets",
+        json={
+            "name": "Backlit",
+            "recipe": {
+                "rotation": 90,
+                "adjustments": {"exposure": 1, "sharpen": 30},
+            },
+        },
+    )
+    assert resp.status_code == 200
+    preset = resp.get_json()["preset"]
+    assert preset["name"] == "Backlit"
+    assert preset["recipe"] == {
+        "version": 1,
+        "adjustments": {"exposure": 1.0, "sharpen": 30.0},
+    }
+
+    # Upsert by name keeps the id, replaces the recipe.
+    resp = client.post(
+        "/api/edit-presets",
+        json={"name": " Backlit ", "recipe": {"adjustments": {"shadows": 25}}},
+    )
+    assert resp.status_code == 200
+    updated = resp.get_json()["preset"]
+    assert updated["id"] == preset["id"]
+    assert updated["recipe"]["adjustments"] == {"shadows": 25.0}
+
+    client.post(
+        "/api/edit-presets",
+        json={"name": "alpine", "recipe": {"adjustments": {"contrast": 5}}},
+    )
+    names = [p["name"] for p in client.get("/api/edit-presets").get_json()["presets"]]
+    assert names == ["alpine", "Backlit"]
+
+    assert client.delete(f"/api/edit-presets/{preset['id']}").status_code == 200
+    assert client.delete(f"/api/edit-presets/{preset['id']}").status_code == 404
+    names = [p["name"] for p in client.get("/api/edit-presets").get_json()["presets"]]
+    assert names == ["alpine"]
+
+
+def test_edit_presets_api_validation(app_and_db):
+    app, db = app_and_db
+    client = app.test_client()
+
+    cases = [
+        {"recipe": {"adjustments": {"exposure": 1}}},              # no name
+        {"name": "  ", "recipe": {"adjustments": {"exposure": 1}}},
+        {"name": "x" * 200, "recipe": {"adjustments": {"exposure": 1}}},
+        {"name": "ok"},                                            # no recipe
+        {"name": "ok", "recipe": 5},
+        {"name": "ok", "recipe": {"rotation": 90}},                # geometry only
+        {"name": "ok", "recipe": {"adjustments": {"exposure": 0}}},
+        {"name": "ok", "recipe": {"adjustments": {"exposure": 99}}},  # out of range
+    ]
+    for payload in cases:
+        resp = client.post("/api/edit-presets", json=payload)
+        assert resp.status_code == 400, payload
+
+    assert client.get("/api/edit-presets").get_json() == {"presets": []}


### PR DESCRIPTION
## What

Named, persistent edit presets: dial in a look once ("high-ISO forest", "backlit water"), save it, apply it to any photo from the editor with one click. Design doc: `docs/plans/2026-07-03-edit-presets-design.md`. Follow-up to #1084 — presets capture the full adjustments state including the new detail (sharpen/NR) sliders.

## Decisions

- **Adjustments-only**: presets store tone + white balance + detail, never geometry (rotation/flip/straighten/crop belong to one photo, not a look). The server strips geometry on save.
- **Global**, not workspace-scoped — a look is the same look in every workspace, like photos and keywords.
- **Upsert by trimmed name** — re-saving "Backlit" overwrites it; the natural tweak-and-re-save loop.
- **Apply replaces the whole adjustments object** (geometry untouched) and only edits the working recipe — nothing persists until the photo is saved. Batch propagation rides the existing Copy Settings flow.

## Implementation

- `db.py`: `edit_presets` table + `list/save/delete_edit_preset` (validated + canonicalized through `normalize_recipe`, same path as photo recipes; empty/geometry-only presets rejected).
- `app.py`: `GET/POST /api/edit-presets`, `DELETE /api/edit-presets/<id>`.
- `photo_editor.html`: Presets band above Adjustments — select + name field + Apply/Save/Delete. Inline name input rather than `window.prompt` (unreliable in the Tauri webview). Selecting a preset prefills the name so overwrite/rename flows are obvious.

## Tests

- `1302 passed, 1 skipped` — CLAUDE.md suite + image_edits + detail, including new DB CRUD tests (upsert, trim, sort, geometry stripping, validation) and API tests (CRUD round-trip, 400 matrix, 404 delete).
- Playwright against a real app instance: empty state, save from live sliders, apply restores adjustments while preserving a 90° rotation, sliders re-sync, upsert keeps one row, delete returns to empty state. No JS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)