### PR TITLE
Import plan: say '0 new photos' outright when every file is a duplicate

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2806,6 +2806,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             reclassify=bool(body.get("reclassify")),
             source_paths=source_paths,
             hash_duplicate_paths=hash_duplicate_paths,
+            # Mirrors /api/jobs/pipeline's local_processing flag. The
+            # planner needs it to know what the post-ingest scan walks:
+            # only local-processing imports may claim "0 new photos to
+            # import, nothing to …" for an all-duplicates selection —
+            # plain copy mode re-scans the real destination, which can
+            # surface existing unprocessed rows as downstream work.
+            local_processing=bool(body.get("local_processing")),
             preview_max_size=body.get("preview_max_size"),
         )
         db = _get_db()

--- a/vireo/pipeline_plan.py
+++ b/vireo/pipeline_plan.py
@@ -159,6 +159,23 @@ def _resolve_labels_for_models(models, labels_files, db):
     return out
 
 
+def _import_without_new_files(params, photo_ids, new_count):
+    """True when import mode is active but the run brings no per-photo work.
+
+    Every selected file is already imported (``new_count == 0``, typically
+    via the hash/metadata duplicate gate) and none of the known copies fall
+    into scope at the selected paths (``photo_ids`` empty — the copies live
+    at other, already-cataloged paths). The per-photo stages will all
+    execute over an empty set, so their "Will run" summaries must say the
+    run imports 0 new photos instead of implying work is coming.
+    """
+    return (
+        params.source_paths is not None
+        and new_count == 0
+        and not photo_ids
+    )
+
+
 def _classify_plan(db, params, photo_ids, new_count=0):
     if params.skip_classify:
         return {
@@ -268,10 +285,18 @@ def _classify_plan(db, params, photo_ids, new_count=0):
                     "fingerprint_reason": fingerprint_reason,
                 },
             }
+        import_no_new = _import_without_new_files(params, photo_ids, new_count)
         if new_count > 0:
             summary = (
                 f"Will run — {new_count} new photo{_plural(new_count)} "
                 f"to detect & classify (MegaDetector runs first)"
+            )
+        elif import_no_new:
+            # All-duplicates import: MegaDetector will get 0 photos, so
+            # "will run first" would falsely promise detection work.
+            summary = (
+                "Will run — 0 new photos to import, nothing to "
+                "detect or classify"
             )
         else:
             summary = (
@@ -291,6 +316,7 @@ def _classify_plan(db, params, photo_ids, new_count=0):
                 "stale": stale_total,
                 "fingerprint_outdated": fingerprint_outdated,
                 "fingerprint_reason": fingerprint_reason,
+                "import_no_new": import_no_new,
             },
         }
 
@@ -466,14 +492,22 @@ def _extract_plan(db, params, photo_ids, pipeline_cfg, new_count=0):
                     "stale": 0, "fingerprint_outdated": False,
                 },
             }
-        return {
-            "state": "will-run",
-            "summary": (
+        import_no_new = _import_without_new_files(params, photo_ids, new_count)
+        if import_no_new:
+            # All-duplicates import: classify has 0 photos to produce
+            # detections from, so nothing will ever become eligible here.
+            summary = "Will run — 0 new photos to import, nothing to extract"
+        else:
+            summary = (
                 "Will run after classify produces detections "
                 "(no eligible photos yet)"
-            ),
+            )
+        return {
+            "state": "will-run",
+            "summary": summary,
             "detail": {"eligible": 0, "pending": 0,
-                       "stale": 0, "fingerprint_outdated": False},
+                       "stale": 0, "fingerprint_outdated": False,
+                       "import_no_new": import_no_new},
         }
     if pending == 0 and stale == 0 and new_count == 0:
         return {
@@ -563,17 +597,25 @@ def _eye_keypoints_plan(db, params, photo_ids, pipeline_cfg, new_count=0):
                     "fingerprint_outdated": stale > 0,
                 },
             }
