### PR TITLE
Import job: remote (SSH) archive destinations (import/process split PR 2, Task 2.7)

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1536,6 +1536,44 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         """Return a JSON error response. Standard shape: {"error": "msg"}."""
         return jsonify({"error": msg}), status
 
+    def _resolve_remote_archive_target(remote_target_id, remote_subpath):
+        """Shared remote-archive-target resolution for the import-photos
+        and pipeline routes.
+
+        Returns ``(remote_archive_config, rsync_bin, None)`` on success,
+        or ``(None, None, error_response)`` when the request can't be
+        served (unknown target, invalid subpath, GNU rsync unavailable).
+        Callers still own their own mutual-exclusivity /
+        local_processing checks — this helper handles only the shared
+        target-lookup + resolve_remote_archive + rsync-availability
+        block that was duplicated across the two endpoints. See PR
+        #1113 review.
+        """
+        import config as cfg
+        import move as move_mod
+        from pipeline_job import resolve_remote_archive
+
+        target = cfg.get_remote_target(remote_target_id)
+        if not target:
+            return None, None, json_error("Remote target not found", status=404)
+        try:
+            remote_archive_config = resolve_remote_archive(
+                target, remote_subpath,
+            )
+        except ValueError as exc:
+            return None, None, json_error(str(exc))
+        effective_cfg = _get_db().get_effective_config(cfg.load())
+        rsync_bin = move_mod.resolve_rsync_bin(
+            effective_cfg.get("rsync_bin", "") or "")
+        if not rsync_bin:
+            return None, None, json_error(
+                "No GNU rsync found for remote archiving — macOS's "
+                "built-in rsync can't drive rsync-over-SSH. Install GNU "
+                "rsync (e.g. `brew install rsync`) or set its path under "
+                "Settings → Paths."
+            )
+        return remote_archive_config, rsync_bin, None
+
     def _coerce_collection_id(raw):
         """Parse an optional collection_id from a request body.
 
@@ -15116,32 +15154,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if remote_subpath and not remote_target_id:
             return json_error("remote_subpath requires remote_target_id")
         if remote_target_id:
-            import config as cfg
-            import move as move_mod
-            from pipeline_job import resolve_remote_archive
-
-            target = cfg.get_remote_target(remote_target_id)
-            if not target:
-                return json_error("Remote target not found", status=404)
-            try:
-                remote_archive_config = resolve_remote_archive(
-                    target, remote_subpath,
+            # Refuse at request time when no GNU rsync exists or the
+            # target is unknown/unsafe — starting a job guaranteed to
+            # fail its transfer helps nobody (mirrors the pipeline and
+            # move-folder endpoints).
+            remote_archive_config, rsync_bin, err = (
+                _resolve_remote_archive_target(
+                    remote_target_id, remote_subpath,
                 )
-            except ValueError as exc:
-                return json_error(str(exc))
-            # Refuse at request time when no GNU rsync exists — starting a job
-            # guaranteed to fail its transfer helps nobody (mirrors the
-            # pipeline and move-folder endpoints).
-            effective_cfg = _get_db().get_effective_config(cfg.load())
-            rsync_bin = move_mod.resolve_rsync_bin(
-                effective_cfg.get("rsync_bin", "") or "")
-            if not rsync_bin:
-                return json_error(
-                    "No GNU rsync found for remote archiving — macOS's "
-                    "built-in rsync can't drive rsync-over-SSH. Install GNU "
-                    "rsync (e.g. `brew install rsync`) or set its path under "
-                    "Settings → Paths."
-                )
+            )
+            if err is not None:
+                return err
             # Catalog at the resolved local mount path.
             destination = remote_archive_config["mount_final"]
 
@@ -17698,32 +17721,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "target over SSH"
             )
         if remote_target_id:
-            import config as cfg
-            import move as move_mod
-            from pipeline_job import resolve_remote_archive
-
-            target = cfg.get_remote_target(remote_target_id)
-            if not target:
-                return json_error("Remote target not found", status=404)
-            try:
-                remote_archive_config = resolve_remote_archive(
-                    target, remote_subpath,
+            # Refuse at request time when no GNU rsync exists or the
+            # target is unknown/unsafe — starting a job guaranteed to
+            # fail its storage preflight helps nobody (mirrors the
+            # move-folder endpoint).
+            remote_archive_config, _rsync_bin, err = (
+                _resolve_remote_archive_target(
+                    remote_target_id, remote_subpath,
                 )
-            except ValueError as exc:
-                return json_error(str(exc))
-            # Refuse at request time when no GNU rsync exists, matching the
-            # move-folder endpoint — starting a job that is guaranteed to
-            # fail its storage preflight helps nobody.
-            effective_cfg = db.get_effective_config(cfg.load())
-            rsync_bin = move_mod.resolve_rsync_bin(
-                effective_cfg.get("rsync_bin", "") or "")
-            if not rsync_bin:
-                return json_error(
-                    "No GNU rsync found for remote archiving — macOS's "
-                    "built-in rsync can't drive rsync-over-SSH. Install GNU "
-                    "rsync (e.g. `brew install rsync`) or set its path under "
-                    "Settings → Paths."
-                )
+            )
+            if err is not None:
+                return err
         if local_processing and not destination and not remote_target_id:
             return json_error(
                 "local_processing requires a destination or a remote target"

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -15036,7 +15036,55 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if not os.path.isdir(s):
                 return json_error(f"source directory not found: {s}")
 
+        # Remote (SSH) archive destination — mirrors the pipeline route's
+        # remote-target request shape (remote_target_id + subpath). The card
+        # is rsynced to remote_path/subpath and cataloged at
+        # mount_path/subpath; ``destination`` is set to the resolved local
+        # mount path so every downstream guard (destination-inside-source,
+        # scan, catalog) applies to the mount exactly as for a local import.
+        remote_target_id = (body.get("remote_target_id") or "").strip()
+        remote_subpath = body.get("remote_subpath", "")
+        if remote_subpath and not isinstance(remote_subpath, str):
+            return json_error("remote_subpath must be a string")
         destination = body.get("destination")
+        remote_archive_config = None
+        if remote_target_id and destination:
+            return json_error(
+                "destination and remote_target_id are mutually exclusive — "
+                "pick a local archive path or a saved remote target, not both"
+            )
+        if remote_subpath and not remote_target_id:
+            return json_error("remote_subpath requires remote_target_id")
+        if remote_target_id:
+            import config as cfg
+            import move as move_mod
+            from pipeline_job import resolve_remote_archive
+
+            target = cfg.get_remote_target(remote_target_id)
+            if not target:
+                return json_error("Remote target not found", status=404)
+            try:
+                remote_archive_config = resolve_remote_archive(
+                    target, remote_subpath,
+                )
+            except ValueError as exc:
+                return json_error(str(exc))
+            # Refuse at request time when no GNU rsync exists — starting a job
+            # guaranteed to fail its transfer helps nobody (mirrors the
+            # pipeline and move-folder endpoints).
+            effective_cfg = _get_db().get_effective_config(cfg.load())
+            rsync_bin = move_mod.resolve_rsync_bin(
+                effective_cfg.get("rsync_bin", "") or "")
+            if not rsync_bin:
+                return json_error(
+                    "No GNU rsync found for remote archiving — macOS's "
+                    "built-in rsync can't drive rsync-over-SSH. Install GNU "
+                    "rsync (e.g. `brew install rsync`) or set its path under "
+                    "Settings → Paths."
+                )
+            # Catalog at the resolved local mount path.
+            destination = remote_archive_config["mount_final"]
+
         if not destination:
             return json_error("destination required")
         if not os.path.isabs(destination):
@@ -15198,6 +15246,26 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         thumb_cache_dir = app.config["THUMB_CACHE_DIR"]
         vireo_dir = os.path.dirname(thumb_cache_dir)
 
+        # Snapshot the resolved remote transport at enqueue time so a
+        # settings edit between click-Start and job-run can't redirect the
+        # archive to a different host/mount than the panel is showing
+        # (mirrors the pipeline route's remote_target_snapshot).
+        remote_target = None
+        if remote_archive_config is not None:
+            import move as move_mod
+
+            spec = move_mod.build_remote_move_spec(
+                remote_archive_config["target"],
+                remote_archive_config["subpath"],
+                rsync_bin,
+            )
+            remote_target = {
+                "rsync_bin": rsync_bin,
+                "remote": spec,
+                "ssh_base": remote_archive_config["ssh_final"],
+                "mount_base": remote_archive_config["mount_final"],
+            }
+
         job_config = {
             "sources": sources,
             "destination": destination,
@@ -15207,6 +15275,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "verify_by_hash": verify_by_hash,
             "recursive": recursive,
             "after_import": after_import,
+            "remote_target_id": remote_target_id or None,
+            "remote_subpath": remote_subpath or None,
         }
 
         def work(job):
@@ -15221,6 +15291,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 verify_by_hash=verify_by_hash,
                 recursive=recursive,
                 after_import=after_import,
+                remote_target=remote_target,
                 vireo_dir=vireo_dir,
                 thumb_cache_dir=thumb_cache_dir,
             )

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1565,6 +1565,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         effective_cfg = _get_db().get_effective_config(cfg.load())
         rsync_bin = move_mod.resolve_rsync_bin(
             effective_cfg.get("rsync_bin", "") or "")
+        # An explicit rsync_bin path in Settings → Paths bypasses the
+        # macOS auto-select guard in resolve_rsync_bin (it just checks
+        # executability), so Apple's /usr/bin/rsync can still land here
+        # even though it can't drive rsync-over-SSH. Fail fast before
+        # enqueue instead of starting a job that dies mid-transfer, the
+        # same way the remote-target list/test routes do.
+        if rsync_bin and not move_mod.is_gnu_rsync(rsync_bin):
+            rsync_bin = None
         if not rsync_bin:
             return None, None, json_error(
                 "No GNU rsync found for remote archiving — macOS's "

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -1658,29 +1658,32 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                 [(d,) for d in sorted(new_dup_dirs)],
             )
             db.conn.commit()
-            # Twin folders may be cataloged through a symlink alias while
-            # ``destination`` is realpath-normalized above.
-            # ``_path_under_destination`` accepts them via realpath, but
-            # scanner's ``_ensure_folder`` walks parents *lexically* until
-            # they equal the scan root — a restrict_dir ``/alias/…``
-            # scanned under root ``/real/archive`` would recurse toward
-            # ``/`` before the ``workspace_folders`` link is ever created,
-            # leaving the verified duplicate-only remote import marked
-            # failed/unsafe. Split by whether the twin's folder path sits
-            # lexically under destination: link the alias-spelled ones
-            # directly (their folder row and the twin's photos already
-            # exist — no self-heal scan needed for workspace visibility),
-            # scan only the lexically-under-destination ones. Mirrors the
-            # local path's split; see PR #1113 review.
+            # Twin folders may be cataloged through a symlink alias, or —
+            # on a case-insensitive destination (macOS/SMB/FAT) — spelled
+            # with different case than ``destination``.
+            # ``_path_under_destination`` accepts both via realpath /
+            # case-fold, but scanner's ``_ensure_folder`` walks ``Path``
+            # parents until they *lexically* (case-sensitive string
+            # equality, independent of the filesystem's case sensitivity)
+            # equal the scan root. A restrict_dir ``/alias/…`` under root
+            # ``/real/archive`` — or a case-only alias like
+            # ``/volumes/nas/…`` under root ``/Volumes/NAS/…`` — would
+            # recurse toward ``/`` before the ``workspace_folders`` link
+            # is ever created, leaving the verified duplicate-only remote
+            # import marked failed/unsafe. Split with a LITERAL
+            # (case-sensitive) prefix check: link case- or symlink-alias
+            # twins directly (their folder row and the twin's photos
+            # already exist — no self-heal scan needed for workspace
+            # visibility), scan only the exactly-cased-under-destination
+            # ones. Mirrors the local path's split; see PR #1113 review.
             lex_dup_dirs = set()
             alias_dup_dirs = set()
+            _dest_lit_norm = destination.rstrip(os.sep)
             for d in new_dup_dirs:
-                d_cmp = (
-                    d.casefold() if _dest_ci else d
-                ).rstrip(os.sep)
+                d_lit = d.rstrip(os.sep)
                 if (
-                    d_cmp == _dest_root_norm
-                    or d_cmp.startswith(_dest_root_norm + os.sep)
+                    d_lit == _dest_lit_norm
+                    or d_lit.startswith(_dest_lit_norm + os.sep)
                 ):
                     lex_dup_dirs.add(d)
                 else:
@@ -2918,26 +2921,30 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         if new_dup_dirs:
             # Twin folders may be cataloged through a symlink alias while
             # ``destination`` is realpath-normalized above. ``_path_under_
-            # destination`` accepts them via realpath, but scanner's
-            # ``_ensure_folder`` walks parents *lexically* until they equal
-            # the scan root — a restrict_dir ``/alias/2026-07-05`` scanned
-            # under root ``/real/archive`` would recurse to ``/alias`` →
-            # ``/`` → ``/`` … and hit Python's recursion limit before the
-            # workspace_folders link is ever created. Split by whether the
-            # twin's folder path sits lexically under destination: link
-            # the alias-spelled ones directly (their folder row and the
+            # destination`` accepts symlink aliases via realpath and
+            # case-only aliases via casefold (on a case-insensitive
+            # destination), but scanner's ``_ensure_folder`` walks
+            # ``Path`` parents until they *lexically* (case-sensitive
+            # string equality, independent of the filesystem's case
+            # sensitivity) equal the scan root. A restrict_dir
+            # ``/alias/2026-07-05`` under root ``/real/archive`` — or a
+            # case-only alias like ``/volumes/nas/…`` under root
+            # ``/Volumes/NAS/…`` — would recurse to ``/alias`` → ``/``
+            # → ``/`` … and hit Python's recursion limit before the
+            # workspace_folders link is ever created. Split with a
+            # LITERAL (case-sensitive) prefix check: link case- or
+            # symlink-alias twins directly (their folder row and the
             # twin's photos already exist — no self-heal scan needed for
-            # workspace visibility), scan only the lexically-under-
-            # destination ones. See PR #1107 review.
+            # workspace visibility), scan only the exactly-cased-under-
+            # destination ones. See PR #1107 / #1113 reviews.
             lex_dup_dirs = set()
             alias_dup_dirs = set()
+            _dest_lit_norm = destination.rstrip(os.sep)
             for d in new_dup_dirs:
-                d_cmp = (
-                    d.casefold() if _dest_ci else d
-                ).rstrip(os.sep)
+                d_lit = d.rstrip(os.sep)
                 if (
-                    d_cmp == _dest_root_norm
-                    or d_cmp.startswith(_dest_root_norm + os.sep)
+                    d_lit == _dest_lit_norm
+                    or d_lit.startswith(_dest_lit_norm + os.sep)
                 ):
                     lex_dup_dirs.add(d)
                 else:

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -1162,11 +1162,46 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                     )
                     # scan() can legitimately leave ``file_hash`` NULL
                     # (large files, prior partial scan, tests that stub
-                    # the hash step). Only fail on a positive mismatch —
-                    # two set hashes that disagree. A missing scan hash
-                    # doesn't prove anything, so don't turn it into a
-                    # spurious failure.
-                    if scan_h is not None and scan_h != src_h_norm:
+                    # the hash step, or a read/permission failure that
+                    # scanner suppresses). A missing scan hash doesn't
+                    # prove anything on its own, but silently accepting
+                    # would let a stale/unreadable mount stamp ``ok``
+                    # under ``verify_by_hash`` — the NAS checksum only
+                    # proves card bytes reached the SSH target, not that
+                    # the cataloged mount path holds those bytes. Rehash
+                    # the mount file directly as the last-line check;
+                    # mirrors the local path's ``_rehash_dest_or_none``
+                    # fallback. See PR #1113 review.
+                    if scan_h is None and src_h_norm is not None:
+                        try:
+                            mount_hash = compute_file_hash(dest_path)
+                        except OSError:
+                            mount_hash = None
+                        mount_norm = (
+                            None if mount_hash == EMPTY_FILE_SHA256
+                            else mount_hash
+                        )
+                        if mount_norm is None or mount_norm != src_h_norm:
+                            copied -= 1
+                            if params.verify_by_hash:
+                                verified -= 1
+                            _counts(rel)["copied"] -= 1
+                            _fail(
+                                rel, dest_path,
+                                "scan wrote no mount row hash and a re-"
+                                "read of the mount file "
+                                + ("disagrees with the source hash"
+                                   if not params.verify_by_hash else
+                                   "disagrees with the hash verified "
+                                   "on the NAS")
+                                + " (mount base is likely stale, "
+                                "unreadable, or misconfigured)",
+                            )
+                            landed = [
+                                e for e in landed if e[0] != dest_path
+                            ]
+                            continue
+                    elif scan_h is not None and scan_h != src_h_norm:
                         copied -= 1
                         if params.verify_by_hash:
                             verified -= 1
@@ -1213,34 +1248,55 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                          os.path.basename(dest_path)),
                     ).fetchone()
                     if companion is not None:
-                        if params.verify_by_hash:
-                            try:
-                                mount_hash = compute_file_hash(dest_path)
-                            except OSError:
-                                mount_hash = None
-                            src_h_norm = (
-                                None if src_hash == EMPTY_FILE_SHA256
-                                else src_hash
-                            )
-                            mount_norm = (
-                                None if mount_hash == EMPTY_FILE_SHA256
-                                else mount_hash
-                            )
-                            if mount_norm != src_h_norm:
-                                copied -= 1
+                        # The paired JPEG's own photo row is gone by
+                        # design (pair-scan merges it into the RAW
+                        # primary), so the non-companion branch above
+                        # can't cross-check its bytes for us. Hash the
+                        # mount JPEG here regardless of
+                        # ``verify_by_hash`` — the non-companion branch
+                        # compares ``scan_h`` vs ``src_h_norm`` even in
+                        # no-verify mode as a stale-mount catalog-
+                        # integrity guard, and paired JPEGs need the
+                        # same protection or a stale/misconfigured
+                        # mount with a same-named but different JPEG
+                        # would enqueue after-import processing against
+                        # the wrong companion. Only the
+                        # ``verified``/``hash_status`` accounting is
+                        # gated behind ``verify_by_hash``. See PR #1113
+                        # review.
+                        try:
+                            mount_hash = compute_file_hash(dest_path)
+                        except OSError:
+                            mount_hash = None
+                        src_h_norm = (
+                            None if src_hash == EMPTY_FILE_SHA256
+                            else src_hash
+                        )
+                        mount_norm = (
+                            None if mount_hash == EMPTY_FILE_SHA256
+                            else mount_hash
+                        )
+                        if mount_norm != src_h_norm:
+                            copied -= 1
+                            if params.verify_by_hash:
                                 verified -= 1
-                                _counts(rel)["copied"] -= 1
-                                _fail(
-                                    rel, dest_path,
-                                    "paired companion mount bytes do "
-                                    "not match the hash verified on "
-                                    "the NAS (mount base is likely "
-                                    "stale or misconfigured)",
-                                )
-                                landed = [
-                                    e for e in landed if e[0] != dest_path
-                                ]
-                                continue
+                            _counts(rel)["copied"] -= 1
+                            _fail(
+                                rel, dest_path,
+                                "paired companion mount bytes do "
+                                "not match the source hash (mount "
+                                "base is likely stale or "
+                                "misconfigured)"
+                                if not params.verify_by_hash else
+                                "paired companion mount bytes do "
+                                "not match the hash verified on "
+                                "the NAS (mount base is likely "
+                                "stale or misconfigured)",
+                            )
+                            landed = [
+                                e for e in landed if e[0] != dest_path
+                            ]
+                            continue
                         # JPEG bytes are represented by the RAW row's
                         # companion_path — accept as landed; leave the
                         # copied/verified counters alone. The RAW row is

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -107,6 +107,96 @@ def _invalidate_new_images(db, root):
 IMPORT_BATCH_SIZE = 200
 
 
+# Case-folded matching is unconditional on darwin/win32 (the OS enforces
+# case-insensitive filesystems). On Linux we probe each source's actual
+# filesystem: a FAT/exFAT/NTFS-mounted SD card is case-insensitive even
+# under a case-sensitive ext4 parent, so a platform-wide check would miss
+# a differently-cased twin path there. See PR #1107 review.
+_CASE_INSENSITIVE_PLATFORM = sys.platform in ("darwin", "win32")
+
+
+def _fs_is_case_insensitive(path):
+    """Probe whether the filesystem at ``path`` treats case as insensitive.
+
+    List an entry inside ``path`` and check whether accessing it under a
+    case-swapped name resolves to the same inode. Probing *inside* the
+    directory (rather than swapping characters in ``path`` itself) is
+    essential when a case-insensitive mount sits under a case-sensitive
+    parent — a FAT/exFAT SD card mounted at ``/mnt/Card`` on Linux under
+    an ext4 root: the ext4 ``/mnt`` cannot resolve ``/Mnt`` or a
+    differently-cased ``Card`` entry (mount-point dentries live in the
+    parent FS), so swapping characters in the ``path`` string always
+    reports case-sensitive regardless of the card's own semantics.
+
+    Any inconclusive result (unlistable, empty, no alpha-containing entry
+    — Nikon-style ``100``/``101``/``102`` roots — or a stat error while
+    comparing) returns True so the caller falls back to case-fold,
+    mirroring the ``/api/jobs/import-photos`` route guard. False on
+    inconclusive would let a differently-cased catalog twin under a
+    source pass duplicate acceptance (or a differently-cased twin folder
+    under the destination skip workspace linking), and
+    ``safe_to_format`` could then go green without a visible off-card
+    copy. See PR #1107 review.
+    """
+    try:
+        entries = os.listdir(path)
+    except OSError:
+        return True
+    for name in entries:
+        for i, c in enumerate(name):
+            if c.isalpha():
+                swapped = name[:i] + c.swapcase() + name[i + 1:]
+                if swapped == name:
+                    continue
+                original_full = os.path.join(path, name)
+                probe_full = os.path.join(path, swapped)
+                if not os.path.exists(probe_full):
+                    return False
+                try:
+                    return os.path.samefile(original_full, probe_full)
+                except OSError:
+                    return True
+    return True
+
+
+def _build_source_root_guard(sources):
+    """Return ``path_under_any_source(path) -> bool`` for the given roots.
+
+    Shared by both the local and remote duplicate gates to reject
+    cataloged twins that live under the card being imported. A stale scan
+    of a mounted card can leave a photos row whose ``folder_path`` IS the
+    card; re-hashing that twin just re-reads the very card file being
+    imported, so accepting it as duplicate proof would flip
+    ``safe_to_format`` green while the card holds the only bytes. Only an
+    off-card twin can back a duplicate skip. See PR #1107 review.
+    """
+    def _norm(s):
+        try:
+            real = os.path.realpath(s)
+        except OSError:
+            real = str(s)
+        ci = _CASE_INSENSITIVE_PLATFORM or _fs_is_case_insensitive(real)
+        return (real.casefold() if ci else real).rstrip(os.sep), ci
+
+    roots = [_norm(s) for s in sources]
+
+    def path_under_any_source(path):
+        try:
+            real = os.path.realpath(path)
+        except OSError:
+            real = str(path)
+        real_folded = real.casefold()
+        for root, ci in roots:
+            if not root:
+                continue
+            cmp = real_folded if ci else real
+            if cmp == root or cmp.startswith(root + os.sep):
+                return True
+        return False
+
+    return path_under_any_source
+
+
 @dataclass
 class ImportParams:
     """Parameters for an import job run."""
@@ -425,6 +515,15 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
     except OSError:
         destination = os.path.normpath(str(params.destination))
 
+    # Reject cataloged twins that live under the card being imported: a stale
+    # scan of the mounted card can leave a photos row whose ``folder_path``
+    # IS the card, and re-hashing it just re-reads the very source we're
+    # supposed to be copying off — which would count the file as
+    # ``skipped_duplicate`` and, when ``verify_by_hash`` is on, still let
+    # ``safe_to_format`` go green over a card whose bytes never crossed the
+    # network. Mirrors the local path's ``_path_under_any_source`` filter.
+    _path_under_any_source = _build_source_root_guard(params.sources)
+
     import move as move_mod
 
     runner.set_steps(job["id"], [
@@ -570,6 +669,16 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         twin_path = os.path.join(
                             twin["folder_path"], twin["filename"],
                         )
+                        # A twin cataloged under any import source root is
+                        # (or may be) the card file being imported this run
+                        # — re-hashing it just re-reads the source, proving
+                        # nothing about an off-card copy. Accepting it would
+                        # count the file as skipped_duplicate and (with
+                        # verify_by_hash) let safe_to_format go green while
+                        # the card holds the only bytes. Mirrors the local
+                        # path's filter. See PR #1113 review.
+                        if _path_under_any_source(twin_path):
+                            continue
                         try:
                             twin_hash = compute_file_hash(twin_path)
                         except OSError:
@@ -792,38 +901,43 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
             else:
                 _invalidate_new_images(db, dest_folder)
 
-            # Hash stamping: ONLY on the checksum-verification path. Without
+            # Catalog-row presence is required on BOTH paths: the route's
+            # copy-and-catalog contract says every landed byte becomes a
+            # photo row, and a landed file with no row after scan is failed
+            # rather than silently left counted as ``copied`` — otherwise a
+            # remote import into an unmounted/misconfigured mount base would
+            # report copied/ok (or copied/NULL, no-verify) with no catalog
+            # trail. (A RAW+JPEG pair whose JPEG row was merged into the RAW
+            # is the main legitimate "no row" case; the RAW carries the
+            # bytes, so failing the JPEG here is conservative but keeps the
+            # pill honest.) Hash stamping (``hash_status='ok'``) still runs
+            # ONLY on the checksum-verification path — without
             # verify_by_hash the rows keep NULL hash_status/hash_checked_at
             # (scan may set file_hash, but we don't claim an integrity
-            # verdict we didn't independently make). A landed file with no
-            # catalog row after scan is failed rather than silently left
-            # unstamped — otherwise it would stay counted as ``copied`` and
-            # flip ``safe_to_format`` green without a stamped ``ok`` verdict.
-            # (A RAW+JPEG pair whose JPEG row was merged into the RAW is the
-            # main "no row" case; the RAW carries the bytes, so failing the
-            # JPEG here is conservative but keeps the pill honest.)
-            if params.verify_by_hash:
-                for dest_path, _sf, _sz, _mt in list(landed):
-                    row = db.conn.execute(
-                        """SELECT p.id FROM photos p
-                           JOIN folders f ON f.id = p.folder_id
-                           WHERE f.path = ? AND p.filename = ?""",
-                        (os.path.dirname(dest_path),
-                         os.path.basename(dest_path)),
-                    ).fetchone()
-                    if row is not None:
+            # verdict we didn't independently make).
+            for dest_path, _sf, _sz, _mt in list(landed):
+                row = db.conn.execute(
+                    """SELECT p.id FROM photos p
+                       JOIN folders f ON f.id = p.folder_id
+                       WHERE f.path = ? AND p.filename = ?""",
+                    (os.path.dirname(dest_path),
+                     os.path.basename(dest_path)),
+                ).fetchone()
+                if row is not None:
+                    if params.verify_by_hash:
                         db.update_photo_hash_check(
                             row["id"], "ok", commit=False,
                         )
-                    else:
-                        copied -= 1
+                else:
+                    copied -= 1
+                    if params.verify_by_hash:
                         verified -= 1
-                        _counts(rel)["copied"] -= 1
-                        _fail(rel, dest_path,
-                              "not cataloged after scan (no photo row)")
-                        landed = [
-                            e for e in landed if e[0] != dest_path
-                        ]
+                    _counts(rel)["copied"] -= 1
+                    _fail(rel, dest_path,
+                          "not cataloged after scan (no photo row)")
+                    landed = [
+                        e for e in landed if e[0] != dest_path
+                    ]
             db.conn.commit()
 
             if params.vireo_dir:
@@ -971,8 +1085,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     except OSError:
         destination = os.path.normpath(str(params.destination))
 
-    # Normalized realpaths of every import source root, used to reject
-    # cataloged twins that live under the card being imported. The
+    # Reject cataloged twins that live under the card being imported. The
     # /api/jobs/import-photos route already refuses destinations that sit
     # inside a source (formatting the card would erase the archive copy),
     # but the duplicate acceptance loop separately trusts any cataloged
@@ -980,85 +1093,9 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     # previously scanned mounted card. That twin's re-hash just re-reads
     # the very card file being imported, so accepting it as duplicate
     # proof would flip ``safe_to_format`` green over a card whose bytes
-    # never made it to the archive. Case-fold on darwin/win32
-    # unconditionally; on Linux probe each source's actual filesystem
-    # because a FAT/exFAT/NTFS-mounted SD card is case-insensitive even
-    # under a case-sensitive ext4 parent — a platform-wide check would
-    # miss a differently-cased twin path there. See PR #1107 review.
-    _case_insensitive_platform = sys.platform in ("darwin", "win32")
-
-    def _fs_is_case_insensitive(path):
-        """Probe whether the filesystem at ``path`` treats case as insensitive.
-
-        List an entry inside ``path`` and check whether accessing it
-        under a case-swapped name resolves to the same inode. Probing
-        *inside* the directory (rather than swapping characters in
-        ``path`` itself) is essential when a case-insensitive mount
-        sits under a case-sensitive parent — a FAT/exFAT SD card
-        mounted at ``/mnt/Card`` on Linux under an ext4 root: the ext4
-        ``/mnt`` cannot resolve ``/Mnt`` or a differently-cased
-        ``Card`` entry (mount-point dentries live in the parent FS),
-        so swapping characters in the ``path`` string always reports
-        case-sensitive regardless of the card's own semantics.
-
-        Any inconclusive result (unlistable, empty, no alpha-containing
-        entry — Nikon-style ``100``/``101``/``102`` roots — or a stat
-        error while comparing) returns True so the caller falls back
-        to case-fold, mirroring the ``/api/jobs/import-photos`` route
-        guard. False on inconclusive would let a differently-cased
-        catalog twin under a source pass duplicate acceptance (or a
-        differently-cased twin folder under the destination skip
-        workspace linking), and ``safe_to_format`` could then go green
-        without a visible off-card copy. See PR #1107 review.
-        """
-        try:
-            entries = os.listdir(path)
-        except OSError:
-            return True
-        for name in entries:
-            for i, c in enumerate(name):
-                if c.isalpha():
-                    swapped = name[:i] + c.swapcase() + name[i + 1:]
-                    if swapped == name:
-                        continue
-                    original_full = os.path.join(path, name)
-                    probe_full = os.path.join(path, swapped)
-                    if not os.path.exists(probe_full):
-                        # Definitive: the case-swap resolves to nothing,
-                        # so the filesystem distinguishes case.
-                        return False
-                    try:
-                        return os.path.samefile(original_full, probe_full)
-                    except OSError:
-                        return True
-        return True
-
-    def _norm_source(s):
-        try:
-            real = os.path.realpath(s)
-        except OSError:
-            real = str(s)
-        ci = _case_insensitive_platform or _fs_is_case_insensitive(real)
-        return (real.casefold() if ci else real).rstrip(os.sep), ci
-
-    # (normalized_root, is_case_insensitive) per source. Per-source ci is
-    # stored so ``_path_under_any_source`` case-folds the candidate path
-    # exactly when the source lives on a case-insensitive filesystem.
-    source_roots = [_norm_source(s) for s in params.sources]
-
-    def _path_under_any_source(path):
-        try:
-            real = os.path.realpath(path)
-        except OSError:
-            real = str(path)
-        real_folded = real.casefold()
-        for root, ci in source_roots:
-            if not root:
-                continue
-            cmp = real_folded if ci else real
-            if cmp == root or cmp.startswith(root + os.sep):
-                return True
-        return False
+    # never made it to the archive. The guard is shared with the remote
+    # (SSH) path via the module-level factory. See PR #1107 review.
+    _path_under_any_source = _build_source_root_guard(params.sources)
 
     # Destination containment for cataloged twin folders. ``destination``
     # is already ``realpath``-resolved above so a symlinked destination
@@ -1083,7 +1120,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                 return True
             p = parent
 
-    _dest_ci = _case_insensitive_platform or _probe_dir_case_insensitive(destination)
+    _dest_ci = _CASE_INSENSITIVE_PLATFORM or _probe_dir_case_insensitive(destination)
     _dest_root_norm = (
         destination.casefold() if _dest_ci else destination
     ).rstrip(os.sep)

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -558,6 +558,18 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         cmp = (real.casefold() if _dest_ci else real).rstrip(os.sep)
         return cmp == _dest_root_norm or cmp.startswith(_dest_root_norm + os.sep)
 
+    # Case-insensitive destinations (macOS APFS/HFS+, SMB, FAT/exFAT)
+    # collapse basenames that differ only by case onto the same on-disk
+    # file. The intra-batch collision map ``claimed_basenames`` keys by
+    # basename, so keying it case-foldedly there makes a second file whose
+    # basename differs from an earlier queued file's only by case (e.g.
+    # ``IMG_0001.JPG`` then ``img_0001.jpg``) collide and advance through
+    # numeric suffixes, instead of being sent to the same effective
+    # receiver path where ``--ignore-existing`` would silently drop it and
+    # the later catalog/hash validation would fail. See PR #1113 review.
+    def _fold_basename(name):
+        return name.casefold() if _dest_ci else name
+
     import move as move_mod
 
     runner.set_steps(job["id"], [
@@ -1015,7 +1027,8 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                     else f"{stem}_{counter}{suffix}"
                 )
                 cand_mount = os.path.join(dest_folder, candidate)
-                if candidate in claimed_basenames:
+                candidate_key = _fold_basename(candidate)
+                if candidate_key in claimed_basenames:
                     # Claimed earlier in this batch (a same-basename sibling
                     # already queued). If that sibling has our exact bytes,
                     # skip as an intra-batch duplicate; otherwise advance.
@@ -1026,7 +1039,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                     # second one being counted as ``skipped_duplicate``.
                     if (
                         checker is not None
-                        and claimed_basenames[candidate] == src_hash
+                        and claimed_basenames[candidate_key] == src_hash
                     ):
                         skipped_duplicate += 1
                         dup_skipped += 1
@@ -1047,7 +1060,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         skipped_duplicate += 1
                         dup_skipped += 1
                         _counts(rel)["skipped_duplicate"] += 1
-                        claimed_basenames[candidate] = src_hash
+                        claimed_basenames[candidate_key] = src_hash
                         # Track the adopted mount path + source-side hash
                         # so the restricted scan below picks it up (mixed
                         # batches with fresh copies otherwise scope the
@@ -1066,7 +1079,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                 break
             if adopted:
                 continue
-            claimed_basenames[dest_basename] = src_hash
+            claimed_basenames[_fold_basename(dest_basename)] = src_hash
             # Only track queued source hashes when duplicate skipping is
             # enabled — the intra-batch dedup that consults this map is
             # gated on ``checker`` above, so populating it with

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -661,6 +661,41 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         unsafe_files.append({"path": str(source_file), "reason": reason})
         log.warning("Remote import failed for %s: %s", source_file, reason)
 
+    # Intra-run bookkeeping so a second byte-identical card file (with a
+    # different basename) in this run is recognized as a duplicate before
+    # ``scan()`` runs — the DB twin lookup can't help until the batch's
+    # ``scan()`` has cataloged the first landing. Mirrors the local path.
+    run_dest_folders = {}
+    run_verified_hashes = {}
+
+    def _record_checker(source_file, dest_folder=None, file_hash=None):
+        """Register a landed/adopted file's identity with the intra-run checker.
+
+        Without this the checker only sees the pre-run catalog, so a later
+        byte-identical card file with a different basename in the same run
+        is rsynced/cataloged again instead of being recognized as an
+        intra-run duplicate. Mirrors the local path's ``_record_checker``.
+        ``DuplicateChecker.record`` re-``os.stat``s the source path — swallow
+        OSError (removable media yanked mid-run) so the run keeps its
+        already-verified landings and only loses the intra-run dedupe
+        optimization. See PR #1113 review.
+        """
+        if checker is None:
+            return
+        try:
+            tokens = checker.record(source_file)
+        except OSError as e:
+            log.warning(
+                "Duplicate-checker record() failed for %s: %s",
+                source_file, e,
+            )
+            return
+        for tok in tokens:
+            if dest_folder is not None:
+                run_dest_folders[tok] = dest_folder
+            if file_hash is not None:
+                run_verified_hashes[tok] = file_hash
+
     for rel, batch in batches:
         if runner.is_cancelled(job["id"]):
             cancelled = True
@@ -749,6 +784,18 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         # dest basename -> src_hash, for intra-batch same-basename collision
         # resolution (FIX 2). Populated as files are queued/skipped.
         claimed_basenames = {}
+        # src_hash set, for intra-batch same-content different-basename
+        # dedup: the local path calls ``_record_checker`` inside its own
+        # batch loop (right after each copy_and_hash_verify), so a byte-
+        # identical second file in the same loop sees the first landing
+        # via ``run_dest_folders`` and is skipped. The remote path
+        # decouples "decide to copy" (this batch loop) from "actually
+        # copied" (the post-loop rsync), so a byte-identical second file
+        # would otherwise sail past the empty ``_seen_hashes`` and get
+        # queued/rsynced/cataloged again. Track queued src hashes here
+        # to catch that case at enqueue time — the file that was already
+        # queued backs this skip. See PR #1113 review.
+        queued_src_hashes = {}
         for source_file in batch:
             if runner.is_cancelled(job["id"]):
                 cancelled = True
@@ -777,40 +824,67 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                                   f"duplicate check failed: {e}")
                             continue
                     accept = False
+                    # Intra-run fast path: an earlier file in this run
+                    # already landed for this identity, so this file's
+                    # bytes are byte-proven by the earlier landing without
+                    # hitting the archive. ``('hash', …)`` tokens carry
+                    # the bytes as their identity; ``('key', …)`` tokens
+                    # need the source's fresh hash to match the run twin's
+                    # verified hash before accepting (two different files
+                    # with the same filename+size+capture-second must not
+                    # dedupe on metadata alone). Without this, the DB
+                    # twin lookup below sees only the pre-``scan()``
+                    # catalog and a byte-identical second file gets
+                    # rsynced/cataloged again. Mirrors the local path.
+                    # See PR #1113 review.
+                    if token in run_dest_folders:
+                        if token[0] == "hash":
+                            accept = True
+                        else:
+                            run_hash = run_verified_hashes.get(token)
+                            if (
+                                src_hash is not None
+                                and run_hash is not None
+                                and src_hash == run_hash
+                            ):
+                                accept = True
                     # Twins whose bytes we actually hashed this run and
                     # matched against the source. Only these back a
                     # duplicate-folder link (a stale/off-destination twin's
                     # folder must not be pulled into the active workspace).
                     verified_twin_rows = []
-                    for twin in twin_rows:
-                        twin_path = os.path.join(
-                            twin["folder_path"], twin["filename"],
-                        )
-                        # A twin cataloged under any import source root is
-                        # (or may be) the card file being imported this run
-                        # — re-hashing it just re-reads the source, proving
-                        # nothing about an off-card copy. Accepting it would
-                        # count the file as skipped_duplicate and (with
-                        # verify_by_hash) let safe_to_format go green while
-                        # the card holds the only bytes. Mirrors the local
-                        # path's filter. See PR #1113 review.
-                        if _path_under_any_source(twin_path):
-                            continue
-                        try:
-                            twin_hash = compute_file_hash(twin_path)
-                        except OSError:
-                            continue
-                        if twin_hash is not None and twin_hash == src_hash:
-                            accept = True
-                            # Keep scanning to collect every byte-verified
-                            # twin's folder — an older run may have written
-                            # the same identity into a different folder
-                            # layout (e.g. ``unsorted`` or a different date
-                            # template), and only the folder we RE-HASHED
-                            # this run is safe to link. Mirrors the local
-                            # path's collect-then-link pattern. See PR
-                            # #1113 review.
-                            verified_twin_rows.append(twin)
+                    if not accept:
+                        for twin in twin_rows:
+                            twin_path = os.path.join(
+                                twin["folder_path"], twin["filename"],
+                            )
+                            # A twin cataloged under any import source root
+                            # is (or may be) the card file being imported
+                            # this run — re-hashing it just re-reads the
+                            # source, proving nothing about an off-card
+                            # copy. Accepting it would count the file as
+                            # skipped_duplicate and (with verify_by_hash)
+                            # let safe_to_format go green while the card
+                            # holds the only bytes. Mirrors the local
+                            # path's filter. See PR #1113 review.
+                            if _path_under_any_source(twin_path):
+                                continue
+                            try:
+                                twin_hash = compute_file_hash(twin_path)
+                            except OSError:
+                                continue
+                            if twin_hash is not None and twin_hash == src_hash:
+                                accept = True
+                                # Keep scanning to collect every byte-
+                                # verified twin's folder — an older run
+                                # may have written the same identity into a
+                                # different folder layout (e.g.
+                                # ``unsorted`` or a different date
+                                # template), and only the folder we
+                                # RE-HASHED this run is safe to link.
+                                # Mirrors the local path's collect-then-
+                                # link pattern. See PR #1113 review.
+                                verified_twin_rows.append(twin)
                     if accept:
                         skipped_duplicate += 1
                         dup_skipped += 1
@@ -829,6 +903,15 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                                 _path_under_destination,
                             ),
                         )
+                        # An intra-run twin's dest_folder isn't cataloged
+                        # yet (scan runs after the batch loop) but WILL be
+                        # by this run's own batch scan, so add it to
+                        # dup_dirs so a duplicate-only follow-up batch
+                        # still finds it visible. Mirrors the local path.
+                        run_dest = run_dest_folders.get(token)
+                        if run_dest is not None:
+                            dup_dirs.add(run_dest)
+                        _record_checker(source_file)
                         continue
             # Collision parity (FIX 2): rsync lands files flat by basename,
             # so two different card files with the same basename in one batch
@@ -849,6 +932,19 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
             except OSError as e:
                 _fail(rel, source_file, str(e))
                 continue
+            # Intra-batch same-content dedup: an earlier file THIS BATCH
+            # queued a byte-identical source under a different basename
+            # (e.g. ``DSC_0001.jpg`` and ``DSC_0002.jpg`` with the same
+            # bytes). The batch's rsync hasn't happened yet, so the DB
+            # twin lookup and ``checker.match()`` above can't see it —
+            # skip here to match the local path's post-copy behaviour.
+            # See PR #1113 review.
+            if src_hash is not None and src_hash in queued_src_hashes:
+                skipped_duplicate += 1
+                dup_skipped += 1
+                _counts(rel)["skipped_duplicate"] += 1
+                _record_checker(source_file, dest_folder, src_hash)
+                continue
             stem, suffix = os.path.splitext(source_file.name)
             counter = 0
             adopted = False
@@ -866,6 +962,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         skipped_duplicate += 1
                         dup_skipped += 1
                         _counts(rel)["skipped_duplicate"] += 1
+                        _record_checker(source_file, dest_folder, src_hash)
                         adopted = True
                         break
                     counter += 1
@@ -888,6 +985,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         # and skip the adopted-but-uncataloged file). See
                         # PR #1113 review.
                         adopted_paths.add(cand_mount)
+                        _record_checker(source_file, dest_folder, src_hash)
                         adopted = True
                         break
                     counter += 1
@@ -897,6 +995,8 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
             if adopted:
                 continue
             claimed_basenames[dest_basename] = src_hash
+            if src_hash is not None:
+                queued_src_hashes[src_hash] = dest_folder
             to_transfer.append((source_file, dest_basename, src_hash))
 
         # --- Per-batch rsync -------------------------------------------
@@ -1045,6 +1145,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                     if params.verify_by_hash:
                         verified += 1
                     landed.append((dest_path, str(sf), src_hash, sz, mt))
+                    _record_checker(sf, dest_folder, src_hash)
 
         # --- Catalog this batch ----------------------------------------
         # Fresh copies AND duplicate skips both need the mount folder
@@ -1358,36 +1459,93 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                 [(d,) for d in sorted(new_dup_dirs)],
             )
             db.conn.commit()
-            try:
-                scan(
-                    destination, db,
-                    restrict_dirs=sorted(new_dup_dirs),
-                    vireo_dir=params.vireo_dir,
-                    thumb_cache_dir=params.thumb_cache_dir,
-                    skip_working_copies=True,
-                    cancel_check=lambda: runner.is_cancelled(job["id"]),
-                )
-                linked_dup_dirs.update(new_dup_dirs)
-            except Exception as e:
+            # Twin folders may be cataloged through a symlink alias while
+            # ``destination`` is realpath-normalized above.
+            # ``_path_under_destination`` accepts them via realpath, but
+            # scanner's ``_ensure_folder`` walks parents *lexically* until
+            # they equal the scan root — a restrict_dir ``/alias/…``
+            # scanned under root ``/real/archive`` would recurse toward
+            # ``/`` before the ``workspace_folders`` link is ever created,
+            # leaving the verified duplicate-only remote import marked
+            # failed/unsafe. Split by whether the twin's folder path sits
+            # lexically under destination: link the alias-spelled ones
+            # directly (their folder row and the twin's photos already
+            # exist — no self-heal scan needed for workspace visibility),
+            # scan only the lexically-under-destination ones. Mirrors the
+            # local path's split; see PR #1113 review.
+            lex_dup_dirs = set()
+            alias_dup_dirs = set()
+            for d in new_dup_dirs:
+                d_cmp = (
+                    d.casefold() if _dest_ci else d
+                ).rstrip(os.sep)
                 if (
-                    isinstance(e, RuntimeError)
-                    and str(e) == "scan cancelled"
-                    and runner.is_cancelled(job["id"])
+                    d_cmp == _dest_root_norm
+                    or d_cmp.startswith(_dest_root_norm + os.sep)
                 ):
-                    cancelled = True
+                    lex_dup_dirs.add(d)
                 else:
-                    log.exception(
-                        "Linking duplicate-matched folders failed: %s",
-                        sorted(new_dup_dirs),
+                    alias_dup_dirs.add(d)
+
+            for d in sorted(alias_dup_dirs):
+                folder_row = db.conn.execute(
+                    "SELECT id FROM folders WHERE path = ?", (d,),
+                ).fetchone()
+                if folder_row is None:
+                    log.warning(
+                        "Alias-spelled dup dir %s vanished from folders "
+                        "between _linkable_twin_dirs and the direct "
+                        "workspace link", d,
                     )
                     dup_link_failed = True
-                    for d in sorted(new_dup_dirs):
-                        unsafe_files.append({
-                            "path": d,
-                            "reason": (
-                                f"duplicate-folder link scan failed: {e}"
-                            ),
-                        })
+                    unsafe_files.append({
+                        "path": d,
+                        "reason": (
+                            "duplicate-folder workspace link failed: "
+                            "folder row not found"
+                        ),
+                    })
+                    continue
+                db.add_workspace_folder(
+                    workspace_id, folder_row["id"], is_root=True,
+                )
+                linked_dup_dirs.add(d)
+                _invalidate_new_images(db, d)
+            db.conn.commit()
+
+            if lex_dup_dirs:
+                try:
+                    scan(
+                        destination, db,
+                        restrict_dirs=sorted(lex_dup_dirs),
+                        vireo_dir=params.vireo_dir,
+                        thumb_cache_dir=params.thumb_cache_dir,
+                        skip_working_copies=True,
+                        cancel_check=lambda: runner.is_cancelled(job["id"]),
+                    )
+                    linked_dup_dirs.update(lex_dup_dirs)
+                    for d in sorted(lex_dup_dirs):
+                        _invalidate_new_images(db, d)
+                except Exception as e:
+                    if (
+                        isinstance(e, RuntimeError)
+                        and str(e) == "scan cancelled"
+                        and runner.is_cancelled(job["id"])
+                    ):
+                        cancelled = True
+                    else:
+                        log.exception(
+                            "Linking duplicate-matched folders failed: %s",
+                            sorted(lex_dup_dirs),
+                        )
+                        dup_link_failed = True
+                        for d in sorted(lex_dup_dirs):
+                            unsafe_files.append({
+                                "path": d,
+                                "reason": (
+                                    f"duplicate-folder link scan failed: {e}"
+                                ),
+                            })
 
         _emit(
             f"{rel}: {_counts(rel)['copied']} copied · "

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -626,6 +626,34 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
             posixpath.join(ssh_base, *rel.split("/")) if rel != "."
             else ssh_base
         )
+        # Reject the whole batch before creating any directories on the card
+        # or hashing candidate files below. When the mount base is an
+        # ancestor of a selected source and the folder template maps back
+        # into that source folder, ``dest_folder`` (and therefore every
+        # ``cand_mount`` under it) resolves inside a source root. The
+        # per-file collision loop below would hash those source-backed
+        # ``cand_mount`` files, byte-match them against the card, and count
+        # them as ``skipped_duplicate`` — with ``verify_by_hash=true`` that
+        # would let ``safe_to_format`` go green over a card whose bytes
+        # never crossed the network. Mirrors the local path's batch-level
+        # dest-under-source guard (formatting the card would erase the
+        # archive copy). See PR #1113 review.
+        if _path_under_any_source(dest_folder):
+            for source_file in batch:
+                emitted += 1
+                _fail(
+                    rel, source_file,
+                    "destination folder resolves inside a source directory "
+                    "(dest_folder would be created under the card being "
+                    "imported); formatting the card would erase the archive "
+                    "copy",
+                )
+            _emit(
+                f"{rel}: {_counts(rel)['copied']} copied · "
+                f"{_counts(rel)['skipped_duplicate']} already present",
+                emitted, discovered,
+            )
+            continue
         os.makedirs(dest_folder, exist_ok=True)
 
         # Promote any pre-existing folder row for this destination out of
@@ -945,6 +973,23 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                     if params.verify_by_hash:
                         verified -= 1
                     _fail(rel, dest_path, f"catalog scan failed: {e}")
+                # A duplicate-only batch (all files matched cataloged
+                # twins) still needs the scan() call to link the twin
+                # folder into the workspace. If landed is empty (no fresh
+                # copies) but dup_skipped > 0 and scan() raised, no
+                # per-file failure was recorded above and safe_to_format
+                # could go green while the duplicate folder never became
+                # visible in the workspace. Record a batch-level failure
+                # for that case so ``failed`` reflects "the workspace
+                # cannot see these bytes" and safe_to_format goes False.
+                # Mirrors the local path's ``dup_link_failed`` gate. See
+                # PR #1113 review.
+                if not landed and dup_skipped > 0:
+                    _fail(
+                        rel, dest_folder,
+                        f"catalog scan failed for duplicate-only batch "
+                        f"(twin folder not linked): {e}",
+                    )
                 landed = []
             else:
                 _invalidate_new_images(db, dest_folder)
@@ -975,51 +1020,65 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                      os.path.basename(dest_path)),
                 ).fetchone()
                 if row is not None:
-                    if params.verify_by_hash:
-                        # Cross-check the scanned MOUNT row's hash against
-                        # the source hash that remote_verify_files just
-                        # confirmed at the NAS. remote_verify_files ran
-                        # card -> ssh_base (the NAS); scan() reads whatever
-                        # is under the mount base. If the mount is stale
-                        # or misconfigured but happens to already contain
-                        # the same <folder>/<filename> we transferred, scan
-                        # populates ``file_hash`` from the mount's (wrong)
-                        # bytes. Stamping ``hash_status='ok'`` on that row
-                        # would let ``safe_to_format`` go green over
-                        # storage we never actually touched. Require the
-                        # scanned row's file_hash to match the verified
-                        # source hash; otherwise fail this file. Mirrors
-                        # the local path's cross-check against
-                        # ``verified_hash``. See PR #1113 review.
-                        #
-                        # Normalize zero-byte convention on both sides:
-                        # scan() writes NULL for zero-byte files;
-                        # ``checker.content_hash`` returns None; a
-                        # checker-less ``compute_file_hash`` returns
-                        # ``EMPTY_FILE_SHA256``. Treat all three as
-                        # equivalent so an empty card file matches its
-                        # empty catalog row.
-                        scan_h = row["file_hash"]
-                        if scan_h == EMPTY_FILE_SHA256:
-                            scan_h = None
-                        src_h_norm = (
-                            None if src_hash == EMPTY_FILE_SHA256
-                            else src_hash
-                        )
-                        if scan_h != src_h_norm:
-                            copied -= 1
+                    # Cross-check the scanned MOUNT row's hash against the
+                    # source hash (the bytes we intended to land). This
+                    # runs even without ``verify_by_hash`` because catalog
+                    # integrity is a separate concern from the format
+                    # honesty gate: a stale/misconfigured mount that
+                    # happens to already contain ``<folder>/<filename>``
+                    # for a name we ``--ignore-existing``-transferred, or
+                    # a receiver-side race that left a different file at
+                    # that path, would otherwise be cataloged against
+                    # unrelated bytes while ``safe_to_format=False``
+                    # (correct on the format side, but the workspace
+                    # catalog now points at the wrong photo). The
+                    # ``hash_status='ok'`` stamp still runs ONLY behind
+                    # ``verify_by_hash`` — that stamp is the independent
+                    # card→NAS attestation, not just "scan and source
+                    # agree on the mount view". Mirrors the local path's
+                    # cross-check against ``verified_hash``. See PR #1113
+                    # review.
+                    #
+                    # Normalize zero-byte convention on both sides:
+                    # scan() writes NULL for zero-byte files;
+                    # ``checker.content_hash`` returns None; a
+                    # checker-less ``compute_file_hash`` returns
+                    # ``EMPTY_FILE_SHA256``. Treat all three as
+                    # equivalent so an empty card file matches its
+                    # empty catalog row.
+                    scan_h = row["file_hash"]
+                    if scan_h == EMPTY_FILE_SHA256:
+                        scan_h = None
+                    src_h_norm = (
+                        None if src_hash == EMPTY_FILE_SHA256
+                        else src_hash
+                    )
+                    # scan() can legitimately leave ``file_hash`` NULL
+                    # (large files, prior partial scan, tests that stub
+                    # the hash step). Only fail on a positive mismatch —
+                    # two set hashes that disagree. A missing scan hash
+                    # doesn't prove anything, so don't turn it into a
+                    # spurious failure.
+                    if scan_h is not None and scan_h != src_h_norm:
+                        copied -= 1
+                        if params.verify_by_hash:
                             verified -= 1
-                            _counts(rel)["copied"] -= 1
-                            _fail(
-                                rel, dest_path,
-                                "scanned mount row hash does not match "
-                                "the hash verified on the NAS (mount "
-                                "base is likely stale or misconfigured)",
-                            )
-                            landed = [
-                                e for e in landed if e[0] != dest_path
-                            ]
-                            continue
+                        _counts(rel)["copied"] -= 1
+                        _fail(
+                            rel, dest_path,
+                            "scanned mount row hash does not match "
+                            "the source hash (mount base is likely "
+                            "stale or misconfigured)"
+                            if not params.verify_by_hash else
+                            "scanned mount row hash does not match "
+                            "the hash verified on the NAS (mount "
+                            "base is likely stale or misconfigured)",
+                        )
+                        landed = [
+                            e for e in landed if e[0] != dest_path
+                        ]
+                        continue
+                    if params.verify_by_hash:
                         db.update_photo_hash_check(
                             row["id"], "ok", commit=False,
                         )

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -628,6 +628,26 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         )
         os.makedirs(dest_folder, exist_ok=True)
 
+        # Promote any pre-existing folder row for this destination out of
+        # ``'missing'``. Mirrors the local path (see
+        # ``UPDATE folders SET status = 'ok' ... status = 'missing'``
+        # after ``os.makedirs`` there): ``scanner.scan()`` only clears
+        # ``'partial'`` on success, and workspace/photo queries hide rows
+        # under ``missing`` folders, so a folder row still labelled
+        # ``'missing'`` (from a prior health check when the NAS mount was
+        # absent) would keep the just-imported photos invisible in the
+        # workspace even after this run lands and hash-stamps them —
+        # ``safe_to_format`` could go green over folders the UI won't
+        # show. We just makedirs'd the folder so the path exists;
+        # preserve ``'partial'`` (a real prior-scan needs-rescan signal).
+        # See PR #1113 review.
+        db.conn.execute(
+            "UPDATE folders SET status = 'ok' "
+            "WHERE path = ? AND status = 'missing'",
+            (dest_folder,),
+        )
+        db.conn.commit()
+
         # Duplicate gate. A remote duplicate skip is only honest when the
         # cataloged twin's bytes are confirmed at the destination; the local
         # path re-hashes the twin's archive file. On the mount that file is
@@ -931,18 +951,21 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
 
             # Catalog-row presence is required on BOTH paths: the route's
             # copy-and-catalog contract says every landed byte becomes a
-            # photo row, and a landed file with no row after scan is failed
-            # rather than silently left counted as ``copied`` — otherwise a
-            # remote import into an unmounted/misconfigured mount base would
-            # report copied/ok (or copied/NULL, no-verify) with no catalog
-            # trail. (A RAW+JPEG pair whose JPEG row was merged into the RAW
-            # is the main legitimate "no row" case; the RAW carries the
-            # bytes, so failing the JPEG here is conservative but keeps the
-            # pill honest.) Hash stamping (``hash_status='ok'``) still runs
-            # ONLY on the checksum-verification path — without
-            # verify_by_hash the rows keep NULL hash_status/hash_checked_at
-            # (scan may set file_hash, but we don't claim an integrity
-            # verdict we didn't independently make).
+            # photo row (directly or via a companion_path on a sibling
+            # row), and a landed file with no row and no companion row
+            # after scan is failed rather than silently left counted as
+            # ``copied`` — otherwise a remote import into an unmounted/
+            # misconfigured mount base would report copied/ok (or
+            # copied/NULL, no-verify) with no catalog trail. The
+            # RAW+JPEG-pair case (scan merges the JPEG row into the RAW
+            # primary via ``companion_path`` and deletes the JPEG row) is
+            # handled explicitly below so a legitimate paired JPEG is
+            # accepted instead of failed. Hash stamping
+            # (``hash_status='ok'``) still runs ONLY on the checksum-
+            # verification path — without verify_by_hash the rows keep
+            # NULL hash_status/hash_checked_at (scan may set file_hash,
+            # but we don't claim an integrity verdict we didn't
+            # independently make).
             for dest_path, _sf, src_hash, _sz, _mt in list(landed):
                 row = db.conn.execute(
                     """SELECT p.id, p.file_hash FROM photos p
