### PR TITLE
Local adjustments PR 1: renderer + schema (subject/background via SAM masks)

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -9372,7 +9372,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     img, recipe,
                     native_size=_recipe_source_dimensions(photo),
                     local_mask=_local_masks.load_snapshot(
-                        os.path.dirname(db_path), photo["id"], recipe,
+                        vireo_dir, photo["id"], recipe,
                     ),
                 )
                 quality = cfg.load().get("working_copy_quality", 92)
@@ -9713,7 +9713,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # aged-out snapshot files (no current recipe or edit-history entry
         # points at them) are reclaimed alongside stale live masks.
         import local_masks
-        gc = local_masks.gc_edit_masks(db, os.path.dirname(db_path))
+        # Snapshots live under dirname(THUMB_CACHE_DIR) — the same root the
+        # snapshot POST endpoint writes to and every render call site reads
+        # from — which is not always dirname(db_path) when create_app is
+        # given a custom thumb-dir under a different parent.
+        gc = local_masks.gc_edit_masks(
+            db, os.path.dirname(app.config["THUMB_CACHE_DIR"])
+        )
         if gc["deleted"]:
             log.info(
                 "Deleted %d unreferenced edit-mask snapshots", gc["deleted"]
@@ -11714,7 +11720,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 img, recipe,
                 native_size=_recipe_source_dimensions(photo),
                 local_mask=_local_masks.load_snapshot(
-                    os.path.dirname(db_path), photo["id"], recipe,
+                    vireo_dir, photo["id"], recipe,
                 ),
             )
             quality = cfg.load().get("working_copy_quality", 92)
@@ -13455,7 +13461,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                                     detail_photo
                                 ),
                                 local_mask=local_masks.load_snapshot(
-                                    os.path.dirname(db_path),
+                                    vireo_dir,
                                     photo["id"], recipe,
                                 ),
                             )
@@ -18593,7 +18599,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 img, recipe, max_size=size,
                 native_size=_recipe_source_dimensions(photo),
                 local_mask=local_masks.load_snapshot(
-                    os.path.dirname(db_path), photo_id, recipe,
+                    vireo_dir, photo_id, recipe,
                 ),
             )
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3969,10 +3969,54 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         photo = db.get_photo(photo_id, verify_workspace=True)
         if not photo:
             return json_error("not found", 404)
-        return jsonify({
-            "photo_id": photo_id,
-            "recipe": db.get_photo_edit_recipe(photo_id),
-        })
+        recipe = db.get_photo_edit_recipe(photo_id)
+        payload = {"photo_id": photo_id, "recipe": recipe}
+        if recipe and recipe.get("local"):
+            import local_masks
+            variant_row = db.conn.execute(
+                "SELECT active_mask_variant FROM photos WHERE id=?",
+                (photo_id,),
+            ).fetchone()
+            variant = variant_row["active_mask_variant"] if variant_row else None
+            mask_row = (
+                db.get_photo_mask(photo_id, variant) if variant else None
+            )
+            payload["local_mask_stale"] = local_masks.is_stale(
+                recipe, mask_row
+            )
+        return jsonify(payload)
+
+    @app.route(
+        "/api/photos/<int:photo_id>/local-mask/snapshot", methods=["POST"]
+    )
+    def api_create_local_mask_snapshot(photo_id):
+        """Freeze the photo's active SAM mask into an edit-mask snapshot.
+
+        Returns the recipe ``local.mask`` fields the editor embeds when
+        saving local adjustments. Renders read only the snapshot, so the
+        live mask can regenerate without silently changing committed edits.
+        """
+        db = _get_db()
+        photo = db.get_photo(photo_id, verify_workspace=True)
+        if not photo:
+            return json_error("not found", 404)
+        import local_masks
+        variant_row = db.conn.execute(
+            "SELECT active_mask_variant FROM photos WHERE id=?",
+            (photo_id,),
+        ).fetchone()
+        variant = variant_row["active_mask_variant"] if variant_row else None
+        mask_row = db.get_photo_mask(photo_id, variant) if variant else None
+        try:
+            mask = local_masks.create_snapshot(
+                photo_id=photo_id,
+                mask_row=mask_row,
+                vireo_dir=os.path.dirname(app.config["THUMB_CACHE_DIR"]),
+                native_size=_recipe_source_dimensions(photo),
+            )
+        except ValueError as e:
+            return json_error(str(e))
+        return jsonify({"mask": mask, "stale": False})
 
     @app.route("/api/photos/<int:photo_id>/edit-recipe", methods=["PUT", "POST"])
     def api_set_photo_edit_recipe(photo_id):
@@ -3989,7 +4033,23 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         photo = db.get_photo(photo_id, verify_workspace=True)
         if not photo:
             return json_error("not found", 404)
-        from image_edits import RecipeError, recipe_to_json
+        from image_edits import RecipeError, normalize_recipe, recipe_to_json
+        try:
+            normalized = normalize_recipe(recipe)
+        except RecipeError as e:
+            return json_error(str(e))
+        local = (normalized or {}).get("local")
+        if local:
+            import local_masks
+            snap = local_masks.snapshot_path(
+                os.path.dirname(app.config["THUMB_CACHE_DIR"]),
+                photo_id, local["mask"]["ref"],
+            )
+            if not os.path.exists(snap):
+                return json_error(
+                    "unknown edit-mask snapshot for this photo; create one "
+                    "via POST /api/photos/<id>/local-mask/snapshot first"
+                )
         old_recipe = db.get_photo_edit_recipe(photo_id)
         try:
             old_value = recipe_to_json(old_recipe) or ""
@@ -4050,6 +4110,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         recipe = body.get("recipe")
         if not isinstance(recipe, dict):
             return json_error("recipe must be a JSON object")
+        if recipe.get("local"):
+            return json_error(
+                "local adjustments cannot be bulk-applied: they reference a "
+                "photo-specific mask snapshot"
+            )
         raw_ids = body.get("photo_ids")
         if not isinstance(raw_ids, list) or not raw_ids:
             return json_error("photo_ids must be a non-empty list")
@@ -9182,6 +9247,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if not recipe:
                 return fallback_path, None
 
