### PR TITLE
Add in-place import mode

### DIFF
--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -85,6 +85,34 @@ def test_import_folder_browser_disables_select_while_pending(live_server, page):
     expect(select_btn).to_be_enabled()
 
 
+def test_use_staging_as_import_source_forces_copy_mode(live_server, page):
+    # Orphaned-staging recovery must copy the staging tree into the archive.
+    # In-place would catalog paths that vanish when staging is cleaned up,
+    # so useStagingAsImportSource() has to flip the mode to Copy regardless
+    # of the page default.
+    url = live_server["url"]
+    page.goto(f"{url}/import")
+
+    # Default is in_place — sanity check before invoking the recovery helper.
+    expect(page.locator("#modeInPlace")).to_be_checked()
+
+    page.evaluate(
+        """
+        () => useStagingAsImportSource({
+          source_root: '/tmp/staging-src',
+          inferred_destination: '/tmp/archive-dest',
+        })
+        """
+    )
+
+    expect(page.locator("#modeCopy")).to_be_checked()
+    expect(page.locator("#modeInPlace")).not_to_be_checked()
+    expect(page.locator("#destInput")).to_have_value("/tmp/archive-dest")
+    expect(page.locator("#sourceList")).to_contain_text("/tmp/staging-src")
+    # updateImportMode() must have run so the destination card is visible again.
+    expect(page.locator("#destCard")).to_be_visible()
+
+
 def test_import_folder_browser_escape_closes_modal(live_server, page):
     url = live_server["url"]
     page.goto(f"{url}/import")

--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -21,6 +21,7 @@ def test_import_destination_browse_button_sets_destination(live_server, page):
     url = live_server["url"]
     page.goto(f"{url}/import")
     page.evaluate("window.pickDirectory = async () => '/tmp/archive'")
+    page.locator("#modeCopy").check()
 
     browse_btn = page.locator("[data-testid='import-destination-browse-btn']")
     expect(browse_btn).to_be_visible()

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -15412,6 +15412,278 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error(str(exc), status=409)
         return jsonify(result)
 