-        return {
-            "state": "will-run",
-            "summary": (
+        import_no_new = _import_without_new_files(params, photo_ids, new_count)
+        if import_no_new:
+            # All-duplicates import: upstream stages run over 0 photos, so
+            # no masks or predictions are coming for this stage to consume.
+            summary = "Will run — 0 new photos to import, nothing to process"
+        else:
+            summary = (
                 "Will run after upstream produces masks + species "
                 "predictions (no eligible photos yet)"
-            ),
+            )
+        return {
+            "state": "will-run",
+            "summary": summary,
             "detail": {
                 "eligible": 0,
                 "pending": 0,
                 "stale": stale,
                 "fingerprint_outdated": stale > 0,
+                "import_no_new": import_no_new,
             },
         }
     if pending == 0 and new_count == 0:
@@ -663,13 +705,26 @@ def _previews_plan(db, params, photo_ids, new_count, effective_cfg):
 
     if eligible == 0 and new_count == 0:
         # Empty scope. The stages will run (the loop is just empty), but
-        # there's nothing to count. Be honest about that.
-        summary = (
-            "Will run — no photos in scope yet"
-            if not previews_skipped
-            else "Will run for thumbnails — no photos in scope (previews "
-                 "skipped: serves originals at full resolution)"
-        )
+        # there's nothing to count. Be honest about that — and when the
+        # emptiness comes from an all-duplicates import, say so outright:
+        # "no photos in scope yet" reads as "photos are coming", but this
+        # run will import 0 new photos.
+        import_no_new = _import_without_new_files(params, photo_ids, new_count)
+        if import_no_new:
+            summary = (
+                "Will run — 0 new photos to import, nothing to process"
+                if not previews_skipped
+                else "Will run for thumbnails — 0 new photos to import, "
+                     "nothing to process (previews skipped: serves "
+                     "originals at full resolution)"
+            )
+        else:
+            summary = (
+                "Will run — no photos in scope yet"
+                if not previews_skipped
+                else "Will run for thumbnails — no photos in scope (previews "
+                     "skipped: serves originals at full resolution)"
+            )
         return {
             "state": "will-run",
             "summary": summary,
@@ -681,6 +736,7 @@ def _previews_plan(db, params, photo_ids, new_count, effective_cfg):
                 "preview_size": preview_size,
                 "previews_skipped": previews_skipped,
                 "new_photos": 0,
+                "import_no_new": import_no_new,
             },
         }
 
@@ -1132,8 +1188,13 @@ def compute_plan(db, params, db_path):
     extract = _extract_plan(db, params, photo_ids, pipeline_cfg, new_count)
     eye = _eye_keypoints_plan(db, params, photo_ids, pipeline_cfg, new_count)
     previews = _previews_plan(db, params, photo_ids, new_count, effective_cfg)
-    upstream_will_run = any(
-        s["state"] == "will-run" for s in (classify, extract, eye)
+    # An all-duplicates import leaves every upstream stage "will-run" over
+    # an empty photo set — that is not new work, and letting it force the
+    # Group stage into "upstream stages have new work to do" would be a
+    # false claim. Fall through to Group's own cache/fingerprint check.
+    upstream_will_run = (
+        not _import_without_new_files(params, photo_ids, new_count)
+        and any(s["state"] == "will-run" for s in (classify, extract, eye))
     )
     regroup = _regroup_plan(db, params, db_path, ws_id, upstream_will_run, effective_cfg)
 

--- a/vireo/pipeline_plan.py
+++ b/vireo/pipeline_plan.py
@@ -58,6 +58,12 @@ class PipelinePlanParams:
     # at plan time, since hashing thousands of files synchronously inside
     # a plan request would block the UI on every settings change.
     hash_duplicate_paths: list | None = None
+    # True when the import run stages files on local disk first (copy mode
+    # with the "Use local disk while processing" toggle on). This changes
+    # what the post-ingest scan walks — the local staging root instead of
+    # the real destination — which is why _import_without_new_files() is
+    # only safe to assert in this mode (see its docstring).
+    local_processing: bool = False
     # Optional API override for the preview tier. Normal pipeline runs leave
     # this unset so the previews substage uses the workspace-effective
     # preview_max_size setting. Explicit 0 means "serve originals"; the
@@ -168,9 +174,23 @@ def _import_without_new_files(params, photo_ids, new_count):
     at other, already-cataloged paths). The per-photo stages will all
     execute over an empty set, so their "Will run" summaries must say the
     run imports 0 new photos instead of implying work is coming.
