### PR TITLE
Fix new-images banner click: instant snapshot from cached walk, visible preparing state

### DIFF
--- a/tests/e2e/test_new_images_pipeline.py
+++ b/tests/e2e/test_new_images_pipeline.py
@@ -151,3 +151,69 @@ def test_new_images_banner_drives_pipeline(fresh_server, page):
     page.goto(f"{url}/browse")
     card = page.locator(".grid-card[data-filename='IMG_0001.JPG']")
     expect(card).to_be_visible(timeout=5000)
+
+
+def test_banner_click_during_walk_shows_preparing_state(fresh_server, page, monkeypatch):
+    """Regression test for the reported banner-click bug: clicking "Create a
+    pipeline" while the server-side new-images walk is still running used to
+    freeze the banner button for ~60s and then silently dump the user on a
+    blank pipeline wizard. Now the click navigates immediately to the
+    pipeline page in a visible "preparing" state that shows live walk
+    progress and converges onto the snapshot once the walk finishes."""
+    import threading
+
+    import new_images as new_images_module
+    from new_images import get_shared_cache
+
+    url = fresh_server["url"]
+    photo_dir = fresh_server["photo_dir"]
+
+    _write_jpeg(photo_dir / "IMG_0002.JPG")
+    _clear_new_images_cache()
+
+    page.goto(f"{url}/browse")
+    banner = page.locator("#newImagesBanner")
+    expect(banner).to_be_visible(timeout=5000)
+
+    # Simulate the real failure conditions: the cache is cold at click time
+    # (as after a scan invalidation) and the walk is slow (as on a large
+    # network volume). The walk reports progress, then blocks until the test
+    # releases it — deterministic, no sleep races.
+    release = threading.Event()
+    real_count = new_images_module.count_new_images_for_workspace
+
+    def slow_count(*args, **kwargs):
+        cb = kwargs.get("progress_callback")
+        if cb:
+            cb(1500, 1)
+        release.wait(timeout=15)
+        return real_count(*args, **kwargs)
+
+    monkeypatch.setattr(
+        new_images_module, "count_new_images_for_workspace", slow_count,
+    )
+    get_shared_cache().clear()
+
+    try:
+        # Click lands on the pipeline page immediately — no frozen button.
+        page.locator("#newImagesBanner .banner-cta").click()
+        page.wait_for_url("**/pipeline?new_images=preparing", timeout=5000)
+
+        # The new-images card is visible and selected while preparing.
+        expect(page.locator("#sourceOptionNewImages")).to_be_visible()
+        expect(page.locator("[data-testid='source-new-images']")).to_be_checked()
+
+        # Live walk progress is shown, not an opaque spinner.
+        status = page.locator("#pipelineActionStatus")
+        expect(status).to_contain_text("1,500 files checked", timeout=10000)
+    finally:
+        release.set()
+
+    # Once the walk finishes, the page converges onto the real snapshot:
+    # URL rewritten to the id, subtitle shows the advertised count.
+    page.wait_for_url(
+        lambda u: "new_images=" in u and "preparing" not in u, timeout=15000,
+    )
+    expect(page.locator("#newImagesCardSubtitle")).to_contain_text(
+        "1 new image", timeout=5000,
+    )

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -7769,9 +7769,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         walk_error = {"exc": None}
 
         def compute(progress_callback=None):
+            # Close explicitly: this connection lives for the whole walk
+            # (minutes on large volumes), and connections left to __del__
+            # accumulate and exhaust the per-process fd limit.
             wdb = Database(db_path)
-            wdb.set_active_workspace(ws_id)
             try:
+                wdb.set_active_workspace(ws_id)
                 return count_new_images_for_workspace(
                     wdb, ws_id, sample_limit=None,
                     progress_callback=progress_callback,
@@ -7779,6 +7782,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             except Exception as e:
                 walk_error["exc"] = e
                 raise
+            finally:
+                wdb.close()
 
         # Surface the walk as an ephemeral job so the user can see it in the
         # bottom panel rather than wondering why their workspace is silent.

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2142,14 +2142,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     app._log_broadcaster = LogBroadcaster(buffer_size=500)
     app._log_broadcaster.install()
 
-    # Per-workspace monotonic timestamp recording when the current snapshot
-    # POST forced a fresh recompute. Subsequent polls on the same request
-    # compare the cache entry's set_at to this value: if the entry was
-    # written after we invalidated, it's the fresh walk's result and can be
-    # reused; if it predates our invalidation, it's a stale navbar probe and
-    # must be re-walked. Cleared when a snapshot is successfully returned.
-    app._new_images_snapshot_kickoff_at = {}
-    app._new_images_snapshot_kickoff_lock = threading.Lock()
+    # Live progress of the most recent new-images walk, keyed by
+    # (db_path, workspace_id). Written by the walk's progress callback and
+    # read by the GET/POST endpoints so a ``pending`` response can say
+    # "38,000 files checked, 2,100 new so far" instead of a bare spinner —
+    # the transparency the banner-click path needs on multi-minute walks
+    # over large network volumes. Values are per-spawn dicts; a new walk
+    # replaces the key wholesale, so readers never see torn state.
+    app._new_images_walk_progress = {}
 
     # Self-healing background backfill of missing working copies. RAW (and
     # oversized JPEG) imports need a JPEG working copy at
@@ -7741,51 +7741,25 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             tabs = list(DEFAULT_TABS)
         return jsonify({"tabs": tabs, "all_pages": ALL_PAGES})
 
-    @app.route("/api/workspaces/active/new-images")
-    def api_workspace_new_images():
-        db = _get_db()
-        ws_id = db._active_workspace_id
-        if ws_id is None:
-            return jsonify({"workspace_id": None, "new_count": 0, "per_root": [], "sample": []})
+    def _new_images_walk_fns(db, ws_id):
+        """Return ``(compute, on_spawn)`` for a transparent background
+        new-images walk, shared by the navbar probe and the snapshot POST.
 
-        def response_payload(result):
-            """Return a small client payload while keeping full paths in cache."""
-            payload = dict(result)
-            payload["workspace_id"] = ws_id
-            sample = payload.get("sample") or []
-            payload["sample"] = sample[:5]
-            payload.pop("sample_complete", None)
-            return payload
+        The walk always runs with ``sample_limit=None`` so the cached result
+        carries the complete list of new-file paths. That is what lets a
+        banner click turn straight into a snapshot of exactly the files the
+        banner advertised, instead of forcing a second multi-minute re-walk
+        of the whole library. Memory cost is one path string per *new* file,
+        which is small even for a full re-import.
 
-        cache = db._new_images_cache
-        db_path = db._db_path
-        cached = cache.get(db_path, ws_id)
-        if cached is not None:
-            return jsonify(response_payload(cached))
-
-        # If a recent compute failed and we're still inside the backoff
-        # window, surface the error instead of kicking off another walk.
-        # Without this, the navbar's pending re-poll keeps hammering a
-        # broken volume / DB and the UI is stuck "checking" forever.
-        recent_err = cache.get_recent_error(db_path, ws_id)
-        if recent_err is not None:
-            return jsonify({
-                "workspace_id": ws_id,
-                "new_count": None,
-                "per_root": [],
-                "sample": [],
-                "error": recent_err,
-            })
-
-        # Cache cold: run the filesystem walk in a background thread so the
-        # navbar's poll doesn't tie up a Flask worker for seconds while
-        # os.walk grinds through a large library. Wait briefly so small
-        # libraries (and the test suite's tmp_path filesystems) still
-        # observe a real count synchronously; longer walks return
-        # ``pending: true`` and the front-end re-polls.
+        ``on_spawn`` surfaces the walk as an ephemeral job in the bottom
+        panel and mirrors its progress into ``app._new_images_walk_progress``
+        so pending API responses can report live totals.
+        """
         from db import Database
         from new_images import count_new_images_for_workspace
 
+        db_path = db._db_path
         # Shared holder for the cache worker's exception (if any), read by
         # the ephemeral job's work_fn after the cache event fires. Without
         # this, a walk that raises (e.g. unreadable volume, DB error) would
@@ -7799,7 +7773,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             wdb.set_active_workspace(ws_id)
             try:
                 return count_new_images_for_workspace(
-                    wdb, ws_id, sample_limit=5, progress_callback=progress_callback,
+                    wdb, ws_id, sample_limit=None,
+                    progress_callback=progress_callback,
                 )
             except Exception as e:
                 walk_error["exc"] = e
@@ -7816,6 +7791,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         def on_spawn(spawn_event):
             progress_state = {"checked": 0, "found": 0}
+            app._new_images_walk_progress[(db_path, ws_id)] = progress_state
 
             def job_work_fn(job):
                 # Mirror the cache worker's lifecycle. ``spawn_event`` fires
@@ -7862,6 +7838,59 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
             return progress_callback
 
+        return compute, on_spawn
+
+    def _new_images_walk_progress_fields(db_path, ws_id):
+        """Live totals of the current/most recent walk for pending payloads."""
+        progress = app._new_images_walk_progress.get((db_path, ws_id)) or {}
+        return {
+            "files_checked": progress.get("checked", 0),
+            "new_count_so_far": progress.get("found", 0),
+        }
+
+    @app.route("/api/workspaces/active/new-images")
+    def api_workspace_new_images():
+        db = _get_db()
+        ws_id = db._active_workspace_id
+        if ws_id is None:
+            return jsonify({"workspace_id": None, "new_count": 0, "per_root": [], "sample": []})
+
+        def response_payload(result):
+            """Return a small client payload while keeping full paths in cache."""
+            payload = dict(result)
+            payload["workspace_id"] = ws_id
+            sample = payload.get("sample") or []
+            payload["sample"] = sample[:5]
+            payload.pop("sample_complete", None)
+            return payload
+
+        cache = db._new_images_cache
+        db_path = db._db_path
+        cached = cache.get(db_path, ws_id)
+        if cached is not None:
+            return jsonify(response_payload(cached))
+
+        # If a recent compute failed and we're still inside the backoff
+        # window, surface the error instead of kicking off another walk.
+        # Without this, the navbar's pending re-poll keeps hammering a
+        # broken volume / DB and the UI is stuck "checking" forever.
+        recent_err = cache.get_recent_error(db_path, ws_id)
+        if recent_err is not None:
+            return jsonify({
+                "workspace_id": ws_id,
+                "new_count": None,
+                "per_root": [],
+                "sample": [],
+                "error": recent_err,
+            })
+
+        # Cache cold: run the filesystem walk in a background thread so the
+        # navbar's poll doesn't tie up a Flask worker for seconds while
+        # os.walk grinds through a large library. Wait briefly so small
+        # libraries (and the test suite's tmp_path filesystems) still
+        # observe a real count synchronously; longer walks return
+        # ``pending: true`` and the front-end re-polls.
+        compute, on_spawn = _new_images_walk_fns(db, ws_id)
         event = cache.kickoff_compute(db_path, ws_id, compute, on_spawn=on_spawn)
         if event.wait(timeout=0.5):
             cached = cache.get(db_path, ws_id)
@@ -7885,6 +7914,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "per_root": [],
             "sample": [],
             "pending": True,
+            **_new_images_walk_progress_fields(db_path, ws_id),
         })
 
     @app.route("/api/workspaces/active/new-images/snapshot", methods=["POST"])
@@ -7895,86 +7925,57 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return jsonify({"error": "no active workspace"}), 400
         cache = db._new_images_cache
         db_path = db._db_path
-        kickoff_key = (db_path, ws_id)
-        kickoff_at_dict = app._new_images_snapshot_kickoff_at
-        kickoff_at_lock = app._new_images_snapshot_kickoff_lock
 
         def create_snapshot_from_result(result):
             file_paths = list(result.get("sample") or [])
             snap_id = db.create_new_images_snapshot(file_paths)
             folders = sorted({os.path.dirname(p) for p in file_paths})
-            with kickoff_at_lock:
-                kickoff_at_dict.pop(kickoff_key, None)
             return jsonify({
                 "snapshot_id": snap_id,
                 "file_count": len(file_paths),
                 "folders": folders,
             })
 
-        session_ttl_seconds = 120
-        now = time.monotonic()
-        with kickoff_at_lock:
-            request_kickoff_at = kickoff_at_dict.get(kickoff_key)
-            started_snapshot_session = (
-                request_kickoff_at is None
-                or now - request_kickoff_at > session_ttl_seconds
-            )
-            if started_snapshot_session:
-                request_kickoff_at = now
-                kickoff_at_dict[kickoff_key] = request_kickoff_at
+        # Trust a live cached walk. The banner count the user just clicked
+        # came from exactly this cache entry (walks always run with
+        # ``sample_limit=None``), so snapshotting it means the pipeline
+        # covers precisely the set the banner advertised — and the click
+        # resolves instantly instead of forcing a multi-minute re-walk of
+        # the whole library. Files that land on disk after that walk are
+        # simply picked up by a later probe and the banner reappears:
+        # self-healing, and honest about what was processed. Scans and
+        # imports invalidate this cache, so a stale entry can't survive the
+        # very actions that consume new images.
+        cached = cache.get(db_path, ws_id)
+        if cached is not None and cached.get("sample_complete"):
+            return create_snapshot_from_result(cached)
 
         recent_err = cache.get_recent_error(db_path, ws_id)
         if recent_err is not None:
-            with kickoff_at_lock:
-                kickoff_at_dict.pop(kickoff_key, None)
             return jsonify({"error": recent_err}), 500
 
-        # Force the snapshot generation forward before trusting any cache for
-        # a newly-started session. A navbar probe may have begun before the
-        # click but finish after ``request_kickoff_at``; invalidating first
-        # drops that stale write (or makes the in-flight worker stale) before
-        # the cache reuse check below.
-        if started_snapshot_session:
-            cache.invalidate_workspaces(db_path, [ws_id])
-
-        # A cached "sample_complete" result may be there because the navbar
-        # probe ran recently — but the cache is not invalidated when files
-        # are copied into a mapped folder, so ``sample`` can omit images
-        # that arrived after that probe. Only trust the cached sample if
-        # this request's snapshot session already forced a fresh walk and
-        # the entry was written *after* that invalidation.
-        cached = cache.get(db_path, ws_id)
-        entry_set_at = cache.get_entry_set_at(db_path, ws_id)
-        if (cached is not None
-                and cached.get("sample_complete")
-                and entry_set_at is not None
-                and entry_set_at >= request_kickoff_at):
-            return create_snapshot_from_result(cached)
-
-        from new_images import count_new_images_for_workspace
-
-        def compute():
-            from db import Database
-            wdb = Database(db_path)
-            wdb.set_active_workspace(ws_id)
-            return count_new_images_for_workspace(wdb, ws_id, sample_limit=None)
-
-        event = cache.kickoff_compute(db_path, ws_id, compute)
+        # Cache cold (e.g. a scan just invalidated it): kick off — or
+        # coalesce onto — a background walk. ``kickoff_compute`` reuses an
+        # in-flight walk for the current generation, so repeated clicks and
+        # poll loops can never stack walks or restart one mid-flight.
+        # ``on_spawn`` registers the same ephemeral bottom-panel job the
+        # navbar probe gets, so a click-triggered walk is just as visible.
+        compute, on_spawn = _new_images_walk_fns(db, ws_id)
+        event = cache.kickoff_compute(db_path, ws_id, compute, on_spawn=on_spawn)
         if event.wait(timeout=0.5):
             cached = cache.get(db_path, ws_id)
