### PR TITLE
[codex] Show metadata extraction progress

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2209,7 +2209,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     },
                 )
 
-            def status_cb(message):
+            def status_cb(message, **_phase):
                 runner.push_event(job["id"], "progress", {
                     "phase": message,
                     "current": job["progress"].get("current", 0),
@@ -2311,7 +2311,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     },
                 )
 
-            def status_cb(message):
+            def status_cb(message, **_phase):
                 runner.push_event(job["id"], "progress", {
                     "phase": message,
                     "current": job["progress"].get("current", 0),
@@ -12449,15 +12449,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             effective_cfg = thread_db.get_effective_config(cfg.load())
             pipeline_cfg = effective_cfg.get("pipeline", {})
 
-            def status_cb(message):
-                runner.update_step(job["id"], "scan", current_file=message)
-                runner.push_event(job["id"], "progress", {
-                    "phase": message,
+            def status_cb(message, phase_current=None, phase_total=None, phase_label=None):
+                progress_payload = {
+                    "phase": phase_label or message,
                     "current": job["progress"].get("current", 0),
                     "total": job["progress"].get("total", 0),
                     "current_file": message,
                     "rate": 0,
-                })
+                    "phase_current": phase_current,
+                    "phase_total": phase_total,
+                    "phase_label": phase_label,
+                }
+                runner.update_step(job["id"], "scan", current_file=message)
+                runner.push_event(job["id"], "progress", progress_payload)
 
             vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
 

--- a/vireo/metadata.py
+++ b/vireo/metadata.py
@@ -225,7 +225,7 @@ def _group_tags(flat_dict):
     return grouped
 
 
-def extract_metadata(file_paths, restricted_tags=None):
+def extract_metadata(file_paths, restricted_tags=None, progress_callback=None):
     """Extract metadata from files using ExifTool.
 
     Args:
@@ -233,6 +233,8 @@ def extract_metadata(file_paths, restricted_tags=None):
         restricted_tags: optional list of tag names to extract (e.g.
             ['-DateTimeOriginal', '-GPSLatitude', '-ImageWidth']).
             If None, extracts all tags.
+        progress_callback: optional callable(current, total) invoked after
+            each ExifTool batch completes.
 
     Returns:
         dict mapping file_path -> grouped metadata dict.
@@ -250,6 +252,8 @@ def extract_metadata(file_paths, restricted_tags=None):
             source = entry.get("SourceFile")
             if source:
                 results[source] = _group_tags(entry)
+        if progress_callback:
+            progress_callback(min(i + len(batch), len(file_paths)), len(file_paths))
 
     return results
 

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -557,6 +557,17 @@ def _progress_event(stages, stage_id, phase, **extra):
         "current": current,
         "total": total,
         "stages": {k: dict(v) for k, v in stages.items()},
+        # JobRunner.push_event merges progress payloads into job["progress"]
+        # rather than replacing them, so a sub-phase (e.g. "Extracting metadata"
+        # with phase_current/phase_total set) would otherwise linger through
+        # every later stage that omits these keys and keep the /api/jobs
+        # poll — and thus the jobs page + navbar sub-progress bar — rendering
+        # a stale phase. Default the triple to None here so callers with no
+        # active sub-phase actively clear it; the update() below lets callers
+        # with a real sub-phase override.
+        "phase_current": None,
+        "phase_total": None,
+        "phase_label": None,
     }
     data.update(extra)
     return data

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -960,10 +960,18 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     runner.update_step(job["id"], "scan",
                                        current_file=os.path.basename(path))
 
-                def status_cb(message):
+                def status_cb(message, phase_current=None, phase_total=None, phase_label=None):
                     runner.update_step(job["id"], "scan", current_file=message)
+                    extra = {"current_file": message}
+                    if phase_current is not None or phase_total is not None:
+                        extra.update({
+                            "phase_current": phase_current,
+                            "phase_total": phase_total,
+                            "phase_label": phase_label,
+                        })
                     _emit_progress(
-                        runner, job["id"], stages, "scan", message,
+                        runner, job["id"], stages, "scan",
+                        phase_label or message, **extra,
                     )
 
                 def cancel_check():

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -1092,7 +1092,9 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
         extract_full_metadata: if True, store full ExifTool JSON in exif_data column
         photo_callback: optional callable(photo_id, path_str) called after each photo is committed
         skip_paths: optional set of absolute path strings to exclude from scanning
-        status_callback: optional callable(message) for phase status updates
+        status_callback: optional callable(message) for phase status updates.
+            Callers may also accept keyword-only ``phase_current``,
+            ``phase_total``, and ``phase_label`` for sub-phase progress.
         recursive: if True (default), scan subfolders; if False, only scan root directory
         restrict_dirs: optional list of directory paths to scan instead of the
             full tree. When provided, only files in these directories are
@@ -1149,11 +1151,29 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
         if cancel_check is not None and cancel_check():
             raise RuntimeError("scan cancelled")
 
+    def _emit_status(message, phase_current=None, phase_total=None, phase_label=None):
+        if not status_callback:
+            return
+        if phase_current is None and phase_total is None and phase_label is None:
+            status_callback(message)
+            return
+        try:
+            status_callback(
+                message,
+                phase_current=phase_current,
+                phase_total=phase_total,
+                phase_label=phase_label,
+            )
+        except TypeError:
+            # Keep compatibility with older one-argument callbacks in tests and
+            # utility callers.
+            status_callback(message)
+
     # Discover all image files (incremental enumeration for progress reporting)
     log.info("Discovering files in %s ...", root)
     _check_cancelled()
     if status_callback:
-        status_callback("Discovering files...")
+        _emit_status("Discovering files...")
     image_files = []
 
     # os.walk + onerror, not Path.rglob: rglob silently skips any
@@ -1265,7 +1285,7 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                     if checked % 100 == 0:
                         _check_cancelled()
                     if checked % 500 == 0 and status_callback:
-                        status_callback(
+                        _emit_status(
                             f"Discovering files... ({len(image_files)} found)"
                         )
                     ext = os.path.splitext(name)[1].lower()
@@ -1301,7 +1321,7 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
                 if checked % 100 == 0:
                     _check_cancelled()
                 if checked % 500 == 0 and status_callback:
-                    status_callback(
+                    _emit_status(
                         f"Discovering files... ({len(image_files)} found)"
                     )
                 if (f.is_file()
@@ -1564,9 +1584,27 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
     # Batch extract metadata via ExifTool only for files that need processing
     paths_to_extract = [str(ip) for ip in files_to_process]
     if paths_to_extract and status_callback:
-        status_callback(f"Extracting metadata ({len(paths_to_extract)} files)...")
+        metadata_total = len(paths_to_extract)
+        _emit_status(
+            f"Extracting metadata (0 / {metadata_total} files)...",
+            phase_current=0,
+            phase_total=metadata_total,
+            phase_label="Extracting metadata",
+        )
     _check_cancelled()
-    metadata_map = extract_metadata(paths_to_extract) if paths_to_extract else {}
+
+    def _metadata_progress(current, total):
+        _emit_status(
+            f"Extracting metadata ({current} / {total} files)...",
+            phase_current=current,
+            phase_total=total,
+            phase_label="Extracting metadata",
+        )
+
+    metadata_map = (
+        extract_metadata(paths_to_extract, progress_callback=_metadata_progress)
+        if paths_to_extract else {}
+    )
     _check_cancelled()
 
     # Compute phash + file_hash in parallel across all files that need
@@ -1576,7 +1614,7 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
     # while the main thread commits the head — no O(n) buffer of features.
     workers = _resolve_worker_count(files_to_process)
     if paths_to_extract and status_callback:
-        status_callback(
+        _emit_status(
             f"Hashing {len(paths_to_extract)} files ({workers} worker{'s' if workers != 1 else ''})..."
         )
 

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -9230,6 +9230,32 @@ function formatDuration(seconds) {
   // Tauri. With multiple concurrent jobs we pick the one that started first
   // (earliest started_at); phases without a known total pulse instead.
   var _lastDockProgress = { state: null, value: -1 };
+  function bpActiveProgress(progress) {
+    if (!progress) return null;
+    if (typeof progress.phase_current === 'number' && progress.phase_total > 0) {
+      return {
+        current: progress.phase_current,
+        total: progress.phase_total,
+        label: progress.phase_label || progress.phase || 'Current phase',
+        phase: true,
+      };
+    }
+    if (progress.total > 0) {
+      return {
+        current: progress.current || 0,
+        total: progress.total,
+        label: 'Overall',
+        phase: false,
+      };
+    }
+    return null;
+  }
+
+  function bpProgressPct(info) {
+    if (!info || !info.total) return 0;
+    return Math.max(0, Math.min(100, Math.round((info.current / info.total) * 100)));
+  }
+
   function updateDockProgress() {
     if (!window.__TAURI_INTERNALS__) return;
     var running = activeJobs.filter(function(j) {
@@ -9245,10 +9271,9 @@ function formatDuration(seconds) {
         var b = longest.started_at || '';
         if (a && (!b || a < b)) longest = running[i];
       }
-      var total = longest.progress && longest.progress.total;
-      var current = longest.progress && longest.progress.current;
-      if (total && total > 0) {
-        var pct = Math.max(0, Math.min(100, Math.round((current / total) * 100)));
+      var progressInfo = bpActiveProgress(longest.progress);
+      if (progressInfo) {
+        var pct = bpProgressPct(progressInfo);
         state = 'normal'; value = pct;
       } else {
         state = 'indeterminate'; value = null;
@@ -9322,11 +9347,12 @@ function formatDuration(seconds) {
   function renderJobList(jobs) {
     var html = '';
     jobs.forEach(function(j) {
-      var pct = j.progress && j.progress.total > 0 ? Math.round((j.progress.current / j.progress.total) * 100) : 0;
+      var progressInfo = bpActiveProgress(j.progress);
+      var pct = progressInfo ? bpProgressPct(progressInfo) : 0;
       var phase = j.progress && j.progress.phase ? j.progress.phase : '';
       var detail = '';
-      if (j.progress && j.progress.total > 0) {
-        detail = j.progress.current.toLocaleString() + '/' + j.progress.total.toLocaleString();
+      if (progressInfo) {
+        detail = progressInfo.current.toLocaleString() + '/' + progressInfo.total.toLocaleString();
         if (pct > 0) detail += ' (' + pct + '%)';
       }
       // Queued/pending work gets a muted dot so the user can tell it apart
@@ -9385,13 +9411,14 @@ function formatDuration(seconds) {
     if (j.progress && j.progress.phase) {
       text += ' — ' + j.progress.phase;
     }
-    if (j.progress && j.progress.total > 0) {
-      var pct = Math.round((j.progress.current / j.progress.total) * 100);
-      var isBytes = j.type && j.type.indexOf('download') !== -1 && j.progress.total > 1000000;
+    var progressInfo = bpActiveProgress(j.progress);
+    if (progressInfo) {
+      var pct = bpProgressPct(progressInfo);
+      var isBytes = j.type && j.type.indexOf('download') !== -1 && progressInfo.total > 1000000;
       if (isBytes) {
-        text += ' ' + (j.progress.current / (1024*1024)).toFixed(0) + '/' + (j.progress.total / (1024*1024)).toFixed(0) + ' MB (' + pct + '%)';
+        text += ' ' + (progressInfo.current / (1024*1024)).toFixed(0) + '/' + (progressInfo.total / (1024*1024)).toFixed(0) + ' MB (' + pct + '%)';
       } else {
-        text += ' ' + j.progress.current.toLocaleString() + '/' + j.progress.total.toLocaleString() + ' (' + pct + '%)';
+        text += ' ' + progressInfo.current.toLocaleString() + '/' + progressInfo.total.toLocaleString() + ' (' + pct + '%)';
       }
       if (j.progress.rate > 0) {
         text += ' ' + (j.progress.rate / (1024*1024)).toFixed(1) + ' MB/s';

--- a/vireo/templates/jobs.html
+++ b/vireo/templates/jobs.html
@@ -315,6 +315,32 @@
     }
   }
 
+  function activeProgress(progress) {
+    if (!progress) return null;
+    if (typeof progress.phase_current === 'number' && progress.phase_total > 0) {
+      return {
+        current: progress.phase_current,
+        total: progress.phase_total,
+        label: progress.phase_label || progress.phase || 'Current phase',
+        phase: true,
+      };
+    }
+    if (progress.total > 0) {
+      return {
+        current: progress.current || 0,
+        total: progress.total,
+        label: 'Overall',
+        phase: false,
+      };
+    }
+    return null;
+  }
+
+  function progressPct(info) {
+    if (!info || !info.total) return 0;
+    return Math.max(0, Math.min(100, Math.round((info.current / info.total) * 100)));
+  }
+
   function renderJobCard(job, options) {
     options = options || {};
     // Queued pipelines are "live" for UI purposes: they have a real
@@ -354,8 +380,9 @@
     html += '<div class="job-detail-meta">';
     html += '<span>Started: ' + new Date(job.started_at).toLocaleTimeString() + '</span>';
     html += '<span>Elapsed: ' + elapsed + '</span>';
-    if (job.progress && job.progress.total > 0) {
-      html += '<span>Overall: ' + Math.round((job.progress.current / job.progress.total) * 100) + '%</span>';
+    var visibleProgress = activeProgress(job.progress);
+    if (visibleProgress) {
+      html += '<span>' + esc(visibleProgress.label) + ': ' + progressPct(visibleProgress) + '%</span>';
     }
     html += '</div>';
 
@@ -371,10 +398,11 @@
       // Fallback for running jobs without steps
       html += '<div class="job-tree"><div style="padding:8px;font-size:13px;color:var(--text-muted);">';
       if (job.progress.phase) html += '<div style="color:var(--accent);font-weight:500;margin-bottom:8px;">' + esc(job.progress.phase) + '</div>';
-      if (job.progress.total > 0) {
-        var pct = Math.round((job.progress.current / job.progress.total) * 100);
+      var fallbackProgress = activeProgress(job.progress);
+      if (fallbackProgress) {
+        var pct = progressPct(fallbackProgress);
         html += '<div class="tree-step-bar" style="width:200px;margin-bottom:4px;"><div class="tree-step-bar-fill" style="width:' + pct + '%"></div></div>';
-        html += '<div>' + job.progress.current.toLocaleString() + ' / ' + job.progress.total.toLocaleString() + '</div>';
+        html += '<div>' + esc(fallbackProgress.label) + ': ' + fallbackProgress.current.toLocaleString() + ' / ' + fallbackProgress.total.toLocaleString() + '</div>';
       }
       if (job.progress.current_file) html += '<div style="margin-top:4px;">' + esc(job.progress.current_file) + '</div>';
       html += '</div></div>';
@@ -644,8 +672,12 @@
       time = timeAgo(j.started_at);
     }
     var detail = '';
+    var visibleProgress = activeProgress(j.progress);
     if (j.status === 'running' && j.progress && j.progress.phase) {
       detail = esc(j.progress.phase);
+      if (visibleProgress && visibleProgress.phase) {
+        detail += ' ' + visibleProgress.current.toLocaleString() + '/' + visibleProgress.total.toLocaleString();
+      }
     } else if (j.summary) {
       detail = esc(j.summary);
     } else if (j.status === 'failed' && j.errors && j.errors.length > 0) {
@@ -654,8 +686,8 @@
       detail = formatElapsed(j.duration);
     }
     var pct = 0;
-    if (j.progress && j.progress.total > 0) {
-      pct = Math.round((j.progress.current / j.progress.total) * 100);
+    if (visibleProgress) {
+      pct = progressPct(visibleProgress);
     }
     var html = '<div class="job-list-item' + selected + '" data-job-id="' + esc(j.id) + '" data-job-source="' + source + '">';
     html += '<div class="job-list-item-header">';

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -1361,7 +1361,7 @@ def test_pipeline_with_broken_collection_repairs_metadata(app_and_db, tmp_path, 
 
     # Mock ExifTool so the test doesn't depend on the binary.
     import scanner
-    def fake_extract(paths, restricted_tags=None):
+    def fake_extract(paths, restricted_tags=None, progress_callback=None):
         return {p: {"File": {"ImageWidth": 640, "ImageHeight": 480},
                     "EXIF": {"DateTimeOriginal": "2024:06:15 10:00:00"},
                     "Composite": {}} for p in paths}
@@ -1434,7 +1434,7 @@ def test_pipeline_repair_does_not_ingest_untracked_files(app_and_db, tmp_path, m
     db.conn.commit()
 
     import scanner
-    def fake_extract(paths, restricted_tags=None):
+    def fake_extract(paths, restricted_tags=None, progress_callback=None):
         return {p: {"File": {"ImageWidth": 640, "ImageHeight": 480},
                     "EXIF": {"DateTimeOriginal": "2024:06:15 10:00:00"},
                     "Composite": {}} for p in paths}
@@ -1558,7 +1558,7 @@ def test_pipeline_repair_does_not_double_process_thumbnails(
     db.conn.commit()
 
     import scanner
-    def fake_extract(paths, restricted_tags=None):
+    def fake_extract(paths, restricted_tags=None, progress_callback=None):
         return {p: {"File": {"ImageWidth": 640, "ImageHeight": 480},
                     "EXIF": {"DateTimeOriginal": "2024:06:15 10:00:00"},
                     "Composite": {}} for p in paths}

--- a/vireo/tests/test_metadata.py
+++ b/vireo/tests/test_metadata.py
@@ -105,6 +105,28 @@ def test_extract_metadata_empty_list():
     assert extract_metadata([]) == {}
 
 
+def test_extract_metadata_reports_batch_progress(monkeypatch):
+    """Batch progress advances once per ExifTool invocation."""
+    import metadata
+
+    paths = [f"/photos/img{i}.jpg" for i in range(5)]
+    progress = []
+
+    def fake_run(file_paths, extra_args=None):
+        return [{"SourceFile": path, "EXIF:Make": "TestCam"} for path in file_paths]
+
+    monkeypatch.setattr(metadata, "_BATCH_SIZE", 2)
+    monkeypatch.setattr(metadata, "_run_exiftool", fake_run)
+
+    results = metadata.extract_metadata(
+        paths,
+        progress_callback=lambda current, total: progress.append((current, total)),
+    )
+
+    assert set(results) == set(paths)
+    assert progress == [(2, 5), (4, 5), (5, 5)]
+
+
 def test_extract_metadata_retries_failed_batches(monkeypatch):
     """A failed ExifTool batch should be split so good files still get metadata."""
     import metadata

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -7300,6 +7300,92 @@ def test_update_stages_emits_weighted_current_total():
     assert data["current"] == 6
 
 
+def test_progress_event_defaults_phase_triple_to_none():
+    """Every progress payload must carry an explicit phase_current /
+    phase_total / phase_label triple. JobRunner.push_event merges progress
+    payloads into job['progress'] rather than replacing them, so a scan
+    sub-phase (e.g. 'Extracting metadata' with numeric phase_current /
+    phase_total) would linger across every later status emission that
+    omits these keys — the jobs page and navbar would keep rendering the
+    stale 'Extracting metadata' bar through 'Hashing ...' and downstream
+    pipeline stages. Callers with no active sub-phase must therefore emit
+    None so the merge actively clears the previous values."""
+    from pipeline_job import _progress_event
+
+    stages = _empty_stages()
+    stages["scan"]["status"] = "running"
+
+    # No phase_* passed → the triple defaults to None and reaches the payload
+    # so the frontend's `typeof phase_current === 'number' && phase_total > 0`
+    # guard falls back to overall progress instead of re-rendering a stale bar.
+    data = _progress_event(stages, "scan", "Hashing 3 files (2 workers)...")
+    assert data["phase_current"] is None
+    assert data["phase_total"] is None
+    assert data["phase_label"] is None
+
+    # Callers with an active sub-phase override the defaults.
+    data = _progress_event(
+        stages, "scan", "Extracting metadata (2 / 3 files)...",
+        phase_current=2,
+        phase_total=3,
+        phase_label="Extracting metadata",
+    )
+    assert data["phase_current"] == 2
+    assert data["phase_total"] == 3
+    assert data["phase_label"] == "Extracting metadata"
+
+
+def test_emit_progress_clears_stale_phase_in_merged_job_progress():
+    """End-to-end: JobRunner.push_event merges into job['progress']; after a
+    scan sub-phase emission followed by a plain status emission, the merged
+    progress dict must show the phase triple cleared to None so /api/jobs
+    polling stops rendering the stale metadata bar."""
+    import queue as _queue
+    import sys as _sys
+
+    _sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
+    from jobs import JobRunner
+    from pipeline_job import _emit_progress
+    from wait import wait_for_job_via_runner
+
+    runner = JobRunner()
+    seen_progress = _queue.Queue()
+
+    def work(job):
+        stages = _empty_stages()
+        stages["scan"]["status"] = "running"
+
+        _emit_progress(
+            runner, job["id"], stages, "scan",
+            "Extracting metadata (2 / 3 files)...",
+            phase_current=2,
+            phase_total=3,
+            phase_label="Extracting metadata",
+        )
+        seen_progress.put(dict(job["progress"]))
+
+        _emit_progress(
+            runner, job["id"], stages, "scan",
+            "Hashing 3 files (2 workers)...",
+        )
+        seen_progress.put(dict(job["progress"]))
+
+        return {"ok": True}
+
+    job_id = runner.start("scan", work)
+    wait_for_job_via_runner(runner, job_id)
+
+    metadata_prog = seen_progress.get_nowait()
+    assert metadata_prog["phase_current"] == 2
+    assert metadata_prog["phase_total"] == 3
+    assert metadata_prog["phase_label"] == "Extracting metadata"
+
+    hashing_prog = seen_progress.get_nowait()
+    assert hashing_prog["phase_current"] is None
+    assert hashing_prog["phase_total"] is None
+    assert hashing_prog["phase_label"] is None
+
+
 # ---------------------------------------------------------------------------
 # Cancel responsiveness in extract_masks / eye_keypoints
 #

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -1611,7 +1611,7 @@ def test_scan_extracts_working_copy_for_raw(tmp_path, monkeypatch):
     nef_file.write_bytes(b"fake raw data")
 
     # Mock ExifTool to return empty metadata
-    monkeypatch.setattr(scanner, "extract_metadata", lambda paths: {})
+    monkeypatch.setattr(scanner, "extract_metadata", lambda paths, **_kwargs: {})
 
     # Mock extract_working_copy to actually create a file (simulates success)
     def fake_extract(source, output, max_size=4096, quality=92):
@@ -1650,7 +1650,7 @@ def test_scan_skips_working_copy_for_jpeg(tmp_path, monkeypatch):
     jpg_file = photo_dir / "IMG_001.jpg"
     Image.new("RGB", (3000, 2000)).save(str(jpg_file), "JPEG")
 
-    monkeypatch.setattr(scanner, "extract_metadata", lambda paths: {})
+    monkeypatch.setattr(scanner, "extract_metadata", lambda paths, **_kwargs: {})
 
     # Mock extract_working_copy -- should never be called for JPEGs
     calls = []
@@ -1693,7 +1693,7 @@ def test_scan_uses_raw_primary_for_raw_working_copy(tmp_path, monkeypatch):
     Image.new("RGB", (6000, 4000), color=(255, 0, 0)).save(str(jpg_file), "JPEG")
 
     # Mock ExifTool
-    monkeypatch.setattr(scanner, "extract_metadata", lambda paths: {})
+    monkeypatch.setattr(scanner, "extract_metadata", lambda paths, **_kwargs: {})
 
     # Track which source file extract_working_copy is called with
     sources_used = []
@@ -1750,7 +1750,7 @@ def test_scan_falls_back_to_companion_when_raw_extraction_fails(
     jpg_file = photo_dir / "IMG_002.jpg"
     Image.new("RGB", (6000, 4000), color=(0, 255, 0)).save(str(jpg_file), "JPEG")
 
-    monkeypatch.setattr(scanner, "extract_metadata", lambda paths: {})
+    monkeypatch.setattr(scanner, "extract_metadata", lambda paths, **_kwargs: {})
 
     sources_used = []
 
@@ -1819,7 +1819,7 @@ def test_scan_falls_back_when_raw_working_copy_short_edge_is_smaller(
     jpg_file = photo_dir / "IMG_004.jpg"
     Image.new("RGB", (6000, 4000), color=(0, 255, 0)).save(str(jpg_file), "JPEG")
 
-    monkeypatch.setattr(scanner, "extract_metadata", lambda paths: {})
+    monkeypatch.setattr(scanner, "extract_metadata", lambda paths, **_kwargs: {})
 
     sources_used = []
 
@@ -1873,7 +1873,7 @@ def test_scan_accepts_near_full_raw_working_copy(tmp_path, monkeypatch):
     jpg_file = photo_dir / "IMG_006.jpg"
     Image.new("RGB", (6000, 4000), color=(0, 255, 0)).save(str(jpg_file), "JPEG")
 
-    monkeypatch.setattr(scanner, "extract_metadata", lambda paths: {})
+    monkeypatch.setattr(scanner, "extract_metadata", lambda paths, **_kwargs: {})
 
     sources_used = []
 
@@ -1945,7 +1945,7 @@ def test_scan_accepts_portrait_raw_working_copy_with_exif_orientation(
         },
     }
 
-    def fake_metadata(paths):
+    def fake_metadata(paths, restricted_tags=None, progress_callback=None):
         return {str(p): portrait_meta for p in paths}
 
     monkeypatch.setattr(scanner, "extract_metadata", fake_metadata)
@@ -2010,7 +2010,7 @@ def test_scan_marks_source_failure_when_raw_and_companion_both_fail(
     jpg_file = photo_dir / "IMG_003.jpg"
     Image.new("RGB", (6000, 4000), color=(0, 0, 255)).save(str(jpg_file), "JPEG")
 
-    monkeypatch.setattr(scanner, "extract_metadata", lambda paths: {})
+    monkeypatch.setattr(scanner, "extract_metadata", lambda paths, **_kwargs: {})
 
     def fake_extract(source, output, max_size=4096, quality=92):
         # Both RAW and companion fail (e.g. RAW unsupported + companion
@@ -2092,7 +2092,7 @@ def _setup_scanned_photo(tmp_path, pil_size=(640, 480)):
     db = Database(str(tmp_path / "test.db"))
     # Mock ExifTool so the first scan populates exif_data with real
     # dimensions, independent of whether exiftool is installed.
-    def fake_extract(paths, restricted_tags=None):
+    def fake_extract(paths, restricted_tags=None, progress_callback=None):
         return {
             p: {"File": {"ImageWidth": pil_size[0], "ImageHeight": pil_size[1]},
                 "EXIF": {}, "Composite": {}}
@@ -2128,7 +2128,7 @@ def test_incremental_rescan_reextracts_when_timestamp_null(tmp_path, monkeypatch
     )
     db.conn.commit()
 
-    def fake_extract(paths, restricted_tags=None):
+    def fake_extract(paths, restricted_tags=None, progress_callback=None):
         return {p: {"File": {"ImageWidth": 640, "ImageHeight": 480},
                     "EXIF": {}, "Composite": {}} for p in paths}
     monkeypatch.setattr(scanner, "extract_metadata", fake_extract)
@@ -2160,7 +2160,7 @@ def test_incremental_rescan_reextracts_when_raw_dims_suspect(tmp_path, monkeypat
     )
     db.conn.commit()
 
-    def fake_extract(paths, restricted_tags=None):
+    def fake_extract(paths, restricted_tags=None, progress_callback=None):
         return {p: {"File": {"ImageWidth": 640, "ImageHeight": 480},
                     "EXIF": {}, "Composite": {}} for p in paths}
     monkeypatch.setattr(scanner, "extract_metadata", fake_extract)
@@ -2192,7 +2192,7 @@ def test_incremental_rescan_skips_small_jpeg_dims_not_raw(tmp_path, monkeypatch)
     db.conn.commit()
 
     called_with = []
-    def fake_extract(paths, restricted_tags=None):
+    def fake_extract(paths, restricted_tags=None, progress_callback=None):
         called_with.append(list(paths))
         return {p: {"File": {"ImageWidth": 640, "ImageHeight": 480},
                     "EXIF": {}, "Composite": {}} for p in paths}
@@ -2225,7 +2225,7 @@ def test_scan_restrict_files_ignores_files_not_in_list(tmp_path, monkeypatch):
 
     db = Database(str(tmp_path / "test.db"))
 
-    def fake_extract(paths, restricted_tags=None):
+    def fake_extract(paths, restricted_tags=None, progress_callback=None):
         return {p: {"File": {"ImageWidth": 640, "ImageHeight": 480},
                     "EXIF": {}, "Composite": {}} for p in paths}
     monkeypatch.setattr(scanner, "extract_metadata", fake_extract)
@@ -2277,7 +2277,7 @@ def test_incremental_rescan_respects_exif_extracted_guard(tmp_path, monkeypatch)
     db.conn.commit()
 
     called_with = []
-    def fake_extract(paths, restricted_tags=None):
+    def fake_extract(paths, restricted_tags=None, progress_callback=None):
         called_with.append(list(paths))
         return {p: {"File": {"ImageWidth": 640, "ImageHeight": 480},
                     "EXIF": {}, "Composite": {}} for p in paths}

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -406,6 +406,39 @@ def test_scan_cancel_check_aborts_before_metadata_extraction(tmp_path, monkeypat
     assert db.get_photos(per_page=100) == []
 
 
+def test_scan_reports_metadata_phase_progress(tmp_path, monkeypatch):
+    """ExifTool batch progress is surfaced as status callback metadata."""
+    import scanner
+    from db import Database
+
+    root = str(tmp_path / "photos")
+    _create_test_images(root, {'': ['img1.jpg', 'img2.jpg', 'img3.jpg']})
+    db = Database(str(tmp_path / "test.db"))
+    status_events = []
+
+    def fake_extract_metadata(paths, progress_callback=None):
+        if progress_callback:
+            progress_callback(2, len(paths))
+            progress_callback(len(paths), len(paths))
+        return {}
+
+    def status_cb(message, **kwargs):
+        status_events.append((message, kwargs))
+
+    monkeypatch.setattr(scanner, "extract_metadata", fake_extract_metadata)
+
+    scanner.scan(root, db, status_callback=status_cb)
+
+    metadata_events = [
+        event for event in status_events
+        if event[1].get("phase_label") == "Extracting metadata"
+    ]
+    assert metadata_events[0][1]["phase_current"] == 0
+    assert metadata_events[0][1]["phase_total"] == 3
+    assert metadata_events[-1][1]["phase_current"] == 3
+    assert metadata_events[-1][1]["phase_total"] == 3
+
+
 def test_scan_non_recursive_only_finds_root_photos(tmp_path):
     """scan(recursive=False) only finds photos in the root folder, not subfolders."""
     from db import Database


### PR DESCRIPTION
## Summary
- report metadata extraction progress after each ExifTool batch
- surface phase-level scan progress in jobs views and dock summaries
- keep scan callbacks backward compatible and cover metadata progress with tests

## Validation
- python -m pytest vireo/tests/test_metadata.py vireo/tests/test_scanner.py::test_scan_reports_metadata_phase_progress vireo/tests/test_scanner.py::test_scan_cancel_check_aborts_before_metadata_extraction
- python -m py_compile vireo/metadata.py vireo/scanner.py vireo/app.py vireo/pipeline_job.py
- python -m ruff check vireo/metadata.py vireo/scanner.py vireo/app.py vireo/pipeline_job.py vireo/tests/test_metadata.py vireo/tests/test_scanner.py
- git diff --check origin/main...