### PR TITLE
Restore import folder multi-select

### DIFF
--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -135,6 +135,55 @@ def test_import_folder_browser_toggles_discontiguous_source_folders(live_server,
     expect(source_list).to_contain_text("/tmp/card-c")
 
 
+def test_import_folder_browser_selects_volumes_from_synthetic_root(live_server, page):
+    # The Volumes shortcut renders /api/volumes as a synthetic root with
+    # browserPath = ''. Volume rows are selectable, so the Add button must
+    # enable once at least one is picked and must submit the selected drives
+    # instead of the (empty) synthetic root.
+    url = live_server["url"]
+    page.goto(f"{url}/import")
+    page.evaluate("window.pickDirectory = async () => null")
+    page.evaluate(
+        """
+        () => {
+          const originalFetch = window.fetch.bind(window);
+          window.fetch = (input, init) => {
+            const target = typeof input === 'string' ? input : input.url;
+            if (target && target.indexOf('/api/volumes') === 0) {
+              return Promise.resolve(new Response(JSON.stringify([
+                {name: 'Volume A', path: '/Volumes/A'},
+                {name: 'Volume B', path: '/Volumes/B'},
+              ]), {status: 200, headers: {'Content-Type': 'application/json'}}));
+            }
+            return originalFetch(input, init);
+          };
+        }
+        """
+    )
+
+    page.locator("[data-testid='import-source-browse-btn']").click()
+    # Non-Mac branch fetches /api/volumes (stubbed) and renders the drives
+    # as selectable rows in a synthetic root with browserPath = ''.
+    page.evaluate("async () => { await browseImportFolderTo('__volumes__'); }")
+
+    items = page.locator("#folderBrowserList .folder-browser-item[data-folder-path]")
+    expect(items).to_have_count(2)
+
+    select_btn = page.locator("#folderBrowserSelectBtn")
+    expect(select_btn).to_be_disabled()
+
+    items.nth(0).click(modifiers=["Control"])
+    items.nth(1).click(modifiers=["Control"])
+
+    expect(select_btn).to_be_enabled()
+    expect(select_btn).to_have_text("Add 2 Folders")
+    select_btn.click()
+
+    source_list = page.locator("#sourceList")
+    expect(source_list).to_contain_text("/Volumes/A")
+    expect(source_list).to_contain_text("/Volumes/B")
+
+
 def test_import_folder_browser_disables_select_while_pending(live_server, page):
     # A stale browserPath from a prior fetch used to remain selectable during
     # the next navigation. If the fetch stalled or failed, clicking "Select

--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -39,11 +39,100 @@ def test_import_browse_button_opens_folder_browser_fallback(live_server, page):
 
     browser = page.locator("[data-testid='import-folder-browser']")
     expect(browser).to_have_class(re.compile(r"\bopen\b"))
-    expect(page.locator("#folderBrowserTitle")).to_have_text("Select Source Folder")
+    expect(page.locator("#folderBrowserTitle")).to_have_text("Select Source Folders")
     expect(page.locator(".folder-browser-panel")).to_have_attribute("role", "dialog")
     expect(page.locator(".folder-browser-panel")).to_have_attribute("aria-modal", "true")
     expect(page.locator(".folder-browser-panel")).to_have_attribute(
         "aria-labelledby", "folderBrowserTitle")
+
+
+def test_import_folder_browser_selects_multiple_source_folders(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/import")
+    page.evaluate("window.pickDirectory = async () => null")
+    page.evaluate(
+        """
+        () => {
+          const originalFetch = window.fetch.bind(window);
+          window.fetch = (input, init) => {
+            const target = typeof input === 'string' ? input : input.url;
+            if (target && target.indexOf('/api/browse') === 0) {
+              return Promise.resolve(new Response(JSON.stringify({
+                path: '/tmp',
+                dirs: [
+                  {name: 'card-a', path: '/tmp/card-a'},
+                  {name: 'card-b', path: '/tmp/card-b'},
+                  {name: 'card-c', path: '/tmp/card-c'},
+                ],
+              }), {status: 200, headers: {'Content-Type': 'application/json'}}));
+            }
+            return originalFetch(input, init);
+          };
+        }
+        """
+    )
+
+    page.locator("[data-testid='import-source-browse-btn']").click()
+    items = page.locator("#folderBrowserList .folder-browser-item[data-folder-path]")
+    expect(items).to_have_count(3)
+
+    items.nth(0).click()
+    items.nth(2).click(modifiers=["Shift"])
+
+    expect(page.locator("#folderBrowserSelectBtn")).to_have_text("Add 3 Folders")
+    page.locator("#folderBrowserSelectBtn").click()
+
+    source_list = page.locator("#sourceList")
+    expect(source_list).to_contain_text("/tmp/card-a")
+    expect(source_list).to_contain_text("/tmp/card-b")
+    expect(source_list).to_contain_text("/tmp/card-c")
+
+
+def test_import_folder_browser_toggles_discontiguous_source_folders(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/import")
+    page.evaluate("window.pickDirectory = async () => null")
+    page.evaluate(
+        """
+        () => {
+          const originalFetch = window.fetch.bind(window);
+          window.fetch = (input, init) => {
+            const target = typeof input === 'string' ? input : input.url;
+            if (target && target.indexOf('/api/browse') === 0) {
+              return Promise.resolve(new Response(JSON.stringify({
+                path: '/tmp',
+                dirs: [
+                  {name: 'card-a', path: '/tmp/card-a'},
+                  {name: 'card-b', path: '/tmp/card-b'},
+                  {name: 'card-c', path: '/tmp/card-c'},
+                ],
+              }), {status: 200, headers: {'Content-Type': 'application/json'}}));
+            }
+            return originalFetch(input, init);
+          };
+        }
+        """
+    )
+
+    page.locator("[data-testid='import-source-browse-btn']").click()
+    items = page.locator("#folderBrowserList .folder-browser-item[data-folder-path]")
+    expect(items).to_have_count(3)
+
+    items.nth(0).click()
+    items.nth(2).evaluate(
+        """el => el.dispatchEvent(new MouseEvent('click', {
+          bubbles: true,
+          ctrlKey: true,
+        }))"""
+    )
+
+    expect(page.locator("#folderBrowserSelectBtn")).to_have_text("Add 2 Folders")
+    page.locator("#folderBrowserSelectBtn").click()
+
+    source_list = page.locator("#sourceList")
+    expect(source_list).to_contain_text("/tmp/card-a")
+    expect(source_list).not_to_contain_text("/tmp/card-b")
+    expect(source_list).to_contain_text("/tmp/card-c")
 
 
 def test_import_folder_browser_disables_select_while_pending(live_server, page):

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -457,8 +457,6 @@ function renderImportFolderBrowser(data, opts) {
       browseImportFolderTo(item.getAttribute('data-browse-path'));
     }
   };
-  const selectBtn = document.getElementById('folderBrowserSelectBtn');
-  if (selectBtn) selectBtn.disabled = !browserPath;
   updateImportBrowserSelection();
 }
 
@@ -513,18 +511,26 @@ function updateImportBrowserSelection() {
       selectBtn.textContent = browserSelectedPaths.length > 1
         ? 'Add ' + browserSelectedPaths.length + ' Folders'
         : 'Add This Folder';
+      // Volumes root renders with browserPath = '' but selectable drive rows.
+      // Enable submission whenever the user has picked at least one, so
+      // multi-select from the Volumes shortcut is reachable.
+      selectBtn.disabled = !browserPath && browserSelectedPaths.length === 0;
     } else {
       selectBtn.textContent = 'Select This Folder';
+      selectBtn.disabled = !browserPath;
     }
   }
 }
 
 function selectImportBrowserFolder() {
-  if (!browserPath) return;
   if (browserMode === 'destination') {
+    if (!browserPath) return;
     document.getElementById('destInput').value = browserPath;
   } else {
-    const paths = browserSelectedPaths.length ? browserSelectedPaths : [browserPath];
+    const paths = browserSelectedPaths.length
+      ? browserSelectedPaths
+      : (browserPath ? [browserPath] : []);
+    if (!paths.length) return;
     paths.forEach(addSourcePath);
   }
   closeImportFolderBrowser();

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -76,6 +76,7 @@ body { display: flex; flex-direction: column; height: 100vh; }
   cursor: pointer; border-bottom: 1px solid color-mix(in srgb, var(--border-primary) 60%, transparent);
 }
 .folder-browser-item:hover { background: var(--bg-hover, rgba(255,255,255,0.05)); }
