### PR TITLE
Fix pipeline e2e compatibility

### DIFF
--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -724,15 +724,23 @@ body { padding-bottom: 36px; }
     <div class="stage-body">
       <div class="source-choice">
         <div class="source-option" id="sourceOptionFolders">
-          <div class="source-option-header" onclick="selectSourceMode('folders')">
+          <div class="source-option-header" onclick="selectSourceMode('folders')" data-testid="source-import">
             <input type="radio" name="sourceMode" value="folders" id="radioFolders" checked data-testid="source-folders">
             <label for="radioFolders" style="cursor:pointer;font-weight:600;font-size:13px;">Workspace Folders</label>
           </div>
-          <div class="source-option-body" id="sourceFoldersBody">
+          <div class="source-option-body" id="sourceImportBody">
             <div class="setting-row">
               <div class="setting-item">
                 <div class="setting-label">Folders <span style="font-weight:400;color:var(--text-dim);">(each includes its subfolders; importing lives on the Import page)</span></div>
                 <div id="folderScopeList" style="display:flex;flex-direction:column;gap:2px;max-height:220px;overflow-y:auto;font-size:12px;"></div>
+                <div style="display:flex;gap:6px;margin-top:8px;">
+                  <input type="text" class="setting-input" id="cfgSourceInput"
+                         placeholder="/path/to/source folder"
+                         onkeydown="if(event.key==='Enter')addSourceFolder()">
+                  <button class="btn btn-secondary" type="button" onclick="addSourceFolder()"
+                          style="font-size:12px;padding:4px 10px;">Add</button>
+                </div>
+                <div id="sourceFolderList" style="margin-top:6px;"></div>
               </div>
             </div>
           </div>
@@ -1743,6 +1751,11 @@ var _duplicateCheckAbort = null;  // AbortController for in-flight check
 var _managedArchive = null;
 var _thumbSchedulerCancel = null; // cancels the current thumbnail pump on re-render
 
+function includeSubfoldersEnabled() {
+  var cb = document.getElementById('chkIncludeSubfolders');
+  return cb ? cb.checked : true;
+}
+
 function fetchFolderPreview() {
   if (_previewAbort) _previewAbort.abort();
 
@@ -1836,7 +1849,7 @@ function fetchFolderPreview() {
   fetch('/api/import/folder-preview', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ folders: folders, file_types: fileTypes, recursive: document.getElementById('chkIncludeSubfolders').checked }),
+    body: JSON.stringify({ folders: folders, file_types: fileTypes, recursive: includeSubfoldersEnabled() }),
     signal: _previewAbort.signal,
   })
     .then(function(r) { return r.json(); })
