### PR TITLE
Fix two e2e failures: batch EXIF-accept regression + stale mask-default test

### DIFF
--- a/tests/e2e/test_lightbox_context_menu.py
+++ b/tests/e2e/test_lightbox_context_menu.py
@@ -72,7 +72,12 @@ def test_lightbox_right_click_opens_menu(live_server, page):
 
 
 def test_lightbox_overlay_toggles_persist_and_context_restores(live_server, page):
-    """Lightbox overlay visibility toggles persist and stay recoverable."""
+    """Lightbox overlay visibility toggles persist and stay recoverable.
+
+    Defaults with no stored preference: boxes/eye/info/chrome visible, masks
+    hidden (PR #1083). One click on each toggle therefore flips boxes, eye,
+    info and chrome OFF but flips masks ON.
+    """
     url = live_server["url"]
     page.goto(f"{url}/browse")
     page.evaluate(
@@ -109,7 +114,7 @@ def test_lightbox_overlay_toggles_persist_and_context_restores(live_server, page
         timeout=2000,
     )
     assert page.evaluate("localStorage.getItem('vireo.lb.boxesVisible')") == "0"
-    assert page.evaluate("localStorage.getItem('vireo.lb.masksVisible')") == "0"
+    assert page.evaluate("localStorage.getItem('vireo.lb.masksVisible')") == "1"
     assert page.evaluate("localStorage.getItem('vireo.lb.eyeVisible')") == "0"
     assert page.evaluate("localStorage.getItem('vireo.lb.infoVisible')") == "0"
     assert page.evaluate("localStorage.getItem('vireo.lb.chromeVisible')") == "0"
@@ -138,7 +143,7 @@ def test_lightbox_overlay_toggles_persist_and_context_restores(live_server, page
         timeout=2000,
     )
     assert page.locator("#lightboxToggleBoxes").inner_text() == "Show Boxes"
-    assert page.locator("#lightboxToggleMasks").inner_text() == "Show Masks"
+    assert page.locator("#lightboxToggleMasks").inner_text() == "Hide Masks"
     assert page.locator("#lightboxToggleEye").inner_text() == "Show Eye"
 
 

--- a/tests/e2e/test_location_section.py
+++ b/tests/e2e/test_location_section.py
@@ -1018,6 +1018,99 @@ def test_exif_suggestion_cleared_by_anchor_drop_then_select_all(
         assert row is None, f"photo {pid} should not have gained a location"
 
 
+def test_exif_suggestion_cleared_by_batch_clear_then_select_all(
+    live_server, page, monkeypatch
+):
+    """Codex P2 (PR #1097): the batch-bar Clear button invokes clearSelection()
+    directly, which used to bypass every EXIF-suggestion scrub path. With
+    A's Accept line visible, Cmd-click B, click the batch-bar Clear button,
+    then Select All on a view that still contains A: renderLocationEmpty's
+    owner-in-selection check would find A in the new batch and re-show the
+    old #locationExifSuggestion. Accept would then apply A's place_id to
+    every selected photo.
+
+    Sequence: open A (suggestion appears) → Cmd-click B (batch mode, A still
+    focused anchor, suggestion preserved) → clearSelection() (mirrors the
+    batch-bar Clear onclick) → Select All / Ctrl+A. The suggestion must
+    stay hidden and dropped from the DOM, and no photo may gain a location.
+    """
+    photo_ids = live_server["data"]["photos"][:3]
+    anchor, other_b, other_c = photo_ids
+    _seed_exif_photos(live_server, [anchor])
+    _seed_reverse_geocode_cache(
+        live_server, 40.785091, -73.968285, _CANNED_PLACE_ID, _CANNED_DETAILS,
+    )
+    _set_api_key()
+
+    import places
+    monkeypatch.setattr(
+        places, "place_details", lambda pid, key: _CANNED_DETAILS,
+    )
+
+    db = live_server["db"]
+
+    page.goto(f"{live_server['url']}/browse")
+    page.locator(".grid-card").first.wait_for(state="visible")
+
+    page.locator(f".grid-card[data-id='{anchor}']").click()
+    _wait_for_detail_loaded(page)
+    accept = page.locator("#locationExifSuggestion button.accept-btn")
+    expect(accept).to_be_visible()
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').dataset.photoId"
+    ) == str(anchor)
+
+    # Grow to batch {A, B} — A is still the focused anchor.
+    page.locator(f".grid-card[data-id='{other_b}']").click(modifiers=["Meta"])
+    page.wait_for_function(
+        "(id) => selectedPhotos.size === 2 && selectedPhotos.has(id)",
+        arg=anchor,
+    )
+    expect(accept).to_be_visible()
+
+    # Click the batch-bar Clear button by invoking the same function it does.
+    # This is the code path the fix targets — clearSelection() bypasses
+    # closeDetail and the selectPhoto deselect scrub, so it needs its own.
+    page.evaluate("() => clearSelection()")
+    page.wait_for_function(
+        "() => selectedPhotos.size === 0 && window.selectedPhotoId == null"
+    )
+
+    # Immediately after Clear, the suggestion must already be scrubbed —
+    # without the fix it would still be tagged with A's id, hidden inside
+    # the empty container waiting to resurrect.
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').dataset.photoId || ''"
+    ) == ""
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').innerHTML"
+    ) == ""
+
+    # Select All — includes the previously-open anchor. Without the fix,
+    # keepSugg would be true (owner A is in the new ids) and A's Accept line
+    # would flash back into the batch panel.
+    page.evaluate("() => selectAllMatchingPhotos()")
+    page.wait_for_function("() => selectedPhotos.size >= 3")
+
+    expect(page.locator("#locationExifSuggestion")).to_be_hidden()
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').innerHTML"
+    ) == ""
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').dataset.photoId || ''"
+    ) == ""
+
+    # No photo in the batch may have gained a location.
+    for pid in (anchor, other_b, other_c):
+        row = db.conn.execute(
+            "SELECT 1 FROM photo_keywords pk "
+            "JOIN keywords k ON k.id = pk.keyword_id "
+            "WHERE pk.photo_id = ? AND k.type = 'location'",
+            (pid,),
+        ).fetchone()
+        assert row is None, f"photo {pid} should not have gained a location"
+
+
 def test_freetext_location_batches_selection_and_refreshes_smart_collection(
     live_server, page
 ):

--- a/tests/e2e/test_location_section.py
+++ b/tests/e2e/test_location_section.py
@@ -926,6 +926,98 @@ def test_exif_suggestion_cleared_by_close_detail(
         assert row is None, f"photo {pid} should not have gained a location"
 
 
+def test_exif_suggestion_cleared_by_anchor_drop_then_select_all(
+    live_server, page, monkeypatch
+):
+    """Codex P2 (PR #1097): Cmd/Ctrl-click that drops the focused anchor out
+    of a non-empty selection bypasses closeDetail. selectPhoto hides the
+    detail panel and nulls selectedPhotoId, but the previous scrub only ran
+    inside closeDetail — so #locationExifSuggestion kept its data-photo-id
+    and Accept button. A later Select All that still contained the dropped
+    anchor would then satisfy renderLocationEmpty's owner-in-selection check
+    and resurrect the anchor's Accept line for the whole batch, letting one
+    click apply the dropped anchor's GPS-derived place to every selected
+    photo.
+
+    Sequence: open A (suggestion appears) → Cmd-click B (batch mode, A still
+    the focused anchor, suggestion preserved) → Cmd-click A to drop the
+    anchor (selectedPhotos={B}, focus dropped, detail panel hidden, but
+    closeDetail is not called) → Select All / Ctrl+A (batch inspector opens
+    with A back in the selection). The suggestion must stay hidden and
+    dropped from the DOM, and no photo in the batch may gain a location.
+    """
+    photo_ids = live_server["data"]["photos"][:3]
+    anchor, other_b, other_c = photo_ids
+    _seed_exif_photos(live_server, [anchor])
+    _seed_reverse_geocode_cache(
+        live_server, 40.785091, -73.968285, _CANNED_PLACE_ID, _CANNED_DETAILS,
+    )
+    _set_api_key()
+
+    import places
+    monkeypatch.setattr(
+        places, "place_details", lambda pid, key: _CANNED_DETAILS,
+    )
+
+    db = live_server["db"]
+
+    page.goto(f"{live_server['url']}/browse")
+    page.locator(".grid-card").first.wait_for(state="visible")
+
+    page.locator(f".grid-card[data-id='{anchor}']").click()
+    _wait_for_detail_loaded(page)
+    accept = page.locator("#locationExifSuggestion button.accept-btn")
+    expect(accept).to_be_visible()
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').dataset.photoId"
+    ) == str(anchor)
+
+    # Grow to batch {A, B} — A is still the focused anchor, so the suggestion
+    # is preserved by design.
+    page.locator(f".grid-card[data-id='{other_b}']").click(modifiers=["Meta"])
+    page.wait_for_function(
+        "(id) => selectedPhotos.size === 2 && selectedPhotos.has(id)",
+        arg=anchor,
+    )
+    expect(accept).to_be_visible()
+
+    # Drop the anchor out of the selection via Cmd-click. selectPhoto's
+    # metaKey branch fires — not closeDetail — so this is the code path the
+    # fix targets. After this, selectedPhotos={B} but the suggestion element
+    # is what we care about: it must not carry A's data-photo-id/innerHTML
+    # into the next batch that includes A.
+    page.locator(f".grid-card[data-id='{anchor}']").click(modifiers=["Meta"])
+    page.wait_for_function(
+        "(id) => selectedPhotos.size === 1 && !selectedPhotos.has(id) && "
+        "window.selectedPhotoId == null",
+        arg=anchor,
+    )
+
+    # Select All — includes the dropped anchor, so the batch inspector opens
+    # with A back in ids. Without the fix, keepSugg would be true and A's
+    # Accept line would flash back into the batch panel.
+    page.evaluate("() => selectAllMatchingPhotos()")
+    page.wait_for_function("() => selectedPhotos.size >= 3")
+
+    expect(page.locator("#locationExifSuggestion")).to_be_hidden()
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').innerHTML"
+    ) == ""
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').dataset.photoId || ''"
+    ) == ""
+
+    # No photo in the batch may have gained a location.
+    for pid in (anchor, other_b, other_c):
+        row = db.conn.execute(
+            "SELECT 1 FROM photo_keywords pk "
+            "JOIN keywords k ON k.id = pk.keyword_id "
+            "WHERE pk.photo_id = ? AND k.type = 'location'",
+            (pid,),
+        ).fetchone()
+        assert row is None, f"photo {pid} should not have gained a location"
+
+
 def test_freetext_location_batches_selection_and_refreshes_smart_collection(
     live_server, page
 ):

