### PR TITLE
Pipeline: SSH remote targets as the archive destination

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -16439,6 +16439,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         destination = body.get("destination")
         local_processing = bool(body.get("local_processing"))
+        remote_target_id = (body.get("remote_target_id") or "").strip()
+        remote_subpath = body.get("remote_subpath", "")
+        if remote_subpath and not isinstance(remote_subpath, str):
+            return json_error("remote_subpath must be a string")
         # Copy-ingest ("destination") is incompatible with snapshot runs:
         # ingest would copy entire source folders, then snapshot filtering
         # would drop the destination-scanned photo ids, producing empty
@@ -16449,8 +16453,57 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             )
         if destination and not os.path.isabs(destination):
             return json_error("destination must be an absolute path")
-        if local_processing and not destination:
-            return json_error("local_processing requires a destination")
+        # Remote (SSH) archive destination — mirrors the Move page's
+        # remote-target request shape (remote_target_id + subpath). It only
+        # makes sense with local_processing: files must be staged and
+        # processed on local disk, then rsynced to the NAS by the archive
+        # stage; a plain copy-mode ingest writes through the local
+        # filesystem and can't target an SSH path.
+        remote_archive_config = None
+        if remote_target_id and destination:
+            return json_error(
+                "destination and remote_target_id are mutually exclusive — "
+                "pick a local archive path or a saved remote target, not both"
+            )
+        if remote_subpath and not remote_target_id:
+            return json_error("remote_subpath requires remote_target_id")
+        if remote_target_id and not local_processing:
+            return json_error(
+                "remote_target_id requires local_processing — files are "
+                "staged and processed locally, then archived to the remote "
+                "target over SSH"
+            )
+        if remote_target_id:
+            import config as cfg
+            import move as move_mod
+            from pipeline_job import resolve_remote_archive
+
+            target = cfg.get_remote_target(remote_target_id)
+            if not target:
+                return json_error("Remote target not found", status=404)
+            try:
+                remote_archive_config = resolve_remote_archive(
+                    target, remote_subpath,
+                )
+            except ValueError as exc:
+                return json_error(str(exc))
+            # Refuse at request time when no GNU rsync exists, matching the
+            # move-folder endpoint — starting a job that is guaranteed to
+            # fail its storage preflight helps nobody.
+            effective_cfg = db.get_effective_config(cfg.load())
+            rsync_bin = move_mod.resolve_rsync_bin(
+                effective_cfg.get("rsync_bin", "") or "")
+            if not rsync_bin:
+                return json_error(
+                    "No GNU rsync found for remote archiving — macOS's "
+                    "built-in rsync can't drive rsync-over-SSH. Install GNU "
+                    "rsync (e.g. `brew install rsync`) or set its path under "
+                    "Settings → Paths."
+                )
+        if local_processing and not destination and not remote_target_id:
+            return json_error(
+                "local_processing requires a destination or a remote target"
+            )
         if local_processing and destination:
             from local_processing import final_destination_name
 
@@ -16484,7 +16537,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             )
 
         folder_template = body.get("folder_template", "%Y/%Y-%m-%d")
-        if destination and folder_template:
+        # A remote archive still ingests through local staging, so the
+        # template gets applied there too — validate it for both shapes.
+        if (destination or remote_target_id) and folder_template:
             from ingest import _is_unsafe_path
             if _is_unsafe_path(folder_template):
                 return json_error("folder_template must be a relative path without '..' or backslashes")
@@ -16496,6 +16551,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             source_snapshot_id=source_snapshot_id,
             destination=destination,
             local_processing=local_processing,
+            remote_target_id=remote_target_id or None,
+            remote_subpath=remote_subpath or "",
             file_types=body.get("file_types", "both"),
             folder_template=folder_template,
             skip_duplicates=body.get("skip_duplicates", True),
@@ -16607,18 +16664,32 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # ``status='queued'`` until the slot opens. Callers receive the
         # same {"job_id": ...} response either way; clients learn about
         # the queued state via /api/jobs/<id> polling or the SSE stream.
+        job_config = {
+            "source": source,
+            "sources": sources,
+            "collection_id": collection_id,
+            "destination": destination,
+            "local_processing": local_processing,
+            "skip_classify": params.skip_classify,
+            "skip_extract_masks": params.skip_extract_masks,
+            "skip_regroup": params.skip_regroup,
+        }
+        if remote_archive_config is not None:
+            # Surface that the archive goes over SSH (and to where) so the
+            # jobs panel can show it, per the UI-transparency rule.
+            target = remote_archive_config["target"]
+            job_config["remote_archive"] = {
+                "target_id": target["id"],
+                "target_name": target["name"],
+                "host": target["host"],
+                "user": target["user"],
+                "subpath": remote_archive_config["subpath"],
+                "ssh_destination": remote_archive_config["ssh_final"],
+                "display": remote_archive_config["display"],
+            }
         job_id = runner.enqueue_pipeline(
             work,
-            config={
-                "source": source,
-                "sources": sources,
-                "collection_id": collection_id,
-                "destination": destination,
-                "local_processing": local_processing,
-                "skip_classify": params.skip_classify,
-                "skip_extract_masks": params.skip_extract_masks,
-                "skip_regroup": params.skip_regroup,
-            },
+            config=job_config,
             workspace_id=active_ws,
             runtime_warning=runtime_warning,
         )

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -16544,6 +16544,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if _is_unsafe_path(folder_template):
                 return json_error("folder_template must be a relative path without '..' or backslashes")
 
+        # Snapshot the resolved target dict so the queued run archives to the
+        # host/mount the user saw at click-Start, not whatever the saved target
+        # gets edited to while another pipeline holds the slot. Mirrors how the
+        # move-folder endpoint captures its remote spec at enqueue rather than
+        # re-reading Settings at execution.
+        remote_target_snapshot = (
+            dict(remote_archive_config["target"])
+            if remote_archive_config is not None else None
+        )
         params = PipelineParams(
             collection_id=collection_id,
             source=source,
@@ -16553,6 +16562,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             local_processing=local_processing,
             remote_target_id=remote_target_id or None,
             remote_subpath=remote_subpath or "",
+            remote_target_snapshot=remote_target_snapshot,
             file_types=body.get("file_types", "both"),
             folder_template=folder_template,
             skip_duplicates=body.get("skip_duplicates", True),

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -446,6 +446,62 @@ def _remote_dir_exists(remote, path):
     return None
 
 
+def _remote_free_bytes(remote, path):
+    """Free bytes on the remote filesystem holding ``path``, via ``df -Pk``
+    over SSH.
+
+    Returns None when the probe couldn't run or parse — callers must treat
+    that as "unknown, skip the check", never as 0 or "plenty", so a flaky
+    link can't fabricate an out-of-space refusal or wave through a full
+    volume. ``df -P`` (POSIX output format) pins the layout: one header
+    line, then one line per filesystem with available KiB in column 4 —
+    GNU, BusyBox, and Synology's df all honor it. ``path`` must exist on
+    the remote (probe the configured base, not a not-yet-created leaf).
+    """
+    cmd = (["ssh"] + ssh_base_args(remote) + [_ssh_target(remote)]
+           + [f"df -Pk {shlex.quote(path)}"])
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if r.returncode != 0:
+        return None
+    lines = [ln for ln in r.stdout.splitlines() if ln.strip()]
+    if len(lines) < 2:
+        return None
+    try:
+        return int(lines[-1].split()[3]) * 1024
+    except (IndexError, ValueError):
+        return None
+
+
+def _remote_tree_bytes(remote, path):
+    """Total bytes already stored under ``path`` on the remote host, via
+    ``du -sk`` over SSH.
+
+    Returns 0 when the path doesn't exist yet, and None when the probe
+    itself couldn't run/parse (unknown — same contract as
+    ``_remote_free_bytes``). Used as the merge/resume credit for a remote
+    archive retry: unlike the local ``existing_archive_bytes`` (a per-file
+    content comparison), du reports whole-tree usage, so callers must cap
+    the credit at the source size to keep unrelated remote content from
+    extending it.
+    """
+    q = shlex.quote(path)
+    cmd = (["ssh"] + ssh_base_args(remote) + [_ssh_target(remote)]
+           + [f"if [ -d {q} ]; then du -sk {q}; else echo 0; fi"])
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if r.returncode != 0:
+        return None
+    try:
+        return int((r.stdout or "").split()[0]) * 1024
+    except (IndexError, ValueError):
+        return None
+
+
 def remote_preflight(remote, dest_path, file_cap=1000):
     """Probe a remote destination for the move UI's merge/resume prompt.
 

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -475,33 +475,6 @@ def _remote_free_bytes(remote, path):
         return None
 
 
-def _remote_tree_bytes(remote, path):
-    """Total bytes already stored under ``path`` on the remote host, via
-    ``du -sk`` over SSH.
-
-    Returns 0 when the path doesn't exist yet, and None when the probe
-    itself couldn't run/parse (unknown — same contract as
-    ``_remote_free_bytes``). Used as the merge/resume credit for a remote
-    archive retry: unlike the local ``existing_archive_bytes`` (a per-file
-    content comparison), du reports whole-tree usage, so callers must cap
-    the credit at the source size to keep unrelated remote content from
-    extending it.
-    """
-    q = shlex.quote(path)
-    cmd = (["ssh"] + ssh_base_args(remote) + [_ssh_target(remote)]
-           + [f"if [ -d {q} ]; then du -sk {q}; else echo 0; fi"])
-    try:
-        r = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
-    except (OSError, subprocess.SubprocessError):
-        return None
-    if r.returncode != 0:
-        return None
-    try:
-        return int((r.stdout or "").split()[0]) * 1024
-    except (IndexError, ValueError):
-        return None
-
-
 def remote_preflight(remote, dest_path, file_cap=1000):
     """Probe a remote destination for the move UI's merge/resume prompt.
 

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1560,7 +1560,6 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 )
                             source_bytes = total_file_bytes(planning_files)
                             remote_summary_bits = []
-                            remote_resume_credit_checked = True
                             if remote_archive is None:
                                 # When a previous archive attempt left a partial
                                 # untracked directory at final_destination, the
@@ -1581,7 +1580,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             else:
                                 # Staging-only local plan (the archive volume
                                 # is the NAS, never the same device), then a
-                                # remote df/du probe for the archive side.
+                                # remote df probe for the archive side.
                                 # Probe failures degrade to "check skipped" —
                                 # logged and surfaced in the step summary and
                                 # result payload, never faked as numbers; the
@@ -1590,38 +1589,29 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 from local_processing import (
                                     RESERVED_FREE_BYTES,
                                 )
-                                from move import (
-                                    _remote_free_bytes,
-                                    _remote_tree_bytes,
-                                )
+                                from move import _remote_free_bytes
                                 plan = storage_plan(
                                     params.destination, source_bytes,
                                 )
                                 target = remote_archive["target"]
-                                remote_existing = _remote_tree_bytes(
-                                    target, remote_archive["ssh_final"],
-                                )
-                                if remote_existing is None:
-                                    log.warning(
-                                        "Couldn't probe existing bytes at %s; "
-                                        "skipping remote resume credit",
-                                        remote_archive["display"],
-                                    )
-                                    remote_summary_bits.append(
-                                        "remote resume-credit check skipped "
-                                        "(probe failed)"
-                                    )
-                                    remote_resume_credit_checked = False
-                                    remote_existing = 0
-                                # du reports whole-tree usage, so cap the
-                                # merge/resume credit at the source size —
-                                # unrelated content already on the NAS can't
-                                # shrink the delta below zero.
-                                existing_credit = min(
-                                    remote_existing, source_bytes,
-                                )
-                                archive_delta = source_bytes - existing_credit
-                                plan["archive_existing_bytes"] = existing_credit
+                                # No merge/resume credit for a remote archive:
+                                # the local resume-credit path (existing_archive_bytes)
+                                # compares each destination file's size+content
+                                # against the source, but a remote equivalent
+                                # would need a per-file walk over SSH. A
+                                # whole-tree `du` reports every byte at the
+                                # path — including unrelated files or stale
+                                # partials that rsync --ignore-existing will
+                                # still copy past — which could cancel out
+                                # source_bytes and let the preflight pass on
+                                # a nearly-full NAS. Budget the full source
+                                # here; a retry whose remaining delta would
+                                # actually fit but the full source wouldn't
+                                # is a rare batch-reject we take over the
+                                # false-positive that lets processing burn
+                                # hours before the transfer fails on space.
+                                archive_delta = source_bytes
+                                plan["archive_existing_bytes"] = 0
                                 plan["archive_required_bytes"] = archive_delta
                                 # df the configured base (just verified as an
                                 # existing writable dir by the connection
