### PR TITLE
Fix collection anchor scan pagination

### DIFF
--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1850,6 +1850,7 @@ var allLoaded = false;
 var selectedPhotoId = null;
 var selectedIndex = -1;
 var anchorRestoreEpoch = 0;
+var collectionAnchorScanDepth = 0;
 var selectedPhotos = new Set(); // multi-select
 var selectionKeywordRequestSeq = 0;
 var selectionKeywordKey = '';
@@ -2733,28 +2734,33 @@ async function filterByCollection(id, options) {
   function anchorScanShouldContinue() {
     return collectionRequestIsCurrent() && anchorRestoreEpoch === restoreEpoch;
   }
-  await loadPhotos();
-  if (!collectionRequestIsCurrent()) return;
-  if (!anchor) return;
-
-  var card = await loadUntilPhotoRendered(anchor.photoId, anchorScanShouldContinue);
-  if (!collectionRequestIsCurrent()) return;
-  if (!anchorRestoreIsPending(anchor, restoreEpoch)) return;
-  if (!card) {
-    clearActiveSelectionAndDetail();
-    return;
-  }
-  selectedPhotoId = anchor.photoId;
-  selectedIndex = photos.findIndex(function(p) { return p.id === anchor.photoId; });
-  refreshCardSelectionVisuals();
-  updateBatchBar();
-  if (anchor.detailVisible) loadDetail(anchor.photoId);
-  requestAnimationFrame(function() {
+  if (anchor) collectionAnchorScanDepth++;
+  try {
+    await loadPhotos();
     if (!collectionRequestIsCurrent()) return;
-    if (!anchorSelectionIsCurrent(anchor, restoreEpoch)) return;
-    restorePhotoAnchor(anchor);
-    updateScrollPosition();
-  });
+    if (!anchor) return;
+
+    var card = await loadUntilPhotoRendered(anchor.photoId, anchorScanShouldContinue);
+    if (!collectionRequestIsCurrent()) return;
+    if (!anchorRestoreIsPending(anchor, restoreEpoch)) return;
+    if (!card) {
+      clearActiveSelectionAndDetail();
+      return;
+    }
+    selectedPhotoId = anchor.photoId;
+    selectedIndex = photos.findIndex(function(p) { return p.id === anchor.photoId; });
+    refreshCardSelectionVisuals();
+    updateBatchBar();
+    if (anchor.detailVisible) loadDetail(anchor.photoId);
+    requestAnimationFrame(function() {
+      if (!collectionRequestIsCurrent()) return;
+      if (!anchorSelectionIsCurrent(anchor, restoreEpoch)) return;
+      restorePhotoAnchor(anchor);
+      updateScrollPosition();
+    });
+  } finally {
+    if (anchor) collectionAnchorScanDepth = Math.max(0, collectionAnchorScanDepth - 1);
+  }
 }
 
 /* ---------- Collection Modal ---------- */
@@ -3348,6 +3354,7 @@ async function loadPhotos(options) {
   loading = true;
   var epoch = loadEpoch;
   var loadSucceeded = false;
+  var suppressAutoHydration = collectionAnchorScanDepth > 0;
   var showLoading = !(options && options.silent) && photos.length === 0;
   var loadingState = document.getElementById('loadingState');
   if (showLoading && loadingState) {
@@ -3426,7 +3433,7 @@ async function loadPhotos(options) {
     if (epoch === loadEpoch) {
       loading = false;
       if (showLoading && loadingState) loadingState.style.display = 'none';
-      if (loadSucceeded) {
+      if (loadSucceeded && !suppressAutoHydration) {
         rearmInfiniteScrollObserver();
         // Chain: keep loading while the viewport is at or past the loading
         // boundary (rAF so the freshly appended cards have a layout first).
@@ -3977,7 +3984,7 @@ function rearmInfiniteScrollObserver() {
    first skeleton cell). Fires on scroll and chains after each successful
    page load until the viewport is covered by real cards. */
 function ensureViewportHydrated() {
-  if (loading || allLoaded || clipSearchActive) return;
+  if (loading || allLoaded || clipSearchActive || collectionAnchorScanDepth > 0) return;
   if (photos.length === 0) return;
   var tail = document.getElementById('gridTail');
   if (!tail || !tail.firstElementChild) return;

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2759,7 +2759,17 @@ async function filterByCollection(id, options) {
       updateScrollPosition();
     });
   } finally {
-    if (anchor) collectionAnchorScanDepth = Math.max(0, collectionAnchorScanDepth - 1);
+    if (anchor) {
+      collectionAnchorScanDepth = Math.max(0, collectionAnchorScanDepth - 1);
+      // Auto-hydration was suppressed for every loadPhotos() call while a scan
+      // was open (including ones from unrelated folder/keyword switches). When
+      // the last scan ends, resume the normal path so the current grid fills
+      // its viewport instead of stalling on skeletons until a manual scroll.
+      if (collectionAnchorScanDepth === 0) {
+        rearmInfiniteScrollObserver();
+        requestAnimationFrame(ensureViewportHydrated);
+      }
+    }
   }
 }
 

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -3364,7 +3364,6 @@ async function loadPhotos(options) {
   loading = true;
   var epoch = loadEpoch;
   var loadSucceeded = false;
-  var suppressAutoHydration = collectionAnchorScanDepth > 0;
   var showLoading = !(options && options.silent) && photos.length === 0;
   var loadingState = document.getElementById('loadingState');
   if (showLoading && loadingState) {
@@ -3443,7 +3442,11 @@ async function loadPhotos(options) {
     if (epoch === loadEpoch) {
       loading = false;
       if (showLoading && loadingState) loadingState.style.display = 'none';
-      if (loadSucceeded && !suppressAutoHydration) {
+      // Re-check the scan depth live (not a load-start snapshot): a stale
+      // scan can drain during our fetch, and its own hydration rAF then
+      // bails on loading=true. In that overlap this load is the current
+      // view's only chance to re-arm.
+      if (loadSucceeded && collectionAnchorScanDepth === 0) {
         rearmInfiniteScrollObserver();
         // Chain: keep loading while the viewport is at or past the loading
         // boundary (rAF so the freshly appended cards have a layout first).


### PR DESCRIPTION
Fixes a race where collection anchor restoration could trigger automatic viewport hydration while an anchor scan was pending or stale. The change tracks active collection anchor scans and suppresses auto-hydration callbacks until the scan completes, so newer selections and collection switches are not clobbered. Validated with `pytest -q tests/e2e/test_collection_context_menu.py --browser chromium`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collection and folder switching so the view restores the correct position more reliably.
  * Prevented extra photo loading while the app is locating the previously viewed item, reducing unexpected scrolling or pagination during transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->