+
+    Only asserted for local-processing imports. In plain copy mode the
+    claim isn't airtight: when ingest copies nothing (everything
+    deduplicated), the post-ingest scan runs with ``restrict=None`` over
+    the REAL destination tree, and ``scanner.scan`` fires the photo
+    callback for existing cataloged rows there — so downstream
+    workspace-scoped stages (classify/extract/regroup) can still find
+    real work among previously-unprocessed destination photos. With
+    local processing on, the post-ingest scan targets the local staging
+    root instead, which stays empty when every file deduplicates (ingest
+    creates the staging dir but copies nothing into it), so "nothing
+    to …" is genuinely true. Copy mode keeps the pre-existing
+    forward-looking summaries and lets Group see upstream will-run.
     """
     return (
-        params.source_paths is not None
+        params.local_processing
+        and params.source_paths is not None
         and new_count == 0
         and not photo_ids
     )

--- a/vireo/pipeline_plan.py
+++ b/vireo/pipeline_plan.py
@@ -863,7 +863,8 @@ def _previews_plan(db, params, photo_ids, new_count, effective_cfg):
     }
 
 
-def _regroup_plan(db, params, db_path, ws_id, upstream_will_run, effective_cfg):
+def _regroup_plan(db, params, db_path, ws_id, upstream_will_run, effective_cfg,
+                  import_no_new=False):
     if params.skip_regroup:
         return {
             "state": "will-skip",
@@ -873,6 +874,23 @@ def _regroup_plan(db, params, db_path, ws_id, upstream_will_run, effective_cfg):
         os.path.dirname(db_path), f"pipeline_results_ws{ws_id}.json",
     )
     cache_exists = os.path.exists(cache_path)
+    if import_no_new:
+        # All-duplicates local-processing import: ingest copies nothing into
+        # the staging root, the post-ingest scan collects 0 photos, so the
+        # job never creates a collection (collection_stage returns on
+        # `if not collected_photo_ids`) and regroup_stage skips on
+        # `not collection_id` (pipeline_job.py). The cache/fingerprint
+        # checks below would promise a Group run the job cannot perform —
+        # say the truth instead.
+        return {
+            "state": "will-skip",
+            "summary": "Will skip — 0 new photos to import, nothing to group",
+            "detail": {
+                "cache_exists": cache_exists,
+                "upstream_will_run": False,
+                "import_no_new": True,
+            },
+        }
     if upstream_will_run:
         return {
             "state": "will-run",
@@ -1211,12 +1229,18 @@ def compute_plan(db, params, db_path):
     # An all-duplicates import leaves every upstream stage "will-run" over
     # an empty photo set — that is not new work, and letting it force the
     # Group stage into "upstream stages have new work to do" would be a
-    # false claim. Fall through to Group's own cache/fingerprint check.
+    # false claim. It also means the job never builds a collection, so
+    # regroup_stage itself will skip — _regroup_plan reports "Will skip"
+    # instead of falling through to its cache/fingerprint check.
+    import_no_new = _import_without_new_files(params, photo_ids, new_count)
     upstream_will_run = (
-        not _import_without_new_files(params, photo_ids, new_count)
+        not import_no_new
         and any(s["state"] == "will-run" for s in (classify, extract, eye))
     )
-    regroup = _regroup_plan(db, params, db_path, ws_id, upstream_will_run, effective_cfg)
+    regroup = _regroup_plan(
+        db, params, db_path, ws_id, upstream_will_run, effective_cfg,
+        import_no_new=import_no_new,
+    )
 
     stages = {
         "Previews": previews,

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -908,7 +908,7 @@ body { padding-bottom: 36px; }
           <div class="setting-row">
             <div class="setting-item">
               <label style="font-size:12px;color:var(--text-secondary);cursor:pointer;">
-                <input type="checkbox" id="chkLocalProcessing" style="accent-color:var(--accent);" onchange="updateStartButton()" data-testid="local-processing-toggle"> Use local disk while processing
+                <input type="checkbox" id="chkLocalProcessing" style="accent-color:var(--accent);" onchange="updateStartButton(); schedulePlanRefresh()" data-testid="local-processing-toggle"> Use local disk while processing
               </label>
               <div style="font-size:11px;color:var(--text-dim);margin-top:4px;line-height:1.4;">
                 Files are staged locally for faster processing, then archived to the destination after verification.
@@ -4876,6 +4876,18 @@ function _buildPlanBody() {
         if (_duplicateResults[p]) hashDupPaths.push(p);
       });
       if (hashDupPaths.length) body.hash_duplicate_paths = hashDupPaths;
+    }
+
+    // The planner's "0 new photos to import, nothing to …" claim for an
+    // all-duplicates selection is only true in local-processing mode:
+    // the post-ingest scan then walks the local staging root (empty when
+    // everything deduplicated), while plain copy mode re-scans the real
+    // destination and can surface existing unprocessed rows as downstream
+    // work. Send the toggle state so the backend can tell the modes
+    // apart — mirrors how /api/jobs/pipeline carries local_processing.
+    if (_sourceMode === 'import' && _copyMode) {
+      var lp = document.getElementById('chkLocalProcessing');
+      body.local_processing = !!(lp && lp.checked);
     }
   }
 

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -4658,6 +4658,10 @@ function _formatPillLabel(stage, planEntry, state) {
   if (eligible === null || eligible === 0) {
     if (state === 'will-run' && labelSetChanged) return 'Different label set';
     if (state === 'will-run' && outdated) return 'Outdated';
+    // All-duplicates import: the stage executes but processes nothing.
+    // A bare "Will run" pill reads as "work will happen" — put the zero
+    // on the pill itself so the user doesn't have to open the card.
+    if (state === 'will-run' && detail.import_no_new) return 'Will run (0 photos)';
     return state === 'done-prior' ? 'Already done' : 'Will run';
   }
 

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -306,6 +306,72 @@ def test_pipeline_local_processing_archives_to_final_destination(
     assert job["result"]["archive"]["final_destination"] == str(final_dest)
 
 
+def test_pipeline_local_processing_all_duplicates_is_clean_noop(
+    setup, tmp_path, monkeypatch
+):
+    """Re-running a local-processing import whose files are ALL already in
+    the library must complete as a clean no-op: ingest skips every file,
+    nothing reaches staging, and the archive stage merges the empty staging
+    root into the existing archive without failing or duplicating photos.
+    Regression guard for the "restart a failed import by re-running it"
+    flow — the retry must stay a safe no-op when everything already made
+    it across on the earlier attempt."""
+    app, db_path = setup
+    src = tmp_path / "card"
+    src.mkdir()
+    final_parent = tmp_path / "nas"
+    final_parent.mkdir()
+    final_dest = final_parent / "Photos"
+
+    img = Image.new("RGB", (16, 16), "white")
+    img.save(src / "test.jpg")
+
+    import local_processing
+
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    monkeypatch.setattr(local_processing, "RESERVED_FREE_BYTES", 0)
+
+    body = {
+        "sources": [str(src)],
+        "destination": str(final_dest),
+        "local_processing": True,
+        "folder_template": "",
+        "skip_duplicates": True,
+        "skip_classify": True,
+        "skip_extract_masks": True,
+        "skip_regroup": True,
+    }
+    with app.test_client() as c:
+        resp = c.post("/api/jobs/pipeline", json=body)
+        assert resp.status_code == 200
+        first = wait_for_job_via_client(c, resp.get_json()["job_id"])
+        assert first["status"] == "completed", first
+
+        # Second run: the same card, every file now a known duplicate.
+        resp = c.post("/api/jobs/pipeline", json=body)
+        assert resp.status_code == 200
+        second = wait_for_job_via_client(c, resp.get_json()["job_id"])
+
+    assert second["status"] == "completed", second
+    assert second["result"]["archive"]["moved"] == 0, second
+    # Pin the path under test: the file must have been SKIPPED by the
+    # duplicate gate, not re-copied and then deduplicated at the merge.
+    ingest_step = next(
+        s for s in second.get("steps", []) if s.get("id") == "ingest"
+    )
+    assert "skipped" in (ingest_step.get("summary") or ""), ingest_step
+    assert "copied" not in (ingest_step.get("summary") or ""), ingest_step
+    # The first run's archived file is untouched and still cataloged once.
+    assert (final_dest / "test.jpg").is_file()
+    from db import Database
+    db = Database(db_path)
+    n = db.conn.execute(
+        "SELECT COUNT(*) FROM photos WHERE filename = 'test.jpg'"
+    ).fetchone()[0]
+    db.close()
+    assert n == 1
+
+
 def test_pipeline_local_processing_merges_into_tracked_destination(
     setup, tmp_path, monkeypatch
 ):

--- a/vireo/tests/test_pipeline_plan.py
+++ b/vireo/tests/test_pipeline_plan.py
@@ -2444,6 +2444,76 @@ def test_import_plan_deduplicates_source_paths(tmp_path, monkeypatch):
     assert plan_mixed["stages"]["Scan"]["detail"]["already_known"] == 1
 
 
+def test_import_plan_all_duplicates_reports_zero_new_photos(
+    tmp_path, monkeypatch
+):
+    """The re-inserted SD card: every selected file is already in the
+    library via the hash/metadata duplicate gate, so the run will import
+    0 new photos and every per-photo stage executes over an empty set.
+    The summaries must say that outright — "no photos in scope yet" and
+    "MegaDetector will run first" read as "work is coming" when none is —
+    and Group must not claim upstream stages have new work to do."""
+    import pipeline as pipeline_mod
+    from pipeline_plan import compute_plan
+    db, _ = _make_db(tmp_path)
+    _stub_models(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        pipeline_mod, "eye_keypoint_stage_preflight", lambda config: None,
+    )
+    paths = ["/cards/SD/IMG_001.NEF", "/cards/SD/IMG_002.NEF"]
+    plan = compute_plan(
+        db,
+        _import_params(
+            paths,
+            model_ids=["m1"],
+            hash_duplicate_paths=list(paths),
+            skip_eye_keypoints=False,
+            skip_regroup=False,
+        ),
+        str(tmp_path / "test.db"),
+    )
+    assert plan["scope"]["new_count"] == 0
+    assert plan["scope"]["known_count"] == 2
+    for suffix in ("Previews", "Classify", "Extract", "EyeKeypoints"):
+        stage = plan["stages"][suffix]
+        assert stage["state"] == "will-run", (suffix, stage)
+        assert "0 new photos to import" in stage["summary"], (suffix, stage)
+        assert stage["detail"]["import_no_new"] is True, (suffix, stage)
+    group = plan["stages"]["Group"]
+    assert "upstream stages have new work" not in group["summary"], group
+
+
+def test_import_plan_with_new_files_keeps_forward_looking_summaries(
+    tmp_path, monkeypatch
+):
+    """Contrast case: an import that DOES bring new files must keep the
+    counting summaries and never claim "0 new photos to import"."""
+    import pipeline as pipeline_mod
+    from pipeline_plan import compute_plan
+    db, _ = _make_db(tmp_path)
+    _stub_models(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        pipeline_mod, "eye_keypoint_stage_preflight", lambda config: None,
+    )
+    plan = compute_plan(
+        db,
+        _import_params(
+            ["/cards/SD/IMG_001.NEF", "/cards/SD/IMG_002.NEF"],
+            model_ids=["m1"],
+            skip_eye_keypoints=False,
+            skip_regroup=False,
+        ),
+        str(tmp_path / "test.db"),
+    )
+    assert plan["scope"]["new_count"] == 2
+    for suffix in ("Previews", "Classify", "Extract", "EyeKeypoints"):
+        stage = plan["stages"][suffix]
+        assert stage["state"] == "will-run", (suffix, stage)
+        assert "0 new photos to import" not in stage["summary"], (suffix, stage)
+        assert not stage["detail"].get("import_no_new"), (suffix, stage)
+    assert plan["stages"]["Group"]["state"] == "will-run"
+
+
 def test_import_plan_all_known_scan_is_done_prior(tmp_path):
     """If every preview file is already in the DB, Scan reports done-prior
     (the run will be a no-op for the scan step). Other stages reflect