--- a/tests/e2e/test_location_section.py
+++ b/tests/e2e/test_location_section.py
@@ -1314,6 +1314,139 @@ def test_exif_suggestion_bails_when_slow_geocode_resolves_after_batch_clear(
         assert row is None, f"photo {pid} should not have gained a location"
 
 
+def test_exif_suggestion_cleared_by_loaddetail_before_select_all(
+    live_server, page, monkeypatch
+):
+    """Codex P2 (PR #1097, 17:23Z): loadDetail(B) hides the panel and awaits
+    /api/photos/B before renderDetail runs — the maybeShowExifSuggestion call
+    that scrubs #locationExifSuggestion only fires once that response
+    resolves. If the user clicks B and quickly hits Select All while B's
+    fetch is still in flight, the previous photo's stale suggestion (with
+    data-photo-id=A) is still in the DOM. renderBatchInspector's
+    preserveExifSuggestion check sees A in the Select All ids and
+    resurrects A's Accept line for the whole batch — clicking it applies
+    A's EXIF place to every selected photo.
+
+    Sequence: open A (suggestion appears, tagged for A) → intercept and
+    hold /api/photos/B → click B (loadDetail starts, fetch held) → Select
+    All (batch inspector opens with A back in ids). The suggestion must
+    stay hidden and no photo may gain a location.
+    """
+    photo_ids = live_server["data"]["photos"][:3]
+    anchor, other_b, other_c = photo_ids
+    # Only the anchor has GPS. B and C have no lat/lng, so their own
+    # maybeShowExifSuggestion calls bail immediately and can't race with
+    # ours (which would mask the bug).
+    _seed_exif_photos(live_server, [anchor])
+    _seed_reverse_geocode_cache(
+        live_server, 40.785091, -73.968285, _CANNED_PLACE_ID, _CANNED_DETAILS,
+    )
+    _set_api_key()
+
+    import places
+    monkeypatch.setattr(
+        places, "place_details", lambda pid, key: _CANNED_DETAILS,
+    )
+
+    db = live_server["db"]
+
+    page.goto(f"{live_server['url']}/browse")
+    page.locator(".grid-card").first.wait_for(state="visible")
+
+    page.locator(f".grid-card[data-id='{anchor}']").click()
+    _wait_for_detail_loaded(page)
+    accept = page.locator("#locationExifSuggestion button.accept-btn")
+    expect(accept).to_be_visible()
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').dataset.photoId"
+    ) == str(anchor)
+
+    # Hold B's detail fetch. This is the code path the fix targets — the
+    # DOM scrubs inside renderDetail (via renderLocationEmpty /
+    # renderLocationFilled) only run once /api/photos/B resolves, so any
+    # Select All that lands during the await used to see A's stale
+    # data-photo-id and resurrect A's Accept line for the batch.
+    held_routes = []
+
+    def _hold_photo_b(route):
+        held_routes.append(route)
+
+    page.route(f"**/api/photos/{other_b}", _hold_photo_b)
+
+    page.locator(f".grid-card[data-id='{other_b}']").click()
+
+    # Wait for loadDetail(B) to have actually started and issued the held
+    # fetch. Once it has, the pre-await scrub in loadDetail must have run
+    # synchronously — the ambient owner pointer is nulled and the DOM tag
+    # is dropped even though B's response hasn't arrived yet.
+    for _ in range(50):
+        if held_routes:
+            break
+        page.wait_for_timeout(100)
+    assert held_routes, "/api/photos/B fetch was never issued"
+    assert page.evaluate("() => window._detailPhotoId") is None
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').dataset.photoId || ''"
+    ) == ""
+
+    # Select All while B's detail is still stalled. Without the pre-await
+    # scrub, keepSugg would be true (A's data-photo-id still present, A in
+    # the Select All ids) and A's Accept line would flash back into the
+    # batch inspector.
+    page.evaluate("() => selectAllMatchingPhotos()")
+    page.wait_for_function("() => selectedPhotos.size >= 3")
+
+    expect(page.locator("#locationExifSuggestion")).to_be_hidden()
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').innerHTML"
+    ) == ""
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').dataset.photoId || ''"
+    ) == ""
+
+    # Release B's held detail response so nothing dangles at teardown.
+    # loadDetail's post-await guard (`selectedPhotos.size <= 1`) will drop
+    # this render anyway now that Select All has promoted the selection,
+    # but we still want the network layer to complete cleanly.
+    held_routes[0].fulfill(
+        status=200,
+        content_type="application/json",
+        body=json.dumps({
+            "id": other_b,
+            "filename": f"photo_{other_b}.jpg",
+            "rating": 0,
+            "flag": None,
+            "color_label": None,
+            "keywords": [],
+            "xmp_keywords": [],
+            "xmp_exists": False,
+            "metadata": {},
+            "location": None,
+            "latitude": None,
+            "longitude": None,
+        }),
+    )
+    page.wait_for_timeout(200)
+
+    # After the response drains, the suggestion must still be gone — the
+    # post-await guard in loadDetail must skip renderDetail while the
+    # batch selection is active.
+    expect(page.locator("#locationExifSuggestion")).to_be_hidden()
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').dataset.photoId || ''"
+    ) == ""
+
+    # No photo in the batch may have gained a location.
+    for pid in (anchor, other_b, other_c):
+        row = db.conn.execute(
+            "SELECT 1 FROM photo_keywords pk "
+            "JOIN keywords k ON k.id = pk.keyword_id "
+            "WHERE pk.photo_id = ? AND k.type = 'location'",
+            (pid,),
+        ).fetchone()
+        assert row is None, f"photo {pid} should not have gained a location"
+
+
 def test_freetext_location_batches_selection_and_refreshes_smart_collection(
     live_server, page
 ):