@@ -1001,6 +1024,57 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                             row["id"], "ok", commit=False,
                         )
                 else:
+                    # RAW+JPEG pairing merges the JPEG's photo row into
+                    # the RAW primary (companion_path) and deletes the
+                    # JPEG's own row, so a landed JPEG whose sibling RAW
+                    # was scanned in the same batch legitimately has no
+                    # row of its own. Look it up as another row's
+                    # companion_path before deciding "not cataloged".
+                    # When verifying, cross-check the mount JPEG bytes
+                    # against the hash confirmed card->NAS (same
+                    # stale-mount guard the non-companion branch runs
+                    # above). Mirrors the local path's companion lookup.
+                    # See PR #1113 review.
+                    companion = db.conn.execute(
+                        """SELECT p.id FROM photos p
+                           JOIN folders f ON f.id = p.folder_id
+                           WHERE f.path = ? AND p.companion_path = ?""",
+                        (os.path.dirname(dest_path),
+                         os.path.basename(dest_path)),
+                    ).fetchone()
+                    if companion is not None:
+                        if params.verify_by_hash:
+                            try:
+                                mount_hash = compute_file_hash(dest_path)
+                            except OSError:
+                                mount_hash = None
+                            src_h_norm = (
+                                None if src_hash == EMPTY_FILE_SHA256
+                                else src_hash
+                            )
+                            mount_norm = (
+                                None if mount_hash == EMPTY_FILE_SHA256
+                                else mount_hash
+                            )
+                            if mount_norm != src_h_norm:
+                                copied -= 1
+                                verified -= 1
+                                _counts(rel)["copied"] -= 1
+                                _fail(
+                                    rel, dest_path,
+                                    "paired companion mount bytes do "
+                                    "not match the hash verified on "
+                                    "the NAS (mount base is likely "
+                                    "stale or misconfigured)",
+                                )
+                                landed = [
+                                    e for e in landed if e[0] != dest_path
+                                ]
+                                continue
+                        # JPEG bytes are represented by the RAW row's
+                        # companion_path — accept as landed; leave the
+                        # copied/verified counters alone.
+                        continue
                     copied -= 1
                     if params.verify_by_hash:
                         verified -= 1

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -49,6 +49,7 @@ import contextlib
 import errno
 import logging
 import os
