### PR TITLE
Restore import page browse buttons

### DIFF
--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -1,0 +1,41 @@
+import re
+
+from playwright.sync_api import expect
+
+
+def test_import_source_browse_button_adds_source_folder(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/import")
+    page.evaluate("window.pickDirectory = async () => ['/tmp/card-a', '/tmp/card-b']")
+
+    browse_btn = page.locator("[data-testid='import-source-browse-btn']")
+    expect(browse_btn).to_be_visible()
+    browse_btn.click()
+
+    source_list = page.locator("#sourceList")
+    expect(source_list).to_contain_text("/tmp/card-a")
+    expect(source_list).to_contain_text("/tmp/card-b")
+
+
+def test_import_destination_browse_button_sets_destination(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/import")
+    page.evaluate("window.pickDirectory = async () => '/tmp/archive'")
+
+    browse_btn = page.locator("[data-testid='import-destination-browse-btn']")
+    expect(browse_btn).to_be_visible()
+    browse_btn.click()
+
+    expect(page.locator("#destInput")).to_have_value("/tmp/archive")
+
+
+def test_import_browse_button_opens_folder_browser_fallback(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/import")
+    page.evaluate("window.pickDirectory = async () => null")
+
+    page.locator("[data-testid='import-source-browse-btn']").click()
+
+    browser = page.locator("[data-testid='import-folder-browser']")
+    expect(browser).to_have_class(re.compile(r"\bopen\b"))
+    expect(page.locator("#folderBrowserTitle")).to_have_text("Select Source Folder")

--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -45,6 +45,45 @@ def test_import_browse_button_opens_folder_browser_fallback(live_server, page):
         "aria-labelledby", "folderBrowserTitle")
 
 
+def test_import_folder_browser_disables_select_while_pending(live_server, page):
+    # A stale browserPath from a prior fetch used to remain selectable during
+    # the next navigation. If the fetch stalled or failed, clicking "Select
+    # This Folder" would submit the previous folder. Guard: the button must
+    # be disabled while /api/browse is in flight and only re-enable once a
+    # real path resolves.
+    url = live_server["url"]
+    page.goto(f"{url}/import")
+    page.evaluate("window.pickDirectory = async () => null")
+    page.evaluate(
+        """
+        () => {
+          const originalFetch = window.fetch.bind(window);
+          window.__releaseBrowse = null;
+          window.fetch = (input, init) => {
+            const target = typeof input === 'string' ? input : input.url;
+            if (target && target.indexOf('/api/browse') === 0) {
+              return new Promise((resolve) => {
+                window.__releaseBrowse = () => resolve(new Response(
+                  JSON.stringify({path: '/tmp/target', dirs: []}),
+                  {status: 200, headers: {'Content-Type': 'application/json'}}
+                ));
+              });
+            }
+            return originalFetch(input, init);
+          };
+        }
+        """
+    )
+
+    page.locator("[data-testid='import-source-browse-btn']").click()
+
+    select_btn = page.locator("#folderBrowserSelectBtn")
+    expect(select_btn).to_be_disabled()
+
+    page.evaluate("() => window.__releaseBrowse && window.__releaseBrowse()")
+    expect(select_btn).to_be_enabled()
+
+
 def test_import_folder_browser_escape_closes_modal(live_server, page):
     url = live_server["url"]
     page.goto(f"{url}/import")

--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -39,3 +39,23 @@ def test_import_browse_button_opens_folder_browser_fallback(live_server, page):
     browser = page.locator("[data-testid='import-folder-browser']")
     expect(browser).to_have_class(re.compile(r"\bopen\b"))
     expect(page.locator("#folderBrowserTitle")).to_have_text("Select Source Folder")
+    expect(page.locator(".folder-browser-panel")).to_have_attribute("role", "dialog")
+    expect(page.locator(".folder-browser-panel")).to_have_attribute("aria-modal", "true")
+    expect(page.locator(".folder-browser-panel")).to_have_attribute(
+        "aria-labelledby", "folderBrowserTitle")
+
+
+def test_import_folder_browser_escape_closes_modal(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/import")
+    page.evaluate("window.pickDirectory = async () => null")
+
+    page.locator("[data-testid='import-source-browse-btn']").click()
+    expect(page.locator("[data-testid='import-folder-browser']")).to_have_class(
+        re.compile(r"\bopen\b"))
+    expect(page.locator(".folder-browser-close")).to_be_focused()
+
+    page.keyboard.press("Escape")
+
+    expect(page.locator("[data-testid='import-folder-browser']")).not_to_have_class(
+        re.compile(r"\bopen\b"))

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -184,7 +184,7 @@ body { display: flex; flex-direction: column; height: 100vh; }
 </div>
 
 <div class="folder-browser-overlay" id="importFolderBrowser" data-testid="import-folder-browser">
-  <div class="folder-browser-panel">
+  <div class="folder-browser-panel" role="dialog" aria-modal="true" aria-labelledby="folderBrowserTitle">
     <div class="folder-browser-header">
       <h3 id="folderBrowserTitle">Select Folder</h3>
       <button class="folder-browser-close" type="button" onclick="closeImportFolderBrowser()">&times;</button>
@@ -217,6 +217,7 @@ let browserMode = 'source';
 let browserPath = '';
 let browserHomePath = '';
 let browserSeq = 0;
+let browserEscHandler = null;
 
 function importEscapeHtml(s) {
   return String(s).replace(/[&<>"']/g, (ch) => ({
@@ -303,7 +304,14 @@ function openImportFolderBrowser(mode) {
   overlay.onclick = (e) => {
     if (e.target === overlay) closeImportFolderBrowser();
   };
+  if (browserEscHandler) document.removeEventListener('keydown', browserEscHandler);
+  browserEscHandler = (e) => {
+    if (e.key === 'Escape') closeImportFolderBrowser();
+  };
+  document.addEventListener('keydown', browserEscHandler);
   document.body.style.overflow = 'hidden';
+  const firstAction = overlay.querySelector('button');
+  if (firstAction) firstAction.focus();
   const startPath = browserMode === 'destination'
     ? (document.getElementById('destInput').value || '').trim()
     : '';
@@ -312,6 +320,10 @@ function openImportFolderBrowser(mode) {
 
 function closeImportFolderBrowser() {
   document.getElementById('importFolderBrowser').classList.remove('open');
+  if (browserEscHandler) {
+    document.removeEventListener('keydown', browserEscHandler);
+    browserEscHandler = null;
+  }
   document.body.style.overflow = '';
 }
 

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -310,6 +310,14 @@ function openImportFolderBrowser(mode) {
   };
   document.addEventListener('keydown', browserEscHandler);
   document.body.style.overflow = 'hidden';
+  // Reset stale state from a prior open. Without this, the initial
+  // browse below is async, and if it stalls or fails (e.g. a prefilled
+  // destination points at a removed drive), clicking "Select This Folder"
+  // would submit the previous session's browserPath and folder list.
+  browserPath = '';
+  document.getElementById('folderBrowserPath').textContent = 'Loading…';
+  document.getElementById('folderBrowserList').innerHTML =
+    '<div class="folder-browser-empty">Loading…</div>';
   const firstAction = overlay.querySelector('button');
   if (firstAction) firstAction.focus();
   const startPath = browserMode === 'destination'

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -47,6 +47,40 @@ body { display: flex; flex-direction: column; height: 100vh; }
 .staging-meta { font-size: 11px; color: var(--text-secondary); margin-top: 3px; }
 .staging-actions { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 8px; }
 .staging-details { margin: 8px 0 0 0; padding-left: 18px; font-size: 11px; color: var(--text-secondary); max-height: 120px; overflow: auto; }
+.folder-browser-overlay {
+  display: none; position: fixed; inset: 0; z-index: 1001;
+  background: rgba(0, 0, 0, 0.45); align-items: center; justify-content: center;
+}
+.folder-browser-overlay.open { display: flex; }
+.folder-browser-panel {
+  width: min(720px, calc(100vw - 32px)); max-height: calc(100vh - 64px);
+  background: var(--bg-secondary); border: 1px solid var(--border-primary);
+  border-radius: 8px; box-shadow: 0 18px 60px rgba(0,0,0,0.35);
+  display: flex; flex-direction: column; overflow: hidden;
+}
+.folder-browser-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 14px 16px; border-bottom: 1px solid var(--border-primary);
+}
+.folder-browser-header h3 { margin: 0; }
+.folder-browser-close { background: none; border: none; color: var(--text-secondary); font-size: 22px; cursor: pointer; }
+.folder-browser-body { padding: 12px 16px; display: flex; flex-direction: column; gap: 10px; min-height: 0; }
+.folder-browser-shortcuts { display: flex; gap: 8px; flex-wrap: wrap; }
+.folder-browser-path { font-size: 12px; color: var(--text-secondary); overflow-wrap: anywhere; }
+.folder-browser-list {
+  height: 320px; overflow: auto; border: 1px solid var(--border-primary);
+  border-radius: 6px; background: var(--bg-tertiary);
+}
+.folder-browser-item {
+  padding: 8px 10px; font-size: 12px; color: var(--text-primary);
+  cursor: pointer; border-bottom: 1px solid color-mix(in srgb, var(--border-primary) 60%, transparent);
+}
+.folder-browser-item:hover { background: var(--bg-hover, rgba(255,255,255,0.05)); }
+.folder-browser-empty { padding: 14px; font-size: 12px; color: var(--text-secondary); }
+.folder-browser-actions {
+  display: flex; gap: 8px; justify-content: flex-end;
+  padding: 12px 16px; border-top: 1px solid var(--border-primary);
+}
 </style>
 </head>
 <body>
@@ -66,8 +100,9 @@ body { display: flex; flex-direction: column; height: 100vh; }
     <div class="card" id="sourceCard">
       <h3>Source</h3>
       <div class="row">
+        <button class="btn btn-primary" id="btnBrowseSource" data-testid="import-source-browse-btn" onclick="browseForSource()">Browse...</button>
         <input type="text" id="sourceInput" list="volumeDatalist"
-               placeholder="Card or folder path — press Enter to add"
+               placeholder="or type a card/folder path and press Enter"
                onkeydown="if(event.key==='Enter'){event.preventDefault();addSource();}">
         <datalist id="volumeDatalist"></datalist>
         <button class="btn" id="btnAddSource" onclick="addSource()">Add</button>
@@ -88,8 +123,9 @@ body { display: flex; flex-direction: column; height: 100vh; }
     <div class="card" id="destCard">
       <h3>Destination</h3>
       <div class="row">
+        <button class="btn btn-primary" id="btnBrowseDestination" data-testid="import-destination-browse-btn" onclick="browseForDestination()">Browse...</button>
         <input type="text" id="destInput" list="recentDestinations"
-               placeholder="Archive folder (e.g. /Volumes/Photography/Raw Files/USA)"
+               placeholder="Archive folder"
                value="">
         <datalist id="recentDestinations"></datalist>
       </div>
@@ -147,6 +183,28 @@ body { display: flex; flex-direction: column; height: 100vh; }
   </div>
 </div>
 
+<div class="folder-browser-overlay" id="importFolderBrowser" data-testid="import-folder-browser">
+  <div class="folder-browser-panel">
+    <div class="folder-browser-header">
+      <h3 id="folderBrowserTitle">Select Folder</h3>
+      <button class="folder-browser-close" type="button" onclick="closeImportFolderBrowser()">&times;</button>
+    </div>
+    <div class="folder-browser-body">
+      <div class="folder-browser-shortcuts">
+        <button class="btn" type="button" onclick="browseImportFolderTo(null)">Home</button>
+        <button class="btn" type="button" onclick="browseImportFolderTo('__pictures__')">Pictures</button>
+        <button class="btn" type="button" onclick="browseImportFolderTo('__volumes__')">Volumes</button>
+      </div>
+      <div class="folder-browser-path" id="folderBrowserPath"></div>
+      <div class="folder-browser-list" id="folderBrowserList"></div>
+    </div>
+    <div class="folder-browser-actions">
+      <button class="btn" type="button" onclick="closeImportFolderBrowser()">Cancel</button>
+      <button class="btn btn-primary" type="button" id="folderBrowserSelectBtn" onclick="selectImportBrowserFolder()">Select This Folder</button>
+    </div>
+  </div>
+</div>
+
 <script>
 /* Import page: posts to /api/jobs/import-photos, renders live per-folder
    progress from the job's SSE stream, and shows the safe-to-format pill
@@ -155,6 +213,20 @@ let sources = [];
 let activeJobId = null;
 let es = null;
 let stagingResultsByPath = {};
+let browserMode = 'source';
+let browserPath = '';
+let browserHomePath = '';
+let browserSeq = 0;
+
+function importEscapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, (ch) => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+  }[ch]));
+}
+
+function importEscapeAttr(s) {
+  return importEscapeHtml(s);
+}
 
 function renderSources() {
   const list = document.getElementById('sourceList');
@@ -175,13 +247,161 @@ function renderSources() {
   });
 }
 
+function addSourcePath(path) {
+  const v = (path || '').trim();
+  if (!v) return false;
+  if (!sources.includes(v)) {
+    sources.push(v);
+    renderSources();
+    return true;
+  }
+  return false;
+}
+
 function addSource() {
   const input = document.getElementById('sourceInput');
   const v = (input.value || '').trim();
   if (!v) return;
-  if (!sources.includes(v)) sources.push(v);
+  addSourcePath(v);
   input.value = '';
-  renderSources();
+}
+
+async function browseForSource() {
+  if (typeof pickDirectory === 'function') {
+    const result = await pickDirectory('Select source folders', { multiple: true });
+    if (result) {
+      const paths = Array.isArray(result) ? result : [result];
+      paths.forEach(addSourcePath);
+      return;
+    }
+    if (typeof isTauri === 'function' && isTauri()) return;
+  }
+  openImportFolderBrowser('source');
+}
+
+async function browseForDestination() {
+  if (typeof pickDirectory === 'function') {
+    const result = await pickDirectory('Select archive folder');
+    if (result) {
+      const path = Array.isArray(result) ? result[0] : result;
+      if (path) document.getElementById('destInput').value = path;
+      return;
+    }
+    if (typeof isTauri === 'function' && isTauri()) return;
+  }
+  openImportFolderBrowser('destination');
+}
+
+function openImportFolderBrowser(mode) {
+  browserMode = mode === 'destination' ? 'destination' : 'source';
+  const overlay = document.getElementById('importFolderBrowser');
+  document.getElementById('folderBrowserTitle').textContent =
+    browserMode === 'source' ? 'Select Source Folder' : 'Select Destination Folder';
+  document.getElementById('folderBrowserSelectBtn').textContent =
+    browserMode === 'source' ? 'Add This Folder' : 'Select This Folder';
+  overlay.classList.add('open');
+  overlay.onclick = (e) => {
+    if (e.target === overlay) closeImportFolderBrowser();
+  };
+  document.body.style.overflow = 'hidden';
+  const startPath = browserMode === 'destination'
+    ? (document.getElementById('destInput').value || '').trim()
+    : '';
+  browseImportFolderTo(startPath || null);
+}
+
+function closeImportFolderBrowser() {
+  document.getElementById('importFolderBrowser').classList.remove('open');
+  document.body.style.overflow = '';
+}
+
+async function browseImportFolderTo(path) {
+  const seq = ++browserSeq;
+  let url = '/api/browse';
+  if (path === '__pictures__') {
+    if (!browserHomePath) {
+      try {
+        const homeResp = await fetch('/api/browse');
+        if (seq !== browserSeq || !homeResp.ok) return;
+        const home = await homeResp.json();
+        browserHomePath = home.path || '';
+      } catch (e) {
+        return;
+      }
+    }
+    url = '/api/browse?path=' + encodeURIComponent(browserHomePath + '/Pictures');
+  } else if (path === '__volumes__') {
+    if (navigator.userAgent.indexOf('Mac') < 0) {
+      try {
+        const resp = await fetch('/api/volumes');
+        if (seq !== browserSeq || !resp.ok) return;
+        const volumes = await resp.json();
+        browserPath = '';
+        renderImportFolderBrowser({ path: '', dirs: volumes || [] }, { syntheticRoot: true });
+      } catch (e) { /* ignore */ }
+      return;
+    }
+    url = '/api/browse?path=' + encodeURIComponent('/Volumes');
+  } else if (path) {
+    url = '/api/browse?path=' + encodeURIComponent(path);
+  }
+
+  try {
+    const resp = await fetch(url);
+    if (seq !== browserSeq) return;
+    if (!resp.ok) {
+      const data = await resp.json().catch(() => ({}));
+      showError(data.error || 'Could not open folder.');
+      return;
+    }
+    const data = await resp.json();
+    browserPath = data.path || '';
+    if (!path) browserHomePath = browserPath;
+    renderImportFolderBrowser(data);
+  } catch (e) {
+    showError(String(e.message || e));
+  }
+}
+
+function renderImportFolderBrowser(data, opts) {
+  document.getElementById('folderBrowserPath').textContent = data.path || 'Volumes';
+  const list = document.getElementById('folderBrowserList');
+  const dirs = data.dirs || [];
+  let html = '';
+  const syntheticRoot = opts && opts.syntheticRoot;
+  let parent = '';
+  if (data.path && data.path.indexOf('\\') !== -1) {
+    parent = data.path.replace(/[\\\/]?[^\\\/]+[\\\/]?$/, '') || data.path;
+    if (/^[A-Za-z]:$/.test(parent)) parent += '\\';
+  } else if (data.path) {
+    parent = data.path.substring(0, data.path.lastIndexOf('/')) || '/';
+  }
+  if (data.path && data.path !== '/' && parent && parent !== data.path) {
+    html += '<div class="folder-browser-item" data-browse-path="' + importEscapeAttr(parent) + '">&#128193; ..</div>';
+  }
+  dirs.forEach((d) => {
+    html += '<div class="folder-browser-item" data-browse-path="' + importEscapeAttr(d.path) + '">&#128193; ' +
+      importEscapeHtml(d.name || d.path) + '</div>';
+  });
+  if (!html) {
+    html = '<div class="folder-browser-empty">' +
+      (syntheticRoot ? 'No volumes found.' : 'No subfolders.') + '</div>';
+  }
+  list.innerHTML = html;
+  list.onclick = (e) => {
+    const item = e.target.closest('.folder-browser-item[data-browse-path]');
+    if (item) browseImportFolderTo(item.getAttribute('data-browse-path'));
+  };
+}
+
+function selectImportBrowserFolder() {
+  if (!browserPath) return;
+  if (browserMode === 'destination') {
+    document.getElementById('destInput').value = browserPath;
+  } else {
+    addSourcePath(browserPath);
+  }
+  closeImportFolderBrowser();
 }
 
 function selectedAfterImport() {

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -310,14 +310,6 @@ function openImportFolderBrowser(mode) {
   };
   document.addEventListener('keydown', browserEscHandler);
   document.body.style.overflow = 'hidden';
-  // Reset stale state from a prior open. Without this, the initial
-  // browse below is async, and if it stalls or fails (e.g. a prefilled
-  // destination points at a removed drive), clicking "Select This Folder"
-  // would submit the previous session's browserPath and folder list.
-  browserPath = '';
-  document.getElementById('folderBrowserPath').textContent = 'Loading…';
-  document.getElementById('folderBrowserList').innerHTML =
-    '<div class="folder-browser-empty">Loading…</div>';
   const firstAction = overlay.querySelector('button');
   if (firstAction) firstAction.focus();
   const startPath = browserMode === 'destination'
@@ -337,6 +329,16 @@ function closeImportFolderBrowser() {
 
 async function browseImportFolderTo(path) {
   const seq = ++browserSeq;
+  // Clear stale selection while this async navigation is pending. Without
+  // this, clicking "Select This Folder" during a slow or failing fetch
+  // submits the previous folder instead of the one the user requested —
+  // both on modal open and mid-session navigation.
+  browserPath = '';
+  const selectBtn = document.getElementById('folderBrowserSelectBtn');
+  if (selectBtn) selectBtn.disabled = true;
+  document.getElementById('folderBrowserPath').textContent = 'Loading…';
+  document.getElementById('folderBrowserList').innerHTML =
+    '<div class="folder-browser-empty">Loading…</div>';
   let url = '/api/browse';
   if (path === '__pictures__') {
     if (!browserHomePath) {
@@ -412,6 +414,8 @@ function renderImportFolderBrowser(data, opts) {
     const item = e.target.closest('.folder-browser-item[data-browse-path]');
     if (item) browseImportFolderTo(item.getAttribute('data-browse-path'));
   };
+  const selectBtn = document.getElementById('folderBrowserSelectBtn');
+  if (selectBtn) selectBtn.disabled = !browserPath;
 }
 
 function selectImportBrowserFolder() {


### PR DESCRIPTION
Adds primary Browse buttons to the Import page for both source selection and archive destination selection. The desktop app uses the native Tauri directory picker, while browser sessions get an in-app folder browser backed by existing browse APIs. This restores the expected file-picker workflow and leaves typed paths as a fallback. Validated with import-page e2e coverage plus navigation and page-load checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a folder browser modal to help choose import source and destination folders.
  * Added “Browse...” actions for both source and destination in the import screen.

* **Bug Fixes**
  * Improved source folder handling by avoiding duplicates and supporting multiple selected folders.
  * Added safer folder navigation and more reliable loading of folder lists.

* **Tests**
  * Added end-to-end coverage for source selection, destination selection, and the folder-browser fallback flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->