### PR TITLE
[codex] Restore Process source browse button

### DIFF
--- a/tests/e2e/test_pipeline.py
+++ b/tests/e2e/test_pipeline.py
@@ -81,6 +81,18 @@ def test_pipeline_source_browse_button_adds_source_folder(live_server, page):
     assert page.evaluate("_sourceMode") == "import"
 
 
+def test_pipeline_source_browse_cancel_keeps_workspace_folder_mode(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/pipeline")
+    assert page.evaluate("_sourceMode") == "folders"
+    page.evaluate("window.pickDirectory = async () => null")
+
+    page.locator("[data-testid='source-browse-btn']").click()
+
+    assert page.evaluate("_sourceMode") == "folders"
+    expect(page.locator("#sourceFolderList")).to_be_empty()
+
+
 def test_pipeline_source_card_expanded_by_default(live_server, page):
     url = live_server["url"]
     page.goto(f"{url}/pipeline")

--- a/tests/e2e/test_pipeline.py
+++ b/tests/e2e/test_pipeline.py
@@ -54,6 +54,33 @@ def test_pipeline_import_source_dims_collection(live_server, page):
     expect(collection_body).to_have_class(re.compile("dimmed"))
 
 
+def test_pipeline_source_browse_button_adds_source_folder(live_server, page):
+    url = live_server["url"]
+    page.route(
+        "**/api/import/folder-preview",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "total_count": 0,
+                "total_size": 0,
+                "type_breakdown": {},
+                "duplicate_count": 0,
+                "files": [],
+            }),
+        ),
+    )
+    page.goto(f"{url}/pipeline")
+    page.evaluate("window.pickDirectory = async () => ['/tmp/vireo-source']")
+
+    browse_btn = page.locator("[data-testid='source-browse-btn']")
+    expect(browse_btn).to_be_visible()
+    browse_btn.click()
+
+    expect(page.locator("#sourceFolderList")).to_contain_text("/tmp/vireo-source")
+    assert page.evaluate("_sourceMode") == "import"
+
+
 def test_pipeline_source_card_expanded_by_default(live_server, page):
     url = live_server["url"]
     page.goto(f"{url}/pipeline")

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -5456,11 +5456,12 @@ function updateCardStates() {
 })();
 
 async function browseForFolder() {
-  if (_sourceMode !== 'import') selectSourceMode('import');
   if (typeof pickDirectory === 'function') {
     var result = await pickDirectory('Select photo folders', { multiple: true });
     if (result) {
       var paths = Array.isArray(result) ? result : [result];
+      var hasPath = paths.some(function(p) { return !!p; });
+      if (hasPath && _sourceMode !== 'import') selectSourceMode('import');
       var added = false;
       for (var i = 0; i < paths.length; i++) {
         if (paths[i] && _sourceFolders.indexOf(paths[i]) === -1) {
@@ -5789,9 +5790,9 @@ function fetchFolderCounts(paths) {
 
 function selectFolder() {
   if (_fbMode === 'source') {
-    if (_sourceMode !== 'import') selectSourceMode('import');
     var picks = _fbSelectedDirs.length ? _fbSelectedDirs : (_fbSelectedDir ? [_fbSelectedDir] : []);
     if (!picks.length) return;
+    if (_sourceMode !== 'import') selectSourceMode('import');
     var added = false;
     for (var i = 0; i < picks.length; i++) {
       if (_sourceFolders.indexOf(picks[i]) === -1) {

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -733,12 +733,13 @@ body { padding-bottom: 36px; }
               <div class="setting-item">
                 <div class="setting-label">Folders <span style="font-weight:400;color:var(--text-dim);">(each includes its subfolders; importing lives on the Import page)</span></div>
                 <div id="folderScopeList" style="display:flex;flex-direction:column;gap:2px;max-height:220px;overflow-y:auto;font-size:12px;"></div>
-                <div style="display:flex;gap:6px;margin-top:8px;">
+                <div style="display:flex;flex-direction:column;gap:6px;margin-top:8px;">
+                  <button class="btn btn-primary" type="button" onclick="browseForFolder()"
+                          style="white-space:nowrap;align-self:flex-start;"
+                          data-testid="source-browse-btn">Browse&hellip;</button>
                   <input type="text" class="setting-input" id="cfgSourceInput"
-                         placeholder="/path/to/source folder"
-                         onkeydown="if(event.key==='Enter')addSourceFolder()">
-                  <button class="btn btn-secondary" type="button" onclick="addSourceFolder()"
-                          style="font-size:12px;padding:4px 10px;">Add</button>
+                         placeholder="or type a path and press Enter"
+                         onkeydown="if(event.key==='Enter'){event.preventDefault();addSourceFolder();}">
                 </div>
                 <div id="sourceFolderList" style="margin-top:6px;"></div>
               </div>
@@ -5455,6 +5456,7 @@ function updateCardStates() {
 })();
 
 async function browseForFolder() {
+  if (_sourceMode !== 'import') selectSourceMode('import');
   if (typeof pickDirectory === 'function') {
     var result = await pickDirectory('Select photo folders', { multiple: true });
     if (result) {
@@ -5787,6 +5789,7 @@ function fetchFolderCounts(paths) {
 
 function selectFolder() {
   if (_fbMode === 'source') {
+    if (_sourceMode !== 'import') selectSourceMode('import');
     var picks = _fbSelectedDirs.length ? _fbSelectedDirs : (_fbSelectedDir ? [_fbSelectedDir] : []);
     if (!picks.length) return;
     var added = false;


### PR DESCRIPTION
## Summary
- Restore the Process page source `Browse...` button as the primary source-folder control.
- Keep typed path entry as a secondary fallback with Enter-to-add behavior.
- Ensure both native picker and folder-browser modal selection switch into import-source mode before adding source folders.
- Add an e2e regression test covering the visible Browse button and picker flow.

## Root Cause
The Import/Process split removed the old source-folder block that contained the primary `Browse...` action. A later compatibility fix restored typed source paths but did not restore the browse control, leaving the less desirable typed-path UI as the only visible way to add external source folders.

## Validation
- `pytest tests/e2e/test_pipeline.py -q`