+import posixpath
 import shutil
 import sys
 import uuid
@@ -120,6 +121,18 @@ class ImportParams:
     # After-import process strategy name. Stored in the job config for the
     # PR 3 chaining hook; unused by the import job itself.
     after_import: str | None = None
+    # Remote (SSH) archive destination (Task 2.7). When set, the card is
+    # rsynced to ``remote_path/subpath`` over SSH instead of copied locally,
+    # and photos are cataloged at ``mount_path/subpath`` (which ``destination``
+    # is set to). The dict shape (built by ``/api/jobs/import-photos`` from
+    # ``config.get_remote_target`` + ``build_remote_move_spec``):
+    #   {"rsync_bin": str,
+    #    "remote": <build_remote_move_spec dict: host/user/port/ssh_key/
+    #               bwlimit_kbps/rsync_bin/ssh_dest_base/mount_dest_base>,
+    #    "ssh_base": remote_path/subpath (NAS-side),
+    #    "mount_base": mount_path/subpath (== destination)}
+    # ``None`` keeps the local copy path unchanged.
+    remote_target: dict | None = None
     # Vireo data dir for working-copy extraction (Task 2.5). None skips
     # extraction (tests, or callers that defer to the scanner backfill).
     vireo_dir: str | None = None
@@ -379,6 +392,542 @@ def _linkable_twin_dirs(rows, under_destination):
     return dirs
 
 
+def _run_remote_import_job(job, runner, db, workspace_id, params):
+    """Import to a remote (SSH) archive destination (Task 2.7).
+
+    Groups the card into destination-folder batches exactly like the local
+    path, but transfers each batch with a single per-batch rsync to
+    ``remote_path/subpath/<rel>`` over SSH (``move.py`` plumbing) instead of
+    ``copy_and_hash_verify``. Photos are cataloged at
+    ``mount_path/subpath/<rel>`` — ``params.destination`` is the local mount
+    base, so ``scan()`` walks the just-rsynced files exactly as it would a
+    local copy.
+
+    Verification: rsync's own transfer integrity by default; a ``--checksum``
+    dry-run (``move._remote_verify_complete``) only when
+    ``params.verify_by_hash``. Catalog rows get ``hash_status='ok'`` +
+    ``hash_checked_at`` ONLY on the checksum path; otherwise both stay NULL
+    (no invented status values). Consequently a remote import without
+    ``verify_by_hash`` honestly reports ``safe_to_format=False`` with the
+    reason ``"enable verify_by_hash for remote verification"`` — the card is
+    off-loaded but its landing wasn't independently hash-confirmed.
+    """
+    from scanner import scan
+
+    rt = params.remote_target
+    remote = rt["remote"]                 # build_remote_move_spec dict
+    rsync_bin = rt.get("rsync_bin") or remote.get("rsync_bin")
+    ssh_base = rt["ssh_base"]             # remote_path/subpath (NAS side)
+    # The catalog/mount base is params.destination (the route sets it to
+    # mount_path/subpath). Normalize identically to the local path.
+    try:
+        destination = os.path.realpath(os.path.normpath(str(params.destination)))
+    except OSError:
+        destination = os.path.normpath(str(params.destination))
+
+    import move as move_mod
+
+    runner.set_steps(job["id"], [
+        {"id": "import", "label": "Copy & catalog"},
+    ])
+    runner.update_step(job["id"], "import", status="running")
+
+    def _emit(phase, current, total, current_file=""):
+        job["progress"]["current"] = current
+        job["progress"]["total"] = total
+        job["progress"]["current_file"] = current_file
+        runner.update_step(
+            job["id"], "import",
+            current_file=current_file,
+            progress={"current": current, "total": total},
+        )
+        runner.push_event(job["id"], "progress", {
+            "phase": phase, "current": current, "total": total,
+            "current_file": current_file,
+        })
+
+    # --- Discover (same enumeration-error handling as the local path) ---
+    _emit("Discovering files", 0, 0)
+    files = []
+    discovery_errors = []
+
+    def _discovery_onerror(exc):
+        discovery_errors.append(exc)
+        log.warning("Import discovery error: %s", exc)
+
+    for src in params.sources:
+        files.extend(discover_source_files(
+            src, params.file_types, recursive=params.recursive,
+            onerror=_discovery_onerror,
+        ))
+    discovered = len(files)
+
+    checker = None
+    if params.skip_duplicates:
+        checker = DuplicateChecker(
+            CatalogIndex.from_db(db), verify_by_hash=params.verify_by_hash,
+        )
+        checker.prepare(files)
+
+    timestamps = _source_file_timestamps(
+        files,
+        capture_times=(
+            {str(f): checker.capture_time(f) for f in files}
+            if checker is not None and not checker.verify_by_hash
+            else None
+        ),
+    )
+
+    groups = {}
+    for f in files:
+        rel = build_destination_path(
+            timestamps.get(f), params.folder_template,
+        ) or "."
+        groups.setdefault(rel, []).append(f)
+    batches = []
+    for rel in sorted(groups):
+        group = groups[rel]
+        for i in range(0, len(group), IMPORT_BATCH_SIZE):
+            batches.append((rel, group[i:i + IMPORT_BATCH_SIZE]))
+
+    # --- Ledger ---------------------------------------------------------
+    copied = 0
+    verified = 0            # count of files independently checksum-verified
+    skipped_duplicate = 0
+    failed = 0
+    unsafe_files = []
+    folder_counts = {}
+    emitted = 0
+    cancelled = False
+    wc_source_paths = {}
+    wc_dest_folders = set()
+
+    def _counts(rel):
+        return folder_counts.setdefault(
+            rel, {"copied": 0, "skipped_duplicate": 0, "failed": 0},
+        )
+
+    def _fail(rel, source_file, reason):
+        nonlocal failed
+        failed += 1
+        _counts(rel)["failed"] += 1
+        unsafe_files.append({"path": str(source_file), "reason": reason})
+        log.warning("Remote import failed for %s: %s", source_file, reason)
+
+    for rel, batch in batches:
+        if runner.is_cancelled(job["id"]):
+            cancelled = True
+            break
+
+        dest_folder = (
+            os.path.normpath(os.path.join(destination, rel))
+            if rel != "." else destination
+        )
+        ssh_dest = (
+            posixpath.join(ssh_base, *rel.split("/")) if rel != "."
+            else ssh_base
+        )
+        os.makedirs(dest_folder, exist_ok=True)
+
+        # Duplicate gate. A remote duplicate skip is only honest when the
+        # cataloged twin's bytes are confirmed at the destination; the local
+        # path re-hashes the twin's archive file. On the mount that file is
+        # locally readable, so reuse the same on-disk re-hash contract.
+        to_transfer = []           # (source_file, dest_basename)
+        dup_skipped = 0
+        # dest basename -> src_hash, for intra-batch same-basename collision
+        # resolution (FIX 2). Populated as files are queued/skipped.
+        claimed_basenames = {}
+        for source_file in batch:
+            if runner.is_cancelled(job["id"]):
+                cancelled = True
+                break
+            emitted += 1
+            _emit(f"{rel}: importing", emitted, discovered, source_file.name)
+            if checker is not None:
+                try:
+                    token = checker.match(source_file)
+                except OSError as e:
+                    _fail(rel, source_file, f"duplicate check failed: {e}")
+                    continue
+                if token is not None:
+                    # Confirm against a cataloged twin's on-disk bytes (mount
+                    # side is locally readable). Only a byte-verified twin
+                    # backs a skip; otherwise import the file normally.
+                    if token[0] == "hash":
+                        twin_rows = _hash_twin_rows(db, token[1])
+                        src_hash = token[1]
+                    else:
+                        twin_rows = _key_twin_rows(db, token[1])
+                        try:
+                            src_hash = checker.content_hash(source_file)
+                        except OSError as e:
+                            _fail(rel, source_file,
+                                  f"duplicate check failed: {e}")
+                            continue
+                    accept = False
+                    for twin in twin_rows:
+                        twin_path = os.path.join(
+                            twin["folder_path"], twin["filename"],
+                        )
+                        try:
+                            twin_hash = compute_file_hash(twin_path)
+                        except OSError:
+                            continue
+                        if twin_hash is not None and twin_hash == src_hash:
+                            accept = True
+                            break
+                    if accept:
+                        skipped_duplicate += 1
+                        dup_skipped += 1
+                        _counts(rel)["skipped_duplicate"] += 1
+                        continue
+            # Collision parity (FIX 2): rsync lands files flat by basename,
+            # so two different card files with the same basename in one batch
+            # would clobber on the NAS. Assign a distinct dest basename per
+            # colliding file, mirroring ingest()/the local path: a byte-
+            # identical file already at the destination (a prior run's copy,
+            # or an earlier card file this batch) is a skip; a different one
+            # advances through numeric suffixes. ``claimed_basenames`` tracks
+            # names taken by earlier files IN THIS BATCH; the mount is
+            # locally readable so already-landed bytes are checked on disk.
+            dest_basename = source_file.name
+            try:
+                src_hash = (
+                    checker.content_hash(source_file)
+                    if checker is not None
+                    else compute_file_hash(str(source_file))
+                )
+            except OSError as e:
+                _fail(rel, source_file, str(e))
+                continue
+            stem, suffix = os.path.splitext(source_file.name)
+            counter = 0
+            adopted = False
+            while True:
+                candidate = (
+                    source_file.name if counter == 0
+                    else f"{stem}_{counter}{suffix}"
+                )
+                cand_mount = os.path.join(dest_folder, candidate)
+                if candidate in claimed_basenames:
+                    # Claimed earlier in this batch (a same-basename sibling
+                    # already queued). If that sibling has our exact bytes,
+                    # skip as an intra-batch duplicate; otherwise advance.
+                    if claimed_basenames[candidate] == src_hash:
+                        skipped_duplicate += 1
+                        dup_skipped += 1
+                        _counts(rel)["skipped_duplicate"] += 1
+                        adopted = True
+                        break
+                    counter += 1
+                    continue
+                if os.path.exists(cand_mount):
+                    # Already on disk (crash-recovery/resume). Byte-identical
+                    # -> skip; different -> advance to the next suffix.
+                    try:
+                        on_disk = compute_file_hash(cand_mount)
+                    except OSError:
+                        on_disk = None
+                    if on_disk is not None and on_disk == src_hash:
+                        skipped_duplicate += 1
+                        dup_skipped += 1
+                        _counts(rel)["skipped_duplicate"] += 1
+                        claimed_basenames[candidate] = src_hash
+                        adopted = True
+                        break
+                    counter += 1
+                    continue
+                dest_basename = candidate
+                break
+            if adopted:
+                continue
+            claimed_basenames[dest_basename] = src_hash
+            to_transfer.append((source_file, dest_basename))
+
+        # --- Per-batch rsync -------------------------------------------
+        landed = []   # (dest_path, card_source, src_size, src_mtime_ns)
+        if to_transfer:
+            extra_args = [
+                "-e", move_mod._ssh_rsh_string(remote),
+                "--partial-dir=.rsync-partial",
+            ]
+            if remote.get("bwlimit_kbps"):
+                extra_args.append(f"--bwlimit={int(remote['bwlimit_kbps'])}")
+            rsync_target = move_mod.rsync_dest_spec(remote, ssh_dest)
+            # rsync creates the leaf itself but not intermediate parents.
+            ok_mkdir, mkdir_detail = move_mod._remote_mkdir_p(remote, ssh_dest)
+            if not ok_mkdir:
+                for sf, _bn in to_transfer:
+                    _fail(rel, sf,
+                          f"remote mkdir failed for {ssh_dest}: {mkdir_detail}")
+            else:
+                # Split into the flat fast path (dest basename == card
+                # basename) and collision-renamed files (transferred and
+                # verified individually to an explicit NAS filename, since a
+                # flat --files-from list to one dir can't rename).
+                flat = [
+                    (sf, bn) for sf, bn in to_transfer
+                    if bn == sf.name
+                ]
+                renamed = [
+                    (sf, bn) for sf, bn in to_transfer
+                    if bn != sf.name
+                ]
+
+                def _do_rsync(src_specs, target, dest_is_dir, extra_args):
+                    try:
+                        rc, stderr, timed_out = move_mod._run_rsync_streamed(
+                            None, target, [], len(src_specs), None,
+                            rsync_bin=rsync_bin, extra_args=extra_args,
+                            src_specs=src_specs,
+                            src_specs_dest_is_dir=dest_is_dir,
+                        )
+                        return rc, stderr, timed_out
+                    except OSError as exc:
+                        return 1, str(exc), False
+
+                transferred = []   # (sf, dest_basename, nas_full_path)
+                # Flat batch: one rsync into the dir.
+                if flat:
+                    rc, stderr, timed_out = _do_rsync(
+                        [str(sf) for sf, _bn in flat], rsync_target, True,
+                        extra_args)
+                    if timed_out:
+                        for sf, _bn in flat:
+                            _fail(rel, sf, "rsync stalled (no progress)")
+                    elif rc != 0:
+                        for sf, _bn in flat:
+                            _fail(rel, sf, f"rsync failed: {stderr.strip()}")
+                    else:
+                        for sf, bn in flat:
+                            transferred.append((
+                                sf, bn, posixpath.join(ssh_dest, bn)))
+                # Renamed files: one rsync each to the explicit NAS file
+                # path (rsync <card> user@host:/dir/DSC_0001_1.jpg).
+                for sf, bn in renamed:
+                    nas_full = posixpath.join(ssh_dest, bn)
+                    rc, stderr, timed_out = _do_rsync(
+                        [str(sf)],
+                        move_mod.rsync_dest_spec(remote, nas_full), False,
+                        extra_args)
+                    if timed_out:
+                        _fail(rel, sf, "rsync stalled (no progress)")
+                    elif rc != 0:
+                        _fail(rel, sf, f"rsync failed: {stderr.strip()}")
+                    else:
+                        transferred.append((sf, bn, nas_full))
+
+                for sf, bn, nas_full in transferred:
+                    dest_path = os.path.join(dest_folder, bn)
+                    # Independent verification (Task 2.7 FIX 1): card -> NAS,
+                    # opt-in behind ``verify_by_hash`` (it reads every NAS
+                    # byte; same knob the local path uses). This compares the
+                    # actual CARD file against its NAS counterpart — the only
+                    # check that confirms the card's bytes landed intact;
+                    # comparing the SMB mount view against the NAS would be
+                    # near-tautological (same physical storage). By default
+                    # the transfer relies on rsync's own integrity checking
+                    # and the run reports ``safe_to_format=False`` (honesty
+                    # gate below) because no independent hash was made.
+                    if params.verify_by_hash:
+                        if bn == sf.name:
+                            v = move_mod.remote_verify_files(
+                                rsync_bin, [str(sf)], rsync_target,
+                                remote, dest_is_dir=True)
+                        else:
+                            # Collision-renamed: verify against the explicit
+                            # NAS name (file->file), not the card basename.
+                            v = move_mod.remote_verify_files(
+                                rsync_bin, [str(sf)],
+                                move_mod.rsync_dest_spec(remote, nas_full),
+                                remote, dest_is_dir=False)
+                        if v is not None:
+                            name, detail = v
+                            reason = (
+                                f"remote verification failed "
+                                f"({detail or name})"
+                                if name == "__ERROR__"
+                                else f"remote verification: '{name}' missing "
+                                     f"or differs at destination"
+                            )
+                            _fail(rel, sf, reason)
+                            continue
+                    try:
+                        st = sf.stat()
+                        sz, mt = st.st_size, st.st_mtime_ns
+                    except OSError:
+                        sz, mt = None, None
+                    copied += 1
+                    _counts(rel)["copied"] += 1
+                    if params.verify_by_hash:
+                        verified += 1
+                    landed.append((dest_path, str(sf), sz, mt))
+
+        # --- Catalog this batch ----------------------------------------
+        # Fresh copies AND duplicate skips both need the mount folder
+        # cataloged+linked (a duplicate-only batch would otherwise leave the
+        # mount folder invisible). scan() over the mount is the same call the
+        # local path makes; the mount is locally walkable.
+        if landed or dup_skipped:
+            landed_paths = {entry[0] for entry in landed}
+            try:
+                scan(
+                    destination, db,
+                    restrict_dirs=[dest_folder],
+                    restrict_files=(landed_paths or None),
+                    vireo_dir=params.vireo_dir,
+                    thumb_cache_dir=params.thumb_cache_dir,
+                    skip_working_copies=True,
+                )
+            except Exception as e:
+                for dest_path, _sf, _sz, _mt in landed:
+                    # Roll back the copied count and fail.
+                    copied -= 1
+                    _counts(rel)["copied"] -= 1
+                    if params.verify_by_hash:
+                        verified -= 1
+                    _fail(rel, dest_path, f"catalog scan failed: {e}")
+                landed = []
+            else:
+                _invalidate_new_images(db, dest_folder)
+
+            # Hash stamping: ONLY on the checksum-verification path. Without
+            # verify_by_hash the rows keep NULL hash_status/hash_checked_at
+            # (scan may set file_hash, but we don't claim an integrity
+            # verdict we didn't independently make). A landed file with no
+            # catalog row after scan is failed rather than silently left
+            # unstamped — otherwise it would stay counted as ``copied`` and
+            # flip ``safe_to_format`` green without a stamped ``ok`` verdict.
+            # (A RAW+JPEG pair whose JPEG row was merged into the RAW is the
+            # main "no row" case; the RAW carries the bytes, so failing the
+            # JPEG here is conservative but keeps the pill honest.)
+            if params.verify_by_hash:
+                for dest_path, _sf, _sz, _mt in list(landed):
+                    row = db.conn.execute(
+                        """SELECT p.id FROM photos p
+                           JOIN folders f ON f.id = p.folder_id
+                           WHERE f.path = ? AND p.filename = ?""",
+                        (os.path.dirname(dest_path),
+                         os.path.basename(dest_path)),
+                    ).fetchone()
+                    if row is not None:
+                        db.update_photo_hash_check(
+                            row["id"], "ok", commit=False,
+                        )
+                    else:
+                        copied -= 1
+                        verified -= 1
+                        _counts(rel)["copied"] -= 1
+                        _fail(rel, dest_path,
+                              "not cataloged after scan (no photo row)")
+                        landed = [
+                            e for e in landed if e[0] != dest_path
+                        ]
+            db.conn.commit()
+
+            if params.vireo_dir:
+                for dest_path, sf, sz, mt in landed:
+                    wc_source_paths[dest_path] = (sf, sz, mt)
+                wc_dest_folders.add(dest_folder)
+
+        _emit(
+            f"{rel}: {_counts(rel)['copied']} copied · "
+            f"{_counts(rel)['skipped_duplicate']} already present",
+            emitted, discovered,
+        )
+        if cancelled:
+            break
+
+    # --- Deferred working-copy extraction ------------------------------
+    if params.vireo_dir and wc_dest_folders and not cancelled:
+        from scanner import _extract_working_copies
+
+        try:
+            _extract_working_copies(
+                db, params.vireo_dir,
+                scope=[(d, "exact") for d in sorted(wc_dest_folders)],
+                source_paths=wc_source_paths,
+                cancel_check=lambda: runner.is_cancelled(job["id"]),
+            )
+        except Exception:
+            log.exception(
+                "Working-copy extraction failed for %s",
+                sorted(wc_dest_folders),
+            )
+        if runner.is_cancelled(job["id"]):
+            cancelled = True
+
+    status = "cancelled" if cancelled else (
+        "failed" if failed else "completed"
+    )
+    runner.update_step(
+        job["id"], "import",
+        status="failed" if status == "failed" else "completed",
+        summary=(
+            f"{copied} copied, {skipped_duplicate} already present, "
+            f"{failed} failed of {discovered} discovered"
+        ),
+    )
+
+    for exc in discovery_errors:
+        unsafe_files.append({
+            "path": str(getattr(exc, "filename", None) or "<discovery>"),
+            "reason": f"source enumeration failed: {exc}",
+        })
+
+    # Scope narrowing (same rules as the local path).
+    partial_scope = not params.recursive
+    if params.file_types != "both":
+        if isinstance(params.file_types, list):
+            normalized_types = {
+                ("." + e.lower().lstrip("."))
+                for e in params.file_types
+                if isinstance(e, str) and e
+            }
+            partial_scope = partial_scope or not SUPPORTED_EXTENSIONS.issubset(
+                normalized_types,
+            )
+        else:
+            partial_scope = True
+
+    # Honesty gate: a remote import is only safe to format when every
+    # discovered file was INDEPENDENTLY hash-confirmed at the destination —
+    # which only happens on the checksum-verification path. Without
+    # verify_by_hash the transfer relied on rsync's own integrity checking,
+    # which we do not surface as a format-the-card guarantee. Report exactly
+    # that with the plan's reason string.
+    remote_unverified = not params.verify_by_hash
+    if remote_unverified and discovered > 0:
+        unsafe_files.append({
+            "path": "<remote>",
+            "reason": "enable verify_by_hash for remote verification",
+        })
+    safe_to_format = (
+        not cancelled
+        and failed == 0
+        and not discovery_errors
+        and not partial_scope
+        and not remote_unverified
+        and (copied + skipped_duplicate) == discovered
+    )
+    result = {
+        "discovered": discovered,
+        "copied": copied,
+        "verified": verified,
+        "skipped_duplicate": skipped_duplicate,
+        "failed": failed,
+        "safe_to_format": safe_to_format,
+        "unsafe_files": unsafe_files,
+        "folders": folder_counts,
+        "cancelled": cancelled,
+        "discovery_errors": len(discovery_errors),
+        "ok": (failed == 0 and not discovery_errors),
+        "errors": [f"{u['path']}: {u['reason']}" for u in unsafe_files],
+    }
+    return result
+
+
 def run_import_job(job, runner, db_path, workspace_id, params):
     """Copy card(s) -> archive, hash-verify, and catalog incrementally.
 
@@ -390,6 +939,13 @@ def run_import_job(job, runner, db_path, workspace_id, params):
 
     db = Database(db_path)
     db.set_active_workspace(workspace_id)
+
+    if params.remote_target is not None:
+        # Remote (SSH) archive: card -> remote_path/subpath over rsync,
+        # cataloged at mount_path/subpath (== params.destination). Kept in a
+        # separate function so the local copy path stays byte-for-byte
+        # unchanged. See Task 2.7.
+        return _run_remote_import_job(job, runner, db, workspace_id, params)
 
     # Normalize once — the raw destination string is passed as ``root`` to
     # both the copy layout (``os.path.normpath(os.path.join(destination,

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -524,6 +524,39 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
     # network. Mirrors the local path's ``_path_under_any_source`` filter.
     _path_under_any_source = _build_source_root_guard(params.sources)
 
+    # Destination containment for cataloged twin folders. Used to scope
+    # ``_linkable_twin_dirs`` to twins under the mount base — an off-
+    # destination twin in some other library root is none of this import's
+    # business. Case-fold on inconclusive/insensitive filesystems (SMB, FAT,
+    # HFS+/APFS) so a differently-cased twin under the mount still matches;
+    # otherwise a duplicate-only remote import could report
+    # ``safe_to_format=True`` while the twin's folder never gets linked
+    # into the active workspace. Mirrors the local path.
+    def _probe_dir_case_insensitive(path):
+        p = os.path.normpath(path)
+        while True:
+            if os.path.isdir(p):
+                return _fs_is_case_insensitive(p)
+            parent = os.path.dirname(p)
+            if parent == p:
+                return True
+            p = parent
+
+    _dest_ci = _CASE_INSENSITIVE_PLATFORM or _probe_dir_case_insensitive(destination)
+    _dest_root_norm = (
+        destination.casefold() if _dest_ci else destination
+    ).rstrip(os.sep)
+
+    def _path_under_destination(path):
+        if not _dest_root_norm:
+            return False
+        try:
+            real = os.path.realpath(path)
+        except OSError:
+            real = str(path)
+        cmp = (real.casefold() if _dest_ci else real).rstrip(os.sep)
+        return cmp == _dest_root_norm or cmp.startswith(_dest_root_norm + os.sep)
+
     import move as move_mod
 
     runner.set_steps(job["id"], [
@@ -600,6 +633,21 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
     cancelled = False
     wc_source_paths = {}
     wc_dest_folders = set()
+    # Photo rows this run created or landed bytes into: fresh copies whose
+    # mount row was cataloged, adopted duplicates whose pre-existing mount
+    # row now belongs to this run, verified cataloged-twin skips, and RAW
+    # primaries that adopted a landed JPEG companion. The after-import
+    # chaining hook scopes its process job to exactly these; without it a
+    # successful remote import falls into the "no new photos" branch and
+    # the requested process job never runs.
+    imported_photo_ids = set()
+    # Dup-twin dirs already scanned/linked across batches (no rescan the
+    # next time the same twin folder appears in a later batch's skip set).
+    linked_dup_dirs = set()
+    # A duplicate-only batch's ONLY workspace-visibility step is the dup-
+    # link scan; if it raises, safe_to_format must go False (imported bytes
+    # exist on disk but the workspace can't see them).
+    dup_link_failed = False
 
     def _counts(rel):
         return folder_counts.setdefault(
@@ -682,6 +730,22 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         # locally readable, so reuse the same on-disk re-hash contract.
         to_transfer = []           # (source_file, dest_basename, src_hash)
         dup_skipped = 0
+        # Twin folders (under destination) whose bytes we RE-HASHED this run
+        # and confirmed against source hashes — safe to scan/link into the
+        # active workspace after this batch's fresh-scan runs. Mirrors the
+        # local path's ``dup_dirs`` per-batch accumulator. See PR #1113 review.
+        dup_dirs = set()
+        # Mount paths already on disk (retry / crash-recovery adopt) that
+        # this run treats as ``skipped_duplicate``. The restricted scan
+        # below has ``restrict_files=landed_paths | adopted_paths`` — a
+        # mixed batch (some copies + some adopted-on-disk) whose
+        # ``landed_paths`` set is non-empty would otherwise scope the scan
+        # so tightly that the adopted mount files, if not yet cataloged,
+        # never get a photo row. ``copied + skipped_duplicate == discovered``
+        # could then still make a verified remote run report
+        # ``safe_to_format=True`` while the pre-existing-but-uncataloged
+        # file has no row. See PR #1113 review.
+        adopted_paths = set()
         # dest basename -> src_hash, for intra-batch same-basename collision
         # resolution (FIX 2). Populated as files are queued/skipped.
         claimed_basenames = {}
@@ -713,6 +777,11 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                                   f"duplicate check failed: {e}")
                             continue
                     accept = False
+                    # Twins whose bytes we actually hashed this run and
+                    # matched against the source. Only these back a
+                    # duplicate-folder link (a stale/off-destination twin's
+                    # folder must not be pulled into the active workspace).
+                    verified_twin_rows = []
                     for twin in twin_rows:
                         twin_path = os.path.join(
                             twin["folder_path"], twin["filename"],
@@ -733,11 +802,33 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                             continue
                         if twin_hash is not None and twin_hash == src_hash:
                             accept = True
-                            break
+                            # Keep scanning to collect every byte-verified
+                            # twin's folder — an older run may have written
+                            # the same identity into a different folder
+                            # layout (e.g. ``unsorted`` or a different date
+                            # template), and only the folder we RE-HASHED
+                            # this run is safe to link. Mirrors the local
+                            # path's collect-then-link pattern. See PR
+                            # #1113 review.
+                            verified_twin_rows.append(twin)
                     if accept:
                         skipped_duplicate += 1
                         dup_skipped += 1
                         _counts(rel)["skipped_duplicate"] += 1
+                        # Preserve the verified twin folders so the follow-
+                        # up dup-link scan can pull them into the active
+                        # workspace. Without this a verified duplicate-only
+                        # remote import whose twins live in a different
+                        # folder than this run's template output would skip
+                        # rsync AND leave the twin folder unlinked while
+                        # safe_to_format still went green. See PR #1113
+                        # review.
+                        dup_dirs.update(
+                            _linkable_twin_dirs(
+                                verified_twin_rows,
+                                _path_under_destination,
+                            ),
+                        )
                         continue
             # Collision parity (FIX 2): rsync lands files flat by basename,
             # so two different card files with the same basename in one batch
@@ -791,6 +882,12 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         dup_skipped += 1
                         _counts(rel)["skipped_duplicate"] += 1
                         claimed_basenames[candidate] = src_hash
+                        # Track the adopted mount path so the restricted
+                        # scan below picks it up (mixed batches with fresh
+                        # copies otherwise scope the scan to landed_paths
+                        # and skip the adopted-but-uncataloged file). See
+                        # PR #1113 review.
+                        adopted_paths.add(cand_mount)
                         adopted = True
                         break
                     counter += 1
@@ -956,11 +1053,21 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         # local path makes; the mount is locally walkable.
         if landed or dup_skipped:
             landed_paths = {entry[0] for entry in landed}
+            # Include collision-loop adopted mount paths so their photo rows
+            # get created by the restricted scan. When ``landed`` is
+            # empty the pre-existing catch-all below (a bare
+            # ``restrict_dirs=[dest_folder]`` scan without ``restrict_files``)
+            # would already discover them via directory walk, but a mixed
+            # batch (some fresh copies + some adopted) has non-empty
+            # ``landed_paths``, and passing that alone as ``restrict_files``
+            # narrows the scan so tightly that the adopted-but-uncataloged
+            # files never become photo rows. See PR #1113 review.
+            scan_files = landed_paths | adopted_paths
             try:
                 scan(
                     destination, db,
                     restrict_dirs=[dest_folder],
-                    restrict_files=(landed_paths or None),
+                    restrict_files=(scan_files or None),
                     vireo_dir=params.vireo_dir,
                     thumb_cache_dir=params.thumb_cache_dir,
                     skip_working_copies=True,
@@ -1082,6 +1189,10 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         db.update_photo_hash_check(
                             row["id"], "ok", commit=False,
                         )
+                    # Fresh mount row this run stamped as valid — the
+                    # after-import chaining hook builds its process job
+                    # collection from these ids.
+                    imported_photo_ids.add(row["id"])
                 else:
                     # RAW+JPEG pairing merges the JPEG's photo row into
                     # the RAW primary (companion_path) and deletes the
@@ -1132,7 +1243,11 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                                 continue
                         # JPEG bytes are represented by the RAW row's
                         # companion_path — accept as landed; leave the
-                        # copied/verified counters alone.
+                        # copied/verified counters alone. The RAW row is
+                        # what the chaining hook should process, so its
+                        # id joins ``imported_photo_ids``. See PR #1113
+                        # review.
+                        imported_photo_ids.add(companion["id"])
                         continue
                     copied -= 1
                     if params.verify_by_hash:
@@ -1143,12 +1258,80 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                     landed = [
                         e for e in landed if e[0] != dest_path
                     ]
+            # Collect photo_ids for adopted-on-disk duplicates that this
+            # run's restricted scan just cataloged. Analogous to how the
+            # local path's ``adopted_dest`` branch pushes the crash-
+            # recovered file's row id into ``imported_photo_ids`` — the
+            # user asked for this photo to be imported, and it's now a
+            # freshly cataloged row, so the after-import chaining hook
+            # should treat it as a new photo. See PR #1113 review.
+            for ap in adopted_paths:
+                row = db.conn.execute(
+                    """SELECT p.id FROM photos p
+                       JOIN folders f ON f.id = p.folder_id
+                       WHERE f.path = ? AND p.filename = ?""",
+                    (os.path.dirname(ap), os.path.basename(ap)),
+                ).fetchone()
+                if row is not None:
+                    imported_photo_ids.add(row["id"])
             db.conn.commit()
 
             if params.vireo_dir:
                 for dest_path, sf, _sh, sz, mt in landed:
                     wc_source_paths[dest_path] = (sf, sz, mt)
                 wc_dest_folders.add(dest_folder)
+
+        # --- Link verified duplicate-twin folders ----------------------
+        # A verified duplicate skip's twin folder may live elsewhere under
+        # the archive (older date-layout, ``unsorted``, etc.). The batch
+        # scan above only touches ``dest_folder``, so without this
+        # follow-up scan the twin folder never becomes visible in the
+        # active workspace even though its bytes back the safe-to-format
+        # skip. Mirrors the local path's dup-link scan (see PR #1107). Any
+        # failure here forces ``safe_to_format=False`` — the file is on
+        # disk but the workspace can't see it. See PR #1113 review.
+        new_dup_dirs = dup_dirs - linked_dup_dirs
+        if new_dup_dirs:
+            # Promote missing rows for twin folders too (a reattached
+            # archive drive with a stale ``missing`` marker wouldn't be
+            # cleared by ``scanner.scan()``'s success stamp, which only
+            # touches ``partial``). Mirrors the fresh-batch promote above.
+            db.conn.executemany(
+                "UPDATE folders SET status = 'ok' "
+                "WHERE path = ? AND status = 'missing'",
+                [(d,) for d in sorted(new_dup_dirs)],
+            )
+            db.conn.commit()
+            try:
+                scan(
+                    destination, db,
+                    restrict_dirs=sorted(new_dup_dirs),
+                    vireo_dir=params.vireo_dir,
+                    thumb_cache_dir=params.thumb_cache_dir,
+                    skip_working_copies=True,
+                    cancel_check=lambda: runner.is_cancelled(job["id"]),
+                )
+                linked_dup_dirs.update(new_dup_dirs)
+            except Exception as e:
+                if (
+                    isinstance(e, RuntimeError)
+                    and str(e) == "scan cancelled"
+                    and runner.is_cancelled(job["id"])
+                ):
+                    cancelled = True
+                else:
+                    log.exception(
+                        "Linking duplicate-matched folders failed: %s",
+                        sorted(new_dup_dirs),
+                    )
+                    dup_link_failed = True
+                    for d in sorted(new_dup_dirs):
+                        unsafe_files.append({
+                            "path": d,
+                            "reason": (
+                                f"duplicate-folder link scan failed: {e}"
+                            ),
+                        })
 
         _emit(
             f"{rel}: {_counts(rel)['copied']} copied · "
@@ -1226,6 +1409,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         not cancelled
         and failed == 0
         and not discovery_errors
+        and not dup_link_failed
         and not partial_scope
         and not remote_unverified
         and (copied + skipped_duplicate) == discovered
@@ -1234,6 +1418,13 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         "discovered": discovered,
         "copied": copied,
         "verified": verified,
+        # Photo rows the after-import chaining hook should process.
+        # Duplicate-only imports intentionally return an empty list so
+        # ``_chain_after_import`` skips into its "no new photos" branch
+        # instead of enqueueing an empty process run — same convention as
+        # the local path. Without this the remote import always missed
+        # after-import processing. See PR #1113 review.
+        "photo_ids": sorted(imported_photo_ids),
         "skipped_duplicate": skipped_duplicate,
         "failed": failed,
         "safe_to_format": safe_to_format,
@@ -1241,7 +1432,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         "folders": folder_counts,
         "cancelled": cancelled,
         "discovery_errors": len(discovery_errors),
-        "ok": (failed == 0 and not discovery_errors),
+        "ok": (failed == 0 and not discovery_errors and not dup_link_failed),
         "errors": [f"{u['path']}: {u['reason']}" for u in unsafe_files],
     }
     return result

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -632,7 +632,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         # cataloged twin's bytes are confirmed at the destination; the local
         # path re-hashes the twin's archive file. On the mount that file is
         # locally readable, so reuse the same on-disk re-hash contract.
-        to_transfer = []           # (source_file, dest_basename)
+        to_transfer = []           # (source_file, dest_basename, src_hash)
         dup_skipped = 0
         # dest basename -> src_hash, for intra-batch same-basename collision
         # resolution (FIX 2). Populated as files are queued/skipped.
@@ -752,14 +752,42 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
             if adopted:
                 continue
             claimed_basenames[dest_basename] = src_hash
-            to_transfer.append((source_file, dest_basename))
+            to_transfer.append((source_file, dest_basename, src_hash))
 
         # --- Per-batch rsync -------------------------------------------
-        landed = []   # (dest_path, card_source, src_size, src_mtime_ns)
+        # landed carries the card-side src_hash so the catalog-stamping loop
+        # below can cross-check the scanned MOUNT row's file_hash against the
+        # hash confirmed on the NAS. Without that carry-through, a stale/
+        # misconfigured mount base that happens to already contain
+        # ``<folder>/<filename>`` for a name we transferred would let scan()
+        # populate the row from unrelated bytes while remote_verify_files
+        # confirmed the NAS bytes — and blind hash_status='ok' stamping would
+        # flip safe_to_format green over storage we never touched. See PR
+        # #1113 review.
+        landed = []   # (dest_path, card_source, src_hash, src_size, src_mtime_ns)
         if to_transfer:
+            # ``--ignore-existing`` protects against basename-race overwrites:
+            # two remote import jobs (or a job racing another writer) that
+            # both passed the earlier mount-side os.path.exists check for
+            # DSC_0001.jpg would otherwise both rsync to the same NAS name
+            # with plain ``rsync -a``, and the second writer would clobber
+            # the first's already-verified bytes. ``--ignore-existing`` tells
+            # rsync's receiver to skip files that already exist there, so
+            # the first landing's bytes stay put. On the verify path, the
+            # subsequent ``rsync -an --checksum`` step then detects the
+            # mismatch between the second writer's card bytes and the
+            # first-writer bytes on the NAS and fails that specific file
+            # honestly; without verification the honesty gate already
+            # reports safe_to_format=False for the whole run, so a masked
+            # race can't quietly flip the pill green. Crash-recovery already
+            # avoids re-transferring files it saw on the mount (hash match
+            # -> skip; hash mismatch -> advance to a suffix that doesn't
+            # exist), so no legitimate flow relies on rsync overwriting an
+            # existing destination file. See PR #1113 review.
             extra_args = [
                 "-e", move_mod._ssh_rsh_string(remote),
                 "--partial-dir=.rsync-partial",
+                "--ignore-existing",
             ]
             if remote.get("bwlimit_kbps"):
                 extra_args.append(f"--bwlimit={int(remote['bwlimit_kbps'])}")
@@ -767,7 +795,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
             # rsync creates the leaf itself but not intermediate parents.
             ok_mkdir, mkdir_detail = move_mod._remote_mkdir_p(remote, ssh_dest)
             if not ok_mkdir:
-                for sf, _bn in to_transfer:
+                for sf, _bn, _sh in to_transfer:
                     _fail(rel, sf,
                           f"remote mkdir failed for {ssh_dest}: {mkdir_detail}")
             else:
@@ -776,11 +804,11 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                 # verified individually to an explicit NAS filename, since a
                 # flat --files-from list to one dir can't rename).
                 flat = [
-                    (sf, bn) for sf, bn in to_transfer
+                    (sf, bn, sh) for sf, bn, sh in to_transfer
                     if bn == sf.name
                 ]
                 renamed = [
-                    (sf, bn) for sf, bn in to_transfer
+                    (sf, bn, sh) for sf, bn, sh in to_transfer
                     if bn != sf.name
                 ]
 
@@ -796,25 +824,25 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                     except OSError as exc:
                         return 1, str(exc), False
 
-                transferred = []   # (sf, dest_basename, nas_full_path)
+                transferred = []   # (sf, dest_basename, src_hash, nas_full_path)
                 # Flat batch: one rsync into the dir.
                 if flat:
                     rc, stderr, timed_out = _do_rsync(
-                        [str(sf) for sf, _bn in flat], rsync_target, True,
+                        [str(sf) for sf, _bn, _sh in flat], rsync_target, True,
                         extra_args)
                     if timed_out:
-                        for sf, _bn in flat:
+                        for sf, _bn, _sh in flat:
                             _fail(rel, sf, "rsync stalled (no progress)")
                     elif rc != 0:
-                        for sf, _bn in flat:
+                        for sf, _bn, _sh in flat:
                             _fail(rel, sf, f"rsync failed: {stderr.strip()}")
                     else:
-                        for sf, bn in flat:
+                        for sf, bn, sh in flat:
                             transferred.append((
-                                sf, bn, posixpath.join(ssh_dest, bn)))
+                                sf, bn, sh, posixpath.join(ssh_dest, bn)))
                 # Renamed files: one rsync each to the explicit NAS file
                 # path (rsync <card> user@host:/dir/DSC_0001_1.jpg).
-                for sf, bn in renamed:
+                for sf, bn, sh in renamed:
                     nas_full = posixpath.join(ssh_dest, bn)
                     rc, stderr, timed_out = _do_rsync(
                         [str(sf)],
@@ -825,9 +853,9 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                     elif rc != 0:
                         _fail(rel, sf, f"rsync failed: {stderr.strip()}")
                     else:
-                        transferred.append((sf, bn, nas_full))
+                        transferred.append((sf, bn, sh, nas_full))
 
-                for sf, bn, nas_full in transferred:
+                for sf, bn, src_hash, nas_full in transferred:
                     dest_path = os.path.join(dest_folder, bn)
                     # Independent verification (Task 2.7 FIX 1): card -> NAS,
                     # opt-in behind ``verify_by_hash`` (it reads every NAS
@@ -871,7 +899,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                     _counts(rel)["copied"] += 1
                     if params.verify_by_hash:
                         verified += 1
-                    landed.append((dest_path, str(sf), sz, mt))
+                    landed.append((dest_path, str(sf), src_hash, sz, mt))
 
         # --- Catalog this batch ----------------------------------------
         # Fresh copies AND duplicate skips both need the mount folder
@@ -890,7 +918,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                     skip_working_copies=True,
                 )
             except Exception as e:
-                for dest_path, _sf, _sz, _mt in landed:
+                for dest_path, _sf, _sh, _sz, _mt in landed:
                     # Roll back the copied count and fail.
                     copied -= 1
                     _counts(rel)["copied"] -= 1
@@ -915,9 +943,9 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
             # verify_by_hash the rows keep NULL hash_status/hash_checked_at
             # (scan may set file_hash, but we don't claim an integrity
             # verdict we didn't independently make).
-            for dest_path, _sf, _sz, _mt in list(landed):
+            for dest_path, _sf, src_hash, _sz, _mt in list(landed):
                 row = db.conn.execute(
-                    """SELECT p.id FROM photos p
+                    """SELECT p.id, p.file_hash FROM photos p
                        JOIN folders f ON f.id = p.folder_id
                        WHERE f.path = ? AND p.filename = ?""",
                     (os.path.dirname(dest_path),
@@ -925,6 +953,50 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                 ).fetchone()
                 if row is not None:
                     if params.verify_by_hash:
