### PR TITLE
Stabilize rapid review hotkey test

### DIFF
--- a/tests/e2e/test_pipeline_rapid_review.py
+++ b/tests/e2e/test_pipeline_rapid_review.py
@@ -141,6 +141,7 @@ def test_rapid_review_decision_keys_advance_through_queue(live_server, page):
     page.goto(f"{live_server['url']}/pipeline/rapid-review")
 
     expect(page.locator("#filename")).to_have_text("a.jpg")
+    expect(page.locator("#applyBtn")).to_be_enabled()
 
     page.keyboard.press("x")
     expect(page.locator("#filename")).to_have_text("b.jpg")


### PR DESCRIPTION
## Summary
Wait for Rapid Review's apply button to be enabled before sending the first decision hotkey in the queue-advance e2e test.

## Why
The page ignores decision keys until burst state has seeded, so waiting on filename text alone can race and drop the first hotkey.

## Validation
- pytest tests/e2e/test_pipeline_rapid_review.py::test_rapid_review_decision_keys_advance_through_queue --browser chromium -q
- pytest tests/e2e/test_pipeline_rapid_review.py --browser chromium -q