@@ -1674,8 +1664,6 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                     "free_space_checked": (
                                         plan["archive_free_bytes"] is not None
                                     ),
-                                    "resume_credit_checked":
-                                        remote_resume_credit_checked,
                                 }
                             if plan["batching_required"]:
                                 # Tell the user which volume came up short — the

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -94,6 +94,15 @@ class PipelineParams:
     # ``mount_path/subpath``, mirroring the Move page's remote folder moves.
     remote_target_id: str | None = None
     remote_subpath: str = ""
+    # Snapshot of the resolved remote target dict (from cfg.get_remote_target)
+    # captured at ENQUEUE time so a queued run archives to the destination the
+    # user saw when they clicked Start, not whatever the saved target got edited
+    # to before the pipeline slot opened. The API always populates this
+    # alongside ``remote_target_id``; when it is None, ``run_pipeline_job``
+    # falls back to re-reading the mutable target (mostly for direct-call
+    # tests). Mirrors how the move-folder endpoint builds its remote spec
+    # before enqueueing.
+    remote_target_snapshot: dict | None = None
     file_types: str = "both"
     folder_template: str = "%Y/%Y-%m-%d"
     skip_duplicates: bool = True
@@ -660,9 +669,16 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
     final_destination = params.destination if params.local_processing else None
     remote_archive = None
     if params.local_processing and params.remote_target_id:
-        import config as _cfg_mod
+        # Prefer the snapshot captured at enqueue time so a settings edit
+        # between click-Start and slot-open cannot redirect the archive to a
+        # different host/mount than the jobs panel is showing. The Settings
+        # fallback is a last resort for callers (mainly tests) that build
+        # PipelineParams by hand without pre-resolving the target.
+        target = params.remote_target_snapshot
+        if not target:
+            import config as _cfg_mod
 
-        target = _cfg_mod.get_remote_target(params.remote_target_id)
+            target = _cfg_mod.get_remote_target(params.remote_target_id)
         if not target:
             raise RuntimeError(
                 f"Remote target '{params.remote_target_id}' not found — it "

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -85,6 +85,15 @@ class PipelineParams:
     source_snapshot_id: int | None = None
     destination: str | None = None
     local_processing: bool = False
+    # Remote (SSH) archive destination for local-processing runs: the id of a
+    # saved remote target (config remote_targets) plus a required relative
+    # subpath naming the archive folder under the target's base paths.
+    # Mutually exclusive with ``destination``; resolved via
+    # ``resolve_remote_archive``. The staged tree is rsynced over SSH to
+    # ``remote_path/subpath`` and the catalog is repointed at
+    # ``mount_path/subpath``, mirroring the Move page's remote folder moves.
+    remote_target_id: str | None = None
+    remote_subpath: str = ""
     file_types: str = "both"
     folder_template: str = "%Y/%Y-%m-%d"
     skip_duplicates: bool = True
@@ -109,6 +118,68 @@ class PipelineParams:
     exclude_paths: set | None = None
     exclude_photo_ids: set | None = None
     recursive: bool = True
+
+
+def resolve_remote_archive(target, subpath):
+    """Resolve a saved remote target + subpath into the pipeline's
+    remote-archive context.
+
+    ``target`` is a validated dict from ``config.get_remote_target``.
+    ``subpath`` names the archive folder under BOTH base paths — it is
+    required (unlike the Move page, where the moved folder's own name
+    provides the landing leaf) because ``move_folder`` lands the staged
+    folder inside a parent keeping its name: the subpath's last segment is
+    the staging root's name, so the archive lands at exactly
+    ``remote_path/subpath`` over SSH while the catalog is repointed at
+    exactly ``mount_path/subpath``.
+
+    Raises ValueError with a user-facing message when the pieces can't form
+    a safe archive destination. Returns a dict:
+
+    * ``target`` — the target passed in.
+    * ``subpath`` — the sanitized relative subpath.
+    * ``parent_subpath`` — subpath minus its last segment ("" for a single
+      segment); feed this to ``build_remote_move_spec`` so the staged leaf
+      lands at the full subpath.
+    * ``ssh_final`` — NAS-side path the archive lands at.
+    * ``mount_final`` — local mount path the catalog points at afterward.
+    * ``display`` — ``user@host:ssh_final`` for messages/UI.
+    """
+    import posixpath
+
+    from move import rsync_dest_spec, sanitize_subpath
+
+    sub = sanitize_subpath(subpath)  # raises ValueError on absolute / '..'
+    if not sub:
+        raise ValueError(
+            "remote_subpath is required — it names the archive folder under "
+            "the remote target's base path (e.g. \"2026/kenya-trip\")."
+        )
+    mount_path = (target.get("mount_path") or "").strip()
+    if not mount_path:
+        raise ValueError(
+            "This remote target has no local mount path, so archived photos "
+            "couldn't stay in your library. Add a mount path under "
+            "Settings → Remote targets."
+        )
+    if not os.path.isabs(mount_path):
+        raise ValueError(
+            "This remote target's local mount path isn't absolute "
+            f"(\"{mount_path}\"). Archived photos would be repointed to a "
+            "path relative to the server's working directory and appear "
+            "missing. Set an absolute mount path under Settings → Remote "
+            "targets."
+        )
+    ssh_final = posixpath.join(target["remote_path"], sub)
+    mount_final = os.path.join(mount_path, *sub.split("/"))
+    return {
+        "target": target,
+        "subpath": sub,
+        "parent_subpath": posixpath.dirname(sub),
+        "ssh_final": ssh_final,
+        "mount_final": mount_final,
+        "display": rsync_dest_spec(target, ssh_final),
+    }
 
 
 def _should_abort(abort_event):
@@ -587,9 +658,32 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
         else os.path.dirname(db_path)
     )
     final_destination = params.destination if params.local_processing else None
+    remote_archive = None
+    if params.local_processing and params.remote_target_id:
+        import config as _cfg_mod
+
+        target = _cfg_mod.get_remote_target(params.remote_target_id)
+        if not target:
+            raise RuntimeError(
+                f"Remote target '{params.remote_target_id}' not found — it "
+                "may have been removed from Settings after this job was "
+                "queued. Pick a saved remote target and retry."
+            )
+        try:
+            remote_archive = resolve_remote_archive(
+                target, params.remote_subpath,
+            )
+        except ValueError as exc:
+            raise RuntimeError(str(exc)) from exc
+        # Everything below that keys off final_destination locally — the
+        # in-flight destination reservation, the tracked-destination
+        # preflight, the staging-root name — cares about where the CATALOG
+        # will point after the archive, which for a remote destination is
+        # the target's local mount path, not the NAS-side path.
+        final_destination = remote_archive["mount_final"]
     staging_parent = None
     archive_destination_reserved = False
-    if params.local_processing and params.destination:
+    if params.local_processing and final_destination:
         from local_processing import staging_root
 
         # Reserve the final destination across the whole process BEFORE any
@@ -608,8 +702,12 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
         archive_destination_reserved = True
 
         staging_parent = os.path.join(effective_vireo_dir, "staging", job["id"])
+        # final_destination (not params.destination, which is None for a
+        # remote archive): the staging root's basename is the leaf the
+        # archive move lands at, and for remote that's the mount-path leaf —
+        # the same last-subpath-segment as the NAS side.
         params.destination = staging_root(
-            effective_vireo_dir, job["id"], params.destination,
+            effective_vireo_dir, job["id"], final_destination,
         )
 
     try:
@@ -1080,6 +1178,46 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             scan_to_thumb.put(_SENTINEL)
 
                         try:
+                            if remote_archive is not None:
+                                import move as move_mod
+
+                                # Refuse BEFORE staging/processing hours of
+                                # work, in the same spirit as the local
+                                # archive-parent checks below: a missing GNU
+                                # rsync or an unreachable target would
+                                # otherwise only surface at the final archive
+                                # move, stranding processed results in
+                                # staging.
+                                rsync_bin = move_mod.resolve_rsync_bin(
+                                    effective_cfg.get("rsync_bin", "") or "",
+                                )
+                                if rsync_bin and not move_mod.is_gnu_rsync(
+                                    rsync_bin,
+                                ):
+                                    rsync_bin = ""
+                                if not rsync_bin:
+                                    _bail_storage(
+                                        "No GNU rsync found for the remote "
+                                        "archive — macOS's built-in rsync "
+                                        "can't drive rsync-over-SSH. Install "
+                                        "GNU rsync (e.g. `brew install "
+                                        "rsync`) or set its path under "
+                                        "Settings → Paths."
+                                    )
+                                    return
+                                conn = move_mod.test_remote_connection(
+                                    remote_archive["target"], rsync_bin,
+                                )
+                                if not conn.get("ok"):
+                                    _bail_storage(
+                                        "Remote archive target "
+                                        f"'{remote_archive['target']['name']}'"
+                                        f" ({remote_archive['display']}) "
+                                        "isn't usable: "
+                                        f"{conn.get('message') or 'connection test failed'}"
+                                    )
+                                    return
+
                             # A tracked archive destination (the import lands at
                             # or inside a folder Vireo already manages) is no
                             # longer a hard failure: the archive move opts into
@@ -1108,6 +1246,14 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 _path_equal_or_descends,
                                 _tracked_destination_overlap,
                             )
+                            # For a remote archive, final_destination is the
+                            # catalog-facing MOUNT path (see where
+                            # remote_archive is resolved) — the tracked check
+                            # applies there too, because a prior remote
+                            # archive to the same target leaves tracked rows
+                            # at the mount path and the archive move merges
+                            # into (or refuses around) those exactly like a
+                            # local destination.
                             preflight_tracked = _tracked_destination_overlap(
                                 thread_db, -1, final_destination,
                             )
@@ -1124,63 +1270,75 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 )
                                 return
 