+    @app.route("/api/jobs/import-in-place", methods=["POST"])
+    def api_job_import_in_place():
+        """Import existing folders without copying files.
+
+        This is the in-place companion to ``/api/jobs/import-photos``: scan
+        selected source folders into the active workspace, leave originals at
+        their current paths, and optionally enqueue the same after-import
+        processing strategy used by archive-copy imports.
+        """
+        from image_loader import is_excluded_scan_path
+
+        body = request.get_json(silent=True) or {}
+        sources = body.get("sources")
+        if isinstance(sources, str):
+            sources = [sources]
+        if not sources or not isinstance(sources, list) or not all(
+            isinstance(s, str) and s for s in sources
+        ):
+            return json_error("sources must be a non-empty list of paths")
+        for s in sources:
+            if is_excluded_scan_path(s):
+                return json_error(
+                    f"source is inside a macOS app-managed library and "
+                    f"cannot be imported: {s}"
+                )
+            if not os.path.isdir(s):
+                return json_error(f"source directory not found: {s}")
+
+        recursive = bool(body.get("recursive", True))
+        db = _get_db()
+        if "after_import" in body:
+            after_import = body.get("after_import")
+        else:
+            import config as cfg
+
+            effective_cfg = db.get_effective_config(cfg.load())
+            after_import = (
+                effective_cfg.get("pipeline", {}).get("default_strategy")
+            )
+        if after_import is not None:
+            if not isinstance(after_import, str):
+                return json_error(
+                    "after_import must be a strategy name or null, got "
+                    f"{type(after_import).__name__}"
+                )
+            from process_strategies import resolve_strategy
+
+            try:
+                resolve_strategy(after_import)
+            except ValueError as e:
+                return json_error(str(e))
+
+        runner = app._job_runner
+        active_ws = db._active_workspace_id
+        thumb_cache_dir = app.config["THUMB_CACHE_DIR"]
+        vireo_dir = os.path.dirname(thumb_cache_dir)
+
+        def _chain_after_import(job, result):
+            if after_import is None:
+                result["after_import_skipped"] = "import-only"
+                return
+            if not result.get("ok"):
+                result["after_import_skipped"] = "import failed"
+                return
+            if result.get("cancelled"):
+                result["after_import_skipped"] = "import cancelled"
+                return
+            photo_ids = result.get("photo_ids") or []
+            if not photo_ids:
+                result["after_import_skipped"] = "no photos"
+                return
+            try:
+                from datetime import datetime as _dt
+
+                thread_db = Database(db_path)
+                thread_db.set_active_workspace(active_ws)
+                col_id = thread_db.add_collection(
+                    "Import " + _dt.now().strftime("%Y-%m-%d %H:%M"),
+                    json.dumps(
+                        [{"field": "photo_ids", "value": photo_ids}]
+                    ),
+                )
+                process_job_id, model_warning = _enqueue_process_job(
+                    thread_db, runner, active_ws,
+                    collection_id=col_id,
+                    strategy_name=after_import,
+                    chained_from=job["id"],
+                )
+                result["process_job_id"] = process_job_id
+                if model_warning:
+                    result["model_warning"] = model_warning
+            except Exception as e:
+                log.exception("after-import chaining failed")
+                result["after_import_skipped"] = (
+                    f"failed to enqueue processing: {e}"
+                )
+
+        def work(job):
+            import config as cfg
+            from scanner import ScanCancelled
+            from scanner import scan as do_scan
+
+            thread_db = Database(db_path)
+            thread_db.set_active_workspace(active_ws)
+            thread_db.check_folder_health()
+            effective_cfg = thread_db.get_effective_config(cfg.load())
+            pipeline_cfg = effective_cfg.get("pipeline", {})
+
+            job["_start_time"] = time.time()
+            runner.set_steps(job["id"], [
+                {"id": "scan", "label": "Import in place"},
+            ])
+            runner.update_step(job["id"], "scan", status="running")
+
+            photo_ids = []
+            seen_photo_ids = set()
+            root_errors = []
+            scan_acc = {"prior": 0, "last_current": 0, "last_total": 0}
+
+            def photo_cb(photo_id, path):
+                if photo_id not in seen_photo_ids:
+                    seen_photo_ids.add(photo_id)
+                    photo_ids.append(photo_id)
+                runner.update_step(
+                    job["id"], "scan", current_file=os.path.basename(path),
+                )
+
+            def progress_cb(current, total):
+                scan_acc["last_current"] = current
+                scan_acc["last_total"] = total
+                cum_current = scan_acc["prior"] + current
+                cum_total = scan_acc["prior"] + total
+                job["progress"]["current"] = cum_current
+                job["progress"]["total"] = cum_total
+                runner.update_step(
+                    job["id"], "scan",
+                    progress={"current": cum_current, "total": cum_total},
+                )
+                runner.push_event(job["id"], "progress", {
+                    "current": cum_current,
+                    "total": cum_total,
+                    "current_file": job["progress"].get("current_file", ""),
+                    "phase": "Importing in place",
+                })
+
+            def status_cb(message, phase_current=None, phase_total=None, phase_label=None):
+                job["progress"]["current_file"] = message
+                runner.update_step(job["id"], "scan", current_file=message)
+                runner.push_event(job["id"], "progress", {
+                    "current": job["progress"].get("current", 0),
+                    "total": job["progress"].get("total", 0),
+                    "current_file": message,
+                    "phase": phase_label or message,
+                    "phase_current": phase_current,
+                    "phase_total": phase_total,
+                    "phase_label": phase_label,
+                })
+
+            def advance_scan_acc():
+                scan_acc["prior"] += scan_acc["last_current"]
+                scan_acc["last_current"] = 0
+                scan_acc["last_total"] = 0
+
+            def cancel_check():
+                return runner.is_cancelled(job["id"])
+
+            cancelled = False
+            for idx, source in enumerate(sources, 1):
+                if cancel_check():
+                    cancelled = True
+                    break
+                phase = (
+                    f"Importing source {idx} of {len(sources)}: {source}"
+                    if len(sources) > 1 else "Importing in place"
+                )
+                runner.push_event(job["id"], "progress", {
+                    "current": job["progress"].get("current", 0),
+                    "total": job["progress"].get("total", 0),
+                    "current_file": phase,
+                    "phase": phase,
+                })
+                try:
+                    do_scan(
+                        source, thread_db,
+                        progress_callback=progress_cb,
+                        extract_full_metadata=pipeline_cfg.get(
+                            "extract_full_metadata", True,
+                        ),
+                        photo_callback=photo_cb,
+                        status_callback=status_cb,
+                        recursive=recursive,
+                        vireo_dir=vireo_dir,
+                        thumb_cache_dir=thumb_cache_dir,
+                        cancel_check=cancel_check,
+                    )
+                except Exception as exc:
+                    if isinstance(exc, ScanCancelled) and cancel_check():
+                        cancelled = True
+                        break
+                    log.exception("In-place import failed for source %s", source)
+                    msg = f"[{source}] {exc}"
+                    root_errors.append(msg)
+                    if msg not in job["errors"]:
+                        job["errors"].append(msg)
+                finally:
+                    try:
+                        _invalidate_new_images_after_scan(thread_db, source)
+                    except Exception as cache_exc:
+                        log.exception(
+                            "Failed to invalidate new-image cache for %s", source,
+                        )
+                        msg = (
+                            f"[{source}] cache invalidation failed after import: "
+                            f"{cache_exc}"
+                        )
+                        root_errors.append(msg)
+                        if msg not in job["errors"]:
+                            job["errors"].append(msg)
+                    advance_scan_acc()
+
+            indexed = len(photo_ids)
+            if cancelled or cancel_check():
+                runner.update_step(
+                    job["id"], "scan", status="cancelled",
+                    summary=f"{indexed} photos (cancelled)",
+                )
+                return {
+                    "mode": "in_place",
+                    "ok": False,
+                    "cancelled": True,
+                    "discovered": indexed,
+                    "indexed": indexed,
+                    "failed": len(root_errors),
+                    "errors": root_errors,
+                    "photo_ids": photo_ids,
+                }
+
+            metadata_warning = _scan_metadata_warning()
+            summary = f"{indexed} photos"
+            if metadata_warning:
+                summary += f" — {metadata_warning}"
+            runner.update_step(
+                job["id"], "scan",
+                status="failed" if root_errors else "completed",
+                summary=summary,
+                error=root_errors[0] if root_errors else None,
+                error_count=len(root_errors) if root_errors else None,
+            )
+            result = {
+                "mode": "in_place",
+                "ok": not root_errors,
+                "discovered": indexed,
+                "indexed": indexed,
+                "failed": len(root_errors),
+                "errors": root_errors,
+                "photo_ids": photo_ids,
+            }
+            _chain_after_import(job, result)
+            return result
+
+        job_config = {
+            "sources": sources,
+            "destination": None,
+            "recursive": recursive,
+            "after_import": after_import,
+            "mode": "in_place",
+        }
+        job_id = runner.start(
+            "import-in-place", work, config=job_config, workspace_id=active_ws,
+        )
+        return jsonify({"job_id": job_id})
+
     @app.route("/api/jobs/import-photos", methods=["POST"])
     def api_job_import_photos():
         """Photo import job: copy card -> archive, hash-verify, catalog
@@ -21101,10 +21373,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
     @app.route("/import")
     def import_page():
-        """Import page (import/process split PR 3): copy card → archive
-        via /api/jobs/import-photos. Templates are Jinja-free by
-        convention — defaults (workspace strategy, recents, template)
-        resolve client-side from /api/config + /api/workspaces/active."""
+        """Import page: add folders in place or copy card → archive.
+
+        Templates are Jinja-free by convention — defaults (workspace
+        strategy, recents, template) resolve client-side from /api/config +
+        /api/workspaces/active.
+        """
         return render_template("import.html")
 
     @app.route("/map")

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -645,6 +645,14 @@ async function deleteStaging(path, btn) {
 function useStagingAsImportSource(result) {
   sources = [result.source_root];
   renderSources();
+  // Staging recovery must copy the temporary staging tree into the archive.
+  // In-place would catalog paths that disappear once staging is cleaned,
+  // leaving missing-folder rows, so force Copy to archive here.
+  const copyRadio = document.getElementById('modeCopy');
+  if (copyRadio) {
+    copyRadio.checked = true;
+    updateImportMode();
+  }
   if (result.inferred_destination) {
     document.getElementById('destInput').value = result.inferred_destination;
   }

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -98,6 +98,11 @@ body { display: flex; flex-direction: column; height: 100vh; }
     </div>
 
     <div class="card" id="sourceCard">
+      <h3>Import mode</h3>
+      <div class="row" style="margin-bottom:14px;">
+        <label><input type="radio" name="importMode" value="in_place" id="modeInPlace" checked onchange="updateImportMode()"> Add in place</label>
+        <label><input type="radio" name="importMode" value="copy" id="modeCopy" onchange="updateImportMode()"> Copy to archive</label>
+      </div>
       <h3>Source</h3>
       <div class="row">
         <button class="btn btn-primary" id="btnBrowseSource" data-testid="import-source-browse-btn" onclick="browseForSource()">Browse...</button>
@@ -110,7 +115,7 @@ body { display: flex; flex-direction: column; height: 100vh; }
       <div class="source-list" id="sourceList"></div>
       <div class="row" style="margin-top:8px;">
         <label><input type="checkbox" id="chkRecursive" checked> Include subfolders</label>
-        <label>File types
+        <label id="fileTypesWrap">File types
           <select id="fileTypes" style="min-width:100px;">
             <option value="both" selected>RAW + JPEG</option>
             <option value="raw">RAW only</option>
@@ -151,7 +156,7 @@ body { display: flex; flex-direction: column; height: 100vh; }
 
     <div class="card">
       <div class="row">
-        <button class="btn" id="btnPreview" onclick="previewImport()">Check for duplicates</button>
+        <button class="btn" id="btnPreview" onclick="previewImport()">Preview import</button>
         <button class="btn btn-primary" id="btnStart" onclick="startImport()">Start import</button>
       </div>
       <div class="preview-summary" id="previewSummary"></div>
@@ -206,9 +211,9 @@ body { display: flex; flex-direction: column; height: 100vh; }
 </div>
 
 <script>
-/* Import page: posts to /api/jobs/import-photos, renders live per-folder
-   progress from the job's SSE stream, and shows the safe-to-format pill
-   with per-file reasons. */
+/* Import page: adds folders in place or copies them to an archive, renders
+   live progress from the job's SSE stream, and only shows safe-to-format
+   messaging for verified archive-copy imports. */
 let sources = [];
 let activeJobId = null;
 let es = null;
@@ -218,6 +223,23 @@ let browserPath = '';
 let browserHomePath = '';
 let browserSeq = 0;
 let browserEscHandler = null;
+let activeImportMode = 'in_place';
+
+function selectedImportMode() {
+  const checked = document.querySelector('input[name="importMode"]:checked');
+  return checked ? checked.value : 'in_place';
+}
+
+function updateImportMode() {
+  activeImportMode = selectedImportMode();
+  const copyMode = activeImportMode === 'copy';
+  document.getElementById('destCard').style.display = copyMode ? '' : 'none';
+  document.getElementById('fileTypesWrap').style.display = copyMode ? '' : 'none';
+  document.getElementById('btnPreview').textContent =
+    copyMode ? 'Check for duplicates' : 'Preview import';
+  document.getElementById('previewSummary').textContent = '';
+  showError('');
+}
 
 function importEscapeHtml(s) {
   return String(s).replace(/[&<>"']/g, (ch) => ({
@@ -632,18 +654,27 @@ function useStagingAsImportSource(result) {
 async function previewImport() {
   showError('');
   if (!sources.length) { showError('Add at least one source folder.'); return; }
+  const copyMode = selectedImportMode() === 'copy';
   const summary = document.getElementById('previewSummary');
   summary.textContent = 'Discovering files…';
   try {
     const resp = await fetch('/api/import/folder-preview', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ folders: sources }),
+      body: JSON.stringify({
+        folders: sources,
+        file_types: copyMode ? document.getElementById('fileTypes').value : 'both',
+        recursive: document.getElementById('chkRecursive').checked,
+      }),
     });
     if (!resp.ok) throw new Error((await resp.json()).error || 'preview failed');
     const data = await resp.json();
     const files = data.files || [];
     if (!files.length) { summary.textContent = 'No importable files found.'; return; }
+    if (!copyMode) {
+      summary.textContent = files.length + ' files found · originals will stay in place';
+      return;
+    }
     summary.textContent = files.length + ' files found — checking for duplicates…';
     // check-duplicates streams results; count flagged paths as they arrive.
     const dupResp = await fetch('/api/import/check-duplicates', {
@@ -705,21 +736,24 @@ function renderFolderTable(el, folders) {
 async function startImport() {
   showError('');
   if (!sources.length) { showError('Add at least one source folder.'); return; }
+  const copyMode = selectedImportMode() === 'copy';
   const destination = (document.getElementById('destInput').value || '').trim();
-  if (!destination) { showError('Choose a destination folder.'); return; }
+  if (copyMode && !destination) { showError('Choose a destination folder.'); return; }
   const body = {
     sources: sources,
-    destination: destination,
-    folder_template: (document.getElementById('folderTemplate').value || '').trim(),
-    file_types: document.getElementById('fileTypes').value,
     recursive: document.getElementById('chkRecursive').checked,
   };
+  if (copyMode) {
+    body.destination = destination;
+    body.folder_template = (document.getElementById('folderTemplate').value || '').trim();
+    body.file_types = document.getElementById('fileTypes').value;
+  }
   if (_afterImportConfigLoaded) {
     body.after_import = selectedAfterImport();
   }
   document.getElementById('btnStart').disabled = true;
   try {
-    const resp = await fetch('/api/jobs/import-photos', {
+    const resp = await fetch(copyMode ? '/api/jobs/import-photos' : '/api/jobs/import-in-place', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
@@ -784,6 +818,27 @@ function renderResult(res, status) {
   const pill = document.getElementById('safeToFormatPill');
   const unsafe = document.getElementById('unsafeList');
   unsafe.innerHTML = '';
+  if (res.mode === 'in_place') {
+    pill.className = res.ok === false ? 'pill pill-bad' : 'pill pill-ok';
+    pill.textContent = res.ok === false
+      ? 'Import finished with errors'
+      : 'Imported in place — original files stayed where they are';
+    const errors = res.errors || [];
+    unsafe.style.display = errors.length ? '' : 'none';
+    errors.forEach((msg) => {
+      const li = document.createElement('li');
+      li.textContent = msg;
+      unsafe.appendChild(li);
+    });
+    document.getElementById('resultSummary').textContent =
+      (res.indexed || res.discovered || 0) + ' indexed' +
+      (res.failed ? ' · ' + res.failed + ' failed' : '') +
+      (status && status !== 'completed' ? ' · job ' + status : '');
+    document.getElementById('resultFolders').innerHTML = '';
+    renderChainInfo(res);
+    renderModelWarning(res);
+    return;
+  }
   if (res.safe_to_format) {
     pill.className = 'pill pill-ok';
     pill.textContent = 'Safe to format the card — every file is verified in the archive';
@@ -811,6 +866,11 @@ function renderResult(res, status) {
     (status && status !== 'completed' ? ' · job ' + status : '');
   renderFolderTable(document.getElementById('resultFolders'), res.folders || {});
 
+  renderChainInfo(res);
+  renderModelWarning(res);
+}
+
+function renderChainInfo(res) {
   const chain = document.getElementById('chainInfo');
   if (res.process_job_id) {
     chain.textContent = 'Processing started as its own job: ' + res.process_job_id;
@@ -819,6 +879,9 @@ function renderResult(res, status) {
   } else {
     chain.textContent = '';
   }
+}
+
+function renderModelWarning(res) {
   const warn = document.getElementById('modelWarning');
   if (res.model_warning) {
     warn.textContent = res.model_warning;
@@ -892,6 +955,7 @@ async function initImportPage() {
   // should omit the key so the server applies pipeline.default_strategy.
   _afterImportConfigLoaded = cfgOk && overridesOk;
   loadOrphanedStaging();
+  updateImportMode();
 }
 initImportPage();
 </script>

--- a/vireo/testing/userfirst/scenarios/import_flow.py
+++ b/vireo/testing/userfirst/scenarios/import_flow.py
@@ -48,11 +48,12 @@ def run(session):
     session.goto("/import")
     session.screenshot("import-initial")
 
-    for el_id in ("sourceInput", "destInput", "afterImportSelect",
+    for el_id in ("sourceInput", "modeCopy", "destInput", "afterImportSelect",
                   "btnStart", "safeToFormatPill"):
         present = session.eval(f"!!document.getElementById('{el_id}')")
         session.assert_that(present, f"expected #{el_id} on /import")
 
+    session.click("#modeCopy")
     session.fill("#sourceInput", card)
     session.click("#btnAddSource")
     added = session.eval(

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -6839,14 +6839,17 @@ def test_import_page_returns_200(app_and_db):
     assert resp.status_code == 200
     html = resp.data.decode()
     assert "navbar" in html
-    # Core controls, by id: the after-import strategy menu (including the
-    # import-only null choice), the duplicate preview trigger, the
-    # safe-to-format pill container, and the start button posting to
-    # /api/jobs/import-photos.
+    # Core controls, by id: the import mode radios, the after-import strategy
+    # menu (including the import-only null choice), the duplicate preview
+    # trigger, the safe-to-format pill container, and the start button posting
+    # to the in-place and copy import endpoints.
+    assert 'id="modeInPlace"' in html
+    assert 'id="modeCopy"' in html
     assert 'id="afterImportSelect"' in html
     assert 'value="__none__"' in html  # "None — import only" option
     assert "/api/import/check-duplicates" in html
     assert 'id="safeToFormatPill"' in html
+    assert "/api/jobs/import-in-place" in html
     assert "/api/jobs/import-photos" in html
 
 

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -3179,6 +3179,33 @@ def test_import_photos_happy_path(app_and_db, tmp_path):
     assert result["safe_to_format"] is True
 
 
+def test_import_in_place_no_destination_required(app_and_db, tmp_path):
+    app, _ = app_and_db
+    client = app.test_client()
+    card = _import_card(tmp_path)
+
+    resp = client.post("/api/jobs/import-in-place", json={
+        "sources": [card],
+        "after_import": None,
+    })
+    assert resp.status_code == 200, resp.get_json()
+    job_id = resp.get_json()["job_id"]
+
+    config = _job_config(client, job_id)
+    assert config["sources"] == [card]
+    assert config["destination"] is None
+    assert config["mode"] == "in_place"
+    assert config["after_import"] is None
+
+    job = wait_for_job_via_client(client, job_id)
+    assert job["status"] == "completed", job
+    result = job["result"]
+    assert result["mode"] == "in_place"
+    assert result["indexed"] == 1
+    assert result["ok"] is True
+    assert result["after_import_skipped"] == "import-only"
+
+
 def test_import_photos_null_after_import_is_import_only(app_and_db, tmp_path):
     """after_import: null means import-only (PR 3's hook short-circuits) —
     same nullable vocabulary as pipeline.default_strategy."""


### PR DESCRIPTION
## Summary
Adds an explicit Import mode choice so folders can be added in place without a destination, while copy-to-archive keeps the verified copy and safe-to-format flow.
Introduces `/api/jobs/import-in-place` to scan selected folders where they are and optionally chain the existing after-import processing strategies.
Updates import page tests and the user-first copy import scenario so the copy workflow selects Copy to archive explicitly.

## Validation
- `python -m py_compile vireo/app.py`
- `pytest -q vireo/tests/test_jobs_api.py::test_import_in_place_no_destination_required vireo/tests/test_app.py::test_import_page_returns_200 tests/e2e/test_import_page.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Import in place” option alongside existing copy-based import.
  * Import screens now show clearer mode selection and update preview/start actions based on the chosen mode.
  * Imports can now run with no destination when using in-place mode.

* **Bug Fixes**
  * Improved import-page behavior by ensuring the correct mode is selected before destination browsing.
  * Updated import results to show in-place progress and completion details more clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->