### PR TITLE
Fix folder tree root repair

### DIFF
--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -118,6 +118,78 @@ def test_workspace_root_materializes_existing_path_descendants(db):
     assert [p["filename"] for p in photos] == ["bird.jpg"]
 
 
+def test_existing_folder_is_reparented_when_surrounding_root_is_added(db):
+    """A standalone folder root should nest once its parent is known."""
+    ws_id = db._active_workspace_id
+    db.set_active_workspace(None)
+    usa_id = db.add_folder("/photos/USA", name="USA")
+    year_id = db.add_folder("/photos/USA/2026", name="2026")
+    date_id = db.add_folder(
+        "/photos/USA/2026/2026-01-19",
+        name="2026-01-19",
+        parent_id=year_id,
+    )
+    db.set_active_workspace(ws_id)
+
+    db.add_workspace_folder(ws_id, year_id)
+    db.add_workspace_folder(ws_id, usa_id)
+
+    # A later scan/import walks the full parent chain and now knows 2026's
+    # parent. Reusing the row must fill in the missing parent_id.
+    assert db.add_folder(
+        "/photos/USA/2026",
+        name="2026",
+        parent_id=usa_id,
+        workspace_root=False,
+    ) == year_id
+
+    tree = {f["id"]: f for f in db.get_folder_tree()}
+    roots = [f for f in tree.values() if f["parent_id"] is None]
+
+    assert [f["id"] for f in roots] == [usa_id]
+    assert tree[year_id]["parent_id"] == usa_id
+    assert tree[date_id]["parent_id"] == year_id
+
+
+def test_database_repairs_parentless_folder_rows_on_open(tmp_path):
+    """Existing databases with parentless path-children should self-heal."""
+    from db import Database
+
+    db_path = str(tmp_path / "test.db")
+    seed = Database(db_path)
+    ws_id = seed._active_workspace_id
+    seed.conn.executemany(
+        "INSERT INTO folders (id, path, name, parent_id) VALUES (?, ?, ?, ?)",
+        [
+            (101, "/photos/USA", "USA", None),
+            (102, "/photos/USA/2026", "2026", None),
+            (103, "/photos/USA/2026/2026-01-19", "2026-01-19", 102),
+        ],
+    )
+    seed.conn.executemany(
+        "INSERT INTO workspace_folders (workspace_id, folder_id, is_root) "
+        "VALUES (?, ?, ?)",
+        [
+            (ws_id, 101, 1),
+            (ws_id, 102, 0),
+            (ws_id, 103, 0),
+        ],
+    )
+    seed.conn.commit()
+    seed.close()
+
+    reopened = Database(db_path)
+    reopened.set_active_workspace(ws_id)
+    try:
+        tree = {f["id"]: f for f in reopened.get_folder_tree()}
+    finally:
+        reopened.close()
+
+    assert tree[101]["parent_id"] is None
+    assert tree[102]["parent_id"] == 101
+    assert tree[103]["parent_id"] == 102
+
+
 def test_workspace_root_hides_materialized_descendant_when_parent_has_photos(db):
     ws_id = db._active_workspace_id
     db.set_active_workspace(None)

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -147,6 +147,20 @@ def _join_subtree_path(root_path: str, relative_path: str) -> str:
     return stripped + sep + sep.join(parts)
 
 
+def _stored_parent_path(path: str) -> str | None:
+    stripped = path.rstrip("/\\")
+    if not stripped or stripped in ("/", "\\"):
+        return None
+    sep_idx = max(stripped.rfind("/"), stripped.rfind("\\"))
+    if sep_idx < 0:
+        return None
+    if sep_idx == 0:
+        return stripped[0]
+    if sep_idx == 2 and len(stripped) >= 2 and stripped[1] == ":":
+        return stripped[:3]
+    return stripped[:sep_idx]
+
+
 def _chunks(values, size=_SQLITE_PARAM_CHUNK_SIZE):
     values = list(values)
     for idx in range(0, len(values), size):
@@ -353,6 +367,7 @@ class Database:
             ):
                 raise IncompatibleDatabaseError(self._db_path, str(e)) from e
             raise
+        self.repair_missing_folder_parents()
         self.ensure_default_workspace()
         # Idempotent legacy-type migration. MUST run before genre seeding
         # so an upgraded DB with e.g. 'descriptive'/'event'/'people' rows
