### PR TITLE
website: update download links for v0.14.0

### DIFF
--- a/website/src/pages/download.astro
+++ b/website/src/pages/download.astro
@@ -6,9 +6,9 @@ const base = import.meta.env.BASE_URL;
 const releaseUrl = (v: string) => `https://github.com/jss367/vireo/releases/download/v${v}`;
 
 // Per-platform versions — updated independently by CI when each platform builds
-const macosArm64Version = '0.13.0';
-const windowsVersion = '0.13.0';
-const linuxVersion = '0.13.0';
+const macosArm64Version = '0.14.0';
+const windowsVersion = '0.14.0';
+const linuxVersion = '0.14.0';
 ---
 
 <Base title="Download — Vireo" description="Download Vireo for macOS, Windows, or Linux. Free, open source, no account required.">


### PR DESCRIPTION
Automated update of download links following the v0.14.0 release. Auto-merges once required checks pass; deploy-website.yml runs on the resulting push to main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the download page to show version 0.14.0 for macOS ARM64, Windows, and Linux.
  * Download buttons and displayed version labels now point to the latest release for each platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->