### PR TITLE
Fix standalone scan cancellation

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -12499,6 +12499,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 runner.update_step(job["id"], "scan", current_file=message)
                 runner.push_event(job["id"], "progress", progress_payload)
 
+            def cancel_check():
+                return runner.is_cancelled(job["id"])
+
             vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
 
             # Per-root failures are caught and recorded rather than
@@ -12516,7 +12519,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             root_errors = []
             scan_failed_roots = set()
             cache_failed_roots = set()
+            cancelled = False
             for idx, root in enumerate(roots_list, 1):
+                if cancel_check():
+                    cancelled = True
+                    break
                 phase = (
                     f"Scanning root {idx} of {len(roots_list)}: {root}"
                     if len(roots_list) > 1
@@ -12538,8 +12545,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         status_callback=status_cb,
                         vireo_dir=vireo_dir,
                         thumb_cache_dir=app.config["THUMB_CACHE_DIR"],
+                        cancel_check=cancel_check,
                     )
                 except Exception as exc:
+                    if str(exc) == "scan cancelled" and cancel_check():
+                        log.info("Scan job %s cancelled during root %s", job["id"], root)
+                        cancelled = True
+                        break
                     log.exception("Scan failed for root %s", root)
                     scan_failed_roots.add(root)
                     msg = f"[{root}] {exc}"
@@ -12572,6 +12584,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         if cache_msg not in job["errors"]:
                             job["errors"].append(cache_msg)
                     advance_scan_acc()
+
+            if cancelled or cancel_check():
+                photo_count = job["progress"].get("current", 0)
+                runner.update_step(
+                    job["id"], "scan", status="cancelled",
+                    summary=f"{photo_count} photos (cancelled)",
+                )
+                runner.update_step(
+                    job["id"], "thumbnails", status="skipped",
+                    summary="skipped (cancelled)",
+                )
+                return {"photos_indexed": photo_count, "cancelled": True}
 
             # Use cumulative processed count, not planned total — on a
             # clean run they're equal; on mixed-outcome runs "current"

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -12423,6 +12423,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             roots_list = list(roots)
 
         def work(job):
+            from scanner import ScanCancelled
             from scanner import scan as do_scan
 
             thread_db = Database(db_path)
@@ -12548,7 +12549,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         cancel_check=cancel_check,
                     )
                 except Exception as exc:
-                    if str(exc) == "scan cancelled" and cancel_check():
+                    if isinstance(exc, ScanCancelled) and cancel_check():
                         log.info("Scan job %s cancelled during root %s", job["id"], root)
                         cancelled = True
                         break

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -953,6 +953,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
             thread_db = None
             try:
                 import config as cfg
+                from scanner import ScanCancelled
                 from scanner import scan as do_scan
 
                 thread_db = Database(db_path)
@@ -1107,7 +1108,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 cancel_check=cancel_check,
                             )
                         except (OSError, RuntimeError) as e:
-                            if str(e) == "scan cancelled" and (
+                            if isinstance(e, ScanCancelled) and (
                                 _should_abort(abort) or runner.is_cancelled(job["id"])
                             ):
                                 abort.set()
@@ -2040,7 +2041,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     runner.update_step(job["id"], "scan", status="completed",
                                        summary=scan_summary)
             except Exception as e:
-                if str(e) == "scan cancelled" and (
+                if isinstance(e, ScanCancelled) and (
                     _should_abort(abort) or runner.is_cancelled(job["id"])
                 ):
                     abort.set()

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -33,6 +33,11 @@ from xmp import read_hierarchical_keywords, read_keywords
 log = logging.getLogger(__name__)
 EMPTY_FILE_SHA256 = hashlib.sha256(b"").hexdigest()
 
+
+class ScanCancelled(RuntimeError):
+    """Raised when a caller cancels scanner.scan via cancel_check."""
+
+
 # scan() runs inside JobRunner/pipeline_job background threads, so the
 # default POSIX "fork" start method is unsafe here: forking a
 # multithreaded process can deadlock. In a PyInstaller bundle, forkserver
@@ -1124,7 +1129,7 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
             — a "Found 0 images" black box from the user's perspective.
         cancel_check: optional callable returning truthy when the caller
             wants scanning to stop promptly. When set, scan raises
-            RuntimeError("scan cancelled") at cancellation checkpoints.
+            ScanCancelled at cancellation checkpoints.
     """
     root_path = Path(root)
     # Don't open the root at all if the root is, or sits inside, an
@@ -1149,7 +1154,7 @@ def scan(root, db, progress_callback=None, incremental=False, extract_full_metad
 
     def _check_cancelled():
         if cancel_check is not None and cancel_check():
-            raise RuntimeError("scan cancelled")
+            raise ScanCancelled("scan cancelled")
 
     def _emit_status(message, phase_current=None, phase_total=None, phase_label=None):
         if not status_callback:

--- a/vireo/tests/test_multi_root_scan.py
+++ b/vireo/tests/test_multi_root_scan.py
@@ -6,6 +6,7 @@ for the SQLite writer lock), a single scan job now iterates roots
 serially so there is no contention in the first place.
 """
 import os
+import threading
 import time
 
 import pytest
@@ -128,6 +129,59 @@ def test_scan_continues_after_one_root_fails(app_and_db, tmp_path, monkeypatch):
     )
     # And errors carry the failure context.
     assert any("bad" in e or "simulated failure" in e for e in data["errors"]), data
+
+
+def test_scan_job_cancel_is_forwarded_to_scanner(app_and_db, tmp_path, monkeypatch):
+    """Cancelling a standalone scan job must interrupt scanner.scan itself."""
+    app, _ = app_and_db
+    client = app.test_client()
+
+    root_a = str(tmp_path / "a")
+    root_b = str(tmp_path / "b")
+    _make_photo(root_a, "a.jpg")
+    _make_photo(root_b, "b.jpg")
+
+    scan_started = threading.Event()
+    scanned_roots = []
+
+    def cancellable_scan(root, db, *args, cancel_check=None, **kwargs):
+        scanned_roots.append(root)
+        assert callable(cancel_check), "scan job did not pass cancel_check"
+        scan_started.set()
+        deadline = time.time() + 5.0
+        while time.time() < deadline:
+            if cancel_check():
+                raise RuntimeError("scan cancelled")
+            time.sleep(0.02)
+        raise AssertionError("scanner.scan never observed cancellation")
+
+    monkeypatch.setattr("scanner.scan", cancellable_scan)
+
+    generate_calls = {"n": 0}
+
+    def tracking_generate_all(*args, **kwargs):
+        generate_calls["n"] += 1
+        return {"generated": 0, "skipped": 0, "errors": []}
+
+    monkeypatch.setattr("thumbnails.generate_all", tracking_generate_all)
+
+    resp = client.post("/api/jobs/scan", json={"roots": [root_a, root_b]})
+    assert resp.status_code == 200, resp.get_json()
+    job_id = resp.get_json()["job_id"]
+    assert scan_started.wait(timeout=2.0), "scan job did not start"
+
+    cancel_resp = client.post(f"/api/jobs/{job_id}/cancel")
+    assert cancel_resp.status_code == 200, cancel_resp.get_json()
+
+    data = _wait_for_terminal(client, job_id)
+    assert data["status"] == "cancelled", data
+    assert scanned_roots == [root_a]
+    assert generate_calls["n"] == 0
+
+    scan_step = next(s for s in data["steps"] if s["id"] == "scan")
+    thumb_step = next(s for s in data["steps"] if s["id"] == "thumbnails")
+    assert scan_step["status"] == "cancelled", scan_step
+    assert thumb_step["status"] == "skipped", thumb_step
 
 
 def test_single_root_string_still_works(app_and_db, tmp_path):

--- a/vireo/tests/test_multi_root_scan.py
+++ b/vireo/tests/test_multi_root_scan.py
@@ -143,6 +143,7 @@ def test_scan_job_cancel_is_forwarded_to_scanner(app_and_db, tmp_path, monkeypat
 
     scan_started = threading.Event()
     scanned_roots = []
+    from scanner import ScanCancelled
 
     def cancellable_scan(root, db, *args, cancel_check=None, **kwargs):
         scanned_roots.append(root)
@@ -151,7 +152,7 @@ def test_scan_job_cancel_is_forwarded_to_scanner(app_and_db, tmp_path, monkeypat
         deadline = time.time() + 5.0
         while time.time() < deadline:
             if cancel_check():
-                raise RuntimeError("scan cancelled")
+                raise ScanCancelled("scan cancelled")
             time.sleep(0.02)
         raise AssertionError("scanner.scan never observed cancellation")
 


### PR DESCRIPTION
## Summary
Fixes standalone scan jobs so cancel requests are forwarded into scanner.scan through cancel_check. When scanner.scan raises its cancellation sentinel, the scan job now exits as cancelled, stops before later roots, and skips thumbnail generation instead of treating the cancel as a root failure.

## Validation
- pytest -q vireo/tests/test_multi_root_scan.py
- pytest -q vireo/tests/test_jobs_api.py::test_job_cancel_running_job_marks_cancelled vireo/tests/test_scanner.py::test_scan_cancel_check_aborts_before_discovery vireo/tests/test_scanner.py::test_scan_cancel_check_aborts_before_metadata_extraction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job cancellation during multi-root scans.
  * Scans now stop promptly when cancelled, rather than continuing through remaining roots.
  * Cancelled jobs now report clearer progress: the scan step is marked cancelled, thumbnail generation is skipped, and the job returns a cancelled result with the number of photos already indexed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->