--- a/tests/e2e/test_location_section.py
+++ b/tests/e2e/test_location_section.py
@@ -1111,6 +1111,209 @@ def test_exif_suggestion_cleared_by_batch_clear_then_select_all(
         assert row is None, f"photo {pid} should not have gained a location"
 
 
+def test_exif_suggestion_bails_when_slow_geocode_resolves_after_close_detail(
+    live_server, page, monkeypatch
+):
+    """Codex P2 (PR #1097, 17:04Z follow-up): closeDetail() scrubs the
+    #locationExifSuggestion DOM but used to leave window._detailPhotoId
+    pointing at the departed photo. maybeShowExifSuggestion's post-await
+    guards checked `_detailPhotoId === requestPhotoId` and
+    `_locationApplyPhotoIds().indexOf(requestPhotoId) !== -1` — after
+    close + Select All, both were still satisfied (the pointer never
+    moved and the departed photo was back in the selection), so a slow
+    reverse-geocode for A would repaint A's Accept line into the batch
+    inspector. Clicking Accept would then apply A's EXIF place to every
+    selected photo.
+
+    Sequence: open A (reverse-geocode intercepted and held) → close the
+    detail panel via the × button → Select All (batch inspector opens
+    with A back in the selection) → release the held response. The
+    suggestion must stay hidden and no photo may gain a location.
+    """
+    photo_ids = live_server["data"]["photos"][:3]
+    anchor, other_b, other_c = photo_ids
+    # Only the anchor has GPS. B and C have no lat/lng, so their own
+    # maybeShowExifSuggestion calls bail immediately and can't race with
+    # ours (which would mask the bug).
+    _seed_exif_photos(live_server, [anchor])
+    _set_api_key()
+
+    import places
+    monkeypatch.setattr(
+        places, "place_details", lambda pid, key: _CANNED_DETAILS,
+    )
+
+    db = live_server["db"]
+
+    held_routes = []
+
+    def _hold_reverse_geocode(route):
+        held_routes.append(route)
+
+    page.route("**/api/places/reverse-geocode**", _hold_reverse_geocode)
+
+    page.goto(f"{live_server['url']}/browse")
+    page.locator(".grid-card").first.wait_for(state="visible")
+
+    page.locator(f".grid-card[data-id='{anchor}']").click()
+    _wait_for_detail_loaded(page)
+
+    # maybeShowExifSuggestion awaits _cfgPromise before fetching, so wait
+    # for the browser to actually issue the reverse-geocode request.
+    for _ in range(50):
+        if held_routes:
+            break
+        page.wait_for_timeout(100)
+    assert held_routes, "reverse-geocode fetch was never issued"
+
+    # Close the detail panel via the × button — the real closeDetail()
+    # path. Escape would also clear selectedPhotos, hiding the bug.
+    page.locator(".detail-close").click()
+    page.wait_for_function("() => window.selectedPhotoId == null")
+    # The scrub null-ed the ambient owner pointer synchronously.
+    assert page.evaluate("() => window._detailPhotoId") is None
+
+    # Select All — the departed anchor is back in the selection.
+    page.evaluate("() => selectAllMatchingPhotos()")
+    page.wait_for_function("() => selectedPhotos.size >= 3")
+
+    # Now release the held reverse-geocode response. Without the fix, the
+    # completion path would repaint A's Accept line into the batch panel
+    # (both async guards still pass because _detailPhotoId still equals A
+    # and A is now in the selection).
+    held_routes[0].fulfill(
+        status=200,
+        content_type="application/json",
+        body=json.dumps({
+            "place_id": _CANNED_PLACE_ID,
+            "summary": _CANNED_DETAILS["name"],
+            "lat": _CANNED_DETAILS["lat"],
+            "lng": _CANNED_DETAILS["lng"],
+            "cached": False,
+        }),
+    )
+    # Give the async completion a chance to run. If it were going to paint,
+    # it'd happen synchronously after the fetch/JSON awaits resolve.
+    page.wait_for_timeout(300)
+
+    expect(page.locator("#locationExifSuggestion")).to_be_hidden()
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').innerHTML"
+    ) == ""
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').dataset.photoId || ''"
+    ) == ""
+
+    # And no photo in the batch may have gained a location.
+    for pid in (anchor, other_b, other_c):
+        row = db.conn.execute(
+            "SELECT 1 FROM photo_keywords pk "
+            "JOIN keywords k ON k.id = pk.keyword_id "
+            "WHERE pk.photo_id = ? AND k.type = 'location'",
+            (pid,),
+        ).fetchone()
+        assert row is None, f"photo {pid} should not have gained a location"
+
+
+def test_exif_suggestion_bails_when_slow_geocode_resolves_after_batch_clear(
+    live_server, page, monkeypatch
+):
+    """Codex P2 (PR #1097, 17:04Z follow-up): the batch-bar Clear button
+    calls clearSelection(), which scrubs the DOM but used to leave
+    window._detailPhotoId pointing at the departed anchor. A pending
+    reverse-geocode for A then resolves after the user hits Clear and
+    Select All (which brings A back into the batch); the async guards
+    still pass, so A's Accept line repaints into the batch inspector and
+    Accept posts A's EXIF place to every selected photo.
+
+    Sequence: open A (reverse-geocode held) → Cmd-click B (batch mode) →
+    clearSelection() (mirrors the batch-bar Clear onclick) → Select All →
+    release the held response. The suggestion must stay hidden and no
+    photo may gain a location.
+    """
+    photo_ids = live_server["data"]["photos"][:3]
+    anchor, other_b, other_c = photo_ids
+    _seed_exif_photos(live_server, [anchor])
+    _set_api_key()
+
+    import places
+    monkeypatch.setattr(
+        places, "place_details", lambda pid, key: _CANNED_DETAILS,
+    )
+
+    db = live_server["db"]
+
+    held_routes = []
+
+    def _hold_reverse_geocode(route):
+        held_routes.append(route)
+
+    page.route("**/api/places/reverse-geocode**", _hold_reverse_geocode)
+
+    page.goto(f"{live_server['url']}/browse")
+    page.locator(".grid-card").first.wait_for(state="visible")
+
+    page.locator(f".grid-card[data-id='{anchor}']").click()
+    _wait_for_detail_loaded(page)
+
+    for _ in range(50):
+        if held_routes:
+            break
+        page.wait_for_timeout(100)
+    assert held_routes, "reverse-geocode fetch was never issued"
+
+    # Grow to batch {A, B} — A is still the focused anchor.
+    page.locator(f".grid-card[data-id='{other_b}']").click(modifiers=["Meta"])
+    page.wait_for_function(
+        "(id) => selectedPhotos.size === 2 && selectedPhotos.has(id)",
+        arg=anchor,
+    )
+
+    # Click the batch-bar Clear button by invoking the same function it
+    # does. This is the code path the fix targets — clearSelection()
+    # bypasses closeDetail entirely, so it needs its own scrubs.
+    page.evaluate("() => clearSelection()")
+    page.wait_for_function(
+        "() => selectedPhotos.size === 0 && window.selectedPhotoId == null"
+    )
+    assert page.evaluate("() => window._detailPhotoId") is None
+
+    # Select All — A is back in the batch.
+    page.evaluate("() => selectAllMatchingPhotos()")
+    page.wait_for_function("() => selectedPhotos.size >= 3")
+
+    # Release the held reverse-geocode response.
+    held_routes[0].fulfill(
+        status=200,
+        content_type="application/json",
+        body=json.dumps({
+            "place_id": _CANNED_PLACE_ID,
+            "summary": _CANNED_DETAILS["name"],
+            "lat": _CANNED_DETAILS["lat"],
+            "lng": _CANNED_DETAILS["lng"],
+            "cached": False,
+        }),
+    )
+    page.wait_for_timeout(300)
+
+    expect(page.locator("#locationExifSuggestion")).to_be_hidden()
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').innerHTML"
+    ) == ""
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').dataset.photoId || ''"
+    ) == ""
+
+    for pid in (anchor, other_b, other_c):
+        row = db.conn.execute(
+            "SELECT 1 FROM photo_keywords pk "
+            "JOIN keywords k ON k.id = pk.keyword_id "
+            "WHERE pk.photo_id = ? AND k.type = 'location'",
+            (pid,),
+        ).fetchone()
+        assert row is None, f"photo {pid} should not have gained a location"
+
+
 def test_freetext_location_batches_selection_and_refreshes_smart_collection(
     live_server, page
 ):

--- a/tests/e2e/test_location_section.py
+++ b/tests/e2e/test_location_section.py
@@ -618,6 +618,117 @@ def test_exif_suggestion_cleared_by_filled_location_render(
     assert row is not None, "photo B should keep its saved location"
 
 
+def test_exif_suggestion_bails_when_slow_geocode_resolves_after_anchor_dropped(
+    live_server, page, monkeypatch
+):
+    """Codex P1 (PR #1097, commit 9d06366c): the post-await path in
+    maybeShowExifSuggestion only guarded on window._detailPhotoId, which
+    batch mode does NOT update when the anchor is dropped from the
+    selection. A slow reverse-geocode for photo A could still stamp and
+    show A's Accept line for a selection that no longer includes A, and
+    clicking it would apply A's place to unrelated photos.
+
+    Sequence: open A (reverse-geocode is intercepted and held) →
+    Cmd-click B → Cmd-click A out → Cmd-click C (selection is now
+    {B, C}) → release A's reverse-geocode response. The suggestion must
+    stay hidden and no other photo may gain a location.
+    """
+    photo_ids = live_server["data"]["photos"][:3]
+    anchor, other_b, other_c = photo_ids
+    # Only the anchor has GPS. B and C have no lat/lng, so their own
+    # maybeShowExifSuggestion calls bail immediately and never race with
+    # ours. If they shared A's canned place_id the bug would be masked.
+    _seed_exif_photos(live_server, [anchor])
+    _set_api_key()
+
+    import places
+    monkeypatch.setattr(
+        places, "place_details", lambda pid, key: _CANNED_DETAILS,
+    )
+
+    db = live_server["db"]
+
+    # Intercept the reverse-geocode call and hold it. Playwright dispatches
+    # the route handler on a background task, so page interactions below
+    # can proceed while the fetch stays pending in the browser.
+    held_routes = []
+
+    def _hold_reverse_geocode(route):
+        held_routes.append(route)
+
+    page.route("**/api/places/reverse-geocode**", _hold_reverse_geocode)
+
+    page.goto(f"{live_server['url']}/browse")
+    page.locator(".grid-card").first.wait_for(state="visible")
+
+    page.locator(f".grid-card[data-id='{anchor}']").click()
+    _wait_for_detail_loaded(page)
+
+    # Wait for the browser to actually issue the reverse-geocode fetch.
+    # maybeShowExifSuggestion awaits _cfgPromise before fetching, so this
+    # is not synchronous with the click.
+    for _ in range(50):
+        if held_routes:
+            break
+        page.wait_for_timeout(100)
+    assert held_routes, "reverse-geocode fetch was never issued"
+
+    # While the response is held, drive the anchor-dropped batch sequence.
+    page.locator(f".grid-card[data-id='{other_b}']").click(modifiers=["Meta"])
+    page.wait_for_function(
+        "(id) => selectedPhotos.size === 2 && selectedPhotos.has(id)",
+        arg=anchor,
+    )
+    page.locator(f".grid-card[data-id='{anchor}']").click(modifiers=["Meta"])
+    page.wait_for_function(
+        "(id) => selectedPhotos.size === 1 && !selectedPhotos.has(id)",
+        arg=anchor,
+    )
+    page.locator(f".grid-card[data-id='{other_c}']").click(modifiers=["Meta"])
+    page.wait_for_function(
+        "(id) => selectedPhotos.size === 2 && !selectedPhotos.has(id)",
+        arg=anchor,
+    )
+
+    # Now release the response. Without the fix, the completion path would
+    # stamp #locationExifSuggestion with A's place because _detailPhotoId
+    # still equals A.
+    held_routes[0].fulfill(
+        status=200,
+        content_type="application/json",
+        body=json.dumps({
+            "place_id": _CANNED_PLACE_ID,
+            "summary": _CANNED_DETAILS["name"],
+            "lat": _CANNED_DETAILS["lat"],
+            "lng": _CANNED_DETAILS["lng"],
+            "cached": False,
+        }),
+    )
+
+    # Give the async completion a chance to run. If it were going to paint
+    # the suggestion, it would happen synchronously after the fetch/JSON
+    # awaits resolve.
+    page.wait_for_timeout(300)
+
+    expect(page.locator("#locationExifSuggestion")).to_be_hidden()
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').innerHTML"
+    ) == ""
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').dataset.photoId || ''"
+    ) == ""
+
+    # And no photo in the surviving selection may have gained a location.
+    for pid in (other_b, other_c):
+        row = db.conn.execute(
+            "SELECT 1 FROM photo_keywords pk "
+            "JOIN keywords k ON k.id = pk.keyword_id "
+            "WHERE pk.photo_id = ? AND k.type = 'location'",
+            (pid,),
+        ).fetchone()
+        assert row is None, f"photo {pid} should not have gained a location"
+
+
 def test_freetext_location_batches_selection_and_refreshes_smart_collection(
     live_server, page
 ):

