### PR TITLE
Add flexible life list export

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -6716,9 +6716,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def _build_life_list_payload(db, photos_per_species=12):
         rows = db.get_life_list_candidates()
         locations_by_species = db.get_life_list_locations()
-        photos_per_species = max(
-            1, min(int(photos_per_species), 100)
-        )
+        if photos_per_species is None:
+            photo_limit = None
+        else:
+            photo_limit = max(
+                1, min(int(photos_per_species), 100)
+            )
 
         buckets = {}
         for row in rows:
@@ -6785,7 +6788,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             preferred_applied = _apply_preferred_photo(
                 photos, preferred_id, "is_life_list_photo"
             )
-            top = photos[:photos_per_species]
+            top = photos if photo_limit is None else photos[:photo_limit]
             species_entries.append({
                 "species": species,
                 "scientific_name": entry["scientific_name"],
@@ -6822,7 +6825,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "meta": {
                 "species_count": len(species_entries),
                 "photo_count": len(distinct_photo_ids),
-                "photos_per_species": photos_per_species,
+                "photos_per_species": photo_limit,
             },
         }
 
@@ -6962,10 +6965,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         lines = []
         for entry in payload.get("species", []):
             for photo in _life_list_export_photos(entry, photo_mode):
-                filename = photo.get("filename")
-                if not filename or filename in seen:
+                photo_id = photo.get("id")
+                if photo_id in seen:
                     continue
-                seen.add(filename)
+                seen.add(photo_id)
+                filename = photo.get("filename")
+                if not filename:
+                    continue
                 lines.append(filename)
         return "\n".join(lines) + ("\n" if lines else "")
 
@@ -6985,9 +6991,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("photos must be best or all")
 
         db = _get_db()
+        payload_photos_per_species = (
+            None if photo_mode == "all"
+            else request.args.get("photos_per_species", 12, type=int)
+        )
         payload = _build_life_list_payload(
             db,
-            photos_per_species=request.args.get("photos_per_species", 12, type=int),
+            photos_per_species=payload_photos_per_species,
         )
         if not _life_list_export_bool_arg("include_locations"):
             _strip_life_list_locations(payload)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -6991,8 +6991,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("photos must be best or all")
 
         db = _get_db()
+        uses_photo_scope = fmt == "files" or (fmt == "csv" and detail == "photos")
         payload_photos_per_species = (
-            None if photo_mode == "all"
+            None if uses_photo_scope and photo_mode == "all"
             else request.args.get("photos_per_species", 12, type=int)
         )
         payload = _build_life_list_payload(

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -7,6 +7,8 @@ Usage:
 import argparse
 import contextlib
 import copy
+import csv
+import io
 import json
 import logging
 import logging.handlers
@@ -6832,6 +6834,185 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             photos_per_species=request.args.get("photos_per_species", 12, type=int),
         )
         return jsonify(payload)
+
+    _LIFE_LIST_EXPORT_FORMATS = {
+        "json": "json",
+        "csv": "csv",
+        "txt": "txt",
+        "text": "txt",
+        "file": "files",
+        "files": "files",
+        "filenames": "files",
+        "file-list": "files",
+    }
+
+    def _life_list_export_bool_arg(name, default=False):
+        raw = request.args.get(name)
+        if raw is None:
+            return default
+        return str(raw).strip().lower() in {"1", "true", "yes", "on"}
+
+    def _strip_life_list_locations(payload):
+        for entry in payload.get("species", []):
+            entry["locations"] = []
+
+    def _life_list_export_photos(entry, mode):
+        if mode == "all":
+            return entry.get("photos") or []
+        best = entry.get("best")
+        return [best] if best else []
+
+    def _life_list_export_response(body, mimetype, extension):
+        today = datetime.now(UTC).date().isoformat()
+        resp = make_response(body)
+        resp.headers["Content-Type"] = mimetype
+        resp.headers["Content-Disposition"] = (
+            f'attachment; filename="vireo-life-list-{today}.{extension}"'
+        )
+        return resp
+
+    def _life_list_species_csv(payload):
+        out = io.StringIO()
+        fieldnames = [
+            "number",
+            "species",
+            "scientific_name",
+            "common_name",
+            "photo_count",
+            "first_seen",
+            "last_seen",
+            "locations",
+            "best_photo_id",
+            "best_filename",
+        ]
+        writer = csv.DictWriter(out, fieldnames=fieldnames)
+        writer.writeheader()
+        for entry in payload.get("species", []):
+            best = entry.get("best") or {}
+            writer.writerow({
+                "number": entry.get("number") or "",
+                "species": entry.get("species") or "",
+                "scientific_name": entry.get("scientific_name") or "",
+                "common_name": entry.get("common_name") or "",
+                "photo_count": entry.get("photo_count") or 0,
+                "first_seen": entry.get("first_seen") or "",
+                "last_seen": entry.get("last_seen") or "",
+                "locations": "; ".join(entry.get("locations") or []),
+                "best_photo_id": best.get("id") or "",
+                "best_filename": best.get("filename") or "",
+            })
+        return out.getvalue()
+
+    def _life_list_photos_csv(payload, photo_mode):
+        out = io.StringIO()
+        fieldnames = [
+            "number",
+            "species",
+            "scientific_name",
+            "common_name",
+            "photo_id",
+            "filename",
+            "timestamp",
+            "is_life_list_photo",
+            "quality_score",
+            "locations",
+        ]
+        writer = csv.DictWriter(out, fieldnames=fieldnames)
+        writer.writeheader()
+        for entry in payload.get("species", []):
+            for photo in _life_list_export_photos(entry, photo_mode):
+                writer.writerow({
+                    "number": entry.get("number") or "",
+                    "species": entry.get("species") or "",
+                    "scientific_name": entry.get("scientific_name") or "",
+                    "common_name": entry.get("common_name") or "",
+                    "photo_id": photo.get("id") or "",
+                    "filename": photo.get("filename") or "",
+                    "timestamp": photo.get("timestamp") or "",
+                    "is_life_list_photo": "yes" if photo.get("is_life_list_photo") else "no",
+                    "quality_score": photo.get("quality_score")
+                    if photo.get("quality_score") is not None else "",
+                    "locations": "; ".join(entry.get("locations") or []),
+                })
+        return out.getvalue()
+
+    def _life_list_text(payload):
+        lines = []
+        for entry in payload.get("species", []):
+            name = entry.get("species") or ""
+            sci = entry.get("scientific_name")
+            if sci and sci != name:
+                name = f"{name} ({sci})"
+            parts = [
+                f"#{entry.get('number') or ''} {name}".strip(),
+                f"{entry.get('photo_count') or 0} photo"
+                + ("" if entry.get("photo_count") == 1 else "s"),
+            ]
+            if entry.get("first_seen"):
+                parts.append(f"first seen {entry['first_seen']}")
+            if entry.get("last_seen") and entry.get("last_seen") != entry.get("first_seen"):
+                parts.append(f"latest {entry['last_seen']}")
+            if entry.get("locations"):
+                parts.append("locations: " + "; ".join(entry["locations"]))
+            lines.append(" - ".join(parts))
+        return "\n".join(lines) + ("\n" if lines else "")
+
+    def _life_list_file_list(payload, photo_mode):
+        seen = set()
+        lines = []
+        for entry in payload.get("species", []):
+            for photo in _life_list_export_photos(entry, photo_mode):
+                filename = photo.get("filename")
+                if not filename or filename in seen:
+                    continue
+                seen.add(filename)
+                lines.append(filename)
+        return "\n".join(lines) + ("\n" if lines else "")
+
+    @app.route("/api/life-list/export")
+    def api_life_list_export():
+        fmt = (request.args.get("format") or "json").strip().lower()
+        fmt = _LIFE_LIST_EXPORT_FORMATS.get(fmt)
+        if not fmt:
+            return json_error("format must be json, csv, txt, or files")
+
+        detail = (request.args.get("detail") or "species").strip().lower()
+        if detail not in {"species", "photos"}:
+            return json_error("detail must be species or photos")
+
+        photo_mode = (request.args.get("photos") or "best").strip().lower()
+        if photo_mode not in {"best", "all"}:
+            return json_error("photos must be best or all")
+
+        db = _get_db()
+        payload = _build_life_list_payload(
+            db,
+            photos_per_species=request.args.get("photos_per_species", 12, type=int),
+        )
+        if not _life_list_export_bool_arg("include_locations"):
+            _strip_life_list_locations(payload)
+
+        if fmt == "json":
+            body = json.dumps(payload, indent=2, ensure_ascii=False) + "\n"
+            return _life_list_export_response(body, "application/json", "json")
+        if fmt == "csv":
+            body = (
+                _life_list_photos_csv(payload, photo_mode)
+                if detail == "photos"
+                else _life_list_species_csv(payload)
+            )
+            return _life_list_export_response(body, "text/csv; charset=utf-8", "csv")
+        if fmt == "files":
+            return _life_list_export_response(
+                _life_list_file_list(payload, photo_mode),
+                "text/plain; charset=utf-8",
+                "txt",
+            )
+        return _life_list_export_response(
+            _life_list_text(payload),
+            "text/plain; charset=utf-8",
+            "txt",
+        )
 
     @app.route("/api/highlights/confirm", methods=["POST"])
     def api_highlights_confirm():

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -6874,6 +6874,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         )
         return resp
 
