### PR TITLE
[codex] Retire pipeline import staging path

### DIFF
--- a/tests/test_staging_recovery.py
+++ b/tests/test_staging_recovery.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+import staging_recovery
 from staging_recovery import (
     delete_verified_staging,
     discover_orphaned_staging,
@@ -109,6 +110,35 @@ def test_orphaned_staging_ignores_matching_archive_in_other_workspace(db, tmp_pa
     assert result["can_delete"] is False
     assert result["unaccounted"] == 1
     assert result["verified"] == 0
+
+
+def test_orphaned_staging_reuses_archive_folder_listing(db, tmp_path, monkeypatch):
+    vireo_dir = tmp_path / "vireo"
+    staged_a = _write(vireo_dir / "staging" / "pipeline-cache" / "USA" / "a.nef")
+    staged_b = _write(vireo_dir / "staging" / "pipeline-cache" / "USA" / "b.nef")
+    archive_dir = tmp_path / "archive" / "USA"
+    _write(archive_dir / "a.nef", staged_a.read_bytes())
+    _write(archive_dir / "b.nef", staged_b.read_bytes())
+    _catalog_photo(db, archive_dir, "a.nef", staged_a.stat().st_size)
+    _catalog_photo(db, archive_dir, "b.nef", staged_b.stat().st_size)
+
+    real_listdir = os.listdir
+    archive_list_calls = []
+
+    def counting_listdir(path):
+        if os.path.realpath(path) == os.path.realpath(archive_dir):
+            archive_list_calls.append(path)
+        return real_listdir(path)
+
+    monkeypatch.setattr(staging_recovery.os, "listdir", counting_listdir)
+
+    result = verify_orphaned_staging(
+        db, str(vireo_dir), str(vireo_dir / "staging" / "pipeline-cache")
+    )
+
+    assert result["status"] == "safe_to_delete"
+    assert result["verified"] == 2
+    assert len(archive_list_calls) == 1
 
 
 def test_orphaned_staging_unreachable_archive_is_not_called_missing(db, tmp_path):

--- a/tests/test_staging_recovery.py
+++ b/tests/test_staging_recovery.py
@@ -88,6 +88,29 @@ def test_orphaned_staging_missing_archive_copy_blocks_delete(db, tmp_path):
     assert (vireo_dir / "staging" / "pipeline-2").exists()
 
 
+def test_orphaned_staging_ignores_matching_archive_in_other_workspace(db, tmp_path):
+    active_ws = db._active_workspace_id
+    other_ws = db.create_workspace("Other")
+    vireo_dir = tmp_path / "vireo"
+    staged = _write(
+        vireo_dir / "staging" / "pipeline-other-ws" / "USA" / "2026" / "a.nef"
+    )
+    archive_file = _write(tmp_path / "archive-other" / "USA" / "2026" / "a.nef")
+
+    db.set_active_workspace(other_ws)
+    _catalog_photo(db, archive_file.parent, "a.nef", staged.stat().st_size)
+    db.set_active_workspace(active_ws)
+
+    result = verify_orphaned_staging(
+        db, str(vireo_dir), str(vireo_dir / "staging" / "pipeline-other-ws")
+    )
+
+    assert result["status"] == "needs_import"
+    assert result["can_delete"] is False
+    assert result["unaccounted"] == 1
+    assert result["verified"] == 0
+
+
 def test_orphaned_staging_unreachable_archive_is_not_called_missing(db, tmp_path):
     vireo_dir = tmp_path / "vireo"
     staged = _write(

--- a/tests/test_staging_recovery.py
+++ b/tests/test_staging_recovery.py
@@ -1,0 +1,136 @@
+import os
+
+import pytest
+from staging_recovery import (
+    delete_verified_staging,
+    discover_orphaned_staging,
+    verify_orphaned_staging,
+)
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    import config as cfg
+    import models
+    from app import create_app
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.setattr(models, "DEFAULT_MODELS_DIR", str(tmp_path / "vireo-models"))
+    monkeypatch.setattr(models, "CONFIG_PATH", str(tmp_path / "models.json"))
+
+    app = create_app(str(tmp_path / "test.db"))
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def _write(path, data=b"abc"):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+    return path
+
+
+def _catalog_photo(db, folder_path, filename, size):
+    folder_id = db.add_folder(str(folder_path), name=os.path.basename(str(folder_path)))
+    return db.add_photo(folder_id, filename, os.path.splitext(filename)[1], size, 1.0)
+
+
+def test_orphaned_staging_verified_files_can_be_deleted(db, tmp_path):
+    vireo_dir = tmp_path / "vireo"
+    staged = _write(
+        vireo_dir / "staging" / "pipeline-1" / "USA" / "2026" / "2026-07-03" / "a.nef"
+    )
+    archive_file = _write(
+        tmp_path / "archive" / "USA" / "2026" / "2026-07-03" / "a.nef"
+    )
+    _catalog_photo(db, archive_file.parent, "a.nef", staged.stat().st_size)
+
+    discovered = discover_orphaned_staging(str(vireo_dir))
+    assert discovered[0]["source_root"].endswith(os.path.join("pipeline-1", "USA"))
+
+    result = verify_orphaned_staging(
+        db, str(vireo_dir), str(vireo_dir / "staging" / "pipeline-1")
+    )
+
+    assert result["status"] == "safe_to_delete"
+    assert result["can_delete"] is True
+    assert result["verified"] == 1
+    assert result["inferred_destination"] == str(tmp_path / "archive" / "USA")
+
+    delete_verified_staging(
+        db, str(vireo_dir), str(vireo_dir / "staging" / "pipeline-1")
+    )
+    assert not (vireo_dir / "staging" / "pipeline-1").exists()
+
+
+def test_orphaned_staging_missing_archive_copy_blocks_delete(db, tmp_path):
+    vireo_dir = tmp_path / "vireo"
+    staged = _write(
+        vireo_dir / "staging" / "pipeline-2" / "USA" / "2026" / "2026-07-03" / "b.nef"
+    )
+    archive_dir = tmp_path / "archive" / "USA" / "2026" / "2026-07-03"
+    archive_dir.mkdir(parents=True)
+    _catalog_photo(db, archive_dir, "b.nef", staged.stat().st_size)
+
+    result = verify_orphaned_staging(
+        db, str(vireo_dir), str(vireo_dir / "staging" / "pipeline-2")
+    )
+
+    assert result["status"] == "needs_import"
+    assert result["can_delete"] is False
+    assert result["unaccounted"] == 1
+    assert "not present" in result["details"][0]["reason"]
+    with pytest.raises(ValueError):
+        delete_verified_staging(
+            db, str(vireo_dir), str(vireo_dir / "staging" / "pipeline-2")
+        )
+    assert (vireo_dir / "staging" / "pipeline-2").exists()
+
+
+def test_orphaned_staging_unreachable_archive_is_not_called_missing(db, tmp_path):
+    vireo_dir = tmp_path / "vireo"
+    staged = _write(
+        vireo_dir / "staging" / "pipeline-3" / "USA" / "2026" / "2026-07-03" / "c.nef"
+    )
+    archive_dir = tmp_path / "offline-archive" / "USA" / "2026" / "2026-07-03"
+    _catalog_photo(db, archive_dir, "c.nef", staged.stat().st_size)
+
+    result = verify_orphaned_staging(
+        db, str(vireo_dir), str(vireo_dir / "staging" / "pipeline-3")
+    )
+
+    assert result["status"] == "unreachable"
+    assert result["can_delete"] is False
+    assert result["unreachable"] == 1
+    assert "not enumerable" in result["details"][0]["reason"]
+
+
+def test_process_pipeline_rejects_retired_import_fields(client, tmp_path):
+    source = tmp_path / "source"
+    source.mkdir()
+    destination = tmp_path / "archive"
+
+    resp = client.post(
+        "/api/jobs/pipeline",
+        json={
+            "source": str(source),
+            "destination": str(destination),
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        },
+    )
+
+    assert resp.status_code == 400
+    assert "import/archive fields" in resp.get_json()["error"]
+
+
+def test_process_plan_rejects_retired_import_fields(client):
+    resp = client.post(
+        "/api/pipeline/plan",
+        json={"source_paths": [], "local_processing": True},
+    )
+
+    assert resp.status_code == 400
+    assert "import/archive fields" in resp.get_json()["error"]

--- a/tests/test_staging_recovery.py
+++ b/tests/test_staging_recovery.py
@@ -112,6 +112,42 @@ def test_orphaned_staging_ignores_matching_archive_in_other_workspace(db, tmp_pa
     assert result["verified"] == 0
 
 
+def test_orphaned_staging_requires_matching_archive_relative_folder(db, tmp_path):
+    vireo_dir = tmp_path / "vireo"
+    staged = _write(
+        vireo_dir / "staging" / "pipeline-path" / "USA" / "2026" / "2026-07-03" / "a.nef"
+    )
+    archive_file = _write(
+        tmp_path / "archive" / "USA" / "2026" / "2026-07-04" / "a.nef"
+    )
+    _catalog_photo(db, archive_file.parent, "a.nef", staged.stat().st_size)
+
+    result = verify_orphaned_staging(
+        db, str(vireo_dir), str(vireo_dir / "staging" / "pipeline-path")
+    )
+
+    assert result["status"] == "needs_import"
+    assert result["can_delete"] is False
+    assert result["unaccounted"] == 1
+    assert result["verified"] == 0
+
+
+def test_orphaned_staging_requires_matching_destination_leaf(db, tmp_path):
+    vireo_dir = tmp_path / "vireo"
+    staged = _write(vireo_dir / "staging" / "pipeline-leaf" / "USA" / "a.nef")
+    archive_file = _write(tmp_path / "archive" / "Brazil" / "a.nef")
+    _catalog_photo(db, archive_file.parent, "a.nef", staged.stat().st_size)
+
+    result = verify_orphaned_staging(
+        db, str(vireo_dir), str(vireo_dir / "staging" / "pipeline-leaf")
+    )
+
+    assert result["status"] == "needs_import"
+    assert result["can_delete"] is False
+    assert result["unaccounted"] == 1
+    assert result["verified"] == 0
+
+
 def test_orphaned_staging_reuses_archive_folder_listing(db, tmp_path, monkeypatch):
     vireo_dir = tmp_path / "vireo"
     staged_a = _write(vireo_dir / "staging" / "pipeline-cache" / "USA" / "a.nef")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2815,6 +2815,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 return json_error("source_paths entries must be strings", 400)
         else:
             source_paths = None
+        deprecated_plan_fields = [
+            key for key in (
+                "destination", "local_processing",
+                "remote_target_id", "remote_subpath",
+            )
+            if body.get(key) not in (None, "", False)
+        ]
+        if deprecated_plan_fields:
+            return json_error(
+                "import/archive fields are no longer accepted by the "
+                "process planner; use the Import page for photo imports",
+                400,
+            )
         # hash_duplicate_paths is the frontend's pre-computed set of source
         # paths that ingest() will skip via the global duplicate gate (copy
         # mode + skip_duplicates=True; metadata-first matching or content
@@ -2910,13 +2923,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             reclassify=bool(body.get("reclassify")),
             source_paths=source_paths,
             hash_duplicate_paths=hash_duplicate_paths,
-            # Mirrors /api/jobs/pipeline's local_processing flag. The
-            # planner needs it to know what the post-ingest scan walks:
-            # only local-processing imports may claim "0 new photos to
-            # import, nothing to …" for an all-duplicates selection —
-            # plain copy mode re-scans the real destination, which can
-            # surface existing unprocessed rows as downstream work.
-            local_processing=bool(body.get("local_processing")),
             preview_max_size=body.get("preview_max_size"),
         )
         db = _get_db()
@@ -15115,6 +15121,58 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         )
         return jsonify({"job_id": job_id})
 
+    @app.route("/api/import/orphaned-staging", methods=["GET"])
+    def api_import_orphaned_staging():
+        """List old pipeline staging folders that need verified recovery."""
+        from staging_recovery import discover_orphaned_staging
+
+        vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+        return jsonify({"items": discover_orphaned_staging(vireo_dir)})
+
+    @app.route("/api/import/orphaned-staging/verify", methods=["POST"])
+    def api_import_orphaned_staging_verify():
+        """Start a verification job for one old pipeline staging folder."""
+        from staging_recovery import verify_orphaned_staging
+
+        body = request.get_json(silent=True) or {}
+        path = body.get("path")
+        if not isinstance(path, str) or not path:
+            return json_error("path required")
+
+        runner = app._job_runner
+        active_ws = _get_db()._active_workspace_id
+        vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+
+        def work(job):
+            thread_db = Database(db_path)
+            thread_db.set_active_workspace(active_ws)
+            return verify_orphaned_staging(thread_db, vireo_dir, path)
+
+        job_id = runner.start(
+            "staging-verify",
+            work,
+            config={"path": path},
+            workspace_id=active_ws,
+        )
+        return jsonify({"job_id": job_id})
+
+    @app.route("/api/import/orphaned-staging", methods=["DELETE"])
+    def api_import_orphaned_staging_delete():
+        """Delete old staging only when a fresh verification is fully green."""
+        from staging_recovery import delete_verified_staging
+
+        body = request.get_json(silent=True) or {}
+        path = body.get("path")
+        if not isinstance(path, str) or not path:
+            return json_error("path required")
+        vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+        db = _get_db()
+        try:
+            result = delete_verified_staging(db, vireo_dir, path)
+        except ValueError as exc:
+            return json_error(str(exc), status=409)
+        return jsonify(result)
+
     @app.route("/api/jobs/import-photos", methods=["POST"])
     def api_job_import_photos():
         """Photo import job: copy card -> archive, hash-verify, catalog
@@ -17355,7 +17413,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         """Streaming pipeline: scan -> thumbnails -> classify -> extract-masks -> regroup.
 
         Overlaps I/O stages and interleaves detection with classification.
-        Provide either 'source' (for import+scan) or 'collection_id' (skip scan).
+        Imports are handled by /api/jobs/import-photos. This route processes
+        existing workspace photos by folder/snapshot/collection scope.
         """
         from pipeline_job import PipelineParams, run_pipeline_job
 
@@ -17679,6 +17738,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     )
                 if not os.path.isdir(source):
                     return json_error(f"source directory not found: {source}")
+
+        deprecated_import_fields = [
+            key for key in (
+                "destination", "local_processing",
+                "remote_target_id", "remote_subpath",
+            )
+            if body.get(key) not in (None, "", False)
+        ]
+        if deprecated_import_fields:
+            return json_error(
+                "import/archive fields are no longer accepted by "
+                "/api/jobs/pipeline; use /api/jobs/import-photos or the "
+                "Import page for photo imports"
+            )
 
         destination = body.get("destination")
         local_processing = bool(body.get("local_processing"))

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -665,6 +665,12 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
     job["_start_time"] = time.time()
     abort = threading.Event()
     errors = job["errors"]  # shared list, append is thread-safe
+    if params.destination or params.local_processing or params.remote_target_id:
+        raise RuntimeError(
+            "Pipeline import/archive mode has been removed. Use the Import "
+            "page or /api/jobs/import-photos to copy photos into the archive, "
+            "then run Process on the imported workspace photos."
+        )
 
     # Effective thumbnail cache directory for every internal call below.
     # Falls back to the historical ``<db_dir>/thumbnails`` convention when
@@ -715,7 +721,6 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
         # will point after the archive, which for a remote destination is
         # the target's local mount path, not the NAS-side path.
         final_destination = remote_archive["mount_final"]
-    staging_parent = None
     archive_destination_reserved = False
     if params.local_processing and final_destination:
         from local_processing import staging_root
@@ -735,7 +740,6 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
             )
         archive_destination_reserved = True
 
-        staging_parent = os.path.join(effective_vireo_dir, "staging", job["id"])
         # final_destination (not params.destination, which is None for a
         # remote archive): the staging root's basename is the leaf the
         # archive move lands at, and for remote that's the mount-path leaf —
@@ -5109,326 +5113,21 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
             _update_stages(runner, job["id"], stages)
 
         def archive_stage():
-            """Move a local-processing staging folder to the final destination."""
-            if not params.local_processing:
-                return
+            """Retired import/archive path guard.
 
-            def _deindex_staging():
-                # scanner_stage may have already registered the staging folder
-                # and its photos' hashes before we got here. Without removing
-                # those rows a retry of the same source would hit ingest()'s
-                # known-hash skip and copy nothing — the user would then
-                # "successfully" archive an empty destination while the
-                # original files only ever existed in the abandoned staging
-                # tree. Leave the on-disk staging files in place so the user
-                # can still recover them.
-                #
-                # Cached thumbnails/previews/working copies for the staged
-                # photos also have to go: the FK cascade clears preview_cache
-                # rows but leaves the on-disk ``{photo_id}.jpg`` files. SQLite
-                # reuses freed rowids, so a retry that lands on one of the
-                # abandoned staging photo IDs would treat the stale cache file
-                # as a valid thumbnail and skip regenerating it.
-                try:
-                    from pipeline import _results_cache_path
-                    from preview_cache import (
-                        cleanup_cached_files_for_deleted_photos,
-                    )
-
-                    thread_db = Database(db_path)
-                    thread_db.set_active_workspace(workspace_id)
-                    folder = thread_db.conn.execute(
-                        "SELECT id FROM folders WHERE path = ?",
-                        (params.destination,),
-                    ).fetchone()
-                    if folder:
-                        result = thread_db.delete_folder(folder["id"])
-                        cleanup_cached_files_for_deleted_photos(
-                            effective_thumb_cache_dir,
-                            result.get("files", []),
-                        )
-                        thread_db.set_workspace_group_state(
-                            workspace_id=workspace_id,
-                            fingerprint=None,
-                            when_ts=None,
-                        )
-                        with contextlib.suppress(OSError):
-                            os.unlink(
-                                _results_cache_path(
-                                    os.path.dirname(db_path), workspace_id,
-                                )
-                            )
-                except Exception:
-                    log.exception(
-                        "Failed to deindex local staging folder on archive skip",
-                    )
-
-            if abort.is_set() or runner.is_cancelled(job["id"]):
-                # Fatal upstream stages (partial scan, thumbnail setup, model
-                # load, detect, classify) set abort and fall through to here
-                # without populating stages[*]["status"] == "failed", so the
-                # already_failed branch below would miss them. Deindex here too
-                # — otherwise the next retry of the same source would treat
-                # every file as a duplicate and publish an empty archive.
-                _deindex_staging()
-                stages["archive"]["status"] = "skipped"
-                runner.update_step(
-                    job["id"], "archive", status="completed", summary="Skipped",
+            Importing photos now runs through import_job.py and
+            /api/jobs/import-photos. The old local-processing archive stage
+            intentionally has no cleanup/deindex path left here: orphaned
+            staging folders are reconciled by staging_recovery.py before any
+            deletion is offered.
+            """
+            if params.local_processing or params.destination:
+                raise RuntimeError(
+                    "Pipeline import/archive mode has been removed. Use the "
+                    "Import page or /api/jobs/import-photos to copy photos "
+                    "into the archive."
                 )
-                _update_stages(runner, job["id"], stages)
-                return
-            if not final_destination:
-                stages["archive"]["status"] = "skipped"
-                runner.update_step(
-                    job["id"], "archive", status="completed", summary="Skipped",
-                )
-                _update_stages(runner, job["id"], stages)
-                return
-            # Don't publish partial results: previews, extract_masks,
-            # eye_keypoints, regroup, and miss can all fail without setting
-            # abort, and run_pipeline_job marks the whole job failed at the
-            # end whenever any stage status is "failed". If we ran the archive
-            # in between, the staged folder would have already moved to
-            # final_destination by the time that failure was raised — leaving
-            # the user with a published archive whose pipeline never finished.
-            # Skip instead so staging stays intact and the failure is visible.
-            already_failed = [
-                name for name, s in stages.items() if s.get("status") == "failed"
-            ]
-            if already_failed:
-                _deindex_staging()
-                stages["archive"]["status"] = "skipped"
-                runner.update_step(
-                    job["id"], "archive",
-                    status="completed",
-                    summary=f"Skipped ({already_failed[0]} failed)",
-                )
-                _update_stages(runner, job["id"], stages)
-                return
-
-            stages["archive"]["status"] = "running"
-            runner.update_step(job["id"], "archive", status="running")
-            _update_stages(runner, job["id"], stages)
-
-            try:
-                import config as cfg
-                from move import move_folder
-
-                thread_db = Database(db_path)
-                thread_db.set_active_workspace(workspace_id)
-                folder = thread_db.conn.execute(
-                    "SELECT id FROM folders WHERE path = ?", (params.destination,)
-                ).fetchone()
-                if not folder:
-                    raise RuntimeError(
-                        f"local staging folder was not indexed: {params.destination}"
-                    )
-
-                effective_cfg = thread_db.get_effective_config(cfg.load())
-                developed_dir = effective_cfg.get("darktable_output_dir", "") or ""
-                archive_parent = os.path.dirname(os.path.normpath(final_destination))
-                remote_spec = None
-                if remote_archive is not None:
-                    import move as move_mod
-
-                    # Re-resolve rsync at archive time: the storage preflight
-                    # verified it hours ago and the binary/config could have
-                    # changed since. move_folder refuses on a missing
-                    # rsync_bin anyway; resolving here gives the actionable
-                    # message before any SSH probing starts.
-                    rsync_bin = move_mod.resolve_rsync_bin(
-                        effective_cfg.get("rsync_bin", "") or "",
-                    )
-                    if rsync_bin and not move_mod.is_gnu_rsync(rsync_bin):
-                        rsync_bin = ""
-                    if not rsync_bin:
-                        raise RuntimeError(
-                            "No GNU rsync available to transfer the archive "
-                            f"to {remote_archive['display']}. Install GNU "
-                            "rsync (e.g. `brew install rsync`) or set its "
-                            "path under Settings → Paths"
-                        )
-                    # parent_subpath (not the full subpath): move_folder
-                    # lands the staged folder INSIDE the spec's bases keeping
-                    # its name, and the staging root is named after the
-                    # subpath's last segment — so the archive lands at
-                    # exactly remote_path/subpath and the catalog repoints
-                    # at exactly mount_path/subpath (== final_destination).
-                    remote_spec = move_mod.build_remote_move_spec(
-                        remote_archive["target"],
-                        remote_archive["parent_subpath"],
-                        rsync_bin,
-                    )
-                total_files = {"value": 0}
-
-                def archive_cb(current, total, filename, phase=None):
-                    total_files["value"] = max(total_files["value"], total or 0)
-                    stages["archive"]["count"] = current
-                    stages["archive"]["total"] = total
-                    runner.update_step(
-                        job["id"], "archive",
-                        current_file=filename,
-                        progress={"current": current, "total": total},
-                    )
-                    _emit_progress(
-                        runner, job["id"], stages, "archive",
-                        phase or "Archiving photos",
-                        current_file=filename,
-                    )
-
-                # Atomically lock the job uncancellable BEFORE the move begins,
-                # but only if Stop is not already pending. move_folder is an
-                # uninterruptible commit step (copy -> verify -> repoint catalog
-                # -> delete originals); once it starts, a Stop press cannot be
-                # honored without leaving partial state. If Stop landed just
-                # before this transition, skip archive and let the outer runner
-                # record the job as cancelled.
-                if not runner.begin_uncancellable(job["id"]):
-                    _deindex_staging()
-                    stages["archive"]["status"] = "skipped"
-                    runner.update_step(
-                        job["id"], "archive",
-                        status="completed", summary="Skipped",
-                    )
-                    _update_stages(runner, job["id"], stages)
-                    return
-
-                # For a remote archive the destination parent comes from
-                # remote_spec (move_folder ignores the positional
-                # destination); merge/retry and tracked-merge semantics are
-                # identical to the local path — move_folder's remote branch
-                # probes existence over SSH, rsyncs with --ignore-existing +
-                # --partial-dir on a resume, checksum-verifies before
-                # deleting staging, and repoints the catalog at the mount
-                # path (final_destination).
-                move_result = move_folder(
-                    thread_db,
-                    folder["id"],
-                    archive_parent,
-                    progress_cb=archive_cb,
-                    developed_dir=developed_dir,
-                    merge=True,
-                    reject_tracked_ancestor=True,
-                    allow_tracked_merge=True,
-                    remote=remote_spec,
-                )
-                if move_result.get("errors"):
-                    raise RuntimeError("; ".join(move_result["errors"]))
-
-                # Merge-into-existing-archive dropped some staged photo rows
-                # (identical filename already archived, or a phantom target
-                # row was replaced). SQLite reuses freed rowids, so any
-                # thumbnail / preview / working-copy / offline-cache file
-                # keyed off one of those ids would silently become a stale
-                # asset for whichever future photo lands on the same id.
-                # Mirror the archive-skip cleanup path so no orphaned cache
-                # files can survive the merge.
-                dropped_ids = move_result.get("dropped_photo_ids") or []
-                if dropped_ids:
-                    from preview_cache import (
-                        cleanup_cached_files_for_deleted_photos,
-                    )
-                    cleanup_cached_files_for_deleted_photos(
-                        effective_thumb_cache_dir,
-                        [{"photo_id": pid} for pid in dropped_ids],
-                    )
-
-                if staging_parent:
-                    with contextlib.suppress(OSError):
-                        os.rmdir(staging_parent)
-
-                # move_folder repointed the catalog at final_destination
-                # before deleting the source originals, so a
-                # ``cleanup_error`` means the archive IS committed — files
-                # are at the destination, but some leftovers remain in
-                # staging (locked file, permission issue, etc.). Report
-                # success with a warning rather than failure: the
-                # alternative ("failed" + "results remain in staging") tells
-                # the user their data is lost when it's actually safe at
-                # final_destination, and would also leave the freshly
-                # created tracked folder row in the catalog while we tried
-                # to deindex a staging row that move_folder_path already
-                # renamed away.
-                cleanup_error = move_result.get("cleanup_error")
-                stages["archive"]["status"] = "completed"
-                moved = move_result.get("moved", 0)
-                merge = move_result.get("merge")
-                if merge:
-                    base = move_result.get(
-                        "merged_into_existing", final_destination,
-                    )
-                    summary = (
-                        f"{merge['new_photos']} new photos archived into "
-                        f"existing archive {base} "
-                        f"({merge['new_folders']} new folders, "
-                        f"{merge['merged_folders']} merged into existing, "
-                        f"{merge['already_present']} already present)"
-                    )
-                    if remote_archive is not None:
-                        summary += (
-                            " — transferred over SSH to "
-                            f"{remote_archive['display']}"
-                        )
-                elif remote_archive is not None:
-                    summary = (
-                        f"{moved} photos archived over SSH to "
-                        f"{remote_archive['display']}"
-                    )
-                else:
-                    summary = f"{moved} photos archived"
-                if cleanup_error:
-                    summary += f" (staging cleanup failed: {cleanup_error})"
-                runner.update_step(
-                    job["id"], "archive", status="completed", summary=summary,
-                )
-                result["archive"] = {
-                    "final_destination": final_destination,
-                    "moved": moved,
-                }
-                if remote_archive is not None:
-                    target = remote_archive["target"]
-                    result["archive"]["remote"] = {
-                        "target_id": target["id"],
-                        "target_name": target["name"],
-                        "host": target["host"],
-                        "user": target["user"],
-                        "ssh_destination": remote_archive["ssh_final"],
-                    }
-                if merge:
-                    result["archive"]["merge"] = merge
-                if cleanup_error:
-                    result["archive"]["cleanup_error"] = cleanup_error
-            except Exception as e:
-                # Name the remote target + subpath the way the local path
-                # names the directory (move_folder's own error text already
-                # covers the local case).
-                prefix = (
-                    f"Archive to {remote_archive['display']} failed: "
-                    if remote_archive is not None else ""
-                )
-                msg = (
-                    f"{prefix}{e}. Processing results remain in local staging: "
-                    f"{params.destination}"
-                )
-                errors.append(f"[archive] Fatal: {msg}")
-                log.exception("Pipeline archive stage failed")
-                # move_folder doesn't repoint the catalog until it has
-                # verified every copied file, so a raise here means the
-                # folders/photos rows still point at the staging tree. If we
-                # leave them indexed, a retry of the same source sees the
-                # staging hashes via ingest()'s global duplicate check, skips
-                # the copy, and "successfully" publishes an empty archive
-                # while the original files remain only under ~/.vireo/staging.
-                # Deindex to match the archive-skip paths above; the on-disk
-                # staging files are left in place per the error message so
-                # the user can still recover them manually.
-                _deindex_staging()
-                stages["archive"]["status"] = "failed"
-                runner.update_step(
-                    job["id"], "archive", status="failed", error=msg,
-                )
-
-            _update_stages(runner, job["id"], stages)
+            return
 
         # --- Launch threads ---
 

--- a/vireo/staging_recovery.py
+++ b/vireo/staging_recovery.py
@@ -138,15 +138,26 @@ def _catalog_candidates(db, filename: str, size: int, staging_root: str) -> list
     return out
 
 
-def _archive_file_status(path: str, expected_size: int) -> tuple[str, str | None]:
+def _archive_file_status(
+    path: str,
+    expected_size: int,
+    listing_cache: dict[str, set[str] | OSError] | None = None,
+) -> tuple[str, str | None]:
     mount_root = _missing_mount_root(path) or _missing_mount_root(os.path.dirname(path))
     if mount_root:
         return "unreachable", f"archive mount root is unavailable: {mount_root}"
     folder = os.path.dirname(path)
-    try:
-        names = set(os.listdir(folder))
-    except OSError as exc:
-        return "unreachable", f"archive folder is not enumerable: {folder} ({exc})"
+    cache = listing_cache if listing_cache is not None else {}
+    cached = cache.get(folder)
+    if cached is None:
+        try:
+            cached = set(os.listdir(folder))
+        except OSError as exc:
+            cached = exc
+        cache[folder] = cached
+    if isinstance(cached, OSError):
+        return "unreachable", f"archive folder is not enumerable: {folder} ({cached})"
+    names = cached
     basename = os.path.basename(path)
     if basename not in names:
         return "missing", f"archive folder is reachable but {basename} is not present"
@@ -206,6 +217,7 @@ def verify_orphaned_staging(db, vireo_dir: str, cleanup_root: str) -> dict:
         "inferred_destination": None,
     }
     inferred: dict[str, int] = {}
+    archive_listing_cache: dict[str, set[str] | OSError] = {}
 
     for staged_path, rel_path, size in files:
         candidates = _catalog_candidates(
@@ -230,7 +242,9 @@ def verify_orphaned_staging(db, vireo_dir: str, cleanup_root: str) -> dict:
             archive_path = os.path.join(
                 candidate["folder_path"], candidate["filename"],
             )
-            status, reason = _archive_file_status(archive_path, size)
+            status, reason = _archive_file_status(
+                archive_path, size, archive_listing_cache,
+            )
             if status == "verified":
                 detail.update({
                     "status": "verified",

--- a/vireo/staging_recovery.py
+++ b/vireo/staging_recovery.py
@@ -1,0 +1,276 @@
+"""Verified recovery helpers for abandoned pipeline staging folders.
+
+Old import-through-process runs staged photos under
+``<vireo_dir>/staging/pipeline-*`` before archiving them. If a run failed or
+was cancelled, those folders may be the only remaining copy of files that did
+not make it to the archive. This module never deletes based on catalog state
+alone: every staged file must match an enumerable archive folder entry by
+filename and byte size before cleanup is allowed.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from dataclasses import dataclass
+
+
+def _missing_mount_root(path: str) -> str | None:
+    """Return a likely unavailable mount root for common archive locations."""
+    posix = os.path.expanduser(path).replace("\\", "/")
+    parts = posix.split("/")
+    if len(parts) >= 3 and parts[0] == "" and parts[1] in {"Volumes", "mnt"}:
+        root = f"/{parts[1]}/{parts[2]}"
+        return root if not os.path.lexists(root) else None
+    if len(parts) >= 4 and parts[0] == "" and parts[1] == "media":
+        root = f"/media/{parts[2]}/{parts[3]}"
+        return root if not os.path.lexists(root) else None
+    return None
+
+
+def _is_relative_to(path: str, root: str) -> bool:
+    try:
+        return os.path.commonpath([
+            os.path.realpath(path),
+            os.path.realpath(root),
+        ]) == os.path.realpath(root)
+    except (OSError, ValueError):
+        return False
+
+
+@dataclass(frozen=True)
+class StagingEntry:
+    cleanup_root: str
+    source_root: str
+
+
+def staging_base(vireo_dir: str) -> str:
+    return os.path.join(vireo_dir, "staging")
+
+
+def _entry_for_pipeline_dir(path: str) -> StagingEntry:
+    """Return cleanup root and likely import source root for one pipeline dir."""
+    children = []
+    direct_files = []
+    try:
+        for name in os.listdir(path):
+            full = os.path.join(path, name)
+            if os.path.isdir(full):
+                children.append(full)
+            elif os.path.isfile(full):
+                direct_files.append(full)
+    except OSError:
+        pass
+    # local_processing.staging_root created pipeline-*/<final-destination-name>.
+    # If the parent contains exactly that one leaf and no direct files, use the
+    # leaf as the import source so a recovery import preserves the original
+    # destination base semantics.
+    source_root = children[0] if len(children) == 1 and not direct_files else path
+    return StagingEntry(cleanup_root=path, source_root=source_root)
+
+
+def discover_orphaned_staging(vireo_dir: str) -> list[dict]:
+    """List abandoned pipeline staging roots with cheap file/size summaries."""
+    base = staging_base(vireo_dir)
+    if not os.path.isdir(base):
+        return []
+    entries: list[dict] = []
+    for name in sorted(os.listdir(base)):
+        if not name.startswith("pipeline-"):
+            continue
+        cleanup_root = os.path.join(base, name)
+        if not os.path.isdir(cleanup_root):
+            continue
+        entry = _entry_for_pipeline_dir(cleanup_root)
+        file_count = 0
+        total_bytes = 0
+        for root, _dirs, files in os.walk(entry.source_root):
+            for filename in files:
+                path = os.path.join(root, filename)
+                try:
+                    st = os.stat(path)
+                except OSError:
+                    continue
+                if not os.path.isfile(path):
+                    continue
+                file_count += 1
+                total_bytes += st.st_size
+        entries.append({
+            "path": entry.cleanup_root,
+            "source_root": entry.source_root,
+            "name": os.path.basename(entry.cleanup_root),
+            "file_count": file_count,
+            "bytes": total_bytes,
+        })
+    return entries
+
+
+def _resolve_entry(vireo_dir: str, cleanup_root: str) -> StagingEntry:
+    base = staging_base(vireo_dir)
+    root = os.path.realpath(cleanup_root)
+    if not _is_relative_to(root, base):
+        raise ValueError("staging path is outside the Vireo staging directory")
+    if not os.path.basename(root).startswith("pipeline-"):
+        raise ValueError("staging path is not a pipeline staging directory")
+    if not os.path.isdir(root):
+        raise ValueError("staging path was not found")
+    return _entry_for_pipeline_dir(root)
+
+
+def _catalog_candidates(db, filename: str, size: int, staging_root: str) -> list[dict]:
+    rows = db.conn.execute(
+        """SELECT p.id AS photo_id, p.filename, p.file_size, f.path AS folder_path
+             FROM photos p
+             JOIN folders f ON f.id = p.folder_id
+            WHERE p.filename = ? AND p.file_size = ?
+            ORDER BY f.path, p.id""",
+        (filename, int(size)),
+    ).fetchall()
+    out = []
+    for row in rows:
+        folder_path = row["folder_path"]
+        if folder_path and _is_relative_to(folder_path, staging_root):
+            continue
+        out.append(dict(row))
+    return out
+
+
+def _archive_file_status(path: str, expected_size: int) -> tuple[str, str | None]:
+    mount_root = _missing_mount_root(path) or _missing_mount_root(os.path.dirname(path))
+    if mount_root:
+        return "unreachable", f"archive mount root is unavailable: {mount_root}"
+    folder = os.path.dirname(path)
+    try:
+        names = set(os.listdir(folder))
+    except OSError as exc:
+        return "unreachable", f"archive folder is not enumerable: {folder} ({exc})"
+    basename = os.path.basename(path)
+    if basename not in names:
+        return "missing", f"archive folder is reachable but {basename} is not present"
+    try:
+        st = os.stat(path)
+    except OSError as exc:
+        return "unreachable", f"archive file could not be stat'ed: {path} ({exc})"
+    if st.st_size != expected_size:
+        return "size_mismatch", (
+            f"archive file size differs: expected {expected_size}, got {st.st_size}"
+        )
+    return "verified", None
+
+
+def _infer_destination(source_root: str, staged_file: str, folder_path: str) -> str:
+    rel_dir = os.path.relpath(os.path.dirname(staged_file), source_root)
+    if rel_dir in ("", "."):
+        return folder_path
+    rel_parts = [p for p in rel_dir.split(os.sep) if p and p != "."]
+    folder_parts = os.path.normpath(folder_path).split(os.sep)
+    if len(folder_parts) >= len(rel_parts) and folder_parts[-len(rel_parts):] == rel_parts:
+        base_parts = folder_parts[:-len(rel_parts)]
+        if not base_parts:
+            return os.sep
+        return os.sep.join(base_parts) or os.sep
+    return folder_path
+
+
+def verify_orphaned_staging(db, vireo_dir: str, cleanup_root: str) -> dict:
+    """Reconcile a staging folder against the catalog and archive filesystem."""
+    entry = _resolve_entry(vireo_dir, cleanup_root)
+    files: list[tuple[str, str, int]] = []
+    for root, _dirs, filenames in os.walk(entry.source_root):
+        for filename in sorted(filenames):
+            path = os.path.join(root, filename)
+            try:
+                st = os.stat(path)
+            except OSError:
+                continue
+            if not os.path.isfile(path):
+                continue
+            rel = os.path.relpath(path, entry.source_root)
+            files.append((path, rel, st.st_size))
+
+    result = {
+        "path": entry.cleanup_root,
+        "source_root": entry.source_root,
+        "name": os.path.basename(entry.cleanup_root),
+        "file_count": len(files),
+        "bytes": sum(size for _path, _rel, size in files),
+        "verified": 0,
+        "unaccounted": 0,
+        "unreachable": 0,
+        "details": [],
+        "can_delete": False,
+        "status": "unknown",
+        "inferred_destination": None,
+    }
+    inferred: dict[str, int] = {}
+
+    for staged_path, rel_path, size in files:
+        candidates = _catalog_candidates(
+            db, os.path.basename(staged_path), size, entry.cleanup_root,
+        )
+        detail = {
+            "path": staged_path,
+            "rel_path": rel_path,
+            "size": size,
+            "status": "unaccounted",
+            "reason": "no cataloged archive photo matches this filename and size",
+            "archive_path": None,
+        }
+        if not candidates:
+            result["unaccounted"] += 1
+            result["details"].append(detail)
+            continue
+
+        saw_unreachable = False
+        last_reason = None
+        for candidate in candidates:
+            archive_path = os.path.join(
+                candidate["folder_path"], candidate["filename"],
+            )
+            status, reason = _archive_file_status(archive_path, size)
+            if status == "verified":
+                detail.update({
+                    "status": "verified",
+                    "reason": None,
+                    "archive_path": archive_path,
+                })
+                result["verified"] += 1
+                dest = _infer_destination(
+                    entry.source_root, staged_path, candidate["folder_path"],
+                )
+                inferred[dest] = inferred.get(dest, 0) + 1
+                break
+            if status == "unreachable":
+                saw_unreachable = True
+            last_reason = reason
+        else:
+            if saw_unreachable:
+                detail["status"] = "unreachable"
+                detail["reason"] = last_reason or "archive location is unreachable"
+                result["unreachable"] += 1
+            else:
+                detail["status"] = "unaccounted"
+                detail["reason"] = last_reason or "archive copy was not verified"
+                result["unaccounted"] += 1
+        result["details"].append(detail)
+
+    if inferred:
+        result["inferred_destination"] = max(inferred.items(), key=lambda kv: kv[1])[0]
+    if result["unreachable"]:
+        result["status"] = "unreachable"
+    elif result["unaccounted"]:
+        result["status"] = "needs_import"
+    else:
+        result["status"] = "safe_to_delete"
+        result["can_delete"] = True
+    return result
+
+
+def delete_verified_staging(db, vireo_dir: str, cleanup_root: str) -> dict:
+    """Delete a staging folder only after a fresh all-files-verified pass."""
+    result = verify_orphaned_staging(db, vireo_dir, cleanup_root)
+    if not result["can_delete"]:
+        raise ValueError("staging folder is not fully verified in the archive")
+    shutil.rmtree(result["path"])
+    result["deleted"] = True
+    return result

--- a/vireo/staging_recovery.py
+++ b/vireo/staging_recovery.py
@@ -118,13 +118,16 @@ def _resolve_entry(vireo_dir: str, cleanup_root: str) -> StagingEntry:
 
 
 def _catalog_candidates(db, filename: str, size: int, staging_root: str) -> list[dict]:
+    ws_id = db._ws_id()
     rows = db.conn.execute(
         """SELECT p.id AS photo_id, p.filename, p.file_size, f.path AS folder_path
              FROM photos p
              JOIN folders f ON f.id = p.folder_id
+             JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+                                      AND wf.workspace_id = ?
             WHERE p.filename = ? AND p.file_size = ?
             ORDER BY f.path, p.id""",
-        (filename, int(size)),
+        (ws_id, filename, int(size)),
     ).fetchall()
     out = []
     for row in rows:

--- a/vireo/staging_recovery.py
+++ b/vireo/staging_recovery.py
@@ -172,6 +172,31 @@ def _archive_file_status(
     return "verified", None
 
 
+def _path_parts(path: str) -> list[str]:
+    normalized = os.path.normpath(path).replace("\\", "/")
+    return [part for part in normalized.split("/") if part and part != "."]
+
+
+def _expected_archive_suffix(entry: StagingEntry, staged_file: str) -> list[str]:
+    rel_dir = os.path.relpath(os.path.dirname(staged_file), entry.source_root)
+    parts: list[str] = []
+    if os.path.realpath(entry.source_root) != os.path.realpath(entry.cleanup_root):
+        parts.append(os.path.basename(entry.source_root))
+    if rel_dir not in ("", "."):
+        parts.extend(_path_parts(rel_dir))
+    return parts
+
+
+def _folder_matches_staged_path(folder_path: str, expected_suffix: list[str]) -> bool:
+    if not expected_suffix:
+        return True
+    folder_parts = _path_parts(folder_path)
+    return (
+        len(folder_parts) >= len(expected_suffix)
+        and folder_parts[-len(expected_suffix):] == expected_suffix
+    )
+
+
 def _infer_destination(source_root: str, staged_file: str, folder_path: str) -> str:
     rel_dir = os.path.relpath(os.path.dirname(staged_file), source_root)
     if rel_dir in ("", "."):
@@ -238,7 +263,12 @@ def verify_orphaned_staging(db, vireo_dir: str, cleanup_root: str) -> dict:
 
         saw_unreachable = False
         last_reason = None
+        expected_suffix = _expected_archive_suffix(entry, staged_path)
         for candidate in candidates:
+            if not _folder_matches_staged_path(
+                candidate["folder_path"], expected_suffix,
+            ):
+                continue
             archive_path = os.path.join(
                 candidate["folder_path"], candidate["filename"],
             )

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -41,12 +41,27 @@ body { display: flex; flex-direction: column; height: 100vh; }
 .result-links a { color: var(--accent); font-size: 12px; }
 #importError { color: var(--danger); font-size: 12px; margin-top: 6px; display: none; }
 .warn { font-size: 12px; color: var(--warning, #bf8700); margin-top: 6px; }
+.staging-items { display: flex; flex-direction: column; gap: 8px; margin-top: 8px; }
+.staging-item { border: 1px solid var(--border-primary); border-radius: 6px; padding: 10px; background: var(--bg-tertiary); }
+.staging-title { font-size: 12px; color: var(--text-primary); font-weight: 600; overflow-wrap: anywhere; }
+.staging-meta { font-size: 11px; color: var(--text-secondary); margin-top: 3px; }
+.staging-actions { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 8px; }
+.staging-details { margin: 8px 0 0 0; padding-left: 18px; font-size: 11px; color: var(--text-secondary); max-height: 120px; overflow: auto; }
 </style>
 </head>
 <body>
 {% include '_navbar.html' %}
 <div class="content">
   <div class="import-wrap">
+
+    <div class="card" id="orphanedStagingCard" style="display:none;">
+      <h3>Recover old staging folders</h3>
+      <div class="hint">
+        Vireo found local staging folders from the retired import-through-process flow.
+        Cleanup is only enabled after every staged file is verified in the archive.
+      </div>
+      <div class="staging-items" id="orphanedStagingItems"></div>
+    </div>
 
     <div class="card" id="sourceCard">
       <h3>Source</h3>
@@ -139,6 +154,7 @@ body { display: flex; flex-direction: column; height: 100vh; }
 let sources = [];
 let activeJobId = null;
 let es = null;
+let stagingResultsByPath = {};
 
 function renderSources() {
   const list = document.getElementById('sourceList');
@@ -188,6 +204,185 @@ function showError(msg) {
   const el = document.getElementById('importError');
   el.textContent = msg;
   el.style.display = msg ? 'block' : 'none';
+}
+
+function formatBytes(n) {
+  n = Number(n || 0);
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let i = 0;
+  while (n >= 1024 && i < units.length - 1) { n /= 1024; i += 1; }
+  return (i === 0 ? String(n) : n.toFixed(n >= 10 ? 1 : 2)) + ' ' + units[i];
+}
+
+async function pollJobResult(jobId) {
+  for (let i = 0; i < 180; i++) {
+    const resp = await fetch('/api/jobs/' + jobId);
+    if (resp.ok) {
+      const job = await resp.json();
+      if (job.status && job.status !== 'running' && job.status !== 'queued') {
+        if (job.status === 'failed') {
+          const msg = (job.errors && job.errors[0]) || 'job failed';
+          throw new Error(msg);
+        }
+        return job.result || {};
+      }
+    }
+    await new Promise(r => setTimeout(r, 1000));
+  }
+  throw new Error('job did not finish in time');
+}
+
+async function loadOrphanedStaging() {
+  try {
+    const resp = await fetch('/api/import/orphaned-staging');
+    if (!resp.ok) return;
+    const data = await resp.json();
+    renderOrphanedStaging(data.items || []);
+  } catch (e) {
+    // Recovery card is best-effort; import itself should remain usable.
+  }
+}
+
+function renderOrphanedStaging(items) {
+  const card = document.getElementById('orphanedStagingCard');
+  const box = document.getElementById('orphanedStagingItems');
+  box.innerHTML = '';
+  if (!items.length) {
+    card.style.display = 'none';
+    return;
+  }
+  card.style.display = '';
+  items.forEach((item) => {
+    const row = document.createElement('div');
+    row.className = 'staging-item';
+    row.dataset.path = item.path;
+
+    const title = document.createElement('div');
+    title.className = 'staging-title';
+    title.textContent = item.name + ' · ' + item.source_root;
+    const meta = document.createElement('div');
+    meta.className = 'staging-meta';
+    meta.textContent = item.file_count + ' files · ' + formatBytes(item.bytes);
+
+    const actions = document.createElement('div');
+    actions.className = 'staging-actions';
+    const verify = document.createElement('button');
+    verify.className = 'btn';
+    verify.textContent = 'Verify before cleanup';
+    verify.onclick = () => verifyStaging(item.path, verify);
+    actions.appendChild(verify);
+
+    row.append(title, meta, actions);
+    box.appendChild(row);
+  });
+}
+
+function appendStagingDetail(row, result) {
+  const old = row.querySelector('.staging-details');
+  if (old) old.remove();
+  const bad = (result.details || []).filter(d => d.status !== 'verified');
+  if (!bad.length) return;
+  const list = document.createElement('ul');
+  list.className = 'staging-details';
+  bad.slice(0, 20).forEach((d) => {
+    const li = document.createElement('li');
+    li.textContent = d.rel_path + ' — ' + d.reason;
+    list.appendChild(li);
+  });
+  if (bad.length > 20) {
+    const li = document.createElement('li');
+    li.textContent = (bad.length - 20) + ' more files not shown';
+    list.appendChild(li);
+  }
+  row.appendChild(list);
+}
+
+function renderStagingVerification(result) {
+  stagingResultsByPath[result.path] = result;
+  const row = Array.from(document.querySelectorAll('.staging-item'))
+    .find(el => el.dataset.path === result.path);
+  if (!row) return;
+  const meta = row.querySelector('.staging-meta');
+  const parts = [
+    result.file_count + ' files',
+    formatBytes(result.bytes),
+    result.verified + ' verified',
+  ];
+  if (result.unaccounted) parts.push(result.unaccounted + ' not in archive');
+  if (result.unreachable) parts.push(result.unreachable + ' unreachable');
+  if (result.inferred_destination) parts.push('archive: ' + result.inferred_destination);
+  meta.textContent = parts.join(' · ');
+
+  const actions = row.querySelector('.staging-actions');
+  actions.innerHTML = '';
+  if (result.can_delete) {
+    const del = document.createElement('button');
+    del.className = 'btn btn-primary';
+    del.textContent = 'Delete verified staging copy';
+    del.onclick = () => deleteStaging(result.path, del);
+    actions.appendChild(del);
+  } else {
+    const use = document.createElement('button');
+    use.className = 'btn';
+    use.textContent = 'Use as import source';
+    use.onclick = () => useStagingAsImportSource(result);
+    actions.appendChild(use);
+    const again = document.createElement('button');
+    again.className = 'btn';
+    again.textContent = 'Verify again';
+    again.onclick = () => verifyStaging(result.path, again);
+    actions.appendChild(again);
+  }
+  appendStagingDetail(row, result);
+}
+
+async function verifyStaging(path, btn) {
+  const oldText = btn.textContent;
+  btn.disabled = true;
+  btn.textContent = 'Verifying...';
+  try {
+    const resp = await fetch('/api/import/orphaned-staging/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path }),
+    });
+    const data = await resp.json();
+    if (!resp.ok) throw new Error(data.error || 'verification failed');
+    const result = await pollJobResult(data.job_id);
+    renderStagingVerification(result);
+  } catch (e) {
+    showError(String(e.message || e));
+    btn.disabled = false;
+    btn.textContent = oldText;
+  }
+}
+
+async function deleteStaging(path, btn) {
+  btn.disabled = true;
+  btn.textContent = 'Re-verifying...';
+  try {
+    const resp = await fetch('/api/import/orphaned-staging', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path }),
+    });
+    const data = await resp.json();
+    if (!resp.ok) throw new Error(data.error || 'cleanup failed');
+    await loadOrphanedStaging();
+  } catch (e) {
+    showError(String(e.message || e));
+    btn.disabled = false;
+    btn.textContent = 'Delete verified staging copy';
+  }
+}
+
+function useStagingAsImportSource(result) {
+  sources = [result.source_root];
+  renderSources();
+  if (result.inferred_destination) {
+    document.getElementById('destInput').value = result.inferred_destination;
+  }
+  document.getElementById('sourceCard').scrollIntoView({ behavior: 'smooth', block: 'start' });
 }
 
 async function previewImport() {
@@ -452,6 +647,7 @@ async function initImportPage() {
   // HTML placeholder rather than the workspace default, and startImport
   // should omit the key so the server applies pipeline.default_strategy.
   _afterImportConfigLoaded = cfgOk && overridesOk;
+  loadOrphanedStaging();
 }
 initImportPage();
 </script>

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -822,9 +822,14 @@ body { padding-bottom: 36px; }
       <!-- Divider -->
       <div style="border-top:1px solid var(--border-primary,#14374E);margin:16px 0;"></div>
 
-      <!-- Section 2: File Copying -->
-      <div class="setting-label">File Copying</div>
-      <div id="destCopySection" data-testid="file-copying-section">
+      <!-- Section 2: Import handoff -->
+      <div class="setting-label">Importing photos</div>
+      <div class="hint" style="font-size:12px;color:var(--text-secondary);line-height:1.4;">
+        Copying cards or folders into the archive now happens on the
+        <a href="/import" style="color:var(--accent);">Import</a> page.
+        Process only works on photos already in the active workspace.
+      </div>
+      <div id="destCopySection" data-testid="file-copying-section" style="display:none;">
         <div class="setting-row">
           <div class="setting-item">
             <label style="font-size:12px;color:var(--text-secondary);cursor:pointer;">
@@ -2919,14 +2924,6 @@ function updateStartButton() {
     if (_destWorkspaceMode === 'new') {
       var wsName = document.getElementById('destNewWsName').value.trim();
       if (!wsName) btn.disabled = true;
-    }
-    if (_sourceMode === 'import' && _copyMode) {
-      if (pipelineRemoteTargetId()) {
-        if (!remoteArchiveSelectionReady()) btn.disabled = true;
-      } else {
-        var dest = document.getElementById('cfgDestination').value.trim();
-        if (!dest) btn.disabled = true;
-      }
     }
   }
 
@@ -5268,17 +5265,6 @@ function _buildPlanBody() {
       if (hashDupPaths.length) body.hash_duplicate_paths = hashDupPaths;
     }
 
-    // The planner's "0 new photos to import, nothing to …" claim for an
-    // all-duplicates selection is only true in local-processing mode:
-    // the post-ingest scan then walks the local staging root (empty when
-    // everything deduplicated), while plain copy mode re-scans the real
-    // destination and can surface existing unprocessed rows as downstream
-    // work. Send the toggle state so the backend can tell the modes
-    // apart — mirrors how /api/jobs/pipeline carries local_processing.
-    if (_sourceMode === 'import' && _copyMode) {
-      var lp = document.getElementById('chkLocalProcessing');
-      body.local_processing = !!(lp && lp.checked);
-    }
   }
 
   body.skip_classify       = !document.getElementById('enableClassify').checked;

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -2227,6 +2227,7 @@ def _remote_pipeline_body(src, **overrides):
     return body
 
 
+@pytest.mark.skip(reason="retired pipeline import/archive destination path")
 def test_pipeline_remote_archive_rejects_both_destinations(
     app_and_db, tmp_path, monkeypatch,
 ):
@@ -2242,6 +2243,7 @@ def test_pipeline_remote_archive_rejects_both_destinations(
     assert "mutually exclusive" in resp.get_json()["error"]
 
 
+@pytest.mark.skip(reason="retired pipeline import/archive destination path")
 def test_pipeline_remote_archive_unknown_target_404(
     app_and_db, tmp_path, monkeypatch,
 ):
@@ -2257,6 +2259,7 @@ def test_pipeline_remote_archive_unknown_target_404(
     assert "not found" in resp.get_json()["error"].lower()
 
 
+@pytest.mark.skip(reason="retired pipeline import/archive destination path")
 def test_pipeline_remote_archive_requires_local_processing(
     app_and_db, tmp_path, monkeypatch,
 ):
@@ -2272,6 +2275,7 @@ def test_pipeline_remote_archive_requires_local_processing(
     assert "local_processing" in resp.get_json()["error"]
 
 
+@pytest.mark.skip(reason="retired pipeline import/archive destination path")
 def test_pipeline_remote_archive_requires_subpath(
     app_and_db, tmp_path, monkeypatch,
 ):
@@ -2291,6 +2295,7 @@ def test_pipeline_remote_archive_requires_subpath(
     assert "remote_subpath" in resp.get_json()["error"]
 
 
+@pytest.mark.skip(reason="retired pipeline import/archive destination path")
 def test_pipeline_remote_archive_rejects_traversal_subpath(
     app_and_db, tmp_path, monkeypatch,
 ):
@@ -2306,6 +2311,7 @@ def test_pipeline_remote_archive_rejects_traversal_subpath(
         assert resp.status_code == 400, bad
 
 
+@pytest.mark.skip(reason="retired pipeline import/archive destination path")
 def test_pipeline_remote_archive_requires_mount_path(
     app_and_db, tmp_path, monkeypatch,
 ):
@@ -2322,6 +2328,7 @@ def test_pipeline_remote_archive_requires_mount_path(
     assert "mount path" in resp.get_json()["error"]
 
 
+@pytest.mark.skip(reason="retired pipeline import/archive destination path")
 def test_pipeline_remote_archive_requires_gnu_rsync(
     app_and_db, tmp_path, monkeypatch,
 ):
@@ -2339,6 +2346,7 @@ def test_pipeline_remote_archive_requires_gnu_rsync(
     assert "rsync" in resp.get_json()["error"].lower()
 
 
+@pytest.mark.skip(reason="retired pipeline import/archive destination path")
 def test_pipeline_local_processing_requires_destination_or_remote(
     app_and_db, tmp_path,
 ):
@@ -2358,6 +2366,7 @@ def test_pipeline_local_processing_requires_destination_or_remote(
     assert "destination" in err and "remote target" in err
 
 
+@pytest.mark.skip(reason="retired pipeline import/archive destination path")
 def test_pipeline_remote_archive_snapshots_target_at_enqueue(
     app_and_db, tmp_path, monkeypatch,
 ):
@@ -2805,24 +2814,24 @@ _ABS_DEST = os.path.abspath("/abs/dest")
         # be written. Both a relative and an absolute path trip this.
         (
             {"destination": "relative/path", "local_processing": False},
-            "destination is not allowed with collection_id or folder_ids",
+            "import/archive fields are no longer accepted",
         ),
         (
             {"destination": _ABS_DEST, "local_processing": False},
-            "destination is not allowed with collection_id or folder_ids",
+            "import/archive fields are no longer accepted",
         ),
         # local_processing + destination + folder scope: same reject —
         # destination check runs before the local_processing scope check.
         (
             {"local_processing": True, "destination": _ABS_DEST},
-            "destination is not allowed with collection_id or folder_ids",
+            "import/archive fields are no longer accepted",
         ),
         # local_processing + folder scope without destination: this
         # trips the "requires a destination or a remote target" guard
         # (which fires before the local_processing + scope check).
         (
             {"local_processing": True},
-            "local_processing requires a destination or a remote target",
+            "import/archive fields are no longer accepted",
         ),
         # Non-boolean miss_enabled — the type-check must fire BEFORE
         # ``db.add_collection`` runs. Previously the check sat after
@@ -2872,8 +2881,7 @@ def test_pipeline_folder_ids_rejects_plain_destination(app_and_db):
             "local_processing": False,
         })
         assert resp.status_code == 400, resp.get_json()
-        assert "destination" in resp.get_json()["error"]
-        assert "folder_ids" in resp.get_json()["error"]
+        assert "import/archive fields" in resp.get_json()["error"]
     assert len(db.get_collections()) == before
 
 
@@ -2891,8 +2899,7 @@ def test_pipeline_collection_id_rejects_plain_destination(app_and_db):
             "local_processing": False,
         })
         assert resp.status_code == 400, resp.get_json()
-        assert "destination" in resp.get_json()["error"]
-        assert "collection_id" in resp.get_json()["error"]
+        assert "import/archive fields" in resp.get_json()["error"]
 
 
 def test_pipeline_folder_ids_chunks_wide_subtree(app_and_db, monkeypatch):

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -503,6 +503,7 @@ def test_pipeline_job_rejects_macos_other_app_bundle(app_and_db, tmp_path):
         assert "macos" in resp.get_json()["error"].lower()
 
 
+@pytest.mark.skip(reason="retired pipeline import/archive destination path")
 def test_pipeline_job_rejects_relative_destination(app_and_db, tmp_path):
     """Pipeline endpoint should reject relative destination paths."""
     app, _ = app_and_db
@@ -941,6 +942,7 @@ def test_job_export_invalid_max_size(app_and_db, tmp_path):
     assert "max_size must be a positive integer" in resp.get_json()["error"]
 
 
+@pytest.mark.skip(reason="retired pipeline import/archive destination path")
 def test_pipeline_ingest_saves_recent_destination(app_and_db, tmp_path, monkeypatch):
     """Starting a pipeline with a destination saves it to recent_destinations in config."""
     import config as cfg
@@ -966,6 +968,7 @@ def test_pipeline_ingest_saves_recent_destination(app_and_db, tmp_path, monkeypa
     assert config["ingest"]["recent_destinations"] == [str(dst)]
 
 
+@pytest.mark.skip(reason="retired pipeline import/archive destination path")
 def test_recent_destinations_deduplicates_and_limits(app_and_db, tmp_path, monkeypatch):
     """Recent destinations deduplicates and limits to 5 entries."""
     import config as cfg

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -181,6 +181,7 @@ def test_import_full_rejects_relative_destination(setup):
         shutil.rmtree(src, ignore_errors=True)
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import/archive path")
 def test_pipeline_local_processing_requires_destination(setup):
     app, db_path = setup
     src = tempfile.mkdtemp()
@@ -199,6 +200,7 @@ def test_pipeline_local_processing_requires_destination(setup):
         shutil.rmtree(src, ignore_errors=True)
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import/archive path")
 def test_pipeline_local_processing_rejects_filesystem_root_destination(
     setup, tmp_path
 ):
@@ -219,6 +221,7 @@ def test_pipeline_local_processing_rejects_filesystem_root_destination(
         assert "filesystem root" in resp.get_json()["error"].lower()
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import/archive path")
 def test_pipeline_local_processing_rejects_collection_id(setup, tmp_path):
     # Collection pipelines set skip_scan and never run ingest, so the
     # staging folder is never created/indexed. Without this rejection
@@ -244,6 +247,7 @@ def test_pipeline_local_processing_rejects_collection_id(setup, tmp_path):
         assert "destination is not allowed with collection_id" in err
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import/archive path")
 def test_pipeline_local_processing_rejects_collection_id_with_stale_sources(
     setup, tmp_path,
 ):
@@ -273,6 +277,7 @@ def test_pipeline_local_processing_rejects_collection_id_with_stale_sources(
         assert "destination is not allowed with collection_id" in err
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import/archive path")
 def test_pipeline_local_processing_archives_to_final_destination(
     setup, tmp_path, monkeypatch
 ):
@@ -309,6 +314,7 @@ def test_pipeline_local_processing_archives_to_final_destination(
     assert job["result"]["archive"]["final_destination"] == str(final_dest)
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import/archive path")
 def test_pipeline_local_processing_all_duplicates_is_clean_noop(
     setup, tmp_path, monkeypatch
 ):
@@ -375,6 +381,7 @@ def test_pipeline_local_processing_all_duplicates_is_clean_noop(
     assert n == 1
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import/archive path")
 def test_pipeline_local_processing_merges_into_tracked_destination(
     setup, tmp_path, monkeypatch
 ):
@@ -475,6 +482,7 @@ def test_pipeline_local_processing_merges_into_tracked_destination(
         db.close()
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import/archive path")
 def test_pipeline_local_processing_merges_into_subfolder_of_tracked_root(
     setup, tmp_path, monkeypatch
 ):
@@ -562,6 +570,7 @@ def test_pipeline_local_processing_merges_into_subfolder_of_tracked_root(
         db.close()
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import/archive path")
 def test_pipeline_refuses_destination_that_wraps_tracked_subfolder(
     setup, tmp_path, monkeypatch,
 ):
@@ -660,6 +669,7 @@ def test_pipeline_refuses_destination_that_wraps_tracked_subfolder(
     assert landed == [], landed
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import/archive path")
 def test_pipeline_merges_new_shoot_into_existing_archive(
     setup, tmp_path, monkeypatch
 ):
@@ -791,6 +801,7 @@ def test_pipeline_merges_new_shoot_into_existing_archive(
         db.close()
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import/archive path")
 def test_pipeline_local_processing_creates_missing_archive_parent(
     setup, tmp_path, monkeypatch
 ):
@@ -832,6 +843,7 @@ def test_pipeline_local_processing_creates_missing_archive_parent(
     assert nonexistent_parent.is_dir()
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import/archive path")
 def test_pipeline_local_processing_detects_missing_archive_mount_root(monkeypatch):
     """Unmounted NAS paths like /Volumes/NAS/Shoot must not be created as
     local stub directories during archive-parent preflight."""
@@ -853,6 +865,7 @@ def test_pipeline_local_processing_detects_missing_archive_mount_root(monkeypatc
     assert pipeline_job._missing_archive_mount_root("/Volumes/NAS") == "/Volumes/NAS"
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import/archive path")
 def test_pipeline_local_processing_rejects_missing_archive_mount_root(
     setup, tmp_path, monkeypatch
 ):
@@ -897,6 +910,7 @@ def test_pipeline_local_processing_rejects_missing_archive_mount_root(
     assert not final_dest.exists()
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import/archive path")
 def test_pipeline_local_processing_skips_archive_when_previews_fail(
     setup, tmp_path, monkeypatch
 ):
@@ -1021,6 +1035,7 @@ def test_pipeline_local_processing_skips_archive_when_previews_fail(
     check_db.close()
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import/archive path")
 def test_pipeline_local_processing_retry_after_skip_actually_copies(
     setup, tmp_path, monkeypatch
 ):
@@ -1091,6 +1106,7 @@ def test_pipeline_local_processing_retry_after_skip_actually_copies(
     )
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import/archive path")
 def test_pipeline_local_processing_fails_ingest_when_files_fail_to_copy(
     setup, tmp_path, monkeypatch
 ):
@@ -1158,6 +1174,7 @@ def test_pipeline_local_processing_fails_ingest_when_files_fail_to_copy(
     assert (staging_root / "good.jpg").is_file()
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import/archive path")
 def test_pipeline_local_processing_ingest_failure_short_circuits_pipeline(
     setup, tmp_path, monkeypatch
 ):
@@ -1242,6 +1259,7 @@ def test_pipeline_local_processing_ingest_failure_short_circuits_pipeline(
     assert (staging_root / "good.jpg").is_file()
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import/archive path")
 def test_pipeline_local_processing_completes_when_cancel_during_archive(
     setup, tmp_path, monkeypatch
 ):
@@ -1312,6 +1330,7 @@ def test_pipeline_local_processing_completes_when_cancel_during_archive(
     assert job["result"]["archive"]["final_destination"] == str(final_dest)
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import/archive path")
 def test_pipeline_local_processing_cancels_before_archive_commit(
     setup, tmp_path, monkeypatch
 ):
@@ -1372,6 +1391,7 @@ def test_pipeline_local_processing_cancels_before_archive_commit(
     assert folder_row is None
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import/archive path")
 def test_pipeline_local_processing_failed_archive_reports_failed_even_after_cancel(
     setup, tmp_path, monkeypatch
 ):
@@ -1451,6 +1471,7 @@ def test_pipeline_local_processing_failed_archive_reports_failed_even_after_canc
     assert job["status"] == "failed", job
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import/archive path")
 def test_pipeline_local_processing_post_commit_cleanup_error_reports_completed(
     setup, tmp_path, monkeypatch
 ):
@@ -1527,6 +1548,7 @@ def test_pipeline_local_processing_post_commit_cleanup_error_reports_completed(
     assert job["result"]["errors"] == []
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import/archive path")
 def test_pipeline_local_processing_deindexes_staging_on_cancel_after_scan(
     setup, tmp_path, monkeypatch
 ):
@@ -1638,6 +1660,7 @@ def test_pipeline_local_processing_deindexes_staging_on_cancel_after_scan(
     check_db.close()
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import/archive path")
 def test_pipeline_local_processing_preflight_filters_duplicates(
     setup, tmp_path, monkeypatch
 ):
@@ -1725,6 +1748,7 @@ def test_pipeline_local_processing_preflight_filters_duplicates(
     assert plan["source_bytes"] <= fresh_bytes, plan
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import/archive path")
 def test_pipeline_local_processing_plans_archive_credit_after_duplicate_filter(
     setup, tmp_path, monkeypatch
 ):
@@ -1809,6 +1833,7 @@ def test_pipeline_local_processing_plans_archive_credit_after_duplicate_filter(
     assert storage_calls[0]["archive_existing_bytes"] == 0
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import/archive path")
 def test_pipeline_local_processing_preflight_probes_existing_final_destination(
     setup, tmp_path, monkeypatch
 ):
@@ -1855,6 +1880,7 @@ def test_pipeline_local_processing_preflight_probes_existing_final_destination(
     assert set(archive_paths) == {str(final_dest)}
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import/archive path")
 def test_pipeline_local_processing_rejects_existing_file_archive_destination(
     setup, tmp_path, monkeypatch
 ):
@@ -1890,6 +1916,7 @@ def test_pipeline_local_processing_rejects_existing_file_archive_destination(
     assert "not a directory" in error_text
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import/archive path")
 def test_pipeline_local_processing_rejects_broken_symlink_archive_destination(
     setup, tmp_path, monkeypatch
 ):
@@ -1941,6 +1968,7 @@ def test_pipeline_local_processing_rejects_broken_symlink_archive_destination(
     assert "not a directory" in error_text
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import/archive path")
 def test_pipeline_local_processing_rejects_archive_path_conflicts(
     setup, tmp_path, monkeypatch
 ):
@@ -1980,6 +2008,7 @@ def test_pipeline_local_processing_rejects_archive_path_conflicts(
     assert "different files at the same import paths" in error_text
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import/archive path")
 def test_pipeline_local_processing_reports_incomplete_archive_files(
     setup, tmp_path, monkeypatch
 ):
@@ -2020,6 +2049,7 @@ def test_pipeline_local_processing_reports_incomplete_archive_files(
     assert "will not suffix around likely corrupt archive files" in error_text
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import/archive path")
 def test_pipeline_local_processing_recognises_indexed_archive_via_alias(
     setup, tmp_path, monkeypatch
 ):
@@ -2087,6 +2117,7 @@ def test_pipeline_local_processing_recognises_indexed_archive_via_alias(
     assert "different files at the same import paths" in error_text
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import/archive path")
 def test_pipeline_local_processing_limits_incomplete_examples_to_incomplete(
     setup, tmp_path, monkeypatch
 ):
@@ -2140,6 +2171,7 @@ def test_pipeline_local_processing_limits_incomplete_examples_to_incomplete(
     assert "conflict.jpg" not in error_text
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import/archive path")
 def test_pipeline_local_processing_conflict_preflight_skips_known_duplicates(
     setup, tmp_path, monkeypatch
 ):
@@ -2204,6 +2236,7 @@ def test_pipeline_local_processing_conflict_preflight_skips_known_duplicates(
     assert job["status"] == "completed", job
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import/archive path")
 def test_pipeline_local_processing_credits_existing_archive_for_resume(
     setup, tmp_path, monkeypatch
 ):
@@ -2256,6 +2289,7 @@ def test_pipeline_local_processing_credits_existing_archive_for_resume(
     assert job["status"] == "completed", job
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import/archive path")
 def test_pipeline_local_processing_does_not_credit_unrelated_archive_content(
     setup, tmp_path, monkeypatch
 ):

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -6,6 +6,8 @@ import os
 import sys
 import threading
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from pipeline_job import (
@@ -303,6 +305,7 @@ def test_pipeline_cancel_via_runner_skips_remaining_stages(tmp_path, monkeypatch
     # cancellation.
 
 
+@pytest.mark.skip(reason="retired pipeline import/archive destination path")
 def test_pipeline_abort_on_nonexistent_source(tmp_path, monkeypatch):
     """Pipeline with nonexistent source should complete gracefully.
 
@@ -1206,6 +1209,7 @@ def test_pipeline_multi_folder_scan_progress_is_monotonic(tmp_path, monkeypatch)
     )
 
 
+@pytest.mark.skip(reason="retired pipeline import/archive destination path")
 def test_pipeline_multi_source_ingest_progress_is_monotonic(tmp_path, monkeypatch):
     """Ingest progress must not move backward at source folder boundaries.
 
@@ -1354,6 +1358,7 @@ def test_emit_progress_lock_held_during_push():
     )
 
 
+@pytest.mark.skip(reason="retired pipeline import/archive destination path")
 def test_pipeline_ingest_updates_step_progress(tmp_path, monkeypatch):
     """Ingest (import) phase should call update_step so the jobs page shows progress."""
     import config as cfg
@@ -1457,6 +1462,7 @@ def test_pipeline_scan_step_gets_status_updates(tmp_path, monkeypatch):
         "Status updates should also push SSE progress events"
 
 
+@pytest.mark.skip(reason="retired pipeline import/archive destination path")
 def test_pipeline_ingest_records_safe_to_eject_counts_on_success(tmp_path, monkeypatch):
     """Once ingest copies everything off the source with no failures, the
     stage (and final result) should carry 'copied'/'skipped_duplicate' counts
@@ -1507,6 +1513,7 @@ def test_pipeline_ingest_records_safe_to_eject_counts_on_success(tmp_path, monke
     assert ingest_completed_events[-1]["copied"] == 2
 
 
+@pytest.mark.skip(reason="retired pipeline import/archive destination path")
 def test_pipeline_ingest_omits_safe_to_eject_counts_on_partial_failure(tmp_path, monkeypatch):
     """Plain copy mode (no local_processing) doesn't abort the run when a file
     fails to copy — it still marks the ingest stage 'completed'. The
@@ -1566,6 +1573,7 @@ def test_pipeline_ingest_omits_safe_to_eject_counts_on_partial_failure(tmp_path,
     assert "copied" not in ingest_completed_events[-1]
 
 
+@pytest.mark.skip(reason="retired pipeline import/archive destination path")
 def test_pipeline_ingest_step_present_only_with_destination(tmp_path, monkeypatch):
     """The 'ingest' step should only appear in step_defs when destination is set."""
     import config as cfg
@@ -1616,6 +1624,7 @@ def test_pipeline_ingest_step_present_only_with_destination(tmp_path, monkeypatc
         "ingest step should come before scan"
 
 
+@pytest.mark.skip(reason="retired pipeline import/archive destination path")
 def test_pipeline_all_duplicates_restricts_scan_to_existing_folders(tmp_path, monkeypatch):
     """When every source file is a duplicate of an existing photo in the DB,
     the scan phase must be restricted to just the folders that hold those
@@ -1716,6 +1725,7 @@ def test_pipeline_all_duplicates_restricts_scan_to_existing_folders(tmp_path, mo
     )
 
 
+@pytest.mark.skip(reason="retired pipeline import/archive destination path")
 def test_pipeline_all_duplicates_links_existing_folders_to_workspace(tmp_path, monkeypatch):
     """When every source file is a duplicate, the folders holding those
     existing duplicates should end up linked to the active workspace after
@@ -1779,6 +1789,7 @@ def test_pipeline_all_duplicates_links_existing_folders_to_workspace(tmp_path, m
     )
 
 
+@pytest.mark.skip(reason="retired pipeline import/archive destination path")
 def test_pipeline_copy_mode_scans_subfolders(tmp_path, monkeypatch):
     """After ingest, scan should use restrict_dirs to target only subfolders
     that received files, while keeping the destination as root for folder hierarchy."""
@@ -1893,6 +1904,7 @@ def test_pipeline_progress_events_carry_stage_id(tmp_path, monkeypatch):
         f"Expected thumbnails stage_id in events; saw: {stage_ids_seen}"
 
 
+@pytest.mark.skip(reason="retired pipeline import/archive destination path")
 def test_pipeline_scan_not_running_during_ingest(tmp_path, monkeypatch):
     """In copy mode, stages.scan should stay 'pending' while ingest runs,
     so the Scan card doesn't pulse during the import sub-phase."""

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -163,6 +163,52 @@ def test_pipeline_params_model_ids_defaults_none():
     assert params.model_ids is None
 
 
+def test_run_pipeline_job_rejects_retired_import_archive_params(tmp_path):
+    import pytest
+
+    cases = [
+        PipelineParams(destination=str(tmp_path / "archive")),
+        PipelineParams(local_processing=True),
+        PipelineParams(remote_target_id="nas1"),
+    ]
+
+    for params in cases:
+        with pytest.raises(RuntimeError, match="Pipeline import/archive mode"):
+            run_pipeline_job(
+                _make_job(), FakeRunner(), str(tmp_path / "test.db"), 1, params
+            )
+
+
+def test_archive_stage_rejects_retired_import_archive_params_late(
+    tmp_path, monkeypatch
+):
+    import pipeline_job
+    import pytest
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    col_id = db.add_collection("Empty", "[]")
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_classify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    @contextlib.contextmanager
+    def mutate_after_regroup(_workspace_id):
+        yield
+        params.destination = str(tmp_path / "archive")
+
+    monkeypatch.setattr(pipeline_job, "acquire_workspace_regroup", mutate_after_regroup)
+
+    with pytest.raises(RuntimeError, match="Pipeline import/archive mode"):
+        run_pipeline_job(_make_job(), FakeRunner(), db_path, ws_id, params)
+
+
 def test_pipeline_job_with_collection_skips_scan(tmp_path, monkeypatch):
     """When collection_id is provided, pipeline should skip scan entirely."""
     import config as cfg

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -10224,6 +10224,7 @@ def _remote_params(env, **overrides):
     return PipelineParams(**kwargs)
 
 
+@pytest.mark.skip(reason="retired pipeline remote archive stage")
 def test_pipeline_remote_archive_end_to_end(tmp_path, monkeypatch):
     """A local-processing run with a remote target stages locally, then
     archives over SSH: rsync is pointed at the NAS-side subpath with
@@ -10279,6 +10280,7 @@ def test_pipeline_remote_archive_end_to_end(tmp_path, monkeypatch):
     assert result["local_processing"]["remote"]["free_space_checked"] is True
 
 
+@pytest.mark.skip(reason="retired pipeline remote archive stage")
 def test_pipeline_remote_archive_preflight_refuses_without_rsync(
     tmp_path, monkeypatch,
 ):
@@ -10304,6 +10306,7 @@ def test_pipeline_remote_archive_preflight_refuses_without_rsync(
     assert env["captured"]["rsync_calls"] == []
 
 
+@pytest.mark.skip(reason="retired pipeline remote archive stage")
 def test_pipeline_remote_archive_preflight_refuses_when_connection_fails(
     tmp_path, monkeypatch,
 ):
@@ -10327,6 +10330,7 @@ def test_pipeline_remote_archive_preflight_refuses_when_connection_fails(
     assert not (tmp_path / "staging").exists()
 
 
+@pytest.mark.skip(reason="retired pipeline remote archive stage")
 def test_pipeline_remote_archive_space_probe_failure_degrades(
     tmp_path, monkeypatch,
 ):
@@ -10353,6 +10357,7 @@ def test_pipeline_remote_archive_space_probe_failure_degrades(
     assert "free-space check skipped" in storage_summaries[-1]
 
 
+@pytest.mark.skip(reason="retired pipeline remote archive stage")
 def test_pipeline_remote_archive_refuses_when_remote_volume_full(
     tmp_path, monkeypatch,
 ):
@@ -10374,6 +10379,7 @@ def test_pipeline_remote_archive_refuses_when_remote_volume_full(
     assert env["captured"]["rsync_calls"] == []
 
 
+@pytest.mark.skip(reason="retired pipeline remote archive stage")
 def test_pipeline_remote_archive_merges_on_retry(tmp_path, monkeypatch):
     """An existing remote destination (an earlier interrupted archive) makes
     the archive move a merge/resume: --ignore-existing so already-present
@@ -10393,6 +10399,7 @@ def test_pipeline_remote_archive_merges_on_retry(tmp_path, monkeypatch):
     assert "--partial-dir=.rsync-partial" in call["extra_args"]
 
 
+@pytest.mark.skip(reason="retired pipeline remote archive stage")
 def test_pipeline_remote_archive_failure_deindexes_staging(
     tmp_path, monkeypatch,
 ):
@@ -10430,6 +10437,7 @@ def test_pipeline_remote_archive_failure_deindexes_staging(
     assert count == 0
 
 
+@pytest.mark.skip(reason="retired pipeline remote archive stage")
 def test_pipeline_remote_archive_snapshot_wins_over_mutated_settings(
     tmp_path, monkeypatch,
 ):
@@ -10479,6 +10487,7 @@ def test_pipeline_remote_archive_snapshot_wins_over_mutated_settings(
     assert result["archive"]["remote"]["target_name"] == "NAS"
 
 
+@pytest.mark.skip(reason="retired pipeline remote archive stage")
 def test_pipeline_remote_archive_falls_back_to_settings_without_snapshot(
     tmp_path, monkeypatch,
 ):

--- a/vireo/tests/test_pipeline_plan.py
+++ b/vireo/tests/test_pipeline_plan.py
@@ -9,6 +9,8 @@ work — independent of whether *any* prior output exists in the workspace.
 import os
 import sys
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 
@@ -2444,6 +2446,7 @@ def test_import_plan_deduplicates_source_paths(tmp_path, monkeypatch):
     assert plan_mixed["stages"]["Scan"]["detail"]["already_known"] == 1
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import planner mode")
 def test_import_plan_all_duplicates_reports_zero_new_photos(
     tmp_path, monkeypatch
 ):
@@ -2538,6 +2541,7 @@ def test_import_plan_all_duplicates_copy_mode_keeps_forward_summaries(
     assert "upstream stages have new work" in group["summary"], group
 
 
+@pytest.mark.skip(reason="retired pipeline local-processing import planner mode")
 def test_import_plan_with_new_files_keeps_forward_looking_summaries(
     tmp_path, monkeypatch
 ):
@@ -2735,34 +2739,15 @@ def test_api_pipeline_plan_rejects_non_string_source_paths_elements(app_and_db):
     assert resp.status_code == 400
 
 
-def test_api_pipeline_plan_parses_local_processing(app_and_db):
-    """The route must thread local_processing through to the planner: an
-    all-duplicates import only gets the "0 new photos to import" wording
-    when the flag is true (staging-root scan), never in plain copy mode
-    (destination re-scan can surface real downstream work)."""
+def test_api_pipeline_plan_rejects_retired_import_fields(app_and_db):
     app, _ = app_and_db
     client = app.test_client()
-    body = {
-        "source_paths": ["/cards/SD/IMG_001.NEF", "/cards/SD/IMG_002.NEF"],
-        "hash_duplicate_paths": [
-            "/cards/SD/IMG_001.NEF", "/cards/SD/IMG_002.NEF",
-        ],
-        "skip_classify": True, "skip_extract_masks": True,
-        "skip_eye_keypoints": True, "skip_regroup": True,
-    }
     resp = client.post(
-        "/api/pipeline/plan", json={**body, "local_processing": True},
+        "/api/pipeline/plan",
+        json={"source_paths": [], "local_processing": True},
     )
-    assert resp.status_code == 200
-    previews = resp.get_json()["stages"]["Previews"]
-    assert previews["detail"]["import_no_new"] is True
-    assert "0 new photos to import" in previews["summary"]
-
-    resp = client.post("/api/pipeline/plan", json=body)  # copy mode
-    assert resp.status_code == 200
-    previews = resp.get_json()["stages"]["Previews"]
-    assert not previews["detail"].get("import_no_new")
-    assert "0 new photos to import" not in previews["summary"]
+    assert resp.status_code == 400
+    assert "import/archive fields" in resp.get_json()["error"]
 
 
 def test_import_plan_empty_source_paths_is_no_op(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- Retire the old `/api/jobs/pipeline` import/archive request shape and guard direct pipeline-job callers from starting the removed staging/archive mode.
- Remove the dangerous `_deindex_staging` archive cleanup path from `pipeline_job.py`.
- Add verified recovery for old `staging/pipeline-*` folders on the Import page: list orphaned staging roots, verify staged files against reachable cataloged archive copies, delete only after a fresh all-green verification, or reuse the staging folder as an import source.
- Update Process page copy/import messaging and mark obsolete pipeline local-processing/remote-archive tests as retired behavior.

## Why

The import/process split moved active photo imports to `/api/jobs/import-photos`, but the old process-pipeline import/archive path still existed behind the API and contained cleanup logic that could deindex staged files before proving the archive had every copy. This PR removes that path from active use and replaces blind staging cleanup with a verifier that distinguishes verified archive copies, missing files, and unreachable archive folders.

## Validation

- `git diff --check`
- `python -m py_compile vireo/staging_recovery.py vireo/app.py vireo/pipeline_job.py vireo/pipeline_plan.py`
- `pytest -q tests/test_staging_recovery.py tests/test_workspaces.py tests/test_headless_integration.py`
- `pytest -q vireo/tests/test_pipeline_plan.py vireo/tests/test_pipeline_job.py vireo/tests/test_pipeline_api.py vireo/tests/test_jobs_api.py -k "retired_import_fields or local_processing or remote_archive or rejects_plain_destination or rejects_destination_with_snapshot or folder_ids_leaves_no_stray_collection or collection_id_rejects_plain_destination or PipelineParams"`
- `pytest -q vireo/tests/test_app.py -k "import_page or process_page"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a recovery workflow for orphaned staging folders, including listing, verification, and safe cleanup.
  * The import page now surfaces recoverable staging folders and lets users verify, reuse, or delete them.

* **Bug Fixes**
  * Legacy import/archive request paths are now rejected with clear errors.
  * Pipeline and import planning now block retired staging and archive behaviors, preventing invalid actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->