### PR TITLE
Acknowledge folder rescan requests

### DIFF
--- a/tests/e2e/test_folder_tree_context_menu.py
+++ b/tests/e2e/test_folder_tree_context_menu.py
@@ -60,7 +60,7 @@ def test_folder_tree_filter_by_folder_fires_filter(live_server, page):
 
 
 def test_folder_tree_rescan_fires_endpoint(live_server, page):
-    """Clicking 'Rescan this Folder' POSTs to /api/folders/<id>/rescan."""
+    """Clicking 'Rescan this Folder' POSTs and acknowledges the click."""
     url = live_server["url"]
     page.goto(f"{url}/browse")
 
@@ -78,6 +78,9 @@ def test_folder_tree_rescan_fires_endpoint(live_server, page):
         menu.locator(
             ".vireo-ctx-item", has_text="Rescan this Folder"
         ).click()
+    expect(page.locator("#toastContainer")).to_contain_text(
+        "Starting folder rescan"
+    )
 
 
 def test_folder_tree_reveal_fires_endpoint(live_server, page):

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -7173,12 +7173,20 @@ async function copyFolderPath(fid) {
   }
 }
 
-function rescanFolder(fid) {
-  fetch('/api/folders/' + fid + '/rescan', {
-    method: 'POST',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({incremental: true}),
-  }).catch(function(err) { console.error('rescanFolder failed', err); });
+async function rescanFolder(fid) {
+  showToast('Starting folder rescan...', 'info');
+  try {
+    var data = await safeFetch('/api/folders/' + fid + '/rescan', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({incremental: true}),
+    }, { toast: false });
+    var suffix = data && data.job_id ? ' (' + data.job_id + ')' : '';
+    showToast('Folder rescan queued' + suffix + '.', 'success');
+  } catch (err) {
+    console.error('rescanFolder failed', err);
+    showToast((err && err.message) || 'Could not start folder rescan.', 'error');
+  }
 }
 
 document.addEventListener('contextmenu', function(e) {


### PR DESCRIPTION
## Summary
Adds immediate toast feedback when a folder-tree context-menu rescan is clicked, then reports whether the scan job was queued or failed.
This makes slow job creation feel acknowledged instead of silently waiting on the POST.
Adds e2e coverage for the acknowledgement toast on the rescan context-menu action.

## Validation
pytest tests/e2e/test_folder_tree_context_menu.py -q