### PR TITLE
Process job: strategy presets, folder scope, workspace default (import/process split PR 1)

### DIFF
--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -2004,3 +2004,99 @@ def test_tabs_are_per_workspace(db):
     db.set_active_workspace(ws2)
     assert db.get_tabs() == DEFAULT_TABS
     assert "logs" not in db.get_tabs()
+
+
+# ---------------------------------------------------------------------------
+# per-workspace default process strategy (import/process split PR 1)
+# ---------------------------------------------------------------------------
+
+
+def _put_default_strategy(client, ws_id, value):
+    return client.put(
+        f"/api/workspaces/{ws_id}",
+        data=json.dumps(
+            {"config_overrides": {"pipeline": {"default_strategy": value}}}
+        ),
+        content_type="application/json",
+    )
+
+
+def test_workspace_default_strategy_saved_and_effective(client):
+    resp = client.post(
+        "/api/workspaces",
+        data=json.dumps({"name": "Strat"}),
+        content_type="application/json",
+    )
+    ws_id = resp.get_json()["id"]
+    resp = _put_default_strategy(client, ws_id, "cull_ready")
+    assert resp.status_code == 200
+
+    import config as cfg
+    from db import Database
+
+    # Read through get_effective_config exactly like the pipeline does.
+    db_path = None
+    with client.application.app_context():
+        db_path = client.application.config["DB_PATH"]
+    db = Database(db_path)
+    db.set_active_workspace(ws_id)
+    effective = db.get_effective_config(cfg.load())
+    assert effective["pipeline"]["default_strategy"] == "cull_ready"
+
+
+def test_workspace_default_strategy_null_means_import_only(client):
+    """None is the "no automatic processing after import" sentinel that
+    PR 3's chaining hook short-circuits on. Saving it must succeed — if
+    this 400s, the "import only" user flow is unreachable."""
+    resp = client.post(
+        "/api/workspaces",
+        data=json.dumps({"name": "StratNull"}),
+        content_type="application/json",
+    )
+    ws_id = resp.get_json()["id"]
+    resp = _put_default_strategy(client, ws_id, None)
+    assert resp.status_code == 200
+
+    import config as cfg
+    from db import Database
+
+    db = Database(client.application.config["DB_PATH"])
+    db.set_active_workspace(ws_id)
+    effective = db.get_effective_config(cfg.load())
+    assert effective["pipeline"]["default_strategy"] is None
+
+
+def test_workspace_default_strategy_unknown_400(client):
+    resp = client.post(
+        "/api/workspaces",
+        data=json.dumps({"name": "StratBad"}),
+        content_type="application/json",
+    )
+    ws_id = resp.get_json()["id"]
+    resp = _put_default_strategy(client, ws_id, "yolo")
+    assert resp.status_code == 400
+    assert "unknown strategy" in resp.get_json()["error"]
+
+
+def test_workspace_default_strategy_none_string_400(client):
+    """The string "none" is not the null sentinel — the "no process" case
+    uses JSON null, matching /api/jobs/pipeline (which also rejects
+    strategy: "none"). One vocabulary across the workspace default, the
+    API body, and the chaining hook."""
+    resp = client.post(
+        "/api/workspaces",
+        data=json.dumps({"name": "StratNoneStr"}),
+        content_type="application/json",
+    )
+    ws_id = resp.get_json()["id"]
+    resp = _put_default_strategy(client, ws_id, "none")
+    assert resp.status_code == 400
+
+
+def test_config_default_strategy_default_is_none():
+    import os
+    import sys
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "vireo"))
+    from config import DEFAULTS
+
+    assert DEFAULTS["pipeline"]["default_strategy"] is None

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -2093,6 +2093,25 @@ def test_workspace_default_strategy_none_string_400(client):
     assert resp.status_code == 400
 
 
+@pytest.mark.parametrize("bad", [5, True, ["cull_ready"], {"name": "full"}])
+def test_workspace_default_strategy_non_string_400(client, bad):
+    """A JSON client sending a number, bool, list, or dict for
+    ``pipeline.default_strategy`` must get a 400 validation error, not a
+    500. Before ``resolve_strategy`` guarded non-string inputs, an
+    array/dict here hit ``name not in STRATEGIES`` and raised
+    ``TypeError: unhashable type`` — which the endpoint didn't catch, so
+    it escaped as a 500. Regression tripwire."""
+    resp = client.post(
+        "/api/workspaces",
+        data=json.dumps({"name": f"StratBadType-{type(bad).__name__}"}),
+        content_type="application/json",
+    )
+    ws_id = resp.get_json()["id"]
+    resp = _put_default_strategy(client, ws_id, bad)
+    assert resp.status_code == 400
+    assert "strategy must be a string" in resp.get_json()["error"]
+
+
 def test_config_default_strategy_default_is_none():
     import os
     import sys

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -2119,3 +2119,106 @@ def test_config_default_strategy_default_is_none():
     from config import DEFAULTS
 
     assert DEFAULTS["pipeline"]["default_strategy"] is None
