### PR TITLE
[codex] Speed up storage cache management modal

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -10142,6 +10142,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not cache_dir:
             return json_error("Unknown cache type")
 
+        raw_limit = request.args.get("limit", type=int)
+        limit = raw_limit if raw_limit and raw_limit > 0 else None
+
         # Load embedding manifest for display names
         manifest = {}
         if cache_type == "embeddings":
@@ -10149,15 +10152,39 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             manifest = _load_manifest()
 
         files = []
+        truncated = False
         if os.path.isdir(cache_dir):
-            for f in sorted(os.listdir(cache_dir)):
-                fp = os.path.join(cache_dir, f)
-                if os.path.isfile(fp) and f != "manifest.json":
-                    entry = {"name": f, "size": os.path.getsize(fp)}
-                    if f in manifest:
-                        entry["meta"] = manifest[f]
-                    files.append(entry)
-        return jsonify({"type": cache_type, "path": cache_dir, "files": files})
+            if limit is None:
+                names = sorted(os.listdir(cache_dir))
+                for f in names:
+                    fp = os.path.join(cache_dir, f)
+                    if os.path.isfile(fp) and f != "manifest.json":
+                        entry = {"name": f, "size": os.path.getsize(fp)}
+                        if f in manifest:
+                            entry["meta"] = manifest[f]
+                        files.append(entry)
+            else:
+                with os.scandir(cache_dir) as entries:
+                    for entry_info in entries:
+                        if entry_info.name == "manifest.json":
+                            continue
+                        if not entry_info.is_file():
+                            continue
+                        if len(files) >= limit:
+                            truncated = True
+                            break
+                        stat = entry_info.stat()
+                        entry = {"name": entry_info.name, "size": stat.st_size}
+                        if entry_info.name in manifest:
+                            entry["meta"] = manifest[entry_info.name]
+                        files.append(entry)
+        return jsonify({
+            "type": cache_type,
+            "path": cache_dir,
+            "files": files,
+            "truncated": truncated,
+            "limit": limit,
+        })
 
     @app.route("/api/storage/clear", methods=["POST"])
     def api_storage_clear():

--- a/vireo/templates/stats.html
+++ b/vireo/templates/stats.html
@@ -334,7 +334,7 @@ body { padding-bottom: 36px; }
       <div id="modalLoading" style="color:var(--text-ghost);font-size:13px;">Loading files...</div>
       <div id="modalFileList" style="display:none;">
         <div class="file-select-bar">
-          <a onclick="selectAllFiles(true)">Select all</a>
+          <a id="modalSelectAllLink" onclick="selectAllFiles(true)">Select all shown</a>
           <a onclick="selectAllFiles(false)">Select none</a>
           <span id="modalSelectedInfo" style="color:var(--text-dim);margin-left:auto;"></span>
         </div>
@@ -345,7 +345,7 @@ body { padding-bottom: 36px; }
       <button class="btn-secondary" onclick="closeStorageModal()">Cancel</button>
       <div>
         <button class="btn-danger" id="modalDeleteSelected" onclick="deleteSelectedFiles()" disabled>Delete Selected</button>
-        <button class="btn-danger" id="modalDeleteAll" onclick="deleteAllFiles()" style="margin-left:8px;">Delete All</button>
+        <button class="btn-danger" id="modalDeleteAll" onclick="deleteAllFiles()" style="margin-left:8px;">Delete Entire Cache</button>
       </div>
     </div>
   </div>
@@ -1013,10 +1013,12 @@ async function loadStoragePanel() {
       {name: 'Models', size: s.models.size, type: null},
       {name: 'HF Cache', size: s.hf_cache.size, type: null},
     ];