+.folder-browser-item.selected { background: color-mix(in srgb, var(--accent) 15%, transparent); }
 .folder-browser-empty { padding: 14px; font-size: 12px; color: var(--text-secondary); }
 .folder-browser-actions {
   display: flex; gap: 8px; justify-content: flex-end;
@@ -202,6 +203,7 @@ body { display: flex; flex-direction: column; height: 100vh; }
       </div>
       <div class="folder-browser-path" id="folderBrowserPath"></div>
       <div class="folder-browser-list" id="folderBrowserList"></div>
+      <div class="folder-browser-path" id="folderBrowserSelection"></div>
     </div>
     <div class="folder-browser-actions">
       <button class="btn" type="button" onclick="closeImportFolderBrowser()">Cancel</button>
@@ -223,6 +225,8 @@ let browserPath = '';
 let browserHomePath = '';
 let browserSeq = 0;
 let browserEscHandler = null;
+let browserSelectedPaths = [];
+let browserSelectAnchorPath = '';
 let activeImportMode = 'in_place';
 
 function selectedImportMode() {
@@ -319,9 +323,10 @@ function openImportFolderBrowser(mode) {
   browserMode = mode === 'destination' ? 'destination' : 'source';
   const overlay = document.getElementById('importFolderBrowser');
   document.getElementById('folderBrowserTitle').textContent =
-    browserMode === 'source' ? 'Select Source Folder' : 'Select Destination Folder';
-  document.getElementById('folderBrowserSelectBtn').textContent =
-    browserMode === 'source' ? 'Add This Folder' : 'Select This Folder';
+    browserMode === 'source' ? 'Select Source Folders' : 'Select Destination Folder';
+  browserSelectedPaths = [];
+  browserSelectAnchorPath = '';
+  updateImportBrowserSelection();
   overlay.classList.add('open');
   overlay.onclick = (e) => {
     if (e.target === overlay) closeImportFolderBrowser();
@@ -356,6 +361,9 @@ async function browseImportFolderTo(path) {
   // submits the previous folder instead of the one the user requested —
   // both on modal open and mid-session navigation.
   browserPath = '';
+  browserSelectedPaths = [];
+  browserSelectAnchorPath = '';
+  updateImportBrowserSelection();
   const selectBtn = document.getElementById('folderBrowserSelectBtn');
   if (selectBtn) selectBtn.disabled = true;
   document.getElementById('folderBrowserPath').textContent = 'Loading…';
@@ -400,6 +408,8 @@ async function browseImportFolderTo(path) {
     }
     const data = await resp.json();
     browserPath = data.path || '';
+    browserSelectedPaths = [];
+    browserSelectAnchorPath = '';
     if (!path) browserHomePath = browserPath;
     renderImportFolderBrowser(data);
   } catch (e) {
@@ -421,10 +431,10 @@ function renderImportFolderBrowser(data, opts) {
     parent = data.path.substring(0, data.path.lastIndexOf('/')) || '/';
   }
   if (data.path && data.path !== '/' && parent && parent !== data.path) {
-    html += '<div class="folder-browser-item" data-browse-path="' + importEscapeAttr(parent) + '">&#128193; ..</div>';
+    html += '<div class="folder-browser-item" data-browse-path="' + importEscapeAttr(parent) + '" data-parent-link="1">&#128193; ..</div>';
   }
   dirs.forEach((d) => {
-    html += '<div class="folder-browser-item" data-browse-path="' + importEscapeAttr(d.path) + '">&#128193; ' +
+    html += '<div class="folder-browser-item" data-browse-path="' + importEscapeAttr(d.path) + '" data-folder-path="' + importEscapeAttr(d.path) + '">&#128193; ' +
       importEscapeHtml(d.name || d.path) + '</div>';
   });
   if (!html) {
@@ -434,10 +444,79 @@ function renderImportFolderBrowser(data, opts) {
   list.innerHTML = html;
   list.onclick = (e) => {
     const item = e.target.closest('.folder-browser-item[data-browse-path]');
-    if (item) browseImportFolderTo(item.getAttribute('data-browse-path'));
+    if (!item) return;
+    if (item.getAttribute('data-parent-link') === '1' || browserMode === 'destination') {
+      browseImportFolderTo(item.getAttribute('data-browse-path'));
+      return;
+    }
+    selectImportBrowserListItem(item, e);
+  };
+  list.ondblclick = (e) => {
+    const item = e.target.closest('.folder-browser-item[data-browse-path]');
+    if (item && item.getAttribute('data-parent-link') !== '1') {
+      browseImportFolderTo(item.getAttribute('data-browse-path'));
+    }
   };
   const selectBtn = document.getElementById('folderBrowserSelectBtn');
   if (selectBtn) selectBtn.disabled = !browserPath;
+  updateImportBrowserSelection();
+}
+
+function selectImportBrowserListItem(item, event) {
+  const path = item.getAttribute('data-folder-path') || item.getAttribute('data-browse-path');
+  if (!path) return;
+  const items = Array.from(document.querySelectorAll('#folderBrowserList .folder-browser-item[data-folder-path]'));
+  const shift = event && event.shiftKey;
+  const toggle = event && (event.metaKey || event.ctrlKey);
+
+  if (shift && browserSelectAnchorPath) {
+    let anchorIdx = items.findIndex((el) => el.getAttribute('data-folder-path') === browserSelectAnchorPath);
+    const clickIdx = items.findIndex((el) => el.getAttribute('data-folder-path') === path);
+    if (clickIdx === -1) return;
+    if (anchorIdx === -1) anchorIdx = clickIdx;
+    const lo = Math.min(anchorIdx, clickIdx);
+    const hi = Math.max(anchorIdx, clickIdx);
+    browserSelectedPaths = items.slice(lo, hi + 1).map((el) => el.getAttribute('data-folder-path'));
+  } else if (toggle) {
+    const idx = browserSelectedPaths.indexOf(path);
+    if (idx === -1) browserSelectedPaths.push(path);
+    else browserSelectedPaths.splice(idx, 1);
+    browserSelectAnchorPath = path;
+  } else {
+    browserSelectedPaths = [path];
+    browserSelectAnchorPath = path;
+  }
+  updateImportBrowserSelection();
+}
+
+function updateImportBrowserSelection() {
+  const selected = {};
+  browserSelectedPaths.forEach((path) => { selected[path] = true; });
+  document.querySelectorAll('#folderBrowserList .folder-browser-item[data-folder-path]').forEach((item) => {
+    item.classList.toggle('selected', !!selected[item.getAttribute('data-folder-path')]);
+  });
+
+  const selection = document.getElementById('folderBrowserSelection');
+  if (selection) {
+    if (browserMode === 'source' && browserSelectedPaths.length > 1) {
+      selection.textContent = browserSelectedPaths.length + ' folders selected';
+    } else if (browserMode === 'source' && browserSelectedPaths.length === 1) {
+      selection.textContent = browserSelectedPaths[0];
+    } else {
+      selection.textContent = '';
+    }
+  }
+
+  const selectBtn = document.getElementById('folderBrowserSelectBtn');
+  if (selectBtn) {
+    if (browserMode === 'source') {
+      selectBtn.textContent = browserSelectedPaths.length > 1
+        ? 'Add ' + browserSelectedPaths.length + ' Folders'
+        : 'Add This Folder';
+    } else {
+      selectBtn.textContent = 'Select This Folder';
+    }
+  }
 }
 
 function selectImportBrowserFolder() {
@@ -445,7 +524,8 @@ function selectImportBrowserFolder() {
   if (browserMode === 'destination') {
     document.getElementById('destInput').value = browserPath;
   } else {
-    addSourcePath(browserPath);
+    const paths = browserSelectedPaths.length ? browserSelectedPaths : [browserPath];
+    paths.forEach(addSourcePath);
   }
   closeImportFolderBrowser();
 }


### PR DESCRIPTION
Restores multi-folder selection in the import page fallback folder browser, matching the behavior still used by the older process browser. Source folders can now be selected with Shift ranges or Cmd/Ctrl toggles before adding them to the import source list. The fix keeps destination browsing as single-folder navigation and preserves the existing current-folder fallback when no child folders are selected. Validated with `pytest tests/e2e/test_import_page.py` and `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-select support in the import folder browser for source folders, including range selection and toggle selection.
  * The modal now shows clearer selection feedback, including selected folder paths or a count summary.

* **Bug Fixes**
  * Improved folder-browser behavior so selections reset correctly when navigating, preventing stale choices from being imported.
  * Updated accessibility and dialog labeling details for the folder-browser modal.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->