-                            # Make sure the archive parent exists NOW. Otherwise
-                            # the pipeline would stage and process everything,
-                            # then fail at the final move_folder call when rsync
-                            # tries to write to a missing parent — leaving the
-                            # staged copy stranded under ~/.vireo/staging with no
-                            # archive at the final destination. Nested archive
-                            # targets like /mnt/nas/NewShoot/Photos are the
-                            # common case: the parent /mnt/nas/NewShoot may not
-                            # have been created yet by the user.
-                            archive_parent = os.path.dirname(
-                                os.path.normpath(final_destination),
-                            )
-                            # Use lexists so a broken/dangling symlink at
-                            # final_destination is caught here too. os.path
-                            # .exists returns False for a broken symlink, so
-                            # a stale link left by an unmounted or moved
-                            # archive root would slip through, let the
-                            # pipeline stage and process everything, and
-                            # only fail when move_folder/rsync tried to
-                            # create a directory at a path already occupied
-                            # by that symlink entry.
-                            if (
-                                os.path.lexists(final_destination)
-                                and not os.path.isdir(final_destination)
-                            ):
-                                _bail_storage(
-                                    f"Archive destination {final_destination} "
-                                    "already exists and is not a directory."
+                            if remote_archive is None:
+                                # Make sure the archive parent exists NOW. Otherwise
+                                # the pipeline would stage and process everything,
+                                # then fail at the final move_folder call when rsync
+                                # tries to write to a missing parent — leaving the
+                                # staged copy stranded under ~/.vireo/staging with no
+                                # archive at the final destination. Nested archive
+                                # targets like /mnt/nas/NewShoot/Photos are the
+                                # common case: the parent /mnt/nas/NewShoot may not
+                                # have been created yet by the user.
+                                #
+                                # All four checks in this branch are
+                                # local-filesystem-only. For a remote archive
+                                # the destination lives on the NAS: the SSH
+                                # connection test above already proved the
+                                # remote base is a writable directory, and
+                                # move_folder's remote path mkdir-p's the
+                                # subpath parents itself. The local mount
+                                # path deliberately isn't probed — it may
+                                # legitimately be unmounted while archiving
+                                # over SSH (that's the point of this mode).
+                                archive_parent = os.path.dirname(
+                                    os.path.normpath(final_destination),
                                 )
-                                return
-                            # Existing archive roots can be mounted volumes; new
-                            # archive leaves have to probe the existing parent.
-                            archive_space_path = (
-                                final_destination
-                                if os.path.exists(final_destination)
-                                else archive_parent
-                            )
-                            missing_mount_root = (
-                                _missing_archive_mount_root(final_destination)
-                                or _missing_archive_mount_root(archive_parent)
-                            )
-                            if missing_mount_root:
-                                _bail_storage(
-                                    f"Archive mount root {missing_mount_root} "
-                                    "is not available. Check that the "
-                                    "destination drive is mounted and writable."
+                                # Use lexists so a broken/dangling symlink at
+                                # final_destination is caught here too. os.path
+                                # .exists returns False for a broken symlink, so
+                                # a stale link left by an unmounted or moved
+                                # archive root would slip through, let the
+                                # pipeline stage and process everything, and
+                                # only fail when move_folder/rsync tried to
+                                # create a directory at a path already occupied
+                                # by that symlink entry.
+                                if (
+                                    os.path.lexists(final_destination)
+                                    and not os.path.isdir(final_destination)
+                                ):
+                                    _bail_storage(
+                                        f"Archive destination {final_destination} "
+                                        "already exists and is not a directory."
+                                    )
+                                    return
+                                # Existing archive roots can be mounted volumes; new
+                                # archive leaves have to probe the existing parent.
+                                archive_space_path = (
+                                    final_destination
+                                    if os.path.exists(final_destination)
+                                    else archive_parent
                                 )
-                                return
-                            try:
-                                os.makedirs(archive_parent, exist_ok=True)
-                            except OSError as exc:
-                                _bail_storage(
-                                    f"Archive parent {archive_parent} could "
-                                    f"not be created: {exc}. Check that the "
-                                    "destination drive is mounted and writable."
+                                missing_mount_root = (
+                                    _missing_archive_mount_root(final_destination)
+                                    or _missing_archive_mount_root(archive_parent)
                                 )
-                                return
+                                if missing_mount_root:
+                                    _bail_storage(
+                                        f"Archive mount root {missing_mount_root} "
+                                        "is not available. Check that the "
+                                        "destination drive is mounted and writable."
+                                    )
+                                    return
+                                try:
+                                    os.makedirs(archive_parent, exist_ok=True)
+                                except OSError as exc:
+                                    _bail_storage(
+                                        f"Archive parent {archive_parent} could "
+                                        f"not be created: {exc}. Check that the "
+                                        "destination drive is mounted and writable."
+                                    )
+                                    return
 
                             os.makedirs(params.destination, exist_ok=True)
                             selected_files = selected_source_files(
@@ -1301,20 +1459,34 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                     )
                                 return indexed
 
-                            archive_report = archive_conflict_report(
-                                final_destination,
-                                selected_files,
-                                params.folder_template,
-                                duplicate_checker=_fresh_checker(),
-                                indexed_paths=_indexed_archive_paths(
+                            if remote_archive is None:
+                                archive_report = archive_conflict_report(
                                     final_destination,
-                                ),
-                            )
-                            archive_conflicts = (
-                                archive_report["empty"]
-                                + archive_report["partial"]
-                                + archive_report["conflicts"]
-                            )
+                                    selected_files,
+                                    params.folder_template,
+                                    duplicate_checker=_fresh_checker(),
+                                    indexed_paths=_indexed_archive_paths(
+                                        final_destination,
+                                    ),
+                                )
+                                archive_conflicts = (
+                                    archive_report["empty"]
+                                    + archive_report["partial"]
+                                    + archive_report["conflicts"]
+                                )
+                            else:
+                                # The conflict report walks the destination
+                                # tree, which for a remote archive lives on
+                                # the NAS and isn't locally walkable. The
+                                # archive move itself runs the equivalent
+                                # guard over SSH before any file is copied —
+                                # move_folder's remote merge path probes with
+                                # ``rsync -an --existing --checksum`` and
+                                # refuses on any same-path file whose bytes
+                                # differ — so a conflict still cancels
+                                # cleanly, just at archive time instead of
+                                # here.
+                                archive_conflicts = []
                             if archive_conflicts:
                                 incomplete = (
                                     archive_report["empty"]
@@ -1387,27 +1559,124 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                     selected_files, _fresh_checker(),
                                 )
                             source_bytes = total_file_bytes(planning_files)
-                            # When a previous archive attempt left a partial
-                            # untracked directory at final_destination, the
-                            # retry uses move_folder(..., merge=True), which
-                            # rsyncs only the missing files. Credit the bytes
-                            # already published so the preflight doesn't
-                            # reject a retry whose remaining delta would fit.
-                            existing_bytes = existing_archive_bytes(
-                                final_destination,
-                                planning_files,
-                                params.folder_template,
-                            )
-                            plan = storage_plan(
-                                params.destination, source_bytes,
-                                archive_parent=archive_space_path,
-                                archive_existing_bytes=existing_bytes,
-                            )
+                            remote_summary_bits = []
+                            remote_resume_credit_checked = True
+                            if remote_archive is None:
+                                # When a previous archive attempt left a partial
+                                # untracked directory at final_destination, the
+                                # retry uses move_folder(..., merge=True), which
+                                # rsyncs only the missing files. Credit the bytes
+                                # already published so the preflight doesn't
+                                # reject a retry whose remaining delta would fit.
+                                existing_bytes = existing_archive_bytes(
+                                    final_destination,
+                                    planning_files,
+                                    params.folder_template,
+                                )
+                                plan = storage_plan(
+                                    params.destination, source_bytes,
+                                    archive_parent=archive_space_path,
+                                    archive_existing_bytes=existing_bytes,
+                                )
+                            else:
+                                # Staging-only local plan (the archive volume
+                                # is the NAS, never the same device), then a
+                                # remote df/du probe for the archive side.
+                                # Probe failures degrade to "check skipped" —
+                                # logged and surfaced in the step summary and
+                                # result payload, never faked as numbers; the
+                                # archive move's own rsync failure is the
+                                # backstop if space actually runs out.
+                                from local_processing import (
+                                    RESERVED_FREE_BYTES,
+                                )
+                                from move import (
+                                    _remote_free_bytes,
+                                    _remote_tree_bytes,
+                                )
+                                plan = storage_plan(
+                                    params.destination, source_bytes,
+                                )
+                                target = remote_archive["target"]
+                                remote_existing = _remote_tree_bytes(
+                                    target, remote_archive["ssh_final"],
+                                )
+                                if remote_existing is None:
+                                    log.warning(
+                                        "Couldn't probe existing bytes at %s; "
+                                        "skipping remote resume credit",
+                                        remote_archive["display"],
+                                    )
+                                    remote_summary_bits.append(
+                                        "remote resume-credit check skipped "
+                                        "(probe failed)"
+                                    )
+                                    remote_resume_credit_checked = False
+                                    remote_existing = 0
+                                # du reports whole-tree usage, so cap the
+                                # merge/resume credit at the source size —
+                                # unrelated content already on the NAS can't
+                                # shrink the delta below zero.
+                                existing_credit = min(
+                                    remote_existing, source_bytes,
+                                )
+                                archive_delta = source_bytes - existing_credit
+                                plan["archive_existing_bytes"] = existing_credit
+                                plan["archive_required_bytes"] = archive_delta
+                                # df the configured base (just verified as an
+                                # existing writable dir by the connection
+                                # test) rather than the not-yet-created leaf.
+                                remote_free = _remote_free_bytes(
+                                    target, target["remote_path"],
+                                )
+                                plan["archive_free_bytes"] = remote_free
+                                if remote_free is None:
+                                    log.warning(
+                                        "Couldn't probe free space at %s; "
+                                        "skipping remote free-space check",
+                                        remote_archive["display"],
+                                    )
+                                    remote_summary_bits.append(
+                                        "remote free-space check skipped "
+                                        "(probe failed)"
+                                    )
+                                    plan["archive_usable_bytes"] = None
+                                else:
+                                    archive_usable = max(
+                                        0, remote_free - RESERVED_FREE_BYTES,
+                                    )
+                                    plan["archive_usable_bytes"] = archive_usable
+                                    plan["archive_enough"] = (
+                                        archive_delta <= archive_usable
+                                    )
+                                    plan["enough"] = (
+                                        plan["staging_enough"]
+                                        and plan["archive_enough"]
+                                    )
+                                    plan["batching_required"] = not plan["enough"]
+                                    remote_summary_bits.append(
+                                        f"{format_bytes(remote_free)} free at "
+                                        f"{target['name']}"
+                                    )
                             result["local_processing"] = {
                                 **plan,
                                 "staging_destination": params.destination,
                                 "final_destination": final_destination,
                             }
+                            if remote_archive is not None:
+                                target = remote_archive["target"]
+                                result["local_processing"]["remote"] = {
+                                    "target_id": target["id"],
+                                    "target_name": target["name"],
+                                    "host": target["host"],
+                                    "user": target["user"],
+                                    "ssh_destination": remote_archive["ssh_final"],
+                                    "free_space_checked": (
+                                        plan["archive_free_bytes"] is not None
+                                    ),
+                                    "resume_credit_checked":
+                                        remote_resume_credit_checked,
+                                }
                             if plan["batching_required"]:
                                 # Tell the user which volume came up short — the
                                 # destination running out of room reads as a
@@ -1415,16 +1684,29 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 # drive) than the staging volume running out
                                 # (free space on ~/.vireo or batch later).
                                 if not plan.get("archive_enough", True):
-                                    _bail_storage(
-                                        "Archive destination needs about "
-                                        f"{format_bytes(plan['archive_required_bytes'])}, "
-                                        "but only "
-                                        f"{format_bytes(plan['archive_usable_bytes'] or 0)} "
-                                        f"is free under {archive_parent} after "
-                                        "the free-space reserve. Free space at "
-                                        "the destination or pick a different "
-                                        "archive folder."
-                                    )
+                                    if remote_archive is not None:
+                                        _bail_storage(
+                                            "Remote archive needs about "
+                                            f"{format_bytes(plan['archive_required_bytes'])}, "
+                                            "but only "
+                                            f"{format_bytes(plan['archive_usable_bytes'] or 0)} "
+                                            "is free at "
+                                            f"{remote_archive['display']} after "
+                                            "the free-space reserve. Free space "
+                                            "on the remote volume or pick a "
+                                            "different target or subpath."
+                                        )
+                                    else:
+                                        _bail_storage(
+                                            "Archive destination needs about "
+                                            f"{format_bytes(plan['archive_required_bytes'])}, "
+                                            "but only "
+                                            f"{format_bytes(plan['archive_usable_bytes'] or 0)} "
+                                            f"is free under {archive_parent} after "
+                                            "the free-space reserve. Free space at "
+                                            "the destination or pick a different "
+                                            "archive folder."
+                                        )
                                 else:
                                     _bail_storage(
                                         "Local processing needs about "
@@ -1441,6 +1723,8 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 f"{format_bytes(plan['required_bytes'])} needed, "
                                 f"{format_bytes(plan['usable_bytes'])} available"
                             )
+                            if remote_summary_bits:
+                                summary += "; " + "; ".join(remote_summary_bits)
                             stages["storage"]["status"] = "completed"
                             runner.update_step(
                                 job["id"], "storage",
@@ -4828,6 +5112,38 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 effective_cfg = thread_db.get_effective_config(cfg.load())
                 developed_dir = effective_cfg.get("darktable_output_dir", "") or ""
                 archive_parent = os.path.dirname(os.path.normpath(final_destination))
+                remote_spec = None
+                if remote_archive is not None:
+                    import move as move_mod
+
+                    # Re-resolve rsync at archive time: the storage preflight
+                    # verified it hours ago and the binary/config could have
+                    # changed since. move_folder refuses on a missing
+                    # rsync_bin anyway; resolving here gives the actionable
+                    # message before any SSH probing starts.
+                    rsync_bin = move_mod.resolve_rsync_bin(
+                        effective_cfg.get("rsync_bin", "") or "",
+                    )
+                    if rsync_bin and not move_mod.is_gnu_rsync(rsync_bin):
+                        rsync_bin = ""
+                    if not rsync_bin:
+                        raise RuntimeError(
+                            "No GNU rsync available to transfer the archive "
+                            f"to {remote_archive['display']}. Install GNU "
+                            "rsync (e.g. `brew install rsync`) or set its "
+                            "path under Settings → Paths"
+                        )
+                    # parent_subpath (not the full subpath): move_folder
+                    # lands the staged folder INSIDE the spec's bases keeping
+                    # its name, and the staging root is named after the
+                    # subpath's last segment — so the archive lands at
+                    # exactly remote_path/subpath and the catalog repoints
+                    # at exactly mount_path/subpath (== final_destination).
+                    remote_spec = move_mod.build_remote_move_spec(
+                        remote_archive["target"],
+                        remote_archive["parent_subpath"],
+                        rsync_bin,
+                    )
                 total_files = {"value": 0}
 
                 def archive_cb(current, total, filename, phase=None):
@@ -4862,6 +5178,14 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     _update_stages(runner, job["id"], stages)
                     return
 
+                # For a remote archive the destination parent comes from
+                # remote_spec (move_folder ignores the positional
+                # destination); merge/retry and tracked-merge semantics are
+                # identical to the local path — move_folder's remote branch
+                # probes existence over SSH, rsyncs with --ignore-existing +
+                # --partial-dir on a resume, checksum-verifies before
+                # deleting staging, and repoints the catalog at the mount
+                # path (final_destination).
                 move_result = move_folder(
                     thread_db,
                     folder["id"],
@@ -4871,6 +5195,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     merge=True,
                     reject_tracked_ancestor=True,
                     allow_tracked_merge=True,
+                    remote=remote_spec,
                 )
                 if move_result.get("errors"):
                     raise RuntimeError("; ".join(move_result["errors"]))
@@ -4924,6 +5249,16 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         f"{merge['merged_folders']} merged into existing, "
                         f"{merge['already_present']} already present)"
                     )
+                    if remote_archive is not None:
+                        summary += (
+                            " — transferred over SSH to "
+                            f"{remote_archive['display']}"
+                        )
+                elif remote_archive is not None:
+                    summary = (
+                        f"{moved} photos archived over SSH to "
+                        f"{remote_archive['display']}"
+                    )
                 else:
                     summary = f"{moved} photos archived"
                 if cleanup_error:
@@ -4935,13 +5270,29 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     "final_destination": final_destination,
                     "moved": moved,
                 }
+                if remote_archive is not None:
+                    target = remote_archive["target"]
+                    result["archive"]["remote"] = {
+                        "target_id": target["id"],
+                        "target_name": target["name"],
+                        "host": target["host"],
+                        "user": target["user"],
+                        "ssh_destination": remote_archive["ssh_final"],
+                    }
                 if merge:
                     result["archive"]["merge"] = merge
                 if cleanup_error:
                     result["archive"]["cleanup_error"] = cleanup_error
             except Exception as e:
+                # Name the remote target + subpath the way the local path
+                # names the directory (move_folder's own error text already
+                # covers the local case).
+                prefix = (
+                    f"Archive to {remote_archive['display']} failed: "
+                    if remote_archive is not None else ""
+                )
                 msg = (
-                    f"{e}. Processing results remain in local staging: "
+                    f"{prefix}{e}. Processing results remain in local staging: "
                     f"{params.destination}"
                 )
                 errors.append(f"[archive] Fatal: {msg}")

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -880,15 +880,30 @@ body { padding-bottom: 36px; }
           <div class="setting-row">
             <div class="setting-item">
               <div class="setting-label">Destination</div>
-              <div style="display:flex;gap:6px;">
-                <input type="text" class="setting-select" id="cfgDestination" list="volumeDatalist"
-                       placeholder="/path/to/photo/library" style="font-family:inherit;flex:1;"
-                       oninput="updateStartButton();markFolderPreviewStale()">
-                <button onclick="openFolderBrowser('destination')" class="btn btn-secondary" style="white-space:nowrap;">Browse&hellip;</button>
+              <div style="margin-bottom:6px;">
+                <select id="cfgDestMode" class="setting-select" style="font-family:inherit;max-width:340px;"
+                        onchange="onDestModeChange()" data-testid="dest-mode-select">
+                  <option value="local">Local path</option>
+                </select>
               </div>
-              <div id="recentDestinations" style="display:none;margin-top:6px;" data-testid="recent-destinations">
-                <div style="font-size:11px;color:var(--text-dim);margin-bottom:4px;">Recent</div>
-                <div id="recentDestList" style="display:flex;flex-wrap:wrap;gap:4px;"></div>
+              <div id="destLocalRows">
+                <div style="display:flex;gap:6px;">
+                  <input type="text" class="setting-select" id="cfgDestination" list="volumeDatalist"
+                         placeholder="/path/to/photo/library" style="font-family:inherit;flex:1;"
+                         oninput="updateStartButton();markFolderPreviewStale()">
+                  <button onclick="openFolderBrowser('destination')" class="btn btn-secondary" style="white-space:nowrap;">Browse&hellip;</button>
+                </div>
+                <div id="recentDestinations" style="display:none;margin-top:6px;" data-testid="recent-destinations">
+                  <div style="font-size:11px;color:var(--text-dim);margin-bottom:4px;">Recent</div>
+                  <div id="recentDestList" style="display:flex;flex-wrap:wrap;gap:4px;"></div>
+                </div>
+              </div>
+              <div id="destRemoteRows" style="display:none;">
+                <input type="text" class="setting-select" id="cfgRemoteSubpath"
+                       placeholder="Archive folder under the target (e.g. 2026/kenya-trip)"
+                       style="font-family:inherit;width:100%;"
+                       oninput="updateRemoteDestPreview();updateStartButton()" data-testid="remote-subpath-input">
+                <div id="remoteDestPreview" style="font-size:11px;margin-top:4px;line-height:1.5;color:var(--text-dim);" data-testid="remote-dest-preview"></div>
               </div>
             </div>
           </div>
@@ -912,6 +927,9 @@ body { padding-bottom: 36px; }
               </label>
               <div style="font-size:11px;color:var(--text-dim);margin-top:4px;line-height:1.4;">
                 Files are staged locally for faster processing, then archived to the destination after verification.
+              </div>
+              <div id="remoteLocalProcessingNote" style="display:none;font-size:11px;color:var(--text-dim);margin-top:4px;line-height:1.4;" data-testid="remote-local-processing-note">
+                Required for SSH targets &mdash; files are staged and processed locally, then transferred over SSH.
               </div>
             </div>
           </div>
@@ -1381,6 +1399,7 @@ function initPipelinePage() {
     refreshPipelinePlan();
   });
   loadVolumes();
+  loadRemoteTargets();
 
   // Pre-fill folders from query params (e.g., from audit panel)
   var urlParams = new URLSearchParams(window.location.search);
@@ -2156,9 +2175,172 @@ function renderSourceFolders() {
 function selectRecentDestination(path) {
   document.getElementById('chkCopyPhotos').checked = true;
   onCopyModeChange();
+  // Recents are local paths — switch back out of any remote mode.
+  document.getElementById('cfgDestMode').value = 'local';
+  onDestModeChange();
   document.getElementById('cfgDestination').value = path;
   updateStartButton();
   markFolderPreviewStale();
+}
+
+/* ---------- Remote (SSH) archive targets ----------
+   Mirrors the Move page's saved-remote-target picker: the archive
+   destination becomes a saved SSH target plus a required subpath naming
+   the archive folder under it. Requires local processing (files are
+   staged locally, then rsynced over SSH by the archive stage). */
+var _remoteTargets = [];
+var _rsyncAvailable = false;
+
+async function loadRemoteTargets() {
+  try {
+    var data = await safeFetch('/api/remote-targets', {}, { toast: false });
+    _remoteTargets = (data && data.targets) || [];
+    _rsyncAvailable = !!(data && data.rsync_available);
+  } catch (e) {
+    _remoteTargets = [];
+    _rsyncAvailable = false;
+  }
+  var sel = document.getElementById('cfgDestMode');
+  if (!sel) return;
+  // Rebuild remote options, keeping the "Local path" option at index 0.
+  while (sel.options.length > 1) sel.remove(1);
+  _remoteTargets.forEach(function(t) {
+    var opt = document.createElement('option');
+    opt.value = 'remote:' + t.id;
+    opt.textContent = t.name + ' — ' + t.user + '@' + t.host + ' (SSH)';
+    sel.appendChild(opt);
+  });
+}
+
+// The remote target id when the destination mode is a remote target, else ''.
+function pipelineRemoteTargetId() {
+  var el = document.getElementById('cfgDestMode');
+  var v = el ? el.value : 'local';
+  return v.indexOf('remote:') === 0 ? v.slice(7) : '';
+}
+
+function pipelineRemoteTarget() {
+  var id = pipelineRemoteTargetId();
+  if (!id) return null;
+  return _remoteTargets.find(function(t) { return t.id === id; }) || null;
+}
+
+function onDestModeChange() {
+  var remoteId = pipelineRemoteTargetId();
+  document.getElementById('destLocalRows').style.display = remoteId ? 'none' : '';
+  document.getElementById('destRemoteRows').style.display = remoteId ? '' : 'none';
+  // SSH targets require the local staging flow: photos can't be processed
+  // in place over SSH, so the archive stage rsyncs the staged tree to the
+  // NAS. Lock the toggle on so its state always matches what the job does.
+  var lp = document.getElementById('chkLocalProcessing');
+  var note = document.getElementById('remoteLocalProcessingNote');
+  if (remoteId) {
+    if (lp) { lp.checked = true; lp.disabled = true; }
+    if (note) note.style.display = '';
+  } else {
+    if (lp) lp.disabled = false;
+    if (note) note.style.display = 'none';
+  }
+  updateRemoteDestPreview();
+  markFolderPreviewStale();
+  updateStartButton();
+  schedulePlanRefresh();
+}
+
+// Normalize a remote-target subpath the same way move.py sanitize_subpath
+// does (see move.html's copy of this helper): trim, fold backslashes,
+// reject absolute paths and '..' traversal, drop empty/'.' segments.
+// Sharing the backend's rules means the path the UI previews is the path
+// the archive will actually write — a UI-transparency requirement.
+function normalizeRemoteSubpath(raw) {
+  var trimmed = (raw || '').trim();
+  if (!trimmed) return {value: '', error: ''};
+  var s = trimmed.replace(/\\/g, '/');
+  if (s.charAt(0) === '/' || /^[A-Za-z]:/.test(s)) {
+    return {value: '', error: 'Subpath must be relative.'};
+  }
+  var parts = [];
+  var segs = s.split('/');
+  for (var i = 0; i < segs.length; i++) {
+    var seg = segs[i];
+    if (seg === '' || seg === '.') continue;
+    if (seg === '..') return {value: '', error: "Subpath may not contain '..'."};
+    parts.push(seg);
+  }
+  return {value: parts.join('/'), error: ''};
+}
+
+// True if `p` looks absolute on either backend OS (POSIX, Windows drive,
+// or UNC). Used to warn before the backend refuses a relative mount path.
+function _isAbsolutePath(p) {
+  if (!p) return false;
+  return p.charAt(0) === '/' || /^[A-Za-z]:[\\\/]/.test(p) || /^\\\\/.test(p);
+}
+
+// Mirror move.py rsync_dest_spec(): bracket IPv6-literal hosts so the
+// preview shows the exact spec rsync will be handed.
+function rsyncDestSpec(user, host, path) {
+  var hostToken = host && host.indexOf(':') !== -1 ? '[' + host + ']' : host;
+  return user + '@' + hostToken + ':' + path;
+}
+
+function _remoteDestWarn(text) {
+  var d = document.createElement('div');
+  d.style.color = 'var(--warning,#f0ad4e)';
+  d.textContent = text;
+  return d;
+}
+
+function updateRemoteDestPreview() {
+  var el = document.getElementById('remoteDestPreview');
+  if (!el) return;
+  el.textContent = '';
+  var t = pipelineRemoteTarget();
+  if (!t) return;
+  var subResult = normalizeRemoteSubpath(
+    document.getElementById('cfgRemoteSubpath').value);
+  if (subResult.error) {
+    el.appendChild(_remoteDestWarn('⚠ ' + subResult.error));
+  } else if (!subResult.value) {
+    var hint = document.createElement('div');
+    hint.textContent = 'Name the archive folder under ' + t.remote_path
+      + ' — e.g. 2026/kenya-trip.';
+    el.appendChild(hint);
+  } else {
+    var line = document.createElement('div');
+    line.textContent = 'Staged locally, then archived over SSH to: ';
+    var span = document.createElement('span');
+    span.style.fontFamily = 'monospace';
+    span.textContent = rsyncDestSpec(
+      t.user, t.host, t.remote_path.replace(/\/+$/, '') + '/' + subResult.value);
+    line.appendChild(span);
+    el.appendChild(line);
+  }
+  if (!_rsyncAvailable) {
+    el.appendChild(_remoteDestWarn('⚠ No GNU rsync found — remote archiving '
+      + 'needs it. Install GNU rsync or set its path under Settings → Paths.'));
+  }
+  if (!t.mount_path) {
+    el.appendChild(_remoteDestWarn('⚠ This target has no local mount path, so '
+      + 'archived photos couldn’t stay in your library. Add one in Settings → '
+      + 'Remote targets.'));
+  } else if (!_isAbsolutePath(t.mount_path)) {
+    el.appendChild(_remoteDestWarn('⚠ This target’s local mount path must be '
+      + 'absolute (e.g. "/Volumes/Photos"). Fix it under Settings → Remote '
+      + 'targets.'));
+  }
+}
+
+// True when the remote archive selection is complete and usable. Mirrors
+// the backend's POST validation so Start is only enabled for a request
+// that would be accepted.
+function remoteArchiveSelectionReady() {
+  var t = pipelineRemoteTarget();
+  if (!t || !_rsyncAvailable) return false;
+  if (!t.mount_path || !_isAbsolutePath(t.mount_path)) return false;
+  var subResult = normalizeRemoteSubpath(
+    document.getElementById('cfgRemoteSubpath').value);
+  return !subResult.error && !!subResult.value;
 }
 
 function onCopyModeChange() {
@@ -2339,9 +2521,11 @@ function markFolderPreviewStale() {
   document.getElementById('folderPreviewStale').style.display = '';
   var btn = document.getElementById('btnPreviewFolders');
   btn.textContent = 'Refresh preview';
-  // Only enable if prerequisites are still met (sources + destination)
+  // Only enable if prerequisites are still met (sources + a LOCAL
+  // destination — the preview can't walk an SSH target).
   var hasSources = _sourceFolders.length > 0;
-  var hasDest = document.getElementById('cfgDestination').value.trim();
+  var hasDest = !pipelineRemoteTargetId()
+    && document.getElementById('cfgDestination').value.trim();
   btn.disabled = !(hasSources && hasDest);
 }
 
@@ -2561,8 +2745,12 @@ function updateStartButton() {
       if (!wsName) btn.disabled = true;
     }
     if (_sourceMode === 'import' && _copyMode) {
-      var dest = document.getElementById('cfgDestination').value.trim();
-      if (!dest) btn.disabled = true;
+      if (pipelineRemoteTargetId()) {
+        if (!remoteArchiveSelectionReady()) btn.disabled = true;
+      } else {
+        var dest = document.getElementById('cfgDestination').value.trim();
+        if (!dest) btn.disabled = true;
+      }
     }
   }
 
@@ -2612,13 +2800,21 @@ function updateStartButton() {
   var previewHint = document.getElementById('previewFoldersHint');
   if (previewBtn) {
     var hasSources = _sourceFolders.length > 0;
-    var hasDest = _copyMode && document.getElementById('cfgDestination').value.trim();
+    var remoteMode = _copyMode && !!pipelineRemoteTargetId();
+    var hasDest = _copyMode && !remoteMode
+      && document.getElementById('cfgDestination').value.trim();
     if (hasSources && hasDest) {
       if (!_folderPreviewShown) previewBtn.disabled = false;
       previewHint.textContent = '';
     } else {
       previewBtn.disabled = true;
-      previewHint.textContent = 'Select source and destination to preview';
+      // The preview walks the destination on the local filesystem; an SSH
+      // target isn't locally walkable, so say the check doesn't run rather
+      // than pretending it did (existing remote files are still handled —
+      // the archive stage merges and refuses on content conflicts).
+      previewHint.textContent = remoteMode && hasSources
+        ? 'Folder preview isn’t available for SSH targets — existing remote files are checked at archive time'
+        : 'Select source and destination to preview';
     }
   }
 
@@ -2867,12 +3063,24 @@ async function startPipeline() {
       if (excluded.length > 0) body.exclude_paths = excluded;
     }
     if (_copyMode) {
-      body.destination = document.getElementById('cfgDestination').value.trim();
+      var remoteTargetId = pipelineRemoteTargetId();
+      if (remoteTargetId) {
+        // Remote (SSH) archive: same request shape as the Move page —
+        // saved target id + relative subpath — and always local processing
+        // (the backend rejects anything else).
+        var subResult = normalizeRemoteSubpath(
+          document.getElementById('cfgRemoteSubpath').value);
+        body.remote_target_id = remoteTargetId;
+        body.remote_subpath = subResult.value;
+        body.local_processing = true;
+      } else {
+        body.destination = document.getElementById('cfgDestination').value.trim();
+        var localProcessing = document.getElementById('chkLocalProcessing');
+        body.local_processing = !!(localProcessing && localProcessing.checked);
+      }
       body.skip_duplicates = document.getElementById('chkSkipDuplicates').checked;
       body.verify_by_hash = document.getElementById('chkVerifyByHash').checked;
       body.folder_template = getSelectedFolderTemplate();
-      var localProcessing = document.getElementById('chkLocalProcessing');
-      body.local_processing = !!(localProcessing && localProcessing.checked);
     }
   } else if (_sourceMode === 'new_images') {
     body.source_snapshot_id = newImagesSnapshotId;

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -2179,3 +2179,173 @@ def test_cancel_queued_endpoint_leaves_other_workspaces_alone(app_and_db):
         # Cancel the surviving queued job so the test fixture's
         # teardown isn't waiting on a pipeline that will never run.
         runner.cancel_job(queued_b)
+
+
+# ---------------------------------------------------------------------------
+# Remote (SSH) archive destination for /api/jobs/pipeline — request
+# validation. These must all reject BEFORE any job starts, so no SSH/rsync
+# seams need faking here; end-to-end runs live in test_pipeline_job.py.
+# ---------------------------------------------------------------------------
+
+def _save_remote_target(monkeypatch, tmp_path, **overrides):
+    """Save one valid remote target into the test-isolated config and make
+    the POST-time GNU-rsync resolution succeed without touching the host."""
+    import config as cfg
+    import move as move_mod
+
+    entry = {
+        "id": "nas1", "name": "NAS", "host": "nas", "user": "me",
+        "remote_path": "/volume1/Photography",
+        "mount_path": str(tmp_path / "mount"),
+    }
+    entry.update(overrides)
+    cfg.save({"remote_targets": [entry]})
+    monkeypatch.setattr(
+        move_mod, "resolve_rsync_bin", lambda configured="": "/usr/bin/rsync",
+    )
+    return entry
+
+
+def _remote_pipeline_body(src, **overrides):
+    body = {
+        "sources": [str(src)],
+        "remote_target_id": "nas1",
+        "remote_subpath": "2026/trip",
+        "local_processing": True,
+        "skip_classify": True,
+        "skip_extract_masks": True,
+        "skip_regroup": True,
+    }
+    body.update(overrides)
+    return body
+
+
+def test_pipeline_remote_archive_rejects_both_destinations(
+    app_and_db, tmp_path, monkeypatch,
+):
+    app, _ = app_and_db
+    _save_remote_target(monkeypatch, tmp_path)
+    src = tmp_path / "card"
+    src.mkdir()
+    client = app.test_client()
+    resp = client.post("/api/jobs/pipeline", json=_remote_pipeline_body(
+        src, destination=str(tmp_path / "archive"),
+    ))
+    assert resp.status_code == 400
+    assert "mutually exclusive" in resp.get_json()["error"]
+
+
+def test_pipeline_remote_archive_unknown_target_404(
+    app_and_db, tmp_path, monkeypatch,
+):
+    app, _ = app_and_db
+    _save_remote_target(monkeypatch, tmp_path)
+    src = tmp_path / "card"
+    src.mkdir()
+    client = app.test_client()
+    resp = client.post("/api/jobs/pipeline", json=_remote_pipeline_body(
+        src, remote_target_id="nope",
+    ))
+    assert resp.status_code == 404
+    assert "not found" in resp.get_json()["error"].lower()
+
+
+def test_pipeline_remote_archive_requires_local_processing(
+    app_and_db, tmp_path, monkeypatch,
+):
+    app, _ = app_and_db
+    _save_remote_target(monkeypatch, tmp_path)
+    src = tmp_path / "card"
+    src.mkdir()
+    client = app.test_client()
+    resp = client.post("/api/jobs/pipeline", json=_remote_pipeline_body(
+        src, local_processing=False,
+    ))
+    assert resp.status_code == 400
+    assert "local_processing" in resp.get_json()["error"]
+
+
+def test_pipeline_remote_archive_requires_subpath(
+    app_and_db, tmp_path, monkeypatch,
+):
+    """No subpath means no archive-folder name: move_folder lands the staged
+    folder inside a parent keeping its name, and the subpath's last segment
+    IS that name. An empty subpath must 400, not silently merge the import
+    into the target's base directory."""
+    app, _ = app_and_db
+    _save_remote_target(monkeypatch, tmp_path)
+    src = tmp_path / "card"
+    src.mkdir()
+    client = app.test_client()
+    resp = client.post("/api/jobs/pipeline", json=_remote_pipeline_body(
+        src, remote_subpath="",
+    ))
+    assert resp.status_code == 400
+    assert "remote_subpath" in resp.get_json()["error"]
+
+
+def test_pipeline_remote_archive_rejects_traversal_subpath(
+    app_and_db, tmp_path, monkeypatch,
+):
+    app, _ = app_and_db
+    _save_remote_target(monkeypatch, tmp_path)
+    src = tmp_path / "card"
+    src.mkdir()
+    client = app.test_client()
+    for bad in ("../escape", "/absolute/path"):
+        resp = client.post("/api/jobs/pipeline", json=_remote_pipeline_body(
+            src, remote_subpath=bad,
+        ))
+        assert resp.status_code == 400, bad
+
+
+def test_pipeline_remote_archive_requires_mount_path(
+    app_and_db, tmp_path, monkeypatch,
+):
+    """A target with no local mount path can't keep archived photos in the
+    library (the catalog is repointed at the mount path after the move) —
+    mirror the move-folder endpoint's refusal."""
+    app, _ = app_and_db
+    _save_remote_target(monkeypatch, tmp_path, mount_path="")
+    src = tmp_path / "card"
+    src.mkdir()
+    client = app.test_client()
+    resp = client.post("/api/jobs/pipeline", json=_remote_pipeline_body(src))
+    assert resp.status_code == 400
+    assert "mount path" in resp.get_json()["error"]
+
+
+def test_pipeline_remote_archive_requires_gnu_rsync(
+    app_and_db, tmp_path, monkeypatch,
+):
+    import move as move_mod
+    app, _ = app_and_db
+    _save_remote_target(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        move_mod, "resolve_rsync_bin", lambda configured="": None,
+    )
+    src = tmp_path / "card"
+    src.mkdir()
+    client = app.test_client()
+    resp = client.post("/api/jobs/pipeline", json=_remote_pipeline_body(src))
+    assert resp.status_code == 400
+    assert "rsync" in resp.get_json()["error"].lower()
+
+
+def test_pipeline_local_processing_requires_destination_or_remote(
+    app_and_db, tmp_path,
+):
+    app, _ = app_and_db
+    src = tmp_path / "card"
+    src.mkdir()
+    client = app.test_client()
+    resp = client.post("/api/jobs/pipeline", json={
+        "sources": [str(src)],
+        "local_processing": True,
+        "skip_classify": True,
+        "skip_extract_masks": True,
+        "skip_regroup": True,
+    })
+    assert resp.status_code == 400
+    err = resp.get_json()["error"]
+    assert "destination" in err and "remote target" in err

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -2349,3 +2349,48 @@ def test_pipeline_local_processing_requires_destination_or_remote(
     assert resp.status_code == 400
     err = resp.get_json()["error"]
     assert "destination" in err and "remote target" in err
+
+
+def test_pipeline_remote_archive_snapshots_target_at_enqueue(
+    app_and_db, tmp_path, monkeypatch,
+):
+    """The endpoint must capture the resolved remote target onto
+    ``PipelineParams.remote_target_snapshot`` at Start-click time. Otherwise a
+    queued pipeline that runs after a settings edit would archive to a
+    different host/mount than the jobs panel is showing — the point of the
+    move-folder endpoint's build-spec-before-enqueue pattern."""
+    import pipeline_job
+    app, _ = app_and_db
+    _save_remote_target(monkeypatch, tmp_path)
+    src = tmp_path / "card"
+    src.mkdir()
+
+    captured = {}
+
+    def fake_run(job, runner, db_path, workspace_id, params,
+                 thumb_cache_dir=None):
+        captured["params"] = params
+        return {}
+
+    monkeypatch.setattr(pipeline_job, "run_pipeline_job", fake_run)
+
+    client = app.test_client()
+    resp = client.post("/api/jobs/pipeline", json=_remote_pipeline_body(src))
+    assert resp.status_code == 200, resp.get_json()
+
+    from wait import wait_for_job_via_runner
+    wait_for_job_via_runner(app._job_runner, resp.get_json()["job_id"])
+
+    params = captured.get("params")
+    assert params is not None, "fake run_pipeline_job was never invoked"
+    snap = params.remote_target_snapshot
+    assert snap is not None, (
+        "PipelineParams must carry a snapshot of the resolved target so the "
+        "queued run archives to what the user picked, not to whatever the "
+        "saved target got edited to before the slot opened"
+    )
+    assert snap["id"] == "nas1"
+    assert snap["host"] == "nas"
+    assert snap["user"] == "me"
+    assert snap["remote_path"] == "/volume1/Photography"
+    assert snap["mount_path"] == str(tmp_path / "mount")

--- a/vireo/tests/test_move_remote.py
+++ b/vireo/tests/test_move_remote.py
@@ -1024,25 +1024,3 @@ def test_remote_free_bytes_returns_none_on_failure(monkeypatch):
     assert move_mod._remote_free_bytes(_PROBE_REMOTE, "/p") is None
 
 
-def test_remote_tree_bytes_parses_du_and_absent_dir(monkeypatch):
-    monkeypatch.setattr(move_mod.subprocess, "run",
-                        lambda *a, **k: _FakeCompleted(0, "1234\t/volume1/x\n"))
-    assert move_mod._remote_tree_bytes(_PROBE_REMOTE, "/volume1/x") == \
-        1234 * 1024
-
-    # Absent directory: the probe's else-branch echoes 0 — a valid answer
-    # (nothing there yet), distinct from a probe failure.
-    monkeypatch.setattr(move_mod.subprocess, "run",
-                        lambda *a, **k: _FakeCompleted(0, "0\n"))
-    assert move_mod._remote_tree_bytes(_PROBE_REMOTE, "/volume1/x") == 0
-
-
-def test_remote_tree_bytes_returns_none_on_failure(monkeypatch):
-    monkeypatch.setattr(move_mod.subprocess, "run",
-                        lambda *a, **k: _FakeCompleted(255, "", "timeout"))
-    assert move_mod._remote_tree_bytes(_PROBE_REMOTE, "/p") is None
-
-    def boom(*a, **k):
-        raise OSError("ssh: not found")
-    monkeypatch.setattr(move_mod.subprocess, "run", boom)
-    assert move_mod._remote_tree_bytes(_PROBE_REMOTE, "/p") is None

--- a/vireo/tests/test_move_remote.py
+++ b/vireo/tests/test_move_remote.py
@@ -980,3 +980,69 @@ def test_test_remote_connection_probes_remote_rsync(monkeypatch):
     res = move_mod.test_remote_connection(remote, "/usr/bin/rsync")
     assert res["remote_rsync_ok"] is True
     assert res["ok"] is True
+
+
+# --------------------------------------------------------------------------
+# Remote df/du probes used by the pipeline's remote-archive storage preflight.
+# --------------------------------------------------------------------------
+
+class _FakeCompleted:
+    def __init__(self, rc=0, stdout="", stderr=""):
+        self.returncode = rc
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+_PROBE_REMOTE = {"host": "nas", "user": "me", "port": 22, "ssh_key": ""}
+
+
+def test_remote_free_bytes_parses_posix_df(monkeypatch):
+    df_out = (
+        "Filesystem     1024-blocks      Used Available Capacity Mounted on\n"
+        "/dev/vg1/lv        1000000    400000    600000      40% /volume1\n"
+    )
+    monkeypatch.setattr(move_mod.subprocess, "run",
+                        lambda *a, **k: _FakeCompleted(0, df_out))
+    assert move_mod._remote_free_bytes(_PROBE_REMOTE, "/volume1/Photo") == \
+        600000 * 1024
+
+
+def test_remote_free_bytes_returns_none_on_failure(monkeypatch):
+    """Probe failures must read as 'unknown' (None), never as a number —
+    the caller skips the check instead of fabricating a verdict."""
+    monkeypatch.setattr(move_mod.subprocess, "run",
+                        lambda *a, **k: _FakeCompleted(1, "", "df: not found"))
+    assert move_mod._remote_free_bytes(_PROBE_REMOTE, "/p") is None
+
+    monkeypatch.setattr(move_mod.subprocess, "run",
+                        lambda *a, **k: _FakeCompleted(0, "garbage\n"))
+    assert move_mod._remote_free_bytes(_PROBE_REMOTE, "/p") is None
+
+    def boom(*a, **k):
+        raise OSError("ssh: not found")
+    monkeypatch.setattr(move_mod.subprocess, "run", boom)
+    assert move_mod._remote_free_bytes(_PROBE_REMOTE, "/p") is None
+
+
+def test_remote_tree_bytes_parses_du_and_absent_dir(monkeypatch):
+    monkeypatch.setattr(move_mod.subprocess, "run",
+                        lambda *a, **k: _FakeCompleted(0, "1234\t/volume1/x\n"))
+    assert move_mod._remote_tree_bytes(_PROBE_REMOTE, "/volume1/x") == \
+        1234 * 1024
+
+    # Absent directory: the probe's else-branch echoes 0 — a valid answer
+    # (nothing there yet), distinct from a probe failure.
+    monkeypatch.setattr(move_mod.subprocess, "run",
+                        lambda *a, **k: _FakeCompleted(0, "0\n"))
+    assert move_mod._remote_tree_bytes(_PROBE_REMOTE, "/volume1/x") == 0
+
+
+def test_remote_tree_bytes_returns_none_on_failure(monkeypatch):
+    monkeypatch.setattr(move_mod.subprocess, "run",
+                        lambda *a, **k: _FakeCompleted(255, "", "timeout"))
+    assert move_mod._remote_tree_bytes(_PROBE_REMOTE, "/p") is None
+
+    def boom(*a, **k):
+        raise OSError("ssh: not found")
+    monkeypatch.setattr(move_mod.subprocess, "run", boom)
+    assert move_mod._remote_tree_bytes(_PROBE_REMOTE, "/p") is None

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -10022,6 +10022,7 @@ def test_pipeline_params_remote_archive_defaults():
     params = PipelineParams(collection_id=1)
     assert params.remote_target_id is None
     assert params.remote_subpath == ""
+    assert params.remote_target_snapshot is None
 
 
 class _RemoteArchiveRunner(FakeRunner):
@@ -10319,3 +10320,71 @@ def test_pipeline_remote_archive_failure_deindexes_staging(
     count = check_db.conn.execute(
         "SELECT COUNT(*) AS n FROM photos").fetchone()["n"]
     assert count == 0
+
+
+def test_pipeline_remote_archive_snapshot_wins_over_mutated_settings(
+    tmp_path, monkeypatch,
+):
+    """A queued pipeline must archive to the target the user saw at Start,
+    not whatever the saved target got edited to before the pipeline slot
+    opened. Editing ``remote_targets`` after PipelineParams is built must not
+    redirect the archive — the ``remote_target_snapshot`` wins over the
+    mutable ``cfg.get_remote_target`` lookup."""
+    import config as cfg
+    env = _remote_env(tmp_path, monkeypatch)
+    snapshot = cfg.get_remote_target("nas1")
+    assert snapshot["host"] == "nas"
+    assert snapshot["remote_path"] == "/volume1/Photography"
+
+    # Simulate a settings edit between click-Start and slot-open: same id,
+    # different host / user / remote_path / mount_path. If the job re-reads
+    # Settings the archive lands in the hijacked place.
+    hijacked_mount = str(tmp_path / "other-mount")
+    cfg.save({"remote_targets": [{
+        "id": "nas1", "name": "NAS-edited", "host": "attacker",
+        "user": "root", "remote_path": "/tmp/hijack",
+        "mount_path": hijacked_mount,
+    }]})
+
+    params = _remote_params(env, remote_target_snapshot=dict(snapshot))
+    runner = _RemoteArchiveRunner()
+    job = _make_job()
+
+    result = run_pipeline_job(
+        job, runner, env["db_path"], env["ws_id"], params)
+
+    call = env["captured"]["rsync_calls"][-1]
+    assert call["dest_spec"] == "me@nas:/volume1/Photography/2026/trip", (
+        "rsync must address the snapshot's host + remote_path, not the "
+        "post-edit target"
+    )
+    assert "attacker" not in call["dest_spec"]
+    assert "/tmp/hijack" not in call["dest_spec"]
+
+    # Catalog was repointed at the snapshot's mount path (photos stay in the
+    # user's original library), not the hijacked mount.
+    assert result["archive"]["final_destination"] == os.path.join(
+        env["mount"], "2026", "trip")
+    assert hijacked_mount not in result["archive"]["final_destination"]
+    # And the job's archive-result payload reflects the snapshot's target
+    # name, not the edited one.
+    assert result["archive"]["remote"]["target_name"] == "NAS"
+
+
+def test_pipeline_remote_archive_falls_back_to_settings_without_snapshot(
+    tmp_path, monkeypatch,
+):
+    """When no snapshot is present (older direct-call test paths) the run
+    still resolves the target from Settings so existing callers keep
+    working."""
+    env = _remote_env(tmp_path, monkeypatch)
+    runner = _RemoteArchiveRunner()
+    job = _make_job()
+
+    # Note: no ``remote_target_snapshot`` — falls back to cfg.get_remote_target.
+    result = run_pipeline_job(
+        job, runner, env["db_path"], env["ws_id"], _remote_params(env))
+
+    assert result["archive"]["moved"] == 1
+    call = env["captured"]["rsync_calls"][-1]
+    assert call["dest_spec"] == "me@nas:/volume1/Photography/2026/trip"

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -10078,7 +10078,6 @@ def _remote_env(tmp_path, monkeypatch, mount_path=None):
         lambda t, r: {"ok": True, "message": "Connection OK"})
     monkeypatch.setattr(
         move_mod, "_remote_free_bytes", lambda t, p: 100 * 1024 ** 3)
-    monkeypatch.setattr(move_mod, "_remote_tree_bytes", lambda t, p: 0)
     monkeypatch.setattr(move_mod, "_remote_dir_exists", lambda r, p: False)
     monkeypatch.setattr(move_mod, "_remote_mkdir_p", lambda r, p: (True, ""))
     monkeypatch.setattr(
@@ -10222,13 +10221,12 @@ def test_pipeline_remote_archive_preflight_refuses_when_connection_fails(
 def test_pipeline_remote_archive_space_probe_failure_degrades(
     tmp_path, monkeypatch,
 ):
-    """df/du probe failures must not fail (or fake) the preflight: the run
-    proceeds, the summary says the checks were skipped, and the result
-    payload marks them unchecked."""
+    """A df probe failure must not fail (or fake) the preflight: the run
+    proceeds, the summary says the check was skipped, and the result
+    payload marks it unchecked."""
     import move as move_mod
     env = _remote_env(tmp_path, monkeypatch)
     monkeypatch.setattr(move_mod, "_remote_free_bytes", lambda t, p: None)
-    monkeypatch.setattr(move_mod, "_remote_tree_bytes", lambda t, p: None)
     runner = _RemoteArchiveRunner()
     job = _make_job()
 
@@ -10238,14 +10236,12 @@ def test_pipeline_remote_archive_space_probe_failure_degrades(
     assert result["archive"]["moved"] == 1
     remote_info = result["local_processing"]["remote"]
     assert remote_info["free_space_checked"] is False
-    assert remote_info["resume_credit_checked"] is False
     storage_summaries = [
         kw.get("summary", "") for _, sid, kw in runner.step_updates
         if sid == "storage" and kw.get("status") == "completed"
     ]
     assert storage_summaries, runner.step_updates
     assert "free-space check skipped" in storage_summaries[-1]
-    assert "resume-credit check skipped" in storage_summaries[-1]
 
 
 def test_pipeline_remote_archive_refuses_when_remote_volume_full(

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -9964,3 +9964,362 @@ def test_pipeline_regroup_failure_finalizes_miss_step_row(tmp_path, monkeypatch)
     db2.set_active_workspace(ws_id)
     rows = db2.conn.execute("SELECT miss_computed_at FROM photos").fetchall()
     assert rows and all(r["miss_computed_at"] is None for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# Remote (SSH) archive destination — resolve_remote_archive unit tests plus
+# end-to-end pipeline runs with the SSH/rsync seams monkeypatched, following
+# the fake pattern in test_move_remote.py.
+# ---------------------------------------------------------------------------
+
+import pytest
+from pipeline_job import resolve_remote_archive
+
+
+def _remote_target(tmp_path, **overrides):
+    target = {
+        "id": "nas1", "name": "NAS", "host": "nas", "user": "me",
+        "port": 22, "ssh_key": "", "bwlimit_kbps": 0,
+        "remote_path": "/volume1/Photography",
+        "mount_path": str(tmp_path / "mount"),
+    }
+    target.update(overrides)
+    return target
+
+
+def test_resolve_remote_archive_joins_both_bases(tmp_path):
+    ctx = resolve_remote_archive(_remote_target(tmp_path), "2026/trip")
+    assert ctx["subpath"] == "2026/trip"
+    assert ctx["parent_subpath"] == "2026"
+    assert ctx["ssh_final"] == "/volume1/Photography/2026/trip"
+    assert ctx["mount_final"] == os.path.join(
+        str(tmp_path / "mount"), "2026", "trip")
+    assert ctx["display"] == "me@nas:/volume1/Photography/2026/trip"
+
+
+def test_resolve_remote_archive_single_segment_subpath(tmp_path):
+    ctx = resolve_remote_archive(_remote_target(tmp_path), "trip")
+    # A single segment has no parent: the move spec's bases are the target's
+    # own base paths and the staged leaf ("trip") lands directly under them.
+    assert ctx["parent_subpath"] == ""
+    assert ctx["ssh_final"] == "/volume1/Photography/trip"
+
+
+def test_resolve_remote_archive_rejects_bad_input(tmp_path):
+    with pytest.raises(ValueError, match="remote_subpath is required"):
+        resolve_remote_archive(_remote_target(tmp_path), "")
+    with pytest.raises(ValueError):
+        resolve_remote_archive(_remote_target(tmp_path), "../escape")
+    with pytest.raises(ValueError, match="mount path"):
+        resolve_remote_archive(
+            _remote_target(tmp_path, mount_path=""), "trip")
+    with pytest.raises(ValueError, match="absolute"):
+        resolve_remote_archive(
+            _remote_target(tmp_path, mount_path="Photos"), "trip")
+
+
+def test_pipeline_params_remote_archive_defaults():
+    params = PipelineParams(collection_id=1)
+    assert params.remote_target_id is None
+    assert params.remote_subpath == ""
+
+
+class _RemoteArchiveRunner(FakeRunner):
+    """FakeRunner + the uncancellable handshake archive_stage requires."""
+
+    def begin_uncancellable(self, job_id):
+        return True
+
+
+def _remote_env(tmp_path, monkeypatch, mount_path=None):
+    """Config + SSH/rsync seam fakes for a remote-archive pipeline run.
+
+    Every subprocess-backed seam in move.py is replaced (same seams
+    test_move_remote.py fakes) so no test ever shells out to ssh/rsync.
+    Returns a dict of captured rsync calls plus the paths the assertions
+    need.
+    """
+    import config as cfg
+    import local_processing
+    import move as move_mod
+    from db import Database
+    from PIL import Image
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    mount = mount_path or str(tmp_path / "mount")
+    cfg.save({"remote_targets": [{
+        "id": "nas1", "name": "NAS", "host": "nas", "user": "me",
+        "remote_path": "/volume1/Photography",
+        "mount_path": mount,
+    }]})
+
+    monkeypatch.setattr(local_processing, "MIN_DERIVED_OVERHEAD_BYTES", 0)
+    monkeypatch.setattr(local_processing, "RESERVED_FREE_BYTES", 0)
+
+    captured = {"rsync_calls": []}
+
+    def fake_rsync(src_path, dest_spec, flags, total, cb, rsync_bin="rsync",
+                   extra_args=None, **kw):
+        captured["rsync_calls"].append({
+            "src": src_path,
+            "dest_spec": dest_spec,
+            "flags": list(flags or []),
+            "rsync_bin": rsync_bin,
+            "extra_args": list(extra_args or []),
+        })
+        return (0, "", False)
+
+    monkeypatch.setattr(
+        move_mod, "resolve_rsync_bin", lambda configured="": "/usr/bin/rsync")
+    monkeypatch.setattr(move_mod, "is_gnu_rsync", lambda p: True)
+    monkeypatch.setattr(
+        move_mod, "test_remote_connection",
+        lambda t, r: {"ok": True, "message": "Connection OK"})
+    monkeypatch.setattr(
+        move_mod, "_remote_free_bytes", lambda t, p: 100 * 1024 ** 3)
+    monkeypatch.setattr(move_mod, "_remote_tree_bytes", lambda t, p: 0)
+    monkeypatch.setattr(move_mod, "_remote_dir_exists", lambda r, p: False)
+    monkeypatch.setattr(move_mod, "_remote_mkdir_p", lambda r, p: (True, ""))
+    monkeypatch.setattr(
+        move_mod, "_find_remote_content_conflict", lambda *a, **k: None)
+    monkeypatch.setattr(
+        move_mod, "_remote_verify_complete", lambda *a, **k: None)
+    monkeypatch.setattr(move_mod, "_run_rsync_streamed", fake_rsync)
+
+    src = tmp_path / "card"
+    src.mkdir()
+    Image.new("RGB", (16, 16), "white").save(str(src / "test.jpg"))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    return {
+        "captured": captured, "src": src, "db_path": db_path, "db": db,
+        "ws_id": ws_id, "mount": mount, "tmp_path": tmp_path,
+    }
+
+
+def _remote_params(env, **overrides):
+    kwargs = {
+        "sources": [str(env["src"])],
+        "local_processing": True,
+        "remote_target_id": "nas1",
+        "remote_subpath": "2026/trip",
+        "folder_template": "",
+        "skip_classify": True,
+        "skip_extract_masks": True,
+        "skip_regroup": True,
+    }
+    kwargs.update(overrides)
+    return PipelineParams(**kwargs)
+
+
+def test_pipeline_remote_archive_end_to_end(tmp_path, monkeypatch):
+    """A local-processing run with a remote target stages locally, then
+    archives over SSH: rsync is pointed at the NAS-side subpath with
+    --partial-dir resume semantics, the catalog is repointed at the mount
+    path, and staging is cleaned up."""
+    env = _remote_env(tmp_path, monkeypatch)
+    runner = _RemoteArchiveRunner()
+    job = _make_job()
+
+    result = run_pipeline_job(
+        job, runner, env["db_path"], env["ws_id"], _remote_params(env))
+
+    mount_final = os.path.join(env["mount"], "2026", "trip")
+
+    # The archive result names both views of the destination.
+    assert result["archive"]["final_destination"] == mount_final
+    assert result["archive"]["moved"] == 1
+    assert result["archive"]["remote"]["ssh_destination"] == \
+        "/volume1/Photography/2026/trip"
+    assert result["archive"]["remote"]["target_name"] == "NAS"
+
+    # rsync addressed the NAS-side subpath, over SSH, with the same
+    # merge-on-retry transport shape the Move page uses.
+    call = env["captured"]["rsync_calls"][-1]
+    assert call["dest_spec"] == "me@nas:/volume1/Photography/2026/trip"
+    assert call["rsync_bin"] == "/usr/bin/rsync"
+    assert "-e" in call["extra_args"]
+    assert "--partial-dir=.rsync-partial" in call["extra_args"]
+    # Fresh destination — not a merge, so no --ignore-existing.
+    assert "--ignore-existing" not in call["flags"]
+
+    # Catalog repointed at the mount path (photos stay in the library).
+    from db import Database
+    check_db = Database(env["db_path"])
+    row = check_db.conn.execute(
+        "SELECT id FROM folders WHERE path = ?", (mount_final,)).fetchone()
+    assert row is not None
+    photo = check_db.conn.execute(
+        "SELECT filename FROM photos WHERE folder_id = ?", (row["id"],),
+    ).fetchone()
+    assert photo["filename"] == "test.jpg"
+
+    # Staging cleaned up (move_folder rmtree'd it after the verify).
+    staging = tmp_path / "staging"
+    assert not staging.exists() or not any(staging.rglob("*.jpg"))
+
+    # Storage-step summary reports the remote free-space check honestly.
+    storage_summaries = [
+        kw.get("summary", "") for _, sid, kw in runner.step_updates
+        if sid == "storage" and kw.get("status") == "completed"
+    ]
+    assert storage_summaries and "free at NAS" in storage_summaries[-1]
+    assert result["local_processing"]["remote"]["free_space_checked"] is True
+
+
+def test_pipeline_remote_archive_preflight_refuses_without_rsync(
+    tmp_path, monkeypatch,
+):
+    """No GNU rsync -> the storage preflight fails BEFORE anything is staged
+    or processed, with an actionable message."""
+    import move as move_mod
+    env = _remote_env(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        move_mod, "resolve_rsync_bin", lambda configured="": None)
+    runner = _RemoteArchiveRunner()
+    job = _make_job()
+
+    with pytest.raises(RuntimeError):
+        run_pipeline_job(
+            job, runner, env["db_path"], env["ws_id"], _remote_params(env))
+
+    assert any(
+        "[storage] Fatal" in e and "rsync" in e.lower() for e in job["errors"]
+    ), job["errors"]
+    # Nothing was staged — the refusal beat the staging mkdir/copy.
+    assert not (tmp_path / "staging").exists()
+    # And no transfer was ever attempted.
+    assert env["captured"]["rsync_calls"] == []
+
+
+def test_pipeline_remote_archive_preflight_refuses_when_connection_fails(
+    tmp_path, monkeypatch,
+):
+    import move as move_mod
+    env = _remote_env(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        move_mod, "test_remote_connection",
+        lambda t, r: {"ok": False, "message": "SSH connection failed - check host"})
+    runner = _RemoteArchiveRunner()
+    job = _make_job()
+
+    with pytest.raises(RuntimeError):
+        run_pipeline_job(
+            job, runner, env["db_path"], env["ws_id"], _remote_params(env))
+
+    fatal = [e for e in job["errors"] if "[storage] Fatal" in e]
+    assert fatal, job["errors"]
+    # The error names the target and carries the connection test's message.
+    assert "NAS" in fatal[0]
+    assert "SSH connection failed" in fatal[0]
+    assert not (tmp_path / "staging").exists()
+
+
+def test_pipeline_remote_archive_space_probe_failure_degrades(
+    tmp_path, monkeypatch,
+):
+    """df/du probe failures must not fail (or fake) the preflight: the run
+    proceeds, the summary says the checks were skipped, and the result
+    payload marks them unchecked."""
+    import move as move_mod
+    env = _remote_env(tmp_path, monkeypatch)
+    monkeypatch.setattr(move_mod, "_remote_free_bytes", lambda t, p: None)
+    monkeypatch.setattr(move_mod, "_remote_tree_bytes", lambda t, p: None)
+    runner = _RemoteArchiveRunner()
+    job = _make_job()
+
+    result = run_pipeline_job(
+        job, runner, env["db_path"], env["ws_id"], _remote_params(env))
+
+    assert result["archive"]["moved"] == 1
+    remote_info = result["local_processing"]["remote"]
+    assert remote_info["free_space_checked"] is False
+    assert remote_info["resume_credit_checked"] is False
+    storage_summaries = [
+        kw.get("summary", "") for _, sid, kw in runner.step_updates
+        if sid == "storage" and kw.get("status") == "completed"
+    ]
+    assert storage_summaries, runner.step_updates
+    assert "free-space check skipped" in storage_summaries[-1]
+    assert "resume-credit check skipped" in storage_summaries[-1]
+
+
+def test_pipeline_remote_archive_refuses_when_remote_volume_full(
+    tmp_path, monkeypatch,
+):
+    import move as move_mod
+    env = _remote_env(tmp_path, monkeypatch)
+    monkeypatch.setattr(move_mod, "_remote_free_bytes", lambda t, p: 0)
+    runner = _RemoteArchiveRunner()
+    job = _make_job()
+
+    with pytest.raises(RuntimeError):
+        run_pipeline_job(
+            job, runner, env["db_path"], env["ws_id"], _remote_params(env))
+
+    fatal = [e for e in job["errors"] if "[storage] Fatal" in e]
+    assert fatal, job["errors"]
+    assert "Remote archive needs about" in fatal[0]
+    assert "me@nas:/volume1/Photography/2026/trip" in fatal[0]
+    # No transfer was attempted.
+    assert env["captured"]["rsync_calls"] == []
+
+
+def test_pipeline_remote_archive_merges_on_retry(tmp_path, monkeypatch):
+    """An existing remote destination (an earlier interrupted archive) makes
+    the archive move a merge/resume: --ignore-existing so already-present
+    files are never overwritten, still with --partial-dir resume."""
+    import move as move_mod
+    env = _remote_env(tmp_path, monkeypatch)
+    monkeypatch.setattr(move_mod, "_remote_dir_exists", lambda r, p: True)
+    runner = _RemoteArchiveRunner()
+    job = _make_job()
+
+    result = run_pipeline_job(
+        job, runner, env["db_path"], env["ws_id"], _remote_params(env))
+
+    assert result["archive"]["moved"] == 1
+    call = env["captured"]["rsync_calls"][-1]
+    assert "--ignore-existing" in call["flags"]
+    assert "--partial-dir=.rsync-partial" in call["extra_args"]
+
+
+def test_pipeline_remote_archive_failure_deindexes_staging(
+    tmp_path, monkeypatch,
+):
+    """A failed remote transfer must deindex the staged folder/photos —
+    otherwise a retry of the same source would hit ingest()'s duplicate
+    skip and publish an empty archive — while leaving the staged files on
+    disk for recovery. Mirrors the local archive-failure contract."""
+    import move as move_mod
+    env = _remote_env(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        move_mod, "_run_rsync_streamed",
+        lambda *a, **k: (1, "rsync error: connection reset", False))
+    runner = _RemoteArchiveRunner()
+    job = _make_job()
+
+    with pytest.raises(RuntimeError):
+        run_pipeline_job(
+            job, runner, env["db_path"], env["ws_id"], _remote_params(env))
+
+    fatal = [e for e in job["errors"] if "[archive] Fatal" in e]
+    assert fatal, job["errors"]
+    # The error names the remote destination, not just the rsync stderr.
+    assert "me@nas:/volume1/Photography/2026/trip" in fatal[0]
+    assert "connection reset" in fatal[0]
+    assert "local staging" in fatal[0]
+
+    # Staged files remain on disk for manual recovery...
+    staged = list((tmp_path / "staging").rglob("test.jpg"))
+    assert staged, "staged files must remain on disk after a failed archive"
+    # ...but the catalog rows are gone, so a retry re-ingests them.
+    from db import Database
+    check_db = Database(env["db_path"])
+    count = check_db.conn.execute(
+        "SELECT COUNT(*) AS n FROM photos").fetchone()["n"]
+    assert count == 0


### PR DESCRIPTION
## Why

The import pipeline's local-processing archive step (`archive_stage` in `pipeline_job.py`) only supported a locally-mounted destination path — unreliable when the NAS is reachable over WiFi/Tailscale but its SMB mount isn't. The Move page already supports saved SSH remote targets (rsync-over-SSH with merge/resume via `--partial-dir`, checksum verification, bandwidth limit). This PR lets the user pick a saved remote target + subpath as the pipeline archive destination, so imports can archive straight to the NAS over SSH.

## What changed

**API (`app.py`)**
- `POST /api/jobs/pipeline` accepts `remote_target_id` + `remote_subpath`, following the move-folder endpoint's request shape and error contract: 400 when combined with `destination`, when `local_processing` is off, when the subpath is missing/absolute/traversal, or when the target lacks an absolute mount path; 404 for an unknown target; 400 when no GNU rsync resolves. Job config carries a `remote_archive` block (target name, host/user, subpath, SSH destination) so the jobs panel can show where the archive really goes.

**Resolution (`pipeline_job.resolve_remote_archive`)**
- A required subpath names the archive folder under BOTH base paths. Its last segment becomes the staging root's name, so `move_folder`'s land-inside-parent semantics put the archive at exactly `remote_path/subpath` over SSH while the catalog repoints at exactly `mount_path/subpath`. `final_destination` internally becomes the catalog-facing mount path, so the in-flight destination reservation and tracked-destination preflight work unchanged.

**Storage preflight (`storage` stage)**
- Staging-space check unchanged (staging is always local).
- Early refusal **before any staging/processing**: GNU rsync resolved via `resolve_rsync_bin` + `is_gnu_rsync`, then `test_remote_connection` — a missing rsync or unreachable/unwritable target fails the preflight with an actionable message instead of failing the final move hours later.
- Tracked-destination overlap is still checked (it has a remote analogue: prior remote archives leave tracked rows at the mount path); the local-only mount-root / archive-parent / conflict-report checks are skipped with comments — `move_folder`'s remote merge path re-runs the content-conflict guard over SSH (`rsync -an --existing --checksum`) before any file is copied.
- Remote free space (`df -Pk` over SSH) and merge/resume credit (`du -sk`, capped at source bytes) probed via two new `_remote_*` helpers in `move.py`, matching the existing helpers' arg-building and error handling. Probe failures degrade gracefully: logged, reported as "check skipped (probe failed)" in the step summary and `result.local_processing.remote` payload — never faked numbers — with the archive move's own verification as the backstop.

**Archive stage**
- When the destination is remote, builds the remote move spec and calls the same `move_folder` remote path the Move page uses: merge-on-retry (`--ignore-existing` + `--partial-dir=.rsync-partial`), checksum verify before deleting staging, deindex-on-failure exactly as the local path. Success summaries and failure messages name the remote target and SSH destination.

**UI (`pipeline.html`)**
- The Destination card gains the saved-remote-target picker + subpath input mirroring `move.html` (same subpath normalization as the backend, IPv6-safe `user@host:path` preview, warnings for missing GNU rsync / missing / relative mount path).
- Honest readiness text per CORE_PHILOSOPHY: "Use local disk while processing" is locked on for SSH targets with a note explaining why; the folder-structure preview says it isn't available for SSH targets and that existing remote files are checked at archive time (rather than pretending the local walk ran).
- The plan endpoint (`pipeline_plan.py`) doesn't take the destination path into account — only the `local_processing` flag, which remains true for remote — so its pills stay accurate without changes. The import duplicate check was verified catalog-based (`CatalogIndex.from_db`) and destination-independent; left alone.

## Tests

New coverage (mocking SSH/rsync at the same seams as `test_move_remote.py` — no test shells out):
- `test_jobs_api.py`: 8 POST-validation tests (mutual exclusion, unknown target 404, requires local_processing, requires/rejects subpath, requires mount path, requires GNU rsync, destination-or-remote).
- `test_pipeline_job.py`: `resolve_remote_archive` unit tests + 7 end-to-end runs — full pipeline archiving over mocked SSH (right rsync spec, `--partial-dir`, catalog repointed at mount path, staging cleaned), preflight early-refusal on missing rsync and failed connection (nothing staged, no transfer attempted), probe-failure degradation ("check skipped" summary + payload flags), remote-volume-full refusal, merge-on-retry (`--ignore-existing`), and deindex-on-failure (staged files kept on disk, catalog rows removed).
- `test_move_remote.py`: 4 parser/contract tests for the new `_remote_free_bytes` / `_remote_tree_bytes` probes.

Results:
```
python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py \
  vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py \
  vireo/tests/test_darktable_api.py vireo/tests/test_config.py vireo/tests/test_move.py \
  vireo/tests/test_move_api.py vireo/tests/test_move_remote.py vireo/tests/test_pipeline_job.py \
  vireo/tests/test_pipeline_plan.py -q
1680 passed, 5 skipped in 87.46s
```
Plus: `test_pipeline_api.py` full file 79 passed (8m34s) and its local-processing subset re-run after the final change (37 passed); `test_move_remote.py` 42 passed after new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)