### PR TITLE
Report Reveal in Finder failures

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4646,6 +4646,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 # photo reveals we open the parent directory instead. Passing
                 # a directory to xdg-open opens the folder in the file manager,
                 # which is exactly what we want for folder reveals.
+                #
+                # Because photo reveals target the parent directory rather than
+                # the file itself, xdg-open will happily succeed for a stale
+                # catalog entry whose folder still exists but whose photo has
+                # been deleted or moved — the user gets a "revealed" toast even
+                # though nothing is selected. Verify the photo file exists first
+                # so those cases surface as failures instead of false successes.
+                if not is_folder and not os.path.isfile(path):
+                    return jsonify({"ok": False, "reason": "photo file not found"})
                 target = path if is_folder else (os.path.dirname(path) or path)
                 # xdg-open doesn't honor `--`; abspath guarantees a leading `/`
                 # so a crafted leading-dash path can't be parsed as a flag.
@@ -4657,7 +4666,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     capture_output=True,
                     text=True,
                 )
-            if proc.returncode != 0:
+            # explorer.exe's exit status is not a reliable success signal:
+            # `explorer /select,<path>` (and `explorer <folder>`) routinely
+            # return 1 even when File Explorer opens correctly, with nothing
+            # useful on stdout/stderr. Skipping the returncode check on Windows
+            # avoids reporting "reveal failed" for reveals that actually worked.
+            if not sys.platform.startswith("win") and proc.returncode != 0:
                 reason = (proc.stderr or proc.stdout or "").strip()
                 if not reason:
                     reason = f"reveal command exited {proc.returncode}"

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4623,7 +4623,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     text=True,
                 )
             elif sys.platform.startswith("win"):
+                # explorer.exe's exit status is not a reliable success signal
+                # (see the returncode-check gate below), so a stale catalog
+                # entry whose path no longer exists would otherwise silently
+                # return ok=True and produce a bogus "Revealed in File
+                # Explorer" toast. Preflight the target path so those cases
+                # surface as failures instead.
                 if is_folder:
+                    if not os.path.isdir(path):
+                        return jsonify({"ok": False, "reason": "folder not found"})
                     # Open the folder itself so the user sees its contents.
                     proc = subprocess.run(
                         ["explorer", path],
@@ -4633,6 +4641,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         text=True,
                     )
                 else:
+                    if not os.path.isfile(path):
+                        return jsonify({"ok": False, "reason": "photo file not found"})
                     proc = subprocess.run(
                         ["explorer", f"/select,{path}"],
                         timeout=5,

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2541,6 +2541,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             + json.dumps(sys.platform)
             + ";\nwindow.VIREO_REVEAL_LABEL = "
             + json.dumps(labels["reveal"])
+            + ";\nwindow.VIREO_FILE_MANAGER_NAME = "
+            + json.dumps(labels["name"])
             + ";\nwindow.VIREO_EDITOR_PATH_PLACEHOLDER = "
             + json.dumps(labels["editor_placeholder"])
             + ";\n",
@@ -4613,14 +4615,30 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 # "open -R <dir>" reveals the folder inside its parent; that's
                 # the right behavior for folder reveals too, consistent with
                 # how Finder treats folder-targeted reveal.
-                subprocess.run(["open", "-R", "--", path], timeout=5, check=False)
+                proc = subprocess.run(
+                    ["open", "-R", "--", path],
+                    timeout=5,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
             elif sys.platform.startswith("win"):
                 if is_folder:
                     # Open the folder itself so the user sees its contents.
-                    subprocess.run(["explorer", path], timeout=5, check=False)
+                    proc = subprocess.run(
+                        ["explorer", path],
+                        timeout=5,
+                        check=False,
+                        capture_output=True,
+                        text=True,
+                    )
                 else:
-                    subprocess.run(
-                        ["explorer", f"/select,{path}"], timeout=5, check=False
+                    proc = subprocess.run(
+                        ["explorer", f"/select,{path}"],
+                        timeout=5,
+                        check=False,
+                        capture_output=True,
+                        text=True,
                     )
             else:
                 # xdg-open on a file has inconsistent behavior across desktops
@@ -4632,7 +4650,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 # xdg-open doesn't honor `--`; abspath guarantees a leading `/`
                 # so a crafted leading-dash path can't be parsed as a flag.
                 target = os.path.abspath(target)
-                subprocess.run(["xdg-open", target], timeout=5, check=False)
+                proc = subprocess.run(
+                    ["xdg-open", target],
+                    timeout=5,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+            if proc.returncode != 0:
+                reason = (proc.stderr or proc.stdout or "").strip()
+                if not reason:
+                    reason = f"reveal command exited {proc.returncode}"
+                return jsonify({"ok": False, "reason": reason})
         except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
             return jsonify({"ok": False, "reason": str(exc)})
         return jsonify({"ok": True})

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -8223,6 +8223,21 @@ function nativeMenuError(msg) {
   else console.error(msg);
 }
 
+function revealFeedbackMessage(data) {
+  if (data && data.ok === false) {
+    return 'Reveal failed: ' + (data.reason || 'unknown error');
+  }
+  return 'Revealed in ' + (window.VIREO_FILE_MANAGER_NAME || 'file manager');
+}
+
+function showRevealFeedback(data) {
+  var isError = data && data.ok === false;
+  var msg = revealFeedbackMessage(data);
+  if (typeof showToast === 'function') showToast(msg, isError ? 'error' : 'success');
+  else if (isError) console.error(msg);
+  else console.info(msg);
+}
+
 function nativeMenuRoute(path) {
   window.location.href = path;
 }

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -6948,6 +6948,8 @@ function revealPhoto(photoId) {
   }).catch(function(err) {
     if (typeof showToast === 'function') {
       showToast('Reveal failed: ' + (err.message || 'request failed'), 'error');
+    } else {
+      console.error('revealPhoto failed', err);
     }
   });
 }

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -6943,7 +6943,13 @@ function revealPhoto(photoId) {
   safeFetch('/api/files/reveal', {
     method: 'POST', headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({photo_id: photoId}),
-  }, { toast: false }).catch(function(){});
+  }, { toast: false }).then(function(data) {
+    if (typeof showRevealFeedback === 'function') showRevealFeedback(data);
+  }).catch(function(err) {
+    if (typeof showToast === 'function') {
+      showToast('Reveal failed: ' + (err.message || 'request failed'), 'error');
+    }
+  });
 }
 
 function viewPhotoOnMap(photoId) {
@@ -7151,13 +7157,19 @@ document.addEventListener('contextmenu', function(e) {
 
 /* ---------- Folder tree context menu ---------- */
 function revealFolder(fid) {
-  // Fire-and-forget: user-visible feedback is the OS file manager opening.
-  // Server logs any failure via the reason field on the response body.
-  fetch('/api/files/reveal', {
+  safeFetch('/api/files/reveal', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({folder_id: fid}),
-  }).catch(function(err) { console.error('revealFolder failed', err); });
+  }, { toast: false }).then(function(data) {
+    if (typeof showRevealFeedback === 'function') showRevealFeedback(data);
+  }).catch(function(err) {
+    if (typeof showToast === 'function') {
+      showToast('Reveal failed: ' + (err.message || 'request failed'), 'error');
+    } else {
+      console.error('revealFolder failed', err);
+    }
+  });
 }
 
 async function copyFolderPath(fid) {

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1414,6 +1414,8 @@ function revealReviewPhoto(photoId) {
   }).catch(function(err) {
     if (typeof showToast === 'function') {
       showToast('Reveal failed: ' + (err.message || 'request failed'), 'error');
+    } else {
+      console.error('revealReviewPhoto failed', err);
     }
   });
 }

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1409,7 +1409,13 @@ function revealReviewPhoto(photoId) {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ photo_id: photoId }),
-  }, { toast: false }).catch(function() {});
+  }, { toast: false }).then(function(data) {
+    if (typeof showRevealFeedback === 'function') showRevealFeedback(data);
+  }).catch(function(err) {
+    if (typeof showToast === 'function') {
+      showToast('Reveal failed: ' + (err.message || 'request failed'), 'error');
+    }
+  });
 }
 
 async function copyReviewPhotoPath(photoId) {

--- a/vireo/tests/test_reveal_api.py
+++ b/vireo/tests/test_reveal_api.py
@@ -36,8 +36,12 @@ def test_reveal_linux_opens_parent(app_and_db):
     app, db = app_and_db
     pid = db.get_photos()[0]["id"]
     expected_parent = os.path.dirname(_expected_full_path(db, pid))
+    # The Linux photo-reveal path verifies the photo file exists before
+    # opening its parent — the sample DB uses synthetic paths, so pretend
+    # the file is on disk so subprocess still gets called.
     with app.test_client() as c, \
          patch("vireo.app.sys.platform", "linux"), \
+         patch("vireo.app.os.path.isfile", return_value=True), \
          patch("vireo.app.subprocess.run") as run:
         run.return_value = MagicMock(returncode=0)
         resp = c.post("/api/files/reveal", json={"photo_id": pid})
@@ -48,6 +52,44 @@ def test_reveal_linux_opens_parent(app_and_db):
         assert args[0] == "xdg-open"
         assert args[1] == os.path.abspath(expected_parent)
         assert len(args) == 2
+
+
+def test_reveal_linux_missing_photo_reports_error(app_and_db):
+    """On Linux, photo reveals target the parent directory, so a stale
+    catalog entry whose parent still exists would silently succeed. The
+    endpoint should check the photo path first and report a real failure.
+    """
+    app, db = app_and_db
+    pid = db.get_photos()[0]["id"]
+    with app.test_client() as c, \
+         patch("vireo.app.sys.platform", "linux"), \
+         patch("vireo.app.os.path.isfile", return_value=False), \
+         patch("vireo.app.subprocess.run") as run:
+        resp = c.post("/api/files/reveal", json={"photo_id": pid})
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["ok"] is False
+        assert body.get("reason")
+        # No xdg-open call — we bail out before invoking the file manager
+        # so the user doesn't get a "revealed" toast for a missing file.
+        run.assert_not_called()
+
+
+def test_reveal_windows_ignores_nonzero_exit(app_and_db):
+    """explorer.exe /select can return exit 1 even when it opens File
+    Explorer successfully. Reporting that as a failure produces bogus
+    "reveal failed" toasts for reveals that actually worked, so the
+    endpoint deliberately ignores explorer.exe's returncode on Windows.
+    """
+    app, db = app_and_db
+    pid = db.get_photos()[0]["id"]
+    with app.test_client() as c, \
+         patch("vireo.app.sys.platform", "win32"), \
+         patch("vireo.app.subprocess.run") as run:
+        run.return_value = MagicMock(returncode=1, stdout="", stderr="")
+        resp = c.post("/api/files/reveal", json={"photo_id": pid})
+        assert resp.status_code == 200
+        assert resp.get_json()["ok"] is True
 
 
 def test_reveal_windows_select(app_and_db):

--- a/vireo/tests/test_reveal_api.py
+++ b/vireo/tests/test_reveal_api.py
@@ -85,6 +85,24 @@ def test_reveal_shell_failure_reports_reason(app_and_db):
         assert "reason" in body
 
 
+def test_reveal_nonzero_exit_reports_reason(app_and_db):
+    app, db = app_and_db
+    pid = db.get_photos()[0]["id"]
+    with app.test_client() as c, \
+         patch("vireo.app.sys.platform", "darwin"), \
+         patch("vireo.app.subprocess.run") as run:
+        run.return_value = MagicMock(
+            returncode=1,
+            stdout="",
+            stderr="The file does not exist.",
+        )
+        resp = c.post("/api/files/reveal", json={"photo_id": pid})
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["ok"] is False
+        assert body["reason"] == "The file does not exist."
+
+
 def test_reveal_invalid_photo_id_returns_400(app_and_db):
     app, _ = app_and_db
     with app.test_client() as c:

--- a/vireo/tests/test_reveal_api.py
+++ b/vireo/tests/test_reveal_api.py
@@ -83,8 +83,12 @@ def test_reveal_windows_ignores_nonzero_exit(app_and_db):
     """
     app, db = app_and_db
     pid = db.get_photos()[0]["id"]
+    # The Windows photo-reveal path preflights the photo file before
+    # launching Explorer; the sample DB uses synthetic paths, so pretend
+    # the file is on disk so subprocess still gets called.
     with app.test_client() as c, \
          patch("vireo.app.sys.platform", "win32"), \
+         patch("vireo.app.os.path.isfile", return_value=True), \
          patch("vireo.app.subprocess.run") as run:
         run.return_value = MagicMock(returncode=1, stdout="", stderr="")
         resp = c.post("/api/files/reveal", json={"photo_id": pid})
@@ -97,6 +101,7 @@ def test_reveal_windows_select(app_and_db):
     pid = db.get_photos()[0]["id"]
     with app.test_client() as c, \
          patch("vireo.app.sys.platform", "win32"), \
+         patch("vireo.app.os.path.isfile", return_value=True), \
          patch("vireo.app.subprocess.run") as run:
         run.return_value = MagicMock(returncode=0)
         resp = c.post("/api/files/reveal", json={"photo_id": pid})
@@ -104,6 +109,28 @@ def test_reveal_windows_select(app_and_db):
         args = run.call_args[0][0]
         assert args[0].lower() == "explorer"
         assert args[1].startswith("/select,")
+
+
+def test_reveal_windows_missing_photo_reports_error(app_and_db):
+    """On Windows, explorer.exe's exit status is unreliable, so a stale
+    catalog entry whose file has been deleted would silently succeed if
+    we launched Explorer anyway. The endpoint should preflight the photo
+    path and report a real failure instead of a bogus success.
+    """
+    app, db = app_and_db
+    pid = db.get_photos()[0]["id"]
+    with app.test_client() as c, \
+         patch("vireo.app.sys.platform", "win32"), \
+         patch("vireo.app.os.path.isfile", return_value=False), \
+         patch("vireo.app.subprocess.run") as run:
+        resp = c.post("/api/files/reveal", json={"photo_id": pid})
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["ok"] is False
+        assert body.get("reason")
+        # No explorer call — bail out before launching the file manager
+        # so the user doesn't get a "revealed" toast for a missing file.
+        run.assert_not_called()
 
 
 def test_reveal_unknown_photo_returns_error(app_and_db):
@@ -197,8 +224,15 @@ def test_reveal_folder_windows_opens_folder(app_and_db):
     """
     app, db = app_and_db
     folder = db.get_folder_tree()[0]
+    # Only override the answer for the target folder; letting the patch
+    # blanket-return True for os.path.isdir would break os.makedirs, which
+    # the DB layer uses to create per-test scratch dirs.
+    real_isdir = os.path.isdir
+    def fake_isdir(p):
+        return True if p == folder["path"] else real_isdir(p)
     with app.test_client() as c, \
          patch("vireo.app.sys.platform", "win32"), \
+         patch("vireo.app.os.path.isdir", side_effect=fake_isdir), \
          patch("vireo.app.subprocess.run") as run:
         run.return_value = MagicMock(returncode=0)
         resp = c.post("/api/files/reveal", json={"folder_id": folder["id"]})
@@ -208,6 +242,28 @@ def test_reveal_folder_windows_opens_folder(app_and_db):
         # No /select, for folder reveals — open the folder itself.
         assert not args[1].startswith("/select,")
         assert args[1] == folder["path"]
+
+
+def test_reveal_folder_windows_missing_reports_error(app_and_db):
+    """A stale folder catalog entry on Windows must report a real failure
+    instead of silently returning ok=True (explorer.exe's returncode is
+    ignored, so preflight is the only signal).
+    """
+    app, db = app_and_db
+    folder = db.get_folder_tree()[0]
+    real_isdir = os.path.isdir
+    def fake_isdir(p):
+        return False if p == folder["path"] else real_isdir(p)
+    with app.test_client() as c, \
+         patch("vireo.app.sys.platform", "win32"), \
+         patch("vireo.app.os.path.isdir", side_effect=fake_isdir), \
+         patch("vireo.app.subprocess.run") as run:
+        resp = c.post("/api/files/reveal", json={"folder_id": folder["id"]})
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["ok"] is False
+        assert body.get("reason")
+        run.assert_not_called()
 
 
 def test_reveal_unknown_folder_returns_404(app_and_db):


### PR DESCRIPTION
## Summary
Report file-manager launch failures from Reveal in Finder instead of treating non-zero exits as success.
Show Browse and Review toasts for successful reveal attempts and for failures such as stale or missing files.
Expose the platform file-manager name to the browser so the feedback matches Finder, File Explorer, or the generic file manager.

## Validation
- pytest vireo/tests/test_reveal_api.py
- pytest vireo/tests/test_app.py -k 'file_manager or reveal or config'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer feedback when revealing files or folders, including success and error messages in the interface.
  * The app now identifies the system file manager by name in user-facing messages.

* **Bug Fixes**
  * Improved handling when a file reveal action fails, so users now see a meaningful error instead of a silent failure.
  * On Linux, reveal actions now report command failures more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->