+                        # Cross-check the scanned MOUNT row's hash against
+                        # the source hash that remote_verify_files just
+                        # confirmed at the NAS. remote_verify_files ran
+                        # card -> ssh_base (the NAS); scan() reads whatever
+                        # is under the mount base. If the mount is stale
+                        # or misconfigured but happens to already contain
+                        # the same <folder>/<filename> we transferred, scan
+                        # populates ``file_hash`` from the mount's (wrong)
+                        # bytes. Stamping ``hash_status='ok'`` on that row
+                        # would let ``safe_to_format`` go green over
+                        # storage we never actually touched. Require the
+                        # scanned row's file_hash to match the verified
+                        # source hash; otherwise fail this file. Mirrors
+                        # the local path's cross-check against
+                        # ``verified_hash``. See PR #1113 review.
+                        #
+                        # Normalize zero-byte convention on both sides:
+                        # scan() writes NULL for zero-byte files;
+                        # ``checker.content_hash`` returns None; a
+                        # checker-less ``compute_file_hash`` returns
+                        # ``EMPTY_FILE_SHA256``. Treat all three as
+                        # equivalent so an empty card file matches its
+                        # empty catalog row.
+                        scan_h = row["file_hash"]
+                        if scan_h == EMPTY_FILE_SHA256:
+                            scan_h = None
+                        src_h_norm = (
+                            None if src_hash == EMPTY_FILE_SHA256
+                            else src_hash
+                        )
+                        if scan_h != src_h_norm:
+                            copied -= 1
+                            verified -= 1
+                            _counts(rel)["copied"] -= 1
+                            _fail(
+                                rel, dest_path,
+                                "scanned mount row hash does not match "
+                                "the hash verified on the NAS (mount "
+                                "base is likely stale or misconfigured)",
+                            )
+                            landed = [
+                                e for e in landed if e[0] != dest_path
+                            ]
+                            continue
                         db.update_photo_hash_check(
                             row["id"], "ok", commit=False,
                         )
@@ -941,7 +1013,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
             db.conn.commit()
 
             if params.vireo_dir:
-                for dest_path, sf, sz, mt in landed:
+                for dest_path, sf, _sh, sz, mt in landed:
                     wc_source_paths[dest_path] = (sf, sz, mt)
                 wc_dest_folders.add(dest_folder)
 

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -502,6 +502,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
     reason ``"enable verify_by_hash for remote verification"`` — the card is
     off-loaded but its landing wasn't independently hash-confirmed.
     """
+    from pipeline_job import _missing_archive_mount_root
     from scanner import scan
 
     rt = params.remote_target
@@ -668,6 +669,23 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
     run_dest_folders = {}
     run_verified_hashes = {}
 
+    # Mount-root preflight (Task 2.7 late follow-up): when a saved remote
+    # target's local mount root is not mounted (for example ``/Volumes/NAS``
+    # or ``/mnt/NAS`` is absent because the share isn't attached), a naive
+    # ``os.makedirs(dest_folder, exist_ok=True)`` in the batch loop below
+    # would create the whole mount tree as an empty local shadow directory
+    # on the internal disk. The SSH rsync still writes to the NAS, but the
+    # subsequent scan reads the fresh local shadow and leaves the import
+    # uncataloged/failed; worse, on macOS/Linux that shadow root can also
+    # prevent the real share from remounting at the configured path. Fail
+    # every batch's files up front with a clear reason instead. Reuses the
+    # pipeline path's ``_missing_archive_mount_root`` helper (only fires
+    # for the ``/Volumes/X``, ``/mnt/X``, and ``/media/user/X`` shapes that
+    # denote removable/network mount roots), computed once here because
+    # every batch's ``dest_folder`` shares ``destination``'s mount root.
+    # See PR #1113 review.
+    _missing_mount_root = _missing_archive_mount_root(destination)
+
     def _record_checker(source_file, dest_folder=None, file_hash=None):
         """Register a landed/adopted file's identity with the intra-run checker.
 
@@ -730,6 +748,30 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                     "(dest_folder would be created under the card being "
                     "imported); formatting the card would erase the archive "
                     "copy",
+                )
+            _emit(
+                f"{rel}: {_counts(rel)['copied']} copied · "
+                f"{_counts(rel)['skipped_duplicate']} already present",
+                emitted, discovered,
+            )
+            continue
+        # Mount-root preflight (see the ``_missing_mount_root`` computation
+        # near the top of this function). Same shape as the dest-under-
+        # source guard: fail every file in the batch with a specific
+        # reason and skip the batch instead of letting ``os.makedirs``
+        # create a local shadow of the unmounted destination. Computed
+        # once outside the loop; the mount-root decision is a property
+        # of ``destination`` and doesn't vary per batch. See PR #1113
+        # review.
+        if _missing_mount_root:
+            for source_file in batch:
+                emitted += 1
+                _fail(
+                    rel, source_file,
+                    f"archive mount root {_missing_mount_root} is not "
+                    "available (destination drive is not mounted; refusing "
+                    "to create a shadow directory tree under it, which "
+                    "would prevent the real share from remounting)",
                 )
             _emit(
                 f"{rel}: {_counts(rel)['copied']} copied · "

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -987,8 +987,20 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
             # bytes). The batch's rsync hasn't happened yet, so the DB
             # twin lookup and ``checker.match()`` above can't see it —
             # skip here to match the local path's post-copy behaviour.
-            # See PR #1113 review.
-            if src_hash is not None and src_hash in queued_src_hashes:
+            # Gated on ``checker`` (``skip_duplicates=True``): the local
+            # path only skips same-content/different-name twins through
+            # ``DuplicateChecker``, so when the user disabled duplicate
+            # skipping both files must be rsynced/cataloged under
+            # distinct names instead of the second one being silently
+            # counted as ``skipped_duplicate`` (which would otherwise let
+            # a verified run report ``safe_to_format=True`` because
+            # ``copied + skipped_duplicate == discovered`` without an
+            # off-card row for the second file). See PR #1113 review.
+            if (
+                checker is not None
+                and src_hash is not None
+                and src_hash in queued_src_hashes
+            ):
                 skipped_duplicate += 1
                 dup_skipped += 1
                 _counts(rel)["skipped_duplicate"] += 1
@@ -1007,7 +1019,15 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                     # Claimed earlier in this batch (a same-basename sibling
                     # already queued). If that sibling has our exact bytes,
                     # skip as an intra-batch duplicate; otherwise advance.
-                    if claimed_basenames[candidate] == src_hash:
+                    # Gated on ``checker`` for the same reason as the
+                    # different-basename intra-batch dedup above: when
+                    # ``skip_duplicates=False``, both files must be
+                    # queued under distinct suffixes instead of the
+                    # second one being counted as ``skipped_duplicate``.
+                    if (
+                        checker is not None
+                        and claimed_basenames[candidate] == src_hash
+                    ):
                         skipped_duplicate += 1
                         dup_skipped += 1
                         _counts(rel)["skipped_duplicate"] += 1
@@ -1047,7 +1067,11 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
             if adopted:
                 continue
             claimed_basenames[dest_basename] = src_hash
-            if src_hash is not None:
+            # Only track queued source hashes when duplicate skipping is
+            # enabled — the intra-batch dedup that consults this map is
+            # gated on ``checker`` above, so populating it with
+            # ``skip_duplicates=False`` would just be dead state.
+            if checker is not None and src_hash is not None:
                 queued_src_hashes[src_hash] = dest_folder
             to_transfer.append((source_file, dest_basename, src_hash))
 

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -1132,6 +1132,20 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                 "-e", move_mod._ssh_rsh_string(remote),
                 "--partial-dir=.rsync-partial",
                 "--ignore-existing",
+                # ``--copy-links`` dereferences symlinked source files so
+                # the NAS receives their referenced bytes instead of a
+                # symlink. The base command is ``rsync -a``, which preserves
+                # symlinks; without ``-L`` a curated card folder that
+                # symlinks to ``/Volumes/Card/DCIM/IMG_0001.JPG`` would send
+                # the symlink itself to the NAS. With ``verify_by_hash``
+                # the mount-side scan follows the symlink through the local
+                # mount, so ``safe_to_format`` can still go green — and
+                # then formatting/unmounting the card breaks the archived
+                # copy. Card-local symlinks aren't legitimately preserved
+                # by an archive of the card contents, and the local path's
+                # ingest reads the referenced file bytes too. See PR #1113
+                # review.
+                "--copy-links",
             ]
             if remote.get("bwlimit_kbps"):
                 extra_args.append(f"--bwlimit={int(remote['bwlimit_kbps'])}")

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -1099,7 +1099,17 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         # flip safe_to_format green over storage we never touched. See PR
         # #1113 review.
         landed = []   # (dest_path, card_source, src_hash, src_size, src_mtime_ns)
-        if to_transfer:
+        # Honor cancellation before any network transfer starts. The break
+        # inside the per-file queue-building loop above sets ``cancelled``
+        # and exits the loop, but ``to_transfer`` still holds files that
+        # were queued (decided but not yet sent). Without this guard the
+        # rsync block below would start copying a partial batch after Stop
+        # was requested. Queued files that never rsync stay on the card
+        # and will be picked up by the next run; ``dup_skipped`` /
+        # ``adopted_paths`` for files already visible on the mount are
+        # still cataloged by the batch-scan block below. See PR #1113
+        # review.
+        if to_transfer and not cancelled:
             # ``--ignore-existing`` protects against basename-race overwrites:
             # two remote import jobs (or a job racing another writer) that
             # both passed the earlier mount-side os.path.exists check for

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -771,16 +771,23 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         # local path's ``dup_dirs`` per-batch accumulator. See PR #1113 review.
         dup_dirs = set()
         # Mount paths already on disk (retry / crash-recovery adopt) that
