### PR TITLE
Make progress bars larger

### DIFF
--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -374,10 +374,10 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
 .bp-job-status.failed { color: var(--danger); }
 .bp-job-elapsed { font-size: 11px; color: var(--text-invisible); margin-left: auto; font-variant-numeric: tabular-nums; }
 .bp-job-progress {
-  height: 3px; background: var(--bg-tertiary); border-radius: 2px; overflow: hidden; margin-bottom: 3px;
+  height: 6px; background: var(--bg-tertiary); border-radius: 3px; overflow: hidden; margin-bottom: 4px;
 }
 .bp-job-progress-fill {
-  height: 100%; background: var(--accent); border-radius: 2px; transition: width 0.3s;
+  height: 100%; background: var(--accent); border-radius: 3px; transition: width 0.3s;
 }
 .bp-job-detail {
   font-size: 11px; color: var(--text-faint);
@@ -1275,7 +1275,7 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
 .inat-card-status.warning { color: var(--warning); }
 .inat-progress { margin-top: 12px; }
 .inat-progress-bar {
-  height: 4px; background: var(--bg-tertiary); border-radius: 2px; overflow: hidden;
+  height: 8px; background: var(--bg-tertiary); border-radius: 4px; overflow: hidden;
 }
 .inat-progress-fill {
   height: 100%; background: var(--accent); width: 0%; transition: width 0.3s;

--- a/vireo/templates/jobs.html
+++ b/vireo/templates/jobs.html
@@ -85,10 +85,10 @@
   overflow: hidden; text-overflow: ellipsis;
 }
 .job-list-item-progress {
-  margin-top: 4px; height: 3px; background: var(--bg-tertiary); border-radius: 2px;
+  margin-top: 5px; height: 6px; background: var(--bg-tertiary); border-radius: 3px;
 }
 .job-list-item-progress-fill {
-  height: 100%; background: var(--accent); border-radius: 2px; transition: width 0.3s;
+  height: 100%; background: var(--accent); border-radius: 3px; transition: width 0.3s;
 }
 .jobs-detail-pane {
   flex: 1; overflow-y: auto; padding: 0;

--- a/vireo/templates/lightroom.html
+++ b/vireo/templates/lightroom.html
@@ -21,12 +21,12 @@ body { padding-bottom: 36px; }
 .path-input:focus { border-color: var(--accent); }
 
 .progress-bar {
-  height: 6px; background: var(--bg-tertiary); border-radius: 3px;
+  height: 10px; background: var(--bg-tertiary); border-radius: 5px;
   overflow: hidden; margin: 12px 0; display: none;
 }
 .progress-bar.active { display: block; }
 .progress-fill {
-  height: 100%; background: var(--accent); border-radius: 3px;
+  height: 100%; background: var(--accent); border-radius: 5px;
   transition: width 0.3s; width: 0;
 }
 

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -107,10 +107,10 @@ body { padding-bottom: 36px; }
 }
 .stage-progress-bar {
   display: inline-flex;
-  width: 80px;
-  height: 6px;
+  width: 112px;
+  height: 8px;
   margin-left: 8px;
-  border-radius: 3px;
+  border-radius: 4px;
   overflow: hidden;
   background: var(--bg-tertiary, #14374E);
   vertical-align: middle;
@@ -371,7 +371,7 @@ body { padding-bottom: 36px; }
 /* Progress bar */
 .progress-wrap { margin-top: 10px; }
 .progress-bar-track {
-  height: 4px; background: var(--bg-tertiary, #14374E); border-radius: 2px; overflow: hidden;
+  height: 8px; background: var(--bg-tertiary, #14374E); border-radius: 4px; overflow: hidden;
 }
 .progress-bar-fill {
   height: 100%; background: var(--accent, #24E5CA); width: 0%; transition: width 0.3s;

--- a/vireo/templates/welcome.html
+++ b/vireo/templates/welcome.html
@@ -73,10 +73,10 @@
 
   .progress-container { display: none; margin-top: 20px; }
   .progress-bar-track {
-    height: 6px; background: var(--bg-tertiary); border-radius: 3px; overflow: hidden;
+    height: 10px; background: var(--bg-tertiary); border-radius: 5px; overflow: hidden;
   }
   .progress-bar-fill {
-    height: 100%; background: var(--accent); border-radius: 3px;
+    height: 100%; background: var(--accent); border-radius: 5px;
     width: 0%; transition: width 0.3s;
   }
   .progress-label { font-size: 12px; color: var(--text-secondary); margin-top: 8px; }


### PR DESCRIPTION
Updates Vireo's in-app progress indicators so they are easier to see while jobs and setup flows are running. Enlarges the compact job bars, pipeline stage bars, setup/model download bars, Lightroom import bar, and iNaturalist progress bar while keeping the existing colors and transitions. Validation: ran git diff --check and reviewed git diff origin/main....