+
+
+# ---------------------------------------------------------------------------
+# Create-workspace config_overrides validation (mirror of PUT validation)
+#
+# Regression tripwires for a validation gap on POST /api/workspaces: the
+# create path used to pass ``body.get("config_overrides")`` straight into
+# db.create_workspace without checking pipeline.default_strategy, so a
+# client could seed a workspace with an unknown strategy that PUT and
+# /api/jobs/pipeline would both reject — later feeding the chaining hook
+# an invalid strategy that only surfaces as a job failure.
+# ---------------------------------------------------------------------------
+
+
+def test_create_workspace_rejects_unknown_default_strategy(client):
+    resp = client.post(
+        "/api/workspaces",
+        data=json.dumps({
+            "name": "StratBadCreate",
+            "config_overrides": {"pipeline": {"default_strategy": "yolo"}},
+        }),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+    assert "unknown strategy" in resp.get_json()["error"]
+
+
+def test_create_workspace_rejects_none_string_default_strategy(client):
+    """POST must match PUT and /api/jobs/pipeline: the "no processing"
+    sentinel is JSON null, not the string ``"none"``."""
+    resp = client.post(
+        "/api/workspaces",
+        data=json.dumps({
+            "name": "StratNoneCreate",
+            "config_overrides": {"pipeline": {"default_strategy": "none"}},
+        }),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.parametrize("bad", [5, True, ["cull_ready"], {"name": "full"}])
+def test_create_workspace_rejects_non_string_default_strategy(client, bad):
+    resp = client.post(
+        "/api/workspaces",
+        data=json.dumps({
+            "name": f"StratBadTypeCreate-{type(bad).__name__}",
+            "config_overrides": {"pipeline": {"default_strategy": bad}},
+        }),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+    assert "strategy must be a string" in resp.get_json()["error"]
+
+
+def test_create_workspace_accepts_valid_default_strategy(client):
+    resp = client.post(
+        "/api/workspaces",
+        data=json.dumps({
+            "name": "StratCreateOK",
+            "config_overrides": {"pipeline": {"default_strategy": "cull_ready"}},
+        }),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    ws_id = resp.get_json()["id"]
+
+    import config as cfg
+    from db import Database
+
+    db = Database(client.application.config["DB_PATH"])
+    db.set_active_workspace(ws_id)
+    effective = db.get_effective_config(cfg.load())
+    assert effective["pipeline"]["default_strategy"] == "cull_ready"
+
+
+def test_create_workspace_accepts_null_default_strategy(client):
+    """Explicit null on create must round-trip — it is the "import only"
+    sentinel and mirrors the PUT path's null acceptance."""
+    resp = client.post(
+        "/api/workspaces",
+        data=json.dumps({
+            "name": "StratCreateNull",
+            "config_overrides": {"pipeline": {"default_strategy": None}},
+        }),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+
+
+def test_create_workspace_rejects_non_object_config_overrides(client):
+    """``config_overrides`` must be a JSON object or null; anything else
+    would be persisted as-is and break the labels accessors."""
+    resp = client.post(
+        "/api/workspaces",
+        data=json.dumps({
+            "name": "StratBadOverrides",
+            "config_overrides": "not-a-dict",
+        }),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+    assert "config_overrides" in resp.get_json()["error"]

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -16619,6 +16619,22 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 return json_error(
                     "folder_ids must be a non-empty list of integers"
                 )
+            # Range-check each folder id before it ever reaches sqlite3
+            # parameter binding. A JSON payload can carry an integer wider
+            # than SQLite's signed 64-bit column type (e.g. 2**63), which
+            # would raise OverflowError inside the workspace-linked lookup
+            # below and escape as a 500. source_snapshot_id already has the
+            # same guard just below; folder-scoped runs need it too.
+            _SQLITE_INT_MIN = -(1 << 63)
+            _SQLITE_INT_MAX = (1 << 63) - 1
+            if any(
+                fid < _SQLITE_INT_MIN or fid > _SQLITE_INT_MAX
+                for fid in folder_ids
+            ):
+                return json_error(
+                    "folder_ids contains a value outside SQLite's "
+                    "signed 64-bit integer range"
+                )
             # Reject folders the active workspace has no claim on (mirrors
             # the rescan guard): a stale UI or crafted request must not
             # pollute this workspace with another workspace's scan output.
@@ -16626,6 +16642,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # active workspace, so unrelated descendants can never leak in.
             ws_for_folders = db._active_workspace_id
             subtree_ids = set()
+            # Import _chunks so the path-prefix workspace filter below can
+            # split large legacy subtrees across multiple IN(...) statements.
+            from db import _SQLITE_PARAM_CHUNK_SIZE, _chunks  # noqa: PLC0415
             for fid in folder_ids:
                 linked = db.conn.execute(
                     "SELECT 1 FROM workspace_folders "
@@ -16637,13 +16656,32 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 # Union — a workspace can link both a root and a nested
                 # folder, so the same descendant can appear twice.
                 subtree_ids.update(db.get_folder_subtree_ids(fid))
+                # get_folder_subtree_ids walks folders.parent_id only, so
+                # legacy rows whose parent_id is NULL — but whose paths sit
+                # under the requested folder — never appear. Every other
+                # subtree consumer in db.py (folder deletion, rescan,
+                # missing-originals, workspace linking) already reads through
+                # _folder_subtree_ids_by_path for exactly this reason;
+                # without the same fallback here, processing a workspace root
+                # would silently skip legacy descendant photos the rest of
+                # the app still treats as part of that folder. Intersect the
+                # path-based descendants with the workspace's folder set so
+                # nothing leaks in from another workspace that happens to
+                # share a path prefix.
+                for chunk in _chunks(db._folder_subtree_ids_by_path(fid)):
+                    marks = ",".join("?" for _ in chunk)
+                    rows = db.conn.execute(
+                        f"SELECT folder_id FROM workspace_folders "
+                        f"WHERE workspace_id = ? AND folder_id IN ({marks})",
+                        [ws_for_folders] + list(chunk),
+                    )
+                    subtree_ids.update(r["folder_id"] for r in rows)
             # A large workspace root can expand into thousands of descendant
             # folder ids — more than SQLite's per-statement bound-parameter
             # cap on legacy builds (SQLITE_MAX_VARIABLE_NUMBER = 999). Chunk
             # the IN(...) lookup so a wide folder subtree doesn't blow up as
             # an OperationalError before the job is even queued. Same pattern
             # db.py uses for other large id scopes (see _chunks in db.py).
-            from db import _SQLITE_PARAM_CHUNK_SIZE  # noqa: PLC0415
             subtree_id_list = list(subtree_ids)
             photo_ids = []
             for start in range(0, len(subtree_id_list), _SQLITE_PARAM_CHUNK_SIZE):

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -16577,13 +16577,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # its subtree, so a workspace root must include every descendant's
         # photos, not just the ones hanging directly off the root.
         #
-        # The ad-hoc collection is *not* inserted here: it is deferred to
-        # ``_materialize_folder_scope_collection`` below, which runs only
-        # after every other request check has passed. If we inserted up
-        # front, a later 400 (relative destination, remote_target_id
-        # mismatch, local_processing conflict, folder_template with '..')
-        # would leave a stray "Process …" collection in the workspace even
-        # though no job was queued.
+        # The ad-hoc collection is *not* inserted here: it is deferred
+        # until after every other request check has passed AND after
+        # ``PipelineParams`` has been fully constructed (see the block
+        # just after the ``PipelineParams(...)`` call below). If we
+        # inserted up front, a later 400 (relative destination,
+        # remote_target_id mismatch, local_processing conflict,
+        # folder_template with '..', or a coercion-time exception inside
+        # PipelineParams) would leave a stray "Process …" collection in
+        # the workspace even though no job was queued.
         folder_ids = body.get("folder_ids")
         pending_folder_collection = None
         if folder_ids is not None:
@@ -16924,39 +16926,43 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # ``exclude_paths`` / ``exclude_photo_ids`` are coerced inside the
         # PipelineParams constructor via ``set(body.get(field, []))``. A
         # JSON ``null`` overrides the default, turning that into
-        # ``set(None)`` which raises TypeError. Since the folder-scope
-        # collection row is committed just below, an unvalidated crash in
-        # PipelineParams would leave a stray "Process …" collection with
-        # no queued job. Reject present-but-non-list values (including
-        # explicit ``null``) up front — same reason miss_enabled is
-        # checked here rather than at the constructor site. Key-presence
-        # (not truthiness) is what matters: missing keys fall through to
-        # the ``[]`` default, but ``{"exclude_paths": null}`` must 400.
-        for _list_field in ("exclude_paths", "exclude_photo_ids"):
-            if _list_field in body and not isinstance(body[_list_field], list):
+        # ``set(None)`` which raises TypeError. A list whose *entries*
+        # aren't hashable (e.g. ``{"exclude_paths": [{}]}``) reaches
+        # ``set([...])`` and raises ``TypeError: unhashable type`` for the
+        # same reason. Both cases would otherwise leave a stray "Process
+        # …" collection when a folder scope is materialized before
+        # PipelineParams runs. Reject at the request boundary so the
+        # caller sees a clean 400 and no side effects. Key-presence (not
+        # truthiness) is what matters: missing keys fall through to the
+        # ``[]`` default, but ``{"exclude_paths": null}`` must 400.
+        if "exclude_paths" in body:
+            _paths_value = body["exclude_paths"]
+            if not isinstance(_paths_value, list):
                 return json_error(
-                    f"{_list_field} must be a list, got "
-                    f"{type(body[_list_field]).__name__}"
+                    "exclude_paths must be a list, got "
+                    f"{type(_paths_value).__name__}"
                 )
-
-        # All request validation has passed — safe to materialize the
-        # folder-scope collection row now. Deferring this insert avoids the
-        # stray "Process …" collection that would linger in the workspace
-        # if any earlier check above returned 400 after add_collection had
-        # already committed.
-        if pending_folder_collection is not None:
-            from datetime import datetime as _dt
-
-            collection_id = db.add_collection(
-                "Process {} {}".format(
-                    pending_folder_collection["leaf"],
-                    _dt.now().strftime("%Y-%m-%d %H:%M"),
-                ),
-                json.dumps([{
-                    "field": "photo_ids",
-                    "value": pending_folder_collection["photo_ids"],
-                }]),
-            )
+            for _entry in _paths_value:
+                if not isinstance(_entry, str):
+                    return json_error(
+                        "exclude_paths entries must be strings, got "
+                        f"{type(_entry).__name__}"
+                    )
+        if "exclude_photo_ids" in body:
+            _ids_value = body["exclude_photo_ids"]
+            if not isinstance(_ids_value, list):
+                return json_error(
+                    "exclude_photo_ids must be a list, got "
+                    f"{type(_ids_value).__name__}"
+                )
+            for _entry in _ids_value:
+                # bool is a subclass of int; exclude it explicitly so the
+                # accepted values stay honest integers.
+                if isinstance(_entry, bool) or not isinstance(_entry, int):
+                    return json_error(
+                        "exclude_photo_ids entries must be integers, got "
+                        f"{type(_entry).__name__}"
+                    )
 
         # Snapshot the resolved target dict so the queued run archives to the
         # host/mount the user saw at click-Start, not whatever the saved target
@@ -16997,6 +17003,27 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             exclude_photo_ids=set(body.get("exclude_photo_ids", [])) or None,
             recursive=body.get("recursive", True),
         )
+
+        # All request validation and param coercion have passed — safe to
+        # materialize the folder-scope collection row now. Deferring the
+        # insert past PipelineParams construction closes the last window
+        # where a coercion-time exception (e.g. an unhashable exclude
+        # entry that slipped past the guards above) could leave a stray
+        # "Process …" collection behind after the request failed.
+        if pending_folder_collection is not None:
+            from datetime import datetime as _dt
+
+            collection_id = db.add_collection(
+                "Process {} {}".format(
+                    pending_folder_collection["leaf"],
+                    _dt.now().strftime("%Y-%m-%d %H:%M"),
+                ),
+                json.dumps([{
+                    "field": "photo_ids",
+                    "value": pending_folder_collection["photo_ids"],
+                }]),
+            )
+            params.collection_id = collection_id
 
         # Auto-skip classify stages if no model is available
         model_warning = None

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -16739,6 +16739,24 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error(
                 "destination is not allowed when source_snapshot_id is set"
             )
+        # Same reasoning for collection- and folder-scope runs: any
+        # ``collection_id`` (whether supplied directly or derived from
+        # ``folder_ids`` below) sets ``skip_scan`` in run_pipeline_job, so
+        # ``scanner_stage`` returns before the ingest block that would copy
+        # to ``destination``. The job's step list still includes ingest for
+        # ``params.destination``, so the user would see a queued process run
+        # that ignores the requested copy target and leaves ingest pending.
+        # Local-processing runs with these scopes are rejected below with a
+        # dedicated message; this guards the plain-``destination`` case that
+        # otherwise slips through when ``local_processing`` is false.
+        if destination and (
+            collection_id is not None or folder_ids is not None
+        ):
+            return json_error(
+                "destination is not allowed with collection_id or folder_ids "
+                "— collection and folder scopes skip ingest, so a copy "
+                "destination would never be written"
+            )
         if destination and not os.path.isabs(destination):
             return json_error("destination must be an absolute path")
         # Remote (SSH) archive destination — mirrors the Move page's

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -16595,14 +16595,23 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # folder-derived ``collection_id`` and run the snapshot scope
             # instead — the job would process a different scope than the
             # request implies.
-            other_scopes = [
-                name for name, value in (
-                    ("collection_id", collection_id),
-                    ("source", source),
-                    ("sources", sources),
-                    ("source_snapshot_id", source_snapshot_id),
-                ) if value is not None
-            ]
+            #
+            # ``source``/``sources`` are checked for truthiness (not just
+            # ``is not None``) because the rest of this endpoint treats
+            # empty string / empty list as omitted (see the required-scope
+            # check below and the ``if sources:`` / ``elif source:``
+            # dispatch above). Otherwise a generic pipeline form that
+            # always emits ``source: ""`` / ``sources: []`` would falsely
+            # 400 every folder-scoped run.
+            other_scopes = []
+            if collection_id is not None:
+                other_scopes.append("collection_id")
+            if source:
+                other_scopes.append("source")
+            if sources:
+                other_scopes.append("sources")
+            if source_snapshot_id is not None:
+                other_scopes.append("source_snapshot_id")
             if other_scopes:
                 return json_error(
                     "folder_ids cannot be combined with "
@@ -16911,6 +16920,24 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 f"miss_enabled must be boolean, got "
                 f"{type(miss_enabled_body).__name__}"
             )
+
+        # ``exclude_paths`` / ``exclude_photo_ids`` are coerced inside the
+        # PipelineParams constructor via ``set(body.get(field, []))``. A
+        # JSON ``null`` overrides the default, turning that into
+        # ``set(None)`` which raises TypeError. Since the folder-scope
+        # collection row is committed just below, an unvalidated crash in
+        # PipelineParams would leave a stray "Process …" collection with
+        # no queued job. Reject present-but-non-list values (including
+        # explicit ``null``) up front — same reason miss_enabled is
+        # checked here rather than at the constructor site. Key-presence
+        # (not truthiness) is what matters: missing keys fall through to
+        # the ``[]`` default, but ``{"exclude_paths": null}`` must 400.
+        for _list_field in ("exclude_paths", "exclude_photo_ids"):
+            if _list_field in body and not isinstance(body[_list_field], list):
+                return json_error(
+                    f"{_list_field} must be a list, got "
+                    f"{type(body[_list_field]).__name__}"
+                )
 
         # All request validation has passed — safe to materialize the
         # folder-scope collection row now. Deferring this insert avoids the

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -7114,6 +7114,39 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         result["folders"] = [dict(f) for f in db.get_workspace_folder_roots(ws["id"])]
         return jsonify(result)
 
+    def _validate_workspace_config_overrides(overrides):
+        """Validate ``config_overrides`` before persist. Returns an error
+        response (from ``json_error``) on rejection, or None on success.
+
+        Shared by POST /api/workspaces and PUT /api/workspaces/<id> so a
+        workspace created with a bogus ``pipeline.default_strategy`` can't
+        later feed the import/process settings or chaining hook an unknown
+        strategy — the update path already rejects it and the create path
+        must too, otherwise the create endpoint becomes a validation bypass.
+        """
+        # Anything else would be persisted as-is and crash the labels
+        # accessors that expect a JSON object (or NULL) in this column.
+        if overrides is not None and not isinstance(overrides, dict):
+            return json_error("config_overrides must be an object or null")
+        # pipeline.default_strategy: None means "no automatic processing
+        # after import" (the chaining hook short-circuits on it) and is
+        # accepted as-is; a string must name a real strategy. The string
+        # "none" is NOT the null sentinel — one vocabulary with
+        # /api/jobs/pipeline, which also rejects it.
+        pipeline_overrides = (overrides or {}).get("pipeline")
+        if (
+            isinstance(pipeline_overrides, dict)
+            and "default_strategy" in pipeline_overrides
+            and pipeline_overrides["default_strategy"] is not None
+        ):
+            from process_strategies import resolve_strategy
+
+            try:
+                resolve_strategy(pipeline_overrides["default_strategy"])
+            except ValueError as e:
+                return json_error(str(e))
+        return None
+
     @app.route("/api/workspaces", methods=["POST"])
     def api_create_workspace():
         db = _get_db()
@@ -7121,8 +7154,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         name = body.get("name", "").strip()
         if not name:
             return json_error("Name is required")
+        config_overrides = body.get("config_overrides")
+        err = _validate_workspace_config_overrides(config_overrides)
+        if err is not None:
+            return err
         try:
-            ws_id = db.create_workspace(name, config_overrides=body.get("config_overrides"))
+            ws_id = db.create_workspace(name, config_overrides=config_overrides)
             # Seed the standard smart collections (All Photos, Flagged, etc.).
             # Startup only seeds the active workspace, so without this a
             # workspace created via the API never gets defaults until it's
@@ -7151,27 +7188,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             kwargs["name"] = body["name"]
         if "config_overrides" in body:
             overrides = body["config_overrides"]
-            # Anything else would be persisted as-is and crash the labels
-            # accessors that expect a JSON object (or NULL) in this column.
-            if overrides is not None and not isinstance(overrides, dict):
-                return json_error("config_overrides must be an object or null")
-            # pipeline.default_strategy: None means "no automatic processing
-            # after import" (the chaining hook short-circuits on it) and is
-            # accepted as-is; a string must name a real strategy. The string
-            # "none" is NOT the null sentinel — one vocabulary with
-            # /api/jobs/pipeline, which also rejects it.
-            pipeline_overrides = (overrides or {}).get("pipeline")
-            if (
-                isinstance(pipeline_overrides, dict)
-                and "default_strategy" in pipeline_overrides
-                and pipeline_overrides["default_strategy"] is not None
-            ):
-                from process_strategies import resolve_strategy
-
-                try:
-                    resolve_strategy(pipeline_overrides["default_strategy"])
-                except ValueError as e:
-                    return json_error(str(e))
+            err = _validate_workspace_config_overrides(overrides)
+            if err is not None:
+                return err
             kwargs["config_overrides"] = overrides
         if "ui_state" in body:
             kwargs["ui_state"] = body["ui_state"]

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -16576,11 +16576,37 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # collection_stage). The rest of the app treats a folder scope as
         # its subtree, so a workspace root must include every descendant's
         # photos, not just the ones hanging directly off the root.
+        #
+        # The ad-hoc collection is *not* inserted here: it is deferred to
+        # ``_materialize_folder_scope_collection`` below, which runs only
+        # after every other request check has passed. If we inserted up
+        # front, a later 400 (relative destination, remote_target_id
+        # mismatch, local_processing conflict, folder_template with '..')
+        # would leave a stray "Process …" collection in the workspace even
+        # though no job was queued.
         folder_ids = body.get("folder_ids")
+        pending_folder_collection = None
         if folder_ids is not None:
-            if collection_id is not None:
+            # A folder scope is itself a scope — combining it with any other
+            # scope selector is ambiguous. Reject *all* other scopes, not
+            # just ``collection_id``: with ``source``/``sources``, later
+            # ``skip_scan`` handling would silently ignore them; with
+            # ``source_snapshot_id``, run_pipeline_job would clear the
+            # folder-derived ``collection_id`` and run the snapshot scope
+            # instead — the job would process a different scope than the
+            # request implies.
+            other_scopes = [
+                name for name, value in (
+                    ("collection_id", collection_id),
+                    ("source", source),
+                    ("sources", sources),
+                    ("source_snapshot_id", source_snapshot_id),
+                ) if value is not None
+            ]
+            if other_scopes:
                 return json_error(
-                    "folder_ids cannot be combined with collection_id"
+                    "folder_ids cannot be combined with "
+                    + ", ".join(other_scopes)
                 )
             if (
                 not isinstance(folder_ids, list)
@@ -16622,17 +16648,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             leaf = os.path.basename(
                 (first["path"] or "").rstrip("/\\")
             ) or "folders"
-            from datetime import datetime as _dt
+            pending_folder_collection = {
+                "leaf": leaf, "photo_ids": photo_ids,
+            }
 
-            collection_id = db.add_collection(
-                "Process {} {}".format(
-                    leaf, _dt.now().strftime("%Y-%m-%d %H:%M"),
-                ),
-                json.dumps([{"field": "photo_ids", "value": photo_ids}]),
+        if (
+            not source and not sources and not collection_id
+            and not source_snapshot_id and pending_folder_collection is None
+        ):
+            return json_error(
+                "source, sources, collection_id, source_snapshot_id, "
+                "or folder_ids required"
             )
-
-        if not source and not sources and not collection_id and not source_snapshot_id:
-            return json_error("source, sources, collection_id, or source_snapshot_id required")
 
         # Validate type before touching SQLite. Non-integer bodies (objects,
         # arrays, non-numeric strings, floats, bools) would otherwise reach
@@ -16770,16 +16797,23 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # photos and then fail in archive_stage with "local staging folder
         # was not indexed". Snapshot-scoped runs are likewise rejected: they
         # also bypass ingest because the snapshot's existing files drive
-        # scan_roots directly. Reject whenever collection_id or
-        # source_snapshot_id is set — a stale source/sources field in the
-        # same request must not slip past, because run_pipeline_job keys
-        # skip_scan off collection_id alone and would still skip ingest.
+        # scan_roots directly. Folder-scope runs materialize a collection
+        # (below) and share the collection contract, so reject them here
+        # too — otherwise the check would fire on the derived collection_id
+        # after we'd already inserted the collection row. Reject whenever
+        # collection_id, source_snapshot_id, or folder_ids is set — a stale
+        # source/sources field in the same request must not slip past,
+        # because run_pipeline_job keys skip_scan off collection_id alone
+        # and would still skip ingest.
         if local_processing and (
-            collection_id is not None or source_snapshot_id is not None
+            collection_id is not None
+            or source_snapshot_id is not None
+            or pending_folder_collection is not None
         ):
             return json_error(
-                "local_processing cannot be combined with collection_id or "
-                "source_snapshot_id — it requires source or sources"
+                "local_processing cannot be combined with collection_id, "
+                "source_snapshot_id, or folder_ids — it requires source "
+                "or sources"
             )
         if local_processing and not source and not sources:
             return json_error(
@@ -16793,6 +16827,25 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             from ingest import _is_unsafe_path
             if _is_unsafe_path(folder_template):
                 return json_error("folder_template must be a relative path without '..' or backslashes")
+
+        # All request validation has passed — safe to materialize the
+        # folder-scope collection row now. Deferring this insert avoids the
+        # stray "Process …" collection that would linger in the workspace
+        # if any earlier check above returned 400 after add_collection had
+        # already committed.
+        if pending_folder_collection is not None:
+            from datetime import datetime as _dt
+
+            collection_id = db.add_collection(
+                "Process {} {}".format(
+                    pending_folder_collection["leaf"],
+                    _dt.now().strftime("%Y-%m-%d %H:%M"),
+                ),
+                json.dumps([{
+                    "field": "photo_ids",
+                    "value": pending_folder_collection["photo_ids"],
+                }]),
+            )
 
         # Snapshot the resolved target dict so the queued run archives to the
         # host/mount the user saw at click-Start, not whatever the saved target

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -16519,6 +16519,34 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         from pipeline_job import PipelineParams, run_pipeline_job
 
         body = request.get_json(silent=True) or {}
+
+        # Named process strategy: expand server-side into stage flags so the
+        # import page, the process page, and import→process chaining share
+        # one vocabulary (process_strategies.py). Key presence — not
+        # truthiness — decides whether a strategy was requested: a
+        # present-but-null strategy must 400 rather than silently fall
+        # through to default processing for a caller who thought null meant
+        # "no processing" (that case is expressed by not calling this
+        # endpoint at all).
+        strategy_name = None
+        if "strategy" in body:
+            strategy_name = body.get("strategy")
+            if not isinstance(strategy_name, str):
+                kind = (
+                    "null" if strategy_name is None
+                    else type(strategy_name).__name__
+                )
+                return json_error(f"strategy must be a string, got {kind}")
+            from process_strategies import resolve_strategy
+
+            try:
+                expanded = resolve_strategy(strategy_name)
+            except ValueError as e:
+                return json_error(str(e))
+            # Expansion supplies *defaults*; explicitly-present body keys
+            # win, so a caller can pin one flag on top of a preset.
+            body = {**expanded, **body}
+
         db = _get_db()
         source = body.get("source")
         sources = body.get("sources")
@@ -16721,6 +16749,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             skip_extract_masks=body.get("skip_extract_masks", False),
             skip_eye_keypoints=body.get("skip_eye_keypoints", False),
             skip_regroup=body.get("skip_regroup", False),
+            miss_enabled=body.get("miss_enabled"),
             preview_max_size=body.get("preview_max_size"),
             exclude_paths=set(body.get("exclude_paths", [])) or None,
             exclude_photo_ids=set(body.get("exclude_photo_ids", [])) or None,
@@ -16824,9 +16853,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "collection_id": collection_id,
             "destination": destination,
             "local_processing": local_processing,
+            "strategy": strategy_name,
             "skip_classify": params.skip_classify,
             "skip_extract_masks": params.skip_extract_masks,
             "skip_regroup": params.skip_regroup,
+            "miss_enabled": params.miss_enabled,
         }
         if remote_archive_config is not None:
             # Surface that the archive goes over SSH (and to where) so the

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -16637,13 +16637,24 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 # Union — a workspace can link both a root and a nested
                 # folder, so the same descendant can appear twice.
                 subtree_ids.update(db.get_folder_subtree_ids(fid))
-            marks = ",".join("?" for _ in subtree_ids)
-            photo_ids = [
-                r["id"] for r in db.conn.execute(
-                    f"SELECT id FROM photos WHERE folder_id IN ({marks})",
-                    tuple(subtree_ids),
+            # A large workspace root can expand into thousands of descendant
+            # folder ids — more than SQLite's per-statement bound-parameter
+            # cap on legacy builds (SQLITE_MAX_VARIABLE_NUMBER = 999). Chunk
+            # the IN(...) lookup so a wide folder subtree doesn't blow up as
+            # an OperationalError before the job is even queued. Same pattern
+            # db.py uses for other large id scopes (see _chunks in db.py).
+            from db import _SQLITE_PARAM_CHUNK_SIZE  # noqa: PLC0415
+            subtree_id_list = list(subtree_ids)
+            photo_ids = []
+            for start in range(0, len(subtree_id_list), _SQLITE_PARAM_CHUNK_SIZE):
+                chunk = subtree_id_list[start:start + _SQLITE_PARAM_CHUNK_SIZE]
+                marks = ",".join("?" for _ in chunk)
+                photo_ids.extend(
+                    r["id"] for r in db.conn.execute(
+                        f"SELECT id FROM photos WHERE folder_id IN ({marks})",
+                        tuple(chunk),
+                    )
                 )
-            ]
             first = db.get_folder(folder_ids[0])
             leaf = os.path.basename(
                 (first["path"] or "").rstrip("/\\")
@@ -16856,6 +16867,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             dict(remote_archive_config["target"])
             if remote_archive_config is not None else None
         )
+
+        # ``miss_enabled`` is tri-state (None / True / False) so ``body.get``
+        # can't apply a default the way boolean skip_* flags do. Validate it
+        # explicitly instead: pipeline_job.py branches on
+        # ``params.miss_enabled is not None`` and then on truthiness, so a
+        # non-bool value like the string "false" would flow through as
+        # truthy — a caller expecting misses off would get them on.
+        miss_enabled_body = body.get("miss_enabled")
+        if miss_enabled_body is not None and not isinstance(miss_enabled_body, bool):
+            return json_error(
+                f"miss_enabled must be boolean, got "
+                f"{type(miss_enabled_body).__name__}"
+            )
         params = PipelineParams(
             collection_id=collection_id,
             source=source,
@@ -16990,6 +17014,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "skip_regroup": params.skip_regroup,
             "miss_enabled": params.miss_enabled,
         }
+        # Preserve the caller's original folder_ids alongside the derived
+        # ad-hoc collection_id so the Jobs page can show both what the user
+        # selected (folder subtree) and the collection the run was pinned to
+        # without a secondary collection lookup.
+        if folder_ids is not None:
+            job_config["folder_ids"] = list(folder_ids)
         if remote_archive_config is not None:
             # Surface that the archive goes over SSH (and to where) so the
             # jobs panel can show it, per the UI-transparency rule.

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -17024,6 +17024,36 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 f"{type(miss_enabled_body).__name__}"
             )
 
+        # Validate ``model_id`` / ``model_ids`` shape BEFORE the folder-scope
+        # collection is materialized. The auto-skip-classify block further
+        # down calls ``list(params.model_ids or [])`` and ``by_id.get(mid, ...)``
+        # in ways that raise TypeError on non-list / non-hashable payloads
+        # (e.g. ``model_ids: 5`` or an entry that's a list/dict). Without
+        # this guard those escape as opaque 500s, and for folder-scoped
+        # runs ``db.add_collection`` has already committed by then, leaving
+        # a stray "Process …" collection in the workspace after the request
+        # fails. Rejecting up front keeps error responses 4xx and prevents
+        # orphaned rows on every scope shape.
+        model_id_body = body.get("model_id")
+        if model_id_body is not None and not isinstance(model_id_body, str):
+            return json_error(
+                f"model_id must be a string, got "
+                f"{type(model_id_body).__name__}"
+            )
+        model_ids_body = body.get("model_ids")
+        if model_ids_body is not None:
+            if not isinstance(model_ids_body, list):
+                return json_error(
+                    f"model_ids must be a list, got "
+                    f"{type(model_ids_body).__name__}"
+                )
+            for _mid in model_ids_body:
+                if not isinstance(_mid, str):
+                    return json_error(
+                        f"model_ids entries must be strings, got "
+                        f"{type(_mid).__name__}"
+                    )
+
         # Snapshot the resolved target dict so the queued run archives to the
         # host/mount the user saw at click-Start, not whatever the saved target
         # gets edited to while another pipeline holds the slot. Mirrors how the

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -7155,6 +7155,23 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # accessors that expect a JSON object (or NULL) in this column.
             if overrides is not None and not isinstance(overrides, dict):
                 return json_error("config_overrides must be an object or null")
+            # pipeline.default_strategy: None means "no automatic processing
+            # after import" (the chaining hook short-circuits on it) and is
+            # accepted as-is; a string must name a real strategy. The string
+            # "none" is NOT the null sentinel — one vocabulary with
+            # /api/jobs/pipeline, which also rejects it.
+            pipeline_overrides = (overrides or {}).get("pipeline")
+            if (
+                isinstance(pipeline_overrides, dict)
+                and "default_strategy" in pipeline_overrides
+                and pipeline_overrides["default_strategy"] is not None
+            ):
+                from process_strategies import resolve_strategy
+
+                try:
+                    resolve_strategy(pipeline_overrides["default_strategy"])
+                except ValueError as e:
+                    return json_error(str(e))
             kwargs["config_overrides"] = overrides
         if "ui_state" in body:
             kwargs["ui_state"] = body["ui_state"]

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -16553,6 +16553,67 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         collection_id = body.get("collection_id")
         source_snapshot_id = body.get("source_snapshot_id")
 
+        # Folder scope: resolve folder_ids to their active-workspace subtrees
+        # and materialize an ad-hoc collection, then proceed as a collection
+        # run — the same pattern import runs use (see pipeline_job's
+        # collection_stage). The rest of the app treats a folder scope as
+        # its subtree, so a workspace root must include every descendant's
+        # photos, not just the ones hanging directly off the root.
+        folder_ids = body.get("folder_ids")
+        if folder_ids is not None:
+            if collection_id is not None:
+                return json_error(
+                    "folder_ids cannot be combined with collection_id"
+                )
+            if (
+                not isinstance(folder_ids, list)
+                or not folder_ids
+                or any(
+                    isinstance(fid, bool) or not isinstance(fid, int)
+                    for fid in folder_ids
+                )
+            ):
+                return json_error(
+                    "folder_ids must be a non-empty list of integers"
+                )
+            # Reject folders the active workspace has no claim on (mirrors
+            # the rescan guard): a stale UI or crafted request must not
+            # pollute this workspace with another workspace's scan output.
+            # get_folder_subtree_ids itself refuses to walk out of the
+            # active workspace, so unrelated descendants can never leak in.
+            ws_for_folders = db._active_workspace_id
+            subtree_ids = set()
+            for fid in folder_ids:
+                linked = db.conn.execute(
+                    "SELECT 1 FROM workspace_folders "
+                    "WHERE workspace_id = ? AND folder_id = ?",
+                    (ws_for_folders, fid),
+                ).fetchone()
+                if not linked:
+                    return json_error("folder not found", 404)
+                # Union — a workspace can link both a root and a nested
+                # folder, so the same descendant can appear twice.
+                subtree_ids.update(db.get_folder_subtree_ids(fid))
+            marks = ",".join("?" for _ in subtree_ids)
+            photo_ids = [
+                r["id"] for r in db.conn.execute(
+                    f"SELECT id FROM photos WHERE folder_id IN ({marks})",
+                    tuple(subtree_ids),
+                )
+            ]
+            first = db.get_folder(folder_ids[0])
+            leaf = os.path.basename(
+                (first["path"] or "").rstrip("/\\")
+            ) or "folders"
+            from datetime import datetime as _dt
+
+            collection_id = db.add_collection(
+                "Process {} {}".format(
+                    leaf, _dt.now().strftime("%Y-%m-%d %H:%M"),
+                ),
+                json.dumps([{"field": "photo_ids", "value": photo_ids}]),
+            )
+
         if not source and not sources and not collection_id and not source_snapshot_id:
             return json_error("source, sources, collection_id, or source_snapshot_id required")
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -16605,6 +16605,53 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # folder_template with '..', or a coercion-time exception inside
         # PipelineParams) would leave a stray "Process …" collection in
         # the workspace even though no job was queued.
+        # ``exclude_paths`` / ``exclude_photo_ids`` are validated up front —
+        # before the folder-scope subtree is resolved — so a folder-scoped
+        # request that includes preview deselections can honor them at
+        # collection-materialization time. run_pipeline_job's
+        # ``_filter_excluded`` only checks ``exclude_photo_ids``; without
+        # applying ``exclude_paths`` at the ad-hoc collection boundary, a
+        # deselected path is still thumbnailed, classified, and regrouped
+        # once the folder collection materializes. Early validation also
+        # matches the coercion the PipelineParams constructor would
+        # otherwise perform via ``set(body.get(field, []))``, where a JSON
+        # ``null`` or unhashable list entry would raise TypeError and leave
+        # a stray "Process …" collection behind. Key-presence (not
+        # truthiness) matters: missing keys fall through to the default,
+        # but ``{"exclude_paths": null}`` must 400.
+        excluded_paths_set: set[str] = set()
+        if "exclude_paths" in body:
+            _paths_value = body["exclude_paths"]
+            if not isinstance(_paths_value, list):
+                return json_error(
+                    "exclude_paths must be a list, got "
+                    f"{type(_paths_value).__name__}"
+                )
+            for _entry in _paths_value:
+                if not isinstance(_entry, str):
+                    return json_error(
+                        "exclude_paths entries must be strings, got "
+                        f"{type(_entry).__name__}"
+                    )
+            excluded_paths_set = set(_paths_value)
+        excluded_photo_ids_set: set[int] = set()
+        if "exclude_photo_ids" in body:
+            _ids_value = body["exclude_photo_ids"]
+            if not isinstance(_ids_value, list):
+                return json_error(
+                    "exclude_photo_ids must be a list, got "
+                    f"{type(_ids_value).__name__}"
+                )
+            for _entry in _ids_value:
+                # bool is a subclass of int; exclude it explicitly so the
+                # accepted values stay honest integers.
+                if isinstance(_entry, bool) or not isinstance(_entry, int):
+                    return json_error(
+                        "exclude_photo_ids entries must be integers, got "
+                        f"{type(_entry).__name__}"
+                    )
+            excluded_photo_ids_set = set(_ids_value)
+
         folder_ids = body.get("folder_ids")
         pending_folder_collection = None
         if folder_ids is not None:
@@ -16713,16 +16760,51 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # an OperationalError before the job is even queued. Same pattern
             # db.py uses for other large id scopes (see _chunks in db.py).
             subtree_id_list = list(subtree_ids)
+            # Fetch the folder paths for the whole subtree so we can compose
+            # per-photo full paths and honor ``exclude_paths`` at the
+            # collection boundary. Skip the lookup entirely when the user
+            # sent no path exclusions — a workspace-root scope can span
+            # thousands of folders and the join is pointless when nothing
+            # would be filtered.
+            folder_path_by_id: dict[int, str] = {}
+            if excluded_paths_set:
+                for start in range(0, len(subtree_id_list), _SQLITE_PARAM_CHUNK_SIZE):
+                    chunk = subtree_id_list[start:start + _SQLITE_PARAM_CHUNK_SIZE]
+                    marks = ",".join("?" for _ in chunk)
+                    for r in db.conn.execute(
+                        f"SELECT id, path FROM folders WHERE id IN ({marks})",
+                        tuple(chunk),
+                    ):
+                        folder_path_by_id[r["id"]] = r["path"] or ""
             photo_ids = []
             for start in range(0, len(subtree_id_list), _SQLITE_PARAM_CHUNK_SIZE):
                 chunk = subtree_id_list[start:start + _SQLITE_PARAM_CHUNK_SIZE]
                 marks = ",".join("?" for _ in chunk)
-                photo_ids.extend(
-                    r["id"] for r in db.conn.execute(
-                        f"SELECT id FROM photos WHERE folder_id IN ({marks})",
-                        tuple(chunk),
-                    )
-                )
+                # Select (id, folder_id, filename) so we can compose each
+                # photo's full path in-Python to compare against
+                # ``exclude_paths``. Matching the same os.path.join shape
+                # scanner/ingest use for their ``skip_paths`` sets keeps
+                # deselections consistent across import and process runs.
+                # Filter ``exclude_photo_ids`` here too so the ad-hoc
+                # collection reflects exactly what the user asked to
+                # process; ``_filter_excluded`` would drop them again later
+                # but there is no reason to bake them into the collection
+                # membership.
+                for r in db.conn.execute(
+                    f"SELECT id, folder_id, filename FROM photos "
+                    f"WHERE folder_id IN ({marks})",
+                    tuple(chunk),
+                ):
+                    if r["id"] in excluded_photo_ids_set:
+                        continue
+                    if excluded_paths_set:
+                        full = os.path.join(
+                            folder_path_by_id.get(r["folder_id"], ""),
+                            r["filename"] or "",
+                        )
+                        if full in excluded_paths_set:
+                            continue
+                    photo_ids.append(r["id"])
             first = db.get_folder(folder_ids[0])
             leaf = os.path.basename(
                 (first["path"] or "").rstrip("/\\")
@@ -16942,47 +17024,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 f"{type(miss_enabled_body).__name__}"
             )
 
-        # ``exclude_paths`` / ``exclude_photo_ids`` are coerced inside the
-        # PipelineParams constructor via ``set(body.get(field, []))``. A
-        # JSON ``null`` overrides the default, turning that into
-        # ``set(None)`` which raises TypeError. A list whose *entries*
-        # aren't hashable (e.g. ``{"exclude_paths": [{}]}``) reaches
-        # ``set([...])`` and raises ``TypeError: unhashable type`` for the
-        # same reason. Both cases would otherwise leave a stray "Process
-        # …" collection when a folder scope is materialized before
-        # PipelineParams runs. Reject at the request boundary so the
-        # caller sees a clean 400 and no side effects. Key-presence (not
-        # truthiness) is what matters: missing keys fall through to the
-        # ``[]`` default, but ``{"exclude_paths": null}`` must 400.
-        if "exclude_paths" in body:
-            _paths_value = body["exclude_paths"]
-            if not isinstance(_paths_value, list):
-                return json_error(
-                    "exclude_paths must be a list, got "
-                    f"{type(_paths_value).__name__}"
-                )
-            for _entry in _paths_value:
-                if not isinstance(_entry, str):
-                    return json_error(
-                        "exclude_paths entries must be strings, got "
-                        f"{type(_entry).__name__}"
-                    )
-        if "exclude_photo_ids" in body:
-            _ids_value = body["exclude_photo_ids"]
-            if not isinstance(_ids_value, list):
-                return json_error(
-                    "exclude_photo_ids must be a list, got "
-                    f"{type(_ids_value).__name__}"
-                )
-            for _entry in _ids_value:
-                # bool is a subclass of int; exclude it explicitly so the
-                # accepted values stay honest integers.
-                if isinstance(_entry, bool) or not isinstance(_entry, int):
-                    return json_error(
-                        "exclude_photo_ids entries must be integers, got "
-                        f"{type(_entry).__name__}"
-                    )
-
         # Snapshot the resolved target dict so the queued run archives to the
         # host/mount the user saw at click-Start, not whatever the saved target
         # gets edited to while another pipeline holds the slot. Mirrors how the
@@ -17018,8 +17059,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             skip_regroup=body.get("skip_regroup", False),
             miss_enabled=body.get("miss_enabled"),
             preview_max_size=body.get("preview_max_size"),
-            exclude_paths=set(body.get("exclude_paths", [])) or None,
-            exclude_photo_ids=set(body.get("exclude_photo_ids", [])) or None,
+            exclude_paths=excluded_paths_set or None,
+            exclude_photo_ids=excluded_photo_ids_set or None,
             recursive=body.get("recursive", True),
         )
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -16857,6 +16857,23 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if _is_unsafe_path(folder_template):
                 return json_error("folder_template must be a relative path without '..' or backslashes")
 
+        # ``miss_enabled`` is tri-state (None / True / False) so ``body.get``
+        # can't apply a default the way boolean skip_* flags do. Validate it
+        # explicitly instead: pipeline_job.py branches on
+        # ``params.miss_enabled is not None`` and then on truthiness, so a
+        # non-bool value like the string "false" would flow through as
+        # truthy — a caller expecting misses off would get them on.
+        #
+        # Validate BEFORE the folder-scope collection is materialized so a
+        # bad value 400s cleanly; otherwise ``db.add_collection`` commits
+        # first and the rejected request leaves a stray "Process …" row.
+        miss_enabled_body = body.get("miss_enabled")
+        if miss_enabled_body is not None and not isinstance(miss_enabled_body, bool):
+            return json_error(
+                f"miss_enabled must be boolean, got "
+                f"{type(miss_enabled_body).__name__}"
+            )
+
         # All request validation has passed — safe to materialize the
         # folder-scope collection row now. Deferring this insert avoids the
         # stray "Process …" collection that would linger in the workspace
@@ -16885,19 +16902,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             dict(remote_archive_config["target"])
             if remote_archive_config is not None else None
         )
-
-        # ``miss_enabled`` is tri-state (None / True / False) so ``body.get``
-        # can't apply a default the way boolean skip_* flags do. Validate it
-        # explicitly instead: pipeline_job.py branches on
-        # ``params.miss_enabled is not None`` and then on truthiness, so a
-        # non-bool value like the string "false" would flow through as
-        # truthy — a caller expecting misses off would get them on.
-        miss_enabled_body = body.get("miss_enabled")
-        if miss_enabled_body is not None and not isinstance(miss_enabled_body, bool):
-            return json_error(
-                f"miss_enabled must be boolean, got "
-                f"{type(miss_enabled_body).__name__}"
-            )
         params = PipelineParams(
             collection_id=collection_id,
             source=source,

--- a/vireo/config.py
+++ b/vireo/config.py
@@ -90,6 +90,10 @@ DEFAULTS = {
     "cull_phash_threshold": 19,
     # --- Pipeline (nested — flows through effective_cfg.get("pipeline")) ---
     "pipeline": {
+        # Process strategy to run after an import. None = no automatic
+        # processing (the "import only" choice); otherwise a name from
+        # process_strategies.STRATEGIES. Per-workspace via config_overrides.
+        "default_strategy": None,
         "w_focus": 0.45,
         "w_exposure": 0.20,
         "w_composition": 0.15,

--- a/vireo/config_schema.py
+++ b/vireo/config_schema.py
@@ -364,11 +364,17 @@ SCHEMA = {
 
     # --- Pipeline (scoring weights & rejection thresholds) ---------------
     "pipeline.default_strategy": {
-        # Workspace-scoped: consumed by the import→process chaining hook
-        # via db.get_effective_config(cfg.load()). None (import only) is the
-        # DEFAULTS value; `nullable` here lets the workspace override the
-        # global default back to null via /api/settings/workspace, and the
-        # settings UI renders the null option so users can pick it.
+        # Workspace-scoped: the stored value the future import→process
+        # chaining hook will read via db.get_effective_config(cfg.load()).
+        # None (import only) is the DEFAULTS value; `nullable` here lets a
+        # workspace override the global default back to null via
+        # /api/settings/workspace, and the settings UI renders the null
+        # option so users can pick it. This PR (the import/process split
+        # phase 1) ships the storage, validation, and UI surfaces only —
+        # the chaining hook that actually enqueues the run at import
+        # completion is added in a follow-up PR, so today the setting is
+        # a stored preference and imports do not auto-chain regardless of
+        # the value.
         "type": "enum",
         "enum": ["full", "cull_ready", "quick_look"],
         "enum_labels": {
@@ -380,7 +386,11 @@ SCHEMA = {
         "null_label": "Import only (no processing)",
         "category": "Pipeline", "scope": "workspace",
         "label": "Default process strategy",
-        "desc": "Strategy run automatically after an import completes on this workspace.",
+        "desc": (
+            "Default strategy for post-import processing on this workspace. "
+            "Stored preference only in this release — automatic "
+            "import→process chaining is wired in a follow-up update."
+        ),
     },
     "pipeline.w_focus": {
         "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,

--- a/vireo/config_schema.py
+++ b/vireo/config_schema.py
@@ -366,8 +366,9 @@ SCHEMA = {
     "pipeline.default_strategy": {
         # Workspace-scoped: consumed by the import→process chaining hook
         # via db.get_effective_config(cfg.load()). None (import only) is the
-        # DEFAULTS value; validation of the workspace override is done in
-        # /api/workspaces/<id> via resolve_strategy so null passes through.
+        # DEFAULTS value; `nullable` here lets the workspace override the
+        # global default back to null via /api/settings/workspace, and the
+        # settings UI renders the null option so users can pick it.
         "type": "enum",
         "enum": ["full", "cull_ready", "quick_look"],
         "enum_labels": {
@@ -375,6 +376,8 @@ SCHEMA = {
             "cull_ready": "Cull-ready",
             "quick_look": "Quick look",
         },
+        "nullable": True,
+        "null_label": "Import only (no processing)",
         "category": "Pipeline", "scope": "workspace",
         "label": "Default process strategy",
         "desc": "Strategy run automatically after an import completes on this workspace.",
@@ -810,11 +813,19 @@ def validate_value(key, raw):
 
     Returns the coerced value. Raises :class:`ValidationError` on any failure
     (unknown key, type mismatch, out-of-range, unknown enum value, etc.).
+
+    Fields with ``nullable: True`` accept ``None`` (and the empty string, as
+    the settings UI serializes a null <option> as ``value=""``) and return
+    ``None`` — used for enums where "unset" is a meaningful third state
+    distinct from any listed choice (e.g. ``pipeline.default_strategy`` where
+    null means "import only, no processing").
     """
     if key not in SCHEMA:
         raise ValidationError(f"unknown setting {key!r}")
     spec = SCHEMA[key]
     kind = spec["type"]
+    if spec.get("nullable") and (raw is None or raw == ""):
+        return None
     value = _coerce(raw, kind)
 
     if kind in ("int", "float"):

--- a/vireo/config_schema.py
+++ b/vireo/config_schema.py
@@ -363,6 +363,22 @@ SCHEMA = {
     },
 
     # --- Pipeline (scoring weights & rejection thresholds) ---------------
+    "pipeline.default_strategy": {
+        # Workspace-scoped: consumed by the import→process chaining hook
+        # via db.get_effective_config(cfg.load()). None (import only) is the
+        # DEFAULTS value; validation of the workspace override is done in
+        # /api/workspaces/<id> via resolve_strategy so null passes through.
+        "type": "enum",
+        "enum": ["full", "cull_ready", "quick_look"],
+        "enum_labels": {
+            "full": "Full",
+            "cull_ready": "Cull-ready",
+            "quick_look": "Quick look",
+        },
+        "category": "Pipeline", "scope": "workspace",
+        "label": "Default process strategy",
+        "desc": "Strategy run automatically after an import completes on this workspace.",
+    },
     "pipeline.w_focus": {
         "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
         "category": "Pipeline", "scope": "both",

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -119,6 +119,13 @@ class PipelineParams:
     skip_regroup: bool = False
     skip_classify: bool = False
     skip_eye_keypoints: bool = False
+    # Per-run override for the config-gated misses stage. None defers to the
+    # workspace-effective ``pipeline.miss_enabled`` (today's behavior); a
+    # bool wins over workspace config in BOTH directions, mirroring how the
+    # skip_* flags override workspace defaults. Process strategies
+    # (process_strategies.py) set this so e.g. cull_ready suppresses misses
+    # on a workspace that has them enabled.
+    miss_enabled: bool | None = None
     download_taxonomy: bool = True
     # None means "use the workspace-effective preview_max_size setting".
     # Explicit values are kept for API/back-compat and tests that need to pin
@@ -4945,10 +4952,9 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                    summary="Skipped")
                 return
 
-            stages["misses"]["status"] = "running"
-            runner.update_step(job["id"], "misses", status="running")
-            _update_stages(runner, job["id"], stages)
-
+            # Hoisted from the try: block below so the miss_enabled guard can
+            # read effective config before the transient "running" status is
+            # written.
             try:
                 from datetime import UTC, datetime
 
@@ -4961,13 +4967,58 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
 
                 effective_cfg = thread_db.get_effective_config(cfg.load())
                 pipeline_cfg = effective_cfg.get("pipeline", {})
+            except Exception as e:
+                # Mark the stage failed BEFORE returning. The transient
+                # "running" write is *below* this guard, so without stamping
+                # "failed" here the stage would stay "pending"; the pipeline
+                # finalizer treats absence-of-failed as success and would
+                # wrongly mark the whole job completed despite a fatal setup
+                # error (cfg.load, Database(...), or any import raising).
+                stages["misses"]["status"] = "failed"
+                runner.update_step(job["id"], "misses", status="failed",
+                                   error=str(e))
+                errors.append(f"[misses] Fatal: {e}")
+                log.exception("Pipeline miss-detection setup failed")
+                _update_stages(runner, job["id"], stages)
+                return
 
+            # Effective miss_enabled: per-run PipelineParams override wins
+            # over workspace config, mirroring how other skip_* flags
+            # override workspace defaults. Inject the effective value into
+            # pipeline_cfg *before* the guard so both branches — the
+            # short-circuit skip AND the fall-through to compute — see the
+            # same value: compute_misses_for_workspace reads
+            # pipeline_cfg["miss_enabled"] itself, so a strategy that
+            # enables misses on a workspace where they're disabled would
+            # otherwise get a silent 0 from compute.
+            if params.miss_enabled is not None:
+                pipeline_cfg = {**pipeline_cfg,
+                                "miss_enabled": params.miss_enabled}
+            miss_enabled = pipeline_cfg.get("miss_enabled", True)
+            if not miss_enabled:
+                # Do NOT fall through to compute_misses_for_workspace: it
+                # returns 0 when disabled and the completion path would then
+                # stamp "0 photos evaluated", which reads as "misses ran and
+                # found none" rather than "misses were disabled". Skipping
+                # here also leaves the miss_computed_at cache marker
+                # unstamped, which pipeline_review's "current-run misses"
+                # shortcut depends on.
+                stages["misses"]["status"] = "skipped"
+                runner.update_step(job["id"], "misses", status="completed",
+                                   summary="Skipped")
+                _update_stages(runner, job["id"], stages)
+                return
+
+            stages["misses"]["status"] = "running"
+            runner.update_step(job["id"], "misses", status="running")
+            _update_stages(runner, job["id"], stages)
+
+            try:
                 # Share one timestamp between the DB write and the saved
                 # pipeline-results cache so pipeline_review's "Review misses"
                 # shortcut can gate on actual recomputation in this run and
                 # scope /misses?since=... to exactly what was just written.
                 now_ts = datetime.now(UTC).isoformat(timespec="microseconds")
-                miss_enabled = pipeline_cfg.get("miss_enabled", True)
 
                 n = compute_misses_for_workspace(
                     thread_db,

--- a/vireo/process_strategies.py
+++ b/vireo/process_strategies.py
@@ -1,0 +1,71 @@
+"""Named processing-stage presets ("process strategies").
+
+A strategy is pure data: a dict of PipelineParams skip-flag overrides plus
+``miss_enabled`` (misses are config-gated, not param-gated). The API layer
+expands a strategy name server-side so the import page, the process page,
+and import→process chaining all share one vocabulary.
+
+Deviation from the design table: cull_ready keeps regroup — it is cheap
+(no GPU) and pipeline_review requires encounters.
+
+The "no processing at all" choice is deliberately NOT a strategy here: it
+is a decision at the import→process boundary, represented as a null
+workspace default (``pipeline.default_strategy``) and a short-circuit in
+the import-completion chaining hook. ``/api/jobs/pipeline`` rejects both
+``strategy: null`` and the literal string ``"none"``.
+
+Stage gate map (recon 2026-07-04, run_pipeline_job in pipeline_job.py):
+
+    stage          gated by
+    -----          --------
+    scan/ingest    skipped whenever collection_id is set (skip_scan)
+    thumbnails     runs on collection photos; per-photo cache skip
+    previews       runs on collection photos; per-photo cache skip
+    model_loader   params.skip_classify
+    detect         params.skip_classify (+ abort / no collection / no models)
+    classify       params.skip_classify (+ same)
+    extract_masks  params.skip_extract_masks
+    eye_keypoints  params.skip_eye_keypoints OR params.skip_extract_masks
+    regroup        params.skip_regroup
+    misses         params.skip_regroup OR params.skip_classify OR
+                   regroup-failed; then config ``miss_enabled`` inside the
+                   stage body (per-run override added alongside this module)
+    archive        params.local_processing only (import runs; removed in PR 4)
+
+Because detect/model_loader are gated by ``skip_classify``, quick_look
+needs no separate ``skip_detect`` flag — skipping classify already skips
+the whole detect/classify chain, and (with ``skip_regroup``) misses too.
+"""
+
+_BASE = {
+    "skip_classify": False,
+    "skip_extract_masks": False,
+    "skip_eye_keypoints": False,
+    "skip_regroup": False,
+    "miss_enabled": True,
+}
+
+STRATEGIES = {
+    "full": {},
+    "cull_ready": {
+        "skip_extract_masks": True,
+        "skip_eye_keypoints": True,
+        "miss_enabled": False,
+    },
+    "quick_look": {
+        "skip_classify": True,
+        "skip_extract_masks": True,
+        "skip_eye_keypoints": True,
+        "skip_regroup": True,
+        "miss_enabled": False,
+    },
+}
+
+
+def resolve_strategy(name):
+    """Expand a strategy name into stage-flag overrides. Raises ValueError."""
+    if name not in STRATEGIES:
+        raise ValueError(
+            f"unknown strategy: {name!r} (expected one of {sorted(STRATEGIES)})"
+        )
+    return {**_BASE, **STRATEGIES[name]}

--- a/vireo/process_strategies.py
+++ b/vireo/process_strategies.py
@@ -63,7 +63,18 @@ STRATEGIES = {
 
 
 def resolve_strategy(name):
-    """Expand a strategy name into stage-flag overrides. Raises ValueError."""
+    """Expand a strategy name into stage-flag overrides. Raises ValueError.
+
+    Non-string inputs (list, dict, int, bool, None) also raise ``ValueError``
+    rather than ``TypeError``: callers that surface ValueError as 400 (both
+    ``/api/jobs/pipeline`` and ``api_update_workspace``'s workspace-override
+    validation) then handle malformed JSON bodies uniformly instead of one
+    path 400ing and the other escaping as a 500.
+    """
+    if not isinstance(name, str):
+        raise ValueError(
+            f"strategy must be a string, got {type(name).__name__}"
+        )
     if name not in STRATEGIES:
         raise ValueError(
             f"unknown strategy: {name!r} (expected one of {sorted(STRATEGIES)})"

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -3578,6 +3578,15 @@ function renderSettingWidget(key, spec, effective) {
       var sel = (opt === effective) ? ' selected' : '';
       return '<option value="' + escapeAttr(opt) + '"' + sel + '>' + escapeHtml(label) + '</option>';
     }).join('');
+    if (spec.nullable) {
+      // Prepend the null option (value="" — the settings PATCH endpoint
+      // treats "" as null when spec.nullable is true) so users can pick
+      // "unset" as a first-class choice even after a non-null default has
+      // been assigned globally.
+      var nullLabel = spec.null_label || '(unset)';
+      var nullSel = (effective == null) ? ' selected' : '';
+      opts = '<option value=""' + nullSel + '>' + escapeHtml(nullLabel) + '</option>' + opts;
+    }
     return '<select ' + keyAttr + ' onchange="onSchemaInputChange(this, true)" '
          +    'style="' + inputStyle + 'min-width:120px;">'
          +   opts + '</select>';

--- a/vireo/tests/test_config_schema.py
+++ b/vireo/tests/test_config_schema.py
@@ -340,6 +340,24 @@ def test_validate_enum_rejects_unknown():
         validate_value("keyword_case", "screaming-snake")
 
 
+def test_validate_nullable_enum_accepts_null():
+    """pipeline.default_strategy is nullable — a workspace override of null
+    (or the settings UI's empty-string proxy for null) must round-trip to
+    Python None so the import→process chaining hook short-circuits."""
+    from config_schema import validate_value
+
+    assert validate_value("pipeline.default_strategy", None) is None
+    assert validate_value("pipeline.default_strategy", "") is None
+    assert validate_value("pipeline.default_strategy", "full") == "full"
+
+
+def test_validate_nullable_enum_rejects_unknown_non_null():
+    from config_schema import ValidationError, validate_value
+
+    with pytest.raises(ValidationError):
+        validate_value("pipeline.default_strategy", "not_a_strategy")
+
+
 def test_validate_string_passthrough():
     from config_schema import validate_value
 

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -2674,17 +2674,30 @@ _ABS_DEST = os.path.abspath("/abs/dest")
 @pytest.mark.parametrize(
     "extra,fragment",
     [
-        # Relative destination — 400 fires at the destination validation.
-        ({"destination": "relative/path", "local_processing": False}, "absolute"),
-        # local_processing + folder scope — 400 fires at the scope check.
+        # Any destination is rejected outright for folder scope — the
+        # scope check fires before the absolute-path guard, because
+        # collection scope skips ingest and a copy destination would never
+        # be written. Both a relative and an absolute path trip this.
+        (
+            {"destination": "relative/path", "local_processing": False},
+            "destination is not allowed with collection_id or folder_ids",
+        ),
+        (
+            {"destination": _ABS_DEST, "local_processing": False},
+            "destination is not allowed with collection_id or folder_ids",
+        ),
+        # local_processing + destination + folder scope: same reject —
+        # destination check runs before the local_processing scope check.
         (
             {"local_processing": True, "destination": _ABS_DEST},
-            "local_processing",
+            "destination is not allowed with collection_id or folder_ids",
         ),
-        # folder_template with '..' — 400 fires at the folder_template check.
+        # local_processing + folder scope without destination: this
+        # trips the "requires a destination or a remote target" guard
+        # (which fires before the local_processing + scope check).
         (
-            {"destination": _ABS_DEST, "folder_template": "../%Y"},
-            "folder_template",
+            {"local_processing": True},
+            "local_processing requires a destination or a remote target",
         ),
     ],
 )
@@ -2706,6 +2719,46 @@ def test_pipeline_folder_ids_leaves_no_stray_collection_on_400(
         assert resp.status_code == 400, resp.get_json()
         assert fragment in resp.get_json()["error"]
     assert len(db.get_collections()) == before
+
+
+def test_pipeline_folder_ids_rejects_plain_destination(app_and_db):
+    """Regression for the Codex review on commit 459e092: a folder-scoped
+    request with ``destination`` and ``local_processing=False`` was
+    previously accepted, materializing the ad-hoc collection and queuing a
+    job whose ingest step could never run (``collection_id`` sets
+    ``skip_scan``). Reject at request time so the user gets a clean 400
+    instead of a queued-but-broken run."""
+    app, db = app_and_db
+    root_id = _folder_id_by_path(db, "/photos/2024")
+    before = len(db.get_collections())
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/pipeline", json={
+            "folder_ids": [root_id],
+            "destination": _ABS_DEST,
+            "local_processing": False,
+        })
+        assert resp.status_code == 400, resp.get_json()
+        assert "destination" in resp.get_json()["error"]
+        assert "folder_ids" in resp.get_json()["error"]
+    assert len(db.get_collections()) == before
+
+
+def test_pipeline_collection_id_rejects_plain_destination(app_and_db):
+    """Same reasoning as the folder-scope regression above, applied to
+    the equivalent ``collection_id + destination`` case: any collection
+    scope sets ``skip_scan`` in run_pipeline_job, so the ingest block
+    that would copy to ``destination`` never runs."""
+    app, _ = app_and_db
+    col_id = _make_collection(app)
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/pipeline", json={
+            "collection_id": col_id,
+            "destination": _ABS_DEST,
+            "local_processing": False,
+        })
+        assert resp.status_code == 400, resp.get_json()
+        assert "destination" in resp.get_json()["error"]
+        assert "collection_id" in resp.get_json()["error"]
 
 
 def test_pipeline_folder_ids_chunks_wide_subtree(app_and_db, monkeypatch):

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -3054,6 +3054,43 @@ def test_pipeline_folder_ids_bad_list_entry_leaves_no_stray_collection(
 @pytest.mark.parametrize(
     "extra",
     [
+        {"model_id": []},
+        {"model_id": 5},
+        {"model_id": {"id": "x"}},
+        {"model_ids": 5},
+        {"model_ids": "megadetector-v6"},
+        {"model_ids": [5]},
+        {"model_ids": [None]},
+        {"model_ids": [{"id": "x"}]},
+    ],
+)
+def test_pipeline_folder_ids_bad_model_selection_leaves_no_stray_collection(
+    app_and_db, extra,
+):
+    """Regression for the Codex review on commit f08b72e: a folder-scoped
+    request with a malformed ``model_id``/``model_ids`` (e.g. ``model_ids: 5``)
+    passed every up-front validation, materialized the ad-hoc collection,
+    and then blew up inside the auto-skip-classify block
+    (``list(params.model_ids or [])`` on a non-list). The 500 left a stray
+    "Process …" row behind. Reject at request time and confirm the
+    workspace's collection count is unchanged."""
+    app, db = app_and_db
+    root_id = _folder_id_by_path(db, "/photos/2024")
+    before = len(db.get_collections())
+    with app.test_client() as client:
+        resp = client.post(
+            "/api/jobs/pipeline",
+            json={"folder_ids": [root_id], "strategy": "full", **extra},
+        )
+        assert resp.status_code == 400, resp.get_json()
+        offending = next(iter(extra))
+        assert offending in resp.get_json()["error"]
+    assert len(db.get_collections()) == before
+
+
+@pytest.mark.parametrize(
+    "extra",
+    [
         {"source": ""},
         {"sources": []},
         {"source": "", "sources": []},

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -2916,3 +2916,63 @@ def test_pipeline_miss_enabled_accepts_bools(app_and_db, monkeypatch):
             assert resp.status_code == 200, resp.get_json()
             cfg = _job_config(client, resp.get_json()["job_id"])
             assert cfg["miss_enabled"] is value
+
+
+@pytest.mark.parametrize(
+    "extra",
+    [
+        {"exclude_paths": None},
+        {"exclude_paths": "not-a-list"},
+        {"exclude_photo_ids": None},
+        {"exclude_photo_ids": {"id": 3}},
+    ],
+)
+def test_pipeline_folder_ids_bad_list_field_leaves_no_stray_collection(
+    app_and_db, extra,
+):
+    """Regression for the Codex review on commit 5dc5a9f: a folder-scoped
+    request with ``"exclude_paths": null`` (or any non-list value) passed
+    every up-front validation, materialized the ad-hoc collection, then
+    exploded at ``set(body.get("exclude_paths", []))`` inside the
+    PipelineParams constructor. The 500 left a stray "Process …" row
+    behind and never queued a job. Reject at request time and confirm
+    the workspace's collection count is unchanged."""
+    app, db = app_and_db
+    root_id = _folder_id_by_path(db, "/photos/2024")
+    before = len(db.get_collections())
+    with app.test_client() as client:
+        resp = client.post(
+            "/api/jobs/pipeline",
+            json={"folder_ids": [root_id], **extra},
+        )
+        assert resp.status_code == 400, resp.get_json()
+        # Error message names the offending field so the caller can fix it.
+        offending = next(iter(extra))
+        assert offending in resp.get_json()["error"]
+    assert len(db.get_collections()) == before
+
+
+@pytest.mark.parametrize(
+    "extra",
+    [
+        {"source": ""},
+        {"sources": []},
+        {"source": "", "sources": []},
+    ],
+)
+def test_pipeline_folder_ids_treats_empty_sources_as_omitted(
+    app_and_db, extra,
+):
+    """A generic pipeline form can emit ``source: ""`` / ``sources: []``
+    as its unfilled defaults. The rest of this endpoint treats those as
+    omitted (see the ``if sources:`` / ``elif source:`` dispatch and the
+    required-scope truthiness check), so the folder-scope conflict guard
+    must too — otherwise every folder-scoped request from such a form
+    would falsely 400 without the client having to delete unused keys."""
+    app, db = app_and_db
+    root_id = _folder_id_by_path(db, "/photos/2024")
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/pipeline", json={
+            "folder_ids": [root_id], "strategy": "quick_look", **extra,
+        })
+        assert resp.status_code == 200, resp.get_json()

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -2623,6 +2623,66 @@ def test_pipeline_folder_ids_rejects_non_int(app_and_db):
         assert resp.status_code == 400
 
 
+@pytest.mark.parametrize(
+    "bad_fid",
+    [
+        1 << 63,          # one past SQLite's signed 64-bit max
+        -(1 << 63) - 1,   # one below SQLite's signed 64-bit min
+        1 << 128,         # obviously out of range
+    ],
+)
+def test_pipeline_folder_ids_rejects_out_of_range_integer(app_and_db, bad_fid):
+    """A JSON-safe integer outside SQLite's signed 64-bit range must be
+    rejected with 400 before it reaches sqlite3 parameter binding.
+    Without the range guard, the workspace-linked lookup binds ``bad_fid``
+    directly and raises ``OverflowError``, which escapes as an opaque 500."""
+    app, _ = app_and_db
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/pipeline", json={
+            "folder_ids": [bad_fid], "strategy": "quick_look",
+        })
+        assert resp.status_code == 400, resp.get_json()
+        assert "folder_ids" in resp.get_json()["error"]
+
+
+def test_pipeline_folder_ids_includes_legacy_null_parent_descendants(app_and_db):
+    """A workspace root's ad-hoc collection must include descendant folders
+    whose ``parent_id`` is NULL even though their paths sit under the root.
+    Older databases carry such rows; ``get_folder_subtree_ids`` alone walks
+    ``folders.parent_id`` and drops them, so processing a workspace root
+    would silently skip legacy descendant photos the rest of the app still
+    treats as part of that folder subtree. Every other subtree consumer
+    (folder deletion, rescan, missing-originals) already reads through
+    ``_folder_subtree_ids_by_path`` — this route must too."""
+    app, db = app_and_db
+    root_id = _folder_id_by_path(db, "/photos/2024")
+    # Insert a descendant folder whose path is under the root but whose
+    # parent_id is NULL — simulating a legacy row from a pre-parent_id
+    # backfill build. Link it to the active workspace so the route's
+    # workspace-safety filter can find it.
+    legacy_id = db.add_folder("/photos/2024/Legacy", name="Legacy")
+    db.conn.execute(
+        "UPDATE folders SET parent_id = NULL WHERE id = ?", (legacy_id,),
+    )
+    db.conn.commit()
+    db.add_workspace_folder(db._active_workspace_id, legacy_id, is_root=False)
+    legacy_photo = db.add_photo(
+        folder_id=legacy_id, filename="legacy.jpg", extension=".jpg",
+        file_size=42, file_mtime=42.0,
+    )
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/pipeline", json={
+            "folder_ids": [root_id], "strategy": "quick_look",
+        })
+        assert resp.status_code == 200, resp.get_json()
+        cfg = _job_config(client, resp.get_json()["job_id"])
+        got = _collection_photo_ids(db, cfg["collection_id"])
+        assert legacy_photo in got, (
+            "legacy NULL-parent_id descendant was omitted from the "
+            "ad-hoc collection — path-prefix fallback missing"
+        )
+
+
 def test_pipeline_folder_ids_with_collection_id_400(app_and_db):
     """Two scopes in one request is ambiguous — reject rather than pick."""
     app, db = app_and_db

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -2529,3 +2529,106 @@ def test_pipeline_explicit_flags_beat_strategy(app_and_db, monkeypatch):
         cfg = _job_config(client, resp.get_json()["job_id"])
         assert cfg["skip_regroup"] is True
         assert cfg["skip_classify"] is False
+
+
+# ---------------------------------------------------------------------------
+# folder-scoped process runs (import/process split PR 1)
+# ---------------------------------------------------------------------------
+
+
+def _folder_id_by_path(db, path):
+    row = db.conn.execute(
+        "SELECT id FROM folders WHERE path = ?", (path,)
+    ).fetchone()
+    assert row is not None, f"fixture folder missing: {path}"
+    return row["id"]
+
+
+def _collection_photo_ids(db, collection_id):
+    return sorted(
+        p["id"] for p in db.get_collection_photos(collection_id, per_page=999999)
+    )
+
+
+def _photo_ids_in_folders(db, folder_ids):
+    marks = ",".join("?" for _ in folder_ids)
+    rows = db.conn.execute(
+        f"SELECT id FROM photos WHERE folder_id IN ({marks})", folder_ids,
+    ).fetchall()
+    return sorted(r["id"] for r in rows)
+
+
+def test_pipeline_folder_ids_creates_adhoc_collection(app_and_db):
+    """A leaf folder scope becomes an ad-hoc collection of exactly that
+    folder's photos, and the run proceeds as a collection run."""
+    app, db = app_and_db
+    child_id = _folder_id_by_path(db, "/photos/2024/January")
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/pipeline", json={
+            "folder_ids": [child_id], "strategy": "quick_look",
+        })
+        assert resp.status_code == 200
+        cfg = _job_config(client, resp.get_json()["job_id"])
+        assert cfg["collection_id"], cfg
+        assert _collection_photo_ids(db, cfg["collection_id"]) == \
+            _photo_ids_in_folders(db, [child_id])
+
+
+def test_pipeline_folder_ids_includes_descendants(app_and_db):
+    """Scoping to a workspace root must include photos in child folders —
+    the rest of the app treats a folder scope as its subtree (see
+    Database.get_folder_subtree_ids). A flat folder_id IN (...) over the
+    raw request would miss the bulk of a dated archive tree."""
+    app, db = app_and_db
+    root_id = _folder_id_by_path(db, "/photos/2024")
+    child_id = _folder_id_by_path(db, "/photos/2024/January")
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/pipeline", json={
+            "folder_ids": [root_id], "strategy": "quick_look",
+        })
+        assert resp.status_code == 200
+        cfg = _job_config(client, resp.get_json()["job_id"])
+        got = _collection_photo_ids(db, cfg["collection_id"])
+        assert got == _photo_ids_in_folders(db, [root_id, child_id])
+        # Regression tripwire: the child's photos are the recursive part.
+        assert set(_photo_ids_in_folders(db, [child_id])) <= set(got)
+
+
+def test_pipeline_folder_ids_unlinked_folder_404(app_and_db):
+    """A folder not linked to the active workspace must 404, mirroring the
+    rescan guard — otherwise a stale UI could pollute this workspace with
+    another workspace's scan output."""
+    app, db = app_and_db
+    original_ws = db._active_workspace_id
+    other_ws = db.create_workspace("Other")
+    db.set_active_workspace(other_ws)
+    foreign_id = db.add_folder("/photos/elsewhere", name="elsewhere")
+    db.set_active_workspace(original_ws)
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/pipeline", json={
+            "folder_ids": [foreign_id], "strategy": "quick_look",
+        })
+        assert resp.status_code == 404
+
+
+def test_pipeline_folder_ids_rejects_non_int(app_and_db):
+    """Malformed ids must 400 before touching SQLite, mirroring the
+    source_snapshot_id validation."""
+    app, _ = app_and_db
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/pipeline", json={
+            "folder_ids": ["../etc"], "strategy": "quick_look",
+        })
+        assert resp.status_code == 400
+
+
+def test_pipeline_folder_ids_with_collection_id_400(app_and_db):
+    """Two scopes in one request is ambiguous — reject rather than pick."""
+    app, db = app_and_db
+    root_id = _folder_id_by_path(db, "/photos/2024")
+    col_id = _make_collection(app)
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/pipeline", json={
+            "folder_ids": [root_id], "collection_id": col_id,
+        })
+        assert resp.status_code == 400

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -2699,6 +2699,15 @@ _ABS_DEST = os.path.abspath("/abs/dest")
             {"local_processing": True},
             "local_processing requires a destination or a remote target",
         ),
+        # Non-boolean miss_enabled — the type-check must fire BEFORE
+        # ``db.add_collection`` runs. Previously the check sat after
+        # materialization, so a rejected request like
+        # ``{"folder_ids": [...], "miss_enabled": "false"}`` left a stray
+        # "Process …" row behind.
+        (
+            {"miss_enabled": "false"},
+            "miss_enabled",
+        ),
     ],
 )
 def test_pipeline_folder_ids_leaves_no_stray_collection_on_400(

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -2664,6 +2664,13 @@ def test_pipeline_folder_ids_with_other_scope_400(app_and_db, extra):
     assert len(db.get_collections()) == before
 
 
+# os.path.abspath keeps the path shape on POSIX ("/abs/dest") but rewrites
+# it to a drive-anchored form on Windows ("C:\abs\dest"), so os.path.isabs
+# passes on both platforms and validation falls through to the later checks
+# each parametrized case is meant to exercise.
+_ABS_DEST = os.path.abspath("/abs/dest")
+
+
 @pytest.mark.parametrize(
     "extra,fragment",
     [
@@ -2671,12 +2678,12 @@ def test_pipeline_folder_ids_with_other_scope_400(app_and_db, extra):
         ({"destination": "relative/path", "local_processing": False}, "absolute"),
         # local_processing + folder scope — 400 fires at the scope check.
         (
-            {"local_processing": True, "destination": "/abs/dest"},
+            {"local_processing": True, "destination": _ABS_DEST},
             "local_processing",
         ),
         # folder_template with '..' — 400 fires at the folder_template check.
         (
-            {"destination": "/abs/dest", "folder_template": "../%Y"},
+            {"destination": _ABS_DEST, "folder_template": "../%Y"},
             "folder_template",
         ),
     ],

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -2955,6 +2955,46 @@ def test_pipeline_folder_ids_bad_list_field_leaves_no_stray_collection(
 @pytest.mark.parametrize(
     "extra",
     [
+        {"exclude_paths": [{}]},
+        {"exclude_paths": [["nested"]]},
+        {"exclude_paths": [None]},
+        {"exclude_paths": [42]},
+        {"exclude_photo_ids": [{}]},
+        {"exclude_photo_ids": ["not-int"]},
+        {"exclude_photo_ids": [None]},
+        {"exclude_photo_ids": [True]},
+    ],
+)
+def test_pipeline_folder_ids_bad_list_entry_leaves_no_stray_collection(
+    app_and_db, extra,
+):
+    """Regression for the Codex review on commit bffdabd: the outer
+    list-type check let a payload like ``{"exclude_paths": [{}]}`` slip
+    past, whereupon ``set(body.get(...))`` inside PipelineParams raised
+    ``TypeError: unhashable type`` — a 500 that left a stray "Process …"
+    collection with no queued job. Reject non-string exclude_paths
+    entries and non-int (or bool) exclude_photo_ids entries at the
+    request boundary and confirm no collection was created."""
+    app, db = app_and_db
+    root_id = _folder_id_by_path(db, "/photos/2024")
+    before = len(db.get_collections())
+    with app.test_client() as client:
+        resp = client.post(
+            "/api/jobs/pipeline",
+            json={"folder_ids": [root_id], **extra},
+        )
+        assert resp.status_code == 400, resp.get_json()
+        offending = next(iter(extra))
+        assert offending in resp.get_json()["error"]
+        # Error message points at "entries" so the caller can distinguish
+        # this from the outer-list-type reject in the sibling regression.
+        assert "entries" in resp.get_json()["error"]
+    assert len(db.get_collections()) == before
+
+
+@pytest.mark.parametrize(
+    "extra",
+    [
         {"source": ""},
         {"sources": []},
         {"source": "", "sources": []},

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -2394,3 +2394,138 @@ def test_pipeline_remote_archive_snapshots_target_at_enqueue(
     assert snap["user"] == "me"
     assert snap["remote_path"] == "/volume1/Photography"
     assert snap["mount_path"] == str(tmp_path / "mount")
+
+
+# ---------------------------------------------------------------------------
+# strategy param on /api/jobs/pipeline (import/process split PR 1)
+# ---------------------------------------------------------------------------
+
+
+def _make_collection(app):
+    import json as json_mod
+
+    from db import Database
+
+    db = Database(app.config["DB_PATH"])
+    db.set_active_workspace(db._active_workspace_id)
+    return db.add_collection("Strategy test", json_mod.dumps([]))
+
+
+def _job_config(client, job_id):
+    resp = client.get(f"/api/jobs/{job_id}")
+    assert resp.status_code == 200
+    return resp.get_json()["config"]
+
+
+def _fake_active_model(monkeypatch):
+    """Keep the route's no-model auto-skip from firing so strategy flags
+    survive to the job config unmangled."""
+    import models
+
+    monkeypatch.setattr(models, "get_active_model", lambda: {"id": "fake"})
+
+
+def test_pipeline_strategy_expands_flags(app_and_db):
+    app, _ = app_and_db
+    col_id = _make_collection(app)
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/pipeline", json={
+            "collection_id": col_id, "strategy": "quick_look",
+        })
+        assert resp.status_code == 200
+        cfg = _job_config(client, resp.get_json()["job_id"])
+        assert cfg["strategy"] == "quick_look"
+        assert cfg["skip_classify"] is True
+        assert cfg["skip_extract_masks"] is True
+        assert cfg["skip_regroup"] is True
+
+
+def test_pipeline_cull_ready_pins_miss_enabled_false(app_and_db, monkeypatch):
+    # quick_look alone can't prove miss_enabled reached PipelineParams:
+    # it also sets skip_classify=True, and the misses stage is downstream
+    # of classify, so an implementation that never wires the strategy's
+    # miss_enabled through to params would still produce a run without
+    # misses (by dint of skip_classify) and this test would go green.
+    # cull_ready has skip_classify=False + miss_enabled=False, so the
+    # only way misses can be suppressed is if the strategy's miss_enabled
+    # actually reaches PipelineParams — that's the property pinned here.
+    app, _ = app_and_db
+    col_id = _make_collection(app)
+    _fake_active_model(monkeypatch)
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/pipeline", json={
+            "collection_id": col_id, "strategy": "cull_ready",
+        })
+        assert resp.status_code == 200
+        cfg = _job_config(client, resp.get_json()["job_id"])
+        assert cfg["strategy"] == "cull_ready"
+        assert cfg["miss_enabled"] is False
+        assert cfg["skip_classify"] is False  # cull_ready keeps classify on
+
+
+def test_pipeline_unknown_strategy_400(app_and_db):
+    app, _ = app_and_db
+    col_id = _make_collection(app)
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/pipeline", json={
+            "collection_id": col_id, "strategy": "yolo",
+        })
+        assert resp.status_code == 400
+        assert "unknown strategy" in resp.get_json()["error"]
+
+
+def test_pipeline_null_strategy_400(app_and_db):
+    # The "no process" case is expressed by NOT calling /api/jobs/pipeline.
+    # A present-but-null strategy must 400 so the server never silently
+    # falls through to default processing when a caller thought they were
+    # opting out. Distinct from "unknown strategy" — null is a shape error.
+    app, _ = app_and_db
+    col_id = _make_collection(app)
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/pipeline", json={
+            "collection_id": col_id, "strategy": None,
+        })
+        assert resp.status_code == 400
+        assert "strategy" in resp.get_json()["error"]
+
+
+def test_pipeline_none_string_strategy_400(app_and_db):
+    # The literal string "none" is not a valid strategy name either
+    # (STRATEGIES only holds full / cull_ready / quick_look).
+    app, _ = app_and_db
+    col_id = _make_collection(app)
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/pipeline", json={
+            "collection_id": col_id, "strategy": "none",
+        })
+        assert resp.status_code == 400
+
+
+def test_pipeline_omitted_strategy_uses_body_params(app_and_db):
+    # No `strategy` key at all -> the route builds PipelineParams from the
+    # body as usual. Distinguishing "omitted" from "null" is exactly why the
+    # route must check key presence, not truthiness.
+    app, _ = app_and_db
+    col_id = _make_collection(app)
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/pipeline", json={"collection_id": col_id})
+        assert resp.status_code == 200
+        cfg = _job_config(client, resp.get_json()["job_id"])
+        assert cfg.get("strategy") is None
+
+
+def test_pipeline_explicit_flags_beat_strategy(app_and_db, monkeypatch):
+    # A caller may pin one flag on top of a strategy; explicit wins. The
+    # fake model keeps the no-model auto-skip from flipping the same flags
+    # and masking a broken merge order.
+    app, _ = app_and_db
+    col_id = _make_collection(app)
+    _fake_active_model(monkeypatch)
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/pipeline", json={
+            "collection_id": col_id, "strategy": "full", "skip_regroup": True,
+        })
+        assert resp.status_code == 200
+        cfg = _job_config(client, resp.get_json()["job_id"])
+        assert cfg["skip_regroup"] is True
+        assert cfg["skip_classify"] is False

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -2683,6 +2683,65 @@ def test_pipeline_folder_ids_includes_legacy_null_parent_descendants(app_and_db)
         )
 
 