+    _storageSummary = {};
 
     var html = '';
     categories.forEach(function(c) {
       if (c.size === 0 && !c.type) return;
+      if (c.type) _storageSummary[c.type] = {count: c.count || 0, size: c.size || 0};
       html += '<div class="stat-card" style="position:relative;">' +
         '<div class="stat-number">' + formatBytes(c.size) + '</div>' +
         '<div class="stat-label">' + c.name +
@@ -1229,6 +1231,8 @@ async function deleteStaleMasks() {
 
 var _modalType = '';
 var _modalFiles = [];
+var _storageSummary = {};
+var STORAGE_MODAL_FILE_LIMIT = 500;
 var STORAGE_INFO = {
   thumbnails: {
     title: 'Thumbnails',
@@ -1256,7 +1260,14 @@ async function openStorageModal(type) {
   document.getElementById('storageModal').classList.add('open');
 
   try {
-    var data = await safeFetch('/api/storage/files?type=' + type, {}, { toast: false });
+    var url = '/api/storage/files?type=' + encodeURIComponent(type);
+    if (type === 'previews' || type === 'thumbnails') {
+      url += '&limit=' + STORAGE_MODAL_FILE_LIMIT;
+      document.getElementById('modalLoading').textContent = 'Loading first ' + STORAGE_MODAL_FILE_LIMIT.toLocaleString() + ' files...';
+    } else {
+      document.getElementById('modalLoading').textContent = 'Loading files...';
+    }
+    var data = await safeFetch(url, {}, { toast: false });
     _modalFiles = data.files || [];
     document.getElementById('modalLoading').style.display = 'none';
     document.getElementById('modalFileList').style.display = 'block';
@@ -1270,6 +1281,15 @@ async function openStorageModal(type) {
     document.getElementById('modalDeleteAll').disabled = false;
 
     var html = '';
+    if (data.truncated) {
+      var summary = _storageSummary[type] || {};
+      var totalCount = summary.count || 0;
+      html += '<li style="color:var(--text-ghost);font-size:12px;padding:8px 0;">Showing the first ' +
+        _modalFiles.length.toLocaleString() +
+        (totalCount ? ' of ' + totalCount.toLocaleString() : '') +
+        ' files. Select all shown and Delete Selected affect only this visible list; Delete Entire Cache removes all ' +
+        info.title.toLowerCase() + '.</li>';
+    }
     _modalFiles.forEach(function(f, i) {
       var displayName = escapeHtml(f.name);
       if (f.meta) {
@@ -1335,7 +1355,9 @@ async function deleteSelectedFiles() {
 
 async function deleteAllFiles() {
   var info = STORAGE_INFO[_modalType] || {title: _modalType};
-  if (!confirm('Delete all ' + _modalFiles.length + ' ' + info.title.toLowerCase() + '? They will be regenerated as needed.')) return;
+  var summary = _storageSummary[_modalType] || {};
+  var count = summary.count || _modalFiles.length;
+  if (!confirm('Delete all ' + count.toLocaleString() + ' ' + info.title.toLowerCase() + '? They will be regenerated as needed.')) return;
   try {
     await safeFetch('/api/storage/clear', {
       method: 'POST',

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -5297,6 +5297,35 @@ def test_storage_delete_files_syncs_preview_cache(client_with_photo):
     assert db.preview_cache_get(photo_id, 1920) is None
 
 
+def test_storage_files_limit_returns_bounded_preview_listing(client_with_photo):
+    """The storage modal can request a bounded first page instead of
+    statting and rendering every preview cache file before opening."""
+    import os
+
+    app, _db, photo_id = client_with_photo
+    client = app.test_client()
+    preview_dir = os.path.join(
+        os.path.dirname(app.config["THUMB_CACHE_DIR"]), "previews"
+    )
+    os.makedirs(preview_dir, exist_ok=True)
+    for size in (640, 1280, 1920):
+        with open(os.path.join(preview_dir, f"{photo_id}_{size}.jpg"), "wb") as f:
+            f.write(b"x" * size)
+
+    resp = client.get("/api/storage/files?type=previews&limit=2")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["limit"] == 2
+    assert data["truncated"] is True
+    assert len(data["files"]) == 2
+
+    resp = client.get("/api/storage/files?type=previews")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["truncated"] is False
+    assert len(data["files"]) == 3
+
+
 def test_storage_clear_thumbnails_resets_thumb_path(client_with_photo):
     """/api/storage/clear type=thumbnails NULLs photos.thumb_path so the
     pipeline plan's count_photos_missing_thumb doesn't report phantoms.


### PR DESCRIPTION
## Summary

This updates the Storage management modal so large preview and thumbnail caches do not require a full file inventory before the dialog can open.

## What changed

- Added optional `limit` support to `/api/storage/files`, preserving the full-list response for existing callers.
- Updated the Storage modal to request a bounded first page for previews and thumbnails.
- Clarified the UI scope: `Select all shown` and `Delete Selected` affect only visible rows, while `Delete Entire Cache` clears the full cache.
- Added regression coverage for bounded preview listings.

## Why

The previous flow scanned and statted every cache file, then rendered every row, before the Manage modal became usable. Large preview caches can contain thousands of disposable JPEGs, which made the modal appear stuck on “Loading files...”.

## Validation

- `pytest vireo/tests/test_photos_api.py -k "storage_files_limit or storage_delete_files_syncs_preview_cache or storage_clear_previews"`
- `python -m compileall -q vireo/app.py`