### PR TITLE
[codex] Fix import page routing

### DIFF
--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -85,7 +85,7 @@ pub mod ids {
 pub fn route_for_id(id: &str) -> Option<&'static str> {
     match id {
         ids::NAV_BROWSE => Some("/browse"),
-        ids::NAV_IMPORT => Some("/lightroom"),
+        ids::NAV_IMPORT => Some("/import"),
         ids::NAV_PIPELINE => Some("/pipeline"),
         ids::NAV_PIPELINE_REVIEW => Some("/pipeline/review"),
         ids::NAV_PIPELINE_RAPID_REVIEW => Some("/pipeline/rapid-review"),

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -245,12 +245,12 @@ pub fn build_menu(app: &AppHandle) -> tauri::Result<tauri::menu::Menu<tauri::Wry
     let mut view_builder = SubmenuBuilder::new(app, "View");
     view_builder = view_builder
         .item(
-            &MenuItemBuilder::with_id(ids::NAV_BROWSE, "Browse")
+            &MenuItemBuilder::with_id(ids::NAV_IMPORT, "Import")
                 .accelerator("CmdOrCtrl+1")
                 .build(app)?,
         )
         .item(
-            &MenuItemBuilder::with_id(ids::NAV_IMPORT, "Import")
+            &MenuItemBuilder::with_id(ids::NAV_BROWSE, "Browse")
                 .accelerator("CmdOrCtrl+2")
                 .build(app)?,
         )

--- a/tests/e2e/test_navigation.py
+++ b/tests/e2e/test_navigation.py
@@ -9,6 +9,14 @@ def test_navbar_links_navigate_to_pipeline(live_server, page):
     expect(page).to_have_url(f"{url}/pipeline")
 
 
+def test_navbar_links_navigate_to_import(live_server, page):
+    """Clicking Import in navbar navigates to the import page."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+    page.click("[data-testid='nav-import']")
+    expect(page).to_have_url(f"{url}/import")
+
+
 def test_navbar_links_navigate_to_jobs(live_server, page):
     """Clicking Jobs in navbar navigates to the jobs page."""
     url = live_server["url"]

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -231,16 +231,6 @@ DEFAULT_TABS = [
     "highlights", "misses", "storage", "settings",
 ]
 
-# Shape of DEFAULT_TABS from the v2-era code that shipped the Storage tab
-# migration (July 2026) but not the v1 import-tab migration. Used by the
-# v3 catch-up to distinguish a genuinely-skipped v1 migration from a user
-# who explicitly unpinned Import from an otherwise-modified tab list.
-_TABS_PRE_V1_V2_ERA = frozenset({
-    "browse", "pipeline", "pipeline_review",
-    "review", "cull", "jobs",
-    "highlights", "misses", "storage", "settings",
-})
-
 
 def commit_with_retry(conn, max_retries=5, base_delay=0.1):
     """Commit ``conn`` with retry on transient "locked"/"busy" errors.
@@ -1003,42 +993,24 @@ class Database:
             self.conn.execute("PRAGMA user_version = 2")
             current_user_version = 2
 
-        # Migration (import/process split catch-up): some databases may have
-        # reached user_version 2 before the v1 import-tab migration above
-        # existed, which skipped adding Import to saved tab rows. "Import
-        # missing" alone is not a safe signal: `set_tabs()` deliberately does
-        # not advance user_version, so a v2 database whose user unpinned
-        # Import also lacks the tab. Only apply the catch-up when the tabs
-        # shape matches the exact pre-v1 v2-era default set — that is the
-        # one shape v1 would have transformed, and any customization (added
-        # tabs, removed anything besides Import) is respected as user
-        # intent rather than a missed migration.
-        if current_user_version < 3:
-            rows = self.conn.execute(
-                "SELECT id, tabs FROM workspaces WHERE tabs IS NOT NULL"
-            ).fetchall()
-            for row in rows:
-                try:
-                    tabs = json.loads(row["tabs"])
-                except (TypeError, ValueError):
-                    continue
-                if not isinstance(tabs, list) or "import" in tabs:
-                    continue
-                if set(tabs) != _TABS_PRE_V1_V2_ERA:
-                    continue
-                tabs.insert(tabs.index("pipeline"), "import")
-                self.conn.execute(
-                    "UPDATE workspaces SET tabs = ? WHERE id = ?",
-                    (json.dumps(tabs), row["id"]),
-                )
-            self.conn.execute("PRAGMA user_version = 3")
-            current_user_version = 3
+        # (Version 3 was briefly used on the fix-import-page-routing branch
+        # for an "import catch-up" that tried to backfill Import for
+        # databases suspected of having skipped the v1 migration. It was
+        # dropped before shipping: chronologically v1 (dae1653, 2026-07-05)
+        # landed before v2 (e988f21, 2026-07-08) and both live in this same
+        # method, so no real database can be at user_version 2 without
+        # having run v1. The catch-up therefore only fired on rows whose
+        # shape matched a user who unpinned Import from the current
+        # default — clobbering a legitimate preference to fix a scenario
+        # that cannot occur. The number is skipped rather than reused so
+        # any dev DB that briefly reached user_version 3 keeps monotonic
+        # ordering into v4.)
 
         # Migration (import page prominence): Import is now the first pinned
         # page, because adding photos is the natural starting workflow. Move
         # an existing Import tab to the front once. Rows that lack Import
-        # are left alone — same reasoning as the v3 catch-up above: a
-        # one-shot migration must not silently re-add a tab a user removed.
+        # are left alone — a one-shot migration must not silently re-add a
+        # tab a user removed.
         if current_user_version < 4:
             rows = self.conn.execute(
                 "SELECT id, tabs FROM workspaces WHERE tabs IS NOT NULL"

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -231,6 +231,16 @@ DEFAULT_TABS = [
     "highlights", "misses", "storage", "settings",
 ]
 
+# Shape of DEFAULT_TABS from the v2-era code that shipped the Storage tab
+# migration (July 2026) but not the v1 import-tab migration. Used by the
+# v3 catch-up to distinguish a genuinely-skipped v1 migration from a user
+# who explicitly unpinned Import from an otherwise-modified tab list.
+_TABS_PRE_V1_V2_ERA = frozenset({
+    "browse", "pipeline", "pipeline_review",
+    "review", "cull", "jobs",
+    "highlights", "misses", "storage", "settings",
+})
+
 
 def commit_with_retry(conn, max_retries=5, base_delay=0.1):
     """Commit ``conn`` with retry on transient "locked"/"busy" errors.
@@ -994,8 +1004,15 @@ class Database:
             current_user_version = 2
 
         # Migration (import/process split catch-up): some databases may have
-        # reached user_version 2 before the import-tab migration above existed,
-        # which skipped adding Import to saved tab rows. Add it once here too.
+        # reached user_version 2 before the v1 import-tab migration above
+        # existed, which skipped adding Import to saved tab rows. "Import
+        # missing" alone is not a safe signal: `set_tabs()` deliberately does
+        # not advance user_version, so a v2 database whose user unpinned
+        # Import also lacks the tab. Only apply the catch-up when the tabs
+        # shape matches the exact pre-v1 v2-era default set — that is the
+        # one shape v1 would have transformed, and any customization (added
+        # tabs, removed anything besides Import) is respected as user
+        # intent rather than a missed migration.
         if current_user_version < 3:
             rows = self.conn.execute(
                 "SELECT id, tabs FROM workspaces WHERE tabs IS NOT NULL"
@@ -1007,10 +1024,9 @@ class Database:
                     continue
                 if not isinstance(tabs, list) or "import" in tabs:
                     continue
-                if "pipeline" in tabs:
-                    tabs.insert(tabs.index("pipeline"), "import")
-                else:
-                    tabs.insert(0, "import")
+                if set(tabs) != _TABS_PRE_V1_V2_ERA:
+                    continue
+                tabs.insert(tabs.index("pipeline"), "import")
                 self.conn.execute(
                     "UPDATE workspaces SET tabs = ? WHERE id = ?",
                     (json.dumps(tabs), row["id"]),
@@ -1019,9 +1035,10 @@ class Database:
             current_user_version = 3
 
         # Migration (import page prominence): Import is now the first pinned
-        # page, because adding photos is the natural starting workflow. Move an
-        # existing Import tab to the front once; if an old row still lacks it,
-        # add it at the front.
+        # page, because adding photos is the natural starting workflow. Move
+        # an existing Import tab to the front once. Rows that lack Import
+        # are left alone — same reasoning as the v3 catch-up above: a
+        # one-shot migration must not silently re-add a tab a user removed.
         if current_user_version < 4:
             rows = self.conn.execute(
                 "SELECT id, tabs FROM workspaces WHERE tabs IS NOT NULL"
@@ -1031,7 +1048,9 @@ class Database:
                     tabs = json.loads(row["tabs"])
                 except (TypeError, ValueError):
                     continue
-                if not isinstance(tabs, list):
+                if not isinstance(tabs, list) or "import" not in tabs:
+                    continue
+                if tabs[0] == "import":
                     continue
                 tabs = [t for t in tabs if t != "import"]
                 tabs.insert(0, "import")

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -226,7 +226,7 @@ ALL_NAV_IDS = frozenset({
 })
 
 DEFAULT_TABS = [
-    "browse", "import", "pipeline", "pipeline_review",
+    "import", "browse", "pipeline", "pipeline_review",
     "review", "cull", "jobs",
     "highlights", "misses", "storage", "settings",
 ]
@@ -963,6 +963,7 @@ class Database:
                     (json.dumps(tabs), row["id"]),
                 )
             self.conn.execute("PRAGMA user_version = 1")
+            current_user_version = 1
 
         # Migration (storage page): cache/storage controls moved out of
         # Settings and Dashboard, so existing workspaces need a visible
@@ -990,6 +991,56 @@ class Database:
                     (json.dumps(tabs), row["id"]),
                 )
             self.conn.execute("PRAGMA user_version = 2")
+            current_user_version = 2
+
+        # Migration (import/process split catch-up): some databases may have
+        # reached user_version 2 before the import-tab migration above existed,
+        # which skipped adding Import to saved tab rows. Add it once here too.
+        if current_user_version < 3:
+            rows = self.conn.execute(
+                "SELECT id, tabs FROM workspaces WHERE tabs IS NOT NULL"
+            ).fetchall()
+            for row in rows:
+                try:
+                    tabs = json.loads(row["tabs"])
+                except (TypeError, ValueError):
+                    continue
+                if not isinstance(tabs, list) or "import" in tabs:
+                    continue
+                if "pipeline" in tabs:
+                    tabs.insert(tabs.index("pipeline"), "import")
+                else:
+                    tabs.insert(0, "import")
+                self.conn.execute(
+                    "UPDATE workspaces SET tabs = ? WHERE id = ?",
+                    (json.dumps(tabs), row["id"]),
+                )
+            self.conn.execute("PRAGMA user_version = 3")
+            current_user_version = 3
+
+        # Migration (import page prominence): Import is now the first pinned
+        # page, because adding photos is the natural starting workflow. Move an
+        # existing Import tab to the front once; if an old row still lacks it,
+        # add it at the front.
+        if current_user_version < 4:
+            rows = self.conn.execute(
+                "SELECT id, tabs FROM workspaces WHERE tabs IS NOT NULL"
+            ).fetchall()
+            for row in rows:
+                try:
+                    tabs = json.loads(row["tabs"])
+                except (TypeError, ValueError):
+                    continue
+                if not isinstance(tabs, list):
+                    continue
+                tabs = [t for t in tabs if t != "import"]
+                tabs.insert(0, "import")
+                self.conn.execute(
+                    "UPDATE workspaces SET tabs = ? WHERE id = ?",
+                    (json.dumps(tabs), row["id"]),
+                )
+            self.conn.execute("PRAGMA user_version = 4")
+            current_user_version = 4
 
         # Migration: drop legacy open_tabs column (replaced by `tabs`).
         try:

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -2287,7 +2287,7 @@ function sendReport() {
 //   - vireo/app.py:ALL_PAGES        (page registry)
 //   - vireo/db.py:DEFAULT_TABS      (default pinned-tabs list)
 window.NAV_DEFAULT_TABS = [
-  'browse', 'import', 'pipeline', 'pipeline_review',
+  'import', 'browse', 'pipeline', 'pipeline_review',
   'review', 'cull', 'jobs',
   'highlights', 'misses', 'storage', 'settings'
 ];
@@ -8504,10 +8504,10 @@ window.handleNativeMenuCommand = async function(command) {
         else nativeMenuRoute('/workspace');
         break;
       case 'import_photos':
-        nativeMenuRoute('/lightroom');
+        nativeMenuRoute('/import');
         break;
       case 'import_folder':
-        nativeMenuRoute('/pipeline');
+        nativeMenuRoute('/import');
         break;
       case 'export_selected':
         if (typeof openExportModal === 'function') openExportModal();

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1556,7 +1556,7 @@ body {
           To get started, import your photos. You can scan a folder of images
           (with or without existing XMP sidecars), or import keywords from a Lightroom catalog.
         </p>
-        <a href="/pipeline" style="display:inline-block;background:var(--accent);color:var(--accent-text);padding:10px 28px;border-radius:4px;font-size:14px;font-weight:600;text-decoration:none;">Import Photos</a>
+        <a href="/import" style="display:inline-block;background:var(--accent);color:var(--accent-text);padding:10px 28px;border-radius:4px;font-size:14px;font-weight:600;text-decoration:none;">Import Photos</a>
       </div>
       <div class="loading-state" id="loadingState">Loading...</div>
     </div>

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -422,11 +422,6 @@ body { padding-bottom: 36px; }
 .dest-option {
   padding: 4px 0;
 }
-#destCopySection.dimmed {
-  opacity: 0.35;
-  pointer-events: none;
-}
-
 /* Pipeline action bar */
 .pipeline-action-bar {
   margin-top: 8px;
@@ -731,17 +726,8 @@ body { padding-bottom: 36px; }
           <div class="source-option-body" id="sourceImportBody">
             <div class="setting-row">
               <div class="setting-item">
-                <div class="setting-label">Folders <span style="font-weight:400;color:var(--text-dim);">(each includes its subfolders; importing lives on the Import page)</span></div>
+                <div class="setting-label">Folders <span style="font-weight:400;color:var(--text-dim);">(each includes its subfolders)</span></div>
                 <div id="folderScopeList" style="display:flex;flex-direction:column;gap:2px;max-height:220px;overflow-y:auto;font-size:12px;"></div>
-                <div style="display:flex;flex-direction:column;gap:6px;margin-top:8px;">
-                  <button class="btn btn-primary" type="button" onclick="browseForFolder()"
-                          style="white-space:nowrap;align-self:flex-start;"
-                          data-testid="source-browse-btn">Browse&hellip;</button>
-                  <input type="text" class="setting-input" id="cfgSourceInput"
-                         placeholder="or type a path and press Enter"
-                         onkeydown="if(event.key==='Enter'){event.preventDefault();addSourceFolder();}">
-                </div>
-                <div id="sourceFolderList" style="margin-top:6px;"></div>
               </div>
             </div>
           </div>
@@ -828,132 +814,6 @@ body { padding-bottom: 36px; }
         </div>
       </div>
 
-      <!-- Divider -->
-      <div style="border-top:1px solid var(--border-primary,#14374E);margin:16px 0;"></div>
-
-      <!-- Section 2: Import handoff -->
-      <div class="setting-label">Importing photos</div>
-      <div class="hint" style="font-size:12px;color:var(--text-secondary);line-height:1.4;">
-        Copying cards or folders into the archive now happens on the
-        <a href="/import" style="color:var(--accent);">Import</a> page.
-        Process only works on photos already in the active workspace.
-      </div>
-      <div id="destCopySection" data-testid="file-copying-section" style="display:none;">
-        <div class="setting-row">
-          <div class="setting-item">
-            <label style="font-size:12px;color:var(--text-secondary);cursor:pointer;">
-              <input type="checkbox" id="chkCopyPhotos" style="accent-color:var(--accent);" onchange="onCopyModeChange()" data-testid="copy-photos-toggle"> Copy photos to another location
-            </label>
-          </div>
-        </div>
-        <div id="copyOnlyFields" style="display:none;" data-testid="destination-section">
-          <div class="setting-row">
-            <div class="setting-item">
-              <div class="setting-label">Destination</div>
-              <div style="margin-bottom:6px;">
-                <select id="cfgDestMode" class="setting-select" style="font-family:inherit;max-width:340px;"
-                        onchange="onDestModeChange()" data-testid="dest-mode-select">
-                  <option value="local">Local path</option>
-                </select>
-              </div>
-              <div id="destLocalRows">
-                <div style="display:flex;gap:6px;">
-                  <input type="text" class="setting-select" id="cfgDestination" list="volumeDatalist"
-                         placeholder="/path/to/photo/library" style="font-family:inherit;flex:1;"
-                         oninput="updateStartButton();markFolderPreviewStale()">
-                  <button onclick="openFolderBrowser('destination')" class="btn btn-secondary" style="white-space:nowrap;">Browse&hellip;</button>
-                </div>
-                <div id="recentDestinations" style="display:none;margin-top:6px;" data-testid="recent-destinations">
-                  <div style="font-size:11px;color:var(--text-dim);margin-bottom:4px;">Recent</div>
-                  <div id="recentDestList" style="display:flex;flex-wrap:wrap;gap:4px;"></div>
-                </div>
-              </div>
-              <div id="destRemoteRows" style="display:none;">
-                <input type="text" class="setting-select" id="cfgRemoteSubpath"
-                       placeholder="Archive folder under the target (e.g. 2026/kenya-trip)"
-                       style="font-family:inherit;width:100%;"
-                       oninput="updateRemoteDestPreview();updateStartButton()" data-testid="remote-subpath-input">
-                <div id="remoteDestPreview" style="font-size:11px;margin-top:4px;line-height:1.5;color:var(--text-dim);" data-testid="remote-dest-preview"></div>
-              </div>
-            </div>
-          </div>
-          <div class="setting-row">
-            <div class="setting-item">
-              <label style="font-size:12px;color:var(--text-secondary);cursor:pointer;">
-                <input type="checkbox" id="chkSkipDuplicates" checked style="accent-color:var(--accent);" onchange="onSkipDuplicatesToggle()"> Skip duplicates
-              </label>
-              <label style="font-size:12px;color:var(--text-secondary);cursor:pointer;display:block;margin:4px 0 0 20px;">
-                <input type="checkbox" id="chkVerifyByHash" style="accent-color:var(--accent);" onchange="onVerifyByHashToggle()"> Verify by full content hash
-              </label>
-              <div style="font-size:11px;color:var(--text-dim);margin:4px 0 0 20px;line-height:1.4;">
-                Off: duplicates are matched by filename, size, and capture time (fast — only files without reliable metadata are read in full). On: every byte of every source file is read and compared — exact, but slow on SD cards.
-              </div>
-            </div>
-          </div>
-          <div class="setting-row">
-            <div class="setting-item">
-              <label style="font-size:12px;color:var(--text-secondary);cursor:pointer;">
-                <input type="checkbox" id="chkLocalProcessing" style="accent-color:var(--accent);" onchange="updateStartButton(); schedulePlanRefresh()" data-testid="local-processing-toggle"> Use local disk while processing
-              </label>
-              <div style="font-size:11px;color:var(--text-dim);margin-top:4px;line-height:1.4;">
-                Files are staged locally for faster processing, then archived to the destination after verification.
-              </div>
-              <div id="remoteLocalProcessingNote" style="display:none;font-size:11px;color:var(--text-dim);margin-top:4px;line-height:1.4;" data-testid="remote-local-processing-note">
-                Required for SSH targets &mdash; files are staged and processed locally, then transferred over SSH.
-              </div>
-            </div>
-          </div>
-          <!-- Folder Organization -->
-          <div style="border-top:1px solid var(--border-primary,#14374E);margin:12px 0;"></div>
-          <div class="setting-row">
-            <div class="setting-item">
-              <div class="setting-label">Folder structure</div>
-              <div style="display:flex;gap:6px;align-items:center;">
-                <select id="cfgFolderTemplate" class="setting-select" style="font-family:inherit;max-width:240px;" onchange="onFolderTemplateChange()">
-                  <option value="%Y/%Y-%m-%d">Year / Date &mdash; 2026/2026-04-08</option>
-                  <option value="%Y-%m-%d">Date only &mdash; 2026-04-08</option>
-                  <option value="%Y/%m">Year / Month &mdash; 2026/04</option>
-                  <option value="%Y">Year only &mdash; 2026</option>
-                  <option value="">Flat &mdash; no subfolders</option>
-                  <option value="__custom__">Custom&hellip;</option>
-                </select>
-              </div>
-              <div id="customTemplateRow" style="display:none;margin-top:6px;">
-                <input type="text" class="setting-select" id="cfgCustomTemplate"
-                       placeholder="%Y/%B" style="font-family:inherit;max-width:240px;"
-                       onblur="if(_folderPreviewShown)previewDestinationFolders()"
-                       onkeydown="if(event.key==='Enter'&&_folderPreviewShown)previewDestinationFolders()"
-                       data-testid="custom-template-input">
-                <div style="font-size:11px;color:var(--text-dim);margin-top:2px;">
-                  Uses strftime format &mdash; e.g. %Y/%B for Year/Month Name
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="setting-row">
-            <div class="setting-item">
-              <button id="btnPreviewFolders" class="btn btn-secondary" onclick="previewDestinationFolders()" disabled
-                      style="font-size:12px;padding:4px 12px;" data-testid="preview-folders-btn">
-                Preview folder structure
-              </button>
-              <span id="previewFoldersHint" style="font-size:11px;color:var(--text-dim);margin-left:8px;">
-                Select source and destination to preview
-              </span>
-            </div>
-          </div>
-          <div id="folderPreviewResults" style="display:none;margin-top:8px;" data-testid="folder-preview-results">
-            <div id="folderPreviewManagedArchive" style="display:none;font-size:12px;line-height:1.4;margin-bottom:8px;padding:6px 8px;border-radius:4px;background:var(--bg-tertiary,#0d2436);border:1px solid var(--accent,#24E5CA);" data-testid="managed-archive-callout"></div>
-            <div id="folderPreviewSummary" style="font-size:12px;font-weight:600;margin-bottom:6px;"></div>
-            <div id="folderPreviewList" style="font-size:12px;max-height:200px;overflow-y:auto;"></div>
-            <div id="folderPreviewStale" style="display:none;font-size:11px;color:var(--warning,#f0ad4e);margin-top:4px;">
-              Source or destination changed &mdash; click Refresh to update
-            </div>
-          </div>
-        </div>
-        <div id="destCopyDisabledNote" style="display:none;font-size:12px;color:var(--text-dim);font-style:italic;margin-top:4px;">
-          Not applicable for existing collections
-        </div>
-      </div>
     </div>
   </div>
 
@@ -1836,43 +1696,7 @@ function fetchFolderPreview() {
     return;
   }
 
-  // Import mode: existing behavior
-  var folders = _sourceFolders;
-  if (!folders.length) {
-    showPreviewPlaceholder();
-    return;
-  }
-
-  var fileTypes = getIngestFileTypes();
-  if (!fileTypes.length) {
-    showPreviewPlaceholder();
-    return;
-  }
-
-  showPreviewLoading();
-  _previewAbort = new AbortController();
-
-  fetch('/api/import/folder-preview', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ folders: folders, file_types: fileTypes, recursive: includeSubfoldersEnabled() }),
-    signal: _previewAbort.signal,
-  })
-    .then(function(r) { return r.json(); })
-    .then(function(data) {
-      _previewData = data;
-      _previewSelected = {};
-      _duplicateResults = {};
-      data.files.forEach(function(f) {
-        _previewSelected[f.path] = !f.duplicate;
-      });
-      renderPreview();
-      if (_copyMode) checkForDuplicates();
-    })
-    .catch(function(err) {
-      if (err.name === 'AbortError') return;
-      showPreviewError('Failed to load preview: ' + err.message);
-    });
+  showPreviewPlaceholder();
 }
 
 function showPreviewPlaceholder() {
@@ -2309,53 +2133,6 @@ function formatBytes(bytes) {
   return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
 }
 
-function addSourceFolder() {
-  var input = document.getElementById('cfgSourceInput');
-  var val = input.value.trim();
-  if (!val || _sourceFolders.indexOf(val) !== -1) return;
-  // Route through selectSourceMode so a prior 'collection' / 'new_images'
-  // / 'folders' selection lifts its copy-section dim and destination
-  // workspace lock. Without this, adding a typed path from those modes
-  // scans correctly but leaves #destCopySection with .dimmed +
-  // pointer-events:none, so the user can't enable Copy photos or pick
-  // a destination.
-  if (_sourceMode !== 'import') selectSourceMode('import');
-  _sourceFolders.push(val);
-  markFolderPreviewStale();
-  input.value = '';
-  renderSourceFolders();
-  updateStartButton();
-  fetchFolderPreview();
-}
-
-function removeSourceFolder(idx) {
-  _sourceFolders.splice(idx, 1);
-  markFolderPreviewStale();
-  renderSourceFolders();
-  updateStartButton();
-  fetchFolderPreview();
-}
-
-function renderSourceFolders() {
-  var el = document.getElementById('sourceFolderList');
-  if (!_sourceFolders.length) { el.innerHTML = ''; return; }
-  el.innerHTML = _sourceFolders.map(function(f, i) {
-    return '<div class="folder-tag"><span>' + escapeHtml(f) +
-      '</span> <span class="folder-tag-remove" onclick="removeSourceFolder(' + i + ')">&times;</span></div>';
-  }).join('');
-}
-
-function selectRecentDestination(path) {
-  document.getElementById('chkCopyPhotos').checked = true;
-  onCopyModeChange();
-  // Recents are local paths — switch back out of any remote mode.
-  document.getElementById('cfgDestMode').value = 'local';
-  onDestModeChange();
-  document.getElementById('cfgDestination').value = path;
-  updateStartButton();
-  markFolderPreviewStale();
-}
-
 /* ---------- Remote (SSH) archive targets ----------
    Mirrors the Move page's saved-remote-target picker: the archive
    destination becomes a saved SSH target plus a required subpath naming
@@ -2691,8 +2468,11 @@ function markFolderPreviewStale() {
   // banner below still prompts the user; the callout is recomputed on refresh.
   _managedArchive = null;
   renderManagedArchiveCallout();
-  document.getElementById('folderPreviewStale').style.display = '';
+  var stale = document.getElementById('folderPreviewStale');
+  if (!stale) return;
+  stale.style.display = '';
   var btn = document.getElementById('btnPreviewFolders');
+  if (!btn) return;
   btn.textContent = 'Refresh preview';
   // Only enable if prerequisites are still met (sources + a LOCAL
   // destination — the preview can't walk an SSH target).
@@ -2706,11 +2486,8 @@ async function selectSourceMode(mode) {
   // Cancel any in-flight duplicate scan before switching context
   if (_duplicateCheckAbort) { _duplicateCheckAbort.abort(); _duplicateCheckAbort = null; }
   _sourceMode = mode;
-  // 'import' (typed paths) shares the Workspace Folders card with
-  // 'folders' (workspace subtree scan), so it drives the same radio
-  // and body-dim state as folders.
-  var isFoldersLike = (mode === 'folders' || mode === 'import');
-  document.getElementById('radioFolders').checked = isFoldersLike;
+  var isFolders = (mode === 'folders');
+  document.getElementById('radioFolders').checked = isFolders;
   document.getElementById('radioCollection').checked = (mode === 'collection');
   var newImgRadio = document.getElementById('radioNewImages');
   if (newImgRadio) newImgRadio.checked = (mode === 'new_images');
@@ -2719,7 +2496,7 @@ async function selectSourceMode(mode) {
   var collBody = document.getElementById('sourceCollectionBody');
   var newImgBody = document.getElementById('sourceNewImagesBody');
 
-  if (isFoldersLike) {
+  if (isFolders) {
     importBody.classList.remove('dimmed');
     collBody.classList.add('dimmed');
     if (newImgBody) newImgBody.classList.add('dimmed');
@@ -2731,22 +2508,6 @@ async function selectSourceMode(mode) {
     importBody.classList.add('dimmed');
     collBody.classList.add('dimmed');
     if (newImgBody) newImgBody.classList.remove('dimmed');
-  }
-
-  var copySection = document.getElementById('destCopySection');
-  var copyNote = document.getElementById('destCopyDisabledNote');
-  // Folder scope re-processes existing workspace photos in place, so the
-  // copy-to-another-location controls have nothing to act on — startPipeline
-  // only serializes body.folder_ids in this mode, and any copy settings the
-  // user checked would be silently discarded. Dim the copy section (same
-  // treatment as collection / new_images) so the UI can't lie about what
-  // will happen.
-  if (mode === 'collection' || mode === 'new_images' || mode === 'folders') {
-    copySection.classList.add('dimmed');
-    copyNote.style.display = '';
-  } else {
-    copySection.classList.remove('dimmed');
-    copyNote.style.display = 'none';
   }
 
   // Snapshot IDs are scoped to the workspace they were captured in, so the
@@ -2951,8 +2712,6 @@ function updateStartButton() {
     btn.disabled = selectedFolderIds().length === 0;
   } else if (_sourceMode === 'new_images') {
     btn.disabled = !newImagesSnapshotId;
-  } else if (_sourceMode === 'import') {
-    btn.disabled = _sourceFolders.length === 0;
   } else {
     var collId = document.getElementById('collectionPicker').value;
     btn.disabled = !collId;
@@ -3011,23 +2770,8 @@ function updateStartButton() {
   var previewBtn = document.getElementById('btnPreviewFolders');
   var previewHint = document.getElementById('previewFoldersHint');
   if (previewBtn) {
-    var hasSources = _sourceFolders.length > 0;
-    var remoteMode = _copyMode && !!pipelineRemoteTargetId();
-    var hasDest = _copyMode && !remoteMode
-      && document.getElementById('cfgDestination').value.trim();
-    if (hasSources && hasDest) {
-      if (!_folderPreviewShown) previewBtn.disabled = false;
-      previewHint.textContent = '';
-    } else {
-      previewBtn.disabled = true;
-      // The preview walks the destination on the local filesystem; an SSH
-      // target isn't locally walkable, so say the check doesn't run rather
-      // than pretending it did (existing remote files are still handled —
-      // the archive stage merges and refuses on content conflicts).
-      previewHint.textContent = remoteMode && hasSources
-        ? 'Folder preview isn’t available for SSH targets — existing remote files are checked at archive time'
-        : 'Select source and destination to preview';
-    }
+    previewBtn.disabled = true;
+    if (previewHint) previewHint.textContent = '';
   }
 
   // Update stage 1 indicator and auto-expand stage 2 when source is ready
@@ -3278,43 +3022,6 @@ async function startPipeline() {
         if (!_previewSelected[f.path]) excluded.push(f.path);
       });
       if (excluded.length > 0) body.exclude_paths = excluded;
-    }
-  } else if (_sourceMode === 'import') {
-    // Import scope: send the added source folders so /api/jobs/pipeline
-    // can scan (and optionally copy) them. Without this branch the
-    // request falls through to the collection path and posts
-    // collection_id: null, which the endpoint rejects as missing scope.
-    body.sources = _sourceFolders.slice();
-    body.file_types = getIngestFileTypes();
-    body.recursive = includeSubfoldersEnabled();
-    if (_copyMode) {
-      body.skip_duplicates = document.getElementById('chkSkipDuplicates').checked;
-      body.verify_by_hash = document.getElementById('chkVerifyByHash').checked;
-      body.folder_template = getSelectedFolderTemplate();
-      var lpCb = document.getElementById('chkLocalProcessing');
-      if (lpCb) body.local_processing = !!lpCb.checked;
-      // Remote SSH archive vs. local archive path. remote_target_id and
-      // destination are mutually exclusive server-side, so send exactly
-      // one — a saved SSH target (plus subpath) when the destination
-      // mode is remote:*, or the local cfgDestination path otherwise.
-      var remoteId = pipelineRemoteTargetId();
-      if (remoteId) {
-        body.remote_target_id = remoteId;
-        var subResult = normalizeRemoteSubpath(
-          document.getElementById('cfgRemoteSubpath').value);
-        body.remote_subpath = subResult.value;
-      } else {
-        body.destination = document.getElementById('cfgDestination').value.trim();
-      }
-    }
-    // Deselections apply by path — import previews have no photo_id
-    // yet, so exclude_photo_ids would drop them silently.
-    if (_previewData && _previewSelected) {
-      var excludedImport = [];
-      _previewData.files.forEach(function(f) {
-        if (!_previewSelected[f.path]) excludedImport.push(f.path);
-      });
-      if (excludedImport.length > 0) body.exclude_paths = excludedImport;
     }
   } else {
     body.collection_id = parseInt(document.getElementById('collectionPicker').value);
@@ -3971,100 +3678,6 @@ async function stopPipeline() {
       actionStatus.textContent = e.message || 'Unable to cancel pipeline';
       actionStatus.className = 'status-msg error';
     }
-  }
-}
-
-async function runImportStep() {
-  var source = _sourceFolders.length > 0 ? _sourceFolders[0] : '';
-  var destination = _copyMode
-    ? document.getElementById('cfgDestination').value.trim()
-    : '';
-
-  var num = document.getElementById('numSource');
-  var status = document.getElementById('statusSource');
-  var progressWrap = document.getElementById('progressSource');
-  var fill = document.getElementById('fillSource');
-  var text = document.getElementById('textSource');
-
-  num.className = 'stage-num running';
-  status.textContent = _copyMode ? 'Starting import...' : 'Scanning folder...';
-  progressWrap.style.display = '';
-  fill.style.width = '0%';
-
-  // Expand the source card
-  document.getElementById('card-source').classList.add('expanded');
-
-  try {
-    var body = {
-      source: source,
-      copy: _copyMode,
-      file_types: getIngestFileTypes(),
-    };
-    if (_copyMode) {
-      body.destination = destination;
-      body.skip_duplicates = document.getElementById('chkSkipDuplicates').checked;
-      body.verify_by_hash = document.getElementById('chkVerifyByHash').checked;
-      body.folder_template = getSelectedFolderTemplate();
-    }
-
-    var data = await safeFetch('/api/jobs/import-full', {
-      method: 'POST',
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify(body),
-    }, { toast: false });
-
-    if (!data.job_id) {
-      status.textContent = data.error || 'Failed to start';
-      num.className = 'stage-num';
-      progressWrap.style.display = 'none';
-      return null;
-    }
-
-    return await new Promise(function(resolve) {
-      safeEventSource('/api/jobs/' + data.job_id + '/stream', {
-        onProgress: function(p) {
-          var pct = p.total > 0 ? Math.round(p.current / p.total * 100) : 0;
-          fill.style.width = pct + '%';
-          var parts = [];
-          if (p.phase) parts.push(p.phase);
-          if (p.total > 0 && p.current > 0) parts.push(p.current + '/' + p.total);
-          if (p.current_file) parts.push(p.current_file);
-          text.textContent = parts.join(' \u2014 ');
-          status.textContent = parts.join(' \u2014 ');
-        },
-        onComplete: function(result) {
-          window.dispatchEvent(new CustomEvent('vireo-job-done', {detail: {job_id: data.job_id}}));
-          if (result.status === 'completed' && result.result) {
-            fill.style.width = '100%';
-            text.textContent = 'Complete';
-            num.className = 'stage-num complete';
-            var r = result.result;
-            var summary = [];
-            if (_copyMode && r.copied != null) summary.push(r.copied + ' imported');
-            if (_copyMode && r.skipped_duplicate > 0) summary.push(r.skipped_duplicate + ' duplicates skipped');
-            if (r.photos_indexed) summary.push(r.photos_indexed + ' indexed');
-            document.getElementById('txtSource').textContent = summary.join(', ');
-            status.textContent = 'Done!';
-            status.className = 'status-msg ok';
-            resolve(r.collection_id);
-          } else {
-            status.textContent = _copyMode ? 'Import failed' : 'Scan failed';
-            num.className = 'stage-num';
-            resolve(null);
-          }
-        },
-        onError: function() {
-          status.textContent = 'Connection lost';
-          num.className = 'stage-num';
-          resolve(null);
-        }
-      });
-    });
-  } catch(e) {
-    status.textContent = 'Error: ' + e.message;
-    num.className = 'stage-num';
-    progressWrap.style.display = 'none';
-    return null;
   }
 }
 
@@ -5283,12 +4896,10 @@ function refreshPipelineUI() {
 function _buildPlanBody() {
   var body = {};
   // Source mode determines how the backend scopes the plan:
+  //   - 'folders': scope = selected workspace folder subtrees.
   //   - 'collection': scope = collection's photo ids (real per-photo status).
-  //   - 'import' / 'new_images': send the SELECTED preview file paths so
-  //     the backend can split them into already-known-vs-new and report
-  //     truthful counts. Without this the plan falls back to whole-workspace
-  //     counts, which renders "Already done" for an import into a
-  //     non-empty workspace — exactly the bug we're fixing.
+  //   - 'new_images': send selected snapshot paths so the backend can split
+  //     them into already-known-vs-new and report truthful counts.
   if (_sourceMode === 'folders') {
     var folderIds = selectedFolderIds();
     if (folderIds.length) body.folder_ids = folderIds;
@@ -5303,7 +4914,7 @@ function _buildPlanBody() {
       });
       if (excludedIds.length) body.exclude_photo_ids = excludedIds;
     }
-  } else if ((_sourceMode === 'import' || _sourceMode === 'new_images')
+  } else if (_sourceMode === 'new_images'
              && _previewData && _previewData.files && _previewSelected) {
     // Send only the selected paths — the user can deselect duplicates
     // or specific files in the preview, and the plan should reflect
@@ -5312,7 +4923,7 @@ function _buildPlanBody() {
     _previewData.files.forEach(function(f) {
       if (_previewSelected[f.path]) selectedPaths.push(f.path);
     });
-    // Always send source_paths in import / new-images mode — even when
+    // Always send source_paths in new-images mode — even when
     // the list is empty (every preview file deselected) or exceeds the
     // backend cap (50k). Dropping the field would make the server fall
     // back to whole-workspace scope, which is the misleading plan this
@@ -5320,25 +4931,6 @@ function _buildPlanBody() {
     // plan. For oversized: the server returns 400 and the plan UI
     // clears — both accurate states.
     body.source_paths = selectedPaths;
-
-    // Copy-mode imports with skip_duplicates=true dedupe by duplicate
-    // identity (metadata key or content hash — same DuplicateChecker as
-    // ingest), not by source path. The /api/import/check-duplicates SSE
-    // feed has already populated _duplicateResults with the matched
-    // preview paths; pass that subset along so the plan counts those as
-    // already known instead of new (otherwise pills overstate work for
-    // files ingest() will silently skip). Only send when the duplicate
-    // gate is actually on; toggling it off must drop the field so the
-    // backend doesn't keep treating the cache as live.
-    var skipDup = document.getElementById('chkSkipDuplicates');
-    if (_copyMode && skipDup && skipDup.checked
-        && Object.keys(_duplicateResults).length > 0) {
-      var hashDupPaths = [];
-      selectedPaths.forEach(function(p) {
-        if (_duplicateResults[p]) hashDupPaths.push(p);
-      });
-      if (hashDupPaths.length) body.hash_duplicate_paths = hashDupPaths;
-    }
 
   }
 
@@ -5370,10 +4962,6 @@ function _buildPlanBody() {
 }
 
 function _planIsWaitingForImportPreview() {
-  if (_sourceMode === 'import') {
-    return _sourceFolders.length > 0 && getIngestFileTypes().length > 0
-      && (_previewLoading || !_previewData);
-  }
   if (_sourceMode === 'new_images') {
     return newImagesSnapshotId !== null && (_previewLoading || !_previewData);
   }
@@ -5456,29 +5044,7 @@ function updateCardStates() {
 })();
 
 async function browseForFolder() {
-  if (typeof pickDirectory === 'function') {
-    var result = await pickDirectory('Select photo folders', { multiple: true });
-    if (result) {
-      var paths = Array.isArray(result) ? result : [result];
-      var hasPath = paths.some(function(p) { return !!p; });
-      if (hasPath && _sourceMode !== 'import') selectSourceMode('import');
-      var added = false;
-      for (var i = 0; i < paths.length; i++) {
-        if (paths[i] && _sourceFolders.indexOf(paths[i]) === -1) {
-          _sourceFolders.push(paths[i]);
-          added = true;
-        }
-      }
-      if (added) {
-        markFolderPreviewStale();
-        renderSourceFolders();
-        updateStartButton();
-        fetchFolderPreview();
-      }
-      return;
-    }
-  }
-  openFolderBrowser('source');
+  window.location.href = '/import';
 }
 
 async function browseForDestination() {
@@ -5790,20 +5356,8 @@ function fetchFolderCounts(paths) {
 
 function selectFolder() {
   if (_fbMode === 'source') {
-    var picks = _fbSelectedDirs.length ? _fbSelectedDirs : (_fbSelectedDir ? [_fbSelectedDir] : []);
-    if (!picks.length) return;
-    if (_sourceMode !== 'import') selectSourceMode('import');
-    var added = false;
-    for (var i = 0; i < picks.length; i++) {
-      if (_sourceFolders.indexOf(picks[i]) === -1) {
-        _sourceFolders.push(picks[i]);
-        added = true;
-      }
-    }
-    if (added) {
-      markFolderPreviewStale();
-      renderSourceFolders();
-    }
+    window.location.href = '/import';
+    return;
   } else {
     if (!_fbSelectedDir) return;
     document.getElementById('cfgDestination').value = _fbSelectedDir;

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -6871,12 +6871,42 @@ def test_process_page_has_no_import_source(app_and_db):
     client = app.test_client()
     html = client.get("/pipeline").data.decode()
     assert 'id="radioImport"' not in html
+    assert 'id="cfgSourceInput"' not in html
+    assert 'id="destCopySection"' not in html
+    assert "/api/jobs/import-full" not in html
     assert 'id="radioFolders"' in html
     assert 'id="radioCollection"' in html
     assert 'id="radioNewImages"' in html
     assert 'id="strategySelect"' in html
     assert "folder_ids" in html
     assert "<title>Vireo - Process</title>" in html
+
+
+def test_browse_empty_state_import_link_targets_import_page(app_and_db):
+    app, _ = app_and_db
+    client = app.test_client()
+    html = client.get("/browse").data.decode()
+    assert 'href="/import"' in html
+    assert 'href="/pipeline" style="display:inline-block' not in html
+
+
+def test_native_import_commands_route_to_import_page():
+    import os
+
+    repo_root = os.path.normpath(
+        os.path.join(os.path.dirname(__file__), "..", "..")
+    )
+    navbar_path = os.path.join(repo_root, "vireo", "templates", "_navbar.html")
+    menu_path = os.path.join(repo_root, "src-tauri", "src", "menu.rs")
+
+    with open(navbar_path, encoding="utf-8") as f:
+        navbar = f.read()
+    with open(menu_path, encoding="utf-8") as f:
+        menu = f.read()
+
+    assert "ids::NAV_IMPORT => Some(\"/import\")" in menu
+    assert "case 'import_photos':\n        nativeMenuRoute('/import');" in navbar
+    assert "case 'import_folder':\n        nativeMenuRoute('/import');" in navbar
 
 
 def test_pipeline_plan_accepts_folder_scope(app_and_db):

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -14704,8 +14704,10 @@ def test_delete_edit_preset(tmp_path):
 
 
 def test_import_tab_in_nav_registries(tmp_path):
-    """import/process split PR 3: the Import tab must be in every server
-    registry or get_tabs silently drops it / set_tabs rejects it."""
+    """import/process split PR 3 + import-page-routing PR: the Import
+    tab must be in every server registry, and must be the leftmost/
+    first pinned page in DEFAULT_TABS since Import is now the natural
+    starting workflow for new workspaces."""
     from db import ALL_NAV_IDS, DEFAULT_TABS, Database
 
     assert "import" in ALL_NAV_IDS
@@ -14732,8 +14734,8 @@ def test_existing_workspaces_gain_import_tab(tmp_path):
     )
     # A real pre-split DB was written by a version that never set
     # PRAGMA user_version, so it reads back as 0. The fresh Database
-    # above already bumped it to 1; reset it so the second init runs
-    # the guarded import-tab migration.
+    # above already bumped it to 4; reset it so the second init runs
+    # every guarded tabs migration from scratch.
     db.conn.execute("PRAGMA user_version = 0")
     db.conn.commit()
     db.close()

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -13152,7 +13152,7 @@ def test_all_nav_ids_covers_every_page():
 def test_default_tabs_is_the_curated_ten():
     from db import DEFAULT_TABS
     assert DEFAULT_TABS == [
-        "browse", "import", "pipeline", "pipeline_review",
+        "import", "browse", "pipeline", "pipeline_review",
         "review", "cull", "jobs",
         "highlights", "misses", "storage", "settings",
     ]
@@ -14709,8 +14709,7 @@ def test_import_tab_in_nav_registries(tmp_path):
     from db import ALL_NAV_IDS, DEFAULT_TABS, Database
 
     assert "import" in ALL_NAV_IDS
-    idx = DEFAULT_TABS.index("import")
-    assert DEFAULT_TABS[idx + 1] == "pipeline", DEFAULT_TABS
+    assert DEFAULT_TABS[0] == "import", DEFAULT_TABS
 
     db = Database(str(tmp_path / "t.db"))
     db.set_tabs(["import", "browse"])
@@ -14718,8 +14717,7 @@ def test_import_tab_in_nav_registries(tmp_path):
 
 
 def test_existing_workspaces_gain_import_tab(tmp_path):
-    """A pre-split workspace tabs row (no 'import') gets it inserted
-    before 'pipeline' on init — reset-in-place, solo-user app."""
+    """A pre-split workspace tabs row gets Import inserted leftmost on init."""
     import json as json_mod
 
     from db import Database
@@ -14744,7 +14742,7 @@ def test_existing_workspaces_gain_import_tab(tmp_path):
     db2.set_active_workspace(ws)
     tabs = db2.get_tabs()
     assert "import" in tabs
-    assert tabs.index("import") == tabs.index("pipeline") - 1
+    assert tabs[0] == "import"
 
 
 def test_import_tab_migration_not_reapplied_after_unpin(tmp_path):

--- a/vireo/tests/test_tabs_api.py
+++ b/vireo/tests/test_tabs_api.py
@@ -153,12 +153,19 @@ def test_get_tabs_endpoint_new_shape(app_and_db):
     assert sample == {"id": "duplicates", "label": "Duplicates", "href": "/duplicates"}
 
 
-def test_tabs_migration_adds_import_for_version_2_database(tmp_path):
-    """Databases that reached user_version 2 without the v1 import-tab
-    migration having run get Import back — but only when the tabs shape
-    matches the exact pre-v1 v2-era default. Any other shape is treated
-    as intentional customization and left alone (see
-    test_tabs_migration_preserves_unpinned_import_on_v2_database)."""
+def test_tabs_migration_leaves_pre_v1_v2_era_shape_alone(tmp_path):
+    """A v2 database whose tabs match the pre-v1 v2-era default shape
+    (10 tabs, no Import) is left untouched by the migration.
+
+    The shape is genuinely ambiguous — it's identical to what a user
+    ends up with after unpinning Import from the *current* v2 default —
+    and chronologically the ambiguity has no cost: v1 (dae1653,
+    2026-07-05) shipped before v2 (e988f21, 2026-07-08), and both live
+    in the same `_create_tables` block, so no real database can be at
+    user_version 2 without having also run v1. A v2 row missing Import
+    is therefore always a user unpin, and Codex flagged (#1134) that
+    silently re-inserting it would clobber that preference. The migration
+    respects the row as-is and advances user_version to 4."""
     import json
 
     from db import Database
@@ -181,12 +188,7 @@ def test_tabs_migration_adds_import_for_version_2_database(tmp_path):
 
     migrated = Database(db_path)
     try:
-        # v3 inserts Import before Process, then v4 moves it to the front.
-        assert migrated.get_tabs() == [
-            "import", "browse", "pipeline", "pipeline_review",
-            "review", "cull", "jobs",
-            "highlights", "misses", "storage", "settings",
-        ]
+        assert migrated.get_tabs() == pre_v1_default
         version = migrated.conn.execute("PRAGMA user_version").fetchone()[0]
         assert version == 4
     finally:
@@ -196,10 +198,10 @@ def test_tabs_migration_adds_import_for_version_2_database(tmp_path):
 def test_tabs_migration_preserves_unpinned_import_on_v2_database(tmp_path):
     """A v2 database whose tabs have been customized (e.g. the user
     unpinned Import from an already-modified list) must not have Import
-    silently re-inserted by the v3 catch-up. Codex flagged this on
-    #1134: `set_tabs()` doesn't advance user_version, so "Import
-    missing at v2" can mean either a skipped v1 or an intentional unpin,
-    and the catch-up must not clobber the latter."""
+    silently re-inserted. Codex flagged this on #1134: `set_tabs()`
+    doesn't advance user_version, so "Import missing at v2" can mean
+    either a skipped v1 or an intentional unpin, and the migration must
+    not clobber the latter."""
     import json
 
     from db import Database
@@ -207,9 +209,9 @@ def test_tabs_migration_preserves_unpinned_import_on_v2_database(tmp_path):
     db_path = str(tmp_path / "tabs-v2-unpinned.db")
     db = Database(db_path)
     ws_id = db._active_workspace_id
-    # Non-default shape (no "storage", no "pipeline_review", etc.). This
-    # cannot be the pre-v1 v2-era default, so the v3 catch-up must
-    # respect it — even though "import" is absent.
+    # Non-default shape (no "storage", no "pipeline_review", etc.).
+    # "import" is absent because the user removed it; the migration must
+    # respect that.
     customized = ["browse", "pipeline", "review"]
     db.conn.execute(
         "UPDATE workspaces SET tabs = ? WHERE id = ?",

--- a/vireo/tests/test_tabs_api.py
+++ b/vireo/tests/test_tabs_api.py
@@ -154,6 +154,11 @@ def test_get_tabs_endpoint_new_shape(app_and_db):
 
 
 def test_tabs_migration_adds_import_for_version_2_database(tmp_path):
+    """Databases that reached user_version 2 without the v1 import-tab
+    migration having run get Import back — but only when the tabs shape
+    matches the exact pre-v1 v2-era default. Any other shape is treated
+    as intentional customization and left alone (see
+    test_tabs_migration_preserves_unpinned_import_on_v2_database)."""
     import json
 
     from db import Database
@@ -161,9 +166,14 @@ def test_tabs_migration_adds_import_for_version_2_database(tmp_path):
     db_path = str(tmp_path / "tabs-v2.db")
     db = Database(db_path)
     ws_id = db._active_workspace_id
+    pre_v1_default = [
+        "browse", "pipeline", "pipeline_review",
+        "review", "cull", "jobs",
+        "highlights", "misses", "storage", "settings",
+    ]
     db.conn.execute(
         "UPDATE workspaces SET tabs = ? WHERE id = ?",
-        (json.dumps(["browse", "pipeline", "review"]), ws_id),
+        (json.dumps(pre_v1_default), ws_id),
     )
     db.conn.execute("PRAGMA user_version = 2")
     db.conn.commit()
@@ -171,7 +181,76 @@ def test_tabs_migration_adds_import_for_version_2_database(tmp_path):
 
     migrated = Database(db_path)
     try:
-        assert migrated.get_tabs() == ["import", "browse", "pipeline", "review"]
+        # v3 inserts Import before Process, then v4 moves it to the front.
+        assert migrated.get_tabs() == [
+            "import", "browse", "pipeline", "pipeline_review",
+            "review", "cull", "jobs",
+            "highlights", "misses", "storage", "settings",
+        ]
+        version = migrated.conn.execute("PRAGMA user_version").fetchone()[0]
+        assert version == 4
+    finally:
+        migrated.close()
+
+
+def test_tabs_migration_preserves_unpinned_import_on_v2_database(tmp_path):
+    """A v2 database whose tabs have been customized (e.g. the user
+    unpinned Import from an already-modified list) must not have Import
+    silently re-inserted by the v3 catch-up. Codex flagged this on
+    #1134: `set_tabs()` doesn't advance user_version, so "Import
+    missing at v2" can mean either a skipped v1 or an intentional unpin,
+    and the catch-up must not clobber the latter."""
+    import json
+
+    from db import Database
+
+    db_path = str(tmp_path / "tabs-v2-unpinned.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    # Non-default shape (no "storage", no "pipeline_review", etc.). This
+    # cannot be the pre-v1 v2-era default, so the v3 catch-up must
+    # respect it — even though "import" is absent.
+    customized = ["browse", "pipeline", "review"]
+    db.conn.execute(
+        "UPDATE workspaces SET tabs = ? WHERE id = ?",
+        (json.dumps(customized), ws_id),
+    )
+    db.conn.execute("PRAGMA user_version = 2")
+    db.conn.commit()
+    db.close()
+
+    migrated = Database(db_path)
+    try:
+        assert migrated.get_tabs() == customized
+        version = migrated.conn.execute("PRAGMA user_version").fetchone()[0]
+        assert version == 4
+    finally:
+        migrated.close()
+
+
+def test_tabs_migration_preserves_unpinned_import_on_v3_database(tmp_path):
+    """A user who unpinned Import after v3 shipped (user_version = 3)
+    must not have Import silently re-added by the v4 prominence
+    migration. v4 must only reorder existing rows, never re-insert."""
+    import json
+
+    from db import Database
+
+    db_path = str(tmp_path / "tabs-v3-unpinned.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    without_import = ["browse", "pipeline", "review"]
+    db.conn.execute(
+        "UPDATE workspaces SET tabs = ? WHERE id = ?",
+        (json.dumps(without_import), ws_id),
+    )
+    db.conn.execute("PRAGMA user_version = 3")
+    db.conn.commit()
+    db.close()
+
+    migrated = Database(db_path)
+    try:
+        assert migrated.get_tabs() == without_import
         version = migrated.conn.execute("PRAGMA user_version").fetchone()[0]
         assert version == 4
     finally:

--- a/vireo/tests/test_tabs_api.py
+++ b/vireo/tests/test_tabs_api.py
@@ -151,3 +151,53 @@ def test_get_tabs_endpoint_new_shape(app_and_db):
     assert ids == expected_ids
     sample = next(p for p in body["all_pages"] if p["id"] == "duplicates")
     assert sample == {"id": "duplicates", "label": "Duplicates", "href": "/duplicates"}
+
+
+def test_tabs_migration_adds_import_for_version_2_database(tmp_path):
+    import json
+
+    from db import Database
+
+    db_path = str(tmp_path / "tabs-v2.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    db.conn.execute(
+        "UPDATE workspaces SET tabs = ? WHERE id = ?",
+        (json.dumps(["browse", "pipeline", "review"]), ws_id),
+    )
+    db.conn.execute("PRAGMA user_version = 2")
+    db.conn.commit()
+    db.close()
+
+    migrated = Database(db_path)
+    try:
+        assert migrated.get_tabs() == ["import", "browse", "pipeline", "review"]
+        version = migrated.conn.execute("PRAGMA user_version").fetchone()[0]
+        assert version == 4
+    finally:
+        migrated.close()
+
+
+def test_tabs_migration_moves_existing_import_to_front(tmp_path):
+    import json
+
+    from db import Database
+
+    db_path = str(tmp_path / "tabs-v3.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    db.conn.execute(
+        "UPDATE workspaces SET tabs = ? WHERE id = ?",
+        (json.dumps(["browse", "pipeline", "import", "review"]), ws_id),
+    )
+    db.conn.execute("PRAGMA user_version = 3")
+    db.conn.commit()
+    db.close()
+
+    migrated = Database(db_path)
+    try:
+        assert migrated.get_tabs() == ["import", "browse", "pipeline", "review"]
+        version = migrated.conn.execute("PRAGMA user_version").fetchone()[0]
+        assert version == 4
+    finally:
+        migrated.close()


### PR DESCRIPTION
## Summary

- Route Import navigation and native File > Import commands to `/import` instead of Lightroom or Process.
- Remove the old external import/copy source controls from the Process page so `/pipeline` only processes existing workspace photos, collections, or new-images snapshots.
- Make Import the leftmost/default pinned page for new workspaces and add saved-tabs migrations so existing workspaces get Import inserted and moved to the front.

## Root Cause

The import/process split was only partially wired: some visible and native entry points still targeted `/pipeline` or `/lightroom`, the Process page retained hidden import-mode UI and submission paths, and the original saved-tabs migration could be skipped by databases already advanced to a later user version. The default pinned-tab order also still put Browse before Import.

## Validation

- `pytest vireo/tests/test_db.py -q -k "default_tabs_is_the_curated_ten or import_tab_in_nav_registries or existing_workspaces_gain_import_tab or import_tab_migration_not_reapplied_after_unpin"`
- `pytest vireo/tests/test_app.py vireo/tests/test_tabs_api.py -q -k "navbar_pages_fallbacks_match or get_tabs_endpoint_new_shape or tabs_migration or import_page or process_page_has_no_import_source or browse_empty_state_import_link_targets_import_page or native_import_commands_route_to_import_page"`
- `pytest tests/e2e/test_navigation.py -q -k "navbar_links_navigate_to_import or navbar_links_navigate_to_pipeline or navbar_links_navigate_to_browse"`
- `pytest tests/e2e/test_page_loads.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Import section now opens consistently from the app navigation, empty-state link, and native menu actions.
  * Import is now shown first in the workspace tab order.

* **Bug Fixes**
  * Fixed navigation so Import-related actions no longer send users to unrelated screens.
  * Improved tab loading for older workspaces so the Import tab appears in the correct position after updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->