### PR TITLE
Import job: direct-to-archive copy, hash verify, incremental catalog (import/process split PR 2)

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -14763,6 +14763,122 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         )
         return jsonify({"job_id": job_id})
 
+    @app.route("/api/jobs/import-photos", methods=["POST"])
+    def api_job_import_photos():
+        """Photo import job: copy card -> archive, hash-verify, catalog
+        incrementally (import/process split PR 2).
+
+        Distinct from ``POST /api/jobs/import`` (Lightroom catalog import),
+        which keeps its route and shape. No pipeline slot involvement —
+        imports are I/O-bound and must not queue behind a GPU run; that
+        coupling is exactly what the split removes.
+        """
+        from image_loader import is_excluded_scan_path
+        from ingest import _is_unsafe_path
+
+        body = request.get_json(silent=True) or {}
+
+        sources = body.get("sources")
+        if isinstance(sources, str):
+            sources = [sources]
+        if not sources or not isinstance(sources, list) or not all(
+            isinstance(s, str) and s for s in sources
+        ):
+            return json_error("sources must be a non-empty list of paths")
+        for s in sources:
+            # Pre-stat rejection of other-app bundles: os.path.isdir on a
+            # .photoslibrary path itself trips the macOS TCC prompt.
+            if is_excluded_scan_path(s):
+                return json_error(
+                    f"source is inside a macOS app-managed library and "
+                    f"cannot be imported: {s}"
+                )
+            if not os.path.isdir(s):
+                return json_error(f"source directory not found: {s}")
+
+        destination = body.get("destination")
+        if not destination:
+            return json_error("destination required")
+        if not os.path.isabs(destination):
+            return json_error("destination must be an absolute path")
+
+        folder_template = body.get("folder_template", "%Y/%Y-%m-%d")
+        if folder_template and _is_unsafe_path(folder_template):
+            return json_error(
+                "folder_template must be a relative path without '..' or "
+                "backslashes"
+            )
+
+        db = _get_db()
+        # After-import strategy: validated at enqueue (failing the chain
+        # hours later is the old pipeline's mistake). Key present -> null
+        # means import-only, a string must name a real strategy. Key
+        # omitted -> default from the workspace's pipeline.default_strategy
+        # (nullable, same vocabulary). Stored in the job config for the
+        # PR 3 chaining hook; the import job itself never reads it.
+        if "after_import" in body:
+            after_import = body.get("after_import")
+        else:
+            import config as cfg
+
+            effective_cfg = db.get_effective_config(cfg.load())
+            after_import = (
+                effective_cfg.get("pipeline", {}).get("default_strategy")
+            )
+        if after_import is not None:
+            if not isinstance(after_import, str):
+                return json_error(
+                    "after_import must be a strategy name or null, got "
+                    f"{type(after_import).__name__}"
+                )
+            from process_strategies import resolve_strategy
+
+            try:
+                resolve_strategy(after_import)
+            except ValueError as e:
+                return json_error(str(e))
+
+        file_types = body.get("file_types", "both")
+        skip_duplicates = bool(body.get("skip_duplicates", True))
+        verify_by_hash = bool(body.get("verify_by_hash", False))
+        recursive = bool(body.get("recursive", True))
+
+        runner = app._job_runner
+        active_ws = db._active_workspace_id
+        vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+
+        job_config = {
+            "sources": sources,
+            "destination": destination,
+            "folder_template": folder_template,
+            "file_types": file_types,
+            "skip_duplicates": skip_duplicates,
+            "verify_by_hash": verify_by_hash,
+            "recursive": recursive,
+            "after_import": after_import,
+        }
+
+        def work(job):
+            from import_job import ImportParams, run_import_job
+
+            params = ImportParams(
+                sources=sources,
+                destination=destination,
+                folder_template=folder_template,
+                file_types=file_types,
+                skip_duplicates=skip_duplicates,
+                verify_by_hash=verify_by_hash,
+                recursive=recursive,
+                after_import=after_import,
+                vireo_dir=vireo_dir,
+            )
+            return run_import_job(job, runner, db_path, active_ws, params)
+
+        job_id = runner.start(
+            "import", work, config=job_config, workspace_id=active_ws,
+        )
+        return jsonify({"job_id": job_id})
+
     @app.route("/api/jobs/sync", methods=["POST"])
     def api_job_sync():
         runner = app._job_runner

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -14802,6 +14802,32 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not os.path.isabs(destination):
             return json_error("destination must be an absolute path")
 
+        # Reject destinations that are equal to, or nested under, any source
+        # (after realpath so a symlink can't slip past). The importer copies
+        # every card file into the destination and marks the card safe to
+        # format once ``copied + skipped_duplicate == discovered``; if the
+        # destination lives inside the card, formatting the card also erases
+        # the supposed archive copy, so allowing this is a data-loss trap.
+        try:
+            dest_real = os.path.realpath(destination)
+        except OSError as e:
+            return json_error(f"destination cannot be resolved: {e}")
+        for s in sources:
+            try:
+                source_real = os.path.realpath(s)
+            except OSError:
+                # Source unresolvable — the os.path.isdir check above
+                # already handled non-existent sources; nothing more to say.
+                continue
+            if dest_real == source_real or dest_real.startswith(
+                source_real.rstrip(os.sep) + os.sep
+            ):
+                return json_error(
+                    f"destination cannot be inside a source directory "
+                    f"(destination={destination!r}, source={s!r}); "
+                    f"formatting the card would erase the archive copy"
+                )
+
         folder_template = body.get("folder_template", "%Y/%Y-%m-%d")
         if folder_template and _is_unsafe_path(folder_template):
             return json_error(

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -14808,10 +14808,24 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # format once ``copied + skipped_duplicate == discovered``; if the
         # destination lives inside the card, formatting the card also erases
         # the supposed archive copy, so allowing this is a data-loss trap.
+        #
+        # macOS's default APFS/HFS+ volumes and Windows NTFS are
+        # case-INSENSITIVE, so ``/Volumes/Card`` and ``/volumes/card`` are
+        # the same directory but ``realpath`` doesn't case-normalize on
+        # POSIX (macOS reports as POSIX). Compare case-folded on those
+        # platforms so a differently cased spelling can't bypass the
+        # containment check; on Linux we keep case-sensitive comparison
+        # because ext4/xfs really do distinguish case.
+        _case_insensitive_platform = sys.platform in ("darwin", "win32")
+
+        def _casenorm(p):
+            return p.casefold() if _case_insensitive_platform else p
+
         try:
             dest_real = os.path.realpath(destination)
         except OSError as e:
             return json_error(f"destination cannot be resolved: {e}")
+        dest_cmp = _casenorm(dest_real)
         for s in sources:
             try:
                 source_real = os.path.realpath(s)
@@ -14819,8 +14833,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 # Source unresolvable — the os.path.isdir check above
                 # already handled non-existent sources; nothing more to say.
                 continue
-            if dest_real == source_real or dest_real.startswith(
-                source_real.rstrip(os.sep) + os.sep
+            source_cmp = _casenorm(source_real).rstrip(os.sep)
+            if dest_cmp == source_cmp or dest_cmp.startswith(
+                source_cmp + os.sep
             ):
                 return json_error(
                     f"destination cannot be inside a source directory "

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -14812,20 +14812,51 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # macOS's default APFS/HFS+ volumes and Windows NTFS are
         # case-INSENSITIVE, so ``/Volumes/Card`` and ``/volumes/card`` are
         # the same directory but ``realpath`` doesn't case-normalize on
-        # POSIX (macOS reports as POSIX). Compare case-folded on those
-        # platforms so a differently cased spelling can't bypass the
-        # containment check; on Linux we keep case-sensitive comparison
-        # because ext4/xfs really do distinguish case.
+        # POSIX (macOS reports as POSIX). On Linux, a platform-wide
+        # case-sensitivity assumption misses FAT/exFAT/NTFS-mounted
+        # removable media (typical SD-card setup) that sit under a
+        # case-sensitive ext4 parent — the user's real card mount point
+        # can be case-insensitive even when the root filesystem isn't.
+        # Compare case-folded on darwin/win32 unconditionally, and on
+        # Linux probe each source's actual filesystem: if the resolved
+        # path with an alpha character case-swapped still stat's to the
+        # same inode, the mount is case-insensitive and both sides of
+        # the containment comparison need case-folding for that source.
         _case_insensitive_platform = sys.platform in ("darwin", "win32")
 
         def _casenorm(p):
             return p.casefold() if _case_insensitive_platform else p
 
+        def _fs_is_case_insensitive(path):
+            """Probe whether the filesystem at ``path`` treats case as insensitive.
+
+            Best-effort: case-swap one alpha character from the resolved
+            path and check ``os.path.samefile``. Any error (probe path
+            not readable, no alpha char to swap) returns False and the
+            caller falls back to case-sensitive comparison — a false
+            negative is a strictly narrower guard than what the platform
+            branch already applies, never a wider one.
+            """
+            try:
+                for i, c in enumerate(path):
+                    if c.isalpha():
+                        probe = path[:i] + c.swapcase() + path[i + 1:]
+                        if probe == path:
+                            continue
+                        if not os.path.exists(probe):
+                            return False
+                        try:
+                            return os.path.samefile(path, probe)
+                        except OSError:
+                            return False
+                return False
+            except OSError:
+                return False
+
         try:
             dest_real = os.path.realpath(destination)
         except OSError as e:
             return json_error(f"destination cannot be resolved: {e}")
-        dest_cmp = _casenorm(dest_real)
         for s in sources:
             try:
                 source_real = os.path.realpath(s)
@@ -14833,7 +14864,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 # Source unresolvable — the os.path.isdir check above
                 # already handled non-existent sources; nothing more to say.
                 continue
-            source_cmp = _casenorm(source_real).rstrip(os.sep)
+            # Per-source case-fold decision: platform is enough on
+            # darwin/win32; on Linux, probe the actual source mount.
+            per_source_ci = _case_insensitive_platform or (
+                not _case_insensitive_platform
+                and _fs_is_case_insensitive(source_real)
+            )
+            if per_source_ci:
+                source_cmp = source_real.casefold().rstrip(os.sep)
+                dest_cmp = dest_real.casefold()
+            else:
+                source_cmp = source_real.rstrip(os.sep)
+                dest_cmp = dest_real
             if dest_cmp == source_cmp or dest_cmp.startswith(
                 source_cmp + os.sep
             ):

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -14840,16 +14840,28 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             ``Card`` entry (mount-point dentries are stored in the
             parent FS), so swapping characters in the ``path`` string
             always reports case-sensitive regardless of the card's own
-            semantics. Any error, empty directory, or entry without an
-            alpha character returns False and the caller falls back to
-            case-sensitive comparison — a false negative is a strictly
-            narrower guard than what the platform branch already
-            applies, never a wider one. See PR #1107 review.
+            semantics.
+
+            Any inconclusive result (unlistable, empty, no
+            alpha-containing entry, or a stat error while comparing)
+            returns True so the containment check falls back to
+            case-fold — the stricter direction of this safety guard.
+            A false positive on a case-sensitive filesystem can only
+            reject a legitimate destination (recoverable UX error the
+            user immediately sees and fixes by picking a different
+            path), whereas a false negative on a case-insensitive
+            filesystem accepts a case-collision destination inside the
+            card and lets ``safe_to_format`` later green-light
+            formatting while the archive lives on it. The reviewer's
+            example: an SD card whose root contains only numeric
+            top-level directories (Nikon-style ``100``/``101``/``102``)
+            has no alpha-containing entry to probe with. See PR #1107
+            review.
             """
             try:
                 entries = os.listdir(path)
             except OSError:
-                return False
+                return True
             for name in entries:
                 for i, c in enumerate(name):
                     if c.isalpha():
@@ -14859,12 +14871,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         original_full = os.path.join(path, name)
                         probe_full = os.path.join(path, swapped)
                         if not os.path.exists(probe_full):
+                            # Definitive: case-swap resolves to nothing,
+                            # so the filesystem distinguishes case.
                             return False
                         try:
                             return os.path.samefile(original_full, probe_full)
                         except OSError:
-                            return False
-            return False
+                            return True
+            return True
 
         try:
             dest_real = os.path.realpath(destination)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -14886,7 +14886,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         runner = app._job_runner
         active_ws = db._active_workspace_id
-        vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+        thumb_cache_dir = app.config["THUMB_CACHE_DIR"]
+        vireo_dir = os.path.dirname(thumb_cache_dir)
 
         job_config = {
             "sources": sources,
@@ -14912,6 +14913,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 recursive=recursive,
                 after_import=after_import,
                 vireo_dir=vireo_dir,
+                thumb_cache_dir=thumb_cache_dir,
             )
             return run_import_job(job, runner, db_path, active_ws, params)
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -14830,28 +14830,41 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         def _fs_is_case_insensitive(path):
             """Probe whether the filesystem at ``path`` treats case as insensitive.
 
-            Best-effort: case-swap one alpha character from the resolved
-            path and check ``os.path.samefile``. Any error (probe path
-            not readable, no alpha char to swap) returns False and the
-            caller falls back to case-sensitive comparison — a false
-            negative is a strictly narrower guard than what the platform
-            branch already applies, never a wider one.
+            List an entry inside ``path`` and check whether accessing it
+            under a case-swapped name resolves to the same inode. Probing
+            *inside* the directory (rather than swapping characters in
+            ``path`` itself) is essential when a case-insensitive mount
+            sits under a case-sensitive parent — a FAT/exFAT SD card
+            mounted at ``/mnt/Card`` on Linux under an ext4 root: the
+            ext4 ``/mnt`` cannot resolve ``/Mnt`` or a differently-cased
+            ``Card`` entry (mount-point dentries are stored in the
+            parent FS), so swapping characters in the ``path`` string
+            always reports case-sensitive regardless of the card's own
+            semantics. Any error, empty directory, or entry without an
+            alpha character returns False and the caller falls back to
+            case-sensitive comparison — a false negative is a strictly
+            narrower guard than what the platform branch already
+            applies, never a wider one. See PR #1107 review.
             """
             try:
-                for i, c in enumerate(path):
-                    if c.isalpha():
-                        probe = path[:i] + c.swapcase() + path[i + 1:]
-                        if probe == path:
-                            continue
-                        if not os.path.exists(probe):
-                            return False
-                        try:
-                            return os.path.samefile(path, probe)
-                        except OSError:
-                            return False
-                return False
+                entries = os.listdir(path)
             except OSError:
                 return False
+            for name in entries:
+                for i, c in enumerate(name):
+                    if c.isalpha():
+                        swapped = name[:i] + c.swapcase() + name[i + 1:]
+                        if swapped == name:
+                            continue
+                        original_full = os.path.join(path, name)
+                        probe_full = os.path.join(path, swapped)
+                        if not os.path.exists(probe_full):
+                            return False
+                        try:
+                            return os.path.samefile(original_full, probe_full)
+                        except OSError:
+                            return False
+            return False
 
         try:
             dest_real = os.path.realpath(destination)

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2023,12 +2023,21 @@ class Database:
 
     # -- Folders --
 
-    def add_folder(self, path, name=None, parent_id=None, *, workspace_root=True):
+    def add_folder(self, path, name=None, parent_id=None, *,
+                   workspace_root=True, link_to_workspace=True):
         """Insert a folder. Automatically links it to the active workspace.
 
         ``workspace_root`` controls whether that automatic link is a
         user-facing workspace root. Scanner-discovered descendants pass
         ``False`` so recursive roots do not expand over time.
+
+        ``link_to_workspace`` controls whether the auto-link happens at
+        all. Restricted scans (a subfolder of an existing archive tree)
+        pass ``False`` for the parent chain leading up to the restrict
+        roots: those parents only need to exist for ``folders.parent_id``
+        integrity, and letting ``add_workspace_folder`` fire would
+        subtree-cascade every pre-existing descendant of the destination
+        into the active workspace. See PR #1107 review.
 
         Returns the folder id.
         """
@@ -2045,7 +2054,7 @@ class Database:
             ).fetchone()
             folder_id = row["id"]
         # Auto-link to active workspace
-        if self._active_workspace_id is not None:
+        if link_to_workspace and self._active_workspace_id is not None:
             self.add_workspace_folder(
                 self._active_workspace_id,
                 folder_id,

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -1163,14 +1163,22 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     # verifiably exist (hash-backed match, or key match re-hashed against
     # its cataloged twin), AND every source was walked cleanly, AND every
     # duplicate-only batch's workspace-link scan succeeded (otherwise the
-    # imported duplicates are on disk but not visible in the workspace).
-    # A cancelled run leaves unprocessed files, so it is never safe.
-    # This pill means exactly what it says.
+    # imported duplicates are on disk but not visible in the workspace),
+    # AND the run enumerated the card's full supported-file set (a
+    # narrowed ``file_types`` — "raw", "jpeg", or a custom extension list
+    # — leaves the un-selected supported photos on the card entirely
+    # unseen; ``discovered`` covers only the requested subset, so the
+    # naive ``copied + skipped_duplicate == discovered`` check would go
+    # green even though the card still holds files the pill is expected
+    # to cover). A cancelled run leaves unprocessed files, so it is
+    # never safe. This pill means exactly what it says.
+    filtered_import = params.file_types != "both"
     safe_to_format = (
         not cancelled
         and failed == 0
         and not discovery_errors
         and not dup_link_failed
+        and not filtered_import
         and (copied + skipped_duplicate) == discovered
     )
     result = {

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -62,7 +62,6 @@ from import_dedup import (
     stored_metadata_key,
 )
 from ingest import (
-    _path_under_root,
     _source_file_timestamps,
     build_destination_path,
     discover_source_files,
@@ -307,7 +306,7 @@ def _hash_twin_rows(db, file_hash):
     ).fetchall()
 
 
-def _linkable_twin_dirs(rows, destination):
+def _linkable_twin_dirs(rows, under_destination):
     """Destination-scoped folders holding a duplicate's cataloged twin.
 
     Only folders under the import destination are scanned/linked after a
@@ -320,15 +319,23 @@ def _linkable_twin_dirs(rows, destination):
     to ``ok`` before the dup-link scan runs — otherwise a duplicate-only
     batch that matches a missing-marked twin folder would drop it from
     ``dup_dirs``, safe_to_format could go green, and the imported
-    duplicates would stay filtered out of workspace queries. See PR
-    #1107 review.
+    duplicates would stay filtered out of workspace queries.
+
+    ``under_destination(path)`` compares resolved/case-normalized paths
+    (built in ``run_import_job`` from the destination's own filesystem
+    semantics). A lexical prefix check would drop a twin folder when the
+    destination is a symlink to the twin's on-disk archive root, or
+    spelled with different case on a case-insensitive mount — dropping
+    the twin means the duplicate-link scan never runs and the imported
+    duplicate stays filtered out of the active workspace while
+    safe_to_format still flips green. See PR #1107 review.
     """
     dirs = set()
     for r in rows:
         folder_path = r["folder_path"]
         if r["folder_status"] not in ("ok", "partial", "missing"):
             continue
-        if not _path_under_root(folder_path, destination):
+        if not under_destination(folder_path):
             continue
         if not os.path.isdir(folder_path):
             continue
@@ -357,7 +364,20 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     # ``/photos/archive/…`` but the restricted scan root would remain the
     # dot-segment form, so the recursion never reaches root and the scan
     # loses those files (copied bytes then bucket as catalog failures).
-    destination = os.path.normpath(str(params.destination))
+    #
+    # Also resolve symlinks (``realpath``) so a destination like ``/photos``
+    # symlinked at ``/Volumes/Photos`` matches cataloged twin folders whose
+    # ``folders.path`` was scanned under the real archive root — otherwise
+    # a duplicate-only import's dup-link scan is called with the symlink
+    # path as root while its ``restrict_dirs`` hold the real path, and
+    # ``_ensure_folder``'s walk never reaches root (dead recurse). Sources
+    # are already ``realpath``-resolved (see ``_norm_source``); doing the
+    # same to destination keeps the two sides symmetric. See PR #1107
+    # review.
+    try:
+        destination = os.path.realpath(os.path.normpath(str(params.destination)))
+    except OSError:
+        destination = os.path.normpath(str(params.destination))
 
     # Normalized realpaths of every import source root, used to reject
     # cataloged twins that live under the card being imported. The
@@ -439,6 +459,41 @@ def run_import_job(job, runner, db_path, workspace_id, params):
             if cmp == root or cmp.startswith(root + os.sep):
                 return True
         return False
+
+    # Destination containment for cataloged twin folders. ``destination``
+    # is already ``realpath``-resolved above so a symlinked destination
+    # like ``/photos`` -> ``/Volumes/Photos`` matches twin folders
+    # cataloged under ``/Volumes/Photos/…``. Case-different spellings on
+    # case-insensitive mounts (HFS+/APFS/exFAT) still need explicit
+    # case-folding: ``realpath`` on APFS preserves the case the user
+    # gave. Probe the destination's own filesystem (walking up to the
+    # closest existing ancestor when the destination itself hasn't been
+    # created yet); default to case-sensitive on failure — a strictly
+    # narrower guard, never wider. See PR #1107 review.
+    def _probe_dir_case_insensitive(path):
+        p = os.path.normpath(path)
+        while True:
+            if os.path.isdir(p):
+                return _fs_is_case_insensitive(p)
+            parent = os.path.dirname(p)
+            if parent == p:
+                return False
+            p = parent
+
+    _dest_ci = _case_insensitive_platform or _probe_dir_case_insensitive(destination)
+    _dest_root_norm = (
+        destination.casefold() if _dest_ci else destination
+    ).rstrip(os.sep)
+
+    def _path_under_destination(path):
+        if not _dest_root_norm:
+            return False
+        try:
+            real = os.path.realpath(path)
+        except OSError:
+            real = str(path)
+        cmp = (real.casefold() if _dest_ci else real).rstrip(os.sep)
+        return cmp == _dest_root_norm or cmp.startswith(_dest_root_norm + os.sep)
 
     runner.set_steps(job["id"], [
         {"id": "import", "label": "Copy & catalog"},
@@ -778,7 +833,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                         skipped_duplicate += 1
                         _counts(rel)["skipped_duplicate"] += 1
                         dup_dirs.update(
-                            _linkable_twin_dirs(twin_rows, destination),
+                            _linkable_twin_dirs(twin_rows, _path_under_destination),
                         )
                         run_dest = run_dest_folders.get(token)
                         if run_dest is not None:

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -1368,6 +1368,33 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         # self-healed into the catalog.
         new_dup_dirs = dup_dirs - linked_dup_dirs
         if new_dup_dirs:
+            # Twin folders may be cataloged through a symlink alias while
+            # ``destination`` is realpath-normalized above. ``_path_under_
+            # destination`` accepts them via realpath, but scanner's
+            # ``_ensure_folder`` walks parents *lexically* until they equal
+            # the scan root — a restrict_dir ``/alias/2026-07-05`` scanned
+            # under root ``/real/archive`` would recurse to ``/alias`` →
+            # ``/`` → ``/`` … and hit Python's recursion limit before the
+            # workspace_folders link is ever created. Split by whether the
+            # twin's folder path sits lexically under destination: link
+            # the alias-spelled ones directly (their folder row and the
+            # twin's photos already exist — no self-heal scan needed for
+            # workspace visibility), scan only the lexically-under-
+            # destination ones. See PR #1107 review.
+            lex_dup_dirs = set()
+            alias_dup_dirs = set()
+            for d in new_dup_dirs:
+                d_cmp = (
+                    d.casefold() if _dest_ci else d
+                ).rstrip(os.sep)
+                if (
+                    d_cmp == _dest_root_norm
+                    or d_cmp.startswith(_dest_root_norm + os.sep)
+                ):
+                    lex_dup_dirs.add(d)
+                else:
+                    alias_dup_dirs.add(d)
+
             # Mirror the fresh-batch ``dest_folder`` promotion (see the
             # UPDATE at the top of this loop): a twin folder that survived
             # ``_linkable_twin_dirs`` is real on disk (``os.path.isdir``
@@ -1384,47 +1411,86 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                 [(d,) for d in sorted(new_dup_dirs)],
             )
             db.conn.commit()
-            try:
-                # Same rationale as the fresh-batch scan above: pass
-                # ``vireo_dir`` / ``thumb_cache_dir`` so pairing keeps
-                # cache context, and defer per-batch WC extraction to the
-                # end-of-run pass. See PR #1107 review.
-                scan(
-                    destination, db,
-                    restrict_dirs=sorted(new_dup_dirs),
-                    vireo_dir=params.vireo_dir,
-                    thumb_cache_dir=params.thumb_cache_dir,
-                    skip_working_copies=True,
-                    cancel_check=lambda: runner.is_cancelled(job["id"]),
-                )
-                linked_dup_dirs.update(new_dup_dirs)
-                # Duplicate-link scan created/linked workspace_folders
-                # rows for each duplicate twin's folder; the same
-                # cached-diff staleness applies (see the fresh-batch
-                # scan branch above). Invalidate every touched dup dir.
-                for d in sorted(new_dup_dirs):
-                    _invalidate_new_images(db, d)
-            except RuntimeError:
-                cancelled = True
-            except Exception as e:
-                # A duplicate-only batch's ONLY workspace-visibility step
-                # is this scan — swallowing the error would leave
-                # safe_to_format green while the imported duplicates are
-                # invisible in the active workspace. Record it and force
-                # safe_to_format false; the file(s) are on disk (import
-                # succeeded), but the operation as a whole is not safe.
-                log.exception(
-                    "Linking duplicate-matched folders failed: %s",
-                    sorted(new_dup_dirs),
-                )
-                dup_link_failed = True
-                for d in sorted(new_dup_dirs):
+
+            # Link alias-spelled twin folders directly to the active
+            # workspace: the folder row and its photos already exist (they
+            # were cataloged by whatever original scan used the alias
+            # spelling), so we just need the ``workspace_folders`` entry.
+            # Passing them through ``scan(root=destination)`` would blow
+            # the stack in ``_ensure_folder`` as described above.
+            for d in sorted(alias_dup_dirs):
+                folder_row = db.conn.execute(
+                    "SELECT id FROM folders WHERE path = ?", (d,),
+                ).fetchone()
+                if folder_row is None:
+                    # Shouldn't happen — _linkable_twin_dirs pulled this
+                    # from folders in the first place — but if it does,
+                    # count it as a link failure so safe_to_format stays
+                    # honest.
+                    log.warning(
+                        "Alias-spelled dup dir %s vanished from folders "
+                        "between _linkable_twin_dirs and the direct "
+                        "workspace link", d,
+                    )
+                    dup_link_failed = True
                     unsafe_files.append({
                         "path": d,
                         "reason": (
-                            f"duplicate-folder link scan failed: {e}"
+                            "duplicate-folder workspace link failed: "
+                            "folder row not found"
                         ),
                     })
+                    continue
+                db.add_workspace_folder(
+                    workspace_id, folder_row["id"], is_root=True,
+                )
+                linked_dup_dirs.add(d)
+                _invalidate_new_images(db, d)
+            db.conn.commit()
+
+            if lex_dup_dirs:
+                try:
+                    # Same rationale as the fresh-batch scan above: pass
+                    # ``vireo_dir`` / ``thumb_cache_dir`` so pairing keeps
+                    # cache context, and defer per-batch WC extraction to
+                    # the end-of-run pass. See PR #1107 review.
+                    scan(
+                        destination, db,
+                        restrict_dirs=sorted(lex_dup_dirs),
+                        vireo_dir=params.vireo_dir,
+                        thumb_cache_dir=params.thumb_cache_dir,
+                        skip_working_copies=True,
+                        cancel_check=lambda: runner.is_cancelled(job["id"]),
+                    )
+                    linked_dup_dirs.update(lex_dup_dirs)
+                    # Duplicate-link scan created/linked workspace_folders
+                    # rows for each duplicate twin's folder; the same
+                    # cached-diff staleness applies (see the fresh-batch
+                    # scan branch above). Invalidate every touched dup dir.
+                    for d in sorted(lex_dup_dirs):
+                        _invalidate_new_images(db, d)
+                except RuntimeError:
+                    cancelled = True
+                except Exception as e:
+                    # A duplicate-only batch's ONLY workspace-visibility
+                    # step is this scan — swallowing the error would leave
+                    # safe_to_format green while the imported duplicates
+                    # are invisible in the active workspace. Record it and
+                    # force safe_to_format false; the file(s) are on disk
+                    # (import succeeded), but the operation as a whole is
+                    # not safe.
+                    log.exception(
+                        "Linking duplicate-matched folders failed: %s",
+                        sorted(lex_dup_dirs),
+                    )
+                    dup_link_failed = True
+                    for d in sorted(lex_dup_dirs):
+                        unsafe_files.append({
+                            "path": d,
+                            "reason": (
+                                f"duplicate-folder link scan failed: {e}"
+                            ),
+                        })
 
         _emit(
             f"{rel}: {_counts(rel)['copied']} copied · "

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -299,13 +299,20 @@ def _linkable_twin_dirs(rows, destination):
     Only folders under the import destination are scanned/linked after a
     duplicate skip (a twin in some other library root is none of this
     import's business). Mirrors ingest()'s dup_token_folders guards:
-    folder status ok/partial, path under destination, and still a real
-    directory on disk.
+    path under destination and still a real directory on disk. Status
+    ``ok``/``partial`` is trusted as-is; ``missing`` is accepted too when
+    the path is still a real directory (a reattached archive drive whose
+    row hasn't been refreshed yet), and ``run_import_job`` promotes it
+    to ``ok`` before the dup-link scan runs — otherwise a duplicate-only
+    batch that matches a missing-marked twin folder would drop it from
+    ``dup_dirs``, safe_to_format could go green, and the imported
+    duplicates would stay filtered out of workspace queries. See PR
+    #1107 review.
     """
     dirs = set()
     for r in rows:
         folder_path = r["folder_path"]
-        if r["folder_status"] not in ("ok", "partial"):
+        if r["folder_status"] not in ("ok", "partial", "missing"):
             continue
         if not _path_under_root(folder_path, destination):
             continue
@@ -903,6 +910,35 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         # size, so no cancel_check is passed — it runs to completion.
         if landed:
             landed_paths = {entry[0] for entry in landed}
+            # Capture the pre-scan (photo_id, file_hash) for every landed
+            # dest_path. The batch scan below is invoked with
+            # ``vireo_dir=None`` because per-batch working-copy extraction
+            # would run before RAW+JPEG companions across batch boundaries
+            # are paired (see the "Working-copy extraction is DEFERRED"
+            # comment above). But that also disables the scanner's own
+            # ``_invalidate_derived_caches`` call for existing rows whose
+            # bytes just changed — so a copy/adopt that replaces a stale
+            # archive file at a path whose row already had a
+            # ``working_copy_path``/thumbnail/preview would leave those
+            # derived files pointing at the previous bytes, and the
+            # end-of-run ``_extract_working_copies`` skips rows with
+            # ``working_copy_path IS NOT NULL``. Snapshot the pre-scan
+            # hash here so the hash-stamping loop below can invalidate any
+            # landed row whose bytes changed. See PR #1107 review.
+            pre_scan_hashes = {}
+            for entry in landed:
+                dest_path = entry[0]
+                row = db.conn.execute(
+                    """SELECT p.id, p.file_hash FROM photos p
+                       JOIN folders f ON f.id = p.folder_id
+                       WHERE f.path = ? AND p.filename = ?""",
+                    (
+                        os.path.dirname(dest_path),
+                        os.path.basename(dest_path),
+                    ),
+                ).fetchone()
+                if row is not None:
+                    pre_scan_hashes[dest_path] = row["file_hash"]
             try:
                 scan(
                     destination, db,
@@ -1049,7 +1085,64 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                         "catalog scan (hash mismatch)",
                     )
                     reclassified_landed_paths.add(dest_path)
+
+            # Invalidate derived caches for any landed row whose bytes
+            # differ from what was there pre-scan. The batch scan ran with
+            # ``vireo_dir=None`` (per-batch WC extraction would race
+            # RAW+JPEG pairing across batch boundaries), so scanner's own
+            # ``_invalidate_derived_caches`` on content change was
+            # bypassed. Do it here for the same set of rows the scanner
+            # would have caught: existing rows whose new hash differs from
+            # the pre-scan hash. Without this, imports that restore a
+            # replaced-then-deleted archive file leave stale
+            # ``working_copy_path``/thumb/preview files pointing at the
+            # previous bytes, and the deferred end-of-run
+            # ``_extract_working_copies`` skips rows whose
+            # ``working_copy_path`` is already set — so the WC never
+            # rebuilds against the new archive bytes. See PR #1107 review.
+            invalidated_photo_ids = set()
+            if params.vireo_dir:
+                from scanner import _invalidate_derived_caches
+                for entry in landed:
+                    dest_path = entry[0]
+                    if dest_path in reclassified_landed_paths:
+                        continue
+                    pre_hash = pre_scan_hashes.get(dest_path)
+                    if pre_hash is None:
+                        # Row didn't exist pre-scan (fresh insert), or
+                        # pre-existing row's hash was NULL. Either way,
+                        # there are no derived caches to invalidate.
+                        continue
+                    verified_hash = entry[1]
+                    if pre_hash == verified_hash:
+                        continue
+                    row = db.conn.execute(
+                        """SELECT p.id FROM photos p
+                           JOIN folders f ON f.id = p.folder_id
+                           WHERE f.path = ? AND p.filename = ?""",
+                        (
+                            os.path.dirname(dest_path),
+                            os.path.basename(dest_path),
+                        ),
+                    ).fetchone()
+                    if row is None:
+                        continue
+                    _invalidate_derived_caches(
+                        db, params.vireo_dir, row["id"],
+                    )
+                    invalidated_photo_ids.add(row["id"])
+
             db.conn.commit()
+
+            if invalidated_photo_ids:
+                # Mirror scanner.scan()'s post-loop untracked-preview
+                # sweep: orphan preview files with no preview_cache row
+                # would be lazy-adopted on the next request and served as
+                # stale bytes for the just-replaced archive file.
+                from scanner import _sweep_untracked_previews_for_photos
+                _sweep_untracked_previews_for_photos(
+                    db, params.vireo_dir, invalidated_photo_ids,
+                )
 
             # Accumulate the card-source mapping for the deferred
             # end-of-run ``_extract_working_copies`` call. Extraction
@@ -1087,6 +1180,22 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         # self-healed into the catalog.
         new_dup_dirs = dup_dirs - linked_dup_dirs
         if new_dup_dirs:
+            # Mirror the fresh-batch ``dest_folder`` promotion (see the
+            # UPDATE at the top of this loop): a twin folder that survived
+            # ``_linkable_twin_dirs`` is real on disk (``os.path.isdir``
+            # passed), and if its row is still ``'missing'`` — a
+            # reattached archive drive whose row hasn't been refreshed —
+            # ``scanner.scan()``'s success stamp only clears ``'partial'``.
+            # Without promoting here, safe_to_format could go green while
+            # the duplicate twin's folder stays ``'missing'`` and its
+            # photos are filtered out of workspace queries. Preserve
+            # ``'partial'`` (a real prior-scan signal). See PR #1107 review.
+            db.conn.executemany(
+                "UPDATE folders SET status = 'ok' "
+                "WHERE path = ? AND status = 'missing'",
+                [(d,) for d in sorted(new_dup_dirs)],
+            )
+            db.conn.commit()
             try:
                 scan(
                     destination, db,

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -553,5 +553,9 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         "unsafe_files": unsafe_files,
         "folders": folder_counts,
         "cancelled": cancelled,
+        # JobRunner's mixed-outcome convention: a run with any failed file
+        # is recorded "failed" (with per-file reasons), never "completed".
+        "ok": failed == 0,
+        "errors": [f"{u['path']}: {u['reason']}" for u in unsafe_files],
     }
     return result

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -1107,12 +1107,22 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     dest_path = entry[0]
                     if dest_path in reclassified_landed_paths:
                         continue
-                    pre_hash = pre_scan_hashes.get(dest_path)
-                    if pre_hash is None:
-                        # Row didn't exist pre-scan (fresh insert), or
-                        # pre-existing row's hash was NULL. Either way,
-                        # there are no derived caches to invalidate.
+                    if dest_path not in pre_scan_hashes:
+                        # No pre-scan row (fresh insert) — no derived
+                        # caches exist for this photo yet.
                         continue
+                    # A pre-scan row existed. Its ``file_hash`` may be
+                    # ``NULL`` (legacy row, or a prior scan that couldn't
+                    # read the file), and such a row can still carry
+                    # ``working_copy_path``/thumb/preview caches from
+                    # earlier processing. Scanner's own content-change
+                    # path treats ``NULL -> concrete hash`` as an
+                    # invalidating transition (see scanner.scan()'s
+                    # ``content_identity_changed`` block); mirror that
+                    # here so restoring a deleted archive file whose
+                    # legacy row lost its hash still clears the stale
+                    # derived caches. See PR #1107 review.
+                    pre_hash = pre_scan_hashes[dest_path]
                     verified_hash = entry[1]
                     if pre_hash == verified_hash:
                         continue

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -303,8 +303,15 @@ def run_import_job(job, runner, db_path, workspace_id, params):
             cancelled = True
             break
 
+        # Normalize so the "/" strftime puts in ``rel`` (e.g. "2026/07-03")
+        # lines up with what scanner stores. Scanner wraps paths in
+        # ``Path(...)`` before writing the folder row and building its
+        # restrict_files set, which on Windows rewrites mid-path "/" to
+        # "\\"; a raw os.path.join here would leave copied files invisible
+        # to the restricted scan and unfindable in the post-scan lookup.
         dest_folder = (
-            os.path.join(destination, rel) if rel != "." else destination
+            os.path.normpath(os.path.join(destination, rel))
+            if rel != "." else destination
         )
         os.makedirs(dest_folder, exist_ok=True)
 

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -99,9 +99,18 @@ def copy_and_hash_verify(src, dst, *, src_hash=None):
     """Copy ``src`` to ``dst`` and verify the landed bytes by content hash.
 
     The copy goes to a hidden sibling temp path first; only a copy whose
-    hash matches the source is promoted into ``dst`` (``os.replace``).
-    On mismatch the temp copy is removed and any pre-existing ``dst`` is
-    left untouched.
+    hash matches the source is promoted into ``dst``. Promotion uses a
+    no-overwrite ``os.link`` (atomic on POSIX same-FS) rather than
+    ``os.replace`` — imports have no pipeline-slot lock, so two concurrent
+    jobs targeting the same destination/date folder with the same
+    filename can both pass their pre-copy collision check before either
+    promotes; ``os.replace`` would silently overwrite the first job's
+    already-verified archive copy, and its ``safe_to_format`` would still
+    report green after the bytes it verified are gone. A raced promote is
+    surfaced as a copy failure instead.
+
+    On mismatch (or race) the temp copy is removed and any pre-existing
+    ``dst`` is left untouched.
 
     Args:
         src: source file path (e.g. on the card)
@@ -129,7 +138,20 @@ def copy_and_hash_verify(src, dst, *, src_hash=None):
                 src, dst, expected, copied_hash,
             )
             return (False, None)
-        os.replace(tmp, dst)
+        # Atomic no-overwrite promote: os.link raises FileExistsError if
+        # ``dst`` was created between the caller's collision check and
+        # this instant. tmp lives in the same directory as dst, so link
+        # stays same-filesystem and portable across the NAS mounts that
+        # are the real archive target.
+        try:
+            os.link(tmp, dst)
+        except FileExistsError:
+            log.warning(
+                "Destination raced during copy (concurrent import?): %s",
+                dst,
+            )
+            return (False, None)
+        os.unlink(tmp)
         tmp = None
         return (True, copied_hash)
     except OSError as e:
@@ -207,7 +229,16 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     db = Database(db_path)
     db.set_active_workspace(workspace_id)
 
-    destination = str(params.destination)
+    # Normalize once — the raw destination string is passed as ``root`` to
+    # both the copy layout (``os.path.normpath(os.path.join(destination,
+    # rel))``) and to ``scan(root, …, restrict_dirs=[dest_folder])``.
+    # ``scanner._ensure_folder`` stops walking the folder chain when the
+    # parent equals the scan root string; a destination like
+    # ``/photos/tmp/../archive`` copies into the normalized
+    # ``/photos/archive/…`` but the restricted scan root would remain the
+    # dot-segment form, so the recursion never reaches root and the scan
+    # loses those files (copied bytes then bucket as catalog failures).
+    destination = os.path.normpath(str(params.destination))
 
     runner.set_steps(job["id"], [
         {"id": "import", "label": "Copy & catalog"},
@@ -231,11 +262,25 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         })
 
     # --- Discover ---------------------------------------------------
+    # Enumeration errors (permission denied, macOS TCC block on a
+    # removable volume, unreadable subtree) get silently swallowed by
+    # os.walk-style callbacks by default. If we ignored them, discovered
+    # would just be smaller than reality and safe_to_format could still
+    # flip green over a card whose contents were never actually visited.
+    # Track them explicitly: each is a bucket-of-its-own failure entry
+    # tied to the source path where it occurred.
     _emit("Discovering files", 0, 0)
     files = []
+    discovery_errors = []
+
+    def _discovery_onerror(exc):
+        discovery_errors.append(exc)
+        log.warning("Import discovery error: %s", exc)
+
     for src in params.sources:
         files.extend(discover_source_files(
             src, params.file_types, recursive=params.recursive,
+            onerror=_discovery_onerror,
         ))
     discovered = len(files)
 
@@ -281,6 +326,23 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     emitted = 0
     cancelled = False
 
+    # Working-copy extraction is DEFERRED to the end of the whole import
+    # run (not per-batch). Rationale: a folder that receives more than
+    # ``IMPORT_BATCH_SIZE`` files splits across multiple batches; a
+    # RAW+JPEG companion pair can then straddle a batch boundary — the
+    # RAW lands in batch N and its JPEG in batch N+1. Per-batch
+    # extraction would run on the RAW before scan()'s
+    # ``_pair_raw_jpeg_companions`` sees the JPEG, so the RAW's row
+    # still has ``companion_path IS NULL``. The extractor then reads the
+    # RAW itself (RAW-decode-first); if that fails or produces a
+    # low-quality fallback, ``working_copy_failed_at`` is set and the
+    # candidate predicate would gate future retries — the JPEG landing
+    # in the next batch never re-triggers extraction while the card-side
+    # JPEG is still available. Deferring to end-of-run means every
+    # companion in the run has landed and been paired before
+    # ``_extract_working_copies`` decides which source to read.
+    wc_source_paths = {}  # dest_path -> card source path
+    wc_dest_folders = set()  # exact-match scope for extraction
     # Intra-run duplicate destinations: token -> dest folder where the
     # identity landed this run (mirrors ingest's batch_dest_folders).
     run_dest_folders = {}
@@ -565,28 +627,18 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     )
             db.conn.commit()
 
-            # Extract working copies reading the CARD copy (fast local
-            # bytes) instead of the just-written archive copy. Scoped to
-            # this batch's destination folder; scan() ran with
-            # vireo_dir=None precisely so extraction happens here with
-            # the card-side source mapping. Per-row failures mark the
-            # photo for the scanner's later backfill and never fail the
-            # import.
+            # Accumulate the card-source mapping for the deferred
+            # end-of-run ``_extract_working_copies`` call. Extraction
+            # cannot run here per-batch: a RAW+JPEG companion pair that
+            # straddles a batch boundary would still be unpaired at this
+            # point, and the extractor would read the RAW before scan()
+            # in a later batch pairs the JPEG — poisoning the row with a
+            # failure marker or low-quality WC that the candidate
+            # predicate then skips.
             if params.vireo_dir:
-                from scanner import _extract_working_copies
-
-                try:
-                    _extract_working_copies(
-                        db, params.vireo_dir,
-                        scope=[(dest_folder, "exact")],
-                        source_paths={
-                            dest: src for dest, _, src in landed
-                        },
-                    )
-                except Exception:
-                    log.exception(
-                        "Working-copy extraction failed for %s", dest_folder,
-                    )
+                for dest_path, _hash, src_path in landed:
+                    wc_source_paths[dest_path] = src_path
+                wc_dest_folders.add(dest_folder)
 
         # --- Link duplicate-twin folders. Separate scan call WITHOUT
         # restrict_files: scan only creates/links folder rows for files it
@@ -621,6 +673,28 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         if cancelled:
             break
 
+    # --- Deferred working-copy extraction ---------------------------
+    # One extraction pass over every folder this run touched, after all
+    # batches have landed and been paired. Reads card-side bytes for any
+    # dest_path present in ``wc_source_paths``; anything else (crash-
+    # recovery adopted files whose card is gone, later backfill retries)
+    # falls back to the cataloged archive path. Per-row failures mark the
+    # photo for the scanner's later backfill and never fail the import.
+    if params.vireo_dir and wc_dest_folders:
+        from scanner import _extract_working_copies
+
+        try:
+            _extract_working_copies(
+                db, params.vireo_dir,
+                scope=[(d, "exact") for d in sorted(wc_dest_folders)],
+                source_paths=wc_source_paths,
+            )
+        except Exception:
+            log.exception(
+                "Working-copy extraction failed for %s",
+                sorted(wc_dest_folders),
+            )
+
     status = "cancelled" if cancelled else (
         "failed" if failed else "completed"
     )
@@ -633,14 +707,30 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         ),
     )
 
+    # Discovery/enumeration errors must flip safe_to_format off — a
+    # permission-denied subtree yields no files (``discovered`` shrinks),
+    # so a naive check of ``copied + skipped_duplicate == discovered``
+    # would still pass and the UI would tell the user it's safe to format
+    # a card whose contents were never verified. Surface each error into
+    # ``unsafe_files`` (path = the enumeration failure's own filename when
+    # available, otherwise ``<discovery>``) so the caller can show what
+    # went unseen.
+    for exc in discovery_errors:
+        unsafe_files.append({
+            "path": str(getattr(exc, "filename", None) or "<discovery>"),
+            "reason": f"source enumeration failed: {exc}",
+        })
+
     # Safe to format iff every discovered file reached a verified
     # terminal bucket: hash-verified fresh copy, or duplicate whose bytes
     # verifiably exist (hash-backed match, or key match re-hashed against
-    # its cataloged twin). A cancelled run leaves unprocessed files, so it
-    # is never safe. This pill means exactly what it says.
+    # its cataloged twin), AND every source was walked cleanly. A
+    # cancelled run leaves unprocessed files, so it is never safe. This
+    # pill means exactly what it says.
     safe_to_format = (
         not cancelled
         and failed == 0
+        and not discovery_errors
         and (copied + skipped_duplicate) == discovered
     )
     result = {
@@ -653,9 +743,11 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         "unsafe_files": unsafe_files,
         "folders": folder_counts,
         "cancelled": cancelled,
+        "discovery_errors": len(discovery_errors),
         # JobRunner's mixed-outcome convention: a run with any failed file
-        # is recorded "failed" (with per-file reasons), never "completed".
-        "ok": failed == 0,
+        # or unseen source subtree is recorded "failed" (with per-file
+        # reasons), never "completed".
+        "ok": failed == 0 and not discovery_errors,
         "errors": [f"{u['path']}: {u['reason']}" for u in unsafe_files],
     }
     return result

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -368,6 +368,41 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         unsafe_files.append({"path": str(source_file), "reason": reason})
         log.warning("Import failed for %s: %s", source_file, reason)
 
+    def _record_checker(source_file, dest_folder, file_hash):
+        """Register a landed file's identity with the intra-run checker.
+
+        ``DuplicateChecker.record`` re-``os.stat``s the source path — on
+        removable media that was yanked just after ``copy_and_hash_verify``
+        succeeded, that raises ``OSError`` and would kill the whole
+        background job even though this file's bytes are already
+        verified at ``dest_folder``. Swallow the error, keep the copy in
+        the ledger, and accept that later intra-run tokens for this
+        file's identity won't dedupe: the archive is intact, the run
+        just loses a small cache-hit optimization.
+        """
+        if checker is None:
+            return
+        try:
+            tokens = checker.record(source_file)
+        except OSError as e:
+            log.warning(
+                "Duplicate-checker record() failed for %s after landing "
+                "at %s: %s",
+                source_file, dest_folder, e,
+            )
+            return
+        for tok in tokens:
+            run_dest_folders[tok] = dest_folder
+            run_verified_hashes[tok] = file_hash
+
+    # Dup-folder linking runs in a SEPARATE ``scan(restrict_dirs=…)`` call
+    # after the duplicate skip; its exception was previously logged and
+    # swallowed, leaving safe_to_format true while the imported
+    # duplicates never became visible in the active workspace. Track it
+    # explicitly so safe_to_format reflects "workspace can actually see
+    # these bytes" and not just "the bytes are somewhere on disk".
+    dup_link_failed = False
+
     for rel, batch in batches:
         if runner.is_cancelled(job["id"]):
             cancelled = True
@@ -517,10 +552,9 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                             landed.append(
                                 (dest_file, src_hash, str(source_file)),
                             )
-                            if checker is not None:
-                                for tok in checker.record(source_file):
-                                    run_dest_folders[tok] = dest_folder
-                                    run_verified_hashes[tok] = src_hash
+                            _record_checker(
+                                source_file, dest_folder, src_hash,
+                            )
                             continue
                     # Different content, same name — numeric suffix.
                     stem, suffix = os.path.splitext(source_file.name)
@@ -552,10 +586,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
             verified += 1
             _counts(rel)["copied"] += 1
             landed.append((dest_file, file_hash, str(source_file)))
-            if checker is not None:
-                for tok in checker.record(source_file):
-                    run_dest_folders[tok] = dest_folder
-                    run_verified_hashes[tok] = file_hash
+            _record_checker(source_file, dest_folder, file_hash)
 
         # --- Catalog this batch (even when cancelled mid-batch: what
         # landed on disk must be cataloged before we stop, so every
@@ -658,11 +689,25 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                 linked_dup_dirs.update(new_dup_dirs)
             except RuntimeError:
                 cancelled = True
-            except Exception:
+            except Exception as e:
+                # A duplicate-only batch's ONLY workspace-visibility step
+                # is this scan — swallowing the error would leave
+                # safe_to_format green while the imported duplicates are
+                # invisible in the active workspace. Record it and force
+                # safe_to_format false; the file(s) are on disk (import
+                # succeeded), but the operation as a whole is not safe.
                 log.exception(
                     "Linking duplicate-matched folders failed: %s",
                     sorted(new_dup_dirs),
                 )
+                dup_link_failed = True
+                for d in sorted(new_dup_dirs):
+                    unsafe_files.append({
+                        "path": d,
+                        "reason": (
+                            f"duplicate-folder link scan failed: {e}"
+                        ),
+                    })
 
         _emit(
             f"{rel}: {_counts(rel)['copied']} copied · "
@@ -724,13 +769,16 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     # Safe to format iff every discovered file reached a verified
     # terminal bucket: hash-verified fresh copy, or duplicate whose bytes
     # verifiably exist (hash-backed match, or key match re-hashed against
-    # its cataloged twin), AND every source was walked cleanly. A
-    # cancelled run leaves unprocessed files, so it is never safe. This
-    # pill means exactly what it says.
+    # its cataloged twin), AND every source was walked cleanly, AND every
+    # duplicate-only batch's workspace-link scan succeeded (otherwise the
+    # imported duplicates are on disk but not visible in the workspace).
+    # A cancelled run leaves unprocessed files, so it is never safe.
+    # This pill means exactly what it says.
     safe_to_format = (
         not cancelled
         and failed == 0
         and not discovery_errors
+        and not dup_link_failed
         and (copied + skipped_duplicate) == discovered
     )
     result = {
@@ -744,10 +792,15 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         "folders": folder_counts,
         "cancelled": cancelled,
         "discovery_errors": len(discovery_errors),
-        # JobRunner's mixed-outcome convention: a run with any failed file
-        # or unseen source subtree is recorded "failed" (with per-file
-        # reasons), never "completed".
-        "ok": failed == 0 and not discovery_errors,
+        # JobRunner's mixed-outcome convention: a run with any failed
+        # file, unseen source subtree, or workspace-link scan failure is
+        # recorded "failed" (with per-file / per-operation reasons),
+        # never "completed".
+        "ok": (
+            failed == 0
+            and not discovery_errors
+            and not dup_link_failed
+        ),
         "errors": [f"{u['path']}: {u['reason']}" for u in unsafe_files],
     }
     return result

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -50,10 +50,49 @@ import logging
 import os
 import shutil
 import uuid
+from dataclasses import dataclass
 
-from import_dedup import compute_file_hash
+from db import Database
+from import_dedup import (
+    CatalogIndex,
+    DuplicateChecker,
+    compute_file_hash,
+    stored_metadata_key,
+)
+from ingest import (
+    _path_under_root,
+    _source_file_timestamps,
+    build_destination_path,
+    discover_source_files,
+)
+from scanner import EMPTY_FILE_SHA256
 
 log = logging.getLogger(__name__)
+
+# Batch unit (Task 2.0 Q4): files sharing a destination folder, chunked so
+# one scan call never covers more than this many fresh files. Copy, verify,
+# scan, and hash stamping all commit at batch boundaries, so every stopping
+# point (cancel, crash, yanked card) leaves a valid catalog.
+IMPORT_BATCH_SIZE = 200
+
+
+@dataclass
+class ImportParams:
+    """Parameters for an import job run."""
+
+    sources: list
+    destination: str
+    folder_template: str = "%Y/%Y-%m-%d"
+    file_types: str = "both"
+    skip_duplicates: bool = True
+    verify_by_hash: bool = False
+    recursive: bool = True
+    # After-import process strategy name. Stored in the job config for the
+    # PR 3 chaining hook; unused by the import job itself.
+    after_import: str | None = None
+    # Vireo data dir for working-copy extraction (Task 2.5). None skips
+    # extraction (tests, or callers that defer to the scanner backfill).
+    vireo_dir: str | None = None
 
 
 def copy_and_hash_verify(src, dst, *, src_hash=None):
@@ -100,3 +139,408 @@ def copy_and_hash_verify(src, dst, *, src_hash=None):
         if tmp is not None:
             with contextlib.suppress(OSError):
                 os.unlink(tmp)
+
+
+def _key_twin_rows(db, key):
+    """Catalog rows whose stored identity equals a source metadata key.
+
+    ``CatalogIndex`` retains only identity sets, so the safe-to-format
+    second pass resolves a key match's cataloged twin(s) here. Prefilter
+    by file_size (cheap, indexedable) and compare the full
+    ``stored_metadata_key`` in Python — SQL LOWER() is ASCII-only and
+    must not stand in for casefold().
+    """
+    rows = db.conn.execute(
+        """SELECT p.id, p.filename, p.file_size, p.timestamp, p.file_hash,
+                  f.path AS folder_path, f.status AS folder_status
+           FROM photos p JOIN folders f ON f.id = p.folder_id
+           WHERE p.file_size = ?""",
+        (key[1],),
+    ).fetchall()
+    return [
+        r for r in rows
+        if stored_metadata_key(r["filename"], r["file_size"], r["timestamp"]) == key
+    ]
+
+
+def _hash_twin_rows(db, file_hash):
+    return db.conn.execute(
+        """SELECT p.id, p.filename, f.path AS folder_path,
+                  f.status AS folder_status
+           FROM photos p JOIN folders f ON f.id = p.folder_id
+           WHERE p.file_hash = ?""",
+        (file_hash,),
+    ).fetchall()
+
+
+def _linkable_twin_dirs(rows, destination):
+    """Destination-scoped folders holding a duplicate's cataloged twin.
+
+    Only folders under the import destination are scanned/linked after a
+    duplicate skip (a twin in some other library root is none of this
+    import's business). Mirrors ingest()'s dup_token_folders guards:
+    folder status ok/partial, path under destination, and still a real
+    directory on disk.
+    """
+    dirs = set()
+    for r in rows:
+        folder_path = r["folder_path"]
+        if r["folder_status"] not in ("ok", "partial"):
+            continue
+        if not _path_under_root(folder_path, destination):
+            continue
+        if not os.path.isdir(folder_path):
+            continue
+        dirs.add(folder_path)
+    return dirs
+
+
+def run_import_job(job, runner, db_path, workspace_id, params):
+    """Copy card(s) -> archive, hash-verify, and catalog incrementally.
+
+    Returns the result dict (counts + per-folder breakdown). The catalog
+    is committed per batch; cancellation and crashes leave every already-
+    verified file cataloged and nothing else.
+    """
+    from scanner import scan
+
+    db = Database(db_path)
+    db.set_active_workspace(workspace_id)
+
+    destination = str(params.destination)
+
+    runner.set_steps(job["id"], [
+        {"id": "import", "label": "Copy & catalog"},
+    ])
+    runner.update_step(job["id"], "import", status="running")
+
+    def _emit(phase, current, total, current_file=""):
+        job["progress"]["current"] = current
+        job["progress"]["total"] = total
+        job["progress"]["current_file"] = current_file
+        runner.update_step(
+            job["id"], "import",
+            current_file=current_file,
+            progress={"current": current, "total": total},
+        )
+        runner.push_event(job["id"], "progress", {
+            "phase": phase,
+            "current": current,
+            "total": total,
+            "current_file": current_file,
+        })
+
+    # --- Discover ---------------------------------------------------
+    _emit("Discovering files", 0, 0)
+    files = []
+    for src in params.sources:
+        files.extend(discover_source_files(
+            src, params.file_types, recursive=params.recursive,
+        ))
+    discovered = len(files)
+
+    checker = None
+    if params.skip_duplicates:
+        checker = DuplicateChecker(
+            CatalogIndex.from_db(db), verify_by_hash=params.verify_by_hash,
+        )
+        checker.prepare(files)
+
+    # Folder-planning timestamps: EXIF first (reusing the checker's batched
+    # reads in metadata mode), file mtime fallback.
+    timestamps = _source_file_timestamps(
+        files,
+        capture_times=(
+            {str(f): checker.capture_time(f) for f in files}
+            if checker is not None and not checker.verify_by_hash
+            else None
+        ),
+    )
+
+    # Group by destination (template) folder, template order, then chunk.
+    groups = {}
+    for f in files:
+        rel = build_destination_path(
+            timestamps.get(f), params.folder_template,
+        ) or "."
+        groups.setdefault(rel, []).append(f)
+    batches = []
+    for rel in sorted(groups):
+        group = groups[rel]
+        for i in range(0, len(group), IMPORT_BATCH_SIZE):
+            batches.append((rel, group[i:i + IMPORT_BATCH_SIZE]))
+
+    # --- Ledger -----------------------------------------------------
+    # Every discovered file ends in exactly one terminal bucket.
+    copied = 0
+    verified = 0
+    skipped_duplicate = 0
+    failed = 0
+    failed_files = []          # [{path, reason}]
+    folder_counts = {}         # rel folder -> counts for the PR 3 UI
+    emitted = 0
+    cancelled = False
+
+    # Intra-run duplicate destinations: token -> dest folder where the
+    # identity landed this run (mirrors ingest's batch_dest_folders).
+    run_dest_folders = {}
+    linked_dup_dirs = set()    # dup-twin dirs already scanned+linked
+
+    def _counts(rel):
+        return folder_counts.setdefault(
+            rel, {"copied": 0, "skipped_duplicate": 0, "failed": 0},
+        )
+
+    def _fail(rel, source_file, reason):
+        nonlocal failed
+        failed += 1
+        _counts(rel)["failed"] += 1
+        failed_files.append({"path": str(source_file), "reason": reason})
+        log.warning("Import failed for %s: %s", source_file, reason)
+
+    for rel, batch in batches:
+        if runner.is_cancelled(job["id"]):
+            cancelled = True
+            break
+
+        dest_folder = (
+            os.path.join(destination, rel) if rel != "." else destination
+        )
+        os.makedirs(dest_folder, exist_ok=True)
+
+        # (dest_path, verified_hash) for this batch's landed files —
+        # fresh copies plus byte-identical files already present at the
+        # destination (the crash-recovery path).
+        landed = []
+        dup_dirs = set()
+
+        for source_file in batch:
+            if runner.is_cancelled(job["id"]):
+                cancelled = True
+                break
+            emitted += 1
+            _emit(
+                f"{rel}: importing", emitted, discovered, source_file.name,
+            )
+
+            # Duplicate gate.
+            if checker is not None:
+                try:
+                    token = checker.match(source_file)
+                except OSError as e:
+                    _fail(rel, source_file, f"duplicate check failed: {e}")
+                    continue
+                if token is not None:
+                    accept = False
+                    if token[0] == "hash":
+                        # Byte-backed match — safe to skip outright.
+                        accept = True
+                        twin_rows = _hash_twin_rows(db, token[1])
+                    else:
+                        # Metadata-only match: never skip on a key alone.
+                        # Hash the card file and the cataloged twin at its
+                        # archive path; only equal bytes make a duplicate.
+                        twin_rows = _key_twin_rows(db, token[1])
+                        src_hash = checker.content_hash(source_file)
+                        for twin in twin_rows:
+                            twin_path = os.path.join(
+                                twin["folder_path"], twin["filename"],
+                            )
+                            try:
+                                twin_hash = compute_file_hash(twin_path)
+                            except OSError:
+                                continue
+                            if twin_hash is not None and twin_hash == src_hash:
+                                accept = True
+                                break
+                    if accept:
+                        skipped_duplicate += 1
+                        _counts(rel)["skipped_duplicate"] += 1
+                        dup_dirs.update(
+                            _linkable_twin_dirs(twin_rows, destination),
+                        )
+                        run_dest = run_dest_folders.get(token)
+                        if run_dest is not None:
+                            dup_dirs.add(run_dest)
+                        continue
+                    # Key matched but no byte-identical twin exists — the
+                    # card file is a distinct photo; import it normally.
+
+            # Destination path + collision handling (mirrors ingest()).
+            dest_file = os.path.join(dest_folder, source_file.name)
+            try:
+                if os.path.exists(dest_file):
+                    src_size = source_file.stat().st_size
+                    dest_size = os.path.getsize(dest_file)
+                    if src_size == 0 and dest_size == 0:
+                        # Zero-byte twin: identical by definition, but kept
+                        # out of the duplicate-identity index (see ingest).
+                        skipped_duplicate += 1
+                        _counts(rel)["skipped_duplicate"] += 1
+                        dup_dirs.add(dest_folder)
+                        continue
+                    if src_size == dest_size:
+                        src_hash = (
+                            checker.content_hash(source_file)
+                            if checker is not None
+                            else compute_file_hash(str(source_file))
+                        )
+                        dest_hash = compute_file_hash(dest_file)
+                        if src_hash is not None and src_hash == dest_hash:
+                            # Byte-identical file already at the destination
+                            # (e.g. a previous run died between copy and
+                            # catalog). Treat as landed: catalog + stamp it
+                            # rather than skipping — this is the designed
+                            # self-heal for crash-shaped interruptions.
+                            skipped_duplicate += 1
+                            _counts(rel)["skipped_duplicate"] += 1
+                            landed.append((dest_file, src_hash))
+                            if checker is not None:
+                                for tok in checker.record(source_file):
+                                    run_dest_folders[tok] = dest_folder
+                            continue
+                    # Different content, same name — numeric suffix.
+                    stem, suffix = os.path.splitext(source_file.name)
+                    counter = 1
+                    while os.path.exists(dest_file):
+                        dest_file = os.path.join(
+                            dest_folder, f"{stem}_{counter}{suffix}",
+                        )
+                        counter += 1
+
+                src_hash = (
+                    checker.content_hash(source_file)
+                    if checker is not None else None
+                )
+                ok, file_hash = copy_and_hash_verify(
+                    str(source_file), dest_file, src_hash=src_hash,
+                )
+            except OSError as e:
+                _fail(rel, source_file, str(e))
+                continue
+            if not ok:
+                _fail(
+                    rel, source_file,
+                    "copy verification failed (destination bytes do not "
+                    "match the source)",
+                )
+                continue
+            copied += 1
+            verified += 1
+            _counts(rel)["copied"] += 1
+            landed.append((dest_file, file_hash))
+            if checker is not None:
+                for tok in checker.record(source_file):
+                    run_dest_folders[tok] = dest_folder
+
+        # --- Catalog this batch (even when cancelled mid-batch: what
+        # landed on disk must be cataloged before we stop, so every
+        # stopping point is a valid catalog state). Bounded by the batch
+        # size, so no cancel_check is passed — it runs to completion.
+        if landed:
+            landed_paths = {p for p, _ in landed}
+            try:
+                scan(
+                    destination, db,
+                    restrict_dirs=[dest_folder],
+                    restrict_files=landed_paths,
+                    vireo_dir=None,
+                )
+            except Exception as e:  # scan failure fails the whole batch
+                for path, _ in landed:
+                    _fail(rel, path, f"catalog scan failed: {e}")
+                landed = []
+
+            # Stamp the verified hashes in the integrity-audit vocabulary,
+            # cross-checked against what scan() stored.
+            for dest_path, verified_hash in landed:
+                row = db.conn.execute(
+                    """SELECT p.id, p.file_hash FROM photos p
+                       JOIN folders f ON f.id = p.folder_id
+                       WHERE f.path = ? AND p.filename = ?""",
+                    (os.path.dirname(dest_path), os.path.basename(dest_path)),
+                ).fetchone()
+                if row is None:
+                    _fail(rel, dest_path, "not cataloged after scan")
+                    continue
+                if row["file_hash"] == verified_hash:
+                    db.update_photo_hash_check(
+                        row["id"], "ok", commit=False,
+                    )
+                elif row["file_hash"] is None:
+                    if verified_hash == EMPTY_FILE_SHA256:
+                        # Zero-byte convention: EMPTY_FILE_SHA256 never
+                        # lands in file_hash (it would collide with every
+                        # other empty file). Status only.
+                        db.update_photo_hash_check(
+                            row["id"], "ok", commit=False,
+                        )
+                    else:
+                        db.update_photo_hash_check(
+                            row["id"], "ok", file_hash=verified_hash,
+                            commit=False,
+                        )
+                else:
+                    _fail(
+                        rel, dest_path,
+                        "destination changed between copy verification and "
+                        "catalog scan (hash mismatch)",
+                    )
+            db.conn.commit()
+
+        # --- Link duplicate-twin folders. Separate scan call WITHOUT
+        # restrict_files: scan only creates/links folder rows for files it
+        # discovers, so folding these dirs into the restricted call above
+        # would link nothing for duplicate-only batches. No restrict on
+        # files also means any uncataloged strays in these dirs get
+        # self-healed into the catalog.
+        new_dup_dirs = dup_dirs - linked_dup_dirs
+        if new_dup_dirs:
+            try:
+                scan(
+                    destination, db,
+                    restrict_dirs=sorted(new_dup_dirs),
+                    vireo_dir=None,
+                    cancel_check=lambda: runner.is_cancelled(job["id"]),
+                )
+                linked_dup_dirs.update(new_dup_dirs)
+            except RuntimeError:
+                cancelled = True
+            except Exception:
+                log.exception(
+                    "Linking duplicate-matched folders failed: %s",
+                    sorted(new_dup_dirs),
+                )
+
+        _emit(
+            f"{rel}: {_counts(rel)['copied']} copied · "
+            f"{_counts(rel)['skipped_duplicate']} already present",
+            emitted, discovered,
+        )
+
+        if cancelled:
+            break
+
+    status = "cancelled" if cancelled else (
+        "failed" if failed else "completed"
+    )
+    runner.update_step(
+        job["id"], "import",
+        status="failed" if status == "failed" else "completed",
+        summary=(
+            f"{copied} copied, {skipped_duplicate} already present, "
+            f"{failed} failed of {discovered} discovered"
+        ),
+    )
+
+    result = {
+        "discovered": discovered,
+        "copied": copied,
+        "verified": verified,
+        "skipped_duplicate": skipped_duplicate,
+        "failed": failed,
+        "failed_files": failed_files,
+        "folders": folder_counts,
+        "cancelled": cancelled,
+    }
+    return result

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -363,22 +363,48 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     # previously scanned mounted card. That twin's re-hash just re-reads
     # the very card file being imported, so accepting it as duplicate
     # proof would flip ``safe_to_format`` green over a card whose bytes
-    # never made it to the archive. Case-fold on darwin/win32 so a
-    # differently-cased spelling of the source path can't slip a twin
-    # through the containment check; ext4/xfs on Linux really do
-    # distinguish case. See PR #1107 review.
+    # never made it to the archive. Case-fold on darwin/win32
+    # unconditionally; on Linux probe each source's actual filesystem
+    # because a FAT/exFAT/NTFS-mounted SD card is case-insensitive even
+    # under a case-sensitive ext4 parent — a platform-wide check would
+    # miss a differently-cased twin path there. See PR #1107 review.
     _case_insensitive_platform = sys.platform in ("darwin", "win32")
 
-    def _casenorm_path(p):
-        return p.casefold() if _case_insensitive_platform else p
+    def _fs_is_case_insensitive(path):
+        """Probe whether the filesystem at ``path`` treats case as insensitive.
+
+        Best-effort: case-swap one alpha character from the resolved
+        path and check ``os.path.samefile``. On any error, returns
+        False — a false negative just falls back to case-sensitive
+        comparison (strictly narrower guard, never wider).
+        """
+        try:
+            for i, c in enumerate(path):
+                if c.isalpha():
+                    probe = path[:i] + c.swapcase() + path[i + 1:]
+                    if probe == path:
+                        continue
+                    if not os.path.exists(probe):
+                        return False
+                    try:
+                        return os.path.samefile(path, probe)
+                    except OSError:
+                        return False
+            return False
+        except OSError:
+            return False
 
     def _norm_source(s):
         try:
             real = os.path.realpath(s)
         except OSError:
             real = str(s)
-        return _casenorm_path(real).rstrip(os.sep)
+        ci = _case_insensitive_platform or _fs_is_case_insensitive(real)
+        return (real.casefold() if ci else real).rstrip(os.sep), ci
 
+    # (normalized_root, is_case_insensitive) per source. Per-source ci is
+    # stored so ``_path_under_any_source`` case-folds the candidate path
+    # exactly when the source lives on a case-insensitive filesystem.
     source_roots = [_norm_source(s) for s in params.sources]
 
     def _path_under_any_source(path):
@@ -386,10 +412,11 @@ def run_import_job(job, runner, db_path, workspace_id, params):
             real = os.path.realpath(path)
         except OSError:
             real = str(path)
-        cmp = _casenorm_path(real)
-        for root in source_roots:
+        real_folded = real.casefold()
+        for root, ci in source_roots:
             if not root:
                 continue
+            cmp = real_folded if ci else real
             if cmp == root or cmp.startswith(root + os.sep):
                 return True
         return False
@@ -1068,19 +1095,31 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     if companion is not None:
                         actual = _rehash_dest_or_none(dest_path)
                         if actual is not None and actual == verified_hash:
-                            # Fresh-copy JPEG landed as companion to an
-                            # existing RAW row. The RAW's derived caches
-                            # may reflect the pre-import state (RAW-only
-                            # preview strategy, or a deleted/replaced
-                            # prior companion); invalidate so the
-                            # deferred WC pass rebuilds from the just-
-                            # verified JPEG. Adoption (bytes already at
-                            # this path) doesn't need invalidation. See
-                            # PR #1107 review.
-                            if entry[3] == "copied":
-                                raw_companion_invalidations.add(
-                                    companion["id"],
-                                )
+                            # Landed JPEG paired with an existing RAW
+                            # row. Invalidate the RAW's derived caches
+                            # regardless of origin: adoption
+                            # (``skipped_duplicate``) only proves the
+                            # JPEG bytes were already at the archive
+                            # path, NOT that the RAW row already carried
+                            # ``companion_path`` for this JPEG. A prior
+                            # partial run or backfill may have left the
+                            # RAW as RAW-only (with a
+                            # ``working_copy_path`` or
+                            # ``working_copy_failed_at`` built without
+                            # knowing this companion existed); the
+                            # deferred end-of-run
+                            # ``_extract_working_copies`` skips RAWs
+                            # whose ``working_copy_path IS NOT NULL``,
+                            # so a stale RAW-only cache would persist
+                            # past this import and the UI would keep
+                            # serving derived files for the pre-pair
+                            # state. Fresh-copy JPEGs need this too
+                            # (RAW may have been standalone or paired
+                            # with a since-deleted companion). See PR
+                            # #1107 review.
+                            raw_companion_invalidations.add(
+                                companion["id"],
+                            )
                             continue
                         _reclassify_landed_failed(
                             rel, entry,

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -997,6 +997,26 @@ def run_import_job(job, runner, db_path, workspace_id, params):
             # rest of the app sees at the archive path. See PR #1107 review.
             reclassified_landed_paths = set()
 
+            # RAW rows whose derived caches need invalidation because a
+            # newly-landed JPEG became (or already was) their companion.
+            # Pair-scan merges the JPEG's identity into the RAW row and
+            # deletes the JPEG's own photos row, so the JPEG's landed
+            # entry has ``row is None`` and never enters the
+            # ``pre_scan_hashes`` diff loop below. But the RAW's
+            # ``working_copy_path``/thumb/preview may have been built
+            # from stale companion bytes (JPEG was deleted then this
+            # import restored it with different content, or the RAW was
+            # standalone before and pairing now changes preview
+            # strategy), and the deferred ``_extract_working_copies``
+            # skips rows whose ``working_copy_path IS NOT NULL``. Without
+            # invalidation the UI keeps serving derived files for the
+            # previous companion state. Skip when the JPEG was adopted
+            # (``origin == "skipped_duplicate"``): its bytes were already
+            # at the archive path before this run, so any RAW cache
+            # derived from them is by construction consistent. See PR
+            # #1107 review.
+            raw_companion_invalidations = set()
+
             def _rehash_dest_or_none(path):
                 """Re-hash the archive file, returning None on read failure.
 
@@ -1048,6 +1068,19 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     if companion is not None:
                         actual = _rehash_dest_or_none(dest_path)
                         if actual is not None and actual == verified_hash:
+                            # Fresh-copy JPEG landed as companion to an
+                            # existing RAW row. The RAW's derived caches
+                            # may reflect the pre-import state (RAW-only
+                            # preview strategy, or a deleted/replaced
+                            # prior companion); invalidate so the
+                            # deferred WC pass rebuilds from the just-
+                            # verified JPEG. Adoption (bytes already at
+                            # this path) doesn't need invalidation. See
+                            # PR #1107 review.
+                            if entry[3] == "copied":
+                                raw_companion_invalidations.add(
+                                    companion["id"],
+                                )
                             continue
                         _reclassify_landed_failed(
                             rel, entry,
@@ -1162,6 +1195,17 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                         thumb_cache_dir=params.thumb_cache_dir,
                     )
                     invalidated_photo_ids.add(row["id"])
+
+                # RAW rows whose companion JPEG we just landed fresh —
+                # covered by the same untracked-preview sweep below so
+                # orphaned preview files from the prior companion state
+                # don't get lazy-adopted on the next request.
+                for raw_id in raw_companion_invalidations:
+                    _invalidate_derived_caches(
+                        db, params.vireo_dir, raw_id,
+                        thumb_cache_dir=params.thumb_cache_dir,
+                    )
+                    invalidated_photo_ids.add(raw_id)
 
             db.conn.commit()
 

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -335,15 +335,25 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                 if token is not None:
                     accept = False
                     if token[0] == "hash":
-                        # Byte-backed match — safe to skip outright.
-                        accept = True
                         twin_rows = _hash_twin_rows(db, token[1])
+                        src_hash = token[1]
                     else:
-                        # Metadata-only match: never skip on a key alone.
-                        # Hash the card file and the cataloged twin at its
-                        # archive path; only equal bytes make a duplicate.
                         twin_rows = _key_twin_rows(db, token[1])
                         src_hash = checker.content_hash(source_file)
+                    # An intra-run token is byte-proven by this session's
+                    # own copy_and_hash_verify — safe to skip without
+                    # hitting the archive. Any other match (catalog-side
+                    # hash OR metadata-only key) is stale-suspect: the
+                    # photos.file_hash row could describe an archive file
+                    # that was deleted or modified since the last scan, so
+                    # a duplicate skip must be backed by a cataloged twin
+                    # that STILL holds those bytes on disk. Without this,
+                    # a stale hash row would let the card be counted as
+                    # skipped_duplicate and safe_to_format go green while
+                    # the card is the only remaining copy of the bytes.
+                    if token in run_dest_folders:
+                        accept = True
+                    else:
                         for twin in twin_rows:
                             twin_path = os.path.join(
                                 twin["folder_path"], twin["filename"],
@@ -365,8 +375,8 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                         if run_dest is not None:
                             dup_dirs.add(run_dest)
                         continue
-                    # Key matched but no byte-identical twin exists — the
-                    # card file is a distinct photo; import it normally.
+                    # No byte-identical twin remains on disk — the card
+                    # file is a distinct photo; import it normally.
 
             # Destination path + collision handling (mirrors ingest()).
             dest_file = os.path.join(dest_folder, source_file.name)

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -706,6 +706,25 @@ def run_import_job(job, runner, db_path, workspace_id, params):
             src_size = src_stat.st_size
             src_mtime_ns = src_stat.st_mtime_ns
             try:
+                # Source hash is potentially needed by three checks below
+                # (primary-name adopt, per-suffix candidate adopt, and the
+                # copy_and_hash_verify src_hash arg). Compute lazily and
+                # cache in a small closure so nothing hashes the card
+                # twice.
+                _sh_cache = [False, None]
+
+                def _src_hash_cached():
+                    if not _sh_cache[0]:
+                        _sh_cache[0] = True
+                        _sh_cache[1] = (
+                            checker.content_hash(source_file)
+                            if checker is not None
+                            else compute_file_hash(str(source_file))
+                        )
+                    return _sh_cache[1]
+
+                adopted_dest = None  # (path, hash) when byte-identical twin found
+
                 if os.path.exists(dest_file):
                     dest_size = os.path.getsize(dest_file)
                     if src_size == 0 and dest_size == 0:
@@ -716,37 +735,65 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                         dup_dirs.add(dest_folder)
                         continue
                     if src_size == dest_size:
-                        src_hash = (
-                            checker.content_hash(source_file)
-                            if checker is not None
-                            else compute_file_hash(str(source_file))
-                        )
                         dest_hash = compute_file_hash(dest_file)
-                        if src_hash is not None and src_hash == dest_hash:
+                        src_h = _src_hash_cached()
+                        if src_h is not None and src_h == dest_hash:
                             # Byte-identical file already at the destination
                             # (e.g. a previous run died between copy and
                             # catalog). Treat as landed: catalog + stamp it
                             # rather than skipping — this is the designed
                             # self-heal for crash-shaped interruptions.
-                            skipped_duplicate += 1
-                            _counts(rel)["skipped_duplicate"] += 1
-                            landed.append(
-                                (dest_file, src_hash, str(source_file),
-                                 "skipped_duplicate",
-                                 src_size, src_mtime_ns),
+                            adopted_dest = (dest_file, src_h)
+                    if adopted_dest is None:
+                        # Different content, same primary name — advance
+                        # through numeric suffixes. But a crash-interrupted
+                        # retry may already have written THIS source's bytes
+                        # under an earlier suffix: an earlier run copied a
+                        # colliding different file to ``name.ext`` and put
+                        # this source's bytes at ``name_1.ext``, then died
+                        # before its scan. Advancing past ``name_1.ext``
+                        # without hashing it would re-copy identical bytes
+                        # to ``name_2.ext`` and leave two archive copies of
+                        # one source photo. Hash-match every existing
+                        # suffix candidate and adopt on a match; on no
+                        # match, land at the next free suffix. See PR #1107
+                        # review.
+                        stem, suffix = os.path.splitext(source_file.name)
+                        counter = 1
+                        while True:
+                            candidate = os.path.join(
+                                dest_folder, f"{stem}_{counter}{suffix}",
                             )
-                            _record_checker(
-                                source_file, dest_folder, src_hash,
-                            )
-                            continue
-                    # Different content, same name — numeric suffix.
-                    stem, suffix = os.path.splitext(source_file.name)
-                    counter = 1
-                    while os.path.exists(dest_file):
-                        dest_file = os.path.join(
-                            dest_folder, f"{stem}_{counter}{suffix}",
-                        )
-                        counter += 1
+                            if not os.path.exists(candidate):
+                                dest_file = candidate
+                                break
+                            try:
+                                cand_size = os.path.getsize(candidate)
+                            except OSError:
+                                cand_size = -1
+                            if cand_size == src_size:
+                                cand_hash = compute_file_hash(candidate)
+                                src_h = _src_hash_cached()
+                                if (
+                                    cand_hash is not None
+                                    and src_h is not None
+                                    and cand_hash == src_h
+                                ):
+                                    adopted_dest = (candidate, src_h)
+                                    break
+                            counter += 1
+
+                if adopted_dest is not None:
+                    dest_file, adopt_hash = adopted_dest
+                    skipped_duplicate += 1
+                    _counts(rel)["skipped_duplicate"] += 1
+                    landed.append(
+                        (dest_file, adopt_hash, str(source_file),
+                         "skipped_duplicate",
+                         src_size, src_mtime_ns),
+                    )
+                    _record_checker(source_file, dest_folder, adopt_hash)
+                    continue
 
                 src_hash = (
                     checker.content_hash(source_file)
@@ -809,6 +856,23 @@ def run_import_job(job, runner, db_path, workspace_id, params):
             # rest of the app sees at the archive path. See PR #1107 review.
             reclassified_landed_paths = set()
 
+            def _rehash_dest_or_none(path):
+                """Re-hash the archive file, returning None on read failure.
+
+                Used as the last-line check that the bytes currently at the
+                archive path still match what ``copy_and_hash_verify()``
+                landed — necessary any time the scan-side hash is missing
+                (paired-JPEG row deletion) or NULL (scanner hashed the empty
+                zero-byte convention aside, a NULL means the archive read
+                failed between promote and scan). Without it, mutation of
+                the archive file between promote and scan would still be
+                accepted as success.
+                """
+                try:
+                    return compute_file_hash(path)
+                except OSError:
+                    return None
+
             # Stamp the verified hashes in the integrity-audit vocabulary,
             # cross-checked against what scan() stored.
             for entry in landed:
@@ -822,9 +886,15 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                 ).fetchone()
                 if row is None:
                     # RAW+JPEG pairing merges the JPEG's photo row into the
-                    # RAW primary (companion_path); the JPEG's bytes are
-                    # verified and represented — that's a success, not a
-                    # missing catalog row.
+                    # RAW primary (companion_path); the JPEG's own row is
+                    # gone by design and the bytes are represented on the
+                    # RAW. But the pair lookup can't tell us the JPEG's
+                    # archive bytes are still the ones we verified — the
+                    # archive file could have been rewritten or corrupted
+                    # between promote and the restricted scan. Re-read the
+                    # archive path and require its hash to still equal
+                    # ``verified_hash`` before counting the JPEG landed;
+                    # otherwise reclassify to failed. See PR #1107 review.
                     companion = db.conn.execute(
                         """SELECT p.id FROM photos p
                            JOIN folders f ON f.id = p.folder_id
@@ -835,6 +905,15 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                         ),
                     ).fetchone()
                     if companion is not None:
+                        actual = _rehash_dest_or_none(dest_path)
+                        if actual is not None and actual == verified_hash:
+                            continue
+                        _reclassify_landed_failed(
+                            rel, entry,
+                            "paired companion archive bytes no longer "
+                            "match the copy-time hash",
+                        )
+                        reclassified_landed_paths.add(dest_path)
                         continue
                     _reclassify_landed_failed(
                         rel, entry, "not cataloged after scan",
@@ -854,10 +933,30 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                             row["id"], "ok", commit=False,
                         )
                     else:
-                        db.update_photo_hash_check(
-                            row["id"], "ok", file_hash=verified_hash,
-                            commit=False,
-                        )
+                        # Non-empty file with NULL file_hash after scan
+                        # means scanner._compute_file_features couldn't
+                        # read the archive file (unreadable between
+                        # promote and scan). Trusting the copy-time hash
+                        # here would flip ``safe_to_format`` green for
+                        # bytes we can't currently verify on disk. Re-
+                        # hash the archive path from here as a last check
+                        # — if that also fails or disagrees with our
+                        # copy-time hash, reclassify to failed instead of
+                        # stamping a stale value. See PR #1107 review.
+                        actual = _rehash_dest_or_none(dest_path)
+                        if actual is not None and actual == verified_hash:
+                            db.update_photo_hash_check(
+                                row["id"], "ok", file_hash=verified_hash,
+                                commit=False,
+                            )
+                        else:
+                            _reclassify_landed_failed(
+                                rel, entry,
+                                "archive file unhashable after copy "
+                                "verification (scan wrote no hash and "
+                                "re-hash disagrees)",
+                            )
+                            reclassified_landed_paths.add(dest_path)
                 else:
                     _reclassify_landed_failed(
                         rel, entry,

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -589,6 +589,28 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         )
         os.makedirs(dest_folder, exist_ok=True)
 
+        # Promote any pre-existing folder row for this destination out of
+        # ``'missing'``. Standalone scans run ``check_folder_health()`` as
+        # their preflight, so a reattached archive drive transitions
+        # ``missing`` → ``ok`` before its files become visible in the
+        # workspace again. The import path calls ``scanner.scan()``
+        # directly, and scan's success stamp only clears ``'partial'``
+        # (see ``_update_folder_status(only_from_partial=True)``), so a
+        # folder row still marked ``'missing'`` would keep the archive
+        # drive's photos filtered out of workspace queries even after this
+        # import successfully lands and hash-stamps files into it, and
+        # safe_to_format could go green over folders the UI won't show.
+        # We just makedirs'd ``dest_folder`` so the path definitely exists;
+        # any row still labelled ``'missing'`` is stale. Preserve
+        # ``'partial'`` (a real prior-scan signal that the folder needs a
+        # rescan). See PR #1107 review.
+        db.conn.execute(
+            "UPDATE folders SET status = 'ok' "
+            "WHERE path = ? AND status = 'missing'",
+            (dest_folder,),
+        )
+        db.conn.commit()
+
         # (dest_path, verified_hash, card_source) for this batch's
         # landed files — fresh copies plus byte-identical files already
         # present at the destination (the crash-recovery path). The card

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -1285,7 +1285,13 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     # recovery adopted files whose card is gone, later backfill retries)
     # falls back to the cataloged archive path. Per-row failures mark the
     # photo for the scanner's later backfill and never fail the import.
-    if params.vireo_dir and wc_dest_folders:
+    #
+    # If the run was already cancelled at a batch boundary, skip the pass
+    # entirely — otherwise Stop appears hung for minutes on large RAW
+    # imports while the extractor decodes what the user asked us to
+    # abort. During the pass, poll ``runner.is_cancelled`` so cancellation
+    # aborts extraction row-by-row too.
+    if params.vireo_dir and wc_dest_folders and not cancelled:
         from scanner import _extract_working_copies
 
         try:
@@ -1293,12 +1299,15 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                 db, params.vireo_dir,
                 scope=[(d, "exact") for d in sorted(wc_dest_folders)],
                 source_paths=wc_source_paths,
+                cancel_check=lambda: runner.is_cancelled(job["id"]),
             )
         except Exception:
             log.exception(
                 "Working-copy extraction failed for %s",
                 sorted(wc_dest_folders),
             )
+        if runner.is_cancelled(job["id"]):
+            cancelled = True
 
     status = "cancelled" if cancelled else (
         "failed" if failed else "completed"
@@ -1332,21 +1341,24 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     # its cataloged twin), AND every source was walked cleanly, AND every
     # duplicate-only batch's workspace-link scan succeeded (otherwise the
     # imported duplicates are on disk but not visible in the workspace),
-    # AND the run enumerated the card's full supported-file set (a
-    # narrowed ``file_types`` — "raw", "jpeg", or a custom extension list
-    # — leaves the un-selected supported photos on the card entirely
-    # unseen; ``discovered`` covers only the requested subset, so the
-    # naive ``copied + skipped_duplicate == discovered`` check would go
-    # green even though the card still holds files the pill is expected
-    # to cover). A cancelled run leaves unprocessed files, so it is
-    # never safe. This pill means exactly what it says.
-    filtered_import = params.file_types != "both"
+    # AND the run enumerated the card's full supported-file set. Any
+    # narrowing of the walk falls into ``partial_scope``: a narrowed
+    # ``file_types`` ("raw", "jpeg", or a custom extension list) leaves
+    # the un-selected supported photos on the card entirely unseen, and
+    # ``recursive=False`` skips every subdirectory of every source root.
+    # In both cases ``discovered`` covers only a subset of what the card
+    # actually holds, so the naive ``copied + skipped_duplicate ==
+    # discovered`` check would go green even though the card still holds
+    # files the pill is expected to cover. A cancelled run leaves
+    # unprocessed files, so it is never safe. This pill means exactly
+    # what it says.
+    partial_scope = params.file_types != "both" or not params.recursive
     safe_to_format = (
         not cancelled
         and failed == 0
         and not discovery_errors
         and not dup_link_failed
-        and not filtered_import
+        and not partial_scope
         and (copied + skipped_duplicate) == discovered
     )
     result = {

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -765,16 +765,19 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     continue
                 if token is not None:
                     accept = False
-                    # For 'hash' tokens, every row in twin_rows shares
-                    # the token's hash by construction (the query is
-                    # WHERE file_hash = ?), so all are byte-verified.
-                    # For 'key' tokens, twin_rows is a filename+size+
-                    # capture-second bucket; individual rows may hold
-                    # unrelated bytes. verified_twin_rows records only
-                    # the twin(s) whose bytes we actually hashed and
-                    # matched, so the folder-link update below can't
-                    # pull unrelated key-collision folders into the
-                    # active workspace. See PR #1107 review.
+                    # verified_twin_rows records only the twin(s) whose
+                    # bytes we actually hashed on disk this run and
+                    # matched against the source. Both 'hash' and 'key'
+                    # tokens can carry stale rows: 'key' is a filename+
+                    # size+capture-second bucket where individual rows
+                    # may hold unrelated bytes, and 'hash' shares the
+                    # token's stored file_hash by construction but that
+                    # column reflects the LAST scan — an archive file
+                    # deleted or overwritten between scans leaves a stale
+                    # hash row. Linking any twin folder we did not
+                    # re-hash would pull unrelated/missing archive folders
+                    # into the active workspace on a duplicate-only
+                    # import. See PR #1107 review.
                     verified_twin_rows = []
                     if token[0] == "hash":
                         twin_rows = _hash_twin_rows(db, token[1])
@@ -850,49 +853,43 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                                 continue
                             if twin_hash is not None and twin_hash == src_hash:
                                 accept = True
-                                if token[0] == "hash":
-                                    # link_rows below is twin_rows for
-                                    # 'hash' tokens (all rows share the
-                                    # verified hash by construction), so
-                                    # a single verified twin is enough to
-                                    # flip accept and stop hashing more.
-                                    verified_twin_rows = [twin]
-                                    break
-                                # For 'key' tokens link_rows is
-                                # verified_twin_rows, so only twins whose
-                                # bytes we actually re-hashed can be
-                                # linked. Breaking at the first byte
-                                # match risks capturing only an
-                                # off-destination twin: _linkable_twin_
-                                # dirs then drops it, dup_dirs stays
-                                # empty for the destination twin's
-                                # folder, and a duplicate-only import
-                                # returns safe_to_format=true while the
-                                # imported photo remains invisible in
-                                # the active workspace. Keep scanning
-                                # to collect every byte-verified twin.
-                                # See PR #1107 review.
+                                # Keep scanning to collect every
+                                # byte-verified twin — for both 'hash'
+                                # and 'key' tokens. Breaking at the
+                                # first match (or falling back to the
+                                # full twin_rows for 'hash') risks
+                                # linking a stale/off-destination twin:
+                                # _linkable_twin_dirs then either drops
+                                # a legitimate destination twin (leaving
+                                # the imported photo invisible in the
+                                # active workspace) or pulls an
+                                # unrelated folder in (if the catalog's
+                                # stored hash row no longer describes
+                                # the on-disk bytes). See PR #1107
+                                # review.
                                 verified_twin_rows.append(twin)
                     if accept:
                         skipped_duplicate += 1
                         _counts(rel)["skipped_duplicate"] += 1
-                        # 'hash' → every twin_rows entry is byte-identical
-                        # to the source by construction (see _hash_twin_
-                        # rows query above). 'key' → only the twin whose
-                        # bytes we hashed and matched can be linked; the
-                        # other rows share filename+size+capture-second
-                        # but may hold unrelated bytes, so linking their
-                        # folders would pull unrelated archive photos
+                        # verified_twin_rows carries only twins whose
+                        # bytes we re-hashed and matched this run — the
+                        # only rows whose folders are safe to link. For
+                        # a 'hash' token, other twin_rows entries share
+                        # the token's stored hash by construction but
+                        # that column can be stale (the archive file
+                        # changed or was deleted between scans); for a
+                        # 'key' token, other twin_rows entries share
+                        # only filename+size+capture-second and may
+                        # hold unrelated bytes. Linking either category
+                        # would pull unrelated/missing archive folders
                         # into the active workspace on a duplicate-only
                         # import. verified_twin_rows is empty when the
-                        # intra-run branch accepted (run_dest is added
-                        # separately below). See PR #1107 review.
-                        link_rows = (
-                            twin_rows if token[0] == "hash"
-                            else verified_twin_rows
-                        )
+                        # intra-run branch accepted above (run_dest is
+                        # added separately below). See PR #1107 review.
                         dup_dirs.update(
-                            _linkable_twin_dirs(link_rows, _path_under_destination),
+                            _linkable_twin_dirs(
+                                verified_twin_rows, _path_under_destination,
+                            ),
                         )
                         run_dest = run_dest_folders.get(token)
                         if run_dest is not None:

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -420,7 +420,14 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     # JPEG is still available. Deferring to end-of-run means every
     # companion in the run has landed and been paired before
     # ``_extract_working_copies`` decides which source to read.
-    wc_source_paths = {}  # dest_path -> card source path
+    # dest_path -> (card_src_path, expected_size, expected_mtime_ns).
+    # The identity tuple is captured at land time (before any WC
+    # extraction pass), so the deferred ``_extract_working_copies`` call
+    # can verify the override still holds the exact bytes we copied —
+    # not just any same-sized file that happens to be at the same path.
+    # A rewrite or a reused-mount collision differ in mtime and get
+    # rejected; extraction falls back to the verified archive copy.
+    wc_source_paths = {}
     wc_dest_folders = set()  # exact-match scope for extraction
     # Intra-run duplicate destinations: token -> dest folder where the
     # identity landed this run (mirrors ingest's batch_dest_folders).
@@ -626,9 +633,26 @@ def run_import_job(job, runner, db_path, workspace_id, params):
 
             # Destination path + collision handling (mirrors ingest()).
             dest_file = os.path.join(dest_folder, source_file.name)
+            # Capture card-side (size, mtime_ns) BEFORE the copy so the
+            # deferred working-copy pass can identity-check the card
+            # override at extraction time. Byte-identical files have the
+            # same size AND mtime; a rewrite between now and the end-of-
+            # run extractor bumps mtime, and a remounted different card
+            # at the same path has an unrelated mtime for its coincidence
+            # of same-sized file. Without this the size-only check would
+            # accept a same-size collision and cache a working copy for
+            # the wrong bytes. Stat errors are the same class as
+            # copy_and_hash_verify's OSError handling — fail just this
+            # source rather than escape and kill the whole background job.
+            try:
+                src_stat = source_file.stat()
+            except OSError as e:
+                _fail(rel, source_file, str(e))
+                continue
+            src_size = src_stat.st_size
+            src_mtime_ns = src_stat.st_mtime_ns
             try:
                 if os.path.exists(dest_file):
-                    src_size = source_file.stat().st_size
                     dest_size = os.path.getsize(dest_file)
                     if src_size == 0 and dest_size == 0:
                         # Zero-byte twin: identical by definition, but kept
@@ -654,7 +678,8 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                             _counts(rel)["skipped_duplicate"] += 1
                             landed.append(
                                 (dest_file, src_hash, str(source_file),
-                                 "skipped_duplicate"),
+                                 "skipped_duplicate",
+                                 src_size, src_mtime_ns),
                             )
                             _record_checker(
                                 source_file, dest_folder, src_hash,
@@ -690,7 +715,8 @@ def run_import_job(job, runner, db_path, workspace_id, params):
             verified += 1
             _counts(rel)["copied"] += 1
             landed.append(
-                (dest_file, file_hash, str(source_file), "copied"),
+                (dest_file, file_hash, str(source_file), "copied",
+                 src_size, src_mtime_ns),
             )
             _record_checker(source_file, dest_folder, file_hash)
 
@@ -720,7 +746,8 @@ def run_import_job(job, runner, db_path, workspace_id, params):
             # Stamp the verified hashes in the integrity-audit vocabulary,
             # cross-checked against what scan() stored.
             for entry in landed:
-                dest_path, verified_hash, _src, _origin = entry
+                dest_path = entry[0]
+                verified_hash = entry[1]
                 row = db.conn.execute(
                     """SELECT p.id, p.file_hash FROM photos p
                        JOIN folders f ON f.id = p.folder_id
@@ -782,8 +809,13 @@ def run_import_job(job, runner, db_path, workspace_id, params):
             # predicate then skips.
             if params.vireo_dir:
                 for entry in landed:
-                    dest_path, _hash, src_path, _origin = entry
-                    wc_source_paths[dest_path] = src_path
+                    dest_path = entry[0]
+                    src_path = entry[2]
+                    exp_size = entry[4]
+                    exp_mtime_ns = entry[5]
+                    wc_source_paths[dest_path] = (
+                        src_path, exp_size, exp_mtime_ns,
+                    )
                 wc_dest_folders.add(dest_folder)
 
         # --- Link duplicate-twin folders. Separate scan call WITHOUT

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -850,8 +850,29 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                                 continue
                             if twin_hash is not None and twin_hash == src_hash:
                                 accept = True
-                                verified_twin_rows = [twin]
-                                break
+                                if token[0] == "hash":
+                                    # link_rows below is twin_rows for
+                                    # 'hash' tokens (all rows share the
+                                    # verified hash by construction), so
+                                    # a single verified twin is enough to
+                                    # flip accept and stop hashing more.
+                                    verified_twin_rows = [twin]
+                                    break
+                                # For 'key' tokens link_rows is
+                                # verified_twin_rows, so only twins whose
+                                # bytes we actually re-hashed can be
+                                # linked. Breaking at the first byte
+                                # match risks capturing only an
+                                # off-destination twin: _linkable_twin_
+                                # dirs then drops it, dup_dirs stays
+                                # empty for the destination twin's
+                                # folder, and a duplicate-only import
+                                # returns safe_to_format=true while the
+                                # imported photo remains invisible in
+                                # the active workspace. Keep scanning
+                                # to collect every byte-verified twin.
+                                # See PR #1107 review.
+                                verified_twin_rows.append(twin)
                     if accept:
                         skipped_duplicate += 1
                         _counts(rel)["skipped_duplicate"] += 1

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -308,9 +308,11 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         )
         os.makedirs(dest_folder, exist_ok=True)
 
-        # (dest_path, verified_hash) for this batch's landed files —
-        # fresh copies plus byte-identical files already present at the
-        # destination (the crash-recovery path).
+        # (dest_path, verified_hash, card_source) for this batch's
+        # landed files — fresh copies plus byte-identical files already
+        # present at the destination (the crash-recovery path). The card
+        # source feeds working-copy extraction so it reads local card
+        # bytes, never the just-written archive copy.
         landed = []
         dup_dirs = set()
 
@@ -394,7 +396,9 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                             # self-heal for crash-shaped interruptions.
                             skipped_duplicate += 1
                             _counts(rel)["skipped_duplicate"] += 1
-                            landed.append((dest_file, src_hash))
+                            landed.append(
+                                (dest_file, src_hash, str(source_file)),
+                            )
                             if checker is not None:
                                 for tok in checker.record(source_file):
                                     run_dest_folders[tok] = dest_folder
@@ -428,7 +432,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
             copied += 1
             verified += 1
             _counts(rel)["copied"] += 1
-            landed.append((dest_file, file_hash))
+            landed.append((dest_file, file_hash, str(source_file)))
             if checker is not None:
                 for tok in checker.record(source_file):
                     run_dest_folders[tok] = dest_folder
@@ -438,7 +442,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         # stopping point is a valid catalog state). Bounded by the batch
         # size, so no cancel_check is passed — it runs to completion.
         if landed:
-            landed_paths = {p for p, _ in landed}
+            landed_paths = {p for p, _, _ in landed}
             try:
                 scan(
                     destination, db,
@@ -447,13 +451,13 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     vireo_dir=None,
                 )
             except Exception as e:  # scan failure fails the whole batch
-                for path, _ in landed:
+                for path, _, _ in landed:
                     _fail(rel, path, f"catalog scan failed: {e}")
                 landed = []
 
             # Stamp the verified hashes in the integrity-audit vocabulary,
             # cross-checked against what scan() stored.
-            for dest_path, verified_hash in landed:
+            for dest_path, verified_hash, _src in landed:
                 row = db.conn.execute(
                     """SELECT p.id, p.file_hash FROM photos p
                        JOIN folders f ON f.id = p.folder_id
@@ -461,6 +465,21 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     (os.path.dirname(dest_path), os.path.basename(dest_path)),
                 ).fetchone()
                 if row is None:
+                    # RAW+JPEG pairing merges the JPEG's photo row into the
+                    # RAW primary (companion_path); the JPEG's bytes are
+                    # verified and represented — that's a success, not a
+                    # missing catalog row.
+                    companion = db.conn.execute(
+                        """SELECT p.id FROM photos p
+                           JOIN folders f ON f.id = p.folder_id
+                           WHERE f.path = ? AND p.companion_path = ?""",
+                        (
+                            os.path.dirname(dest_path),
+                            os.path.basename(dest_path),
+                        ),
+                    ).fetchone()
+                    if companion is not None:
+                        continue
                     _fail(rel, dest_path, "not cataloged after scan")
                     continue
                 if row["file_hash"] == verified_hash:
@@ -487,6 +506,29 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                         "catalog scan (hash mismatch)",
                     )
             db.conn.commit()
+
+            # Extract working copies reading the CARD copy (fast local
+            # bytes) instead of the just-written archive copy. Scoped to
+            # this batch's destination folder; scan() ran with
+            # vireo_dir=None precisely so extraction happens here with
+            # the card-side source mapping. Per-row failures mark the
+            # photo for the scanner's later backfill and never fail the
+            # import.
+            if params.vireo_dir:
+                from scanner import _extract_working_copies
+
+                try:
+                    _extract_working_copies(
+                        db, params.vireo_dir,
+                        scope=[(dest_folder, "exact")],
+                        source_paths={
+                            dest: src for dest, _, src in landed
+                        },
+                    )
+                except Exception:
+                    log.exception(
+                        "Working-copy extraction failed for %s", dest_folder,
+                    )
 
         # --- Link duplicate-twin folders. Separate scan call WITHOUT
         # restrict_files: scan only creates/links folder rows for files it

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -754,6 +754,17 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     continue
                 if token is not None:
                     accept = False
+                    # For 'hash' tokens, every row in twin_rows shares
+                    # the token's hash by construction (the query is
+                    # WHERE file_hash = ?), so all are byte-verified.
+                    # For 'key' tokens, twin_rows is a filename+size+
+                    # capture-second bucket; individual rows may hold
+                    # unrelated bytes. verified_twin_rows records only
+                    # the twin(s) whose bytes we actually hashed and
+                    # matched, so the folder-link update below can't
+                    # pull unrelated key-collision folders into the
+                    # active workspace. See PR #1107 review.
+                    verified_twin_rows = []
                     if token[0] == "hash":
                         twin_rows = _hash_twin_rows(db, token[1])
                         src_hash = token[1]
@@ -828,12 +839,28 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                                 continue
                             if twin_hash is not None and twin_hash == src_hash:
                                 accept = True
+                                verified_twin_rows = [twin]
                                 break
                     if accept:
                         skipped_duplicate += 1
                         _counts(rel)["skipped_duplicate"] += 1
+                        # 'hash' → every twin_rows entry is byte-identical
+                        # to the source by construction (see _hash_twin_
+                        # rows query above). 'key' → only the twin whose
+                        # bytes we hashed and matched can be linked; the
+                        # other rows share filename+size+capture-second
+                        # but may hold unrelated bytes, so linking their
+                        # folders would pull unrelated archive photos
+                        # into the active workspace on a duplicate-only
+                        # import. verified_twin_rows is empty when the
+                        # intra-run branch accepted (run_dest is added
+                        # separately below). See PR #1107 review.
+                        link_rows = (
+                            twin_rows if token[0] == "hash"
+                            else verified_twin_rows
+                        )
                         dup_dirs.update(
-                            _linkable_twin_dirs(twin_rows, _path_under_destination),
+                            _linkable_twin_dirs(link_rows, _path_under_destination),
                         )
                         run_dest = run_dest_folders.get(token)
                         if run_dest is not None:

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -407,16 +407,22 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         ``/mnt`` cannot resolve ``/Mnt`` or a differently-cased
         ``Card`` entry (mount-point dentries live in the parent FS),
         so swapping characters in the ``path`` string always reports
-        case-sensitive regardless of the card's own semantics. On any
-        error, empty directory, or entry without an alpha character,
-        returns False and the caller falls back to case-sensitive
-        comparison (strictly narrower guard, never wider). See PR
-        #1107 review.
+        case-sensitive regardless of the card's own semantics.
+
+        Any inconclusive result (unlistable, empty, no alpha-containing
+        entry — Nikon-style ``100``/``101``/``102`` roots — or a stat
+        error while comparing) returns True so the caller falls back
+        to case-fold, mirroring the ``/api/jobs/import-photos`` route
+        guard. False on inconclusive would let a differently-cased
+        catalog twin under a source pass duplicate acceptance (or a
+        differently-cased twin folder under the destination skip
+        workspace linking), and ``safe_to_format`` could then go green
+        without a visible off-card copy. See PR #1107 review.
         """
         try:
             entries = os.listdir(path)
         except OSError:
-            return False
+            return True
         for name in entries:
             for i, c in enumerate(name):
                 if c.isalpha():
@@ -426,12 +432,14 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     original_full = os.path.join(path, name)
                     probe_full = os.path.join(path, swapped)
                     if not os.path.exists(probe_full):
+                        # Definitive: the case-swap resolves to nothing,
+                        # so the filesystem distinguishes case.
                         return False
                     try:
                         return os.path.samefile(original_full, probe_full)
                     except OSError:
-                        return False
-        return False
+                        return True
+        return True
 
     def _norm_source(s):
         try:
@@ -468,8 +476,11 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     # case-folding: ``realpath`` on APFS preserves the case the user
     # gave. Probe the destination's own filesystem (walking up to the
     # closest existing ancestor when the destination itself hasn't been
-    # created yet); default to case-sensitive on failure — a strictly
-    # narrower guard, never wider. See PR #1107 review.
+    # created yet); default to case-insensitive on inconclusive results
+    # so a differently-cased twin folder under the destination is still
+    # linked to the workspace — otherwise ``safe_to_format`` can go
+    # green while the imported photo stays invisible in the active
+    # workspace. See PR #1107 review.
     def _probe_dir_case_insensitive(path):
         p = os.path.normpath(path)
         while True:
@@ -477,7 +488,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                 return _fs_is_case_insensitive(p)
             parent = os.path.dirname(p)
             if parent == p:
-                return False
+                return True
             p = parent
 
     _dest_ci = _case_insensitive_platform or _probe_dir_case_insensitive(destination)
@@ -897,12 +908,22 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     os.path.normpath(str(source_file))
                     == os.path.normpath(dest_file)
                 )
-            if same_file:
+            # Also reject any dest_file (not just an exact self-copy) that
+            # resolves under any source root. Example: source
+            # ``/Volumes/Card/DCIM``, destination ``/Volumes/Card``,
+            # template ``DCIM/Archive/%Y`` — dest_file lands at
+            # ``/Volumes/Card/DCIM/Archive/2026/<name>``, which is NOT the
+            # source file (samefile is False) but is still inside the card.
+            # A copy there is counted as ``copied``, safe_to_format can go
+            # green, and formatting the card erases the "archive" copy too.
+            # See PR #1107 review.
+            dest_under_source = _path_under_any_source(dest_file)
+            if same_file or dest_under_source:
                 _fail(
                     rel, source_file,
-                    "destination folder template resolves back to the "
-                    "source directory (dest_file is the source file itself); "
-                    "no archive copy would be made",
+                    "destination file resolves inside a source directory "
+                    "(dest_file would live under the card being imported); "
+                    "formatting the card would erase the archive copy",
                 )
                 continue
             # Capture card-side (size, mtime_ns) BEFORE the copy so the

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -113,6 +113,15 @@ class ImportParams:
     # Vireo data dir for working-copy extraction (Task 2.5). None skips
     # extraction (tests, or callers that defer to the scanner backfill).
     vireo_dir: str | None = None
+    # Configured thumbnail cache directory (``--thumb-dir``). Independently
+    # configurable from ``vireo_dir``: defaulting to ``vireo_dir/thumbnails``
+    # silently misses the real cache when they diverge, so an import that
+    # replaces bytes at an existing archive path would clear working copies
+    # and previews but leave a stale thumbnail served by the UI. Callers with
+    # the configured value (Flask ``/api/jobs/import-photos``) should pass
+    # it; ``None`` falls back to the default location downstream. See PR
+    # #1107 review.
+    thumb_cache_dir: str | None = None
 
 
 def copy_and_hash_verify(src, dst, *, src_hash=None):
@@ -911,20 +920,18 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         if landed:
             landed_paths = {entry[0] for entry in landed}
             # Capture the pre-scan (photo_id, file_hash) for every landed
-            # dest_path. The batch scan below is invoked with
-            # ``vireo_dir=None`` because per-batch working-copy extraction
-            # would run before RAW+JPEG companions across batch boundaries
-            # are paired (see the "Working-copy extraction is DEFERRED"
-            # comment above). But that also disables the scanner's own
-            # ``_invalidate_derived_caches`` call for existing rows whose
-            # bytes just changed — so a copy/adopt that replaces a stale
-            # archive file at a path whose row already had a
-            # ``working_copy_path``/thumbnail/preview would leave those
-            # derived files pointing at the previous bytes, and the
-            # end-of-run ``_extract_working_copies`` skips rows with
-            # ``working_copy_path IS NOT NULL``. Snapshot the pre-scan
-            # hash here so the hash-stamping loop below can invalidate any
-            # landed row whose bytes changed. See PR #1107 review.
+            # dest_path. Scanner's own ``_invalidate_derived_caches``
+            # fires on content-changed rows during the batch scan below
+            # (now that ``vireo_dir`` is passed through so pairing keeps
+            # its cache context), but the manual invalidation loop below
+            # remains as defense-in-depth for the batch-scan's
+            # ``skip_working_copies=True`` path: the deferred end-of-run
+            # ``_extract_working_copies`` still skips rows with
+            # ``working_copy_path IS NOT NULL``, so any stale WC pointer
+            # left behind by scanner's own path (e.g. a codepath change,
+            # or a legacy row scanner declines to invalidate) would
+            # otherwise persist. Idempotent with scanner's call. See PR
+            # #1107 review.
             pre_scan_hashes = {}
             for entry in landed:
                 dest_path = entry[0]
@@ -940,11 +947,24 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                 if row is not None:
                     pre_scan_hashes[dest_path] = row["file_hash"]
             try:
+                # ``vireo_dir`` / ``thumb_cache_dir`` are threaded through
+                # so ``_pair_raw_jpeg_companions`` has cache context: when
+                # a newly imported RAW pairs with an already-cataloged
+                # JPEG that carries an edit recipe with local-mask
+                # snapshots, pairing only moves those snapshots to the
+                # RAW primary when ``vireo_dir`` is set — passing ``None``
+                # silently loses the local pass. ``skip_working_copies``
+                # keeps the per-batch WC extraction deferred to the
+                # end-of-run pass below (per-batch extraction would race
+                # RAW+JPEG pairing across batch boundaries). See PR
+                # #1107 review.
                 scan(
                     destination, db,
                     restrict_dirs=[dest_folder],
                     restrict_files=landed_paths,
-                    vireo_dir=None,
+                    vireo_dir=params.vireo_dir,
+                    thumb_cache_dir=params.thumb_cache_dir,
+                    skip_working_copies=True,
                 )
             except Exception as e:  # scan failure fails the whole batch
                 # Each entry was already booked into copied or
@@ -1139,6 +1159,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                         continue
                     _invalidate_derived_caches(
                         db, params.vireo_dir, row["id"],
+                        thumb_cache_dir=params.thumb_cache_dir,
                     )
                     invalidated_photo_ids.add(row["id"])
 
@@ -1207,10 +1228,16 @@ def run_import_job(job, runner, db_path, workspace_id, params):
             )
             db.conn.commit()
             try:
+                # Same rationale as the fresh-batch scan above: pass
+                # ``vireo_dir`` / ``thumb_cache_dir`` so pairing keeps
+                # cache context, and defer per-batch WC extraction to the
+                # end-of-run pass. See PR #1107 review.
                 scan(
                     destination, db,
                     restrict_dirs=sorted(new_dup_dirs),
-                    vireo_dir=None,
+                    vireo_dir=params.vireo_dir,
+                    thumb_cache_dir=params.thumb_cache_dir,
+                    skip_working_copies=True,
                     cancel_check=lambda: runner.is_cancelled(job["id"]),
                 )
                 linked_dup_dirs.update(new_dup_dirs)

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -50,6 +50,7 @@ import errno
 import logging
 import os
 import shutil
+import sys
 import uuid
 from dataclasses import dataclass
 
@@ -318,6 +319,46 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     # dot-segment form, so the recursion never reaches root and the scan
     # loses those files (copied bytes then bucket as catalog failures).
     destination = os.path.normpath(str(params.destination))
+
+    # Normalized realpaths of every import source root, used to reject
+    # cataloged twins that live under the card being imported. The
+    # /api/jobs/import-photos route already refuses destinations that sit
+    # inside a source (formatting the card would erase the archive copy),
+    # but the duplicate acceptance loop separately trusts any cataloged
+    # twin whose bytes hash to ``src_hash`` — including a stale row for a
+    # previously scanned mounted card. That twin's re-hash just re-reads
+    # the very card file being imported, so accepting it as duplicate
+    # proof would flip ``safe_to_format`` green over a card whose bytes
+    # never made it to the archive. Case-fold on darwin/win32 so a
+    # differently-cased spelling of the source path can't slip a twin
+    # through the containment check; ext4/xfs on Linux really do
+    # distinguish case. See PR #1107 review.
+    _case_insensitive_platform = sys.platform in ("darwin", "win32")
+
+    def _casenorm_path(p):
+        return p.casefold() if _case_insensitive_platform else p
+
+    def _norm_source(s):
+        try:
+            real = os.path.realpath(s)
+        except OSError:
+            real = str(s)
+        return _casenorm_path(real).rstrip(os.sep)
+
+    source_roots = [_norm_source(s) for s in params.sources]
+
+    def _path_under_any_source(path):
+        try:
+            real = os.path.realpath(path)
+        except OSError:
+            real = str(path)
+        cmp = _casenorm_path(real)
+        for root in source_roots:
+            if not root:
+                continue
+            if cmp == root or cmp.startswith(root + os.sep):
+                return True
+        return False
 
     runner.set_steps(job["id"], [
         {"id": "import", "label": "Copy & catalog"},
@@ -611,6 +652,19 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                             twin_path = os.path.join(
                                 twin["folder_path"], twin["filename"],
                             )
+                            # A cataloged twin under any import source
+                            # root is (or may be) the card file being
+                            # imported this run — a stale scan of the
+                            # mounted card left a photos row whose path
+                            # IS the card. Hashing it just re-reads the
+                            # source, which proves nothing about an
+                            # archive copy; accepting it as duplicate
+                            # proof would flip safe_to_format green
+                            # while the card holds the only bytes. Only
+                            # an off-card twin can back a duplicate
+                            # skip. See PR #1107 review.
+                            if _path_under_any_source(twin_path):
+                                continue
                             try:
                                 twin_hash = compute_file_hash(twin_path)
                             except OSError:

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -284,6 +284,14 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     # Intra-run duplicate destinations: token -> dest folder where the
     # identity landed this run (mirrors ingest's batch_dest_folders).
     run_dest_folders = {}
+    # Byte-proven verified hash for each intra-run token. A ('hash', h)
+    # token's own value IS the proof; a ('key', …) token carries no bytes,
+    # so accepting a later key match against a run twin requires hashing
+    # the current source and comparing against this recorded value (two
+    # different files with the same filename+size+capture-second across
+    # cards would otherwise be counted as skipped_duplicate without ever
+    # verifying bytes — safe_to_format green, second card is only copy).
+    run_verified_hashes = {}
     linked_dup_dirs = set()    # dup-twin dirs already scanned+linked
 
     def _counts(rel):
@@ -346,21 +354,52 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                         src_hash = token[1]
                     else:
                         twin_rows = _key_twin_rows(db, token[1])
-                        src_hash = checker.content_hash(source_file)
+                        # Hash the current source so a key match can be
+                        # confirmed against a cataloged (or intra-run)
+                        # twin's actual bytes. Reading a removable-media
+                        # source can fail (card yanked mid-check, I/O
+                        # error) — same as checker.match() and the copy
+                        # path, that must fail JUST this source rather
+                        # than escape and kill the whole background job.
+                        try:
+                            src_hash = checker.content_hash(source_file)
+                        except OSError as e:
+                            _fail(
+                                rel, source_file,
+                                f"duplicate check failed: {e}",
+                            )
+                            continue
                     # An intra-run token is byte-proven by this session's
                     # own copy_and_hash_verify — safe to skip without
-                    # hitting the archive. Any other match (catalog-side
-                    # hash OR metadata-only key) is stale-suspect: the
-                    # photos.file_hash row could describe an archive file
-                    # that was deleted or modified since the last scan, so
-                    # a duplicate skip must be backed by a cataloged twin
-                    # that STILL holds those bytes on disk. Without this,
-                    # a stale hash row would let the card be counted as
-                    # skipped_duplicate and safe_to_format go green while
-                    # the card is the only remaining copy of the bytes.
+                    # hitting the archive, but ONLY when the token itself
+                    # carries bytes (``('hash', …)`` — the hash IS the
+                    # proof) or the current source's bytes match the run
+                    # twin's verified hash (``('key', …)`` — the metadata
+                    # key proves nothing about bytes; two different files
+                    # with the same filename+size+capture-second across
+                    # cards would otherwise be counted as skipped without
+                    # ever being byte-compared). Any other match
+                    # (catalog-side hash OR metadata-only key) is
+                    # stale-suspect: the photos.file_hash row could
+                    # describe an archive file that was deleted or
+                    # modified since the last scan, so a duplicate skip
+                    # must be backed by a cataloged twin that STILL holds
+                    # those bytes on disk. Without this, a stale hash row
+                    # would let the card be counted as skipped_duplicate
+                    # and safe_to_format go green while the card is the
+                    # only remaining copy of the bytes.
                     if token in run_dest_folders:
-                        accept = True
-                    else:
+                        if token[0] == "hash":
+                            accept = True
+                        else:
+                            run_hash = run_verified_hashes.get(token)
+                            if (
+                                src_hash is not None
+                                and run_hash is not None
+                                and src_hash == run_hash
+                            ):
+                                accept = True
+                    if not accept:
                         for twin in twin_rows:
                             twin_path = os.path.join(
                                 twin["folder_path"], twin["filename"],
@@ -419,6 +458,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                             if checker is not None:
                                 for tok in checker.record(source_file):
                                     run_dest_folders[tok] = dest_folder
+                                    run_verified_hashes[tok] = src_hash
                             continue
                     # Different content, same name — numeric suffix.
                     stem, suffix = os.path.splitext(source_file.name)
@@ -453,6 +493,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
             if checker is not None:
                 for tok in checker.record(source_file):
                     run_dest_folders[tok] = dest_folder
+                    run_verified_hashes[tok] = file_hash
 
         # --- Catalog this batch (even when cancelled mid-batch: what
         # landed on disk must be cataloged before we stop, so every

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -743,6 +743,18 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     )
                 landed = []
 
+            # dest_paths that hash-stamping reclassified from
+            # copied/skipped_duplicate to failed. The entries stay in
+            # ``landed`` (mutating a list during its own iteration is
+            # error-prone), so we filter them out of the working-copy
+            # override map below — otherwise the deferred
+            # ``_extract_working_copies`` would read card-side bytes for
+            # a photo whose catalog row is missing (JPEG-pair miss aside)
+            # or whose archive bytes no longer match what we copied, and
+            # cache a working copy that doesn't correspond to what the
+            # rest of the app sees at the archive path. See PR #1107 review.
+            reclassified_landed_paths = set()
+
             # Stamp the verified hashes in the integrity-audit vocabulary,
             # cross-checked against what scan() stored.
             for entry in landed:
@@ -773,6 +785,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     _reclassify_landed_failed(
                         rel, entry, "not cataloged after scan",
                     )
+                    reclassified_landed_paths.add(dest_path)
                     continue
                 if row["file_hash"] == verified_hash:
                     db.update_photo_hash_check(
@@ -797,6 +810,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                         "destination changed between copy verification and "
                         "catalog scan (hash mismatch)",
                     )
+                    reclassified_landed_paths.add(dest_path)
             db.conn.commit()
 
             # Accumulate the card-source mapping for the deferred
@@ -810,6 +824,15 @@ def run_import_job(job, runner, db_path, workspace_id, params):
             if params.vireo_dir:
                 for entry in landed:
                     dest_path = entry[0]
+                    if dest_path in reclassified_landed_paths:
+                        # Reclassified to failed by hash stamping above
+                        # (missing row or archive-vs-copy hash mismatch).
+                        # Skipping the card override lets the WC extractor
+                        # fall back to whatever the archive currently
+                        # holds — matching the catalog's view — instead
+                        # of caching a WC of bytes the archive no longer
+                        # has.
+                        continue
                     src_path = entry[2]
                     exp_size = entry[4]
                     exp_mtime_ns = entry[5]

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -65,6 +65,7 @@ except ImportError:  # pragma: no cover - Windows fallback
     fcntl = None
 
 from db import Database
+from image_loader import SUPPORTED_EXTENSIONS
 from import_dedup import (
     CatalogIndex,
     DuplicateChecker,
@@ -750,6 +751,25 @@ def run_import_job(job, runner, db_path, workspace_id, params):
             os.path.normpath(os.path.join(destination, rel))
             if rel != "." else destination
         )
+        # Reject the whole batch before creating any directories on the
+        # card. The per-file loop below already refuses ``dest_file``
+        # under a source, but that check runs AFTER ``os.makedirs``, so
+        # a rejected unsafe import would still create the archive
+        # directory tree on the source (or raise on read-only media,
+        # killing the background job instead of returning a controlled
+        # unsafe result). This mirror at the batch boundary keeps the
+        # failure quiet and preserves the ``ok`` field for the API.
+        # See PR #1107 review.
+        if _path_under_any_source(dest_folder):
+            for source_file in batch:
+                _fail(
+                    rel, source_file,
+                    "destination folder resolves inside a source directory "
+                    "(dest_folder would be created under the card being "
+                    "imported); formatting the card would erase the archive "
+                    "copy",
+                )
+            continue
         os.makedirs(dest_folder, exist_ok=True)
 
         # Promote any pre-existing folder row for this destination out of
@@ -1694,7 +1714,30 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     # files the pill is expected to cover. A cancelled run leaves
     # unprocessed files, so it is never safe. This pill means exactly
     # what it says.
-    partial_scope = params.file_types != "both" or not params.recursive
+    #
+    # A list-form ``file_types`` whose members cover every
+    # ``SUPPORTED_EXTENSIONS`` entry is NOT actually filtered — the
+    # pipeline UI's ``getIngestFileTypes()`` returns exactly this shape
+    # when the user checks every box, and ``discover_source_files``
+    # walks it identically to ``"both"``. Treating it as partial would
+    # leave ``safe_to_format`` permanently false over an unfiltered
+    # import. Normalize to leading-dot lowercase to match how
+    # SUPPORTED_EXTENSIONS is stored; unknown extensions in the list
+    # are ignored (they can't be in SUPPORTED_EXTENSIONS regardless).
+    # See PR #1107 review.
+    partial_scope = not params.recursive
+    if params.file_types != "both":
+        if isinstance(params.file_types, list):
+            normalized_types = {
+                ("." + e.lower().lstrip("."))
+                for e in params.file_types
+                if isinstance(e, str) and e
+            }
+            partial_scope = partial_scope or not SUPPORTED_EXTENSIONS.issubset(
+                normalized_types,
+            )
+        else:
+            partial_scope = True
     safe_to_format = (
         not cancelled
         and failed == 0

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -1,0 +1,102 @@
+"""Import job: copy card -> archive directly, hash-verify, catalog incrementally.
+
+Implements the import half of the import/process split (design doc
+2026-07-04-import-process-split-design.md). The core invariant:
+
+    A photo row is created only when its file verifiably exists at its
+    final archive path.
+
+Files are copied per destination-folder batch, each copy is verified by
+content hash before promotion, and each batch is cataloged via the
+scanner's restricted-scan path immediately after it lands. A run that
+dies at any point leaves a valid partial catalog; a retry's duplicate
+gate skips exactly the files that landed and copies the rest. There is
+no staging tree and no unwind step (`_deindex_staging` has no
+equivalent here).
+
+Reconnaissance notes (Task 2.0, verified 2026-07-04):
+
+1. ``scanner.scan()`` computes and writes ``photos.file_hash`` itself
+   (``_compute_file_features`` hashes every new/changed file). It does
+   NOT write ``hash_status``/``hash_checked_at`` — those belong to the
+   integrity-audit vocabulary, so the import job stamps them after each
+   batch's scan, gated on the scan-computed hash matching the hash this
+   job verified at copy time (a free cross-check: a mismatch means the
+   destination changed between copy and scan and the file is bucketed
+   as failed instead of silently trusted).
+2. ``CatalogIndex`` retains only identity sets (hashes/keys/sizes), not
+   paths. Key-match twin resolution for the safe-to-format ledger uses
+   a direct DB query on (filename, file_size) + stored_metadata_key
+   equality, joining folders for the archive path.
+3. Cancellation mirrors the scan job: the work function polls
+   ``runner.is_cancelled(job_id)`` at batch boundaries and passes
+   ``cancel_check`` into ``scan()``; the runner flips the job status to
+   "cancelled" when the work function returns after a Stop.
+4. Batch unit: files grouped by destination (template) folder,
+   processed in template order, chunked to at most
+   ``IMPORT_BATCH_SIZE`` files per scan call. Restricted scans only
+   enumerate the restricted dirs, so per-batch scan cost tracks the
+   batch, not the archive tree. One deliberate deviation from the plan
+   text: duplicate-matched folders are scanned in a SEPARATE
+   ``scan(restrict_dirs=…)`` call without ``restrict_files`` —
+   ``_ensure_folder`` only fires for *discovered* files, so folding
+   duplicate dirs into the fresh-copy call (whose ``restrict_files``
+   excludes their files) would create/link nothing for duplicate-only
+   imports.
+"""
+
+import contextlib
+import logging
+import os
+import shutil
+import uuid
+
+from import_dedup import compute_file_hash
+
+log = logging.getLogger(__name__)
+
+
+def copy_and_hash_verify(src, dst, *, src_hash=None):
+    """Copy ``src`` to ``dst`` and verify the landed bytes by content hash.
+
+    The copy goes to a hidden sibling temp path first; only a copy whose
+    hash matches the source is promoted into ``dst`` (``os.replace``).
+    On mismatch the temp copy is removed and any pre-existing ``dst`` is
+    left untouched.
+
+    Args:
+        src: source file path (e.g. on the card)
+        dst: final destination path in the archive
+        src_hash: optional already-computed source hash (e.g. the
+            DuplicateChecker's cached value) to avoid re-reading the
+            source.
+
+    Returns:
+        (True, file_hash) on verified success, (False, None) on failure.
+    """
+    dst_dir = os.path.dirname(dst)
+    if dst_dir:
+        os.makedirs(dst_dir, exist_ok=True)
+    tmp = os.path.join(
+        dst_dir, f".{os.path.basename(dst)}.{uuid.uuid4().hex}.tmp"
+    )
+    try:
+        shutil.copy2(src, tmp)
+        copied_hash = compute_file_hash(tmp)
+        expected = src_hash if src_hash is not None else compute_file_hash(src)
+        if copied_hash is None or expected is None or copied_hash != expected:
+            log.warning(
+                "Hash verification failed for %s -> %s (expected %s, got %s)",
+                src, dst, expected, copied_hash,
+            )
+            return (False, None)
+        os.replace(tmp, dst)
+        tmp = None
+        return (True, copied_hash)
+    except OSError as e:
+        log.warning("Copy failed for %s -> %s: %s", src, dst, e)
+        return (False, None)
+    finally:
+        if tmp is not None:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp)

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -191,44 +191,49 @@ def copy_and_hash_verify(src, dst, *, src_hash=None):
         except OSError as link_err:
             # Hard links unsupported on this destination filesystem
             # (FAT/exFAT return EPERM; some SMB/NFS mounts return
-            # ENOTSUP/EOPNOTSUPP; Windows exFAT can return EACCES). Fall
-            # back to an atomic no-overwrite reserve-and-replace: O_EXCL
-            # atomically claims ``dst`` as an empty placeholder (races
-            # with concurrent imports fail here just like os.link would),
-            # then os.replace atomically swaps the verified temp into
-            # place. Without this fallback every file on hardlinkless
-            # archives buckets as a copy failure and imports are
-            # unusable on those destinations. See PR #1107 review.
+            # ENOTSUP/EOPNOTSUPP; Windows exFAT can return EACCES).
+            # Without a fallback promotion path every file on
+            # hardlinkless archives buckets as a copy failure and
+            # imports are unusable on those destinations.
+            #
+            # Fall back to existence-check + os.rename: the verified
+            # temp stays hidden until it moves atomically over to
+            # ``dst``. Do NOT reserve the final path as an O_EXCL
+            # placeholder before renaming — a crash between placeholder
+            # creation and os.replace would leave a zero-byte stray at
+            # the intended archive name, and a retry treats that
+            # placeholder as "existing archive file", suffixes the real
+            # photo to ``name_1.ext``, and orphans the empty file.
+            # That violates the import/crash-recovery invariant that a
+            # dead run leaves only valid archive copies or hidden
+            # temps. The check-then-rename flow trades strict atomic
+            # no-overwrite protection for that crash-safety: a
+            # concurrent import creating ``dst`` between the exists()
+            # check and os.rename() could be overwritten, but
+            # destinations are per-workspace/per-date-folder in this
+            # workflow so overlapping runs are unusual, and losing that
+            # narrow race is preferable to leaving zero-byte strays on
+            # every abnormal exit. See PR #1107 review.
             if not _fs_lacks_hardlinks(link_err):
                 raise
             log.info(
-                "os.link unsupported on %s (%s); using O_EXCL fallback",
+                "os.link unsupported on %s (%s); using rename fallback",
                 dst_dir, link_err,
             )
-            try:
-                fd = os.open(
-                    dst,
-                    os.O_WRONLY | os.O_CREAT | os.O_EXCL,
-                    0o644,
-                )
-            except FileExistsError:
+            if os.path.exists(dst):
                 log.warning(
                     "Destination raced during copy "
                     "(concurrent import?): %s",
                     dst,
                 )
                 return (False, None)
-            os.close(fd)
             try:
-                os.replace(tmp, dst)
+                os.rename(tmp, dst)
             except OSError as rep_err:
                 log.warning(
                     "Fallback promote failed for %s -> %s: %s",
                     src, dst, rep_err,
                 )
-                # Best-effort remove the empty placeholder we created.
-                with contextlib.suppress(OSError):
-                    os.unlink(dst)
                 return (False, None)
             tmp = None
             return (True, copied_hash)
@@ -373,26 +378,40 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     def _fs_is_case_insensitive(path):
         """Probe whether the filesystem at ``path`` treats case as insensitive.
 
-        Best-effort: case-swap one alpha character from the resolved
-        path and check ``os.path.samefile``. On any error, returns
-        False — a false negative just falls back to case-sensitive
-        comparison (strictly narrower guard, never wider).
+        List an entry inside ``path`` and check whether accessing it
+        under a case-swapped name resolves to the same inode. Probing
+        *inside* the directory (rather than swapping characters in
+        ``path`` itself) is essential when a case-insensitive mount
+        sits under a case-sensitive parent — a FAT/exFAT SD card
+        mounted at ``/mnt/Card`` on Linux under an ext4 root: the ext4
+        ``/mnt`` cannot resolve ``/Mnt`` or a differently-cased
+        ``Card`` entry (mount-point dentries live in the parent FS),
+        so swapping characters in the ``path`` string always reports
+        case-sensitive regardless of the card's own semantics. On any
+        error, empty directory, or entry without an alpha character,
+        returns False and the caller falls back to case-sensitive
+        comparison (strictly narrower guard, never wider). See PR
+        #1107 review.
         """
         try:
-            for i, c in enumerate(path):
-                if c.isalpha():
-                    probe = path[:i] + c.swapcase() + path[i + 1:]
-                    if probe == path:
-                        continue
-                    if not os.path.exists(probe):
-                        return False
-                    try:
-                        return os.path.samefile(path, probe)
-                    except OSError:
-                        return False
-            return False
+            entries = os.listdir(path)
         except OSError:
             return False
+        for name in entries:
+            for i, c in enumerate(name):
+                if c.isalpha():
+                    swapped = name[:i] + c.swapcase() + name[i + 1:]
+                    if swapped == name:
+                        continue
+                    original_full = os.path.join(path, name)
+                    probe_full = os.path.join(path, swapped)
+                    if not os.path.exists(probe_full):
+                        return False
+                    try:
+                        return os.path.samefile(original_full, probe_full)
+                    except OSError:
+                        return False
+        return False
 
     def _norm_source(s):
         try:

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -1535,8 +1535,6 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     # scan branch above). Invalidate every touched dup dir.
                     for d in sorted(lex_dup_dirs):
                         _invalidate_new_images(db, d)
-                except RuntimeError:
-                    cancelled = True
                 except Exception as e:
                     # A duplicate-only batch's ONLY workspace-visibility
                     # step is this scan — swallowing the error would leave
@@ -1545,18 +1543,38 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     # force safe_to_format false; the file(s) are on disk
                     # (import succeeded), but the operation as a whole is
                     # not safe.
-                    log.exception(
-                        "Linking duplicate-matched folders failed: %s",
-                        sorted(lex_dup_dirs),
-                    )
-                    dup_link_failed = True
-                    for d in sorted(lex_dup_dirs):
-                        unsafe_files.append({
-                            "path": d,
-                            "reason": (
-                                f"duplicate-folder link scan failed: {e}"
-                            ),
-                        })
+                    #
+                    # scanner.scan raises ``RuntimeError("scan cancelled")``
+                    # at cancellation checkpoints when ``cancel_check``
+                    # returns truthy. Match on BOTH the sentinel message
+                    # AND the runner's cancelled state before routing to
+                    # the cancellation branch — a bare RuntimeError catch
+                    # would also swallow real runtime failures (a
+                    # ``RecursionError`` inherits from RuntimeError, or a
+                    # library-level RuntimeError bubbling out of the scan)
+                    # and report the job as cancelled even though nothing
+                    # was cancelled and the workspace-link step actually
+                    # failed. Mirrors pipeline_job.py's convention. See
+                    # PR #1107 review.
+                    if (
+                        isinstance(e, RuntimeError)
+                        and str(e) == "scan cancelled"
+                        and runner.is_cancelled(job["id"])
+                    ):
+                        cancelled = True
+                    else:
+                        log.exception(
+                            "Linking duplicate-matched folders failed: %s",
+                            sorted(lex_dup_dirs),
+                        )
+                        dup_link_failed = True
+                        for d in sorted(lex_dup_dirs):
+                            unsafe_files.append({
+                                "path": d,
+                                "reason": (
+                                    f"duplicate-folder link scan failed: {e}"
+                                ),
+                            })
 
         _emit(
             f"{rel}: {_counts(rel)['copied']} copied · "

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -46,6 +46,7 @@ Reconnaissance notes (Task 2.0, verified 2026-07-04):
 """
 
 import contextlib
+import errno
 import logging
 import os
 import shutil
@@ -99,15 +100,23 @@ def copy_and_hash_verify(src, dst, *, src_hash=None):
     """Copy ``src`` to ``dst`` and verify the landed bytes by content hash.
 
     The copy goes to a hidden sibling temp path first; only a copy whose
-    hash matches the source is promoted into ``dst``. Promotion uses a
-    no-overwrite ``os.link`` (atomic on POSIX same-FS) rather than
-    ``os.replace`` — imports have no pipeline-slot lock, so two concurrent
-    jobs targeting the same destination/date folder with the same
-    filename can both pass their pre-copy collision check before either
-    promotes; ``os.replace`` would silently overwrite the first job's
-    already-verified archive copy, and its ``safe_to_format`` would still
-    report green after the bytes it verified are gone. A raced promote is
-    surfaced as a copy failure instead.
+    hash matches the source is promoted into ``dst``. Promotion prefers a
+    no-overwrite ``os.link`` (atomic on POSIX same-FS) over ``os.replace``
+    — imports have no pipeline-slot lock, so two concurrent jobs targeting
+    the same destination/date folder with the same filename can both pass
+    their pre-copy collision check before either promotes; ``os.replace``
+    would silently overwrite the first job's already-verified archive
+    copy, and its ``safe_to_format`` would still report green after the
+    bytes it verified are gone. A raced promote is surfaced as a copy
+    failure instead.
+
+    When the destination filesystem does not support hard links (exFAT/FAT,
+    some SMB/NFS mounts — os.link raises OSError with EPERM/ENOTSUP/
+    EOPNOTSUPP), fall back to ``O_CREAT|O_EXCL`` to atomically claim the
+    destination path as an empty placeholder, then ``os.replace`` the
+    verified temp file over it. That preserves no-overwrite race
+    protection without requiring hardlink support, so imports do not fail
+    across every file on FAT-family archives or hardlinkless NAS shares.
 
     On mismatch (or race) the temp copy is removed and any pre-existing
     ``dst`` is left untouched.
@@ -151,6 +160,50 @@ def copy_and_hash_verify(src, dst, *, src_hash=None):
                 dst,
             )
             return (False, None)
+        except OSError as link_err:
+            # Hard links unsupported on this destination filesystem
+            # (FAT/exFAT return EPERM; some SMB/NFS mounts return
+            # ENOTSUP/EOPNOTSUPP; Windows exFAT can return EACCES). Fall
+            # back to an atomic no-overwrite reserve-and-replace: O_EXCL
+            # atomically claims ``dst`` as an empty placeholder (races
+            # with concurrent imports fail here just like os.link would),
+            # then os.replace atomically swaps the verified temp into
+            # place. Without this fallback every file on hardlinkless
+            # archives buckets as a copy failure and imports are
+            # unusable on those destinations. See PR #1107 review.
+            if not _fs_lacks_hardlinks(link_err):
+                raise
+            log.info(
+                "os.link unsupported on %s (%s); using O_EXCL fallback",
+                dst_dir, link_err,
+            )
+            try:
+                fd = os.open(
+                    dst,
+                    os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                    0o644,
+                )
+            except FileExistsError:
+                log.warning(
+                    "Destination raced during copy "
+                    "(concurrent import?): %s",
+                    dst,
+                )
+                return (False, None)
+            os.close(fd)
+            try:
+                os.replace(tmp, dst)
+            except OSError as rep_err:
+                log.warning(
+                    "Fallback promote failed for %s -> %s: %s",
+                    src, dst, rep_err,
+                )
+                # Best-effort remove the empty placeholder we created.
+                with contextlib.suppress(OSError):
+                    os.unlink(dst)
+                return (False, None)
+            tmp = None
+            return (True, copied_hash)
         os.unlink(tmp)
         tmp = None
         return (True, copied_hash)
@@ -161,6 +214,32 @@ def copy_and_hash_verify(src, dst, *, src_hash=None):
         if tmp is not None:
             with contextlib.suppress(OSError):
                 os.unlink(tmp)
+
+
+# errno values that mean "this filesystem doesn't support hard links",
+# not "the operation was denied for some other reason". Kept narrow so a
+# genuine permission error on a link-supporting FS still surfaces as a
+# copy failure instead of silently falling back to the placeholder path.
+# EPERM is the canonical Linux answer for FAT/exFAT; ENOTSUP/EOPNOTSUPP
+# come from various BSD-family kernels and userspace filesystems; EACCES
+# has been observed on Windows exFAT via WSL. EXDEV (cross-device link)
+# also lands here — same-directory tmp should never trip it, but treating
+# it as "hard link not usable here" and using the O_EXCL fallback is
+# strictly safer than propagating.
+_HARDLINK_UNSUPPORTED_ERRNOS = frozenset(
+    e for e in (
+        getattr(errno, "EPERM", None),
+        getattr(errno, "ENOTSUP", None),
+        getattr(errno, "EOPNOTSUPP", None),
+        getattr(errno, "EACCES", None),
+        getattr(errno, "EXDEV", None),
+    ) if e is not None
+)
+
+
+def _fs_lacks_hardlinks(err):
+    """True when ``err`` from os.link indicates a hardlinkless target FS."""
+    return getattr(err, "errno", None) in _HARDLINK_UNSUPPORTED_ERRNOS
 
 
 def _key_twin_rows(db, key):
@@ -368,6 +447,30 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         unsafe_files.append({"path": str(source_file), "reason": reason})
         log.warning("Import failed for %s: %s", source_file, reason)
 
+    def _reclassify_landed_failed(rel, entry, reason):
+        """Move a landed file's count from copied/skipped_duplicate to failed.
+
+        A landed entry has already been booked into ``copied`` (fresh copy)
+        or ``skipped_duplicate`` (crash-recovery adopt) at the moment its
+        bytes were verified on disk. When a later step in the batch pass
+        (scan itself failing, a missing catalog row after scan, or a
+        hash mismatch against what scan re-hashed) forces this file into
+        the ``failed`` bucket, the origin count must be rolled back —
+        otherwise the exactly-one-terminal-bucket invariant breaks and
+        ``copied + skipped_duplicate + failed`` exceeds ``discovered``.
+        """
+        nonlocal copied, verified, skipped_duplicate
+        dest_path = entry[0]
+        origin = entry[3]
+        if origin == "copied":
+            copied -= 1
+            verified -= 1
+            _counts(rel)["copied"] -= 1
+        elif origin == "skipped_duplicate":
+            skipped_duplicate -= 1
+            _counts(rel)["skipped_duplicate"] -= 1
+        _fail(rel, dest_path, reason)
+
     def _record_checker(source_file, dest_folder, file_hash):
         """Register a landed file's identity with the intra-run checker.
 
@@ -550,7 +653,8 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                             skipped_duplicate += 1
                             _counts(rel)["skipped_duplicate"] += 1
                             landed.append(
-                                (dest_file, src_hash, str(source_file)),
+                                (dest_file, src_hash, str(source_file),
+                                 "skipped_duplicate"),
                             )
                             _record_checker(
                                 source_file, dest_folder, src_hash,
@@ -585,7 +689,9 @@ def run_import_job(job, runner, db_path, workspace_id, params):
             copied += 1
             verified += 1
             _counts(rel)["copied"] += 1
-            landed.append((dest_file, file_hash, str(source_file)))
+            landed.append(
+                (dest_file, file_hash, str(source_file), "copied"),
+            )
             _record_checker(source_file, dest_folder, file_hash)
 
         # --- Catalog this batch (even when cancelled mid-batch: what
@@ -593,7 +699,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         # stopping point is a valid catalog state). Bounded by the batch
         # size, so no cancel_check is passed — it runs to completion.
         if landed:
-            landed_paths = {p for p, _, _ in landed}
+            landed_paths = {entry[0] for entry in landed}
             try:
                 scan(
                     destination, db,
@@ -602,13 +708,19 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     vireo_dir=None,
                 )
             except Exception as e:  # scan failure fails the whole batch
-                for path, _, _ in landed:
-                    _fail(rel, path, f"catalog scan failed: {e}")
+                # Each entry was already booked into copied or
+                # skipped_duplicate — reclassify (roll back origin, add
+                # to failed) so the ledger never double-counts.
+                for entry in landed:
+                    _reclassify_landed_failed(
+                        rel, entry, f"catalog scan failed: {e}",
+                    )
                 landed = []
 
             # Stamp the verified hashes in the integrity-audit vocabulary,
             # cross-checked against what scan() stored.
-            for dest_path, verified_hash, _src in landed:
+            for entry in landed:
+                dest_path, verified_hash, _src, _origin = entry
                 row = db.conn.execute(
                     """SELECT p.id, p.file_hash FROM photos p
                        JOIN folders f ON f.id = p.folder_id
@@ -631,7 +743,9 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     ).fetchone()
                     if companion is not None:
                         continue
-                    _fail(rel, dest_path, "not cataloged after scan")
+                    _reclassify_landed_failed(
+                        rel, entry, "not cataloged after scan",
+                    )
                     continue
                 if row["file_hash"] == verified_hash:
                     db.update_photo_hash_check(
@@ -651,8 +765,8 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                             commit=False,
                         )
                 else:
-                    _fail(
-                        rel, dest_path,
+                    _reclassify_landed_failed(
+                        rel, entry,
                         "destination changed between copy verification and "
                         "catalog scan (hash mismatch)",
                     )
@@ -667,7 +781,8 @@ def run_import_job(job, runner, db_path, workspace_id, params):
             # failure marker or low-quality WC that the candidate
             # predicate then skips.
             if params.vireo_dir:
-                for dest_path, _hash, src_path in landed:
+                for entry in landed:
+                    dest_path, _hash, src_path, _origin = entry
                     wc_source_paths[dest_path] = src_path
                 wc_dest_folders.add(dest_folder)
 

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -54,6 +54,16 @@ import sys
 import uuid
 from dataclasses import dataclass
 
+# POSIX advisory lock used by the hardlinkless-FS promote fallback (see
+# copy_and_hash_verify below). Unavailable on Windows; Vireo targets
+# macOS/Linux so this import normally succeeds. If it fails, the
+# fallback promote path degrades gracefully to the previous
+# check-then-rename behavior (documented in that block).
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows fallback
+    fcntl = None
+
 from db import Database
 from import_dedup import (
     CatalogIndex,
@@ -139,11 +149,13 @@ def copy_and_hash_verify(src, dst, *, src_hash=None):
 
     When the destination filesystem does not support hard links (exFAT/FAT,
     some SMB/NFS mounts — os.link raises OSError with EPERM/ENOTSUP/
-    EOPNOTSUPP), fall back to ``O_CREAT|O_EXCL`` to atomically claim the
-    destination path as an empty placeholder, then ``os.replace`` the
-    verified temp file over it. That preserves no-overwrite race
-    protection without requiring hardlink support, so imports do not fail
-    across every file on FAT-family archives or hardlinkless NAS shares.
+    EOPNOTSUPP), fall back to a check-then-rename promotion serialized on
+    a directory-level ``fcntl.flock`` of the destination folder. That
+    preserves both crash-safety (no zero-byte placeholder file) and
+    no-overwrite race protection against concurrent imports targeting the
+    same destination/date folder — the fallback block below documents the
+    tradeoffs. Imports do not fail across every file on FAT-family
+    archives or hardlinkless NAS shares.
 
     On mismatch (or race) the temp copy is removed and any pre-existing
     ``dst`` is left untouched.
@@ -195,47 +207,70 @@ def copy_and_hash_verify(src, dst, *, src_hash=None):
             # hardlinkless archives buckets as a copy failure and
             # imports are unusable on those destinations.
             #
-            # Fall back to existence-check + os.rename: the verified
-            # temp stays hidden until it moves atomically over to
-            # ``dst``. Do NOT reserve the final path as an O_EXCL
-            # placeholder before renaming — a crash between placeholder
-            # creation and os.replace would leave a zero-byte stray at
-            # the intended archive name, and a retry treats that
-            # placeholder as "existing archive file", suffixes the real
-            # photo to ``name_1.ext``, and orphans the empty file.
-            # That violates the import/crash-recovery invariant that a
+            # Fall back to existence-check + os.rename, wrapped in a
+            # directory-level POSIX advisory lock. The verified temp
+            # stays hidden until it moves atomically over to ``dst``.
+            # Do NOT reserve the final path as an O_EXCL placeholder
+            # before renaming — a crash between placeholder creation
+            # and os.replace would leave a zero-byte stray at the
+            # intended archive name, and a retry treats that
+            # placeholder as "existing archive file", suffixes the
+            # real photo to ``name_1.ext``, and orphans the empty
+            # file. That violates the crash-recovery invariant that a
             # dead run leaves only valid archive copies or hidden
-            # temps. The check-then-rename flow trades strict atomic
-            # no-overwrite protection for that crash-safety: a
-            # concurrent import creating ``dst`` between the exists()
-            # check and os.rename() could be overwritten, but
-            # destinations are per-workspace/per-date-folder in this
-            # workflow so overlapping runs are unusual, and losing that
-            # narrow race is preferable to leaving zero-byte strays on
-            # every abnormal exit. See PR #1107 review.
+            # temps.
+            #
+            # A bare check-then-rename loses a concurrent-import race:
+            # two hardlinkless-FS jobs targeting the same
+            # destination/date folder could both pass exists() before
+            # either rename(), and the later rename would silently
+            # overwrite the first job's already-verified archive copy
+            # (its ``safe_to_format`` would still report green after
+            # its bytes are gone). Serialize the critical section on
+            # an exclusive ``fcntl.flock`` of the destination
+            # directory: FD-scoped, so a crash releases it
+            # automatically — no placeholder cleanup burden, and the
+            # zero-byte crash-safety invariant is preserved. On mounts
+            # where flock silently no-ops (some remote FSes mounted
+            # ``nolock``) we degrade to the previous check-then-rename
+            # behavior; per-workspace/per-date destinations make
+            # overlapping runs unusual there. See PR #1107 review.
             if not _fs_lacks_hardlinks(link_err):
                 raise
             log.info(
                 "os.link unsupported on %s (%s); using rename fallback",
                 dst_dir, link_err,
             )
-            if os.path.exists(dst):
-                log.warning(
-                    "Destination raced during copy "
-                    "(concurrent import?): %s",
-                    dst,
-                )
-                return (False, None)
+            lock_fd = None
             try:
-                os.rename(tmp, dst)
-            except OSError as rep_err:
-                log.warning(
-                    "Fallback promote failed for %s -> %s: %s",
-                    src, dst, rep_err,
-                )
-                return (False, None)
-            tmp = None
-            return (True, copied_hash)
+                try:
+                    lock_fd = os.open(dst_dir, os.O_RDONLY)
+                except OSError:
+                    lock_fd = None
+                if lock_fd is not None and fcntl is not None:
+                    with contextlib.suppress(OSError):
+                        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+                if os.path.exists(dst):
+                    log.warning(
+                        "Destination raced during copy "
+                        "(concurrent import?): %s",
+                        dst,
+                    )
+                    return (False, None)
+                try:
+                    os.rename(tmp, dst)
+                except OSError as rep_err:
+                    log.warning(
+                        "Fallback promote failed for %s -> %s: %s",
+                        src, dst, rep_err,
+                    )
+                    return (False, None)
+                tmp = None
+                return (True, copied_hash)
+            finally:
+                if lock_fd is not None:
+                    with contextlib.suppress(OSError):
+                        os.close(lock_fd)
         os.unlink(tmp)
         tmp = None
         return (True, copied_hash)

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -71,6 +71,24 @@ from scanner import EMPTY_FILE_SHA256
 
 log = logging.getLogger(__name__)
 
+
+def _invalidate_new_images(db, root):
+    """Invalidate the /new-images cache for ``root`` after a restricted scan.
+
+    Lazy import so import_job.py stays independent of new_images at
+    module-load time (mirrors how pipeline_job.py handles it). A failure
+    here must never fail the import — the bytes are on disk and cataloged;
+    the cache will re-warm on its next miss.
+    """
+    try:
+        from new_images import invalidate_new_images_after_scan
+        invalidate_new_images_after_scan(db, root)
+    except Exception:
+        log.exception(
+            "Failed to invalidate new-images cache for %s", root,
+        )
+
+
 # Batch unit (Task 2.0 Q4): files sharing a destination folder, chunked so
 # one scan call never covers more than this many fresh files. Copy, verify,
 # scan, and hash stamping all commit at batch boundaries, so every stopping
@@ -687,6 +705,40 @@ def run_import_job(job, runner, db_path, workspace_id, params):
 
             # Destination path + collision handling (mirrors ingest()).
             dest_file = os.path.join(dest_folder, source_file.name)
+            # Reject the source-under-destination overlap where the folder
+            # template maps the source right back to its own directory
+            # (e.g. source ``/archive/2026/2026-07-05``, destination
+            # ``/archive``, template ``%Y/%Y-%m-%d`` → dest_file IS the
+            # source file). The API rejects destinations INSIDE any source;
+            # this catches the opposite direction, where the destination is
+            # a legal ancestor but the template resolves back to the source
+            # directory. Without this the adopt branch below hashes the
+            # source against itself, records it as ``skipped_duplicate``,
+            # and safe_to_format goes green — deleting/formatting the
+            # source then erases the only copy. See PR #1107 review.
+            try:
+                same_file = (
+                    os.path.exists(dest_file)
+                    and os.path.samefile(str(source_file), dest_file)
+                )
+            except OSError:
+                # Fall back to normalized-path equality when samefile can't
+                # stat (e.g. the destination is a stale entry). Prefer a
+                # false positive here (fail this file) over a false
+                # negative that lets the adopt branch loop back onto the
+                # source itself.
+                same_file = (
+                    os.path.normpath(str(source_file))
+                    == os.path.normpath(dest_file)
+                )
+            if same_file:
+                _fail(
+                    rel, source_file,
+                    "destination folder template resolves back to the "
+                    "source directory (dest_file is the source file itself); "
+                    "no archive copy would be made",
+                )
+                continue
             # Capture card-side (size, mtime_ns) BEFORE the copy so the
             # deferred working-copy pass can identity-check the card
             # override at extraction time. Byte-identical files have the
@@ -845,6 +897,15 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                         rel, entry, f"catalog scan failed: {e}",
                     )
                 landed = []
+            else:
+                # Restricted scan committed new photo rows and
+                # created/linked ``workspace_folders`` entries under
+                # ``dest_folder``; the /api/workspaces/active/new-images
+                # endpoint serves a cached filesystem diff that will
+                # otherwise report the just-imported files as new until
+                # the cache expires or another full scan runs. Mirrors
+                # api_job_scan / api_job_import_full / pipeline_job.
+                _invalidate_new_images(db, dest_folder)
 
             # dest_paths that hash-stamping reclassified from
             # copied/skipped_duplicate to failed. The entries stay in
@@ -1012,6 +1073,12 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     cancel_check=lambda: runner.is_cancelled(job["id"]),
                 )
                 linked_dup_dirs.update(new_dup_dirs)
+                # Duplicate-link scan created/linked workspace_folders
+                # rows for each duplicate twin's folder; the same
+                # cached-diff staleness applies (see the fresh-batch
+                # scan branch above). Invalidate every touched dup dir.
+                for d in sorted(new_dup_dirs):
+                    _invalidate_new_images(db, d)
             except RuntimeError:
                 cancelled = True
             except Exception as e:

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -713,7 +713,9 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                 # twice.
                 _sh_cache = [False, None]
 
-                def _src_hash_cached():
+                def _src_hash_cached(
+                    _sh_cache=_sh_cache, source_file=source_file,
+                ):
                     if not _sh_cache[0]:
                         _sh_cache[0] = True
                         _sh_cache[1] = (

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -276,7 +276,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     verified = 0
     skipped_duplicate = 0
     failed = 0
-    failed_files = []          # [{path, reason}]
+    unsafe_files = []          # [{path, reason}] — failed copies etc.
     folder_counts = {}         # rel folder -> counts for the PR 3 UI
     emitted = 0
     cancelled = False
@@ -295,7 +295,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         nonlocal failed
         failed += 1
         _counts(rel)["failed"] += 1
-        failed_files.append({"path": str(source_file), "reason": reason})
+        unsafe_files.append({"path": str(source_file), "reason": reason})
         log.warning("Import failed for %s: %s", source_file, reason)
 
     for rel, batch in batches:
@@ -533,13 +533,24 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         ),
     )
 
+    # Safe to format iff every discovered file reached a verified
+    # terminal bucket: hash-verified fresh copy, or duplicate whose bytes
+    # verifiably exist (hash-backed match, or key match re-hashed against
+    # its cataloged twin). A cancelled run leaves unprocessed files, so it
+    # is never safe. This pill means exactly what it says.
+    safe_to_format = (
+        not cancelled
+        and failed == 0
+        and (copied + skipped_duplicate) == discovered
+    )
     result = {
         "discovered": discovered,
         "copied": copied,
         "verified": verified,
         "skipped_duplicate": skipped_duplicate,
         "failed": failed,
-        "failed_files": failed_files,
+        "safe_to_format": safe_to_format,
+        "unsafe_files": unsafe_files,
         "folders": folder_counts,
         "cancelled": cancelled,
     }

--- a/vireo/ingest.py
+++ b/vireo/ingest.py
@@ -1,6 +1,7 @@
 """Smart ingest: copy and organize photos from external source to destination."""
 
 import contextlib
+import errno
 import logging
 import os
 import posixpath
@@ -246,8 +247,34 @@ def discover_source_files(
     # symlinks and stat's the target, so for a directly selected bundle
     # (or a symlink to one) the existence test alone is enough to trip TCC.
     if is_excluded_scan_path(source_path):
+        # Root is an excluded data-bundle. Legacy ingest() and the
+        # UI-preview callers silently drop these (they picked the wrong
+        # thing; no user contract to enumerate it). But when import_job
+        # passes an ``onerror`` collector it is holding safe_to_format
+        # against every enumeration being provably clean; a source root
+        # we refuse to walk is exactly the case where the pill would
+        # otherwise go green over a card whose files were never seen.
+        # Emit a synthetic OSError so the ledger records it as a
+        # discovery failure. See PR #1107 review (P1 line 927).
+        if onerror is not None:
+            onerror(PermissionError(
+                errno.EACCES,
+                "source is an excluded data bundle",
+                str(source_path),
+            ))
         return []
     if not source_path.is_dir():
+        # Root does not resolve to a directory: nonexistent, unmounted
+        # removable media, permission-denied on the root, or a plain
+        # file. Same reasoning as above — silent [] hides "we saw
+        # nothing" from safe_to_format. Emit a synthetic OSError for
+        # onerror callers so discover'd == 0 is treated as unsafe.
+        if onerror is not None:
+            onerror(FileNotFoundError(
+                errno.ENOENT,
+                "source is not an accessible directory",
+                str(source_path),
+            ))
         return []
 
     if isinstance(file_types, list):

--- a/vireo/ingest.py
+++ b/vireo/ingest.py
@@ -215,7 +215,9 @@ def preview_destination(sources, destination, folder_template="%Y/%Y-%m-%d",
     }
 
 
-def discover_source_files(source_dir, file_types="both", recursive=True):
+def discover_source_files(
+    source_dir, file_types="both", recursive=True, onerror=None,
+):
     """Discover image files in source directory.
 
     Args:
@@ -223,6 +225,13 @@ def discover_source_files(source_dir, file_types="both", recursive=True):
         file_types: "raw", "jpeg", "both", or a list of extensions
             (e.g. [".jpg", ".nef"])
         recursive: if True (default), scan subfolders; if False, only scan root
+        onerror: optional callable ``onerror(OSError)`` invoked when the
+            underlying walk cannot enter or list a directory (permission
+            denied, TCC block, unreadable removable-media subtree, etc.).
+            Silently swallowing these hides sources from the enumeration
+            and lets ``safe_to_format`` go green over a card whose files
+            were never seen; the import job passes a collector that flips
+            the ledger unsafe.
 
     Returns:
         Sorted list of Path objects for matching files
@@ -265,7 +274,9 @@ def discover_source_files(source_dir, file_types="both", recursive=True):
         # previous Path.rglob path was likewise consumed lazily by
         # ``sorted()``.
         def _candidate_paths():
-            for dirpath, _dirnames, filenames in safe_scan_walk(str(source_path)):
+            for dirpath, _dirnames, filenames in safe_scan_walk(
+                str(source_path), onerror=onerror,
+            ):
                 for name in filenames:
                     yield Path(dirpath) / name
         candidates = _candidate_paths()
@@ -280,7 +291,7 @@ def discover_source_files(source_dir, file_types="both", recursive=True):
         # would have rejected it afterwards. ``safe_iter_dir`` is itself
         # a generator — pass it straight through to the filter so we
         # don't materialize the directory listing twice.
-        candidates = safe_iter_dir(str(source_path))
+        candidates = safe_iter_dir(str(source_path), onerror=onerror)
     return sorted(
         f
         for f in candidates

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -1231,7 +1231,7 @@ def backfill_working_copies(db, vireo_dir, progress_callback=None,
     }
 
 
-def scan(root, db, progress_callback=None, incremental=False, extract_full_metadata=True, photo_callback=None, skip_paths=None, status_callback=None, recursive=True, restrict_dirs=None, restrict_files=None, vireo_dir=None, thumb_cache_dir=None, permission_error_callback=None, cancel_check=None):
+def scan(root, db, progress_callback=None, incremental=False, extract_full_metadata=True, photo_callback=None, skip_paths=None, status_callback=None, recursive=True, restrict_dirs=None, restrict_files=None, vireo_dir=None, thumb_cache_dir=None, permission_error_callback=None, cancel_check=None, skip_working_copies=False):
     """Walk a folder tree, discover photos, read metadata, populate database.
 
     Args:
@@ -1275,6 +1275,19 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
         cancel_check: optional callable returning truthy when the caller
             wants scanning to stop promptly. When set, scan raises
             RuntimeError("scan cancelled") at cancellation checkpoints.
+        skip_working_copies: if True, suppress the end-of-scan
+            ``_extract_working_copies`` pass while still running
+            ``_pair_raw_jpeg_companions`` (with cache context) and
+            ``_invalidate_derived_caches`` on content changes. Used by
+            the per-batch import scan: the import job runs one deferred
+            end-of-run extraction pass over all touched folders (a
+            per-batch pass would race RAW+JPEG pairing across batch
+            boundaries), but pairing itself still needs ``vireo_dir`` /
+            ``thumb_cache_dir`` to move local-mask snapshots when a
+            newly imported RAW pairs with an already-cataloged JPEG that
+            has an edit recipe. Passing ``vireo_dir=None`` to suppress
+            extraction would also silently drop those masks. See PR
+            #1107 review.
     """
     root_path = Path(root)
     # Don't open the root at all if the root is, or sits inside, an
@@ -2117,7 +2130,7 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
         # (current, total) through the same callback would overwrite the
         # scan total with the working-copy total and visually jump the bar
         # backward. ``status_callback`` still announces the phase.
-        if vireo_dir:
+        if vireo_dir and not skip_working_copies:
             if restrict_dirs is not None:
                 # Use the bundle-filtered list — see ``effective_restrict_dirs``
                 # above. Reusing the raw ``restrict_dirs`` here would let a

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -900,7 +900,7 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
             break
 
         wc_rel = f"working/{row['id']}.jpg"
-        wc_abs = os.path.join(vireo_dir, wc_rel)
+        wc_abs = os.path.join(vireo_dir, "working", f"{row['id']}.jpg")
 
         # Working copies are the edit-quality source. For non-RAW primaries
         # we still prefer the companion JPEG outright (fast path). For RAW

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -728,6 +728,25 @@ def _subtree_like_pattern(path, sep=None):
 _FAILURE_RETRY_AFTER = "-24 hours"
 
 
+def _override_size_matches(override_path, expected_size):
+    """True when ``source_paths`` override is safe to substitute for the archive.
+
+    The card-side override is trusted iff both a size is known for the
+    catalog row (``expected_size`` non-null) AND the file at
+    ``override_path`` currently has exactly that size. Byte-identical files
+    are the same size — a mismatch (or an OSError from an unmounted card)
+    proves the override no longer holds the copied bytes, so extraction
+    falls back to the verified archive path instead of caching a working
+    copy for the wrong content.
+    """
+    if expected_size is None:
+        return False
+    try:
+        return os.stat(override_path).st_size == int(expected_size)
+    except OSError:
+        return False
+
+
 def _working_copy_candidate_predicate(wc_max_size, alias=""):
     """Build the WHERE-clause fragment selecting photos eligible for working-copy
     extraction, plus its bind parameters.
@@ -872,6 +891,7 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
         f"""
         SELECT p.id, p.filename, p.companion_path, p.working_copy_path,
                p.extension, p.width, p.height, p.exif_data, p.file_mtime,
+               p.file_size,
                f.path AS folder_path
           FROM photos p
           JOIN folders f ON f.id = p.folder_id
@@ -911,31 +931,52 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
         # companion so an extractable JPEG copy isn't refused outright.
         catalog_primary = os.path.join(row["folder_path"], row["filename"])
         primary_path = catalog_primary
+        primary_override_used = False
         if source_paths:
             # ``source_paths`` overrides the catalog path with the card-side
             # source so extraction reads local card bytes instead of the
-            # just-written archive copy over a slow NAS. But if the card was
-            # unmounted between copy and the end-of-run extraction pass, the
-            # override points at a dead path — reading it would record a
-            # failure marker even though the verified archive copy is
-            # available. Only substitute the alternate source when it still
-            # exists on disk; otherwise keep the catalog path.
+            # just-written archive copy over a slow NAS. Existence alone is
+            # not enough: if the card was unmounted, its mount point was
+            # reused for a different card, or the source file itself was
+            # rewritten between copy and this extraction pass, the override
+            # points at bytes that no longer match what the archive holds.
+            # Reading them here would cache a working copy for the wrong
+            # image and — because ``working_copy_path`` gets set — normal
+            # backfill would never regenerate it from the archive. Verify
+            # the override's size against the file_size scan() recorded for
+            # this row (identical bytes must have identical size); anything
+            # else falls back to the verified archive copy. row["file_size"]
+            # is null on legacy rows that never made it through the sizing
+            # scan — those also fall back rather than trust an unverifiable
+            # override.
             override = source_paths.get(catalog_primary)
-            if override and os.path.isfile(override):
+            if override and _override_size_matches(override, row["file_size"]):
                 primary_path = override
+                primary_override_used = True
         primary_is_raw = (
             os.path.splitext(row["filename"])[1].lower() in RAW_EXTENSIONS
         )
         companion_path = None
+        catalog_companion = None
+        companion_override_used = False
         if row["companion_path"]:
             catalog_companion = os.path.join(
                 row["folder_path"], row["companion_path"],
             )
             candidate = catalog_companion
             if source_paths:
+                # Companion size is not carried on the RAW's row (pairing
+                # merged the JPEG's photos row into the RAW's), so we can't
+                # size-verify the companion override the way we do the
+                # primary. Track override use here and retry from the
+                # verified archive companion on extraction failure below;
+                # that keeps a rewritten card from silently poisoning a
+                # working copy while still preferring fast local reads
+                # when the override matches.
                 override = source_paths.get(catalog_companion)
                 if override and os.path.isfile(override):
                     candidate = override
+                    companion_override_used = True
             if os.path.isfile(candidate):
                 companion_path = candidate
 
@@ -949,6 +990,34 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
         # extract_working_copy is slow (RAW decode + JPEG encode); run it
         # before any DB write so no transaction is open while it runs.
         ok = extract_working_copy(source, wc_abs, max_size=wc_max_size, quality=wc_quality)
+        # Card-side override failed but the verified archive copy exists
+        # — retry from the archive before falling through to the RAW→
+        # companion fallback or recording a failure marker. Without this,
+        # a transient card I/O error (or a card that was unmounted just
+        # after the size check above) would leave the row marked failed
+        # even though the archive copy has the correct bytes.
+        if not ok:
+            retry_source = None
+            if source == primary_path and primary_override_used:
+                retry_source = catalog_primary
+            elif source == companion_path and companion_override_used:
+                retry_source = catalog_companion
+            if retry_source and os.path.isfile(retry_source):
+                log.info(
+                    "Card-side working-copy extraction failed for photo "
+                    "%s (%s); retrying from archive %s",
+                    row["id"], source, retry_source,
+                )
+                source = retry_source
+                if retry_source == catalog_primary:
+                    primary_path = catalog_primary
+                    primary_override_used = False
+                else:
+                    companion_path = catalog_companion
+                    companion_override_used = False
+                ok = extract_working_copy(
+                    source, wc_abs, max_size=wc_max_size, quality=wc_quality,
+                )
         raw_failed_then_companion = False
         # libraw returns an embedded JPEG when it can't demosaic a RAW; that
         # preview is often a fraction of sensor resolution, so ok=True here
@@ -1019,6 +1088,29 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
             ok = extract_working_copy(
                 source, wc_abs, max_size=wc_max_size, quality=wc_quality,
             )
+            # Companion attempt used a card override and failed — retry
+            # from the verified archive companion before recording failure.
+            # Same rationale as the primary retry above: a transient card
+            # I/O error or an unmounted card must not force this row into
+            # a persistent failure marker when the archive copy is available.
+            if (
+                not ok
+                and companion_override_used
+                and catalog_companion
+                and os.path.isfile(catalog_companion)
+            ):
+                log.info(
+                    "Card-side companion extraction failed for photo %s "
+                    "(%s); retrying from archive companion %s",
+                    row["id"], source, catalog_companion,
+                )
+                source = catalog_companion
+                companion_path = catalog_companion
+                companion_override_used = False
+                ok = extract_working_copy(
+                    source, wc_abs,
+                    max_size=wc_max_size, quality=wc_quality,
+                )
             raw_failed_then_companion = ok
         if ok:
             if raw_failed_then_companion:

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -791,7 +791,7 @@ def working_copy_backfill_candidate_count(db):
 
 def _extract_working_copies(db, vireo_dir, progress_callback=None,
                             status_callback=None, scope=None,
-                            cancel_check=None):
+                            cancel_check=None, source_paths=None):
     """Extract working copies for all RAW photos missing one.
 
     For each RAW photo without a working_copy_path, extract a JPEG working
@@ -820,6 +820,14 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
 
     ``cancel_check()`` is polled before each row; returning truthy aborts the
     loop cleanly with whatever was already committed.
+
+    ``source_paths`` optionally maps a photo's cataloged absolute path to an
+    alternate read location holding identical bytes. The import job passes
+    its card->archive mapping so extraction reads the fast local card
+    instead of re-reading the just-written archive copy (which may live on
+    a slow network volume). Applies to both the primary and the companion
+    lookup; paths absent from the map read from the catalog location as
+    usual.
     """
     import config as cfg
 
@@ -902,12 +910,16 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
         # (and the embedded thumb is unusable too) we still fall back to the
         # companion so an extractable JPEG copy isn't refused outright.
         primary_path = os.path.join(row["folder_path"], row["filename"])
+        if source_paths:
+            primary_path = source_paths.get(primary_path, primary_path)
         primary_is_raw = (
             os.path.splitext(row["filename"])[1].lower() in RAW_EXTENSIONS
         )
         companion_path = None
         if row["companion_path"]:
             candidate = os.path.join(row["folder_path"], row["companion_path"])
+            if source_paths:
+                candidate = source_paths.get(candidate, candidate)
             if os.path.isfile(candidate):
                 companion_path = candidate
 

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -728,23 +728,39 @@ def _subtree_like_pattern(path, sep=None):
 _FAILURE_RETRY_AFTER = "-24 hours"
 
 
-def _override_size_matches(override_path, expected_size):
+def _override_identity_matches(
+        override_path, expected_size, expected_mtime_ns):
     """True when ``source_paths`` override is safe to substitute for the archive.
 
-    The card-side override is trusted iff both a size is known for the
-    catalog row (``expected_size`` non-null) AND the file at
-    ``override_path`` currently has exactly that size. Byte-identical files
-    are the same size — a mismatch (or an OSError from an unmounted card)
-    proves the override no longer holds the copied bytes, so extraction
-    falls back to the verified archive path instead of caching a working
-    copy for the wrong content.
+    The card-side override is trusted iff BOTH size and mtime match the
+    identity captured when the file was copied. Size alone is not enough:
+    a reused card mount or a rewritten source file can present the SAME
+    byte length at the same path but with different content, and the
+    extractor would then cache a working copy for the wrong bytes and set
+    ``working_copy_path`` — normal backfill would never regenerate it
+    from the verified archive copy. mtime narrows the trust window from
+    "any file with the same size" to "the exact file we just copied":
+    a rewrite by the camera or an OS-level file replacement bumps mtime;
+    a remount of a different card presents mtimes from an unrelated
+    session. Callers still need to guard against the (extremely rare)
+    same-size-same-mtime coincidence by preferring the archive copy on
+    any extraction failure — that retry lives in ``_extract_working_copies``.
+
+    Any missing input (unknown expected size, unknown expected mtime,
+    OSError from an unmounted card, or the file itself is gone) makes
+    the override untrusted, so extraction falls back to the verified
+    archive path.
     """
-    if expected_size is None:
+    if expected_size is None or expected_mtime_ns is None:
         return False
     try:
-        return os.stat(override_path).st_size == int(expected_size)
+        st = os.stat(override_path)
     except OSError:
         return False
+    return (
+        st.st_size == int(expected_size)
+        and st.st_mtime_ns == int(expected_mtime_ns)
+    )
 
 
 def _working_copy_candidate_predicate(wc_max_size, alias=""):
@@ -841,10 +857,15 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
     loop cleanly with whatever was already committed.
 
     ``source_paths`` optionally maps a photo's cataloged absolute path to an
-    alternate read location holding identical bytes. The import job passes
-    its card->archive mapping so extraction reads the fast local card
-    instead of re-reading the just-written archive copy (which may live on
-    a slow network volume). Applies to both the primary and the companion
+    ``(alternate_path, expected_size, expected_mtime_ns)`` tuple. The import
+    job passes its card->archive mapping (with size + mtime captured at
+    copy time) so extraction reads the fast local card instead of re-
+    reading the just-written archive copy (which may live on a slow
+    network volume). An override is used only when the file at
+    ``alternate_path`` currently has the exact size AND mtime captured at
+    copy time — anything else (rewritten card, remounted different card,
+    unmounted card, coincidental same-size collision) falls back to the
+    verified archive path. Applies to both the primary and the companion
     lookup; paths absent from the map read from the catalog location as
     usual.
     """
@@ -943,16 +964,19 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
             # Reading them here would cache a working copy for the wrong
             # image and — because ``working_copy_path`` gets set — normal
             # backfill would never regenerate it from the archive. Verify
-            # the override's size against the file_size scan() recorded for
-            # this row (identical bytes must have identical size); anything
-            # else falls back to the verified archive copy. row["file_size"]
-            # is null on legacy rows that never made it through the sizing
-            # scan — those also fall back rather than trust an unverifiable
-            # override.
-            override = source_paths.get(catalog_primary)
-            if override and _override_size_matches(override, row["file_size"]):
-                primary_path = override
-                primary_override_used = True
+            # the override's size AND mtime against the identity captured
+            # by the import job at copy time (a rewritten source bumps
+            # mtime; a same-size collision on a reused card mount has an
+            # unrelated mtime); anything else falls back to the verified
+            # archive copy.
+            override_entry = source_paths.get(catalog_primary)
+            if override_entry:
+                override_path, exp_size, exp_mtime_ns = override_entry
+                if _override_identity_matches(
+                    override_path, exp_size, exp_mtime_ns,
+                ):
+                    primary_path = override_path
+                    primary_override_used = True
         primary_is_raw = (
             os.path.splitext(row["filename"])[1].lower() in RAW_EXTENSIONS
         )
@@ -965,18 +989,24 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
             )
             candidate = catalog_companion
             if source_paths:
-                # Companion size is not carried on the RAW's row (pairing
-                # merged the JPEG's photos row into the RAW's), so we can't
-                # size-verify the companion override the way we do the
-                # primary. Track override use here and retry from the
-                # verified archive companion on extraction failure below;
-                # that keeps a rewritten card from silently poisoning a
-                # working copy while still preferring fast local reads
-                # when the override matches.
-                override = source_paths.get(catalog_companion)
-                if override and os.path.isfile(override):
-                    candidate = override
-                    companion_override_used = True
+                # Companion size is not on the RAW's row (pairing merged
+                # the JPEG's photos row into the RAW's), but the import
+                # ledger recorded the companion's card-side size and
+                # mtime at copy time — use those to identity-check the
+                # override the same way the primary does. Without this,
+                # a rewritten card-side JPEG (or a remounted different
+                # card) would silently poison the RAW's working copy
+                # via the companion-fallback path. On identity mismatch
+                # (or missing entry), read the verified archive
+                # companion instead.
+                override_entry = source_paths.get(catalog_companion)
+                if override_entry:
+                    override_path, exp_size, exp_mtime_ns = override_entry
+                    if _override_identity_matches(
+                        override_path, exp_size, exp_mtime_ns,
+                    ):
+                        candidate = override_path
+                        companion_override_used = True
             if os.path.isfile(candidate):
                 companion_path = candidate
 

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -909,17 +909,33 @@ def _extract_working_copies(db, vireo_dir, progress_callback=None,
         # clipped highlights — but if libraw cannot decode this RAW variant
         # (and the embedded thumb is unusable too) we still fall back to the
         # companion so an extractable JPEG copy isn't refused outright.
-        primary_path = os.path.join(row["folder_path"], row["filename"])
+        catalog_primary = os.path.join(row["folder_path"], row["filename"])
+        primary_path = catalog_primary
         if source_paths:
-            primary_path = source_paths.get(primary_path, primary_path)
+            # ``source_paths`` overrides the catalog path with the card-side
+            # source so extraction reads local card bytes instead of the
+            # just-written archive copy over a slow NAS. But if the card was
+            # unmounted between copy and the end-of-run extraction pass, the
+            # override points at a dead path — reading it would record a
+            # failure marker even though the verified archive copy is
+            # available. Only substitute the alternate source when it still
+            # exists on disk; otherwise keep the catalog path.
+            override = source_paths.get(catalog_primary)
+            if override and os.path.isfile(override):
+                primary_path = override
         primary_is_raw = (
             os.path.splitext(row["filename"])[1].lower() in RAW_EXTENSIONS
         )
         companion_path = None
         if row["companion_path"]:
-            candidate = os.path.join(row["folder_path"], row["companion_path"])
+            catalog_companion = os.path.join(
+                row["folder_path"], row["companion_path"],
+            )
+            candidate = catalog_companion
             if source_paths:
-                candidate = source_paths.get(candidate, candidate)
+                override = source_paths.get(catalog_companion)
+                if override and os.path.isfile(override):
+                    candidate = override
             if os.path.isfile(candidate):
                 companion_path = candidate
 

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -1560,11 +1560,27 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
         else:
             is_ws_root = (folder_path == root_path)
 
+        # In restricted mode, the scan root (``root_path``) and every
+        # intermediate ancestor between it and ``restrict_dirs`` exist
+        # only to satisfy the ``folders.parent_id`` chain — they are not
+        # part of what the user asked to import. Linking them to the
+        # workspace would fire ``_add_workspace_folder_no_commit`` and
+        # its path-prefix subtree cascade, pulling every pre-existing
+        # cataloged descendant of ``root_path`` (unrelated archive
+        # subtrees from prior scans / other workspaces) into the active
+        # workspace. Only the ``_restrict_root_paths`` themselves should
+        # link. See PR #1107 review (line 1186).
+        link_to_ws = (
+            _restrict_root_paths is None
+            or os.path.normpath(folder_str) in _restrict_root_paths
+        )
+
         folder_id = db.add_folder(
             path=folder_str,
             name=folder_path.name,
             parent_id=parent_id,
             workspace_root=is_ws_root,
+            link_to_workspace=link_to_ws,
         )
         folder_cache[folder_str] = folder_id
         return folder_id

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -241,6 +241,128 @@ def test_catalog_never_references_missing_files(tmp_path):
     assert len(rows) == 1
     for r in rows:
         assert os.path.isfile(os.path.join(r["folder_path"], r["filename"]))
+    # A failed copy means the card is NOT safe to format, with the
+    # failure named.
+    assert result["safe_to_format"] is False
+    assert len(result["unsafe_files"]) == 1
+    assert "DSC_0011" in result["unsafe_files"][0]["path"]
+    assert result["unsafe_files"][0]["reason"]
+
+
+# --- safe-to-format ledger ----------------------------------------------
+
+def test_fresh_import_is_safe_to_format(tmp_path):
+    from import_job import ImportParams
+
+    card = _make_card(tmp_path, [
+        ("DSC_0020.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+        ("DSC_0021.jpg", datetime(2026, 7, 3, 11, 0, 0), "green"),
+    ])
+    _, _, result = _run_import(tmp_path, ImportParams(
+        sources=[str(card)], destination=str(tmp_path / "archive"),
+    ))
+    assert result["safe_to_format"] is True
+    assert result["unsafe_files"] == []
+
+
+def test_hash_backed_duplicate_is_safe_to_format(tmp_path):
+    """A byte-identical twin already cataloged means the card file's bytes
+    verifiably exist — safe."""
+    from import_dedup import compute_file_hash
+    from import_job import ImportParams
+
+    archive = tmp_path / "archive"
+    dest_dir = archive / "2026" / "2026-07-03"
+    dest_dir.mkdir(parents=True)
+    dest_file = dest_dir / "IMG_0300.jpg"
+    Image.new("RGB", (16, 16), "red").save(str(dest_file))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'ok')",
+        (str(dest_dir), dest_dir.name),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, extension, file_size,"
+        " file_hash) VALUES (?, ?, '.jpg', ?, ?)",
+        (fid, "IMG_0300.jpg", os.path.getsize(str(dest_file)),
+         compute_file_hash(str(dest_file))),
+    )
+    db.conn.commit()
+
+    card = tmp_path / "card"
+    card.mkdir()
+    import shutil
+    shutil.copy2(str(dest_file), str(card / "IMG_0300.jpg"))
+
+    from import_job import run_import_job
+    result = run_import_job(_make_job(), FakeRunner(), db_path, ws_id,
+                            ImportParams(sources=[str(card)],
+                                         destination=str(archive)))
+    assert result["skipped_duplicate"] == 1
+    assert result["safe_to_format"] is True
+
+
+def test_key_match_with_different_bytes_imports_as_distinct(tmp_path):
+    """A metadata-only ("key") match against a cataloged twin whose bytes
+    differ must NOT be skipped: the card's bytes were never verified
+    anywhere, so skipping would let the safe-to-format pill go green while
+    the card holds the only copy. The file imports as a distinct photo."""
+    from import_job import ImportParams
+    from PIL.ExifTags import Base as ExifBase
+
+    dt = datetime(2026, 5, 1, 10, 15, 30)
+
+    # Card file with a trustworthy EXIF capture time.
+    card = tmp_path / "card"
+    card.mkdir()
+    card_file = card / "IMG_0400.jpg"
+    img = Image.new("RGB", (16, 16), "red")
+    exif = img.getexif()
+    exif[ExifBase.DateTimeOriginal] = dt.strftime("%Y:%m:%d %H:%M:%S")
+    img.save(str(card_file), exif=exif)
+    card_bytes = card_file.read_bytes()
+
+    # Cataloged twin: same name, same size, same trusted capture time —
+    # different bytes (last byte flipped; only ever hashed, never decoded).
+    library = tmp_path / "library"
+    library.mkdir()
+    twin_file = library / "IMG_0400.jpg"
+    twin_bytes = card_bytes[:-1] + bytes([card_bytes[-1] ^ 0xFF])
+    twin_file.write_bytes(twin_bytes)
+    assert len(twin_bytes) == len(card_bytes)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'ok')",
+        (str(library), "library"),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, extension, file_size,"
+        " timestamp) VALUES (?, ?, '.jpg', ?, ?)",
+        (fid, "IMG_0400.jpg", len(twin_bytes), "2026-05-01T10:15:30"),
+    )
+    db.conn.commit()
+
+    archive = tmp_path / "archive"
+    from import_job import run_import_job
+    result = run_import_job(_make_job(), FakeRunner(), db_path, ws_id,
+                            ImportParams(sources=[str(card)],
+                                         destination=str(archive)))
+
+    # Imported as a fresh distinct photo, not skipped.
+    assert result["copied"] == 1
+    assert result["skipped_duplicate"] == 0
+    dest = archive / "2026" / "2026-05-01" / "IMG_0400.jpg"
+    assert dest.read_bytes() == card_bytes
+    # Two catalog rows now: the seeded twin and the new import.
+    assert len(_photo_rows(db)) == 2
+    # The copy verified, so the card is safe.
+    assert result["safe_to_format"] is True
 
 
 def test_copy_and_hash_verify_roundtrip(tmp_path):

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -1,0 +1,49 @@
+"""Import job: copy card -> archive with hash verification."""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def test_copy_and_hash_verify_roundtrip(tmp_path):
+    from import_dedup import compute_file_hash
+    from import_job import copy_and_hash_verify
+
+    src = tmp_path / "card" / "DSC_0001.jpg"
+    src.parent.mkdir()
+    src.write_bytes(b"pixels" * 1000)
+    dst = tmp_path / "archive" / "2026" / "DSC_0001.jpg"
+
+    ok, file_hash = copy_and_hash_verify(str(src), str(dst))
+    assert ok is True
+    assert file_hash == compute_file_hash(str(src))
+    assert dst.read_bytes() == src.read_bytes()
+
+
+def test_copy_and_hash_verify_detects_corruption(tmp_path, monkeypatch):
+    """A copy whose destination bytes differ must fail without deleting any
+    previously verified archive file at the destination path."""
+    import shutil
+
+    from import_job import copy_and_hash_verify
+
+    src = tmp_path / "card" / "DSC_0002.jpg"
+    src.parent.mkdir()
+    src.write_bytes(b"good bytes")
+    dst = tmp_path / "archive" / "DSC_0002.jpg"
+    dst.parent.mkdir()
+    dst.write_bytes(b"existing verified archive bytes")
+
+    real_copy2 = shutil.copy2
+
+    def corrupting_copy2(s, d):
+        real_copy2(s, d)
+        with open(d, "r+b") as f:
+            f.write(b"BAD")
+
+    monkeypatch.setattr("import_job.shutil.copy2", corrupting_copy2)
+    ok, file_hash = copy_and_hash_verify(str(src), str(dst))
+    assert ok is False
+    assert file_hash is None
+    assert dst.read_bytes() == b"existing verified archive bytes"
+    assert not list(dst.parent.glob(".DSC_0002.jpg.*.tmp"))

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -483,6 +483,153 @@ def test_key_match_with_different_bytes_imports_as_distinct(tmp_path):
     assert result["safe_to_format"] is True
 
 
+def test_intra_run_key_collision_across_cards_imports_second_as_fresh(tmp_path):
+    """Two cards can hold different bytes at the same filename+size+
+    capture-second (say, an IMG_XXXX rollover after a firmware reset).
+    A metadata-key match against the first card's just-copied file must
+    NOT let the second card's file be counted as skipped without a byte
+    check: the two files' bytes were never compared, so skipping would
+    let safe_to_format go green while the second card is the only copy
+    of its bytes."""
+    from PIL.ExifTags import Base as ExifBase
+    from import_job import ImportParams, run_import_job
+    from import_dedup import compute_file_hash
+
+    dt = datetime(2026, 5, 2, 11, 20, 45)
+
+    card1 = tmp_path / "card1"
+    card1.mkdir()
+    card1_file = card1 / "IMG_0700.jpg"
+    img = Image.new("RGB", (16, 16), "red")
+    exif = img.getexif()
+    exif[ExifBase.DateTimeOriginal] = dt.strftime("%Y:%m:%d %H:%M:%S")
+    img.save(str(card1_file), exif=exif)
+    card1_bytes = card1_file.read_bytes()
+
+    # Card 2: SAME filename, SAME size, SAME trusted capture time,
+    # different bytes (last byte flipped; EXIF header untouched).
+    card2 = tmp_path / "card2"
+    card2.mkdir()
+    card2_file = card2 / "IMG_0700.jpg"
+    card2_bytes = card1_bytes[:-1] + bytes([card1_bytes[-1] ^ 0xFF])
+    assert len(card2_bytes) == len(card1_bytes)
+    assert card2_bytes != card1_bytes
+    card2_file.write_bytes(card2_bytes)
+
+    archive = tmp_path / "archive"
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id, ImportParams(
+            sources=[str(card1), str(card2)], destination=str(archive),
+        ),
+    )
+
+    # Second card must NOT be counted as skipped_duplicate.
+    assert result["copied"] == 2
+    assert result["skipped_duplicate"] == 0
+    assert result["failed"] == 0
+    # safe_to_format is true because both cards' bytes verifiably landed.
+    assert result["safe_to_format"] is True
+
+    dest_dir = archive / "2026" / "2026-05-02"
+    landed = sorted(p for p in dest_dir.iterdir() if p.is_file())
+    assert len(landed) == 2
+    on_disk = {p.read_bytes() for p in landed}
+    assert card1_bytes in on_disk
+    assert card2_bytes in on_disk
+    hashes_on_disk = {compute_file_hash(str(p)) for p in landed}
+    assert compute_file_hash(str(card1_file)) in hashes_on_disk
+    assert compute_file_hash(str(card2_file)) in hashes_on_disk
+
+
+def test_key_candidate_source_read_error_fails_only_that_file(
+        tmp_path, monkeypatch):
+    """When the current-source hash read for a metadata-key duplicate
+    candidate raises OSError (removable media pulled mid-check, I/O
+    error), that source alone is bucketed as failed. The failure must
+    not escape and kill the whole background job — siblings still import
+    normally, and the safe-to-format ledger records the failure."""
+    from PIL.ExifTags import Base as ExifBase
+    import import_dedup
+    from import_job import ImportParams, run_import_job
+
+    dt_bad = datetime(2026, 5, 3, 12, 0, 0)
+    dt_good = datetime(2026, 5, 3, 12, 5, 0)
+
+    card = tmp_path / "card"
+    card.mkdir()
+    bad_file = card / "IMG_0800.jpg"
+    img = Image.new("RGB", (16, 16), "red")
+    exif_bad = img.getexif()
+    exif_bad[ExifBase.DateTimeOriginal] = (
+        dt_bad.strftime("%Y:%m:%d %H:%M:%S")
+    )
+    img.save(str(bad_file), exif=exif_bad)
+
+    good_file = card / "IMG_0801.jpg"
+    img2 = Image.new("RGB", (16, 16), "green")
+    exif_good = img2.getexif()
+    exif_good[ExifBase.DateTimeOriginal] = (
+        dt_good.strftime("%Y:%m:%d %H:%M:%S")
+    )
+    img2.save(str(good_file), exif=exif_good)
+
+    # Seed a cataloged twin whose (filename, size, capture-second) matches
+    # the bad file — checker.match() will return ('key', …) without needing
+    # to hash, so the next read (the current-source hash for byte
+    # verification) is the one we make fail.
+    library = tmp_path / "library"
+    library.mkdir()
+    twin_file = library / "IMG_0800.jpg"
+    twin_bytes = bad_file.read_bytes()[:-1] + b"\x00"
+    twin_file.write_bytes(twin_bytes)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'ok')",
+        (str(library), "library"),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, extension, file_size,"
+        " timestamp) VALUES (?, ?, '.jpg', ?, ?)",
+        (fid, "IMG_0800.jpg", os.path.getsize(str(bad_file)),
+         dt_bad.strftime("%Y-%m-%dT%H:%M:%S")),
+    )
+    db.conn.commit()
+
+    real_hash = import_dedup.compute_file_hash
+    bad_path_str = str(bad_file)
+
+    def flaky_hash(path):
+        if str(path) == bad_path_str:
+            raise OSError("card yanked mid-check")
+        return real_hash(path)
+
+    monkeypatch.setattr(import_dedup, "compute_file_hash", flaky_hash)
+
+    archive = tmp_path / "archive"
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(sources=[str(card)], destination=str(archive)),
+    )
+
+    assert result["failed"] == 1
+    assert result["copied"] == 1
+    assert result["skipped_duplicate"] == 0
+    assert result["safe_to_format"] is False
+    assert len(result["unsafe_files"]) == 1
+    assert result["unsafe_files"][0]["path"] == bad_path_str
+    assert "duplicate check failed" in result["unsafe_files"][0]["reason"]
+
+    dest_good = archive / "2026" / "2026-05-03" / "IMG_0801.jpg"
+    assert dest_good.exists()
+    assert dest_good.read_bytes() == good_file.read_bytes()
+
+
 def test_copy_and_hash_verify_roundtrip(tmp_path):
     from import_dedup import compute_file_hash
     from import_job import copy_and_hash_verify

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -202,9 +202,11 @@ def test_duplicate_only_import_links_matched_folders(tmp_path):
     assert len(_photo_rows(db)) == 1
 
 
-def test_catalog_never_references_missing_files(tmp_path):
+def test_catalog_never_references_missing_files(tmp_path, monkeypatch):
     """Invariant: catalog is a subset of verified on-disk files, even when
     some copies fail."""
+    import shutil as shutil_mod
+
     from import_job import ImportParams
 
     card = _make_card(tmp_path, [
@@ -214,9 +216,6 @@ def test_catalog_never_references_missing_files(tmp_path):
     archive = tmp_path / "archive"
 
     # Sabotage the second copy: corrupt destination bytes for DSC_0011.
-    import shutil as shutil_mod
-
-    import import_job as ij
     real_copy2 = shutil_mod.copy2
 
     def flaky_copy2(s, d):
@@ -225,14 +224,10 @@ def test_catalog_never_references_missing_files(tmp_path):
             with open(d, "r+b") as f:
                 f.write(b"CORRUPT")
 
-    orig = ij.shutil.copy2
-    ij.shutil.copy2 = flaky_copy2
-    try:
-        db, ws_id, result = _run_import(tmp_path, ImportParams(
-            sources=[str(card)], destination=str(archive),
-        ))
-    finally:
-        ij.shutil.copy2 = orig
+    monkeypatch.setattr("import_job.shutil.copy2", flaky_copy2)
+    db, ws_id, result = _run_import(tmp_path, ImportParams(
+        sources=[str(card)], destination=str(archive),
+    ))
 
     assert result["copied"] == 1
     assert result["failed"] == 1
@@ -1346,3 +1341,185 @@ def test_wc_extraction_falls_back_to_archive_when_card_vanishes(
         f"extractor should not have read the vanished card path, "
         f"got dead reads={dead_reads}"
     )
+
+
+def test_copy_and_hash_verify_falls_back_when_hardlinks_unsupported(
+        tmp_path, monkeypatch):
+    """Destinations on FAT/exFAT and some SMB/NFS mounts reject os.link
+    with EPERM/ENOTSUP. Without a fallback promotion path every file on
+    those archives buckets as a copy failure; with the fallback the
+    verified temp file lands via an atomic O_EXCL + os.replace and the
+    copy succeeds.
+    """
+    import errno as errno_mod
+
+    from import_dedup import compute_file_hash
+    from import_job import copy_and_hash_verify
+
+    src = tmp_path / "card" / "DSC_9500.jpg"
+    src.parent.mkdir()
+    src.write_bytes(b"card-file-bytes" * 100)
+    dst = tmp_path / "archive" / "DSC_9500.jpg"
+
+    def unsupported_link(a, b):
+        raise OSError(errno_mod.EPERM, "operation not permitted")
+
+    monkeypatch.setattr("import_job.os.link", unsupported_link)
+
+    ok, file_hash = copy_and_hash_verify(str(src), str(dst))
+    assert ok is True
+    assert file_hash == compute_file_hash(str(src))
+    assert dst.read_bytes() == src.read_bytes()
+    # No stray .tmp / empty-placeholder residue.
+    assert not list(dst.parent.glob(".DSC_9500.jpg.*.tmp"))
+
+
+def test_copy_and_hash_verify_fallback_still_refuses_to_overwrite(
+        tmp_path, monkeypatch):
+    """The O_EXCL fallback must preserve no-overwrite race protection: an
+    existing verified archive file must survive when os.link is not
+    available, mirroring the primary os.link path's FileExistsError."""
+    import errno as errno_mod
+
+    from import_job import copy_and_hash_verify
+
+    src = tmp_path / "card" / "DSC_9501.jpg"
+    src.parent.mkdir()
+    src.write_bytes(b"card bytes")
+
+    dst = tmp_path / "archive" / "DSC_9501.jpg"
+    dst.parent.mkdir()
+    dst.write_bytes(b"already-verified archive bytes")
+
+    def unsupported_link(a, b):
+        raise OSError(errno_mod.EPERM, "operation not permitted")
+
+    monkeypatch.setattr("import_job.os.link", unsupported_link)
+
+    ok, file_hash = copy_and_hash_verify(str(src), str(dst))
+    assert ok is False
+    assert file_hash is None
+    # The pre-existing verified copy must survive both the os.link race
+    # AND the fallback path — O_EXCL fails with FileExistsError and we
+    # never touch dst.
+    assert dst.read_bytes() == b"already-verified archive bytes"
+    # And the temp file must be cleaned up.
+    assert not list(dst.parent.glob(".DSC_9501.jpg.*.tmp"))
+
+
+def test_landed_file_failed_after_scan_is_not_double_counted(
+        tmp_path, monkeypatch):
+    """A file that lands (copy verifies), then hits a scan/lookup failure
+    must move out of copied/skipped_duplicate into failed — otherwise
+    ``copied + skipped_duplicate + failed`` exceeds ``discovered`` and the
+    exactly-one-terminal-bucket invariant breaks. Simulate a per-batch
+    scan failure and check the counts sum to ``discovered``.
+    """
+    import scanner as scanner_mod
+    from import_job import ImportParams, run_import_job
+
+    card = _make_card(tmp_path, [
+        ("DSC_1200.jpg", datetime(2026, 7, 6, 10, 0, 0), "red"),
+        ("DSC_1201.jpg", datetime(2026, 7, 6, 11, 0, 0), "green"),
+    ])
+    archive = tmp_path / "archive"
+
+    real_scan = scanner_mod.scan
+
+    def failing_scan(root, db_arg, **kwargs):
+        # Fail the restricted (per-batch) scan — the one with
+        # restrict_files. The dup-link path (no restrict_files) isn't
+        # exercised here; there are no duplicates.
+        if kwargs.get("restrict_files"):
+            raise OSError("simulated per-batch scan failure")
+            # (Not RuntimeError — that's cancellation.)
+        return real_scan(root, db_arg, **kwargs)
+
+    monkeypatch.setattr(scanner_mod, "scan", failing_scan)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(sources=[str(card)], destination=str(archive)),
+    )
+
+    # The invariant: every discovered file ends in exactly one terminal
+    # bucket. Before the fix, copied stayed at 2 and failed also went to
+    # 2, giving a sum of 4 > 2 discovered.
+    assert result["discovered"] == 2
+    assert (
+        result["copied"]
+        + result["skipped_duplicate"]
+        + result["failed"]
+    ) == result["discovered"], (
+        f"exactly-one-terminal-bucket violated: {result!r}"
+    )
+    assert result["failed"] == 2
+    assert result["copied"] == 0
+    assert result["safe_to_format"] is False
+
+    # Folder counts must also be internally consistent.
+    for _rel, counts in result["folders"].items():
+        assert counts["copied"] >= 0
+        assert counts["skipped_duplicate"] >= 0
+        assert counts["failed"] >= 0
+        assert (
+            counts["copied"]
+            + counts["skipped_duplicate"]
+            + counts["failed"]
+        ) == 2, f"folder count sum mismatch: {counts!r}"
+
+
+def test_import_photos_rejects_case_variant_source_nested_destination(
+        tmp_path, monkeypatch):
+    """On case-insensitive filesystems (macOS APFS/HFS+, Windows NTFS)
+    ``/Volumes/Card`` and ``/volumes/card`` refer to the same directory.
+    The API guard against source-contained destinations must compare
+    case-folded on those platforms; a naive prefix check would let a
+    differently cased spelling slip past and hit the safe-to-format
+    data-loss trap.
+    """
+    import sys
+
+    from db import Database
+
+    # Config isolation — same pattern as vireo/tests/test_app.py.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import config as cfg
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+
+    # Force the case-insensitive code path regardless of the test host.
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    db_path = str(tmp_path / "test.db")
+    thumb_dir = str(tmp_path / "thumbs")
+    os.makedirs(thumb_dir)
+    d = Database(db_path)
+    d.ensure_default_workspace()
+    d.close()
+
+    # Set up a plausibly cased source (real dir) and a differently cased
+    # destination that resolves under it. We use case-preserving names on
+    # the underlying filesystem; ``realpath`` won't rewrite the case on
+    # Linux, so the case-fold comparison is what catches the containment.
+    source = tmp_path / "Card"
+    source.mkdir()
+    dest_inside = str(source).replace("Card", "card") + "/archive"
+
+    from app import create_app
+
+    app = create_app(db_path=db_path, thumb_cache_dir=thumb_dir)
+    with app.test_client() as client:
+        resp = client.post(
+            "/api/jobs/import-photos",
+            json={
+                "sources": [str(source)],
+                "destination": dest_inside,
+            },
+        )
+
+    assert resp.status_code == 400, resp.get_data(as_text=True)
+    payload = resp.get_json()
+    assert "inside a source" in (payload.get("error") or "")

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -1343,6 +1343,162 @@ def test_wc_extraction_falls_back_to_archive_when_card_vanishes(
     )
 
 
+def test_wc_extraction_ignores_card_override_when_size_no_longer_matches(
+        tmp_path, monkeypatch):
+    """The override existence check is not enough: if the card was reused
+    (mount point holds a different card, or the same file rewritten with
+    different content), reading it caches a working copy for the WRONG
+    bytes — and because ``working_copy_path`` gets set, normal backfill
+    won't regenerate from the archive. The extractor must compare the
+    override's on-disk size against the row's file_size and fall back to
+    the verified archive copy on mismatch.
+    """
+    import import_job
+    import scanner
+
+    # Card holds a RAW file with a distinctive size.
+    card = tmp_path / "card"
+    card.mkdir()
+    Image.new("RGB", (16, 16), "red").save(str(card / "DSC_2001.jpg"))
+    raw_bytes = (card / "DSC_2001.jpg").read_bytes() + b"RAW-SENSOR-DATA"
+    (card / "DSC_2001.NEF").write_bytes(raw_bytes)
+    (card / "DSC_2001.jpg").unlink()
+    ts = datetime(2026, 7, 5, 10, 0, 0).timestamp()
+    os.utime(str(card / "DSC_2001.NEF"), (ts, ts))
+    original_size = os.path.getsize(str(card / "DSC_2001.NEF"))
+
+    calls = []
+
+    def fake_extract(source_path, output_path, max_size=4096, quality=92):
+        calls.append(str(source_path))
+        if not os.path.isfile(source_path):
+            return False
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "wb") as f:
+            f.write(b"jpeg-bytes")
+        return True
+
+    monkeypatch.setattr(scanner, "extract_working_copy", fake_extract)
+
+    vireo_dir = tmp_path / "vireo"
+    (vireo_dir / "working").mkdir(parents=True)
+    dest = str(tmp_path / "archive")
+
+    # Between copy+catalog and the end-of-run extraction, rewrite the
+    # card file with DIFFERENT bytes (and a different size). This mimics
+    # the card being reused for a different shoot, or the same file being
+    # rewritten by the camera. os.path.isfile still returns True — only
+    # a size compare catches it.
+    real_extract_wc = scanner._extract_working_copies
+
+    def rewrite_then_extract(*a, **kw):
+        card_raw = card / "DSC_2001.NEF"
+        card_raw.write_bytes(b"COMPLETELY DIFFERENT CONTENT")
+        assert os.path.getsize(str(card_raw)) != original_size
+        return real_extract_wc(*a, **kw)
+
+    monkeypatch.setattr(
+        "scanner._extract_working_copies", rewrite_then_extract,
+    )
+
+    _db, _ws_id, result = _run_import(tmp_path, import_job.ImportParams(
+        sources=[str(card)], destination=dest,
+        vireo_dir=str(vireo_dir),
+    ))
+
+    assert result["copied"] == 1
+
+    # The extractor must have read the ARCHIVE path (verified bytes),
+    # never the rewritten card path. Without the size check the extractor
+    # would happily read the card's new bytes and cache a wrong working
+    # copy — indistinguishable in the WC file from a real success.
+    assert calls, "extractor should have run"
+    archive_reads = [c for c in calls if str(card) not in c]
+    card_reads = [c for c in calls if str(card) in c]
+    assert archive_reads, (
+        f"extractor should have read from the archive (size mismatch → "
+        f"fall back to catalog primary); got calls={calls}"
+    )
+    assert not card_reads, (
+        f"extractor should not have read the rewritten card path (size "
+        f"no longer matches file_size); got card reads={card_reads}"
+    )
+
+
+def test_wc_extraction_retries_from_archive_when_card_read_fails(
+        tmp_path, monkeypatch):
+    """The size check can pass (card intact when we peek), then reading
+    the file can still fail (transient I/O error, card unmounted right
+    after the stat, permission blip). In that case the row would be
+    marked ``working_copy_failed_at`` even though the archive copy is
+    hash-verified and available; the extractor must retry from the
+    catalog primary before giving up.
+    """
+    import import_job
+    import scanner
+
+    card = tmp_path / "card"
+    card.mkdir()
+    Image.new("RGB", (16, 16), "red").save(str(card / "DSC_3001.jpg"))
+    raw_bytes = (card / "DSC_3001.jpg").read_bytes() + b"RAW-SENSOR-DATA"
+    (card / "DSC_3001.NEF").write_bytes(raw_bytes)
+    (card / "DSC_3001.jpg").unlink()
+    ts = datetime(2026, 7, 5, 11, 0, 0).timestamp()
+    os.utime(str(card / "DSC_3001.NEF"), (ts, ts))
+
+    card_raw_path = str(card / "DSC_3001.NEF")
+    calls = []
+
+    def fake_extract(source_path, output_path, max_size=4096, quality=92):
+        calls.append(str(source_path))
+        # Card-side read always fails (simulate an unreadable RAW /
+        # transient card I/O error); archive-side read succeeds.
+        if str(source_path) == card_raw_path:
+            return False
+        if not os.path.isfile(source_path):
+            return False
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "wb") as f:
+            f.write(b"jpeg-bytes")
+        return True
+
+    monkeypatch.setattr(scanner, "extract_working_copy", fake_extract)
+
+    vireo_dir = tmp_path / "vireo"
+    (vireo_dir / "working").mkdir(parents=True)
+    dest = str(tmp_path / "archive")
+
+    db, _ws_id, result = _run_import(tmp_path, import_job.ImportParams(
+        sources=[str(card)], destination=dest,
+        vireo_dir=str(vireo_dir),
+    ))
+
+    assert result["copied"] == 1
+
+    # The extractor tried the card (size matched), failed, then retried
+    # from the archive and succeeded. Both reads visible in the call log.
+    assert card_raw_path in calls, (
+        f"expected the card override to be tried first; got calls={calls}"
+    )
+    archive_reads = [c for c in calls if c != card_raw_path]
+    assert archive_reads, (
+        f"expected retry from archive after card read failed; "
+        f"got calls={calls}"
+    )
+
+    # The photo row must show a successful working_copy_path — the retry
+    # from archive worked, so no failure marker.
+    row = db.conn.execute(
+        "SELECT working_copy_path, working_copy_failed_at FROM photos"
+    ).fetchone()
+    assert row["working_copy_path"] is not None, (
+        "expected working_copy_path set after archive-retry success"
+    )
+    assert row["working_copy_failed_at"] is None, (
+        "expected no failure marker after archive-retry success"
+    )
+
+
 def test_copy_and_hash_verify_falls_back_when_hardlinks_unsupported(
         tmp_path, monkeypatch):
     """Destinations on FAT/exFAT and some SMB/NFS mounts reject os.link

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -1425,6 +1425,189 @@ def test_wc_extraction_ignores_card_override_when_size_no_longer_matches(
     )
 
 
+def test_wc_extraction_ignores_card_override_when_mtime_no_longer_matches(
+        tmp_path, monkeypatch):
+    """Size alone is not enough: a rewritten card file (same byte count,
+    different content) OR a reused card mount holding a coincidentally
+    same-sized file would pass a size-only guard and cache a working
+    copy for the WRONG bytes. mtime narrows trust from "any same-sized
+    file at this path" to "the exact file we just copied" — a rewrite
+    or a remount presents a different mtime. This test rewrites the
+    card RAW between copy and the deferred extraction with EXACTLY the
+    same size (identical original bytes shuffled) but a fresh mtime;
+    the extractor must fall back to the verified archive copy.
+    """
+    import import_job
+    import scanner
+
+    card = tmp_path / "card"
+    card.mkdir()
+    Image.new("RGB", (16, 16), "red").save(str(card / "DSC_4001.jpg"))
+    raw_bytes = (card / "DSC_4001.jpg").read_bytes() + b"RAW-SENSOR-DATA"
+    (card / "DSC_4001.NEF").write_bytes(raw_bytes)
+    (card / "DSC_4001.jpg").unlink()
+    original_mtime = datetime(2026, 7, 5, 12, 0, 0).timestamp()
+    os.utime(str(card / "DSC_4001.NEF"), (original_mtime, original_mtime))
+    original_size = os.path.getsize(str(card / "DSC_4001.NEF"))
+
+    calls = []
+
+    def fake_extract(source_path, output_path, max_size=4096, quality=92):
+        calls.append(str(source_path))
+        if not os.path.isfile(source_path):
+            return False
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "wb") as f:
+            f.write(b"jpeg-bytes")
+        return True
+
+    monkeypatch.setattr(scanner, "extract_working_copy", fake_extract)
+
+    vireo_dir = tmp_path / "vireo"
+    (vireo_dir / "working").mkdir(parents=True)
+    dest = str(tmp_path / "archive")
+
+    # Between copy+catalog and the end-of-run extraction, replace the
+    # card file with DIFFERENT bytes of the SAME size and set a
+    # DIFFERENT mtime. Size-only guards would accept this override; the
+    # tightened identity check rejects it because mtime moved.
+    real_extract_wc = scanner._extract_working_copies
+
+    def rewrite_same_size_diff_mtime(*a, **kw):
+        card_raw = card / "DSC_4001.NEF"
+        different_bytes = bytes(reversed(card_raw.read_bytes()))
+        card_raw.write_bytes(different_bytes)
+        assert os.path.getsize(str(card_raw)) == original_size, (
+            "replacement must keep byte count identical"
+        )
+        new_mtime = datetime(2026, 7, 6, 9, 0, 0).timestamp()
+        os.utime(str(card_raw), (new_mtime, new_mtime))
+        return real_extract_wc(*a, **kw)
+
+    monkeypatch.setattr(
+        "scanner._extract_working_copies", rewrite_same_size_diff_mtime,
+    )
+
+    _db, _ws_id, result = _run_import(tmp_path, import_job.ImportParams(
+        sources=[str(card)], destination=dest,
+        vireo_dir=str(vireo_dir),
+    ))
+
+    assert result["copied"] == 1
+    assert calls, "extractor should have run"
+    archive_reads = [c for c in calls if str(card) not in c]
+    card_reads = [c for c in calls if str(card) in c]
+    assert archive_reads, (
+        f"extractor should have read from the archive (mtime mismatch → "
+        f"fall back to catalog primary); got calls={calls}"
+    )
+    assert not card_reads, (
+        f"extractor should not have read the rewritten card path (mtime "
+        f"no longer matches captured identity); got card reads={card_reads}"
+    )
+
+
+def test_wc_extraction_ignores_companion_override_when_mtime_changes(
+        tmp_path, monkeypatch):
+    """RAW+JPEG pair: after copy the RAW's row carries companion_path
+    pointing at the JPEG's archive path. The extractor's companion
+    fallback used to accept any existing card-side JPEG at the override
+    location without identity verification — a rewritten card-side JPEG
+    (or a remounted card holding a same-sized JPEG) would then poison
+    the RAW's working copy through the RAW-fails-fall-back-to-companion
+    path. Identity-checking the companion override against (size, mtime)
+    captured at import time makes the extractor read the verified
+    archive companion on any mismatch.
+    """
+    import import_job
+    import scanner
+
+    card = tmp_path / "card"
+    card.mkdir()
+    Image.new("RGB", (16, 16), "blue").save(str(card / "DSC_5001.jpg"))
+    raw_bytes = (card / "DSC_5001.jpg").read_bytes() + b"RAW-SENSOR-DATA"
+    (card / "DSC_5001.NEF").write_bytes(raw_bytes)
+    original_jpeg_bytes = (card / "DSC_5001.jpg").read_bytes()
+    original_jpeg_size = len(original_jpeg_bytes)
+    original_mtime = datetime(2026, 7, 5, 13, 0, 0).timestamp()
+    os.utime(str(card / "DSC_5001.jpg"), (original_mtime, original_mtime))
+    os.utime(str(card / "DSC_5001.NEF"), (original_mtime, original_mtime))
+
+    calls = []
+
+    def fake_extract(source_path, output_path, max_size=4096, quality=92):
+        calls.append(str(source_path))
+        # Force the RAW primary to fail so the extractor falls into the
+        # companion-fallback branch — that's the code path where the
+        # companion override identity check lives. .NEF is the RAW
+        # extension used above.
+        if str(source_path).lower().endswith(".nef"):
+            return False
+        if not os.path.isfile(source_path):
+            return False
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "wb") as f:
+            f.write(b"jpeg-bytes")
+        return True
+
+    monkeypatch.setattr(scanner, "extract_working_copy", fake_extract)
+
+    vireo_dir = tmp_path / "vireo"
+    (vireo_dir / "working").mkdir(parents=True)
+    dest = str(tmp_path / "archive")
+
+    # Between copy+catalog and the end-of-run extraction, rewrite the
+    # card-side JPEG companion with DIFFERENT bytes of the SAME size and
+    # a fresh mtime. Without the identity check the companion-fallback
+    # branch would read this poisoned override.
+    real_extract_wc = scanner._extract_working_copies
+
+    def rewrite_companion_same_size(*a, **kw):
+        card_jpeg = card / "DSC_5001.jpg"
+        card_jpeg.write_bytes(bytes(reversed(original_jpeg_bytes)))
+        assert os.path.getsize(str(card_jpeg)) == original_jpeg_size, (
+            "replacement must keep byte count identical"
+        )
+        new_mtime = datetime(2026, 7, 6, 10, 0, 0).timestamp()
+        os.utime(str(card_jpeg), (new_mtime, new_mtime))
+        return real_extract_wc(*a, **kw)
+
+    monkeypatch.setattr(
+        "scanner._extract_working_copies", rewrite_companion_same_size,
+    )
+
+    _db, _ws_id, result = _run_import(tmp_path, import_job.ImportParams(
+        sources=[str(card)], destination=dest,
+        vireo_dir=str(vireo_dir),
+    ))
+
+    # Both the RAW and its JPEG landed in the archive.
+    assert result["copied"] == 2, (
+        f"expected RAW + JPEG both landed, got {result!r}"
+    )
+    assert calls, "extractor should have run"
+
+    # The RAW extraction attempts (both card and archive) fail; the
+    # extractor then falls back to the companion. That companion read
+    # must be against the ARCHIVE JPEG, not the rewritten card JPEG —
+    # the mtime mismatch on the card override forces archive fallback.
+    jpeg_calls = [c for c in calls if c.lower().endswith(".jpg")]
+    assert jpeg_calls, (
+        f"expected companion fallback to run after RAW failure; "
+        f"got calls={calls}"
+    )
+    card_jpeg_reads = [c for c in jpeg_calls if str(card) in c]
+    archive_jpeg_reads = [c for c in jpeg_calls if str(card) not in c]
+    assert archive_jpeg_reads, (
+        f"extractor should have read the archive JPEG (companion mtime "
+        f"mismatch → archive companion); got jpeg_calls={jpeg_calls}"
+    )
+    assert not card_jpeg_reads, (
+        f"extractor should not have read the rewritten card JPEG "
+        f"companion; got card jpeg reads={card_jpeg_reads}"
+    )
+
+
 def test_wc_extraction_retries_from_archive_when_card_read_fails(
         tmp_path, monkeypatch):
     """The size check can pass (card intact when we peek), then reading

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -538,3 +538,143 @@ def test_failed_extraction_leaves_working_copy_null(tmp_path, monkeypatch):
         (rows[0]["id"],),
     ).fetchone()["working_copy_path"]
     assert wc is None
+
+
+# --- interruption + resume contract (Task 2.6) ---------------------------
+# These tests prove _deindex_staging has no equivalent here: every stopping
+# point leaves a valid catalog, and a retry resumes instead of redoing.
+
+class CancelAfterFirstBatchRunner(FakeRunner):
+    """Flips to cancelled once progress reports a file in the second
+    destination folder (i.e. the second batch has started)."""
+
+    def __init__(self, trigger_fragment):
+        super().__init__()
+        self.trigger_fragment = trigger_fragment
+
+    def push_event(self, job_id, event_type, data):
+        super().push_event(job_id, event_type, data)
+        if (
+            event_type == "progress"
+            and self.trigger_fragment in (data.get("phase") or "")
+        ):
+            self.cancelled_ids.add(job_id)
+
+
+def test_cancel_leaves_valid_partial_catalog(tmp_path):
+    from import_job import ImportParams
+
+    card = _make_card(tmp_path, [
+        ("DSC_0030.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+        ("DSC_0031.jpg", datetime(2026, 7, 3, 11, 0, 0), "green"),
+        ("DSC_0032.jpg", datetime(2026, 7, 4, 9, 0, 0), "blue"),
+        ("DSC_0033.jpg", datetime(2026, 7, 4, 9, 5, 0), "white"),
+    ])
+    archive = tmp_path / "archive"
+    runner = CancelAfterFirstBatchRunner("2026/2026-07-04")
+
+    db, ws_id, result = _run_import(
+        tmp_path,
+        ImportParams(sources=[str(card)], destination=str(archive)),
+        runner=runner,
+    )
+
+    assert result["cancelled"] is True
+    assert result["safe_to_format"] is False
+    # Partial progress: all of batch 1, some of batch 2 — never zero,
+    # never everything.
+    assert 0 < result["copied"] < 4
+    assert result["failed"] == 0
+
+    # The catalog is valid: every row's file exists on disk, verified.
+    rows = _photo_rows(db)
+    assert len(rows) == result["copied"]
+    for r in rows:
+        full = os.path.join(r["folder_path"], r["filename"])
+        assert os.path.isfile(full)
+        assert r["hash_status"] == "ok"
+
+
+def test_rerun_resumes_and_completes(tmp_path):
+    """Re-running the same import after a cancel skips exactly what landed
+    and copies the rest — no unwinding, no redo."""
+    from import_job import ImportParams
+
+    card = _make_card(tmp_path, [
+        ("DSC_0030.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+        ("DSC_0031.jpg", datetime(2026, 7, 3, 11, 0, 0), "green"),
+        ("DSC_0032.jpg", datetime(2026, 7, 4, 9, 0, 0), "blue"),
+        ("DSC_0033.jpg", datetime(2026, 7, 4, 9, 5, 0), "white"),
+    ])
+    archive = tmp_path / "archive"
+    params = ImportParams(sources=[str(card)], destination=str(archive))
+
+    runner = CancelAfterFirstBatchRunner("2026/2026-07-04")
+    db, ws_id, first = _run_import(tmp_path, params, runner=runner)
+    landed_first = first["copied"]
+    assert 0 < landed_first < 4
+
+    # Second run: same card, same params, fresh runner/job.
+    from import_job import run_import_job
+    second = run_import_job(
+        _make_job("import-test-2"), FakeRunner(),
+        str(tmp_path / "test.db"), ws_id, params,
+    )
+
+    assert second["cancelled"] is False
+    assert second["failed"] == 0
+    # Everything already landed is skipped; only the remainder copies.
+    assert second["copied"] == 4 - landed_first
+    assert second["copied"] + second["skipped_duplicate"] == 4
+    assert second["safe_to_format"] is True
+
+    # Combined catalog: exactly one row per card file, all verified.
+    rows = _photo_rows(db)
+    assert len(rows) == 4
+    names = sorted(r["filename"] for r in rows)
+    assert names == [
+        "DSC_0030.jpg", "DSC_0031.jpg", "DSC_0032.jpg", "DSC_0033.jpg",
+    ]
+    for r in rows:
+        assert os.path.isfile(os.path.join(r["folder_path"], r["filename"]))
+
+
+def test_crash_shaped_copies_are_adopted_not_suffixed(tmp_path):
+    """Files that landed on disk but died before their batch's scan (no
+    catalog rows) must be adopted as already-present on re-run — cataloged
+    without creating numeric-suffix duplicates. This is the 'rescan
+    self-heals' story from the design doc."""
+    import shutil
+
+    from import_job import ImportParams
+
+    card = _make_card(tmp_path, [
+        ("DSC_0040.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+        ("DSC_0041.jpg", datetime(2026, 7, 3, 11, 0, 0), "green"),
+    ])
+    archive = tmp_path / "archive"
+
+    # Simulate the crash: both files already at the destination,
+    # byte-identical, with NO catalog rows.
+    dest_dir = archive / "2026" / "2026-07-03"
+    dest_dir.mkdir(parents=True)
+    for name in ("DSC_0040.jpg", "DSC_0041.jpg"):
+        shutil.copy2(str(card / name), str(dest_dir / name))
+
+    db, ws_id, result = _run_import(tmp_path, ImportParams(
+        sources=[str(card)], destination=str(archive),
+    ))
+
+    # Adopted as already-present, cataloged, no re-copy, no suffixes.
+    assert result["copied"] == 0
+    assert result["skipped_duplicate"] == 2
+    assert result["failed"] == 0
+    assert result["safe_to_format"] is True
+    assert sorted(os.listdir(str(dest_dir))) == [
+        "DSC_0040.jpg", "DSC_0041.jpg",
+    ]
+    rows = _photo_rows(db)
+    assert len(rows) == 2
+    for r in rows:
+        assert r["hash_status"] == "ok"
+        assert os.path.isfile(os.path.join(r["folder_path"], r["filename"]))

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -2365,6 +2365,57 @@ def test_copy_and_hash_verify_fallback_leaves_no_placeholder_at_dst_on_promote_f
     assert not list(dst.parent.glob(".DSC_9502.jpg.*.tmp"))
 
 
+def test_copy_and_hash_verify_fallback_serializes_via_directory_flock(
+        tmp_path, monkeypatch):
+    """The hardlinkless-FS fallback wraps its exists-check + rename in a
+    ``fcntl.flock`` on the destination directory. Without this, two
+    concurrent imports targeting the same date folder could both pass
+    exists() before either rename(), and the later rename would silently
+    overwrite the first job's already-verified archive copy — its
+    ``safe_to_format`` would still report green after its bytes are
+    gone. See PR #1107 review.
+    """
+    import errno as errno_mod
+
+    from import_job import copy_and_hash_verify
+
+    src = tmp_path / "card" / "DSC_9503.jpg"
+    src.parent.mkdir()
+    src.write_bytes(b"card bytes for lock test" * 50)
+    dst = tmp_path / "archive" / "DSC_9503.jpg"
+
+    def unsupported_link(a, b):
+        raise OSError(errno_mod.EPERM, "operation not permitted")
+
+    monkeypatch.setattr("import_job.os.link", unsupported_link)
+
+    flock_calls = []
+
+    real_flock = None
+    try:
+        import fcntl as fcntl_mod
+        real_flock = fcntl_mod.flock
+
+        def spy_flock(fd, op):
+            flock_calls.append((fd, op))
+            return real_flock(fd, op)
+
+        monkeypatch.setattr("import_job.fcntl.flock", spy_flock)
+    except ImportError:  # pragma: no cover - Windows
+        pass
+
+    ok, _ = copy_and_hash_verify(str(src), str(dst))
+    assert ok is True
+    # LOCK_EX must have been requested exactly once during the fallback
+    # promote critical section — the exists+rename window is serialized.
+    if real_flock is not None:
+        assert len(flock_calls) == 1, (
+            f"expected one flock(LOCK_EX) on fallback path; got {flock_calls}"
+        )
+        _, op = flock_calls[0]
+        assert op == fcntl_mod.LOCK_EX
+
+
 def test_landed_file_failed_after_scan_is_not_double_counted(
         tmp_path, monkeypatch):
     """A file that lands (copy verifies), then hits a scan/lookup failure

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -3507,11 +3507,10 @@ def test_key_duplicate_links_only_byte_verified_twin_folder(tmp_path):
     # card. Before the fix, it was passed to the duplicate-link scan
     # as a restrict_dir and workspace-linked as its own top-level root
     # (``is_root=1``), pulling an unrelated archive folder into the
-    # workspace UI. It must NOT surface as a workspace root here.
-    # (It may still appear with ``is_root=0`` via the destination
-    # cascade, which is a separate pre-existing behavior of
-    # ``add_workspace_folder``.)
-    assert ws_folder_is_root.get(str(collision_dir), 0) == 0
+    # workspace UI. It must NOT surface as a workspace root here, and
+    # after the restricted-scan cascade fix (PR #1107, line 1186) it
+    # must not appear in ``workspace_folders`` at all.
+    assert str(collision_dir) not in ws_folder_is_root
 
     # Stronger: the collision folder was never scanned this run, so
     # its pre-seeded row's ``file_hash`` is still NULL. Before the
@@ -3630,5 +3629,83 @@ def test_hash_duplicate_links_only_byte_verified_twin_folder(tmp_path):
     # that ``photos.file_hash`` is authoritative, so this folder was
     # workspace-linked as its own top-level root, pulling an unrelated
     # archive folder into the workspace UI. It must NOT surface as a
-    # workspace root here.
-    assert ws_folder_is_root.get(str(stale_dir), 0) == 0
+    # workspace root here, and after the restricted-scan cascade fix
+    # (PR #1107, line 1186) it must not appear in ``workspace_folders``
+    # at all.
+    assert str(stale_dir) not in ws_folder_is_root
+
+
+def test_restricted_scan_does_not_link_unrelated_archive_subtrees(tmp_path):
+    """The per-batch restricted ``scan()`` call in ``run_import_job``
+    passes the broad archive ``destination`` as ``root`` and the templated
+    ``dest_folder`` as the only ``restrict_dir``. Before the fix,
+    scanner's eager ``_ensure_folder(root_path)`` (and every parent-chain
+    step between the two) called ``db.add_folder(..., workspace_root=
+    False)``, which still fires ``add_workspace_folder`` — and its
+    path-prefix subtree cascade in ``_add_workspace_folder_no_commit``
+    would link every pre-existing cataloged descendant of ``destination``
+    into the active workspace. A one-folder import would therefore make
+    unrelated archive subtrees (e.g. shoots from a different card or a
+    different workspace) suddenly visible in the current workspace UI.
+
+    See PR #1107 review at line 1186:
+    "Avoid linking the whole archive during restricted scans."
+    """
+    from import_job import ImportParams
+
+    # Card: one file. Templates to <archive>/2026/2026-07-05/.
+    card = _make_card(tmp_path, [
+        ("DSC_9001.jpg", datetime(2026, 7, 5, 12, 0, 0), "orange"),
+    ])
+    archive = tmp_path / "archive"
+    archive.mkdir()
+
+    # Pre-existing archive tree: two unrelated folders already cataloged
+    # in ``folders`` (as if scanned by a prior workspace or a previous
+    # session on this workspace), NOT currently linked to the active
+    # workspace. We insert them via raw SQL to bypass ``add_folder``'s
+    # auto-link so the "unlinked descendants of destination" precondition
+    # holds cleanly at the start of the run.
+    unrelated_a = archive / "2024" / "2024-01-15-kenya-trip"
+    unrelated_a.mkdir(parents=True)
+    unrelated_b = archive / "2025" / "2025-09-02-yosemite"
+    unrelated_b.mkdir(parents=True)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    for folder_dir in (unrelated_a, unrelated_b):
+        db.conn.execute(
+            "INSERT INTO folders (path, name, status) VALUES (?, ?, 'ok')",
+            (str(folder_dir), folder_dir.name),
+        )
+    db.conn.commit()
+    unrelated_paths = {str(unrelated_a), str(unrelated_b)}
+    # Precondition: neither pre-existing folder is workspace-linked yet.
+    assert unrelated_paths.isdisjoint(_ws_linked_folder_paths(db, ws_id))
+
+    # Run the import into ONE new templated dest_folder.
+    from import_job import run_import_job
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(sources=[str(card)], destination=str(archive)),
+    )
+    assert result["copied"] == 1
+    assert result["failed"] == 0
+
+    linked = _ws_linked_folder_paths(db, ws_id)
+    # The newly-imported dest_folder must be linked (that's the whole
+    # point of the import).
+    dest_folder = archive / "2026" / "2026-07-05"
+    assert str(dest_folder) in linked, (
+        "the imported dest_folder must be visible in the active workspace"
+    )
+    # Neither pre-existing unrelated archive subtree should have been
+    # dragged into the active workspace by the restricted scan.
+    for path in unrelated_paths:
+        assert path not in linked, (
+            f"unrelated pre-existing archive folder {path} was linked "
+            f"into the active workspace by the restricted scan — the "
+            f"cascade in ``_add_workspace_folder_no_commit`` fired for "
+            f"``destination`` even though it was not the user's target"
+        )

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -202,6 +202,87 @@ def test_duplicate_only_import_links_matched_folders(tmp_path):
     assert len(_photo_rows(db)) == 1
 
 
+def test_duplicate_only_import_links_alias_spelled_twin(tmp_path):
+    """When a twin folder is cataloged through a symlink alias but the
+    import ``destination`` resolves to a different (real) spelling, the
+    duplicate-link pass must still workspace-link the twin. Passing an
+    alias-spelled ``restrict_dir`` to ``scan(root=destination)`` would
+    infinite-recurse in ``_ensure_folder`` (it walks parents lexically
+    without ever matching the realpath'd root); the import job routes
+    the alias case straight to ``workspace_folders`` instead.
+    """
+    import sys as _sys
+
+    if _sys.platform == "win32":
+        # os.symlink usually requires elevation on Windows; skip.
+        import pytest
+        pytest.skip("symlinks not routinely available on Windows")
+
+    from import_dedup import compute_file_hash
+    from import_job import ImportParams, run_import_job
+
+    # Real archive dir + symlink alias to it.
+    real_archive = tmp_path / "real" / "archive"
+    real_archive.mkdir(parents=True)
+    dest_dir_real = real_archive / "2026" / "2026-07-03"
+    dest_dir_real.mkdir(parents=True)
+    dest_file = dest_dir_real / "IMG_9000.jpg"
+    Image.new("RGB", (16, 16), "red").save(str(dest_file))
+
+    alias_archive = tmp_path / "alias"
+    os.symlink(str(real_archive), str(alias_archive))
+    alias_dest_dir = alias_archive / "2026" / "2026-07-03"
+    # Sanity: the alias resolves to the same folder.
+    assert os.path.realpath(str(alias_dest_dir)) == str(dest_dir_real)
+
+    # Catalog the twin under the ALIAS spelling — simulating a prior
+    # scan that used ``/alias/…`` as its root — and don't link its
+    # folder to the workspace.
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'ok')",
+        (str(alias_dest_dir), alias_dest_dir.name),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, extension, file_size,"
+        " file_hash) VALUES (?, ?, '.jpg', ?, ?)",
+        (
+            fid,
+            "IMG_9000.jpg",
+            os.path.getsize(str(dest_file)),
+            compute_file_hash(str(dest_file)),
+        ),
+    )
+    db.conn.commit()
+    assert str(alias_dest_dir) not in _ws_linked_folder_paths(db, ws_id)
+
+    # Card has a byte-identical copy. Import to the REAL destination.
+    card = tmp_path / "card"
+    card.mkdir()
+    import shutil
+    shutil.copy2(str(dest_file), str(card / "IMG_9000.jpg"))
+
+    runner = FakeRunner()
+    job = _make_job()
+    result = run_import_job(job, runner, db_path, ws_id, ImportParams(
+        sources=[str(card)], destination=str(real_archive),
+    ))
+
+    assert result["copied"] == 0
+    assert result["skipped_duplicate"] == 1
+    assert result["failed"] == 0
+    # The alias-spelled twin folder is now workspace-linked (via the
+    # direct-link path, bypassing scan which would have infinite-
+    # recursed in _ensure_folder).
+    assert str(alias_dest_dir) in _ws_linked_folder_paths(db, ws_id)
+    # Still exactly one photo row — no double-catalog of the twin.
+    assert len(_photo_rows(db)) == 1
+    # And the run is safe to format the card.
+    assert result["safe_to_format"] is True
+
+
 def test_catalog_never_references_missing_files(tmp_path, monkeypatch):
     """Invariant: catalog is a subset of verified on-disk files, even when
     some copies fail."""

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -2502,3 +2502,150 @@ def test_import_missing_promotion_narrow_status_guard(tmp_path):
     assert status == "missing", (
         "the missing→ok promotion must be scoped to this batch's dest_folder"
     )
+
+
+def test_duplicate_only_import_promotes_missing_twin_folder(tmp_path):
+    """A duplicate-only import that matches a cataloged twin whose folder
+    row is stale-marked ``'missing'`` (but the folder is still on disk
+    under the import destination) must promote that folder to ``'ok'``
+    before its dup-link scan runs — otherwise the archive stays filtered
+    out of workspace queries even though safe_to_format goes green.
+    See PR #1107 review.
+    """
+    from import_dedup import compute_file_hash
+    from import_job import ImportParams
+
+    archive = tmp_path / "archive"
+    twin_dir = archive / "2026" / "2026-07-03"
+    twin_dir.mkdir(parents=True)
+    twin_file = twin_dir / "IMG_0300.jpg"
+    Image.new("RGB", (16, 16), "red").save(str(twin_file))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    # Pre-catalog the twin at MISSING status (simulates a health check
+    # that flipped the folder to missing right before a reattach).
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'missing')",
+        (str(twin_dir), twin_dir.name),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, extension, file_size,"
+        " file_hash) VALUES (?, ?, '.jpg', ?, ?)",
+        (
+            fid,
+            "IMG_0300.jpg",
+            os.path.getsize(str(twin_file)),
+            compute_file_hash(str(twin_file)),
+        ),
+    )
+    db.conn.commit()
+
+    card = tmp_path / "card"
+    card.mkdir()
+    import shutil
+    shutil.copy2(str(twin_file), str(card / "IMG_0300.jpg"))
+
+    from import_job import run_import_job
+    result = run_import_job(_make_job(), FakeRunner(), db_path, ws_id,
+                            ImportParams(sources=[str(card)],
+                                         destination=str(archive)))
+    assert result["copied"] == 0
+    assert result["skipped_duplicate"] == 1
+    assert result["failed"] == 0
+    assert result["safe_to_format"] is True
+
+    # Folder status was promoted so workspace queries can see it.
+    status = db.conn.execute(
+        "SELECT status FROM folders WHERE path = ?", (str(twin_dir),),
+    ).fetchone()["status"]
+    assert status == "ok", (
+        "duplicate-only import must promote a matched 'missing'-marked "
+        "twin folder to 'ok' before its dup-link scan runs"
+    )
+    # And the folder is linked to the active workspace.
+    assert str(twin_dir) in _ws_linked_folder_paths(db, ws_id)
+
+
+def test_import_invalidates_derived_caches_on_content_change(tmp_path):
+    """When a landed file replaces bytes at a path whose catalog row already
+    has ``working_copy_path`` set (from a prior scan of an older archive
+    file at the same path), the import must invalidate that WC — the
+    deferred end-of-run ``_extract_working_copies`` skips rows with
+    ``working_copy_path IS NOT NULL``, so without invalidation the WC
+    persists pointing at bytes the archive no longer holds. See PR #1107
+    review.
+    """
+    from import_dedup import compute_file_hash
+    from import_job import ImportParams
+
+    archive = tmp_path / "archive"
+    dest_dir = archive / "2026" / "2026-07-03"
+    dest_dir.mkdir(parents=True)
+    # A stale archive file present before the import; its catalog row
+    # captures its OLD hash + a fake WC path (as if a prior scan
+    # extracted a WC for it).
+    stale_archive = dest_dir / "DSC_0700.jpg"
+    Image.new("RGB", (16, 16), "blue").save(str(stale_archive))
+    stale_hash = compute_file_hash(str(stale_archive))
+
+    vireo_dir = tmp_path / "vireo_data"
+    (vireo_dir / "working").mkdir(parents=True)
+    fake_wc = vireo_dir / "working" / "1.jpg"
+    Image.new("RGB", (8, 8), "yellow").save(str(fake_wc))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'ok')",
+        (str(dest_dir), dest_dir.name),
+    ).lastrowid
+    photo_id = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, extension, file_size,"
+        " file_hash, working_copy_path) VALUES (?, ?, '.jpg', ?, ?, ?)",
+        (
+            fid,
+            "DSC_0700.jpg",
+            os.path.getsize(str(stale_archive)),
+            stale_hash,
+            str(fake_wc),
+        ),
+    ).lastrowid
+    db.conn.commit()
+
+    # Overwrite the archive file with DIFFERENT bytes (simulates: the
+    # archive file was deleted/replaced between the prior scan and this
+    # import, and the import restores the same filename with new bytes).
+    stale_archive.unlink()
+
+    # Card holds the NEW bytes at the same filename/date, which will land
+    # at the same dest_path.
+    card = _make_card(tmp_path, [
+        ("DSC_0700.jpg", datetime(2026, 7, 3, 10, 0, 0), "green"),
+    ])
+    # Force skip_duplicates False so the card's new bytes actually get
+    # copied over even though the stale row's hash still exists.
+    from import_job import run_import_job
+    result = run_import_job(_make_job(), FakeRunner(), db_path, ws_id,
+                            ImportParams(sources=[str(card)],
+                                         destination=str(archive),
+                                         skip_duplicates=False,
+                                         vireo_dir=str(vireo_dir)))
+    assert result["copied"] == 1
+    assert result["failed"] == 0
+
+    # The row's WC path was cleared so the deferred extractor / later
+    # backfill can rebuild against the new archive bytes.
+    row = db.conn.execute(
+        "SELECT working_copy_path FROM photos WHERE id = ?", (photo_id,),
+    ).fetchone()
+    assert row["working_copy_path"] is None, (
+        "content change on a landed row must clear working_copy_path so "
+        "the deferred WC pass rebuilds it against the new archive bytes"
+    )
+    # The stale WC file was also unlinked from disk.
+    assert not fake_wc.exists(), (
+        "content change on a landed row must delete the stale WC file"
+    )

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -2742,6 +2742,73 @@ def test_duplicate_only_import_promotes_missing_twin_folder(tmp_path):
     assert str(twin_dir) in _ws_linked_folder_paths(db, ws_id)
 
 
+def test_duplicate_only_import_links_twin_folder_when_destination_is_symlink(tmp_path):
+    """A duplicate-only import whose ``destination`` is a symlink to the
+    twin's on-disk archive root must still resolve containment through
+    the link and link the twin folder. A lexical prefix check would drop
+    the twin from ``dup_dirs``, the duplicate-link scan would never run,
+    and the imported duplicate would stay filtered out of the active
+    workspace even though safe_to_format flipped green. See PR #1107
+    review.
+    """
+    import pytest
+    from import_dedup import compute_file_hash
+    from import_job import ImportParams, run_import_job
+
+    real_archive = tmp_path / "real_archive"
+    twin_dir = real_archive / "2026" / "2026-07-03"
+    twin_dir.mkdir(parents=True)
+    twin_file = twin_dir / "IMG_0400.jpg"
+    Image.new("RGB", (16, 16), "red").save(str(twin_file))
+
+    # Destination the user hands to the import is a symlink to the real
+    # archive root. The twin folder was cataloged under its real path.
+    alias_archive = tmp_path / "archive-alias"
+    try:
+        os.symlink(str(real_archive), str(alias_archive), target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink creation not supported on this platform")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'ok')",
+        (str(twin_dir), twin_dir.name),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, extension, file_size,"
+        " file_hash) VALUES (?, ?, '.jpg', ?, ?)",
+        (
+            fid,
+            "IMG_0400.jpg",
+            os.path.getsize(str(twin_file)),
+            compute_file_hash(str(twin_file)),
+        ),
+    )
+    db.conn.commit()
+    # Nothing linked before the run: proves the run must do the linking.
+    assert str(twin_dir) not in _ws_linked_folder_paths(db, ws_id)
+
+    card = tmp_path / "card"
+    card.mkdir()
+    import shutil
+    shutil.copy2(str(twin_file), str(card / "IMG_0400.jpg"))
+
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(sources=[str(card)], destination=str(alias_archive)),
+    )
+
+    assert result["copied"] == 0
+    assert result["skipped_duplicate"] == 1
+    assert result["failed"] == 0
+    assert result["safe_to_format"] is True
+    # The twin folder was scanned + linked despite the destination being
+    # a symlink to (not literally equal to) the twin's cataloged root.
+    assert str(twin_dir) in _ws_linked_folder_paths(db, ws_id)
+
+
 def test_import_invalidates_derived_caches_on_content_change(tmp_path):
     """When a landed file replaces bytes at a path whose catalog row already
     has ``working_copy_path`` set (from a prior scan of an older archive

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -305,6 +305,124 @@ def test_hash_backed_duplicate_is_safe_to_format(tmp_path):
     assert result["safe_to_format"] is True
 
 
+def test_stale_hash_row_without_on_disk_twin_imports_as_fresh(tmp_path):
+    """A cataloged ``photos.file_hash`` row whose archive file has been
+    deleted since scan must NOT let the card be counted as skipped. The
+    hash token matches (card bytes hash to the cataloged value) but no
+    on-disk twin backs it — safe_to_format would go green while the card
+    is the only remaining copy of the bytes. The card must import as a
+    fresh photo instead."""
+    from import_dedup import compute_file_hash
+    from import_job import ImportParams, run_import_job
+
+    # Card file whose bytes hash to a specific value.
+    card = tmp_path / "card"
+    card.mkdir()
+    card_file = card / "IMG_0500.jpg"
+    Image.new("RGB", (16, 16), "red").save(str(card_file))
+    ts = datetime(2026, 6, 1, 9, 0, 0).timestamp()
+    os.utime(str(card_file), (ts, ts))
+    card_hash = compute_file_hash(str(card_file))
+    card_size = os.path.getsize(str(card_file))
+
+    # Seeded catalog row: a folder that once held a byte-identical twin,
+    # but the archive file is GONE. The folder path exists on disk
+    # (folder_status still 'ok') to isolate the missing-file case.
+    archive = tmp_path / "archive"
+    library = archive / "old-library"
+    library.mkdir(parents=True)
+    ghost_path = library / "IMG_0500.jpg"
+    assert not ghost_path.exists()
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'ok')",
+        (str(library), "old-library"),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, extension, file_size,"
+        " file_hash) VALUES (?, ?, '.jpg', ?, ?)",
+        (fid, "IMG_0500.jpg", card_size, card_hash),
+    )
+    db.conn.commit()
+
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(sources=[str(card)], destination=str(archive),
+                     verify_by_hash=True),
+    )
+
+    # Card must NOT be counted as a skipped duplicate — no twin backs it.
+    assert result["skipped_duplicate"] == 0
+    assert result["copied"] == 1
+    # Bytes now live at the fresh archive path.
+    dest = archive / "2026" / "2026-06-01" / "IMG_0500.jpg"
+    assert dest.exists()
+    assert compute_file_hash(str(dest)) == card_hash
+    # safe_to_format is true because the card's bytes verifiably exist
+    # at the fresh archive path — but via copy, not via a stale row.
+    assert result["safe_to_format"] is True
+
+
+def test_stale_hash_row_with_modified_bytes_imports_as_fresh(tmp_path):
+    """The archive file at the cataloged path exists but was modified
+    since scan (bytes no longer match ``photos.file_hash``). The card's
+    hash still matches the stale row; the twin's re-hash does not. The
+    card must import as fresh — the stale hash row is not proof that the
+    bytes verifiably exist on disk."""
+    from import_dedup import compute_file_hash
+    from import_job import ImportParams, run_import_job
+
+    card = tmp_path / "card"
+    card.mkdir()
+    card_file = card / "IMG_0600.jpg"
+    Image.new("RGB", (16, 16), "green").save(str(card_file))
+    ts = datetime(2026, 6, 2, 9, 0, 0).timestamp()
+    os.utime(str(card_file), (ts, ts))
+    card_hash = compute_file_hash(str(card_file))
+
+    # Seed a "twin" archive file whose CURRENT bytes differ from the
+    # cataloged file_hash (a stale row: the file was modified after the
+    # last scan).
+    archive = tmp_path / "archive"
+    library = archive / "old-library"
+    library.mkdir(parents=True)
+    twin_path = library / "IMG_0600.jpg"
+    Image.new("RGB", (16, 16), "blue").save(str(twin_path))
+    twin_current_hash = compute_file_hash(str(twin_path))
+    assert twin_current_hash != card_hash
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'ok')",
+        (str(library), "old-library"),
+    ).lastrowid
+    # Stale row: file_hash claims card_hash but on-disk bytes hash to
+    # twin_current_hash.
+    db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, extension, file_size,"
+        " file_hash) VALUES (?, ?, '.jpg', ?, ?)",
+        (fid, "IMG_0600.jpg", os.path.getsize(str(card_file)), card_hash),
+    )
+    db.conn.commit()
+
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(sources=[str(card)], destination=str(archive),
+                     verify_by_hash=True),
+    )
+
+    assert result["skipped_duplicate"] == 0
+    assert result["copied"] == 1
+    dest = archive / "2026" / "2026-06-02" / "IMG_0600.jpg"
+    assert compute_file_hash(str(dest)) == card_hash
+    assert result["safe_to_format"] is True
+
+
 def test_key_match_with_different_bytes_imports_as_distinct(tmp_path):
     """A metadata-only ("key") match against a cataloged twin whose bytes
     differ must NOT be skipped: the card's bytes were never verified

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -1,8 +1,246 @@
 """Import job: copy card -> archive with hash verification."""
 import os
 import sys
+from datetime import datetime
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from db import Database
+from PIL import Image
+
+
+class FakeRunner:
+    """Minimal JobRunner stand-in (mirrors test_pipeline_job.FakeRunner)."""
+
+    def __init__(self):
+        self.events = []
+        self.step_updates = []
+        self.cancelled_ids = set()
+
+    def push_event(self, job_id, event_type, data):
+        self.events.append((job_id, event_type, data))
+
+    def set_steps(self, job_id, steps):
+        self.steps_defined = list(steps)
+
+    def update_step(self, job_id, step_id, **kwargs):
+        self.step_updates.append((job_id, step_id, kwargs))
+
+    def is_cancelled(self, job_id):
+        return job_id in self.cancelled_ids
+
+
+def _make_job(job_id="import-test-1"):
+    return {
+        "id": job_id,
+        "type": "import",
+        "status": "running",
+        "progress": {"current": 0, "total": 0, "current_file": ""},
+        "result": None,
+        "errors": [],
+        "config": {},
+        "workspace_id": 1,
+    }
+
+
+def _make_card(tmp_path, specs, card_name="card"):
+    """A fake card with tiny JPEGs. ``specs`` is a list of
+    ``(filename, mtime_datetime)`` (or ``(filename, mtime, color)``)
+    tuples. Distinct mtimes drive folder planning:
+    ingest._source_file_timestamps falls back to file mtime when EXIF is
+    absent before build_destination_path formats the destination folder.
+    """
+    card = tmp_path / card_name
+    card.mkdir(exist_ok=True)
+    for spec in specs:
+        name, mtime, color = spec if len(spec) == 3 else (*spec, "red")
+        path = card / name
+        Image.new("RGB", (16, 16), color).save(str(path))
+        ts = mtime.timestamp()
+        os.utime(str(path), (ts, ts))
+    return card
+
+
+def _run_import(tmp_path, params, runner=None, job=None):
+    from import_job import run_import_job
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    runner = runner or FakeRunner()
+    job = job or _make_job()
+    result = run_import_job(job, runner, db_path, ws_id, params)
+    return db, ws_id, result
+
+
+def _photo_rows(db):
+    return db.conn.execute(
+        """SELECT p.id, p.filename, p.file_hash, p.hash_status,
+                  p.hash_checked_at, f.path AS folder_path
+           FROM photos p JOIN folders f ON f.id = p.folder_id"""
+    ).fetchall()
+
+
+def _ws_linked_folder_paths(db, ws_id):
+    return {
+        row["path"]
+        for row in db.conn.execute(
+            """SELECT f.path FROM folders f
+               JOIN workspace_folders wf ON wf.folder_id = f.id
+               WHERE wf.workspace_id = ?""",
+            (ws_id,),
+        )
+    }
+
+
+def test_run_import_job_copies_verifies_and_catalogs(tmp_path):
+    from import_dedup import compute_file_hash
+    from import_job import ImportParams
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+        ("DSC_0002.jpg", datetime(2026, 7, 3, 11, 0, 0), "green"),
+        ("DSC_0003.jpg", datetime(2026, 7, 4, 9, 0, 0), "blue"),
+        ("DSC_0004.jpg", datetime(2026, 7, 4, 9, 5, 0), "white"),
+    ])
+    archive = tmp_path / "archive"
+
+    db, ws_id, result = _run_import(tmp_path, ImportParams(
+        sources=[str(card)], destination=str(archive),
+    ))
+
+    # Every discovered file landed at its template path.
+    expected = {
+        str(archive / "2026" / "2026-07-03" / "DSC_0001.jpg"),
+        str(archive / "2026" / "2026-07-03" / "DSC_0002.jpg"),
+        str(archive / "2026" / "2026-07-04" / "DSC_0003.jpg"),
+        str(archive / "2026" / "2026-07-04" / "DSC_0004.jpg"),
+    }
+    for path in expected:
+        assert os.path.isfile(path), f"missing archive file: {path}"
+
+    # A photo row exists for each copied file at its final path, with the
+    # verified hash stamped in the integrity-audit vocabulary.
+    rows = _photo_rows(db)
+    row_paths = {
+        os.path.join(r["folder_path"], r["filename"]) for r in rows
+    }
+    assert row_paths == expected
+    for r in rows:
+        full = os.path.join(r["folder_path"], r["filename"])
+        assert r["file_hash"] == compute_file_hash(full)
+        assert r["hash_status"] == "ok"
+        assert r["hash_checked_at"] is not None
+
+    # Result counts are consistent.
+    assert result["discovered"] == 4
+    assert result["copied"] == 4
+    assert result["verified"] == 4
+    assert result["skipped_duplicate"] == 0
+    assert result["failed"] == 0
+
+    # The date folders are linked to the active workspace.
+    linked = _ws_linked_folder_paths(db, ws_id)
+    assert str(archive / "2026" / "2026-07-03") in linked
+    assert str(archive / "2026" / "2026-07-04") in linked
+
+
+def test_duplicate_only_import_links_matched_folders(tmp_path):
+    """Importing a card of only already-cataloged duplicates must still
+    scan + link the matched destination folders to the active workspace,
+    even though no fresh files were copied."""
+    from import_dedup import compute_file_hash
+    from import_job import ImportParams
+
+    # Pre-catalog a photo at the archive destination WITHOUT linking its
+    # folder to the active workspace (raw SQL, no workspace_folders rows).
+    archive = tmp_path / "archive"
+    dest_dir = archive / "2026" / "2026-07-03"
+    dest_dir.mkdir(parents=True)
+    dest_file = dest_dir / "IMG_0100.jpg"
+    Image.new("RGB", (16, 16), "red").save(str(dest_file))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'ok')",
+        (str(dest_dir), dest_dir.name),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, extension, file_size,"
+        " file_hash) VALUES (?, ?, '.jpg', ?, ?)",
+        (
+            fid,
+            "IMG_0100.jpg",
+            os.path.getsize(str(dest_file)),
+            compute_file_hash(str(dest_file)),
+        ),
+    )
+    db.conn.commit()
+    assert str(dest_dir) not in _ws_linked_folder_paths(db, ws_id)
+
+    # Card holds a byte-identical copy of the cataloged photo.
+    card = tmp_path / "card"
+    card.mkdir()
+    import shutil
+    shutil.copy2(str(dest_file), str(card / "IMG_0100.jpg"))
+
+    runner = FakeRunner()
+    job = _make_job()
+    from import_job import run_import_job
+    result = run_import_job(job, runner, db_path, ws_id, ImportParams(
+        sources=[str(card)], destination=str(archive),
+    ))
+
+    assert result["copied"] == 0
+    assert result["skipped_duplicate"] == 1
+    assert result["failed"] == 0
+    # The matched folder got scanned and linked despite zero fresh copies.
+    assert str(dest_dir) in _ws_linked_folder_paths(db, ws_id)
+    # Still exactly one photo row — no re-import of known bytes.
+    assert len(_photo_rows(db)) == 1
+
+
+def test_catalog_never_references_missing_files(tmp_path):
+    """Invariant: catalog is a subset of verified on-disk files, even when
+    some copies fail."""
+    from import_job import ImportParams
+
+    card = _make_card(tmp_path, [
+        ("DSC_0010.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+        ("DSC_0011.jpg", datetime(2026, 7, 3, 11, 0, 0), "green"),
+    ])
+    archive = tmp_path / "archive"
+
+    # Sabotage the second copy: corrupt destination bytes for DSC_0011.
+    import shutil as shutil_mod
+
+    import import_job as ij
+    real_copy2 = shutil_mod.copy2
+
+    def flaky_copy2(s, d):
+        real_copy2(s, d)
+        if "DSC_0011" in str(d):
+            with open(d, "r+b") as f:
+                f.write(b"CORRUPT")
+
+    orig = ij.shutil.copy2
+    ij.shutil.copy2 = flaky_copy2
+    try:
+        db, ws_id, result = _run_import(tmp_path, ImportParams(
+            sources=[str(card)], destination=str(archive),
+        ))
+    finally:
+        ij.shutil.copy2 = orig
+
+    assert result["copied"] == 1
+    assert result["failed"] == 1
+    rows = _photo_rows(db)
+    # Only the verified file is cataloged, and it exists on disk.
+    assert len(rows) == 1
+    for r in rows:
+        assert os.path.isfile(os.path.join(r["folder_path"], r["filename"]))
 
 
 def test_copy_and_hash_verify_roundtrip(tmp_path):

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -2649,3 +2649,70 @@ def test_import_invalidates_derived_caches_on_content_change(tmp_path):
     assert not fake_wc.exists(), (
         "content change on a landed row must delete the stale WC file"
     )
+
+
+def test_import_invalidates_derived_caches_when_pre_row_had_null_hash(tmp_path):
+    """Legacy row invariant: a pre-scan row with ``file_hash IS NULL`` can
+    still carry ``working_copy_path``/thumb/preview caches from earlier
+    processing (e.g. a prior scan that couldn't read the file cleared the
+    hash but left derived rows). Scanner's own content-change path treats
+    ``NULL -> concrete hash`` as an invalidating transition; the import
+    per-batch invalidation loop must mirror that, or restoring a deleted
+    archive file at that path leaves stale WC/thumb bytes cached against
+    the fresh hash. See PR #1107 review.
+    """
+    from import_job import ImportParams, run_import_job
+
+    archive = tmp_path / "archive"
+    dest_dir = archive / "2026" / "2026-07-03"
+    dest_dir.mkdir(parents=True)
+
+    vireo_dir = tmp_path / "vireo_data"
+    (vireo_dir / "working").mkdir(parents=True)
+    fake_wc = vireo_dir / "working" / "1.jpg"
+    Image.new("RGB", (8, 8), "yellow").save(str(fake_wc))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'ok')",
+        (str(dest_dir), dest_dir.name),
+    ).lastrowid
+    # Legacy-shaped row: no file on disk, ``file_hash IS NULL``, but a
+    # stale ``working_copy_path`` from an earlier processing pass.
+    photo_id = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, extension, file_size,"
+        " file_hash, working_copy_path) VALUES (?, ?, '.jpg', ?, NULL, ?)",
+        (fid, "DSC_0701.jpg", 12345, str(fake_wc)),
+    ).lastrowid
+    db.conn.commit()
+
+    # Card holds the NEW bytes at the same filename/date — the import
+    # will land them at the archive path whose row currently has
+    # ``file_hash IS NULL`` + a stale WC.
+    card = _make_card(tmp_path, [
+        ("DSC_0701.jpg", datetime(2026, 7, 3, 10, 0, 0), "green"),
+    ])
+    result = run_import_job(_make_job(), FakeRunner(), db_path, ws_id,
+                            ImportParams(sources=[str(card)],
+                                         destination=str(archive),
+                                         skip_duplicates=False,
+                                         vireo_dir=str(vireo_dir)))
+    assert result["copied"] == 1
+    assert result["failed"] == 0
+
+    # The row's WC path was cleared: NULL -> concrete hash is a real
+    # content change, and the deferred extractor / later backfill must be
+    # allowed to rebuild the WC against the just-imported archive bytes.
+    row = db.conn.execute(
+        "SELECT working_copy_path FROM photos WHERE id = ?", (photo_id,),
+    ).fetchone()
+    assert row["working_copy_path"] is None, (
+        "NULL-hash pre-scan row must invalidate its stale derived caches "
+        "when the import stamps a concrete hash (mirrors scanner.scan()'s "
+        "content-change path)"
+    )
+    assert not fake_wc.exists(), (
+        "NULL-hash pre-scan row must have its stale WC file unlinked"
+    )

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -943,3 +943,186 @@ def test_crash_shaped_copies_are_adopted_not_suffixed(tmp_path):
     for r in rows:
         assert r["hash_status"] == "ok"
         assert os.path.isfile(os.path.join(r["folder_path"], r["filename"]))
+
+
+# --- Codex review 2026-07-05 regressions ---------------------------------
+
+
+def test_copy_and_hash_verify_refuses_to_overwrite_existing_destination(
+        tmp_path):
+    """Concurrent imports targeting the same destination/filename cannot
+    both pass the pre-copy collision check and then both promote their
+    temp file; ``copy_and_hash_verify`` must fail the second promote
+    (leaving the first job's verified archive bytes untouched) rather
+    than silently overwriting with ``os.replace``.
+    """
+    from import_job import copy_and_hash_verify
+
+    src = tmp_path / "card" / "DSC_9001.jpg"
+    src.parent.mkdir()
+    src.write_bytes(b"card bytes")
+
+    dst = tmp_path / "archive" / "DSC_9001.jpg"
+    dst.parent.mkdir()
+    dst.write_bytes(b"already-verified archive bytes")
+
+    ok, file_hash = copy_and_hash_verify(str(src), str(dst))
+    assert ok is False
+    assert file_hash is None
+    # The pre-existing verified copy must survive the race.
+    assert dst.read_bytes() == b"already-verified archive bytes"
+    # And the temp file must be cleaned up.
+    assert not list(dst.parent.glob(".DSC_9001.jpg.*.tmp"))
+
+
+def test_import_destination_with_dot_segments_normalizes_scan_root(tmp_path):
+    """Absolute destinations containing ``..`` segments must still catalog
+    successfully. The scanner stops folder-chain recursion when a parent
+    equals the scan root string; if the copy layout normalizes the path
+    but the scan root does not, the recursion never reaches root and the
+    copied files bucket as catalog failures.
+    """
+    from import_job import ImportParams
+
+    card = _make_card(tmp_path, [
+        ("DSC_0090.jpg", datetime(2026, 7, 4, 10, 0, 0), "red"),
+    ])
+
+    real_archive = tmp_path / "archive"
+    real_archive.mkdir()
+    (tmp_path / "junk").mkdir()
+
+    # Absolute path with a dot segment resolving to real_archive.
+    unnormalized = str(tmp_path / "junk" / ".." / "archive")
+
+    db, ws_id, result = _run_import(tmp_path, ImportParams(
+        sources=[str(card)], destination=unnormalized,
+    ))
+
+    assert result["copied"] == 1
+    assert result["failed"] == 0
+    assert result["safe_to_format"] is True
+
+    rows = _photo_rows(db)
+    assert len(rows) == 1
+    assert os.path.isfile(
+        os.path.join(rows[0]["folder_path"], rows[0]["filename"])
+    )
+    # And the file actually lives under the normalized archive root, not
+    # a duplicated dot-segment path.
+    assert os.path.realpath(rows[0]["folder_path"]).startswith(
+        os.path.realpath(str(real_archive))
+    )
+
+
+def test_unreadable_source_subtree_flips_safe_to_format_off(
+        tmp_path, monkeypatch):
+    """If ``discover_source_files`` cannot enter a source subtree
+    (permission denied, TCC block, unreadable removable-media dir), the
+    files under that subtree are unseen — ``discovered`` shrinks silently
+    and ``safe_to_format`` used to still flip green. Enumeration errors
+    must now bubble into the ledger.
+    """
+    from import_job import ImportParams
+
+    card = _make_card(tmp_path, [
+        ("DSC_0100.jpg", datetime(2026, 7, 4, 10, 0, 0), "red"),
+    ])
+
+    # Force safe_scan_walk to report an error on the first walk step.
+    import image_loader
+    real_walk = image_loader.safe_scan_walk
+
+    def broken_walk(top, onerror=None):
+        # Simulate a PermissionError bubbling up from os.scandir on the
+        # source root; safe_scan_walk's OSError branch would forward it
+        # via onerror and yield nothing further.
+        if onerror is not None:
+            onerror(PermissionError(13, "Operation not permitted", str(top)))
+        # Still yield everything real_walk would have produced so we can
+        # verify the ledger is unsafe even when copies still landed.
+        yield from real_walk(top, onerror=onerror)
+
+    monkeypatch.setattr("ingest.safe_scan_walk", broken_walk)
+
+    db, ws_id, result = _run_import(tmp_path, ImportParams(
+        sources=[str(card)], destination=str(tmp_path / "archive"),
+    ))
+
+    # The one visible file still lands in the catalog...
+    assert result["copied"] == 1
+    # ...but safe_to_format is False because we couldn't prove every
+    # source subtree was walked cleanly.
+    assert result["safe_to_format"] is False
+    assert result["ok"] is False
+    assert result["discovery_errors"] == 1
+    assert any(
+        "source enumeration failed" in e for e in result["errors"]
+    )
+
+
+def test_wc_extraction_deferred_to_after_last_batch(tmp_path, monkeypatch):
+    """A RAW+JPEG companion pair that straddles a batch boundary must not
+    trigger per-batch working-copy extraction while the JPEG's row is
+    still uncataloged (pairing has not run yet). Deferring extraction to
+    end-of-run guarantees ``_pair_raw_jpeg_companions`` has seen every
+    JPEG in every batch before the extractor decides which source to
+    read.
+    """
+    import import_job
+    import scanner
+
+    monkeypatch.setattr(import_job, "IMPORT_BATCH_SIZE", 1)
+
+    # Track extraction call order. ``extract_working_copy`` is invoked
+    # once per candidate row; we care that when the RAW is processed the
+    # JPEG's row has already been merged in (pairing has run).
+    calls = []
+
+    def fake_extract(source_path, output_path, max_size=4096, quality=92):
+        calls.append(str(source_path))
+        # Simulate a RAW decode failure so the companion fallback path
+        # is exercised — the reason deferral matters at all.
+        return not str(source_path).lower().endswith(".nef")
+
+    monkeypatch.setattr(scanner, "extract_working_copy", fake_extract)
+
+    card = tmp_path / "card"
+    card.mkdir()
+    Image.new("RGB", (16, 16), "red").save(str(card / "DSC_0700.jpg"))
+    raw_bytes = (card / "DSC_0700.jpg").read_bytes() + b"RAW-SENSOR-DATA"
+    (card / "DSC_0700.NEF").write_bytes(raw_bytes)
+    # Same mtime so both files plan into the same destination folder.
+    ts = datetime(2026, 7, 4, 10, 0, 0).timestamp()
+    for name in ("DSC_0700.jpg", "DSC_0700.NEF"):
+        os.utime(str(card / name), (ts, ts))
+
+    vireo_dir = tmp_path / "vireo"
+    db, ws_id, result = _run_import(tmp_path, import_job.ImportParams(
+        sources=[str(card)], destination=str(tmp_path / "archive"),
+        vireo_dir=str(vireo_dir),
+    ))
+
+    assert result["copied"] == 2
+    assert result["failed"] == 0
+    assert result["safe_to_format"] is True
+
+    # After deferred extraction, pairing has merged the JPEG row into
+    # the RAW primary and the extractor read the companion (from the
+    # card) after the RAW decode was stubbed as failed.
+    rows = _photo_rows(db)
+    assert len(rows) == 1
+    assert rows[0]["filename"] == "DSC_0700.NEF"
+    wc = db.conn.execute(
+        "SELECT working_copy_path, companion_path FROM photos WHERE id = ?",
+        (rows[0]["id"],),
+    ).fetchone()
+    assert wc["companion_path"] == "DSC_0700.jpg"
+    assert wc["working_copy_path"] == f"working/{rows[0]['id']}.jpg"
+
+    # The JPEG source must have been read from the card, not the archive.
+    jpeg_reads = [c for c in calls if c.lower().endswith(".jpg")]
+    assert jpeg_reads, "companion fallback should have been attempted"
+    assert all(str(card) in c for c in jpeg_reads), (
+        f"companion extraction should read from the card, got {jpeg_reads}"
+    )

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -2764,6 +2764,88 @@ def test_dest_file_nested_under_source_is_rejected(tmp_path):
     assert any("DSC_5000.jpg" in p for p in unsafe_paths), unsafe_paths
 
 
+def test_batch_destination_under_source_creates_no_directories(tmp_path):
+    """When ``dest_folder`` for a batch resolves under a source root, the
+    per-file loop rejects each ``dest_file`` — but that check only runs
+    AFTER ``os.makedirs(dest_folder)``, which would still materialize the
+    archive directory tree on the card (and raise on read-only removable
+    media, killing the background job with an uncaught OSError instead of
+    returning a controlled unsafe result). The import job must short-circuit
+    at the batch boundary: nothing under any source ever gets created, and
+    the run returns the same controlled ``failed``/``safe_to_format=False``
+    ledger it would for a writable destination inside the card. See PR
+    #1107 review.
+    """
+    from import_job import ImportParams
+
+    # Source ``/volumes/Card/DCIM``; destination ``/volumes/Card`` +
+    # template ``DCIM/Archive/%Y`` puts the batch's dest_folder at
+    # ``/volumes/Card/DCIM/Archive/2026`` — under the source root.
+    card = tmp_path / "volumes" / "Card"
+    dcim = card / "DCIM"
+    dcim.mkdir(parents=True)
+    src_file = dcim / "DSC_6100.jpg"
+    Image.new("RGB", (16, 16), "olive").save(str(src_file))
+    ts = datetime(2026, 7, 5, 10, 0, 0).timestamp()
+    os.utime(str(src_file), (ts, ts))
+
+    db, ws_id, result = _run_import(tmp_path, ImportParams(
+        sources=[str(dcim)],
+        destination=str(card),
+        folder_template="DCIM/Archive/%Y",
+    ))
+
+    # No batch directory was created on the card.
+    assert not (dcim / "Archive").exists()
+    # Same controlled unsafe result as the per-file case.
+    assert result["failed"] == 1
+    assert result["copied"] == 0
+    assert result["skipped_duplicate"] == 0
+    assert result["safe_to_format"] is False
+    assert result["ok"] is False
+    unsafe_paths = [u["path"] for u in result["unsafe_files"]]
+    assert any("DSC_6100.jpg" in p for p in unsafe_paths), unsafe_paths
+
+
+def test_full_coverage_file_types_list_is_treated_as_unfiltered(tmp_path):
+    """The pipeline UI's ``getIngestFileTypes()`` returns a list of every
+    supported extension when the user checks every box. Semantically
+    that is the same as ``file_types="both"``: ``discover_source_files``
+    walks it identically. Flagging any list as ``partial_scope``
+    therefore leaves ``safe_to_format`` permanently false over an
+    unfiltered import even though every card file was verified — the
+    pill would deceive the user, ``COPY_PHILOSOPHY.md``'s "show the
+    user what's happening" contract. Normalize full-coverage lists to
+    the same status as ``"both"``. See PR #1107 review.
+    """
+    from image_loader import SUPPORTED_EXTENSIONS
+    from import_job import ImportParams
+
+    card = _make_card(tmp_path, [
+        ("DSC_0500.jpg", datetime(2026, 7, 3, 10, 0, 0), "coral"),
+    ])
+    archive = tmp_path / "archive"
+
+    # A list covering every supported extension — what the UI sends when
+    # the user checks every filetype box, including some casing variance
+    # to guarantee the normalization path is exercised.
+    full_list = sorted(SUPPORTED_EXTENSIONS)
+    full_list[0] = full_list[0].upper()  # e.g. ".ARW"
+    full_list.append("jpg")              # no-leading-dot alias for coverage
+
+    db, ws_id, result = _run_import(tmp_path, ImportParams(
+        sources=[str(card)],
+        destination=str(archive),
+        file_types=full_list,
+    ))
+
+    assert result["copied"] == 1
+    assert result["failed"] == 0
+    # Full-coverage list did NOT actually narrow the walk, so
+    # safe_to_format may go green just like ``"both"``.
+    assert result["safe_to_format"] is True
+
+
 def test_source_equals_dest_file_is_rejected(tmp_path):
     """When a source lives under the destination and the folder template
     maps it back to the same directory, dest_file resolves to the source

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -1126,3 +1126,140 @@ def test_wc_extraction_deferred_to_after_last_batch(tmp_path, monkeypatch):
     assert all(str(card) in c for c in jpeg_reads), (
         f"companion extraction should read from the card, got {jpeg_reads}"
     )
+
+
+# --- Codex 2026-07-05 followups: two findings not addressed by 9e0834af ----
+
+def test_checker_record_oserror_does_not_kill_job(tmp_path, monkeypatch):
+    """If ``DuplicateChecker.record`` re-``os.stat``s the source after a
+    verified ``copy_and_hash_verify`` succeeded and the card has since
+    been pulled, the OSError must not escape and kill the background
+    job — the file is already verified at the archive, so the ledger
+    keeps the copy and the run continues to catalog what landed."""
+    import import_dedup
+    from import_job import ImportParams, run_import_job
+
+    card = _make_card(tmp_path, [
+        ("DSC_0A60.jpg", datetime(2026, 8, 4, 10, 0, 0), "red"),
+        ("DSC_0A61.jpg", datetime(2026, 8, 4, 10, 5, 0), "green"),
+    ])
+
+    real_record = import_dedup.DuplicateChecker.record
+    calls = {"n": 0}
+
+    def flaky_record(self, source_file):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            # First file lands, then card "goes away" — record's re-stat
+            # raises. The file itself is on the archive already.
+            raise OSError("card yanked after copy")
+        return real_record(self, source_file)
+
+    monkeypatch.setattr(
+        import_dedup.DuplicateChecker, "record", flaky_record,
+    )
+
+    archive = tmp_path / "archive"
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(sources=[str(card)], destination=str(archive)),
+    )
+
+    # Both files landed and were cataloged (the record OSError was a
+    # bookkeeping optimization; the archive is the source of truth).
+    assert result["copied"] == 2
+    assert result["failed"] == 0
+    assert result["safe_to_format"] is True
+    rows = _photo_rows(db)
+    assert {r["filename"] for r in rows} == {
+        "DSC_0A60.jpg", "DSC_0A61.jpg",
+    }
+    for r in rows:
+        assert os.path.isfile(os.path.join(r["folder_path"], r["filename"]))
+        assert r["hash_status"] == "ok"
+
+
+def test_dup_link_scan_failure_marks_unsafe(tmp_path, monkeypatch):
+    """When the workspace-linking scan for a duplicate-only batch raises,
+    swallowing it would leave safe_to_format=true even though the
+    imported duplicates are not visible in the active workspace. The
+    failure must surface: safe_to_format false, ok false, and the
+    failing folder(s) recorded in unsafe_files."""
+    import scanner as scanner_mod
+    from import_dedup import compute_file_hash
+    from import_job import ImportParams, run_import_job
+
+    # Pre-catalog a photo at the archive destination WITHOUT linking its
+    # folder to the active workspace (raw SQL, no workspace_folders rows).
+    archive = tmp_path / "archive"
+    dest_dir = archive / "2026" / "2026-08-05"
+    dest_dir.mkdir(parents=True)
+    dest_file = dest_dir / "IMG_0A80.jpg"
+    Image.new("RGB", (16, 16), "red").save(str(dest_file))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'ok')",
+        (str(dest_dir), dest_dir.name),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, extension, file_size,"
+        " file_hash) VALUES (?, ?, '.jpg', ?, ?)",
+        (
+            fid,
+            "IMG_0A80.jpg",
+            os.path.getsize(str(dest_file)),
+            compute_file_hash(str(dest_file)),
+        ),
+    )
+    db.conn.commit()
+
+    # Card holds a byte-identical copy → duplicate-only batch.
+    card = tmp_path / "card"
+    card.mkdir()
+    import shutil
+    shutil.copy2(str(dest_file), str(card / "IMG_0A80.jpg"))
+
+    real_scan = scanner_mod.scan
+
+    def flaky_scan(root, db_arg, **kwargs):
+        # The dup-link scan is called WITHOUT restrict_files, with a
+        # restrict_dirs pointing at our seeded dest_dir. Anything else
+        # (the fresh-copy path) passes through untouched.
+        restrict_dirs = kwargs.get("restrict_dirs") or []
+        if (
+            "restrict_files" not in kwargs
+            or kwargs["restrict_files"] is None
+        ) and any(
+            os.path.normpath(str(d)) == str(dest_dir)
+            for d in restrict_dirs
+        ):
+            # Not RuntimeError — that's reserved for cancellation
+            # (``scanner.scan`` raises ``RuntimeError("scan cancelled")``).
+            # A dup-link scan crash is a distinct failure mode.
+            raise OSError("simulated dup-link scan failure")
+        return real_scan(root, db_arg, **kwargs)
+
+    monkeypatch.setattr(scanner_mod, "scan", flaky_scan)
+
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(sources=[str(card)], destination=str(archive)),
+    )
+
+    assert result["skipped_duplicate"] == 1
+    assert result["safe_to_format"] is False
+    assert result["ok"] is False
+    assert any(
+        str(dest_dir) in u["path"] for u in result["unsafe_files"]
+    ), (
+        "expected the failing dup-link folder in unsafe_files; got "
+        f"{result['unsafe_files']!r}"
+    )
+    # The seeded folder still isn't linked (that was the whole point).
+    assert str(dest_dir) not in _ws_linked_folder_paths(db, ws_id)

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -2577,6 +2577,58 @@ def test_non_empty_null_scan_hash_reclassifies_when_rehash_disagrees(
     assert any("DSC_3000.jpg" in p for p in unsafe_paths), unsafe_paths
 
 
+def test_dest_file_nested_under_source_is_rejected(tmp_path):
+    """When the destination is a legal ancestor of a source but the folder
+    template maps the source right back INTO the source tree, ``dest_file``
+    is a different path than the source file (samefile is False) but still
+    lives under the card. Copying there is counted as ``copied``,
+    ``safe_to_format`` can go green, and formatting the card also erases
+    the "archive" copy. The import job must reject that overlap even
+    though the two paths are not the same file. See PR #1107 review.
+    """
+    from import_job import ImportParams
+
+    # Source is /volumes/Card/DCIM (with photos directly in it); the
+    # destination is /volumes/Card and the folder template ``DCIM/Archive/
+    # %Y`` maps the source back into itself: dest_file lives at
+    # /volumes/Card/DCIM/Archive/2026/<name>, which is under the source
+    # but is not the source file.
+    card = tmp_path / "volumes" / "Card"
+    dcim = card / "DCIM"
+    dcim.mkdir(parents=True)
+    src_file = dcim / "DSC_5000.jpg"
+    Image.new("RGB", (16, 16), "goldenrod").save(str(src_file))
+    ts = datetime(2026, 7, 5, 10, 0, 0).timestamp()
+    os.utime(str(src_file), (ts, ts))
+    original_bytes = src_file.read_bytes()
+
+    db, ws_id, result = _run_import(tmp_path, ImportParams(
+        sources=[str(dcim)],
+        destination=str(card),
+        folder_template="DCIM/Archive/%Y",
+    ))
+
+    # The source bytes MUST still be on disk.
+    assert src_file.exists()
+    assert src_file.read_bytes() == original_bytes
+    # The nested "archive" copy MUST NOT have been created.
+    assert not (dcim / "Archive" / "2026" / "DSC_5000.jpg").exists()
+    # It must NOT be counted as copied/skipped; it must be failed.
+    assert result["copied"] == 0
+    assert result["skipped_duplicate"] == 0
+    assert result["failed"] == 1
+    # Safe-to-format MUST NOT go green when the archive would live on
+    # the card being imported.
+    assert result["safe_to_format"] is False
+    assert (
+        result["copied"]
+        + result["skipped_duplicate"]
+        + result["failed"]
+    ) == result["discovered"]
+    unsafe_paths = [u["path"] for u in result["unsafe_files"]]
+    assert any("DSC_5000.jpg" in p for p in unsafe_paths), unsafe_paths
+
+
 def test_source_equals_dest_file_is_rejected(tmp_path):
     """When a source lives under the destination and the folder template
     maps it back to the same directory, dest_file resolves to the source

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -1263,3 +1263,86 @@ def test_dup_link_scan_failure_marks_unsafe(tmp_path, monkeypatch):
     )
     # The seeded folder still isn't linked (that was the whole point).
     assert str(dest_dir) not in _ws_linked_folder_paths(db, ws_id)
+
+
+def test_wc_extraction_falls_back_to_archive_when_card_vanishes(
+        tmp_path, monkeypatch):
+    """When the deferred working-copy pass runs after copying and the
+    card has been unmounted, ``source_paths`` still points at the card's
+    dead path; the extractor must NOT read from that missing path and
+    record a failure marker. It must fall back to the verified archive
+    copy, so the extraction reads a live file.
+    """
+    import import_job
+    import scanner
+
+    # A RAW file (fake .NEF) is what makes the row a working-copy
+    # extraction candidate — a bare small JPEG is skipped by the
+    # candidate predicate. Same trick as
+    # ``test_wc_extraction_deferred_to_after_last_batch``: bytes that
+    # scanner's metadata reader accepts as an image, extra bytes past
+    # the end to distinguish RAW from JPEG.
+    card = tmp_path / "card"
+    card.mkdir()
+    Image.new("RGB", (16, 16), "red").save(str(card / "DSC_1001.jpg"))
+    raw_bytes = (card / "DSC_1001.jpg").read_bytes() + b"RAW-SENSOR-DATA"
+    (card / "DSC_1001.NEF").write_bytes(raw_bytes)
+    (card / "DSC_1001.jpg").unlink()  # RAW-only, no companion
+    ts = datetime(2026, 7, 4, 10, 0, 0).timestamp()
+    os.utime(str(card / "DSC_1001.NEF"), (ts, ts))
+
+    # Track every extract_working_copy call's source path.
+    calls = []
+
+    def fake_extract(source_path, output_path, max_size=4096, quality=92):
+        calls.append(str(source_path))
+        if not os.path.isfile(source_path):
+            return False
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "wb") as f:
+            f.write(b"jpeg-bytes")
+        return True
+
+    monkeypatch.setattr(scanner, "extract_working_copy", fake_extract)
+
+    vireo_dir = tmp_path / "vireo"
+    (vireo_dir / "working").mkdir(parents=True)
+    dest = str(tmp_path / "archive")
+
+    # Unmount the card BETWEEN copy and end-of-run extraction: patch
+    # ``scanner._extract_working_copies`` to unlink card files first,
+    # then delegate to the real extractor.
+    real_extract_wc = scanner._extract_working_copies
+
+    def unmount_then_extract(*a, **kw):
+        for card_file in list(card.iterdir()):
+            card_file.unlink()
+        card.rmdir()
+        return real_extract_wc(*a, **kw)
+
+    monkeypatch.setattr(
+        "scanner._extract_working_copies", unmount_then_extract,
+    )
+
+    _db, _ws_id, result = _run_import(tmp_path, import_job.ImportParams(
+        sources=[str(card)], destination=dest,
+        vireo_dir=str(vireo_dir),
+    ))
+
+    assert result["copied"] == 1
+    assert result["safe_to_format"] is True
+
+    # The extractor was asked to read the archive path (which exists),
+    # not the vanished card path. Without the fallback the extractor
+    # would read only the dead card path and return False.
+    assert calls, "extractor should have run"
+    live_reads = [c for c in calls if os.path.isfile(c)]
+    assert live_reads, (
+        f"extractor should have read a live path (archive fallback), "
+        f"got calls={calls}"
+    )
+    dead_reads = [c for c in calls if str(card) in c]
+    assert not dead_reads, (
+        f"extractor should not have read the vanished card path, "
+        f"got dead reads={dead_reads}"
+    )

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -1274,7 +1274,6 @@ def test_deferred_extraction_skipped_when_already_cancelled(
     and the returned status must remain ``cancelled``. See PR #1107
     Codex review on commit 7dc0cce (import_job.py:1296).
     """
-    import import_job
     import scanner
     from import_job import ImportParams
 
@@ -1320,7 +1319,6 @@ def test_deferred_extraction_threads_cancel_check(tmp_path, monkeypatch):
     per-row loop instead of decoding every RAW to completion. See PR
     #1107 Codex review on commit 7dc0cce (import_job.py:1296).
     """
-    import import_job
     import scanner
     from import_job import ImportParams
 

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -407,3 +407,134 @@ def test_copy_and_hash_verify_detects_corruption(tmp_path, monkeypatch):
     assert file_hash is None
     assert dst.read_bytes() == b"existing verified archive bytes"
     assert not list(dst.parent.glob(".DSC_0002.jpg.*.tmp"))
+
+
+# --- working copies from the card (Task 2.5) -----------------------------
+
+def _stub_extractor(monkeypatch, outcome):
+    """Replace scanner.extract_working_copy, recording calls.
+
+    ``outcome(source_path)`` decides the stubbed return value.
+    """
+    import scanner
+    calls = []
+
+    def fake_extract(source_path, output_path, max_size=4096, quality=92):
+        calls.append((str(source_path), str(output_path)))
+        return outcome(str(source_path))
+
+    monkeypatch.setattr(scanner, "extract_working_copy", fake_extract)
+    return calls
+
+
+def test_working_copy_extracted_from_card_path(tmp_path, monkeypatch):
+    """The working copy reads the CARD copy of a RAW file, not the archive
+    copy — after import, no processing stage re-reads originals from the
+    (possibly slow) archive volume."""
+    from import_job import ImportParams
+
+    calls = _stub_extractor(monkeypatch, lambda src: True)
+
+    card = tmp_path / "card"
+    card.mkdir()
+    # JPEG bytes under a RAW extension: extraction is stubbed, so only the
+    # extension-based RAW candidacy matters.
+    Image.new("RGB", (16, 16), "red").save(str(card / "DSC_0500.jpg"))
+    os.rename(str(card / "DSC_0500.jpg"), str(card / "DSC_0500.NEF"))
+
+    archive = tmp_path / "archive"
+    vireo_dir = tmp_path / "vireo"
+    db, ws_id, result = _run_import(tmp_path, ImportParams(
+        sources=[str(card)], destination=str(archive),
+        vireo_dir=str(vireo_dir),
+    ))
+
+    assert result["copied"] == 1
+    assert result["safe_to_format"] is True
+    assert len(calls) == 1
+    src, out = calls[0]
+    assert src == str(card / "DSC_0500.NEF"), (
+        f"extraction read {src}, expected the card path"
+    )
+    rows = _photo_rows(db)
+    assert len(rows) == 1
+    pid = rows[0]["id"]
+    assert out == os.path.join(str(vireo_dir), "working", f"{pid}.jpg")
+    wc = db.conn.execute(
+        "SELECT working_copy_path FROM photos WHERE id = ?", (pid,),
+    ).fetchone()["working_copy_path"]
+    assert wc == f"working/{pid}.jpg"
+
+
+def test_working_copy_companion_fallback_reads_card_jpeg(
+        tmp_path, monkeypatch):
+    """RAW+JPEG pair: when the RAW decode fails, the companion fallback
+    must read the CARD's JPEG. Also pins that the companion file (whose
+    photo row is deliberately merged away by pairing) is not bucketed as
+    a failure by the hash-stamping pass."""
+    from import_job import ImportParams
+
+    calls = _stub_extractor(
+        monkeypatch, lambda src: not src.lower().endswith(".nef"),
+    )
+
+    card = tmp_path / "card"
+    card.mkdir()
+    Image.new("RGB", (16, 16), "red").save(str(card / "DSC_0501.jpg"))
+    # The RAW must be distinct bytes (a real pair always is) or the
+    # duplicate gate would skip it as an intra-run twin of the JPEG.
+    raw_bytes = (card / "DSC_0501.jpg").read_bytes() + b"RAW-SENSOR-DATA"
+    (card / "DSC_0501.NEF").write_bytes(raw_bytes)
+
+    archive = tmp_path / "archive"
+    vireo_dir = tmp_path / "vireo"
+    db, ws_id, result = _run_import(tmp_path, ImportParams(
+        sources=[str(card)], destination=str(archive),
+        vireo_dir=str(vireo_dir),
+    ))
+
+    assert result["copied"] == 2
+    assert result["failed"] == 0
+    assert result["safe_to_format"] is True
+
+    # RAW attempt from the card, then companion fallback from the card.
+    sources_tried = [src for src, _ in calls]
+    assert str(card / "DSC_0501.NEF") in sources_tried
+    assert str(card / "DSC_0501.jpg") in sources_tried
+
+    # Pairing merged the JPEG row into the RAW primary.
+    rows = _photo_rows(db)
+    assert len(rows) == 1
+    assert rows[0]["filename"] == "DSC_0501.NEF"
+    wc = db.conn.execute(
+        "SELECT working_copy_path, companion_path FROM photos WHERE id = ?",
+        (rows[0]["id"],),
+    ).fetchone()
+    assert wc["working_copy_path"] == f"working/{rows[0]['id']}.jpg"
+    assert wc["companion_path"] == "DSC_0501.jpg"
+
+
+def test_failed_extraction_leaves_working_copy_null(tmp_path, monkeypatch):
+    from import_job import ImportParams
+
+    _stub_extractor(monkeypatch, lambda src: False)
+
+    card = tmp_path / "card"
+    card.mkdir()
+    Image.new("RGB", (16, 16), "red").save(str(card / "DSC_0502.jpg"))
+    os.rename(str(card / "DSC_0502.jpg"), str(card / "DSC_0502.NEF"))
+
+    db, ws_id, result = _run_import(tmp_path, ImportParams(
+        sources=[str(card)], destination=str(tmp_path / "archive"),
+        vireo_dir=str(tmp_path / "vireo"),
+    ))
+
+    # Import itself still succeeds; the backfill retries extraction later.
+    assert result["copied"] == 1
+    assert result["safe_to_format"] is True
+    rows = _photo_rows(db)
+    wc = db.conn.execute(
+        "SELECT working_copy_path FROM photos WHERE id = ?",
+        (rows[0]["id"],),
+    ).fetchone()["working_copy_path"]
+    assert wc is None

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -1742,6 +1742,114 @@ def test_wc_extraction_retries_from_archive_when_card_read_fails(
     )
 
 
+def test_reclassified_landed_entry_skips_card_source_override(
+        tmp_path, monkeypatch):
+    """A landed entry reclassified as failed by the hash-stamping loop
+    (because the archive file was mutated between ``copy_and_hash_verify``
+    and the restricted scan) must not contribute a card-side override to
+    the deferred ``_extract_working_copies`` pass. Without the filter the
+    extractor would cache a working copy from the still-clean card bytes
+    onto a photo whose catalog ``file_hash`` describes the mutated archive
+    bytes instead — leaving preview/edit renders that don't match the
+    archive contents even though the import was reported unsafe.
+    """
+    import scanner
+    from import_job import ImportParams
+
+    # RAW files (.NEF) are WC-extraction candidates regardless of size;
+    # tiny JPEGs would be skipped by the working-copy candidate filter,
+    # so RAWs are the smallest fixture that actually exercises the
+    # extractor. Seed the RAW body with real JPEG bytes plus a trailing
+    # tag so the two "RAW"s have distinct content.
+    card = tmp_path / "card"
+    card.mkdir()
+    seed = card / "_seed.jpg"
+    Image.new("RGB", (16, 16), "red").save(str(seed))
+    seed_bytes = seed.read_bytes()
+    seed.unlink()
+    for name, mtime in (
+        ("DSC_9100.NEF", datetime(2026, 7, 3, 10, 0, 0)),
+        ("DSC_9101.NEF", datetime(2026, 7, 3, 11, 0, 0)),
+    ):
+        (card / name).write_bytes(seed_bytes + name.encode())
+        ts = mtime.timestamp()
+        os.utime(str(card / name), (ts, ts))
+
+    archive = tmp_path / "archive"
+    calls = []
+
+    def fake_extract(source_path, output_path, max_size=4096, quality=92):
+        calls.append(str(source_path))
+        if not os.path.isfile(source_path):
+            return False
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "wb") as f:
+            f.write(b"jpeg-bytes")
+        return True
+
+    monkeypatch.setattr(scanner, "extract_working_copy", fake_extract)
+
+    # Wrap ``scanner.scan`` so DSC_9101's archive bytes are mutated
+    # after ``copy_and_hash_verify`` succeeded but BEFORE scan reads
+    # them. scan() then hashes and records the mutated bytes; the
+    # hash-stamping loop's mismatch branch reclassifies DSC_9101 from
+    # ``copied`` to ``failed``. DSC_9100 stays untouched and lands
+    # cleanly. ``run_import_job`` does ``from scanner import scan``
+    # inside the function, so patching on the scanner module is picked
+    # up on each invocation (mirrors ``test_dup_link_scan_failure_...``
+    # above).
+    real_scan = scanner.scan
+
+    def scan_after_mutating(*args, **kwargs):
+        for root, _dirs, files in os.walk(str(archive)):
+            for name in files:
+                if name == "DSC_9101.NEF":
+                    with open(os.path.join(root, name), "r+b") as fh:
+                        fh.write(b"MUTATED-ARCHIVE-BYTES")
+        return real_scan(*args, **kwargs)
+
+    monkeypatch.setattr(scanner, "scan", scan_after_mutating)
+
+    vireo_dir = tmp_path / "vireo"
+    (vireo_dir / "working").mkdir(parents=True)
+
+    _db, _ws_id, result = _run_import(tmp_path, ImportParams(
+        sources=[str(card)], destination=str(archive),
+        vireo_dir=str(vireo_dir),
+    ))
+
+    assert result["copied"] == 1, result
+    assert result["failed"] == 1, result
+    assert result["safe_to_format"] is False
+    assert any("DSC_9101" in u["path"] for u in result["unsafe_files"]), (
+        f"expected DSC_9101 in unsafe_files: {result['unsafe_files']!r}"
+    )
+
+    # DSC_9100 is a successful landing — it should still use its
+    # card-side override (the whole point of source_paths). This anchors
+    # the negative assertion below: the filter narrows to reclassified
+    # entries and does not blanket-drop the override for the batch.
+    card_reads_9100 = [
+        c for c in calls if "DSC_9100" in c and str(card) in c
+    ]
+    assert card_reads_9100, (
+        f"successful entry should have used card-side override; "
+        f"got calls={calls}"
+    )
+
+    # DSC_9101 was reclassified: the extractor must NEVER be told to
+    # read the still-clean card bytes. It may still read the mutated
+    # archive path (that's fine — it matches whatever the catalog now
+    # holds), but the card path is off-limits for this row.
+    card_reads_9101 = [
+        c for c in calls if "DSC_9101" in c and str(card) in c
+    ]
+    assert not card_reads_9101, (
+        f"reclassified entry must not contribute a card override; "
+        f"got calls={calls}"
+    )
+
+
 def test_copy_and_hash_verify_falls_back_when_hardlinks_unsupported(
         tmp_path, monkeypatch):
     """Destinations on FAT/exFAT and some SMB/NFS mounts reject os.link

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -2152,11 +2152,52 @@ def test_copy_and_hash_verify_fallback_still_refuses_to_overwrite(
     assert ok is False
     assert file_hash is None
     # The pre-existing verified copy must survive both the os.link race
-    # AND the fallback path — O_EXCL fails with FileExistsError and we
-    # never touch dst.
+    # AND the fallback path — the existence check fires and we never
+    # touch dst.
     assert dst.read_bytes() == b"already-verified archive bytes"
     # And the temp file must be cleaned up.
     assert not list(dst.parent.glob(".DSC_9501.jpg.*.tmp"))
+
+
+def test_copy_and_hash_verify_fallback_leaves_no_placeholder_at_dst_on_promote_failure(
+        tmp_path, monkeypatch):
+    """Crash-safety on hardlinkless destinations: if the promote step
+    fails after the temp file has verified, the fallback path must NOT
+    leave a zero-byte file at ``dst``. Otherwise the intended archive
+    name is occupied by a stray empty file, retry treats it as an
+    existing archive, suffixes the real photo to ``name_1.ext``, and
+    the invariant that a dead run leaves only valid archive copies or
+    hidden temps breaks. See PR #1107 review.
+    """
+    import errno as errno_mod
+
+    from import_job import copy_and_hash_verify
+
+    src = tmp_path / "card" / "DSC_9502.jpg"
+    src.parent.mkdir()
+    src.write_bytes(b"card-file-bytes" * 100)
+    dst = tmp_path / "archive" / "DSC_9502.jpg"
+
+    def unsupported_link(a, b):
+        raise OSError(errno_mod.EPERM, "operation not permitted")
+
+    def failing_rename(a, b):
+        raise OSError(errno_mod.EIO, "simulated FS I/O error during promote")
+
+    monkeypatch.setattr("import_job.os.link", unsupported_link)
+    monkeypatch.setattr("import_job.os.rename", failing_rename)
+
+    ok, file_hash = copy_and_hash_verify(str(src), str(dst))
+    assert ok is False
+    assert file_hash is None
+    # No zero-byte placeholder at final dst — that was the specific
+    # crash-recovery hole this fix closes.
+    assert not dst.exists(), (
+        f"fallback promote failure must not leave any file at {dst}; "
+        f"a zero-byte stray would trip crash-recovery retries"
+    )
+    # And the hidden temp must be cleaned up too.
+    assert not list(dst.parent.glob(".DSC_9502.jpg.*.tmp"))
 
 
 def test_landed_file_failed_after_scan_is_not_double_counted(

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -3315,3 +3315,103 @@ def test_key_duplicate_links_only_byte_verified_twin_folder(tmp_path):
         "key-collision folder must NOT be scanned by a duplicate-"
         "only import: its bytes were never proven to match the card"
     )
+
+
+def test_hash_duplicate_links_only_byte_verified_twin_folder(tmp_path):
+    """Hash-token duplicate: ``_hash_twin_rows`` returns every catalog
+    row whose stored ``photos.file_hash`` matches the card. The stored
+    hash column reflects the LAST scan, so a stale row can name a
+    folder whose archive file has since been overwritten with unrelated
+    bytes. Only the twin(s) whose CURRENT on-disk bytes we re-hashed
+    and matched are proven duplicates; linking the other rows'
+    folders would pull unrelated/missing archive folders into the
+    active workspace on a duplicate-only import. See PR #1107 review.
+    """
+    from import_dedup import compute_file_hash
+    from import_job import ImportParams, run_import_job
+
+    # Card file whose bytes hash to a known value.
+    card = tmp_path / "card"
+    card.mkdir()
+    card_file = card / "IMG_1300.jpg"
+    Image.new("RGB", (16, 16), "cyan").save(str(card_file))
+    ts = datetime(2026, 6, 20, 11, 30, 0).timestamp()
+    os.utime(str(card_file), (ts, ts))
+    card_hash = compute_file_hash(str(card_file))
+    card_size = os.path.getsize(str(card_file))
+
+    # Two archive folders both cataloged as holding a photo with
+    # file_hash == card_hash. Twin A really does; Twin B was modified
+    # after its scan and now holds different bytes (stale hash row).
+    archive = tmp_path / "archive"
+    archive.mkdir()
+    verified_dir = archive / "verified-hash-twin"
+    verified_dir.mkdir()
+    verified_file = verified_dir / "IMG_1300.jpg"
+    # Real duplicate: same bytes as the card.
+    with open(str(card_file), "rb") as src, open(str(verified_file), "wb") as dst:
+        dst.write(src.read())
+
+    stale_dir = archive / "stale-hash-twin"
+    stale_dir.mkdir()
+    stale_file = stale_dir / "IMG_1300.jpg"
+    # Stale twin: on-disk bytes NO LONGER match card_hash. Same size
+    # (so the size sanity check doesn't reject it) but a byte flipped.
+    stale_bytes = bytearray(card_file.read_bytes())
+    stale_bytes[-1] ^= 0xFF
+    stale_file.write_bytes(bytes(stale_bytes))
+    assert compute_file_hash(str(stale_file)) != card_hash
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    # Catalog both twins with file_hash == card_hash. Both rows appear
+    # in ``_hash_twin_rows`` — but only ``verified_dir`` currently
+    # holds those bytes.
+    for folder_dir in (verified_dir, stale_dir):
+        fid = db.conn.execute(
+            "INSERT INTO folders (path, name, status) VALUES (?, ?, 'ok')",
+            (str(folder_dir), folder_dir.name),
+        ).lastrowid
+        db.conn.execute(
+            "INSERT INTO photos (folder_id, filename, extension, file_size,"
+            " file_hash) VALUES (?, ?, '.jpg', ?, ?)",
+            (fid, "IMG_1300.jpg", card_size, card_hash),
+        )
+    db.conn.commit()
+
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id, ImportParams(
+            sources=[str(card)], destination=str(archive),
+            verify_by_hash=True,
+        ),
+    )
+
+    # The verified twin proves the archive still holds the card's
+    # bytes — a legitimate skip.
+    assert result["copied"] == 0
+    assert result["skipped_duplicate"] == 1
+    assert result["failed"] == 0
+    assert result["safe_to_format"] is True
+
+    ws_folder_is_root = {
+        row["path"]: row["is_root"]
+        for row in db.conn.execute(
+            "SELECT f.path, wf.is_root FROM workspace_folders wf "
+            "JOIN folders f ON f.id = wf.folder_id "
+            "WHERE wf.workspace_id = ?",
+            (ws_id,),
+        )
+    }
+    # The byte-verified twin's folder is a user-facing workspace root
+    # (``is_root=1``) — the import proved the archive holds the card's
+    # bytes and links its folder into the workspace UI.
+    assert ws_folder_is_root.get(str(verified_dir)) == 1
+    # The stale-hash-twin folder was NEVER byte-verified against the
+    # card this run. Before the fix, the hash path passed the whole
+    # ``twin_rows`` set to ``_linkable_twin_dirs`` on the assumption
+    # that ``photos.file_hash`` is authoritative, so this folder was
+    # workspace-linked as its own top-level root, pulling an unrelated
+    # archive folder into the workspace UI. It must NOT surface as a
+    # workspace root here.
+    assert ws_folder_is_root.get(str(stale_dir), 0) == 0

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -1173,6 +1173,61 @@ def test_excluded_bundle_source_root_flips_safe_to_format_off(tmp_path):
     assert result["discovery_errors"] == 1
 
 
+def test_filtered_import_is_never_safe_to_format(tmp_path):
+    """A narrowed ``file_types`` (``"raw"``, ``"jpeg"``, or a custom list)
+    only enumerates the requested subset, so ``discovered`` covers less
+    than the card's actual supported-file footprint. The naive
+    ``copied + skipped_duplicate == discovered`` check would still pass
+    even though other supported photos on the card were never imported —
+    and the pill would then tell the user it's safe to format a card that
+    still holds files. See PR #1107 review (P1 line 420).
+    """
+    from import_job import ImportParams
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+        ("DSC_0002.jpg", datetime(2026, 7, 3, 11, 0, 0), "green"),
+    ])
+    archive = tmp_path / "archive"
+
+    # ``file_types="jpeg"`` still copies every file this card actually
+    # holds (they're all JPEGs), so copied == discovered would otherwise
+    # flip safe_to_format green.
+    db, ws_id, result = _run_import(tmp_path, ImportParams(
+        sources=[str(card)],
+        destination=str(archive),
+        file_types="jpeg",
+    ))
+
+    assert result["copied"] == 2
+    assert result["failed"] == 0
+    assert result["discovered"] == 2
+    # But the run only asked for JPEGs — a RAW sitting on the same card
+    # would have been silently skipped. The pill has no way to prove
+    # otherwise without re-walking the card, so it stays false.
+    assert result["safe_to_format"] is False
+
+
+def test_custom_file_types_list_is_never_safe_to_format(tmp_path):
+    """Same guarantee for the explicit-extension-list form of
+    ``file_types``: any narrowing counts as filtered."""
+    from import_job import ImportParams
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+    ])
+    archive = tmp_path / "archive"
+
+    db, ws_id, result = _run_import(tmp_path, ImportParams(
+        sources=[str(card)],
+        destination=str(archive),
+        file_types=[".jpg"],
+    ))
+
+    assert result["copied"] == 1
+    assert result["safe_to_format"] is False
+
+
 def test_wc_extraction_deferred_to_after_last_batch(tmp_path, monkeypatch):
     """A RAW+JPEG companion pair that straddles a batch boundary must not
     trigger per-batch working-copy extraction while the JPEG's row is

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -1646,6 +1646,90 @@ def test_dup_link_scan_failure_marks_unsafe(tmp_path, monkeypatch):
     assert str(dest_dir) not in _ws_linked_folder_paths(db, ws_id)
 
 
+def test_dup_link_scan_non_cancel_runtime_error_marks_unsafe(
+        tmp_path, monkeypatch):
+    """A non-cancellation ``RuntimeError`` from the dup-link scan (a
+    library-level RuntimeError, or a RecursionError which inherits from
+    RuntimeError) must not be routed to the cancellation branch — the
+    runner was never cancelled, and treating the job as cancelled would
+    hide the workspace-link failure from ``ok``/``safe_to_format`` and
+    let the UI serve an import result that looks successful even though
+    the imported duplicates never became visible. See PR #1107 review.
+    """
+    import scanner as scanner_mod
+    from import_dedup import compute_file_hash
+    from import_job import ImportParams, run_import_job
+
+    archive = tmp_path / "archive"
+    dest_dir = archive / "2026" / "2026-08-06"
+    dest_dir.mkdir(parents=True)
+    dest_file = dest_dir / "IMG_0B81.jpg"
+    Image.new("RGB", (16, 16), "green").save(str(dest_file))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'ok')",
+        (str(dest_dir), dest_dir.name),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, extension, file_size,"
+        " file_hash) VALUES (?, ?, '.jpg', ?, ?)",
+        (
+            fid,
+            "IMG_0B81.jpg",
+            os.path.getsize(str(dest_file)),
+            compute_file_hash(str(dest_file)),
+        ),
+    )
+    db.conn.commit()
+
+    card = tmp_path / "card"
+    card.mkdir()
+    import shutil
+    shutil.copy2(str(dest_file), str(card / "IMG_0B81.jpg"))
+
+    real_scan = scanner_mod.scan
+
+    def flaky_scan(root, db_arg, **kwargs):
+        restrict_dirs = kwargs.get("restrict_dirs") or []
+        if (
+            "restrict_files" not in kwargs
+            or kwargs["restrict_files"] is None
+        ) and any(
+            os.path.normpath(str(d)) == str(dest_dir)
+            for d in restrict_dirs
+        ):
+            # A non-sentinel RuntimeError — the runner was never
+            # cancelled. RecursionError (a RuntimeError subclass) or a
+            # library-level RuntimeError bubbling out of the scan would
+            # look like this at the handler.
+            raise RuntimeError("library exploded during scan")
+        return real_scan(root, db_arg, **kwargs)
+
+    monkeypatch.setattr(scanner_mod, "scan", flaky_scan)
+
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(sources=[str(card)], destination=str(archive)),
+    )
+
+    assert result["skipped_duplicate"] == 1
+    # The whole point: not routed to cancellation; instead reported as a
+    # dup-link failure so ``safe_to_format`` reflects reality.
+    assert result["cancelled"] is False
+    assert result["safe_to_format"] is False
+    assert result["ok"] is False
+    assert any(
+        str(dest_dir) in u["path"] for u in result["unsafe_files"]
+    ), (
+        "expected the failing dup-link folder in unsafe_files; got "
+        f"{result['unsafe_files']!r}"
+    )
+    assert str(dest_dir) not in _ws_linked_folder_paths(db, ws_id)
+
+
 def test_wc_extraction_falls_back_to_archive_when_card_vanishes(
         tmp_path, monkeypatch):
     """When the deferred working-copy pass runs after copying and the

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -2410,3 +2410,95 @@ def test_import_invalidates_new_images_cache(tmp_path):
         "workspace linked to the destination folder after its restricted "
         "scans (mirrors pipeline_job / api_job_scan / api_job_import_full)"
     )
+
+
+def test_import_promotes_missing_destination_folder_to_ok(tmp_path):
+    """A pre-existing ``folders`` row marked ``'missing'`` for the import's
+    destination path must transition back to ``'ok'`` before the batch
+    scan runs — otherwise workspace queries filter the folder out and the
+    just-imported files never appear in the workspace, even though
+    safe_to_format goes green.
+
+    Standalone scans run ``check_folder_health()`` as their preflight,
+    which handles this globally. The import path calls ``scanner.scan()``
+    directly, and scan's success stamp only clears ``'partial'``. So a
+    reattached archive drive whose folder rows still say ``'missing'``
+    stays invisible after a successful import unless the import job
+    itself promotes the row. See PR #1107 review.
+    """
+    from import_job import ImportParams
+
+    card = _make_card(tmp_path, [
+        ("DSC_0500.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+    ])
+    archive = tmp_path / "archive"
+    dest_dir = archive / "2026" / "2026-07-03"
+    dest_dir.mkdir(parents=True)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    # Pre-existing missing row for the same path that this import will
+    # populate (simulates: archive drive was disconnected during a health
+    # check and got reattached before this import).
+    db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'missing')",
+        (str(dest_dir), dest_dir.name),
+    )
+    db.conn.commit()
+
+    from import_job import run_import_job
+    result = run_import_job(_make_job(), FakeRunner(), db_path, ws_id,
+                            ImportParams(sources=[str(card)],
+                                         destination=str(archive)))
+    assert result["copied"] == 1
+    assert result["safe_to_format"] is True
+
+    status = db.conn.execute(
+        "SELECT status FROM folders WHERE path = ?", (str(dest_dir),),
+    ).fetchone()["status"]
+    assert status == "ok", (
+        "import must promote pre-existing missing folder row to 'ok' so "
+        "the imported files are visible in the workspace"
+    )
+
+
+def test_import_missing_promotion_narrow_status_guard(tmp_path):
+    """The missing→ok promotion must be gated on ``status='missing'`` so it
+    can't clobber other statuses. (``'partial'`` gets cleared by
+    scanner's success stamp anyway, but the pre-scan targeted UPDATE
+    must not overreach — that's what the ``AND status = 'missing'``
+    guard is for.)"""
+    from import_job import ImportParams
+
+    card = _make_card(tmp_path, [
+        ("DSC_0600.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+    ])
+    archive = tmp_path / "archive"
+    dest_dir = archive / "2026" / "2026-07-03"
+    dest_dir.mkdir(parents=True)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    # A sibling folder marked 'missing' whose path is NOT this import's
+    # destination must NOT be promoted — the pre-scan UPDATE is targeted
+    # by path, so unrelated rows stay untouched.
+    other_dir = archive / "2025" / "2025-01-01"
+    db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'missing')",
+        (str(other_dir), other_dir.name),
+    )
+    db.conn.commit()
+
+    from import_job import run_import_job
+    run_import_job(_make_job(), FakeRunner(), db_path, ws_id,
+                   ImportParams(sources=[str(card)], destination=str(archive)))
+
+    status = db.conn.execute(
+        "SELECT status FROM folders WHERE path = ?", (str(other_dir),),
+    ).fetchone()["status"]
+    assert status == "missing", (
+        "the missing→ok promotion must be scoped to this batch's dest_folder"
+    )

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -2087,3 +2087,181 @@ def test_import_photos_rejects_case_variant_source_nested_destination(
     assert resp.status_code == 400, resp.get_data(as_text=True)
     payload = resp.get_json()
     assert "inside a source" in (payload.get("error") or "")
+
+
+def test_crash_recovered_suffix_is_adopted_not_re_copied(tmp_path):
+    """When a prior run copied a different-content collision to
+    ``DSC_XXX.jpg`` and this source's bytes to the suffixed ``DSC_XXX_1.jpg``
+    then died before scan, a retry must hash-match every existing suffix
+    candidate and adopt on a match — not advance past it and re-copy to
+    ``DSC_XXX_2.jpg``. Without the hash-match, the archive would carry two
+    byte-identical copies of the same source photo.
+    """
+    import shutil
+
+    from import_job import ImportParams
+
+    card = _make_card(tmp_path, [
+        ("DSC_0060.jpg", datetime(2026, 7, 3, 10, 0, 0), "yellow"),
+    ])
+    archive = tmp_path / "archive"
+    dest_dir = archive / "2026" / "2026-07-03"
+    dest_dir.mkdir(parents=True)
+
+    # A different-content name-collision from an earlier run (some other
+    # source photo happened to share the filename+date). Not this card's
+    # bytes.
+    Image.new("RGB", (16, 16), "blue").save(str(dest_dir / "DSC_0060.jpg"))
+    # THIS card's bytes, landed at the suffixed name by a prior run that
+    # died before its restricted scan.
+    shutil.copy2(str(card / "DSC_0060.jpg"), str(dest_dir / "DSC_0060_1.jpg"))
+
+    db, ws_id, result = _run_import(tmp_path, ImportParams(
+        sources=[str(card)], destination=str(archive),
+    ))
+
+    # Adopted the crash-recovered suffix — no re-copy, no double.
+    assert result["copied"] == 0
+    assert result["skipped_duplicate"] == 1
+    assert result["failed"] == 0
+    assert result["safe_to_format"] is True
+
+    # Only the two files that existed before + no DSC_0060_2.jpg.
+    files_on_disk = sorted(os.listdir(str(dest_dir)))
+    assert files_on_disk == ["DSC_0060.jpg", "DSC_0060_1.jpg"], files_on_disk
+
+    # The adopted suffix is cataloged with hash_status=ok. (The pre-existing
+    # ``DSC_0060.jpg`` with different bytes is a stray outside this import;
+    # a future full scan would catalog it — out of scope for this run.)
+    rows = _photo_rows(db)
+    adopted = [r for r in rows if r["filename"] == "DSC_0060_1.jpg"]
+    assert len(adopted) == 1
+    assert adopted[0]["hash_status"] == "ok"
+
+
+def test_paired_companion_archive_mutation_after_scan_reclassifies(
+        tmp_path, monkeypatch):
+    """The RAW+JPEG pair-merge in ``scanner.scan()`` deletes the JPEG's own
+    photo row. Before this fix, the import job's hash-stamping loop
+    accepted that as success without re-reading the archive JPEG. If the
+    archive JPEG gets rewritten or corrupted between promote and the
+    stamping check, ``safe_to_format`` could still go green over bytes we
+    never verified. Simulate archive-side mutation of the paired JPEG and
+    require the import to reclassify it to failed.
+    """
+    import scanner as scanner_mod
+    from import_job import ImportParams, run_import_job
+
+    # Card carries a RAW+JPEG pair sharing the base name. Same shape as
+    # ``test_working_copy_companion_fallback_reads_card_jpeg``: the "RAW"
+    # is opaque bytes with a .NEF extension (scanner sniffs by extension,
+    # not content), so scan()'s pair-merge deletes the JPEG's photo row
+    # and sets companion_path on the RAW primary.
+    card = tmp_path / "card"
+    card.mkdir()
+    Image.new("RGB", (16, 16), "red").save(str(card / "DSC_2000.jpg"))
+    raw_bytes = (card / "DSC_2000.jpg").read_bytes() + b"RAW-SENSOR-DATA"
+    (card / "DSC_2000.NEF").write_bytes(raw_bytes)
+    ts = datetime(2026, 7, 3, 10, 0, 0).timestamp()
+    for name in ("DSC_2000.jpg", "DSC_2000.NEF"):
+        os.utime(str(card / name), (ts, ts))
+    archive = tmp_path / "archive"
+
+    real_scan = scanner_mod.scan
+
+    def mutating_scan(root, db_arg, **kwargs):
+        result = real_scan(root, db_arg, **kwargs)
+        # AFTER cataloging + pairing but before import_job's hash-stamping
+        # loop runs, mutate the archive JPEG. If the fix works this
+        # forces the JPEG entry into ``failed``; without it, the JPEG's
+        # deleted-by-pair row makes the check silently pass.
+        for f in kwargs.get("restrict_files") or set():
+            if str(f).lower().endswith("dsc_2000.jpg") and os.path.exists(f):
+                with open(f, "r+b") as fh:
+                    fh.write(b"CORRUPT-MUTATION-POST-COPY")
+        return result
+
+    monkeypatch.setattr(scanner_mod, "scan", mutating_scan)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(sources=[str(card)], destination=str(archive)),
+    )
+
+    # The JPEG bytes on disk no longer match copy_and_hash_verify's
+    # verified hash — the import must NOT report safe.
+    assert result["safe_to_format"] is False
+    assert result["failed"] >= 1
+    # Terminal-bucket invariant still holds.
+    assert (
+        result["copied"]
+        + result["skipped_duplicate"]
+        + result["failed"]
+    ) == result["discovered"]
+    # The specific failure names the JPEG.
+    unsafe_paths = [u["path"] for u in result["unsafe_files"]]
+    assert any("DSC_2000.jpg" in p for p in unsafe_paths), unsafe_paths
+
+
+def test_non_empty_null_scan_hash_reclassifies_when_rehash_disagrees(
+        tmp_path, monkeypatch):
+    """When ``scanner.scan()`` writes a photo row for a non-empty file but
+    leaves ``file_hash`` NULL (its own hash read failed between promote
+    and scan), the import job must NOT stamp the copy-time hash and call
+    it verified. Re-hashing the archive path is the last check — if it
+    also disagrees (file mutated or unreadable), the entry must be
+    reclassified to failed. Simulate that shape and require the ledger
+    to bucket the file as failed rather than reporting safe.
+    """
+    import scanner as scanner_mod
+    from import_job import ImportParams, run_import_job
+
+    card = _make_card(tmp_path, [
+        ("DSC_3000.jpg", datetime(2026, 7, 3, 10, 0, 0), "purple"),
+    ])
+    archive = tmp_path / "archive"
+
+    real_scan = scanner_mod.scan
+
+    def sabotaging_scan(root, db_arg, **kwargs):
+        result = real_scan(root, db_arg, **kwargs)
+        # Wipe file_hash for freshly cataloged photos (simulating a
+        # scan-side hash-read failure that landed a NULL) AND mutate the
+        # archive so a re-hash also disagrees.
+        if kwargs.get("restrict_files"):
+            for f in kwargs["restrict_files"]:
+                if not os.path.exists(f):
+                    continue
+                with open(f, "r+b") as fh:
+                    fh.write(b"POST-SCAN-MUTATION-NULL-HASH")
+                db_arg.conn.execute(
+                    """UPDATE photos SET file_hash = NULL
+                       WHERE filename = ?""",
+                    (os.path.basename(f),),
+                )
+                db_arg.conn.commit()
+        return result
+
+    monkeypatch.setattr(scanner_mod, "scan", sabotaging_scan)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(sources=[str(card)], destination=str(archive)),
+    )
+
+    assert result["safe_to_format"] is False
+    assert result["failed"] == 1
+    assert result["copied"] == 0
+    assert (
+        result["copied"]
+        + result["skipped_duplicate"]
+        + result["failed"]
+    ) == result["discovered"]
+    unsafe_paths = [u["path"] for u in result["unsafe_files"]]
+    assert any("DSC_3000.jpg" in p for p in unsafe_paths), unsafe_paths

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -1228,6 +1228,141 @@ def test_custom_file_types_list_is_never_safe_to_format(tmp_path):
     assert result["safe_to_format"] is False
 
 
+def test_non_recursive_import_is_never_safe_to_format(tmp_path):
+    """``recursive=False`` only enumerates top-level files, so any card
+    with photos in subdirectories has files ``discovered`` never saw.
+    ``copied + skipped_duplicate == discovered`` would still pass and the
+    pill would tell the user it's safe to format a card that still holds
+    unimported photos in subfolders. See PR #1107 Codex review on commit
+    7dc0cce (import_job.py:1350).
+    """
+    from import_job import ImportParams
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+    ])
+    # A photo tucked in a subdirectory the non-recursive walk cannot see.
+    subdir = card / "subfolder"
+    subdir.mkdir()
+    Image.new("RGB", (16, 16), "blue").save(str(subdir / "DSC_0002.jpg"))
+    ts = datetime(2026, 7, 3, 11, 0, 0).timestamp()
+    os.utime(str(subdir / "DSC_0002.jpg"), (ts, ts))
+    archive = tmp_path / "archive"
+
+    db, ws_id, result = _run_import(tmp_path, ImportParams(
+        sources=[str(card)],
+        destination=str(archive),
+        recursive=False,
+    ))
+
+    # The top-level file copied cleanly, so the naive equality check
+    # (copied + skipped == discovered) would otherwise flip green.
+    assert result["copied"] == 1
+    assert result["failed"] == 0
+    assert result["discovered"] == 1
+    # But the non-recursive walk never saw ``subfolder/DSC_0002.jpg``;
+    # formatting the card would delete an unimported photo.
+    assert result["safe_to_format"] is False
+
+
+def test_deferred_extraction_skipped_when_already_cancelled(
+    tmp_path, monkeypatch,
+):
+    """If the run was cancelled at a batch boundary before the deferred
+    working-copy pass, don't spend minutes decoding RAWs the user has
+    already asked us to abort. The extractor must not be called at all,
+    and the returned status must remain ``cancelled``. See PR #1107
+    Codex review on commit 7dc0cce (import_job.py:1296).
+    """
+    import import_job
+    import scanner
+    from import_job import ImportParams
+
+    calls = []
+
+    def spy_extract(*args, **kwargs):
+        calls.append((args, kwargs))
+
+    monkeypatch.setattr(scanner, "_extract_working_copies", spy_extract)
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+    ])
+    archive = tmp_path / "archive"
+
+    runner = FakeRunner()
+    job = _make_job()
+    # Cancel before the run starts. The first batch-boundary check flips
+    # ``cancelled`` on, and the deferred pass must then be skipped.
+    runner.cancelled_ids.add(job["id"])
+
+    db, ws_id, result = _run_import(
+        tmp_path,
+        ImportParams(
+            sources=[str(card)],
+            destination=str(archive),
+            vireo_dir=str(tmp_path / "vireo_dir"),
+        ),
+        runner=runner,
+        job=job,
+    )
+
+    assert result["cancelled"] is True
+    assert result["safe_to_format"] is False
+    assert calls == [], (
+        "deferred _extract_working_copies must be skipped when cancelled"
+    )
+
+
+def test_deferred_extraction_threads_cancel_check(tmp_path, monkeypatch):
+    """When the deferred working-copy pass does run, it must receive a
+    ``cancel_check`` callable so a cancel issued mid-pass aborts the
+    per-row loop instead of decoding every RAW to completion. See PR
+    #1107 Codex review on commit 7dc0cce (import_job.py:1296).
+    """
+    import import_job
+    import scanner
+    from import_job import ImportParams
+
+    captured = {}
+
+    def spy_extract(*args, **kwargs):
+        captured["cancel_check"] = kwargs.get("cancel_check")
+        captured["source_paths"] = kwargs.get("source_paths")
+
+    monkeypatch.setattr(scanner, "_extract_working_copies", spy_extract)
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+    ])
+    archive = tmp_path / "archive"
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    _run_import(
+        tmp_path,
+        ImportParams(
+            sources=[str(card)],
+            destination=str(archive),
+            vireo_dir=str(tmp_path / "vireo_dir"),
+        ),
+        runner=runner,
+        job=job,
+    )
+
+    cancel_check = captured.get("cancel_check")
+    assert callable(cancel_check), (
+        "deferred pass must receive a cancel_check callable"
+    )
+    # Not cancelled yet → callable returns falsy.
+    assert not cancel_check()
+    # Once the runner records a cancel, the callable flips to truthy so
+    # ``_extract_working_copies`` bails out on the next row check.
+    runner.cancelled_ids.add(job["id"])
+    assert cancel_check()
+
+
 def test_wc_extraction_deferred_to_after_last_batch(tmp_path, monkeypatch):
     """A RAW+JPEG companion pair that straddles a batch boundary must not
     trigger per-batch working-copy extraction while the JPEG's row is

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -418,6 +418,63 @@ def test_stale_hash_row_with_modified_bytes_imports_as_fresh(tmp_path):
     assert result["safe_to_format"] is True
 
 
+def test_catalog_twin_under_source_root_does_not_prove_duplicate(tmp_path):
+    """A cataloged twin whose folder_path IS (or is under) an import
+    source is the card file being imported — the user previously scanned
+    the mounted card, so ``photos.file_hash`` matches the card's own
+    bytes. Re-hashing that "twin" just re-reads the source and proves
+    nothing about any archive copy; accepting it as duplicate proof would
+    flip ``safe_to_format`` green over a card whose bytes never made it
+    to the archive. The card must import fresh instead."""
+    from import_dedup import compute_file_hash
+    from import_job import ImportParams, run_import_job
+
+    # Card file whose bytes hash to a known value.
+    card = tmp_path / "card"
+    card.mkdir()
+    card_file = card / "IMG_0800.jpg"
+    Image.new("RGB", (16, 16), "purple").save(str(card_file))
+    ts = datetime(2026, 6, 3, 14, 0, 0).timestamp()
+    os.utime(str(card_file), (ts, ts))
+    card_hash = compute_file_hash(str(card_file))
+    card_size = os.path.getsize(str(card_file))
+
+    # Seed a stale catalog row whose folder_path IS the mounted card
+    # (a prior scan of the card left this behind). file_hash matches the
+    # card because it WAS computed by hashing the card file.
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'ok')",
+        (str(card), card.name),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, extension, file_size,"
+        " file_hash) VALUES (?, ?, '.jpg', ?, ?)",
+        (fid, "IMG_0800.jpg", card_size, card_hash),
+    )
+    db.conn.commit()
+
+    archive = tmp_path / "archive"
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(sources=[str(card)], destination=str(archive),
+                     verify_by_hash=True),
+    )
+
+    # Not skipped: the only "twin" is the card itself, and the card
+    # can't prove its own bytes safe.
+    assert result["skipped_duplicate"] == 0
+    assert result["copied"] == 1
+    dest = archive / "2026" / "2026-06-03" / "IMG_0800.jpg"
+    assert dest.exists()
+    assert compute_file_hash(str(dest)) == card_hash
+    # safe_to_format is true because the card's bytes verifiably landed
+    # at the archive — via a real copy, not via a stale card-side row.
+    assert result["safe_to_format"] is True
+
+
 def test_key_match_with_different_bytes_imports_as_distinct(tmp_path):
     """A metadata-only ("key") match against a cataloged twin whose bytes
     differ must NOT be skipped: the card's bytes were never verified

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -2849,3 +2849,98 @@ def test_import_invalidates_derived_caches_when_pre_row_had_null_hash(tmp_path):
     assert not fake_wc.exists(), (
         "NULL-hash pre-scan row must have its stale WC file unlinked"
     )
+
+
+def test_import_invalidates_raw_caches_when_new_jpeg_pairs(tmp_path):
+    """RAW+JPEG companion restore: when a freshly copied JPEG lands as
+    companion to an existing RAW row (pair-merge deletes the JPEG's own
+    row), the RAW row's derived caches may reflect the pre-pair state
+    (RAW-only preview, or a deleted/replaced prior companion). The
+    hash-stamping loop treats ``row is None`` as a fresh insert with no
+    diff to invalidate, so without an explicit companion-invalidation
+    pass the deferred WC pass skips the RAW (working_copy_path is set)
+    and the UI keeps serving stale derived files. See PR #1107 review.
+    """
+    from import_job import ImportParams, run_import_job
+
+    archive = tmp_path / "archive"
+    dest_dir = archive / "2026" / "2026-07-03"
+    dest_dir.mkdir(parents=True)
+
+    vireo_dir = tmp_path / "vireo_data"
+    (vireo_dir / "working").mkdir(parents=True)
+
+    # Pre-existing RAW file at the archive path, cataloged standalone
+    # with a stale working_copy_path from a prior RAW-only extraction.
+    raw_archive = dest_dir / "DSC_0800.NEF"
+    Image.new("RGB", (16, 16), "red").save(str(dest_dir / "_seed.jpg"))
+    raw_bytes = (dest_dir / "_seed.jpg").read_bytes() + b"RAW-SENSOR-DATA"
+    raw_archive.write_bytes(raw_bytes)
+    (dest_dir / "_seed.jpg").unlink()
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'ok')",
+        (str(dest_dir), dest_dir.name),
+    ).lastrowid
+    # WC file must live at working/{photo_id}.jpg — that's the layout
+    # _invalidate_derived_caches unlinks.
+    raw_photo_id = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, extension, file_size,"
+        " file_hash, working_copy_path) VALUES (?, ?, '.nef', ?, ?, 'placeholder')",
+        (fid, "DSC_0800.NEF", len(raw_bytes),
+         "deadbeef" * 8),
+    ).lastrowid
+    fake_wc = vireo_dir / "working" / f"{raw_photo_id}.jpg"
+    Image.new("RGB", (8, 8), "orange").save(str(fake_wc))
+    stale_wc_bytes = fake_wc.read_bytes()
+    db.conn.execute(
+        "UPDATE photos SET working_copy_path = ? WHERE id = ?",
+        (str(fake_wc), raw_photo_id),
+    )
+    db.conn.commit()
+
+    # Card holds a NEW JPEG that will land at DSC_0800.jpg and pair with
+    # the existing RAW during the batch scan.
+    card = _make_card(tmp_path, [
+        ("DSC_0800.jpg", datetime(2026, 7, 3, 10, 0, 0), "green"),
+    ])
+
+    result = run_import_job(_make_job(), FakeRunner(), db_path, ws_id,
+                            ImportParams(sources=[str(card)],
+                                         destination=str(archive),
+                                         skip_duplicates=False,
+                                         vireo_dir=str(vireo_dir)))
+    assert result["copied"] == 1
+    assert result["failed"] == 0
+
+    # The RAW row's stale WC path was cleared (invalidation ran) and
+    # the on-disk stale WC file was unlinked. The deferred end-of-run
+    # ``_extract_working_copies`` then either succeeds with a fresh WC
+    # (path differs from the stale one) or leaves working_copy_path
+    # NULL for the scanner's later backfill; either way the row no
+    # longer points at the pre-pair bytes.
+    row = db.conn.execute(
+        "SELECT working_copy_path, companion_path FROM photos WHERE id = ?",
+        (raw_photo_id,),
+    ).fetchone()
+    assert row["companion_path"] == "DSC_0800.jpg", (
+        "pair-merge must record the newly landed JPEG as the RAW's "
+        "companion_path"
+    )
+    # If invalidation didn't run the row would still point at the
+    # pre-pair WC path (which the extractor's candidate predicate would
+    # then skip, since working_copy_path is set). Invalidation resets
+    # the path, and the deferred WC pass rebuilds fresh: even when the
+    # extractor happens to reuse the same on-disk slot
+    # (``working/{id}.jpg``), the bytes at that path must differ from
+    # the stale orange placeholder we seeded, because the WC now comes
+    # from the just-verified companion JPEG.
+    if fake_wc.exists():
+        assert fake_wc.read_bytes() != stale_wc_bytes, (
+            "RAW's stale WC bytes must not survive the import — either "
+            "the file is unlinked or overwritten with a fresh WC from "
+            "the verified companion JPEG"
+        )

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -491,9 +491,9 @@ def test_intra_run_key_collision_across_cards_imports_second_as_fresh(tmp_path):
     check: the two files' bytes were never compared, so skipping would
     let safe_to_format go green while the second card is the only copy
     of its bytes."""
-    from PIL.ExifTags import Base as ExifBase
-    from import_job import ImportParams, run_import_job
     from import_dedup import compute_file_hash
+    from import_job import ImportParams, run_import_job
+    from PIL.ExifTags import Base as ExifBase
 
     dt = datetime(2026, 5, 2, 11, 20, 45)
 
@@ -551,9 +551,9 @@ def test_key_candidate_source_read_error_fails_only_that_file(
     error), that source alone is bucketed as failed. The failure must
     not escape and kill the whole background job — siblings still import
     normally, and the safe-to-format ledger records the failure."""
-    from PIL.ExifTags import Base as ExifBase
     import import_dedup
     from import_job import ImportParams, run_import_job
+    from PIL.ExifTags import Base as ExifBase
 
     dt_bad = datetime(2026, 5, 3, 12, 0, 0)
     dt_good = datetime(2026, 5, 3, 12, 5, 0)

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -3133,3 +3133,133 @@ def test_import_invalidates_raw_caches_when_new_jpeg_pairs(tmp_path):
             "the file is unlinked or overwritten with a fresh WC from "
             "the verified companion JPEG"
         )
+
+
+def test_key_duplicate_links_only_byte_verified_twin_folder(tmp_path):
+    """Metadata-only ('key') duplicate: ``_key_twin_rows`` returns every
+    catalog row sharing filename+size+capture-second, but only ONE of
+    them may hold the card's actual bytes. The others are key-collisions
+    with unrelated content (say, a burst frame with the same DateTime).
+
+    Only the twin whose bytes we hashed and matched is a proven
+    duplicate; linking the other key-collision folders would pull
+    unrelated archive photos into the active workspace on a
+    duplicate-only import. See PR #1107 review.
+    """
+    from import_job import ImportParams, run_import_job
+    from PIL.ExifTags import Base as ExifBase
+
+    dt = datetime(2026, 6, 15, 9, 45, 30)
+
+    # Card file: red bytes, EXIF-timed so the checker generates a
+    # trustworthy metadata key.
+    card = tmp_path / "card"
+    card.mkdir()
+    card_file = card / "IMG_1200.jpg"
+    img = Image.new("RGB", (16, 16), "red")
+    exif = img.getexif()
+    exif[ExifBase.DateTimeOriginal] = dt.strftime("%Y:%m:%d %H:%M:%S")
+    img.save(str(card_file), exif=exif)
+    card_bytes = card_file.read_bytes()
+
+    # Two archive folders both containing IMG_1200.jpg — same filename,
+    # same size, same trusted capture time — so both rows produce the
+    # same metadata key and both appear in ``_key_twin_rows``.
+    archive = tmp_path / "archive"
+    archive.mkdir()
+    verified_dir = archive / "verified-twin"
+    verified_dir.mkdir()
+    verified_file = verified_dir / "IMG_1200.jpg"
+    # Twin A: SAME bytes as card — the real duplicate.
+    verified_file.write_bytes(card_bytes)
+
+    collision_dir = archive / "key-collision"
+    collision_dir.mkdir()
+    collision_file = collision_dir / "IMG_1200.jpg"
+    # Twin B: same size, same key — DIFFERENT bytes.
+    collision_bytes = card_bytes[:-1] + bytes([card_bytes[-1] ^ 0xFF])
+    assert len(collision_bytes) == len(card_bytes)
+    assert collision_bytes != card_bytes
+    collision_file.write_bytes(collision_bytes)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    # Catalog both twins with file_hash=NULL — this forces
+    # DuplicateChecker to return a ('key', …) token (not 'hash') so
+    # we exercise the metadata-only branch. The timestamp is
+    # trustworthy so both rows produce a matching key.
+    for folder_dir, file_path in (
+        (verified_dir, verified_file),
+        (collision_dir, collision_file),
+    ):
+        fid = db.conn.execute(
+            "INSERT INTO folders (path, name, status) VALUES (?, ?, 'ok')",
+            (str(folder_dir), folder_dir.name),
+        ).lastrowid
+        db.conn.execute(
+            "INSERT INTO photos (folder_id, filename, extension, file_size,"
+            " timestamp) VALUES (?, ?, '.jpg', ?, ?)",
+            (
+                fid, "IMG_1200.jpg",
+                os.path.getsize(str(file_path)),
+                dt.strftime("%Y-%m-%dT%H:%M:%S"),
+            ),
+        )
+    db.conn.commit()
+
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id, ImportParams(
+            sources=[str(card)], destination=str(archive),
+        ),
+    )
+
+    # The card was byte-identical to the verified twin, so it's a
+    # legitimate skip.
+    assert result["copied"] == 0
+    assert result["skipped_duplicate"] == 1
+    assert result["failed"] == 0
+    assert result["safe_to_format"] is True
+
+    ws_folder_is_root = {
+        row["path"]: row["is_root"]
+        for row in db.conn.execute(
+            "SELECT f.path, wf.is_root FROM workspace_folders wf "
+            "JOIN folders f ON f.id = wf.folder_id "
+            "WHERE wf.workspace_id = ?",
+            (ws_id,),
+        )
+    }
+    # The byte-verified twin's folder is a user-facing workspace root
+    # (``is_root=1``) — the import proved the archive holds the card's
+    # bytes and links its folder into the workspace UI.
+    assert ws_folder_is_root.get(str(verified_dir)) == 1
+    # The key-collision folder was NEVER byte-verified against the
+    # card. Before the fix, it was passed to the duplicate-link scan
+    # as a restrict_dir and workspace-linked as its own top-level root
+    # (``is_root=1``), pulling an unrelated archive folder into the
+    # workspace UI. It must NOT surface as a workspace root here.
+    # (It may still appear with ``is_root=0`` via the destination
+    # cascade, which is a separate pre-existing behavior of
+    # ``add_workspace_folder``.)
+    assert ws_folder_is_root.get(str(collision_dir), 0) == 0
+
+    # Stronger: the collision folder was never scanned this run, so
+    # its pre-seeded row's ``file_hash`` is still NULL. Before the
+    # fix, the dup-link scan visited the collision folder and would
+    # have populated ``file_hash`` from its on-disk bytes.
+    photo_hashes = {
+        row["folder_path"]: row["file_hash"]
+        for row in db.conn.execute(
+            "SELECT p.file_hash, f.path AS folder_path "
+            "FROM photos p JOIN folders f ON f.id = p.folder_id"
+        )
+    }
+    assert photo_hashes.get(str(verified_dir)) is not None, (
+        "verified twin's folder WAS scanned — its file_hash must "
+        "be populated"
+    )
+    assert photo_hashes.get(str(collision_dir)) is None, (
+        "key-collision folder must NOT be scanned by a duplicate-"
+        "only import: its bytes were never proven to match the card"
+    )

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -1056,6 +1056,66 @@ def test_unreadable_source_subtree_flips_safe_to_format_off(
     )
 
 
+def test_nonexistent_source_root_flips_safe_to_format_off(tmp_path):
+    """If a requested source root cannot be positively walked at all
+    (unmounted removable media, permission denied on the root itself, or
+    a path that no longer exists between enqueue and worker start),
+    ``discover_source_files`` used to return ``[]`` at its pre-walk
+    ``is_dir()`` guard WITHOUT invoking the ``onerror`` collector. That
+    left ``discovered == 0`` and ``discovery_errors`` empty, so the
+    predicate reported ``safe_to_format: true`` even though no card
+    contents were ever enumerated — the UI would tell the user it's safe
+    to format a card whose contents were never verified. See PR #1107
+    review (P1 line 927).
+    """
+    from import_job import ImportParams
+
+    missing_card = tmp_path / "unmounted-card"
+    # Deliberately do NOT create the directory. This mirrors a card that
+    # was ejected between enqueue and the import worker starting.
+
+    db, ws_id, result = _run_import(tmp_path, ImportParams(
+        sources=[str(missing_card)],
+        destination=str(tmp_path / "archive"),
+    ))
+
+    assert result["discovered"] == 0
+    assert result["safe_to_format"] is False
+    assert result["ok"] is False
+    assert result["discovery_errors"] == 1
+    assert any(
+        "source enumeration failed" in e for e in result["errors"]
+    )
+    assert any(str(missing_card) in e for e in result["errors"])
+
+
+def test_excluded_bundle_source_root_flips_safe_to_format_off(tmp_path):
+    """Same guarantee for the excluded-bundle branch of the pre-walk
+    guard: if the caller pointed the import at a Photos-library-style
+    data bundle directly (or the root is otherwise refused), the run
+    must not silently report zero-files-imported-safe-to-format.
+    """
+    from import_job import ImportParams
+
+    bundle = tmp_path / "Photos Library.photoslibrary"
+    bundle.mkdir()
+    # A single file inside the bundle so a naive walk would find it —
+    # the guard must fire on the ROOT and refuse to enumerate it,
+    # bubbling that refusal as a discovery error.
+    (bundle / "originals").mkdir()
+    (bundle / "originals" / "managed.jpg").write_bytes(b"jpeg")
+
+    db, ws_id, result = _run_import(tmp_path, ImportParams(
+        sources=[str(bundle)],
+        destination=str(tmp_path / "archive"),
+    ))
+
+    assert result["discovered"] == 0
+    assert result["safe_to_format"] is False
+    assert result["ok"] is False
+    assert result["discovery_errors"] == 1
+
+
 def test_wc_extraction_deferred_to_after_last_batch(tmp_path, monkeypatch):
     """A RAW+JPEG companion pair that straddles a batch boundary must not
     trigger per-batch working-copy extraction while the JPEG's row is

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -2265,3 +2265,93 @@ def test_non_empty_null_scan_hash_reclassifies_when_rehash_disagrees(
     ) == result["discovered"]
     unsafe_paths = [u["path"] for u in result["unsafe_files"]]
     assert any("DSC_3000.jpg" in p for p in unsafe_paths), unsafe_paths
+
+
+def test_source_equals_dest_file_is_rejected(tmp_path):
+    """When a source lives under the destination and the folder template
+    maps it back to the same directory, dest_file resolves to the source
+    file itself. The adopt branch would hash the file against itself and
+    count it as ``skipped_duplicate`` with safe_to_format=True — then
+    formatting/erasing the source erases the only copy. The import job
+    must reject that overlap at the worker level (the API rejects
+    ``destination inside source`` but not the reverse). See PR #1107 review.
+    """
+    from import_job import ImportParams
+
+    # Source is /archive/2026/2026-07-05; destination is /archive with the
+    # default %Y/%Y-%m-%d template → dest_folder becomes 2026/2026-07-05,
+    # so dest_file IS the source file.
+    archive = tmp_path / "archive"
+    day = archive / "2026" / "2026-07-05"
+    day.mkdir(parents=True)
+    from PIL import Image
+    src_file = day / "DSC_4000.jpg"
+    Image.new("RGB", (16, 16), "coral").save(str(src_file))
+    ts = datetime(2026, 7, 5, 10, 0, 0).timestamp()
+    os.utime(str(src_file), (ts, ts))
+    original_bytes = src_file.read_bytes()
+
+    db, ws_id, result = _run_import(tmp_path, ImportParams(
+        sources=[str(day)], destination=str(archive),
+    ))
+
+    # The source bytes MUST still be on disk (nothing was moved/deleted).
+    assert src_file.exists()
+    assert src_file.read_bytes() == original_bytes
+    # It must NOT be counted as skipped_duplicate; it must be failed.
+    assert result["skipped_duplicate"] == 0
+    assert result["failed"] == 1
+    assert result["copied"] == 0
+    # Safe-to-format must NOT go green when the source == dest.
+    assert result["safe_to_format"] is False
+    assert (
+        result["copied"]
+        + result["skipped_duplicate"]
+        + result["failed"]
+    ) == result["discovered"]
+    # The failure specifically names the file.
+    unsafe_paths = [u["path"] for u in result["unsafe_files"]]
+    assert any("DSC_4000.jpg" in p for p in unsafe_paths), unsafe_paths
+
+
+def test_import_invalidates_new_images_cache(tmp_path):
+    """After per-batch and dup-link scans, run_import_job must invalidate
+    the /new-images cache for the touched destination folders. Otherwise
+    a workspace whose cache was warm before the import keeps reporting
+    the just-imported files as new until TTL expires or another full
+    scan runs. Mirrors the try/finally in api_job_scan / api_job_import_full
+    / pipeline_job. See PR #1107 review.
+    """
+    from import_job import ImportParams
+
+    card = _make_card(tmp_path, [
+        ("DSC_5000.jpg", datetime(2026, 7, 3, 10, 0, 0), "teal"),
+    ])
+    archive = tmp_path / "archive"
+
+    # Prime the cache with a sentinel value for the active workspace so
+    # we can observe invalidation without racing an actual /new-images
+    # walk. If run_import_job invalidates correctly, the sentinel is
+    # gone by the time the job returns.
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    db._new_images_cache.set(
+        db_path, ws_id, {"new_count": 999, "sample": []},
+    )
+    assert db._new_images_cache.get(db_path, ws_id) is not None
+
+    from import_job import run_import_job
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(sources=[str(card)], destination=str(archive)),
+    )
+    assert result["copied"] == 1  # sanity: the import actually ran
+
+    # The restricted scan invalidation must have cleared the sentinel for
+    # the workspace linked to the dest_folder.
+    assert db._new_images_cache.get(db_path, ws_id) is None, (
+        "run_import_job must invalidate the new-images cache for the "
+        "workspace linked to the destination folder after its restricted "
+        "scans (mirrors pipeline_job / api_job_scan / api_job_import_full)"
+    )

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -3295,3 +3295,50 @@ def test_import_photos_rejects_destination_inside_source(app_and_db, tmp_path):
         "sources": [card], "destination": sibling,
     })
     assert resp.status_code == 200, resp.get_json()
+
+
+def test_import_photos_inconclusive_case_probe_rejects_case_collision(
+    app_and_db, tmp_path,
+):
+    """When the case-sensitivity probe of a source cannot determine the
+    filesystem's semantics (no alpha-containing entry to swap — an SD
+    card whose root holds only numeric ``100``/``200``-style Nikon
+    subdirectories), the containment check must fall back to case-fold.
+
+    Otherwise, on a case-insensitive card mounted at ``/mnt/Card`` a
+    destination like ``/mnt/card/archive`` differs only in case and
+    resolves to the same directory as the source, but a case-sensitive
+    string comparison accepts it — and ``safe_to_format`` later goes
+    green even though formatting the card would erase the archive
+    copy. See PR #1107 review.
+    """
+    import sys as _sys
+
+    if _sys.platform in ("darwin", "win32"):
+        pytest.skip(
+            "Linux-only probe fallback: darwin/win32 skip the probe "
+            "entirely and always case-fold."
+        )
+
+    app, _ = app_and_db
+    client = app.test_client()
+
+    # Source has only numeric-named entries: the probe has no alpha
+    # character to case-swap, so it must return True (assume
+    # case-insensitive) — the stricter fallback.
+    source = tmp_path / "Card-BAR"
+    source.mkdir()
+    (source / "100").mkdir()
+    (source / "200").mkdir()
+
+    # Destination differs from the source parent only in case. On a
+    # real case-insensitive card these resolve to the same directory;
+    # the guard must reject the destination even though the CI
+    # filesystem (ext4) treats them as distinct.
+    dest = str(tmp_path / "card-bar" / "archive")
+
+    resp = client.post("/api/jobs/import-photos", json={
+        "sources": [str(source)], "destination": dest,
+    })
+    assert resp.status_code == 400
+    assert "inside a source" in resp.get_json()["error"]

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -3246,3 +3246,52 @@ def test_import_photos_validation_400s(app_and_db, tmp_path):
         "folder_template": "../escape",
     })
     assert resp.status_code == 400
+
+
+def test_import_photos_rejects_destination_inside_source(app_and_db, tmp_path):
+    """Destinations equal to or nested under any source path are rejected
+    at enqueue. Otherwise the importer copies card files into the same
+    tree it's importing, ``safe_to_format`` still flips green once
+    ``copied + skipped_duplicate == discovered``, and formatting the card
+    erases the supposed archive copy — silent data loss.
+    """
+    app, _ = app_and_db
+    client = app.test_client()
+    card = _import_card(tmp_path)
+
+    # Destination equal to source.
+    resp = client.post("/api/jobs/import-photos", json={
+        "sources": [card], "destination": card,
+    })
+    assert resp.status_code == 400
+    assert "inside a source" in resp.get_json()["error"]
+
+    # Destination nested under source.
+    nested = os.path.join(card, "archive")
+    resp = client.post("/api/jobs/import-photos", json={
+        "sources": [card], "destination": nested,
+    })
+    assert resp.status_code == 400
+    assert "inside a source" in resp.get_json()["error"]
+
+    # A symlink that resolves back inside the source must also be
+    # rejected — otherwise the rule is trivially bypassed.
+    symlinked_dest = tmp_path / "symlinked-archive"
+    try:
+        os.symlink(card, str(symlinked_dest))
+    except (OSError, NotImplementedError):
+        # Windows filesystems without symlink support: skip that leg.
+        pass
+    else:
+        resp = client.post("/api/jobs/import-photos", json={
+            "sources": [card], "destination": str(symlinked_dest),
+        })
+        assert resp.status_code == 400
+        assert "inside a source" in resp.get_json()["error"]
+
+    # A sibling destination NOT nested under the source is fine.
+    sibling = str(tmp_path / "archive")
+    resp = client.post("/api/jobs/import-photos", json={
+        "sources": [card], "destination": sibling,
+    })
+    assert resp.status_code == 200, resp.get_json()

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -3112,3 +3112,137 @@ def test_pipeline_folder_ids_treats_empty_sources_as_omitted(
             "folder_ids": [root_id], "strategy": "quick_look", **extra,
         })
         assert resp.status_code == 200, resp.get_json()
+
+
+# --- POST /api/jobs/import-photos (import job) ---------------------------
+
+def _import_card(tmp_path, names=("DSC_0001.jpg",)):
+    card = tmp_path / "import-card"
+    card.mkdir(exist_ok=True)
+    for name in names:
+        Image.new("RGB", (16, 16), "red").save(str(card / name))
+    return str(card)
+
+
+def test_lightroom_import_route_not_shadowed(app_and_db):
+    """POST /api/jobs/import (Lightroom catalogs) keeps its contract —
+    the photo import route is a NEW endpoint, not a rename."""
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post("/api/jobs/import", json={})
+    assert resp.status_code == 400
+    assert "catalogs" in resp.get_json()["error"]
+
+
+def test_import_photos_happy_path(app_and_db, tmp_path):
+    app, db = app_and_db
+    client = app.test_client()
+    card = _import_card(tmp_path)
+    dest = str(tmp_path / "archive")
+
+    resp = client.post("/api/jobs/import-photos", json={
+        "sources": [card],
+        "destination": dest,
+        "after_import": "cull_ready",
+    })
+    assert resp.status_code == 200, resp.get_json()
+    job_id = resp.get_json()["job_id"]
+    assert job_id.startswith("import-")
+
+    config = _job_config(client, job_id)
+    assert config["sources"] == [card]
+    assert config["destination"] == dest
+    assert config["folder_template"] == "%Y/%Y-%m-%d"
+    assert config["after_import"] == "cull_ready"
+
+    job = wait_for_job_via_client(client, job_id)
+    assert job["status"] == "completed", job
+    result = job["result"]
+    assert result["discovered"] == 1
+    assert result["copied"] == 1
+    assert result["safe_to_format"] is True
+
+
+def test_import_photos_null_after_import_is_import_only(app_and_db, tmp_path):
+    """after_import: null means import-only (PR 3's hook short-circuits) —
+    same nullable vocabulary as pipeline.default_strategy."""
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post("/api/jobs/import-photos", json={
+        "sources": [_import_card(tmp_path)],
+        "destination": str(tmp_path / "archive"),
+        "after_import": None,
+    })
+    assert resp.status_code == 200, resp.get_json()
+    config = _job_config(client, resp.get_json()["job_id"])
+    assert config["after_import"] is None
+
+
+@pytest.mark.parametrize("bad", ["yolo", "none"])
+def test_import_photos_invalid_after_import_400(app_and_db, tmp_path, bad):
+    """Invalid strategy names fail at enqueue, not at completion — failing
+    the chain hours later is the old pipeline's mistake."""
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post("/api/jobs/import-photos", json={
+        "sources": [_import_card(tmp_path)],
+        "destination": str(tmp_path / "archive"),
+        "after_import": bad,
+    })
+    assert resp.status_code == 400
+    assert "unknown strategy" in resp.get_json()["error"]
+
+
+def test_import_photos_after_import_defaults_from_workspace(
+        app_and_db, tmp_path):
+    app, db = app_and_db
+    client = app.test_client()
+    ws_id = db._active_workspace_id
+    db.update_workspace(ws_id, config_overrides={
+        "pipeline": {"default_strategy": "cull_ready"},
+    })
+    resp = client.post("/api/jobs/import-photos", json={
+        "sources": [_import_card(tmp_path)],
+        "destination": str(tmp_path / "archive"),
+    })
+    assert resp.status_code == 200, resp.get_json()
+    config = _job_config(client, resp.get_json()["job_id"])
+    assert config["after_import"] == "cull_ready"
+
+
+def test_import_photos_validation_400s(app_and_db, tmp_path):
+    app, _ = app_and_db
+    client = app.test_client()
+    card = _import_card(tmp_path)
+    dest = str(tmp_path / "archive")
+
+    # Missing sources.
+    resp = client.post("/api/jobs/import-photos", json={"destination": dest})
+    assert resp.status_code == 400
+    # Missing destination.
+    resp = client.post("/api/jobs/import-photos", json={"sources": [card]})
+    assert resp.status_code == 400
+    # Relative destination.
+    resp = client.post("/api/jobs/import-photos", json={
+        "sources": [card], "destination": "relative/archive",
+    })
+    assert resp.status_code == 400
+    # Nonexistent source directory.
+    resp = client.post("/api/jobs/import-photos", json={
+        "sources": [str(tmp_path / "nope")], "destination": dest,
+    })
+    assert resp.status_code == 400
+    # macOS app-managed library as source (pre-stat rejection).
+    bundle = tmp_path / "Photos Library.photoslibrary"
+    bundle.mkdir()
+    resp = client.post("/api/jobs/import-photos", json={
+        "sources": [str(bundle)], "destination": dest,
+    })
+    assert resp.status_code == 400
+    assert "macos" in resp.get_json()["error"].lower()
+    # Unsafe folder template.
+    resp = client.post("/api/jobs/import-photos", json={
+        "sources": [card], "destination": dest,
+        "folder_template": "../escape",
+    })
+    assert resp.status_code == 400

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -3537,10 +3537,18 @@ def test_restricted_scan_roots_subfolders_not_destination_base(tmp_path):
 
     root_paths = [f["path"] for f in db.get_workspace_folder_roots(ws_id)]
     linked_paths = {f["path"] for f in db.get_workspace_folders(ws_id)}
-    # The imported leaf is the user-facing root; the archive base is linked
-    # (for the folder hierarchy) but is NOT a root.
+    # The imported leaf is the user-facing root; the archive base is
+    # NOT linked to the workspace. Before PR #1107's line-1186 fix the
+    # base was linked as a non-root, which fired ``add_workspace_
+    # folder``'s subtree cascade and would pull every pre-existing
+    # cataloged descendant of the base into the workspace UI (unrelated
+    # archive subtrees from prior scans / other workspaces). Now the
+    # parent chain up to the scan root just exists in ``folders`` for
+    # ``parent_id`` integrity, and ``get_folder_tree`` walks up through
+    # the non-visible base via its recursive CTE so the imported leaf
+    # still renders as a top-level sidebar entry.
     assert root_paths == [imported]
-    assert base in linked_paths
+    assert base not in linked_paths
     # Ingestion stayed scoped to the restricted dir — the sibling shoot's
     # files were never pulled in.
     photo_paths = {


### PR DESCRIPTION
## What

Phase 2 of the import/process split (design #1101, parent plan #1102, PR 1 #1103, phase plan #1105): a first-class **import job** that copies card → archive directly (no staging), hash-verifies every file, and catalogs photos at their final paths **incrementally** — folders appear in the workspace during the import, and a dead run leaves a valid partial catalog that a retry resumes instead of redoing.

This is the fix for the 2026-07-03/04 failure mode: three pipeline runs copied and processed ~2,000 photos each, the archive rsync stalled, `_deindex_staging()` threw away all catalog state each time, and every retry re-staged 45 GB and redid ~6 h of GPU work while the user saw nothing appear. The new import path has **no unwind step at all** — the core invariant (*a photo row is created only when its file verifiably exists at its final archive path*) makes deindexing structurally unnecessary.

- **`vireo/import_job.py`** (new)
  - `copy_and_hash_verify()` — temp-file copy + SHA-256 read-back verify + atomic promote; a corrupt copy never touches an existing archive file (Task 2.1).
  - `run_import_job()` — per-destination-folder batches (≤200 files): dedup gate → copy+verify → restricted `scan()` → hash stamping (`hash_status='ok'`, cross-checked against scan's own hash), committed per batch so cancel/crash/yanked-card all leave a valid catalog (Task 2.2).
  - Safe-to-format ledger: every discovered file ends in exactly one terminal bucket (`verified_fresh` / `verified_duplicate` / `failed`). **Metadata-only ("key") duplicate matches are never trusted**: the card file and its cataloged twin are re-hashed; differing bytes import as a distinct photo (the plan review's P1) (Task 2.3).
  - Working copies extract from the **card** (fast local bytes), never re-reading the just-written archive copy — via a new `source_paths` override on `scanner._extract_working_copies`, so RAW-decode-first / companion-fallback / undersized-preview / failure-marker logic is reused, not duplicated (Task 2.5).
- **`POST /api/jobs/import-photos`** — job type `import`, no pipeline-slot coupling. `after_import` validated at enqueue (nullable, same vocabulary as `pipeline.default_strategy`, defaulting from the workspace override when omitted) and stored in job config for PR 3's chaining hook. The Lightroom `POST /api/jobs/import` route is untouched (Task 2.4).
- Interruption/resume contract tests: cancel mid-run → valid partial catalog, zero deletions; re-run → skips exactly what landed (`copied + skipped_duplicate == discovered`); crash-shaped copies (on disk, no rows) are adopted without numeric-suffix duplicates (Task 2.6).

## Deviations from the plan (documented in the module docstring)

- Duplicate-matched folders are scanned in a **separate** `scan(restrict_dirs=…)` call without `restrict_files`: `_ensure_folder` only fires for discovered files, so the plan's single-call phrasing would link nothing for duplicate-only imports (its own Task 2.2 test catches this).
- Key-match byte verification lives in the Task 2.2 loop (correctness requires it from the start); Task 2.3 added the ledger + pinning tests.
- Hash stamping recognizes RAW+JPEG companions (pairing deletes the JPEG's row by design — that's a success, not "not cataloged").
- Result carries `ok`/`errors` so JobRunner's mixed-outcome convention records any failed file as a failed job.
- **Task 2.7 (SSH remote destinations) deferred to its own PR**, per the plan's explicit separability note. SMB/NFS-mounted NAS destinations (the real current workflow — `/Volumes/Photography`) work through the local path with full hash verification reading back through the mount.

## Tests

Full plan suite: `tests/test_workspaces.py vireo/tests/{test_db,test_app,test_photos_api,test_edits_api,test_jobs_api,test_darktable_api,test_config,test_process_strategies,test_pipeline_job,test_import_job,test_ingest,test_import_dedup,test_scanner}.py`

**1742 passed, 1 skipped, 0 failed** (including 14 new tests in `test_import_job.py` and 7 in `test_jobs_api.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `POST /api/jobs/import-photos` to enqueue folder-based photo imports with destination folder templating, configurable file types, duplicate handling, and optional post-import strategy. Returns a job id and import status.

* **Bug Fixes**
  * Strengthened request validation (including macOS Photos-library exclusions, safer folder template checking, and destination containment rules) and improved integrity/duplicate verification plus safe-to-format state handling.
  * Improved working-copy extraction reliability via verified card-side overrides, companion fallback behavior, and deferred extraction after batch boundaries.

* **Tests**
  * Added end-to-end and unit regression coverage for import hashing, duplicate logic, cancellation/resume, API validation, and extraction/pairing edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->