### PR TITLE
Auto-merge on trusted approval/thumbsup/reaction, not just claude-agent PRs

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -424,7 +424,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR: ${{ github.event.issue.number }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
         run: |
+          if [[ " $TRUSTED_ACTORS " != *" $COMMENT_AUTHOR "* ]]; then
+            echo "PR #${PR}: +1 from ${COMMENT_AUTHOR} is not in TRUSTED_ACTORS; skipping auto-merge."
+            exit 0
+          fi
+
           base=$(gh pr view "$PR" --repo "$REPO" --json baseRefName -q .baseRefName)
           head=$(gh pr view "$PR" --repo "$REPO" --json headRefName -q .headRefName)
           head_sha=$(gh pr view "$PR" --repo "$REPO" --json headRefOid -q .headRefOid)

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -348,12 +348,13 @@ jobs:
             Task: resolve-conflicts
             PRs: ${{ steps.conflicts.outputs.pr_csv }}
 
-  # Enable squash auto-merge after an approving review on an agent PR.
+  # Enable squash auto-merge after an approving review from a trusted actor.
+  # Not gated on the claude-agent label — a trusted approval should be
+  # sufficient regardless of how the PR was created.
   merge-on-approval:
     if: >-
       github.event_name == 'pull_request_review'
       && github.event.review.state == 'approved'
-      && contains(github.event.pull_request.labels.*.name, 'claude-agent')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -401,14 +402,14 @@ jobs:
             --subject "${title} (#${PR})"
           echo "Auto-merge enabled on PR #${PR}. GitHub will merge when CI passes."
 
-  # Enable squash auto-merge after a trusted thumbs-up comment on an agent PR.
+  # Enable squash auto-merge after a trusted thumbs-up comment. Not gated on
+  # the claude-agent label — see merge-on-approval above.
   merge-on-thumbsup:
     if: >-
       github.event_name == 'issue_comment'
       && github.event.issue.pull_request
       && (github.event.comment.body == '+1'
           || github.event.comment.body == '👍')
-      && contains(github.event.issue.labels.*.name, 'claude-agent')
       && (github.event.comment.author_association == 'OWNER'
           || github.event.comment.author_association == 'COLLABORATOR'
           || github.actor == 'chatgpt-codex-connector[bot]')
@@ -472,9 +473,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Not gated on the claude-agent label — a trusted reaction should
+          # be sufficient regardless of how the PR was created.
           prs=$(gh pr list --repo "${{ github.repository }}" \
             --state open \
-            --label "$AGENT_LABEL" \
             --limit 1000 \
             --json number -q '.[].number')
 

--- a/docs/pr-agent-routine.md
+++ b/docs/pr-agent-routine.md
@@ -127,8 +127,9 @@ re-asserts this at handling time.
   to resolve conflicts. If GitHub still reports mergeability as `UNKNOWN` after
   retries, the workflow sends that PR to the routine so a real conflict is not
   missed.
-- Approved `claude-agent` PRs, trusted `+1` comments, or trusted `+1`
-  reactions after the latest PR activity: enables squash auto-merge.
+- A trusted approving review, trusted `+1` comment, or trusted `+1` reaction
+  after the latest PR activity: enables squash auto-merge on any open PR
+  targeting `main` (not limited to `claude-agent`-labeled PRs).
 
 Auto-merge calls use `gh pr merge --match-head-commit` so approval applies to
 the expected PR head commit rather than a newer unreviewed push. Auto-merge


### PR DESCRIPTION
## Summary
- All three merge jobs in `pr-agent.yml` (`merge-on-approval`, `merge-on-thumbsup`, `merge-on-reaction`) required the PR to carry the `claude-agent` label before a trusted approval/`+1`/reaction would trigger auto-merge.
- This meant a PR opened directly (not through `/claude-fix` or a Codex review that added the label) never qualified for auto-merge even with a trusted `+1` and green CI — e.g. PR #1089 had a `chatgpt-codex-connector[bot]` `+1` reaction and all-green checks but was never picked up.
- Dropped the label requirement from all three jobs — a trusted actor's approval/comment/reaction is now sufficient on its own, matching what's already documented in the project's PR Agent System description (trust gating is still enforced via `TRUSTED_ACTORS` / author association checks, unchanged).
- Updated `docs/pr-agent-routine.md` to match.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr-agent.yml'))"` — parses cleanly
- [x] Manually reviewed each edited `if:`/`gh pr list` block for dangling operators after removing the label clauses
- [ ] No automated test exercises GitHub Actions expression logic; behavior will be confirmed live the next time a trusted reaction/comment/approval lands on an unlabeled open PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Squash auto-merge can now be triggered by trusted approvals and trusted `+1`/👍 reactions on any open PR targeting `main`, not just specially labeled PRs.
* **Documentation**
  * Updated the auto-merge behavior description to reflect the broader eligibility for trusted reviews and reactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->