### PR TITLE
Local adjustments PR 2: editor UI (Subject/Background bands, overlay, stale update)

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -6,6 +6,7 @@ Usage:
 
 import argparse
 import contextlib
+import copy
 import json
 import logging
 import logging.handlers
@@ -4110,11 +4111,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         recipe = body.get("recipe")
         if not isinstance(recipe, dict):
             return json_error("recipe must be a JSON object")
-        if recipe.get("local"):
-            return json_error(
-                "local adjustments cannot be bulk-applied: they reference a "
-                "photo-specific mask snapshot"
-            )
         raw_ids = body.get("photo_ids")
         if not isinstance(raw_ids, list) or not raw_ids:
             return json_error("photo_ids must be a non-empty list")
@@ -4141,18 +4137,57 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             description = "Pasted edit settings"
         description = description.strip()
 
+        has_local = bool(recipe.get("local"))
+        vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+
         items = []
         applied = []
         skipped = []
+        local_errors = {}
         for pid in ids:
             photo = db.get_photo(pid, verify_workspace=True)
             if not photo:
                 skipped.append(pid)
                 continue
+            target_recipe = recipe
+            if has_local:
+                # Local adjustments reference a photo-specific mask, so each
+                # target gets its OWN snapshot (frozen from its active mask);
+                # the slider values copy, the mask does not. Photos without a
+                # usable mask are skipped and reported, not silently given a
+                # wrong mask.
+                import local_masks
+                variant_row = db.conn.execute(
+                    "SELECT active_mask_variant FROM photos WHERE id=?",
+                    (pid,),
+                ).fetchone()
+                variant = (
+                    variant_row["active_mask_variant"] if variant_row else None
+                )
+                mask_row = (
+                    db.get_photo_mask(pid, variant) if variant else None
+                )
+                try:
+                    target_mask = local_masks.create_snapshot(
+                        photo_id=pid,
+                        mask_row=mask_row,
+                        vireo_dir=vireo_dir,
+                        native_size=_recipe_source_dimensions(photo),
+                    )
+                except ValueError as e:
+                    skipped.append(pid)
+                    local_errors[str(pid)] = str(e)
+                    continue
+                target_recipe = copy.deepcopy(recipe)
+                target_local_mask = dict(
+                    target_recipe["local"].get("mask") or {}
+                )
+                target_local_mask.update(target_mask)
+                target_recipe["local"]["mask"] = target_local_mask
             old_recipe = db.get_photo_edit_recipe(pid)
             old_value = recipe_to_json(old_recipe) or ""
             try:
-                new_recipe = db.set_photo_edit_recipe(pid, recipe, verify_workspace=True)
+                new_recipe = db.set_photo_edit_recipe(pid, target_recipe, verify_workspace=True)
             except (RecipeError, ValueError):
                 skipped.append(pid)
                 continue
@@ -4170,13 +4205,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             _invalidate_photo_render_cache(db, applied)
         if items:
             db.record_edit("edit_recipe", description, target_json, items, is_batch=True)
-        return jsonify({
+        payload = {
             "ok": True,
             "applied": applied,
             "skipped": skipped,
             "count": len(applied),
             "recipe": db.get_photo_edit_recipe(applied[0]) if applied else None,
-        })
+        }
+        if local_errors:
+            payload["local_errors"] = local_errors
+        return jsonify(payload)
 
     @app.route("/api/edit-presets", methods=["GET", "POST"])
     def api_edit_presets():
@@ -18751,6 +18789,81 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if size not in allowed_preview_sizes():
             return "Unsupported size", 400
         return _serve_preview(photo_id, size)
+
+    @app.route("/photos/<int:photo_id>/edit-mask-preview")
+    def serve_edit_mask_preview(photo_id):
+        """Serve a recipe's transformed, feathered local-weight map as a
+        tinted RGBA PNG aligned with the (uncropped) editor preview.
+
+        The existing lightbox mask endpoint serves the live photo_masks file
+        untouched; this one shows the pixels the renderer actually weights —
+        the recipe's snapshot after geometry and feathering — so the editor
+        overlay can never disagree with the saved render.
+        """
+        import io
+
+        import numpy as np
+        from PIL import Image
+
+        db = _get_db()
+        photo = db.get_photo(photo_id, verify_workspace=True)
+        if not photo:
+            return "Not found", 404
+        try:
+            size = int(request.args.get("size", "1920"))
+        except ValueError:
+            return "Invalid size", 400
+        size = max(256, min(3840, size))
+
+        raw_recipe = request.args.get("recipe")
+        if raw_recipe:
+            try:
+                recipe = json.loads(raw_recipe)
+            except (TypeError, ValueError):
+                return "Invalid recipe", 400
+        else:
+            recipe = db.get_photo_edit_recipe(photo_id) or {}
+
+        import local_masks
+        from image_edits import (
+            RecipeError,
+            local_weight_map,
+            normalize_recipe,
+        )
+        try:
+            normalized = normalize_recipe(recipe) or {}
+        except RecipeError as e:
+            return str(e), 400
+        if not normalized.get("local"):
+            return "Recipe has no local adjustments", 404
+        # The editor preview is uncropped; the overlay must align with it.
+        display_recipe = dict(normalized)
+        display_recipe.pop("crop", None)
+
+        vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+        snapshot = local_masks.load_snapshot(vireo_dir, photo_id, normalized)
+        if snapshot is None:
+            return "No usable edit-mask snapshot", 404
+        source_dims = _scaled_recipe_source_dimensions(photo, size)
+        if not source_dims[0] or not source_dims[1]:
+            source_dims = snapshot.size
+        weight = local_weight_map(
+            snapshot, source_dims, display_recipe,
+            native_size=_recipe_source_dimensions(photo),
+        )
+        if weight is None:
+            return "Mask does not fit this photo", 404
+
+        height, width = weight.shape
+        rgba = np.zeros((height, width, 4), dtype=np.uint8)
+        # Accent teal at up to ~60% opacity where the subject weight is 1.
+        rgba[..., 0] = 112
+        rgba[..., 1] = 199
+        rgba[..., 2] = 186
+        rgba[..., 3] = np.clip(weight * 150.0 + 0.5, 0, 255).astype(np.uint8)
+        buf = io.BytesIO()
+        Image.fromarray(rgba, "RGBA").save(buf, format="PNG")
+        return Response(buf.getvalue(), mimetype="image/png")
 
     @app.route("/photos/<int:photo_id>/edit-preview")
     def serve_photo_edit_preview(photo_id):

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4144,6 +4144,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         applied = []
         skipped = []
         local_errors = {}