+def test_pipeline_folder_ids_honors_exclude_paths(app_and_db):
+    """A folder-scoped run with ``exclude_paths`` must drop the deselected
+    photos from the ad-hoc collection itself. Once ``params.collection_id``
+    is set, ``run_pipeline_job`` takes the collection path and its
+    ``_filter_excluded`` helper only checks ``exclude_photo_ids``, so an
+    excluded path would otherwise still be thumbnailed, classified, and
+    regrouped. Filter at the materialization boundary so the collection
+    reflects exactly the photos the user asked to process."""
+    app, db = app_and_db
+    root_id = _folder_id_by_path(db, "/photos/2024")
+    child_id = _folder_id_by_path(db, "/photos/2024/January")
+    # Photos in the fixture are keyed on folder + filename; the effective
+    # "path" for exclude_paths matching is os.path.join(folder.path, filename)
+    # — same shape scanner/ingest use for their skip_paths sets.
+    excluded_root_file = os.path.join("/photos/2024", "bird1.jpg")
+    excluded_child_file = os.path.join(
+        "/photos/2024/January", "bird2.jpg",
+    )
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/pipeline", json={
+            "folder_ids": [root_id], "strategy": "quick_look",
+            "exclude_paths": [excluded_root_file, excluded_child_file],
+        })
+        assert resp.status_code == 200, resp.get_json()
+        cfg = _job_config(client, resp.get_json()["job_id"])
+        got = set(_collection_photo_ids(db, cfg["collection_id"]))
+        subtree = set(_photo_ids_in_folders(db, [root_id, child_id]))
+        # Only the non-excluded photo (bird3 in the root) remains.
+        remaining = {
+            r["id"] for r in db.conn.execute(
+                "SELECT id FROM photos WHERE folder_id = ? AND filename = ?",
+                (root_id, "bird3.jpg"),
+            )
+        }
+        assert got == remaining
+        assert got < subtree, "exclusion produced no reduction — filter no-op"
+
+
+def test_pipeline_folder_ids_honors_exclude_photo_ids(app_and_db):
+    """The ad-hoc collection also drops photos in ``exclude_photo_ids`` so
+    its membership matches what the user selected — even though
+    ``_filter_excluded`` would drop them again downstream."""
+    app, db = app_and_db
+    root_id = _folder_id_by_path(db, "/photos/2024")
+    child_id = _folder_id_by_path(db, "/photos/2024/January")
+    all_ids = _photo_ids_in_folders(db, [root_id, child_id])
+    excluded = all_ids[0]
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/pipeline", json={
+            "folder_ids": [root_id], "strategy": "quick_look",
+            "exclude_photo_ids": [excluded],
+        })
+        assert resp.status_code == 200, resp.get_json()
+        cfg = _job_config(client, resp.get_json()["job_id"])
+        got = set(_collection_photo_ids(db, cfg["collection_id"]))
+        assert excluded not in got
+        assert got == set(all_ids) - {excluded}
+
+
 def test_pipeline_folder_ids_with_collection_id_400(app_and_db):
     """Two scopes in one request is ambiguous — reject rather than pick."""
     app, db = app_and_db

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -2,6 +2,7 @@ import json
 import os
 import time
 