+            import local_masks as _local_masks
             from image_edits import (
                 EDIT_MATH_VERSION,
                 apply_recipe_to_loaded_image,
@@ -9305,6 +9371,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 rendered = apply_recipe_to_loaded_image(
                     img, recipe,
                     native_size=_recipe_source_dimensions(photo),
+                    local_mask=_local_masks.load_snapshot(
+                        os.path.dirname(db_path), photo["id"], recipe,
+                    ),
                 )
                 quality = cfg.load().get("working_copy_quality", 92)
                 fd, tmp_path = tempfile.mkstemp(
@@ -9640,7 +9709,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         )
         n = db.delete_stale_masks(detector_confidence=min_detector_conf)
         log.info("Deleted %d stale masks", n)
-        return jsonify({"ok": True, "deleted": n})
+        # Edit-mask snapshots piggyback on the same sweep: unreferenced,
+        # aged-out snapshot files (no current recipe or edit-history entry
+        # points at them) are reclaimed alongside stale live masks.
+        import local_masks
+        gc = local_masks.gc_edit_masks(db, os.path.dirname(db_path))
+        if gc["deleted"]:
+            log.info(
+                "Deleted %d unreferenced edit-mask snapshots", gc["deleted"]
+            )
+        return jsonify({
+            "ok": True, "deleted": n, "snapshots_deleted": gc["deleted"],
+        })
 
     @app.route("/api/storage/files")
     def api_storage_files():
@@ -11517,6 +11597,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not recipe:
             return fallback_path, None
 
+        import local_masks as _local_masks
         from image_edits import (
             EDIT_MATH_VERSION,
             apply_recipe_to_loaded_image,
@@ -11632,6 +11713,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             rendered = apply_recipe_to_loaded_image(
                 img, recipe,
                 native_size=_recipe_source_dimensions(photo),
+                local_mask=_local_masks.load_snapshot(
+                    os.path.dirname(db_path), photo["id"], recipe,
+                ),
             )
             quality = cfg.load().get("working_copy_quality", 92)
             fd, tmp_path = tempfile.mkstemp(
@@ -13364,10 +13448,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                                     canonical = companion_abs
                     if img:
                         if recipe:
+                            import local_masks
                             img = apply_recipe_to_loaded_image(
                                 img, recipe, max_size=max_size,
                                 native_size=_recipe_source_dimensions(
                                     detail_photo
+                                ),
+                                local_mask=local_masks.load_snapshot(
+                                    os.path.dirname(db_path),
+                                    photo["id"], recipe,
                                 ),
                             )
                         img.save(cache_path, format="JPEG", quality=preview_quality)
@@ -18498,10 +18587,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             _record_working_copy_failure(db, photo, canonical)
             return "Could not load image", 500
         if recipe:
+            import local_masks
             from image_edits import apply_recipe_to_loaded_image
             img = apply_recipe_to_loaded_image(
                 img, recipe, max_size=size,
                 native_size=_recipe_source_dimensions(photo),
+                local_mask=local_masks.load_snapshot(
+                    os.path.dirname(db_path), photo_id, recipe,
+                ),
             )
 
         preview_quality = cfg.load().get("preview_quality", 90)
@@ -18755,10 +18848,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         native_dims,
                         recipe,
                     )
+            import local_masks
             img = apply_recipe_to_loaded_image(
                 img, recipe_json, max_size=size,
                 native_size=native_dims,
                 detail_scale=preview_detail_scale,
+                local_mask=local_masks.load_snapshot(
+                    vireo_dir, photo_id, recipe_json,
+                ),
             )
         except RecipeError as e:
             return str(e), 400
@@ -19018,10 +19115,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if img is None:
                 _record_working_copy_failure(db, photo, image_path)
                 return "Could not load image", 500
+            import local_masks
             from image_edits import apply_recipe_to_loaded_image
             img = apply_recipe_to_loaded_image(
                 img, recipe,
                 native_size=_recipe_source_dimensions(photo),
+                local_mask=local_masks.load_snapshot(
+                    vireo_dir, photo_id, recipe,
+                ),
             )
             originals_dir = os.path.join(vireo_dir, "originals")
             cache_path = os.path.join(originals_dir, f"{photo_id}.jpg")

--- a/vireo/export.py
+++ b/vireo/export.py
@@ -369,9 +369,13 @@ def export_photos(db, vireo_dir, photo_ids, destination, options=None, progress_
                     progress_cb(i + 1, len(photo_ids), photo["filename"])
                 continue
             if recipe:
+                import local_masks
                 img = apply_recipe_to_loaded_image(
                     img, recipe, max_size=max_size,
                     native_size=_recipe_source_dimensions(photo, exif_data),
+                    local_mask=local_masks.load_snapshot(
+                        vireo_dir, pid, recipe,
+                    ),
                 )
             _save_export_image(img, out_path, format_info, quality)
             img.close()

--- a/vireo/image_edits.py
+++ b/vireo/image_edits.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import json
 import math
+import re
 
 from PIL import Image
 
@@ -47,6 +48,18 @@ SHARPEN_RADIUS_DEFAULT = 1.0
 # per-pixel tone pipeline. A recipe containing only these must not run the
 # tone pass at all (so a detail-only edit stays byte-exact outside detail).
 _DETAIL_KEYS = frozenset({"sharpen", "sharpen_radius", "noise_reduction"})
+
+# Local (mask-weighted) adjustments — see
+# docs/plans/2026-07-03-local-adjustments-design.md. Region values are deltas
+# on top of the global adjustments and share the global ranges; the v1 set
+# deliberately excludes whites/blacks/vibrance/white-balance.
+_LOCAL_REGION_NAMES = ("subject", "background")
+_LOCAL_ADJUSTMENT_KEYS = frozenset({
+    "exposure", "highlights", "shadows", "contrast", "saturation",
+    "sharpen", "noise_reduction",
+})
+LOCAL_FEATHER_RANGE = (0.0, 200.0)
+_LOCAL_MASK_REF_RE = re.compile(r"^[0-9a-f]{12}$")
 
 _WHITE_BALANCE_RANGES = {
     "temperature": (-100.0, 100.0),
@@ -223,7 +236,120 @@ def normalize_recipe(recipe):
     if normalized_adjustments:
         out["adjustments"] = normalized_adjustments
 
+    local = recipe.get("local")
+    if local not in (None, "", {}):
+        normalized_local = _normalize_local(local)
+        if normalized_local is not None:
+            out["local"] = normalized_local
+
     return out if len(out) > 1 else None
+
+
+def _normalize_local(local):
+    """Validate and canonicalize the local (mask-weighted) section.
+
+    Returns None when every region normalizes away — the shared mask never
+    persists without at least one active region referencing it.
+    """
+    if not isinstance(local, dict):
+        raise RecipeError("local must be an object")
+
+    regions_in = local.get("regions")
+    if regions_in in (None, ""):
+        regions_in = []
+    if not isinstance(regions_in, list):
+        raise RecipeError("local.regions must be an array")
+
+    normalized_regions = []
+    seen = set()
+    for entry in regions_in:
+        if not isinstance(entry, dict):
+            raise RecipeError("local.regions entries must be objects")
+        region = entry.get("region")
+        if region not in _LOCAL_REGION_NAMES:
+            raise RecipeError("local region must be 'subject' or 'background'")
+        if region in seen:
+            raise RecipeError(f"duplicate local region '{region}'")
+        seen.add(region)
+
+        adjustments_in = entry.get("adjustments")
+        if adjustments_in is None:
+            adjustments_in = {}
+        if not isinstance(adjustments_in, dict):
+            raise RecipeError("local adjustments must be an object")
+        normalized_adj = {}
+        for name, raw in adjustments_in.items():
+            if raw in (None, ""):
+                continue
+            if name == "sharpen_radius":
+                # A region radius is an absolute override of the effective
+                # branch radius (which may come from global sharpen), so it
+                # is kept even without a region sharpen delta and its 1.0
+                # value is meaningful — no default-drop like the global key.
+                if isinstance(raw, bool) or not isinstance(raw, int | float):
+                    raise RecipeError(
+                        "sharpen_radius adjustment must be numeric"
+                    )
+                radius = float(raw)
+                lo, hi = SHARPEN_RADIUS_RANGE
+                if not math.isfinite(radius) or radius < lo or radius > hi:
+                    raise RecipeError(
+                        f"sharpen_radius adjustment must be between "
+                        f"{lo:g} and {hi:g}"
+                    )
+                normalized_adj[name] = round(radius, 6)
+                continue
+            if name not in _LOCAL_ADJUSTMENT_KEYS:
+                raise RecipeError(
+                    f"{name} adjustment is not supported in local regions"
+                )
+            if isinstance(raw, bool) or not isinstance(raw, int | float):
+                raise RecipeError(f"{name} adjustment must be numeric")
+            val = float(raw)
+            lo, hi = _ADJUSTMENT_RANGES[name]
+            if not math.isfinite(val) or val < lo or val > hi:
+                raise RecipeError(
+                    f"{name} adjustment must be between {lo:g} and {hi:g}"
+                )
+            if abs(val) > 1e-9:
+                normalized_adj[name] = round(val, 6)
+        if normalized_adj:
+            normalized_regions.append(
+                {"region": region, "adjustments": normalized_adj}
+            )
+
+    if not normalized_regions:
+        return None
+
+    mask_in = local.get("mask")
+    if not isinstance(mask_in, dict):
+        raise RecipeError("local.mask is required when regions are present")
+    ref = mask_in.get("ref")
+    if not isinstance(ref, str) or not _LOCAL_MASK_REF_RE.match(ref):
+        raise RecipeError(
+            "local.mask.ref must be a 12-character lowercase hex id"
+        )
+    digest = mask_in.get("source_digest")
+    if not isinstance(digest, str) or not digest.strip() or len(digest) > 128:
+        raise RecipeError("local.mask.source_digest is required")
+    normalized_mask = {"ref": ref, "source_digest": digest}
+
+    feather = mask_in.get("feather", 0)
+    if feather in (None, ""):
+        feather = 0
+    if isinstance(feather, bool) or not isinstance(feather, int | float):
+        raise RecipeError("local.mask.feather must be numeric")
+    feather = float(feather)
+    lo, hi = LOCAL_FEATHER_RANGE
+    if not math.isfinite(feather) or feather < lo or feather > hi:
+        raise RecipeError(
+            f"local.mask.feather must be between {lo:g} and {hi:g}"
+        )
+    if abs(feather) > 1e-9:
+        normalized_mask["feather"] = round(feather, 4)
+
+    normalized_regions.sort(key=lambda entry: entry["region"])
+    return {"mask": normalized_mask, "regions": normalized_regions}
 
 
 def recipe_to_json(recipe):

--- a/vireo/image_edits.py
+++ b/vireo/image_edits.py
@@ -365,13 +365,20 @@ def recipe_to_json(recipe):
 _ADJUST_TILE_PIXELS = 4_000_000
 
 
-def _apply_adjustments(img, adjustments):
+def _apply_adjustments(
+    img, adjustments, local_weight=None, local_subject=None,
+    local_background=None,
+):
     """Apply tonal adjustments to a PIL image via the linear tone pipeline.
 
     Bridges PIL <-> numpy: promotes the image to RGB(A), runs the shared
     per-pixel pipeline in :mod:`tone` (linear-light exposure/white balance with
     a highlight shoulder, then display-space tonal/color controls), and merges
-    any alpha channel back unchanged.
+    any alpha channel back unchanged. ``local_weight`` (a full-frame float
+    subject-weight array) plus per-region delta dicts route through the
+    weighted tone branch; the weight is sliced along the same row tiles as
+    the image, which keeps tiling numerically identical to a whole-frame
+    pass (the pipeline stays strictly per-pixel).
     """
     import numpy as np
 
@@ -420,6 +427,11 @@ def _apply_adjustments(img, adjustments):
             contrast=contrast,
             vibrance=vibrance,
             saturation=saturation,
+            local_weight=(
+                local_weight[top:bottom] if local_weight is not None else None
+            ),
+            local_subject=local_subject,
+            local_background=local_background,
         )
         out8[top:bottom, :, :3] = np.clip(adj * 255.0 + 0.5, 0, 255).astype(
             np.uint8
@@ -434,13 +446,13 @@ def _apply_adjustments(img, adjustments):
     return Image.fromarray(out8, "RGB")
 
 
-def apply_recipe(img, recipe):
-    """Apply a normalized edit recipe to a PIL image and return a new image."""
-    normalized = normalize_recipe(recipe)
-    if normalized is None:
-        return img
+def _apply_geometry(image, normalized):
+    """Apply the recipe's geometry ops (rotate/flip/straighten/crop).
 
-    result = img.copy()
+    Used for both the photo and the local-adjustment mask so their pixels
+    stay aligned through every transform.
+    """
+    result = image
 
     rotation = normalized.get("rotation", 0)
     if rotation:
@@ -473,13 +485,124 @@ def apply_recipe(img, recipe):
         bottom = max(top + 1, min(ih, bottom))
         result = result.crop((left, top, right, bottom))
 
+    return result
+
+
+_LOCAL_TONE_KEYS = frozenset(
+    {"exposure", "highlights", "shadows", "contrast", "saturation"}
+)
+
+
+def _local_region_deltas(local, keys):
+    """Split a normalized local section into (subject, background) dicts
+    restricted to ``keys``."""
+    subject = {}
+    background = {}
+    for entry in (local or {}).get("regions") or []:
+        target = subject if entry["region"] == "subject" else background
+        for name, value in entry["adjustments"].items():
+            if name in keys:
+                target[name] = value
+    return subject, background
+
+
+def _fit_mask_to_source(mask, size):
+    """Uniform-scale a snapshot mask onto the loaded source, or None.
+
+    None means the mask cannot be trusted to line up (aspect disagreement
+    beyond tolerance — e.g. an embedded-preview-crop RAW) and the local pass
+    must be disabled rather than misaligned.
+    """
+    try:
+        from .local_masks import ASPECT_TOLERANCE
+    except ImportError:
+        from local_masks import ASPECT_TOLERANCE
+
+    mask_w, mask_h = mask.size
+    target_w, target_h = size
+    if min(mask_w, mask_h, target_w, target_h) <= 0:
+        return None
+    target_ar = target_w / target_h
+    if abs(mask_w / mask_h - target_ar) / target_ar > ASPECT_TOLERANCE:
+        return None
+    if mask.size != size:
+        mask = mask.resize(size, Image.Resampling.BILINEAR)
+    return mask
+
+
+def _feathered_weight(mask_img, sigma):
+    """Mask image -> [0,1] float weight map, Gaussian-feathered by sigma."""
+    import numpy as np
+
+    arr = np.asarray(mask_img, dtype=np.float32) / 255.0
+    if sigma > 0.3:
+        try:
+            from .detail import _gaussian_blur
+        except ImportError:
+            from detail import _gaussian_blur
+        arr = _gaussian_blur(arr, sigma)
+    return np.clip(arr, 0.0, 1.0)
+
+
+def _apply_recipe_impl(img, normalized, local_mask, native_size):
+    """Geometry + weighted tone. Returns (image, geometry-transformed mask).
+
+    The returned mask is None whenever the local pass is disabled (no local
+    section, no usable mask) — callers must then skip local detail too, so a
+    degraded render fails toward "no local edits", never toward applying a
+    region edit to the whole frame.
+    """
+    local = normalized.get("local")
+    fitted = None
+    if local and local_mask is not None:
+        fitted = _fit_mask_to_source(local_mask, img.size)
+        if fitted is None:
+            import logging
+            logging.getLogger(__name__).warning(
+                "Local-adjustment mask does not fit the render source "
+                "(size %s vs mask %s); local pass disabled for this render",
+                img.size, local_mask.size,
+            )
+
+    result = _apply_geometry(img.copy(), normalized)
+    mask_geo = _apply_geometry(fitted, normalized) if fitted is not None else None
+
     adjustments = normalized.get("adjustments") or {}
     tone_adjustments = {
         k: v for k, v in adjustments.items() if k not in _DETAIL_KEYS
     }
-    if tone_adjustments:
+    subject_tone, background_tone = (
+        _local_region_deltas(local, _LOCAL_TONE_KEYS)
+        if mask_geo is not None else ({}, {})
+    )
+    if subject_tone or background_tone:
+        scale = detail_render_scale(result.size, native_size, normalized)
+        feather = (local["mask"].get("feather") or 0.0) * scale
+        weight = _feathered_weight(mask_geo, feather)
+        result = _apply_adjustments(
+            result, tone_adjustments,
+            local_weight=weight,
+            local_subject=subject_tone,
+            local_background=background_tone,
+        )
+    elif tone_adjustments:
         result = _apply_adjustments(result, tone_adjustments)
 
+    return result, mask_geo
+
+
+def apply_recipe(img, recipe, local_mask=None, native_size=None):
+    """Apply a normalized edit recipe to a PIL image and return a new image.
+
+    ``local_mask`` is the recipe's edit-mask snapshot (PIL 'L', source
+    working space — see local_masks.load_snapshot); without it any local
+    regions in the recipe are skipped. Note the detail pass (global and
+    local) runs in :func:`apply_recipe_to_loaded_image`, not here.
+    """
+    normalized = normalize_recipe(recipe)
+    if normalized is None:
+        return img
+    result, _ = _apply_recipe_impl(img, normalized, local_mask, native_size)
     return result
 
 
@@ -515,8 +638,32 @@ def detail_render_scale(rendered_size, native_size, recipe):
     return max(rendered_size) / native_long
 
 
+def _combine_detail(adjustments, region):
+    """Effective detail params for one region: global + delta, clamped.
+
+    ``sharpen_radius`` is an absolute override (a kernel size, not a
+    strength), falling back to the global radius.
+    """
+    def clamped(name):
+        lo, hi = _ADJUSTMENT_RANGES[name]
+        total = float(adjustments.get(name, 0.0)) + float(region.get(name, 0.0))
+        return min(hi, max(lo, total))
+
+    return {
+        "sharpen": clamped("sharpen"),
+        "sharpen_radius": float(
+            region.get(
+                "sharpen_radius",
+                adjustments.get("sharpen_radius", SHARPEN_RADIUS_DEFAULT),
+            )
+        ),
+        "noise_reduction": clamped("noise_reduction"),
+    }
+
+
 def apply_recipe_to_loaded_image(
     img, recipe, max_size=None, native_size=None, detail_scale=None,
+    local_mask=None,
 ):
     """Apply edits, constrain the long edge, then run the detail pass.
 
@@ -524,7 +671,10 @@ def apply_recipe_to_loaded_image(
     pixels, so they run last — at output resolution, with kernels scaled by
     ``detail_render_scale`` — approximating the full-resolution render
     downscaled. Callers that know the photo's native dimensions pass them via
-    ``native_size`` (see render_source.recipe_source_dimensions).
+    ``native_size`` (see render_source.recipe_source_dimensions); callers
+    rendering a recipe with local regions pass the loaded snapshot via
+    ``local_mask`` (see local_masks.load_snapshot) — without it any local
+    regions are skipped entirely.
 
     ``detail_scale`` overrides the scale computed from this call's recipe.
     Use it when rendering a modified recipe (e.g. the edit-preview endpoint
@@ -532,13 +682,70 @@ def apply_recipe_to_loaded_image(
     what the unmodified recipe's saved render would produce — otherwise a
     tighter crop scales sharpen/NR up in the saved output but not in the
     preview, and the two disagree for cropped detail edits.
+
+    Local detail runs as a two-branch blend: the detail pass executes once
+    per distinct (global + region delta) parameter set on the tone output,
+    and the outputs blend by the feathered weight map. A single pass can't
+    represent two regions (NR mutates the image before sharpening reads
+    it), and composing each branch with the global baseline guarantees
+    whole-photo sharpen/NR is never dropped when a local delta is added.
     """
     normalized = normalize_recipe(recipe)
-    result = apply_recipe(img, normalized)
+    if normalized is None:
+        result, mask_geo = img, None
+    else:
+        result, mask_geo = _apply_recipe_impl(
+            img, normalized, local_mask, native_size
+        )
     if max_size and max_size > 0 and max(result.size) > max_size:
         result.thumbnail((max_size, max_size), resample=Image.Resampling.LANCZOS)
 
     adjustments = (normalized or {}).get("adjustments") or {}
+    local = (normalized or {}).get("local")
+    scale = (
+        detail_scale
+        if detail_scale is not None
+        else detail_render_scale(result.size, native_size, normalized)
+    )
+
+    subject_detail, background_detail = (
+        _local_region_deltas(local, _DETAIL_KEYS)
+        if (local and mask_geo is not None) else ({}, {})
+    )
+    if subject_detail or background_detail:
+        import numpy as np
+
+        try:
+            from .detail import apply_detail
+        except ImportError:
+            from detail import apply_detail
+
+        subject_params = _combine_detail(adjustments, subject_detail)
+        background_params = _combine_detail(adjustments, background_detail)
+        if subject_params == background_params:
+            if subject_params["sharpen"] or subject_params["noise_reduction"]:
+                result = apply_detail(result, scale=scale, **subject_params)
+            return result
+        subject_out = apply_detail(result, scale=scale, **subject_params)
+        background_out = apply_detail(result, scale=scale, **background_params)
+        feather = (local["mask"].get("feather") or 0.0) * scale
+        weight = _feathered_weight(
+            mask_geo.resize(subject_out.size, Image.Resampling.BILINEAR),
+            feather,
+        )[..., None]
+        subject_arr = np.asarray(subject_out).astype(np.float32)
+        background_arr = np.asarray(background_out).astype(np.float32)
+        blended = subject_arr.copy()
+        blended[..., :3] = (
+            subject_arr[..., :3] * weight
+            + background_arr[..., :3] * (1.0 - weight)
+        )
+        out8 = np.clip(blended + 0.5, 0, 255).astype(np.uint8)
+        if out8.shape[-1] == 4:
+            # Alpha passes through unchanged (identical in both branches).
+            out8[..., 3] = np.asarray(subject_out)[..., 3]
+        return Image.fromarray(out8, subject_out.mode)
+
     sharpen = adjustments.get("sharpen", 0.0)
     noise_reduction = adjustments.get("noise_reduction", 0.0)
     if sharpen or noise_reduction:
@@ -547,11 +754,6 @@ def apply_recipe_to_loaded_image(
         except ImportError:
             from detail import apply_detail
 
-        scale = (
-            detail_scale
-            if detail_scale is not None
-            else detail_render_scale(result.size, native_size, normalized)
-        )
         result = apply_detail(
             result,
             sharpen=sharpen,

--- a/vireo/image_edits.py
+++ b/vireo/image_edits.py
@@ -544,13 +544,23 @@ def _feathered_weight(mask_img, sigma):
     return np.clip(arr, 0.0, 1.0)
 
 
-def _apply_recipe_impl(img, normalized, local_mask, native_size):
+def _apply_recipe_impl(
+    img, normalized, local_mask, native_size, detail_scale=None,
+):
     """Geometry + weighted tone. Returns (image, geometry-transformed mask).
 
     The returned mask is None whenever the local pass is disabled (no local
     section, no usable mask) — callers must then skip local detail too, so a
     degraded render fails toward "no local edits", never toward applying a
     region edit to the whole frame.
+
+    ``detail_scale`` overrides the scale used to convert ``local.mask.feather``
+    (native pixels) into a blur sigma for the tone pass. Callers that also
+    override the scale for the detail pass (e.g. the edit-preview endpoint,
+    which strips crop from the recipe but wants the saved-render scale) must
+    pass the same override here — otherwise the tone falloff uses the scale
+    computed from the crop-stripped recipe while detail uses the saved-render
+    scale, and preview mask geometry disagrees with the saved output.
     """
     local = normalized.get("local")
     fitted = None
@@ -576,7 +586,11 @@ def _apply_recipe_impl(img, normalized, local_mask, native_size):
         if mask_geo is not None else ({}, {})
     )
     if subject_tone or background_tone:
-        scale = detail_render_scale(result.size, native_size, normalized)
+        scale = (
+            detail_scale
+            if detail_scale is not None
+            else detail_render_scale(result.size, native_size, normalized)
+        )
         feather = (local["mask"].get("feather") or 0.0) * scale
         weight = _feathered_weight(mask_geo, feather)
         result = _apply_adjustments(
@@ -695,7 +709,8 @@ def apply_recipe_to_loaded_image(
         result, mask_geo = img, None
     else:
         result, mask_geo = _apply_recipe_impl(
-            img, normalized, local_mask, native_size
+            img, normalized, local_mask, native_size,
+            detail_scale=detail_scale,
         )
     if max_size and max_size > 0 and max(result.size) > max_size:
         result.thumbnail((max_size, max_size), resample=Image.Resampling.LANCZOS)

--- a/vireo/image_edits.py
+++ b/vireo/image_edits.py
@@ -58,6 +58,16 @@ _LOCAL_ADJUSTMENT_KEYS = frozenset({
     "exposure", "highlights", "shadows", "contrast", "saturation",
     "sharpen", "noise_reduction",
 })
+# Region values are deltas layered on top of the global adjustments, so
+# sharpen and noise_reduction — whose globals are [0, 100] — need to accept
+# negative deltas here (e.g. background sharpen -70 against global sharpen 70
+# zeroes sharpen in the background). ``_combine_detail`` clamps the sum back
+# into the global range before rendering.
+_LOCAL_ADJUSTMENT_RANGES = {
+    **_ADJUSTMENT_RANGES,
+    "sharpen": (-100.0, 100.0),
+    "noise_reduction": (-100.0, 100.0),
+}
 LOCAL_FEATHER_RANGE = (0.0, 200.0)
 _LOCAL_MASK_REF_RE = re.compile(r"^[0-9a-f]{12}$")
 
@@ -306,7 +316,7 @@ def _normalize_local(local):
             if isinstance(raw, bool) or not isinstance(raw, int | float):
                 raise RecipeError(f"{name} adjustment must be numeric")
             val = float(raw)
-            lo, hi = _ADJUSTMENT_RANGES[name]
+            lo, hi = _LOCAL_ADJUSTMENT_RANGES[name]
             if not math.isfinite(val) or val < lo or val > hi:
                 raise RecipeError(
                     f"{name} adjustment must be between {lo:g} and {hi:g}"

--- a/vireo/local_masks.py
+++ b/vireo/local_masks.py
@@ -245,6 +245,42 @@ def is_stale(recipe, active_mask_row):
         return True
 
 
+def transfer_snapshots(vireo_dir, old_photo_id, new_photo_id):
+    """Rename a photo's snapshot files to a new photo id.
+
+    Snapshot files are named ``<photo_id>.<ref>.png`` and looked up by
+    ``snapshot_path(vireo_dir, photo_id, ref)``. When the scanner folds a
+    JPEG companion into a RAW primary (see ``_pair_raw_jpeg_companions``),
+    the recipe rows and edit-history rows get reassigned from the
+    companion's photo_id to the primary's, but the file names still carry
+    the companion's id — so ``load_snapshot`` for the transferred recipe
+    silently misses the file and every render disables the local pass.
+    Move the files here so lookups by the new id find them.
+
+    Byte-identical snapshots for the same ref hash to the same file name,
+    so ``os.replace`` on a pre-existing destination is safe (same content).
+    """
+    directory = edit_masks_dir(vireo_dir)
+    if not os.path.isdir(directory):
+        return
+    prefix = f"{int(old_photo_id)}."
+    for name in os.listdir(directory):
+        if not name.startswith(prefix):
+            continue
+        match = _SNAPSHOT_FILE_RE.match(name)
+        if not match or int(match.group(1)) != int(old_photo_id):
+            continue
+        src = os.path.join(directory, name)
+        dst = snapshot_path(vireo_dir, int(new_photo_id), match.group(2))
+        try:
+            os.replace(src, dst)
+        except OSError:
+            log.warning(
+                "Could not transfer edit-mask snapshot %s -> %s",
+                src, dst, exc_info=True,
+            )
+
+
 def _referenced_refs(db):
     """Every local.mask.ref reachable from current recipes or edit history."""
     refs = set()

--- a/vireo/local_masks.py
+++ b/vireo/local_masks.py
@@ -17,10 +17,12 @@ from __future__ import annotations
 
 import contextlib
 import hashlib
+import io
 import json
 import logging
 import os
 import re
+import tempfile
 import time
 
 from PIL import Image
@@ -50,14 +52,7 @@ def snapshot_path(vireo_dir, photo_id, ref):
     return os.path.join(edit_masks_dir(vireo_dir), f"{photo_id}.{ref}.png")
 
 
-def source_digest(mask_row):
-    """Digest over the snapshot's source inputs: mask file bytes + the
-    prompt/detector metadata that produced it. This is the staleness signal —
-    the snapshot's own pixels are never compared."""
-    h = hashlib.sha1()
-    with open(mask_row["path"], "rb") as f:
-        for chunk in iter(lambda: f.read(1 << 20), b""):
-            h.update(chunk)
+def _mix_source_meta(h, mask_row):
     meta = json.dumps(
         {
             "variant": mask_row.get("variant"),
@@ -70,6 +65,33 @@ def source_digest(mask_row):
         sort_keys=True,
     )
     h.update(meta.encode("utf-8"))
+
+
+def _source_digest_from_bytes(mask_bytes, mask_row):
+    """Digest from an already-read mask buffer + prompt/detector metadata.
+
+    Used by ``create_snapshot`` so the ``ref`` (hash of the snapshotted
+    bytes) and ``source_digest`` (staleness signal) describe the SAME
+    bytes, even if a mask-extraction job rewrites the live mask file
+    between the initial read and the digest — otherwise the recipe would
+    record ``source_digest`` over new bytes while the snapshot file holds
+    the old ones, and ``is_stale()`` would silently report "current" for
+    a stale render.
+    """
+    h = hashlib.sha1(mask_bytes)
+    _mix_source_meta(h, mask_row)
+    return f"sha1:{h.hexdigest()}"
+
+
+def source_digest(mask_row):
+    """Digest over the snapshot's source inputs: mask file bytes + the
+    prompt/detector metadata that produced it. This is the staleness signal —
+    the snapshot's own pixels are never compared."""
+    h = hashlib.sha1()
+    with open(mask_row["path"], "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    _mix_source_meta(h, mask_row)
     return f"sha1:{h.hexdigest()}"
 
 
@@ -90,7 +112,12 @@ def create_snapshot(*, photo_id, mask_row, vireo_dir, native_size=None):
 
     with open(src_path, "rb") as f:
         data = f.read()
-    with Image.open(src_path) as img:
+    # Open the image from the copied buffer, not the live path — a
+    # mask-extraction job rewriting src_path between the read above and
+    # the size check would otherwise let us aspect-check different bytes
+    # than we snapshot, and could pass a validation that the snapshotted
+    # bytes should have failed.
+    with Image.open(io.BytesIO(data)) as img:
         mask_w, mask_h = img.size
     if native_size:
         native_w, native_h = native_size
@@ -108,10 +135,23 @@ def create_snapshot(*, photo_id, mask_row, vireo_dir, native_size=None):
     dest = snapshot_path(vireo_dir, photo_id, ref)
     if not os.path.exists(dest):
         os.makedirs(os.path.dirname(dest), exist_ok=True)
-        tmp = dest + ".tmp"
-        with open(tmp, "wb") as f:
-            f.write(data)
-        os.replace(tmp, dest)
+        # Per-call tempfile so concurrent POSTs for the same
+        # (photo, ref) don't race on a shared ``dest + ".tmp"``: with a
+        # deterministic name, one writer's ``os.replace()`` can steal the
+        # other's tmp path out from under it, causing the loser to raise
+        # FileNotFoundError. mkstemp gives each writer a unique name.
+        fd, tmp = tempfile.mkstemp(
+            prefix=f".{photo_id}.{ref}.", suffix=".png.tmp",
+            dir=os.path.dirname(dest),
+        )
+        try:
+            with os.fdopen(fd, "wb") as f:
+                f.write(data)
+            os.replace(tmp, dest)
+        except OSError:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp)
+            raise
     else:
         # Refresh mtime so the GC grace window is measured from *this*
         # snapshot request, not from whenever the file was first written.
@@ -121,7 +161,14 @@ def create_snapshot(*, photo_id, mask_row, vireo_dir, native_size=None):
         # it, breaking the just-returned ref.
         with contextlib.suppress(OSError):
             os.utime(dest, None)
-    return {"ref": ref, "source_digest": source_digest(mask_row)}
+    # Digest the same bytes we snapshotted — never re-open src_path —
+    # so a mask-extraction job rewriting the live file mid-snapshot
+    # can't cause us to record source_digest over NEW bytes while the
+    # returned ref points at OLD ones.
+    return {
+        "ref": ref,
+        "source_digest": _source_digest_from_bytes(data, mask_row),
+    }
 
 
 def load_snapshot(vireo_dir, photo_id, recipe):

--- a/vireo/local_masks.py
+++ b/vireo/local_masks.py
@@ -119,6 +119,15 @@ def create_snapshot(*, photo_id, mask_row, vireo_dir, native_size=None):
     # bytes should have failed.
     try:
         with Image.open(io.BytesIO(data)) as img:
+            # Force a full decode on this buffer — Image.open only reads
+            # the header, so a mask-extraction job interrupted after
+            # writing a valid PNG header but before the IDAT chunks
+            # completed would otherwise pass this check, get snapshotted
+            # and hashed, and then silently disable every render's local
+            # pass when load_snapshot() later fails on the truncated body.
+            # img.load() decodes here so the same truncated bytes turn
+            # into a recoverable 400 at snapshot time.
+            img.load()
             mask_w, mask_h = img.size
     except (OSError, ValueError) as e:
         # Truncated/non-image bytes → UnidentifiedImageError (subclass of

--- a/vireo/local_masks.py
+++ b/vireo/local_masks.py
@@ -117,8 +117,16 @@ def create_snapshot(*, photo_id, mask_row, vireo_dir, native_size=None):
     # the size check would otherwise let us aspect-check different bytes
     # than we snapshot, and could pass a validation that the snapshotted
     # bytes should have failed.
-    with Image.open(io.BytesIO(data)) as img:
-        mask_w, mask_h = img.size
+    try:
+        with Image.open(io.BytesIO(data)) as img:
+            mask_w, mask_h = img.size
+    except (OSError, ValueError) as e:
+        # Truncated/non-image bytes → UnidentifiedImageError (subclass of
+        # OSError) or a decode OSError. Surface as ValueError so the
+        # snapshot endpoint returns a recoverable 400 rather than a 500.
+        raise ValueError(
+            f"active subject mask is not a readable image: {e}"
+        ) from e
     if native_size:
         native_w, native_h = native_size
         if native_w and native_h and mask_w and mask_h:

--- a/vireo/local_masks.py
+++ b/vireo/local_masks.py
@@ -280,6 +280,18 @@ def gc_edit_masks(db, vireo_dir, grace_seconds=GC_GRACE_SECONDS):
             if os.path.getmtime(path) > cutoff:
                 kept += 1
                 continue
+            # Re-stat immediately before deleting. Between the first mtime
+            # check above and here, a concurrent POST /local-mask/snapshot
+            # can reuse this file, refresh its mtime via os.utime, and
+            # return its ref — deleting after that would break the
+            # just-returned ref before the recipe save can pin it. The
+            # window remains non-zero (an os.utime after this check still
+            # loses), but rechecking shrinks it to the syscall gap and
+            # catches every refresh that lands after the initial listdir
+            # walk.
+            if os.path.getmtime(path) > cutoff:
+                kept += 1
+                continue
             os.remove(path)
             deleted += 1
         except OSError:

--- a/vireo/local_masks.py
+++ b/vireo/local_masks.py
@@ -1,0 +1,209 @@
+"""Edit-mask snapshots for local (mask-weighted) adjustments.
+
+A recipe's ``local.mask.ref`` points at a content-addressed copy of the
+photo's active SAM mask, frozen at the moment the local adjustment was
+added, so renders stay a deterministic function of (source pixels, recipe)
+— the live mask can regenerate without silently changing committed edits.
+Staleness against the live mask is detected from ``source_digest`` (a hash
+over the source mask file plus the prompt/detector metadata that produced
+it), never by comparing snapshot pixels. See
+docs/plans/2026-07-03-local-adjustments-design.md; this module implements
+the trimmed v1 scope: one snapshot per recipe (copied from the active
+photo_masks file for every photo type), aspect-checked at creation, with a
+simple grace-window GC instead of a publish/GC lock protocol.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import time
+
+from PIL import Image
+
+log = logging.getLogger(__name__)
+
+EDIT_MASKS_SUBDIR = "edit-masks"
+
+# Relative width/height-ratio disagreement beyond which a mask cannot be
+# uniform-scaled onto the photo (e.g. a 16:9 embedded-preview mask against a
+# 3:2 sensor). Local adjustments are refused rather than misaligned.
+ASPECT_TOLERANCE = 0.01
+
+# Unreferenced snapshot files younger than this are never deleted, so GC can
+# run concurrently with snapshot creation / recipe saves without a lock.
+GC_GRACE_SECONDS = 24 * 3600
+
+_REF_RE = re.compile(r"^[0-9a-f]{12}$")
+_SNAPSHOT_FILE_RE = re.compile(r"^(\d+)\.([0-9a-f]{12})\.png$")
+
+
+def edit_masks_dir(vireo_dir):
+    return os.path.join(vireo_dir, EDIT_MASKS_SUBDIR)
+
+
+def snapshot_path(vireo_dir, photo_id, ref):
+    return os.path.join(edit_masks_dir(vireo_dir), f"{photo_id}.{ref}.png")
+
+
+def source_digest(mask_row):
+    """Digest over the snapshot's source inputs: mask file bytes + the
+    prompt/detector metadata that produced it. This is the staleness signal —
+    the snapshot's own pixels are never compared."""
+    h = hashlib.sha1()
+    with open(mask_row["path"], "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    meta = json.dumps(
+        {
+            "variant": mask_row.get("variant"),
+            "detector_model": mask_row.get("detector_model"),
+            "prompt": [
+                mask_row.get("prompt_x"), mask_row.get("prompt_y"),
+                mask_row.get("prompt_w"), mask_row.get("prompt_h"),
+            ],
+        },
+        sort_keys=True,
+    )
+    h.update(meta.encode("utf-8"))
+    return f"sha1:{h.hexdigest()}"
+
+
+def create_snapshot(*, photo_id, mask_row, vireo_dir, native_size=None):
+    """Freeze the active mask into a content-addressed snapshot.
+
+    Returns the recipe ``local.mask`` fields ``{"ref", "source_digest"}``.
+    Raises ValueError when there is no usable mask or when the mask's aspect
+    cannot be uniform-scaled onto the photo (``native_size`` is the
+    orientation-corrected native (width, height); see
+    render_source.recipe_source_dimensions).
+    """
+    if not mask_row or not mask_row.get("path"):
+        raise ValueError("photo has no active subject mask")
+    src_path = mask_row["path"]
+    if not os.path.exists(src_path):
+        raise ValueError("active subject mask file is missing")
+
+    with open(src_path, "rb") as f:
+        data = f.read()
+    with Image.open(src_path) as img:
+        mask_w, mask_h = img.size
+    if native_size:
+        native_w, native_h = native_size
+        if native_w and native_h and mask_w and mask_h:
+            mask_ar = mask_w / mask_h
+            native_ar = native_w / native_h
+            if abs(mask_ar - native_ar) / native_ar > ASPECT_TOLERANCE:
+                raise ValueError(
+                    "subject mask aspect does not match the photo "
+                    f"({mask_w}x{mask_h} vs {native_w}x{native_h}); "
+                    "local adjustments need a mask regenerated for this photo"
+                )
+
+    ref = hashlib.sha1(data).hexdigest()[:12]
+    dest = snapshot_path(vireo_dir, photo_id, ref)
+    if not os.path.exists(dest):
+        os.makedirs(os.path.dirname(dest), exist_ok=True)
+        tmp = dest + ".tmp"
+        with open(tmp, "wb") as f:
+            f.write(data)
+        os.replace(tmp, dest)
+    return {"ref": ref, "source_digest": source_digest(mask_row)}
+
+
+def load_snapshot(vireo_dir, photo_id, recipe):
+    """Return the recipe's snapshot as a PIL 'L' image, or None.
+
+    None means "no local pass": the recipe has no local section, or the
+    snapshot file is missing/unreadable — the renderer disables every local
+    region (never inverts a missing mask into a background weight of 1).
+    """
+    local = (recipe or {}).get("local") if isinstance(recipe, dict) else None
+    if not local:
+        return None
+    ref = ((local.get("mask") or {}).get("ref")) or ""
+    if not _REF_RE.match(ref):
+        return None
+    path = snapshot_path(vireo_dir, photo_id, ref)
+    try:
+        with Image.open(path) as img:
+            return img.convert("L").copy()
+    except (OSError, ValueError):
+        log.warning(
+            "Edit-mask snapshot missing/unreadable for photo %s ref %s; "
+            "local adjustments disabled for this render",
+            photo_id, ref,
+        )
+        return None
+
+
+def is_stale(recipe, active_mask_row):
+    """True when the live active mask no longer matches the recipe snapshot's
+    recorded source (prompt moved, detector changed, mask file rewritten, or
+    the mask went away). Recipes without a local section are never stale."""
+    local = (recipe or {}).get("local") if isinstance(recipe, dict) else None
+    if not local:
+        return False
+    recorded = (local.get("mask") or {}).get("source_digest")
+    if not recorded:
+        return True
+    if not active_mask_row or not active_mask_row.get("path"):
+        return True
+    try:
+        return source_digest(active_mask_row) != recorded
+    except OSError:
+        return True
+
+
+def _referenced_refs(db):
+    """Every local.mask.ref reachable from current recipes or edit history."""
+    refs = set()
+    pattern = re.compile(r'"ref":\s*"([0-9a-f]{12})"')
+    queries = (
+        "SELECT recipe_json AS v FROM photo_edit_recipes "
+        "WHERE recipe_json LIKE '%\"local\"%'",
+        "SELECT old_value AS v FROM edit_history_items "
+        "WHERE old_value LIKE '%\"local\"%'",
+        "SELECT new_value AS v FROM edit_history_items "
+        "WHERE new_value LIKE '%\"local\"%'",
+    )
+    for query in queries:
+        for row in db.conn.execute(query).fetchall():
+            refs.update(pattern.findall(row["v"] or ""))
+    return refs
+
+
+def gc_edit_masks(db, vireo_dir, grace_seconds=GC_GRACE_SECONDS):
+    """Delete snapshot files no recipe (current or history) references.
+
+    Files younger than ``grace_seconds`` are kept regardless, which makes
+    the sweep safe against snapshots created moments before their recipe
+    row commits — no locking needed for a single-process app.
+    """
+    directory = edit_masks_dir(vireo_dir)
+    if not os.path.isdir(directory):
+        return {"deleted": 0, "kept": 0}
+    refs = _referenced_refs(db)
+    cutoff = time.time() - grace_seconds
+    deleted = kept = 0
+    for name in os.listdir(directory):
+        path = os.path.join(directory, name)
+        if name.endswith(".tmp"):
+            match = None
+        else:
+            match = _SNAPSHOT_FILE_RE.match(name)
+        try:
+            if match and match.group(2) in refs:
+                kept += 1
+                continue
+            if os.path.getmtime(path) > cutoff:
+                kept += 1
+                continue
+            os.remove(path)
+            deleted += 1
+        except OSError:
+            log.warning("Could not GC edit-mask file %s", path, exc_info=True)
+    return {"deleted": deleted, "kept": kept}

--- a/vireo/local_masks.py
+++ b/vireo/local_masks.py
@@ -15,6 +15,7 @@ simple grace-window GC instead of a publish/GC lock protocol.
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
 import logging
@@ -118,10 +119,8 @@ def create_snapshot(*, photo_id, mask_row, vireo_dir, native_size=None):
         # created hours ago for a recipe that was never saved) can be
         # swept between this call and the recipe save that re-references
         # it, breaking the just-returned ref.
-        try:
+        with contextlib.suppress(OSError):
             os.utime(dest, None)
-        except OSError:
-            pass
     return {"ref": ref, "source_digest": source_digest(mask_row)}
 
 

--- a/vireo/local_masks.py
+++ b/vireo/local_masks.py
@@ -111,6 +111,17 @@ def create_snapshot(*, photo_id, mask_row, vireo_dir, native_size=None):
         with open(tmp, "wb") as f:
             f.write(data)
         os.replace(tmp, dest)
+    else:
+        # Refresh mtime so the GC grace window is measured from *this*
+        # snapshot request, not from whenever the file was first written.
+        # Otherwise an aged, currently-unreferenced snapshot (e.g. one
+        # created hours ago for a recipe that was never saved) can be
+        # swept between this call and the recipe save that re-references
+        # it, breaking the just-returned ref.
+        try:
+            os.utime(dest, None)
+        except OSError:
+            pass
     return {"ref": ref, "source_digest": source_digest(mask_row)}
 
 

--- a/vireo/local_masks.py
+++ b/vireo/local_masks.py
@@ -155,7 +155,20 @@ def create_snapshot(*, photo_id, mask_row, vireo_dir, native_size=None):
         try:
             with os.fdopen(fd, "wb") as f:
                 f.write(data)
-            os.replace(tmp, dest)
+            try:
+                os.replace(tmp, dest)
+            except PermissionError:
+                # Windows: concurrent os.replace() calls targeting the
+                # same destination can raise PermissionError even after
+                # another writer has already published the same content
+                # (MoveFileExW serializes and the loser sees "Access is
+                # denied"). Every writer for this (photo, ref) writes
+                # byte-identical bytes, so "dest exists" IS a successful
+                # publish — clean up our tmp and treat it as done.
+                if not os.path.exists(dest):
+                    raise
+                with contextlib.suppress(OSError):
+                    os.unlink(tmp)
         except OSError:
             with contextlib.suppress(OSError):
                 os.unlink(tmp)

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -2374,7 +2374,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                         detail_photo
                                     ),
                                     local_mask=local_masks.load_snapshot(
-                                        os.path.dirname(db_path),
+                                        effective_vireo_dir,
                                         photo["id"], recipe,
                                     ),
                                 )

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -2367,10 +2367,15 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                         canonical = companion_abs
                         if img:
                             if recipe:
+                                import local_masks
                                 img = apply_recipe_to_loaded_image(
                                     img, recipe, max_size=max_size,
                                     native_size=_recipe_source_dimensions(
                                         detail_photo
+                                    ),
+                                    local_mask=local_masks.load_snapshot(
+                                        os.path.dirname(db_path),
+                                        photo["id"], recipe,
                                     ),
                                 )
                             # Atomic write: with SLOT_CAP > 1 two pipelines

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -498,6 +498,12 @@ def _pair_raw_jpeg_companions(db, vireo_dir=None, thumb_cache_dir=None):
                 (primary["id"], companion["id"]),
             )
             if vireo_dir:
+                # Local-adjustment mask snapshots are looked up by
+                # (photo_id, ref); the transferred recipe now points at
+                # primary["id"], so the files must move with it or every
+                # render silently disables the local pass.
+                from local_masks import transfer_snapshots
+                transfer_snapshots(vireo_dir, companion["id"], primary["id"])
                 _invalidate_derived_caches(
                     db, vireo_dir, primary["id"],
                     thumb_cache_dir=thumb_cache_dir,

--- a/vireo/tests/test_image_edits.py
+++ b/vireo/tests/test_image_edits.py
@@ -487,6 +487,48 @@ def test_normalize_recipe_rejects_invalid_local(local, message):
         normalize_recipe({"local": local})
 
 
+def test_normalize_recipe_accepts_negative_local_detail_deltas():
+    # Region values are deltas layered on top of the globals; a background
+    # sharpen -70 against global sharpen 70 legitimately zeroes sharpen in the
+    # background. Rejecting negative deltas would force users to drop the
+    # global sharpen entirely instead of just excluding the background from it.
+    out = normalize_recipe(
+        {
+            "adjustments": {"sharpen": 70, "noise_reduction": 30},
+            "local": {
+                "mask": {"ref": "a1b2c3d4e5f6", "source_digest": "d"},
+                "regions": [
+                    {
+                        "region": "background",
+                        "adjustments": {"sharpen": -70, "noise_reduction": -30},
+                    },
+                ],
+            },
+        }
+    )
+    assert out["local"]["regions"] == [
+        {
+            "region": "background",
+            "adjustments": {"sharpen": -70.0, "noise_reduction": -30.0},
+        }
+    ]
+    # Out-of-range deltas still rejected: -100 is the floor.
+    with pytest.raises(RecipeError, match="sharpen"):
+        normalize_recipe(
+            {
+                "local": {
+                    "mask": {"ref": "a1b2c3d4e5f6", "source_digest": "d"},
+                    "regions": [
+                        {
+                            "region": "subject",
+                            "adjustments": {"sharpen": -150},
+                        },
+                    ],
+                },
+            }
+        )
+
+
 def test_local_recipe_json_is_canonical_and_stable():
     recipe = {
         "local": {

--- a/vireo/tests/test_image_edits.py
+++ b/vireo/tests/test_image_edits.py
@@ -358,3 +358,142 @@ def test_edit_math_version_template_constant_matches_python():
         'could not find `var _VIREO_EDIT_MATH_VERSION = ...;` in _navbar.html'
     )
     assert int(match.group(1)) == image_edits.EDIT_MATH_VERSION
+
+
+def test_normalize_recipe_accepts_local_section():
+    assert normalize_recipe(
+        {
+            "adjustments": {"exposure": 0.3},
+            "local": {
+                "mask": {
+                    "ref": "a1b2c3d4e5f6",
+                    "source_digest": "sha1:0011223344556677",
+                    "feather": 12.5,
+                },
+                "regions": [
+                    {
+                        "region": "subject",
+                        "adjustments": {"exposure": 0.6, "sharpen": 30},
+                    },
+                    {
+                        "region": "background",
+                        "adjustments": {"saturation": -15, "noise_reduction": 40},
+                    },
+                ],
+            },
+        }
+    ) == {
+        "version": 1,
+        "adjustments": {"exposure": 0.3},
+        "local": {
+            "mask": {
+                "ref": "a1b2c3d4e5f6",
+                "source_digest": "sha1:0011223344556677",
+                "feather": 12.5,
+            },
+            # Canonical order: sorted by region name.
+            "regions": [
+                {
+                    "region": "background",
+                    "adjustments": {"saturation": -15.0, "noise_reduction": 40.0},
+                },
+                {
+                    "region": "subject",
+                    "adjustments": {"exposure": 0.6, "sharpen": 30.0},
+                },
+            ],
+        },
+    }
+
+
+def test_normalize_recipe_drops_empty_local_sections():
+    # No regions at all, empty regions, and all-zero regions each drop the
+    # entire local block (the shared mask never persists alone).
+    mask = {"ref": "a1b2c3d4e5f6", "source_digest": "d"}
+    assert normalize_recipe({"local": {}}) is None
+    assert normalize_recipe({"local": {"mask": mask, "regions": []}}) is None
+    assert normalize_recipe(
+        {
+            "local": {
+                "mask": mask,
+                "regions": [
+                    {"region": "subject", "adjustments": {"exposure": 0}},
+                ],
+            }
+        }
+    ) is None
+
+
+def test_normalize_recipe_drops_local_feather_at_zero():
+    out = normalize_recipe(
+        {
+            "local": {
+                "mask": {
+                    "ref": "a1b2c3d4e5f6",
+                    "source_digest": "d",
+                    "feather": 0,
+                },
+                "regions": [
+                    {"region": "subject", "adjustments": {"exposure": 1}},
+                ],
+            }
+        }
+    )
+    assert "feather" not in out["local"]["mask"]
+
+
+@pytest.mark.parametrize(
+    ("local", "message"),
+    [
+        ([], "local must be an object"),
+        ({"mask": {"ref": "a1b2c3d4e5f6", "source_digest": "d"},
+          "regions": "subject"}, "regions must be an array"),
+        ({"regions": [{"region": "subject", "adjustments": {"exposure": 1}}]},
+         "local.mask"),
+        ({"mask": {"source_digest": "d"},
+          "regions": [{"region": "subject", "adjustments": {"exposure": 1}}]},
+         "mask.ref"),
+        ({"mask": {"ref": "NOT-HEX-12ch", "source_digest": "d"},
+          "regions": [{"region": "subject", "adjustments": {"exposure": 1}}]},
+         "mask.ref"),
+        ({"mask": {"ref": "a1b2c3d4e5f6"},
+          "regions": [{"region": "subject", "adjustments": {"exposure": 1}}]},
+         "source_digest"),
+        ({"mask": {"ref": "a1b2c3d4e5f6", "source_digest": "d", "feather": -1},
+          "regions": [{"region": "subject", "adjustments": {"exposure": 1}}]},
+         "feather"),
+        ({"mask": {"ref": "a1b2c3d4e5f6", "source_digest": "d", "feather": 999},
+          "regions": [{"region": "subject", "adjustments": {"exposure": 1}}]},
+         "feather"),
+        ({"mask": {"ref": "a1b2c3d4e5f6", "source_digest": "d"},
+          "regions": [{"region": "sky", "adjustments": {"exposure": 1}}]},
+         "region"),
+        ({"mask": {"ref": "a1b2c3d4e5f6", "source_digest": "d"},
+          "regions": [
+              {"region": "subject", "adjustments": {"exposure": 1}},
+              {"region": "subject", "adjustments": {"exposure": 2}},
+          ]}, "duplicate"),
+        ({"mask": {"ref": "a1b2c3d4e5f6", "source_digest": "d"},
+          "regions": [{"region": "subject", "adjustments": {"exposure": 99}}]},
+         "exposure"),
+        ({"mask": {"ref": "a1b2c3d4e5f6", "source_digest": "d"},
+          "regions": [{"region": "subject",
+                       "adjustments": {"whites": 20}}]},
+         "whites"),
+    ],
+)
+def test_normalize_recipe_rejects_invalid_local(local, message):
+    with pytest.raises(RecipeError, match=message):
+        normalize_recipe({"local": local})
+
+
+def test_local_recipe_json_is_canonical_and_stable():
+    recipe = {
+        "local": {
+            "mask": {"ref": "a1b2c3d4e5f6", "source_digest": "d"},
+            "regions": [
+                {"region": "subject", "adjustments": {"exposure": 1}},
+            ],
+        }
+    }
+    assert recipe_to_json(recipe) == recipe_to_json(normalize_recipe(recipe))

--- a/vireo/tests/test_local_masks.py
+++ b/vireo/tests/test_local_masks.py
@@ -74,6 +74,30 @@ def test_create_snapshot_copies_and_is_content_addressed(tmp_path):
     assert again["ref"] == mask["ref"]
 
 
+def test_create_snapshot_refreshes_mtime_on_reuse(tmp_path):
+    # An aged, currently-unreferenced snapshot that a new create_snapshot()
+    # returns must have its mtime bumped, so the GC grace window is measured
+    # from *this* request — otherwise a stale-mask sweep can delete the file
+    # after we returned its ref but before the recipe save re-references it.
+    src = _write_mask(str(tmp_path / "1.sam2-small.png"))
+    row = _mask_row(src)
+    mask = local_masks.create_snapshot(
+        photo_id=1, mask_row=row, vireo_dir=str(tmp_path),
+        native_size=(800, 600),
+    )
+    snap = local_masks.snapshot_path(str(tmp_path), 1, mask["ref"])
+
+    aged = time.time() - 30 * 24 * 3600
+    os.utime(snap, (aged, aged))
+    assert os.path.getmtime(snap) < time.time() - 24 * 3600
+
+    local_masks.create_snapshot(
+        photo_id=1, mask_row=row, vireo_dir=str(tmp_path),
+        native_size=(800, 600),
+    )
+    assert os.path.getmtime(snap) > time.time() - 60
+
+
 def test_source_digest_tracks_source_inputs(tmp_path):
     src = _write_mask(str(tmp_path / "1.sam2-small.png"))
     row = _mask_row(src)

--- a/vireo/tests/test_local_masks.py
+++ b/vireo/tests/test_local_masks.py
@@ -347,3 +347,49 @@ def test_gc_respects_references_history_and_grace(tmp_path, monkeypatch):
         # app layer, not db.set_photo_edit_recipe) — then it must collect.
         assert not os.path.exists(referenced)
     db.close()
+
+
+def test_gc_rechecks_mtime_before_deleting(tmp_path, monkeypatch):
+    """A concurrent POST /local-mask/snapshot that reuses an unreferenced
+    file refreshes its mtime between the sweep's initial mtime check and the
+    ``os.remove()`` call. Without a second stat, the sweep would still delete
+    the just-touched file and break the ref before the recipe save can pin
+    it. The recheck must catch that refresh."""
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    fid = db.add_folder(str(tmp_path), name="photos")
+    pid = db.add_photo(
+        folder_id=fid, filename="a.jpg", extension=".jpg",
+        file_size=1, file_mtime=1.0, width=800, height=600,
+    )
+
+    orphan = local_masks.snapshot_path(str(tmp_path), pid, "0123456789ab")
+    os.makedirs(os.path.dirname(orphan), exist_ok=True)
+    _write_mask(orphan, box=(1, 1, 10, 10))
+    old = time.time() - 30 * 24 * 3600
+    os.utime(orphan, (old, old))
+
+    real_getmtime = os.path.getmtime
+    calls = {"n": 0}
+
+    def flaky_getmtime(path):
+        calls["n"] += 1
+        # First stat: aged, so the sweep decides to delete. Simulate a
+        # concurrent create_snapshot() refreshing the mtime in between.
+        if calls["n"] == 1:
+            return old
+        os.utime(path, None)
+        return real_getmtime(path)
+
+    monkeypatch.setattr(local_masks.os.path, "getmtime", flaky_getmtime)
+    result = local_masks.gc_edit_masks(db, str(tmp_path))
+
+    assert os.path.exists(orphan), (
+        "recheck should have caught the mtime refresh and skipped delete"
+    )
+    assert result["deleted"] == 0
+    assert result["kept"] == 1
+    db.close()

--- a/vireo/tests/test_local_masks.py
+++ b/vireo/tests/test_local_masks.py
@@ -1,0 +1,207 @@
+"""Tests for edit-mask snapshots (local adjustments, PR 1).
+
+Covers snapshot creation from the active photo_masks file, source-digest
+staleness, loading, and grace-window GC. See
+docs/plans/2026-07-03-local-adjustments-design.md (trimmed v1 scope).
+"""
+
+import os
+import sys
+import time
+
+import numpy as np
+import pytest
+from PIL import Image
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import local_masks
+
+
+def _write_mask(path, width=80, height=60, box=(20, 10, 40, 40)):
+    arr = np.zeros((height, width), dtype=np.uint8)
+    x, y, w, h = box
+    arr[y:y + h, x:x + w] = 255
+    Image.fromarray(arr, "L").save(path, "PNG")
+    return path
+
+
+def _mask_row(path, variant="sam2-small"):
+    return {
+        "variant": variant,
+        "path": path,
+        "detector_model": "megadetector-v6",
+        "prompt_x": 0.25,
+        "prompt_y": 0.17,
+        "prompt_w": 0.5,
+        "prompt_h": 0.66,
+    }
+
+
+def _local_recipe(mask):
+    return {
+        "local": {
+            "mask": mask,
+            "regions": [
+                {"region": "subject", "adjustments": {"exposure": 1}},
+            ],
+        }
+    }
+
+
+def test_create_snapshot_copies_and_is_content_addressed(tmp_path):
+    src = _write_mask(str(tmp_path / "1.sam2-small.png"))
+    row = _mask_row(src)
+
+    mask = local_masks.create_snapshot(
+        photo_id=1, mask_row=row, vireo_dir=str(tmp_path),
+        native_size=(800, 600),
+    )
+
+    assert set(mask) == {"ref", "source_digest"}
+    assert len(mask["ref"]) == 12 and int(mask["ref"], 16) >= 0
+    snap = local_masks.snapshot_path(str(tmp_path), 1, mask["ref"])
+    assert os.path.exists(snap)
+    with Image.open(snap) as img, Image.open(src) as orig:
+        assert np.array_equal(np.asarray(img.convert("L")),
+                              np.asarray(orig.convert("L")))
+
+    # Same source bytes -> same ref (idempotent, no duplicate files).
+    again = local_masks.create_snapshot(
+        photo_id=1, mask_row=row, vireo_dir=str(tmp_path),
+        native_size=(800, 600),
+    )
+    assert again["ref"] == mask["ref"]
+
+
+def test_source_digest_tracks_source_inputs(tmp_path):
+    src = _write_mask(str(tmp_path / "1.sam2-small.png"))
+    row = _mask_row(src)
+    base = local_masks.source_digest(row)
+
+    # Same inputs -> same digest.
+    assert local_masks.source_digest(_mask_row(src)) == base
+
+    # Different prompt -> different digest.
+    moved = _mask_row(src)
+    moved["prompt_x"] = 0.4
+    assert local_masks.source_digest(moved) != base
+
+    # Different file bytes -> different digest.
+    _write_mask(src, box=(5, 5, 20, 20))
+    assert local_masks.source_digest(_mask_row(src)) != base
+
+
+def test_create_snapshot_rejects_aspect_mismatch(tmp_path):
+    # 80x60 mask (4:3) against a 16:9 photo must refuse rather than
+    # misalign local weights.
+    src = _write_mask(str(tmp_path / "1.sam2-small.png"))
+
+    with pytest.raises(ValueError, match="aspect"):
+        local_masks.create_snapshot(
+            photo_id=1, mask_row=_mask_row(src), vireo_dir=str(tmp_path),
+            native_size=(1920, 1080),
+        )
+
+
+def test_load_snapshot_roundtrip_and_missing(tmp_path):
+    src = _write_mask(str(tmp_path / "1.sam2-small.png"))
+    mask = local_masks.create_snapshot(
+        photo_id=1, mask_row=_mask_row(src), vireo_dir=str(tmp_path),
+        native_size=(800, 600),
+    )
+    recipe = _local_recipe(dict(mask))
+
+    loaded = local_masks.load_snapshot(str(tmp_path), 1, recipe)
+    assert loaded is not None and loaded.mode == "L"
+    assert loaded.size == (80, 60)
+
+    # Recipes without local load nothing.
+    assert local_masks.load_snapshot(str(tmp_path), 1, {"rotation": 90}) is None
+    assert local_masks.load_snapshot(str(tmp_path), 1, None) is None
+
+    # Missing file: None, no raise (renderer disables the local pass).
+    os.remove(local_masks.snapshot_path(str(tmp_path), 1, mask["ref"]))
+    assert local_masks.load_snapshot(str(tmp_path), 1, recipe) is None
+
+
+def test_staleness_compares_source_metadata(tmp_path):
+    src = _write_mask(str(tmp_path / "1.sam2-small.png"))
+    row = _mask_row(src)
+    mask = local_masks.create_snapshot(
+        photo_id=1, mask_row=row, vireo_dir=str(tmp_path),
+        native_size=(800, 600),
+    )
+    recipe = _local_recipe(dict(mask))
+
+    assert local_masks.is_stale(recipe, row) is False
+
+    # Prompt moved (detector re-run) -> stale.
+    moved = dict(row)
+    moved["prompt_x"] = 0.4
+    assert local_masks.is_stale(recipe, moved) is True
+
+    # Mask file rewritten in place -> stale.
+    _write_mask(src, box=(5, 5, 20, 20))
+    assert local_masks.is_stale(recipe, row) is True
+
+    # No live mask row at all -> treated as stale (mask went away).
+    assert local_masks.is_stale(recipe, None) is True
+
+    # Recipes without local are never stale.
+    assert local_masks.is_stale({"rotation": 90}, row) is False
+
+
+def test_gc_respects_references_history_and_grace(tmp_path, monkeypatch):
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    fid = db.add_folder(str(tmp_path), name="photos")
+    pid = db.add_photo(
+        folder_id=fid, filename="a.jpg", extension=".jpg",
+        file_size=1, file_mtime=1.0, width=800, height=600,
+    )
+
+    src = _write_mask(str(tmp_path / "mask-src.png"))
+    mask = local_masks.create_snapshot(
+        photo_id=pid, mask_row=_mask_row(src), vireo_dir=str(tmp_path),
+        native_size=(800, 600),
+    )
+    referenced = local_masks.snapshot_path(str(tmp_path), pid, mask["ref"])
+    db.set_photo_edit_recipe(pid, _local_recipe(dict(mask)))
+
+    # A second, unreferenced snapshot file: old enough to collect.
+    orphan = local_masks.snapshot_path(str(tmp_path), pid, "0123456789ab")
+    _write_mask(orphan, box=(1, 1, 10, 10))
+    old = time.time() - 7 * 24 * 3600
+    os.utime(orphan, (old, old))
+
+    # A third, unreferenced but recent file: inside the grace window.
+    recent = local_masks.snapshot_path(str(tmp_path), pid, "ba9876543210")
+    _write_mask(recent, box=(2, 2, 10, 10))
+
+    result = local_masks.gc_edit_masks(db, str(tmp_path))
+
+    assert not os.path.exists(orphan)
+    assert os.path.exists(referenced)
+    assert os.path.exists(recent)
+    assert result["deleted"] == 1
+
+    # Clearing the recipe keeps the ref alive through edit history.
+    db.set_photo_edit_recipe(pid, None)
+    history_rows = db.conn.execute(
+        "SELECT COUNT(*) AS n FROM edit_history_items "
+        "WHERE old_value LIKE '%' || ? || '%' OR new_value LIKE '%' || ? || '%'",
+        (mask["ref"], mask["ref"]),
+    ).fetchone()
+    os.utime(referenced, (old, old))
+    result = local_masks.gc_edit_masks(db, str(tmp_path))
+    if history_rows["n"]:
+        assert os.path.exists(referenced)
+    else:
+        # No history captured the ref (recipe API records history at the
+        # app layer, not db.set_photo_edit_recipe) — then it must collect.
+        assert not os.path.exists(referenced)
+    db.close()

--- a/vireo/tests/test_local_masks.py
+++ b/vireo/tests/test_local_masks.py
@@ -219,6 +219,21 @@ def test_create_snapshot_concurrent_publishes_dont_race_on_shared_tempfile(tmp_p
     assert leftover == [], f"leaked tempfiles: {leftover!r}"
 
 
+def test_create_snapshot_rejects_corrupt_mask_file(tmp_path):
+    # A truncated / non-image mask file must surface as ValueError, not
+    # PIL's UnidentifiedImageError, so the snapshot endpoint returns a
+    # recoverable 400 ("regenerate the mask") instead of a 500.
+    src = str(tmp_path / "1.sam2-small.png")
+    with open(src, "wb") as f:
+        f.write(b"not a real png")
+
+    with pytest.raises(ValueError, match="not a readable image"):
+        local_masks.create_snapshot(
+            photo_id=1, mask_row=_mask_row(src), vireo_dir=str(tmp_path),
+            native_size=(800, 600),
+        )
+
+
 def test_create_snapshot_rejects_aspect_mismatch(tmp_path):
     # 80x60 mask (4:3) against a 16:9 photo must refuse rather than
     # misalign local weights.

--- a/vireo/tests/test_local_masks.py
+++ b/vireo/tests/test_local_masks.py
@@ -234,6 +234,30 @@ def test_create_snapshot_rejects_corrupt_mask_file(tmp_path):
         )
 
 
+def test_create_snapshot_rejects_valid_header_truncated_body(tmp_path):
+    # A mask-extraction job interrupted mid-write can leave a file with a
+    # valid PNG header (Image.open() succeeds, .size is readable) but a
+    # truncated IDAT body that only fails when Pillow actually decodes.
+    # Without a forced decode the snapshot endpoint would accept the file,
+    # copy it verbatim, and every subsequent render would silently disable
+    # local adjustments when load_snapshot() hits the same decode error.
+    good = str(tmp_path / "good.png")
+    _write_mask(good, width=80, height=60)
+    full = open(good, "rb").read()
+    # Slice off half the file — the PNG header and IHDR chunk are intact,
+    # so Image.open() reports width/height, but decoding the pixel stream
+    # will fail.
+    truncated = str(tmp_path / "1.sam2-small.png")
+    with open(truncated, "wb") as f:
+        f.write(full[: len(full) // 2])
+
+    with pytest.raises(ValueError, match="not a readable image"):
+        local_masks.create_snapshot(
+            photo_id=1, mask_row=_mask_row(truncated),
+            vireo_dir=str(tmp_path), native_size=(800, 600),
+        )
+
+
 def test_create_snapshot_rejects_aspect_mismatch(tmp_path):
     # 80x60 mask (4:3) against a 16:9 photo must refuse rather than
     # misalign local weights.

--- a/vireo/tests/test_local_masks.py
+++ b/vireo/tests/test_local_masks.py
@@ -5,8 +5,10 @@ staleness, loading, and grace-window GC. See
 docs/plans/2026-07-03-local-adjustments-design.md (trimmed v1 scope).
 """
 
+import hashlib
 import os
 import sys
+import threading
 import time
 
 import numpy as np
@@ -114,6 +116,107 @@ def test_source_digest_tracks_source_inputs(tmp_path):
     # Different file bytes -> different digest.
     _write_mask(src, box=(5, 5, 20, 20))
     assert local_masks.source_digest(_mask_row(src)) != base
+
+
+def test_create_snapshot_digest_matches_snapshotted_bytes(tmp_path):
+    """The returned ``source_digest`` must describe the bytes actually
+    frozen into the snapshot file. If it were computed by re-reading the
+    live mask path, a mask-extraction job rewriting the file mid-snapshot
+    could leave ``ref`` (snapshot bytes) and ``source_digest`` (live bytes)
+    describing different content — ``is_stale()`` would report ``False`` for
+    a snapshot that no longer matches its source, and the render would use
+    stale pixels while claiming to be current."""
+    src = _write_mask(str(tmp_path / "1.sam2-small.png"))
+    row = _mask_row(src)
+    mask = local_masks.create_snapshot(
+        photo_id=1, mask_row=row, vireo_dir=str(tmp_path),
+        native_size=(800, 600),
+    )
+    snap = local_masks.snapshot_path(str(tmp_path), 1, mask["ref"])
+    with open(snap, "rb") as f:
+        snap_bytes = f.read()
+    assert mask["source_digest"] == local_masks._source_digest_from_bytes(
+        snap_bytes, row
+    )
+
+
+def test_create_snapshot_digest_survives_concurrent_source_rewrite(tmp_path, monkeypatch):
+    """When a mask-extraction job rewrites the live mask between the
+    snapshot copy and the digest, ``source_digest`` must describe the
+    bytes we snapshotted, not the new live bytes — otherwise ``is_stale()``
+    would report ``False`` for a snapshot that no longer matches, and the
+    render would silently use stale pixels while claiming to be current."""
+    src = str(tmp_path / "1.sam2-small.png")
+    _write_mask(src, box=(20, 10, 40, 40))
+    row = _mask_row(src)
+    original_digest = local_masks.source_digest(row)
+
+    real_image_open = local_masks.Image.open
+    rewritten = {"done": False}
+
+    def rewrite_and_open(*args, **kwargs):
+        # ``Image.open`` runs after ``data = f.read()`` in create_snapshot,
+        # so mutating the live file here reproduces the TOCTOU: with the
+        # old code the subsequent source_digest() call would re-read the
+        # (now different) live bytes and disagree with ``ref``.
+        if not rewritten["done"]:
+            _write_mask(src, box=(5, 5, 10, 10))
+            rewritten["done"] = True
+        return real_image_open(*args, **kwargs)
+
+    monkeypatch.setattr(local_masks.Image, "open", rewrite_and_open)
+    mask = local_masks.create_snapshot(
+        photo_id=1, mask_row=row, vireo_dir=str(tmp_path),
+        native_size=(80, 60),
+    )
+    # Sanity: the live file's digest really did change during the call.
+    assert local_masks.source_digest(row) != original_digest
+    # But the recorded source_digest describes the snapshotted bytes.
+    assert mask["source_digest"] == original_digest
+
+
+def test_create_snapshot_concurrent_publishes_dont_race_on_shared_tempfile(tmp_path):
+    """Two POSTs for the same (photo, mask) racing on snapshot creation
+    must both succeed. With a deterministic ``dest + ".tmp"`` path both
+    writers would name the same tmp file; whichever ``os.replace()`` lands
+    first steals the other's tmp path, and the loser raises
+    ``FileNotFoundError`` (500 to the client). A per-call ``mkstemp`` name
+    keeps the writers isolated."""
+    src = _write_mask(str(tmp_path / "1.sam2-small.png"))
+    row = _mask_row(src)
+
+    barrier = threading.Barrier(8)
+    errors: list[BaseException] = []
+
+    def worker():
+        try:
+            barrier.wait(timeout=5)
+            local_masks.create_snapshot(
+                photo_id=1, mask_row=row, vireo_dir=str(tmp_path),
+                native_size=(80, 60),
+            )
+        except BaseException as exc:  # includes threading errors
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"concurrent create_snapshot raised: {errors!r}"
+    with open(src, "rb") as f:
+        expected_ref = hashlib.sha1(f.read()).hexdigest()[:12]
+    assert os.path.exists(
+        local_masks.snapshot_path(str(tmp_path), 1, expected_ref)
+    )
+    # No leftover *.png.tmp files — every writer either publishes or
+    # cleans up its own tmp.
+    leftover = sorted(
+        n for n in os.listdir(local_masks.edit_masks_dir(str(tmp_path)))
+        if n.endswith(".tmp")
+    )
+    assert leftover == [], f"leaked tempfiles: {leftover!r}"
 
 
 def test_create_snapshot_rejects_aspect_mismatch(tmp_path):

--- a/vireo/tests/test_local_render.py
+++ b/vireo/tests/test_local_render.py
@@ -1,0 +1,263 @@
+"""End-to-end render tests for local (mask-weighted) adjustments.
+
+Synthetic masks through apply_recipe_to_loaded_image: weighted tone,
+geometry-transformed weights, feathering, two-branch local detail, and the
+all-or-nothing disable when the mask is unusable.
+"""
+
+import os
+import sys
+
+import numpy as np
+from PIL import Image, ImageFilter
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import image_edits
+from image_edits import apply_recipe_to_loaded_image
+
+MASK_REF = "a1b2c3d4e5f6"
+
+
+def _left_half_mask(width=80, height=60):
+    arr = np.zeros((height, width), dtype=np.uint8)
+    arr[:, : width // 2] = 255
+    return Image.fromarray(arr, "L")
+
+
+def _gray(width=80, height=60, level=100):
+    return Image.new("RGB", (width, height), (level, level, level))
+
+
+def _local(regions, feather=None):
+    mask = {"ref": MASK_REF, "source_digest": "d"}
+    if feather is not None:
+        mask["feather"] = feather
+    return {"mask": mask, "regions": regions}
+
+
+def _luma(img):
+    arr = np.asarray(img).astype(np.float32)
+    return 0.2126 * arr[..., 0] + 0.7152 * arr[..., 1] + 0.0722 * arr[..., 2]
+
+
+def test_subject_exposure_brightens_only_masked_half():
+    img = _gray()
+    recipe = {
+        "local": _local(
+            [{"region": "subject", "adjustments": {"exposure": 1.5}}]
+        )
+    }
+
+    out = apply_recipe_to_loaded_image(
+        img, recipe, native_size=(80, 60), local_mask=_left_half_mask()
+    )
+
+    y = _luma(out)
+    base = _luma(img)
+    assert np.mean(y[:, :35]) > np.mean(base[:, :35]) + 30
+    # Unmasked side stays put (small tolerance for float round-trip).
+    assert np.max(np.abs(y[:, 45:] - base[:, 45:])) <= 1.0
+
+
+def test_background_region_uses_inverse_weight():
+    img = _gray(level=150)
+    recipe = {
+        "local": _local(
+            [{"region": "background", "adjustments": {"exposure": -2.0}}]
+        )
+    }
+
+    out = apply_recipe_to_loaded_image(
+        img, recipe, native_size=(80, 60), local_mask=_left_half_mask()
+    )
+
+    y = _luma(out)
+    assert np.mean(y[:, :35]) > 140          # subject half untouched
+    assert np.mean(y[:, 45:]) < 90           # background half darkened
+
+
+def test_weight_follows_recipe_geometry():
+    # Flip horizontal: the brightened half must flip with the image.
+    img = _gray()
+    recipe = {
+        "flip": {"horizontal": True},
+        "local": _local(
+            [{"region": "subject", "adjustments": {"exposure": 1.5}}]
+        ),
+    }
+
+    out = apply_recipe_to_loaded_image(
+        img, recipe, native_size=(80, 60), local_mask=_left_half_mask()
+    )
+
+    y = _luma(out)
+    assert np.mean(y[:, 45:]) > np.mean(y[:, :35]) + 30
+
+
+def test_weight_respects_crop():
+    # Cropping to the masked half yields a fully brightened result.
+    img = _gray()
+    recipe = {
+        "crop": {"x": 0.0, "y": 0.0, "w": 0.5, "h": 1.0},
+        "local": _local(
+            [{"region": "subject", "adjustments": {"exposure": 1.5}}]
+        ),
+    }
+
+    out = apply_recipe_to_loaded_image(
+        img, recipe, native_size=(80, 60), local_mask=_left_half_mask()
+    )
+
+    y = _luma(out)
+    base = _luma(img)
+    assert np.min(y) > np.mean(base) + 25
+
+
+def test_missing_mask_disables_all_local_regions():
+    img = _gray()
+    recipe = {
+        "adjustments": {"contrast": 20},
+        "local": _local(
+            [
+                {"region": "subject", "adjustments": {"exposure": 2.0}},
+                {"region": "background", "adjustments": {"exposure": -2.0}},
+            ]
+        ),
+    }
+
+    with_local_but_no_mask = apply_recipe_to_loaded_image(
+        img, recipe, native_size=(80, 60), local_mask=None
+    )
+    global_only = apply_recipe_to_loaded_image(
+        img, {"adjustments": {"contrast": 20}}, native_size=(80, 60)
+    )
+
+    assert np.array_equal(
+        np.asarray(with_local_but_no_mask), np.asarray(global_only)
+    )
+
+
+def test_aspect_mismatched_mask_disables_local():
+    img = _gray()
+    recipe = {
+        "local": _local(
+            [{"region": "subject", "adjustments": {"exposure": 2.0}}]
+        )
+    }
+    square_mask = _left_half_mask(width=60, height=60)  # 1:1 vs 4:3 photo
+
+    out = apply_recipe_to_loaded_image(
+        img, recipe, native_size=(80, 60), local_mask=square_mask
+    )
+
+    assert np.array_equal(np.asarray(out), np.asarray(img))
+
+
+def test_feather_softens_the_transition():
+    img = _gray()
+    hard_recipe = {
+        "local": _local(
+            [{"region": "subject", "adjustments": {"exposure": 2.0}}]
+        )
+    }
+    soft_recipe = {
+        "local": _local(
+            [{"region": "subject", "adjustments": {"exposure": 2.0}}],
+            feather=8.0,
+        )
+    }
+
+    hard = _luma(apply_recipe_to_loaded_image(
+        img, hard_recipe, native_size=(80, 60), local_mask=_left_half_mask()
+    ))
+    soft = _luma(apply_recipe_to_loaded_image(
+        img, soft_recipe, native_size=(80, 60), local_mask=_left_half_mask()
+    ))
+
+    # Max adjacent-column jump across the seam is smaller when feathered.
+    hard_step = np.max(np.abs(np.diff(np.mean(hard, axis=0))))
+    soft_step = np.max(np.abs(np.diff(np.mean(soft, axis=0))))
+    assert soft_step < hard_step * 0.6
+
+
+def test_local_detail_two_branch_blend():
+    # Soft edges in both halves; subject-only sharpen must raise acutance on
+    # the masked half and leave the other half at the global (unsharpened)
+    # rendering.
+    arr = np.zeros((60, 80, 3), dtype=np.uint8)
+    arr[:, 12:20, :] = 200   # edge inside subject half
+    arr[:, 52:60, :] = 200   # edge inside background half
+    img = Image.fromarray(arr, "RGB").filter(ImageFilter.GaussianBlur(1.2))
+
+    recipe = {
+        "local": _local(
+            [{"region": "subject", "adjustments": {"sharpen": 90}}]
+        )
+    }
+
+    out = apply_recipe_to_loaded_image(
+        img, recipe, native_size=(80, 60), local_mask=_left_half_mask()
+    )
+
+    base = _luma(img)
+    y = _luma(out)
+
+    def max_step(y2d, lo, hi):
+        return float(np.max(np.abs(np.diff(y2d[:, lo:hi], axis=1))))
+
+    assert max_step(y, 6, 26) > max_step(base, 6, 26) * 1.15
+    assert abs(max_step(y, 46, 66) - max_step(base, 46, 66)) < 2.0
+
+
+def test_local_detail_composes_with_global_detail():
+    # Global sharpen everywhere + extra subject NR: background half must keep
+    # the global sharpening (not lose it because a local branch ran).
+    arr = np.zeros((60, 80, 3), dtype=np.uint8)
+    arr[:, 52:60, :] = 200
+    img = Image.fromarray(arr, "RGB").filter(ImageFilter.GaussianBlur(1.2))
+
+    recipe = {
+        "adjustments": {"sharpen": 70},
+        "local": _local(
+            [{"region": "subject", "adjustments": {"noise_reduction": 60}}]
+        ),
+    }
+    global_only = {"adjustments": {"sharpen": 70}}
+
+    out = _luma(apply_recipe_to_loaded_image(
+        img, recipe, native_size=(80, 60), local_mask=_left_half_mask()
+    ))
+    ref = _luma(apply_recipe_to_loaded_image(
+        img, global_only, native_size=(80, 60)
+    ))
+
+    # Background half matches the global-sharpen render closely.
+    assert np.max(np.abs(out[:, 46:] - ref[:, 46:])) <= 2.0
+
+
+def test_weighted_tone_tiling_matches_single_pass(monkeypatch):
+    rng = np.random.default_rng(21)
+    src = rng.integers(0, 256, size=(90, 17, 3), dtype=np.uint8)
+    img = Image.fromarray(src, "RGB")
+    mask = _left_half_mask(width=17, height=90)
+    recipe = {
+        "adjustments": {"exposure": 0.4},
+        "local": _local(
+            [
+                {"region": "subject", "adjustments": {"exposure": 1.0}},
+                {"region": "background", "adjustments": {"saturation": -40}},
+            ],
+            feather=3.0,
+        ),
+    }
+
+    whole = np.asarray(apply_recipe_to_loaded_image(
+        img, recipe, native_size=(17, 90), local_mask=mask
+    ))
+    monkeypatch.setattr(image_edits, "_ADJUST_TILE_PIXELS", 17)
+    tiled = np.asarray(apply_recipe_to_loaded_image(
+        img, recipe, native_size=(17, 90), local_mask=mask
+    ))
+
+    assert np.array_equal(whole, tiled)

--- a/vireo/tests/test_local_render.py
+++ b/vireo/tests/test_local_render.py
@@ -181,6 +181,35 @@ def test_feather_softens_the_transition():
     assert soft_step < hard_step * 0.6
 
 
+def test_local_tone_feather_uses_detail_scale_override():
+    # The edit-preview endpoint strips crop from the recipe and passes
+    # detail_scale computed from the crop-inclusive recipe. The local tone
+    # feather must honour that override so the preview's mask falloff matches
+    # what the saved (cropped) render will produce; otherwise the tone pass
+    # uses the crop-stripped scale while the detail pass uses the saved-render
+    # scale and preview/export disagree for cropped feathered local edits.
+    img = _gray()
+    recipe = {
+        "local": _local(
+            [{"region": "subject", "adjustments": {"exposure": 2.0}}],
+            feather=8.0,
+        )
+    }
+
+    def seam_step(detail_scale):
+        out = apply_recipe_to_loaded_image(
+            img, recipe, native_size=(80, 60), local_mask=_left_half_mask(),
+            detail_scale=detail_scale,
+        )
+        y = _luma(out)
+        return float(np.max(np.abs(np.diff(np.mean(y, axis=0)))))
+
+    default = seam_step(None)          # scale=1.0 from the uncropped recipe
+    small_scale = seam_step(0.25)      # simulates a 4x tighter saved render
+    # Smaller scale → narrower feather → harder transition (larger step).
+    assert small_scale > default * 1.5
+
+
 def test_local_detail_two_branch_blend():
     # Soft edges in both halves; subject-only sharpen must raise acutance on
     # the masked half and leave the other half at the global (unsharpened)

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -7847,3 +7847,103 @@ def test_edit_preview_renders_local_adjustments(client_with_photo):
     left = float(np.mean(arr[:, :360]))
     right = float(np.mean(arr[:, 440:]))
     assert left > right + 40  # subject half brightened by +2 EV
+
+
+def test_local_snapshot_root_matches_thumb_cache_dir(tmp_path, monkeypatch):
+    """Regression: renders must read snapshots from the same root the
+    snapshot endpoint writes to.
+
+    When ``create_app`` is given a ``thumb_cache_dir`` whose parent
+    differs from ``dirname(db_path)``, snapshots land under
+    ``dirname(THUMB_CACHE_DIR)/edit-masks`` but earlier revisions of
+    every render call site looked in ``dirname(db_path)/edit-masks`` and
+    silently rendered without the local pass. This test lays out that
+    split-directory topology and asserts the local adjustment actually
+    lands in the preview.
+    """
+    import io
+    import json
+
+    import numpy as np
+    from PIL import Image as PILImage
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import config as cfg
+    import models
+    from app import create_app
+    from db import Database
+
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setattr(
+        models, "DEFAULT_MODELS_DIR", str(tmp_path / "vireo-models"),
+    )
+    monkeypatch.setattr(
+        models, "CONFIG_PATH", str(tmp_path / "models.json"),
+    )
+
+    photos_dir = tmp_path / "photos"
+    photos_dir.mkdir()
+    src = photos_dir / "test.jpg"
+    PILImage.new("RGB", (800, 600), (180, 90, 40)).save(
+        str(src), "JPEG", quality=85,
+    )
+
+    # Key: db_root and cache_root have distinct parents. dirname(db_path)
+    # is now unrelated to dirname(thumb_cache_dir); the app must not use
+    # the former to find snapshots the endpoint saved under the latter.
+    db_root = tmp_path / "db_root"
+    db_root.mkdir()
+    cache_root = tmp_path / "cache_root"
+    cache_root.mkdir()
+    thumb_dir = cache_root / "thumbnails"
+    thumb_dir.mkdir()
+    db_path = str(db_root / "vireo.db")
+
+    db = Database(db_path)
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+    fid = db.add_folder(str(photos_dir), name="photos")
+    photo_id = db.add_photo(
+        folder_id=fid, filename="test.jpg", extension=".jpg",
+        file_size=os.path.getsize(src),
+        file_mtime=os.path.getmtime(src),
+        width=800, height=600,
+    )
+
+    _register_active_mask(db, photo_id, str(photos_dir))
+
+    app = create_app(
+        db_path=db_path, thumb_cache_dir=str(thumb_dir),
+        api_token="test-token-123",
+    )
+    client = app.test_client()
+
+    mask = client.post(
+        f"/api/photos/{photo_id}/local-mask/snapshot"
+    ).get_json()["mask"]
+
+    # Snapshot must have been written under the thumb-cache root, not
+    # under the db root.
+    assert (cache_root / "edit-masks").is_dir()
+    assert not (db_root / "edit-masks").exists()
+
+    recipe = _local_recipe_payload(mask)["recipe"]
+    resp = client.get(
+        f"/photos/{photo_id}/edit-preview",
+        query_string={"size": "800", "recipe": json.dumps(recipe)},
+    )
+    assert resp.status_code == 200
+    with PILImage.open(io.BytesIO(resp.data)) as img:
+        arr = np.asarray(img.convert("RGB")).astype(np.float32)
+
+    left = float(np.mean(arr[:, :360]))
+    right = float(np.mean(arr[:, 440:]))
+    # If the renderer used dirname(db_path) for the snapshot root the
+    # local pass would silently no-op and both halves would match.
+    assert left > right + 40, (
+        f"local adjustment did not apply (left={left:.1f}, "
+        f"right={right:.1f}); snapshot root likely disagrees with the "
+        "endpoint's write root"
+    )
+
+    db.close()

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -7693,3 +7693,157 @@ def test_edit_presets_api_validation(app_and_db):
         assert resp.status_code == 400, payload
 
     assert client.get("/api/edit-presets").get_json() == {"presets": []}
+
+
+def _register_active_mask(db, photo_id, mask_dir, width=800, height=600):
+    """Write a left-half subject mask PNG and make it the photo's active mask."""
+    import numpy as np
+    from PIL import Image as PILImage
+
+    path = os.path.join(mask_dir, f"{photo_id}.sam2-small.png")
+    arr = np.zeros((height, width), dtype=np.uint8)
+    arr[:, : width // 2] = 255
+    PILImage.fromarray(arr, "L").save(path, "PNG")
+    db.upsert_photo_mask(
+        photo_id, "sam2-small", path, "megadetector-v6",
+        0.0, 0.0, 0.5, 1.0,
+    )
+    db.set_active_mask_variant(photo_id, "sam2-small")
+    return path
+
+
+def _local_recipe_payload(mask, regions=None):
+    return {
+        "recipe": {
+            "local": {
+                "mask": mask,
+                "regions": regions or [
+                    {"region": "subject", "adjustments": {"exposure": 2.0}},
+                ],
+            }
+        }
+    }
+
+
+def test_local_mask_snapshot_endpoint_requires_active_mask(client_with_photo):
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+
+    resp = client.post(f"/api/photos/{photo_id}/local-mask/snapshot")
+    assert resp.status_code == 400
+    assert "mask" in resp.get_json()["error"].lower()
+
+    assert client.post("/api/photos/999999/local-mask/snapshot").status_code == 404
+
+
+def test_local_mask_snapshot_and_recipe_roundtrip(client_with_photo):
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    folder = db.conn.execute("SELECT path FROM folders").fetchone()
+    _register_active_mask(db, photo_id, folder["path"])
+
+    resp = client.post(f"/api/photos/{photo_id}/local-mask/snapshot")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    mask = body["mask"]
+    assert set(mask) == {"ref", "source_digest"}
+    assert body["stale"] is False
+
+    resp = client.put(
+        f"/api/photos/{photo_id}/edit-recipe",
+        json=_local_recipe_payload(mask),
+    )
+    assert resp.status_code == 200
+    saved = resp.get_json()["recipe"]
+    assert saved["local"]["mask"]["ref"] == mask["ref"]
+
+    got = client.get(f"/api/photos/{photo_id}/edit-recipe").get_json()
+    assert got["recipe"]["local"]["mask"]["ref"] == mask["ref"]
+    assert got["local_mask_stale"] is False
+
+
+def test_local_recipe_stale_flag_tracks_live_mask(client_with_photo):
+    import numpy as np
+    from PIL import Image as PILImage
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    folder = db.conn.execute("SELECT path FROM folders").fetchone()
+    mask_path = _register_active_mask(db, photo_id, folder["path"])
+
+    mask = client.post(
+        f"/api/photos/{photo_id}/local-mask/snapshot"
+    ).get_json()["mask"]
+    client.put(
+        f"/api/photos/{photo_id}/edit-recipe",
+        json=_local_recipe_payload(mask),
+    )
+
+    # Rewrite the live mask (as a detector/SAM re-run would).
+    arr = np.zeros((600, 800), dtype=np.uint8)
+    arr[:300, :] = 255
+    PILImage.fromarray(arr, "L").save(mask_path, "PNG")
+
+    got = client.get(f"/api/photos/{photo_id}/edit-recipe").get_json()
+    assert got["local_mask_stale"] is True
+
+
+def test_local_recipe_rejects_unknown_snapshot_ref(client_with_photo):
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+
+    resp = client.put(
+        f"/api/photos/{photo_id}/edit-recipe",
+        json=_local_recipe_payload(
+            {"ref": "eeeeeeeeeeee", "source_digest": "d"}
+        ),
+    )
+    assert resp.status_code == 400
+    assert "snapshot" in resp.get_json()["error"].lower()
+
+
+def test_bulk_apply_rejects_local_sections(client_with_photo):
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+
+    resp = client.post(
+        "/api/photos/edit-recipe/apply",
+        json={
+            "photo_ids": [photo_id],
+            "recipe": _local_recipe_payload(
+                {"ref": "eeeeeeeeeeee", "source_digest": "d"}
+            )["recipe"],
+        },
+    )
+    assert resp.status_code == 400
+    assert "local" in resp.get_json()["error"].lower()
+
+
+def test_edit_preview_renders_local_adjustments(client_with_photo):
+    import io
+    import json
+
+    import numpy as np
+    from PIL import Image as PILImage
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    folder = db.conn.execute("SELECT path FROM folders").fetchone()
+    _register_active_mask(db, photo_id, folder["path"])
+
+    mask = client.post(
+        f"/api/photos/{photo_id}/local-mask/snapshot"
+    ).get_json()["mask"]
+    recipe = _local_recipe_payload(mask)["recipe"]
+
+    resp = client.get(
+        f"/photos/{photo_id}/edit-preview",
+        query_string={"size": "800", "recipe": json.dumps(recipe)},
+    )
+    assert resp.status_code == 200
+    with PILImage.open(io.BytesIO(resp.data)) as img:
+        arr = np.asarray(img.convert("RGB")).astype(np.float32)
+
+    left = float(np.mean(arr[:, :360]))
+    right = float(np.mean(arr[:, 440:]))
+    assert left > right + 40  # subject half brightened by +2 EV

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -1060,6 +1060,64 @@ def test_pairing_transfers_edit_recipe_from_companion(tmp_path):
     assert db.get_photo_edit_recipe(photo["id"]) is None
 
 
+def test_pairing_transfers_local_mask_snapshot_files(tmp_path):
+    """Pairing raw+JPEG must move edit-mask snapshot files to the primary id.
+
+    Snapshot lookup uses ``<photo_id>.<ref>.png``. Without renaming the
+    files when the recipe row's photo_id changes, ``load_snapshot`` misses
+    the file and every render silently disables the local pass.
+    """
+    from db import Database
+    from local_masks import edit_masks_dir, snapshot_path
+    from scanner import _pair_raw_jpeg_companions
+
+    img_dir = tmp_path / "photos"
+    img_dir.mkdir()
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder(str(img_dir), name="photos")
+    jpeg_id = db.add_photo(
+        folder_id=fid, filename="IMG_002.jpg", extension=".jpg",
+        file_size=1000, file_mtime=1.0,
+    )
+    raw_id = db.add_photo(
+        folder_id=fid, filename="IMG_002.cr3", extension=".cr3",
+        file_size=2000, file_mtime=1.0,
+    )
+
+    # Set a recipe on the JPEG (any recipe — this test is about the file
+    # rename, not recipe schema). The pairing code moves the row to the RAW.
+    db.set_photo_edit_recipe(jpeg_id, {"rotation": 90})
+
+    # Drop a snapshot file at <jpeg_id>.<ref>.png as if we'd called the
+    # snapshot endpoint on the JPEG before pairing.
+    ref = "abcdef012345"
+    os.makedirs(edit_masks_dir(str(tmp_path)), exist_ok=True)
+    src_snap = snapshot_path(str(tmp_path), jpeg_id, ref)
+    with open(src_snap, "wb") as f:
+        f.write(b"snapshot-bytes")
+    # Also leave a decoy file for a different photo_id so the transfer
+    # doesn't over-match.
+    decoy = os.path.join(edit_masks_dir(str(tmp_path)), f"99999.{ref}.png")
+    with open(decoy, "wb") as f:
+        f.write(b"decoy-bytes")
+
+    _pair_raw_jpeg_companions(db, vireo_dir=str(tmp_path))
+
+    photo = db.conn.execute(
+        "SELECT id, filename FROM photos"
+    ).fetchone()
+    assert photo["filename"] == "IMG_002.cr3"
+    primary_id = photo["id"]
+    assert primary_id == raw_id
+
+    # The companion's snapshot file must have moved to the primary id.
+    assert not os.path.exists(src_snap)
+    assert os.path.exists(snapshot_path(str(tmp_path), primary_id, ref))
+    # Decoy for an unrelated photo id must not be touched.
+    assert os.path.exists(decoy)
+
+
 def test_pairing_does_not_copy_rejected_flag_to_raw(tmp_path):
     """A companion JPEG's 'rejected' flag (e.g. set by the duplicate
     auto-resolver when the JPEG has a byte-identical twin) must not be

--- a/vireo/tests/test_tone.py
+++ b/vireo/tests/test_tone.py
@@ -146,3 +146,97 @@ def test_positive_vibrance_prefers_less_saturated_colors():
     low_gain = float(np.max(low_out) - np.min(low_out)) / float(np.max(low) - np.min(low))
     high_gain = float(np.max(high_out) - np.min(high_out)) / float(np.max(high) - np.min(high))
     assert low_gain > high_gain
+
+
+# --- local (mask-weighted) tone -------------------------------------------
+
+
+def _halves_weight(height=4, width=8):
+    """Weight 1.0 on the left half, 0.0 on the right."""
+    w = np.zeros((height, width), dtype=np.float32)
+    w[:, : width // 2] = 1.0
+    return w
+
+
+def test_local_weight_none_matches_global_only():
+    rng = np.random.default_rng(9)
+    px = rng.random((4, 8, 3)).astype(np.float32)
+    a = apply_adjustments(px, exposure=0.7, shadows=20)
+    b = apply_adjustments(
+        px, exposure=0.7, shadows=20,
+        local_weight=None, local_subject=None, local_background=None,
+    )
+    assert np.array_equal(a, b)
+
+
+def test_local_exposure_applies_only_inside_weight():
+    px = np.full((4, 8, 3), 0.2, dtype=np.float32)
+    w = _halves_weight()
+
+    out = apply_adjustments(
+        px, local_weight=w, local_subject={"exposure": 1.0},
+    )
+    global_only = apply_adjustments(px)
+
+    # Right half (w=0) identical to the no-local render.
+    assert np.allclose(out[:, 4:], global_only[:, 4:], atol=1e-6)
+    # Left half brightened by ~one stop in linear light.
+    left_lin = srgb_to_linear(out[:, :4, 0])
+    base_lin = srgb_to_linear(px[:, :4, 0])
+    assert np.allclose(left_lin, base_lin * 2.0, rtol=0.02)
+
+
+def test_local_background_applies_to_inverse_weight():
+    px = np.full((4, 8, 3), 0.5, dtype=np.float32)
+    w = _halves_weight()
+
+    out = apply_adjustments(
+        px, local_weight=w, local_background={"exposure": -1.0},
+    )
+
+    # Subject half untouched, background half darkened.
+    assert np.allclose(out[:, :4], px[:, :4], atol=1e-3)
+    assert np.all(out[:, 4:, 0] < 0.4)
+
+
+def test_local_deltas_compose_with_global():
+    # Global +40 shadows, subject delta -40: subject area nets to no shadow
+    # lift, background keeps the global lift.
+    px = np.full((4, 8, 3), 0.15, dtype=np.float32)
+    w = _halves_weight()
+
+    out = apply_adjustments(
+        px, shadows=40, local_weight=w, local_subject={"shadows": -40},
+    )
+    no_lift = apply_adjustments(px)
+    lifted = apply_adjustments(px, shadows=40)
+
+    assert np.allclose(out[:, :4], no_lift[:, :4], atol=1e-3)
+    assert np.allclose(out[:, 4:], lifted[:, 4:], atol=1e-3)
+
+
+def test_local_saturation_weighted():
+    px = np.zeros((2, 2, 3), dtype=np.float32)
+    px[..., 0] = 0.7
+    px[..., 1] = 0.3
+    px[..., 2] = 0.3
+    w = np.array([[1.0, 0.0], [1.0, 0.0]], dtype=np.float32)
+
+    out = apply_adjustments(
+        px, local_weight=w, local_subject={"saturation": -100},
+    )
+
+    # w=1 column fully desaturated (channels equal), w=0 column unchanged.
+    assert np.allclose(out[:, 0, 0], out[:, 0, 1], atol=1e-4)
+    assert np.allclose(out[:, 1], px[:, 1], atol=1e-4)
+
+
+def test_local_fractional_weight_is_between():
+    px = np.full((1, 3, 3), 0.25, dtype=np.float32)
+    w = np.array([[0.0, 0.5, 1.0]], dtype=np.float32)
+
+    out = apply_adjustments(
+        px, local_weight=w, local_subject={"exposure": 1.5},
+    )
+
+    assert out[0, 0, 0] < out[0, 1, 0] < out[0, 2, 0]

--- a/vireo/thumbnails.py
+++ b/vireo/thumbnails.py
@@ -175,9 +175,16 @@ def generate_thumbnail(
             img.close()
             return None
     if recipe:
+        import local_masks
         from image_edits import apply_recipe_to_loaded_image
+        # cache_dir is <vireo_dir>/thumbnails, the same root derivation the
+        # app uses (dirname of THUMB_CACHE_DIR), so snapshots resolve here
+        # without threading vireo_dir through every caller.
         img = apply_recipe_to_loaded_image(
             img, recipe, max_size=size, native_size=native_size,
+            local_mask=local_masks.load_snapshot(
+                os.path.dirname(os.path.abspath(cache_dir)), photo_id, recipe,
+            ),
         )
 
     os.makedirs(cache_dir, exist_ok=True)

--- a/vireo/tone.py
+++ b/vireo/tone.py
@@ -126,7 +126,17 @@ def _luma(rgb):
 
 
 def _blend_range(rgb, amount, mask):
-    """Move masked pixels toward white or black without hard clipping."""
+    """Move masked pixels toward white or black without hard clipping.
+
+    ``amount`` is a scalar in [-100, 100], or a per-pixel array of the same
+    (broadcastable) shape for local (mask-weighted) adjustments.
+    """
+    if np.ndim(amount) > 0:
+        amount = np.asarray(amount, dtype=np.float32) / 100.0
+        scaled = mask * np.abs(amount)
+        return np.where(
+            amount > 0, rgb + (1.0 - rgb) * scaled, rgb - rgb * scaled
+        )
     amount = float(amount) / 100.0
     if abs(amount) < 1e-9:
         return rgb
@@ -143,9 +153,9 @@ def apply_range_adjustments(
     out = np.asarray(rgb, dtype=np.float32)
     lum = _luma(out)
 
-    if shadows:
+    if np.any(shadows):
         out = _blend_range(out, shadows, (1.0 - smoothstep(0.05, 0.65, lum)) * 0.48)
-    if highlights:
+    if np.any(highlights):
         out = _blend_range(out, highlights, smoothstep(0.35, 0.95, lum) * 0.42)
     if blacks:
         out = _blend_range(out, blacks, (1.0 - smoothstep(0.00, 0.30, lum)) * 0.34)
@@ -183,6 +193,9 @@ def apply_adjustments(
     contrast=0.0,
     vibrance=0.0,
     saturation=0.0,
+    local_weight=None,
+    local_subject=None,
+    local_background=None,
 ):
     """Apply tonal adjustments to an sRGB float image and return sRGB float.
 
@@ -200,8 +213,38 @@ def apply_adjustments(
 
     Returns:
         float32 array, same shape, sRGB-encoded and clipped to [0,1].
+
+    Local (mask-weighted) adjustments: ``local_weight`` is a per-pixel
+    subject weight shaped ``(..., )`` matching the image's spatial dims;
+    ``local_subject`` / ``local_background`` are dicts of *deltas* on top of
+    the global values (keys: exposure, highlights, shadows, contrast,
+    saturation). Effective per-pixel amounts are
+    ``global + subject·w + background·(1−w)``, clamped to each control's
+    global range. The weight is an extra per-pixel *input*, not a
+    neighborhood op, so this pipeline (and its future shader transcription)
+    stays strictly per-pixel. When no local inputs are given, execution
+    takes the original global-only path unchanged — byte-identical output.
     """
     rgb = np.asarray(rgb, dtype=np.float32)
+
+    subject = local_subject or {}
+    background = local_background or {}
+    if local_weight is not None and (subject or background):
+        return _apply_adjustments_weighted(
+            rgb,
+            weight=np.asarray(local_weight, dtype=np.float32),
+            subject=subject,
+            background=background,
+            exposure=exposure,
+            white_balance=white_balance,
+            highlights=highlights,
+            shadows=shadows,
+            whites=whites,
+            blacks=blacks,
+            contrast=contrast,
+            vibrance=vibrance,
+            saturation=saturation,
+        )
 
     # --- scene-referred ops, in linear light ---
     lin_pre = srgb_to_linear(rgb)
@@ -247,6 +290,101 @@ def apply_adjustments(
     if vibrance:
         disp = apply_vibrance(disp, vibrance)
     if saturation:
+        s = np.float32(max(0.0, 1.0 + float(saturation) / 100.0))
+        luma = _luma(disp)
+        disp = luma + (disp - luma) * s
+
+    return np.clip(disp, 0.0, 1.0)
+
+
+# Global ranges the weighted amounts clamp to — the local composition
+# contract is `clamp(global + subject·w + background·(1−w))` per control.
+_LOCAL_CLAMPS = {
+    "exposure": (-5.0, 5.0),
+    "highlights": (-100.0, 100.0),
+    "shadows": (-100.0, 100.0),
+    "contrast": (-100.0, 100.0),
+    "saturation": (-100.0, 100.0),
+}
+
+
+def _apply_adjustments_weighted(
+    rgb, *, weight, subject, background, exposure, white_balance,
+    highlights, shadows, whites, blacks, contrast, vibrance, saturation,
+):
+    """Local (mask-weighted) variant of :func:`apply_adjustments`.
+
+    Kept as a separate branch so the global-only path above stays literally
+    unchanged (its byte-exactness backs the no-cache-purge guarantee and the
+    shader-parity test). Controls without local deltas run the same scalar
+    math as the global path; controls with deltas run the identical formulas
+    with a per-pixel amount map.
+    """
+    w = weight[..., None]
+
+    def amount_map(name, global_value):
+        """Per-pixel amount for a control, or None to use the scalar path."""
+        s = float(subject.get(name) or 0.0)
+        b = float(background.get(name) or 0.0)
+        if abs(s) < 1e-9 and abs(b) < 1e-9:
+            return None
+        lo, hi = _LOCAL_CLAMPS[name]
+        return np.clip(
+            np.float32(global_value) + np.float32(s) * w + np.float32(b) * (1.0 - w),
+            lo, hi,
+        )
+
+    # --- scene-referred ops, in linear light ---
+    lin_pre = srgb_to_linear(rgb)
+    lin = lin_pre
+    ev_map = amount_map("exposure", exposure)
+    if ev_map is not None:
+        lin = lin * np.exp2(ev_map)
+        max_gain = 2.0 ** float(np.max(ev_map))
+    else:
+        exp_gain = 2.0 ** float(exposure)
+        if exposure:
+            lin = lin * np.float32(exp_gain)
+        max_gain = exp_gain
+    gr = gg = gb = 1.0
+    if white_balance:
+        gr, gg, gb = white_balance_gains(white_balance)
+        lin = lin * np.array([gr, gg, gb], dtype=np.float32)
+    # Same push-gate and monotonicity clamp as the global path; with a
+    # per-pixel gain the clamp is already per-pixel-correct, and gating on
+    # the maximum gain only controls whether the shoulder runs at all.
+    if max_gain * max(gr, gg, gb) > 1.0 + 1e-6:
+        rolled = highlight_rolloff(lin)
+        lin = np.maximum(rolled, np.minimum(lin_pre, lin))
+
+    # --- display-referred ops, in sRGB ---
+    disp = linear_to_srgb(lin)
+    hi_amt = amount_map("highlights", highlights)
+    sh_amt = amount_map("shadows", shadows)
+    hi_arg = highlights if hi_amt is None else hi_amt
+    sh_arg = shadows if sh_amt is None else sh_amt
+    if np.any(hi_arg) or np.any(sh_arg) or whites or blacks:
+        disp = apply_range_adjustments(
+            disp,
+            highlights=hi_arg,
+            shadows=sh_arg,
+            whites=whites,
+            blacks=blacks,
+        )
+    c_amt = amount_map("contrast", contrast)
+    if c_amt is not None:
+        disp = (disp - 0.5) * (1.0 + c_amt / 100.0) + 0.5
+    elif contrast:
+        c = np.float32(1.0 + float(contrast) / 100.0)
+        disp = (disp - 0.5) * c + 0.5
+    if vibrance:
+        disp = apply_vibrance(disp, vibrance)
+    s_amt = amount_map("saturation", saturation)
+    if s_amt is not None:
+        s = np.maximum(0.0, 1.0 + s_amt / 100.0).astype(np.float32)
+        luma = _luma(disp)
+        disp = luma + (disp - luma) * s
+    elif saturation:
         s = np.float32(max(0.0, 1.0 + float(saturation) / 100.0))
         luma = _luma(disp)
         disp = luma + (disp - luma) * s


### PR DESCRIPTION
## What

First of the three PRs from the local-adjustments design (#1088): the recipe schema and full rendering path for mask-weighted subject/background adjustments. No UI yet — that's PR 2. Everything is exercisable through the API today (snapshot → save recipe → any render path).

- **Schema**: `local: {mask: {ref, source_digest, feather}, regions: [{region, adjustments}]}`. Region values are deltas on top of the global adjustments (v1 keys: exposure, highlights, shadows, contrast, saturation + sharpen/sharpen_radius/noise_reduction), canonicalized and range-checked like everything else; empty regions drop the whole section.
- **Snapshots (`vireo/local_masks.py`)**: `POST /api/photos/<id>/local-mask/snapshot` freezes the active SAM mask into a content-addressed copy under `<db_dir>/edit-masks/`; renders read only the snapshot, so live-mask regeneration never silently changes committed edits. Staleness (`local_mask_stale` on recipe GET) compares recorded source metadata (mask file digest + prompt + detector + variant), never snapshot pixels. Unreferenced snapshots GC on the existing stale-mask sweep, guarded by a 24h mtime grace window and edit-history reachability.
- **Rendering**: the snapshot rides through the recipe's geometry (rotate/flip/straighten/crop) alongside the image, feathers at each consumer's resolution, and drives (a) per-pixel weighted tone inside the existing linear-light pipeline (`global + subject·w + background·(1−w)`, clamped) and (b) a two-branch detail pass — the detail pipeline runs once per distinct (global + region delta) parameter set and blends by the weight map, so whole-photo sharpen/NR is never dropped and subject-sharpen + background-NR compose correctly.
- **Safety**: a missing/unreadable/aspect-mismatched mask disables **all** local regions with a warning (never inverts into a whole-frame background edit); the global-only tone path is untouched code (byte-identical, shader-parity test unchanged, no `EDIT_MATH_VERSION` bump); bulk apply rejects local sections until PR 2 adds per-target resnapshot.
- All 8 render call sites (edit-preview, preview cache + warmup, thumbnails, exports, external-edit, iNat, originals cache) load the snapshot and render local regions.

## Stated v1 cuts from the design doc (#1088)

Per the trimmed scope discussed on that PR: single snapshot per recipe (no per-decode-basis variant families) — degraded render paths (embedded-JPEG fallback, aspect-mismatched proxies) disable the local pass with a warning instead of getting their own variants; `tempfile + os.replace` publish + mtime grace window instead of the publish/GC lock protocol; snapshot creation copies the active mask (no SAM re-run in demosaic space — RAWs whose mask aspect disagrees with the sensor are refused at snapshot time); bulk-apply resnapshot and the editor UI/overlay endpoint land in PR 2. Every cut degrades to "local adjustments off, honestly" — never to wrong pixels.

## Tests

- `1462 passed, 3 skipped`: CLAUDE.md suite + image_edits/tone/shader-parity/detail/thumbnails/export, plus new `test_local_masks.py` (snapshot, digest, staleness, GC/grace/history), `test_local_render.py` (weighted tone, geometry-following weights, crop/flip, feather, two-branch detail, global-detail preservation, all-or-nothing disable, tiling equivalence), schema tests, and API tests (snapshot endpoint, round-trip, stale flag, unknown-ref 400, bulk-apply guard, edit-preview render).
- `498 passed`: full pipeline suites.
- End-to-end on a live app instance: registered a mask, snapshotted via the endpoint, saved a two-region recipe, and verified the edit-preview brightened/sharpened the subject half (+31 mean luma) while darkening/desaturating the background half (−48) in a single render, with `local_mask_stale: false` on GET.

🤖 Generated with [Claude Code](https://claude.com/claude-code)