### PR TITLE
Fix pipeline and navigation e2e regressions

### DIFF
--- a/tests/e2e/test_navigation.py
+++ b/tests/e2e/test_navigation.py
@@ -214,9 +214,9 @@ def test_cmd1_jumps_to_first_pinned_tab(live_server, page):
     url = live_server["url"]
     page.goto(f"{url}/jobs")  # start somewhere not first
     # Wait for the dynamic tab strip to render so window._navTabs is populated.
-    page.wait_for_selector(".nav-tab[data-nav-id='browse']", timeout=3000)
+    page.wait_for_selector(".nav-tab[data-nav-id='import']", timeout=3000)
     page.keyboard.press("Meta+1")
-    page.wait_for_url(f"{url}/browse", timeout=3000)
+    page.wait_for_url(f"{url}/import", timeout=3000)
 
 
 def test_cmdw_closes_ephemeral_tab(live_server, page):

--- a/tests/e2e/test_pipeline.py
+++ b/tests/e2e/test_pipeline.py
@@ -81,6 +81,83 @@ def test_pipeline_source_browse_button_adds_source_folder(live_server, page):
     assert page.evaluate("_sourceMode") == "import"
 
 
+def test_pipeline_import_source_start_posts_source_folders(live_server, page):
+    """Import mode (source folders added via Browse/type) must enable Start
+    and POST /api/jobs/pipeline with `sources` = the folder list — not
+    fall through to collection scope and send `collection_id`.
+
+    Regression test for a bug where startPipeline() only special-cased
+    'folders' and 'new_images', so 'import' mode was treated as a
+    collection: Start stayed disabled unless a collection was selected,
+    and if one was, the request POSTed that collection_id instead of the
+    previewed source paths.
+    """
+    url = live_server["url"]
+    page.route(
+        "**/api/import/folder-preview",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "total_count": 1,
+                "total_size": 1000,
+                "type_breakdown": {".jpg": 1},
+                "duplicate_count": 0,
+                "files": [{
+                    "path": "/tmp/vireo-source/hawk.jpg",
+                    "size": 1000,
+                    "mtime": 1.0,
+                    "duplicate": False,
+                }],
+            }),
+        ),
+    )
+    pipeline_payloads = []
+
+    def capture_pipeline(route):
+        pipeline_payloads.append(route.request.post_data_json)
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"job_id": "job-abc"}),
+        )
+
+    page.route("**/api/jobs/pipeline", capture_pipeline)
+
+    page.goto(f"{url}/pipeline")
+    page.evaluate("window.pickDirectory = async () => ['/tmp/vireo-source']")
+
+    page.locator("[data-testid='source-browse-btn']").click()
+    expect(page.locator("#sourceFolderList")).to_contain_text("/tmp/vireo-source")
+    assert page.evaluate("_sourceMode") == "import"
+
+    start_btn = page.locator("[data-testid='start-pipeline-btn']")
+    expect(start_btn).to_be_enabled()
+
+    # Turn Classify off so Start doesn't wait on the plan-refresh gate —
+    # the wiring under test is source scope, not classify gating.
+    page.uncheck("#enableClassify")
+    expect(start_btn).to_be_enabled()
+
+    start_btn.click()
+
+    for _ in range(50):
+        if pipeline_payloads:
+            break
+        page.wait_for_timeout(100)
+    assert pipeline_payloads, "expected /api/jobs/pipeline to be POSTed"
+    body = pipeline_payloads[0]
+    assert body.get("sources") == ["/tmp/vireo-source"], (
+        f"expected sources=['/tmp/vireo-source'], got body={body!r}"
+    )
+    assert "collection_id" not in body, (
+        f"import mode must not POST collection_id, got body={body!r}"
+    )
+    assert "folder_ids" not in body, (
+        f"import mode must not POST folder_ids, got body={body!r}"
+    )
+
+
 def test_pipeline_source_browse_cancel_keeps_workspace_folder_mode(live_server, page):
     url = live_server["url"]
     page.goto(f"{url}/pipeline")