@@ -1096,6 +1111,29 @@ class Database:
                 "WHERE id=? AND active_mask_variant IS NULL",
                 (r["id"],),
             )
+        self.conn.commit()
+
+    def repair_missing_folder_parents(self):
+        """Fill parent_id for legacy folder rows whose parent path is known."""
+        rows = self.conn.execute(
+            "SELECT id, path, parent_id FROM folders"
+        ).fetchall()
+        path_to_id = {r["path"]: r["id"] for r in rows}
+        updates = []
+        for row in rows:
+            if row["parent_id"] is not None:
+                continue
+            parent_path = _stored_parent_path(row["path"])
+            parent_id = path_to_id.get(parent_path)
+            if parent_id is None or parent_id == row["id"]:
+                continue
+            updates.append((parent_id, row["id"]))
+        if not updates:
+            return
+        self.conn.executemany(
+            "UPDATE folders SET parent_id = ? WHERE id = ?",
+            updates,
+        )
         self.conn.commit()
 
     # -- Workspaces --
@@ -2059,9 +2097,19 @@ class Database:
             folder_id = cur.lastrowid
         else:
             row = self.conn.execute(
-                "SELECT id FROM folders WHERE path = ?", (path,)
+                "SELECT id, parent_id FROM folders WHERE path = ?", (path,)
             ).fetchone()
             folder_id = row["id"]
+            if (
+                parent_id is not None
+                and row["parent_id"] is None
+                and folder_id != parent_id
+            ):
+                self.conn.execute(
+                    "UPDATE folders SET parent_id = ? WHERE id = ?",
+                    (parent_id, folder_id),
+                )
+                commit_with_retry(self.conn)
         # Auto-link to active workspace
         if link_to_workspace and self._active_workspace_id is not None:
             self.add_workspace_folder(

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -887,6 +887,17 @@ class Database:
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_keywords_place_id "
             "ON keywords(place_id) WHERE place_id IS NOT NULL"
         )
+        # Migration: folders.parent_id. Truly legacy databases predate the
+        # column, and CREATE TABLE IF NOT EXISTS above is a no-op for them —
+        # so add the column here so repair_missing_folder_parents() (and
+        # every other query that reads parent_id) can run.
+        try:
+            self.conn.execute("SELECT parent_id FROM folders LIMIT 0")
+        except sqlite3.OperationalError:
+            self.conn.execute(
+                "ALTER TABLE folders "
+                "ADD COLUMN parent_id INTEGER REFERENCES folders(id)"
+            )
         # Phase 1 storage-philosophy migration: classifier embeddings move
         # from single-slot photos.(embedding, embedding_model) columns into
         # the per-(photo, model, variant) photo_embeddings table. Rows whose

--- a/vireo/tests/test_new_images_api.py
+++ b/vireo/tests/test_new_images_api.py
@@ -523,8 +523,23 @@ def test_post_snapshot_creates_row_with_current_new_images(app_and_db):
     _touch_image(str(folder / "IMG_002.JPG"))
 
     with app.test_client() as client:
-        resp = client.post("/api/workspaces/active/new-images/snapshot")
-        assert resp.status_code == 200
+        # The endpoint returns 202 while the background walk is in flight;
+        # under CI load the fast-path 500ms wait can be exceeded. Poll like a
+        # real client would — this matches test_post_snapshot_reuses_walk_across_polls.
+        import time as _time
+        deadline = _time.monotonic() + 5.0
+        resp = None
+        while _time.monotonic() < deadline:
+            resp = client.post("/api/workspaces/active/new-images/snapshot")
+            if resp.status_code == 200:
+                break
+            assert resp.status_code == 202, (
+                f"unexpected status {resp.status_code}: {resp.get_data(as_text=True)}"
+            )
+            _time.sleep(0.05)
+        assert resp is not None and resp.status_code == 200, (
+            f"snapshot never converged; last status {resp and resp.status_code}"
+        )
         data = resp.get_json()
         assert data["file_count"] == 2
         assert isinstance(data["snapshot_id"], int)


### PR DESCRIPTION
Fixes folder sidebar duplication when an existing folder row was first stored as a standalone root and later gains a surrounding parent path. The database now repairs parentless path-child folders on open and fills a missing parent_id when add_folder reuses an existing row. This keeps previously affected libraries self-healing and prevents later imports from showing mixed root hierarchies. Validated with workspace, scanner, DB folder-tree, archive-merge, and import-root regression tests.