+import pytest
 from PIL import Image
 from wait import wait_for_job_via_client, wait_for_job_via_runner
 
@@ -2632,3 +2633,69 @@ def test_pipeline_folder_ids_with_collection_id_400(app_and_db):
             "folder_ids": [root_id], "collection_id": col_id,
         })
         assert resp.status_code == 400
+
+
+@pytest.mark.parametrize(
+    "extra",
+    [
+        {"source": "/tmp/foo"},
+        {"sources": ["/tmp/foo", "/tmp/bar"]},
+        {"source_snapshot_id": 999},
+    ],
+)
+def test_pipeline_folder_ids_with_other_scope_400(app_and_db, extra):
+    """Reject folder_ids combined with *any* other scope — not just
+    collection_id. Otherwise run_pipeline_job silently ignores the source
+    (because collection_id skips scanning) or clears the folder-derived
+    collection_id when a snapshot is present, and the job processes a
+    different scope than the request implied. Also verifies no stray
+    ad-hoc collection was inserted before the rejection: the check must
+    fire before ``add_collection`` runs."""
+    app, db = app_and_db
+    root_id = _folder_id_by_path(db, "/photos/2024")
+    before = len(db.get_collections())
+    with app.test_client() as client:
+        resp = client.post(
+            "/api/jobs/pipeline",
+            json={"folder_ids": [root_id], **extra},
+        )
+        assert resp.status_code == 400
+        assert "folder_ids cannot be combined with" in resp.get_json()["error"]
+    assert len(db.get_collections()) == before
+
+
+@pytest.mark.parametrize(
+    "extra,fragment",
+    [
+        # Relative destination — 400 fires at the destination validation.
+        ({"destination": "relative/path", "local_processing": False}, "absolute"),
+        # local_processing + folder scope — 400 fires at the scope check.
+        (
+            {"local_processing": True, "destination": "/abs/dest"},
+            "local_processing",
+        ),
+        # folder_template with '..' — 400 fires at the folder_template check.
+        (
+            {"destination": "/abs/dest", "folder_template": "../%Y"},
+            "folder_template",
+        ),
+    ],
+)
+def test_pipeline_folder_ids_leaves_no_stray_collection_on_400(
+    app_and_db, extra, fragment,
+):
+    """A rejected folder-scope request must not leave a "Process …"
+    collection sitting in the workspace. The ad-hoc insert has to happen
+    after every other request check has passed, otherwise the workspace
+    accumulates junk every time the caller trips a later validation."""
+    app, db = app_and_db
+    root_id = _folder_id_by_path(db, "/photos/2024")
+    before = len(db.get_collections())
+    with app.test_client() as client:
+        resp = client.post(
+            "/api/jobs/pipeline",
+            json={"folder_ids": [root_id], **extra},
+        )
+        assert resp.status_code == 400, resp.get_json()
+        assert fragment in resp.get_json()["error"]
+    assert len(db.get_collections()) == before

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -2706,3 +2706,91 @@ def test_pipeline_folder_ids_leaves_no_stray_collection_on_400(
         assert resp.status_code == 400, resp.get_json()
         assert fragment in resp.get_json()["error"]
     assert len(db.get_collections()) == before
+
+
+def test_pipeline_folder_ids_chunks_wide_subtree(app_and_db, monkeypatch):
+    """A folder root that expands into thousands of descendant folder ids
+    must not overflow SQLite's per-statement bound-variable cap
+    (SQLITE_MAX_VARIABLE_NUMBER = 999 on legacy builds). Force the chunk
+    size down and verify a subtree several times its width still resolves
+    correctly — a single unchunked ``folder_id IN (?,...,?)`` would raise
+    OperationalError before the job was queued and surface as a 500."""
+    import db as db_module
+
+    monkeypatch.setattr(db_module, "_SQLITE_PARAM_CHUNK_SIZE", 3)
+
+    app, db = app_and_db
+    parent = db.add_folder("/photos/wide", name="wide")
+    photo_ids = []
+    for i in range(10):
+        sub = db.add_folder(
+            f"/photos/wide/sub{i}", name=f"sub{i}", parent_id=parent,
+        )
+        pid = db.add_photo(
+            folder_id=sub, filename=f"p{i}.jpg", extension=".jpg",
+            file_size=100 + i, file_mtime=100.0 + i,
+        )
+        photo_ids.append(pid)
+    db.add_workspace_folder(db._active_workspace_id, parent)
+
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/pipeline", json={
+            "folder_ids": [parent], "strategy": "quick_look",
+        })
+        assert resp.status_code == 200, resp.get_json()
+        cfg = _job_config(client, resp.get_json()["job_id"])
+        got = _collection_photo_ids(db, cfg["collection_id"])
+        assert set(photo_ids) <= set(got)
+
+
+def test_pipeline_folder_ids_persisted_in_job_config(app_and_db):
+    """job_config records the caller's original folder_ids alongside the
+    derived ad-hoc collection_id. Without this the Jobs page can show only
+    the derived collection, not the folder subtree the user selected —
+    reconstructing the selection from the collection is impossible once the
+    ad-hoc collection is renamed or deleted."""
+    app, db = app_and_db
+    root_id = _folder_id_by_path(db, "/photos/2024")
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/pipeline", json={
+            "folder_ids": [root_id], "strategy": "quick_look",
+        })
+        assert resp.status_code == 200
+        cfg = _job_config(client, resp.get_json()["job_id"])
+        assert cfg.get("folder_ids") == [root_id]
+        # Sanity: the derived collection_id is still there so consumers can
+        # keep using the collection-scoped code path.
+        assert cfg.get("collection_id")
+
+
+@pytest.mark.parametrize("bad", ["false", "true", 0, 1, "yes", [], {}])
+def test_pipeline_miss_enabled_rejects_non_bool(app_and_db, bad):
+    """miss_enabled is tri-state (None / True / False) — a truthy non-bool
+    like the string ``"false"`` would flow through pipeline_job's
+    ``params.miss_enabled is not None`` guard, then be treated as truthy in
+    ``not miss_enabled``, silently turning misses ON when the caller wanted
+    them OFF. Type-check at enqueue so the caller sees a clean 400."""
+    app, _ = app_and_db
+    col_id = _make_collection(app)
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/pipeline", json={
+            "collection_id": col_id, "miss_enabled": bad,
+        })
+        assert resp.status_code == 400, resp.get_json()
+        assert "miss_enabled" in resp.get_json()["error"]
+
+
+def test_pipeline_miss_enabled_accepts_bools(app_and_db, monkeypatch):
+    """The complement of the reject test — real bools survive to job_config
+    so a strategy override or a caller explicit toggle can actually take."""
+    app, _ = app_and_db
+    _fake_active_model(monkeypatch)
+    col_id = _make_collection(app)
+    with app.test_client() as client:
+        for value in (True, False):
+            resp = client.post("/api/jobs/pipeline", json={
+                "collection_id": col_id, "miss_enabled": value,
+            })
+            assert resp.status_code == 200, resp.get_json()
+            cfg = _job_config(client, resp.get_json()["job_id"])
+            assert cfg["miss_enabled"] is value

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -224,6 +224,10 @@ def test_pipeline_local_processing_rejects_collection_id(setup, tmp_path):
     # staging folder is never created/indexed. Without this rejection
     # the job would burn through every processing stage and then fail
     # at archive_stage with "local staging folder was not indexed".