+        applied_recipes = {}
         for pid in ids:
             photo = db.get_photo(pid, verify_workspace=True)
             if not photo:
@@ -4174,7 +4175,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         vireo_dir=vireo_dir,
                         native_size=_recipe_source_dimensions(photo),
                     )
-                except ValueError as e:
+                except (ValueError, OSError) as e:
+                    # OSError covers disk-write failures inside create_snapshot
+                    # (os.makedirs, f.write, os.replace) so a transient I/O
+                    # hiccup on one target doesn't abort the whole batch.
                     skipped.append(pid)
                     local_errors[str(pid)] = str(e)
                     continue
@@ -4193,6 +4197,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 continue
             new_value = recipe_to_json(new_recipe) or ""
             applied.append(pid)
+            applied_recipes[str(pid)] = new_recipe
             if old_value != new_value:
                 _queue_edit_recipe_sync(db, pid, new_value)
                 items.append({
@@ -4205,12 +4210,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             _invalidate_photo_render_cache(db, applied)
         if items:
             db.record_edit("edit_recipe", description, target_json, items, is_batch=True)
+        # ``recipes`` maps each applied id to the recipe actually stored for
+        # it — critical when ``has_local`` is true because each target has
+        # its own mask snapshot ref, so callers cannot reuse the pasted
+        # recipe (or the first applied recipe) for every id. ``recipe`` is
+        # kept as the first applied recipe for backwards compatibility.
         payload = {
             "ok": True,
             "applied": applied,
             "skipped": skipped,
             "count": len(applied),
-            "recipe": db.get_photo_edit_recipe(applied[0]) if applied else None,
+            "recipe": applied_recipes[str(applied[0])] if applied else None,
+            "recipes": applied_recipes,
         }
         if local_errors:
             payload["local_errors"] = local_errors

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -18827,9 +18827,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         import local_masks
         from image_edits import (
             RecipeError,
+            detail_render_scale,
             local_weight_map,
             normalize_recipe,
         )
+        from render_source import rendered_recipe_long_edge
         try:
             normalized = normalize_recipe(recipe) or {}
         except RecipeError as e:
@@ -18847,9 +18849,28 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         source_dims = _scaled_recipe_source_dimensions(photo, size)
         if not source_dims[0] or not source_dims[1]:
             source_dims = snapshot.size
+        # Feather scale must reflect the SAVED (cropped) render even though
+        # the overlay is aligned with the uncropped preview — mirrors what
+        # /edit-preview passes to apply_recipe_to_loaded_image. Otherwise
+        # a cropped recipe's overlay halo drifts from the pixels the saved
+        # render actually weights.
+        native_dims = _recipe_source_dimensions(photo)
+        preview_detail_scale = None
+        if native_dims and native_dims[0] and native_dims[1]:
+            saved_native_long = float(rendered_recipe_long_edge(
+                native_dims[0], native_dims[1], normalized,
+            ))
+            if saved_native_long > 0:
+                saved_rendered_long = min(float(size), saved_native_long)
+                preview_detail_scale = detail_render_scale(
+                    (saved_rendered_long, saved_rendered_long),
+                    native_dims,
+                    normalized,
+                )
         weight = local_weight_map(
             snapshot, source_dims, display_recipe,
-            native_size=_recipe_source_dimensions(photo),
+            native_size=native_dims,
+            detail_scale=preview_detail_scale,
         )
         if weight is None:
             return "Mask does not fit this photo", 404

--- a/vireo/image_edits.py
+++ b/vireo/image_edits.py
@@ -791,13 +791,24 @@ def apply_recipe_to_loaded_image(
     return result
 
 
-def local_weight_map(local_mask, source_size, recipe, native_size=None):
+def local_weight_map(
+    local_mask, source_size, recipe, native_size=None, detail_scale=None,
+):
     """The local-adjustment weight map exactly as the renderer computes it.
 
     For overlay/preview consumers: fit the snapshot to the render source,
     ride the recipe's geometry, feather at this resolution. Returns a float
     [0,1] array, or None when the recipe has no local section or the mask
     cannot be trusted to line up (same disable conditions as rendering).
+
+    ``detail_scale`` overrides the scale used to convert the recipe's
+    feather amount into pixels. Use it when the caller has already
+    stripped crop from ``recipe`` to align with an uncropped preview
+    (the edit-mask-preview endpoint does this) so the feather still
+    matches the halo the saved cropped render will actually produce —
+    otherwise the overlay recomputes the scale from the crop-stripped
+    recipe and disagrees with what /edit-preview passes to
+    :func:`apply_recipe_to_loaded_image`.
     """
     normalized = normalize_recipe(recipe)
     local = (normalized or {}).get("local")
@@ -807,7 +818,11 @@ def local_weight_map(local_mask, source_size, recipe, native_size=None):
     if fitted is None:
         return None
     mask_geo = _apply_geometry(fitted, normalized)
-    scale = detail_render_scale(mask_geo.size, native_size, normalized)
+    scale = (
+        detail_scale
+        if detail_scale is not None
+        else detail_render_scale(mask_geo.size, native_size, normalized)
+    )
     feather = (local["mask"].get("feather") or 0.0) * scale
     return _feathered_weight(mask_geo, feather)
 

--- a/vireo/image_edits.py
+++ b/vireo/image_edits.py
@@ -791,6 +791,27 @@ def apply_recipe_to_loaded_image(
     return result
 
 
+def local_weight_map(local_mask, source_size, recipe, native_size=None):
+    """The local-adjustment weight map exactly as the renderer computes it.
+
+    For overlay/preview consumers: fit the snapshot to the render source,
+    ride the recipe's geometry, feather at this resolution. Returns a float
+    [0,1] array, or None when the recipe has no local section or the mask
+    cannot be trusted to line up (same disable conditions as rendering).
+    """
+    normalized = normalize_recipe(recipe)
+    local = (normalized or {}).get("local")
+    if not local or local_mask is None:
+        return None
+    fitted = _fit_mask_to_source(local_mask, source_size)
+    if fitted is None:
+        return None
+    mask_geo = _apply_geometry(fitted, normalized)
+    scale = detail_render_scale(mask_geo.size, native_size, normalized)
+    feather = (local["mask"].get("feather") or 0.0) * scale
+    return _feathered_weight(mask_geo, feather)
+
+
 def copy_recipe(recipe):
     """Return a detached normalized recipe dict for API responses."""
     normalized = normalize_recipe(recipe)

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -4299,8 +4299,16 @@ async function pasteEditSettingsToSelection() {
     var count = data.count || 0;
     var skipped = Array.isArray(data.skipped) ? data.skipped.length : 0;
     if (typeof window.vireoRefreshEditRecipeCache === 'function' && Array.isArray(data.applied)) {
+      // Prefer the server's per-id recipe map: with local adjustments each
+      // target now carries its own mask-snapshot ref, so reusing the copied
+      // recipe (or the first applied one) would cache wrong refs on all
+      // non-first ids until a full refetch.
+      var recipes = data.recipes && typeof data.recipes === 'object' ? data.recipes : null;
       var updates = {};
-      data.applied.forEach(function(pid) { updates[String(pid)] = data.recipe || copied.recipe; });
+      data.applied.forEach(function(pid) {
+        var key = String(pid);
+        updates[key] = (recipes && recipes[key]) || data.recipe || copied.recipe;
+      });
       window.vireoRefreshEditRecipeCache(updates);
     }
     var appliedMsg = 'Pasted edit settings to ' + count.toLocaleString() + ' photo' + (count === 1 ? '' : 's');

--- a/vireo/templates/photo_editor.html
+++ b/vireo/templates/photo_editor.html
@@ -633,6 +633,7 @@ var editorState = {
   localStale: false,
   maskOverlay: false,
   maskOverlaySeq: 0,
+  maskOverlayTimer: null,
   previewSeq: 0,
   previewTimer: null,
   drag: null,
@@ -1108,6 +1109,20 @@ function schedulePreview() {
   }, 140);
 }
 
+function scheduleMaskOverlayRefresh() {
+  // Debounced counterpart to schedulePreview() for crop-only edits that
+  // don't schedule a preview: /edit-mask-preview reads the current crop
+  // to compute the saved-render feather scale, so dragging/resetting/
+  // changing crop aspect changes the halo the overlay is meant to show.
+  // Without this the visible mask lags until an unrelated slider or zoom
+  // forces a reload.
+  if (editorState.maskOverlayTimer) clearTimeout(editorState.maskOverlayTimer);
+  editorState.maskOverlayTimer = setTimeout(function() {
+    editorState.maskOverlayTimer = null;
+    refreshMaskOverlay();
+  }, 140);
+}
+
 function renderCropBox() {
   var img = document.getElementById('editorImg');
   var box = document.getElementById('editorCropBox');
@@ -1133,6 +1148,11 @@ function markChanged(render) {
   updateDirtyState();
   renderCropBox();
   if (render || wasShowingBefore) schedulePreview();
+  // Crop-only edits (resetCrop, setAspect, drag pointermove) pass
+  // render=false, so the preview isn't rescheduled — but the mask
+  // overlay depends on the current crop for its feather scale, so it
+  // must reload too whenever it's currently on.
+  else if (editorState.maskOverlay) scheduleMaskOverlayRefresh();
 }
 
 function rotateRecipe(delta) {

--- a/vireo/templates/photo_editor.html
+++ b/vireo/templates/photo_editor.html
@@ -224,6 +224,37 @@ body {
   gap: 8px;
   margin: 10px 0;
 }
+#maskOverlayImg {
+  position: absolute;
+  left: 0;
+  top: 0;
+  pointer-events: none;
+}
+.local-stale-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin: 8px 0;
+  padding: 6px 8px;
+  border: 1px solid var(--warning, #f0b84f);
+  border-radius: 4px;
+  color: var(--warning, #f0b84f);
+  font-size: 12px;
+}
+.local-region-title {
+  margin: 12px 0 2px;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.local-unavailable-note {
+  margin: 8px 0;
+  color: var(--text-muted);
+  font-size: 12px;
+}
 .preset-row select,
 .preset-row input[type="text"] {
   width: 100%;
@@ -389,6 +420,7 @@ body {
     <div class="editor-canvas-wrap" id="editorCanvasWrap">
       <div class="editor-canvas" id="editorCanvas">
         <img id="editorImg" alt="">
+        <img id="maskOverlayImg" alt="" aria-hidden="true" style="display:none">
         <div class="crop-box" id="editorCropBox">
           <span class="crop-handle nw" data-handle="nw"></span>
           <span class="crop-handle ne" data-handle="ne"></span>
@@ -548,6 +580,32 @@ body {
         <button class="editor-btn" type="button" onclick="resetDetail()">Reset Detail</button>
       </div>
     </div>
+
+    <div class="panel-band" id="localBand" style="display:none">
+      <div class="panel-title">Local (Subject / Background)</div>
+      <div class="local-stale-banner" id="localStaleBanner" style="display:none">
+        <span>Newer subject mask available</span>
+        <button class="editor-btn" type="button" onclick="updateLocalMask()">Update</button>
+      </div>
+      <div class="button-row">
+        <button class="editor-btn" id="maskOverlayBtn" type="button" onclick="toggleMaskOverlay()">Show Mask</button>
+        <button class="editor-btn" type="button" onclick="resetLocal()">Reset Local</button>
+      </div>
+      <div class="control-row">
+        <label for="featherRange">Feather</label>
+        <input id="featherRange" type="range" min="0" max="200" step="1" value="0" oninput="setLocalFeather(this.value)">
+        <span class="control-value" id="featherValue">0</span>
+      </div>
+      <div class="local-region-title">Subject</div>
+      <div id="subjectLocalControls"></div>
+      <div class="local-region-title">Background</div>
+      <div id="backgroundLocalControls"></div>
+    </div>
+
+    <div class="panel-band" id="localUnavailableBand" style="display:none">
+      <div class="panel-title">Local (Subject / Background)</div>
+      <p class="local-unavailable-note">No subject mask for this photo &mdash; run the pipeline's mask stage to enable local adjustments.</p>
+    </div>
   </aside>
 
   <aside class="history-panel">
@@ -568,6 +626,13 @@ var editorState = {
   savedRecipe: {},
   recipe: {},
   presets: [],
+  localDraft: {subject: {}, background: {}, feather: 0},
+  localMask: null,
+  localMaskPromise: null,
+  localAvailable: false,
+  localStale: false,
+  maskOverlay: false,
+  maskOverlaySeq: 0,
   previewSeq: 0,
   previewTimer: null,
   drag: null,
@@ -862,6 +927,11 @@ function updateRecipeSummary() {
       else parts.push(key);
     });
   }
+  if (r.local && r.local.regions) {
+    r.local.regions.forEach(function(entry) {
+      parts.push('local ' + entry.region);
+    });
+  }
   document.getElementById('recipeSummary').textContent = parts.length ? parts.join(' | ') : 'No edits';
 }
 
@@ -890,6 +960,7 @@ function syncControls() {
   var straight = Number(r.straighten || 0);
   document.getElementById('straightenRange').value = String(straight);
   document.getElementById('straightenValue').textContent = straight.toFixed(1);
+  syncLocalControls();
   renderCropBox();
   updateDirtyState();
 }
@@ -1017,6 +1088,7 @@ function updatePreview() {
       : 'Preview uses the current unsaved recipe') + suffix;
     renderCropBox();
     updateHistogramFeedback();
+    refreshMaskOverlay();
   };
   img.onerror = function() {
     if (seq !== editorState.previewSeq) return;
@@ -1260,6 +1332,257 @@ async function deleteSelectedPreset() {
       showToast(e.message || 'Could not delete preset', 'error');
     }
   }
+}
+
+// --- Local (mask-weighted) adjustments --------------------------------------
+// Subject/Background deltas driven by the photo's SAM mask, frozen into an
+// edit-mask snapshot on first touch so saved renders never shift under a
+// regenerated mask. See docs/plans/2026-07-03-local-adjustments-design.md.
+
+var LOCAL_REGIONS = ['subject', 'background'];
+var LOCAL_CONTROL_DEFS = [
+  ['exposure', 'Exposure', -5, 5, 0.1, true],
+  ['shadows', 'Shadows', -100, 100, 1, false],
+  ['highlights', 'Highlights', -100, 100, 1, false],
+  ['saturation', 'Saturation', -100, 100, 1, false],
+  ['sharpen', 'Sharpen', -100, 100, 1, false],
+  ['noise_reduction', 'Denoise', -100, 100, 1, false],
+];
+
+function buildLocalControls() {
+  LOCAL_REGIONS.forEach(function(region) {
+    var host = document.getElementById(region + 'LocalControls');
+    if (!host || host.childElementCount) return;
+    LOCAL_CONTROL_DEFS.forEach(function(def) {
+      var key = def[0];
+      var id = 'local_' + region + '_' + key;
+      var row = document.createElement('div');
+      row.className = 'control-row';
+      row.innerHTML =
+        '<label for="' + id + 'Range">' + def[1] + '</label>' +
+        '<input id="' + id + 'Range" type="range" min="' + def[2] +
+        '" max="' + def[3] + '" step="' + def[4] + '" value="0">' +
+        '<span class="control-value" id="' + id + 'Value">' +
+        (def[5] ? '0.0' : '0') + '</span>';
+      host.appendChild(row);
+      row.querySelector('input').addEventListener('input', function() {
+        setLocalAdjustment(region, key, this.value, def[5]);
+      });
+    });
+  });
+}
+
+function localRegionValues(recipe) {
+  var out = {subject: {}, background: {}, feather: 0};
+  var local = recipe && recipe.local || {};
+  (local.regions || []).forEach(function(entry) {
+    if (out[entry.region]) {
+      out[entry.region] = Object.assign({}, entry.adjustments || {});
+    }
+  });
+  out.feather = Number((local.mask || {}).feather || 0);
+  return out;
+}
+
+function rebuildLocalSection() {
+  var draft = editorState.localDraft;
+  var regions = [];
+  LOCAL_REGIONS.forEach(function(region) {
+    var adj = {};
+    LOCAL_CONTROL_DEFS.forEach(function(def) {
+      var v = Number(draft[region][def[0]] || 0);
+      if (Math.abs(v) > 0.000001) adj[def[0]] = v;
+    });
+    if (Object.keys(adj).length) regions.push({region: region, adjustments: adj});
+  });
+  // Mirror normalize_recipe's canonical region order so the dirty-state
+  // comparison stays stable against the server's saved form.
+  regions.sort(function(a, b) { return a.region < b.region ? -1 : 1; });
+  if (!regions.length || !editorState.localMask) {
+    delete editorState.recipe.local;
+    return;
+  }
+  var mask = {
+    ref: editorState.localMask.ref,
+    source_digest: editorState.localMask.source_digest,
+  };
+  if (Math.abs(Number(draft.feather || 0)) > 0.000001) {
+    mask.feather = Number(draft.feather);
+  }
+  editorState.recipe.local = {mask: mask, regions: regions};
+}
+
+function syncLocalControls() {
+  var vals = localRegionValues(editorState.recipe);
+  editorState.localDraft = {
+    subject: vals.subject,
+    background: vals.background,
+    feather: vals.feather,
+  };
+  var savedMask = (editorState.recipe.local || {}).mask;
+  if (savedMask && savedMask.ref) {
+    editorState.localMask = {
+      ref: savedMask.ref,
+      source_digest: savedMask.source_digest,
+    };
+  }
+  LOCAL_REGIONS.forEach(function(region) {
+    LOCAL_CONTROL_DEFS.forEach(function(def) {
+      var id = 'local_' + region + '_' + def[0];
+      var input = document.getElementById(id + 'Range');
+      var label = document.getElementById(id + 'Value');
+      var v = Number(vals[region][def[0]] || 0);
+      if (input) input.value = String(v);
+      if (label) label.textContent = def[5] ? v.toFixed(1) : String(Math.round(v));
+    });
+  });
+  var feather = document.getElementById('featherRange');
+  if (feather) feather.value = String(vals.feather || 0);
+  var featherLabel = document.getElementById('featherValue');
+  if (featherLabel) featherLabel.textContent = String(Math.round(vals.feather || 0));
+  updateLocalBandVisibility();
+}
+
+function updateLocalBandVisibility() {
+  var available = editorState.localAvailable || !!editorState.recipe.local;
+  var band = document.getElementById('localBand');
+  var unavailable = document.getElementById('localUnavailableBand');
+  if (band) band.style.display = available ? '' : 'none';
+  if (unavailable) unavailable.style.display = available ? 'none' : '';
+  var banner = document.getElementById('localStaleBanner');
+  if (banner) banner.style.display = editorState.localStale ? '' : 'none';
+}
+
+function ensureLocalMask() {
+  if (editorState.localMask) return Promise.resolve(editorState.localMask);
+  if (!editorState.localMaskPromise) {
+    var photoId = editorState.photoId;
+    editorState.localMaskPromise = safeFetch(
+      '/api/photos/' + photoId + '/local-mask/snapshot',
+      {method: 'POST'}, {toast: false}
+    ).then(function(data) {
+      if (editorState.photoId === photoId) editorState.localMask = data.mask;
+      return data.mask;
+    }).catch(function(e) {
+      if (editorState.photoId === photoId) {
+        editorState.localMaskPromise = null;
+        editorState.localAvailable = false;
+        updateLocalBandVisibility();
+        if (typeof showToast === 'function') {
+          showToast(e.message || 'Could not snapshot the subject mask', 'error');
+        }
+      }
+      throw e;
+    });
+  }
+  return editorState.localMaskPromise;
+}
+
+function setLocalAdjustment(region, key, raw, fixed) {
+  if (editorState.loading) return;
+  var v = Number(raw) || 0;
+  editorState.localDraft[region][key] = v;
+  var label = document.getElementById('local_' + region + '_' + key + 'Value');
+  if (label) label.textContent = fixed ? v.toFixed(1) : String(Math.round(v));
+  if (editorState.localMask) {
+    rebuildLocalSection();
+    markChanged(true);
+  } else {
+    // First touch: freeze the active mask into a snapshot, then attach the
+    // pending slider state. The snapshot is content-addressed, so repeat
+    // calls are idempotent.
+    ensureLocalMask().then(function() {
+      rebuildLocalSection();
+      markChanged(true);
+    }).catch(function() {});
+  }
+}
+
+function setLocalFeather(raw) {
+  if (editorState.loading) return;
+  var v = Number(raw) || 0;
+  editorState.localDraft.feather = v;
+  var label = document.getElementById('featherValue');
+  if (label) label.textContent = String(Math.round(v));
+  if (editorState.localMask) {
+    rebuildLocalSection();
+    markChanged(true);
+  } else {
+    ensureLocalMask().then(function() {
+      rebuildLocalSection();
+      markChanged(true);
+    }).catch(function() {});
+  }
+}
+
+function resetLocal() {
+  editorState.localDraft = {subject: {}, background: {}, feather: 0};
+  delete editorState.recipe.local;
+  syncLocalControls();
+  markChanged(true);
+}
+
+async function updateLocalMask() {
+  var photoId = editorState.photoId;
+  try {
+    var data = await safeFetch(
+      '/api/photos/' + photoId + '/local-mask/snapshot',
+      {method: 'POST'}, {toast: false}
+    );
+    if (editorState.photoId !== photoId) return;
+    editorState.localMask = data.mask;
+    editorState.localStale = false;
+    rebuildLocalSection();
+    updateLocalBandVisibility();
+    markChanged(true);
+    if (typeof showToast === 'function') {
+      showToast('Subject mask updated — save to keep it', 'success');
+    }
+  } catch (e) {
+    if (typeof showToast === 'function') {
+      showToast(e.message || 'Could not update the subject mask', 'error');
+    }
+  }
+}
+
+function toggleMaskOverlay() {
+  editorState.maskOverlay = !editorState.maskOverlay;
+  setButtonActive('maskOverlayBtn', editorState.maskOverlay);
+  refreshMaskOverlay();
+}
+
+function refreshMaskOverlay() {
+  var overlay = document.getElementById('maskOverlayImg');
+  if (!overlay) return;
+  var recipe = editorState.showBefore
+    ? previewRecipeFor(editorState.savedRecipe)
+    : previewRecipe();
+  if (!editorState.maskOverlay || !recipe.local) {
+    overlay.style.display = 'none';
+    overlay.removeAttribute('src');
+    return;
+  }
+  var size = editorState.zoomMode === 'actual' ? 3840 : 1920;
+  var seq = ++editorState.maskOverlaySeq;
+  overlay.onload = function() {
+    if (seq !== editorState.maskOverlaySeq) return;
+    positionMaskOverlay();
+    overlay.style.display = '';
+  };
+  overlay.onerror = function() {
+    if (seq !== editorState.maskOverlaySeq) return;
+    overlay.style.display = 'none';
+  };
+  overlay.src = '/photos/' + editorState.photoId + '/edit-mask-preview?size=' +
+    size + '&recipe=' + encodeURIComponent(JSON.stringify(recipe)) + '&v=' + seq;
+}
+
+function positionMaskOverlay() {
+  var img = document.getElementById('editorImg');
+  var overlay = document.getElementById('maskOverlayImg');
+  if (!img || !overlay) return;
+  overlay.style.width = img.clientWidth + 'px';
+  overlay.style.height = img.clientHeight + 'px';
 }
 
 function resetDetail() {
@@ -1774,6 +2097,27 @@ async function loadPhoto(photoId, opts) {
     editorState.savedRecipe = cloneRecipe(photo.edit_recipe || {});
     editorState.recipe = cloneRecipe(photo.edit_recipe || {});
     ensureCrop(editorState.recipe);
+    editorState.localMask = null;
+    editorState.localMaskPromise = null;
+    editorState.localAvailable = false;
+    editorState.localStale = false;
+    editorState.maskOverlay = false;
+    setButtonActive('maskOverlayBtn', false);
+    refreshMaskOverlay();
+    safeFetch('/api/photos/' + photoId + '/masks', {}, {toast: false})
+      .then(function(d) {
+        if (editorState.photoId !== photoId) return;
+        editorState.localAvailable = !!d.active;
+        updateLocalBandVisibility();
+      }).catch(function() {});
+    if (photo.edit_recipe && photo.edit_recipe.local) {
+      safeFetch('/api/photos/' + photoId + '/edit-recipe', {}, {toast: false})
+        .then(function(d) {
+          if (editorState.photoId !== photoId) return;
+          editorState.localStale = !!d.local_mask_stale;
+          updateLocalBandVisibility();
+        }).catch(function() {});
+    }
     document.getElementById('editorFilename').textContent = photo.filename || ('Photo ' + photoId);
     var dim = photo.width && photo.height ? photo.width + ' x ' + photo.height : 'Photo ' + photoId;
     document.getElementById('editorSubhead').textContent = dim;
@@ -1804,6 +2148,7 @@ function initEditorKeyboard() {
 async function initEditor() {
   initCropDrag();
   initEditorKeyboard();
+  buildLocalControls();
   clearHistogramFeedback();
   setZoomMode('fit');
   loadPresets();

--- a/vireo/templates/photo_editor.html
+++ b/vireo/templates/photo_editor.html
@@ -1564,6 +1564,12 @@ function refreshMaskOverlay() {
     ? previewRecipeFor(editorState.savedRecipe)
     : previewRecipe();
   if (!editorState.maskOverlay || !recipe.local) {
+    // Bump the sequence and clear handlers so any in-flight preview load
+    // can't win the race and re-show an overlay the user just hid (or one
+    // from a previous photo during navigation).
+    editorState.maskOverlaySeq++;
+    overlay.onload = null;
+    overlay.onerror = null;
     overlay.style.display = 'none';
     overlay.removeAttribute('src');
     return;
@@ -1771,6 +1777,10 @@ async function autoTone() {
     var sampleCrop = cloneRecipe({crop: ensureCrop(editorState.recipe)}).crop;
     var base = previewRecipeFor(editorState.recipe);
     delete base.adjustments;
+    // Strip local (Subject/Background) edits too — otherwise the analysis
+    // render samples pixels the user has already locally edited, and Auto
+    // Tone compensates for those, computing wrong global exposure/highlights.
+    delete base.local;
     var src = '/photos/' + editorState.photoId + '/edit-preview?size=1024&analysis=1&recipe=' +
       encodeURIComponent(JSON.stringify(base));
     var img = await _loadImage(src);

--- a/vireo/templates/photo_editor.html
+++ b/vireo/templates/photo_editor.html
@@ -1425,6 +1425,12 @@ function syncLocalControls() {
       ref: savedMask.ref,
       source_digest: savedMask.source_digest,
     };
+  } else {
+    // No saved local recipe: clear the cached snapshot so the next local
+    // slider touch re-freezes the CURRENT active mask instead of taking the
+    // stale-ref fast path in ensureLocalMask().
+    editorState.localMask = null;
+    editorState.localMaskPromise = null;
   }
   LOCAL_REGIONS.forEach(function(region) {
     LOCAL_CONTROL_DEFS.forEach(function(def) {

--- a/vireo/templates/photo_editor.html
+++ b/vireo/templates/photo_editor.html
@@ -1560,9 +1560,16 @@ function toggleMaskOverlay() {
 function refreshMaskOverlay() {
   var overlay = document.getElementById('maskOverlayImg');
   if (!overlay) return;
-  var recipe = editorState.showBefore
-    ? previewRecipeFor(editorState.savedRecipe)
-    : previewRecipe();
+  // Keep crop in the overlay recipe. /edit-mask-preview strips crop only
+  // for geometry alignment with the uncropped editor preview, but still
+  // uses the ORIGINAL cropped recipe to compute the saved-render feather
+  // scale (mirroring what /edit-preview passes to
+  // apply_recipe_to_loaded_image). Sending a crop-stripped recipe here
+  // would let the endpoint recompute the scale from the uncropped
+  // dimensions and the overlay halo would drift from the pixels the
+  // saved cropped render actually weights.
+  var source = editorState.showBefore ? editorState.savedRecipe : editorState.recipe;
+  var recipe = recipeForSave(source || {});
   if (!editorState.maskOverlay || !recipe.local) {
     // Bump the sequence and clear handlers so any in-flight preview load
     // can't win the race and re-show an overlay the user just hid (or one

--- a/vireo/templates/photo_editor.html
+++ b/vireo/templates/photo_editor.html
@@ -1483,14 +1483,20 @@ function ensureLocalMask() {
   if (editorState.localMask) return Promise.resolve(editorState.localMask);
   if (!editorState.localMaskPromise) {
     var photoId = editorState.photoId;
-    editorState.localMaskPromise = safeFetch(
+    // A concurrent resetLocal() / photo change clears localMaskPromise while
+    // the snapshot POST is in flight; without the identity guard below, the
+    // late resolver would re-cache a pre-reset snapshot and the next slider
+    // touch would save that stale ref instead of freezing the current mask.
+    var pending = safeFetch(
       '/api/photos/' + photoId + '/local-mask/snapshot',
       {method: 'POST'}, {toast: false}
     ).then(function(data) {
-      if (editorState.photoId === photoId) editorState.localMask = data.mask;
+      if (editorState.photoId === photoId && editorState.localMaskPromise === pending) {
+        editorState.localMask = data.mask;
+      }
       return data.mask;
     }).catch(function(e) {
-      if (editorState.photoId === photoId) {
+      if (editorState.photoId === photoId && editorState.localMaskPromise === pending) {
         editorState.localMaskPromise = null;
         editorState.localAvailable = false;
         updateLocalBandVisibility();
@@ -1500,6 +1506,7 @@ function ensureLocalMask() {
       }
       throw e;
     });
+    editorState.localMaskPromise = pending;
   }
   return editorState.localMaskPromise;
 }

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -8022,6 +8022,73 @@ def test_edit_mask_preview_serves_transformed_weight_map(client_with_photo):
         assert img.size == (800, 600)
 
 
+def test_edit_mask_preview_feather_scale_matches_saved_render(client_with_photo):
+    """Overlay feather uses the SAVED (cropped) render's scale.
+
+    Regression: the endpoint strips crop before calling ``local_weight_map``
+    so the overlay lines up with the uncropped editor preview, but the
+    feather scale must still come from the original (cropped) recipe —
+    that is what ``/edit-preview`` passes to
+    ``apply_recipe_to_loaded_image`` as ``detail_scale``. Otherwise a
+    cropped recipe's overlay halo drifts from the pixels the saved render
+    actually weights.
+    """
+    import io
+    import json
+
+    import numpy as np
+    from PIL import Image as PILImage
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    folder = db.conn.execute("SELECT path FROM folders").fetchone()
+    _register_active_mask(db, photo_id, folder["path"])
+    mask = client.post(
+        f"/api/photos/{photo_id}/local-mask/snapshot"
+    ).get_json()["mask"]
+
+    # Large feather + tight crop so the crop-derived scale doubles the
+    # crop-stripped one: photo native = 800x600, size = 400.
+    #   Old (buggy) scale = 400/800 = 0.5 (crop-stripped, uncropped long)
+    #   New scale         = 320/320 = 1.0 (saved cropped render)
+    # so the fix should ~2x the Gaussian-feather sigma.
+    payload = _local_recipe_payload(dict(mask, feather=50.0))
+    payload["recipe"]["crop"] = {"x": 0.1, "y": 0.1, "w": 0.4, "h": 0.4}
+    recipe_cropped = payload["recipe"]
+    recipe_full = dict(recipe_cropped)
+    recipe_full.pop("crop")
+
+    def _overlay_alpha(recipe):
+        resp = client.get(
+            f"/photos/{photo_id}/edit-mask-preview",
+            query_string={"size": "400", "recipe": json.dumps(recipe)},
+        )
+        assert resp.status_code == 200
+        with PILImage.open(io.BytesIO(resp.data)) as img:
+            assert img.size == (400, 300)
+            return np.asarray(img)[..., 3].astype(np.float32)
+
+    alpha_cropped = _overlay_alpha(recipe_cropped)
+    alpha_full = _overlay_alpha(recipe_full)
+
+    # Both overlays are aligned with the uncropped preview (400x300), so
+    # the mask's left/right split sits at the same column in each. The
+    # difference is only the feather sigma.
+    def _transition_width(alpha):
+        # Count columns whose mid-row alpha lies in the Gaussian
+        # transition band around the step edge at x ~ 200.
+        row = alpha[150]
+        return int(np.count_nonzero((row > 5) & (row < 145)))
+
+    w_cropped = _transition_width(alpha_cropped)
+    w_full = _transition_width(alpha_full)
+    assert w_cropped > w_full + 20, (
+        f"cropped-recipe overlay halo ({w_cropped}px) should be materially "
+        f"wider than the uncropped ({w_full}px) — the endpoint likely used "
+        "the crop-stripped recipe's scale instead of the saved-render scale."
+    )
+
+
 def test_edit_mask_preview_missing_snapshot_404s(client_with_photo):
     import json
 

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -8164,3 +8164,13 @@ def test_bulk_apply_resnapshots_local_per_target(client_with_photo):
     assert r2["local"]["mask"]["ref"] != source_mask["ref"]
     assert r2["local"]["regions"] == r1["local"]["regions"]
     assert db.get_photo_edit_recipe(pid3) is None
+
+    # The response exposes a per-photo recipe map so the client cache stays
+    # in sync — reusing `data.recipe` (the first applied) for every id
+    # would silently poison non-first photos with the wrong mask ref until
+    # a full refetch.
+    recipes = data["recipes"]
+    assert set(recipes) == {str(photo_id), str(pid2)}
+    assert recipes[str(photo_id)]["local"]["mask"]["ref"] == r1["local"]["mask"]["ref"]
+    assert recipes[str(pid2)]["local"]["mask"]["ref"] == r2["local"]["mask"]["ref"]
+    assert recipes[str(pid2)]["local"]["mask"]["ref"] != recipes[str(photo_id)]["local"]["mask"]["ref"]

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -7802,7 +7802,10 @@ def test_local_recipe_rejects_unknown_snapshot_ref(client_with_photo):
     assert "snapshot" in resp.get_json()["error"].lower()
 
 
-def test_bulk_apply_rejects_local_sections(client_with_photo):
+def test_bulk_apply_local_skips_photos_without_masks(client_with_photo):
+    """Bulk apply with a local section re-snapshots per target (PR 2);
+    targets without a usable active mask are skipped and reported instead
+    of silently receiving a wrong mask."""
     app, db, photo_id = client_with_photo
     client = app.test_client()
 
@@ -7815,8 +7818,12 @@ def test_bulk_apply_rejects_local_sections(client_with_photo):
             )["recipe"],
         },
     )
-    assert resp.status_code == 400
-    assert "local" in resp.get_json()["error"].lower()
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["applied"] == []
+    assert data["skipped"] == [photo_id]
+    assert "mask" in data["local_errors"][str(photo_id)].lower()
+    assert db.get_photo_edit_recipe(photo_id) is None
 
 
 def test_edit_preview_renders_local_adjustments(client_with_photo):
@@ -7947,3 +7954,146 @@ def test_local_snapshot_root_matches_thumb_cache_dir(tmp_path, monkeypatch):
     )
 
     db.close()
+
+
+def test_edit_mask_preview_requires_local_recipe(client_with_photo):
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+
+    resp = client.get(
+        f"/photos/{photo_id}/edit-mask-preview",
+        query_string={"recipe": '{"rotation":90}'},
+    )
+    assert resp.status_code == 404
+    assert client.get("/photos/999999/edit-mask-preview").status_code == 404
+
+
+def test_edit_mask_preview_serves_transformed_weight_map(client_with_photo):
+    import io
+    import json
+
+    import numpy as np
+    from PIL import Image as PILImage
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    folder = db.conn.execute("SELECT path FROM folders").fetchone()
+    _register_active_mask(db, photo_id, folder["path"])
+    mask = client.post(
+        f"/api/photos/{photo_id}/local-mask/snapshot"
+    ).get_json()["mask"]
+
+    recipe = _local_recipe_payload(mask)["recipe"]
+    resp = client.get(
+        f"/photos/{photo_id}/edit-mask-preview",
+        query_string={"size": "800", "recipe": json.dumps(recipe)},
+    )
+    assert resp.status_code == 200
+    assert resp.mimetype == "image/png"
+    with PILImage.open(io.BytesIO(resp.data)) as img:
+        assert img.mode == "RGBA"
+        assert img.size == (800, 600)
+        alpha = np.asarray(img)[..., 3].astype(np.float32)
+
+    # Left (subject) half opaque-ish, right transparent.
+    assert np.mean(alpha[:, :360]) > 60
+    assert np.mean(alpha[:, 440:]) < 5
+
+    # Geometry rides along: flipping horizontally moves the weight.
+    recipe_flipped = dict(recipe)
+    recipe_flipped["flip"] = {"horizontal": True}
+    resp = client.get(
+        f"/photos/{photo_id}/edit-mask-preview",
+        query_string={"size": "800", "recipe": json.dumps(recipe_flipped)},
+    )
+    with PILImage.open(io.BytesIO(resp.data)) as img:
+        alpha = np.asarray(img)[..., 3].astype(np.float32)
+    assert np.mean(alpha[:, 440:]) > 60
+    assert np.mean(alpha[:, :360]) < 5
+
+    # The editor preview is uncropped, so the overlay ignores crop too.
+    recipe_cropped = dict(recipe)
+    recipe_cropped["crop"] = {"x": 0.5, "y": 0.0, "w": 0.5, "h": 1.0}
+    resp = client.get(
+        f"/photos/{photo_id}/edit-mask-preview",
+        query_string={"size": "800", "recipe": json.dumps(recipe_cropped)},
+    )
+    with PILImage.open(io.BytesIO(resp.data)) as img:
+        assert img.size == (800, 600)
+
+
+def test_edit_mask_preview_missing_snapshot_404s(client_with_photo):
+    import json
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+
+    recipe = _local_recipe_payload(
+        {"ref": "eeeeeeeeeeee", "source_digest": "d"}
+    )["recipe"]
+    resp = client.get(
+        f"/photos/{photo_id}/edit-mask-preview",
+        query_string={"recipe": json.dumps(recipe)},
+    )
+    assert resp.status_code == 404
+
+
+def test_bulk_apply_resnapshots_local_per_target(client_with_photo):
+    import numpy as np
+    from PIL import Image as PILImage
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    folder = db.conn.execute("SELECT path FROM folders").fetchone()
+
+    # Second photo with its own (different) mask; third with no mask at all.
+    src2 = os.path.join(folder["path"], "second.jpg")
+    PILImage.new("RGB", (800, 600), (90, 120, 60)).save(src2, "JPEG")
+    pid2 = db.add_photo(
+        folder_id=db.conn.execute("SELECT id FROM folders").fetchone()["id"],
+        filename="second.jpg", extension=".jpg",
+        file_size=os.path.getsize(src2), file_mtime=os.path.getmtime(src2),
+        width=800, height=600,
+    )
+    src3 = os.path.join(folder["path"], "third.jpg")
+    PILImage.new("RGB", (800, 600), (10, 20, 30)).save(src3, "JPEG")
+    pid3 = db.add_photo(
+        folder_id=db.conn.execute("SELECT id FROM folders").fetchone()["id"],
+        filename="third.jpg", extension=".jpg",
+        file_size=os.path.getsize(src3), file_mtime=os.path.getmtime(src3),
+        width=800, height=600,
+    )
+
+    _register_active_mask(db, photo_id, folder["path"])
+    # pid2 gets a top-half mask so its snapshot differs from pid1's.
+    path2 = os.path.join(folder["path"], f"{pid2}.sam2-small.png")
+    arr = np.zeros((600, 800), dtype=np.uint8)
+    arr[:300, :] = 255
+    PILImage.fromarray(arr, "L").save(path2, "PNG")
+    db.upsert_photo_mask(
+        pid2, "sam2-small", path2, "megadetector-v6", 0.0, 0.0, 1.0, 0.5,
+    )
+    db.set_active_mask_variant(pid2, "sam2-small")
+
+    source_mask = client.post(
+        f"/api/photos/{photo_id}/local-mask/snapshot"
+    ).get_json()["mask"]
+    recipe = _local_recipe_payload(source_mask)["recipe"]
+
+    resp = client.post(
+        "/api/photos/edit-recipe/apply",
+        json={"photo_ids": [photo_id, pid2, pid3], "recipe": recipe},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert sorted(data["applied"]) == sorted([photo_id, pid2])
+    assert pid3 in data["skipped"]
+    assert str(pid3) in {str(k) for k in data.get("local_errors", {})}
+
+    # Each target references its OWN snapshot, not the source photo's.
+    r1 = db.get_photo_edit_recipe(photo_id)
+    r2 = db.get_photo_edit_recipe(pid2)
+    assert r1["local"]["mask"]["ref"] == source_mask["ref"]
+    assert r2["local"]["mask"]["ref"] != source_mask["ref"]
+    assert r2["local"]["regions"] == r1["local"]["regions"]
+    assert db.get_photo_edit_recipe(pid3) is None


### PR DESCRIPTION
## What

Second of the three PRs from the local-adjustments design (#1088), on top of the merged renderer (#1096). This makes the feature usable from the editor.

**Editor (`photo_editor.html`)**
- **Subject / Background bands** with per-region delta sliders (Exposure, Shadows, Highlights, Saturation, Sharpen, Denoise — negative detail deltas supported per the PR 1 review hardening) plus a shared **Feather** slider. Shown only when the photo has an active mask; otherwise an honest one-liner ("No subject mask — run the pipeline's mask stage"), never dead sliders.
- **Snapshot-on-first-touch**: the first local slider movement POSTs `/local-mask/snapshot`, embeds the returned content-addressed ref + source digest in the working recipe, and re-renders. Idempotent and cached per photo; a snapshot failure surfaces a toast and reverts to the unavailable state.
- **Mask overlay toggle**: a teal weight-map overlay composited on the preview, served by the new endpoint below — the pixels shown are exactly the weights the renderer uses, including geometry and feather.
- **Stale-mask banner**: when the recipe GET reports `local_mask_stale`, the band shows "Newer subject mask available — Update"; Update re-snapshots, rotates the ref in the working recipe, and marks it dirty (an ordinary undoable save, per the design's explicit-not-automatic staleness rule).
- Client-side canonical ordering mirrors `normalize_recipe` so the dirty-state comparison stays stable across save round-trips.

**Backend**
- `GET /photos/<id>/edit-mask-preview` — renders the recipe's transformed, feathered weight map as a tinted RGBA PNG aligned with the uncropped editor preview, built on a new public `image_edits.local_weight_map` helper (single source of truth with the renderer). The existing lightbox mask endpoint serves the raw live mask, which is exactly what the renderer doesn't use.
- **Bulk apply / Copy Settings now supports local sections**: each target photo gets its own snapshot frozen from its own active mask (slider values copy; masks don't). Targets without a usable mask are skipped and reported in a new `local_errors` field. This lifts the PR 1 guard; the PR 1 guard test is updated to assert the new skip-and-report behavior.

## Tests

- `1485 passed, 3 skipped` across the CLAUDE.md suite + all edit/tone/detail/local suites, including new tests for the overlay endpoint (weight map dims/alpha, geometry-following, crop-ignoring, 404s) and per-target bulk resnapshot (own-ref per target, skip+report without mask).
- Playwright against a live instance: bands render saved local recipes and restore mask refs; overlay toggles and requests `edit-mask-preview`; slider → save → round-trip with clean dirty state; Reset Local; no-mask photo shows the unavailable note; first touch on a masked photo fires the snapshot and embeds the ref; rewriting the live mask surfaces the stale banner, and Update rotates the ref and clears it. No JS errors.

Remaining after this: PR 3 (optional WebGL live-preview mask texture) and the watch-and-see RAW aspect-mismatch regeneration path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local subject/background adjustments for batch edits, including per-photo handling and improved UI controls (feather, show mask, reset).
  * Introduced an **Edit Mask Preview** endpoint/view that renders the local-weight overlay as a tinted PNG aligned to the editor preview.
  * Batch edit results now return per-photo stored recipes (when applicable) for more accurate editor syncing.
* **Bug Fixes**
  * Batch edits no longer fail when some photos lack a usable local mask—those photos are skipped with per-photo error details.
  * Mask previews now consistently match the correct geometry, transforms, and saved feather/transition scale.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->