-        # this run treats as ``skipped_duplicate``. The restricted scan
-        # below has ``restrict_files=landed_paths | adopted_paths`` — a
-        # mixed batch (some copies + some adopted-on-disk) whose
-        # ``landed_paths`` set is non-empty would otherwise scope the scan
-        # so tightly that the adopted mount files, if not yet cataloged,
-        # never get a photo row. ``copied + skipped_duplicate == discovered``
-        # could then still make a verified remote run report
-        # ``safe_to_format=True`` while the pre-existing-but-uncataloged
-        # file has no row. See PR #1113 review.
-        adopted_paths = set()
+        # this run treats as ``skipped_duplicate``. Maps ``mount_path ->
+        # (source_file, src_hash)`` so the post-scan pass can (a) attribute
+        # a failure back to the card file if the adopted mount file
+        # vanished or was replaced between the adopt-time hash check and
+        # ``scan()`` (scanner drops missing/unreadable files silently
+        # rather than raising) and (b) re-check the mount bytes still
+        # match the source hash before leaving the skip counted. The
+        # restricted scan below has ``restrict_files=landed_paths |
+        # adopted_paths.keys()`` — a mixed batch (some copies + some
+        # adopted-on-disk) whose ``landed_paths`` set is non-empty would
+        # otherwise scope the scan so tightly that the adopted mount
+        # files, if not yet cataloged, never get a photo row.
+        # ``copied + skipped_duplicate == discovered`` could then still
+        # make a verified remote run report ``safe_to_format=True`` while
+        # the pre-existing-but-uncataloged file has no row. See PR #1113
+        # review.
+        adopted_paths = {}
         # dest basename -> src_hash, for intra-batch same-basename collision
         # resolution (FIX 2). Populated as files are queued/skipped.
         claimed_basenames = {}
@@ -979,12 +986,15 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                         dup_skipped += 1
                         _counts(rel)["skipped_duplicate"] += 1
                         claimed_basenames[candidate] = src_hash
-                        # Track the adopted mount path so the restricted
-                        # scan below picks it up (mixed batches with fresh
-                        # copies otherwise scope the scan to landed_paths
-                        # and skip the adopted-but-uncataloged file). See
-                        # PR #1113 review.
-                        adopted_paths.add(cand_mount)
+                        # Track the adopted mount path + source-side hash
+                        # so the restricted scan below picks it up (mixed
+                        # batches with fresh copies otherwise scope the
+                        # scan to landed_paths and skip the adopted-but-
+                        # uncataloged file) and the post-scan validation
+                        # can re-check that the mount bytes still equal
+                        # ``src_hash`` before leaving the skip counted.
+                        # See PR #1113 review.
+                        adopted_paths[cand_mount] = (source_file, src_hash)
                         _record_checker(source_file, dest_folder, src_hash)
                         adopted = True
                         break
@@ -1163,7 +1173,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
             # ``landed_paths``, and passing that alone as ``restrict_files``
             # narrows the scan so tightly that the adopted-but-uncataloged
             # files never become photo rows. See PR #1113 review.
-            scan_files = landed_paths | adopted_paths
+            scan_files = landed_paths | set(adopted_paths.keys())
             try:
                 scan(
                     destination, db,
@@ -1415,22 +1425,145 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                     landed = [
                         e for e in landed if e[0] != dest_path
                     ]
-            # Collect photo_ids for adopted-on-disk duplicates that this
-            # run's restricted scan just cataloged. Analogous to how the
-            # local path's ``adopted_dest`` branch pushes the crash-
-            # recovered file's row id into ``imported_photo_ids`` — the
-            # user asked for this photo to be imported, and it's now a
-            # freshly cataloged row, so the after-import chaining hook
-            # should treat it as a new photo. See PR #1113 review.
-            for ap in adopted_paths:
+            # Validate adopted-on-disk duplicates and collect photo_ids
+            # for the ones the restricted scan just cataloged. The
+            # collision-loop accepted these files as ``skipped_duplicate``
+            # because their mount bytes hashed equal to the card at that
+            # instant, but two windows are still open by the time the
+            # scan runs:
+            #   1) The adopted file may have been deleted or replaced
+            #      between the adopt-time hash check and ``scan()`` —
+            #      scanner drops missing/unreadable files silently rather
+            #      than raising, so a vanished adopted file leaves no
+            #      photo row AND no failure, while
+            #      ``copied + skipped_duplicate == discovered`` still lets
+            #      a verified remote import report ``safe_to_format=True``
+            #      over storage that no longer holds those bytes.
+            #   2) A stale/misconfigured mount where scan() populated a
+            #      row from unrelated same-name bytes would leave the
+            #      catalog pointing at the wrong photo while the skip
+            #      count stays.
+            # Treat adopted paths like landed entries: require a direct
+            # or companion row, and re-hash the mount file (or trust
+            # scan's file_hash when it wrote one) to confirm the bytes
+            # still equal ``src_hash`` before leaving the skip counted.
+            # A failed check rolls back the ``skipped_duplicate`` count
+            # so ``failed > 0`` and ``safe_to_format`` goes False. On
+            # success, add the row id to ``imported_photo_ids`` so the
+            # after-import chaining hook treats this photo as new
+            # (mirrors the local path's ``adopted_dest`` bookkeeping).
+            # See PR #1113 review.
+            for ap, (adopt_source, adopt_src_hash) in list(
+                adopted_paths.items()
+            ):
                 row = db.conn.execute(
-                    """SELECT p.id FROM photos p
+                    """SELECT p.id, p.file_hash FROM photos p
                        JOIN folders f ON f.id = p.folder_id
                        WHERE f.path = ? AND p.filename = ?""",
                     (os.path.dirname(ap), os.path.basename(ap)),
                 ).fetchone()
+                row_id = None
+                scan_h_raw = None
+                is_companion = False
                 if row is not None:
-                    imported_photo_ids.add(row["id"])
+                    row_id = row["id"]
+                    scan_h_raw = row["file_hash"]
+                else:
+                    # RAW+JPEG pairing merges the JPEG's photo row into
+                    # the RAW primary and deletes the JPEG's own row, so
+                    # an adopted JPEG whose sibling RAW was scanned in
+                    # this batch legitimately has no row of its own.
+                    # Accept it as landed only via the companion lookup
+                    # — a JPEG paired with an existing RAW is
+                    # represented on the RAW row. The companion row
+                    # doesn't carry the adopted file's ``file_hash``,
+                    # so force a mount re-read below to still cross-
+                    # check the bytes.
+                    companion = db.conn.execute(
+                        """SELECT p.id FROM photos p
+                           JOIN folders f ON f.id = p.folder_id
+                           WHERE f.path = ? AND p.companion_path = ?""",
+                        (os.path.dirname(ap), os.path.basename(ap)),
+                    ).fetchone()
+                    if companion is not None:
+                        row_id = companion["id"]
+                        is_companion = True
+                if row_id is None:
+                    # No direct row, no companion — the adopted file
+                    # vanished or was replaced with a name scan() did
+                    # not consider a companion of anything (scanner
+                    # skipped it). Roll back the skip and fail the
+                    # source file.
+                    skipped_duplicate -= 1
+                    dup_skipped -= 1
+                    _counts(rel)["skipped_duplicate"] -= 1
+                    _fail(
+                        rel, adopt_source,
+                        f"adopted mount file {ap} vanished or was "
+                        "replaced before catalog scan (no photo row "
+                        "and no companion row)",
+                    )
+                    continue
+                src_h_norm = (
+                    None if adopt_src_hash == EMPTY_FILE_SHA256
+                    else adopt_src_hash
+                )
+                scan_h = (
+                    None if scan_h_raw == EMPTY_FILE_SHA256 else scan_h_raw
+                )
+                if is_companion or scan_h is None:
+                    # Companion row carries no scan hash for this
+                    # adopted path, and scan may legitimately leave
+                    # ``file_hash`` NULL (read/permission failure,
+                    # scanner-stubbed test seams) — either way, re-read
+                    # the mount file directly and compare against the
+                    # adopt-time source hash. Without this a
+                    # replaced-between-adopt-and-scan mount file would
+                    # sit as a photo row with unrelated bytes while the
+                    # skip count kept ``failed = 0``.
+                    #
+                    # ``compute_file_hash`` returns
+                    # ``EMPTY_FILE_SHA256`` for a zero-byte file and
+                    # raises ``OSError`` when the file was deleted or
+                    # is unreadable — treat only the exception as a
+                    # read failure so a legitimate zero-byte adopted
+                    # file (whose adopt-time src_hash was
+                    # ``EMPTY_FILE_SHA256`` too, normalized to None on
+                    # both sides) is still accepted.
+                    read_failed = False
+                    try:
+                        mount_hash = compute_file_hash(ap)
+                    except OSError:
+                        mount_hash = None
+                        read_failed = True
+                    mount_norm = (
+                        None if mount_hash == EMPTY_FILE_SHA256
+                        else mount_hash
+                    )
+                    if read_failed or mount_norm != src_h_norm:
+                        skipped_duplicate -= 1
+                        dup_skipped -= 1
+                        _counts(rel)["skipped_duplicate"] -= 1
+                        _fail(
+                            rel, adopt_source,
+                            f"adopted mount file {ap} bytes no longer "
+                            "match the source hash (mount file was "
+                            "replaced or became unreadable between the "
+                            "adopt-time hash check and catalog scan)",
+                        )
+                        continue
+                elif scan_h != src_h_norm:
+                    skipped_duplicate -= 1
+                    dup_skipped -= 1
+                    _counts(rel)["skipped_duplicate"] -= 1
+                    _fail(
+                        rel, adopt_source,
+                        f"adopted mount file {ap} scan hash disagrees "
+                        "with the source hash (mount base is likely "
+                        "stale or misconfigured)",
+                    )
+                    continue
+                imported_photo_ids.add(row_id)
             db.conn.commit()
 
             if params.vireo_dir:

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -630,9 +630,69 @@ def _remote_verify_complete(rsync_bin, src_path, rsync_target, remote):
     return None
 
 
+def remote_verify_files(rsync_bin, src_specs, rsync_target, remote,
+                        dest_is_dir=True):
+    """Verify an explicit list of source FILES against a remote path.
+
+    The file-list counterpart to ``_remote_verify_complete`` (which compares
+    whole directories). The import job rsyncs a batch's card files flat by
+    basename into ``rsync_target/``; this runs ``rsync -an --checksum
+    <card files...> rsync_target/`` — a dry run that reports (via
+    ``--out-format=%n``) every listed file whose counterpart at the remote is
+    missing or differs by checksum. Because the sources are the actual CARD
+    files, this genuinely confirms the card's bytes landed intact on the NAS
+    (comparing the local SMB mount view against the NAS would be
+    near-tautological — same physical storage — and would never catch a
+    corrupt transfer). Basename-flat comparison lines up with how the
+    transfer landed the files.
+
+    ``dest_is_dir`` (default True) treats ``rsync_target`` as a directory
+    (``rsync_target/``), so each source lands under its own basename. Set it
+    False to verify a single source file against an explicit remote FILE path
+    (no trailing ``/``): the import job uses this to verify a collision-
+    renamed file (card ``DSC_0001.jpg`` landed at NAS ``DSC_0001_1.jpg``)
+    against its actual NAS name.
+
+    Returns:
+      * ``None`` — every listed source file is present at the remote with
+        matching content.
+      * ``(name, None)`` — first source file (rsync's ``%n`` relative name)
+        still absent/different at the remote.
+      * ``("__ERROR__", detail)`` — the verification rsync itself failed or
+        timed out; treated as a verification failure.
+
+    Bandwidth-cheap: the NAS checksums its own local disk and only hashes
+    cross the wire.
+    """
+    if not src_specs:
+        return None
+    cmd = [rsync_bin, "-an", "--checksum", "--out-format=%n",
+           "-e", _ssh_rsh_string(remote)]
+    cmd += list(src_specs)
+    cmd += [rsync_target + "/" if dest_is_dir else rsync_target]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True,
+                              timeout=REMOTE_VERIFY_TIMEOUT)
+    except subprocess.TimeoutExpired:
+        return ("__ERROR__", f"verification timed out after "
+                f"{REMOTE_VERIFY_TIMEOUT // 60} minutes")
+    except OSError as exc:
+        return ("__ERROR__", str(exc))
+    if proc.returncode != 0:
+        return ("__ERROR__",
+                proc.stderr.strip() or f"rsync exit {proc.returncode}")
+    for line in proc.stdout.splitlines():
+        name = line.rstrip("\n")
+        if not name or name.endswith("/"):
+            continue  # directory entry, not a file needing transfer
+        return (name, None)
+    return None
+
+
 def _run_rsync_streamed(src_path, dest_spec, rsync_flags, total_files,
                         progress_cb, rsync_bin="rsync", extra_args=None,
-                        stall_timeout=RSYNC_STALL_TIMEOUT):
+                        stall_timeout=RSYNC_STALL_TIMEOUT, src_specs=None,
+                        src_specs_dest_is_dir=True):
     """Run rsync, reporting each transferred file through progress_cb.
 
     rsync's ``--out-format=%n`` prints the relative name of every item it
@@ -645,6 +705,18 @@ def _run_rsync_streamed(src_path, dest_spec, rsync_flags, total_files,
     for remote moves) and ``extra_args`` carries the SSH transport flags
     (``-e ssh ...``, ``--partial``, ``--bwlimit``). ``rsync_flags`` is a list;
     empty strings are dropped so a fresh move can pass no extra flag.
+
+    By default the whole ``src_path`` directory is transferred (``src_path
+    + "/"``), the shape ``move_folder`` uses. ``src_specs`` overrides this
+    with an explicit list of source *file* paths — the import job's per-batch
+    remote copy passes the batch's card files (which land flat by basename
+    under ``dest_spec/``), so no local staging tree is materialized. When
+    ``src_specs`` is given, ``dest_spec`` is suffixed with ``/`` (files land
+    inside the destination directory) unless ``src_specs_dest_is_dir`` is
+    False — the import job's collision-rename path passes a single source
+    file and an explicit remote FILE path (e.g.
+    ``user@host:/dir/DSC_0001_1.jpg``) so the renamed file lands under the
+    chosen name rather than its own basename.
 
     Returns ``(returncode, stderr, timed_out)``. ``timed_out`` is True when
     rsync made no forward progress for ``stall_timeout`` seconds and was
@@ -666,7 +738,11 @@ def _run_rsync_streamed(src_path, dest_spec, rsync_flags, total_files,
     cmd = [rsync_bin, "-a", "--out-format=%n"]
     cmd += list(extra_args or [])
     cmd += [f for f in (rsync_flags or []) if f]
-    cmd += [src_path + "/", dest_spec + "/"]
+    if src_specs is not None:
+        cmd += list(src_specs)
+        cmd += [dest_spec + "/" if src_specs_dest_is_dir else dest_spec]
+    else:
+        cmd += [src_path + "/", dest_spec + "/"]
     master_fd = slave_fd = None
     if hasattr(os, "openpty"):
         try:

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -666,8 +666,15 @@ def remote_verify_files(rsync_bin, src_specs, rsync_target, remote,
     """
     if not src_specs:
         return None
-    cmd = [rsync_bin, "-an", "--checksum", "--out-format=%n",
-           "-e", _ssh_rsh_string(remote)]
+    # ``--copy-links`` matches the import-transfer rsync (``_run_remote_import
+    # _job`` passes it): the transfer sends the REFERENCED file bytes for a
+    # symlinked source, so the source-side hash here must be computed on the
+    # same referenced file (not the symlink itself). Without it, ``rsync
+    # -an`` (which includes ``-l``) sees a symlink at the source and a real
+    # file on the NAS, treats them as mismatched, and reports the just-
+    # transferred file as verification-failed. See PR #1113 review.
+    cmd = [rsync_bin, "-an", "--checksum", "--copy-links",
+           "--out-format=%n", "-e", _ssh_rsh_string(remote)]
     cmd += list(src_specs)
     cmd += [rsync_target + "/" if dest_is_dir else rsync_target]
     try:

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -5570,6 +5570,78 @@ def test_remote_import_records_landings_in_intra_run_checker(
     assert len(all_transferred) == 1, all_transferred
 
 
+def test_remote_import_queues_both_when_skip_duplicates_disabled(
+        tmp_path, monkeypatch):
+    """With ``skip_duplicates=False`` and ``verify_by_hash`` true, a remote
+    batch that contains two byte-identical files with different basenames
+    must rsync/catalog BOTH files instead of counting the second as
+    ``skipped_duplicate``.
+
+    The remote intra-batch content-dedup shortcut hashes ``src_hash``
+    regardless of whether ``DuplicateChecker`` is active, so before the
+    fix the second file was silently skipped and — because
+    ``copied + skipped_duplicate == discovered`` — a verified run could
+    still report ``safe_to_format=True`` without an off-card row for the
+    second file. The local path only dedupes intra-batch same-content
+    twins through ``DuplicateChecker``, so disabling duplicate skipping
+    must queue both files here too. See PR #1113 review."""
+    import shutil as _shutil
+
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    # Two files, same bytes, same date (same batch), different basenames.
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+    ])
+    _shutil.copy2(str(card / "DSC_0001.jpg"), str(card / "DSC_0002.jpg"))
+    ts = datetime(2026, 7, 3, 10, 0, 0).timestamp()
+    os.utime(str(card / "DSC_0002.jpg"), (ts, ts))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra, verify_by_hash=True,
+            skip_duplicates=False,
+        ),
+    )
+
+    # Both files must land as ``copied``; nothing may be counted as
+    # ``skipped_duplicate`` because the user opted out of dedup.
+    assert result["failed"] == 0, result
+    assert result["copied"] == 2, result
+    assert result["skipped_duplicate"] == 0, result
+
+    # And both card files must actually reach the rsync transport (not
+    # just the counters), otherwise the off-card row for the second file
+    # is fictional.
+    all_transferred = sorted({
+        os.path.basename(s)
+        for c in calls["rsync"] for s in c["src_specs"]
+    })
+    assert all_transferred == ["DSC_0001.jpg", "DSC_0002.jpg"], (
+        all_transferred, calls["rsync"])
+
+    # Both source paths must end up cataloged as distinct photo rows on
+    # the mount so ``safe_to_format=True`` isn't a lie.
+    rows = db.conn.execute(
+        "SELECT filename FROM photos ORDER BY filename",
+    ).fetchall()
+    filenames = sorted(r["filename"] for r in rows)
+    assert len(filenames) == 2, filenames
+    # Basenames may include a numeric suffix if rsync flat-lands both to
+    # the same mount folder — what matters is that there are two distinct
+    # rows and both card files were transferred.
+    assert result["safe_to_format"] is True, result
+
+
 def test_remote_import_refuses_when_mount_root_absent(tmp_path, monkeypatch):
     """When a saved remote target's local mount root (``/Volumes/NAS``,
     ``/mnt/NAS``, ``/media/user/NAS``) is not currently mounted, the

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -5544,9 +5544,14 @@ def test_remote_import_links_case_only_twin_folder(tmp_path, monkeypatch):
     # prefix common to destination and the twin (a differently-cased leaf
     # still matches the literal prefix check inside ``lex_dup_dirs``).
     lower_root = tmp_path / "archive_root"
-    lower_root.mkdir()
+    lower_root.mkdir(exist_ok=True)
     upper_root = tmp_path / "ARCHIVE_ROOT"
-    upper_root.mkdir()
+    # On a case-insensitive host FS (macOS APFS/HFS+, Windows NTFS in the
+    # default configuration) the two spellings resolve to a single physical
+    # directory, so the second mkdir would raise FileExistsError; the
+    # existing dir already serves both cases. On case-sensitive Linux the
+    # dir does not yet exist and this creates the second physical dir.
+    upper_root.mkdir(exist_ok=True)
     ra = _remote_archive_for(lower_root)
     calls = _remote_calls(ra)
     _install_fake_remote_rsync(monkeypatch, calls, verify=None)

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -5837,3 +5837,96 @@ def test_remote_import_refuses_when_mount_root_absent(tmp_path, monkeypatch):
         f"shadow directory was created at {fake_mount_base}: "
         "the preflight failed to prevent os.makedirs"
     )
+
+
+def test_remote_import_case_only_basename_collision_on_ci_destination(
+        tmp_path, monkeypatch):
+    """On a case-insensitive destination (macOS APFS/HFS+, SMB, FAT/exFAT),
+    two DIFFERENT card files whose basenames differ only by case (e.g.
+    ``IMG_0001.JPG`` and ``img_0001.jpg``) collapse onto the same effective
+    on-disk file. The intra-batch collision map ``claimed_basenames`` must
+    key case-foldedly on such destinations so the second file is detected
+    as colliding and advanced to a numeric-suffixed name, otherwise both
+    are queued as distinct entries into the same flat rsync — where
+    ``--ignore-existing`` drops the second and the later catalog/hash
+    validation fails instead of the local path's rename-to-suffix
+    behaviour. See PR #1113 review."""
+    import import_job as _ij
+    from import_job import ImportParams, run_import_job
+
+    # Force the case-insensitive destination code path regardless of the
+    # test host filesystem (Linux ext4 is case-sensitive). The module-
+    # level constant _dest_ci consults; sys.platform monkeypatch wouldn't
+    # work because the constant is bound at import time.
+    monkeypatch.setattr(_ij, "_CASE_INSENSITIVE_PLATFORM", True)
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    # Two DIFFERENT-content files whose basenames differ only by case,
+    # same date (same batch). Distinct colors -> distinct bytes so the
+    # intra-batch same-content dedup shortcut can't hide the collision.
+    card = _make_card(tmp_path, [
+        ("IMG_0001.JPG", datetime(2026, 7, 3, 10, 0, 0), "red"),
+        ("img_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "blue"),
+    ])
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra, verify_by_hash=True,
+        ),
+    )
+
+    # Both must land as ``copied``, neither as ``skipped_duplicate`` (the
+    # bytes are different so intra-batch content dedup doesn't apply).
+    assert result["failed"] == 0, result
+    assert result["copied"] == 2, result
+    assert result["skipped_duplicate"] == 0, result
+
+    # Both card files must actually reach the transport under DISTINCT
+    # dest basenames whose case-folded forms are also distinct (the whole
+    # point of the fix: without it both share the effective receiver path
+    # on a CI destination).
+    all_transferred_dest = []
+    for c in calls["rsync"]:
+        if c["dest_is_dir"]:
+            for s in c["src_specs"]:
+                all_transferred_dest.append(os.path.basename(s))
+        else:
+            # File dest: name is the last path segment of dest_spec.
+            all_transferred_dest.append(
+                c["dest_spec"].rsplit("/", 1)[-1])
+    folded = [n.casefold() for n in all_transferred_dest]
+    assert len(folded) == 2, (all_transferred_dest, calls["rsync"])
+    assert len(set(folded)) == 2, (
+        "case-folded dest basenames must be distinct after the "
+        "collision loop; both files landed under the same effective "
+        "receiver name",
+        all_transferred_dest,
+    )
+
+    # And a collision-renamed rsync call MUST have fired (dest_is_dir=
+    # False) — that's the rename-to-suffix path the local import uses.
+    # Without the case-fold fix both files would go into a single flat
+    # rsync (dest_is_dir=True) and be silently coalesced by the CI
+    # receiver.
+    renamed_calls = [c for c in calls["rsync"] if not c["dest_is_dir"]]
+    assert renamed_calls, (
+        "expected a collision-renamed single-file rsync call for the "
+        "case-only basename collision",
+        calls["rsync"],
+    )
+
+    # Two distinct rows on the mount whose (case-folded) filenames are
+    # also distinct: the catalog reflects two off-card files, not one.
+    rows = _photo_rows(db)
+    assert len(rows) == 2, [dict(r) for r in rows]
+    folded_rows = {r["filename"].casefold() for r in rows}
+    assert len(folded_rows) == 2, [dict(r) for r in rows]
+    assert result["safe_to_format"] is True, result

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -3709,3 +3709,416 @@ def test_restricted_scan_does_not_link_unrelated_archive_subtrees(tmp_path):
             f"cascade in ``_add_workspace_folder_no_commit`` fired for "
             f"``destination`` even though it was not the user's target"
         )
