### PR TITLE
Add Enter-to-save shortcut in photo editor

### DIFF
--- a/vireo/templates/photo_editor.html
+++ b/vireo/templates/photo_editor.html
@@ -2192,6 +2192,13 @@ function initEditorKeyboard() {
     if (tag === 'input' || tag === 'textarea' || tag === 'select' || (t && t.isContentEditable)) return;
     if (e.key === 'ArrowLeft') { e.preventDefault(); editorNav(-1); }
     else if (e.key === 'ArrowRight') { e.preventDefault(); editorNav(1); }
+    else if (e.key === 'Enter') {
+      // Enter locks in the current edit (crop, straighten, adjustments) by
+      // committing the working recipe — same as clicking Save Changes. No-op
+      // when there's nothing to save so it doesn't fire on an unchanged photo.
+      var saveBtn = document.getElementById('saveBtn');
+      if (saveBtn && !saveBtn.disabled) { e.preventDefault(); saveRecipe(); }
+    }
   });
 }
 

--- a/vireo/templates/photo_editor.html
+++ b/vireo/templates/photo_editor.html
@@ -2194,8 +2194,14 @@ function initEditorKeyboard() {
     else if (e.key === 'ArrowRight') { e.preventDefault(); editorNav(1); }
     else if (e.key === 'Enter') {
       // Enter locks in the current edit (crop, straighten, adjustments) by
-      // committing the working recipe — same as clicking Save Changes. No-op
-      // when there's nothing to save so it doesn't fire on an unchanged photo.
+      // committing the working recipe — same as clicking Save Changes. Skip
+      // when focus is on a control with native Enter activation (button, link,
+      // summary, role="button") so tabbing to Reset All / Back / a transform
+      // button and pressing Enter still triggers that control. No-op when
+      // there's nothing to save so it doesn't fire on an unchanged photo.
+      var role = t && t.getAttribute ? t.getAttribute('role') : null;
+      if (tag === 'button' || tag === 'a' || tag === 'summary' || tag === 'label' ||
+          role === 'button' || role === 'link' || role === 'menuitem' || role === 'tab') return;
       var saveBtn = document.getElementById('saveBtn');
       if (saveBtn && !saveBtn.disabled) { e.preventDefault(); saveRecipe(); }
     }


### PR DESCRIPTION
## What

Pressing **Enter** in the photo editor now commits the working recipe (crop, straighten, adjustments) — the same action as clicking **Save Changes**. This gives a keyboard way to "lock in" a crop, which previously didn't exist: the editor only bound ← / → for photo navigation.

### Why

Crops in Vireo are already live/continuous (dragging handles or clicking an aspect button immediately updates the working recipe), but nothing persisted them except the Save Changes button. Users reaching for Enter to "accept" a crop got no response. Enter now maps to that commit step.

### Behavior / guards

- Enter calls `saveRecipe()` **only when the Save button is enabled** (i.e. there are unsaved changes); otherwise it's a no-op and doesn't `preventDefault`.
- The existing `input`/`textarea`/`select`/`contentEditable` guard is unchanged, so Enter inside text fields (e.g. the preset-name input) still goes to the field, not the save handler.
- Modifier-key presses (⌘/Ctrl/Alt) still early-return as before.

## Testing

- `python -m pytest vireo/tests/test_edits_api.py -q` → 43 passed (save-path coverage; the change itself is client-side keyboard handling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)