### PR TITLE
Life List Explorer: taxonomic completeness explorer (orders → families → genera → species)

### DIFF
--- a/docs/plans/2026-07-07-life-list-explorer-design.md
+++ b/docs/plans/2026-07-07-life-list-explorer-design.md
@@ -1,0 +1,120 @@
+# Life List Explorer — taxonomic completeness explorer
+
+**Date:** 2026-07-07
+**Status:** Design approved, ready for implementation plan
+
+## Goal
+
+Let the user visually explore how complete their life list is at every
+taxonomic level. For a chosen class (birds by default), show how many
+**orders / families / genera / species** exist in total and how many they
+have **found** (photographed and tagged), with drill-down from orders all the
+way to a found+missing species checklist. It should look really nice.
+
+## Key finding that shapes everything
+
+Vireo's `taxa` table already holds the **complete iNaturalist reference
+taxonomy** (Animalia/Plantae/Fungi, hundreds of thousands of taxa), fully
+linked parent→child via `parent_id` from species up to kingdom
+(`vireo/db.py:495`, `vireo/taxonomy.py:441`). So the **denominator** ("how many
+bird orders/families/etc. exist") is a local query — no external checklist to
+source or ship. The local taxonomy *is* the world checklist.
+
+- **Denominator** = reference taxa at each rank under the chosen root class.
+- **Numerator** = tagged species (`keywords.taxon_id`) walked up their
+  `parent_id` chains, deduped per rank.
+
+Two real dependencies the UI must handle honestly (No-black-boxes rule):
+- The user must have run the **download-taxonomy** job, or there is no
+  denominator.
+- Tagged species with `taxon_id IS NULL` cannot be placed in the tree and must
+  not silently undercount.
+
+## Decisions (all approved)
+
+1. **Scope:** any class, **Birds (Aves) as default**; a class selector lets the
+   user switch to Mammalia, Insecta, etc. (only classes they have tagged
+   species in).
+2. **Visual paradigm:** drill-down **cards with progress rings** as the
+   backbone; a **sunburst** showpiece on top. Cards are the source of truth for
+   exact "X of N"; sunburst is the wow-factor / whole-shape overview.
+3. **Leaf experience:** species leaf shows **found + missing** — found lit with
+   a thumbnail, missing dimmed with a "not yet" state (gap-finder).
+4. **Honesty states surfaced explicitly:** taxonomy-not-downloaded CTA; and an
+   unmatched-species footnote/list for tagged species with no `taxon_id`.
+5. **Placement:** a **tab on `/life-list`** — "List" (today's view) and
+   "Explorer" (new). Tab state in the URL (`?view=explorer`).
+6. **Data scope:** **match whatever the existing life list uses**
+   (`_build_life_list_payload()` / `get_life_list_candidates()`), so Explorer
+   and List always agree on the same numerator/denominator. Confirm exact scope
+   (workspace vs global) during planning.
+
+## Backend
+
+New endpoint: `GET /api/life-list/explorer?root=<taxon_id|Aves>` returning the
+completeness tree for one class.
+
+Computation (all from the local `taxa` tree + the user's tags):
+1. **Denominator** — count reference taxa at each rank among the root class's
+   descendants; precompute each node's descendant-species set so any node knows
+   its total.
+2. **Numerator** — tagged species (`keywords.is_species=1 AND taxon_id NOT
+   NULL`, scoped to match the existing life list); walk each up `parent_id`,
+   marking every ancestor found and tallying found-species-per-node.
+3. **Per node** payload: `name`, `common_name`, `rank`, `found_count`,
+   `total_count`, `pct`, children.
+
+Payload shape:
+- One call returns the class tree down to **genus** with counts (orders →
+  families → genera is a few thousand nodes for birds — fine in one response).
+- **Species leaves load per-genus** on drill-in via `?parent=<genus_id>` to keep
+  responses light; leaves return **found + missing**, found ones with a
+  best-photo thumbnail id.
+
+Honesty fields in the payload:
+- `taxonomy_ready: false` when no reference taxa exist under the root → UI shows
+  download-taxonomy CTA.
+- `unmatched_species` — count + list of tagged species with `taxon_id IS NULL`.
+
+DB: add methods in `db.py` (e.g. `get_taxon_completeness(root, ...)`) using a
+recursive CTE over `parent_id`. Tests in `vireo/tests/`.
+
+## Frontend
+
+`/life-list` gains two tabs — **List** (today's view, untouched) and
+**Explorer**. Tab state in URL (`?view=explorer`), linkable/refresh-safe.
+
+Explorer layout, top → bottom:
+1. **Class selector** — defaults to Birds (Aves); lists classes the user has
+   tagged species in. Switching re-roots everything.
+2. **Sunburst showpiece** — inner ring orders → families → genera → outer
+   species; arcs shaded by % found (filled = found, ghosted = missing), sized by
+   species count. Hover tooltip "X/N · %"; click a wedge zooms and drives the
+   drill-down below. Lightweight inline SVG/canvas, no heavy library (matches
+   Vireo's vanilla-JS / inline-style convention).
+3. **Breadcrumb** — Birds › Passeriformes › Passerellidae, each crumb clickable.
+4. **Card grid** — cards for the current level (orders, then families, then
+   genera), each with a **progress ring** + "38/71 families · 54%". Click drills
+   down.
+5. **Species leaf** — found+missing checklist; found with thumbnail, missing
+   dimmed with a "not yet" tag.
+
+States (No-black-boxes):
+- Taxonomy not downloaded → full-panel CTA with the existing download-taxonomy
+  job button.
+- Unmatched-species footnote with click-through list.
+- Empty class → honest "No tagged species in this class yet."
+
+## Rollout (each stage independently shippable)
+
+1. Backend endpoint + DB method + tests.
+2. Tab + card-grid drill-down + species leaf + honesty states (the fully-usable
+   core).
+3. Sunburst showpiece as a second pass on top.
+
+## Tests
+
+- DB completeness math: found/total/pct, ancestor rollup, dedup across multiple
+  species sharing an ancestor.
+- Endpoint states: ready / not-ready / unmatched-species present.
+- Scope matches the existing life list.

--- a/docs/plans/2026-07-07-life-list-explorer-plan.md
+++ b/docs/plans/2026-07-07-life-list-explorer-plan.md
@@ -1,0 +1,767 @@
+# Life List Explorer Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a taxonomic completeness explorer to `/life-list` that shows, for a chosen class (birds by default), how many orders/families/genera/species exist and how many the user has found, with drill-down cards + progress rings and a sunburst showpiece.
+
+**Architecture:** A new DB method computes the class subtree from the local iNaturalist reference taxonomy (already in `taxa`, linked by `parent_id`) via a recursive CTE, then rolls up found-vs-total in Python from the workspace-scoped set of tagged species taxa. A new `/api/life-list/explorer` endpoint serves the tree + honesty states; a species-leaf endpoint serves found+missing species per genus. The `life_list.html` template gains a two-tab layout (List / Explorer); the Explorer tab renders class selector → sunburst → breadcrumb → card grid → species leaf, all vanilla JS + inline styles using existing theme vars.
+
+**Tech Stack:** Flask, SQLite (recursive CTE), Jinja2, vanilla JS, inline SVG (sunburst). Tests via pytest (`vireo/tests/`).
+
+**Design doc:** `docs/plans/2026-07-07-life-list-explorer-design.md`
+
+---
+
+## Background facts (verified in codebase)
+
+- `taxa` table (`vireo/db.py:495`): `id, inat_id, name, common_name, rank, parent_id, kingdom`. Index `idx_taxa_parent ON taxa(parent_id)` exists (`db.py:822`). `rank` values are lowercase: `kingdom, phylum, class, order, family, genus, species` (`vireo/taxonomy.py:210`). The table holds the **complete** iNat taxonomy once downloaded, not just user-seen taxa.
+- `keywords.taxon_id` (`db.py:505`) links a species keyword to its `taxa` row. `photo_keywords` links photos↔keywords.
+- Existing life-list eligibility & workspace scope (MATCH THIS EXACTLY) — `get_life_list_candidates()` (`db.py:9077`):
+  ```sql
+  FROM photo_keywords pk
+  JOIN keywords k ON k.id = pk.keyword_id AND (k.is_species = 1 OR k.type = 'taxonomy')
+  JOIN photos p ON p.id = pk.photo_id
+  JOIN workspace_folders wf ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
+  JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')
+  LEFT JOIN taxa t ON t.id = k.taxon_id
+  WHERE COALESCE(p.flag, 'none') != 'rejected'
+  ```
+- `_ws_id()` (`db.py:1184`) returns the active workspace id (raises if unset).
+- Life-list page route: `@app.route("/life-list")` → `life_list_page()` (`app.py:2539`). JSON: `@app.route("/api/life-list")` → `api_life_list()` (`app.py:6933`), building via `_build_life_list_payload()` (`app.py:6817`). All use `db = _get_db()`.
+- Thumbnails served at `/thumbnails/<id>.jpg` (`app.py:16117`). Template helper `photoThumbnailUrl(photo)` (life_list.html:208).
+- Taxonomy readiness already exposed at `/api/taxonomy/info` (`app.py:11591`) and `/api/classify/config` (`taxonomy_available`, `taxonomy_species_count`). Download job: `POST /api/jobs/download-taxonomy` (`app.py:11597`).
+- Tabs pattern to copy: `vireo/templates/audit.html` (`.tabs`/`.tab`/`.tab-panel` CSS lines 41-81; `switchTab()` JS lines 180-187).
+- Theme vars available (from `vireo/static/vireo-theme.css`): `--bg-primary/secondary/tertiary/input/panel`, `--border-primary/secondary/subtle`, `--text-primary/secondary/muted/dim`, `--accent`, `--accent-hover`, `--accent-text`.
+- Test fixtures (`vireo/tests/conftest.py`): `db` fixture (line 107, temp-file Database), `app_and_db` fixture (line 115, seeded photos/keywords + test client, `api_token="test-token-123"`). Seed helpers: `db.add_folder`, `db.add_photo`, `db.add_keyword`, `db.tag_photo`, `db.ensure_default_workspace`, `db.set_active_workspace`.
+
+---
+
+## STAGE 1 — Backend: DB completeness engine + endpoints
+
+### Task 1: DB helper — resolve default class + taxonomy readiness
+
+**Files:**
+- Modify: `vireo/db.py` (add methods near the other taxa/life-list methods, ~line 9116)
+- Test: `vireo/tests/test_db.py`
+
+**Step 1: Write the failing test**
+
+Add a small taxa-seeding helper at the top of the test module (reused by later tasks). Insert a mini bird tree so tests don't need the real taxonomy:
+
+```python
+def _seed_bird_taxonomy(db):
+    """Insert a tiny Aves subtree: class Aves > 2 orders > families > genera > species.
+    Returns dict of name -> taxa id."""
+    rows = [
+        # (inat_id, name, common_name, rank, parent_name, kingdom)
+        (3,     "Aves",           "Birds",         "class",   None,             "Animalia"),
+        (7251,  "Passeriformes",  "Perching Birds","order",   "Aves",           "Animalia"),
+        (67566, "Passerellidae",  "New World Sparrows","family","Passeriformes", "Animalia"),
+        (9100,  "Melospiza",      None,            "genus",   "Passerellidae",  "Animalia"),
+        (9101,  "Melospiza melodia","Song Sparrow","species", "Melospiza",      "Animalia"),
+        (9102,  "Melospiza georgiana","Swamp Sparrow","species","Melospiza",    "Animalia"),
+        (9200,  "Zonotrichia",    None,            "genus",   "Passerellidae",  "Animalia"),
+        (9201,  "Zonotrichia albicollis","White-throated Sparrow","species","Zonotrichia","Animalia"),
+        (4000,  "Anseriformes",   "Waterfowl",     "order",   "Aves",           "Animalia"),
+        (4100,  "Anatidae",       "Ducks",         "family",  "Anseriformes",   "Animalia"),
+        (4200,  "Anas",           None,            "genus",   "Anatidae",       "Animalia"),
+        (4201,  "Anas platyrhynchos","Mallard",    "species", "Anas",           "Animalia"),
+    ]
+    ids = {}
+    for inat_id, name, common, rank, parent, kingdom in rows:
+        parent_id = ids.get(parent)
+        cur = db.conn.execute(
+            "INSERT INTO taxa (inat_id, name, common_name, rank, parent_id, kingdom)"
+            " VALUES (?,?,?,?,?,?)",
+            (inat_id, name, common, rank, parent_id, kingdom),
+        )
+        ids[name] = cur.lastrowid
+    db.conn.commit()
+    return ids
+
+
+def test_get_default_explorer_root_finds_aves(db):
+    assert db.get_explorer_root() is None  # no taxonomy yet
+    ids = _seed_bird_taxonomy(db)
+    root = db.get_explorer_root()
+    assert root["id"] == ids["Aves"]
+    assert root["name"] == "Aves"
+    assert root["rank"] == "class"
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `python -m pytest vireo/tests/test_db.py::test_get_default_explorer_root_finds_aves -v`
+Expected: FAIL (`AttributeError: 'Database' object has no attribute 'get_explorer_root'`).
+
+**Step 3: Implement**
+
+Add to `vireo/db.py`:
+
+```python
+def get_explorer_root(self, name="Aves", rank="class"):
+    """Return {id,name,common_name,rank} for the default explorer root class,
+    or None when the reference taxonomy has not been downloaded."""
+    row = self.conn.execute(
+        "SELECT id, name, common_name, rank FROM taxa"
+        " WHERE name = ? AND rank = ? LIMIT 1",
+        (name, rank),
+    ).fetchone()
+    return dict(row) if row else None
+```
+
+**Step 4: Run to verify it passes**
+
+Run: `python -m pytest vireo/tests/test_db.py::test_get_default_explorer_root_finds_aves -v`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "feat(life-list): resolve default explorer root class (Aves)"
+```
+
+---
+
+### Task 2: DB — workspace-scoped found species taxa + unmatched species
+
+**Files:**
+- Modify: `vireo/db.py`
+- Test: `vireo/tests/test_db.py`
+
+**Step 1: Write the failing test**
+
+```python
+def test_life_list_taxon_ids_scope(db):
+    ids = _seed_bird_taxonomy(db)
+    ws = db.ensure_default_workspace(); db.set_active_workspace(ws)
+    fid = db.add_folder('/p', name='p')
+    p1 = db.add_photo(folder_id=fid, filename='a.jpg', extension='.jpg',
+                      file_size=1, file_mtime=1.0, timestamp='2024-01-01T00:00:00')
+    p2 = db.add_photo(folder_id=fid, filename='b.jpg', extension='.jpg',
+                      file_size=1, file_mtime=2.0, timestamp='2024-01-02T00:00:00')
+    # Matched species keyword (linked to Song Sparrow taxon)
+    k1 = db.add_keyword('Song Sparrow'); db.tag_photo(p1, k1)
+    db.conn.execute("UPDATE keywords SET is_species=1, taxon_id=? WHERE id=?",
+                    (ids['Melospiza melodia'], k1)); db.conn.commit()
+    # Unmatched species keyword (is_species but no taxon_id)
+    k2 = db.add_keyword('Mystery Warbler'); db.tag_photo(p2, k2)
+    db.conn.execute("UPDATE keywords SET is_species=1 WHERE id=?", (k2,)); db.conn.commit()
+
+    found = db.get_life_list_taxon_ids()
+    assert found == {ids['Melospiza melodia']}
+    unmatched = db.get_life_list_unmatched_species()
+    assert 'Mystery Warbler' in unmatched
+
+def test_life_list_taxon_ids_excludes_rejected(db):
+    ids = _seed_bird_taxonomy(db)
+    ws = db.ensure_default_workspace(); db.set_active_workspace(ws)
+    fid = db.add_folder('/p', name='p')
+    p = db.add_photo(folder_id=fid, filename='a.jpg', extension='.jpg',
+                     file_size=1, file_mtime=1.0)
+    k = db.add_keyword('Song Sparrow'); db.tag_photo(p, k)
+    db.conn.execute("UPDATE keywords SET is_species=1, taxon_id=? WHERE id=?",
+                    (ids['Melospiza melodia'], k)); db.conn.commit()
+    db.update_photo_flag(p, 'rejected')  # verify method name in db.py; else set p.flag directly
+    assert db.get_life_list_taxon_ids() == set()
+```
+
+> NOTE for implementer: confirm the exact "reject a photo" helper name in `db.py` (search `flag`); if none, `db.conn.execute("UPDATE photos SET flag='rejected' WHERE id=?", (p,))`.
+
+**Step 2: Run — expect FAIL** (`get_life_list_taxon_ids` missing).
+
+**Step 3: Implement** — mirror `get_life_list_candidates` scoping exactly:
+
+```python
+def get_life_list_taxon_ids(self):
+    """Distinct taxa ids of workspace-scoped tagged species (same eligibility
+    as get_life_list_candidates), excluding species keywords with no taxon_id."""
+    ws = self._ws_id()
+    rows = self.conn.execute(
+        """SELECT DISTINCT k.taxon_id AS tid
+           FROM photo_keywords pk
+           JOIN keywords k ON k.id = pk.keyword_id
+            AND (k.is_species = 1 OR k.type = 'taxonomy')
+           JOIN photos p ON p.id = pk.photo_id
+           JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+            AND wf.workspace_id = ?
+           JOIN folders f ON f.id = p.folder_id
+            AND f.status IN ('ok', 'partial')
+           WHERE COALESCE(p.flag, 'none') != 'rejected'
+             AND k.taxon_id IS NOT NULL""",
+        (ws,),
+    ).fetchall()
+    return {r["tid"] for r in rows}
+
+def get_life_list_unmatched_species(self):
+    """Names of workspace-scoped tagged species keywords with no taxon_id —
+    surfaced honestly in the explorer as 'not counted'."""
+    ws = self._ws_id()
+    rows = self.conn.execute(
+        """SELECT DISTINCT k.name AS name
+           FROM photo_keywords pk
+           JOIN keywords k ON k.id = pk.keyword_id
+            AND (k.is_species = 1 OR k.type = 'taxonomy')
+           JOIN photos p ON p.id = pk.photo_id
+           JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+            AND wf.workspace_id = ?
+           JOIN folders f ON f.id = p.folder_id
+            AND f.status IN ('ok', 'partial')
+           WHERE COALESCE(p.flag, 'none') != 'rejected'
+             AND k.taxon_id IS NULL
+           ORDER BY k.name""",
+        (ws,),
+    ).fetchall()
+    return [r["name"] for r in rows]
+```
+
+**Step 4: Run — expect PASS.**
+
+**Step 5: Commit**
+
+```bash
+git add vireo/db.py vireo/tests/test_db.py
+git commit -m "feat(life-list): workspace-scoped found taxa + unmatched species queries"
+```
+
+---
+
+### Task 3: DB — taxon subtree fetch (recursive CTE)
+
+**Files:** Modify `vireo/db.py`; Test `vireo/tests/test_db.py`.
+
+**Step 1: Failing test**
+
+```python
+def test_get_taxon_subtree(db):
+    ids = _seed_bird_taxonomy(db)
+    rows = db.get_taxon_subtree(ids['Aves'])
+    by_name = {r['name']: r for r in rows}
+    assert by_name['Aves']['rank'] == 'class'
+    assert by_name['Melospiza melodia']['rank'] == 'species'
+    # parent linkage preserved
+    assert by_name['Passeriformes']['parent_id'] == ids['Aves']
+    assert by_name['Melospiza']['parent_id'] == ids['Passerellidae']
+    # subtree of a genus is just its species + itself
+    sub = {r['name'] for r in db.get_taxon_subtree(ids['Melospiza'])}
+    assert sub == {'Melospiza', 'Melospiza melodia', 'Melospiza georgiana'}
+```
+
+**Step 2: Run — expect FAIL.**
+
+**Step 3: Implement** (downward CTE; `idx_taxa_parent` makes the join efficient):
+
+```python
+def get_taxon_subtree(self, root_id, max_depth=12):
+    """All taxa in the subtree rooted at root_id (inclusive), as dict rows
+    with id, name, common_name, rank, parent_id. Uses the parent_id index."""
+    return [dict(r) for r in self.conn.execute(
+        """WITH RECURSIVE subtree(id, name, common_name, rank, parent_id, depth) AS (
+               SELECT id, name, common_name, rank, parent_id, 0
+               FROM taxa WHERE id = ?
+               UNION ALL
+               SELECT t.id, t.name, t.common_name, t.rank, t.parent_id, s.depth + 1
+               FROM taxa t JOIN subtree s ON t.parent_id = s.id
+               WHERE s.depth < ?
+           )
+           SELECT id, name, common_name, rank, parent_id FROM subtree""",
+        (root_id, max_depth),
+    ).fetchall()]
+```
+
+**Step 4: Run — expect PASS.**
+
+**Step 5: Commit** `feat(life-list): recursive taxon subtree fetch`.
+
+---
+
+### Task 4: DB — classes the user has tagged species in (for the selector)
+
+**Files:** Modify `vireo/db.py`; Test `vireo/tests/test_db.py`.
+
+**Step 1: Failing test**
+
+```python
+def test_get_classes_for_taxa(db):
+    ids = _seed_bird_taxonomy(db)
+    classes = db.get_classes_for_taxa({ids['Melospiza melodia']})
+    assert [c['name'] for c in classes] == ['Aves']
+    assert db.get_classes_for_taxa(set()) == []
+```
+
+**Step 2: Run — expect FAIL.**
+
+**Step 3: Implement** (upward CTE to each species' class ancestor):
+
+```python
+def get_classes_for_taxa(self, taxon_ids):
+    """Distinct class-rank ancestors of the given taxa, for the explorer's
+    class selector. Returns [{id,name,common_name}] ordered by name."""
+    ids = [t for t in taxon_ids if t is not None]
+    if not ids:
+        return []
+    placeholders = ",".join("?" for _ in ids)
+    rows = self.conn.execute(
+        f"""WITH RECURSIVE up(id) AS (
+                SELECT id FROM taxa WHERE id IN ({placeholders})
+                UNION
+                SELECT t.parent_id FROM taxa t JOIN up u ON t.id = u.id
+                WHERE t.parent_id IS NOT NULL
+            )
+            SELECT DISTINCT t.id, t.name, t.common_name
+            FROM up u JOIN taxa t ON t.id = u.id
+            WHERE t.rank = 'class'
+            ORDER BY COALESCE(t.common_name, t.name)""",
+        ids,
+    ).fetchall()
+    return [dict(r) for r in rows]
+```
+
+**Step 4: Run — expect PASS.**
+
+**Step 5: Commit** `feat(life-list): class ancestors for explorer selector`.
+
+---
+
+### Task 5: DB — best photo per found species taxon (for the leaf)
+
+**Files:** Modify `vireo/db.py`; Test `vireo/tests/test_db.py`.
+
+**Step 1: Failing test**
+
+```python
+def test_best_photo_by_taxon(db):
+    ids = _seed_bird_taxonomy(db)
+    ws = db.ensure_default_workspace(); db.set_active_workspace(ws)
+    fid = db.add_folder('/p', name='p')
+    p1 = db.add_photo(folder_id=fid, filename='low.jpg', extension='.jpg',
+                      file_size=1, file_mtime=1.0)
+    p2 = db.add_photo(folder_id=fid, filename='high.jpg', extension='.jpg',
+                      file_size=1, file_mtime=2.0)
+    db.update_photo_quality_score(p1, 0.2)  # confirm method name; else UPDATE photos SET quality_score
+    db.update_photo_quality_score(p2, 0.9)
+    k = db.add_keyword('Song Sparrow'); db.tag_photo(p1, k); db.tag_photo(p2, k)
+    db.conn.execute("UPDATE keywords SET is_species=1, taxon_id=? WHERE id=?",
+                    (ids['Melospiza melodia'], k)); db.conn.commit()
+    best = db.get_life_list_best_photo_by_taxon([ids['Melospiza melodia']])
+    assert best[ids['Melospiza melodia']]['filename'] == 'high.jpg'
+```
+
+> NOTE: confirm quality-score setter name in db.py; fall back to raw UPDATE if absent.
+
+**Step 2: Run — expect FAIL.**
+
+**Step 3: Implement** (one representative photo per taxon, workspace-scoped, best quality_score then newest):
+
+```python
+def get_life_list_best_photo_by_taxon(self, taxon_ids):
+    """Map taxon_id -> {id, filename} of a representative (highest quality_score,
+    newest) workspace-scoped photo for that species. Missing taxa are absent."""
+    ids = [t for t in taxon_ids if t is not None]
+    if not ids:
+        return {}
+    ws = self._ws_id()
+    placeholders = ",".join("?" for _ in ids)
+    rows = self.conn.execute(
+        f"""SELECT k.taxon_id AS tid, p.id, p.filename, p.quality_score, p.timestamp
+            FROM photo_keywords pk
+            JOIN keywords k ON k.id = pk.keyword_id AND k.taxon_id IN ({placeholders})
+            JOIN photos p ON p.id = pk.photo_id
+            JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+             AND wf.workspace_id = ?
+            JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok','partial')
+            WHERE COALESCE(p.flag, 'none') != 'rejected'
+            ORDER BY k.taxon_id,
+                     COALESCE(p.quality_score, -1) DESC,
+                     COALESCE(p.timestamp, '') DESC""",
+        ids + [ws],
+    ).fetchall()
+    best = {}
+    for r in rows:
+        if r["tid"] not in best:  # first row per taxon is the best by ORDER BY
+            best[r["tid"]] = {"id": r["id"], "filename": r["filename"]}
+    return best
+```
+
+**Step 4: Run — expect PASS.**
+
+**Step 5: Commit** `feat(life-list): representative photo per species taxon`.
+
+---
+
+### Task 6: Payload builder — roll up the completeness tree (pure function)
+
+**Files:**
+- Modify: `vireo/app.py` (add `_build_explorer_payload(db, root_id=None)` near `_build_life_list_payload`, ~line 6931)
+- Test: `vireo/tests/test_app.py`
+
+The rollup is pure Python over Task 3's subtree + Task 2's found set. Compute per node: `found_species`, `total_species`, and for immediate children `found_children`/`total_children`; plus a top-line `summary` of found/total per rank.
+
+**Step 1: Failing test** (unit-test the builder directly with the seeded tree):
+
+```python
+def test_build_explorer_payload_rollup(db):
+    from app import _build_explorer_payload
+    ids = _seed_bird_taxonomy(db)
+    ws = db.ensure_default_workspace(); db.set_active_workspace(ws)
+    fid = db.add_folder('/p', name='p')
+    p = db.add_photo(folder_id=fid, filename='a.jpg', extension='.jpg',
+                     file_size=1, file_mtime=1.0)
+    k = db.add_keyword('Song Sparrow'); db.tag_photo(p, k)
+    db.conn.execute("UPDATE keywords SET is_species=1, taxon_id=? WHERE id=?",
+                    (ids['Melospiza melodia'], k)); db.conn.commit()
+
+    payload = _build_explorer_payload(db)
+    assert payload['taxonomy_ready'] is True
+    assert payload['root']['name'] == 'Aves'
+    s = payload['summary']
+    assert s['species'] == {'found': 1, 'total': 4}     # 4 species seeded
+    assert s['genus']   == {'found': 1, 'total': 3}
+    assert s['family']  == {'found': 1, 'total': 2}
+    assert s['order']   == {'found': 1, 'total': 2}
+    # Passeriformes order node carries family child counts + species rollup
+    orders = {n['name']: n for n in payload['nodes']}
+    passeri = orders['Passeriformes']
+    assert passeri['found_species'] == 1 and passeri['total_species'] == 3
+    assert passeri['child_rank'] == 'family'
+    assert passeri['found_children'] == 1 and passeri['total_children'] == 1
+
+def test_build_explorer_payload_not_ready(db):
+    from app import _build_explorer_payload
+    ws = db.ensure_default_workspace(); db.set_active_workspace(ws)
+    payload = _build_explorer_payload(db)
+    assert payload['taxonomy_ready'] is False
+    assert payload['nodes'] == []
+```
+
+**Step 2: Run — expect FAIL.**
+
+**Step 3: Implement** in `vireo/app.py`:
+
+```python
+_EXPLORER_RANKS = ["order", "family", "genus", "species"]
+_EXPLORER_CHILD_RANK = {"class": "order", "order": "family",
+                        "family": "genus", "genus": "species"}
+
+def _build_explorer_payload(db, root_id=None):
+    """Completeness tree (down to genus) for one class. Species leaves load
+    separately via _build_explorer_species. Honest about the two failure
+    states: taxonomy-not-downloaded and unmatched species."""
+    root = (db.get_explorer_root() if root_id is None
+            else db.get_taxon_by_id(root_id))   # add thin getter or inline SELECT
+    if root is None:
+        return {"taxonomy_ready": False, "root": None, "summary": {},
+                "nodes": [], "unmatched_species": {"count": 0, "names": []},
+                "classes": []}
+
+    rows = db.get_taxon_subtree(root["id"])
+    found = db.get_life_list_taxon_ids()
+
+    # Build node index + children lists.
+    nodes = {r["id"]: {**r, "children": [], "found_species": 0,
+                       "total_species": 0} for r in rows}
+    for n in nodes.values():
+        pid = n["parent_id"]
+        if pid in nodes and pid != n["id"]:
+            nodes[pid]["children"].append(n)
+
+    # Post-order rollup of species totals/found.
+    def rollup(node):
+        if node["rank"] == "species":
+            node["total_species"] = 1
+            node["found_species"] = 1 if node["id"] in found else 0
+        else:
+            for c in node["children"]:
+                rollup(c)
+                node["total_species"] += c["total_species"]
+                node["found_species"] += c["found_species"]
+    rollup(nodes[root["id"]])
+
+    # Per-rank summary across the whole class.
+    summary = {r: {"found": 0, "total": 0} for r in _EXPLORER_RANKS}
+    for n in nodes.values():
+        if n["rank"] in summary:
+            summary[n["rank"]]["total"] += 1
+            if n["found_species"] > 0:
+                summary[n["rank"]]["found"] += 1
+
+    def to_out(node):
+        child_rank = _EXPLORER_CHILD_RANK.get(node["rank"])
+        kids = [c for c in node["children"]]
+        found_children = sum(1 for c in kids if c["found_species"] > 0)
+        out = {
+            "id": node["id"], "name": node["name"],
+            "common_name": node["common_name"], "rank": node["rank"],
+            "found_species": node["found_species"],
+            "total_species": node["total_species"],
+            "child_rank": child_rank,
+            "found_children": found_children,
+            "total_children": len(kids),
+        }
+        # Materialize tree down to genus; species leaves load on demand.
+        if node["rank"] != "genus":
+            out["children"] = [to_out(c) for c in
+                               sorted(kids, key=lambda c: (c["found_species"] == 0,
+                                      (c["common_name"] or c["name"]).lower()))]
+        else:
+            out["children"] = []  # species fetched via leaf endpoint
+        return out
+
+    top = [to_out(c) for c in sorted(nodes[root["id"]]["children"],
+           key=lambda c: (c["found_species"] == 0,
+                          (c["common_name"] or c["name"]).lower()))]
+
+    unmatched = db.get_life_list_unmatched_species()
+    classes = db.get_classes_for_taxa(found)
+    return {
+        "taxonomy_ready": True,
+        "root": {"id": root["id"], "name": root["name"],
+                 "common_name": root.get("common_name"), "rank": root["rank"]},
+        "summary": summary,
+        "nodes": top,
+        "unmatched_species": {"count": len(unmatched), "names": unmatched[:200]},
+        "classes": classes,
+    }
+```
+
+> Add a tiny `db.get_taxon_by_id(id)` helper (SELECT id,name,common_name,rank,parent_id) if not present — used for non-default roots.
+
+**Step 4: Run — expect PASS.**
+
+**Step 5: Commit** `feat(life-list): explorer completeness rollup builder`.
+
+---
+
+### Task 7: Species-leaf builder (found + missing under a genus)
+
+**Files:** Modify `vireo/app.py`; Test `vireo/tests/test_app.py`.
+
+**Step 1: Failing test**
+
+```python
+def test_build_explorer_species_leaf(db):
+    from app import _build_explorer_species
+    ids = _seed_bird_taxonomy(db)
+    ws = db.ensure_default_workspace(); db.set_active_workspace(ws)
+    fid = db.add_folder('/p', name='p')
+    p = db.add_photo(folder_id=fid, filename='a.jpg', extension='.jpg',
+                     file_size=1, file_mtime=1.0)
+    k = db.add_keyword('Song Sparrow'); db.tag_photo(p, k)
+    db.conn.execute("UPDATE keywords SET is_species=1, taxon_id=? WHERE id=?",
+                    (ids['Melospiza melodia'], k)); db.conn.commit()
+    out = _build_explorer_species(db, ids['Melospiza'])
+    by = {s['name']: s for s in out['species']}
+    assert by['Melospiza melodia']['found'] is True
+    assert by['Melospiza melodia']['photo']['filename'] == 'a.jpg'
+    assert by['Melospiza georgiana']['found'] is False
+    assert by['Melospiza georgiana'].get('photo') is None
+    # found first, then missing; each block alphabetical
+    assert [s['found'] for s in out['species']] == [True, False]
+```
+
+**Step 2: Run — expect FAIL.**
+
+**Step 3: Implement**
+
+```python
+def _build_explorer_species(db, genus_id):
+    """Found+missing species directly under a genus, found ones with a
+    representative photo. Found sorted first, then missing; each alphabetical."""
+    rows = [r for r in db.get_taxon_subtree(genus_id, max_depth=1)
+            if r["rank"] == "species"]
+    found = db.get_life_list_taxon_ids()
+    found_ids = [r["id"] for r in rows if r["id"] in found]
+    photos = db.get_life_list_best_photo_by_taxon(found_ids)
+    species = []
+    for r in rows:
+        is_found = r["id"] in found
+        species.append({
+            "id": r["id"], "name": r["name"], "common_name": r["common_name"],
+            "found": is_found,
+            "photo": photos.get(r["id"]) if is_found else None,
+        })
+    species.sort(key=lambda s: (not s["found"],
+                                (s["common_name"] or s["name"]).lower()))
+    return {"genus_id": genus_id, "species": species}
+```
+
+**Step 4: Run — expect PASS.**
+
+**Step 5: Commit** `feat(life-list): explorer species leaf builder`.
+
+---
+
+### Task 8: Endpoints — `/api/life-list/explorer` and species leaf
+
+**Files:** Modify `vireo/app.py` (near `api_life_list`, ~line 6940); Test `vireo/tests/test_app.py`.
+
+**Step 1: Failing test** (through the Flask client; extend `app_and_db` seed or seed inline). Add taxa + link a keyword inside the test:
+
+```python
+def test_api_explorer_endpoint(app_and_db):
+    app, db = app_and_db
+    ids = _seed_bird_taxonomy(db)
+    # Link the fixture's existing 'Cardinal' keyword to a bird taxon so it counts.
+    db.conn.execute("UPDATE keywords SET is_species=1, taxon_id=? WHERE name='Cardinal'",
+                    (ids['Melospiza melodia'],)); db.conn.commit()
+    client = app.test_client()
+    r = client.get('/api/life-list/explorer')
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data['taxonomy_ready'] is True
+    assert data['root']['name'] == 'Aves'
+    assert data['summary']['order']['total'] == 2
+    # species leaf
+    r2 = client.get(f"/api/life-list/explorer/species?genus={ids['Melospiza']}")
+    assert r2.status_code == 200
+    assert {s['name'] for s in r2.get_json()['species']} == \
+        {'Melospiza melodia', 'Melospiza georgiana'}
+
+def test_api_explorer_not_ready(app_and_db):
+    app, db = app_and_db  # fixture has no taxa
+    r = app.test_client().get('/api/life-list/explorer')
+    assert r.status_code == 200
+    assert r.get_json()['taxonomy_ready'] is False
+```
+
+**Step 2: Run — expect FAIL.**
+
+**Step 3: Implement** (match existing route style, `db = _get_db()`):
+
+```python
+@app.route("/api/life-list/explorer")
+def api_life_list_explorer():
+    db = _get_db()
+    root_id = request.args.get("root", type=int)  # None -> default Aves
+    return jsonify(_build_explorer_payload(db, root_id=root_id))
+
+@app.route("/api/life-list/explorer/species")
+def api_life_list_explorer_species():
+    db = _get_db()
+    genus_id = request.args.get("genus", type=int)
+    if not genus_id:
+        return jsonify({"genus_id": None, "species": []})
+    return jsonify(_build_explorer_species(db, genus_id))
+```
+
+> `?root` accepts a taxa id (from the class selector). The bare word "Aves" is handled server-side by defaulting when `root` is absent, so the frontend passes ids only.
+
+**Step 4: Run — expect PASS.** Then run the full backend suite:
+`python -m pytest vireo/tests/test_db.py vireo/tests/test_app.py -q`
+
+**Step 5: Commit** `feat(life-list): explorer API endpoints`.
+
+---
+
+## STAGE 2 — Frontend: tabs + drill-down + leaf + honesty states
+
+### Task 9: Add List/Explorer tabs to life_list.html (List unchanged)
+
+**Files:** Modify `vireo/templates/life_list.html`.
+
+**Steps:**
+1. Wrap the existing controls bar + `#content` + `#emptyState` in a panel `<div class="ll-tabpanel active" id="tab-list">`.
+2. Add a tab bar above the panels (copy `.tabs/.tab/.tab-panel` CSS + `switchTab` JS from `audit.html:41-81,180-187`, renamed to `ll-tab*` to avoid collisions):
+   ```html
+   <div class="ll-tabs">
+     <div class="ll-tab active" data-tab="list" onclick="llSwitchTab('list')">List</div>
+     <div class="ll-tab" data-tab="explorer" onclick="llSwitchTab('explorer')">Explorer</div>
+   </div>
+   ```
+3. Add empty `<div class="ll-tabpanel" id="tab-explorer"></div>` panel (filled by later tasks).
+4. `llSwitchTab(name)`: toggle `.active` on `.ll-tab` and `.ll-tabpanel` (`id === 'tab-'+name`); push `?view=<name>` via `history.replaceState`; on first switch to explorer, call `loadExplorer()` (Task 10) once (guard with a `explorerLoaded` flag).
+5. On page load, read `?view=` and activate that tab (default `list`).
+
+**Verify:** `python vireo/app.py --db ~/.vireo/vireo.db --port 8080` → open `/life-list`, confirm List tab looks identical to before and the Explorer tab switches. Commit `feat(life-list): List/Explorer tab shell`.
+
+---
+
+### Task 10: Explorer data load + honesty states + class selector
+
+**Files:** Modify `vireo/templates/life_list.html` (JS + CSS in the inline blocks).
+
+**Behavior:**
+- `loadExplorer(rootId)` → `safeFetch('/api/life-list/explorer' + (rootId?('?root='+rootId):''))`, store in `explorerData`, call `renderExplorer()`.
+- **Not ready:** if `!explorerData.taxonomy_ready`, render a full-panel CTA into `#tab-explorer`: heading "Download the taxonomy to see completeness", body explaining it needs the reference taxonomy, and a button that POSTs `/api/jobs/download-taxonomy` (reuse existing job-trigger pattern; the app already polls jobs). Do NOT show fake 0/0.
+- **Empty class:** if ready but `summary.species.total===0` for the chosen root, show "No reference taxa for this class." If `summary.species.found===0`, still render the tree (all missing) — that's valid.
+- **Class selector:** a `<select id="explorerClass">` populated from `explorerData.classes` (value = class id), defaulting to the current root; `Birds`/`Aves` label uses `common_name || name`. On change → `loadExplorer(value)`. If the default root (Aves) isn't in `classes` (user has no birds yet) still include it as the first option so birds is always selectable.
+- **Unmatched footnote:** if `unmatched_species.count > 0`, render a small muted line under the summary: `"<n> tagged species aren't matched to the taxonomy and aren't counted here"` with a `<details>` listing `unmatched_species.names`.
+
+**CSS:** reuse theme vars; CTA uses `.publish-btn` style. **Verify** the three states by toggling taxonomy in a scratch DB (or temporarily forcing `taxonomy_ready:false`). Commit `feat(life-list): explorer load + honesty states + class selector`.
+
+---
+
+### Task 11: Summary bar + breadcrumb + card grid drill-down
+
+**Files:** Modify `vireo/templates/life_list.html`.
+
+**State:** `explorerPath = []` (array of `{id,name,rank}` from class root down). Current level = children at `explorerPath`'s tail (or top-level `explorerData.nodes` when path empty).
+
+**Render:**
+1. **Summary bar** (always visible for current root): four chips — `"30/44 orders · 120/250 families · 800/2300 genera · 1200/11000 species"` from `explorerData.summary`. Tabular-nums.
+2. **Breadcrumb:** `Birds › Passeriformes › Passerellidae`, each crumb clickable → truncates `explorerPath` and re-renders. First crumb = root class label.
+3. **Card grid:** one card per node at the current level. Card shows:
+   - **Progress ring** (inline SVG, two `<circle>`, stroke-dasharray by `found_species/total_species`; accent stroke on `var(--bg-tertiary)` track). Center label = `pct%`.
+   - Name (`common_name || name`), scientific name (italic, muted) when common differs.
+   - Subtitle: `"<found_children>/<total_children> <child_rank>s · <found_species>/<total_species> species"`.
+   - Dim the card (`opacity:.55`) when `found_species===0` (a group you've never touched) — honest "not started" signal.
+4. **Click** a card:
+   - genus card → fetch species leaf (Task 12).
+   - other → push node to `explorerPath`, re-render from its `children`.
+
+Reuse `.species-card` look (rounded, `--bg-secondary`, `--border-primary`, hover `--accent`). New classes `.ll-ring`, `.ll-summary`, `.ll-crumbs`. **Verify** drill Birds → order → family → genus in the running app. Commit `feat(life-list): explorer summary, breadcrumb, drill-down cards`.
+
+---
+
+### Task 12: Species leaf (found + missing)
+
+**Files:** Modify `vireo/templates/life_list.html`.
+
+**Behavior:** on genus click, `safeFetch('/api/life-list/explorer/species?genus='+id)`; render a grid under the breadcrumb:
+- **Found** species: thumbnail (`photoThumbnailUrl(sp.photo)` → `/thumbnails/<id>.jpg`), name, common name, a lit "✓ seen" chip. Clicking the thumbnail opens the existing lightbox if easy (optional; else no-op).
+- **Missing** species: dimmed card (no image, placeholder tile in `--bg-tertiary`), name, common name, a muted "not yet" chip.
+- Header line: `"<found>/<total> species in <genus>"`.
+- A toggle `"Show missing only"` (checkbox) to help gap-hunting (client-side filter).
+
+**Verify** a genus where you have some but not all species shows found lit + missing dimmed. Commit `feat(life-list): explorer species leaf with found+missing`.
+
+---
+
+## STAGE 3 — Sunburst showpiece
+
+### Task 13: Sunburst overview at the top of the Explorer tab
+
+**Files:** Modify `vireo/templates/life_list.html`.
+
+**Behavior:** inline SVG radial diagram built from `explorerData.nodes` (down to genus) + on-demand species rings are out of scope — sunburst goes class-center → orders → families → genera (3 rings). No external library.
+- Compute each node's angular span proportional to its `total_species` (so big orders read bigger). Recurse to assign child spans within the parent's arc.
+- Each arc: fill = `var(--accent)` at opacity scaled by `found_species/total_species` (0 → ghost `var(--bg-tertiary)`, 1 → full accent). Stroke `var(--bg-primary)` hairline between arcs.
+- **Hover:** tooltip `"<name> — <found>/<total> species (<pct>%)"`.
+- **Click** an arc: set `explorerPath` to that node's lineage and re-render the cards/breadcrumb below (drives the drill-down). Clicking center resets to top.
+- Keep it a fixed square (e.g. 360×360), centered, above the summary bar. Degrade gracefully: if `nodes` empty, hide the sunburst.
+
+Helper: build an id→node lineage map from `explorerData.nodes` during render so arc→path is O(1).
+
+**Verify** the sunburst renders for birds, arcs shade by completeness, hover shows counts, clicking an arc drills the cards below. Commit `feat(life-list): sunburst completeness overview`.
+
+---
+
+## Final verification
+
+1. Full project test command (from CLAUDE.md):
+   ```bash
+   python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py \
+     vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py \
+     vireo/tests/test_darktable_api.py vireo/tests/test_config.py -v
+   ```
+   Expected: green (ignore the known pre-existing failures noted in project memory).
+2. Manual: run the app, download taxonomy if needed, drill Birds → order → family → genus → species, switch the class selector to Mammalia, confirm the unmatched-species footnote appears when you have species keywords without `taxon_id`.
+3. `gh pr create --base main` with a summary of what changed + test results. Stages 1/2/3 can be separate commits in one PR (each was independently shippable).
+
+## Notes / DRY / YAGNI
+
+- Reuse `_get_db()`, `safeFetch`, `photoThumbnailUrl`, `.species-card`, `.publish-btn`, and the `audit.html` tab pattern rather than inventing new ones.
+- Do NOT ship a fake denominator when taxonomy is absent — the CTA state is a hard requirement (CORE_PHILOSOPHY "No black boxes").
+- Confirm helper names before use: photo flag setter, quality-score setter, `get_taxon_by_id`. Add thin getters only if missing.
+- Class selector, sunburst species rings, lightbox-on-leaf-click are the only "nice to have" edges — everything else is core.

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1437,6 +1437,114 @@ def _scan_metadata_warning():
     return scan_metadata_warning()
 
 
+_EXPLORER_RANKS = ["order", "family", "genus", "species"]
+_EXPLORER_CHILD_RANK = {"class": "order", "order": "family",
+                        "family": "genus", "genus": "species"}
+
+
+def _build_explorer_payload(db, root_id=None):
+    """Completeness tree (down to genus) for one class. Species leaves load
+    separately via _build_explorer_species. Honest about the two failure
+    states: taxonomy-not-downloaded and unmatched species."""
+    root = (db.get_explorer_root() if root_id is None
+            else db.get_taxon_by_id(root_id))
+    if root is None:
+        return {"taxonomy_ready": False, "root": None, "summary": {},
+                "nodes": [], "unmatched_species": {"count": 0, "names": []},
+                "classes": []}
+
+    rows = db.get_taxon_subtree(root["id"])
+    found = db.get_life_list_taxon_ids()
+
+    # Build node index + children lists.
+    nodes = {r["id"]: {**r, "children": [], "found_species": 0,
+                       "total_species": 0} for r in rows}
+    for n in nodes.values():
+        pid = n["parent_id"]
+        if pid in nodes and pid != n["id"]:
+            nodes[pid]["children"].append(n)
+
+    # Post-order rollup of species totals/found.
+    def rollup(node):
+        if node["rank"] == "species":
+            node["total_species"] = 1
+            node["found_species"] = 1 if node["id"] in found else 0
+        else:
+            for c in node["children"]:
+                rollup(c)
+                node["total_species"] += c["total_species"]
+                node["found_species"] += c["found_species"]
+    rollup(nodes[root["id"]])
+
+    # Per-rank summary across the whole class.
+    summary = {r: {"found": 0, "total": 0} for r in _EXPLORER_RANKS}
+    for n in nodes.values():
+        if n["rank"] in summary:
+            summary[n["rank"]]["total"] += 1
+            if n["found_species"] > 0:
+                summary[n["rank"]]["found"] += 1
+
+    def to_out(node):
+        child_rank = _EXPLORER_CHILD_RANK.get(node["rank"])
+        kids = list(node["children"])
+        found_children = sum(1 for c in kids if c["found_species"] > 0)
+        out = {
+            "id": node["id"], "name": node["name"],
+            "common_name": node["common_name"], "rank": node["rank"],
+            "found_species": node["found_species"],
+            "total_species": node["total_species"],
+            "child_rank": child_rank,
+            "found_children": found_children,
+            "total_children": len(kids),
+        }
+        # Materialize tree down to genus; species leaves load on demand.
+        if node["rank"] != "genus":
+            out["children"] = [to_out(c) for c in sorted(
+                kids, key=lambda c: (c["found_species"] == 0,
+                                     (c["common_name"] or c["name"]).lower()))]
+        else:
+            out["children"] = []  # species fetched via leaf endpoint
+        return out
+
+    top = [to_out(c) for c in sorted(
+        nodes[root["id"]]["children"],
+        key=lambda c: (c["found_species"] == 0,
+                       (c["common_name"] or c["name"]).lower()))]
+
+    unmatched = db.get_life_list_unmatched_species()
+    classes = db.get_classes_for_taxa(found)
+    return {
+        "taxonomy_ready": True,
+        "root": {"id": root["id"], "name": root["name"],
+                 "common_name": root.get("common_name"), "rank": root["rank"]},
+        "summary": summary,
+        "nodes": top,
+        "unmatched_species": {"count": len(unmatched), "names": unmatched[:200]},
+        "classes": classes,
+    }
+
+
+def _build_explorer_species(db, genus_id):
+    """Found+missing species directly under a genus, found ones with a
+    representative photo. Found sorted first, then missing; each alphabetical."""
+    rows = [r for r in db.get_taxon_subtree(genus_id, max_depth=1)
+            if r["rank"] == "species"]
+    found = db.get_life_list_taxon_ids()
+    found_ids = [r["id"] for r in rows if r["id"] in found]
+    photos = db.get_life_list_best_photo_by_taxon(found_ids)
+    species = []
+    for r in rows:
+        is_found = r["id"] in found
+        species.append({
+            "id": r["id"], "name": r["name"], "common_name": r["common_name"],
+            "found": is_found,
+            "photo": photos.get(r["id"]) if is_found else None,
+        })
+    species.sort(key=lambda s: (not s["found"],
+                                (s["common_name"] or s["name"]).lower()))
+    return {"genus_id": genus_id, "species": species}
+
+
 def create_app(db_path, thumb_cache_dir=None, api_token=None):
     """Create the Flask app for the Vireo photo browser.
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1449,9 +1449,17 @@ def _build_explorer_payload(db, root_id=None):
     root = (db.get_explorer_root() if root_id is None
             else db.get_taxon_by_id(root_id))
     if root is None:
-        return {"taxonomy_ready": False, "root": None, "summary": {},
-                "nodes": [], "unmatched_species": {"count": 0, "names": []},
-                "classes": []}
+        # Taxonomy absent (default lookup found no Aves class) -> not ready.
+        return {"taxonomy_ready": False, "valid_root": False, "root": None,
+                "summary": {}, "nodes": [],
+                "unmatched_species": {"count": 0, "names": []}, "classes": []}
+    if root["rank"] != "class":
+        # Explorer roots must be class-rank; an order/family/etc. root produces a
+        # semantically confusing summary (e.g. an order counting itself). The
+        # taxonomy exists, but this root is not valid.
+        return {"taxonomy_ready": True, "valid_root": False, "root": None,
+                "summary": {}, "nodes": [],
+                "unmatched_species": {"count": 0, "names": []}, "classes": []}
 
     rows = db.get_taxon_subtree(root["id"])
     found = db.get_life_list_taxon_ids()
@@ -1515,6 +1523,7 @@ def _build_explorer_payload(db, root_id=None):
     classes = db.get_classes_for_taxa(found)
     return {
         "taxonomy_ready": True,
+        "valid_root": True,
         "root": {"id": root["id"], "name": root["name"],
                  "common_name": root.get("common_name"), "rank": root["rank"]},
         "summary": summary,

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -7047,6 +7047,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         )
         return jsonify(payload)
 
+    @app.route("/api/life-list/explorer")
+    def api_life_list_explorer():
+        db = _get_db()
+        root_id = request.args.get("root", type=int)  # None -> default Aves
+        return jsonify(_build_explorer_payload(db, root_id=root_id))
+
+    @app.route("/api/life-list/explorer/species")
+    def api_life_list_explorer_species():
+        db = _get_db()
+        genus_id = request.args.get("genus", type=int)
+        if not genus_id:
+            return jsonify({"genus_id": None, "species": []})
+        return jsonify(_build_explorer_species(db, genus_id))
+
     _LIFE_LIST_EXPORT_FORMATS = {
         "json": "json",
         "csv": "csv",

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1521,6 +1521,18 @@ def _build_explorer_payload(db, root_id=None):
 
     unmatched = db.get_life_list_unmatched_species()
     classes = db.get_classes_for_taxa(found)
+    # Always include the default Aves class in the selector, regardless of the
+    # currently selected root. `get_classes_for_taxa(found)` only returns classes
+    # the user has actually tagged in, so a user who tags only non-bird species
+    # and then picks that class would otherwise lose Birds from the selector with
+    # no in-page way back to the default view.
+    default_root = root if root_id is None else db.get_explorer_root()
+    if default_root is not None and not any(
+        c["id"] == default_root["id"] for c in classes
+    ):
+        classes.insert(0, {"id": default_root["id"],
+                           "name": default_root["name"],
+                           "common_name": default_root.get("common_name")})
     return {
         "taxonomy_ready": True,
         "valid_root": True,

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -9169,6 +9169,10 @@ class Database:
     def get_taxon_subtree(self, root_id, max_depth=12):
         """All taxa in the subtree rooted at root_id (inclusive), as dict rows
         with id, name, common_name, rank, parent_id. Uses the parent_id index."""
+        # The depth cap is safe because the taxonomy loader keeps only major
+        # ranks (see vireo/taxonomy.py MAJOR_RANK_LEVELS), giving a real
+        # class->species depth of ~4. Raise the cap if intermediate ranks are
+        # ever kept.
         return [dict(r) for r in self.conn.execute(
             """WITH RECURSIVE subtree(id, name, common_name, rank, parent_id, depth) AS (
                    SELECT id, name, common_name, rank, parent_id, 0

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -9126,41 +9126,48 @@ class Database:
         return dict(row) if row else None
 
     def get_life_list_taxon_ids(self):
-        """Distinct taxa ids of workspace-scoped tagged species (same eligibility
-        as get_life_list_candidates), excluding species keywords with no taxon_id."""
+        """Distinct species-rank taxa ids of workspace-scoped tagged species (same
+        eligibility as get_life_list_candidates). Excludes species keywords with no
+        taxon_id AND taxonomy tags that resolve to a taxon above species rank
+        (genus, family, etc.). Higher-rank matches are surfaced via
+        get_life_list_unmatched_species so the explorer's found/total math stays
+        at species rank and non-species tags aren't silently undercounted."""
         ws = self._ws_id()
         rows = self.conn.execute(
             """SELECT DISTINCT k.taxon_id AS tid
                FROM photo_keywords pk
                JOIN keywords k ON k.id = pk.keyword_id
                 AND (k.is_species = 1 OR k.type = 'taxonomy')
+               JOIN taxa t ON t.id = k.taxon_id AND t.rank = 'species'
                JOIN photos p ON p.id = pk.photo_id
                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
                 AND wf.workspace_id = ?
                JOIN folders f ON f.id = p.folder_id
                 AND f.status IN ('ok', 'partial')
-               WHERE COALESCE(p.flag, 'none') != 'rejected'
-                 AND k.taxon_id IS NOT NULL""",
+               WHERE COALESCE(p.flag, 'none') != 'rejected'""",
             (ws,),
         ).fetchall()
         return {r["tid"] for r in rows}
 
     def get_life_list_unmatched_species(self):
-        """Names of workspace-scoped tagged species keywords with no taxon_id —
-        surfaced honestly in the explorer as 'not counted'."""
+        """Names of workspace-scoped tagged species keywords that can't be counted
+        at species rank — either no linked taxon at all, or a link that lands on
+        a taxon above species (genus/family/etc.). Surfaced honestly in the
+        explorer as 'not counted' so higher-rank matches aren't silently dropped."""
         ws = self._ws_id()
         rows = self.conn.execute(
             """SELECT DISTINCT k.name AS name
                FROM photo_keywords pk
                JOIN keywords k ON k.id = pk.keyword_id
                 AND (k.is_species = 1 OR k.type = 'taxonomy')
+               LEFT JOIN taxa t ON t.id = k.taxon_id
                JOIN photos p ON p.id = pk.photo_id
                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
                 AND wf.workspace_id = ?
                JOIN folders f ON f.id = p.folder_id
                 AND f.status IN ('ok', 'partial')
                WHERE COALESCE(p.flag, 'none') != 'rejected'
-                 AND k.taxon_id IS NULL
+                 AND (k.taxon_id IS NULL OR t.rank IS NULL OR t.rank != 'species')
                ORDER BY k.name""",
             (ws,),
         ).fetchall()

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -9195,25 +9195,35 @@ class Database:
 
     def get_classes_for_taxa(self, taxon_ids):
         """Distinct class-rank ancestors of the given taxa, for the explorer's
-        class selector. Returns [{id,name,common_name}] ordered by name."""
+        class selector. Returns [{id,name,common_name}] ordered by name.
+
+        Callers pass the full life-list `found` set, which can exceed SQLite's
+        bound-parameter limit on large life lists — chunk the seed IDs and
+        merge the distinct classes across chunks so the endpoint doesn't 500.
+        """
         ids = [t for t in taxon_ids if t is not None]
         if not ids:
             return []
-        placeholders = ",".join("?" for _ in ids)
-        rows = self.conn.execute(
-            f"""WITH RECURSIVE up(id) AS (
-                    SELECT id FROM taxa WHERE id IN ({placeholders})
-                    UNION
-                    SELECT t.parent_id FROM taxa t JOIN up u ON t.id = u.id
-                    WHERE t.parent_id IS NOT NULL
-                )
-                SELECT DISTINCT t.id, t.name, t.common_name
-                FROM up u JOIN taxa t ON t.id = u.id
-                WHERE t.rank = 'class'
-                ORDER BY COALESCE(t.common_name, t.name)""",
-            ids,
-        ).fetchall()
-        return [dict(r) for r in rows]
+        seen = {}
+        for chunk in _chunks(ids):
+            placeholders = ",".join("?" for _ in chunk)
+            rows = self.conn.execute(
+                f"""WITH RECURSIVE up(id) AS (
+                        SELECT id FROM taxa WHERE id IN ({placeholders})
+                        UNION
+                        SELECT t.parent_id FROM taxa t JOIN up u ON t.id = u.id
+                        WHERE t.parent_id IS NOT NULL
+                    )
+                    SELECT DISTINCT t.id, t.name, t.common_name
+                    FROM up u JOIN taxa t ON t.id = u.id
+                    WHERE t.rank = 'class'""",
+                chunk,
+            ).fetchall()
+            for r in rows:
+                if r["id"] not in seen:
+                    seen[r["id"]] = dict(r)
+        return sorted(seen.values(),
+                      key=lambda r: r["common_name"] or r["name"])
 
     def get_life_list_best_photo_by_taxon(self, taxon_ids):
         """Map taxon_id -> {id, filename} of a representative (highest quality_score,

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -9125,6 +9125,121 @@ class Database:
         ).fetchone()
         return dict(row) if row else None
 
+    def get_life_list_taxon_ids(self):
+        """Distinct taxa ids of workspace-scoped tagged species (same eligibility
+        as get_life_list_candidates), excluding species keywords with no taxon_id."""
+        ws = self._ws_id()
+        rows = self.conn.execute(
+            """SELECT DISTINCT k.taxon_id AS tid
+               FROM photo_keywords pk
+               JOIN keywords k ON k.id = pk.keyword_id
+                AND (k.is_species = 1 OR k.type = 'taxonomy')
+               JOIN photos p ON p.id = pk.photo_id
+               JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+                AND wf.workspace_id = ?
+               JOIN folders f ON f.id = p.folder_id
+                AND f.status IN ('ok', 'partial')
+               WHERE COALESCE(p.flag, 'none') != 'rejected'
+                 AND k.taxon_id IS NOT NULL""",
+            (ws,),
+        ).fetchall()
+        return {r["tid"] for r in rows}
+
+    def get_life_list_unmatched_species(self):
+        """Names of workspace-scoped tagged species keywords with no taxon_id —
+        surfaced honestly in the explorer as 'not counted'."""
+        ws = self._ws_id()
+        rows = self.conn.execute(
+            """SELECT DISTINCT k.name AS name
+               FROM photo_keywords pk
+               JOIN keywords k ON k.id = pk.keyword_id
+                AND (k.is_species = 1 OR k.type = 'taxonomy')
+               JOIN photos p ON p.id = pk.photo_id
+               JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+                AND wf.workspace_id = ?
+               JOIN folders f ON f.id = p.folder_id
+                AND f.status IN ('ok', 'partial')
+               WHERE COALESCE(p.flag, 'none') != 'rejected'
+                 AND k.taxon_id IS NULL
+               ORDER BY k.name""",
+            (ws,),
+        ).fetchall()
+        return [r["name"] for r in rows]
+
+    def get_taxon_subtree(self, root_id, max_depth=12):
+        """All taxa in the subtree rooted at root_id (inclusive), as dict rows
+        with id, name, common_name, rank, parent_id. Uses the parent_id index."""
+        return [dict(r) for r in self.conn.execute(
+            """WITH RECURSIVE subtree(id, name, common_name, rank, parent_id, depth) AS (
+                   SELECT id, name, common_name, rank, parent_id, 0
+                   FROM taxa WHERE id = ?
+                   UNION ALL
+                   SELECT t.id, t.name, t.common_name, t.rank, t.parent_id, s.depth + 1
+                   FROM taxa t JOIN subtree s ON t.parent_id = s.id
+                   WHERE s.depth < ?
+               )
+               SELECT id, name, common_name, rank, parent_id FROM subtree""",
+            (root_id, max_depth),
+        ).fetchall()]
+
+    def get_classes_for_taxa(self, taxon_ids):
+        """Distinct class-rank ancestors of the given taxa, for the explorer's
+        class selector. Returns [{id,name,common_name}] ordered by name."""
+        ids = [t for t in taxon_ids if t is not None]
+        if not ids:
+            return []
+        placeholders = ",".join("?" for _ in ids)
+        rows = self.conn.execute(
+            f"""WITH RECURSIVE up(id) AS (
+                    SELECT id FROM taxa WHERE id IN ({placeholders})
+                    UNION
+                    SELECT t.parent_id FROM taxa t JOIN up u ON t.id = u.id
+                    WHERE t.parent_id IS NOT NULL
+                )
+                SELECT DISTINCT t.id, t.name, t.common_name
+                FROM up u JOIN taxa t ON t.id = u.id
+                WHERE t.rank = 'class'
+                ORDER BY COALESCE(t.common_name, t.name)""",
+            ids,
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    def get_life_list_best_photo_by_taxon(self, taxon_ids):
+        """Map taxon_id -> {id, filename} of a representative (highest quality_score,
+        newest) workspace-scoped photo for that species. Missing taxa are absent."""
+        ids = [t for t in taxon_ids if t is not None]
+        if not ids:
+            return {}
+        ws = self._ws_id()
+        placeholders = ",".join("?" for _ in ids)
+        rows = self.conn.execute(
+            f"""SELECT k.taxon_id AS tid, p.id, p.filename, p.quality_score, p.timestamp
+                FROM photo_keywords pk
+                JOIN keywords k ON k.id = pk.keyword_id AND k.taxon_id IN ({placeholders})
+                JOIN photos p ON p.id = pk.photo_id
+                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+                 AND wf.workspace_id = ?
+                JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok','partial')
+                WHERE COALESCE(p.flag, 'none') != 'rejected'
+                ORDER BY k.taxon_id,
+                         COALESCE(p.quality_score, -1) DESC,
+                         COALESCE(p.timestamp, '') DESC""",
+            ids + [ws],
+        ).fetchall()
+        best = {}
+        for r in rows:
+            if r["tid"] not in best:  # first row per taxon is the best by ORDER BY
+                best[r["tid"]] = {"id": r["id"], "filename": r["filename"]}
+        return best
+
+    def get_taxon_by_id(self, taxon_id):
+        """Thin getter for a single taxon row (for non-default explorer roots)."""
+        row = self.conn.execute(
+            "SELECT id, name, common_name, rank, parent_id FROM taxa WHERE id = ?",
+            (taxon_id,),
+        ).fetchone()
+        return dict(row) if row else None
+
     def get_photo_life_list_species(self, photo_id):
         """Return this photo's lifelist-eligible species names in the active
         workspace, ordered by name.

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -9115,6 +9115,16 @@ class Database:
             (ws,),
         ).fetchall()
 
+    def get_explorer_root(self, name="Aves", rank="class"):
+        """Return {id,name,common_name,rank} for the default explorer root class,
+        or None when the reference taxonomy has not been downloaded."""
+        row = self.conn.execute(
+            "SELECT id, name, common_name, rank FROM taxa"
+            " WHERE name = ? AND rank = ? LIMIT 1",
+            (name, rank),
+        ).fetchone()
+        return dict(row) if row else None
+
     def get_photo_life_list_species(self, photo_id):
         """Return this photo's lifelist-eligible species names in the active
         workspace, ordered by name.

--- a/vireo/templates/life_list.html
+++ b/vireo/templates/life_list.html
@@ -53,6 +53,21 @@
   .ll-tab.active { color:var(--text-primary); border-bottom-color:var(--accent); }
   .ll-tabpanel { display:none; }
   .ll-tabpanel.active { display:block; }
+
+  /* --- Explorer --- */
+  .ll-exp { padding:16px 24px; }
+  .ll-exp-cta { max-width:520px; margin:60px auto; text-align:center; color:var(--text-secondary); }
+  .ll-exp-cta h2 { font-size:18px; color:var(--text-primary); margin-bottom:10px; }
+  .ll-exp-cta p { font-size:13px; line-height:1.5; margin-bottom:18px; }
+  .ll-exp-empty { text-align:center; padding:60px 24px; color:var(--text-secondary); font-size:14px; }
+  .ll-exp-controls { display:flex; align-items:center; gap:12px; flex-wrap:wrap; margin-bottom:14px; }
+  .ll-exp-controls label { font-size:13px; color:var(--text-secondary); }
+  .ll-exp-controls select { font-size:13px; padding:4px 8px; background:var(--bg-input); color:var(--text-primary); border:1px solid var(--border-secondary); border-radius:4px; }
+
+  .ll-unmatched { font-size:12px; color:var(--text-muted); margin-bottom:14px; }
+  .ll-unmatched details { margin-top:4px; }
+  .ll-unmatched summary { cursor:pointer; color:var(--text-secondary); }
+  .ll-unmatched ul { margin:6px 0 0 16px; padding:0; columns:2; font-size:12px; }
 </style>
 </head>
 <body>
@@ -421,8 +436,120 @@ document.addEventListener('lifelist:changed', function() {
   loadLifeList();
 });
 
+// ---------------- Explorer: data load + honesty states (Task 10) ----------------
+
+// Load the explorer tree for a class (rootId = class taxon id, or omit for
+// the default Aves root). Stores the payload and re-renders.
+async function loadExplorer(rootId) {
+  var panel = document.getElementById('tab-explorer');
+  panel.innerHTML = '<div class="ll-exp"><div class="ll-exp-empty">Loading…</div></div>';
+  try {
+    explorerData = await safeFetch('/api/life-list/explorer' + (rootId ? ('?root=' + encodeURIComponent(rootId)) : ''));
+  } catch (e) {
+    panel.innerHTML = '<div class="ll-exp"><div class="ll-exp-empty">Failed to load explorer.</div></div>';
+    return;
+  }
+  explorerPath = [];   // reset drill path whenever a new class is loaded
+  renderExplorer();
+}
+
+// Trigger the taxonomy download job, then poll it and reload the explorer on
+// completion. Mirrors settings.html's downloadTaxonomy() pattern.
+async function explorerDownloadTaxonomy(btn) {
+  btn.disabled = true;
+  btn.textContent = 'Downloading… (see Jobs panel)';
+  try {
+    var data = await safeFetch('/api/jobs/download-taxonomy', { method: 'POST' }, { toast: false });
+    if (typeof safeEventSource === 'function' && data && data.job_id) {
+      safeEventSource('/api/jobs/' + data.job_id + '/stream', {
+        onComplete: function() { loadExplorer(); }
+      });
+    }
+  } catch (e) {
+    btn.disabled = false;
+    btn.textContent = 'Download the taxonomy';
+  }
+}
+
+function renderExplorer() {
+  var panel = document.getElementById('tab-explorer');
+  var d = explorerData || {};
+
+  // Honesty state 1: reference taxonomy not downloaded — no fake 0/0.
+  if (!d.taxonomy_ready) {
+    panel.innerHTML =
+      '<div class="ll-exp"><div class="ll-exp-cta">'
+      + '<h2>Download the taxonomy to see completeness</h2>'
+      + '<p>The explorer compares your tagged species against the full iNaturalist '
+      + 'reference taxonomy (orders, families, genera, species). That reference '
+      + "hasn't been downloaded yet, so there are no totals to measure against.</p>"
+      + '<button class="publish-btn" onclick="explorerDownloadTaxonomy(this)">Download the taxonomy</button>'
+      + '</div></div>';
+    return;
+  }
+
+  var html = '<div class="ll-exp">';
+
+  // Class selector — always includes the current root so Birds stays selectable
+  // even before the user has tagged any birds.
+  html += '<div class="ll-exp-controls">';
+  html += '<label for="explorerClass">Class</label>';
+  html += '<select id="explorerClass" onchange="loadExplorer(this.value)">';
+  var classes = (d.classes || []).slice();
+  var root = d.root || {};
+  var seenRoot = classes.some(function(c) { return c.id === root.id; });
+  if (root.id != null && !seenRoot) {
+    classes.unshift({ id: root.id, name: root.name, common_name: root.common_name });
+  }
+  classes.forEach(function(c) {
+    var label = c.common_name || c.name;
+    var sel = (root.id != null && c.id === root.id) ? ' selected' : '';
+    html += '<option value="' + escapeAttr(c.id) + '"' + sel + '>' + escapeAttr(label) + '</option>';
+  });
+  html += '</select>';
+  html += '</div>';
+
+  var summary = d.summary || {};
+  var speciesTotal = summary.species ? summary.species.total : 0;
+
+  // Honesty state 2: taxonomy ready but this class has no reference taxa.
+  if (!speciesTotal) {
+    html += '<div class="ll-exp-empty">No reference taxa for this class.</div>';
+    html += renderUnmatched(d);
+    html += '</div>';
+    panel.innerHTML = html;
+    return;
+  }
+
+  html += renderUnmatched(d);
+  html += '<div id="explorerBody"></div>';
+  html += '</div>';
+  panel.innerHTML = html;
+}
+
+// Muted footnote for tagged species that aren't matched to the taxonomy and so
+// aren't counted here. If the name list is truncated, say so plainly.
+function renderUnmatched(d) {
+  var u = d.unmatched_species || { count: 0, names: [] };
+  if (!u.count) return '';
+  var names = u.names || [];
+  var truncated = u.count > names.length;
+  var html = '<div class="ll-unmatched">';
+  html += u.count + " tagged species aren't matched to the taxonomy and aren't counted here.";
+  html += '<details><summary>'
+    + (truncated ? ('Show the first ' + names.length + ' of ' + u.count) : 'Show them')
+    + '</summary><ul>';
+  names.forEach(function(n) { html += '<li>' + escapeHtml(n) + '</li>'; });
+  html += '</ul>';
+  if (truncated) html += '<div style="margin-top:4px;">…and ' + (u.count - names.length) + ' more not shown.</div>';
+  html += '</details></div>';
+  return html;
+}
+
 // ---------------- Explorer tab ----------------
 var explorerLoaded = false;   // lazy-load guard: fetch explorer once on first open
+var explorerData = null;      // last payload from /api/life-list/explorer
+var explorerPath = [];        // [{id,name,rank}] drill path from class root down
 
 function llSwitchTab(name) {
   document.querySelectorAll('.ll-tab').forEach(function(t) {
@@ -441,9 +568,6 @@ function llSwitchTab(name) {
     loadExplorer();
   }
 }
-
-// Placeholder — filled in by Task 10.
-async function loadExplorer(rootId) {}
 
 loadLifeList();
 

--- a/vireo/templates/life_list.html
+++ b/vireo/templates/life_list.html
@@ -90,6 +90,20 @@
   .ll-card-sub { font-size:12px; color:var(--text-secondary); margin-top:6px; font-variant-numeric:tabular-nums; }
   .ll-ring { flex:0 0 auto; }
   .ll-ring text { font-size:13px; font-weight:600; fill:var(--text-primary); font-variant-numeric:tabular-nums; }
+
+  .ll-leaf-head { display:flex; align-items:center; gap:16px; flex-wrap:wrap; margin-bottom:14px; }
+  .ll-leaf-head h3 { font-size:16px; color:var(--text-primary); margin:0; font-variant-numeric:tabular-nums; }
+  .ll-leaf-head label { font-size:13px; color:var(--text-secondary); display:flex; align-items:center; gap:6px; }
+  .ll-leaf-grid { display:grid; grid-template-columns:repeat(auto-fill, minmax(180px, 1fr)); gap:14px; }
+  .ll-sp { border-radius:8px; overflow:hidden; background:var(--bg-secondary); border:1px solid var(--border-primary); }
+  .ll-sp.missing { opacity:.6; }
+  .ll-sp img, .ll-sp .ll-sp-ph { width:100%; aspect-ratio:3/2; object-fit:cover; display:block; background:var(--bg-tertiary); }
+  .ll-sp-info { padding:8px 10px 10px; }
+  .ll-sp-name { font-size:14px; font-weight:600; color:var(--text-primary); }
+  .ll-sp-common { font-size:12px; color:var(--text-secondary); margin-top:1px; }
+  .ll-sp-chip { display:inline-block; margin-top:6px; padding:1px 8px; border-radius:999px; font-size:11px; }
+  .ll-sp-chip.seen { background:var(--accent); color:var(--accent-text); }
+  .ll-sp-chip.notyet { background:var(--bg-tertiary); color:var(--text-muted); }
 </style>
 </head>
 <body>
@@ -689,8 +703,72 @@ function renderExplorerCard(n) {
     + '</div></div>';
 }
 
-// Genus species leaf — implemented in Task 12.
-function loadExplorerSpecies(node) {}
+// ---------------- Explorer: species leaf (Task 12) ----------------
+
+var explorerLeafData = null;   // last species-leaf payload
+var explorerLeafGenus = null;  // {id,name,rank} of the genus being shown
+
+async function loadExplorerSpecies(node) {
+  explorerLeafGenus = { id: node.id, name: node.common_name || node.name, rank: node.rank };
+  explorerPath.push(explorerLeafGenus);
+  var body = document.getElementById('explorerBody');
+  if (body) body.innerHTML = renderBreadcrumb() + '<div class="ll-exp-empty">Loading species…</div>';
+  try {
+    explorerLeafData = await safeFetch('/api/life-list/explorer/species?genus=' + encodeURIComponent(node.id));
+  } catch (e) {
+    if (body) body.innerHTML = renderBreadcrumb() + '<div class="ll-exp-empty">Failed to load species.</div>';
+    return;
+  }
+  renderExplorerLeaf(false);
+}
+
+function renderExplorerLeaf(missingOnly) {
+  var body = document.getElementById('explorerBody');
+  if (!body) return;
+  var species = (explorerLeafData && explorerLeafData.species) || [];
+  var found = species.filter(function(s) { return s.found; }).length;
+  var genusName = explorerLeafGenus ? explorerLeafGenus.name : '';
+
+  var html = renderBreadcrumb();
+  html += '<div class="ll-leaf-head">';
+  html += '<h3>' + found + '/' + species.length + ' species in ' + escapeHtml(genusName) + '</h3>';
+  html += '<label><input type="checkbox" id="explorerMissingOnly"' + (missingOnly ? ' checked' : '') + '> Show missing only</label>';
+  html += '</div>';
+
+  var shown = missingOnly ? species.filter(function(s) { return !s.found; }) : species;
+  html += '<div class="ll-leaf-grid">';
+  shown.forEach(function(s) { html += renderSpeciesTile(s); });
+  html += '</div>';
+  if (!shown.length) html += '<div class="ll-exp-empty">Nothing to show.</div>';
+  body.innerHTML = html;
+
+  // renderBreadcrumb defers its own handlers; wire the checkbox here.
+  var chk = document.getElementById('explorerMissingOnly');
+  if (chk) chk.addEventListener('change', function() { renderExplorerLeaf(chk.checked); });
+}
+
+function renderSpeciesTile(s) {
+  var common = (s.common_name && s.common_name !== s.name)
+    ? '<div class="ll-sp-common">' + escapeHtml(s.common_name) + '</div>' : '';
+  if (s.found) {
+    var thumb = s.photo ? photoThumbnailUrl(s.photo) : '';
+    var img = thumb
+      ? '<img src="' + escapeAttr(thumb) + '" alt="' + escapeAttr(s.photo ? s.photo.filename : s.name) + '" loading="lazy">'
+      : '<div class="ll-sp-ph"></div>';
+    return '<div class="ll-sp">' + img
+      + '<div class="ll-sp-info">'
+      + '<div class="ll-sp-name">' + escapeHtml(s.name) + '</div>'
+      + common
+      + '<span class="ll-sp-chip seen">✓ seen</span>'
+      + '</div></div>';
+  }
+  return '<div class="ll-sp missing"><div class="ll-sp-ph"></div>'
+    + '<div class="ll-sp-info">'
+    + '<div class="ll-sp-name">' + escapeHtml(s.name) + '</div>'
+    + common
+    + '<span class="ll-sp-chip notyet">not yet</span>'
+    + '</div></div>';
+}
 
 // ---------------- Explorer tab ----------------
 var explorerLoaded = false;   // lazy-load guard: fetch explorer once on first open

--- a/vireo/templates/life_list.html
+++ b/vireo/templates/life_list.html
@@ -45,10 +45,25 @@
   .lifelist-empty a { color:var(--accent); }
   /* .lifelist-lb-panel styles now live in _navbar.html — the "Add to Life
      List" lightbox panel is shared across every page's lightbox. */
+
+  /* --- List / Explorer tabs (pattern adapted from audit.html, renamed ll-*) --- */
+  .ll-tabs { display:flex; gap:0; padding:0 24px; background:var(--bg-secondary); border-bottom:1px solid var(--border-primary); }
+  .ll-tab { padding:12px 20px; cursor:pointer; font-size:13px; color:var(--text-muted); border-bottom:2px solid transparent; transition:color 0.15s, border-color 0.15s; user-select:none; }
+  .ll-tab:hover { color:var(--text-primary); }
+  .ll-tab.active { color:var(--text-primary); border-bottom-color:var(--accent); }
+  .ll-tabpanel { display:none; }
+  .ll-tabpanel.active { display:block; }
 </style>
 </head>
 <body>
 {% include '_navbar.html' %}
+
+<div class="ll-tabs">
+  <div class="ll-tab active" data-tab="list" onclick="llSwitchTab('list')">List</div>
+  <div class="ll-tab" data-tab="explorer" onclick="llSwitchTab('explorer')">Explorer</div>
+</div>
+
+<div class="ll-tabpanel active" id="tab-list">
 
 <div class="lifelist-controls" id="controlsBar">
   <div class="control-group">
@@ -153,6 +168,10 @@
      predictions on the <a href="/highlights">Highlights</a> page or tag
      photos while browsing.</p>
 </div>
+
+</div><!-- /#tab-list -->
+
+<div class="ll-tabpanel" id="tab-explorer"></div>
 
 <script>
 var currentData = null;
@@ -402,7 +421,38 @@ document.addEventListener('lifelist:changed', function() {
   loadLifeList();
 });
 
+// ---------------- Explorer tab ----------------
+var explorerLoaded = false;   // lazy-load guard: fetch explorer once on first open
+
+function llSwitchTab(name) {
+  document.querySelectorAll('.ll-tab').forEach(function(t) {
+    t.classList.toggle('active', t.dataset.tab === name);
+  });
+  document.querySelectorAll('.ll-tabpanel').forEach(function(p) {
+    p.classList.toggle('active', p.id === 'tab-' + name);
+  });
+  try {
+    var url = new URL(window.location.href);
+    url.searchParams.set('view', name);
+    history.replaceState(null, '', url.toString());
+  } catch (e) {}
+  if (name === 'explorer' && !explorerLoaded) {
+    explorerLoaded = true;
+    loadExplorer();
+  }
+}
+
+// Placeholder — filled in by Task 10.
+async function loadExplorer(rootId) {}
+
 loadLifeList();
+
+// Initial tab from ?view= (defaults to list).
+(function() {
+  var view = 'list';
+  try { view = new URLSearchParams(window.location.search).get('view') || 'list'; } catch (e) {}
+  if (view === 'explorer') llSwitchTab('explorer');
+})();
 </script>
 </body>
 </html>

--- a/vireo/templates/life_list.html
+++ b/vireo/templates/life_list.html
@@ -104,6 +104,20 @@
   .ll-sp-chip { display:inline-block; margin-top:6px; padding:1px 8px; border-radius:999px; font-size:11px; }
   .ll-sp-chip.seen { background:var(--accent); color:var(--accent-text); }
   .ll-sp-chip.notyet { background:var(--bg-tertiary); color:var(--text-muted); }
+
+  /* Sunburst completeness overview (Task 13) */
+  .ll-sunburst { display:flex; justify-content:center; margin:4px 0 20px; }
+  .ll-sb-svg { display:block; }
+  .ll-sb-svg .ll-sb-arc { cursor:pointer; stroke:var(--bg-primary); stroke-width:1; }
+  .ll-sb-svg .ll-sb-arc:hover { stroke:var(--accent); stroke-width:1.5; }
+  .ll-sb-svg .ll-sb-center { cursor:pointer; fill:var(--bg-tertiary); stroke:var(--bg-primary); stroke-width:1; }
+  .ll-sb-svg .ll-sb-center:hover { fill:var(--bg-input); }
+  .ll-sb-svg .ll-sb-center-label { fill:var(--text-primary); font-size:12px; font-weight:600; pointer-events:none; font-variant-numeric:tabular-nums; text-anchor:middle; dominant-baseline:central; }
+  .ll-sb-tooltip { position:fixed; z-index:9999; pointer-events:none; background:var(--bg-panel); color:var(--text-primary);
+    border:1px solid var(--border-secondary); border-radius:6px; padding:6px 9px; font-size:12px; line-height:1.4;
+    max-width:260px; box-shadow:0 4px 14px rgba(0,0,0,.35); display:none; font-variant-numeric:tabular-nums; }
+  .ll-sb-tooltip b { color:var(--text-primary); }
+  .ll-sb-tooltip .ll-sb-tt-sci { color:var(--text-secondary); font-style:italic; }
 </style>
 </head>
 <body>
@@ -557,12 +571,17 @@ function renderExplorer() {
     return;
   }
 
+  // Sunburst goes above the summary chips; rebuilt on every explorer render
+  // (class switch / reload) so no stale SVG survives — panel.innerHTML below
+  // wipes any prior container.
+  html += '<div class="ll-sunburst" id="explorerSunburst"></div>';
   html += renderSummaryBar(summary);
   html += renderUnmatched(d);
   html += '<div id="explorerBody"></div>';
   html += '</div>';
   panel.innerHTML = html;
 
+  renderSunburst();
   wireBreadcrumb(document.getElementById('explorerBody'));
   renderExplorerBody();
 }
@@ -674,6 +693,224 @@ function renderBreadcrumb() {
   // Crumb click handling is delegated once via wireBreadcrumb() on #explorerBody;
   // no per-render handler attachment here.
   return html;
+}
+
+// ---------------- Explorer: sunburst overview (Task 13) ----------------
+//
+// Whole-class completeness at a glance: three rings out from the center —
+// orders (inner) → families (middle) → genera (outer), built from
+// explorerData.nodes (the tree materialized down to genus; species are NOT
+// in that tree, so there is no species ring). Each node's angular span is
+// proportional to its total_species; children partition their parent's arc in
+// the same order the cards use (explorerData.nodes is already found-first-then-
+// alpha from the server). Arc fill is var(--accent) at an opacity scaled by
+// found_species/total_species, over a var(--bg-tertiary) ghost track, so an
+// untouched branch reads clearly faded and a complete branch fully saturated.
+// Clicking an arc drills the cards below via the same explorerPath the cards
+// and breadcrumb use; clicking the center resets to the top level.
+
+var explorerSunburstLineage = {};   // node id -> [{id,name,rank}] root→node lineage
+
+// Convert a polar point (center + radius + angle in radians, 0 = top,
+// clockwise) to SVG x/y. Returns a string "x,y".
+function llPolar(cx, cy, r, a) {
+  return (cx + r * Math.sin(a)).toFixed(3) + ',' + (cy - r * Math.cos(a)).toFixed(3);
+}
+
+// SVG path for a single ring segment (annular sector) spanning [a0,a1] radians
+// between inner radius r0 and outer radius r1.
+function llArcPath(cx, cy, r0, r1, a0, a1) {
+  // A single child spanning (near) a full 360° collapses to a degenerate arc
+  // because start==end. Draw a full annulus (two stacked half-arcs) instead.
+  if ((a1 - a0) >= 2 * Math.PI - 1e-6) {
+    var m = a0 + Math.PI;
+    return llArcPath(cx, cy, r0, r1, a0, m) + ' ' + llArcPath(cx, cy, r0, r1, m, a1);
+  }
+  var largeArc = (a1 - a0) > Math.PI ? 1 : 0;
+  var p0 = llPolar(cx, cy, r1, a0);   // outer start
+  var p1 = llPolar(cx, cy, r1, a1);   // outer end
+  var p2 = llPolar(cx, cy, r0, a1);   // inner end
+  var p3 = llPolar(cx, cy, r0, a0);   // inner start
+  return 'M' + p0
+    + ' A' + r1.toFixed(3) + ',' + r1.toFixed(3) + ' 0 ' + largeArc + ' 1 ' + p1
+    + ' L' + p2
+    + ' A' + r0.toFixed(3) + ',' + r0.toFixed(3) + ' 0 ' + largeArc + ' 0 ' + p3
+    + ' Z';
+}
+
+// Accent fill at an opacity scaled by completeness. 0 found → a ghost track so
+// untouched branches read faded; 1.0 → full accent. Zero-total arcs (should not
+// happen below genus, but guard anyway) render as the plain track.
+function llArcFill(found, total) {
+  if (!total || total <= 0) return { fill: 'var(--bg-tertiary)', op: 1 };
+  var frac = Math.max(0, Math.min(1, found / total));
+  if (frac <= 0) return { fill: 'var(--bg-tertiary)', op: 1 };
+  return { fill: 'var(--accent)', op: (0.15 + 0.85 * frac) };
+}
+
+function renderSunburst() {
+  var host = document.getElementById('explorerSunburst');
+  if (!host) return;
+  var top = (explorerData && explorerData.nodes) || [];
+  explorerSunburstLineage = {};
+
+  // Total angular weight = sum of order total_species. Guard total==0 / empty:
+  // hide the sunburst entirely (honesty states already cover those below).
+  var classTotal = 0;
+  top.forEach(function(n) { classTotal += (n.total_species || 0); });
+  if (!top.length || classTotal <= 0) { host.innerHTML = ''; host.style.display = 'none'; return; }
+  host.style.display = 'flex';
+
+  var SIZE = 360, cx = SIZE / 2, cy = SIZE / 2;
+  var R_CENTER = 46;                       // clickable reset hub
+  var rings = [R_CENTER, 92, 138, 176];    // ring boundaries: center→order→family→genus
+
+  var root = (explorerData && explorerData.root) || {};
+  var rootLineage = [];   // lineage entries accumulate as we recurse
+  var arcs = [];          // collected {path, fill, op, tip, lineage}
+
+  var FULL = 2 * Math.PI;
+
+  // Recurse a level, laying children out proportional to total_species within
+  // [a0,a1]. depth 0 = orders, 1 = families, 2 = genera (last ring).
+  function layout(list, a0, a1, depth, lineage) {
+    if (depth > 2 || !list || !list.length) return;
+    var span = a1 - a0;
+    // Denominator = sum of this level's total_species; fall back to equal
+    // partition if every child is zero (degenerate, keeps geometry valid).
+    var sum = 0;
+    list.forEach(function(n) { sum += (n.total_species || 0); });
+    var equal = sum <= 0;
+    var cursor = a0;
+    list.forEach(function(n) {
+      var w = equal ? (span / list.length)
+                    : (span * (n.total_species || 0) / sum);
+      var s = cursor, e = cursor + w;
+      cursor = e;
+      if (w <= 0) return;   // zero-weight child gets no arc
+      var lin = lineage.concat([{ id: n.id, name: n.common_name || n.name, rank: n.rank }]);
+      explorerSunburstLineage[n.id] = lin;
+      var shade = llArcFill(n.found_species || 0, n.total_species || 0);
+      arcs.push({
+        id: n.id,
+        path: llArcPath(cx, cy, rings[depth], rings[depth + 1], s, e),
+        fill: shade.fill, op: shade.op,
+        name: n.common_name || n.name,
+        sci: (n.common_name && n.common_name !== n.name) ? n.name : '',
+        found: n.found_species || 0, total: n.total_species || 0
+      });
+      layout(n.children || [], s, e, depth + 1, lin);
+    });
+  }
+  layout(top, 0, FULL, 0, rootLineage);
+
+  var parts = [];
+  parts.push('<svg class="ll-sb-svg" width="' + SIZE + '" height="' + SIZE + '" viewBox="0 0 ' + SIZE + ' ' + SIZE + '"'
+    + ' role="img" aria-label="Taxonomic completeness sunburst">');
+  arcs.forEach(function(a) {
+    var pct = a.total > 0 ? Math.round((a.found / a.total) * 100) : 0;
+    parts.push('<path class="ll-sb-arc" d="' + a.path + '" fill="' + a.fill + '"'
+      + ' fill-opacity="' + a.op.toFixed(3) + '"'
+      + ' data-id="' + escapeAttr(a.id) + '"'
+      + ' data-name="' + escapeAttr(a.name) + '"'
+      + ' data-sci="' + escapeAttr(a.sci) + '"'
+      + ' data-found="' + a.found + '" data-total="' + a.total + '" data-pct="' + pct + '"></path>');
+  });
+  // Center hub = reset-to-top control, labeled with class-level completeness.
+  var summary = (explorerData && explorerData.summary) || {};
+  var sp = summary.species || { found: 0, total: 0 };
+  var centerPct = sp.total > 0 ? Math.round((sp.found / sp.total) * 100) : 0;
+  var centerLabel = escapeHtml((root.common_name || root.name || 'All'));
+  parts.push('<circle class="ll-sb-center" id="explorerSunburstCenter" cx="' + cx + '" cy="' + cy + '" r="' + R_CENTER + '"'
+    + ' data-name="' + escapeAttr(root.common_name || root.name || 'All') + '"'
+    + ' data-found="' + sp.found + '" data-total="' + sp.total + '" data-pct="' + centerPct + '"></circle>');
+  parts.push('<text class="ll-sb-center-label" x="' + cx + '" y="' + (cy - 6) + '">' + centerLabel + '</text>');
+  parts.push('<text class="ll-sb-center-label" x="' + cx + '" y="' + (cy + 11) + '" style="font-size:11px;fill:var(--text-secondary)">' + centerPct + '%</text>');
+  parts.push('</svg>');
+  host.innerHTML = parts.join('');
+
+  wireSunburst(host);
+}
+
+// Shared floating tooltip element (one per document, reused).
+function llSunburstTooltip() {
+  var tip = document.getElementById('explorerSunburstTip');
+  if (!tip) {
+    tip = document.createElement('div');
+    tip.id = 'explorerSunburstTip';
+    tip.className = 'll-sb-tooltip';
+    document.body.appendChild(tip);
+  }
+  return tip;
+}
+
+function wireSunburst(host) {
+  var svg = host.querySelector('.ll-sb-svg');
+  if (!svg) return;
+  var tip = llSunburstTooltip();
+
+  function showTip(el, ev) {
+    var name = el.getAttribute('data-name') || '';
+    var sci = el.getAttribute('data-sci') || '';
+    var found = el.getAttribute('data-found') || '0';
+    var total = el.getAttribute('data-total') || '0';
+    var pct = el.getAttribute('data-pct') || '0';
+    var html = '<b>' + escapeHtml(name) + '</b>';
+    if (sci) html += ' <span class="ll-sb-tt-sci">' + escapeHtml(sci) + '</span>';
+    html += '<br>' + escapeHtml(found) + '/' + escapeHtml(total) + ' species (' + escapeHtml(pct) + '%)';
+    tip.innerHTML = html;
+    tip.style.display = 'block';
+    moveTip(ev);
+  }
+  function moveTip(ev) {
+    // Offset from cursor; clamp to viewport so the tip never spills off-screen.
+    var pad = 14, tw = tip.offsetWidth, th = tip.offsetHeight;
+    var x = ev.clientX + pad, y = ev.clientY + pad;
+    if (x + tw > window.innerWidth - 6) x = ev.clientX - pad - tw;
+    if (y + th > window.innerHeight - 6) y = ev.clientY - pad - th;
+    tip.style.left = Math.max(6, x) + 'px';
+    tip.style.top = Math.max(6, y) + 'px';
+  }
+  function hideTip() { tip.style.display = 'none'; }
+
+  svg.addEventListener('mousemove', function(ev) {
+    var t = ev.target.closest('.ll-sb-arc, .ll-sb-center');
+    if (t) { showTip(t, ev); } else { hideTip(); }
+  });
+  svg.addEventListener('mouseleave', hideTip);
+
+  // Click an arc → drill via its precomputed lineage; click center → reset.
+  svg.addEventListener('click', function(ev) {
+    var center = ev.target.closest('.ll-sb-center');
+    if (center) {
+      explorerPath = [];
+      hideTip();
+      renderExplorerBody();
+      return;
+    }
+    var arc = ev.target.closest('.ll-sb-arc');
+    if (!arc) return;
+    var id = parseInt(arc.getAttribute('data-id'), 10);
+    var lineage = explorerSunburstLineage[id];
+    if (!lineage) return;
+    hideTip();
+    // Genus arcs: drilling to a genus loads its species leaf (matches card
+    // behavior); anything above genus just sets the path and shows cards.
+    var leaf = lineage[lineage.length - 1];
+    if (leaf.rank === 'genus') {
+      // Set path to the genus's parent chain, then load species (which pushes
+      // the genus crumb itself), mirroring a card click on that genus.
+      explorerPath = lineage.slice(0, -1);
+      var node = currentExplorerNodes().find(function(n) { return n.id === id; });
+      if (node) { loadExplorerSpecies(node); return; }
+      // Fallback: if the node isn't in the current level, just set the full path.
+      explorerPath = lineage.slice();
+      renderExplorerBody();
+      return;
+    }
+    explorerPath = lineage.slice();
+    renderExplorerBody();
+  });
 }
 
 // Inline SVG progress ring: accent arc over a --bg-tertiary track, pct% center.

--- a/vireo/templates/life_list.html
+++ b/vireo/templates/life_list.html
@@ -563,7 +563,23 @@ function renderExplorer() {
   html += '</div>';
   panel.innerHTML = html;
 
+  wireBreadcrumb(document.getElementById('explorerBody'));
   renderExplorerBody();
+}
+
+// Single delegated click listener for breadcrumb crumbs. Attached once to the
+// persistent #explorerBody container, so re-rendering its innerHTML (cards,
+// species leaf, loading states) never accumulates duplicate handlers.
+function wireBreadcrumb(container) {
+  if (!container) return;
+  container.addEventListener('click', function(event) {
+    var crumb = event.target.closest('.ll-crumb');
+    if (!crumb || !container.contains(crumb)) return;
+    var depth = parseInt(crumb.getAttribute('data-depth'), 10);
+    if (isNaN(depth) || depth === explorerPath.length) return;   // current crumb: no-op
+    explorerPath = explorerPath.slice(0, depth);
+    renderExplorerBody();
+  });
 }
 
 // Muted footnote for tagged species that aren't matched to the taxonomy and so
@@ -655,19 +671,8 @@ function renderBreadcrumb() {
       + escapeHtml(step.name) + '</span>';
   });
   html += '</div>';
-  // Attach handlers after render (deferred so innerHTML exists).
-  setTimeout(function() {
-    var body = document.getElementById('explorerBody');
-    if (!body) return;
-    body.querySelectorAll('.ll-crumb').forEach(function(c) {
-      c.addEventListener('click', function() {
-        var depth = parseInt(c.getAttribute('data-depth'), 10);
-        if (depth === explorerPath.length) return;   // current crumb: no-op
-        explorerPath = explorerPath.slice(0, depth);
-        renderExplorerBody();
-      });
-    });
-  }, 0);
+  // Crumb click handling is delegated once via wireBreadcrumb() on #explorerBody;
+  // no per-render handler attachment here.
   return html;
 }
 
@@ -686,12 +691,18 @@ function renderRing(found, total) {
     + '</svg>';
 }
 
+function rankPlural(rank, n) {
+  var map = { order: 'orders', family: 'families', genus: 'genera',
+              species: 'species', class: 'classes' };
+  return map[rank] || (rank + 's');
+}
+
 function renderExplorerCard(n) {
   var name = n.common_name || n.name;
   var sci = (n.common_name && n.common_name !== n.name)
     ? '<div class="ll-card-sci">' + escapeHtml(n.name) + '</div>' : '';
-  var childRank = n.child_rank || 'children';
-  var sub = n.found_children + '/' + n.total_children + ' ' + childRank + 's · '
+  var childRank = n.child_rank ? rankPlural(n.child_rank) : 'children';
+  var sub = n.found_children + '/' + n.total_children + ' ' + childRank + ' · '
     + n.found_species + '/' + n.total_species + ' species';
   var emptyCls = (n.found_species === 0) ? ' empty' : '';
   return '<div class="ll-card' + emptyCls + '" data-id="' + escapeAttr(n.id) + '">'
@@ -742,7 +753,7 @@ function renderExplorerLeaf(missingOnly) {
   if (!shown.length) html += '<div class="ll-exp-empty">Nothing to show.</div>';
   body.innerHTML = html;
 
-  // renderBreadcrumb defers its own handlers; wire the checkbox here.
+  // Breadcrumb clicks are handled by the delegated wireBreadcrumb listener; wire the checkbox here.
   var chk = document.getElementById('explorerMissingOnly');
   if (chk) chk.addEventListener('change', function() { renderExplorerLeaf(chk.checked); });
 }

--- a/vireo/templates/life_list.html
+++ b/vireo/templates/life_list.html
@@ -609,7 +609,7 @@ function renderUnmatched(d) {
   var names = u.names || [];
   var truncated = u.count > names.length;
   var html = '<div class="ll-unmatched">';
-  html += u.count + " tagged species aren't matched to the taxonomy and aren't counted here.";
+  html += u.count + " tagged species aren't counted here (unmatched, or matched above species rank).";
   html += '<details><summary>'
     + (truncated ? ('Show the first ' + names.length + ' of ' + u.count) : 'Show them')
     + '</summary><ul>';

--- a/vireo/templates/life_list.html
+++ b/vireo/templates/life_list.html
@@ -68,6 +68,28 @@
   .ll-unmatched details { margin-top:4px; }
   .ll-unmatched summary { cursor:pointer; color:var(--text-secondary); }
   .ll-unmatched ul { margin:6px 0 0 16px; padding:0; columns:2; font-size:12px; }
+
+  .ll-summary { display:flex; flex-wrap:wrap; gap:8px; margin-bottom:14px; }
+  .ll-sumchip { padding:6px 12px; border-radius:8px; background:var(--bg-secondary); border:1px solid var(--border-primary); font-size:13px; color:var(--text-secondary); font-variant-numeric:tabular-nums; }
+  .ll-sumchip b { color:var(--text-primary); font-weight:600; }
+
+  .ll-crumbs { display:flex; flex-wrap:wrap; align-items:center; gap:4px; margin-bottom:16px; font-size:13px; }
+  .ll-crumb { color:var(--accent); cursor:pointer; }
+  .ll-crumb:hover { text-decoration:underline; }
+  .ll-crumb.current { color:var(--text-primary); cursor:default; }
+  .ll-crumb.current:hover { text-decoration:none; }
+  .ll-crumb-sep { color:var(--text-dim); }
+
+  .ll-cards { display:grid; grid-template-columns:repeat(auto-fill, minmax(240px, 1fr)); gap:16px; }
+  .ll-card { display:flex; gap:12px; align-items:center; padding:12px 14px; border-radius:8px; background:var(--bg-secondary); border:1px solid var(--border-primary); cursor:pointer; }
+  .ll-card:hover { border-color:var(--accent); }
+  .ll-card.empty { opacity:.55; }
+  .ll-card-body { min-width:0; }
+  .ll-card-name { font-size:15px; font-weight:600; color:var(--text-primary); }
+  .ll-card-sci { font-size:12px; font-style:italic; color:var(--text-secondary); margin-top:1px; }
+  .ll-card-sub { font-size:12px; color:var(--text-secondary); margin-top:6px; font-variant-numeric:tabular-nums; }
+  .ll-ring { flex:0 0 auto; }
+  .ll-ring text { font-size:13px; font-weight:600; fill:var(--text-primary); font-variant-numeric:tabular-nums; }
 </style>
 </head>
 <body>
@@ -521,10 +543,13 @@ function renderExplorer() {
     return;
   }
 
+  html += renderSummaryBar(summary);
   html += renderUnmatched(d);
   html += '<div id="explorerBody"></div>';
   html += '</div>';
   panel.innerHTML = html;
+
+  renderExplorerBody();
 }
 
 // Muted footnote for tagged species that aren't matched to the taxonomy and so
@@ -545,6 +570,127 @@ function renderUnmatched(d) {
   html += '</details></div>';
   return html;
 }
+
+// ---------------- Explorer: summary + breadcrumb + cards (Task 11) ----------------
+
+function renderSummaryBar(summary) {
+  var order = summary.order || { found: 0, total: 0 };
+  var family = summary.family || { found: 0, total: 0 };
+  var genus = summary.genus || { found: 0, total: 0 };
+  var species = summary.species || { found: 0, total: 0 };
+  function chip(v, label) {
+    return '<span class="ll-sumchip"><b>' + v.found + '/' + v.total + '</b> ' + label + '</span>';
+  }
+  return '<div class="ll-summary">'
+    + chip(order, 'orders')
+    + chip(family, 'families')
+    + chip(genus, 'genera')
+    + chip(species, 'species')
+    + '</div>';
+}
+
+// Return the list of nodes at the current drill level, honoring explorerPath.
+function currentExplorerNodes() {
+  var nodes = explorerData.nodes || [];
+  for (var i = 0; i < explorerPath.length; i++) {
+    var step = explorerPath[i];
+    var match = nodes.find(function(n) { return n.id === step.id; });
+    if (!match) return [];
+    nodes = match.children || [];
+  }
+  return nodes;
+}
+
+function renderExplorerBody() {
+  var body = document.getElementById('explorerBody');
+  if (!body) return;
+  var html = renderBreadcrumb();
+
+  var nodes = currentExplorerNodes();
+  html += '<div class="ll-cards">';
+  nodes.forEach(function(n) { html += renderExplorerCard(n); });
+  html += '</div>';
+  body.innerHTML = html;
+
+  body.querySelectorAll('.ll-card').forEach(function(card) {
+    card.addEventListener('click', function() {
+      var id = parseInt(card.getAttribute('data-id'), 10);
+      var node = currentExplorerNodes().find(function(n) { return n.id === id; });
+      if (!node) return;
+      if (node.rank === 'genus') {
+        loadExplorerSpecies(node);
+      } else {
+        explorerPath.push({ id: node.id, name: node.common_name || node.name, rank: node.rank });
+        renderExplorerBody();
+      }
+    });
+  });
+}
+
+function renderBreadcrumb() {
+  var root = explorerData.root || {};
+  var rootLabel = root.common_name || root.name || 'Class';
+  var html = '<div class="ll-crumbs">';
+  var isRootCurrent = explorerPath.length === 0;
+  html += '<span class="ll-crumb' + (isRootCurrent ? ' current' : '') + '" data-depth="0">'
+    + escapeHtml(rootLabel) + '</span>';
+  explorerPath.forEach(function(step, i) {
+    var current = (i === explorerPath.length - 1);
+    html += '<span class="ll-crumb-sep">›</span>';
+    html += '<span class="ll-crumb' + (current ? ' current' : '') + '" data-depth="' + (i + 1) + '">'
+      + escapeHtml(step.name) + '</span>';
+  });
+  html += '</div>';
+  // Attach handlers after render (deferred so innerHTML exists).
+  setTimeout(function() {
+    var body = document.getElementById('explorerBody');
+    if (!body) return;
+    body.querySelectorAll('.ll-crumb').forEach(function(c) {
+      c.addEventListener('click', function() {
+        var depth = parseInt(c.getAttribute('data-depth'), 10);
+        if (depth === explorerPath.length) return;   // current crumb: no-op
+        explorerPath = explorerPath.slice(0, depth);
+        renderExplorerBody();
+      });
+    });
+  }, 0);
+  return html;
+}
+
+// Inline SVG progress ring: accent arc over a --bg-tertiary track, pct% center.
+function renderRing(found, total) {
+  var pct = total > 0 ? Math.round((found / total) * 100) : 0;
+  var r = 20, cx = 24, cy = 24;
+  var circ = 2 * Math.PI * r;
+  var dash = circ * (total > 0 ? found / total : 0);
+  return '<svg class="ll-ring" width="48" height="48" viewBox="0 0 48 48">'
+    + '<circle cx="' + cx + '" cy="' + cy + '" r="' + r + '" fill="none" stroke="var(--bg-tertiary)" stroke-width="4"/>'
+    + '<circle cx="' + cx + '" cy="' + cy + '" r="' + r + '" fill="none" stroke="var(--accent)" stroke-width="4"'
+    + ' stroke-dasharray="' + dash.toFixed(2) + ' ' + circ.toFixed(2) + '"'
+    + ' stroke-linecap="round" transform="rotate(-90 ' + cx + ' ' + cy + ')"/>'
+    + '<text x="' + cx + '" y="' + cy + '" text-anchor="middle" dominant-baseline="central">' + pct + '%</text>'
+    + '</svg>';
+}
+
+function renderExplorerCard(n) {
+  var name = n.common_name || n.name;
+  var sci = (n.common_name && n.common_name !== n.name)
+    ? '<div class="ll-card-sci">' + escapeHtml(n.name) + '</div>' : '';
+  var childRank = n.child_rank || 'children';
+  var sub = n.found_children + '/' + n.total_children + ' ' + childRank + 's · '
+    + n.found_species + '/' + n.total_species + ' species';
+  var emptyCls = (n.found_species === 0) ? ' empty' : '';
+  return '<div class="ll-card' + emptyCls + '" data-id="' + escapeAttr(n.id) + '">'
+    + renderRing(n.found_species, n.total_species)
+    + '<div class="ll-card-body">'
+    + '<div class="ll-card-name">' + escapeHtml(name) + '</div>'
+    + sci
+    + '<div class="ll-card-sub">' + sub + '</div>'
+    + '</div></div>';
+}
+
+// Genus species leaf — implemented in Task 12.
+function loadExplorerSpecies(node) {}
 
 // ---------------- Explorer tab ----------------
 var explorerLoaded = false;   // lazy-load guard: fetch explorer once on first open

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -6955,3 +6955,26 @@ def test_build_explorer_payload_not_ready(db):
     payload = _build_explorer_payload(db)
     assert payload['taxonomy_ready'] is False
     assert payload['nodes'] == []
+
+
+def test_build_explorer_species_leaf(db):
+    from app import _build_explorer_species
+    ids = _seed_bird_taxonomy(db)
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    fid = db.add_folder('/p', name='p')
+    p = db.add_photo(folder_id=fid, filename='a.jpg', extension='.jpg',
+                     file_size=1, file_mtime=1.0)
+    k = db.add_keyword('Song Sparrow')
+    db.tag_photo(p, k)
+    db.conn.execute("UPDATE keywords SET is_species=1, taxon_id=? WHERE id=?",
+                    (ids['Melospiza melodia'], k))
+    db.conn.commit()
+    out = _build_explorer_species(db, ids['Melospiza'])
+    by = {s['name']: s for s in out['species']}
+    assert by['Melospiza melodia']['found'] is True
+    assert by['Melospiza melodia']['photo']['filename'] == 'a.jpg'
+    assert by['Melospiza georgiana']['found'] is False
+    assert by['Melospiza georgiana'].get('photo') is None
+    # found first, then missing; each block alphabetical
+    assert [s['found'] for s in out['species']] == [True, False]

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -6882,3 +6882,76 @@ def test_pipeline_plan_folder_scope_unlinked_404(app_and_db):
     client = app.test_client()
     resp = client.post("/api/pipeline/plan", json={"folder_ids": [foreign]})
     assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Life list explorer (taxonomic completeness)
+# ---------------------------------------------------------------------------
+
+def _seed_bird_taxonomy(db):
+    """Insert a tiny Aves subtree: class Aves > 2 orders > families > genera > species.
+    Returns dict of name -> taxa id. (Mirror of the helper in test_db.py.)"""
+    rows = [
+        (3,     "Aves",           "Birds",         "class",   None,             "Animalia"),
+        (7251,  "Passeriformes",  "Perching Birds", "order",  "Aves",           "Animalia"),
+        (67566, "Passerellidae",  "New World Sparrows", "family", "Passeriformes", "Animalia"),
+        (9100,  "Melospiza",      None,            "genus",   "Passerellidae",  "Animalia"),
+        (9101,  "Melospiza melodia", "Song Sparrow", "species", "Melospiza",    "Animalia"),
+        (9102,  "Melospiza georgiana", "Swamp Sparrow", "species", "Melospiza",  "Animalia"),
+        (9200,  "Zonotrichia",    None,            "genus",   "Passerellidae",  "Animalia"),
+        (9201,  "Zonotrichia albicollis", "White-throated Sparrow", "species", "Zonotrichia", "Animalia"),
+        (4000,  "Anseriformes",   "Waterfowl",     "order",   "Aves",           "Animalia"),
+        (4100,  "Anatidae",       "Ducks",         "family",  "Anseriformes",   "Animalia"),
+        (4200,  "Anas",           None,            "genus",   "Anatidae",       "Animalia"),
+        (4201,  "Anas platyrhynchos", "Mallard",   "species", "Anas",           "Animalia"),
+    ]
+    ids = {}
+    for inat_id, name, common, rank, parent, kingdom in rows:
+        parent_id = ids.get(parent)
+        cur = db.conn.execute(
+            "INSERT INTO taxa (inat_id, name, common_name, rank, parent_id, kingdom)"
+            " VALUES (?,?,?,?,?,?)",
+            (inat_id, name, common, rank, parent_id, kingdom),
+        )
+        ids[name] = cur.lastrowid
+    db.conn.commit()
+    return ids
+
+
+def test_build_explorer_payload_rollup(db):
+    from app import _build_explorer_payload
+    ids = _seed_bird_taxonomy(db)
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    fid = db.add_folder('/p', name='p')
+    p = db.add_photo(folder_id=fid, filename='a.jpg', extension='.jpg',
+                     file_size=1, file_mtime=1.0)
+    k = db.add_keyword('Song Sparrow')
+    db.tag_photo(p, k)
+    db.conn.execute("UPDATE keywords SET is_species=1, taxon_id=? WHERE id=?",
+                    (ids['Melospiza melodia'], k))
+    db.conn.commit()
+
+    payload = _build_explorer_payload(db)
+    assert payload['taxonomy_ready'] is True
+    assert payload['root']['name'] == 'Aves'
+    s = payload['summary']
+    assert s['species'] == {'found': 1, 'total': 4}     # 4 species seeded
+    assert s['genus'] == {'found': 1, 'total': 3}
+    assert s['family'] == {'found': 1, 'total': 2}
+    assert s['order'] == {'found': 1, 'total': 2}
+    # Passeriformes order node carries family child counts + species rollup
+    orders = {n['name']: n for n in payload['nodes']}
+    passeri = orders['Passeriformes']
+    assert passeri['found_species'] == 1 and passeri['total_species'] == 3
+    assert passeri['child_rank'] == 'family'
+    assert passeri['found_children'] == 1 and passeri['total_children'] == 1
+
+
+def test_build_explorer_payload_not_ready(db):
+    from app import _build_explorer_payload
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    payload = _build_explorer_payload(db)
+    assert payload['taxonomy_ready'] is False
+    assert payload['nodes'] == []

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -6978,3 +6978,31 @@ def test_build_explorer_species_leaf(db):
     assert by['Melospiza georgiana'].get('photo') is None
     # found first, then missing; each block alphabetical
     assert [s['found'] for s in out['species']] == [True, False]
+
+
+def test_api_explorer_endpoint(app_and_db):
+    app, db = app_and_db
+    ids = _seed_bird_taxonomy(db)
+    # Link the fixture's existing 'Cardinal' keyword to a bird taxon so it counts.
+    db.conn.execute("UPDATE keywords SET is_species=1, taxon_id=? WHERE name='Cardinal'",
+                    (ids['Melospiza melodia'],))
+    db.conn.commit()
+    client = app.test_client()
+    r = client.get('/api/life-list/explorer')
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data['taxonomy_ready'] is True
+    assert data['root']['name'] == 'Aves'
+    assert data['summary']['order']['total'] == 2
+    # species leaf
+    r2 = client.get(f"/api/life-list/explorer/species?genus={ids['Melospiza']}")
+    assert r2.status_code == 200
+    assert {s['name'] for s in r2.get_json()['species']} == \
+        {'Melospiza melodia', 'Melospiza georgiana'}
+
+
+def test_api_explorer_not_ready(app_and_db):
+    app, db = app_and_db  # fixture has no taxa
+    r = app.test_client().get('/api/life-list/explorer')
+    assert r.status_code == 200
+    assert r.get_json()['taxonomy_ready'] is False

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -7066,3 +7066,47 @@ def test_api_explorer_not_ready(app_and_db):
     r = app.test_client().get('/api/life-list/explorer')
     assert r.status_code == 200
     assert r.get_json()['taxonomy_ready'] is False
+
+
+def _seed_mammal_taxon(db):
+    """Add a second class-rank taxon (Mammalia) so multi-class selector tests
+    have somewhere to switch to. Returns the class row id."""
+    cur = db.conn.execute(
+        "INSERT INTO taxa (inat_id, name, common_name, rank, parent_id, kingdom)"
+        " VALUES (?,?,?,?,?,?)",
+        (40151, 'Mammalia', 'Mammals', 'class', None, 'Animalia'),
+    )
+    db.conn.commit()
+    return cur.lastrowid
+
+
+def test_build_explorer_payload_always_includes_default_aves_class(db):
+    # Codex P2: after switching away from Aves, the default Birds class must
+    # stay in the selector so the user has an in-page way back to it. Recomputing
+    # `classes` only from *found* taxa would otherwise drop Birds when the user's
+    # only tagged species are outside Aves.
+    from app import _build_explorer_payload
+    ids = _seed_bird_taxonomy(db)
+    mammalia_id = _seed_mammal_taxon(db)
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    # User has tagged species — but NONE of them are birds.
+    fid = db.add_folder('/p', name='p')
+    # No mammal species seeded; leave the mammal tag unmatched so `found` is
+    # empty but the class ancestor list would still not include Aves without
+    # the fix. That still isolates the "default Aves always present" behavior.
+
+    # No found taxa at all -> Aves must still be in the returned classes when
+    # the root is the default (Aves).
+    payload_default = _build_explorer_payload(db)
+    assert any(c['name'] == 'Aves' for c in payload_default['classes'])
+
+    # Switching to Mammalia (a class the user has no *matched* species in):
+    # the returned classes list must STILL include Aves as a fallback, so the
+    # client can rebuild the selector without losing Birds.
+    payload_mammal = _build_explorer_payload(db, root_id=mammalia_id)
+    class_names = [c['name'] for c in payload_mammal['classes']]
+    assert 'Aves' in class_names, (
+        "Default Aves class must remain in the selector after switching to a "
+        "non-Aves class, otherwise the user has no in-page way back to Birds"
+    )

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -6957,6 +6957,66 @@ def test_build_explorer_payload_not_ready(db):
     assert payload['nodes'] == []
 
 
+def test_build_explorer_payload_rejects_non_class_root(db):
+    from app import _build_explorer_payload
+    ids = _seed_bird_taxonomy(db)
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    # An order-rank taxon is NOT a valid explorer root: reject it.
+    payload = _build_explorer_payload(db, root_id=ids['Passeriformes'])
+    assert payload['taxonomy_ready'] is True
+    assert payload['valid_root'] is False
+    assert payload['root'] is None
+    assert payload['nodes'] == []
+    assert payload['summary'] == {}
+    # The default (Aves, a class) is a valid root.
+    default_payload = _build_explorer_payload(db)
+    assert default_payload['taxonomy_ready'] is True
+    assert default_payload['valid_root'] is not False
+    assert default_payload['root']['name'] == 'Aves'
+
+
+def test_build_explorer_payload_multi_found_species_rollup(db):
+    from app import _build_explorer_payload
+    ids = _seed_bird_taxonomy(db)
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    fid = db.add_folder('/p', name='p')
+    p1 = db.add_photo(folder_id=fid, filename='a.jpg', extension='.jpg',
+                      file_size=1, file_mtime=1.0)
+    p2 = db.add_photo(folder_id=fid, filename='b.jpg', extension='.jpg',
+                      file_size=1, file_mtime=2.0)
+    # Tag BOTH Melospiza species as found (two keywords, one per taxon).
+    k1 = db.add_keyword('Song Sparrow')
+    db.tag_photo(p1, k1)
+    db.conn.execute("UPDATE keywords SET is_species=1, taxon_id=? WHERE id=?",
+                    (ids['Melospiza melodia'], k1))
+    k2 = db.add_keyword('Swamp Sparrow')
+    db.tag_photo(p2, k2)
+    db.conn.execute("UPDATE keywords SET is_species=1, taxon_id=? WHERE id=?",
+                    (ids['Melospiza georgiana'], k2))
+    db.conn.commit()
+
+    payload = _build_explorer_payload(db)
+    nodes = {n['name']: n for n in payload['nodes']}
+    # Passeriformes order -> Passerellidae family -> Melospiza + Zonotrichia genera.
+    passeri = nodes['Passeriformes']
+    passerellidae = {c['name']: c for c in passeri['children']}['Passerellidae']
+    melospiza = {c['name']: c for c in passerellidae['children']}['Melospiza']
+    # Both Melospiza species found.
+    assert melospiza['found_species'] == 2
+    assert melospiza['total_species'] == 2
+    # Family: both found species roll up, but only ONE genus (Melospiza) has any.
+    assert passerellidae['found_species'] == 2
+    assert passerellidae['found_children'] == 1
+    # Zonotrichia albicollis is NOT tagged -> Zonotrichia genus has none.
+    zonotrichia = {c['name']: c for c in passerellidae['children']}['Zonotrichia']
+    assert zonotrichia['found_species'] == 0
+    # Summary: 2 species found, but only 1 genus counts as found.
+    assert payload['summary']['species']['found'] == 2
+    assert payload['summary']['genus']['found'] == 1
+
+
 def test_build_explorer_species_leaf(db):
     from app import _build_explorer_species
     ids = _seed_bird_taxonomy(db)

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -14814,3 +14814,46 @@ def test_get_default_explorer_root_finds_aves(db):
     assert root["id"] == ids["Aves"]
     assert root["name"] == "Aves"
     assert root["rank"] == "class"
+
+
+def test_life_list_taxon_ids_scope(db):
+    ids = _seed_bird_taxonomy(db)
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    fid = db.add_folder('/p', name='p')
+    p1 = db.add_photo(folder_id=fid, filename='a.jpg', extension='.jpg',
+                      file_size=1, file_mtime=1.0, timestamp='2024-01-01T00:00:00')
+    p2 = db.add_photo(folder_id=fid, filename='b.jpg', extension='.jpg',
+                      file_size=1, file_mtime=2.0, timestamp='2024-01-02T00:00:00')
+    # Matched species keyword (linked to Song Sparrow taxon)
+    k1 = db.add_keyword('Song Sparrow')
+    db.tag_photo(p1, k1)
+    db.conn.execute("UPDATE keywords SET is_species=1, taxon_id=? WHERE id=?",
+                    (ids['Melospiza melodia'], k1))
+    db.conn.commit()
+    # Unmatched species keyword (is_species but no taxon_id)
+    k2 = db.add_keyword('Mystery Warbler')
+    db.tag_photo(p2, k2)
+    db.conn.execute("UPDATE keywords SET is_species=1 WHERE id=?", (k2,))
+    db.conn.commit()
+
+    found = db.get_life_list_taxon_ids()
+    assert found == {ids['Melospiza melodia']}
+    unmatched = db.get_life_list_unmatched_species()
+    assert 'Mystery Warbler' in unmatched
+
+
+def test_life_list_taxon_ids_excludes_rejected(db):
+    ids = _seed_bird_taxonomy(db)
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    fid = db.add_folder('/p', name='p')
+    p = db.add_photo(folder_id=fid, filename='a.jpg', extension='.jpg',
+                     file_size=1, file_mtime=1.0)
+    k = db.add_keyword('Song Sparrow')
+    db.tag_photo(p, k)
+    db.conn.execute("UPDATE keywords SET is_species=1, taxon_id=? WHERE id=?",
+                    (ids['Melospiza melodia'], k))
+    db.conn.commit()
+    db.update_photo_flag(p, 'rejected')
+    assert db.get_life_list_taxon_ids() == set()

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -14871,3 +14871,10 @@ def test_get_taxon_subtree(db):
     # subtree of a genus is just its species + itself
     sub = {r['name'] for r in db.get_taxon_subtree(ids['Melospiza'])}
     assert sub == {'Melospiza', 'Melospiza melodia', 'Melospiza georgiana'}
+
+
+def test_get_classes_for_taxa(db):
+    ids = _seed_bird_taxonomy(db)
+    classes = db.get_classes_for_taxa({ids['Melospiza melodia']})
+    assert [c['name'] for c in classes] == ['Aves']
+    assert db.get_classes_for_taxa(set()) == []

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -14878,3 +14878,26 @@ def test_get_classes_for_taxa(db):
     classes = db.get_classes_for_taxa({ids['Melospiza melodia']})
     assert [c['name'] for c in classes] == ['Aves']
     assert db.get_classes_for_taxa(set()) == []
+
+
+def test_best_photo_by_taxon(db):
+    ids = _seed_bird_taxonomy(db)
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    fid = db.add_folder('/p', name='p')
+    p1 = db.add_photo(folder_id=fid, filename='low.jpg', extension='.jpg',
+                      file_size=1, file_mtime=1.0)
+    p2 = db.add_photo(folder_id=fid, filename='high.jpg', extension='.jpg',
+                      file_size=1, file_mtime=2.0)
+    # No update_photo_quality_score helper in db.py; set the column directly.
+    db.conn.execute("UPDATE photos SET quality_score=? WHERE id=?", (0.2, p1))
+    db.conn.execute("UPDATE photos SET quality_score=? WHERE id=?", (0.9, p2))
+    db.conn.commit()
+    k = db.add_keyword('Song Sparrow')
+    db.tag_photo(p1, k)
+    db.tag_photo(p2, k)
+    db.conn.execute("UPDATE keywords SET is_species=1, taxon_id=? WHERE id=?",
+                    (ids['Melospiza melodia'], k))
+    db.conn.commit()
+    best = db.get_life_list_best_photo_by_taxon([ids['Melospiza melodia']])
+    assert best[ids['Melospiza melodia']]['filename'] == 'high.jpg'

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -14770,3 +14770,47 @@ def test_import_tab_migration_not_reapplied_after_unpin(tmp_path):
     db2 = Database(db_path)
     db2.set_active_workspace(ws)
     assert "import" not in db2.get_tabs()
+
+
+# ---------------------------------------------------------------------------
+# Life list explorer (taxonomic completeness) — shared taxa seeding helper
+# ---------------------------------------------------------------------------
+
+def _seed_bird_taxonomy(db):
+    """Insert a tiny Aves subtree: class Aves > 2 orders > families > genera > species.
+    Returns dict of name -> taxa id."""
+    rows = [
+        # (inat_id, name, common_name, rank, parent_name, kingdom)
+        (3,     "Aves",           "Birds",         "class",   None,             "Animalia"),
+        (7251,  "Passeriformes",  "Perching Birds","order",   "Aves",           "Animalia"),
+        (67566, "Passerellidae",  "New World Sparrows","family","Passeriformes", "Animalia"),
+        (9100,  "Melospiza",      None,            "genus",   "Passerellidae",  "Animalia"),
+        (9101,  "Melospiza melodia","Song Sparrow","species", "Melospiza",      "Animalia"),
+        (9102,  "Melospiza georgiana","Swamp Sparrow","species","Melospiza",    "Animalia"),
+        (9200,  "Zonotrichia",    None,            "genus",   "Passerellidae",  "Animalia"),
+        (9201,  "Zonotrichia albicollis","White-throated Sparrow","species","Zonotrichia","Animalia"),
+        (4000,  "Anseriformes",   "Waterfowl",     "order",   "Aves",           "Animalia"),
+        (4100,  "Anatidae",       "Ducks",         "family",  "Anseriformes",   "Animalia"),
+        (4200,  "Anas",           None,            "genus",   "Anatidae",       "Animalia"),
+        (4201,  "Anas platyrhynchos","Mallard",    "species", "Anas",           "Animalia"),
+    ]
+    ids = {}
+    for inat_id, name, common, rank, parent, kingdom in rows:
+        parent_id = ids.get(parent)
+        cur = db.conn.execute(
+            "INSERT INTO taxa (inat_id, name, common_name, rank, parent_id, kingdom)"
+            " VALUES (?,?,?,?,?,?)",
+            (inat_id, name, common, rank, parent_id, kingdom),
+        )
+        ids[name] = cur.lastrowid
+    db.conn.commit()
+    return ids
+
+
+def test_get_default_explorer_root_finds_aves(db):
+    assert db.get_explorer_root() is None  # no taxonomy yet
+    ids = _seed_bird_taxonomy(db)
+    root = db.get_explorer_root()
+    assert root["id"] == ids["Aves"]
+    assert root["name"] == "Aves"
+    assert root["rank"] == "class"

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -14857,3 +14857,17 @@ def test_life_list_taxon_ids_excludes_rejected(db):
     db.conn.commit()
     db.update_photo_flag(p, 'rejected')
     assert db.get_life_list_taxon_ids() == set()
+
+
+def test_get_taxon_subtree(db):
+    ids = _seed_bird_taxonomy(db)
+    rows = db.get_taxon_subtree(ids['Aves'])
+    by_name = {r['name']: r for r in rows}
+    assert by_name['Aves']['rank'] == 'class'
+    assert by_name['Melospiza melodia']['rank'] == 'species'
+    # parent linkage preserved
+    assert by_name['Passeriformes']['parent_id'] == ids['Aves']
+    assert by_name['Melospiza']['parent_id'] == ids['Passerellidae']
+    # subtree of a genus is just its species + itself
+    sub = {r['name'] for r in db.get_taxon_subtree(ids['Melospiza'])}
+    assert sub == {'Melospiza', 'Melospiza melodia', 'Melospiza georgiana'}

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -14903,6 +14903,21 @@ def test_get_classes_for_taxa(db):
     assert db.get_classes_for_taxa(set()) == []
 
 
+def test_get_classes_for_taxa_chunks_large_id_lists(db):
+    """`/api/life-list/explorer` passes the whole life-list `found` set, which can
+    exceed SQLite's bound-parameter limit — the query must chunk and merge."""
+    from vireo.db import _SQLITE_PARAM_CHUNK_SIZE
+    ids = _seed_bird_taxonomy(db)
+    # A pile of non-existent taxon ids (well above the chunk size) plus one real
+    # species id. A single un-chunked IN () would exceed SQLite's parameter cap;
+    # the chunked implementation must still find Aves via the real id.
+    n_fillers = _SQLITE_PARAM_CHUNK_SIZE * 3 + 25
+    seed = {10_000_000 + i for i in range(n_fillers)}
+    seed.add(ids['Melospiza melodia'])
+    classes = db.get_classes_for_taxa(seed)
+    assert [c['name'] for c in classes] == ['Aves']
+
+
 def test_best_photo_by_taxon(db):
     ids = _seed_bird_taxonomy(db)
     ws = db.ensure_default_workspace()

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -14843,6 +14843,29 @@ def test_life_list_taxon_ids_scope(db):
     assert 'Mystery Warbler' in unmatched
 
 
+def test_life_list_taxon_ids_excludes_non_species_matches(db):
+    # A taxonomy tag that resolves to a genus (or any rank above species) must
+    # NOT show up as a "found" taxon — the explorer only counts at species rank
+    # and would otherwise silently drop the match. It should surface in the
+    # unmatched list instead so the "not counted" honesty footnote is accurate.
+    ids = _seed_bird_taxonomy(db)
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+    fid = db.add_folder('/p', name='p')
+    p = db.add_photo(folder_id=fid, filename='a.jpg', extension='.jpg',
+                     file_size=1, file_mtime=1.0)
+    # Tag with a keyword that links to the Melospiza *genus*, not a species.
+    k = db.add_keyword('Melospiza sp.')
+    db.tag_photo(p, k)
+    db.conn.execute("UPDATE keywords SET is_species=1, taxon_id=? WHERE id=?",
+                    (ids['Melospiza'], k))
+    db.conn.commit()
+
+    assert db.get_life_list_taxon_ids() == set()
+    unmatched = db.get_life_list_unmatched_species()
+    assert 'Melospiza sp.' in unmatched
+
+
 def test_life_list_taxon_ids_excludes_rejected(db):
     ids = _seed_bird_taxonomy(db)
     ws = db.ensure_default_workspace()


### PR DESCRIPTION
## What & why

Adds a **taxonomic completeness explorer** to `/life-list`. Until now the life list only told you a species count; now you can see, for a chosen class (**Birds by default**, switchable to any class you've tagged), how many **orders / families / genera / species** exist in total and how many you've **found** — drilling from orders all the way down to a found-vs-missing species checklist, with a sunburst overview on top.

The denominator ("how many bird orders exist") comes entirely from the **local iNaturalist reference taxonomy** already in the `taxa` table (fully linked via `parent_id`) — no external checklist to source or ship.

## UI (new "Explorer" tab beside "List")

- **Sunburst showpiece** — inner ring orders → families → genera, arcs sized by species count and shaded by % found (ghosted = unfound, saturated = complete). Hover for `X/N species (pct%)`; click an arc to drill; click the hub to reset.
- **Summary chips** — `3/4 orders · 5/6 families · 7/8 genera · 8/14 species`.
- **Drill-down cards** with progress rings, found-first ordering, unfound groups dimmed.
- **Breadcrumb** (Birds › Passeriformes › Passerellidae › Melospiza).
- **Species leaf** — found species with thumbnails + "✓ seen", missing species dimmed with "not yet", plus a "Show missing only" gap-finder filter.

## No-black-boxes honesty (per CORE_PHILOSOPHY)

- Taxonomy not downloaded → a clear **download CTA**, never a fake `0/0`.
- Tagged species that can't be matched to the reference tree → surfaced as an honest footnote ("N species not matched, not counted"), never silently undercounted.
- Explorer uses the **exact same workspace scope / eligibility** as the existing life list (`get_life_list_candidates`), so List and Explorer always agree. (Verified: missing-folder photos are excluded identically.)

## Backend

- New DB methods (`vireo/db.py`): `get_explorer_root`, `get_life_list_taxon_ids`, `get_life_list_unmatched_species`, `get_taxon_subtree` (recursive CTE), `get_classes_for_taxa` (recursive CTE), `get_life_list_best_photo_by_taxon`, `get_taxon_by_id`.
- Rollup builder + endpoints (`vireo/app.py`): `_build_explorer_payload` (post-order found/total rollup, per-rank summary, class-rank root guard), `_build_explorer_species`, and routes `GET /api/life-list/explorer` + `GET /api/life-list/explorer/species`.

## Testing

- **1397 passed, 2 skipped** on the full project suite (`test_workspaces`, `test_db`, `test_app`, `test_photos_api`, `test_edits_api`, `test_jobs_api`, `test_darktable_api`, `test_config`). The 2 skips are pre-existing.
- New unit tests cover the completeness math (found/total/pct, ancestor rollup, multi-species dedup), workspace-scope parity, rejected-photo exclusion, honesty states (not-ready / unmatched), non-class root guard, and the species leaf.
- **Browser-verified** end-to-end with Playwright against a seeded bird DB: tab switching, List-tab non-regression, order→family→genus→species drill-down, rings/shading, breadcrumb, species leaf found+missing, "Show missing only", class selector, unmatched footnote, and full sunburst interaction (hover tooltip, order-arc drill, genus-arc → species leaf, center reset) — **zero console errors**.

## Notes

- Built in three independently-shippable stages (backend → drill-down UI → sunburst); each stage was code-reviewed (adversarial focus on completeness math, workspace-scope parity, injection, and SVG edge cases) with no Critical/Important issues surviving.
- Design + implementation plan committed under `docs/plans/2026-07-07-life-list-explorer-*.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Explorer” view for the life list, with drill-down browsing, breadcrumb navigation, and a completeness overview.
  * Added species-level views that show found and missing taxa, plus a “show missing only” option.
  * Added support for loading the explorer from a separate tab while keeping the existing list view.

* **Bug Fixes**
  * Improved handling for cases where taxonomy data is unavailable or species entries can’t be matched to a taxon.
  * Added clearer display of incomplete and unmatched results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->