+    # The destination+collection_id guard fires first for this shape and
+    # rejects it with a scope-specific message; the older
+    # local_processing+collection_id guard still catches the no-destination
+    # variant (covered separately by test_jobs_api.py).
     app, _db_path = setup
     dest = tmp_path / "archive"
     with app.test_client() as c:
@@ -237,8 +241,7 @@ def test_pipeline_local_processing_rejects_collection_id(setup, tmp_path):
         })
         assert resp.status_code == 400
         err = resp.get_json()["error"].lower()
-        assert "local_processing" in err
-        assert "collection_id" in err
+        assert "destination is not allowed with collection_id" in err
 
 
 def test_pipeline_local_processing_rejects_collection_id_with_stale_sources(
@@ -248,8 +251,9 @@ def test_pipeline_local_processing_rejects_collection_id_with_stale_sources(
     # request that mixes collection_id with a stale source/sources field
     # still skips ingest — the staging folder never gets created or
     # indexed and archive_stage fails with "local staging folder was not
-    # indexed". The API guard must reject collection_id outright when
-    # local_processing is on, not just the no-source case.
+    # indexed". Same shape as above (destination + collection_id +
+    # local_processing) so the destination-scope guard rejects it first;
+    # the stale sources field must not slip past.
     app, _db_path = setup
     src = tmp_path / "card"
     src.mkdir()
@@ -266,8 +270,7 @@ def test_pipeline_local_processing_rejects_collection_id_with_stale_sources(
         })
         assert resp.status_code == 400
         err = resp.get_json()["error"].lower()
-        assert "local_processing" in err
-        assert "collection_id" in err
+        assert "destination is not allowed with collection_id" in err
 
 
 def test_pipeline_local_processing_archives_to_final_destination(

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -10402,7 +10402,7 @@ def test_pipeline_params_miss_enabled_defaults_none():
 
 
 def _run_pipeline_for_miss_tests(tmp_path, monkeypatch, *, pipeline_cfg,
-                                 params_extra):
+                                 params_extra, expect_runtime_error=False):
     """Run a collection pipeline far enough to reach miss_stage.
 
     classify must complete (model_loader failure sets abort, and the misses
@@ -10411,6 +10411,12 @@ def _run_pipeline_for_miss_tests(tmp_path, monkeypatch, *, pipeline_cfg,
     gate skips when regroup failed), so stub run_full_pipeline /
     save_results / load_photo_features. Returns (runner, result, spy_calls)
     where spy_calls captures every compute_misses_for_workspace invocation.
+
+    ``expect_runtime_error`` is opt-in: the setup-failure test needs to swallow
+    the RuntimeError so it can inspect ``job["_fatal_error"]``, but the
+    override tests must let unexpected pipeline aborts propagate — otherwise
+    an earlier stage failing would make miss_stage skip for the wrong reason
+    and the test would pass on a false green.
     """
     import json as json_mod
 
@@ -10429,7 +10435,7 @@ def _run_pipeline_for_miss_tests(tmp_path, monkeypatch, *, pipeline_cfg,
         misses_mod = None
 
     monkeypatch.setenv("HOME", str(tmp_path))
-    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
     with open(cfg.CONFIG_PATH, "w") as f:
         json_mod.dump({"pipeline": pipeline_cfg}, f)
 
@@ -10509,10 +10515,16 @@ def _run_pipeline_for_miss_tests(tmp_path, monkeypatch, *, pipeline_cfg,
     )
     runner = FakeRunner()
     job = _make_job()
-    # A fatal stage error makes run_pipeline_job raise after recording it on
-    # the job; the setup-failure test inspects job["_fatal_error"] instead.
+    # Suppression is opt-in — the setup-failure test needs to inspect
+    # job["_fatal_error"] after the recorded RuntimeError, but the
+    # miss_enabled override tests must let unexpected aborts propagate so
+    # the miss_stage.skipped assertion can't pass because an earlier stage
+    # failed for an unrelated reason.
     result = None
-    with contextlib.suppress(RuntimeError):
+    if expect_runtime_error:
+        with contextlib.suppress(RuntimeError):
+            result = run_pipeline_job(job, runner, db_path, ws_id, params)
+    else:
         result = run_pipeline_job(job, runner, db_path, ws_id, params)
     return runner, result, spy_calls, job
 
@@ -10581,6 +10593,7 @@ def test_miss_stage_setup_failure_marks_stage_failed(tmp_path, monkeypatch):
             tmp, mk,
             pipeline_cfg={"miss_enabled": True},
             params_extra={},
+            expect_runtime_error=True,
         )
 
     runner, result, spy_calls, job = run(tmp_path, monkeypatch)
@@ -10616,7 +10629,7 @@ def test_collection_rerun_redoes_only_missing_work(tmp_path, monkeypatch):
     from db import Database
 
     monkeypatch.setenv("HOME", str(tmp_path))
-    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
 
     db_path = str(tmp_path / "test.db")
     db = Database(db_path)

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -10594,3 +10594,132 @@ def test_miss_stage_setup_failure_marks_stage_failed(tmp_path, monkeypatch):
     assert str(job.get("_fatal_error", "")).startswith("[misses] Fatal:"), (
         job.get("_fatal_error"), job.get("errors")
     )
+
+
+# ---------------------------------------------------------------------------
+# per-photo resume contract (import/process split PR 1)
+# ---------------------------------------------------------------------------
+
+
+def test_collection_rerun_redoes_only_missing_work(tmp_path, monkeypatch):
+    """The process job's core promise: re-running the same strategy over the
+    same photos re-does only what's missing. Second run must report zero
+    generated thumbnails/previews and a fully cache-hit classify. If this
+    fails, the failure is the finding — fix the specific stage's skip
+    check rather than loosening the assertion."""
+    import json as json_mod
+
+    import classifier as classifier_mod
+    import classify_job
+    import config as cfg
+    import numpy as np
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    photo_ids = []
+    for i, name in enumerate(("a.jpg", "b.jpg")):
+        pid = db.add_photo(folder_id, name, ".jpg", 1000 + i, 1_000_000.0 + i)
+        _drop_jpeg(folder_path, name)
+        # Pre-seed one detection per photo so the classify loop has a
+        # primary detection to classify (and, on run 2, to find cached
+        # predictions for). Mirrors the reclassify tests' setup.
+        db.save_detections(
+            pid,
+            [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+              "confidence": 0.9, "category": "animal"}],
+            detector_model="MegaDetector",
+        )
+        photo_ids.append(pid)
+    col_id = db.add_collection(
+        "Resume test",
+        json_mod.dumps([{"field": "photo_ids", "value": photo_ids}]),
+    )
+
+    _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
+    def fake_detect_batch(batch, folders, runner, job, reclassify, db_,
+                          det_conf_threshold=None, already_detected_ids=None,
+                          cached_detections=None):
+        det_map = {}
+        for p in batch:
+            # The classify loop expects plain dicts (the real _detect_batch
+            # returns them); sqlite3.Row has no .get.
+            dets = [dict(d) for d in db_.get_detections(p["id"])]
+            if dets:
+                det_map[p["id"]] = dets
+        return det_map, 0, {p["id"] for p in batch}
+
+    monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
+
+    inference_calls = []
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def encode_image(self, *args, **kwargs):
+            inference_calls.append("encode_image")
+            return np.zeros(512, dtype=np.float32)
+
+        def classify_with_embedding(self, img, threshold=0):
+            inference_calls.append("classify_with_embedding")
+            return (
+                [{"species": "Robin", "score": 0.9}],
+                np.zeros(512, dtype=np.float32),
+            )
+
+        def classify_batch_with_embedding(self, images, threshold=0):
+            inference_calls.append("classify_batch_with_embedding")
+            zero = np.zeros(512, dtype=np.float32)
+            return [([{"species": "Robin", "score": 0.9}], zero)
+                    for _ in images]
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    def run_once():
+        params = PipelineParams(
+            collection_id=col_id,
+            skip_extract_masks=True,
+            skip_regroup=True,
+        )
+        runner = FakeRunner()
+        job = _make_job()
+        return run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    first = run_once()
+    n = len(photo_ids)
+    assert first["stages"]["thumbnails"]["generated"] == n, first["stages"]
+    assert first["stages"]["previews"]["generated"] == n, first["stages"]
+    assert first["stages"]["classify"]["predictions_stored"] == n, (
+        first["stages"]
+    )
+    assert inference_calls, "first run never invoked the classifier"
+
+    inference_calls.clear()
+    second = run_once()
+    assert second["stages"]["thumbnails"] == {
+        "generated": 0, "skipped": n, "failed": 0,
+    }, second["stages"]
+    assert second["stages"]["previews"]["generated"] == 0, second["stages"]
+    assert second["stages"]["previews"]["skipped"] == n, second["stages"]
+    assert second["stages"]["previews"]["failed"] == 0, second["stages"]
+    assert second["stages"]["classify"]["already_classified"] == n, (
+        second["stages"]
+    )
+    # NOTE: predictions_stored is NOT asserted to be 0 on the rerun — the
+    # cached branch deliberately re-surfaces cached predictions into
+    # raw_results so downstream grouping/storage sees them, and storage
+    # re-upserts the same rows (idempotent, cheap). The expensive contract
+    # is that no model inference happens at all on a fully-cached rerun:
+    assert inference_calls == [], (
+        f"rerun invoked the classifier: {inference_calls}"
+    )

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -10388,3 +10388,209 @@ def test_pipeline_remote_archive_falls_back_to_settings_without_snapshot(
     assert result["archive"]["moved"] == 1
     call = env["captured"]["rsync_calls"][-1]
     assert call["dest_spec"] == "me@nas:/volume1/Photography/2026/trip"
+
+
+# ---------------------------------------------------------------------------
+# miss_enabled per-run override (process strategies, import/process split PR 1)
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_params_miss_enabled_defaults_none():
+    """None means "defer to workspace config" — today's behavior."""
+    params = PipelineParams()
+    assert params.miss_enabled is None
+
+
+def _run_pipeline_for_miss_tests(tmp_path, monkeypatch, *, pipeline_cfg,
+                                 params_extra):
+    """Run a collection pipeline far enough to reach miss_stage.
+
+    classify must complete (model_loader failure sets abort, and the misses
+    gate skips on abort), so install a fake downloaded model, a fake
+    Classifier, and a fake _detect_batch. regroup must succeed (the misses
+    gate skips when regroup failed), so stub run_full_pipeline /
+    save_results / load_photo_features. Returns (runner, result, spy_calls)
+    where spy_calls captures every compute_misses_for_workspace invocation.
+    """
+    import json as json_mod
+
+    import classifier as classifier_mod
+    import classify_job
+    import config as cfg
+    import numpy as np
+    import pipeline as pipeline_mod
+    from db import Database
+
+    try:
+        import misses as misses_mod
+    except ImportError:
+        # The setup-failure test poisons sys.modules["misses"] so the miss
+        # stage's own import raises; the spy is unused on that path.
+        misses_mod = None
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    with open(cfg.CONFIG_PATH, "w") as f:
+        json_mod.dump({"pipeline": pipeline_cfg}, f)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    photo_id = db.add_photo(folder_id, "test.jpg", ".jpg", 12345, 1_000_000.0)
+    _drop_jpeg(folder_path, "test.jpg")
+    col_id = db.add_collection(
+        "Test",
+        json_mod.dumps([{"field": "photo_ids", "value": [photo_id]}]),
+    )
+
+    _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
+    def fake_detect_batch(batch, folders, runner, job, reclassify, db_,
+                          det_conf_threshold=None, already_detected_ids=None,
+                          cached_detections=None):
+        return {}, 0, {p["id"] for p in batch}
+
+    monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def encode_image(self, *args, **kwargs):
+            return np.zeros(512, dtype=np.float32)
+
+        def classify_with_embedding(self, img, threshold=0):
+            return (
+                [{"species": "Robin", "score": 0.9}],
+                np.zeros(512, dtype=np.float32),
+            )
+
+        def classify_batch_with_embedding(self, images, threshold=0):
+            zero = np.zeros(512, dtype=np.float32)
+            return [([{"species": "Robin", "score": 0.9}], zero)
+                    for _ in images]
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    monkeypatch.setattr(
+        pipeline_mod, "run_full_pipeline",
+        lambda photos, config=None, emit_trace=False: {
+            "summary": {"groups": 1}, "photos": photos,
+        },
+    )
+    monkeypatch.setattr(
+        pipeline_mod, "save_results", lambda results, cache_dir, ws: None,
+    )
+    monkeypatch.setattr(
+        pipeline_mod, "load_photo_features",
+        lambda thread_db, collection_id=None, config=None: [{"id": photo_id}],
+    )
+
+    spy_calls = []
+
+    def spy_compute(thread_db, p_cfg, collection_id=None,
+                    exclude_photo_ids=None, now=None):
+        spy_calls.append({"pipeline_cfg": dict(p_cfg)})
+        return 3
+
+    if misses_mod is not None:
+        monkeypatch.setattr(
+            misses_mod, "compute_misses_for_workspace", spy_compute,
+        )
+
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_extract_masks=True,
+        **params_extra,
+    )
+    runner = FakeRunner()
+    job = _make_job()
+    # A fatal stage error makes run_pipeline_job raise after recording it on
+    # the job; the setup-failure test inspects job["_fatal_error"] instead.
+    result = None
+    with contextlib.suppress(RuntimeError):
+        result = run_pipeline_job(job, runner, db_path, ws_id, params)
+    return runner, result, spy_calls, job
+
+
+def _last_stages(runner):
+    progress_events = [
+        data for (_, evt, data) in runner.events
+        if evt == "progress" and "stages" in data
+    ]
+    assert progress_events, "pipeline emitted no progress events"
+    return progress_events[-1]["stages"]
+
+
+def test_miss_enabled_false_param_short_circuits_before_compute(
+    tmp_path, monkeypatch,
+):
+    """Skip direction: workspace says True, params say False -> the stage
+    records skipped and compute_misses_for_workspace is never invoked. A
+    local-variable-only implementation (gating just the cache marker)
+    would still call compute and fail this test."""
+    runner, result, spy_calls, job = _run_pipeline_for_miss_tests(
+        tmp_path, monkeypatch,
+        pipeline_cfg={"miss_enabled": True},
+        params_extra={"miss_enabled": False},
+    )
+    assert spy_calls == [], "compute_misses_for_workspace ran despite override"
+    assert _last_stages(runner)["misses"]["status"] == "skipped"
+    miss_steps = [
+        kw for (_, step, kw) in runner.step_updates if step == "misses"
+    ]
+    assert {"status": "completed", "summary": "Skipped"} in miss_steps
+
+
+def test_miss_enabled_true_param_overrides_disabled_workspace(
+    tmp_path, monkeypatch,
+):
+    """Enable direction: workspace says False, params say True -> compute IS
+    invoked and sees the injected effective value. Without injection the
+    compute call reads workspace-False and silently evaluates nothing."""
+    runner, result, spy_calls, job = _run_pipeline_for_miss_tests(
+        tmp_path, monkeypatch,
+        pipeline_cfg={"miss_enabled": False},
+        params_extra={"miss_enabled": True},
+    )
+    assert len(spy_calls) == 1, "compute_misses_for_workspace did not run"
+    assert spy_calls[0]["pipeline_cfg"].get("miss_enabled") is True
+    assert _last_stages(runner)["misses"]["status"] == "completed"
+    miss_steps = [
+        kw for (_, step, kw) in runner.step_updates if step == "misses"
+    ]
+    assert {"status": "completed", "summary": "3 photos evaluated"} in miss_steps
+
+
+def test_miss_stage_setup_failure_marks_stage_failed(tmp_path, monkeypatch):
+    """Setup-failure direction: if the miss stage's setup (imports, DB,
+    config load) raises, the stage must record failed — not linger as
+    pending while the job completes "successfully". Pins the contract the
+    hoisted-setup refactor could otherwise regress. Only miss_stage imports
+    the misses module, so poisoning it in sys.modules scopes the failure to
+    exactly this stage."""
+    import sys as sys_mod
+
+    def run(tmp, mk):
+        mk.setitem(sys_mod.modules, "misses", None)
+        return _run_pipeline_for_miss_tests(
+            tmp, mk,
+            pipeline_cfg={"miss_enabled": True},
+            params_extra={},
+        )
+
+    runner, result, spy_calls, job = run(tmp_path, monkeypatch)
+    assert spy_calls == []
+    assert _last_stages(runner)["misses"]["status"] == "failed"
+    miss_steps = [
+        kw for (_, step, kw) in runner.step_updates if step == "misses"
+    ]
+    assert any(kw.get("status") == "failed" and kw.get("error")
+               for kw in miss_steps), miss_steps
+    assert str(job.get("_fatal_error", "")).startswith("[misses] Fatal:"), (
+        job.get("_fatal_error"), job.get("errors")
+    )