--- a/tests/e2e/test_location_section.py
+++ b/tests/e2e/test_location_section.py
@@ -729,6 +729,130 @@ def test_exif_suggestion_bails_when_slow_geocode_resolves_after_anchor_dropped(
         assert row is None, f"photo {pid} should not have gained a location"
 
 
+def test_exif_suggestion_bails_when_slow_geocode_resolves_after_location_saved(
+    live_server, page
+):
+    """Codex P2 (PR #1097, commit accf79ce): if the reverse-geocode fetch
+    for photo A is still pending while the user saves a free-text location
+    for A via the input, renderLocationFilled scrubs the suggestion element
+    — but the pending completion path in maybeShowExifSuggestion only
+    guarded on _detailPhotoId and the active selection, both of which are
+    still A. So it re-stamped a stale Accept line into the (now-hidden)
+    empty container. A later Cmd-click into a batch then preserved the
+    suggestion (owner A is in selection) and revealed it, letting Accept
+    overwrite A's saved location and push A's EXIF place to the other
+    photo in the batch.
+
+    Sequence: open A (reverse-geocode held) → type a free-text location
+    for A and hit Enter → filled state renders → release the held
+    reverse-geocode response → Cmd-click B. The suggestion must stay
+    hidden and empty, and A's saved location must survive.
+    """
+    photo_ids = live_server["data"]["photos"][:2]
+    anchor, other_b = photo_ids
+    # Only the anchor has GPS. If B shared it, B's own maybeShowExifSuggestion
+    # would race and could mask the bug.
+    _seed_exif_photos(live_server, [anchor])
+    _set_api_key()
+
+    db = live_server["db"]
+
+    held_routes = []
+
+    def _hold_reverse_geocode(route):
+        held_routes.append(route)
+
+    page.route("**/api/places/reverse-geocode**", _hold_reverse_geocode)
+
+    page.goto(f"{live_server['url']}/browse")
+    page.locator(".grid-card").first.wait_for(state="visible")
+
+    page.locator(f".grid-card[data-id='{anchor}']").click()
+    _wait_for_detail_loaded(page)
+
+    for _ in range(50):
+        if held_routes:
+            break
+        page.wait_for_timeout(100)
+    assert held_routes, "reverse-geocode fetch was never issued"
+
+    # With the fetch still held, save a free-text location for the anchor.
+    saved_text = "the meadow behind the cabin"
+    inp = page.locator("#locationInput")
+    inp.wait_for(state="visible")
+    inp.fill(saved_text)
+    inp.press("Enter")
+
+    expect(page.locator("#locationFilled")).to_be_visible()
+    expect(page.locator("#locationFilled .filled-place")).to_have_text(saved_text)
+    expect(page.locator("#locationEmpty")).to_be_hidden()
+    # renderLocationFilled scrubs the suggestion when the filled state
+    # renders — so before we release the pending fetch, the suggestion is
+    # already clean.
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').dataset.photoId || ''"
+    ) == ""
+
+    # Release the held reverse-geocode response. Without the fix, the
+    # completion path repaints the suggestion because _detailPhotoId and
+    # the selection are still A.
+    held_routes[0].fulfill(
+        status=200,
+        content_type="application/json",
+        body=json.dumps({
+            "place_id": _CANNED_PLACE_ID,
+            "summary": _CANNED_DETAILS["name"],
+            "lat": _CANNED_DETAILS["lat"],
+            "lng": _CANNED_DETAILS["lng"],
+            "cached": False,
+        }),
+    )
+    page.wait_for_timeout(300)
+
+    # The suggestion element must stay scrubbed even before we enter batch
+    # mode — no stale owner id, no stale Accept HTML.
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').innerHTML"
+    ) == ""
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').dataset.photoId || ''"
+    ) == ""
+
+    # Cmd-click B into the selection. renderBatchInspector passes
+    # preserveExifSuggestion; if the fix didn't hold, the preserved
+    # (stale) suggestion for A would become visible here.
+    page.locator(f".grid-card[data-id='{other_b}']").click(modifiers=["Meta"])
+    page.wait_for_function("() => selectedPhotos.size === 2")
+
+    expect(page.locator("#locationExifSuggestion")).to_be_hidden()
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').innerHTML"
+    ) == ""
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').dataset.photoId || ''"
+    ) == ""
+
+    # A keeps the free-text location it just saved…
+    row_a = db.conn.execute(
+        "SELECT k.name FROM photo_keywords pk "
+        "JOIN keywords k ON k.id = pk.keyword_id "
+        "WHERE pk.photo_id = ? AND k.type = 'location'",
+        (anchor,),
+    ).fetchone()
+    assert row_a is not None, "anchor should keep its saved location"
+    assert row_a[0] == saved_text, (
+        f"anchor's location should still be '{saved_text}', got {row_a[0]!r}"
+    )
+    # …and B never gained one from a resurrected Accept line.
+    row_b = db.conn.execute(
+        "SELECT 1 FROM photo_keywords pk "
+        "JOIN keywords k ON k.id = pk.keyword_id "
+        "WHERE pk.photo_id = ? AND k.type = 'location'",
+        (other_b,),
+    ).fetchone()
+    assert row_b is None, "other photo should not have gained a location"
+
+
 def test_freetext_location_batches_selection_and_refreshes_smart_collection(
     live_server, page
 ):

--- a/tests/e2e/test_location_section.py
+++ b/tests/e2e/test_location_section.py
@@ -853,6 +853,79 @@ def test_exif_suggestion_bails_when_slow_geocode_resolves_after_location_saved(
     assert row_b is None, "other photo should not have gained a location"
 
 
+def test_exif_suggestion_cleared_by_close_detail(
+    live_server, page, monkeypatch
+):
+    """Codex P2 (PR #1097): closing the detail panel used to leave the EXIF
+    suggestion element populated (hidden along with its parent, but with the
+    original owner's data-photo-id and Accept button still in the DOM). A
+    later batch that included that owner — e.g. Select All / Ctrl+A on a view
+    that still contains the closed anchor — would satisfy
+    renderLocationEmpty's owner-in-selection check and resurrect the anchor's
+    Accept line for the entire selection. Clicking Accept would then apply
+    the closed anchor's GPS-derived place to every selected photo.
+
+    Sequence: open A (suggestion appears) → closeDetail (× button) →
+    Select All (batch inspector opens; selection includes A). The suggestion
+    must stay hidden and dropped from the DOM.
+    """
+    photo_ids = live_server["data"]["photos"][:3]
+    anchor, other_b, other_c = photo_ids
+    _seed_exif_photos(live_server, [anchor])
+    _seed_reverse_geocode_cache(
+        live_server, 40.785091, -73.968285, _CANNED_PLACE_ID, _CANNED_DETAILS,
+    )
+    _set_api_key()
+
+    import places
+    monkeypatch.setattr(
+        places, "place_details", lambda pid, key: _CANNED_DETAILS,
+    )
+
+    db = live_server["db"]
+
+    page.goto(f"{live_server['url']}/browse")
+    page.locator(".grid-card").first.wait_for(state="visible")
+
+    page.locator(f".grid-card[data-id='{anchor}']").click()
+    _wait_for_detail_loaded(page)
+    accept = page.locator("#locationExifSuggestion button.accept-btn")
+    expect(accept).to_be_visible()
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').dataset.photoId"
+    ) == str(anchor)
+
+    # Close the detail panel via the × button, which drives the real
+    # closeDetail() path (Escape would also call clearSelection and empty
+    # selectedPhotos, masking the bug).
+    page.locator(".detail-close").click()
+    page.wait_for_function("() => window.selectedPhotoId == null")
+
+    # Select All — includes the closed anchor, so the batch inspector opens
+    # with A in ids. Without the fix, keepSugg would be true and A's Accept
+    # line would flash back into the batch panel.
+    page.evaluate("() => selectAllMatchingPhotos()")
+    page.wait_for_function("() => selectedPhotos.size >= 3")
+
+    expect(page.locator("#locationExifSuggestion")).to_be_hidden()
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').innerHTML"
+    ) == ""
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').dataset.photoId || ''"
+    ) == ""
+
+    # No photo in the batch may have gained a location.
+    for pid in (anchor, other_b, other_c):
+        row = db.conn.execute(
+            "SELECT 1 FROM photo_keywords pk "
+            "JOIN keywords k ON k.id = pk.keyword_id "
+            "WHERE pk.photo_id = ? AND k.type = 'location'",
+            (pid,),
+        ).fetchone()
+        assert row is None, f"photo {pid} should not have gained a location"
+
+
 def test_freetext_location_batches_selection_and_refreshes_smart_collection(
     live_server, page
 ):

--- a/tests/e2e/test_location_section.py
+++ b/tests/e2e/test_location_section.py
@@ -480,6 +480,84 @@ def test_exif_accept_batches_selection_and_refreshes_smart_collection(
     assert db.count_collection_photos(collection_id) == 0
 
 
+def test_exif_suggestion_clears_when_anchor_leaves_selection(
+    live_server, page, monkeypatch
+):
+    """Codex P1 (PR #1097): if the photo that produced the EXIF suggestion is
+    removed from the selection before Accept is clicked, the suggestion must
+    not survive to apply that anchor's GPS-derived location to unrelated
+    photos still in the selection.
+
+    Sequence: open A (suggestion appears) → Cmd-click B (suggestion stays,
+    anchor still in selection) → Cmd-click A to remove → Cmd-click C. Now the
+    selection is {B, C} and A is gone; the suggestion (which is A's) must be
+    cleared so batch Accept can't silently push A's place to B and C.
+    """
+    photo_ids = live_server["data"]["photos"][:3]
+    anchor, other_b, other_c = photo_ids
+    # Give only the anchor EXIF GPS. If every photo shared the same canned
+    # place_id, the bug would be invisible even without the fix.
+    _seed_exif_photos(live_server, [anchor])
+    _seed_reverse_geocode_cache(
+        live_server, 40.785091, -73.968285, _CANNED_PLACE_ID, _CANNED_DETAILS,
+    )
+    _set_api_key()
+
+    import places
+    monkeypatch.setattr(
+        places, "place_details", lambda pid, key: _CANNED_DETAILS,
+    )
+
+    db = live_server["db"]
+
+    page.goto(f"{live_server['url']}/browse")
+    page.locator(".grid-card").first.wait_for(state="visible")
+
+    page.locator(f".grid-card[data-id='{anchor}']").click()
+    _wait_for_detail_loaded(page)
+    accept = page.locator("#locationExifSuggestion button.accept-btn")
+    expect(accept).to_be_visible()
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').dataset.photoId"
+    ) == str(anchor)
+
+    page.locator(f".grid-card[data-id='{other_b}']").click(modifiers=["Meta"])
+    page.wait_for_function(
+        "(id) => selectedPhotos.size === 2 && selectedPhotos.has(id)",
+        arg=anchor,
+    )
+    expect(accept).to_be_visible()
+
+    page.locator(f".grid-card[data-id='{anchor}']").click(modifiers=["Meta"])
+    page.wait_for_function(
+        "(id) => selectedPhotos.size === 1 && !selectedPhotos.has(id)",
+        arg=anchor,
+    )
+
+    page.locator(f".grid-card[data-id='{other_c}']").click(modifiers=["Meta"])
+    page.wait_for_function(
+        "(id) => selectedPhotos.size === 2 && !selectedPhotos.has(id)",
+        arg=anchor,
+    )
+
+    expect(page.locator("#locationExifSuggestion")).to_be_hidden()
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').innerHTML"
+    ) == ""
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').dataset.photoId || ''"
+    ) == ""
+
+    for pid in (other_b, other_c):
+        row = db.conn.execute(
+            "SELECT 1 FROM photo_keywords pk "
+            "JOIN keywords k ON k.id = pk.keyword_id "
+            "WHERE pk.photo_id = ? AND k.type = 'location'",
+            (pid,),
+        ).fetchone()
+        assert row is None, f"photo {pid} should not have gained a location"
+
+
 def test_freetext_location_batches_selection_and_refreshes_smart_collection(
     live_server, page
 ):