+
+
+# --------------------------------------------------------------------------
+# Task 2.7: Remote (SSH) archive destination.
+#
+# The card is rsynced to ``remote_path/subpath`` over SSH and cataloged at
+# ``mount_path/subpath`` (resolve_remote_archive's mapping). The SSH/rsync
+# transport seams are monkeypatched — the fake rsync writes the batch's
+# files into the local mount (standing in for the NAS as seen through the
+# SMB mount), so ``scan()`` catalogs them at the mount path exactly as it
+# would against a real mounted NAS. No network is touched.
+# --------------------------------------------------------------------------
+
+def _remote_archive_for(tmp_path, subpath="2026/2026-07-03"):
+    """Build a resolved remote-archive dict (resolve_remote_archive shape)
+    plus the local mount base. The mount is a real tmp_path dir so scan()
+    can walk the cataloged files after the fake rsync lands them there."""
+    from move import build_remote_move_spec
+
+    mount_base = tmp_path / "mount"
+    mount_base.mkdir(exist_ok=True)
+    target = {
+        "id": "nas1", "name": "NAS", "host": "nas", "user": "me",
+        "port": 22, "ssh_key": "", "bwlimit_kbps": 0,
+        "remote_path": "/volume1/Photography",
+        "mount_path": str(mount_base),
+    }
+    spec = build_remote_move_spec(target, "", "/usr/bin/rsync")
+    return {
+        "target": target,
+        "rsync_bin": "/usr/bin/rsync",
+        "remote": spec,  # host/user/port/ssh_key/bwlimit/ssh_dest_base/...
+        "ssh_base": target["remote_path"],
+        "mount_base": str(mount_base),
+    }
+
+
+def _install_fake_remote_rsync(monkeypatch, calls, *, verify=None):
+    """Monkeypatch move's transport seams so a remote import never touches
+    the network. The fake rsync copies the explicit source files into the
+    local mount dir derived from the SSH dest path, recording every
+    invocation in ``calls`` (list of dicts). ``verify`` overrides
+    _remote_verify_complete's return (None == fully verified)."""
+    import os as _os
+    import shutil as _shutil
+
+    import move as _move
+
+    def fake_rsync(src_path, dest_spec, rsync_flags, total_files,
+                   progress_cb, rsync_bin="rsync", extra_args=None,
+                   src_specs=None, src_specs_dest_is_dir=True, **kw):
+        # dest_spec is ``user@host:/volume1/Photography/2026/2026-07-03``
+        # (a NAS dir) or, for a collision-renamed single file,
+        # ``user@host:/.../DSC_0001_1.jpg`` (a NAS FILE). Map the NAS path
+        # back to the local mount by swapping the SSH base prefix.
+        ssh_path = dest_spec.split(":", 1)[1]
+        if src_specs_dest_is_dir:
+            rel = _os.path.relpath(ssh_path, calls["_ssh_base"])
+            mount_dir = _os.path.join(calls["_mount_base"], rel)
+            _os.makedirs(mount_dir, exist_ok=True)
+            for s in src_specs:
+                _shutil.copy2(
+                    s, _os.path.join(mount_dir, _os.path.basename(s)))
+        else:
+            # File dest: exactly one source, landing under the chosen name.
+            rel = _os.path.relpath(ssh_path, calls["_ssh_base"])
+            mount_file = _os.path.join(calls["_mount_base"], rel)
+            _os.makedirs(_os.path.dirname(mount_file), exist_ok=True)
+            _shutil.copy2(src_specs[0], mount_file)
+        calls["rsync"].append({
+            "src_specs": list(src_specs), "dest_spec": dest_spec,
+            "rsync_bin": rsync_bin, "extra_args": list(extra_args or []),
+            "flags": list(rsync_flags or []),
+            "dest_is_dir": src_specs_dest_is_dir,
+        })
+        return (0, "", False)
+
+    monkeypatch.setattr(_move, "_run_rsync_streamed", fake_rsync)
+    monkeypatch.setattr(_move, "_remote_mkdir_p", lambda r, p: (True, ""))
+
+    # Card -> NAS verification seam (Task 2.7 FIX 1). ``verify`` may be a
+    # plain return value, or a callable ``fn(src_specs) -> return`` so a
+    # test can fail one specific card file by basename.
+    def fake_verify_files(rsync_bin, src_specs, rsync_target, remote,
+                          **kw):
+        calls["verify"] += 1
+        calls["verify_src_specs"].append(list(src_specs))
+        if callable(verify):
+            return verify(src_specs)
+        return verify
+
+    monkeypatch.setattr(_move, "remote_verify_files", fake_verify_files)
+
+
+def _remote_calls(remote_archive):
+    return {
+        "rsync": [], "verify": 0, "verify_src_specs": [],
+        "_ssh_base": remote_archive["ssh_base"],
+        "_mount_base": remote_archive["mount_base"],
+    }
+
+
+def test_remote_import_rsyncs_to_remote_and_catalogs_at_mount(
+        tmp_path, monkeypatch):
+    """A remote destination rsyncs the card into ``remote_path/subpath`` and
+    catalogs the resulting rows at ``mount_path/subpath`` — the catalog
+    paths are the local mount, never the NAS path."""
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+        ("DSC_0002.jpg", datetime(2026, 7, 3, 11, 0, 0), "green"),
+    ])
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra,
+        ),
+    )
+
+    assert result["failed"] == 0
+    assert result["copied"] == 2
+    # rsync addressed the SSH target with the NAS-side path.
+    assert calls["rsync"], "no rsync invocation captured"
+    dests = {c["dest_spec"] for c in calls["rsync"]}
+    assert dests == {"me@nas:/volume1/Photography/2026/2026-07-03"}
+    for c in calls["rsync"]:
+        assert c["rsync_bin"] == "/usr/bin/rsync"
+
+    # Catalog rows point at the LOCAL MOUNT path, not the NAS path.
+    rows = _photo_rows(db)
+    row_paths = {os.path.join(r["folder_path"], r["filename"]) for r in rows}
+    mount_dir = os.path.join(ra["mount_base"], "2026", "2026-07-03")
+    assert row_paths == {
+        os.path.join(mount_dir, "DSC_0001.jpg"),
+        os.path.join(mount_dir, "DSC_0002.jpg"),
+    }
+    for r in row_paths:
+        assert "/volume1/Photography" not in r
+    # The mount folder is linked to the active workspace.
+    assert mount_dir in _ws_linked_folder_paths(db, ws_id)
+
+
+def test_remote_import_per_batch_rsync_invocation(tmp_path, monkeypatch):
+    """Each destination-folder batch issues its own rsync invocation (the
+    per-batch commit unit), captured by the fake harness."""
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    # Two distinct template folders -> two batches -> two rsync calls.
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+        ("DSC_0002.jpg", datetime(2026, 7, 4, 9, 0, 0), "blue"),
+    ])
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra,
+        ),
+    )
+
+    dests = sorted(c["dest_spec"] for c in calls["rsync"])
+    assert dests == [
+        "me@nas:/volume1/Photography/2026/2026-07-03",
+        "me@nas:/volume1/Photography/2026/2026-07-04",
+    ]
+
+
+def test_remote_import_without_verify_leaves_hashes_null_and_unsafe(
+        tmp_path, monkeypatch):
+    """Without verify_by_hash the transfer relies on rsync's own integrity
+    checking only: catalog rows keep NULL hash_status/hash_checked_at (no
+    invented status values) and the run honestly reports safe_to_format
+    False with the exact remote-verification reason."""
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+    ])
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra, verify_by_hash=False,
+        ),
+    )
+
+    assert result["failed"] == 0
+    assert result["copied"] == 1
+    # No checksum verification ran.
+    assert calls["verify"] == 0
+    # Rows have NULL hash_status / hash_checked_at (not a fabricated value).
+    rows = _photo_rows(db)
+    assert rows
+    for r in rows:
+        assert r["hash_status"] is None
+        assert r["hash_checked_at"] is None
+    # Honest pill: not safe to format, exact reason string.
+    assert result["safe_to_format"] is False
+    assert any(
+        u["reason"] == "enable verify_by_hash for remote verification"
+        for u in result["unsafe_files"]
+    ), result["unsafe_files"]
+
+
+def test_remote_import_with_verify_stamps_ok_and_can_be_safe(
+        tmp_path, monkeypatch):
+    """With verify_by_hash a card->NAS --checksum dry-run runs; when it
+    confirms every file, rows get hash_status='ok' and the run may report
+    safe_to_format True."""
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+        ("DSC_0002.jpg", datetime(2026, 7, 3, 11, 0, 0), "green"),
+    ])
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra, verify_by_hash=True,
+        ),
+    )
+
+    assert result["failed"] == 0
+    assert result["copied"] == 2
+    # The checksum dry-run ran (at least once).
+    assert calls["verify"] >= 1
+    rows = _photo_rows(db)
+    assert rows
+    for r in rows:
+        assert r["hash_status"] == "ok"
+        assert r["hash_checked_at"] is not None
+        assert r["file_hash"] is not None
+    assert result["safe_to_format"] is True
+    assert result["unsafe_files"] == []
+
+
+def test_remote_verify_checks_card_files_not_mount(tmp_path, monkeypatch):
+    """FIX 1: verification must be genuinely card -> NAS. The verify seam's
+    source args must be the CARD file paths, never the local mount folder
+    (which is the same physical storage as the NAS, making that comparison
+    tautological)."""
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+        ("DSC_0002.jpg", datetime(2026, 7, 3, 11, 0, 0), "green"),
+    ])
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra, verify_by_hash=True,
+        ),
+    )
+
+    assert calls["verify_src_specs"], "verify seam was never called"
+    verified_sources = {
+        os.path.realpath(s)
+        for batch in calls["verify_src_specs"] for s in batch
+    }
+    expected_card = {
+        os.path.realpath(str(card / "DSC_0001.jpg")),
+        os.path.realpath(str(card / "DSC_0002.jpg")),
+    }
+    assert verified_sources == expected_card, verified_sources
+    # And NOT the mount folder / mount files.
+    for s in verified_sources:
+        assert ra["mount_base"] not in s
+
+
+def test_remote_import_verify_failure_fails_specific_file(
+        tmp_path, monkeypatch):
+    """FIX 1: when the card->NAS verify reports a specific card file
+    missing/different at the NAS, only THAT file fails (no hash_status='ok'
+    row for it) and safe_to_format is False; a sibling that verified is
+    stamped ok."""
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+
+    def verify_fn(src_specs):
+        # Report DSC_0001.jpg as still differing/absent at the NAS.
+        for s in src_specs:
+            if os.path.basename(s) == "DSC_0001.jpg":
+                return ("DSC_0001.jpg", None)
+        return None
+
+    _install_fake_remote_rsync(monkeypatch, calls, verify=verify_fn)
+
+    # Both files land in the SAME date folder -> one batch, so the batch's
+    # verify sees both and reports one bad.
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+        ("DSC_0002.jpg", datetime(2026, 7, 3, 10, 5, 0), "green"),
+    ])
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra, verify_by_hash=True,
+        ),
+    )
+
+    assert result["failed"] == 1
+    assert result["safe_to_format"] is False
+    assert any(
+        "DSC_0001.jpg" in u["path"] or "DSC_0001.jpg" in u["reason"]
+        for u in result["unsafe_files"]
+    ), result["unsafe_files"]
+
+    # The failed file must NOT carry an 'ok' hash verdict; the sibling that
+    # verified must.
+    rows = {r["filename"]: r for r in _photo_rows(db)}
+    if "DSC_0001.jpg" in rows:
+        assert rows["DSC_0001.jpg"]["hash_status"] != "ok"
+    assert rows["DSC_0002.jpg"]["hash_status"] == "ok"
+
+
+def test_remote_import_same_basename_collision_parity(tmp_path, monkeypatch):
+    """FIX 2: two DIFFERENT card files with the same basename destined for
+    one date folder must both land under distinct names on the NAS and be
+    cataloged as distinct photos — never silently clobber."""
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    # Same basename, different content, in two card subdirs, same mtime
+    # (same date folder). Distinct colors -> distinct bytes.
+    card = tmp_path / "card"
+    (card / "DCIM" / "100").mkdir(parents=True)
+    (card / "DCIM" / "101").mkdir(parents=True)
+    from PIL import Image as _Image
+    p1 = card / "DCIM" / "100" / "DSC_0001.jpg"
+    p2 = card / "DCIM" / "101" / "DSC_0001.jpg"
+    _Image.new("RGB", (16, 16), "red").save(str(p1))
+    _Image.new("RGB", (16, 16), "blue").save(str(p2))
+    ts = datetime(2026, 7, 3, 10, 0, 0).timestamp()
+    for p in (p1, p2):
+        os.utime(str(p), (ts, ts))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra,
+        ),
+    )
+
+    assert result["failed"] == 0, result["unsafe_files"]
+    # Both cataloged as distinct photos.
+    rows = _photo_rows(db)
+    assert len(rows) == 2, [dict(r) for r in rows]
+    filenames = sorted(r["filename"] for r in rows)
+    # Distinct on-disk names: the second landed under a numeric suffix.
+    assert filenames == ["DSC_0001.jpg", "DSC_0001_1.jpg"], filenames
+    # Both files physically exist at the mount, distinct content.
+    mount_dir = os.path.join(ra["mount_base"], "2026", "2026-07-03")
+    b0 = open(os.path.join(mount_dir, "DSC_0001.jpg"), "rb").read()
+    b1 = open(os.path.join(mount_dir, "DSC_0001_1.jpg"), "rb").read()
+    assert b0 != b1

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -4413,3 +4413,281 @@ def test_remote_import_fails_when_mount_row_hash_disagrees_with_verified_card(
     if "DSC_0001.jpg" in rows:
         assert rows["DSC_0001.jpg"]["hash_status"] != "ok", dict(
             rows["DSC_0001.jpg"])
+
+
+def test_remote_import_promotes_missing_destination_folder_to_ok(
+        tmp_path, monkeypatch):
+    """A remote import that lands into a folder whose ``folders`` row is
+    currently ``status='missing'`` (e.g. a previous health check ran while
+    the NAS mount was absent) must promote the row to ``'ok'`` after
+    makedirs — mirroring the local path. ``scanner.scan()`` only clears
+    ``'partial'`` on success, so a row still labelled ``'missing'`` would
+    keep the imported photos hidden from workspace queries while
+    ``safe_to_format`` could still flip green. See PR #1113 review."""
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+    ])
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    # Pre-seed the destination folder row as missing (as if a prior health
+    # check ran while the NAS mount was offline).
+    mount_dir = os.path.join(ra["mount_base"], "2026", "2026-07-03")
+    os.makedirs(mount_dir, exist_ok=True)
+    db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'missing')",
+        (mount_dir, os.path.basename(mount_dir)),
+    )
+    db.conn.commit()
+
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra, verify_by_hash=True,
+        ),
+    )
+
+    assert result["copied"] == 1, result
+    assert result["failed"] == 0, result
+
+    # The folder row must have flipped out of 'missing'. Otherwise
+    # workspace queries would filter the just-imported photo out.
+    row = db.conn.execute(
+        "SELECT status FROM folders WHERE path = ?", (mount_dir,),
+    ).fetchone()
+    assert row is not None, "destination folder row disappeared"
+    assert row["status"] == "ok", (
+        f"expected status='ok' after remote import into a previously "
+        f"missing folder; got {row['status']!r}"
+    )
+
+    # And the imported photo is visible in the active workspace.
+    linked = _ws_linked_folder_paths(db, ws_id)
+    assert mount_dir in linked, linked
+
+
+def test_remote_import_promotes_missing_folder_preserves_partial(
+        tmp_path, monkeypatch):
+    """Guard-rail: the missing→ok promote must NOT stomp a row currently
+    labelled ``'partial'`` (a real prior-scan needs-rescan signal). The
+    local path preserves ``'partial'``; the remote path must too."""
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    card = _make_card(tmp_path, [
+        ("DSC_0002.jpg", datetime(2026, 7, 3, 10, 0, 0), "blue"),
+    ])
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    mount_dir = os.path.join(ra["mount_base"], "2026", "2026-07-03")
+    os.makedirs(mount_dir, exist_ok=True)
+    db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'partial')",
+        (mount_dir, os.path.basename(mount_dir)),
+    )
+    db.conn.commit()
+
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra, verify_by_hash=True,
+        ),
+    )
+    assert result["failed"] == 0, result
+
+    row = db.conn.execute(
+        "SELECT status FROM folders WHERE path = ?", (mount_dir,),
+    ).fetchone()
+    # scan() may clear partial→ok on its own success stamp; the point of
+    # this test is that our missing→ok UPDATE did NOT stomp partial before
+    # scan ran. Either 'ok' (scan cleared it) or 'partial' (scan
+    # preserved it) is acceptable; anything else means our UPDATE
+    # over-reached.
+    assert row["status"] in ("ok", "partial"), (
+        f"missing→ok UPDATE must preserve 'partial'; got {row['status']!r}"
+    )
+
+
+def test_remote_import_accepts_paired_jpeg_companion_row(
+        tmp_path, monkeypatch):
+    """When a remote batch lands a JPEG whose sibling RAW is already
+    cataloged in the same destination folder, ``scanner.scan()`` runs
+    ``_pair_raw_jpeg_companions`` which merges the JPEG into the RAW row
+    (``companion_path``) and DELETES the JPEG's own row. The catalog-row
+    presence check must recognize this legitimate ``row is None`` case
+    via the companion lookup instead of failing the JPEG as
+    ``not cataloged after scan``. Mirrors the local path. See PR #1113
+    review."""
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    # Seed an existing RAW file at the destination + its catalog row.
+    mount_dir = os.path.join(ra["mount_base"], "2026", "2026-07-03")
+    os.makedirs(mount_dir, exist_ok=True)
+    raw_seed = os.path.join(mount_dir, "_seed.jpg")
+    Image.new("RGB", (16, 16), "red").save(raw_seed)
+    raw_bytes = open(raw_seed, "rb").read() + b"RAW-SENSOR-DATA"
+    os.unlink(raw_seed)
+    raw_path = os.path.join(mount_dir, "DSC_0800.NEF")
+    with open(raw_path, "wb") as f:
+        f.write(raw_bytes)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'ok')",
+        (mount_dir, os.path.basename(mount_dir)),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, extension, file_size,"
+        " file_hash) VALUES (?, ?, '.nef', ?, ?)",
+        (fid, "DSC_0800.NEF", len(raw_bytes), "deadbeef" * 8),
+    )
+    db.conn.commit()
+
+    # Card holds a new JPEG that will land as DSC_0800.jpg and pair with
+    # the pre-existing RAW during the batch's restricted scan.
+    card = _make_card(tmp_path, [
+        ("DSC_0800.jpg", datetime(2026, 7, 3, 10, 0, 0), "green"),
+    ])
+
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra, verify_by_hash=True,
+        ),
+    )
+
+    # The paired JPEG must NOT be reported as "not cataloged after scan"
+    # — its bytes are represented by the RAW row's companion_path.
+    assert result["copied"] == 1, result
+    assert result["failed"] == 0, result
+    assert not any(
+        "not cataloged" in u["reason"]
+        for u in result["unsafe_files"]
+    ), result["unsafe_files"]
+
+    # The RAW row now records the JPEG as its companion.
+    raw_row = db.conn.execute(
+        "SELECT companion_path FROM photos WHERE filename = 'DSC_0800.NEF'",
+    ).fetchone()
+    assert raw_row["companion_path"] == "DSC_0800.jpg", (
+        f"pair-merge must record JPEG on the RAW; got {dict(raw_row)}"
+    )
+    # And the JPEG has no standalone row of its own.
+    jpeg_row = db.conn.execute(
+        "SELECT id FROM photos WHERE filename = 'DSC_0800.jpg'",
+    ).fetchone()
+    assert jpeg_row is None, (
+        "paired JPEG must not keep a standalone row after pair-merge"
+    )
+
+
+def test_remote_import_paired_jpeg_verify_fails_on_mount_hash_mismatch(
+        tmp_path, monkeypatch):
+    """Cross-check parity: when the paired JPEG's mount bytes disagree
+    with the source hash confirmed on the NAS (stale/misconfigured
+    mount), the ``verify_by_hash`` branch must fail the JPEG instead of
+    silently accepting it via the companion row. Same guard the non-
+    companion branch runs; the pair-merged JPEG can't be exempt from
+    it."""
+    import move as _move
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+
+    # Seed the existing RAW at the mount.
+    mount_dir = os.path.join(ra["mount_base"], "2026", "2026-07-03")
+    os.makedirs(mount_dir, exist_ok=True)
+    raw_seed = os.path.join(mount_dir, "_seed.jpg")
+    Image.new("RGB", (16, 16), "red").save(raw_seed)
+    raw_bytes = open(raw_seed, "rb").read() + b"RAW-SENSOR-DATA"
+    os.unlink(raw_seed)
+    raw_path = os.path.join(mount_dir, "DSC_0800.NEF")
+    with open(raw_path, "wb") as f:
+        f.write(raw_bytes)
+
+    # Fake rsync that "lands" the JPEG at the mount but with WRONG bytes
+    # (the wrong-storage stand-in). NAS-side card verify still succeeds.
+    def fake_rsync_wrong_bytes(
+            src_path, dest_spec, rsync_flags, total_files,
+            progress_cb, rsync_bin="rsync", extra_args=None,
+            src_specs=None, src_specs_dest_is_dir=True, **kw):
+        calls["rsync"].append({
+            "src_specs": list(src_specs or []),
+            "extra_args": list(extra_args or []),
+        })
+        ssh_path = dest_spec.split(":", 1)[1]
+        rel = os.path.relpath(ssh_path, ra["ssh_base"])
+        if src_specs_dest_is_dir:
+            mount_dst = os.path.join(ra["mount_base"], rel)
+            os.makedirs(mount_dst, exist_ok=True)
+            for s in src_specs:
+                Image.new("RGB", (16, 16), "yellow").save(
+                    os.path.join(mount_dst, os.path.basename(s)))
+        else:
+            mount_file = os.path.join(ra["mount_base"], rel)
+            os.makedirs(os.path.dirname(mount_file), exist_ok=True)
+            Image.new("RGB", (16, 16), "yellow").save(mount_file)
+        return (0, "", False)
+
+    monkeypatch.setattr(_move, "_run_rsync_streamed", fake_rsync_wrong_bytes)
+    monkeypatch.setattr(_move, "_remote_mkdir_p", lambda r, p: (True, ""))
+    monkeypatch.setattr(_move, "remote_verify_files",
+                        lambda *a, **kw: None)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'ok')",
+        (mount_dir, os.path.basename(mount_dir)),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, extension, file_size,"
+        " file_hash) VALUES (?, ?, '.nef', ?, ?)",
+        (fid, "DSC_0800.NEF", len(raw_bytes), "deadbeef" * 8),
+    )
+    db.conn.commit()
+
+    card = _make_card(tmp_path, [
+        ("DSC_0800.jpg", datetime(2026, 7, 3, 10, 0, 0), "green"),
+    ])
+
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra, verify_by_hash=True,
+        ),
+    )
+
+    assert result["copied"] == 0, result
+    assert result["failed"] == 1, result
+    assert result["safe_to_format"] is False, result
+    assert any(
+        "paired companion mount bytes" in u["reason"]
+        for u in result["unsafe_files"]
+    ), result["unsafe_files"]

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -4691,3 +4691,256 @@ def test_remote_import_paired_jpeg_verify_fails_on_mount_hash_mismatch(
         "paired companion mount bytes" in u["reason"]
         for u in result["unsafe_files"]
     ), result["unsafe_files"]
+
+
+def test_remote_import_rejects_dest_folder_under_source(
+        tmp_path, monkeypatch):
+    """When the mount base is an ancestor of a selected source and the
+    folder template maps back into that source folder, ``dest_folder``
+    (and every ``cand_mount`` under it) resolves inside a source root.
+    The per-file collision loop would otherwise hash those source-backed
+    ``cand_mount`` files, byte-match them against the card, and count
+    them as ``skipped_duplicate`` — with ``verify_by_hash=True`` that
+    would let ``safe_to_format`` flip green over a card whose bytes
+    never crossed the network. The batch-level guard (mirroring the
+    local path at ``_path_under_any_source(dest_folder)``) must reject
+    the whole batch before makedirs and before any duplicate-adopt
+    hashing runs. See PR #1113 review."""
+    import move as _move
+    from import_job import ImportParams, run_import_job
+
+    # Set up a card that ALSO serves as the mount base — the folder
+    # template ``2026/2026-07-03`` under the card is the dest_folder.
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+    ])
+
+    # Build a remote-archive dict whose mount_base points at the card
+    # itself. rsync should never be invoked in this scenario because the
+    # batch is rejected before makedirs.
+    from move import build_remote_move_spec
+    target = {
+        "id": "nas1", "name": "NAS", "host": "nas", "user": "me",
+        "port": 22, "ssh_key": "", "bwlimit_kbps": 0,
+        "remote_path": "/volume1/Photography",
+        "mount_path": str(card),
+    }
+    spec = build_remote_move_spec(target, "", "/usr/bin/rsync")
+    ra = {
+        "target": target,
+        "rsync_bin": "/usr/bin/rsync",
+        "remote": spec,
+        "ssh_base": target["remote_path"],
+        "mount_base": str(card),
+    }
+    calls = {
+        "rsync": [], "verify": 0, "verify_src_specs": [],
+        "_ssh_base": ra["ssh_base"], "_mount_base": ra["mount_base"],
+    }
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+    # A stat-refusing OSError never needed: the guard runs before any
+    # duplicate-adopt hashing that would touch cand_mount.
+
+    # Also monkeypatch compute_file_hash to blow up if reached — the
+    # guard's job is to prevent us ever hashing a source-backed
+    # cand_mount as "already at destination".
+    import import_job as _ij
+
+    def _refuse_hash(path):
+        raise AssertionError(
+            f"unexpected hash of {path!r} — dest-under-source guard "
+            "should have rejected the batch before this call"
+        )
+
+    orig_hash = _ij.compute_file_hash
+    monkeypatch.setattr(_ij, "compute_file_hash", _refuse_hash)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra, verify_by_hash=True,
+        ),
+    )
+    # Restore hash for any later use in this test.
+    monkeypatch.setattr(_ij, "compute_file_hash", orig_hash)
+    monkeypatch.setattr(_move, "_run_rsync_streamed", lambda *a, **kw: (
+        (_ for _ in ()).throw(AssertionError("rsync should not run"))
+    ))
+
+    # No rsync invocation happened — the batch was rejected up front.
+    assert calls["rsync"] == [], calls["rsync"]
+    # Every file lands in ``failed`` with the dest-under-source reason.
+    assert result["failed"] == 1, result
+    assert result["copied"] == 0, result
+    assert result["skipped_duplicate"] == 0, result
+    assert result["safe_to_format"] is False, result
+    assert any(
+        "destination folder resolves inside a source directory"
+        in u["reason"]
+        for u in result["unsafe_files"]
+    ), result["unsafe_files"]
+
+
+def test_remote_import_no_verify_fails_on_mount_hash_mismatch(
+        tmp_path, monkeypatch):
+    """Catalog-integrity guard on the no-verify path: when
+    ``verify_by_hash=False`` and the mount base is stale/misconfigured
+    (or an ``--ignore-existing``-blocked race left a different file at
+    the same mount path), the row-presence check alone would let
+    ``run_import_job`` return ``copied`` while the catalog row points
+    at the wrong bytes. The scanned row's ``file_hash`` must be
+    cross-checked against ``src_hash`` regardless of ``verify_by_hash``,
+    with only the ``hash_status='ok'`` stamp still gated on the
+    checksum-verification path. See PR #1113 review."""
+    import move as _move
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+
+    def fake_rsync_writes_wrong_bytes(
+            src_path, dest_spec, rsync_flags, total_files,
+            progress_cb, rsync_bin="rsync", extra_args=None,
+            src_specs=None, src_specs_dest_is_dir=True, **kw):
+        calls["rsync"].append({
+            "src_specs": list(src_specs or []),
+            "extra_args": list(extra_args or []),
+        })
+        ssh_path = dest_spec.split(":", 1)[1]
+        rel = os.path.relpath(ssh_path, ra["ssh_base"])
+        if src_specs_dest_is_dir:
+            mount_dst = os.path.join(ra["mount_base"], rel)
+            os.makedirs(mount_dst, exist_ok=True)
+            for s in src_specs:
+                Image.new("RGB", (16, 16), "yellow").save(
+                    os.path.join(mount_dst, os.path.basename(s)))
+        else:
+            mount_file = os.path.join(ra["mount_base"], rel)
+            os.makedirs(os.path.dirname(mount_file), exist_ok=True)
+            Image.new("RGB", (16, 16), "yellow").save(mount_file)
+        return (0, "", False)
+
+    monkeypatch.setattr(_move, "_run_rsync_streamed",
+                        fake_rsync_writes_wrong_bytes)
+    monkeypatch.setattr(_move, "_remote_mkdir_p", lambda r, p: (True, ""))
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+    ])
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra, verify_by_hash=False,
+        ),
+    )
+
+    # The mismatch must be detected even without verify_by_hash — the
+    # catalog cannot silently point at unrelated bytes.
+    assert result["copied"] == 0, result
+    assert result["failed"] == 1, result
+    assert result["safe_to_format"] is False, result
+    assert any(
+        "scanned mount row hash" in u["reason"]
+        for u in result["unsafe_files"]
+    ), result["unsafe_files"]
+    # No hash_status='ok' stamp on the no-verify path even if the row
+    # survived — that stamp remains gated on the checksum path.
+    rows = {r["filename"]: r for r in _photo_rows(db)}
+    if "DSC_0001.jpg" in rows:
+        assert rows["DSC_0001.jpg"]["hash_status"] != "ok", dict(
+            rows["DSC_0001.jpg"])
+
+
+def test_remote_import_dup_only_batch_records_failure_when_scan_raises(
+        tmp_path, monkeypatch):
+    """A duplicate-only remote batch (every card file matched a
+    cataloged twin) still needs ``scan()`` to link the twin folder into
+    the workspace. If ``landed`` is empty (no fresh copies) but
+    ``dup_skipped > 0`` and ``scan()`` raises, no per-file failure was
+    recorded and ``safe_to_format`` could flip green while the duplicate
+    folder never became visible in the workspace. The exception handler
+    must record a batch-level failure for that case, mirroring the local
+    path's ``dup_link_failed`` gate. See PR #1113 review."""
+    import scanner as _scanner
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    # Card holds one file whose bytes already exist on the archive at a
+    # pre-seeded twin folder — the duplicate gate will match and skip.
+    from import_dedup import compute_file_hash as _hash
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+    ])
+    card_file = str(card / "DSC_0001.jpg")
+    src_hash = _hash(card_file)
+
+    # Seed an archive folder that owns the byte-identical twin (outside
+    # any import source — the check that Codex asked for filters
+    # source-backed twins, so we need a real off-card twin).
+    archive_twin_dir = tmp_path / "archive_twin"
+    archive_twin_dir.mkdir()
+    twin_path = archive_twin_dir / "DSC_0001.jpg"
+    import shutil as _shutil
+    _shutil.copy2(card_file, str(twin_path))
+    # scan the twin folder into the DB so DuplicateChecker sees a hash
+    # match token.
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    _scanner.scan(str(archive_twin_dir), db)
+    # Sanity: the twin row is present with the right hash.
+    twin_rows = db.conn.execute(
+        "SELECT p.file_hash, f.path FROM photos p "
+        "JOIN folders f ON f.id = p.folder_id "
+        "WHERE p.filename = 'DSC_0001.jpg'",
+    ).fetchall()
+    assert twin_rows and twin_rows[0]["file_hash"] == src_hash, [
+        dict(r) for r in twin_rows]
+
+    # Now monkeypatch scan() to raise ONLY on the import job's
+    # per-batch call (the dup-only batch's twin-folder link scan). The
+    # patched scan is bound after the pre-seed above, so it doesn't
+    # interfere with our own setup.
+    orig_scan = _scanner.scan
+
+    def failing_scan(*args, **kwargs):
+        raise RuntimeError("scan blew up (simulated NAS mount error)")
+
+    monkeypatch.setattr(_scanner, "scan", failing_scan)
+
+    try:
+        result = run_import_job(
+            _make_job(), FakeRunner(), db_path, ws_id,
+            ImportParams(
+                sources=[str(card)], destination=ra["mount_base"],
+                remote_target=ra, verify_by_hash=True,
+            ),
+        )
+    finally:
+        monkeypatch.setattr(_scanner, "scan", orig_scan)
+
+    # rsync never ran — the file was accepted as a duplicate against the
+    # off-card twin.
+    assert calls["rsync"] == [], calls["rsync"]
+    # A duplicate-only batch whose scan() raised must NOT report
+    # safe_to_format=True. The batch-level failure marker forces
+    # failed>0, which flips safe_to_format False.
+    assert result["failed"] >= 1, result
+    assert result["safe_to_format"] is False, result
+    assert result["skipped_duplicate"] == 1, result
+    assert any(
+        "duplicate-only batch" in u["reason"]
+        for u in result["unsafe_files"]
+    ), result["unsafe_files"]

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -5515,6 +5515,106 @@ def test_remote_import_links_alias_spelled_twin_folder(tmp_path, monkeypatch):
     assert alias_twin_folder in linked_after, sorted(linked_after)
 
 
