### PR TITLE
Serve with waitress instead of the Flask dev server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "exifread>=3.0",
     "send2trash>=1.8.0",
     "tokenizers>=0.21.0",
+    "waitress>=3.0.2",
 ]
 
 [project.optional-dependencies]

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -19523,7 +19523,13 @@ def main():
         token=api_token, mode=mode,
     )
 
-    app.run(host="127.0.0.1", port=port, debug=False, threaded=True)
+    # Waitress uses a fixed thread pool (default 4). Each open SSE stream
+    # (bottom-panel logs, job progress, import duplicate check) pins one
+    # thread for its whole lifetime, so the pool must be sized well above
+    # the plausible number of concurrent streams or page loads queue
+    # behind them and the app appears frozen.
+    from waitress import serve as waitress_serve
+    waitress_serve(app, host="127.0.0.1", port=port, threads=16)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- Replaced `app.run(...)` with `waitress.serve(app, host="127.0.0.1", port=port, threads=16)` in `vireo/app.py`.
- Added `waitress>=3.0.2` to `pyproject.toml` dependencies.

## Why

The Flask dev server isn't meant for deployment: single process, unbounded per-request threads, less robust socket handling. Waitress is a production-quality pure-Python WSGI server (the one Flask's own deployment docs recommend), and being pure Python it bundles cleanly into the PyInstaller sidecar with no extra spec changes — it's traced from the static import.

`threads=16` rather than waitress's default of 4 is load-bearing: each open SSE stream (bottom-panel log stream, job progress, import duplicate check) pins a pool thread for its whole lifetime. With the default pool, two open streams plus one slow request would starve page loads.

## Notes

- `uv.lock` is intentionally untouched: it's already stale relative to pyproject on main (added once in 0b92f3fe, never updated through three release bumps), CI installs with `pip install -e .` so it isn't used there, and regenerating it currently fails on a pre-existing conflict in the `export` extra (deeplabcut pins numpy<2 vs the project's numpy>=2.4.2). That's a separate cleanup.

## Testing

- Full suite from project CLAUDE.md: **1253 passed, 1 skipped** (test_workspaces, test_db, test_app, test_photos_api, test_edits_api, test_jobs_api, test_darktable_api, test_config).
- Live smoke test against a running instance (isolated HOME/db): `Server: waitress` header confirmed; `/` redirects to `/welcome` → 200; `/api/logs/stream` delivers SSE events and keepalives; with **6 concurrent SSE streams held open**, `/` and `/api/version` still respond in ~1ms — the scenario that would deadlock waitress's default 4-thread pool.
- `ruff check` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)