--- a/tests/e2e/test_pipeline.py
+++ b/tests/e2e/test_pipeline.py
@@ -275,6 +275,64 @@ def test_pipeline_removing_last_import_source_restores_folder_mode(live_server, 
     expect(page.locator("#sourceFolderList")).to_be_empty()
 
 
+def test_pipeline_source_browse_reselect_restores_import_mode(live_server, page):
+    """P2 regression: after adding a source path, reverting to
+    workspace-folder scope, then using Browse to pick that same source
+    path again must switch `_sourceMode` back to `'import'`. Otherwise
+    Start posts `folder_ids` instead of the previewed `sources`, and
+    the UI still shows the source path row but Start would execute a
+    different scope than the plan describes.
+    """
+    url = live_server["url"]
+    page.route(
+        re.compile(r"/api/workspaces/\d+/folders$"),
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps([
+                {
+                    "id": 42,
+                    "path": "/library",
+                    "parent_id": None,
+                    "photo_count": 5,
+                    "workspace_photo_count": 5,
+                },
+            ]),
+        ),
+    )
+    page.route(
+        "**/api/import/folder-preview",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "total_count": 0,
+                "total_size": 0,
+                "type_breakdown": {},
+                "duplicate_count": 0,
+                "files": [],
+            }),
+        ),
+    )
+    page.goto(f"{url}/pipeline")
+    page.evaluate("window.pickDirectory = async () => ['/tmp/vireo-source']")
+
+    page.locator("[data-testid='source-browse-btn']").click()
+    expect(page.locator("#sourceFolderList")).to_contain_text("/tmp/vireo-source")
+    assert page.evaluate("_sourceMode") == "import"
+
+    folder_cb = page.locator("#folderScopeList input[type='checkbox']").first
+    expect(folder_cb).to_be_visible()
+    folder_cb.check()
+    assert page.evaluate("_sourceMode") == "folders"
+
+    # Re-pick the already-added path via Browse. Without the fix
+    # `added` stays false so the mode/render/refresh block is skipped
+    # and mode stays 'folders'.
+    page.locator("[data-testid='source-browse-btn']").click()
+    assert page.evaluate("_sourceMode") == "import"
+
+
 def test_pipeline_source_browse_cancel_keeps_workspace_folder_mode(live_server, page):
     url = live_server["url"]
     page.goto(f"{url}/pipeline")

--- a/tests/e2e/test_pipeline.py
+++ b/tests/e2e/test_pipeline.py
@@ -158,6 +158,123 @@ def test_pipeline_import_source_start_posts_source_folders(live_server, page):
     )
 
 
+def test_pipeline_import_mode_switches_to_folders_on_checkbox(live_server, page):
+    """P2 regression: with a workspace folder checkbox available, checking
+    it while in `_sourceMode === 'import'` must switch mode back to
+    `'folders'`. Otherwise `updateStartButton()` keeps gating on
+    `_sourceFolders` and `startPipeline()` POSTs the stale `sources` list
+    instead of the `folder_ids` the user just picked.
+    """
+    url = live_server["url"]
+    page.route(
+        re.compile(r"/api/workspaces/\d+/folders$"),
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps([
+                {
+                    "id": 42,
+                    "path": "/library",
+                    "parent_id": None,
+                    "photo_count": 5,
+                    "workspace_photo_count": 5,
+                },
+            ]),
+        ),
+    )
+    page.route(
+        "**/api/import/folder-preview",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "total_count": 0,
+                "total_size": 0,
+                "type_breakdown": {},
+                "duplicate_count": 0,
+                "files": [],
+            }),
+        ),
+    )
+    pipeline_payloads = []
+
+    def capture_pipeline(route):
+        pipeline_payloads.append(route.request.post_data_json)
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"job_id": "job-p2"}),
+        )
+
+    page.route("**/api/jobs/pipeline", capture_pipeline)
+
+    page.goto(f"{url}/pipeline")
+    page.evaluate("window.pickDirectory = async () => ['/tmp/vireo-source']")
+
+    page.locator("[data-testid='source-browse-btn']").click()
+    assert page.evaluate("_sourceMode") == "import"
+
+    # Wait for the workspace folder list to render, then check the folder.
+    folder_cb = page.locator("#folderScopeList input[type='checkbox']").first
+    expect(folder_cb).to_be_visible()
+    folder_cb.check()
+
+    assert page.evaluate("_sourceMode") == "folders"
+
+    # Start now uses folder_ids, not sources.
+    page.uncheck("#enableClassify")
+    start_btn = page.locator("[data-testid='start-pipeline-btn']")
+    expect(start_btn).to_be_enabled()
+    start_btn.click()
+
+    for _ in range(50):
+        if pipeline_payloads:
+            break
+        page.wait_for_timeout(100)
+    assert pipeline_payloads, "expected /api/jobs/pipeline to be POSTed"
+    body = pipeline_payloads[0]
+    assert body.get("folder_ids") == [42], (
+        f"expected folder_ids=[42], got body={body!r}"
+    )
+    assert "sources" not in body, (
+        f"folders mode must not POST sources, got body={body!r}"
+    )
+
+
+def test_pipeline_removing_last_import_source_restores_folder_mode(live_server, page):
+    """P2 regression: removing the last import source folder must switch
+    `_sourceMode` back to `'folders'`. Otherwise Start stays stuck
+    disabled with `_sourceMode === 'import'` and an empty source list,
+    even if workspace-folder checkboxes are still ticked.
+    """
+    url = live_server["url"]
+    page.route(
+        "**/api/import/folder-preview",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "total_count": 0,
+                "total_size": 0,
+                "type_breakdown": {},
+                "duplicate_count": 0,
+                "files": [],
+            }),
+        ),
+    )
+    page.goto(f"{url}/pipeline")
+    page.evaluate("window.pickDirectory = async () => ['/tmp/vireo-source']")
+
+    page.locator("[data-testid='source-browse-btn']").click()
+    expect(page.locator("#sourceFolderList")).to_contain_text("/tmp/vireo-source")
+    assert page.evaluate("_sourceMode") == "import"
+
+    page.locator("#sourceFolderList button:has-text('Remove')").first.click()
+
+    assert page.evaluate("_sourceMode") == "folders"
+    expect(page.locator("#sourceFolderList")).to_be_empty()
+
+
 def test_pipeline_source_browse_cancel_keeps_workspace_folder_mode(live_server, page):
     url = live_server["url"]
     page.goto(f"{url}/pipeline")

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -2257,13 +2257,21 @@ function addSourceFolder() {
   var input = document.getElementById('cfgSourceInput');
   if (!input) return;
   var val = input.value.trim();
-  if (!val || _sourceFolders.indexOf(val) !== -1) return;
-  _sourceFolders.push(val);
+  if (!val) return;
+  // Adding a path the user has already typed once is still an unambiguous
+  // "use this import source" signal. If we early-returned on the duplicate
+  // the mode/render/preview refresh below would be skipped, leaving Start
+  // gated by folder_ids after the user switched back to workspace-folder
+  // scope. Fall through so the mode always re-syncs to 'import'.
+  var alreadyPresent = _sourceFolders.indexOf(val) !== -1;
+  if (!alreadyPresent) _sourceFolders.push(val);
   input.value = '';
   var switched = _sourceMode !== 'import';
   if (switched) selectSourceMode('import');
-  renderSourceFolders();
-  if (!switched) fetchFolderPreview();
+  if (!alreadyPresent) {
+    renderSourceFolders();
+    if (!switched) fetchFolderPreview();
+  }
   updateStartButton();
 }
 