--- a/vireo/tests/test_process_strategies.py
+++ b/vireo/tests/test_process_strategies.py
@@ -41,3 +41,14 @@ def test_quick_look_is_thumbs_and_previews_only():
 def test_unknown_strategy_raises():
     with pytest.raises(ValueError, match="unknown strategy"):
         resolve_strategy("yolo")
+
+
+@pytest.mark.parametrize("bad", [None, 5, True, ["cull_ready"], {"name": "full"}])
+def test_non_string_strategy_raises_value_error(bad):
+    """Both callers surface ``ValueError`` as 400 (``/api/jobs/pipeline`` and
+    ``api_update_workspace`` for ``pipeline.default_strategy``). A dict/list
+    reaching ``name not in STRATEGIES`` would otherwise raise ``TypeError``
+    (unhashable type) and escape as a 500 from the workspace endpoint, which
+    lacks the string type-guard the pipeline route has."""
+    with pytest.raises(ValueError, match="strategy must be a string"):
+        resolve_strategy(bad)

--- a/vireo/tests/test_process_strategies.py
+++ b/vireo/tests/test_process_strategies.py
@@ -1,0 +1,43 @@
+"""Strategy presets are pure data: name -> PipelineParams overrides."""
+import pytest
+from process_strategies import STRATEGIES, resolve_strategy
+
+
+def test_known_strategies():
+    # The whitelist is deliberately narrow: only *processing* presets.
+    # The design doc's "None" / import-only choice is NOT a fourth
+    # entry here — it lives at the import→process boundary (workspace
+    # default in Task 1.5, chaining hook in PR 3). Adding an entry like
+    # "none" here would make the process-job API accept it and enqueue
+    # a no-op run instead of letting the chaining hook short-circuit.
+    assert set(STRATEGIES) == {"full", "cull_ready", "quick_look"}
+
+
+def test_full_skips_nothing():
+    flags = resolve_strategy("full")
+    assert not any(v for k, v in flags.items() if k.startswith("skip_"))
+    assert flags["miss_enabled"] is True
+
+
+def test_cull_ready_skips_expensive_extras():
+    flags = resolve_strategy("cull_ready")
+    assert flags["skip_extract_masks"] is True
+    assert flags["skip_eye_keypoints"] is True
+    assert flags["miss_enabled"] is False
+    # classify and regroup stay on: review pages need predictions + encounters
+    assert flags["skip_classify"] is False
+    assert flags["skip_regroup"] is False
+
+
+def test_quick_look_is_thumbs_and_previews_only():
+    flags = resolve_strategy("quick_look")
+    assert flags["skip_classify"] is True
+    assert flags["skip_extract_masks"] is True
+    assert flags["skip_eye_keypoints"] is True
+    assert flags["skip_regroup"] is True
+    assert flags["miss_enabled"] is False
+
+
+def test_unknown_strategy_raises():
+    with pytest.raises(ValueError, match="unknown strategy"):
+        resolve_strategy("yolo")