--- a/tests/e2e/test_location_section.py
+++ b/tests/e2e/test_location_section.py
@@ -1314,6 +1314,160 @@ def test_exif_suggestion_bails_when_slow_geocode_resolves_after_batch_clear(
         assert row is None, f"photo {pid} should not have gained a location"
 
 
+def test_exif_suggestion_bails_when_slow_geocode_resolves_after_batch_location_saved(
+    live_server, page
+):
+    """Codex P2 (PR #1097, 17:39Z): the earlier post-await guard bailed only
+    if #locationFilled was visible right when the reverse-geocode resolved.
+    That misses the batch save: after POST /api/batch/location{,/text}
+    succeeds, renderLocationFilled briefly shows #locationFilled, then
+    _afterLocationMutation runs renderBatchInspector which calls
+    renderLocationEmpty and rehides #locationFilled — so the DOM check sees
+    "not filled" and the completion path repaints A's stale Accept line
+    into the batch inspector. Clicking Accept then posts A's EXIF place to
+    the whole batch, overwriting the just-saved batch location.
+
+    Fixed by bumping window._locationMutationEpoch at the top of
+    _afterLocationMutation and comparing against the epoch captured at
+    fetch time. Any successful save/clear/accept between the fetch and the
+    post-await paint moves the epoch and the paint bails.
+
+    Sequence: open A (reverse-geocode held) → Cmd-click B (batch mode) →
+    type a batch free-text location and hit Enter (renderBatchInspector
+    rehides #locationFilled after the save) → release the held response.
+    The suggestion must stay hidden/empty and both A and B must keep the
+    just-saved batch location — not A's held EXIF place.
+    """
+    photo_ids = live_server["data"]["photos"][:2]
+    anchor, other_b = photo_ids
+    # Only the anchor has GPS. If B shared it, B's own maybeShowExifSuggestion
+    # would fire on entry to batch mode (renderBatchInspector doesn't fetch,
+    # but a prior render might have) and confuse the assertion.
+    _seed_exif_photos(live_server, [anchor])
+    _set_api_key()
+
+    db = live_server["db"]
+
+    held_routes = []
+
+    def _hold_reverse_geocode(route):
+        held_routes.append(route)
+
+    page.route("**/api/places/reverse-geocode**", _hold_reverse_geocode)
+
+    page.goto(f"{live_server['url']}/browse")
+    page.locator(".grid-card").first.wait_for(state="visible")
+
+    page.locator(f".grid-card[data-id='{anchor}']").click()
+    _wait_for_detail_loaded(page)
+
+    for _ in range(50):
+        if held_routes:
+            break
+        page.wait_for_timeout(100)
+    assert held_routes, "reverse-geocode fetch was never issued"
+
+    # Grow the selection to {A, B}. A stays the ambient _detailPhotoId, so
+    # without the fix the post-await guard's owner/selection checks still
+    # pass when the held response resolves.
+    page.locator(f".grid-card[data-id='{other_b}']").click(modifiers=["Meta"])
+    page.wait_for_function(
+        "(id) => selectedPhotos.size === 2 && selectedPhotos.has(id)",
+        arg=anchor,
+    )
+
+    # Save a batch free-text location. This is the mutation window: the
+    # POST returns, renderLocationFilled briefly shows the filled row, then
+    # _afterLocationMutation → renderBatchInspector rehides it. The
+    # completion path in maybeShowExifSuggestion would otherwise see
+    # #locationFilled hidden and repaint.
+    saved_text = "the shared batch meadow"
+    inp = page.locator("#locationInput")
+    inp.wait_for(state="visible")
+    inp.fill(saved_text)
+    inp.press("Enter")
+
+    # Wait for the batch save to complete: A and B both persisted, and the
+    # batch inspector has re-rendered (so #locationFilled is hidden again).
+    page.wait_for_function(
+        "() => selectedPhotos.size === 2"
+        " && document.getElementById('locationFilled').hidden === true"
+    )
+    for _ in range(50):
+        row_a = db.conn.execute(
+            "SELECT k.name FROM photo_keywords pk "
+            "JOIN keywords k ON k.id = pk.keyword_id "
+            "WHERE pk.photo_id = ? AND k.type = 'location'",
+            (anchor,),
+        ).fetchone()
+        row_b = db.conn.execute(
+            "SELECT k.name FROM photo_keywords pk "
+            "JOIN keywords k ON k.id = pk.keyword_id "
+            "WHERE pk.photo_id = ? AND k.type = 'location'",
+            (other_b,),
+        ).fetchone()
+        if row_a is not None and row_b is not None:
+            break
+        page.wait_for_timeout(100)
+    assert row_a is not None and row_a[0] == saved_text, (
+        f"anchor should have the batch-saved location, got {row_a!r}"
+    )
+    assert row_b is not None and row_b[0] == saved_text, (
+        f"other photo should have the batch-saved location, got {row_b!r}"
+    )
+
+    # renderLocationFilled scrubbed the suggestion inline (before the batch
+    # inspector re-render), so it's already clean here.
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').dataset.photoId || ''"
+    ) == ""
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').innerHTML"
+    ) == ""
+
+    # Now release the held reverse-geocode response. Without the epoch
+    # bump, the completion path repaints A's suggestion because
+    # _detailPhotoId is still A, the selection {A,B} still includes A, and
+    # #locationFilled is hidden.
+    held_routes[0].fulfill(
+        status=200,
+        content_type="application/json",
+        body=json.dumps({
+            "place_id": _CANNED_PLACE_ID,
+            "summary": _CANNED_DETAILS["name"],
+            "lat": _CANNED_DETAILS["lat"],
+            "lng": _CANNED_DETAILS["lng"],
+            "cached": False,
+        }),
+    )
+    page.wait_for_timeout(300)
+
+    # Suggestion must stay scrubbed — no stale owner id, no Accept line.
+    expect(page.locator("#locationExifSuggestion")).to_be_hidden()
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').innerHTML"
+    ) == ""
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').dataset.photoId || ''"
+    ) == ""
+
+    # And the just-saved batch location must survive — no photo may end up
+    # with A's held EXIF place.
+    for pid, label in ((anchor, "anchor"), (other_b, "other")):
+        rows = db.conn.execute(
+            "SELECT k.name FROM photo_keywords pk "
+            "JOIN keywords k ON k.id = pk.keyword_id "
+            "WHERE pk.photo_id = ? AND k.type = 'location'",
+            (pid,),
+        ).fetchall()
+        assert len(rows) == 1, (
+            f"{label} should have exactly one location keyword, got {rows!r}"
+        )
+        assert rows[0][0] == saved_text, (
+            f"{label}'s location should still be {saved_text!r}, got {rows[0][0]!r}"
+        )
+
+
 def test_exif_suggestion_cleared_by_loaddetail_before_select_all(
     live_server, page, monkeypatch
 ):