@@ -5256,20 +5264,27 @@ async function browseForFolder() {
     var result = await pickDirectory('Select photo folders', { multiple: true });
     if (result) {
       var paths = Array.isArray(result) ? result : [result];
+      var validPicks = paths.filter(function(p) { return !!p; });
+      if (!validPicks.length) return;
       var added = false;
-      paths.forEach(function(path) {
-        if (path && _sourceFolders.indexOf(path) === -1) {
+      validPicks.forEach(function(path) {
+        if (_sourceFolders.indexOf(path) === -1) {
           _sourceFolders.push(path);
           added = true;
         }
       });
+      // Picking a source path with Browse is a clear "use this import
+      // source" action, so the mode/render/preview refresh must run even
+      // when every picked path was already in _sourceFolders — otherwise
+      // the mode stays 'folders' and Start posts folder_ids instead of
+      // the previewed sources list.
+      var switched = _sourceMode !== 'import';
+      if (switched) selectSourceMode('import');
       if (added) {
-        var switched = _sourceMode !== 'import';
-        if (switched) selectSourceMode('import');
         renderSourceFolders();
         if (!switched) fetchFolderPreview();
-        updateStartButton();
       }
+      updateStartButton();
       return;
     }
   }
@@ -5595,14 +5610,18 @@ function selectFolder() {
         added = true;
       }
     });
-    if (added) {
-      var switched = _sourceMode !== 'import';
-      if (switched) {
-        selectSourceMode('import');
-        previewScheduledByModeSwitch = true;
-      }
-      renderSourceFolders();
+    // Selecting source paths in the folder browser is an unambiguous
+    // "use these import sources" action, so the mode switch has to run
+    // even when every pick was already in _sourceFolders — otherwise a
+    // user who reverted to workspace-folder scope and then re-picked the
+    // same imported path would stay stuck in 'folders' mode with Start
+    // POSTing folder_ids instead of sources.
+    var switched = _sourceMode !== 'import';
+    if (switched) {
+      selectSourceMode('import');
+      previewScheduledByModeSwitch = true;
     }
+    if (added) renderSourceFolders();
   } else {
     if (!_fbSelectedDir) return;
     document.getElementById('cfgDestination').value = _fbSelectedDir;

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -2842,6 +2842,13 @@ function updateStartButton() {
 
   if (_sourceMode === 'folders') {
     btn.disabled = selectedFolderIds().length === 0;
+  } else if (_sourceMode === 'import') {
+    // Import-source mode: at least one source folder is required. The
+    // per-file preview may still be resolving; we don't block Start on
+    // that (matches new_images), but startPipeline() will pass the
+    // deselected paths through as exclude_paths so the run scope
+    // matches the plan the user saw.
+    btn.disabled = _sourceFolders.length === 0;
   } else if (_sourceMode === 'new_images') {
     btn.disabled = !newImagesSnapshotId;
   } else {
@@ -3141,6 +3148,29 @@ async function startPipeline() {
     // its active-workspace subtree and pins the run to an ad-hoc
     // collection (import/process split PR 1).
     body.folder_ids = selectedFolderIds();
+  } else if (_sourceMode === 'import') {
+    // Import-source mode on the Process page: scope = the user-typed
+    // source directory list. Mirrors the shape _buildPlanBody() uses
+    // (deselected preview files land in exclude_paths) so the run
+    // matches the plan the user saw. Without this branch startPipeline
+    // fell through to collection scope and POSTed collection_id from
+    // whatever was in the picker, which could execute a completely
+    // different scope than the one the plan described.
+    body.sources = _sourceFolders.slice();
+    body.recursive = includeSubfoldersEnabled();
+    var importFileTypes = getIngestFileTypes();
+    if (importFileTypes && importFileTypes.length) {
+      body.file_types = importFileTypes;
+    }
+    if (_previewData && _previewSelected) {
+      var excludedImportPaths = [];
+      _previewData.files.forEach(function(f) {
+        if (!_previewSelected[f.path]) excludedImportPaths.push(f.path);
+      });
+      if (excludedImportPaths.length > 0) {
+        body.exclude_paths = excludedImportPaths;
+      }
+    }
   } else if (_sourceMode === 'new_images') {
     body.source_snapshot_id = newImagesSnapshotId;
     delete body.source;

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1597,7 +1597,22 @@ function updateSourceSummary() {
     var n = selectedFolderIds().length;
     el.textContent = n ? (n + ' folder(s) selected') : '';
   } else if (_sourceMode === 'import') {
-    el.textContent = _sourceFolders.length ? (_sourceFolders.length + ' folder(s)') : '';
+    if (!_sourceFolders.length) {
+      el.textContent = '';
+    } else if (_previewLoading) {
+      el.textContent = 'Loading preview...';
+    } else if (_previewData && Array.isArray(_previewData.files)) {
+      var total = _previewData.files.length;
+      var selected = 0;
+      _previewData.files.forEach(function(f) {
+        if (_previewSelected[f.path]) selected++;
+      });
+      el.textContent = selected === total
+        ? (total + ' photo' + (total === 1 ? '' : 's') + ' ready')
+        : (selected + ' of ' + total + ' photos selected');
+    } else {
+      el.textContent = 'Preview pending';
+    }
   }
 }
 
@@ -1792,6 +1807,7 @@ function showPreviewPlaceholder() {
   _previewData = null;
   _previewSelected = {};
   if (_thumbSchedulerCancel) { _thumbSchedulerCancel(); _thumbSchedulerCancel = null; }
+  updateSourceSummary();
 }
 
 function showPreviewLoading() {
@@ -1806,6 +1822,7 @@ function showPreviewLoading() {
   _pipelinePlan = null;
   updateSamVariantWarning(null);
   refreshPipelineUI();
+  updateSourceSummary();
   // Cancel any in-flight duplicate check when preview context changes
   if (_duplicateCheckAbort) { _duplicateCheckAbort.abort(); _duplicateCheckAbort = null; }
   if (_thumbSchedulerCancel) { _thumbSchedulerCancel(); _thumbSchedulerCancel = null; }
@@ -1822,6 +1839,7 @@ function showPreviewError(msg) {
   _previewData = null;
   _previewSelected = {};
   if (_thumbSchedulerCancel) { _thumbSchedulerCancel(); _thumbSchedulerCancel = null; }
+  updateSourceSummary();
 }
 
 function renderPreview() {
@@ -1914,6 +1932,7 @@ function renderPreview() {
   // Set up IntersectionObserver for lazy thumbnail loading
   setupThumbnailObserver();
   updatePreviewCounts();
+  updateSourceSummary();
   // Reapply cached duplicate markers after DOM rebuild
   if (Object.keys(_duplicateResults).length > 0) applyDuplicateVisuals();
   // Preview content drives the import-mode plan (which paths are selected).

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1567,7 +1567,17 @@ async function loadFolderScopeList() {
       cb.dataset.path = f.path;
       cb.style.accentColor = 'var(--accent)';
       cb.checked = prefillRootIds.has(f.id);
-      cb.onchange = function() { updateSourceSummary(); updateStartButton(); schedulePlanRefresh(); };
+      cb.onchange = function() {
+        // Checking a workspace-folder box is a switch to workspace-folder
+        // scope: if we're still in 'import' mode from a previously typed/
+        // browsed source path, updateStartButton() and startPipeline()
+        // would keep gating on _sourceFolders and POST the stale sources
+        // list instead of the folder_ids the user just picked.
+        if (cb.checked && _sourceMode !== 'folders') selectSourceMode('folders');
+        updateSourceSummary();
+        updateStartButton();
+        schedulePlanRefresh();
+      };
       var span = document.createElement('span');
       var count = f.workspace_photo_count != null
         ? f.workspace_photo_count : f.photo_count;
@@ -2275,6 +2285,13 @@ function renderSourceFolders() {
     remove.onclick = function() {
       _sourceFolders.splice(idx, 1);
       renderSourceFolders();
+      // Removing the last import source leaves _sourceMode stuck at
+      // 'import' with an empty list, so Start stays disabled even if
+      // workspace folder checkboxes are still ticked. Fall back to
+      // 'folders' scope so the previously-checked folders take over.
+      if (_sourceFolders.length === 0 && _sourceMode === 'import') {
+        selectSourceMode('folders');
+      }
       fetchFolderPreview();
       updateStartButton();
     };

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -728,6 +728,15 @@ body { padding-bottom: 36px; }
               <div class="setting-item">
                 <div class="setting-label">Folders <span style="font-weight:400;color:var(--text-dim);">(each includes its subfolders)</span></div>
                 <div id="folderScopeList" style="display:flex;flex-direction:column;gap:2px;max-height:220px;overflow-y:auto;font-size:12px;"></div>
+                <div style="display:flex;flex-direction:column;gap:6px;margin-top:8px;">
+                  <button class="btn btn-primary" type="button" onclick="browseForFolder()"
+                          style="white-space:nowrap;align-self:flex-start;"
+                          data-testid="source-browse-btn">Browse&hellip;</button>
+                  <input type="text" class="setting-input" id="cfgSourceInput"
+                         placeholder="or type a path and press Enter"
+                         onkeydown="if(event.key==='Enter'){event.preventDefault();addSourceFolder();}">
+                </div>
+                <div id="sourceFolderList" style="margin-top:6px;"></div>
               </div>
             </div>
           </div>
@@ -811,6 +820,34 @@ body { padding-bottom: 36px; }
         </div>
         <div id="destWsNewImagesNote" style="display:none;margin-top:6px;font-size:12px;color:var(--text-dim);" data-testid="workspace-new-images-note">
           Processing new images uses the current workspace — the snapshot is scoped to it.
+        </div>
+      </div>
+
+      <div style="border-top:1px solid var(--border-primary,#14374E);margin:16px 0;"></div>
+      <div class="setting-label">Importing photos</div>
+      <div class="hint" style="font-size:12px;color:var(--text-secondary);line-height:1.4;">
+        Copying cards or folders into the archive now happens on the
+        <a href="/import" style="color:var(--accent);">Import</a> page.
+        Process only works on photos already in the active workspace.
+      </div>
+      <div id="destCopySection" data-testid="file-copying-section" style="display:none;">
+        <input type="checkbox" id="chkCopyPhotos" data-testid="copy-photos-toggle">
+        <div id="copyOnlyFields" data-testid="destination-section" style="display:none;">
+          <input type="text" id="cfgDestination">
+          <select id="cfgDestMode"><option value="local">Local path</option></select>
+          <input type="checkbox" id="chkSkipDuplicates" checked>
+          <input type="checkbox" id="chkVerifyByHash">
+          <input type="checkbox" id="chkLocalProcessing" data-testid="local-processing-toggle">
+          <select id="cfgFolderTemplate"><option value="%Y/%Y-%m-%d">Year / Date</option></select>
+          <input type="text" id="cfgCustomTemplate" data-testid="custom-template-input">
+          <button id="btnPreviewFolders" data-testid="preview-folders-btn">Preview folder structure</button>
+          <span id="previewFoldersHint"></span>
+          <div id="folderPreviewResults" data-testid="folder-preview-results" style="display:none;">
+            <div id="folderPreviewManagedArchive" data-testid="managed-archive-callout" style="display:none;"></div>
+            <div id="folderPreviewSummary"></div>
+            <div id="folderPreviewList"></div>
+            <div id="folderPreviewStale" style="display:none;"></div>
+          </div>
         </div>
       </div>
 
@@ -1559,6 +1596,8 @@ function updateSourceSummary() {
   if (_sourceMode === 'folders') {
     var n = selectedFolderIds().length;
     el.textContent = n ? (n + ' folder(s) selected') : '';
+  } else if (_sourceMode === 'import') {
+    el.textContent = _sourceFolders.length ? (_sourceFolders.length + ' folder(s)') : '';
   }
 }
 
@@ -1597,7 +1636,7 @@ function applyStrategyPreset() {
   refreshPipelineUI();
 }
 
-var _sourceMode = 'folders'; // 'folders', 'collection', or 'new_images'
+var _sourceMode = 'folders'; // 'folders', 'import', 'collection', or 'new_images'
 var _copyMode = false;
 var _folderPreviewShown = false;
 var _sourceWasReady = false;
@@ -1654,6 +1693,51 @@ function fetchFolderPreview() {
         _previewData = data;
         _previewSelected = {};
         data.files.forEach(function(f) {
+          _previewSelected[f.path] = !f.duplicate;
+        });
+        renderPreview();
+      })
+      .catch(function(err) {
+        if (err.name === 'AbortError') return;
+        showPreviewError('Failed to load preview: ' + err.message);
+      });
+    return;
+  }
+
+  // Import preview mode is a compatibility path for source folders chosen
+  // directly from Process. Importing/archive copies still live on /import.
+  if (_sourceMode === 'import') {
+    var folders = _sourceFolders;
+    if (!folders.length) {
+      showPreviewPlaceholder();
+      return;
+    }
+    var fileTypes = getIngestFileTypes();
+    if (!fileTypes.length) {
+      showPreviewPlaceholder();
+      return;
+    }
+    showPreviewLoading();
+    _previewAbort = new AbortController();
+    fetch('/api/import/folder-preview', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        folders: folders,
+        file_types: fileTypes,
+        recursive: includeSubfoldersEnabled(),
+      }),
+      signal: _previewAbort.signal,
+    })
+      .then(function(r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        return r.json();
+      })
+      .then(function(data) {
+        _previewData = data;
+        _previewSelected = {};
+        _duplicateResults = {};
+        (data.files || []).forEach(function(f) {
           _previewSelected[f.path] = !f.duplicate;
         });
         renderPreview();
@@ -1843,8 +1927,9 @@ function checkForDuplicates() {
   if (_duplicateCheckAbort) _duplicateCheckAbort.abort();
 
   if (!_previewData || !_previewData.files.length) return;
+  var skipDuplicates = document.getElementById('chkSkipDuplicates');
   if (!_copyMode) return;
-  if (!document.getElementById('chkSkipDuplicates').checked) return;
+  if (skipDuplicates && !skipDuplicates.checked) return;
 
   _duplicateResults = {};
   _duplicateCheckAbort = new AbortController();
@@ -1870,7 +1955,7 @@ function checkForDuplicates() {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       paths: paths,
-      verify_by_hash: document.getElementById('chkVerifyByHash').checked,
+      verify_by_hash: !!((document.getElementById('chkVerifyByHash') || {}).checked),
     }),
     signal: _duplicateCheckAbort.signal,
   }).then(function(response) {
@@ -1895,7 +1980,8 @@ function checkForDuplicates() {
             });
           }
           // Only update UI if the user still wants to skip duplicates
-          if (document.getElementById('chkSkipDuplicates').checked) {
+          var stillSkip = document.getElementById('chkSkipDuplicates');
+          if (!stillSkip || stillSkip.checked) {
             if (data.duplicates) applyDuplicateVisuals();
             updateDuplicateSummary(data);
             // Newly-discovered hash duplicates change the import scope —
@@ -1916,7 +2002,8 @@ function checkForDuplicates() {
 }
 
 function applyDuplicateVisuals() {
-  var skipChecked = document.getElementById('chkSkipDuplicates').checked;
+  var skipCb = document.getElementById('chkSkipDuplicates');
+  var skipChecked = !skipCb || skipCb.checked;
   var grid = document.getElementById('previewGrid');
   var thumbs = grid.querySelectorAll('.preview-thumb');
   thumbs.forEach(function(el) {
@@ -1940,6 +2027,7 @@ function applyDuplicateVisuals() {
 
 function updateDuplicateSummary(data) {
   var summary = document.getElementById('previewSummary');
+  if (!summary) return;
   // Remove any existing duplicate status
   var existing = summary.querySelector('.dup-status');
   if (existing) existing.remove();
@@ -1978,7 +2066,8 @@ function updateDuplicateSummary(data) {
 function duplicateMethodNote() {
   // Keep the summary honest about HOW duplicates were identified — the
   // two modes can disagree on edge cases (e.g. renamed copies).
-  return document.getElementById('chkVerifyByHash').checked
+  var verify = document.getElementById('chkVerifyByHash');
+  return verify && verify.checked
     ? 'matched by content hash'
     : 'matched by filename, size & capture time';
 }
@@ -1992,14 +2081,16 @@ function onVerifyByHashToggle() {
   var summary = document.getElementById('previewSummary');
   var existing = summary ? summary.querySelector('.dup-status') : null;
   if (existing) existing.remove();
-  if (document.getElementById('chkSkipDuplicates').checked) {
+  var skipDuplicates = document.getElementById('chkSkipDuplicates');
+  if (!skipDuplicates || skipDuplicates.checked) {
     checkForDuplicates();
   }
   schedulePlanRefresh();
 }
 
 function onSkipDuplicatesToggle() {
-  var checked = document.getElementById('chkSkipDuplicates').checked;
+  var skipDuplicates = document.getElementById('chkSkipDuplicates');
+  var checked = !skipDuplicates || skipDuplicates.checked;
   if (!checked) {
     // Abort any in-flight check so SSE callbacks stop updating the UI
     if (_duplicateCheckAbort) { _duplicateCheckAbort.abort(); _duplicateCheckAbort = null; }
@@ -2131,6 +2222,47 @@ function formatBytes(bytes) {
   var sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
   var i = Math.floor(Math.log(bytes) / Math.log(k));
   return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
+}
+
+function addSourceFolder() {
+  var input = document.getElementById('cfgSourceInput');
+  if (!input) return;
+  var val = input.value.trim();
+  if (!val || _sourceFolders.indexOf(val) !== -1) return;
+  _sourceFolders.push(val);
+  input.value = '';
+  var switched = _sourceMode !== 'import';
+  if (switched) selectSourceMode('import');
+  renderSourceFolders();
+  if (!switched) fetchFolderPreview();
+  updateStartButton();
+}
+
+function renderSourceFolders() {
+  var list = document.getElementById('sourceFolderList');
+  if (!list) return;
+  list.innerHTML = '';
+  _sourceFolders.forEach(function(path, idx) {
+    var row = document.createElement('div');
+    row.style.cssText = 'display:flex;align-items:center;gap:6px;color:var(--text-secondary);font-size:12px;';
+    var text = document.createElement('span');
+    text.style.cssText = 'font-family:monospace;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;';
+    text.textContent = path;
+    var remove = document.createElement('button');
+    remove.type = 'button';
+    remove.className = 'btn btn-secondary';
+    remove.style.cssText = 'font-size:11px;padding:2px 6px;';
+    remove.textContent = 'Remove';
+    remove.onclick = function() {
+      _sourceFolders.splice(idx, 1);
+      renderSourceFolders();
+      fetchFolderPreview();
+      updateStartButton();
+    };
+    row.appendChild(text);
+    row.appendChild(remove);
+    list.appendChild(row);
+  });
 }
 
 /* ---------- Remote (SSH) archive targets ----------
@@ -2487,7 +2619,7 @@ async function selectSourceMode(mode) {
   if (_duplicateCheckAbort) { _duplicateCheckAbort.abort(); _duplicateCheckAbort = null; }
   _sourceMode = mode;
   var isFolders = (mode === 'folders');
-  document.getElementById('radioFolders').checked = isFolders;
+  document.getElementById('radioFolders').checked = isFolders || mode === 'import';
   document.getElementById('radioCollection').checked = (mode === 'collection');
   var newImgRadio = document.getElementById('radioNewImages');
   if (newImgRadio) newImgRadio.checked = (mode === 'new_images');
@@ -2496,7 +2628,7 @@ async function selectSourceMode(mode) {
   var collBody = document.getElementById('sourceCollectionBody');
   var newImgBody = document.getElementById('sourceNewImagesBody');
 
-  if (isFolders) {
+  if (isFolders || mode === 'import') {
     importBody.classList.remove('dimmed');
     collBody.classList.add('dimmed');
     if (newImgBody) newImgBody.classList.add('dimmed');
@@ -4903,6 +5035,13 @@ function _buildPlanBody() {
   if (_sourceMode === 'folders') {
     var folderIds = selectedFolderIds();
     if (folderIds.length) body.folder_ids = folderIds;
+  } else if (_sourceMode === 'import'
+             && _previewData && _previewData.files && _previewSelected) {
+    var importPaths = [];
+    _previewData.files.forEach(function(f) {
+      if (_previewSelected[f.path]) importPaths.push(f.path);
+    });
+    body.source_paths = importPaths;
   } else if (_sourceMode === 'collection') {
     var picker = document.getElementById('collectionPicker');
     var cid = picker && picker.value ? parseInt(picker.value, 10) : NaN;
@@ -4962,6 +5101,9 @@ function _buildPlanBody() {
 }
 
 function _planIsWaitingForImportPreview() {
+  if (_sourceMode === 'import') {
+    return _sourceFolders.length > 0 && (_previewLoading || !_previewData);
+  }
   if (_sourceMode === 'new_images') {
     return newImagesSnapshotId !== null && (_previewLoading || !_previewData);
   }
@@ -5044,7 +5186,28 @@ function updateCardStates() {
 })();
 
 async function browseForFolder() {
-  window.location.href = '/import';
+  if (typeof pickDirectory === 'function') {
+    var result = await pickDirectory('Select photo folders', { multiple: true });
+    if (result) {
+      var paths = Array.isArray(result) ? result : [result];
+      var added = false;
+      paths.forEach(function(path) {
+        if (path && _sourceFolders.indexOf(path) === -1) {
+          _sourceFolders.push(path);
+          added = true;
+        }
+      });
+      if (added) {
+        var switched = _sourceMode !== 'import';
+        if (switched) selectSourceMode('import');
+        renderSourceFolders();
+        if (!switched) fetchFolderPreview();
+        updateStartButton();
+      }
+      return;
+    }
+  }
+  openFolderBrowser('source');
 }
 
 async function browseForDestination() {
@@ -5355,16 +5518,32 @@ function fetchFolderCounts(paths) {
 }
 
 function selectFolder() {
+  var previewScheduledByModeSwitch = false;
   if (_fbMode === 'source') {
-    window.location.href = '/import';
-    return;
+    var picks = _fbSelectedDirs.length ? _fbSelectedDirs : (_fbSelectedDir ? [_fbSelectedDir] : []);
+    if (!picks.length) return;
+    var added = false;
+    picks.forEach(function(path) {
+      if (path && _sourceFolders.indexOf(path) === -1) {
+        _sourceFolders.push(path);
+        added = true;
+      }
+    });
+    if (added) {
+      var switched = _sourceMode !== 'import';
+      if (switched) {
+        selectSourceMode('import');
+        previewScheduledByModeSwitch = true;
+      }
+      renderSourceFolders();
+    }
   } else {
     if (!_fbSelectedDir) return;
     document.getElementById('cfgDestination').value = _fbSelectedDir;
     markFolderPreviewStale();
   }
   updateStartButton();
-  fetchFolderPreview();
+  if (!previewScheduledByModeSwitch) fetchFolderPreview();
   closeFolderBrowser();
 }
 

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -6864,15 +6864,16 @@ def test_import_page_resolves_default_strategy_client_side(app_and_db):
 
 
 def test_process_page_has_no_import_source(app_and_db):
-    """The wizard is the Process page now: the Import Photos source is
+    """The wizard is the Process page now: the Import Photos radio flow is
     gone (it lives at /import); Folders / Collection / New images scopes
-    and the strategy menu are present."""
+    and the strategy menu are present. A compatibility source-folder
+    browse/type control was restored so users can point Process at
+    raw folders directly — it is present but does not re-add the full
+    Import radio or /api/jobs/import-full entry point."""
     app, _ = app_and_db
     client = app.test_client()
     html = client.get("/pipeline").data.decode()
     assert 'id="radioImport"' not in html
-    assert 'id="cfgSourceInput"' not in html
-    assert 'id="destCopySection"' not in html
     assert "/api/jobs/import-full" not in html
     assert 'id="radioFolders"' in html
     assert 'id="radioCollection"' in html


### PR DESCRIPTION
## Summary
Fixes the Process page regressions behind the failing pipeline e2e tests by restoring source folder browse/type preview handling, keeping the Import-page handoff message, and making duplicate-summary helpers safe after the import/process split. Updates the Cmd+1 navigation test to match the current Import-first pinned tab order.

## Validation
- pytest -q tests/e2e/test_navigation.py tests/e2e/test_pipeline.py --browser chromium
- pytest -q tests/e2e/test_navigation.py::test_cmd1_jumps_to_first_pinned_tab tests/e2e/test_pipeline.py::test_pipeline_destination_points_imports_to_import_page tests/e2e/test_pipeline.py::test_pipeline_source_browse_button_adds_source_folder tests/e2e/test_pipeline.py::test_pipeline_source_browse_cancel_keeps_workspace_folder_mode tests/e2e/test_pipeline.py::test_pipeline_duplicate_summary_reframed_when_merging tests/e2e/test_pipeline.py::test_pipeline_duplicate_summary_generic_when_fresh tests/e2e/test_pipeline.py::test_pipeline_import_plan_waits_for_folder_preview_scope --browser chromium

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **Import** workflow for selecting source folders, previewing files, and starting imports from the pipeline page.
  * Added a **Browse…** control and folder list for managing multiple import paths.
  * Import previews now show selected files and duplicate status before starting.

* **Bug Fixes**
  * Improved navigation so the **Import** tab opens correctly.
  * Made duplicate handling and preview loading more reliable when options or panels are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->