+def test_remote_import_links_case_only_twin_folder(tmp_path, monkeypatch):
+    """On a case-insensitive destination (macOS APFS/HFS+, SMB, FAT), a
+    cataloged twin folder whose stored path differs from ``destination``
+    only by case is accepted via ``_path_under_destination``'s casefold
+    check. But scanner's ``_ensure_folder`` walks ``Path`` parents until
+    they *lexically* (case-sensitive string equality, independent of the
+    underlying filesystem) equal the scan root — a restrict_dir like
+    ``/volumes/nas/…`` under root ``/Volumes/NAS/…`` recurses toward
+    ``/`` and marks the verified duplicate-only remote import failed/
+    unsafe before the workspace link is created. The dup-link split must
+    route case-only aliases through the direct-link path (the same code
+    path as symlink aliases), not scan them. See PR #1113 review.
+    """
+    import import_job as _ij
+    from import_dedup import compute_file_hash as _hash
+    from import_job import ImportParams, run_import_job
+
+    # Force the case-insensitive destination code path regardless of the
+    # test host filesystem (Linux ext4 is case-sensitive). This is the
+    # module-level constant _dest_ci consults; sys.platform monkeypatch
+    # wouldn't work because the constant is bound at import time.
+    monkeypatch.setattr(_ij, "_CASE_INSENSITIVE_PLATFORM", True)
+
+    # Build the remote archive rooted under a case-neutral parent so we can
+    # spell the destination and the twin's DB path with a differently-cased
+    # ancestor. The bug only triggers when the CASE MISMATCH lies in the
+    # prefix common to destination and the twin (a differently-cased leaf
+    # still matches the literal prefix check inside ``lex_dup_dirs``).
+    lower_root = tmp_path / "archive_root"
+    lower_root.mkdir()
+    upper_root = tmp_path / "ARCHIVE_ROOT"
+    upper_root.mkdir()
+    ra = _remote_archive_for(lower_root)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+    ])
+    card_file = str(card / "DSC_0001.jpg")
+    src_hash = _hash(card_file)
+
+    real_mount_base = ra["mount_base"]  # lower_root/mount
+    # Twin folder cataloged with an ANCESTOR case-mismatch: the destination
+    # is ``<tmp>/archive_root/mount`` (lowercase), and the twin's DB path
+    # lives under ``<tmp>/ARCHIVE_ROOT/mount/unsorted``. On a real
+    # case-insensitive volume these are the same physical directory; on
+    # the case-sensitive Linux test filesystem we materialize both real
+    # directories so ``os.path.isdir`` succeeds. The bug fires purely in
+    # the string comparison inside the dup-link classification: the twin's
+    # DB path casefold-matches ``destination`` (routing it to ``lex_dup_
+    # dirs``), but its literal prefix doesn't match — passing that path to
+    # ``scan(destination, restrict_dirs=[…])`` would blow scanner's
+    # parent-walk.
+    lex_mount_case = str(upper_root / "mount")
+    os.makedirs(lex_mount_case, exist_ok=True)
+    twin_folder_case = os.path.join(lex_mount_case, "unsorted")
+    os.makedirs(twin_folder_case, exist_ok=True)
+    twin_path_case = os.path.join(twin_folder_case, "DSC_0001.jpg")
+    import shutil as _shutil
+    _shutil.copy2(card_file, twin_path_case)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'ok')",
+        (twin_folder_case, os.path.basename(twin_folder_case)),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, extension, file_size,"
+        " file_hash) VALUES (?, ?, '.jpg', ?, ?)",
+        (fid, "DSC_0001.jpg", os.path.getsize(twin_path_case), src_hash),
+    )
+    db.conn.commit()
+    assert twin_folder_case not in _ws_linked_folder_paths(db, ws_id)
+
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=real_mount_base,
+            remote_target=ra, verify_by_hash=True,
+        ),
+    )
+
+    # rsync stayed silent — card accepted as a duplicate.
+    assert calls["rsync"] == [], calls["rsync"]
+    assert result["skipped_duplicate"] == 1, result
+    # The case-only-alias twin folder MUST be linked into the active
+    # workspace via the direct-link path. Without the case-only fix, the
+    # dup-link scan would receive the differently-cased folder path as a
+    # restrict_dir and scanner's parent-walk would blow up before the
+    # workspace_folders row was created — flipping safe_to_format to
+    # False on a legitimately verified duplicate-only run.
+    assert result["failed"] == 0, result
+    assert result["safe_to_format"] is True, result
+    linked_after = _ws_linked_folder_paths(db, ws_id)
+    assert twin_folder_case in linked_after, sorted(linked_after)
+
+
 def test_remote_import_records_landings_in_intra_run_checker(
         tmp_path, monkeypatch):
     """With ``skip_duplicates=True`` (the default) and ``verify_by_hash``

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -5568,3 +5568,100 @@ def test_remote_import_records_landings_in_intra_run_checker(
         s for c in calls["rsync"] for s in c["src_specs"]
     ]
     assert len(all_transferred) == 1, all_transferred
+
+
+def test_remote_import_refuses_when_mount_root_absent(tmp_path, monkeypatch):
+    """When a saved remote target's local mount root (``/Volumes/NAS``,
+    ``/mnt/NAS``, ``/media/user/NAS``) is not currently mounted, the
+    remote import must fail before ``os.makedirs(dest_folder)`` creates a
+    local shadow of the mount tree on the internal disk. The SSH rsync
+    could still push to the NAS, but the batch scan then reads the empty
+    shadow and leaves the import uncataloged; on macOS/Linux the shadow
+    root can also prevent the real share from remounting. Mirrors the
+    pipeline path's ``_missing_archive_mount_root`` preflight. See PR
+    #1113 review."""
+    import move as _move
+    import pipeline_job as _pj
+    from import_job import ImportParams, run_import_job
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+        ("DSC_0002.jpg", datetime(2026, 7, 3, 11, 0, 0), "green"),
+    ])
+
+    # Build a resolved-archive dict whose mount base sits under a
+    # (simulated) unmounted volume. The pipeline helper only fires for
+    # the specific ``/Volumes/*`` / ``/mnt/*`` / ``/media/*/*`` shapes,
+    # so monkeypatch it to report our fake mount base as missing —
+    # analogous to how test_pipeline_api's
+    # ``test_pipeline_local_processing_rejects_missing_archive_mount_root``
+    # stubs the helper.
+    fake_mount_base = str(tmp_path / "Volumes_NAS_Photos")
+    target = {
+        "id": "nas1", "name": "NAS", "host": "nas", "user": "me",
+        "port": 22, "ssh_key": "", "bwlimit_kbps": 0,
+        "remote_path": "/volume1/Photography",
+        "mount_path": fake_mount_base,
+    }
+    from move import build_remote_move_spec
+    spec = build_remote_move_spec(target, "", "/usr/bin/rsync")
+    ra = {
+        "target": target,
+        "rsync_bin": "/usr/bin/rsync",
+        "remote": spec,
+        "ssh_base": target["remote_path"],
+        "mount_base": fake_mount_base,
+    }
+
+    monkeypatch.setattr(
+        _pj, "_missing_archive_mount_root",
+        lambda path: (
+            "/Volumes/NAS"
+            if path.startswith(fake_mount_base) else None
+        ),
+    )
+
+    # rsync must NEVER run — the batch is rejected before makedirs and
+    # before any transport call.
+    def _refuse_rsync(*a, **kw):
+        raise AssertionError(
+            "rsync should not run when the mount root is absent"
+        )
+
+    monkeypatch.setattr(_move, "_run_rsync_streamed", _refuse_rsync)
+    monkeypatch.setattr(_move, "_remote_mkdir_p", lambda r, p: (True, ""))
+    monkeypatch.setattr(
+        _move, "remote_verify_files",
+        lambda *a, **kw: (
+            (_ for _ in ()).throw(
+                AssertionError("verify should not run either")
+            )
+        ),
+    )
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra, verify_by_hash=True,
+        ),
+    )
+
+    # Every discovered card file lands in ``failed`` with the
+    # mount-root reason; the guarded ``os.makedirs`` never ran, so no
+    # shadow tree exists under the fake mount base.
+    assert result["failed"] == 2, result
+    assert result["copied"] == 0, result
+    assert result["skipped_duplicate"] == 0, result
+    assert result["safe_to_format"] is False, result
+    assert all(
+        "/Volumes/NAS" in u["reason"] and "not available" in u["reason"]
+        for u in result["unsafe_files"] if u["path"] != "<remote>"
+    ), result["unsafe_files"]
+    assert not os.path.exists(fake_mount_base), (
+        f"shadow directory was created at {fake_mount_base}: "
+        "the preflight failed to prevent os.makedirs"
+    )

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -5428,3 +5428,143 @@ def test_progress_events_carry_live_per_folder_counts(tmp_path):
     assert any(0 < t < 4 for t in progress_folder_totals), (
         progress_folder_totals
     )
+
+
+def test_remote_import_links_alias_spelled_twin_folder(tmp_path, monkeypatch):
+    """A verified duplicate skip whose twin was cataloged through a symlink
+    alias of the mount base is accepted via ``_path_under_destination``'s
+    realpath check, but the follow-up dup-link scan cannot pass the alias
+    to ``scan(destination, restrict_dirs=[alias])`` — scanner's
+    ``_ensure_folder`` walks parents lexically and would recurse toward
+    ``/`` before creating the workspace link, marking the import failed/
+    unsafe. The remote path must mirror the local split: link alias-
+    spelled dup dirs directly via ``add_workspace_folder`` rather than
+    scanning them. See PR #1113 review."""
+    if not hasattr(os, "symlink"):
+        return
+    from import_dedup import compute_file_hash as _hash
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    # Card holds one photo whose bytes ALREADY exist under the real mount
+    # base in an "unsorted" folder.
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+    ])
+    card_file = str(card / "DSC_0001.jpg")
+    src_hash = _hash(card_file)
+
+    real_mount_base = ra["mount_base"]
+    twin_folder_real = os.path.join(real_mount_base, "unsorted")
+    os.makedirs(twin_folder_real, exist_ok=True)
+    twin_path_real = os.path.join(twin_folder_real, "DSC_0001.jpg")
+    import shutil as _shutil
+    _shutil.copy2(card_file, twin_path_real)
+
+    # Alias root points at the same physical directory via symlink. The
+    # twin's cataloged folder path is spelled through the alias — NOT
+    # lexically under the mount base — so scanner._ensure_folder's parent
+    # walk would recurse toward / rather than stopping at the destination
+    # root; the remote dup-link scan must link this folder directly via
+    # add_workspace_folder without calling scan() on the alias path.
+    try:
+        alias_root = str(tmp_path / "mount_alias")
+        os.symlink(real_mount_base, alias_root)
+    except OSError:
+        # No symlink support / permission — skip: the failure mode this
+        # test proves needs a real alias on disk.
+        return
+    alias_twin_folder = os.path.join(alias_root, "unsorted")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'ok')",
+        (alias_twin_folder, os.path.basename(alias_twin_folder)),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, extension, file_size,"
+        " file_hash) VALUES (?, ?, '.jpg', ?, ?)",
+        (fid, "DSC_0001.jpg", os.path.getsize(twin_path_real), src_hash),
+    )
+    db.conn.commit()
+    assert alias_twin_folder not in _ws_linked_folder_paths(db, ws_id)
+
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=real_mount_base,
+            remote_target=ra, verify_by_hash=True,
+        ),
+    )
+
+    # rsync stayed silent — card accepted as a duplicate.
+    assert calls["rsync"] == [], calls["rsync"]
+    assert result["skipped_duplicate"] == 1, result
+    # The alias-spelled twin folder MUST be linked into the active
+    # workspace — without the alias/lex split, the dup-link scan would
+    # blow up on _ensure_folder's parent walk and the job would report
+    # failed/unsafe.
+    assert result["failed"] == 0, result
+    assert result["safe_to_format"] is True, result
+    linked_after = _ws_linked_folder_paths(db, ws_id)
+    assert alias_twin_folder in linked_after, sorted(linked_after)
+
+
+def test_remote_import_records_landings_in_intra_run_checker(
+        tmp_path, monkeypatch):
+    """With ``skip_duplicates=True`` (the default) and ``verify_by_hash``
+    true, a remote batch that contains two byte-identical files with
+    different basenames must record the first landing with the intra-run
+    duplicate checker so the second file is recognized as an intra-run
+    duplicate — otherwise the checker only ever sees the pre-run catalog,
+    and both files get rsynced/cataloged separately.
+
+    Mirrors the local path's ``_record_checker`` after every accepted
+    landing. See PR #1113 review."""
+    import shutil as _shutil
+
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    # Two files, same bytes (same color -> same PIL-encoded JPEG), same
+    # date (same batch), different basenames.
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+    ])
+    _shutil.copy2(str(card / "DSC_0001.jpg"), str(card / "DSC_0002.jpg"))
+    ts = datetime(2026, 7, 3, 10, 0, 0).timestamp()
+    os.utime(str(card / "DSC_0002.jpg"), (ts, ts))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra, verify_by_hash=True,
+        ),
+    )
+
+    # Exactly one file lands on the NAS; the second is an intra-run
+    # duplicate — without the record() call, both would be rsynced.
+    assert result["failed"] == 0, result
+    assert result["copied"] == 1, result
+    assert result["skipped_duplicate"] == 1, result
+
+    # The rsync fake records each source it moved. Sum across all calls
+    # must be exactly one card file (the flat batch may or may not
+    # coalesce depending on collision handling, but the DEDUPED count is
+    # what the checker enforces).
+    all_transferred = [
+        s for c in calls["rsync"] for s in c["src_specs"]
+    ]
+    assert len(all_transferred) == 1, all_transferred

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -5867,6 +5867,25 @@ def test_remote_import_case_only_basename_collision_on_ci_destination(
     import import_job as _ij
     from import_job import ImportParams, run_import_job
 
+    # Skip on a case-insensitive host filesystem (macOS APFS/HFS+, Windows
+    # NTFS in the default configuration): the two case-only-different card
+    # files can't both exist on such a filesystem — writing ``img_0001.jpg``
+    # after ``IMG_0001.JPG`` overwrites the first, so discovery only sees
+    # ONE file and the destination-side collision loop we're trying to
+    # exercise has nothing to collide against. The production behaviour
+    # itself is unaffected (the collision loop keys ``claimed_basenames``
+    # case-foldedly whenever ``_dest_ci`` is true regardless of the card
+    # filesystem); this is a test-fixture limitation, not a code bug.
+    _probe_dir = tmp_path / "_case_probe"
+    _probe_dir.mkdir()
+    (_probe_dir / "CaseProbe.txt").write_text("")
+    if (_probe_dir / "caseprobe.txt").exists():
+        import pytest
+        pytest.skip(
+            "case-insensitive host filesystem cannot hold two card files "
+            "whose basenames differ only by case",
+        )
+
     # Force the case-insensitive destination code path regardless of the
     # test host filesystem (Linux ext4 is case-sensitive). The module-
     # level constant _dest_ci consults; sys.platform monkeypatch wouldn't

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -4328,6 +4328,63 @@ def test_remote_import_rsync_uses_ignore_existing_to_survive_basename_races(
         )
 
 
+def test_remote_import_rsync_dereferences_symlinked_source_files(
+        tmp_path, monkeypatch):
+    """A curated card folder that symlinks to the real image files (or a
+    source root that's itself a symlink into ``/Volumes/Card/DCIM``) must
+    land the referenced BYTES on the NAS, not the symlink itself. The base
+    rsync command is ``rsync -a``, which preserves symlinks: without
+    ``--copy-links`` the NAS would receive a symlink pointing back at the
+    card path, and formatting/unmounting the card would break the archive.
+    With ``verify_by_hash`` the mount-side scan follows the symlink through
+    the mount, so ``safe_to_format`` could still go green over an archive
+    that only contains symlinks. Regression: every import rsync must carry
+    ``--copy-links``."""
+    import pytest
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    if not hasattr(os, "symlink"):
+        pytest.skip("symlinks not available on this platform")
+
+    # Real files live under ``real_card``; the ``curated`` folder we hand to
+    # the import contains symlinks to them. Each symlink is what
+    # ``run_import_job`` walks and hands to rsync — a plain ``rsync -a``
+    # would preserve the link.
+    real_card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+        ("DSC_0002.jpg", datetime(2026, 7, 3, 11, 0, 0), "green"),
+    ], card_name="real_card")
+    curated = tmp_path / "curated"
+    curated.mkdir()
+    for name in ("DSC_0001.jpg", "DSC_0002.jpg"):
+        try:
+            os.symlink(str(real_card / name), str(curated / name))
+        except (OSError, NotImplementedError):
+            pytest.skip("symlink creation not supported on this platform")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(curated)], destination=ra["mount_base"],
+            remote_target=ra,
+        ),
+    )
+
+    assert calls["rsync"], "no rsync invocation captured"
+    for c in calls["rsync"]:
+        assert "--copy-links" in c["extra_args"], (
+            "rsync invocation missing --copy-links symlink-dereference "
+            f"guard: {c['extra_args']}"
+        )
+
+
 def test_remote_import_fails_when_mount_row_hash_disagrees_with_verified_card(
         tmp_path, monkeypatch):
     """``remote_verify_files`` runs card -> NAS (``ssh_base``); ``scan()``

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -5834,9 +5834,17 @@ def test_remote_import_refuses_when_mount_root_absent(tmp_path, monkeypatch):
     assert result["copied"] == 0, result
     assert result["skipped_duplicate"] == 0, result
     assert result["safe_to_format"] is False, result
+    # Filter out the ``<remote>`` honesty-gate marker so a regression that
+    # drops the per-file mount-root reason (or funnels everything into a
+    # ``<remote>`` entry) does not make the ``all()`` below vacuously true
+    # over an empty generator; assert the filtered subset is non-empty first.
+    non_remote = [
+        u for u in result["unsafe_files"] if u["path"] != "<remote>"
+    ]
+    assert non_remote, result["unsafe_files"]
     assert all(
         "/Volumes/NAS" in u["reason"] and "not available" in u["reason"]
-        for u in result["unsafe_files"] if u["path"] != "<remote>"
+        for u in non_remote
     ), result["unsafe_files"]
     assert not os.path.exists(fake_mount_base), (
         f"shadow directory was created at {fake_mount_base}: "
@@ -5935,3 +5943,77 @@ def test_remote_import_case_only_basename_collision_on_ci_destination(
     folded_rows = {r["filename"].casefold() for r in rows}
     assert len(folded_rows) == 2, [dict(r) for r in rows]
     assert result["safe_to_format"] is True, result
+
+
+def test_remote_import_cancel_mid_batch_does_not_start_rsync(
+        tmp_path, monkeypatch):
+    """When Stop is requested inside the per-file queue-building loop of a
+    remote import — after one or more files have been appended to
+    ``to_transfer`` but before the per-batch rsync fires — the guard on
+    ``if to_transfer:`` must keep the network transfer from starting. The
+    remote path decouples "decide to copy" (the queue-building loop) from
+    "actually copied" (the post-loop rsync), so the mid-batch cancel-break
+    on its own leaves queued files that would still be sent by the block
+    below. Queued files that never rsync stay on the card and get picked
+    up by the next run. See PR #1113 review."""
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    # Two files in the SAME batch (same date -> same rel folder) so the
+    # per-file queue loop iterates twice within one batch: file 1 gets
+    # queued into ``to_transfer``, then the runner flips ``cancelled`` on
+    # file 1's ``importing`` progress event, and file 2's iteration sees
+    # the cancel and breaks. Without the guard, the rsync block below
+    # would still copy file 1 after Stop was requested.
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+        ("DSC_0002.jpg", datetime(2026, 7, 3, 10, 5, 0), "green"),
+    ])
+
+    # ``CancelAfterFirstBatchRunner`` matches its trigger fragment against
+    # the progress event's ``phase`` and flips cancelled inside
+    # ``push_event`` — so file 1's ``_emit(f"{rel}: importing", …)`` at
+    # the top of its loop body cancels the runner before file 2's
+    # iteration, which is exactly the "queued but not yet sent" race the
+    # guard exists to close.
+    runner = CancelAfterFirstBatchRunner("2026/2026-07-03: importing")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    result = run_import_job(
+        _make_job(), runner, db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra, verify_by_hash=True,
+        ),
+    )
+
+    assert result["cancelled"] is True, result
+    # No rsync call — neither the flat batch transfer nor a collision-
+    # renamed single-file transfer may fire once ``cancelled`` is set.
+    assert calls["rsync"] == [], calls["rsync"]
+    # And no card->NAS verification either (verification only runs for
+    # files that were actually transferred).
+    assert calls["verify"] == 0, calls
+    assert result["copied"] == 0, result
+    assert result["failed"] == 0, result
+    # A cancelled run must not report ``safe_to_format=True`` — the
+    # honesty gate below already covers this, but assert it directly so
+    # a regression that also drops the cancel guard is caught here.
+    assert result["safe_to_format"] is False, result
+
+    # Nothing landed on the mount either. The fake rsync copies each
+    # src file into ``mount_base/rel`` — after cancel there must be no
+    # such file under the batch's dest folder.
+    dest_dir = os.path.join(ra["mount_base"], "2026", "2026-07-03")
+    landed = (
+        os.listdir(dest_dir) if os.path.isdir(dest_dir) else []
+    )
+    assert landed == [], (
+        f"no card files should have landed on the mount after "
+        f"cancellation, but found: {landed}"
+    )

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -4946,6 +4946,202 @@ def test_remote_import_dup_only_batch_records_failure_when_scan_raises(
     ), result["unsafe_files"]
 
 
+def test_remote_import_links_verified_twin_folder_in_other_layout(
+        tmp_path, monkeypatch):
+    """A verified duplicate skip's twin folder may live under the mount
+    destination in a DIFFERENT sub-folder than this run's template output
+    (e.g. an older ``unsorted`` or ``%Y-%m-%d`` layout). Without carrying
+    the verified twin dir into a follow-up dup-link scan, the card is
+    skipped as a duplicate but the twin folder never becomes visible in
+    the active workspace — safe_to_format could go green over folders
+    the UI won't show. See PR #1113 review."""
+    from import_dedup import compute_file_hash as _hash
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    # Card holds one photo whose bytes ALREADY exist under the mount base
+    # in an "unsorted" sub-folder — an older layout the run's %Y/%Y-%m-%d
+    # template does not target.
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+    ])
+    card_file = str(card / "DSC_0001.jpg")
+    src_hash = _hash(card_file)
+
+    twin_folder = os.path.join(ra["mount_base"], "unsorted")
+    os.makedirs(twin_folder, exist_ok=True)
+    twin_path = os.path.join(twin_folder, "DSC_0001.jpg")
+    import shutil as _shutil
+    _shutil.copy2(card_file, twin_path)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    # Catalog the twin via raw SQL so its folder row is NOT linked into
+    # the active workspace (running scanner.scan() here would link it via
+    # the cascade in ``_add_workspace_folder_no_commit``, breaking the
+    # test's "before" state). The duplicate-skip case is exactly "a byte-
+    # identical twin is cataloged somewhere in the archive but the
+    # user's active workspace does not yet see it yet".
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'ok')",
+        (twin_folder, os.path.basename(twin_folder)),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, extension, file_size,"
+        " file_hash) VALUES (?, ?, '.jpg', ?, ?)",
+        (fid, "DSC_0001.jpg", os.path.getsize(twin_path), src_hash),
+    )
+    db.conn.commit()
+    linked_before = _ws_linked_folder_paths(db, ws_id)
+    assert twin_folder not in linked_before, linked_before
+
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra, verify_by_hash=True,
+        ),
+    )
+
+    # rsync stayed silent — the card was accepted as a duplicate.
+    assert calls["rsync"] == [], calls["rsync"]
+    assert result["skipped_duplicate"] == 1, result
+    assert result["failed"] == 0, result
+    assert result["safe_to_format"] is True, result
+    # The verified twin folder is now visible in the active workspace,
+    # even though it lives in a different sub-folder than the run's own
+    # dest_folder (%Y/%Y-%m-%d template would have produced
+    # ``2026/2026-07-03``, not ``unsorted``).
+    linked_after = _ws_linked_folder_paths(db, ws_id)
+    assert twin_folder in linked_after, {
+        "before": sorted(linked_before), "after": sorted(linked_after),
+        "twin_folder": twin_folder,
+    }
+
+
+def test_remote_import_scans_adopted_duplicate_in_mixed_batch(
+        tmp_path, monkeypatch):
+    """A retry / crash-recovery batch that (a) copies one fresh file AND
+    (b) finds a byte-identical file already on the mount for a different
+    card file must catalog BOTH: the fresh copy AND the adopted duplicate.
+
+    Without adding adopted mount paths to the restricted scan's
+    ``restrict_files`` set, ``landed_paths`` alone scopes the scan so
+    tightly that the adopted-but-uncataloged mount file is left without
+    a photo row, while ``copied + skipped_duplicate == discovered`` still
+    lets a verified remote run report ``safe_to_format=True`` for an
+    invisible file. See PR #1113 review."""
+    import shutil as _shutil
+
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    # Both files belong to the same destination batch (same date), so
+    # they share a single fresh scan call.
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+        ("DSC_0002.jpg", datetime(2026, 7, 3, 11, 0, 0), "green"),
+    ])
+
+    # Pre-seed the mount destination with DSC_0001 (crash-recovery: a
+    # prior run wrote it but died before catalog). Duplicates-index
+    # (skip_duplicates=True default) sees no cataloged twin for it, so
+    # the collision loop's on-disk hash-match branch fires and adopts
+    # the mount file. DSC_0002 is a fresh copy this run.
+    dest_folder = os.path.join(
+        ra["mount_base"], "2026", "2026-07-03",
+    )
+    os.makedirs(dest_folder, exist_ok=True)
+    seeded = os.path.join(dest_folder, "DSC_0001.jpg")
+    _shutil.copy2(str(card / "DSC_0001.jpg"), seeded)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra, verify_by_hash=True,
+        ),
+    )
+
+    assert result["failed"] == 0, result
+    assert result["copied"] == 1, result       # DSC_0002 fresh
+    assert result["skipped_duplicate"] == 1, result  # DSC_0001 adopted
+
+    # BOTH files are cataloged at the mount path (the adopted duplicate
+    # is not orphaned).
+    rows = _photo_rows(db)
+    row_paths = {os.path.join(r["folder_path"], r["filename"]) for r in rows}
+    assert seeded in row_paths, row_paths
+    assert os.path.join(dest_folder, "DSC_0002.jpg") in row_paths, row_paths
+
+    # The pre-existing-but-now-adopted file is included in the run's
+    # photo_ids so the after-import chaining hook processes it.
+    adopted_row = next(
+        r for r in rows if os.path.join(r["folder_path"], r["filename"]) == seeded
+    )
+    assert adopted_row["id"] in result["photo_ids"], result["photo_ids"]
+
+
+def test_remote_import_result_carries_imported_photo_ids(
+        tmp_path, monkeypatch):
+    """The after-import chaining hook builds its process-job collection
+    from ``result['photo_ids']``. The remote path must populate this the
+    same way the local path does: freshly cataloged mount rows go in;
+    duplicate-only imports return an empty list so the hook falls into
+    "no new photos" instead of enqueueing an empty process run. See PR
+    #1113 review."""
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+        ("DSC_0002.jpg", datetime(2026, 7, 3, 11, 0, 0), "green"),
+    ])
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    # First run: two fresh copies -> two photo_ids in the result.
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra, verify_by_hash=True,
+        ),
+    )
+    assert result["failed"] == 0, result
+    assert result["copied"] == 2, result
+    all_ids = sorted(r["id"] for r in _photo_rows(db))
+    assert sorted(result["photo_ids"]) == all_ids
+    assert len(all_ids) == 2
+
+    # Duplicates-only rerun: present but empty — chaining hook must skip
+    # into "no new photos" rather than enqueue an empty process run.
+    rerun_result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra, verify_by_hash=True,
+        ),
+    )
+    assert rerun_result["photo_ids"] == []
+    assert rerun_result["skipped_duplicate"] == 2
+
+
 def test_result_carries_imported_photo_ids(tmp_path):
     """The after-import chaining hook builds the process job's collection
     from the freshly imported rows; the result must name them."""

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -4122,3 +4122,167 @@ def test_remote_import_same_basename_collision_parity(tmp_path, monkeypatch):
     b0 = open(os.path.join(mount_dir, "DSC_0001.jpg"), "rb").read()
     b1 = open(os.path.join(mount_dir, "DSC_0001_1.jpg"), "rb").read()
     assert b0 != b1
