### PR TITLE
Import dedup: metadata-first duplicate gate with verify-by-hash option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ Tests use temp databases. `vireo/tests/test_app.py` isolates config via `cfg.CON
 - `vireo/app.py` — Flask app with all routes. Created via `create_app(db_path, thumb_cache_dir)`.
 - `vireo/db.py` — `Database` class. SQLite with workspace support. Auto-creates Default workspace and restores last-used workspace on init.
 - `vireo/duplicates.py` — Pure exact-duplicate resolver (winner/loser decision + metadata merge). Consumed by `db.apply_duplicate_resolution` and the scan job.
+- `vireo/import_dedup.py` — Metadata-first duplicate gate for imports (`CatalogIndex` + `DuplicateChecker`): match by (filename, size, EXIF capture time) with a content-hash fallback for missing/placeholder metadata; `verify_by_hash` restores hash-everything. Shared by `ingest()`, `/api/import/check-duplicates`, and the local-processing preflight so duplicate previews always agree with what ingest actually skips.
 - `vireo/jobs.py` — `JobRunner` for background tasks (scan, classify, thumbnails, etc.) with SSE progress streaming.
 - `vireo/config.py` — Global config read/write from `~/.vireo/config.json`.
 - `vireo/templates/_navbar.html` — Shared navbar included by all pages. Contains workspace switcher, bottom panel, lightbox, theme system.

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2770,10 +2770,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         else:
             source_paths = None
         # hash_duplicate_paths is the frontend's pre-computed set of source
-        # paths that ingest() will skip via the file_hash global-dedup gate
-        # (copy mode + skip_duplicates=True). Same shape/limits as
+        # paths that ingest() will skip via the global duplicate gate (copy
+        # mode + skip_duplicates=True; metadata-first matching or content
+        # hashes depending on the verify-by-hash toggle — the preview and
+        # ingest share import_dedup.DuplicateChecker, so the set matches
+        # what ingest will actually skip). Same shape/limits as
         # source_paths; the planner subtracts these from new_count so the
-        # plan doesn't overstate work for hash-skipped files.
+        # plan doesn't overstate work for duplicate-skipped files.
         if "hash_duplicate_paths" in body:
             hash_duplicate_paths = body.get("hash_duplicate_paths")
             if not isinstance(hash_duplicate_paths, list):
@@ -10515,21 +10518,25 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def api_import_check_duplicates():
         """Stream duplicate detection results via SSE.
 
-        Accepts {"paths": [...]}, hashes each file, checks against DB,
-        and streams batches of duplicate paths back to the client.
+        Accepts {"paths": [...], "verify_by_hash": bool} and streams
+        batches of duplicate paths back to the client. Uses the same
+        DuplicateChecker as ingest() — metadata-first with a content-hash
+        fallback by default, hash-everything when verify_by_hash — so the
+        preview's DUPLICATE badges and count are exactly the files the
+        import step will skip.
         """
         body = request.get_json(silent=True) or {}
         paths = body.get("paths", [])
+        verify_by_hash = bool(body.get("verify_by_hash"))
         if not paths:
             return json_error("paths required", 400)
 
-        from scanner import EMPTY_FILE_SHA256, compute_file_hash
+        from import_dedup import CatalogIndex, DuplicateChecker
 
         db = _get_db()
-        rows = db.conn.execute(
-            "SELECT file_hash FROM photos WHERE file_hash IS NOT NULL"
-        ).fetchall()
-        known_hashes = {r["file_hash"] for r in rows}
+        checker = DuplicateChecker(
+            CatalogIndex.from_db(db), verify_by_hash=verify_by_hash,
+        )
 
         BATCH_SIZE = 20
 
@@ -10537,30 +10544,25 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             total = len(paths)
             duplicate_count = 0
             batch_duplicates = []
-            # Also track hashes seen in this run so identical source files
-            # (not yet in DB) are reported as duplicates of each other,
-            # matching the behaviour of the actual import step.
-            seen_hashes = set()
+            # Batch the EXIF header reads once up front (no-op in
+            # verify_by_hash mode). Intra-run duplicate tracking lives in
+            # the checker: identical source files not yet in the DB are
+            # reported as duplicates of each other, matching the actual
+            # import step.
+            checker.prepare([Path(p) for p in paths])
 
             for checked, path in enumerate(paths, 1):
+                # Zero-byte placeholders are non-duplicates (the checker
+                # gives them no identity), and unreadable/missing files
+                # are skipped; both fall through so the batch-yield block
+                # below still runs. A `continue` would swallow any
+                # already-queued `batch_duplicates` whenever such a file
+                # landed on the last path or on a batch boundary, leaving
+                # the UI unable to deselect those known dupes.
                 try:
-                    file_hash = compute_file_hash(path)
-                    # Treat zero-byte placeholders as non-duplicates, but fall
-                    # through so the batch-yield block below still runs.
-                    # A `continue` here would swallow any already-queued
-                    # `batch_duplicates` whenever an empty file landed on the
-                    # last path or on a `checked % BATCH_SIZE == 0` boundary,
-                    # leaving the UI unable to deselect those known dupes.
-                    is_empty_placeholder = (
-                        file_hash == EMPTY_FILE_SHA256
-                        and os.path.getsize(path) == 0
-                    )
-                    if not is_empty_placeholder:
-                        if file_hash in known_hashes or file_hash in seen_hashes:
-                            batch_duplicates.append(path)
-                            duplicate_count += 1
-                        else:
-                            seen_hashes.add(file_hash)
+                    if checker.check_and_record(Path(path)):
+                        batch_duplicates.append(path)
+                        duplicate_count += 1
                 except OSError:
                     pass  # Skip unreadable/missing files
 
@@ -13400,6 +13402,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         file_types = body.get("file_types", "both")
         folder_template = body.get("folder_template", "%Y/%Y-%m-%d")
         skip_duplicates = body.get("skip_duplicates", True)
+        verify_by_hash = bool(body.get("verify_by_hash"))
 
         if not source or not destination:
             return json_error("source and destination are required")
@@ -13454,6 +13457,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 file_types=file_types,
                 folder_template=folder_template,
                 skip_duplicates=skip_duplicates,
+                verify_by_hash=verify_by_hash,
                 progress_callback=progress_cb,
             )
             return result
@@ -14269,6 +14273,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         file_types = body.get("file_types", "both")
         folder_template = body.get("folder_template", "%Y/%Y-%m-%d")
         skip_duplicates = body.get("skip_duplicates", True)
+        verify_by_hash = bool(body.get("verify_by_hash"))
         copy = body.get("copy", True)
         exclude_paths = set(body.get("exclude_paths", []))
 
@@ -14348,6 +14353,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     file_types=file_types,
                     folder_template=folder_template,
                     skip_duplicates=skip_duplicates,
+                    verify_by_hash=verify_by_hash,
                     progress_callback=ingest_cb,
                     skip_paths=exclude_paths or None,
                 )
@@ -16486,6 +16492,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             file_types=body.get("file_types", "both"),
             folder_template=folder_template,
             skip_duplicates=body.get("skip_duplicates", True),
+            verify_by_hash=bool(body.get("verify_by_hash")),
             labels_file=body.get("labels_file"),
             labels_files=body.get("labels_files"),
             model_id=body.get("model_id"),

--- a/vireo/import_dedup.py
+++ b/vireo/import_dedup.py
@@ -1,0 +1,462 @@
+"""Shared duplicate-identity logic for card/folder imports.
+
+Vireo's historical import duplicate gate was exact: SHA-256 every source
+file and compare against ``photos.file_hash``. Correct, but importing from
+an SD card meant reading every byte of the card — often twice, once for the
+preview's duplicate scan and again at ingest — before a single file was
+copied. At card-reader speeds that is minutes of pure I/O for a check that
+Lightroom-style importers answer from metadata in seconds.
+
+This module implements the metadata-first gate shared by the import preview
+(``/api/import/check-duplicates``), ``ingest()``, and the local-processing
+preflight helpers, so every duplicate count the UI shows is computed by
+exactly the same rules ingest applies:
+
+* Heuristic mode (default): a source file is a duplicate when a cataloged
+  photo matches its (filename, byte size, capture time to the second).
+  The capture time comes from EXIF only — never file mtime — so the key is
+  a property of the file's bytes, not of how it was copied around. When
+  the timestamp is missing or looks like a placeholder (epoch-era year,
+  exactly-midnight clock), the file falls back to the exact content hash —
+  and even then only when some cataloged photo has the same byte size,
+  because a size with no cataloged twin cannot be an exact duplicate.
+* Verify mode (``verify_by_hash=True``): the historical behavior — hash
+  every non-empty source file and compare against cataloged hashes.
+
+Failure modes, by construction:
+
+* False positive (skipping a real photo) needs another photo with the same
+  filename AND byte size AND to-the-second capture time. Same-second bursts
+  of fixed-size uncompressed RAW frames are disambiguated by filename;
+  placeholder clocks are excluded by the trustworthiness rule.
+* False negative (re-copying a renamed true duplicate) is self-healing:
+  the post-import scan hashes everything on local disk and the duplicates
+  page flags the extra copy.
+"""
+
+import contextlib
+import logging
+import os
+import re
+from datetime import datetime
+from pathlib import Path
+
+from grouping import read_exif_timestamp
+from scanner import EMPTY_FILE_SHA256, compute_file_hash
+
+log = logging.getLogger(__name__)
+
+# Camera clocks that were never set report epoch-era dates (1970 Unix,
+# 1980 FAT) or a firmware default like 2015-01-01/2021-01-01 starting at
+# midnight. A pre-1990 year can't be a digital photo; an exactly-midnight
+# clock (to the second) is overwhelmingly a placeholder rather than a real
+# 00:00:00 exposure. Both fall back to the exact content check.
+_MIN_TRUSTWORTHY_YEAR = 1990
+
+_EXIFTOOL_DT_RE = re.compile(
+    r"(\d{4}):(\d{2}):(\d{2})[ T](\d{2}):(\d{2}):(\d{2})"
+)
+
+
+def parse_metadata_timestamp(value):
+    if not value:
+        return None
+    match = _EXIFTOOL_DT_RE.search(str(value))
+    if not match:
+        return None
+    try:
+        return datetime(
+            int(match.group(1)),
+            int(match.group(2)),
+            int(match.group(3)),
+            int(match.group(4)),
+            int(match.group(5)),
+            int(match.group(6)),
+        )
+    except ValueError:
+        return None
+
+
+def metadata_capture_timestamp(metadata):
+    for group_name in ("EXIF", "XMP", "QuickTime", "Composite"):
+        group = metadata.get(group_name)
+        if not isinstance(group, dict):
+            continue
+        for key in (
+            "DateTimeOriginal",
+            "CreateDate",
+            "DateTimeDigitized",
+            "SubSecDateTimeOriginal",
+            "MediaCreateDate",
+            "TrackCreateDate",
+        ):
+            dt = parse_metadata_timestamp(group.get(key))
+            if dt is not None:
+                return dt
+    return None
+
+
+def source_capture_timestamps(files):
+    """Resolve EXIF capture timestamps for source files. No mtime fallback.
+
+    Uses the lightweight Pillow/exifread reader first, then batches the
+    leftovers (HEIC, video, exotic RAW) through ExifTool. Files with no
+    readable capture timestamp map to None — deliberately NOT file mtime,
+    because mtime is a property of the copy, not of the photo, and this
+    map feeds duplicate identity. Callers that want mtime for folder
+    planning apply their own fallback (see ingest._source_file_timestamps).
+    """
+    timestamps = {}
+    missing = []
+
+    for source_file in files:
+        exif_dt = None
+        with contextlib.suppress(OSError, ValueError):
+            exif_dt = read_exif_timestamp(str(source_file))
+        if exif_dt is None:
+            missing.append(source_file)
+        else:
+            timestamps[source_file] = exif_dt
+
+    if missing:
+        try:
+            from metadata import extract_metadata
+
+            metadata_by_path = extract_metadata(
+                [str(path) for path in missing],
+                restricted_tags=[
+                    "-DateTimeOriginal",
+                    "-CreateDate",
+                    "-DateTimeDigitized",
+                    "-SubSecDateTimeOriginal",
+                    "-MediaCreateDate",
+                    "-TrackCreateDate",
+                ],
+            )
+        except Exception:
+            log.debug(
+                "Could not read ExifTool metadata for capture timestamps",
+                exc_info=True,
+            )
+            metadata_by_path = {}
+
+        for source_file in missing:
+            metadata = metadata_by_path.get(str(source_file), {})
+            timestamps[source_file] = metadata_capture_timestamp(metadata)
+
+    return timestamps
+
+
+def timestamp_is_trustworthy(dt):
+    """True when a capture timestamp is a safe duplicate-identity signal."""
+    return (
+        dt is not None
+        and dt.year >= _MIN_TRUSTWORTHY_YEAR
+        and not (dt.hour == 0 and dt.minute == 0 and dt.second == 0)
+    )
+
+
+def metadata_key(filename, file_size, dt):
+    """Duplicate-identity key for a source file with a trusted timestamp.
+
+    Second precision (not sub-second): the catalog stores sub-seconds when
+    the camera provides them, but the lightweight source-side readers are
+    second-precision, so both sides truncate. Filename keeps same-second
+    same-size burst frames apart. Casefolded because FAT card readers and
+    APFS disagree about filename case.
+    """
+    return (filename.casefold(), int(file_size), dt.strftime("%Y-%m-%dT%H:%M:%S"))
+
+
+def stored_metadata_key(filename, file_size, ts_text):
+    """metadata_key equivalent for a photos-table row, or None.
+
+    ``photos.timestamp`` is ISO text ("2026-03-28T14:30:12.340000" or
+    without the fraction); the first 19 chars are the to-the-second form.
+    Applies the same trustworthiness rule as the source side via string
+    comparison so building the index doesn't parse a datetime per row.
+    """
+    if not filename or not file_size or not ts_text or len(ts_text) < 19:
+        return None
+    if ts_text[:4] < str(_MIN_TRUSTWORTHY_YEAR) or ts_text[11:19] == "00:00:00":
+        return None
+    return (filename.casefold(), int(file_size), ts_text[:19])
+
+
+class CatalogIndex:
+    """Immutable duplicate-identity view of the photos table.
+
+    Build once per import operation and share across DuplicateChecker
+    instances (the preview, the preflight, and ingest each need fresh
+    seen-state, but the catalog side is identical).
+    """
+
+    __slots__ = (
+        "known_hashes",
+        "known_keys",
+        "hash_sizes",
+        "unkeyed_hash_sizes",
+        "sizes_complete",
+    )
+
+    def __init__(self, known_hashes=None, known_keys=None, hash_sizes=None,
+                 unkeyed_hash_sizes=None, sizes_complete=False):
+        self.known_hashes = known_hashes or set()
+        self.known_keys = known_keys or set()
+        # Byte sizes of cataloged photos that carry a file_hash: the
+        # fallback content check only reads files whose size has a
+        # cataloged twin. sizes_complete guards the shortcut — if any
+        # hashed row is missing file_size, size absence proves nothing
+        # and every fallback candidate gets hashed.
+        self.hash_sizes = hash_sizes or set()
+        # Sizes of hashed rows that could NOT produce a metadata key
+        # (timestamp missing or placeholder). For a source file of one of
+        # these sizes, a key miss cannot prove novelty — the cataloged
+        # twin would never key-match — so the checker falls through to
+        # the exact content check even when the source metadata is
+        # trusted.
+        self.unkeyed_hash_sizes = unkeyed_hash_sizes or set()
+        self.sizes_complete = sizes_complete
+
+    @classmethod
+    def from_db(cls, db):
+        known_hashes = set()
+        known_keys = set()
+        hash_sizes = set()
+        unkeyed_hash_sizes = set()
+        sizes_complete = True
+        rows = db.conn.execute(
+            "SELECT filename, file_size, timestamp, file_hash FROM photos"
+        ).fetchall()
+        for row in rows:
+            key = stored_metadata_key(
+                row["filename"], row["file_size"], row["timestamp"],
+            )
+            if key is not None:
+                known_keys.add(key)
+            file_hash = row["file_hash"]
+            if file_hash is not None:
+                known_hashes.add(file_hash)
+                if row["file_size"]:
+                    hash_sizes.add(int(row["file_size"]))
+                    if key is None:
+                        unkeyed_hash_sizes.add(int(row["file_size"]))
+                else:
+                    sizes_complete = False
+        return cls(
+            known_hashes, known_keys, hash_sizes, unkeyed_hash_sizes,
+            sizes_complete,
+        )
+
+    @classmethod
+    def from_hashes(cls, hashes):
+        """Index over a bare hash set (no sizes known → no size shortcut)."""
+        return cls(known_hashes=set(hashes), sizes_complete=False)
+
+
+class DuplicateChecker:
+    """Stateful "would ingest skip this source file?" oracle.
+
+    One instance per pass that mirrors ingest's accumulator semantics:
+    identities recorded via record()/check_and_record() are treated as
+    known by later match() calls, exactly like ingest treats files it has
+    already copied. Share one instance across a multi-source ingest loop;
+    build a fresh one (same CatalogIndex) for each independent prediction
+    pass so predictions don't pollute each other.
+
+    ``times_cache`` may be a shared dict so several checkers over the same
+    card (preflight then ingest) read each file's EXIF header only once.
+    """
+
+    def __init__(self, index, verify_by_hash=False, times_cache=None):
+        self.index = index
+        self.verify_by_hash = verify_by_hash
+        self._seen_hashes = set()
+        self._seen_keys = set()
+        self._seen_sizes = set()
+        # size -> {str paths} of files recorded WITHOUT any identity
+        # (no trusted metadata, body never read). A later same-size file
+        # in the fallback path promotes these to hashed identities so
+        # byte-identical intra-batch twins with no usable metadata are
+        # still deduplicated exactly — only the colliding pair pays for
+        # content reads, not the whole batch.
+        self._seen_unhashed = {}
+        # str(path) -> datetime|None; EXIF-only capture times.
+        self._times = times_cache if times_cache is not None else {}
+        # str(path) -> str|None; content hash (None for zero-byte files,
+        # which carry no duplicate identity anywhere in Vireo).
+        self._hashes = {}
+        # Set when hashes with unknown sizes are merged in (legacy
+        # extra_known_hashes callers): the size shortcut can no longer
+        # prove a miss, so every fallback candidate gets hashed.
+        self._unsized_hashes = False
+
+    def add_known_hashes(self, hashes):
+        self._seen_hashes.update(hashes)
+        if hashes:
+            self._unsized_hashes = True
+
+    def prepare(self, files):
+        """Batch-resolve EXIF capture times (no-op in verify mode)."""
+        if self.verify_by_hash:
+            return
+        pending = [f for f in files if str(f) not in self._times]
+        if not pending:
+            return
+        resolved = source_capture_timestamps(pending)
+        for source_file, dt in resolved.items():
+            self._times[str(source_file)] = dt
+
+    def capture_time(self, source_file):
+        """EXIF capture time (or None), resolving lazily if not prepared."""
+        path_str = str(source_file)
+        if path_str not in self._times:
+            self._times[path_str] = source_capture_timestamps(
+                [Path(path_str)]
+            ).get(Path(path_str))
+        return self._times[path_str]
+
+    def content_hash(self, source_file):
+        """Cached content hash; None for zero-byte files. May raise OSError."""
+        path_str = str(source_file)
+        if path_str not in self._hashes:
+            file_hash = compute_file_hash(path_str)
+            if file_hash == EMPTY_FILE_SHA256 and os.path.getsize(path_str) == 0:
+                file_hash = None
+            self._hashes[path_str] = file_hash
+        return self._hashes[path_str]
+
+    def _metadata_key_of(self, source_file, size):
+        dt = self.capture_time(source_file)
+        if not timestamp_is_trustworthy(dt):
+            return None
+        return metadata_key(Path(str(source_file)).name, size, dt)
+
+    def _size_could_match(self, size):
+        if self._unsized_hashes or not self.index.sizes_complete:
+            return True
+        return (
+            size in self.index.hash_sizes
+            or size in self._seen_sizes
+            or size in self._seen_unhashed
+        )
+
+    def _promote_unhashed(self, size):
+        """Hash recorded-but-unhashed files of ``size`` into _seen_hashes."""
+        pending = self._seen_unhashed.pop(size, None)
+        if not pending:
+            return
+        for path_str in pending:
+            with contextlib.suppress(OSError):
+                file_hash = self.content_hash(path_str)
+                if file_hash is not None:
+                    self._seen_hashes.add(file_hash)
+                    self._seen_sizes.add(size)
+
+    def match(self, source_file):
+        """Return the matched identity token if ``source_file`` duplicates a
+        known photo, else None.
+
+        Tokens are ('key', metadata_key) or ('hash', content_hash) — opaque
+        to most callers, but ingest maps them to the destination folders
+        holding the original so the post-import scan can link those
+        folders into the workspace. May raise OSError (unreadable file).
+        """
+        size = os.stat(str(source_file)).st_size
+        if size == 0:
+            return None
+
+        if self.verify_by_hash:
+            file_hash = self.content_hash(source_file)
+            if file_hash is not None and (
+                file_hash in self.index.known_hashes
+                or file_hash in self._seen_hashes
+            ):
+                return ("hash", file_hash)
+            return None
+
+        key = self._metadata_key_of(source_file, size)
+        if key is not None:
+            if key in self.index.known_keys or key in self._seen_keys:
+                return ("key", key)
+            if (
+                self.index.sizes_complete
+                and not self._unsized_hashes
+                and size not in self.index.unkeyed_hash_sizes
+            ):
+                # Trusted metadata with no cataloged twin: a duplicate of
+                # a cataloged photo would carry the catalog's own
+                # filename, size and capture time, so a key miss means
+                # "new" without reading the file body. (Renamed true
+                # duplicates slip through here and are caught by the
+                # post-import scan.)
+                return None
+            # Some cataloged photo of this exact size has a hash but no
+            # usable timestamp (or hash sizes aren't fully known) — a key
+            # miss can't prove novelty, so fall through to the exact
+            # content check.
+
+        # Metadata missing or placeholder — poke harder with the exact
+        # content check, but only when some known photo could plausibly
+        # match by size.
+        if not self._size_could_match(size):
+            return None
+        self._promote_unhashed(size)
+        file_hash = self.content_hash(source_file)
+        if file_hash is not None and (
+            file_hash in self.index.known_hashes
+            or file_hash in self._seen_hashes
+        ):
+            return ("hash", file_hash)
+        return None
+
+    def record(self, source_file):
+        """Register a non-duplicate file's identity as known.
+
+        Call after deciding to keep/copy the file so later occurrences of
+        the same content are treated as duplicates (ingest's intra-batch
+        and cross-source accumulator semantics). Returns the tokens
+        recorded so callers can attach bookkeeping (e.g. the destination
+        folder the copy landed in) to each. May raise OSError.
+        """
+        size = os.stat(str(source_file)).st_size
+        if size == 0:
+            # Zero-byte files carry no duplicate identity anywhere in
+            # Vireo; every empty file would otherwise alias every other.
+            return ()
+
+        tokens = []
+        if self.verify_by_hash:
+            file_hash = self.content_hash(source_file)
+            if file_hash is not None:
+                self._seen_hashes.add(file_hash)
+                tokens.append(("hash", file_hash))
+            return tuple(tokens)
+
+        key = self._metadata_key_of(source_file, size)
+        if key is not None:
+            self._seen_keys.add(key)
+            tokens.append(("key", key))
+        # If the fallback already paid for a hash, keep it — it's free
+        # and lets a later byte-identical file with different metadata
+        # context (or an explicit content check) match exactly.
+        file_hash = self._hashes.get(str(source_file))
+        if file_hash is not None:
+            self._seen_hashes.add(file_hash)
+            self._seen_sizes.add(size)
+            tokens.append(("hash", file_hash))
+        elif key is None:
+            # No identity at all (untrusted metadata, body never read).
+            # Park the size so a later same-size fallback candidate
+            # promotes this file to a hashed identity — a byte-identical
+            # twin necessarily has the same size and equally-untrusted
+            # metadata, so it lands in the fallback path and finds it.
+            self._seen_unhashed.setdefault(size, set()).add(str(source_file))
+        return tuple(tokens)
+
+    def check_and_record(self, source_file):
+        """True if duplicate; otherwise record its identity and return False."""
+        if self.match(source_file) is not None:
+            return True
+        self.record(source_file)
+        return False

--- a/vireo/ingest.py
+++ b/vireo/ingest.py
@@ -4,13 +4,11 @@ import contextlib
 import logging
 import os
 import posixpath
-import re
 import shutil
 import sys
 from datetime import datetime
 from pathlib import Path
 
-from grouping import read_exif_timestamp
 from image_loader import (
     IMAGE_EXTENSIONS,
     RAW_EXTENSIONS,
@@ -19,7 +17,13 @@ from image_loader import (
     safe_iter_dir,
     safe_scan_walk,
 )
-from scanner import EMPTY_FILE_SHA256, compute_file_hash
+from import_dedup import (
+    CatalogIndex,
+    DuplicateChecker,
+    source_capture_timestamps,
+    stored_metadata_key,
+)
+from scanner import compute_file_hash
 
 log = logging.getLogger(__name__)
 
@@ -138,100 +142,27 @@ def build_destination_path(exif_timestamp, template="%Y/%Y-%m-%d"):
     return result
 
 
-_EXIFTOOL_DT_RE = re.compile(
-    r"(\d{4}):(\d{2}):(\d{2})[ T](\d{2}):(\d{2}):(\d{2})"
-)
+def _source_file_timestamps(files, capture_times=None):
+    """Resolve timestamps for date-folder planning.
 
-
-def _parse_metadata_timestamp(value):
-    if not value:
-        return None
-    match = _EXIFTOOL_DT_RE.search(str(value))
-    if not match:
-        return None
-    try:
-        return datetime(
-            int(match.group(1)),
-            int(match.group(2)),
-            int(match.group(3)),
-            int(match.group(4)),
-            int(match.group(5)),
-            int(match.group(6)),
-        )
-    except ValueError:
-        return None
-
-
-def _metadata_capture_timestamp(metadata):
-    for group_name in ("EXIF", "XMP", "QuickTime", "Composite"):
-        group = metadata.get(group_name)
-        if not isinstance(group, dict):
-            continue
-        for key in (
-            "DateTimeOriginal",
-            "CreateDate",
-            "DateTimeDigitized",
-            "SubSecDateTimeOriginal",
-            "MediaCreateDate",
-            "TrackCreateDate",
-        ):
-            dt = _parse_metadata_timestamp(group.get(key))
-            if dt is not None:
-                return dt
-    return None
-
-
-def _source_file_timestamps(files):
-    """Resolve capture timestamps for source files.
-
-    Use the existing lightweight EXIF reader first. For files it cannot parse,
-    ask ExifTool in batches via metadata.extract_metadata, then fall back to
-    file modification time. This keeps date-folder planning aligned with the
-    richer metadata path used elsewhere in Vireo without requiring ExifTool
-    for the common JPEG/RAW fast path.
+    EXIF capture time first (lightweight reader, then batched ExifTool —
+    see import_dedup.source_capture_timestamps), falling back to file
+    modification time. The mtime fallback is fine here because these
+    timestamps only pick destination folders; duplicate identity uses the
+    EXIF-only map directly. Pass ``capture_times`` (a str(path) -> datetime
+    map) to reuse already-resolved EXIF reads instead of re-reading.
     """
-    timestamps = {}
-    missing = []
+    if capture_times is not None:
+        timestamps = {f: capture_times.get(str(f)) for f in files}
+    else:
+        timestamps = source_capture_timestamps(files)
 
-    for source_file in files:
-        exif_dt = None
-        with contextlib.suppress(OSError, ValueError):
-            exif_dt = read_exif_timestamp(str(source_file))
+    for source_file, exif_dt in timestamps.items():
         if exif_dt is None:
-            missing.append(source_file)
-        else:
-            timestamps[source_file] = exif_dt
-
-    if missing:
-        try:
-            from metadata import extract_metadata
-
-            metadata_by_path = extract_metadata(
-                [str(path) for path in missing],
-                restricted_tags=[
-                    "-DateTimeOriginal",
-                    "-CreateDate",
-                    "-DateTimeDigitized",
-                    "-SubSecDateTimeOriginal",
-                    "-MediaCreateDate",
-                    "-TrackCreateDate",
-                ],
-            )
-        except Exception:
-            log.debug(
-                "Could not read ExifTool metadata for import timestamps",
-                exc_info=True,
-            )
-            metadata_by_path = {}
-
-        for source_file in missing:
-            metadata = metadata_by_path.get(str(source_file), {})
-            exif_dt = _metadata_capture_timestamp(metadata)
-            if exif_dt is None:
-                with contextlib.suppress(OSError, ValueError, OverflowError):
-                    exif_dt = datetime.fromtimestamp(source_file.stat().st_mtime)
-            timestamps[source_file] = exif_dt
-
+            with contextlib.suppress(OSError, ValueError, OverflowError):
+                timestamps[source_file] = datetime.fromtimestamp(
+                    source_file.stat().st_mtime
+                )
     return timestamps
 
 
@@ -370,22 +301,36 @@ def ingest(
     extra_known_hashes=None,
     skip_paths=None,
     recursive=True,
+    verify_by_hash=False,
+    duplicate_checker=None,
 ):
     """Copy and organize photos from source to destination.
 
     Args:
         source_dir: path to source (e.g., /Volumes/SD_CARD)
         destination_dir: path to destination (e.g., /Volumes/NAS/Photos)
-        db: Database instance (used for duplicate hash lookup)
+        db: Database instance (used for duplicate identity lookup)
         file_types: "raw", "jpeg", or "both"
         folder_template: strftime format for destination subfolder
-        skip_duplicates: if True, skip files whose hash matches existing file
+        skip_duplicates: if True, skip files that duplicate a cataloged
+            photo. By default duplicates are identified by metadata —
+            (filename, size, EXIF capture time) — with a content-hash
+            fallback for files whose metadata is missing or placeholder;
+            see import_dedup for the exact rules and failure modes.
         progress_callback: optional callable(current, total, filename)
-        extra_known_hashes: optional set of hashes to treat as known in
-            addition to those already in the DB.  Pass a shared mutable set
-            when calling ingest() in a loop so that files copied by earlier
-            iterations are treated as duplicates by later ones even though
-            they have not been scanned into the DB yet.
+        extra_known_hashes: optional set of content hashes to treat as
+            known in addition to the catalog. Kept for callers that only
+            have hashes; note it disables the size shortcut on the hash
+            fallback. Prefer passing a shared ``duplicate_checker``.
+        verify_by_hash: if True, identify duplicates by content hash alone
+            (reads every byte of every source file — the historical exact
+            behavior).
+        duplicate_checker: optional import_dedup.DuplicateChecker to use
+            (and mutate) instead of building one from ``db``. Pass a shared
+            instance when calling ingest() in a loop so files copied by
+            earlier iterations are treated as duplicates by later ones even
+            though they have not been scanned into the DB yet. Its
+            ``verify_by_hash`` takes precedence over the argument above.
 
     Returns:
         dict with counts: copied, skipped_duplicate, failed, total
@@ -395,19 +340,22 @@ def ingest(
         files = [f for f in files if str(f) not in skip_paths]
     total = len(files)
 
-    # Load known hashes from database for duplicate detection and merge with
-    # any hashes accumulated by previous ingest() calls in the same session.
-    known_hashes = set()
-    known_hash_folders: dict[str, set[str]] = {}
+    # Duplicate oracle over the whole catalog. A source file matching any
+    # existing photo in the DB (even in another library root) is skipped
+    # so we don't silently duplicate bytes on disk. See import_dedup for
+    # the identity rules (metadata-first with hash fallback by default;
+    # hash-everything when verify_by_hash).
+    checker = None
+    dup_token_folders: dict[tuple, set[str]] = {}
     if skip_duplicates:
-        # Global hash set for dedup decisions. A source file matching any
-        # existing photo in the DB (even in another library root) is skipped
-        # so we don't silently duplicate bytes on disk.
-        rows = db.conn.execute(
-            "SELECT file_hash FROM photos WHERE file_hash IS NOT NULL"
-        ).fetchall()
-        known_hashes = {r["file_hash"] for r in rows}
-        # Destination-scoped hash -> set-of-folder-paths map for populating
+        checker = duplicate_checker
+        if checker is None:
+            checker = DuplicateChecker(
+                CatalogIndex.from_db(db), verify_by_hash=verify_by_hash,
+            )
+        if extra_known_hashes:
+            checker.add_known_hashes(extra_known_hashes)
+        # Destination-scoped identity -> set-of-folder-paths map for populating
         # the caller's post-ingest scan restrict_dirs. The same hash can
         # legitimately appear in more than one destination subfolder (e.g.,
         # the user copied the same photo into multiple date folders), and
@@ -489,10 +437,11 @@ def ingest(
             dest_like_prefix_param = dest_like_prefix
         if dest_path_sql_stripped:
             folder_rows = db.conn.execute(
-                f"""SELECT p.file_hash, f.path AS folder_path
+                f"""SELECT p.file_hash, p.filename, p.file_size, p.timestamp,
+                          f.path AS folder_path
                    FROM photos p
                    JOIN folders f ON p.folder_id = f.id
-                   WHERE p.file_hash IS NOT NULL
+                   WHERE (p.file_hash IS NOT NULL OR p.timestamp IS NOT NULL)
                      AND f.status IN ('ok', 'partial')
                      AND (
                        {path_sql_expr} = ?
@@ -502,10 +451,11 @@ def ingest(
             ).fetchall()
         else:
             folder_rows = db.conn.execute(
-                """SELECT p.file_hash, f.path AS folder_path
+                """SELECT p.file_hash, p.filename, p.file_size, p.timestamp,
+                          f.path AS folder_path
                    FROM photos p
                    JOIN folders f ON p.folder_id = f.id
-                   WHERE p.file_hash IS NOT NULL
+                   WHERE (p.file_hash IS NOT NULL OR p.timestamp IS NOT NULL)
                      AND f.status IN ('ok', 'partial')"""
             ).fetchall()
         for r in folder_rows:
@@ -519,9 +469,20 @@ def ingest(
                 continue
             if not Path(folder_path).is_dir():
                 continue
-            known_hash_folders.setdefault(r["file_hash"], set()).add(folder_path)
-        if extra_known_hashes:
-            known_hashes |= extra_known_hashes
+            # Index the row under both identity forms — the checker may
+            # match a source either way, and each match token must map to
+            # the folders holding the original.
+            if r["file_hash"] is not None:
+                dup_token_folders.setdefault(
+                    ("hash", r["file_hash"]), set(),
+                ).add(folder_path)
+            row_key = stored_metadata_key(
+                r["filename"], r["file_size"], r["timestamp"],
+            )
+            if row_key is not None:
+                dup_token_folders.setdefault(
+                    ("key", row_key), set(),
+                ).add(folder_path)
 
     copied = 0
     skipped_duplicate = 0
@@ -530,73 +491,85 @@ def ingest(
     duplicate_folders: set[str] = set()
     emitted = 0
 
-    # Pass 1: hash each file and partition into duplicates vs. survivors.
-    # Timestamp resolution is deferred to Pass 2 so a duplicate-only
-    # re-import of a large card does not run the EXIF/ExifTool prepass on
-    # files we already have — the duplicate gate short-circuits first.
-    to_copy: list[tuple[Path, str]] = []
+    # Pass 1: partition into duplicates vs. survivors. The checker's EXIF
+    # prepass batches header reads across the whole card; only files with
+    # missing/placeholder metadata (and a plausible size twin) get their
+    # bytes read for the hash fallback — or every file when verify_by_hash.
+    if checker is not None:
+        checker.prepare(files)
+    to_copy: list[Path] = []
     for source_file in files:
+        if checker is not None:
+            try:
+                token = checker.match(source_file)
+            except Exception as e:
+                log.warning("Failed to ingest %s: %s", source_file, e)
+                failed += 1
+                emitted += 1
+                if progress_callback:
+                    progress_callback(emitted, total, source_file.name)
+                continue
+
+            if token is not None:
+                skipped_duplicate += 1
+                # Record every destination folder that holds a copy of
+                # this file, not just one. The pipeline uses this set
+                # verbatim as restrict_dirs, so if we only report one
+                # folder the others never get linked to the active
+                # workspace.
+                duplicate_folders.update(
+                    dup_token_folders.get(token, ())
+                )
+                emitted += 1
+                if progress_callback:
+                    progress_callback(emitted, total, source_file.name)
+                continue
+
+        to_copy.append(source_file)
+
+    # Pass 2: resolve folder-planning timestamps for survivors and copy.
+    # In the default metadata mode the checker already resolved every
+    # file's EXIF time for the duplicate gate — reuse those reads and only
+    # add the mtime fallback. In verify/no-skip modes, batch the
+    # EXIF/ExifTool prepass over just the survivors.
+    timestamps = _source_file_timestamps(
+        to_copy,
+        capture_times=(
+            {str(f): checker.capture_time(f) for f in to_copy}
+            if checker is not None and not checker.verify_by_hash
+            else None
+        ),
+    )
+
+    # Records the destination folder where each identity token actually
+    # landed during this batch. Populated only when pass 2 marks an
+    # identity as known (successful copy or exact-match destination
+    # collision) so an intra-batch duplicate can report the correct
+    # post-import scan folder.
+    batch_dest_folders: dict[tuple, str] = {}
+
+    for source_file in to_copy:
         try:
-            file_hash = compute_file_hash(str(source_file))
-            if file_hash == EMPTY_FILE_SHA256 and source_file.stat().st_size == 0:
-                file_hash = None
-        except Exception as e:
-            log.warning("Failed to ingest %s: %s", source_file, e)
-            failed += 1
-            emitted += 1
-            if progress_callback:
-                progress_callback(emitted, total, source_file.name)
-            continue
+            # Intra-batch dedup: a byte-identical sibling earlier in this
+            # batch already landed (or matched an existing destination
+            # file). Skip without re-copying. We intentionally defer the
+            # checker.record() mark to pass 2 success rather than
+            # recording it in pass 1 — if the primary's copy fails (e.g.
+            # the destination filename collides with a directory of the
+            # same name), the sibling still gets a chance to import the
+            # bytes.
+            if checker is not None:
+                token = checker.match(source_file)
+                if token is not None:
+                    skipped_duplicate += 1
+                    dest = batch_dest_folders.get(token)
+                    if dest is not None:
+                        duplicate_folders.add(dest)
+                    emitted += 1
+                    if progress_callback:
+                        progress_callback(emitted, total, source_file.name)
+                    continue
 
-        if skip_duplicates and file_hash is not None and file_hash in known_hashes:
-            skipped_duplicate += 1
-            # Record every destination folder that holds a copy of
-            # this file, not just one. The pipeline uses this set
-            # verbatim as restrict_dirs, so if we only report one
-            # folder the others never get linked to the active
-            # workspace.
-            duplicate_folders.update(
-                known_hash_folders.get(file_hash, ())
-            )
-            emitted += 1
-            if progress_callback:
-                progress_callback(emitted, total, source_file.name)
-            continue
-
-        to_copy.append((source_file, file_hash))
-
-    # Pass 2: resolve timestamps only for survivors and copy. Batching
-    # ExifTool across survivors keeps the fresh-card import fast for
-    # formats that lack lightweight EXIF (HEIC, video) without paying
-    # that cost for files the duplicate gate already rejected.
-    timestamps = _source_file_timestamps([s for s, _ in to_copy])
-
-    # Records the destination folder where each hash actually landed
-    # during this batch. Populated only when pass 2 marks a hash as
-    # known (successful copy or exact-match destination collision) so
-    # an intra-batch duplicate can report the correct post-import scan
-    # folder.
-    batch_dest_folders: dict[str, str] = {}
-
-    for source_file, file_hash in to_copy:
-        # Intra-batch dedup: a byte-identical sibling earlier in this
-        # batch already landed (or matched an existing destination
-        # file). Skip without re-copying. We intentionally defer this
-        # mark to pass 2 success rather than recording it in pass 1 —
-        # if the primary's copy fails (e.g. the destination filename
-        # collides with a directory of the same name), the sibling
-        # still gets a chance to import the bytes.
-        if skip_duplicates and file_hash is not None and file_hash in known_hashes:
-            skipped_duplicate += 1
-            dest = batch_dest_folders.get(file_hash)
-            if dest is not None:
-                duplicate_folders.add(dest)
-            emitted += 1
-            if progress_callback:
-                progress_callback(emitted, total, source_file.name)
-            continue
-
-        try:
             rel_folder = build_destination_path(
                 timestamps.get(source_file), folder_template
             )
@@ -607,42 +580,49 @@ def ingest(
 
             # Handle filename collision (different file, same name)
             if dest_file.exists():
+                src_size = source_file.stat().st_size
+                dest_size = dest_file.stat().st_size
                 # Zero-byte ↔ zero-byte at the same destination path IS
                 # the same file (every empty file is bit-identical to
-                # every other), but pass 1 cleared ``file_hash`` to
-                # ``None`` for zero-byte sources so EMPTY_FILE_SHA256
-                # doesn't carry duplicate identity. The hash-based
-                # exact-match branch below therefore can't recognise
-                # this collision, and a ``skip_duplicates`` retry of an
-                # interrupted card import would otherwise fall through
-                # to the numeric-suffix branch and start creating
-                # ``name_1.ext``, ``name_2.ext`` placeholder copies of
-                # the same empty file forever. ``known_hashes`` /
-                # ``batch_dest_folders`` are deliberately NOT updated —
-                # zero-byte files are kept out of the duplicate-identity
-                # index everywhere else, and this skip mirrors that.
-                src_is_empty = (
-                    file_hash is None
-                    and source_file.stat().st_size == 0
-                )
-                if src_is_empty and dest_file.stat().st_size == 0:
+                # every other), but zero-byte files carry no duplicate
+                # identity so the content-match branch below can't
+                # recognise this collision, and a ``skip_duplicates``
+                # retry of an interrupted card import would otherwise
+                # fall through to the numeric-suffix branch and start
+                # creating ``name_1.ext``, ``name_2.ext`` placeholder
+                # copies of the same empty file forever. The checker is
+                # deliberately NOT updated — zero-byte files are kept out
+                # of the duplicate-identity index everywhere else, and
+                # this skip mirrors that.
+                if src_size == 0 and dest_size == 0:
                     skipped_duplicate += 1
                     duplicate_folders.add(str(dest_folder))
                     emitted += 1
                     if progress_callback:
                         progress_callback(emitted, total, source_file.name)
                     continue
-                dest_hash = compute_file_hash(str(dest_file))
-                if file_hash is not None and file_hash == dest_hash:
-                    # Exact same file already there
-                    skipped_duplicate += 1
-                    known_hashes.add(file_hash)
-                    batch_dest_folders[file_hash] = str(dest_folder)
-                    duplicate_folders.add(str(dest_folder))
-                    emitted += 1
-                    if progress_callback:
-                        progress_callback(emitted, total, source_file.name)
-                    continue
+                # Same size could be the same bytes — settle it by exact
+                # content, never by metadata (a wrong skip here would
+                # silently drop a photo). Different size proves a
+                # different file with no reads at all.
+                if src_size == dest_size:
+                    src_hash = (
+                        checker.content_hash(source_file)
+                        if checker is not None
+                        else compute_file_hash(str(source_file))
+                    )
+                    dest_hash = compute_file_hash(str(dest_file))
+                    if src_hash is not None and src_hash == dest_hash:
+                        # Exact same file already there
+                        skipped_duplicate += 1
+                        if checker is not None:
+                            for token in checker.record(source_file):
+                                batch_dest_folders[token] = str(dest_folder)
+                        duplicate_folders.add(str(dest_folder))
+                        emitted += 1
+                        if progress_callback:
+                            progress_callback(emitted, total, source_file.name)
+                        continue
                 # Different file, same name — add numeric suffix
                 stem = dest_file.stem
                 suffix = dest_file.suffix
@@ -652,9 +632,9 @@ def ingest(
                     counter += 1
 
             shutil.copy2(str(source_file), str(dest_file))
-            if file_hash is not None:
-                known_hashes.add(file_hash)
-                batch_dest_folders[file_hash] = str(dest_folder)
+            if checker is not None:
+                for token in checker.record(source_file):
+                    batch_dest_folders[token] = str(dest_folder)
             copied_paths.append(str(dest_file))
             copied += 1
 

--- a/vireo/local_processing.py
+++ b/vireo/local_processing.py
@@ -75,32 +75,27 @@ def total_file_bytes(files: list[Path]) -> int:
     return total
 
 
-def _duplicate_identity(path: Path) -> str | None:
-    """Return ``path``'s duplicate-identity hash, or ``None`` if it has
-    none.
+def _as_duplicate_checker(duplicates):
+    """Normalize a duplicate-oracle argument to a DuplicateChecker.
 
-    Mirrors ingest()'s zero-byte rule: a zero-byte source clears its
-    hash to ``None`` before duplicate checks so ``EMPTY_FILE_SHA256``
-    never enters the identity index. Every empty file is bit-identical
-    to every other, so treating them as duplicates by hash would either
-    drop legitimate placeholders or, in the same-name-collision branch,
-    mint endless ``name_1.ext`` siblings on retry. The preflight callers
-    here must skip empty files for the same reason: an earlier zero-byte
-    source must not poison ``seen_hashes`` and cause a later zero-byte
-    source's same-path conflict to be falsely skipped, and the
-    duplicate-filter survivor list must not collapse two empty sources
-    into one when ingest would copy both.
+    Callers with full catalog context pass a DuplicateChecker (built by
+    pipeline_job over a CatalogIndex, so predictions here use the exact
+    rules — and mode — the real ingest will). Legacy callers and tests
+    that only have a bare hash set still work: it becomes a hash-only
+    checker in verify mode, which is the historical exact behavior.
+    DuplicateChecker inherits ingest()'s zero-byte rule — empty files
+    carry no duplicate identity, so an earlier zero-byte source can't
+    cause a later zero-byte source's same-path conflict to be falsely
+    skipped, and the duplicate-filter survivor list can't collapse two
+    empty sources ingest would both copy.
     """
-    from scanner import EMPTY_FILE_SHA256, compute_file_hash
+    from import_dedup import CatalogIndex, DuplicateChecker
 
-    file_hash = compute_file_hash(str(path))
-    if file_hash == EMPTY_FILE_SHA256:
-        try:
-            if path.stat().st_size == 0:
-                return None
-        except OSError:
-            return None
-    return file_hash
+    if duplicates is None or isinstance(duplicates, DuplicateChecker):
+        return duplicates
+    return DuplicateChecker(
+        CatalogIndex.from_hashes(duplicates), verify_by_hash=True,
+    )
 
 
 def _suffix_against(folder_taken: set[str], name: str) -> str:
@@ -143,6 +138,7 @@ def archive_conflict_report(
     folder_template: str = "%Y/%Y-%m-%d",
     *,
     known_hashes: set[str] | None = None,
+    duplicate_checker=None,
     indexed_paths: set[str] | None = None,
 ) -> dict[str, list[str]]:
     """Return existing archive paths that would block merge-mode archive.
@@ -154,24 +150,24 @@ def archive_conflict_report(
     The check mirrors ``ingest()``'s staging behavior so it only flags real
     archive conflicts:
 
-    * When ``known_hashes`` is provided, sources whose content hash is
-      already known to the catalog are treated as ingest skips — they never
-      reach staging, so they cannot conflict at the final archive step.
-      Callers normally pass the catalog hash set when ``skip_duplicates``
-      is enabled. Duplicate identity is checked before a source claims
-      an archive filename so skipped duplicates cannot shift later
-      survivors onto suffixed paths that ingest would not use.
+    * When ``duplicate_checker`` (an import_dedup.DuplicateChecker — pass a
+      FRESH instance, its seen-state is consumed here) or ``known_hashes``
+      (legacy bare hash set, checked in exact/verify mode) is provided,
+      sources the checker recognizes as catalog duplicates are treated as
+      ingest skips — they never reach staging, so they cannot conflict at
+      the final archive step. Duplicate identity is checked before a
+      source claims an archive filename so skipped duplicates cannot shift
+      later survivors onto suffixed paths that ingest would not use.
     * When two surviving sources land in the same archive subfolder under
       the same filename, ingest stages the first at the unsuffixed name
       and the second under ``name_1.ext`` (then ``name_2.ext`` ...). The
       preflight tracks per-folder occupied names so the existing archive's
       same-name file is only compared to the first survivor's content,
       not also (incorrectly) to the second survivor's.
-    * When ``known_hashes`` is in use, earlier survivors are added to
-      ``seen_hashes`` as they claim names. Mirrors ingest()'s
-      ``extra_known_hashes`` accumulator so the same card/folder selected
-      twice still recognises the second occurrence as an intra-batch
-      duplicate that ingest would skip.
+    * Earlier survivors are recorded in the checker as they claim names.
+      Mirrors ingest()'s shared-checker accumulator so the same
+      card/folder selected twice still recognises the second occurrence
+      as an intra-batch duplicate that ingest would skip.
 
     If ``indexed_paths`` is provided, same-path differences are split into:
 
@@ -201,33 +197,23 @@ def archive_conflict_report(
         }
         if indexed_paths is not None else None
     )
-    seen_hashes: set[str] | None = (
-        set(known_hashes) if known_hashes is not None else None
-    )
+    checker = duplicate_checker or _as_duplicate_checker(known_hashes)
+    if checker is not None:
+        checker.prepare(files)
     # Per-archive-subfolder name slots already claimed by earlier survivors
     # in this iteration. Mirrors the per-batch staging tree ingest builds.
     occupied: dict[str, set[str]] = {}
 
     def _skip_or_record_survivor(source_file: Path) -> bool:
         """Return True when ingest would skip ``source_file`` as a duplicate."""
-        if seen_hashes is None:
+        if checker is None:
             return False
         try:
-            file_hash = _duplicate_identity(source_file)
+            return checker.check_and_record(source_file)
         except OSError:
-            # ingest() treats hash failures as per-file failures before copy,
-            # so they do not claim destination names.
+            # ingest() treats identity-check failures as per-file failures
+            # before copy, so they do not claim destination names.
             return True
-        # Zero-byte survivors carry no duplicate identity in ingest, so
-        # don't pollute ``seen_hashes`` with ``EMPTY_FILE_SHA256`` — that
-        # would cause a later zero-byte source's same-path conflict to be
-        # falsely skipped as an intra-batch duplicate.
-        if file_hash is None:
-            return False
-        if file_hash in seen_hashes:
-            return True
-        seen_hashes.add(file_hash)
-        return False
 
     for source_file in files:
         try:
@@ -359,18 +345,18 @@ def existing_archive_bytes(
     return total
 
 
-def non_duplicate_files(
-    files: list[Path], known_hashes: set[str],
-) -> list[Path]:
-    """Return ``files`` minus any whose content hash is already known.
+def non_duplicate_files(files: list[Path], duplicates) -> list[Path]:
+    """Return ``files`` minus any the duplicate gate would skip.
 
     Mirrors the duplicate gate ingest() applies with skip_duplicates=True so
     the local-storage preflight estimate matches what ingest will actually
-    copy. ``known_hashes`` covers files already in the catalog; this also
-    tracks hashes seen earlier in ``files`` so intra-run duplicates (the
-    same card folder selected twice, or two source folders sharing a file)
-    yield only the first occurrence — ingest() likewise copies the first and
-    skips later matches via its ``extra_known_hashes`` accumulator.
+    copy. ``duplicates`` is an import_dedup.DuplicateChecker (pass a FRESH
+    instance — its seen-state is consumed here) or a legacy bare hash set,
+    normalized via _as_duplicate_checker. Files whose identity was seen
+    earlier in ``files`` are dropped too, so intra-run duplicates (the same
+    card folder selected twice, or two source folders sharing a file) yield
+    only the first occurrence — ingest() likewise copies the first and
+    skips later matches via its shared-checker accumulator.
 
     Returning the file list (not just a byte sum) lets callers feed the
     survivor set back into ``existing_archive_bytes`` so the destination
@@ -380,31 +366,24 @@ def non_duplicate_files(
     the destination-space preflight even when the fresh files still need
     room at the archive.
     """
-    seen = set(known_hashes)
+    checker = _as_duplicate_checker(duplicates)
+    if checker is None:
+        return list(files)
+    checker.prepare(files)
     survivors: list[Path] = []
     for path in files:
         try:
-            file_hash = _duplicate_identity(path)
+            if checker.check_and_record(path):
+                continue
         except OSError:
             continue
-        # Zero-byte sources have no duplicate identity in ingest, so
-        # every empty file is a survivor and contributes nothing to
-        # ``seen`` — matching ingest's behavior where two empty sources
-        # both get copied (the second as ``name_1.ext`` if the
-        # destination already has the unsuffixed slot).
-        if file_hash is None:
-            survivors.append(path)
-            continue
-        if file_hash in seen:
-            continue
         survivors.append(path)
-        seen.add(file_hash)
     return survivors
 
 
-def non_duplicate_bytes(files: list[Path], known_hashes: set[str]) -> int:
-    """Sum bytes of ``files`` whose content hash isn't already known."""
-    return total_file_bytes(non_duplicate_files(files, known_hashes))
+def non_duplicate_bytes(files: list[Path], duplicates) -> int:
+    """Sum bytes of ``files`` the duplicate gate would let through."""
+    return total_file_bytes(non_duplicate_files(files, duplicates))
 
 
 def estimate_required_bytes(source_bytes: int) -> int:

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -88,6 +88,10 @@ class PipelineParams:
     file_types: str = "both"
     folder_template: str = "%Y/%Y-%m-%d"
     skip_duplicates: bool = True
+    # Identify duplicates by content hash alone (reads every byte of every
+    # source file). Default False: metadata-first matching with a hash
+    # fallback — see import_dedup.
+    verify_by_hash: bool = False
     labels_file: str | None = None
     labels_files: list | None = None
     model_id: str | None = None
@@ -1016,7 +1020,29 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 if params.destination:
                     from pathlib import Path
 
+                    from import_dedup import CatalogIndex, DuplicateChecker
                     from ingest import ingest as do_ingest
+
+                    # Duplicate-oracle infrastructure shared by the
+                    # local-processing preflight and the ingest loop. The
+                    # catalog index is loaded once; every prediction pass
+                    # gets a FRESH checker over it (seen-state must not
+                    # leak between predictions or into the real ingest),
+                    # while the shared times cache keeps each source
+                    # file's EXIF header read to once per run.
+                    dedup_times_cache: dict = {}
+                    catalog_index = None
+                    if params.skip_duplicates:
+                        catalog_index = CatalogIndex.from_db(thread_db)
+
+                    def _fresh_checker():
+                        if catalog_index is None:
+                            return None
+                        return DuplicateChecker(
+                            catalog_index,
+                            verify_by_hash=params.verify_by_hash,
+                            times_cache=dedup_times_cache,
+                        )
 
                     if params.local_processing:
                         from local_processing import (
@@ -1164,22 +1190,14 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 exclude_paths=params.exclude_paths,
                             )
                             # When skip_duplicates is on, ingest() will skip
-                            # sources whose content hash is already in the
-                            # catalog before they ever reach staging. Pass
-                            # those known hashes to the conflict preflight so
-                            # a duplicate-source that happens to share an
-                            # archive path with an unrelated file does not
-                            # falsely abort the run — ingest will not copy
-                            # it, so it cannot conflict at archive time.
-                            catalog_hashes: set[str] | None = None
-                            if params.skip_duplicates:
-                                catalog_hashes = {
-                                    row["file_hash"]
-                                    for row in thread_db.conn.execute(
-                                        "SELECT file_hash FROM photos "
-                                        "WHERE file_hash IS NOT NULL"
-                                    )
-                                }
+                            # sources that duplicate cataloged photos before
+                            # they ever reach staging. Give the conflict
+                            # preflight a fresh instance of the same
+                            # duplicate oracle so a duplicate-source that
+                            # happens to share an archive path with an
+                            # unrelated file does not falsely abort the run
+                            # — ingest will not copy it, so it cannot
+                            # conflict at archive time.
 
                             from move import _case_insensitive_root
 
@@ -1287,7 +1305,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 final_destination,
                                 selected_files,
                                 params.folder_template,
-                                known_hashes=catalog_hashes,
+                                duplicate_checker=_fresh_checker(),
                                 indexed_paths=_indexed_archive_paths(
                                     final_destination,
                                 ),
@@ -1358,7 +1376,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             if (
                                 params.skip_duplicates
                                 and selected_files
-                                and catalog_hashes is not None
+                                and catalog_index is not None
                             ):
                                 # Plan against the exact files ingest will
                                 # stage, not the full selection. This keeps
@@ -1366,7 +1384,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 # with skip_duplicates even when the unfiltered
                                 # plan appears to have enough space.
                                 planning_files = non_duplicate_files(
-                                    selected_files, catalog_hashes,
+                                    selected_files, _fresh_checker(),
                                 )
                             source_bytes = total_file_bytes(planning_files)
                             # When a previous archive attempt left a partial
@@ -1465,7 +1483,12 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     runner.update_step(job["id"], "ingest", status="running")
                     _update_stages(runner, job["id"], stages)
 
-                    accumulated_hashes: set = set()
+                    # One shared checker across the whole source loop: files
+                    # copied by earlier iterations are recorded in it, so
+                    # later sources treat them as duplicates even before the
+                    # DB scan (this replaces the old accumulated-hashes
+                    # re-read of every copied file between sources).
+                    ingest_checker = _fresh_checker()
                     all_copied_paths: list = []
                     all_duplicate_folders: set = set()
                     total_copied = 0
@@ -1481,7 +1504,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 folder_template=params.folder_template,
                                 skip_duplicates=params.skip_duplicates,
                                 progress_callback=ingest_cb,
-                                extra_known_hashes=accumulated_hashes,
+                                duplicate_checker=ingest_checker,
                                 skip_paths=params.exclude_paths,
                                 recursive=params.recursive,
                             )
@@ -1492,15 +1515,6 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         total_copied += result_info.get("copied", 0)
                         total_skipped += result_info.get("skipped_duplicate", 0)
                         total_failed += result_info.get("failed", 0)
-                        # Collect hashes of files just copied so the next source
-                        # iteration treats them as known even before the DB scan.
-                        if params.skip_duplicates:
-                            import contextlib
-
-                            from scanner import compute_file_hash
-                            for path in result_info.get("copied_paths", []):
-                                with contextlib.suppress(OSError):
-                                    accumulated_hashes.add(compute_file_hash(path))
 
                     # In local-processing mode, ingest failures must fail the
                     # ingest stage so archive_stage's "any earlier stage failed"

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -897,6 +897,12 @@ body { padding-bottom: 36px; }
               <label style="font-size:12px;color:var(--text-secondary);cursor:pointer;">
                 <input type="checkbox" id="chkSkipDuplicates" checked style="accent-color:var(--accent);" onchange="onSkipDuplicatesToggle()"> Skip duplicates
               </label>
+              <label style="font-size:12px;color:var(--text-secondary);cursor:pointer;display:block;margin:4px 0 0 20px;">
+                <input type="checkbox" id="chkVerifyByHash" style="accent-color:var(--accent);" onchange="onVerifyByHashToggle()"> Verify by full content hash
+              </label>
+              <div style="font-size:11px;color:var(--text-dim);margin:4px 0 0 20px;line-height:1.4;">
+                Off: duplicates are matched by filename, size, and capture time (fast — only files without reliable metadata are read in full). On: every byte of every source file is read and compared — exact, but slow on SD cards.
+              </div>
             </div>
           </div>
           <div class="setting-row">
@@ -1853,7 +1859,10 @@ function checkForDuplicates() {
   fetch('/api/import/check-duplicates', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ paths: paths }),
+    body: JSON.stringify({
+      paths: paths,
+      verify_by_hash: document.getElementById('chkVerifyByHash').checked,
+    }),
     signal: _duplicateCheckAbort.signal,
   }).then(function(response) {
     if (!response.ok) return;
@@ -1928,6 +1937,7 @@ function updateDuplicateSummary(data) {
 
   var span = document.createElement('span');
   span.className = 'stat dup-status';
+  span.title = duplicateMethodNote();
   if (data.done) {
     if (data.duplicate_count > 0) {
       if (_managedArchive) {
@@ -1956,6 +1966,29 @@ function updateDuplicateSummary(data) {
   if (span.innerHTML || span.textContent) summary.appendChild(span);
 }
 
+function duplicateMethodNote() {
+  // Keep the summary honest about HOW duplicates were identified — the
+  // two modes can disagree on edge cases (e.g. renamed copies).
+  return document.getElementById('chkVerifyByHash').checked
+    ? 'matched by content hash'
+    : 'matched by filename, size & capture time';
+}
+
+function onVerifyByHashToggle() {
+  // The two modes can classify files differently, so cached results are
+  // stale the moment the mode changes: drop them and re-scan.
+  if (_duplicateCheckAbort) { _duplicateCheckAbort.abort(); _duplicateCheckAbort = null; }
+  _duplicateResults = {};
+  applyDuplicateVisuals();
+  var summary = document.getElementById('previewSummary');
+  var existing = summary ? summary.querySelector('.dup-status') : null;
+  if (existing) existing.remove();
+  if (document.getElementById('chkSkipDuplicates').checked) {
+    checkForDuplicates();
+  }
+  schedulePlanRefresh();
+}
+
 function onSkipDuplicatesToggle() {
   var checked = document.getElementById('chkSkipDuplicates').checked;
   if (!checked) {
@@ -1976,6 +2009,7 @@ function onSkipDuplicatesToggle() {
     if (dupCount > 0) {
       var span = document.createElement('span');
       span.className = 'stat dup-status';
+      span.title = duplicateMethodNote();
       span.innerHTML = _managedArchive
         ? '<span class="stat-value">' + dupCount + '</span> already in your library (will be skipped)'
         : '<span class="stat-value">' + dupCount + '</span> already imported';
@@ -2835,6 +2869,7 @@ async function startPipeline() {
     if (_copyMode) {
       body.destination = document.getElementById('cfgDestination').value.trim();
       body.skip_duplicates = document.getElementById('chkSkipDuplicates').checked;
+      body.verify_by_hash = document.getElementById('chkVerifyByHash').checked;
       body.folder_template = getSelectedFolderTemplate();
       var localProcessing = document.getElementById('chkLocalProcessing');
       body.local_processing = !!(localProcessing && localProcessing.checked);
@@ -3509,6 +3544,7 @@ async function runImportStep() {
     if (_copyMode) {
       body.destination = destination;
       body.skip_duplicates = document.getElementById('chkSkipDuplicates').checked;
+      body.verify_by_hash = document.getElementById('chkVerifyByHash').checked;
       body.folder_template = getSelectedFolderTemplate();
     }
 
@@ -4819,14 +4855,15 @@ function _buildPlanBody() {
     // clears — both accurate states.
     body.source_paths = selectedPaths;
 
-    // Copy-mode imports with skip_duplicates=true dedupe by file_hash, not
-    // by source path. The /api/import/check-duplicates SSE feed has
-    // already populated _duplicateResults with the hash-matched preview
-    // paths; pass that subset along so the plan counts those as already
-    // known instead of new (otherwise pills overstate work for files
-    // ingest() will silently skip). Only send when the duplicate gate is
-    // actually on; toggling it off must drop the field so the backend
-    // doesn't keep treating the cache as live.
+    // Copy-mode imports with skip_duplicates=true dedupe by duplicate
+    // identity (metadata key or content hash — same DuplicateChecker as
+    // ingest), not by source path. The /api/import/check-duplicates SSE
+    // feed has already populated _duplicateResults with the matched
+    // preview paths; pass that subset along so the plan counts those as
+    // already known instead of new (otherwise pills overstate work for
+    // files ingest() will silently skip). Only send when the duplicate
+    // gate is actually on; toggling it off must drop the field so the
+    // backend doesn't keep treating the cache as live.
     var skipDup = document.getElementById('chkSkipDuplicates');
     if (_copyMode && skipDup && skipDup.checked
         && Object.keys(_duplicateResults).length > 0) {

--- a/vireo/tests/test_check_duplicates.py
+++ b/vireo/tests/test_check_duplicates.py
@@ -81,6 +81,91 @@ def test_check_duplicates_marks_known_hashes(app_and_db, tmp_path):
     assert str(source / "unique.jpg") not in all_duplicates
 
 
+def test_check_duplicates_metadata_match_without_hashing(
+    app_and_db, tmp_path, monkeypatch
+):
+    """A cataloged (filename, size, capture time) twin is flagged as a
+    duplicate without any content read — the default heuristic mode."""
+    from datetime import datetime
+
+    from PIL.ExifTags import Base as ExifBase
+
+    app, db, fid = app_and_db
+
+    source = tmp_path / "source"
+    source.mkdir()
+    img = Image.new("RGB", (50, 50), color="red")
+    exif = img.getexif()
+    exif[ExifBase.DateTimeOriginal] = "2026:05:01 10:15:30"
+    img.save(str(source / "IMG_0001.jpg"), exif=exif)
+
+    db.add_photo(
+        folder_id=fid,
+        filename="IMG_0001.jpg",
+        extension=".jpg",
+        file_size=os.path.getsize(str(source / "IMG_0001.jpg")),
+        file_mtime=1.0,
+        timestamp=datetime(2026, 5, 1, 10, 15, 30).isoformat(),
+    )
+
+    import import_dedup
+
+    def _boom(path, *a, **kw):
+        raise AssertionError(f"content hash computed for {path}")
+
+    monkeypatch.setattr(import_dedup, "compute_file_hash", _boom)
+
+    client = app.test_client()
+    resp = client.post("/api/import/check-duplicates", json={
+        "paths": [str(source / "IMG_0001.jpg")],
+    })
+    events = parse_sse_events(resp.data)
+    done = [e for e in events if e.get("done")]
+    assert done[0]["duplicate_count"] == 1
+
+
+def test_check_duplicates_verify_by_hash_flag(app_and_db, tmp_path):
+    """verify_by_hash=true restores exact content matching — a renamed
+    duplicate the heuristic treats as new is flagged."""
+    from datetime import datetime
+
+    from PIL.ExifTags import Base as ExifBase
+
+    app, db, fid = app_and_db
+    from scanner import compute_file_hash
+
+    source = tmp_path / "source"
+    source.mkdir()
+    img = Image.new("RGB", (50, 50), color="red")
+    exif = img.getexif()
+    exif[ExifBase.DateTimeOriginal] = "2026:05:01 10:15:30"
+    img.save(str(source / "renamed.jpg"), exif=exif)
+
+    db.add_photo(
+        folder_id=fid,
+        filename="IMG_0001.jpg",
+        extension=".jpg",
+        file_size=os.path.getsize(str(source / "renamed.jpg")),
+        file_mtime=1.0,
+        timestamp=datetime(2026, 5, 1, 10, 15, 30).isoformat(),
+        file_hash=compute_file_hash(str(source / "renamed.jpg")),
+    )
+
+    client = app.test_client()
+    resp = client.post("/api/import/check-duplicates", json={
+        "paths": [str(source / "renamed.jpg")],
+    })
+    done = [e for e in parse_sse_events(resp.data) if e.get("done")]
+    assert done[0]["duplicate_count"] == 0  # heuristic: filename mismatch
+
+    resp = client.post("/api/import/check-duplicates", json={
+        "paths": [str(source / "renamed.jpg")],
+        "verify_by_hash": True,
+    })
+    done = [e for e in parse_sse_events(resp.data) if e.get("done")]
+    assert done[0]["duplicate_count"] == 1
+
+
 def test_check_duplicates_no_paths(app_and_db):
     """Returns error when no paths provided."""
     app, _, _ = app_and_db

--- a/vireo/tests/test_import_dedup.py
+++ b/vireo/tests/test_import_dedup.py
@@ -1,0 +1,440 @@
+"""Tests for the metadata-first import duplicate gate (import_dedup)."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from datetime import datetime
+
+import import_dedup
+from db import Database
+from import_dedup import (
+    CatalogIndex,
+    DuplicateChecker,
+    metadata_key,
+    stored_metadata_key,
+    timestamp_is_trustworthy,
+)
+from ingest import ingest
+from PIL import Image
+from PIL.ExifTags import Base as ExifBase
+
+
+def _save_jpeg(path, *, exif_dt=None, color="red", size=(80, 80)):
+    """Write a JPEG, optionally with an EXIF DateTimeOriginal."""
+    img = Image.new("RGB", size, color=color)
+    if exif_dt is None:
+        img.save(str(path))
+    else:
+        exif = img.getexif()
+        exif[ExifBase.DateTimeOriginal] = exif_dt.strftime("%Y:%m:%d %H:%M:%S")
+        img.save(str(path), exif=exif)
+
+
+def _seed_photo(db, tmp_path, filename, source_path, timestamp=None,
+                file_hash=None, folder_name="library"):
+    """Insert a folder+photo row mimicking a scanned catalog entry."""
+    folder = tmp_path / folder_name
+    folder.mkdir(exist_ok=True)
+    fid_row = db.conn.execute(
+        "SELECT id FROM folders WHERE path = ?", (str(folder),)
+    ).fetchone()
+    fid = fid_row["id"] if fid_row else db.add_folder(str(folder), name=folder_name)
+    db.conn.execute(
+        "UPDATE folders SET status = 'ok' WHERE id = ?", (fid,)
+    )
+    db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, extension, file_size,"
+        " timestamp, file_hash) VALUES (?, ?, ?, ?, ?, ?)",
+        (
+            fid,
+            filename,
+            os.path.splitext(filename)[1],
+            os.path.getsize(str(source_path)),
+            timestamp,
+            file_hash,
+        ),
+    )
+    db.conn.commit()
+    return folder
+
+
+def _forbid_hashing(monkeypatch):
+    """Make any content read explode, proving the heuristic never hashed."""
+
+    def _boom(path, *a, **kw):
+        raise AssertionError(f"content hash computed for {path}")
+
+    monkeypatch.setattr(import_dedup, "compute_file_hash", _boom)
+    import ingest as ingest_module
+
+    monkeypatch.setattr(ingest_module, "compute_file_hash", _boom)
+
+
+# --- trustworthiness rules ---------------------------------------------
+
+def test_timestamp_trustworthiness():
+    assert timestamp_is_trustworthy(datetime(2026, 5, 1, 10, 15, 30))
+    # Missing, epoch-era, and exactly-midnight placeholder clocks are out.
+    assert not timestamp_is_trustworthy(None)
+    assert not timestamp_is_trustworthy(datetime(1980, 1, 1, 10, 15, 30))
+    assert not timestamp_is_trustworthy(datetime(2021, 1, 1, 0, 0, 0))
+    # Midnight-adjacent real times stay trusted.
+    assert timestamp_is_trustworthy(datetime(2026, 5, 1, 0, 0, 1))
+
+
+def test_stored_key_matches_source_key_with_subseconds():
+    """Catalog sub-second timestamps truncate to the source's whole second."""
+    dt = datetime(2026, 5, 1, 10, 15, 30)
+    assert (
+        stored_metadata_key("IMG_0001.NEF", 1234, "2026-05-01T10:15:30.250000")
+        == metadata_key("img_0001.nef", 1234, dt)
+    )
+    assert stored_metadata_key("IMG_0001.NEF", 1234, "1980-01-01T10:15:30") is None
+    assert stored_metadata_key("IMG_0001.NEF", 1234, "2021-01-01T00:00:00") is None
+    assert stored_metadata_key("IMG_0001.NEF", None, "2026-05-01T10:15:30") is None
+    assert stored_metadata_key(None, 1234, "2026-05-01T10:15:30") is None
+
+
+# --- checker unit behavior ---------------------------------------------
+
+def test_metadata_match_skips_without_reading_content(tmp_path, monkeypatch):
+    db = Database(str(tmp_path / "test.db"))
+    src = tmp_path / "card"
+    src.mkdir()
+    dt = datetime(2026, 5, 1, 10, 15, 30)
+    _save_jpeg(src / "IMG_0001.jpg", exif_dt=dt)
+    _seed_photo(
+        db, tmp_path, "IMG_0001.jpg", src / "IMG_0001.jpg",
+        timestamp="2026-05-01T10:15:30",
+    )
+
+    _forbid_hashing(monkeypatch)
+    checker = DuplicateChecker(CatalogIndex.from_db(db))
+    token = checker.match(src / "IMG_0001.jpg")
+    assert token is not None
+    assert token[0] == "key"
+
+
+def test_size_prefilter_skips_hashing_for_unseen_sizes(tmp_path, monkeypatch):
+    """A metadata-less file whose size has no cataloged twin is copied
+    without any content read at all."""
+    db = Database(str(tmp_path / "test.db"))
+    src = tmp_path / "card"
+    src.mkdir()
+    _save_jpeg(src / "no_exif.jpg")  # no EXIF -> hash-fallback candidate
+
+    _forbid_hashing(monkeypatch)
+    checker = DuplicateChecker(CatalogIndex.from_db(db))
+    assert checker.match(src / "no_exif.jpg") is None
+
+
+def test_missing_metadata_falls_back_to_hash(tmp_path):
+    """No usable EXIF + size twin in the catalog -> exact content check."""
+    from scanner import compute_file_hash
+
+    db = Database(str(tmp_path / "test.db"))
+    src = tmp_path / "card"
+    src.mkdir()
+    _save_jpeg(src / "no_exif.jpg")
+    file_hash = compute_file_hash(str(src / "no_exif.jpg"))
+    _seed_photo(
+        db, tmp_path, "renamed_in_library.jpg", src / "no_exif.jpg",
+        timestamp=None, file_hash=file_hash,
+    )
+
+    checker = DuplicateChecker(CatalogIndex.from_db(db))
+    token = checker.match(src / "no_exif.jpg")
+    assert token == ("hash", file_hash)
+
+
+def test_placeholder_timestamp_falls_back_to_hash(tmp_path):
+    """A generic midnight clock is not trusted as identity."""
+    from scanner import compute_file_hash
+
+    db = Database(str(tmp_path / "test.db"))
+    src = tmp_path / "card"
+    src.mkdir()
+    _save_jpeg(src / "IMG_0001.jpg", exif_dt=datetime(2021, 1, 1, 0, 0, 0))
+    file_hash = compute_file_hash(str(src / "IMG_0001.jpg"))
+    _seed_photo(
+        db, tmp_path, "IMG_0001.jpg", src / "IMG_0001.jpg",
+        timestamp="2021-01-01T00:00:00", file_hash=file_hash,
+    )
+
+    checker = DuplicateChecker(CatalogIndex.from_db(db))
+    # The placeholder key is excluded on BOTH sides; the hash still hits.
+    token = checker.match(src / "IMG_0001.jpg")
+    assert token == ("hash", file_hash)
+
+
+def test_same_second_same_size_burst_frames_not_conflated(
+    tmp_path, monkeypatch
+):
+    """Fixed-size RAW burst frames in the same second differ by filename."""
+    db = Database(str(tmp_path / "test.db"))
+    src = tmp_path / "card"
+    src.mkdir()
+    # Two "uncompressed RAW" frames: identical size, same capture second.
+    (src / "IMG_0002.dng").write_bytes(b"\x01" * 4096)
+    (src / "IMG_0003.dng").write_bytes(b"\x02" * 4096)
+    dt_iso = "2026-05-01T10:15:30"
+    _seed_photo(
+        db, tmp_path, "IMG_0002.dng", src / "IMG_0002.dng", timestamp=dt_iso,
+    )
+
+    dt = datetime(2026, 5, 1, 10, 15, 30)
+    monkeypatch.setattr(
+        import_dedup,
+        "source_capture_timestamps",
+        lambda files: {f: dt for f in files},
+    )
+    checker = DuplicateChecker(CatalogIndex.from_db(db))
+    checker.prepare([src / "IMG_0002.dng", src / "IMG_0003.dng"])
+    assert checker.match(src / "IMG_0002.dng") is not None
+    # Same size + same second but a different filename: NOT a duplicate.
+    assert checker.match(src / "IMG_0003.dng") is None
+
+
+def test_key_miss_still_hashes_when_catalog_row_lacks_timestamp(tmp_path):
+    """A cataloged photo with a hash but no stored timestamp can never
+    key-match, so a trusted-metadata source of the same size must fall
+    through to the exact content check instead of being declared new."""
+    from scanner import compute_file_hash
+
+    db = Database(str(tmp_path / "test.db"))
+    src = tmp_path / "card"
+    src.mkdir()
+    dt = datetime(2026, 5, 1, 10, 15, 30)
+    _save_jpeg(src / "IMG_0001.jpg", exif_dt=dt)
+    file_hash = compute_file_hash(str(src / "IMG_0001.jpg"))
+    # Scan-time ExifTool failure: hash + size recorded, timestamp NULL.
+    _seed_photo(
+        db, tmp_path, "IMG_0001.jpg", src / "IMG_0001.jpg",
+        timestamp=None, file_hash=file_hash,
+    )
+
+    checker = DuplicateChecker(CatalogIndex.from_db(db))
+    assert checker.match(src / "IMG_0001.jpg") == ("hash", file_hash)
+
+
+def test_verify_by_hash_catches_renamed_duplicate(tmp_path):
+    """The heuristic intentionally re-imports renamed twins; the verify
+    checkbox restores the exact behavior."""
+    from scanner import compute_file_hash
+
+    db = Database(str(tmp_path / "test.db"))
+    src = tmp_path / "card"
+    src.mkdir()
+    dt = datetime(2026, 5, 1, 10, 15, 30)
+    _save_jpeg(src / "renamed.jpg", exif_dt=dt)
+    file_hash = compute_file_hash(str(src / "renamed.jpg"))
+    _seed_photo(
+        db, tmp_path, "IMG_0001.jpg", src / "renamed.jpg",
+        timestamp="2026-05-01T10:15:30", file_hash=file_hash,
+    )
+
+    index = CatalogIndex.from_db(db)
+    # Heuristic: trusted metadata, filename mismatch -> treated as new.
+    assert DuplicateChecker(index).match(src / "renamed.jpg") is None
+    # Verify mode: exact content identity wins.
+    assert DuplicateChecker(index, verify_by_hash=True).match(
+        src / "renamed.jpg"
+    ) == ("hash", file_hash)
+
+
+def test_intra_batch_twins_without_metadata_promote_to_hash(tmp_path):
+    """Recording an identity-less file parks its size; a same-size
+    fallback candidate later promotes it to a hashed identity."""
+    import shutil
+
+    db = Database(str(tmp_path / "test.db"))
+    src = tmp_path / "card"
+    src.mkdir()
+    _save_jpeg(src / "a.jpg")
+    shutil.copyfile(str(src / "a.jpg"), str(src / "b.jpg"))
+
+    checker = DuplicateChecker(CatalogIndex.from_db(db))
+    assert checker.check_and_record(src / "a.jpg") is False
+    assert checker.check_and_record(src / "b.jpg") is True
+
+
+# --- ingest() end-to-end ------------------------------------------------
+
+def test_ingest_metadata_skip_reads_no_bytes_and_reports_folders(
+    tmp_path, monkeypatch
+):
+    """Re-importing a card of cataloged photos copies nothing, reads no
+    file bodies, and reports the destination folders holding the
+    originals (for the post-import scan's restrict_dirs)."""
+    db = Database(str(tmp_path / "test.db"))
+    dst = tmp_path / "nas"
+    dst.mkdir()
+    src = tmp_path / "card"
+    src.mkdir()
+    dt = datetime(2026, 5, 1, 10, 15, 30)
+    _save_jpeg(src / "IMG_0001.jpg", exif_dt=dt, color="red")
+    _save_jpeg(src / "IMG_0002.jpg", exif_dt=dt, color="blue", size=(90, 90))
+
+    # Originals live under the destination in a dated folder.
+    lib_folder = dst / "2026" / "2026-05-01"
+    lib_folder.mkdir(parents=True)
+    for name in ("IMG_0001.jpg", "IMG_0002.jpg"):
+        (lib_folder / name).write_bytes((src / name).read_bytes())
+        _seed_photo(
+            db, tmp_path, name, src / name,
+            timestamp="2026-05-01T10:15:30",
+            folder_name="unused",
+        )
+    # Point the seeded folder rows at the real library folder.
+    db.conn.execute(
+        "UPDATE folders SET path = ?, status = 'ok'", (str(lib_folder),)
+    )
+    db.conn.commit()
+
+    _forbid_hashing(monkeypatch)
+    result = ingest(str(src), str(dst), db=db, skip_duplicates=True)
+
+    assert result["copied"] == 0
+    assert result["skipped_duplicate"] == 2
+    assert result["duplicate_folders"] == [str(lib_folder)]
+
+
+def test_ingest_verify_by_hash_matches_old_behavior(tmp_path):
+    """verify_by_hash=True skips a renamed duplicate the heuristic
+    would re-import."""
+    from scanner import compute_file_hash
+
+    db = Database(str(tmp_path / "test.db"))
+    dst = tmp_path / "nas"
+    dst.mkdir()
+    src = tmp_path / "card"
+    src.mkdir()
+    dt = datetime(2026, 5, 1, 10, 15, 30)
+    _save_jpeg(src / "renamed.jpg", exif_dt=dt)
+    _seed_photo(
+        db, tmp_path, "IMG_0001.jpg", src / "renamed.jpg",
+        timestamp="2026-05-01T10:15:30",
+        file_hash=compute_file_hash(str(src / "renamed.jpg")),
+    )
+
+    result = ingest(
+        str(src), str(dst), db=db, skip_duplicates=True, verify_by_hash=True,
+    )
+    assert result["copied"] == 0
+    assert result["skipped_duplicate"] == 1
+
+    # Heuristic mode re-imports it (documented tradeoff, self-healed by
+    # the post-import scan's exact duplicate detection).
+    result2 = ingest(str(src), str(dst), db=db, skip_duplicates=True)
+    assert result2["copied"] == 1
+
+
+def test_ingest_same_name_collision_still_exact(tmp_path):
+    """The destination-collision branch never trusts metadata: same name,
+    same size, same second, different bytes -> suffixed copy, not a skip."""
+    db = Database(str(tmp_path / "test.db"))
+    dst = tmp_path / "nas"
+    dst.mkdir()
+    src = tmp_path / "card"
+    src.mkdir()
+    dt = datetime(2026, 5, 1, 10, 15, 30)
+    _save_jpeg(src / "IMG_0001.jpg", exif_dt=dt, color="red")
+
+    # A different file with the same name and size already sits at the
+    # destination path this import will choose.
+    dest_folder = dst / "2026" / "2026-05-01"
+    dest_folder.mkdir(parents=True)
+    src_bytes = (src / "IMG_0001.jpg").read_bytes()
+    altered = bytearray(src_bytes)
+    altered[-1] ^= 0xFF
+    (dest_folder / "IMG_0001.jpg").write_bytes(bytes(altered))
+
+    result = ingest(str(src), str(dst), db=db, skip_duplicates=True)
+    assert result["copied"] == 1
+    assert (dest_folder / "IMG_0001_1.jpg").exists()
+
+
+def test_ingest_same_name_collision_identical_skips(tmp_path):
+    """Byte-identical file already at the chosen destination path is
+    recognized by exact content compare (companion-JPEG re-import path)."""
+    db = Database(str(tmp_path / "test.db"))
+    dst = tmp_path / "nas"
+    dst.mkdir()
+    src = tmp_path / "card"
+    src.mkdir()
+    dt = datetime(2026, 5, 1, 10, 15, 30)
+    _save_jpeg(src / "IMG_0001.jpg", exif_dt=dt)
+
+    dest_folder = dst / "2026" / "2026-05-01"
+    dest_folder.mkdir(parents=True)
+    (dest_folder / "IMG_0001.jpg").write_bytes(
+        (src / "IMG_0001.jpg").read_bytes()
+    )
+
+    result = ingest(str(src), str(dst), db=db, skip_duplicates=True)
+    assert result["copied"] == 0
+    assert result["skipped_duplicate"] == 1
+    assert not (dest_folder / "IMG_0001_1.jpg").exists()
+
+
+def test_shared_checker_dedupes_across_ingest_calls(tmp_path, monkeypatch):
+    """One checker shared across a multi-source loop treats files copied
+    by an earlier call as duplicates in later calls — without re-reading
+    the copied files (the old accumulated-hashes rescan)."""
+    db = Database(str(tmp_path / "test.db"))
+    dst = tmp_path / "nas"
+    dst.mkdir()
+    dt = datetime(2026, 5, 1, 10, 15, 30)
+    card_a = tmp_path / "card_a"
+    card_b = tmp_path / "card_b"
+    card_a.mkdir()
+    card_b.mkdir()
+    _save_jpeg(card_a / "IMG_0001.jpg", exif_dt=dt)
+    (card_b / "IMG_0001.jpg").write_bytes(
+        (card_a / "IMG_0001.jpg").read_bytes()
+    )
+
+    checker = DuplicateChecker(CatalogIndex.from_db(db))
+    result_a = ingest(
+        str(card_a), str(dst), db=db, skip_duplicates=True,
+        duplicate_checker=checker,
+    )
+    assert result_a["copied"] == 1
+
+    _forbid_hashing(monkeypatch)
+    result_b = ingest(
+        str(card_b), str(dst), db=db, skip_duplicates=True,
+        duplicate_checker=checker,
+    )
+    assert result_b["copied"] == 0
+    assert result_b["skipped_duplicate"] == 1
+
+
+# --- preflight helpers use the same oracle ------------------------------
+
+def test_non_duplicate_files_accepts_checker_and_legacy_set(tmp_path):
+    from local_processing import non_duplicate_files
+    from scanner import compute_file_hash
+
+    db = Database(str(tmp_path / "test.db"))
+    src = tmp_path / "card"
+    src.mkdir()
+    dt = datetime(2026, 5, 1, 10, 15, 30)
+    _save_jpeg(src / "IMG_0001.jpg", exif_dt=dt)
+    _save_jpeg(src / "IMG_0002.jpg", exif_dt=dt, color="blue", size=(90, 90))
+    _seed_photo(
+        db, tmp_path, "IMG_0001.jpg", src / "IMG_0001.jpg",
+        timestamp="2026-05-01T10:15:30",
+    )
+
+    files = [src / "IMG_0001.jpg", src / "IMG_0002.jpg"]
+    survivors = non_duplicate_files(files, DuplicateChecker(CatalogIndex.from_db(db)))
+    assert survivors == [src / "IMG_0002.jpg"]
+
+    # Legacy bare-hash-set callers still get exact behavior.
+    legacy = non_duplicate_files(
+        files, {compute_file_hash(str(src / "IMG_0001.jpg"))},
+    )
+    assert legacy == [src / "IMG_0002.jpg"]

--- a/vireo/tests/test_ingest.py
+++ b/vireo/tests/test_ingest.py
@@ -348,7 +348,7 @@ def test_ingest_uses_metadata_dates_when_lightweight_exif_fails(
     tmp_path, monkeypatch
 ):
     """ExifTool metadata keeps copied files split by capture date."""
-    import ingest as ingest_module
+    import import_dedup as import_dedup_module
     import metadata as metadata_module
 
     src = tmp_path / "sd_card"
@@ -362,7 +362,9 @@ def test_ingest_uses_metadata_dates_when_lightweight_exif_fails(
         mtime = datetime(2026, 3, 30, 12, 0, 0).timestamp()
         os.utime(str(src / name), (mtime, mtime))
 
-    monkeypatch.setattr(ingest_module, "read_exif_timestamp", lambda _path: None)
+    monkeypatch.setattr(
+        import_dedup_module, "read_exif_timestamp", lambda _path: None
+    )
 
     def fake_extract_metadata(paths, restricted_tags=None):
         return {
@@ -381,12 +383,13 @@ def test_ingest_uses_metadata_dates_when_lightweight_exif_fails(
     assert not (dst / "2026" / "2026-03-30" / "a.jpg").exists()
 
 
-def test_ingest_skips_timestamp_resolution_for_duplicates(
-    tmp_path, monkeypatch
-):
-    """Duplicate-only re-imports must not trigger EXIF or ExifTool work."""
-    import ingest as ingest_module
-    import metadata as metadata_module
+def test_ingest_duplicate_only_reimport_skips_all(tmp_path, monkeypatch):
+    """A card whose files all match extra_known_hashes copies nothing.
+
+    The heuristic gate resolves EXIF capture times up front (cheap header
+    reads — that's the point of the metadata-first design), but files
+    matching known hashes must still be skipped without being copied.
+    """
     from scanner import compute_file_hash
 
     src = tmp_path / "sd_card"
@@ -400,22 +403,6 @@ def test_ingest_skips_timestamp_resolution_for_duplicates(
         Image.new("RGB", (100, 100), color=(i * 80, 0, 0)).save(str(src / name))
         hashes.add(compute_file_hash(str(src / name)))
 
-    exif_calls: list[str] = []
-    extract_calls: list[list[str]] = []
-
-    def tracking_read_exif(path):
-        exif_calls.append(path)
-        return None
-
-    def tracking_extract_metadata(paths, restricted_tags=None):
-        extract_calls.append(list(paths))
-        return {}
-
-    monkeypatch.setattr(ingest_module, "read_exif_timestamp", tracking_read_exif)
-    monkeypatch.setattr(
-        metadata_module, "extract_metadata", tracking_extract_metadata
-    )
-
     db = Database(str(tmp_path / "test.db"))
     result = ingest(
         str(src),
@@ -427,10 +414,6 @@ def test_ingest_skips_timestamp_resolution_for_duplicates(
 
     assert result["copied"] == 0
     assert result["skipped_duplicate"] == 2
-    # The duplicate gate short-circuits before any timestamp work runs,
-    # so neither the lightweight EXIF reader nor ExifTool is touched.
-    assert exif_calls == []
-    assert extract_calls == []
 
 
 def test_ingest_unsorted_fallback(tmp_path):
@@ -511,17 +494,22 @@ def test_ingest_skip_duplicates_within_single_batch(tmp_path):
     assert len(on_disk) == 1
 
 
-def test_ingest_intra_batch_dup_retries_after_primary_failure(tmp_path):
-    """If the primary copy of a hash fails in pass 2, a byte-identical
-    sibling in the same batch still gets a chance to import the bytes.
+def test_ingest_intra_batch_dup_retries_after_primary_failure(
+    tmp_path, monkeypatch
+):
+    """If the primary copy of a duplicate pair fails in pass 2, a
+    byte-identical sibling in the same batch still gets a chance to
+    import the bytes.
 
     Regression: when intra-batch dedup was eagerly marked in pass 1, a
     failed primary copy left every byte-identical sibling permanently
-    skipped — no copy ever landed for that hash even though the user
+    skipped — no copy ever landed for that content even though the user
     asked for ``skip_duplicates=True`` (which only means "don't import
     bytes I already have", not "give up if the first try fails").
     """
     import shutil
+
+    import ingest as ingest_module
 
     src = tmp_path / "sd_card"
     dst = tmp_path / "nas"
@@ -535,12 +523,15 @@ def test_ingest_intra_batch_dup_retries_after_primary_failure(tmp_path):
     os.utime(str(src / "IMG_001.jpg"), (mtime, mtime))
     os.utime(str(src / "IMG_002.jpg"), (mtime, mtime))
 
-    # Squat the primary's destination path with a directory of the same
-    # name. shutil.copy2 (and compute_file_hash on the "dest_file")
-    # then raise IsADirectoryError, so the primary fails in pass 2.
-    dest_folder = dst / "2026" / "2026-03-28"
-    dest_folder.mkdir(parents=True)
-    (dest_folder / "IMG_001.jpg").mkdir()
+    # Fail the primary's copy only; the sibling's copy must proceed.
+    real_copy2 = ingest_module.shutil.copy2
+
+    def failing_copy2(src_path, dst_path):
+        if str(src_path).endswith("IMG_001.jpg"):
+            raise OSError("simulated copy failure")
+        return real_copy2(src_path, dst_path)
+
+    monkeypatch.setattr(ingest_module.shutil, "copy2", failing_copy2)
 
     db = Database(str(tmp_path / "test.db"))
     result = ingest(str(src), str(dst), db=db, skip_duplicates=True)
@@ -549,6 +540,7 @@ def test_ingest_intra_batch_dup_retries_after_primary_failure(tmp_path):
     assert result["copied"] == 1, result
     assert result["skipped_duplicate"] == 0, result
     # The sibling should have landed under the date folder.
+    dest_folder = dst / "2026" / "2026-03-28"
     files_on_disk = sorted(
         p.name for p in dest_folder.iterdir() if p.is_file()
     )
@@ -1725,7 +1717,7 @@ def test_preview_destination_uses_metadata_dates_when_lightweight_exif_fails(
     tmp_path, monkeypatch
 ):
     """Preview keeps capture-date folders when ExifTool has the date."""
-    import ingest as ingest_module
+    import import_dedup as import_dedup_module
     import metadata as metadata_module
 
     src = tmp_path / "sd_card"
@@ -1738,7 +1730,9 @@ def test_preview_destination_uses_metadata_dates_when_lightweight_exif_fails(
         mtime = datetime(2026, 3, 30, 12, 0, 0).timestamp()
         os.utime(str(src / name), (mtime, mtime))
 
-    monkeypatch.setattr(ingest_module, "read_exif_timestamp", lambda _path: None)
+    monkeypatch.setattr(
+        import_dedup_module, "read_exif_timestamp", lambda _path: None
+    )
 
     def fake_extract_metadata(paths, restricted_tags=None):
         return {

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -1603,7 +1603,8 @@ def test_pipeline_local_processing_preflight_filters_duplicates(
     db.add_workspace_folder(ws_id, folder_id)
     db.add_photo(
         folder_id=folder_id, filename="dup.jpg", extension=".jpg",
-        file_size=10, file_mtime=1.0, file_hash=dup_hash,
+        file_size=(src / "dup.jpg").stat().st_size, file_mtime=1.0,
+        file_hash=dup_hash,
     )
     db.close()
 
@@ -1685,7 +1686,8 @@ def test_pipeline_local_processing_plans_archive_credit_after_duplicate_filter(
     db.add_workspace_folder(ws_id, folder_id)
     db.add_photo(
         folder_id=folder_id, filename="dup.jpg", extension=".jpg",
-        file_size=10, file_mtime=1.0, file_hash=dup_hash,
+        file_size=(src / "dup.jpg").stat().st_size, file_mtime=1.0,
+        file_hash=dup_hash,
     )
     db.close()
 
@@ -2097,7 +2099,8 @@ def test_pipeline_local_processing_conflict_preflight_skips_known_duplicates(
     db.add_workspace_folder(ws_id, folder_id)
     db.add_photo(
         folder_id=folder_id, filename="dup.jpg", extension=".jpg",
-        file_size=10, file_mtime=1.0, file_hash=dup_hash,
+        file_size=dup_path.stat().st_size, file_mtime=1.0,
+        file_hash=dup_hash,
     )
     db.close()
 


### PR DESCRIPTION
## Why

Importing from an SD card read every byte of the card **twice** — once for the import preview's duplicate scan (`/api/import/check-duplicates`) and again in `ingest()` pass 1 — to SHA-256 every file before copying anything. At card-reader speeds that's minutes of pure I/O for a question Lightroom answers from metadata in seconds. (Discussion: why Lightroom's import + duplicate scan feels much faster than Vireo's.)

## What changed

**New `vireo/import_dedup.py`** — `CatalogIndex` + `DuplicateChecker`, the single duplicate oracle shared by `ingest()`, the preview endpoint, and the local-processing preflight (`archive_conflict_report`, `non_duplicate_files`), so duplicate badges, storage plans, and the actual import always agree.

**Default (heuristic) mode** — a source file is a duplicate when a cataloged photo matches its (filename, byte size, EXIF capture time to the second). Only file headers are read. Exact hashing remains wherever metadata can't settle it:

- Missing or placeholder timestamps (epoch-era year, exactly-midnight clock) fall back to the content hash — gated by byte size, since a size with no cataloged twin can't be an exact duplicate.
- Cataloged rows with a hash but no usable timestamp force the exact check for same-size sources (a key miss can't prove novelty there).
- Destination filename collisions are always settled by exact content compare (same-size gate first), never by metadata — a wrong skip there would drop a photo.
- Intra-batch twins with no usable metadata promote lazily to hashed identities — only the colliding pair pays for content reads.
- Same-second, same-size uncompressed-RAW burst frames are kept apart by the filename component of the key.

**Verify checkbox** — "Verify by full content hash" on the import panel restores the historical hash-everything behavior end to end (`verify_by_hash` through check-duplicates, `/api/jobs/pipeline`, `/api/jobs/import-full`, `/api/jobs/ingest`). The duplicate-count summary now carries a tooltip saying which method produced it.

**Pipeline loop** — one shared checker across the multi-source ingest loop replaces the old accumulated-hashes pass that re-read every copied file between sources; preflight predictions get fresh checkers over the same catalog index with a shared EXIF-times cache.

**Known tradeoff (documented in module docstring):** a renamed true duplicate is re-imported in heuristic mode (Lightroom behaves the same); the post-import scan hashes everything on local disk and the duplicates page flags it — self-healing. Verify mode catches it up front.

## Tests

- New `vireo/tests/test_import_dedup.py` (16 tests): trustworthiness rules, no-content-read key matches, size prefilter, placeholder-timestamp fallback, burst-frame protection, unkeyed-catalog-row fallback, verify-mode parity, collision exactness, shared-checker cross-source dedup, preflight helper compatibility (checker + legacy hash-set).
- check-duplicates endpoint: heuristic no-hash match + `verify_by_hash` flag tests.
- Updated 3 `test_pipeline_api` seeds that stored `file_size=10` for a real file (the size prefilter correctly proved those rows couldn't match); updated 2 `test_ingest` tests for symbols that moved / behavior that inverted by design.
- Full suite: **3851 passed, 9 skipped**; the only failure (`test_userfirst_harness_integration::test_sweep_flags_missing_static_asset`) fails identically on the base commit without these changes (verified via stash). `test_models.py` excluded per its known collection-crashing monkeypatch bug; `test_pipeline_api.py` run separately in full (304 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)