--- a/vireo/tests/test_settings_api.py
+++ b/vireo/tests/test_settings_api.py
@@ -478,6 +478,25 @@ def test_patch_workspace_value_beats_global_in_effective(app_and_db):
     assert values["global"]["classification_threshold"] == 0.5
 
 
+def test_patch_workspace_nullable_enum_accepts_null_for_import_only(app_and_db):
+    """A workspace can override the global pipeline.default_strategy back to
+    null (import-only, no automatic processing). The settings UI wires the
+    ``(unset)`` option as ``value=""`` — the endpoint must accept that as
+    null, not reject it as an unknown enum value, otherwise a workspace can
+    never escape a globally-set default from the UI."""
+    app, _ = app_and_db
+    client = app.test_client()
+    for wire_value in ("", None):
+        resp = client.patch(
+            "/api/settings/workspace",
+            json={"key": "pipeline.default_strategy", "value": wire_value},
+        )
+        assert resp.status_code == 200, resp.get_json()
+        assert resp.get_json()["value"] is None
+        values = client.get("/api/settings/values").get_json()
+        assert values["workspace"]["pipeline.default_strategy"] is None
+
+
 # ---------------------------------------------------------------------------
 # DELETE /api/settings/workspace/<dotted-key>
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Phase 1 of the import/process split (design #1101, plan #1102): a "process job" is a collection-scoped pipeline run with a named strategy, plus the scoping and defaults the later phases build on.

- **`vireo/process_strategies.py`** — strategy presets as pure data (`full` / `cull_ready` / `quick_look`), each expanding to the existing `PipelineParams` skip flags plus `miss_enabled`. Includes the recon map of every stage gate; `skip_classify` already gates model-loading/detect/classify, so no `skip_detect` was needed. `cull_ready` keeps regroup (cheap, and pipeline_review needs encounters) — documented deviation from the design table.
- **Per-run `miss_enabled` override on `PipelineParams`** — bidirectional: a strategy can suppress misses on a workspace that has them enabled (short-circuits before compute, no stale `miss_computed_at` stamp) and enable them on a workspace that has them disabled (effective value injected into `pipeline_cfg` so `compute_misses_for_workspace` sees it). Stage setup hoisted above the transient "running" write with its own failed-stage recording.
- **`POST /api/jobs/pipeline` accepts `strategy`** — expansion supplies defaults, explicit body flags win. Key presence (not truthiness) decides: `strategy: null` and the literal `"none"` are 400s; the no-processing case is expressed by not calling the endpoint (that's the workspace-default/chaining contract for PR 3).
- **Folder-scoped runs** — `folder_ids` expand to their active-workspace subtrees via `get_folder_subtree_ids` and materialize an ad-hoc collection (same pattern import runs use). Unlinked folders 404 like the rescan guard; malformed ids and mixed scopes 400.
- **Per-workspace default strategy** — `pipeline.default_strategy` (nullable) in config DEFAULTS, validated at workspace-override save; `null` = import-only.
- **Resume contract pinned** — rerunning the same collection generates zero thumbnails/previews, reports every photo `already_classified`, and never invokes the classifier. (`predictions_stored` is deliberately not pinned to 0: the cached branch re-upserts cached rows for downstream grouping.)

## Tests

Full gate: `tests/test_workspaces.py` + `vireo/tests/{test_db,test_app,test_photos_api,test_edits_api,test_jobs_api,test_darktable_api,test_config,test_process_strategies,test_pipeline_job}.py` → **1469 passed, 1 skipped**. All new behavior TDD'd (RED verified before each implementation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “process strategy” presets for pipeline runs (including *quick look*, *cull ready*, and *full*), with a workspace default to control import-only/unset behavior.
  * Added folder-scoped pipeline job support (`folder_ids`), including descendant handling and exclusion-aware photo selection.

* **Bug Fixes**
  * Improved request validation and clearer error responses for strategy, scope conflicts, and folder/destination/local-processing combinations.
  * Updated miss-detection behavior: disabled runs now skip cleanly; setup failures correctly mark the stage as failed.

* **Tests**
  * Expanded coverage for nullable strategy settings, API validation, folder scoping, and miss-enabled override + rerun cache behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->