+
+
+# --------------------------------------------------------------------------
+# PR #1113 review regressions.
+# --------------------------------------------------------------------------
+
+def test_remote_import_source_card_twin_does_not_back_duplicate_skip(
+        tmp_path, monkeypatch):
+    """A stale ``photos`` row whose folder path IS the card being imported
+    must not back a remote duplicate skip. Re-hashing that twin just
+    re-reads the card, proving nothing about an off-card copy; accepting
+    it would count the file as ``skipped_duplicate`` and, with
+    ``verify_by_hash`` on, let ``safe_to_format`` flip green over a card
+    whose bytes never crossed the network. Mirrors the local path's
+    source-root filter."""
+    from import_job import ImportParams, run_import_job
+    from scanner import scan
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+    ])
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    # Seed the catalog with a row whose folder path IS the card — as if the
+    # mounted card had been scanned into the DB in a previous session.
+    scan(str(card), db)
+    seeded = _photo_rows(db)
+    assert seeded, "expected pre-seeded catalog row for the card file"
+    assert any(r["folder_path"] == str(card) for r in seeded), \
+        [dict(r) for r in seeded]
+
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra, verify_by_hash=True,
+        ),
+    )
+
+    # The card file must have been copied off — not skipped as a duplicate.
+    assert result["copied"] == 1, result
+    assert result["skipped_duplicate"] == 0, result
+    # rsync actually ran with the card file.
+    assert calls["rsync"], "no rsync invocation captured"
+    src_specs = {
+        os.path.basename(s)
+        for c in calls["rsync"] for s in c["src_specs"]
+    }
+    assert "DSC_0001.jpg" in src_specs, src_specs
+    # A row now exists under the mount path (the new archive copy), not
+    # just the card.
+    rows = _photo_rows(db)
+    mount_dir = os.path.join(ra["mount_base"], "2026", "2026-07-03")
+    row_paths = {os.path.join(r["folder_path"], r["filename"]) for r in rows}
+    assert os.path.join(mount_dir, "DSC_0001.jpg") in row_paths, row_paths
+
+
+def test_remote_import_no_verify_fails_uncataloged_landings(
+        tmp_path, monkeypatch):
+    """Without ``verify_by_hash`` the row-presence check still runs — a
+    remote rsync that returns success without actually populating the local
+    mount (unmounted/misconfigured mount base) must not report
+    ``copied``/NULL for a file with no catalog row. It fails and
+    ``safe_to_format`` cannot flip green off a ghost success."""
+    import move as _move
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+
+    # Fake rsync that pretends to succeed but writes nothing to the local
+    # mount — simulates a real rsync succeeding at the NAS while the local
+    # mount base points at an unmounted / wrong path so scan() sees no
+    # landed files.
+    def fake_rsync_no_write(src_path, dest_spec, rsync_flags, total_files,
+                            progress_cb, rsync_bin="rsync", extra_args=None,
+                            src_specs=None, src_specs_dest_is_dir=True, **kw):
+        calls["rsync"].append({
+            "src_specs": list(src_specs or []),
+            "dest_spec": dest_spec,
+        })
+        return (0, "", False)
+
+    monkeypatch.setattr(_move, "_run_rsync_streamed", fake_rsync_no_write)
+    monkeypatch.setattr(_move, "_remote_mkdir_p", lambda r, p: (True, ""))
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+    ])
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra, verify_by_hash=False,
+        ),
+    )
+
+    # The file "landed" per rsync's return but scan() found nothing on the
+    # mount, so it must be failed instead of counted as copied.
+    assert result["copied"] == 0, result
+    assert result["failed"] == 1, result
+    assert any(
+        "not cataloged" in u["reason"]
+        for u in result["unsafe_files"]
+    ), result["unsafe_files"]
+    assert result["safe_to_format"] is False
+
+
+def test_remote_import_verify_fails_uncataloged_landings(
+        tmp_path, monkeypatch):
+    """Parity check: the ``verify_by_hash=True`` path also fails a landed
+    file with no catalog row (it did before this fix; the refactor must
+    preserve that)."""
+    import move as _move
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+
+    def fake_rsync_no_write(src_path, dest_spec, rsync_flags, total_files,
+                            progress_cb, rsync_bin="rsync", extra_args=None,
+                            src_specs=None, src_specs_dest_is_dir=True, **kw):
+        calls["rsync"].append({"src_specs": list(src_specs or [])})
+        return (0, "", False)
+
+    monkeypatch.setattr(_move, "_run_rsync_streamed", fake_rsync_no_write)
+    monkeypatch.setattr(_move, "_remote_mkdir_p", lambda r, p: (True, ""))
+    monkeypatch.setattr(
+        _move, "remote_verify_files",
+        lambda *a, **kw: None,
+    )
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+    ])
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra, verify_by_hash=True,
+        ),
+    )
+
+    assert result["copied"] == 0, result
+    assert result["failed"] == 1, result
+    assert any(
+        "not cataloged" in u["reason"]
+        for u in result["unsafe_files"]
+    ), result["unsafe_files"]

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -5142,6 +5142,228 @@ def test_remote_import_result_carries_imported_photo_ids(
     assert rerun_result["skipped_duplicate"] == 2
 
 
+def test_remote_import_null_scan_hash_but_mount_matches_still_ok(
+        tmp_path, monkeypatch):
+    """When scan() creates the photo row but leaves ``file_hash`` NULL —
+    e.g. scanner's hash step was skipped or the row survives from a prior
+    partial scan — the remote path must fall back to re-hashing the
+    mount file (mirroring the local path's ``_rehash_dest_or_none``)
+    instead of trusting the stamp behind ``verify_by_hash`` on a row
+    whose bytes we haven't confirmed. When the re-hash matches the
+    source, accept the landing and stamp ``ok``. Guards against
+    regression on the fresh path where the mount is fine. See PR #1113
+    review."""
+    import scanner as _scanner
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    # Fake rsync copies card -> mount with matching bytes.
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+    ])
+
+    db_path = str(tmp_path / "test.db")
+
+    # Wrap scan() to null out the file_hash the scanner wrote, simulating
+    # the "row exists but hash unknown" case Codex flagged.
+    orig_scan = _scanner.scan
+
+    def scan_then_null_hash(destination, db_arg, **kw):
+        rv = orig_scan(destination, db_arg, **kw)
+        db_arg.conn.execute(
+            "UPDATE photos SET file_hash = NULL "
+            "WHERE filename = 'DSC_0001.jpg'"
+        )
+        db_arg.conn.commit()
+        return rv
+
+    monkeypatch.setattr(_scanner, "scan", scan_then_null_hash)
+
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra, verify_by_hash=True,
+        ),
+    )
+
+    # Rehash matched the source hash, so the landing is accepted and
+    # stamped ok. copied=1, failed=0.
+    assert result["failed"] == 0, result
+    assert result["copied"] == 1, result
+    assert result["safe_to_format"] is True, result
+    rows = {r["filename"]: r for r in _photo_rows(db)}
+    assert rows["DSC_0001.jpg"]["hash_status"] == "ok", dict(
+        rows["DSC_0001.jpg"])
+
+
+def test_remote_import_null_scan_hash_with_stale_mount_fails(
+        tmp_path, monkeypatch):
+    """The key Codex case: scan() leaves ``file_hash`` NULL AND the
+    mount file the row points at is unreadable/gone/different by the
+    time we try to confirm it. Without a re-hash fallback the code would
+    fall through to stamp ``hash_status='ok'`` under ``verify_by_hash``
+    on a row whose bytes we never confirmed (the NAS checksum only
+    proves the card bytes reached the SSH target, not that the mount
+    path holds those bytes). Must fail the landing and keep
+    safe_to_format False. See PR #1113 review."""
+    import scanner as _scanner
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+    ])
+
+    db_path = str(tmp_path / "test.db")
+
+    # Wrap scan() to null the file_hash AND delete the mount file so the
+    # rehash fallback returns None.
+    orig_scan = _scanner.scan
+    mount_file = os.path.join(
+        ra["mount_base"], "2026", "2026-07-03", "DSC_0001.jpg",
+    )
+
+    def scan_then_null_and_wipe(destination, db_arg, **kw):
+        rv = orig_scan(destination, db_arg, **kw)
+        db_arg.conn.execute(
+            "UPDATE photos SET file_hash = NULL "
+            "WHERE filename = 'DSC_0001.jpg'"
+        )
+        db_arg.conn.commit()
+        if os.path.exists(mount_file):
+            os.unlink(mount_file)
+        return rv
+
+    monkeypatch.setattr(_scanner, "scan", scan_then_null_and_wipe)
+
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra, verify_by_hash=True,
+        ),
+    )
+
+    assert result["copied"] == 0, result
+    assert result["failed"] == 1, result
+    assert result["safe_to_format"] is False, result
+    assert any(
+        "scan wrote no mount row hash" in u["reason"]
+        for u in result["unsafe_files"]
+    ), result["unsafe_files"]
+    # No hash_status='ok' stamp — the guard must have short-circuited
+    # before update_photo_hash_check ran.
+    rows = {r["filename"]: r for r in _photo_rows(db)}
+    if "DSC_0001.jpg" in rows:
+        assert rows["DSC_0001.jpg"]["hash_status"] != "ok", dict(
+            rows["DSC_0001.jpg"])
+
+
+def test_remote_import_paired_jpeg_no_verify_fails_on_mount_mismatch(
+        tmp_path, monkeypatch):
+    """Companion parity with the non-companion branch: without
+    ``verify_by_hash`` the non-companion path still cross-checks the
+    scanned row's ``file_hash`` against ``src_hash`` as a stale-mount
+    catalog-integrity guard. Paired JPEGs (whose own row is deleted by
+    pair-merge) must get the same protection — otherwise a stale/
+    misconfigured mount with same-named but different JPEG bytes would
+    be enqueued for after-import processing against the wrong companion
+    even in no-verify mode. See PR #1113 review."""
+    import move as _move
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+
+    # Seed an existing RAW at the mount + catalog row so scan()'s
+    # pair-merge will fold the just-landed JPEG into the RAW's
+    # companion_path.
+    mount_dir = os.path.join(ra["mount_base"], "2026", "2026-07-03")
+    os.makedirs(mount_dir, exist_ok=True)
+    raw_seed = os.path.join(mount_dir, "_seed.jpg")
+    Image.new("RGB", (16, 16), "red").save(raw_seed)
+    raw_bytes = open(raw_seed, "rb").read() + b"RAW-SENSOR-DATA"
+    os.unlink(raw_seed)
+    raw_path = os.path.join(mount_dir, "DSC_0800.NEF")
+    with open(raw_path, "wb") as f:
+        f.write(raw_bytes)
+
+    # Fake rsync writes WRONG bytes for the JPEG at the mount (the
+    # stale/misconfigured-mount stand-in Codex called out).
+    def fake_rsync_wrong_bytes(
+            src_path, dest_spec, rsync_flags, total_files,
+            progress_cb, rsync_bin="rsync", extra_args=None,
+            src_specs=None, src_specs_dest_is_dir=True, **kw):
+        calls["rsync"].append({
+            "src_specs": list(src_specs or []),
+            "extra_args": list(extra_args or []),
+        })
+        ssh_path = dest_spec.split(":", 1)[1]
+        rel = os.path.relpath(ssh_path, ra["ssh_base"])
+        if src_specs_dest_is_dir:
+            mount_dst = os.path.join(ra["mount_base"], rel)
+            os.makedirs(mount_dst, exist_ok=True)
+            for s in src_specs:
+                Image.new("RGB", (16, 16), "yellow").save(
+                    os.path.join(mount_dst, os.path.basename(s)))
+        else:
+            mount_file = os.path.join(ra["mount_base"], rel)
+            os.makedirs(os.path.dirname(mount_file), exist_ok=True)
+            Image.new("RGB", (16, 16), "yellow").save(mount_file)
+        return (0, "", False)
+
+    monkeypatch.setattr(_move, "_run_rsync_streamed", fake_rsync_wrong_bytes)
+    monkeypatch.setattr(_move, "_remote_mkdir_p", lambda r, p: (True, ""))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'ok')",
+        (mount_dir, os.path.basename(mount_dir)),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, extension, file_size,"
+        " file_hash) VALUES (?, ?, '.nef', ?, ?)",
+        (fid, "DSC_0800.NEF", len(raw_bytes), "deadbeef" * 8),
+    )
+    db.conn.commit()
+
+    card = _make_card(tmp_path, [
+        ("DSC_0800.jpg", datetime(2026, 7, 3, 10, 0, 0), "green"),
+    ])
+
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra, verify_by_hash=False,
+        ),
+    )
+
+    # Even without verify_by_hash, the companion-branch mount-hash
+    # cross-check must fire — same guard the non-companion branch runs.
+    assert result["copied"] == 0, result
+    assert result["failed"] == 1, result
+    assert result["safe_to_format"] is False, result
+    assert any(
+        "paired companion mount bytes" in u["reason"]
+        and "source hash" in u["reason"]
+        for u in result["unsafe_files"]
+    ), result["unsafe_files"]
+
+
 def test_result_carries_imported_photo_ids(tmp_path):
     """The after-import chaining hook builds the process job's collection
     from the freshly imported rows; the result must name them."""

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -4286,3 +4286,130 @@ def test_remote_import_verify_fails_uncataloged_landings(
         "not cataloged" in u["reason"]
         for u in result["unsafe_files"]
     ), result["unsafe_files"]
+
+
+def test_remote_import_rsync_uses_ignore_existing_to_survive_basename_races(
+        tmp_path, monkeypatch):
+    """Two remote import jobs (or a job racing another writer) that plan to
+    land different bytes under the same basename would both pass the earlier
+    mount-side ``os.path.exists`` collision check. Plain ``rsync -a`` would
+    then let the second writer clobber the first's already-verified NAS
+    bytes; ``--ignore-existing`` on the transfer flag list stops rsync
+    from overwriting the receiver-side file, and the verify step still
+    catches the mismatch. Regression: the transport flags must include
+    ``--ignore-existing`` on every rsync call the remote import issues."""
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+    _install_fake_remote_rsync(monkeypatch, calls, verify=None)
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+        ("DSC_0002.jpg", datetime(2026, 7, 3, 10, 5, 0), "green"),
+    ])
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra,
+        ),
+    )
+
+    assert calls["rsync"], "no rsync invocation captured"
+    for c in calls["rsync"]:
+        assert "--ignore-existing" in c["extra_args"], (
+            "rsync invocation missing --ignore-existing "
+            f"race-guard: {c['extra_args']}"
+        )
+
+
+def test_remote_import_fails_when_mount_row_hash_disagrees_with_verified_card(
+        tmp_path, monkeypatch):
+    """``remote_verify_files`` runs card -> NAS (``ssh_base``); ``scan()``
+    reads under the local mount. If the mount base is stale/misconfigured
+    but happens to already contain the same ``<folder>/<filename>`` we
+    transferred, scan populates the row from unrelated bytes. Stamping
+    ``hash_status='ok'`` on that row would flip ``safe_to_format`` green
+    over storage we never touched. This exercises the cross-check: the
+    landed file is failed rather than stamped ok, and safe_to_format
+    stays False."""
+    import move as _move
+    from import_job import ImportParams, run_import_job
+
+    ra = _remote_archive_for(tmp_path)
+    calls = _remote_calls(ra)
+
+    card = _make_card(tmp_path, [
+        ("DSC_0001.jpg", datetime(2026, 7, 3, 10, 0, 0), "red"),
+    ])
+
+    # Fake rsync that "lands" the file under the destination BUT with
+    # wrong bytes — the scenario Codex flagged: the NAS is fine (verify
+    # step below reports OK), but the mount base points at different
+    # storage whose bytes at ``<folder>/<filename>`` don't match the
+    # card. scan() will pick up the wrong-storage hash; the cross-check
+    # must fail this file rather than stamp ``hash_status='ok'``.
+    def fake_rsync_writes_wrong_bytes(
+            src_path, dest_spec, rsync_flags, total_files,
+            progress_cb, rsync_bin="rsync", extra_args=None,
+            src_specs=None, src_specs_dest_is_dir=True, **kw):
+        calls["rsync"].append({
+            "src_specs": list(src_specs or []),
+            "dest_spec": dest_spec,
+            "extra_args": list(extra_args or []),
+        })
+        # Map the SSH dest_spec back to the mount side and write a file
+        # with DIFFERENT bytes than the card — the wrong-storage stand-in.
+        ssh_path = dest_spec.split(":", 1)[1]
+        if src_specs_dest_is_dir:
+            rel = os.path.relpath(ssh_path, ra["ssh_base"])
+            mount_dir = os.path.join(ra["mount_base"], rel)
+            os.makedirs(mount_dir, exist_ok=True)
+            from PIL import Image as _Image
+            for s in src_specs:
+                _Image.new("RGB", (16, 16), "green").save(
+                    os.path.join(mount_dir, os.path.basename(s)))
+        else:
+            rel = os.path.relpath(ssh_path, ra["ssh_base"])
+            mount_file = os.path.join(ra["mount_base"], rel)
+            os.makedirs(os.path.dirname(mount_file), exist_ok=True)
+            from PIL import Image as _Image
+            _Image.new("RGB", (16, 16), "green").save(mount_file)
+        return (0, "", False)
+
+    monkeypatch.setattr(_move, "_run_rsync_streamed",
+                        fake_rsync_writes_wrong_bytes)
+    monkeypatch.setattr(_move, "_remote_mkdir_p", lambda r, p: (True, ""))
+    # NAS-side card verification succeeds (the card bytes DID make it to
+    # the NAS in this scenario). The mount just doesn't show them.
+    monkeypatch.setattr(_move, "remote_verify_files",
+                        lambda *a, **kw: None)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)], destination=ra["mount_base"],
+            remote_target=ra, verify_by_hash=True,
+        ),
+    )
+
+    assert result["copied"] == 0, result
+    assert result["failed"] == 1, result
+    assert result["safe_to_format"] is False, result
+    assert any(
+        "scanned mount row hash" in u["reason"]
+        for u in result["unsafe_files"]
+    ), result["unsafe_files"]
+    rows = {r["filename"]: r for r in _photo_rows(db)}
+    # The row must NOT carry an 'ok' verdict.
+    if "DSC_0001.jpg" in rows:
+        assert rows["DSC_0001.jpg"]["hash_status"] != "ok", dict(
+            rows["DSC_0001.jpg"])

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -2204,6 +2204,12 @@ def _save_remote_target(monkeypatch, tmp_path, **overrides):
     monkeypatch.setattr(
         move_mod, "resolve_rsync_bin", lambda configured="": "/usr/bin/rsync",
     )
+    # resolve_rsync_bin returns any executable path an operator explicitly
+    # configured, so the import/pipeline route additionally verifies the
+    # candidate is GNU rsync (Apple openrsync can't drive SSH). Stub the
+    # check so happy-path tests don't depend on a real GNU rsync being
+    # installed in the CI environment.
+    monkeypatch.setattr(move_mod, "is_gnu_rsync", lambda _rb: True)
     return entry
 
 
@@ -3468,6 +3474,29 @@ def test_import_photos_remote_requires_gnu_rsync(
     _save_remote_target(monkeypatch, tmp_path)
     monkeypatch.setattr(
         move_mod, "resolve_rsync_bin", lambda configured="": None)
+    client = app.test_client()
+    card = _import_card(tmp_path)
+    resp = client.post(
+        "/api/jobs/import-photos", json=_remote_import_body(card))
+    assert resp.status_code == 400
+    assert "rsync" in resp.get_json()["error"].lower()
+
+
+def test_import_photos_remote_rejects_openrsync_before_enqueue(
+        app_and_db, tmp_path, monkeypatch):
+    """resolve_rsync_bin returns any executable file, so a user who
+    explicitly sets Settings→Paths to macOS's /usr/bin/rsync (Apple
+    openrsync) passes the presence check even though openrsync can't
+    drive rsync-over-SSH. The route must additionally consult
+    is_gnu_rsync and fail fast at enqueue instead of starting a job that
+    dies mid-transfer. See PR #1113 review."""
+    import move as move_mod
+    app, _ = app_and_db
+    _save_remote_target(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        move_mod, "resolve_rsync_bin",
+        lambda configured="": "/usr/bin/rsync")
+    monkeypatch.setattr(move_mod, "is_gnu_rsync", lambda p: False)
     client = app.test_client()
     card = _import_card(tmp_path)
     resp = client.post(

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -3342,3 +3342,135 @@ def test_import_photos_inconclusive_case_probe_rejects_case_collision(
     })
     assert resp.status_code == 400
     assert "inside a source" in resp.get_json()["error"]
+
+
+# --- POST /api/jobs/import-photos remote (SSH) archive target ------------
+#
+# Mirror the pipeline route's remote-target guards: accept a saved
+# remote_target_id + remote_subpath, reject the bad shapes.
+
+def _remote_import_body(card, **overrides):
+    body = {
+        "sources": [card],
+        "remote_target_id": "nas1",
+        "remote_subpath": "2026/trip",
+    }
+    body.update(overrides)
+    return body
+
+
+def test_import_photos_remote_happy_path(app_and_db, tmp_path, monkeypatch):
+    """A valid remote target + subpath enqueues an import job whose config
+    records the target and subpath and whose destination is the resolved
+    mount path (mount_path/subpath)."""
+    app, _ = app_and_db
+    _save_remote_target(monkeypatch, tmp_path)
+    client = app.test_client()
+    card = _import_card(tmp_path)
+
+    resp = client.post(
+        "/api/jobs/import-photos", json=_remote_import_body(card))
+    assert resp.status_code == 200, resp.get_json()
+    job_id = resp.get_json()["job_id"]
+    assert job_id.startswith("import-")
+
+    config = _job_config(client, job_id)
+    assert config["remote_target_id"] == "nas1"
+    assert config["remote_subpath"] == "2026/trip"
+    # Destination recorded as the resolved local mount path.
+    expected_dest = os.path.join(str(tmp_path / "mount"), "2026", "trip")
+    assert config["destination"] == expected_dest
+
+
+def test_import_photos_remote_and_destination_mutually_exclusive(
+        app_and_db, tmp_path, monkeypatch):
+    app, _ = app_and_db
+    _save_remote_target(monkeypatch, tmp_path)
+    client = app.test_client()
+    card = _import_card(tmp_path)
+    resp = client.post("/api/jobs/import-photos", json=_remote_import_body(
+        card, destination=str(tmp_path / "archive"),
+    ))
+    assert resp.status_code == 400
+    assert "mutually exclusive" in resp.get_json()["error"]
+
+
+def test_import_photos_remote_unknown_target_404(
+        app_and_db, tmp_path, monkeypatch):
+    app, _ = app_and_db
+    _save_remote_target(monkeypatch, tmp_path)
+    client = app.test_client()
+    card = _import_card(tmp_path)
+    resp = client.post("/api/jobs/import-photos", json=_remote_import_body(
+        card, remote_target_id="nope",
+    ))
+    assert resp.status_code == 404
+    assert "not found" in resp.get_json()["error"].lower()
+
+
+def test_import_photos_remote_requires_subpath(
+        app_and_db, tmp_path, monkeypatch):
+    app, _ = app_and_db
+    _save_remote_target(monkeypatch, tmp_path)
+    client = app.test_client()
+    card = _import_card(tmp_path)
+    resp = client.post("/api/jobs/import-photos", json=_remote_import_body(
+        card, remote_subpath="",
+    ))
+    assert resp.status_code == 400
+    assert "remote_subpath" in resp.get_json()["error"]
+
+
+def test_import_photos_remote_subpath_requires_target(
+        app_and_db, tmp_path, monkeypatch):
+    app, _ = app_and_db
+    _save_remote_target(monkeypatch, tmp_path)
+    client = app.test_client()
+    card = _import_card(tmp_path)
+    resp = client.post("/api/jobs/import-photos", json={
+        "sources": [card], "remote_subpath": "2026/trip",
+    })
+    assert resp.status_code == 400
+    assert "remote_subpath requires remote_target_id" in \
+        resp.get_json()["error"]
+
+
+def test_import_photos_remote_rejects_traversal_subpath(
+        app_and_db, tmp_path, monkeypatch):
+    app, _ = app_and_db
+    _save_remote_target(monkeypatch, tmp_path)
+    client = app.test_client()
+    card = _import_card(tmp_path)
+    for bad in ("../escape", "/absolute/path"):
+        resp = client.post(
+            "/api/jobs/import-photos",
+            json=_remote_import_body(card, remote_subpath=bad),
+        )
+        assert resp.status_code == 400, bad
+
+
+def test_import_photos_remote_requires_mount_path(
+        app_and_db, tmp_path, monkeypatch):
+    app, _ = app_and_db
+    _save_remote_target(monkeypatch, tmp_path, mount_path="")
+    client = app.test_client()
+    card = _import_card(tmp_path)
+    resp = client.post(
+        "/api/jobs/import-photos", json=_remote_import_body(card))
+    assert resp.status_code == 400
+    assert "mount path" in resp.get_json()["error"]
+
+
+def test_import_photos_remote_requires_gnu_rsync(
+        app_and_db, tmp_path, monkeypatch):
+    import move as move_mod
+    app, _ = app_and_db
+    _save_remote_target(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        move_mod, "resolve_rsync_bin", lambda configured="": None)
+    client = app.test_client()
+    card = _import_card(tmp_path)
+    resp = client.post(
+        "/api/jobs/import-photos", json=_remote_import_body(card))
+    assert resp.status_code == 400
+    assert "rsync" in resp.get_json()["error"].lower()


### PR DESCRIPTION
## What

Completes **Task 2.7** of the import-job plan (`docs/plans/2026-07-04-import-job-plan.md`), which #1107 deferred: an **opt-in SSH remote archive destination** for the new import job (`run_import_job`). The local/SMB import path is byte-for-byte unchanged; this adds a second transport.

This is the "support SSH as well as local/SMB" piece — SSH is the more robust transport for pushing a shoot to the NAS over the network (the SMB stalls that motivated the import/process split are an SMB artifact), while the archive stays browsable at the mount path and hash-verify remains an opt-in knob.

## How

- **Transfer:** rsync card → `remote_path/subpath` over SSH; catalog rows land at the browsable `mount_path/subpath` (`resolve_remote_archive` mapping). No local staging tree — `move._run_rsync_streamed` gains an opt-in `src_specs` file-list mode.
- **Verification is genuinely card → NAS.** `move.remote_verify_files` runs `rsync -an --checksum <card files> <nas target>` and fails only the specific card file the NAS didn't confirm. Gated behind `verify_by_hash`; without it, rows keep NULL `hash_status`/`hash_checked_at` and `safe_to_format` honestly reports `False` with reason `"enable verify_by_hash for remote verification"`. A mount-vs-NAS check would be tautological (same physical storage), so it is deliberately avoided — the "safe to format" pill must mean exactly what it says (CORE_PHILOSOPHY: no black boxes).
- **Same-basename collision parity** with the local path: colliding files land under numeric-suffixed names on the NAS (each transferred individually to an explicit filename) instead of silently clobbering.
- **Route:** `POST /api/jobs/import-photos` accepts `remote_target_id` + `remote_subpath`, mirroring the pipeline route's guards (mutual exclusivity with `destination`, unknown-target 404, GNU-rsync availability refusal); the transport is snapshotted at enqueue.

### Known scope boundary
Cross-folder duplicate-twin linking is simplified for the remote path (only the current batch's dest folder is linked, not arbitrary twin folders elsewhere in the archive). Documented inline. Honesty is preserved (remote-without-verify is already `safe=False`; with-verify, duplicates are byte-confirmed).

## Tests

Full plan suite: **1847 passed, 2 skipped** (pre-existing platform skips). `ruff check vireo/ tests/` clean. New coverage: card→NAS verify targets the card paths (not the mount), verify-failure fails the specific file and blocks safe-to-format, no-verify leaves hashes NULL + unsafe, and same-basename collision lands distinct rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added remote SSH/rsync “archive destination” support for photo imports, including per-batch transfers and workspace linking for verified duplicates.

* **Bug Fixes**
  * Improved remote import request validation (mutual exclusivity, safe subpath rules, non-empty target requirements) and clearer errors for missing/unsupported rsync.
  * Strengthened remote integrity behavior: verification stamps hashes when enabled and rolls back/fails only the specific mismatched landings.

* **Tests**
  * Expanded end-to-end coverage for remote rsync routing, batching, verification modes, collisions, and edge-case failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->