--- a/tests/e2e/test_location_section.py
+++ b/tests/e2e/test_location_section.py
@@ -558,6 +558,66 @@ def test_exif_suggestion_clears_when_anchor_leaves_selection(
         assert row is None, f"photo {pid} should not have gained a location"
 
 
+def test_exif_suggestion_cleared_by_filled_location_render(
+    live_server, page
+):
+    """Codex P2 (PR #1097): opening a photo with a saved location renders the
+    filled state without running maybeShowExifSuggestion, so a suggestion
+    fetched for the previous photo used to survive (hidden) in #locationEmpty.
+    Cmd-clicking that previous photo back into a batch would then resurrect
+    its Accept line for a selection whose other member already has a location.
+
+    Sequence: open A (suggestion appears) → open B with a saved location
+    (filled render must clear A's suggestion) → Cmd-click A ({B, A} batch).
+    The suggestion must stay gone.
+    """
+    photo_ids = live_server["data"]["photos"][:2]
+    photo_a, photo_b = photo_ids
+    _seed_exif_photos(live_server, [photo_a])
+    _seed_reverse_geocode_cache(
+        live_server, 40.785091, -73.968285, _CANNED_PLACE_ID, _CANNED_DETAILS,
+    )
+    _set_api_key()
+
+    db = live_server["db"]
+    existing_location_id = db.get_or_create_text_location("Existing Spot")
+    db.set_photo_location(photo_b, existing_location_id)
+
+    page.goto(f"{live_server['url']}/browse")
+    page.locator(".grid-card").first.wait_for(state="visible")
+
+    page.locator(f".grid-card[data-id='{photo_a}']").click()
+    _wait_for_detail_loaded(page)
+    expect(page.locator("#locationExifSuggestion button.accept-btn")).to_be_visible()
+
+    page.locator(f".grid-card[data-id='{photo_b}']").click()
+    expect(page.locator("#locationFilled")).to_be_visible()
+    expect(page.locator("#locationFilled .filled-place")).to_have_text("Existing Spot")
+    # The filled render must scrub the previous photo's suggestion entirely,
+    # not just rely on #locationEmpty being hidden.
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').innerHTML"
+    ) == ""
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').dataset.photoId || ''"
+    ) == ""
+
+    page.locator(f".grid-card[data-id='{photo_a}']").click(modifiers=["Meta"])
+    page.wait_for_function("() => selectedPhotos.size === 2")
+
+    expect(page.locator("#locationExifSuggestion")).to_be_hidden()
+    assert page.evaluate(
+        "() => document.getElementById('locationExifSuggestion').innerHTML"
+    ) == ""
+
+    # B's saved location is untouched.
+    row = db.conn.execute(
+        "SELECT 1 FROM photo_keywords WHERE photo_id = ? AND keyword_id = ?",
+        (photo_b, existing_location_id),
+    ).fetchone()
+    assert row is not None, "photo B should keep its saved location"
+
+
 def test_freetext_location_batches_selection_and_refreshes_smart_collection(
     live_server, page
 ):

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -6217,6 +6217,17 @@ async function maybeShowExifSuggestion(photo) {
     // out → Cmd-click C would otherwise paint A's Accept line for {B,C}.
     if (window._detailPhotoId !== requestPhotoId) return;
     if (_locationApplyPhotoIds().indexOf(requestPhotoId) === -1) return;
+    // Third race: while we were awaiting reverse-geocode, the user saved a
+    // location for this photo (via the input, a keyword pick, or a batch
+    // op). renderLocationFilled scrubbed #locationExifSuggestion, but both
+    // guards above still pass because _detailPhotoId and the selection
+    // haven't moved. Painting into the (now-hidden) empty container would
+    // stash A's stale Accept line; a later Cmd-click preserving the
+    // suggestion for a batch would resurrect it and let Accept overwrite
+    // the saved location. Bail if #locationFilled is on screen. (Codex P2
+    // on PR #1097.)
+    var filled = document.getElementById('locationFilled');
+    if (filled && !filled.hidden) return;
 
     sugg.innerHTML = '';
     var text = document.createElement('span');

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3887,12 +3887,7 @@ function selectPhoto(e, id, idx) {
       // selection check and resurrect the anchor's Accept line for the
       // whole batch — clicking it would apply the dropped anchor's GPS
       // place to every selected photo. Codex P2 on PR #1097.
-      var sugg = document.getElementById('locationExifSuggestion');
-      if (sugg) {
-        sugg.hidden = true;
-        sugg.innerHTML = '';
-        if (sugg.dataset) delete sugg.dataset.photoId;
-      }
+      clearExifSuggestion();
     }
   } else {
     // Normal click: single select
@@ -5073,6 +5068,14 @@ function clearSelection() {
   selectedPhotos.clear();
   selectedPhotoId = null;
   selectedIndex = -1;
+  // Batch-bar Clear (and every other caller) has to scrub the EXIF suggestion
+  // too. Without this, the suggestion element keeps its data-photo-id and
+  // Accept button after clearing, so a later Select All that still contains
+  // the previously-open anchor satisfies renderLocationEmpty's owner-in-
+  // selection check and resurrects the anchor's Accept line for the whole
+  // batch — one click would apply the anchor's GPS-derived place to every
+  // selected photo. Codex P2 on PR #1097.
+  clearExifSuggestion();
   document.querySelectorAll('.grid-card').forEach(function(el) {
     el.classList.remove('selected');
   });
@@ -5422,12 +5425,7 @@ function closeDetail() {
   // renderLocationEmpty's owner-in-selection check and resurrect the anchor's
   // Accept line for the whole batch — clicking it would apply the anchor's
   // GPS-derived place to every selected photo. Codex P2 on PR #1097.
-  var sugg = document.getElementById('locationExifSuggestion');
-  if (sugg) {
-    sugg.hidden = true;
-    sugg.innerHTML = '';
-    if (sugg.dataset) delete sugg.dataset.photoId;
-  }
+  clearExifSuggestion();
   // Re-highlight any cmd/shift-click selections that survive detail close.
   // A blanket .remove('selected') would leave selectedPhotos armed for batch
   // actions with no visible indicator — e.g. click A -> cmd-click B -> cmd-click
@@ -6131,6 +6129,18 @@ async function clearPhotoLocation() {
   }
 }
 
+// Scrub the inline EXIF suggestion line (hide, empty innerHTML, drop the
+// data-photo-id owner tag). Every scrub site must go through this helper so
+// they can't silently diverge — e.g. if a future scrub also needs to clear a
+// stored placeId. Codex nitpick on PR #1097.
+function clearExifSuggestion() {
+  var sugg = document.getElementById('locationExifSuggestion');
+  if (!sugg) return;
+  sugg.hidden = true;
+  sugg.innerHTML = '';
+  if (sugg.dataset) delete sugg.dataset.photoId;
+}
+
 function renderLocationFilled(loc) {
   var filled = document.getElementById('locationFilled');
   var empty = document.getElementById('locationEmpty');
@@ -6160,12 +6170,7 @@ function renderLocationFilled(loc) {
   // (suggestion fetched) → open B with a saved location → Cmd-click A would
   // otherwise resurrect A's Accept line for the {B, A} batch and overwrite
   // B's location (Codex P2 on PR #1097). Clear it at the source instead.
-  var sugg = document.getElementById('locationExifSuggestion');
-  if (sugg) {
-    sugg.hidden = true;
-    sugg.innerHTML = '';
-    if (sugg.dataset) delete sugg.dataset.photoId;
-  }
+  clearExifSuggestion();
 }
 
 function renderLocationEmpty(opts) {
@@ -6197,11 +6202,7 @@ function renderLocationEmpty(opts) {
       && Array.isArray(opts.selectionIds)
       && opts.selectionIds.indexOf(owner) !== -1;
   }
-  if (!keepSugg) {
-    sugg.hidden = true;
-    sugg.innerHTML = '';
-    if (sugg.dataset) delete sugg.dataset.photoId;
-  }
+  if (!keepSugg) clearExifSuggestion();
 }
 
 /* When a photo with EXIF GPS but no location keyword is opened, fetch a
@@ -6209,11 +6210,9 @@ function renderLocationEmpty(opts) {
    silently when there's no key or no coords; the proxy returns null when
    Google has no match for the cell. */
 async function maybeShowExifSuggestion(photo) {
+  clearExifSuggestion();
   var sugg = document.getElementById('locationExifSuggestion');
   if (!sugg) return;
-  sugg.hidden = true;
-  sugg.innerHTML = '';
-  if (sugg.dataset) delete sugg.dataset.photoId;
 
   if (!photo) return;
   if (photo.location) return;
@@ -6296,12 +6295,7 @@ async function acceptExifSuggestion(placeId) {
     if (resp && resp.location) {
       renderLocationFilled(resp.location);
     }
-    var sugg = document.getElementById('locationExifSuggestion');
-    if (sugg) {
-      sugg.hidden = true;
-      sugg.innerHTML = '';
-      if (sugg.dataset) delete sugg.dataset.photoId;
-    }
+    clearExifSuggestion();
     await _afterLocationMutation(useBatch ? ids : [photoId], photoId);
   } catch(e) {
     _showLocationError('Could not save location.');

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -4225,7 +4225,10 @@ function updateSelectionPanel(ids) {
   panel.classList.remove('hidden');
   document.getElementById('selectionCount').textContent = ids.length.toLocaleString() + ' photos selected';
   updatePasteEditSection(ids);
-  renderBatchInspector(ids);
+  // Keep any EXIF suggestion fetched for the anchor photo: Accept is
+  // batch-aware (_locationApplyPhotoIds), so growing the selection is the
+  // designed way to apply one suggestion to many photos.
+  renderBatchInspector(ids, { preserveExifSuggestion: true });
   if (ids.length > 1000) {
     selectionKeywordKey = selectionIdsKey(ids);
     selectionKeywordMissingById = {};
@@ -5692,7 +5695,7 @@ function renderBatchInspector(ids, opts) {
   // (e.g. a /api/photos/color_labels fetch resolving, a batch rating shortcut)
   // triggers _refreshBatchInspectorIfActive, and we'd otherwise erase it.
   if (!opts.preserveLocation) {
-    renderLocationEmpty();
+    renderLocationEmpty({ preserveExifSuggestion: opts.preserveExifSuggestion });
   }
 }
 
@@ -6125,7 +6128,8 @@ function renderLocationFilled(loc) {
   if (input) input.value = '';
 }
 
-function renderLocationEmpty() {
+function renderLocationEmpty(opts) {
+  opts = opts || {};
   var filled = document.getElementById('locationFilled');
   var empty = document.getElementById('locationEmpty');
   if (!filled || !empty) return;
@@ -6137,11 +6141,15 @@ function renderLocationEmpty() {
   hideLocationKeywordSuggestions();
   // Reset any prior EXIF suggestion. The caller (renderDetail) re-runs
   // maybeShowExifSuggestion(photo) after this, which decides whether to
-  // populate the line for the new photo.
-  var sugg = document.getElementById('locationExifSuggestion');
-  if (sugg) {
-    sugg.hidden = true;
-    sugg.innerHTML = '';
+  // populate the line for the new photo. Entering batch mode preserves it
+  // instead (preserveExifSuggestion) so the anchor's suggestion stays
+  // acceptable for the whole selection.
+  if (!opts.preserveExifSuggestion) {
+    var sugg = document.getElementById('locationExifSuggestion');
+    if (sugg) {
+      sugg.hidden = true;
+      sugg.innerHTML = '';
+    }
   }
 }
 

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3888,6 +3888,13 @@ function selectPhoto(e, id, idx) {
       // whole batch — clicking it would apply the dropped anchor's GPS
       // place to every selected photo. Codex P2 on PR #1097.
       clearExifSuggestion();
+      // And null the ambient detail-photo pointer maybeShowExifSuggestion's
+      // post-await guard reads. If A's reverse-geocode is still in flight
+      // when we drop A here, the completion runs later; leaving
+      // _detailPhotoId pointing at A means a subsequent Select All that
+      // contains A would let the async paint path resurrect A's Accept line
+      // into the batch inspector. Codex P2 on PR #1097 (17:04Z follow-up).
+      window._detailPhotoId = null;
     }
   } else {
     // Normal click: single select
@@ -5076,6 +5083,15 @@ function clearSelection() {
   // batch — one click would apply the anchor's GPS-derived place to every
   // selected photo. Codex P2 on PR #1097.
   clearExifSuggestion();
+  // Also drop the ambient detail-photo pointer maybeShowExifSuggestion's
+  // post-await path uses as its owner check. Scrubbing the DOM alone isn't
+  // enough: a reverse-geocode fetch that was in flight when the user clicked
+  // Clear still resolves later, and if _detailPhotoId still points at the
+  // departed anchor a subsequent Select All that contains that photo
+  // re-satisfies both async guards and repaints A's Accept line into the
+  // batch inspector — clicking it would apply A's EXIF place to every
+  // selected photo. Codex P2 on PR #1097 (17:04Z follow-up).
+  window._detailPhotoId = null;
   document.querySelectorAll('.grid-card').forEach(function(el) {
     el.classList.remove('selected');
   });
@@ -5426,6 +5442,14 @@ function closeDetail() {
   // Accept line for the whole batch — clicking it would apply the anchor's
   // GPS-derived place to every selected photo. Codex P2 on PR #1097.
   clearExifSuggestion();
+  // Null the ambient detail-photo pointer for the same reason. maybeShowExif
+  // Suggestion's post-await guard uses window._detailPhotoId as its owner
+  // check: if a reverse-geocode was in flight when we closed the panel, the
+  // fetch keeps running and later resolves. With the pointer still set, a
+  // Ctrl+A that includes the departed photo would satisfy both async guards
+  // and repaint A's Accept line into the batch inspector. Codex P2 on
+  // PR #1097 (17:04Z follow-up).
+  window._detailPhotoId = null;
   // Re-highlight any cmd/shift-click selections that survive detail close.
   // A blanket .remove('selected') would leave selectedPhotos armed for batch
   // actions with no visible indicator — e.g. click A -> cmd-click B -> cmd-click
@@ -6231,19 +6255,29 @@ async function maybeShowExifSuggestion(photo) {
     if (!r.ok) return;
     var data = await r.json();
     if (!data || !data.place_id || !data.summary) return;
-    // Two races the post-await guard must handle. The first (a stale
-    // response for a photo the detail already navigated away from) is
-    // caught by _detailPhotoId. The second (a slow response for an anchor
-    // the user has since dropped from a batch) needs a selection check:
-    // batch mode doesn't move _detailPhotoId when a member is removed, so
-    // the anchor pointer can still match while getActiveSelection() no
-    // longer includes it — and Accept posts to getActiveSelection(). Codex
-    // P1 on PR #1097: open A (slow geocode) → Cmd-click B → Cmd-click A
-    // out → Cmd-click C would otherwise paint A's Accept line for {B,C}.
+    // Three races the post-await guards must handle.
+    //   1. Stale response for a photo the detail already navigated away
+    //      from (open A → open B): caught by _detailPhotoId, which
+    //      renderDetail overwrites on every open.
+    //   2. Slow response for an anchor the user has since dropped from a
+    //      batch (open A → Cmd-click B → Cmd-click A out → Cmd-click C):
+    //      renderBatchInspector never touches _detailPhotoId, so the anchor
+    //      pointer could still match while getActiveSelection() no longer
+    //      includes A. Accept posts to getActiveSelection(), so the guard
+    //      must recheck selection membership too. Codex P1 on PR #1097.
+    //   3. Slow response for a photo the user has left behind by closing
+    //      the detail panel, clearing the batch, or Cmd-click-dropping the
+    //      anchor, then Select All that brings the departed photo back
+    //      into the batch. The DOM scrub in each of those sites isn't
+    //      enough on its own: without also nulling _detailPhotoId the
+    //      pointer keeps matching after Select All re-includes the photo,
+    //      and Accept would apply the departed anchor's EXIF place to the
+    //      whole batch. Those sites now null _detailPhotoId, so the first
+    //      guard catches this race too. Codex P2 on PR #1097 (17:04Z).
     if (window._detailPhotoId !== requestPhotoId) return;
     if (_locationApplyPhotoIds().indexOf(requestPhotoId) === -1) return;
-    // Third race: while we were awaiting reverse-geocode, the user saved a
-    // location for this photo (via the input, a keyword pick, or a batch
+    // Fourth race: while we were awaiting reverse-geocode, the user saved
+    // a location for this photo (via the input, a keyword pick, or a batch
     // op). renderLocationFilled scrubbed #locationExifSuggestion, but both
     // guards above still pass because _detailPhotoId and the selection
     // haven't moved. Painting into the (now-hidden) empty container would

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -5695,7 +5695,10 @@ function renderBatchInspector(ids, opts) {
   // (e.g. a /api/photos/color_labels fetch resolving, a batch rating shortcut)
   // triggers _refreshBatchInspectorIfActive, and we'd otherwise erase it.
   if (!opts.preserveLocation) {
-    renderLocationEmpty({ preserveExifSuggestion: opts.preserveExifSuggestion });
+    renderLocationEmpty({
+      preserveExifSuggestion: opts.preserveExifSuggestion,
+      selectionIds: ids,
+    });
   }
 }
 
@@ -6143,13 +6146,24 @@ function renderLocationEmpty(opts) {
   // maybeShowExifSuggestion(photo) after this, which decides whether to
   // populate the line for the new photo. Entering batch mode preserves it
   // instead (preserveExifSuggestion) so the anchor's suggestion stays
-  // acceptable for the whole selection.
-  if (!opts.preserveExifSuggestion) {
-    var sugg = document.getElementById('locationExifSuggestion');
-    if (sugg) {
-      sugg.hidden = true;
-      sugg.innerHTML = '';
-    }
+  // acceptable for the whole selection — but only while the photo that
+  // produced it is still in the selection. Otherwise Accept would apply
+  // that anchor's GPS-derived location to unrelated photos (Codex P1 on
+  // PR #1097: open A → Cmd-click B → Cmd-click A to drop → Cmd-click C).
+  var sugg = document.getElementById('locationExifSuggestion');
+  if (!sugg) return;
+  var keepSugg = false;
+  if (opts.preserveExifSuggestion) {
+    var ownerAttr = sugg.dataset ? sugg.dataset.photoId : '';
+    var owner = ownerAttr ? parseInt(ownerAttr, 10) : NaN;
+    keepSugg = !isNaN(owner)
+      && Array.isArray(opts.selectionIds)
+      && opts.selectionIds.indexOf(owner) !== -1;
+  }
+  if (!keepSugg) {
+    sugg.hidden = true;
+    sugg.innerHTML = '';
+    if (sugg.dataset) delete sugg.dataset.photoId;
   }
 }
 
@@ -6162,6 +6176,7 @@ async function maybeShowExifSuggestion(photo) {
   if (!sugg) return;
   sugg.hidden = true;
   sugg.innerHTML = '';
+  if (sugg.dataset) delete sugg.dataset.photoId;
 
   if (!photo) return;
   if (photo.location) return;
@@ -6195,6 +6210,7 @@ async function maybeShowExifSuggestion(photo) {
     });
     sugg.appendChild(text);
     sugg.appendChild(btn);
+    sugg.dataset.photoId = String(requestPhotoId);
     sugg.hidden = false;
   } catch (e) {
     console.warn('reverse-geocode suggestion failed:', e);
@@ -6226,6 +6242,7 @@ async function acceptExifSuggestion(placeId) {
     if (sugg) {
       sugg.hidden = true;
       sugg.innerHTML = '';
+      if (sugg.dataset) delete sugg.dataset.photoId;
     }
     await _afterLocationMutation(useBatch ? ids : [photoId], photoId);
   } catch(e) {

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -5402,6 +5402,18 @@ function closeDetail() {
   hideDetailPanel();
   selectedPhotoId = null;
   selectedIndex = -1;
+  // Drop any lingering EXIF suggestion attached to the closed detail photo.
+  // Without this, the element keeps its data-photo-id and Accept button; a
+  // later Ctrl+A (or any batch that still contains that photo) would satisfy
+  // renderLocationEmpty's owner-in-selection check and resurrect the anchor's
+  // Accept line for the whole batch — clicking it would apply the anchor's
+  // GPS-derived place to every selected photo. Codex P2 on PR #1097.
+  var sugg = document.getElementById('locationExifSuggestion');
+  if (sugg) {
+    sugg.hidden = true;
+    sugg.innerHTML = '';
+    if (sugg.dataset) delete sugg.dataset.photoId;
+  }
   // Re-highlight any cmd/shift-click selections that survive detail close.
   // A blanket .remove('selected') would leave selectedPhotos armed for batch
   // actions with no visible indicator — e.g. click A -> cmd-click B -> cmd-click

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -6129,6 +6129,17 @@ function renderLocationFilled(loc) {
   // Reset the input value for next time.
   var input = document.getElementById('locationInput');
   if (input) input.value = '';
+  // Once a saved location is on screen any pending EXIF suggestion is moot,
+  // and leaving it (hidden) in #locationEmpty makes it stale state: open A
+  // (suggestion fetched) → open B with a saved location → Cmd-click A would
+  // otherwise resurrect A's Accept line for the {B, A} batch and overwrite
+  // B's location (Codex P2 on PR #1097). Clear it at the source instead.
+  var sugg = document.getElementById('locationExifSuggestion');
+  if (sugg) {
+    sugg.hidden = true;
+    sugg.innerHTML = '';
+    if (sugg.dataset) delete sugg.dataset.photoId;
+  }
 }
 
 function renderLocationEmpty(opts) {

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3879,6 +3879,20 @@ function selectPhoto(e, id, idx) {
         if (summary) summary.classList.remove('hidden');
         loadSummary();
       }
+      // Same reason as closeDetail: the dropped anchor's EXIF suggestion is
+      // still tagged with its data-photo-id (hidden along with the detail
+      // panel). This path bypasses closeDetail entirely, so without an
+      // explicit scrub a later Select All (or any batch that still contains
+      // the dropped photo) would satisfy renderLocationEmpty's owner-in-
+      // selection check and resurrect the anchor's Accept line for the
+      // whole batch — clicking it would apply the dropped anchor's GPS
+      // place to every selected photo. Codex P2 on PR #1097.
+      var sugg = document.getElementById('locationExifSuggestion');
+      if (sugg) {
+        sugg.hidden = true;
+        sugg.innerHTML = '';
+        if (sugg.dataset) delete sugg.dataset.photoId;
+      }
     }
   } else {
     // Normal click: single select

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -5978,6 +5978,15 @@ function _locationApplyPhotoIds() {
 }
 
 async function _afterLocationMutation(photoIds, detailPhotoId) {
+  // Bump the location-mutation epoch so any in-flight reverse-geocode from an
+  // earlier maybeShowExifSuggestion(A) bails out of its post-await paint. Every
+  // save/clear/accept path funnels through here, so this is the single choke
+  // point where the batch-save-during-pending-geocode race can be closed.
+  // Codex P2 on PR #1097 (17:39Z): open A → Cmd-click B → save batch location
+  // for {A,B} → geocode resolves. renderBatchInspector rehides #locationFilled,
+  // so the DOM-only guard in maybeShowExifSuggestion can't tell the batch was
+  // just given a location and repaints A's stale Accept line.
+  window._locationMutationEpoch = (window._locationMutationEpoch || 0) + 1;
   invalidateKeywordAutocompleteCache();
   loadKeywords();
   scheduleCollectionCountsRefresh();
@@ -6257,13 +6266,19 @@ async function maybeShowExifSuggestion(photo) {
   if (photo.location) return;
   if (photo.latitude == null || photo.longitude == null) return;
 
-  await _cfgPromise;
-  var apiKey = (window.GOOGLE_MAPS_API_KEY || '').trim();
-  if (!apiKey) return;
-
   // Capture the photo id at request time so a slow reverse-geocode for an
   // older photo doesn't paint into the suggestion line for a newer one.
   var requestPhotoId = photo.id;
+  // Capture the location-mutation epoch BEFORE the first await, so any
+  // save/clear/accept during _cfgPromise or the reverse-geocode fetch bumps
+  // the counter past what we captured. The post-await guard bails on any
+  // mismatch. Closes the batch-save-during-pending-geocode race that the
+  // DOM `!filled.hidden` check alone can't catch (see below).
+  var requestEpoch = window._locationMutationEpoch || 0;
+
+  await _cfgPromise;
+  var apiKey = (window.GOOGLE_MAPS_API_KEY || '').trim();
+  if (!apiKey) return;
   try {
     var params = new URLSearchParams({lat: photo.latitude, lng: photo.longitude});
     var r = await fetch('/api/places/reverse-geocode?' + params.toString());
@@ -6293,13 +6308,18 @@ async function maybeShowExifSuggestion(photo) {
     if (_locationApplyPhotoIds().indexOf(requestPhotoId) === -1) return;
     // Fourth race: while we were awaiting reverse-geocode, the user saved
     // a location for this photo (via the input, a keyword pick, or a batch
-    // op). renderLocationFilled scrubbed #locationExifSuggestion, but both
-    // guards above still pass because _detailPhotoId and the selection
-    // haven't moved. Painting into the (now-hidden) empty container would
-    // stash A's stale Accept line; a later Cmd-click preserving the
-    // suggestion for a batch would resurrect it and let Accept overwrite
-    // the saved location. Bail if #locationFilled is on screen. (Codex P2
-    // on PR #1097.)
+    // op). Every mutation path funnels through _afterLocationMutation, which
+    // bumps _locationMutationEpoch. If it moved, bail. (Codex P2 on PR #1097
+    // at 17:39Z: save-batch-location-during-pending-geocode overwriting the
+    // just-saved batch location. The DOM `!filled.hidden` check below alone
+    // can't catch that — after a batch save, _afterLocationMutation runs
+    // renderBatchInspector → renderLocationEmpty, which rehides
+    // #locationFilled, so the paint sneaks through.)
+    if ((window._locationMutationEpoch || 0) !== requestEpoch) return;
+    // Defense-in-depth: if a filled row is on screen right now, whoever
+    // painted it wanted the suggestion gone. The epoch check above already
+    // covers the batch race; this catches any future save site that renders
+    // filled without funneling through _afterLocationMutation.
     var filled = document.getElementById('locationFilled');
     if (filled && !filled.hidden) return;
 

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -6206,7 +6206,17 @@ async function maybeShowExifSuggestion(photo) {
     if (!r.ok) return;
     var data = await r.json();
     if (!data || !data.place_id || !data.summary) return;
+    // Two races the post-await guard must handle. The first (a stale
+    // response for a photo the detail already navigated away from) is
+    // caught by _detailPhotoId. The second (a slow response for an anchor
+    // the user has since dropped from a batch) needs a selection check:
+    // batch mode doesn't move _detailPhotoId when a member is removed, so
+    // the anchor pointer can still match while getActiveSelection() no
+    // longer includes it — and Accept posts to getActiveSelection(). Codex
+    // P1 on PR #1097: open A (slow geocode) → Cmd-click B → Cmd-click A
+    // out → Cmd-click C would otherwise paint A's Accept line for {B,C}.
     if (window._detailPhotoId !== requestPhotoId) return;
+    if (_locationApplyPhotoIds().indexOf(requestPhotoId) === -1) return;
 
     sugg.innerHTML = '';
     var text = document.createElement('span');

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -5158,6 +5158,21 @@ async function loadDetail(id) {
   if (detail) detail.classList.remove('batch-mode');
   if (detail) detail.classList.toggle('visible', window._detailPhotoId === id);
 
+  // Kill any stale EXIF suggestion tagged for a *different* photo before the
+  // fetch returns. Otherwise: open A (suggestion shown, data-photo-id=A) →
+  // click B → Select All lands before B's /api/photos response resolves.
+  // renderBatchInspector's preserveExifSuggestion check finds A's stale
+  // data-photo-id, sees A is in the Select All ids, and resurrects A's
+  // Accept line for the whole batch — clicking it applies A's GPS place to
+  // every selected photo. Also null _detailPhotoId so any in-flight
+  // reverse-geocode for A can't repaint through maybeShowExifSuggestion's
+  // post-await guard once the batch inspector is on screen. Codex P2 on
+  // PR #1097 (17:23Z).
+  if (window._detailPhotoId !== id) {
+    clearExifSuggestion();
+    window._detailPhotoId = null;
+  }
+
   try {
     var photo = await safeFetch('/api/photos/' + id, {}, { toast: false });
     // Re-check after the fetch: a Cmd/Ctrl-click landing during the await can

--- a/vireo/tests/test_jobs.py
+++ b/vireo/tests/test_jobs.py
@@ -528,7 +528,6 @@ def test_job_steps_tracking(tmp_path):
 def test_job_history_persists_steps_tree(tmp_path):
     """Completed jobs persist their step tree to job_history."""
     import json
-    import time
 
     from db import Database
     from jobs import JobRunner
@@ -551,9 +550,10 @@ def test_job_history_persists_steps_tree(tmp_path):
 
     job_id = runner.start("scan", work, workspace_id=ws_id)
 
-    wait_for_job_via_runner(runner, job_id)
-
-    time.sleep(0.5)
+    # wait_for_history=True blocks until the worker thread has flushed the
+    # job_history row; the previous fixed time.sleep(0.5) raced the worker
+    # on slower Windows I/O and left get_history returning [].
+    wait_for_job_via_runner(runner, job_id, wait_for_history=True)
 
     history = runner.get_history(db, limit=1)
     assert len(history) > 0


### PR DESCRIPTION
## What

Fixes the two e2e tests failing on `main` (reproducible in isolation, not flaky):

**1. `test_exif_accept_batches_selection_and_refreshes_smart_collection` — product regression from #1085.**
The batch inspector calls `renderLocationEmpty()` when a multi-selection forms, which wiped `#locationExifSuggestion`. That broke the batch EXIF-accept workflow built in #947/#958: open a photo in the "GPS Without Location Keyword" collection, Cmd-click more photos, click **Accept** — the Accept line vanished the moment the selection grew. `acceptExifSuggestion` was already selection-aware (`_locationApplyPhotoIds` → `/api/batch/location`), so entering batch mode now preserves the anchor photo's suggestion. Every other `renderLocationEmpty` caller (single-photo render, clear, filled-fallback, post-mutation re-render) still clears it, so no stale suggestion survives an actual location change.

**2. `test_lightbox_overlay_toggles_persist_and_context_restores` — test stale after #1083.**
#1083 intentionally flipped the lightbox mask overlay's no-preference default to hidden, but the test still assumed default-visible. One click on the masks toggle now turns masks ON, so the persisted value is `"1"` and the reloaded button reads "Hide Masks". Test updated to the new intended defaults (other toggles unchanged).

## Test results

- `tests/e2e/test_lightbox_context_menu.py` + `tests/e2e/test_location_section.py`: **23 passed**
- Required unit suite (workspaces, db, app, photos/edits/jobs/darktable API, config): **1253 passed, 1 skipped**
- Browse/multi-select e2e (`test_browse_single_select`, `test_misses_multi_select`, `test_browse_context_menu`, `test_browse_lightbox`, `test_keywords_link`): **84 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batch-mode EXIF “Accept” location suggestions so they stay tied to the correct anchor photo, are cleared when selection/panels change, and don’t reappear due to slow reverse-geocode responses.
  * Ensured saving a location properly scrubs any prior EXIF suggestion state.
  * Fixed lightbox mask-toggle persistence/restoration so reopening shows the correct “Hide Masks/Show Masks” state.
* **Tests**
  * Expanded end-to-end coverage for EXIF suggestion lifecycle across many selection/detail timing scenarios.
  * Reduced a test timing race in job history verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->