-            entry_set_at = cache.get_entry_set_at(db_path, ws_id)
-            if (cached is not None
-                    and cached.get("sample_complete")
-                    and entry_set_at is not None
-                    and entry_set_at >= request_kickoff_at):
+            if cached is not None and cached.get("sample_complete"):
                 return create_snapshot_from_result(cached)
             recent_err = cache.get_recent_error(db_path, ws_id)
             if recent_err is not None:
-                with kickoff_at_lock:
-                    kickoff_at_dict.pop(kickoff_key, None)
                 return jsonify({"error": recent_err}), 500
 
-        return jsonify({"pending": True}), 202
+        # Still walking. Report live progress so the client can show
+        # "N files checked, M new so far" instead of an opaque spinner.
+        return jsonify({
+            "pending": True,
+            **_new_images_walk_progress_fields(db_path, ws_id),
+        }), 202
 
     @app.route(
         "/api/workspaces/active/new-images/snapshot/<int:snapshot_id>",

--- a/vireo/new_images.py
+++ b/vireo/new_images.py
@@ -278,24 +278,6 @@ class NewImagesCache:
                 return None
             return result
 
-    def get_entry_set_at(self, db_path, workspace_id):
-        """Return the monotonic timestamp at which the current cache entry was
-        written, or ``None`` if there is no live entry. Callers use this to
-        distinguish a cache write that happened *before* their request from
-        one that happened *after*, so that a snapshot POST can tell whether
-        the cached sample reflects disk state at click time or was left over
-        from an earlier navbar probe."""
-        key = (db_path, workspace_id)
-        with self._lock:
-            entry = self._entries.get(key)
-            if entry is None:
-                return None
-            _result, set_at = entry
-            if time.monotonic() - set_at > self._ttl:
-                del self._entries[key]
-                return None
-            return set_at
-
     def has_inflight(self, db_path, workspace_id):
         """Return True if a background compute is currently running for
         ``(db_path, workspace_id)``. Callers use this to coalesce onto an

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -2002,8 +2002,38 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             f"and Folders (or Removable/Network Volumes) and "
                             f"grant Vireo access."
                         )
+                    # Snapshot-scoped: hand the scanner the exact file set
+                    # captured at snapshot time so a file that landed in the
+                    # folder AFTER the snapshot doesn't get cataloged here.
+                    # Without this, the scan walks the whole folder, commits
+                    # a photos row for the late arrival, then the collection
+                    # stage filters it out of downstream work AND the finally
+                    # block invalidates the new-images cache — orphaning the
+                    # file (cataloged in DB, never classified, never
+                    # re-surfaced by a later banner probe). Skipping it at
+                    # scan time keeps it uncataloged so the next probe
+                    # rediscovers it.
+                    snapshot_files_set = (
+                        set(snapshot_paths) if snapshot_paths is not None else None
+                    )
                     for src_folder in sources:
                         scanned_roots.append(src_folder)
+                        snapshot_restrict_dirs = None
+                        snapshot_restrict_files = None
+                        if snapshot_files_set is not None:
+                            src_norm = os.path.normpath(src_folder)
+                            prefix = (
+                                src_norm if src_norm.endswith(os.sep)
+                                else src_norm + os.sep
+                            )
+                            files_under_src = [
+                                p for p in snapshot_paths
+                                if os.path.normpath(p).startswith(prefix)
+                            ]
+                            snapshot_restrict_files = set(files_under_src)
+                            snapshot_restrict_dirs = sorted(
+                                {os.path.dirname(p) for p in files_under_src}
+                            )
                         try:
                             do_scan(
                                 src_folder, thread_db,
@@ -2014,6 +2044,8 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 skip_paths=params.exclude_paths,
                                 status_callback=status_cb,
                                 recursive=params.recursive,
+                                restrict_dirs=snapshot_restrict_dirs,
+                                restrict_files=snapshot_restrict_files,
                                 vireo_dir=effective_vireo_dir,
                                 thumb_cache_dir=effective_thumb_cache_dir,
                                 permission_error_callback=_on_denied,
@@ -2091,11 +2123,14 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
 
             # Snapshot-scoped runs: resolve the captured file paths to photo IDs
             # now that the scanner has committed rows, and trim the collection
-            # to exactly that set. A late-arriving file (landed in the folder
-            # after the snapshot) was still scanned — we walk the whole folder —
-            # but must not be classified or scored. Any snapshot path that never
-            # resolved (file was moved/deleted between snapshot and pipeline
-            # run) is logged so an unexpectedly small collection is auditable.
+            # to exactly that set. The scan stage already restricted the walk
+            # to the snapshot's file set via ``restrict_dirs`` + ``restrict_files``
+            # so late arrivals aren't cataloged in the first place; this filter
+            # is a belt-and-suspenders trim in case a pre-existing (already
+            # cataloged) photo somehow ends up in ``collected_photo_ids``. Any
+            # snapshot path that never resolved (file was moved/deleted between
+            # snapshot and pipeline run) is logged so an unexpectedly small
+            # collection is auditable.
             if snapshot_paths is not None:
                 resolver_db = Database(db_path)
                 resolver_db.set_active_workspace(workspace_id)

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -9894,42 +9894,30 @@ function dismissNewImagesBanner() {
   }
 }
 
-function _sleepNewImages(ms) {
-  return new Promise(function(resolve) { setTimeout(resolve, ms); });
-}
-
 async function createPipelineFromNewImages(btn) {
   if (btn && btn.disabled) return;
-  const originalText = btn ? btn.textContent : '';
   if (btn) {
     btn.disabled = true;
-    btn.textContent = 'Preparing...';
+    btn.textContent = 'Opening...';
   }
+  // One POST, then navigate. When the walk that produced the banner count is
+  // still cached (the common case), this returns the snapshot instantly and
+  // we deep-link to it. If the server is still walking (202) — or anything
+  // goes wrong — land on the pipeline page in its "preparing" state, which
+  // owns the polling and shows live walk progress. Never poll here holding
+  // the user on a frozen button, and never dump them on a blank wizard with
+  // no explanation.
   try {
-    const maxAttempts = 20;  // About one minute at 3s intervals.
-    for (let attempt = 0; attempt < maxAttempts; attempt++) {
-      const r = await fetch('/api/workspaces/active/new-images/snapshot', {method: 'POST'});
-      if (r.status === 202) {
-        if (btn) btn.textContent = 'Still preparing...';
-        await _sleepNewImages(3000);
-        continue;
-      }
-      if (!r.ok) throw new Error('snapshot failed');
+    const r = await fetch('/api/workspaces/active/new-images/snapshot', {method: 'POST'});
+    if (r.ok && r.status !== 202) {
       const data = await r.json();
-      if (!data || data.snapshot_id == null) throw new Error('snapshot missing');
-      window.location.href = `/pipeline?new_images=${data.snapshot_id}`;
-      return;
+      if (data && data.snapshot_id != null) {
+        window.location.href = `/pipeline?new_images=${data.snapshot_id}`;
+        return;
+      }
     }
-    throw new Error('snapshot timed out');
-  } catch (e) {
-    // Fall back to the existing behavior — blank pipeline wizard.
-    window.location.href = '/pipeline';
-  } finally {
-    if (btn) {
-      btn.disabled = false;
-      btn.textContent = originalText || 'Create a pipeline';
-    }
-  }
+  } catch (e) { /* fall through to the preparing page */ }
+  window.location.href = '/pipeline?new_images=preparing';
 }
 
 // Run on page load and every 60s. Banner dismissal is per-workspace via

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1420,31 +1420,72 @@ document.addEventListener('DOMContentLoaded', refreshPipelineUI);
 
 // -- New images (Stage 1 third option) --
 var newImagesSnapshotId = null;
+// True while a snapshot-creation poll loop is running, so re-clicking the
+// card (or a banner deep-link racing a click) can't start a second loop.
+var _newImagesSnapshotCreating = false;
 
 function sleepNewImagesSnapshot(ms) {
   return new Promise(function(resolve) { setTimeout(resolve, ms); });
 }
 
 async function createNewImagesSnapshotWithRetry(onPending) {
-  var maxAttempts = 20;  // About one minute at 3s intervals.
-  for (var attempt = 0; attempt < maxAttempts; attempt++) {
+  // Poll until the server-side walk reaches a terminal state — snapshot
+  // created (200) or walk failed (500). No attempt cap: the walk over a
+  // large network volume can take minutes, and giving up early is exactly
+  // what used to strand users on a blank wizard with no explanation. Each
+  // 202 carries live walk progress (files_checked / new_count_so_far) which
+  // is passed to onPending so the caller can show real numbers instead of
+  // an opaque spinner. Navigating away naturally stops the loop.
+  for (;;) {
     var resp = await fetch('/api/workspaces/active/new-images/snapshot', {method: 'POST'});
     if (resp.status === 202) {
-      if (typeof onPending === 'function') onPending(attempt);
+      var progress = null;
+      try { progress = await resp.json(); } catch (e) { /* keep polling */ }
+      if (typeof onPending === 'function') onPending(progress || {});
       await sleepNewImagesSnapshot(3000);
       continue;
     }
-    if (!resp.ok) throw new Error('snapshot failed');
+    if (!resp.ok) {
+      var errMsg = 'snapshot failed';
+      try {
+        var errBody = await resp.json();
+        if (errBody && errBody.error) errMsg = errBody.error;
+      } catch (e) { /* keep the generic message */ }
+      throw new Error(errMsg);
+    }
     var data = await resp.json();
     if (!data || data.snapshot_id == null) throw new Error('snapshot missing');
     return data.snapshot_id;
   }
-  throw new Error('snapshot timed out');
 }
 
 async function initNewImagesCard() {
   var params = new URLSearchParams(window.location.search);
   var deepLinkId = params.get('new_images');
+  if (deepLinkId === 'preparing') {
+    // Banner click while the server-side walk was still running. The navbar
+    // navigates here immediately instead of freezing on the banner button;
+    // this page owns the wait. Show the card right away in a visible
+    // preparing state — selectSourceMode runs the unbounded snapshot poll
+    // and streams walk progress into the status line and card subtitle.
+    renderNewImagesCardPreparing();
+    await selectSourceMode('new_images');
+    if (newImagesSnapshotId != null) {
+      history.replaceState(null, '', '/pipeline?new_images=' + newImagesSnapshotId);
+      try {
+        var pr = await fetch('/api/workspaces/active/new-images/snapshot/' + newImagesSnapshotId);
+        if (pr.ok) {
+          var psnap = await pr.json();
+          renderNewImagesCard(psnap.file_count, psnap.folder_paths || []);
+        }
+      } catch (e) { /* counts are cosmetic; the snapshot itself is set */ }
+    } else {
+      // selectSourceMode already put the failure reason in the status line.
+      document.getElementById('newImagesCardSubtitle').textContent =
+        ' — could not build the list, click to retry';
+    }
+    return;
+  }
   if (deepLinkId) {
     try {
       var r = await fetch('/api/workspaces/active/new-images/snapshot/' + encodeURIComponent(deepLinkId));
@@ -1503,6 +1544,17 @@ async function probeNewImagesCard() {
   } finally {
     _newImagesProbeInFlight = false;
   }
+}
+
+function renderNewImagesCardPreparing() {
+  var card = document.getElementById('sourceOptionNewImages');
+  var orSep = document.getElementById('sourceOrNewImages');
+  if (!card || !orSep) return;
+  card.style.display = '';
+  orSep.style.display = '';
+  document.getElementById('newImagesCardSubtitle').textContent =
+    ' — finding new images…';
+  document.getElementById('newImagesFolderList').innerHTML = '';
 }
 
 function renderNewImagesCard(count, folders) {
@@ -2698,8 +2750,11 @@ async function selectSourceMode(mode) {
   // so stale state from the previous mode can't slip through during await.
   updateStartButton();
 
-  if (mode === 'new_images' && newImagesSnapshotId === null) {
-    // User is selecting the card directly (no deep-link) — freeze the list now.
+  if (mode === 'new_images' && newImagesSnapshotId === null
+      && !_newImagesSnapshotCreating) {
+    // Freeze the list now (card click or banner deep-link). The guard stops
+    // a second click from stacking a parallel poll loop on the first one.
+    _newImagesSnapshotCreating = true;
     var actionStatus = document.getElementById('pipelineActionStatus');
     var snapshotError = null;
     try {
@@ -2707,14 +2762,31 @@ async function selectSourceMode(mode) {
         actionStatus.textContent = 'Preparing new-images snapshot...';
         actionStatus.className = 'status-msg';
       }
-      newImagesSnapshotId = await createNewImagesSnapshotWithRetry(function() {
-        if (actionStatus) {
-          actionStatus.textContent = 'Still preparing new-images snapshot...';
+      newImagesSnapshotId = await createNewImagesSnapshotWithRetry(function(progress) {
+        // Show the walk's real totals so a multi-minute scan of a big
+        // library reads as work happening, not a stuck page.
+        var text = 'Scanning your folders for new images…';
+        if (progress && progress.files_checked > 0) {
+          text = 'Scanning for new images — '
+            + progress.files_checked.toLocaleString() + ' files checked, '
+            + (progress.new_count_so_far || 0).toLocaleString() + ' new so far…';
+        }
+        if (actionStatus) actionStatus.textContent = text;
+        var subtitle = document.getElementById('newImagesCardSubtitle');
+        if (subtitle && progress && progress.files_checked > 0) {
+          subtitle.textContent = ' — '
+            + (progress.new_count_so_far || 0).toLocaleString()
+            + ' found so far…';
         }
       });
+      if (actionStatus) actionStatus.textContent = '';
     } catch (e) {
       // Leave snapshot id null; submit will fail validation via updateStartButton.
-      snapshotError = 'New-images snapshot is still being prepared. Try again in a moment.';
+      snapshotError = 'Could not build the new-images list: '
+        + ((e && e.message) ? e.message : 'unknown error')
+        + '. Click the card to retry.';
+    } finally {
+      _newImagesSnapshotCreating = false;
     }
     // Snapshot resolved (or failed) — refresh start-button state.
     updateStartButton();

--- a/vireo/tests/test_new_images_api.py
+++ b/vireo/tests/test_new_images_api.py
@@ -839,15 +839,40 @@ def test_post_snapshot_second_click_reuses_cache_until_invalidated(app_and_db, m
         new_images_module, "count_new_images_for_workspace", counting,
     )
 
+    import time
+
+    def _post_until_ready(client):
+        # Cold-cache POSTs trigger an async walk; under CI load a single
+        # POST can exceed the endpoint's ~500ms fast-path wait and return
+        # 202. Poll like a real client would — this matches
+        # test_post_snapshot_creates_row_with_current_new_images. Repeat
+        # POSTs coalesce onto the in-flight walk, so polling never inflates
+        # call_count.
+        deadline = time.monotonic() + 5.0
+        resp = None
+        while time.monotonic() < deadline:
+            resp = client.post("/api/workspaces/active/new-images/snapshot")
+            if resp.status_code == 200:
+                return resp
+            assert resp.status_code == 202, (
+                f"unexpected status {resp.status_code}: "
+                f"{resp.get_data(as_text=True)}"
+            )
+            time.sleep(0.05)
+        raise AssertionError(
+            f"snapshot never converged; last status "
+            f"{resp and resp.status_code}"
+        )
+
     with app.test_client() as client:
-        first = client.post("/api/workspaces/active/new-images/snapshot")
-        assert first.status_code == 200
+        first = _post_until_ready(client)
         assert first.get_json()["file_count"] == 1
         calls_after_first = call_count["n"]
         assert calls_after_first >= 1
 
         # User copies another image, then clicks again while the cache is
-        # live: same set as advertised, no walk.
+        # live: same set as advertised, no walk. Cache hits are synchronous,
+        # so a single POST is deterministic here.
         _touch_image(str(folder / "IMG_002.JPG"))
         second = client.post("/api/workspaces/active/new-images/snapshot")
         assert second.status_code == 200
@@ -860,8 +885,7 @@ def test_post_snapshot_second_click_reuses_cache_until_invalidated(app_and_db, m
         # A scan/import invalidates the cache; the next click re-walks and
         # sees the new arrival.
         get_shared_cache().invalidate_workspaces(db._db_path, [ws_id])
-        third = client.post("/api/workspaces/active/new-images/snapshot")
-        assert third.status_code == 200
+        third = _post_until_ready(client)
         assert third.get_json()["file_count"] == 2, (
             "post-invalidation click must recompute and pick up the new file"
         )

--- a/vireo/tests/test_new_images_api.py
+++ b/vireo/tests/test_new_images_api.py
@@ -161,9 +161,10 @@ def test_api_new_images_returns_cached_after_background_compute_finishes(app_and
     assert data["new_count"] == 1
 
 
-def test_api_new_images_response_keeps_navbar_cache_bounded(app_and_db):
-    """The navbar only needs a tiny sample. Keep that probe's cache bounded;
-    the snapshot POST performs its own full walk when the user clicks."""
+def test_api_new_images_response_trims_sample_but_caches_full_list(app_and_db):
+    """The navbar payload only needs a tiny sample, but the cache must hold
+    the complete new-file list: that is what lets a banner click turn into a
+    snapshot of exactly the advertised files without a second full walk."""
     import time
 
     from new_images import get_shared_cache
@@ -191,8 +192,8 @@ def test_api_new_images_response_keeps_navbar_cache_bounded(app_and_db):
             break
         time.sleep(0.01)
     assert cached is not None
-    assert cached["sample_complete"] is False
-    assert len(cached["sample"]) == 5
+    assert cached["sample_complete"] is True
+    assert len(cached["sample"]) == 8
 
 
 def test_api_new_images_cached_response_slices_without_full_copy(app_and_db):
@@ -549,14 +550,15 @@ def test_post_snapshot_creates_row_with_current_new_images(app_and_db):
     assert snap["file_count"] == 2
 
 
-def test_post_snapshot_recomputes_over_navbar_populated_cache(app_and_db):
-    """The navbar probe populates the shared new-images cache and holds it
-    for the ``NewImagesCache`` TTL. Ordinary file copies into a mapped folder
-    do not invalidate it, so a user who gets a banner count, drops more
-    images into the folder, and then clicks "Create a pipeline" must not
-    receive a snapshot built from the stale cached sample — the endpoint
-    must re-walk the disk at click time. Verifies the fix for the Codex
-    review comment on the async-snapshot PR."""
+def test_post_snapshot_reuses_live_navbar_cache_without_rewalk(app_and_db, monkeypatch):
+    """The banner count the user clicks came from the cached walk, so the
+    snapshot must be built from exactly that entry — instantly, with no
+    re-walk. On a large network volume a forced re-walk takes minutes, which
+    is what used to strand the click on a frozen "Preparing..." button.
+    Files that land on disk after the cached walk are deliberately NOT in
+    the snapshot: the next probe picks them up and the banner reappears
+    (self-healing), keeping the snapshot honest to what the banner said."""
+    import new_images as new_images_module
     from new_images import get_shared_cache
 
     app, db, ws_id, tmp_path = app_and_db
@@ -565,7 +567,7 @@ def test_post_snapshot_recomputes_over_navbar_populated_cache(app_and_db):
     db.add_folder(str(folder))
 
     # Simulate the navbar's cache after an earlier probe: two images were
-    # on disk and captured in the sample.
+    # on disk and captured in the (complete) sample.
     old_paths = [str(folder / "IMG_001.JPG"), str(folder / "IMG_002.JPG")]
     for p in old_paths:
         _touch_image(p)
@@ -580,62 +582,24 @@ def test_post_snapshot_recomputes_over_navbar_populated_cache(app_and_db):
     fresh_path = str(folder / "IMG_003.JPG")
     _touch_image(fresh_path)
 
+    def boom(*args, **kwargs):
+        raise AssertionError("click must not trigger a re-walk while the cache is live")
+
+    monkeypatch.setattr(
+        new_images_module, "count_new_images_for_workspace", boom,
+    )
+
     with app.test_client() as client:
         resp = client.post("/api/workspaces/active/new-images/snapshot")
         assert resp.status_code == 200
         data = resp.get_json()
-        # The endpoint must have re-walked and picked up the third file,
-        # not returned the two-file navbar cache.
-        assert data["file_count"] == 3, (
-            f"expected fresh walk to include new file, got {data!r}"
+        assert data["file_count"] == 2, (
+            f"expected snapshot of the advertised cached set, got {data!r}"
         )
 
     snap = db.get_new_images_snapshot(data["snapshot_id"])
-    assert snap["file_count"] == 3
-    assert fresh_path in snap["file_paths"]
-
-
-def test_post_snapshot_invalidates_before_trusting_newer_navbar_cache(
-        app_and_db, monkeypatch):
-    """A navbar walk can begin before the click but write its cache after the
-    snapshot session timestamp. The first snapshot POST must invalidate before
-    checking cache freshness, so that pre-click walk cannot masquerade as the
-    snapshot-owned result."""
-    import app as app_module
-    from new_images import get_shared_cache
-
-    fake_now = {"value": 200.0}
-    monkeypatch.setattr(
-        app_module.time, "monotonic", lambda: fake_now["value"],
-    )
-
-    app, db, ws_id, tmp_path = app_and_db
-    folder = tmp_path / "photos"
-    folder.mkdir()
-    db.add_folder(str(folder))
-    old_path = str(folder / "IMG_001.JPG")
-    fresh_path = str(folder / "IMG_002.JPG")
-    _touch_image(old_path)
-    _touch_image(fresh_path)
-
-    # Simulate a navbar worker that started before the click but wrote cache
-    # just after the snapshot session's kickoff timestamp.
-    get_shared_cache().set(db._db_path, ws_id, {
-        "new_count": 1,
-        "per_root": [{"folder_id": 1, "path": str(folder), "new_count": 1}],
-        "sample": [old_path],
-        "sample_complete": True,
-    })
-    fake_now["value"] = 100.0
-
-    with app.test_client() as client:
-        resp = client.post("/api/workspaces/active/new-images/snapshot")
-        assert resp.status_code == 200
-        data = resp.get_json()
-        assert data["file_count"] == 2
-
-    snap = db.get_new_images_snapshot(data["snapshot_id"])
-    assert fresh_path in snap["file_paths"]
+    assert snap["file_paths"] == old_paths
+    assert fresh_path not in snap["file_paths"]
 
 
 def test_post_snapshot_reuses_walk_across_polls(app_and_db, monkeypatch):
@@ -711,13 +675,12 @@ def test_post_snapshot_reuses_walk_across_polls(app_and_db, monkeypatch):
         release.set()
 
 
-def test_post_snapshot_queues_fresh_walk_when_navbar_walk_inflight(
+def test_post_snapshot_coalesces_onto_inflight_navbar_walk(
         app_and_db, monkeypatch):
-    """A snapshot click must not accept an already-running navbar probe as
-    the snapshot source. That probe began before the click, so files copied
-    while it was walking could be missing. The POST should invalidate the
-    generation, wait for the stale walk only as a queueing point, then return
-    a snapshot from the fresh rerun it owns."""
+    """A click while the navbar's walk is still running must ride that walk
+    — return 202 without tearing it down or starting a parallel one — and
+    then snapshot the walk's result once it lands. Restarting the walk on
+    every click is what made large-library clicks never converge."""
     import threading
     import time
 
@@ -729,17 +692,15 @@ def test_post_snapshot_queues_fresh_walk_when_navbar_walk_inflight(
     folder.mkdir()
     db.add_folder(str(folder))
     old_path = str(folder / "IMG_001.JPG")
-    fresh_path = str(folder / "IMG_002.JPG")
     _touch_image(old_path)
-    _touch_image(fresh_path)
 
-    old_started = threading.Event()
-    old_release = threading.Event()
-    fresh_calls = {"n": 0}
+    walk_started = threading.Event()
+    walk_release = threading.Event()
+    extra_calls = {"n": 0}
 
-    def old_navbar_compute():
-        old_started.set()
-        old_release.wait(timeout=5)
+    def inflight_navbar_compute():
+        walk_started.set()
+        walk_release.wait(timeout=5)
         return {
             "new_count": 1,
             "per_root": [{"folder_id": 1, "path": str(folder), "new_count": 1}],
@@ -747,34 +708,27 @@ def test_post_snapshot_queues_fresh_walk_when_navbar_walk_inflight(
             "sample_complete": True,
         }
 
-    def fresh_snapshot_count(*args, **kwargs):
-        fresh_calls["n"] += 1
-        return {
-            "new_count": 2,
-            "per_root": [{"folder_id": 1, "path": str(folder), "new_count": 2}],
-            "sample": [old_path, fresh_path],
-            "sample_complete": True,
-        }
+    def unexpected_second_walk(*args, **kwargs):
+        extra_calls["n"] += 1
+        raise AssertionError("POST must coalesce, not start a second walk")
 
     cache = get_shared_cache()
-    cache.kickoff_compute(db._db_path, ws_id, old_navbar_compute)
-    assert old_started.wait(timeout=2), "navbar walk never started"
+    cache.kickoff_compute(db._db_path, ws_id, inflight_navbar_compute)
+    assert walk_started.wait(timeout=2), "navbar walk never started"
     monkeypatch.setattr(
         new_images_module, "count_new_images_for_workspace",
-        fresh_snapshot_count,
+        unexpected_second_walk,
     )
 
     try:
         with app.test_client() as client:
             first = client.post("/api/workspaces/active/new-images/snapshot")
             assert first.status_code == 202
-            assert first.get_json() == {"pending": True}
-            assert fresh_calls["n"] == 0, (
-                "fresh rerun should be queued behind the existing walk, not "
-                "started in parallel"
-            )
+            body = first.get_json()
+            assert body["pending"] is True
+            assert extra_calls["n"] == 0
 
-            old_release.set()
+            walk_release.set()
             deadline = time.monotonic() + 2.0
             resp = None
             while time.monotonic() < deadline:
@@ -784,58 +738,17 @@ def test_post_snapshot_queues_fresh_walk_when_navbar_walk_inflight(
                 time.sleep(0.05)
 
             assert resp is not None and resp.status_code == 200, (
-                f"snapshot never converged after queued rerun; "
+                f"snapshot never converged after walk finished; "
                 f"last={resp and resp.status_code}"
             )
             data = resp.get_json()
-            assert data["file_count"] == 2
-            assert fresh_calls["n"] == 1
+            assert data["file_count"] == 1
+            assert extra_calls["n"] == 0
 
         snap = db.get_new_images_snapshot(data["snapshot_id"])
-        assert snap["file_paths"] == [old_path, fresh_path]
+        assert snap["file_paths"] == [old_path]
     finally:
-        old_release.set()
-
-
-def test_post_snapshot_expires_abandoned_session_before_reuse(app_and_db):
-    """If a client abandons a 202 snapshot session, its kickoff marker must
-    not let a later click reuse that old session's cached sample. Once the
-    marker is older than the client retry window, a new POST must invalidate
-    and recompute from current disk state."""
-    import time
-
-    from new_images import get_shared_cache
-
-    app, db, ws_id, tmp_path = app_and_db
-    folder = tmp_path / "photos"
-    folder.mkdir()
-    db.add_folder(str(folder))
-    old_path = str(folder / "IMG_001.JPG")
-    fresh_path = str(folder / "IMG_002.JPG")
-    _touch_image(old_path)
-
-    cache = get_shared_cache()
-    with app._new_images_snapshot_kickoff_lock:
-        app._new_images_snapshot_kickoff_at[(db._db_path, ws_id)] = (
-            time.monotonic() - 121
-        )
-    cache.set(db._db_path, ws_id, {
-        "new_count": 1,
-        "per_root": [{"folder_id": 1, "path": str(folder), "new_count": 1}],
-        "sample": [old_path],
-        "sample_complete": True,
-    })
-
-    _touch_image(fresh_path)
-
-    with app.test_client() as client:
-        resp = client.post("/api/workspaces/active/new-images/snapshot")
-        assert resp.status_code == 200
-        data = resp.get_json()
-        assert data["file_count"] == 2
-
-    snap = db.get_new_images_snapshot(data["snapshot_id"])
-    assert fresh_path in snap["file_paths"]
+        walk_release.set()
 
 
 def test_post_snapshot_surfaces_async_error_without_retry_loop(
@@ -900,12 +813,15 @@ def test_post_snapshot_surfaces_async_error_without_retry_loop(
         release.set()
 
 
-def test_post_snapshot_next_click_after_success_forces_fresh_walk(app_and_db, monkeypatch):
-    """After a snapshot returns successfully, a fresh click (e.g. the user
-    dismissed the pipeline and clicked "Create a pipeline" again after
-    dropping more files) must trigger a new walk — the previous snapshot
-    session's cache reuse must not linger and mask new arrivals."""
+def test_post_snapshot_second_click_reuses_cache_until_invalidated(app_and_db, monkeypatch):
+    """A second click while the cached walk is still live reuses it — same
+    advertised set, no re-walk. Once the cache is invalidated (what every
+    scan and import does via ``invalidate_new_images_after_scan``), the next
+    click re-walks and picks up files that arrived in between. That is the
+    self-healing contract that replaced the old force-a-walk-per-click
+    behavior, which took minutes per click on large network volumes."""
     import new_images as new_images_module
+    from new_images import get_shared_cache
 
     app, db, ws_id, tmp_path = app_and_db
     folder = tmp_path / "photos"
@@ -930,17 +846,26 @@ def test_post_snapshot_next_click_after_success_forces_fresh_walk(app_and_db, mo
         calls_after_first = call_count["n"]
         assert calls_after_first >= 1
 
-        # User copies another image, then clicks again.
+        # User copies another image, then clicks again while the cache is
+        # live: same set as advertised, no walk.
         _touch_image(str(folder / "IMG_002.JPG"))
         second = client.post("/api/workspaces/active/new-images/snapshot")
         assert second.status_code == 200
-        assert second.get_json()["file_count"] == 2, (
-            "second click must recompute and pick up newly-copied file"
-        )
-        assert call_count["n"] > calls_after_first, (
-            f"second click must trigger a fresh walk; "
+        assert second.get_json()["file_count"] == 1
+        assert call_count["n"] == calls_after_first, (
+            f"second click within cache TTL must not re-walk; "
             f"call_count went {calls_after_first} -> {call_count['n']}"
         )
+
+        # A scan/import invalidates the cache; the next click re-walks and
+        # sees the new arrival.
+        get_shared_cache().invalidate_workspaces(db._db_path, [ws_id])
+        third = client.post("/api/workspaces/active/new-images/snapshot")
+        assert third.status_code == 200
+        assert third.get_json()["file_count"] == 2, (
+            "post-invalidation click must recompute and pick up the new file"
+        )
+        assert call_count["n"] > calls_after_first
 
 
 def test_post_snapshot_returns_pending_when_cache_is_incomplete(app_and_db, monkeypatch):
@@ -970,8 +895,117 @@ def test_post_snapshot_returns_pending_when_cache_is_incomplete(app_and_db, monk
         with app.test_client() as client:
             resp = client.post("/api/workspaces/active/new-images/snapshot")
             assert resp.status_code == 202
-            assert resp.get_json() == {"pending": True}
+            body = resp.get_json()
+            assert body["pending"] is True
+            # Pending responses carry live walk progress so the client can
+            # show real numbers instead of an opaque spinner.
+            assert "files_checked" in body
+            assert "new_count_so_far" in body
             assert started.is_set()
+    finally:
+        release.set()
+
+
+def test_post_snapshot_202_reports_live_walk_progress(app_and_db, monkeypatch):
+    """While the walk runs, snapshot polls must report its live totals so the
+    pipeline page can show "N files checked, M new so far" instead of an
+    opaque spinner — the transparency requirement for multi-minute walks."""
+    import threading
+    import time
+
+    import new_images as new_images_module
+
+    app, db, ws_id, tmp_path = app_and_db
+    folder = tmp_path / "photos"
+    _touch_image(str(folder / "IMG_001.JPG"))
+    db.add_folder(str(folder))
+
+    release = threading.Event()
+
+    def slow_count(*args, progress_callback=None, **kwargs):
+        assert progress_callback is not None, (
+            "POST-spawned walks must wire the transparency progress callback"
+        )
+        progress_callback(1234, 56)
+        release.wait(timeout=5)
+        return {
+            "new_count": 1,
+            "per_root": [],
+            "sample": [str(folder / "IMG_001.JPG")],
+            "sample_complete": True,
+        }
+
+    monkeypatch.setattr(
+        new_images_module, "count_new_images_for_workspace", slow_count,
+    )
+
+    try:
+        with app.test_client() as client:
+            deadline = time.monotonic() + 2.0
+            body = None
+            while time.monotonic() < deadline:
+                resp = client.post("/api/workspaces/active/new-images/snapshot")
+                assert resp.status_code == 202
+                body = resp.get_json()
+                if body.get("files_checked"):
+                    break
+                time.sleep(0.02)
+            assert body is not None
+            assert body["pending"] is True
+            assert body["files_checked"] == 1234
+            assert body["new_count_so_far"] == 56
+    finally:
+        release.set()
+
+
+def test_post_snapshot_registers_ephemeral_job_when_walk_needed(
+        app_and_db, monkeypatch):
+    """A click-triggered walk must be just as visible in the bottom panel as
+    a navbar-triggered one: same ephemeral ``new_images_walk`` job."""
+    import threading
+    import time
+
+    import new_images as new_images_module
+
+    app, db, ws_id, tmp_path = app_and_db
+    folder = tmp_path / "photos"
+    _touch_image(str(folder / "IMG_001.JPG"))
+    db.add_folder(str(folder))
+
+    release = threading.Event()
+    started = threading.Event()
+    real_count = new_images_module.count_new_images_for_workspace
+
+    def slow_count(*args, **kwargs):
+        started.set()
+        release.wait(timeout=5)
+        return real_count(*args, **kwargs)
+
+    monkeypatch.setattr(
+        new_images_module, "count_new_images_for_workspace", slow_count,
+    )
+
+    try:
+        with app.test_client() as client:
+            resp = client.post("/api/workspaces/active/new-images/snapshot")
+            assert resp.status_code == 202
+            assert started.is_set()
+            deadline = time.monotonic() + 2.0
+            walk_jobs = []
+            while time.monotonic() < deadline:
+                active = client.get("/api/jobs").get_json()["active"]
+                walk_jobs = [
+                    j for j in active if j["type"] == "new_images_walk"
+                ]
+                if walk_jobs:
+                    break
+                time.sleep(0.02)
+            assert walk_jobs, (
+                "expected a new_images_walk job in /api/jobs while the "
+                "click-triggered walk is in flight"
+            )
+            assert walk_jobs[0]["status"] == "running"
+            assert walk_jobs[0]["workspace_id"] == ws_id
     finally:
         release.set()
 

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -6468,10 +6468,13 @@ def test_pipeline_with_snapshot_scans_only_snapshot_folders(tmp_path, monkeypatc
 
 def test_pipeline_snapshot_excludes_late_arriving_files(tmp_path, monkeypatch):
     """Files that land in a registered folder AFTER a snapshot is captured
-    must still be scanned (we walk the folder), but downstream stages
-    (classify, extract_masks, regroup) must be constrained to the snapshot's
-    photo-id set. Verified via DB state: only the early (snapshot) photo
-    should have a predictions row after the pipeline completes.
+    must NOT be cataloged by the pipeline scan. If they were, downstream
+    filtering would keep them out of classify/extract_masks/regroup, but the
+    finally-block cache invalidation still runs — orphaning the file
+    (cataloged in DB, never processed, never re-surfaced by a later banner
+    probe). Instead, the scan is restricted to the snapshot's file set so
+    late arrivals remain uncataloged and the next new-images probe
+    rediscovers them.
     """
     import classifier as classifier_mod
     import classify_job
@@ -6500,8 +6503,9 @@ def test_pipeline_snapshot_excludes_late_arriving_files(tmp_path, monkeypatch):
     snap_id = db.create_new_images_snapshot([str(folder / "IMG_early.JPG")])
 
     # "Late" file — arrives after the snapshot but before the pipeline runs.
-    # The scanner will ingest it (same folder), but downstream stages must
-    # skip it.
+    # The scanner must NOT catalog it — it lives in the same folder as the
+    # snapshot file, but restrict_files scopes the walk to the exact
+    # snapshot paths so late arrivals stay new.
     Image.new("RGB", (16, 16), (200, 50, 50)).save(
         str(folder / "IMG_late.JPG")
     )
@@ -6576,8 +6580,10 @@ def test_pipeline_snapshot_excludes_late_arriving_files(tmp_path, monkeypatch):
     job = _make_job()
     run_pipeline_job(job, runner, db_path, ws_id, params)
 
-    # Verify via DB: both files were scanned (scan walks the folder), but
-    # only the early one should have a prediction row.
+    # Verify via DB: only the snapshot (early) file should be cataloged. The
+    # late file stays off-catalog so the next new-images probe finds it and
+    # the banner reappears — self-healing freshness the Codex P1 review
+    # called out.
     verify_db = Database(db_path)
     verify_db.set_active_workspace(ws_id)
 
@@ -6586,8 +6592,9 @@ def test_pipeline_snapshot_excludes_late_arriving_files(tmp_path, monkeypatch):
             "SELECT filename FROM photos"
         ).fetchall()
     }
-    assert scanned == {"IMG_early.JPG", "IMG_late.JPG"}, (
-        f"scan should ingest both files in the folder, got {scanned}"
+    assert scanned == {"IMG_early.JPG"}, (
+        f"scan must skip files not in the snapshot so late arrivals stay "
+        f"discoverable by future probes, got {scanned}"
     )
 
     classified_names = {

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -6613,6 +6613,21 @@ def test_pipeline_snapshot_excludes_late_arriving_files(tmp_path, monkeypatch):
         f"{classified_names}"
     )
 
+    # The self-healing contract end-to-end: a fresh new-images walk still
+    # reports the late file as new, so the banner re-raises for it.
+    from new_images import count_new_images_for_workspace
+    post_run = count_new_images_for_workspace(
+        verify_db, ws_id, sample_limit=None,
+    )
+    assert post_run["new_count"] == 1, (
+        f"late file must still be new after a snapshot-scoped run, "
+        f"got {post_run}"
+    )
+    assert post_run["sample"] == [str(folder / "IMG_late.JPG")], (
+        f"expected the late file in the new-images sample, got "
+        f"{post_run['sample']}"
+    )
+
 
 def test_pipeline_snapshot_collapses_overlapping_scan_roots(tmp_path, monkeypatch):
     """When the snapshot contains files at both a folder and a nested subfolder


### PR DESCRIPTION
## Problem

Clicking the "N new images detected" banner on a large library (~92k files on an SMB volume) froze the banner button on "Preparing..." for ~60 seconds, then silently dumped the user on a blank pipeline wizard while the walk kept running invisibly server-side. Three compounding causes:

1. **The click always threw away the walk that produced the count.** The navbar probe cached its walk with `sample_limit=5`, so the entry was never `sample_complete` and the snapshot POST couldn't reuse it — worse, the first POST of a "session" deliberately invalidated the cache and started a fresh full walk of the entire library.
2. **The client gave up after ~60s and failed silently.** Both poll loops (navbar + pipeline page) capped at 20 attempts × 3s, then fell back to a blank `/pipeline` with no message. The click-triggered walk also had no `on_spawn`, so it didn't even appear in the bottom panel.
3. **Clicking again made it worse.** After the 120s session TTL, a second click invalidated the cache mid-walk, dropping the in-flight result and restarting from zero — on slow volumes the walk never converged.

## Fix

**Backend** (`vireo/app.py`, `vireo/new_images.py`):
- All new-images walks run with `sample_limit=None`, so the cache holds the complete new-file list (HTTP payload still trims the sample to 5). The snapshot POST trusts a live `sample_complete` cache entry: the click resolves instantly, and the snapshot contains **exactly the files the banner advertised**. Files that land later are self-healing — the next probe re-raises the banner. Scans/imports still invalidate the cache.
- Removed the per-click snapshot-session machinery (kickoff timestamps + forced invalidation) and the now-dead `NewImagesCache.get_entry_set_at`. Cold-cache POSTs coalesce onto any in-flight walk instead of tearing it down.
- Click-triggered walks register the same ephemeral bottom-panel job as navbar ones; 202 responses carry live progress (`files_checked` / `new_count_so_far`).

**Frontend** (`_navbar.html`, `pipeline.html`):
- Banner button: one POST, then navigate immediately — to `/pipeline?new_images=<id>` when ready, else `/pipeline?new_images=preparing`. No frozen button, no silent blank-wizard fallback.
- Pipeline page owns the wait: visible preparing card, unbounded polling (terminal states are the walk finishing or failing, not an arbitrary cap), live "N files checked, M new so far" status, honest error + click-to-retry.

## Semantics change (deliberate)

The old "always re-walk at click time" behavior (from an earlier Codex review) guaranteed freshness but cost a full multi-minute walk per click. New contract: **snapshot = what the banner said**, freshness is restored by cache invalidation on scan/import and the banner reappearing for late arrivals. Five tests encoding the old semantics were rewritten accordingly.

## Tests

- `vireo/tests/test_new_images_api.py`: 33/33 — rewrote 5 tests (cache reuse instead of forced re-walk, coalescing onto in-flight walks, invalidation-driven freshness), added 2 (202 progress fields, POST-spawned ephemeral job).
- `tests/e2e/test_new_images_pipeline.py`: 2/2 — added a Playwright regression test for the exact reported scenario (banner click during a slow walk → lands on preparing state → shows live progress → converges onto the snapshot).
- New-images-adjacent files (pipeline, import, scanner, jobs, cache): **677 passed**.
- CLAUDE.md required suite: **1468 passed, 2 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a smoother “New images” flow with a preparing state while images are being discovered.
  * The pipeline page now shows live progress during long-running image scans and updates automatically when ready.

* **Bug Fixes**
  * Clicking the “New images” banner now opens the pipeline immediately instead of relying on repeated retries.
  * Improved reuse of recent image scan results so the newest available images are shown more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->