+    def _life_list_csv_cell(value):
+        if value is None:
+            return ""
+        text = str(value)
+        stripped = text.lstrip(" \t\r\n")
+        if stripped[:1] in {"=", "+", "-", "@"}:
+            return "'" + text
+        return text
+
     def _life_list_species_csv(payload):
         out = io.StringIO()
         fieldnames = [
@@ -6894,15 +6903,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             best = entry.get("best") or {}
             writer.writerow({
                 "number": entry.get("number") or "",
-                "species": entry.get("species") or "",
-                "scientific_name": entry.get("scientific_name") or "",
-                "common_name": entry.get("common_name") or "",
+                "species": _life_list_csv_cell(entry.get("species")),
+                "scientific_name": _life_list_csv_cell(entry.get("scientific_name")),
+                "common_name": _life_list_csv_cell(entry.get("common_name")),
                 "photo_count": entry.get("photo_count") or 0,
-                "first_seen": entry.get("first_seen") or "",
-                "last_seen": entry.get("last_seen") or "",
-                "locations": "; ".join(entry.get("locations") or []),
+                "first_seen": _life_list_csv_cell(entry.get("first_seen")),
+                "last_seen": _life_list_csv_cell(entry.get("last_seen")),
+                "locations": _life_list_csv_cell(
+                    "; ".join(entry.get("locations") or [])
+                ),
                 "best_photo_id": best.get("id") or "",
-                "best_filename": best.get("filename") or "",
+                "best_filename": _life_list_csv_cell(best.get("filename")),
             })
         return out.getvalue()
 
@@ -6926,16 +6937,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             for photo in _life_list_export_photos(entry, photo_mode):
                 writer.writerow({
                     "number": entry.get("number") or "",
-                    "species": entry.get("species") or "",
-                    "scientific_name": entry.get("scientific_name") or "",
-                    "common_name": entry.get("common_name") or "",
+                    "species": _life_list_csv_cell(entry.get("species")),
+                    "scientific_name": _life_list_csv_cell(entry.get("scientific_name")),
+                    "common_name": _life_list_csv_cell(entry.get("common_name")),
                     "photo_id": photo.get("id") or "",
-                    "filename": photo.get("filename") or "",
-                    "timestamp": photo.get("timestamp") or "",
+                    "filename": _life_list_csv_cell(photo.get("filename")),
+                    "timestamp": _life_list_csv_cell(photo.get("timestamp")),
                     "is_life_list_photo": "yes" if photo.get("is_life_list_photo") else "no",
                     "quality_score": photo.get("quality_score")
                     if photo.get("quality_score") is not None else "",
-                    "locations": "; ".join(entry.get("locations") or []),
+                    "locations": _life_list_csv_cell(
+                        "; ".join(entry.get("locations") or [])
+                    ),
                 })
         return out.getvalue()
 

--- a/vireo/templates/life_list.html
+++ b/vireo/templates/life_list.html
@@ -13,12 +13,18 @@
   .control-group label { font-size:13px; color:var(--text-secondary); white-space:nowrap; }
   .control-group input[type=search], .control-group select { font-size:13px; padding:4px 8px; background:var(--bg-input); color:var(--text-primary); border:1px solid var(--border-secondary); border-radius:4px; }
   .control-group input[type=search] { width:180px; }
-  .publish-btn { margin-left:auto; border:1px solid var(--accent); background:transparent; color:var(--accent); border-radius:4px; padding:5px 10px; font-size:12px; cursor:pointer; }
+  .lifelist-actions { margin-left:auto; display:flex; gap:8px; align-items:center; }
+  .publish-btn { border:1px solid var(--accent); background:transparent; color:var(--accent); border-radius:4px; padding:5px 10px; font-size:12px; cursor:pointer; }
   .publish-btn:hover { background:rgba(99, 179, 237, 0.08); }
   .publish-path-row { display:flex; gap:8px; align-items:center; }
   .publish-path-row .modal-input { flex:1; }
   .publish-option { display:flex; gap:8px; align-items:flex-start; margin-top:12px; font-size:13px; color:var(--text-secondary); }
   .publish-status { min-height:16px; margin-top:10px; font-size:12px; color:var(--text-secondary); }
+  .export-grid { display:grid; grid-template-columns:1fr 1fr; gap:12px; }
+  @media (max-width: 640px) {
+    .lifelist-actions { margin-left:0; width:100%; justify-content:flex-end; }
+    .export-grid { grid-template-columns:1fr; }
+  }
 
   .lifelist-meta { padding:8px 24px; font-size:12px; color:var(--text-secondary); }
 
@@ -58,10 +64,53 @@
       <option value="most-photos">Most photos</option>
     </select>
   </div>
-  <button class="publish-btn" onclick="openPublishModal()">Publish Site</button>
+  <div class="lifelist-actions">
+    <button class="publish-btn" onclick="openExportModal()">Export...</button>
+    <button class="publish-btn" onclick="openPublishModal()">Publish Site</button>
+  </div>
 </div>
 
 <div class="lifelist-meta" id="meta"></div>
+
+<div class="modal-overlay" id="exportModal" onclick="if(event.target===this)closeExportModal()">
+  <div class="modal">
+    <h3>Export Life List</h3>
+    <div class="export-grid">
+      <div>
+        <label class="modal-label" for="exportFormat">Format</label>
+        <select id="exportFormat" class="modal-input" onchange="updateExportControls()">
+          <option value="json">JSON data</option>
+          <option value="csv">CSV spreadsheet</option>
+          <option value="txt">Text list</option>
+          <option value="files">Filename list</option>
+        </select>
+      </div>
+      <div id="exportDetailWrap">
+        <label class="modal-label" for="exportDetail">Rows</label>
+        <select id="exportDetail" class="modal-input" onchange="updateExportControls()">
+          <option value="species">Species summary</option>
+          <option value="photos">Photo rows</option>
+        </select>
+      </div>
+      <div id="exportPhotosWrap">
+        <label class="modal-label" for="exportPhotos">Photos</label>
+        <select id="exportPhotos" class="modal-input">
+          <option value="best">Representative photo per species</option>
+          <option value="all">All listed photos</option>
+        </select>
+      </div>
+      <label class="publish-option" style="margin-top:22px;">
+        <input id="exportLocations" type="checkbox">
+        <span>Include location keywords.</span>
+      </label>
+    </div>
+    <div class="publish-status" id="exportStatus"></div>
+    <div class="modal-actions">
+      <button id="exportSubmitBtn" class="modal-btn modal-btn-primary" onclick="downloadLifeListExport()">Export</button>
+      <button class="modal-btn modal-btn-cancel" onclick="closeExportModal()">Cancel</button>
+    </div>
+  </div>
+</div>
 
 <div class="modal-overlay" id="publishModal">
   <div class="modal">
@@ -248,6 +297,48 @@ document.getElementById('speciesSearch').addEventListener('input', debounceRende
 document.getElementById('sortSelect').addEventListener('change', function() {
   if (currentData) render();
 });
+
+function openExportModal() {
+  var modal = document.getElementById('exportModal');
+  var status = document.getElementById('exportStatus');
+  if (status) status.textContent = '';
+  updateExportControls();
+  modal.classList.add('open');
+  setTimeout(function() {
+    var input = document.getElementById('exportFormat');
+    if (input) input.focus();
+  }, 0);
+}
+
+function closeExportModal() {
+  document.getElementById('exportModal').classList.remove('open');
+}
+
+function updateExportControls() {
+  var format = document.getElementById('exportFormat').value;
+  var detailWrap = document.getElementById('exportDetailWrap');
+  var photosWrap = document.getElementById('exportPhotosWrap');
+  var detail = document.getElementById('exportDetail').value;
+  detailWrap.style.display = format === 'csv' ? '' : 'none';
+  photosWrap.style.display = (
+    format === 'files' || (format === 'csv' && detail === 'photos')
+  ) ? '' : 'none';
+}
+
+function downloadLifeListExport() {
+  var format = document.getElementById('exportFormat').value;
+  var detail = document.getElementById('exportDetail').value;
+  var photos = document.getElementById('exportPhotos').value;
+  var includeLocations = document.getElementById('exportLocations').checked ? '1' : '0';
+  var params = new URLSearchParams({
+    format: format,
+    detail: detail,
+    photos: photos,
+    include_locations: includeLocations,
+  });
+  window.location.href = '/api/life-list/export?' + params.toString();
+  closeExportModal();
+}
 
 function openPublishModal() {
   var modal = document.getElementById('publishModal');

--- a/vireo/templates/life_list.html
+++ b/vireo/templates/life_list.html
@@ -333,9 +333,11 @@ function downloadLifeListExport() {
   var params = new URLSearchParams({
     format: format,
     detail: detail,
-    photos: photos,
     include_locations: includeLocations,
   });
+  if (format === 'files' || (format === 'csv' && detail === 'photos')) {
+    params.set('photos', photos);
+  }
   window.location.href = '/api/life-list/export?' + params.toString();
   closeExportModal();
 }

--- a/vireo/tests/test_life_list.py
+++ b/vireo/tests/test_life_list.py
@@ -1,4 +1,7 @@
 """Tests for the Life List page and /api/life-list."""
+import csv
+import io
+import json
 import os
 
 import pytest
@@ -102,6 +105,7 @@ def test_page_renders(life_app):
     resp = app.test_client().get("/life-list")
     assert resp.status_code == 200
     assert b"Life List" in resp.data
+    assert b"Export Life List" in resp.data
 
 
 def test_groups_by_species_and_counts(life_app):
@@ -268,3 +272,69 @@ def test_same_named_species_keywords_dedupe_photos(life_app):
     assert len(photo_ids) == len(set(photo_ids))
     # Workspace-wide distinct-photo count is unaffected.
     assert data["meta"]["photo_count"] == 3
+
+
+def test_life_list_export_json_attachment(life_app):
+    app, _, _ = life_app
+    resp = app.test_client().get("/api/life-list/export?format=json")
+    assert resp.status_code == 200
+    assert resp.headers["Content-Type"] == "application/json"
+    assert "attachment" in resp.headers.get("Content-Disposition", "")
+    assert "vireo-life-list-" in resp.headers.get("Content-Disposition", "")
+
+    data = json.loads(resp.get_data(as_text=True))
+    assert data["meta"]["species_count"] == 2
+    cardinal = _entry(data, "Northern Cardinal")
+    assert cardinal["locations"] == []
+
+
+def test_life_list_export_species_csv_with_locations(life_app):
+    app, _, _ = life_app
+    resp = app.test_client().get(
+        "/api/life-list/export?format=csv&include_locations=1"
+    )
+    assert resp.status_code == 200
+    assert resp.headers["Content-Type"].startswith("text/csv")
+
+    rows = list(csv.DictReader(io.StringIO(resp.get_data(as_text=True))))
+    assert [r["species"] for r in rows] == ["House Sparrow", "Northern Cardinal"]
+    cardinal = next(r for r in rows if r["species"] == "Northern Cardinal")
+    assert cardinal["locations"] == "Backyard"
+    assert cardinal["best_filename"] == "card2.jpg"
+
+
+def test_life_list_export_photo_csv_all_photos(life_app):
+    app, _, ids = life_app
+    resp = app.test_client().get(
+        "/api/life-list/export?format=csv&detail=photos&photos=all"
+    )
+    assert resp.status_code == 200
+
+    rows = list(csv.DictReader(io.StringIO(resp.get_data(as_text=True))))
+    assert [int(r["photo_id"]) for r in rows] == [ids["p3"], ids["p2"], ids["p1"]]
+    assert all(r["locations"] == "" for r in rows)
+
+
+def test_life_list_export_text_and_file_lists(life_app):
+    app, _, _ = life_app
+    client = app.test_client()
+
+    text_resp = client.get("/api/life-list/export?format=txt&include_locations=1")
+    assert text_resp.status_code == 200
+    text = text_resp.get_data(as_text=True)
+    assert "#1 House Sparrow (Passer domesticus)" in text
+    assert "locations: Backyard" in text
+
+    files_resp = client.get("/api/life-list/export?format=file&photos=all")
+    assert files_resp.status_code == 200
+    assert files_resp.get_data(as_text=True).splitlines() == [
+        "sparrow1.jpg",
+        "card2.jpg",
+        "card1.jpg",
+    ]
+
+
+def test_life_list_export_rejects_unknown_format(life_app):
+    app, _, _ = life_app
+    resp = app.test_client().get("/api/life-list/export?format=pdf")
+    assert resp.status_code == 400

--- a/vireo/tests/test_life_list.py
+++ b/vireo/tests/test_life_list.py
@@ -315,6 +315,57 @@ def test_life_list_export_photo_csv_all_photos(life_app):
     assert all(r["locations"] == "" for r in rows)
 
 
+def test_life_list_export_all_photos_is_not_limited_to_page_count(life_app):
+    app, db, ids = life_app
+    k_card = db.add_keyword("Northern Cardinal", is_species=True)
+    extra_ids = []
+    for i in range(13):
+        pid = db.add_photo(
+            folder_id=ids["folder"],
+            filename=f"card-extra-{i}.jpg",
+            extension=".jpg",
+            file_size=1000,
+            file_mtime=20.0 + i,
+            timestamp=f"2024-05-{i + 1:02d}T08:00:00",
+        )
+        db.tag_photo(pid, k_card)
+        extra_ids.append(pid)
+
+    page_payload = _get_life_list(app)
+    cardinal = _entry(page_payload, "Northern Cardinal")
+    assert cardinal["photo_count"] == 15
+    assert len(cardinal["photos"]) == 12
+
+    resp = app.test_client().get(
+        "/api/life-list/export?format=csv&detail=photos&photos=all"
+    )
+    rows = list(csv.DictReader(io.StringIO(resp.get_data(as_text=True))))
+    cardinal_rows = [r for r in rows if r["species"] == "Northern Cardinal"]
+    assert len(cardinal_rows) == 15
+    exported_ids = {int(r["photo_id"]) for r in cardinal_rows}
+    assert set(extra_ids).issubset(exported_ids)
+
+
+def test_life_list_file_export_keeps_duplicate_filenames_by_photo_id(life_app):
+    app, db, ids = life_app
+    k_card = db.add_keyword("Northern Cardinal", is_species=True)
+    other_folder = db.add_folder("/photos/2025", name="2025")
+    for folder_id in (ids["folder"], other_folder):
+        pid = db.add_photo(
+            folder_id=folder_id,
+            filename="DSC_0001.JPG",
+            extension=".JPG",
+            file_size=1000,
+            file_mtime=30.0 + folder_id,
+            timestamp=f"2024-06-{folder_id:02d}T08:00:00",
+        )
+        db.tag_photo(pid, k_card)
+
+    resp = app.test_client().get("/api/life-list/export?format=file&photos=all")
+    assert resp.status_code == 200
+    assert resp.get_data(as_text=True).splitlines().count("DSC_0001.JPG") == 2
+
+
 def test_life_list_export_text_and_file_lists(life_app):
     app, _, _ = life_app
     client = app.test_client()

--- a/vireo/tests/test_life_list.py
+++ b/vireo/tests/test_life_list.py
@@ -346,6 +346,36 @@ def test_life_list_export_all_photos_is_not_limited_to_page_count(life_app):
     assert set(extra_ids).issubset(exported_ids)
 
 
+def test_life_list_summary_exports_ignore_hidden_all_photo_scope(life_app):
+    app, db, ids = life_app
+    k_card = db.add_keyword("Northern Cardinal", is_species=True)
+    for i in range(13):
+        pid = db.add_photo(
+            folder_id=ids["folder"],
+            filename=f"card-hidden-scope-{i}.jpg",
+            extension=".jpg",
+            file_size=1000,
+            file_mtime=40.0 + i,
+            timestamp=f"2024-07-{i + 1:02d}T08:00:00",
+        )
+        db.tag_photo(pid, k_card)
+
+    resp = app.test_client().get("/api/life-list/export?format=json&photos=all")
+    assert resp.status_code == 200
+    data = json.loads(resp.get_data(as_text=True))
+    cardinal = _entry(data, "Northern Cardinal")
+    assert cardinal["photo_count"] == 15
+    assert len(cardinal["photos"]) == 12
+    assert data["meta"]["photos_per_species"] == 12
+
+    csv_resp = app.test_client().get(
+        "/api/life-list/export?format=csv&detail=species&photos=all"
+    )
+    rows = list(csv.DictReader(io.StringIO(csv_resp.get_data(as_text=True))))
+    cardinal_row = next(r for r in rows if r["species"] == "Northern Cardinal")
+    assert cardinal_row["photo_count"] == "15"
+
+
 def test_life_list_file_export_keeps_duplicate_filenames_by_photo_id(life_app):
     app, db, ids = life_app
     k_card = db.add_keyword("Northern Cardinal", is_species=True)

--- a/vireo/tests/test_life_list.py
+++ b/vireo/tests/test_life_list.py
@@ -303,6 +303,39 @@ def test_life_list_export_species_csv_with_locations(life_app):
     assert cardinal["best_filename"] == "card2.jpg"
 
 
+def test_life_list_export_csv_escapes_formula_leading_cells(life_app):
+    app, db, ids = life_app
+    p_formula = db.add_photo(
+        folder_id=ids["folder"],
+        filename="@formula.jpg",
+        extension=".jpg",
+        file_size=1000,
+        file_mtime=10.0,
+        timestamp="2024-06-01T08:00:00",
+    )
+    k_species = db.add_keyword("=2+2", is_species=True)
+    k_location = db.add_keyword("+Backyard", kw_type="location")
+    db.tag_photo(p_formula, k_species)
+    db.tag_photo(p_formula, k_location)
+
+    resp = app.test_client().get(
+        "/api/life-list/export?format=csv&include_locations=1"
+    )
+    rows = list(csv.DictReader(io.StringIO(resp.get_data(as_text=True))))
+    formula_row = next(r for r in rows if r["species"] == "'=2+2")
+    assert formula_row["locations"] == "'+Backyard"
+    assert formula_row["best_filename"] == "'@formula.jpg"
+
+    photo_resp = app.test_client().get(
+        "/api/life-list/export?format=csv&detail=photos&photos=all"
+        "&include_locations=1"
+    )
+    photo_rows = list(csv.DictReader(io.StringIO(photo_resp.get_data(as_text=True))))
+    photo_row = next(r for r in photo_rows if r["species"] == "'=2+2")
+    assert photo_row["filename"] == "'@formula.jpg"
+    assert photo_row["locations"] == "'+Backyard"
+
+
 def test_life_list_export_photo_csv_all_photos(life_app):
     app, _, ids = life_app
     resp = app.test_client().get(


### PR DESCRIPTION
Adds a downloadable Life List export endpoint with JSON, CSV, plain text, and filename-list formats.
The Life List page now has an Export modal for choosing row detail, photo scope, and whether to include location keywords.
CSV/text/file exports are derived from the existing Life List payload so the page and exports stay consistent.
Validated with `pytest vireo/tests/test_life_list.py`.