--- a/vireo/tests/test_pipeline_plan.py
+++ b/vireo/tests/test_pipeline_plan.py
@@ -2453,8 +2453,11 @@ def test_import_plan_all_duplicates_reports_zero_new_photos(
     over an empty set — the post-ingest scan walks the local staging root,
     which stays empty when everything deduplicated.
     The summaries must say that outright — "no photos in scope yet" and
-    "MegaDetector will run first" read as "work is coming" when none is —
-    and Group must not claim upstream stages have new work to do."""
+    "MegaDetector will run first" read as "work is coming" when none is.
+    Group must report "Will skip": with 0 collected photos the job never
+    creates a collection, and regroup_stage skips on `not collection_id` —
+    so any "Will run" claim (upstream work, no cached grouping, stale
+    cache) would promise a Group run the job cannot perform."""
     import pipeline as pipeline_mod
     from pipeline_plan import compute_plan
     db, _ = _make_db(tmp_path)
@@ -2483,7 +2486,12 @@ def test_import_plan_all_duplicates_reports_zero_new_photos(
         assert "0 new photos to import" in stage["summary"], (suffix, stage)
         assert stage["detail"]["import_no_new"] is True, (suffix, stage)
     group = plan["stages"]["Group"]
-    assert "upstream stages have new work" not in group["summary"], group
+    assert group["state"] == "will-skip", group
+    assert "nothing to group" in group["summary"], group
+    assert "0 new photos to import" in group["summary"], group
+    assert group["detail"]["import_no_new"] is True, group
+    assert group["detail"]["upstream_will_run"] is False, group
+    assert "cache_exists" in group["detail"], group
 
 
 def test_import_plan_all_duplicates_copy_mode_keeps_forward_summaries(

--- a/vireo/tests/test_pipeline_plan.py
+++ b/vireo/tests/test_pipeline_plan.py
@@ -2447,12 +2447,57 @@ def test_import_plan_deduplicates_source_paths(tmp_path, monkeypatch):
 def test_import_plan_all_duplicates_reports_zero_new_photos(
     tmp_path, monkeypatch
 ):
-    """The re-inserted SD card: every selected file is already in the
-    library via the hash/metadata duplicate gate, so the run will import
-    0 new photos and every per-photo stage executes over an empty set.
+    """The re-inserted SD card (local-processing mode): every selected
+    file is already in the library via the hash/metadata duplicate gate,
+    so the run will import 0 new photos and every per-photo stage executes
+    over an empty set — the post-ingest scan walks the local staging root,
+    which stays empty when everything deduplicated.
     The summaries must say that outright — "no photos in scope yet" and
     "MegaDetector will run first" read as "work is coming" when none is —
     and Group must not claim upstream stages have new work to do."""
+    import pipeline as pipeline_mod
+    from pipeline_plan import compute_plan
+    db, _ = _make_db(tmp_path)
+    _stub_models(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        pipeline_mod, "eye_keypoint_stage_preflight", lambda config: None,
+    )
+    paths = ["/cards/SD/IMG_001.NEF", "/cards/SD/IMG_002.NEF"]
+    plan = compute_plan(
+        db,
+        _import_params(
+            paths,
+            model_ids=["m1"],
+            hash_duplicate_paths=list(paths),
+            local_processing=True,
+            skip_eye_keypoints=False,
+            skip_regroup=False,
+        ),
+        str(tmp_path / "test.db"),
+    )
+    assert plan["scope"]["new_count"] == 0
+    assert plan["scope"]["known_count"] == 2
+    for suffix in ("Previews", "Classify", "Extract", "EyeKeypoints"):
+        stage = plan["stages"][suffix]
+        assert stage["state"] == "will-run", (suffix, stage)
+        assert "0 new photos to import" in stage["summary"], (suffix, stage)
+        assert stage["detail"]["import_no_new"] is True, (suffix, stage)
+    group = plan["stages"]["Group"]
+    assert "upstream stages have new work" not in group["summary"], group
+
+
+def test_import_plan_all_duplicates_copy_mode_keeps_forward_summaries(
+    tmp_path, monkeypatch
+):
+    """Contrast case for the above: same all-duplicates selection but in
+    plain copy mode (local_processing off). Here "nothing to …" would
+    overclaim: with no copied paths the post-ingest scan runs with
+    restrict=None over the REAL destination, and scanner.scan fires the
+    photo callback for existing cataloged rows there — so downstream
+    workspace-scoped stages can still find real work among
+    previously-unprocessed destination photos. The plan must keep the
+    pre-existing forward-looking summaries and let Group see upstream
+    as will-run."""
     import pipeline as pipeline_mod
     from pipeline_plan import compute_plan
     db, _ = _make_db(tmp_path)
@@ -2477,17 +2522,20 @@ def test_import_plan_all_duplicates_reports_zero_new_photos(
     for suffix in ("Previews", "Classify", "Extract", "EyeKeypoints"):
         stage = plan["stages"][suffix]
         assert stage["state"] == "will-run", (suffix, stage)
-        assert "0 new photos to import" in stage["summary"], (suffix, stage)
-        assert stage["detail"]["import_no_new"] is True, (suffix, stage)
+        assert "0 new photos to import" not in stage["summary"], (suffix, stage)
+        assert not stage["detail"].get("import_no_new"), (suffix, stage)
+    assert "no photos in scope yet" in plan["stages"]["Previews"]["summary"]
     group = plan["stages"]["Group"]
-    assert "upstream stages have new work" not in group["summary"], group
+    assert group["state"] == "will-run"
+    assert "upstream stages have new work" in group["summary"], group
 
 
 def test_import_plan_with_new_files_keeps_forward_looking_summaries(
     tmp_path, monkeypatch
 ):
     """Contrast case: an import that DOES bring new files must keep the
-    counting summaries and never claim "0 new photos to import"."""
+    counting summaries and never claim "0 new photos to import" — even in
+    local-processing mode, where the all-duplicates wording is allowed."""
     import pipeline as pipeline_mod
     from pipeline_plan import compute_plan
     db, _ = _make_db(tmp_path)
@@ -2500,6 +2548,7 @@ def test_import_plan_with_new_files_keeps_forward_looking_summaries(
         _import_params(
             ["/cards/SD/IMG_001.NEF", "/cards/SD/IMG_002.NEF"],
             model_ids=["m1"],
+            local_processing=True,
             skip_eye_keypoints=False,
             skip_regroup=False,
         ),
@@ -2676,6 +2725,36 @@ def test_api_pipeline_plan_rejects_non_string_source_paths_elements(app_and_db):
         },
     )
     assert resp.status_code == 400
+
+
+def test_api_pipeline_plan_parses_local_processing(app_and_db):
+    """The route must thread local_processing through to the planner: an
+    all-duplicates import only gets the "0 new photos to import" wording
+    when the flag is true (staging-root scan), never in plain copy mode
+    (destination re-scan can surface real downstream work)."""
+    app, _ = app_and_db
+    client = app.test_client()
+    body = {
+        "source_paths": ["/cards/SD/IMG_001.NEF", "/cards/SD/IMG_002.NEF"],
+        "hash_duplicate_paths": [
+            "/cards/SD/IMG_001.NEF", "/cards/SD/IMG_002.NEF",
+        ],
+        "skip_classify": True, "skip_extract_masks": True,
+        "skip_eye_keypoints": True, "skip_regroup": True,
+    }
+    resp = client.post(
+        "/api/pipeline/plan", json={**body, "local_processing": True},
+    )
+    assert resp.status_code == 200
+    previews = resp.get_json()["stages"]["Previews"]
+    assert previews["detail"]["import_no_new"] is True
+    assert "0 new photos to import" in previews["summary"]
+
+    resp = client.post("/api/pipeline/plan", json=body)  # copy mode
+    assert resp.status_code == 200
+    previews = resp.get_json()["stages"]["Previews"]
+    assert not previews["detail"].get("import_no_new")
+    assert "0 new photos to import" not in previews["summary"]
 
 
 def test_import_plan_empty_source_paths_is_no_op(tmp_path, monkeypatch):


### PR DESCRIPTION
## What changed

Re-inserting an already-imported card left the Process page claiming **"5789 already imported"** while every stage pill said a bare **WILL RUN** — "no photos in scope yet", "MegaDetector will run first", "upstream stages have new work to do". That reads as "a full processing run is coming" when the run would import and process **0 photos**.

- **`pipeline_plan.py`**: new `_import_without_new_files()` detects import mode where every selected file is already in the library (hash/metadata duplicate gate) and no known copy falls into scope. The Previews/Classify/Extract/EyeKeypoints empty-scope summaries now say **"Will run — 0 new photos to import, nothing to …"** and carry `detail.import_no_new` for the UI.
- **Group stage honesty**: an all-duplicates import no longer forces "Will re-group — upstream stages have new work to do" (upstream has zero work). The regroup plan falls through to its own cache/fingerprint check.
- **`pipeline.html`**: the pill itself renders **"Will run (0 photos)"** instead of a bare "Will run" when `import_no_new` is set, so the zero is visible without opening the card.

## Regression coverage

- `test_import_plan_all_duplicates_reports_zero_new_photos` — fails on main (bare summaries, phantom Group claim), passes here.
- `test_import_plan_with_new_files_keeps_forward_looking_summaries` — contrast guard: imports with new files keep the counting summaries.
- `test_pipeline_local_processing_all_duplicates_is_clean_noop` — pins the end-to-end behavior of re-running a local-processing import whose files all already made it: ingest skips everything, the archive stage merges the empty staging root cleanly, no duplicate photo rows. This is the "restart a failed import by re-running it" recovery path; it already worked, now it's guarded.

## Test results

`1628 passed, 1 skipped` across workspaces, db, app, photos/edits/jobs/darktable/config APIs, pipeline plan/api/job, and local processing suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pipeline planning now better reflects local-disk processing, showing when a run has “0 new photos” and when stages will actually do work.
  * The pipeline UI updates its plan status more accurately for duplicate-only selections.

* **Bug Fixes**
  * Fixed incorrect “will run” messaging for duplicate-only imports.
  * Grouping and preview/extract stages now skip or summarize empty-work runs correctly.

* **Tests**
  * Added regression coverage for local-processing duplicate imports and pipeline plan behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->