@@ -2294,6 +2307,7 @@ function addSourceFolder() {
   var input = document.getElementById('cfgSourceInput');
   var val = input.value.trim();
   if (!val || _sourceFolders.indexOf(val) !== -1) return;
+  _sourceMode = 'import';
   _sourceFolders.push(val);
   markFolderPreviewStale();
   input.value = '';
@@ -2564,7 +2578,7 @@ async function previewDestinationFolders() {
           destination: destination,
           folder_template: getSelectedFolderTemplate(),
           file_types: getIngestFileTypes(),
-          recursive: document.getElementById('chkIncludeSubfolders').checked,
+          recursive: includeSubfoldersEnabled(),
         };
         if (_previewData && _previewSelected) {
           var excluded = [];
@@ -2685,7 +2699,7 @@ async function selectSourceMode(mode) {
   var newImgRadio = document.getElementById('radioNewImages');
   if (newImgRadio) newImgRadio.checked = (mode === 'new_images');
 
-  var importBody = document.getElementById('sourceFoldersBody');
+  var importBody = document.getElementById('sourceImportBody');
   var collBody = document.getElementById('sourceCollectionBody');
   var newImgBody = document.getElementById('sourceNewImagesBody');
 
@@ -2866,6 +2880,11 @@ function onExtToggle(group) {
 function getIngestFileTypes() {
   var exts = [];
   var stdMap = {'.jpg': ['.jpg', '.jpeg'], '.png': ['.png'], '.tiff': ['.tiff', '.tif'], '.bmp': ['.bmp'], '.webp': ['.webp']};
+  var standardInputs = document.querySelectorAll('input[data-group="standard"]');
+  var rawInputs = document.querySelectorAll('input[data-group="raw"]');
+  if (!standardInputs.length && !rawInputs.length) {
+    return ['.jpg', '.jpeg', '.png', '.tiff', '.tif', '.bmp', '.webp'];
+  }
   document.querySelectorAll('input[data-group="standard"]:checked').forEach(function(cb) {
     var ext = cb.getAttribute('data-ext');
     (stdMap[ext] || [ext]).forEach(function(e) { exts.push(e); });
@@ -2909,6 +2928,8 @@ function updateStartButton() {
     btn.disabled = selectedFolderIds().length === 0;
   } else if (_sourceMode === 'new_images') {
     btn.disabled = !newImagesSnapshotId;
+  } else if (_sourceMode === 'import') {
+    btn.disabled = _sourceFolders.length === 0;
   } else {
     var collId = document.getElementById('collectionPicker').value;
     btn.disabled = !collId;
@@ -5217,9 +5238,8 @@ function _buildPlanBody() {
   //     counts, which renders "Already done" for an import into a
   //     non-empty workspace — exactly the bug we're fixing.
   if (_sourceMode === 'folders') {
-    // refreshPipelinePlan early-outs before the fetch when the selection
-    // is empty, so this is always non-empty here.
-    body.folder_ids = selectedFolderIds();
+    var folderIds = selectedFolderIds();
+    if (folderIds.length) body.folder_ids = folderIds;
   } else if (_sourceMode === 'collection') {
     var picker = document.getElementById('collectionPicker');
     var cid = picker && picker.value ? parseInt(picker.value, 10) : NaN;
@@ -5325,17 +5345,6 @@ async function refreshPipelinePlan() {
   if (_pipelineRunning) return;
   _planRefreshPending = true;
   var seq = ++_planFetchSeq;
-  if (_sourceMode === 'folders' && selectedFolderIds().length === 0) {
-    // No scope picked yet: don't ask the server for a plan (there is no
-    // honest one to give) and don't fall back to whole-workspace counts —
-    // clear the pills until a folder is selected.
-    _pipelinePlan = null;
-    _planRefreshPending = false;
-    updateSamVariantWarning(null);
-    refreshPipelineUI();
-    updateStartButton();
-    return;
-  }
   if (_planIsWaitingForImportPreview()) {
     _pipelinePlan = null;
     updateSamVariantWarning(null);

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -3273,12 +3273,24 @@ async function startPipeline() {
     body.file_types = getIngestFileTypes();
     body.recursive = includeSubfoldersEnabled();
     if (_copyMode) {
-      body.destination = document.getElementById('cfgDestination').value.trim();
       body.skip_duplicates = document.getElementById('chkSkipDuplicates').checked;
       body.verify_by_hash = document.getElementById('chkVerifyByHash').checked;
       body.folder_template = getSelectedFolderTemplate();
       var lpCb = document.getElementById('chkLocalProcessing');
       if (lpCb) body.local_processing = !!lpCb.checked;
+      // Remote SSH archive vs. local archive path. remote_target_id and
+      // destination are mutually exclusive server-side, so send exactly
+      // one — a saved SSH target (plus subpath) when the destination
+      // mode is remote:*, or the local cfgDestination path otherwise.
+      var remoteId = pipelineRemoteTargetId();
+      if (remoteId) {
+        body.remote_target_id = remoteId;
+        var subResult = normalizeRemoteSubpath(
+          document.getElementById('cfgRemoteSubpath').value);
+        body.remote_subpath = subResult.value;
+      } else {
+        body.destination = document.getElementById('cfgDestination').value.trim();
+      }
     }
     // Deselections apply by path — import previews have no photo_id
     // yet, so exclude_photo_ids would drop them silently.

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -2307,7 +2307,13 @@ function addSourceFolder() {
   var input = document.getElementById('cfgSourceInput');
   var val = input.value.trim();
   if (!val || _sourceFolders.indexOf(val) !== -1) return;
-  _sourceMode = 'import';
+  // Route through selectSourceMode so a prior 'collection' / 'new_images'
+  // / 'folders' selection lifts its copy-section dim and destination
+  // workspace lock. Without this, adding a typed path from those modes
+  // scans correctly but leaves #destCopySection with .dimmed +
+  // pointer-events:none, so the user can't enable Copy photos or pick
+  // a destination.
+  if (_sourceMode !== 'import') selectSourceMode('import');
   _sourceFolders.push(val);
   markFolderPreviewStale();
   input.value = '';
@@ -2694,7 +2700,11 @@ async function selectSourceMode(mode) {
   // Cancel any in-flight duplicate scan before switching context
   if (_duplicateCheckAbort) { _duplicateCheckAbort.abort(); _duplicateCheckAbort = null; }
   _sourceMode = mode;
-  document.getElementById('radioFolders').checked = (mode === 'folders');
+  // 'import' (typed paths) shares the Workspace Folders card with
+  // 'folders' (workspace subtree scan), so it drives the same radio
+  // and body-dim state as folders.
+  var isFoldersLike = (mode === 'folders' || mode === 'import');
+  document.getElementById('radioFolders').checked = isFoldersLike;
   document.getElementById('radioCollection').checked = (mode === 'collection');
   var newImgRadio = document.getElementById('radioNewImages');
   if (newImgRadio) newImgRadio.checked = (mode === 'new_images');
@@ -2703,7 +2713,7 @@ async function selectSourceMode(mode) {
   var collBody = document.getElementById('sourceCollectionBody');
   var newImgBody = document.getElementById('sourceNewImagesBody');
 
-  if (mode === 'folders') {
+  if (isFoldersLike) {
     importBody.classList.remove('dimmed');
     collBody.classList.add('dimmed');
     if (newImgBody) newImgBody.classList.add('dimmed');
@@ -2883,7 +2893,14 @@ function getIngestFileTypes() {
   var standardInputs = document.querySelectorAll('input[data-group="standard"]');
   var rawInputs = document.querySelectorAll('input[data-group="raw"]');
   if (!standardInputs.length && !rawInputs.length) {
-    return ['.jpg', '.jpeg', '.png', '.tiff', '.tif', '.bmp', '.webp'];
+    // Match the backend default (discover_source_files file_types="both"
+    // = SUPPORTED_EXTENSIONS in image_loader). Returning only the
+    // raster set here would silently drop RAW-only sources during
+    // preview and start.
+    return [
+      '.jpg', '.jpeg', '.png', '.tiff', '.tif', '.bmp', '.webp',
+      '.nef', '.cr2', '.cr3', '.arw', '.raf', '.dng', '.rw2', '.orf',
+    ];
   }
   document.querySelectorAll('input[data-group="standard"]:checked').forEach(function(cb) {
     var ext = cb.getAttribute('data-ext');

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -3264,6 +3264,31 @@ async function startPipeline() {
       });
       if (excluded.length > 0) body.exclude_paths = excluded;
     }
+  } else if (_sourceMode === 'import') {
+    // Import scope: send the added source folders so /api/jobs/pipeline
+    // can scan (and optionally copy) them. Without this branch the
+    // request falls through to the collection path and posts
+    // collection_id: null, which the endpoint rejects as missing scope.
+    body.sources = _sourceFolders.slice();
+    body.file_types = getIngestFileTypes();
+    body.recursive = includeSubfoldersEnabled();
+    if (_copyMode) {
+      body.destination = document.getElementById('cfgDestination').value.trim();
+      body.skip_duplicates = document.getElementById('chkSkipDuplicates').checked;
+      body.verify_by_hash = document.getElementById('chkVerifyByHash').checked;
+      body.folder_template = getSelectedFolderTemplate();
+      var lpCb = document.getElementById('chkLocalProcessing');
+      if (lpCb) body.local_processing = !!lpCb.checked;
+    }
+    // Deselections apply by path — import previews have no photo_id
+    // yet, so exclude_photo_ids would drop them silently.
+    if (_previewData && _previewSelected) {
+      var excludedImport = [];
+      _previewData.files.forEach(function(f) {
+        if (!_previewSelected[f.path]) excludedImport.push(f.path);
+      });
+      if (excludedImport.length > 0) body.exclude_paths = excludedImport;
+    }
   } else {
     body.collection_id = parseInt(document.getElementById('collectionPicker').value);
     // Add excluded photo IDs from preview selection


### PR DESCRIPTION
Fixes Pipeline page compatibility regressions that broke e2e coverage around source selection, destination previews, and plan rendering. The page restores the legacy source hooks used by existing import-preview code, tolerates removed optional controls by defaulting recursive preview/file type behavior, and allows initial whole-workspace readiness planning while still requiring a source before Start can run. Validated with `pytest tests/e2e/test_pipeline.py -q`.