### PR TITLE
Show "safe to eject" once import finishes copying source

### DIFF
--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1560,6 +1560,23 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         return
                     else:
                         stages["ingest"]["status"] = "completed"
+                        # Ingest is the only stage that ever reads the source
+                        # (SD card/etc.) — everything after this point works
+                        # from the copy. Record counts so the UI can tell the
+                        # user the card is safe to eject instead of leaving
+                        # them to guess. Only claim this when every discovered
+                        # file actually made it off the card: local_processing
+                        # aborts above on any failure, but plain copy mode
+                        # (local_processing=False) reaches this branch even
+                        # with total_failed > 0, and the card still holds
+                        # files that never got copied.
+                        if total_failed == 0:
+                            stages["ingest"]["copied"] = total_copied
+                            stages["ingest"]["skipped_duplicate"] = total_skipped
+                            result["stages"]["ingest"] = {
+                                "copied": total_copied,
+                                "skipped_duplicate": total_skipped,
+                            }
                         runner.update_step(
                             job["id"], "ingest", status="completed",
                             summary=summary,

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -3036,6 +3036,23 @@ function _formatETA(seconds) {
   return h + 'h ' + m + 'm';
 }
 
+// Ingest is the only stage that ever reads the source (SD card/etc.) — every
+// later stage works off the copy it made. Once it reports success, surface
+// that explicitly instead of leaving the user to guess whether the card is
+// still in use (`ingestInfo.copied` is absent entirely in scan-in-place mode,
+// where there was never a copy and the card stays needed for the whole run).
+function _showSourceEjectSafe(ingestInfo) {
+  if (!ingestInfo || typeof ingestInfo.copied !== 'number') return;
+  var statusSourceEl = document.getElementById('statusSource');
+  if (!statusSourceEl) return;
+  var parts = [ingestInfo.copied.toLocaleString() + ' copied'];
+  if (ingestInfo.skipped_duplicate) {
+    parts.push(ingestInfo.skipped_duplicate.toLocaleString() + ' already present');
+  }
+  statusSourceEl.textContent = parts.join(', ') + ' — the card is safe to eject.';
+  statusSourceEl.className = 'status-msg ok';
+}
+
 function _updatePipelineStageUI(p) {
   var stages = p.stages || {};
 
@@ -3110,6 +3127,7 @@ function _updatePipelineStageUI(p) {
       if (a.completed > 0) {
         _stageOutcomes[cardSuffix2] = 'done';
         _setPill(cardSuffix2, 'done');
+        if (cardSuffix2 === 'Source') _showSourceEjectSafe(stages['ingest']);
       } else {
         // Every substage was skipped. Backend 'skipped' covers both
         // user-disabled stages and auto-skip; pick the right label so a
@@ -3259,8 +3277,12 @@ function _onPipelineComplete(result) {
     var fillSource = document.getElementById('fillSource');
     if (fillSource && fillSource.style.width && fillSource.style.width !== '0%') {
       fillSource.style.width = '100%';
-      var statusSourceEl = document.getElementById('statusSource');
-      if (statusSourceEl) { statusSourceEl.textContent = 'Done!'; statusSourceEl.className = 'status-msg ok'; }
+      if (stageResults.ingest && typeof stageResults.ingest.copied === 'number') {
+        _showSourceEjectSafe(stageResults.ingest);
+      } else {
+        var statusSourceEl = document.getElementById('statusSource');
+        if (statusSourceEl) { statusSourceEl.textContent = 'Done!'; statusSourceEl.className = 'status-msg ok'; }
+      }
     }
   }
 

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -1411,6 +1411,115 @@ def test_pipeline_scan_step_gets_status_updates(tmp_path, monkeypatch):
         "Status updates should also push SSE progress events"
 
 
+def test_pipeline_ingest_records_safe_to_eject_counts_on_success(tmp_path, monkeypatch):
+    """Once ingest copies everything off the source with no failures, the
+    stage (and final result) should carry 'copied'/'skipped_duplicate' counts
+    so the UI can tell the user the source (e.g. an SD card) is safe to eject.
+    """
+    import config as cfg
+    from db import Database
+    from PIL import Image
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    src = tmp_path / "source"
+    src.mkdir()
+    for name, color in [("a.jpg", "red"), ("b.jpg", "blue")]:
+        img = Image.new("RGB", (100, 100), color)
+        img.save(str(src / name))
+
+    dest = tmp_path / "dest"
+    dest.mkdir()
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    params = PipelineParams(
+        source=str(src),
+        destination=str(dest),
+        skip_classify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    result = run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    assert result["stages"]["ingest"]["copied"] == 2
+    assert result["stages"]["ingest"]["skipped_duplicate"] == 0
+
+    # The live SSE stream should carry the same counts on the completed event.
+    ingest_completed_events = [
+        e[2]["stages"]["ingest"] for e in runner.events
+        if e[1] == "progress" and e[2]["stages"].get("ingest", {}).get("status") == "completed"
+    ]
+    assert ingest_completed_events, "expected a progress event with ingest completed"
+    assert ingest_completed_events[-1]["copied"] == 2
+
+
+def test_pipeline_ingest_omits_safe_to_eject_counts_on_partial_failure(tmp_path, monkeypatch):
+    """Plain copy mode (no local_processing) doesn't abort the run when a file
+    fails to copy — it still marks the ingest stage 'completed'. The
+    safe-to-eject counts must NOT be published in that case, since the source
+    still holds a file that never made it to the destination.
+    """
+    import config as cfg
+    import ingest as ingest_module
+    from db import Database
+    from PIL import Image
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    src = tmp_path / "source"
+    src.mkdir()
+    for name, color in [("a.jpg", "red"), ("b.jpg", "blue")]:
+        img = Image.new("RGB", (100, 100), color)
+        img.save(str(src / name))
+
+    dest = tmp_path / "dest"
+    dest.mkdir()
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    real_copy2 = ingest_module.shutil.copy2
+
+    def flaky_copy2(source, destination, *args, **kwargs):
+        if str(source).endswith("b.jpg"):
+            raise OSError("simulated card read error")
+        return real_copy2(source, destination, *args, **kwargs)
+
+    monkeypatch.setattr(ingest_module.shutil, "copy2", flaky_copy2)
+
+    params = PipelineParams(
+        source=str(src),
+        destination=str(dest),
+        skip_classify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    result = run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    assert "ingest" not in result["stages"] or "copied" not in result["stages"]["ingest"]
+
+    ingest_completed_events = [
+        e[2]["stages"]["ingest"] for e in runner.events
+        if e[1] == "progress" and e[2]["stages"].get("ingest", {}).get("status") == "completed"
+    ]
+    assert ingest_completed_events, "expected a progress event with ingest completed"
+    assert "copied" not in ingest_completed_events[-1]
+
+
 def test_pipeline_ingest_step_present_only_with_destination(tmp_path, monkeypatch):
     """The 'ingest' step should only appear in step_defs when destination is set."""
     import config as cfg


### PR DESCRIPTION
## Summary
- Ingest is the only pipeline stage that reads the source (e.g. an SD card) — every later stage (thumbnails, classify, extract, previews, regroup, archive) works off the local copy it made.
- Once ingest completes with zero copy failures, the backend now records `copied`/`skipped_duplicate` counts on the stage and final result.
- The pipeline page's Source card surfaces this live and after the run finishes as "N copied — the card is safe to eject.", replacing the generic "Done!" message. Plain copy mode with partial failures (no local_processing, some files failed) correctly omits the claim since the source still holds un-copied files.

## Test plan
- [x] `python -m pytest vireo/tests/test_pipeline_job.py -k ingest -q` — 6 passed, including two new tests covering the success and partial-failure cases
- [x] `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_pipeline_job.py vireo/tests/test_pipeline.py vireo/tests/test_pipeline_api.py -q` — 1574 passed, 1 skipped
- [x] Manually verified in a browser against a throwaway DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)