### PR TITLE
Simplify default bird identification pipeline

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3050,10 +3050,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # review) shows Group as "Disabled" in the plan even though the
         # actual run prepares species review results — the exact "plan
         # summary is wrong for the default workflow" transparency failure
-        # the review flagged. An explicit ``review_mode`` in the body wins
-        # if both are present (Advanced/Custom callers that want to
-        # override the preset's review path).
-        review_mode = body.get("review_mode")
+        # the review flagged. Strategy expansion supplies *defaults*;
+        # explicitly-present body keys still win, so an Advanced/Custom
+        # caller can pin one flag on top of a preset (mirrors the merge
+        # /api/jobs/pipeline runs). Copying only ``review_mode`` from
+        # the expansion, as the previous shape did, left ``skip_* =
+        # False`` in ``PipelinePlanParams`` when a caller sent only
+        # ``{"strategy": "identify"}`` (or ``"quick_look"``), so the plan
+        # promised Classify/Extract/Group work the actual strategy job
+        # would skip.
         if "strategy" in body and body.get("strategy"):
             strategy_name = body.get("strategy")
             if not isinstance(strategy_name, str):
@@ -3066,8 +3071,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 expanded = resolve_strategy(strategy_name)
             except ValueError as e:
                 return json_error(str(e), 400)
-            if review_mode is None:
-                review_mode = expanded.get("review_mode")
+            body = {**expanded, **body}
+        review_mode = body.get("review_mode")
         if review_mode is not None and not isinstance(review_mode, str):
             return json_error(
                 "review_mode must be a string or null, got "

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -17874,6 +17874,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             skip_eye_keypoints=expanded["skip_eye_keypoints"],
             skip_regroup=expanded["skip_regroup"],
             miss_enabled=expanded["miss_enabled"],
+            review_mode=expanded["review_mode"],
         )
         model_warning = _apply_no_model_auto_skip(params)
 
@@ -17905,6 +17906,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "skip_classify": params.skip_classify,
             "skip_extract_masks": params.skip_extract_masks,
             "skip_regroup": params.skip_regroup,
+            "review_mode": params.review_mode,
             "miss_enabled": params.miss_enabled,
         }
         if chained_from:
@@ -18461,6 +18463,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             skip_extract_masks=body.get("skip_extract_masks", False),
             skip_eye_keypoints=body.get("skip_eye_keypoints", False),
             skip_regroup=body.get("skip_regroup", False),
+            # ``review_mode`` reaches ``body`` only through the strategy
+            # expansion at the top of this handler (identify sets it to
+            # ``"species"``). Callers who send skip_regroup without a
+            # strategy — Advanced/Custom on the Process page, or API
+            # clients refreshing classifications only — leave it None so
+            # regroup_stage skips instead of overwriting the workspace
+            # cache with all-REVIEW output.
+            review_mode=body.get("review_mode"),
             miss_enabled=body.get("miss_enabled"),
             preview_max_size=body.get("preview_max_size"),
             exclude_paths=excluded_paths_set or None,
@@ -18564,6 +18574,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "skip_classify": params.skip_classify,
             "skip_extract_masks": params.skip_extract_masks,
             "skip_regroup": params.skip_regroup,
+            "review_mode": params.review_mode,
             "miss_enabled": params.miss_enabled,
         }
         # Preserve the caller's original folder_ids alongside the derived

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3044,6 +3044,35 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         tuple(chunk),
                     )
                 )
+        # Expand a named strategy the same way /api/jobs/pipeline does so
+        # the plan describes the run the same job body would produce.
+        # Without this, the identify preset (skip_regroup=True + species
+        # review) shows Group as "Disabled" in the plan even though the
+        # actual run prepares species review results — the exact "plan
+        # summary is wrong for the default workflow" transparency failure
+        # the review flagged. An explicit ``review_mode`` in the body wins
+        # if both are present (Advanced/Custom callers that want to
+        # override the preset's review path).
+        review_mode = body.get("review_mode")
+        if "strategy" in body and body.get("strategy"):
+            strategy_name = body.get("strategy")
+            if not isinstance(strategy_name, str):
+                return json_error(
+                    "strategy must be a string, got "
+                    f"{type(strategy_name).__name__}", 400,
+                )
+            from process_strategies import resolve_strategy
+            try:
+                expanded = resolve_strategy(strategy_name)
+            except ValueError as e:
+                return json_error(str(e), 400)
+            if review_mode is None:
+                review_mode = expanded.get("review_mode")
+        if review_mode is not None and not isinstance(review_mode, str):
+            return json_error(
+                "review_mode must be a string or null, got "
+                f"{type(review_mode).__name__}", 400,
+            )
         params = PipelinePlanParams(
             collection_id=body.get("collection_id"),
             photo_ids=scope_photo_ids,
@@ -3060,6 +3089,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             source_paths=source_paths,
             hash_duplicate_paths=hash_duplicate_paths,
             preview_max_size=body.get("preview_max_size"),
+            review_mode=review_mode,
         )
         db = _get_db()
         return jsonify(compute_plan(db, params, db_path))

--- a/vireo/config_schema.py
+++ b/vireo/config_schema.py
@@ -376,8 +376,9 @@ SCHEMA = {
         # a stored preference and imports do not auto-chain regardless of
         # the value.
         "type": "enum",
-        "enum": ["full", "cull_ready", "quick_look"],
+        "enum": ["identify", "full", "cull_ready", "quick_look"],
         "enum_labels": {
+            "identify": "Identify birds",
             "full": "Full",
             "cull_ready": "Cull-ready",
             "quick_look": "Quick look",

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -930,13 +930,19 @@ def serialize_results(results):
     return out
 
 
-def save_results(results, cache_dir, workspace_id):
+def save_results(results, cache_dir, workspace_id, preserve_miss_marker=True):
     """Save serialized pipeline results to a JSON cache file.
 
     Args:
         results: dict from run_full_pipeline()
         cache_dir: directory containing the database (e.g. ~/.vireo/)
         workspace_id: active workspace ID
+        preserve_miss_marker: when True (default) and the new results
+            lack ``miss_computed_at``, carry the previous cache's marker
+            forward. Set False for pipelines that produce a
+            semantically-fresh cache the prior miss stage cannot describe
+            (e.g. the identify/species-only path), so Pipeline Review
+            doesn't surface stale misses from an earlier full run.
 
     Returns:
         path to the saved JSON file
@@ -949,7 +955,11 @@ def save_results(results, cache_dir, workspace_id):
     # this pipeline run. reflow/regroup-live don't touch miss flags,
     # so overwriting this marker with a fresh save would make the
     # shortcut hide itself after every threshold tweak.
-    if "miss_computed_at" not in serialized and os.path.exists(path):
+    if (
+        preserve_miss_marker
+        and "miss_computed_at" not in serialized
+        and os.path.exists(path)
+    ):
         existing = _load_results_json(path)
         if existing and existing.get("miss_computed_at"):
             serialized["miss_computed_at"] = existing["miss_computed_at"]

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -538,6 +538,45 @@ def run_full_pipeline(photos, config=None, emit_trace=False):
     }
 
 
+def run_species_review_pipeline(photos, config=None, emit_trace=False):
+    """Build review results from species predictions without quality triage.
+
+    This is the default user-facing processing path: it keeps encounter/burst
+    grouping and species consensus available for Pipeline Review, but does not
+    run or imply the experimental quality/culling stack.
+    """
+    encounters = run_grouping(photos, config=config, emit_trace=emit_trace)
+    all_photos = []
+
+    for enc in encounters:
+        bursts = enc.get("bursts") or []
+        if bursts:
+            for burst in bursts:
+                for photo in burst:
+                    photo["label"] = "REVIEW"
+                    photo["reject_reasons"] = []
+                    all_photos.append(photo)
+        else:
+            for photo in enc.get("photos", []):
+                photo["label"] = "REVIEW"
+                photo["reject_reasons"] = []
+                all_photos.append(photo)
+
+    summary = _make_summary(encounters, all_photos)
+    log.info(
+        "Species review pipeline complete: %d photos → %d REVIEW",
+        summary["total_photos"],
+        summary["review_count"],
+    )
+
+    return {
+        "review_mode": "species",
+        "encounters": encounters,
+        "photos": all_photos,
+        "summary": summary,
+    }
+
+
 def run_selected_batch_review(photos, config=None):
     """Build normal pipeline-review results for one temporary photo batch.
 
@@ -879,6 +918,8 @@ def serialize_results(results):
         "photos": [_clean_photo(p) for p in results["photos"]],
         "summary": results["summary"],
     }
+    if results.get("review_mode"):
+        out["review_mode"] = results["review_mode"]
     # miss_computed_at is attached by pipeline_job's miss_stage and
     # consumed by pipeline_review's "Review misses" shortcut to gate
     # on actual recomputation in this run. Pass it through when the

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -117,6 +117,13 @@ class PipelineParams:
     reclassify: bool = False
     skip_extract_masks: bool = False
     skip_regroup: bool = False
+    # Distinguishes the identify preset's species-only review from a
+    # generic ``skip_regroup=True`` run. Only set to ``"species"`` by
+    # ``process_strategies.identify`` — Advanced/Custom on the Process
+    # page and API clients sending ``skip_regroup: true`` without a
+    # strategy leave this ``None`` so regroup_stage skips cleanly instead
+    # of overwriting the workspace cache with all-REVIEW output.
+    review_mode: str | None = None
     skip_classify: bool = False
     skip_eye_keypoints: bool = False
     # Per-run override for the config-gated misses stage. None defers to the
@@ -4874,10 +4881,34 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
         def regroup_stage():
             """Run pipeline grouping + scoring + triage from cached features."""
             if params.skip_regroup:
-                if abort.is_set() or not collection_id or params.skip_classify:
+                # Only take the species-review save path when the caller
+                # explicitly asked for it (the identify preset sets
+                # ``review_mode="species"`` via process_strategies). A
+                # classify-only run without that opt-in — Advanced/Custom
+                # on the Process page, or an API client sending
+                # ``skip_regroup: true`` — must NOT overwrite
+                # ``pipeline_results_ws*.json`` with all-REVIEW species
+                # output, since that would silently reintroduce the
+                # culling-pipeline downgrade the reviewer flagged (the
+                # user just wanted to refresh classifications, not turn
+                # the workspace cache into a species-review cache).
+                do_species = (
+                    params.review_mode == "species"
+                    and not abort.is_set()
+                    and collection_id
+                    and not params.skip_classify
+                )
+                if not do_species:
                     stages["regroup"]["status"] = "skipped"
                     runner.update_step(job["id"], "regroup", status="completed",
                                        summary="Skipped")
+                    # Emit a progress event so the SSE stream (and tests
+                    # asserting on the last progress payload) can see the
+                    # stage's terminal "skipped" state. Without this, a
+                    # downstream miss_stage that also short-circuits
+                    # leaves the last stages dict stuck at whatever the
+                    # detect/classify stage emitted last.
+                    _update_stages(runner, job["id"], stages)
                     return
                 try:
                     import config as cfg

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -4915,6 +4915,22 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         )
                         cache_dir = os.path.dirname(db_path)
                         save_results(results, cache_dir, workspace_id)
+                        # The species-only pipeline overwrites
+                        # pipeline_results_ws*.json with review-only output
+                        # (no burst/keep/reject scoring). If a prior full
+                        # regroup left a valid last_group_fingerprint stamped
+                        # on the workspace, pipeline_plan._group_plan would
+                        # match it against current settings and report
+                        # "done-prior" — silently letting an advanced Group
+                        # & Score run be skipped even though the cache no
+                        # longer contains any triage output. Invalidate the
+                        # stamp so a subsequent full run is correctly shown
+                        # as will-run.
+                        thread_db.set_workspace_group_state(
+                            workspace_id=workspace_id,
+                            fingerprint=None,
+                            when_ts=None,
+                        )
                         result["stages"]["review"] = results.get("summary", {})
 
                     stages["regroup"]["status"] = "completed"

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -4914,7 +4914,20 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             emit_trace=True,
                         )
                         cache_dir = os.path.dirname(db_path)
-                        save_results(results, cache_dir, workspace_id)
+                        # Don't preserve miss_computed_at from any prior
+                        # full run. The identify strategy skips the miss
+                        # stage entirely, so the cache we're writing has
+                        # no misses of its own; carrying the old marker
+                        # forward would make Pipeline Review call
+                        # /api/misses?since=<old marker> and render miss
+                        # rows from the previous full run as if they were
+                        # produced by this identify pass.
+                        save_results(
+                            results,
+                            cache_dir,
+                            workspace_id,
+                            preserve_miss_marker=False,
+                        )
                         # The species-only pipeline overwrites
                         # pipeline_results_ws*.json with review-only output
                         # (no burst/keep/reject scoring). If a prior full

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -905,6 +905,8 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
         if not params.skip_regroup:
             step_defs.append({"id": "regroup", "label": "Group encounters"})
             step_defs.append({"id": "misses", "label": "Flag missed shots"})
+        elif not params.skip_classify:
+            step_defs.append({"id": "regroup", "label": "Prepare review"})
         if params.local_processing:
             step_defs.append({"id": "archive", "label": "Archive to destination"})
         runner.set_steps(job["id"], step_defs)
@@ -4871,7 +4873,67 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
 
         def regroup_stage():
             """Run pipeline grouping + scoring + triage from cached features."""
-            if params.skip_regroup or abort.is_set() or not collection_id:
+            if params.skip_regroup:
+                if abort.is_set() or not collection_id or params.skip_classify:
+                    stages["regroup"]["status"] = "skipped"
+                    runner.update_step(job["id"], "regroup", status="completed",
+                                       summary="Skipped")
+                    return
+                try:
+                    import config as cfg
+                    from pipeline import (
+                        load_photo_features,
+                        run_species_review_pipeline,
+                        save_results,
+                    )
+
+                    thread_db = Database(db_path)
+                    thread_db.set_active_workspace(workspace_id)
+
+                    effective_cfg = thread_db.get_effective_config(cfg.load())
+                    pipeline_cfg = effective_cfg.get("pipeline", {})
+
+                    photos = load_photo_features(
+                        thread_db,
+                        collection_id=collection_id,
+                        config=effective_cfg,
+                    )
+                    if params.exclude_photo_ids:
+                        photos = [
+                            p for p in photos
+                            if p["id"] not in params.exclude_photo_ids
+                        ]
+                    if not photos:
+                        result["stages"]["review"] = {
+                            "error": "No photos with pipeline features found.",
+                        }
+                    else:
+                        results = run_species_review_pipeline(
+                            photos,
+                            config=pipeline_cfg,
+                            emit_trace=True,
+                        )
+                        cache_dir = os.path.dirname(db_path)
+                        save_results(results, cache_dir, workspace_id)
+                        result["stages"]["review"] = results.get("summary", {})
+
+                    stages["regroup"]["status"] = "completed"
+                    runner.update_step(
+                        job["id"], "regroup",
+                        status="completed",
+                        summary="Review results ready" if photos else "No photos to group",
+                    )
+                except Exception as e:
+                    errors.append(f"[review] Fatal: {e}")
+                    log.exception("Pipeline species-review stage failed")
+                    stages["regroup"]["status"] = "failed"
+                    runner.update_step(
+                        job["id"], "regroup", status="failed", error=str(e),
+                    )
+                _update_stages(runner, job["id"], stages)
+                return
+
+            if abort.is_set() or not collection_id:
                 stages["regroup"]["status"] = "skipped"
                 runner.update_step(job["id"], "regroup", status="completed",
                                    summary="Skipped")

--- a/vireo/pipeline_plan.py
+++ b/vireo/pipeline_plan.py
@@ -75,6 +75,15 @@ class PipelinePlanParams:
     # preview_max_size setting. Explicit 0 means "serve originals"; the
     # previews substage no-ops.
     preview_max_size: int | None = None
+    # Distinguishes the identify preset's species-only review path from a
+    # generic ``skip_regroup=True`` run. When ``"species"`` the Group stage
+    # is NOT skipped — the run enters ``regroup_stage``'s species branch and
+    # writes species-review results to ``pipeline_results_ws*.json``. The
+    # plan must reflect that work honestly instead of the "Disabled" pill
+    # ``skip_regroup=True`` normally implies. Populated by
+    # /api/pipeline/plan from the ``strategy`` (or explicit ``review_mode``)
+    # in the request body — the same expansion ``/api/jobs/pipeline`` runs.
+    review_mode: str | None = None
 
 
 def _plural(n, s="s"):
@@ -872,6 +881,26 @@ def _previews_plan(db, params, photo_ids, new_count, effective_cfg):
 def _regroup_plan(db, params, db_path, ws_id, upstream_will_run, effective_cfg,
                   import_no_new=False):
     if params.skip_regroup:
+        # The identify preset sets ``skip_regroup=True`` but flags
+        # ``review_mode="species"``, and ``regroup_stage`` (pipeline_job.py)
+        # then runs the species-review pipeline and overwrites
+        # ``pipeline_results_ws*.json`` with review-only output. The stage is
+        # NOT actually skipped — reporting "Disabled" would lie about the
+        # work the next press performs (and would let the user think the
+        # existing full-Group cache survives, when in reality identify wipes
+        # ``last_group_fingerprint`` and rewrites the cache).
+        if (
+            params.review_mode == "species"
+            and not params.skip_classify
+            and not import_no_new
+        ):
+            return {
+                "state": "will-run",
+                "summary": (
+                    "Will prepare species review — no grouping/scoring"
+                ),
+                "detail": {"review_mode": "species"},
+            }
         return {
             "state": "will-skip",
             "summary": "Disabled — stage will be skipped",

--- a/vireo/pipeline_plan.py
+++ b/vireo/pipeline_plan.py
@@ -90,6 +90,34 @@ def _plural(n, s="s"):
     return s if n != 1 else ""
 
 
+def _classify_would_run_after_auto_skip(params):
+    """Mirror ``_apply_no_model_auto_skip`` (app.py) at plan time.
+
+    ``/api/jobs/pipeline`` flips ``skip_classify`` (and by the same rule
+    ``skip_regroup``) to True when the caller didn't already disable
+    classify AND no downloaded/active model is available. The plan must
+    apply the same degradation before promising downstream work — in
+    particular the identify preset's species-review branch of
+    ``_regroup_plan``, which returns ``will-run`` solely from
+    ``review_mode="species"`` and would otherwise advertise
+    "Will prepare species review" for a job that will only show the
+    no-model warning and skip regroup.
+
+    Returns True when classify would actually run at job time.
+    """
+    if params.skip_classify:
+        return False
+    from models import get_active_model, get_models
+
+    requested_ids = list(params.model_ids or [])
+    if requested_ids:
+        by_id = {m["id"]: m for m in get_models()}
+        return all(
+            by_id.get(mid, {}).get("downloaded") for mid in requested_ids
+        )
+    return get_active_model() is not None
+
+
 def _resolve_models(model_ids):
     """Resolve UI model_ids to the (id, name, model_str, model_type) entries
     written into classifier_runs. Unknown ids are dropped — the plan reflects
@@ -889,10 +917,20 @@ def _regroup_plan(db, params, db_path, ws_id, upstream_will_run, effective_cfg,
         # work the next press performs (and would let the user think the
         # existing full-Group cache survives, when in reality identify wipes
         # ``last_group_fingerprint`` and rewrites the cache).
+        #
+        # But ``regroup_stage``'s species branch requires classify to
+        # produce/have produced species predictions, and
+        # ``/api/jobs/pipeline`` auto-flips ``skip_classify=True`` (and
+        # ``skip_regroup=True``) when no downloaded/active model is
+        # available. Without the same gate here, the plan promises
+        # "Will prepare species review" on installs with no model where
+        # the job will only surface the no-model warning and skip
+        # regroup — the exact transparency failure the review flagged.
         if (
             params.review_mode == "species"
             and not params.skip_classify
             and not import_no_new
+            and _classify_would_run_after_auto_skip(params)
         ):
             return {
                 "state": "will-run",

--- a/vireo/process_strategies.py
+++ b/vireo/process_strategies.py
@@ -5,8 +5,10 @@ A strategy is pure data: a dict of PipelineParams skip-flag overrides plus
 expands a strategy name server-side so the import page, the process page,
 and import→process chaining all share one vocabulary.
 
-Deviation from the design table: cull_ready keeps regroup — it is cheap
-(no GPU) and pipeline_review requires encounters.
+The default user-facing preset is ``identify``: detect/classify birds and
+write lightweight review results, but skip the experimental quality/culling
+stack (SAM2 masks, DINO embeddings, eye focus, and quality triage). The full
+quality pipeline remains available for Advanced Mode.
 
 The "no processing at all" choice is deliberately NOT a strategy here: it
 is a decision at the import→process boundary, represented as a null
@@ -46,6 +48,12 @@ _BASE = {
 }
 
 STRATEGIES = {
+    "identify": {
+        "skip_extract_masks": True,
+        "skip_eye_keypoints": True,
+        "skip_regroup": True,
+        "miss_enabled": False,
+    },
     "full": {},
     "cull_ready": {
         "skip_extract_masks": True,

--- a/vireo/process_strategies.py
+++ b/vireo/process_strategies.py
@@ -45,6 +45,14 @@ _BASE = {
     "skip_eye_keypoints": False,
     "skip_regroup": False,
     "miss_enabled": True,
+    # Distinguishes the identify preset's species-only review path from
+    # a generic ``skip_regroup=True`` run (Advanced/Custom on the Process
+    # page, or an API caller that just wants to refresh classifications
+    # without touching grouping). Without this, ``pipeline_job``'s
+    # regroup_stage would treat every classify-only run as species-review
+    # and overwrite ``pipeline_results_ws*.json`` with all-REVIEW output,
+    # silently downgrading the cache for callers who never asked for it.
+    "review_mode": None,
 }
 
 STRATEGIES = {
@@ -53,6 +61,7 @@ STRATEGIES = {
         "skip_eye_keypoints": True,
         "skip_regroup": True,
         "miss_enabled": False,
+        "review_mode": "species",
     },
     "full": {},
     "cull_ready": {

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1771,7 +1771,7 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
   <span class="nav-spacer"></span>
   <span class="nav-icon" onclick="openReportModal()" title="Report Issue" id="reportToggle">&#9888;</span>
   <span class="nav-icon" onclick="openHelpModal()" title="Help (F1)" id="helpToggle">&#63;</span>
-  <span class="nav-icon" onclick="toggleDevMode()" title="Toggle developer mode" id="devModeToggle" style="opacity:0.4;">&#9881;</span>
+  <span class="nav-icon" onclick="toggleAdvancedMode()" title="Toggle advanced mode" id="devModeToggle" style="opacity:0.4;">&#9881;</span>
   <span class="nav-icon" onclick="toggleTheme()" title="Toggle light/dark mode" id="themeToggle">&#9788;</span>
   <span class="nav-icon" onclick="toggleBottomPanel()" title="Toggle panel">
     &#9638;
@@ -8974,27 +8974,36 @@ function formatDuration(seconds) {
     btn.title = 'Theme: ' + theme.name + ' (click to cycle)';
   }
 
-  // Dev mode system
+  // Advanced mode system. Keep the old dev-mode names as aliases so pages
+  // and tests that still use them continue to work.
   (function() {
-    var on = localStorage.getItem('vireo_dev_mode') === 'true';
+    var stored = localStorage.getItem('vireo_advanced_mode');
+    if (stored == null) stored = localStorage.getItem('vireo_dev_mode');
+    var on = stored === 'true';
+    document.documentElement.setAttribute('data-advanced-mode', on ? 'true' : 'false');
     document.documentElement.setAttribute('data-dev-mode', on ? 'true' : 'false');
     var btn = document.getElementById('devModeToggle');
-    if (btn) { btn.style.opacity = on ? '1' : '0.4'; btn.title = 'Developer mode: ' + (on ? 'ON' : 'OFF'); }
+    if (btn) { btn.style.opacity = on ? '1' : '0.4'; btn.title = 'Advanced mode: ' + (on ? 'ON' : 'OFF'); }
   })();
 
-  window.isDevMode = function() {
-    return document.documentElement.getAttribute('data-dev-mode') === 'true';
+  window.isAdvancedMode = function() {
+    return document.documentElement.getAttribute('data-advanced-mode') === 'true';
   };
+  window.isDevMode = window.isAdvancedMode;
 
-  window.toggleDevMode = function() {
-    var on = !isDevMode();
+  window.toggleAdvancedMode = function() {
+    var on = !isAdvancedMode();
+    document.documentElement.setAttribute('data-advanced-mode', on ? 'true' : 'false');
     document.documentElement.setAttribute('data-dev-mode', on ? 'true' : 'false');
+    localStorage.setItem('vireo_advanced_mode', on ? 'true' : 'false');
     localStorage.setItem('vireo_dev_mode', on ? 'true' : 'false');
     var btn = document.getElementById('devModeToggle');
-    if (btn) { btn.style.opacity = on ? '1' : '0.4'; btn.title = 'Developer mode: ' + (on ? 'ON' : 'OFF'); }
+    if (btn) { btn.style.opacity = on ? '1' : '0.4'; btn.title = 'Advanced mode: ' + (on ? 'ON' : 'OFF'); }
     // Notify pages that may want to re-render
+    window.dispatchEvent(new Event('advancedmodechange'));
     window.dispatchEvent(new Event('devmodechange'));
   };
+  window.toggleDevMode = window.toggleAdvancedMode;
 
   function init() {
     // Restore panel state and height

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -465,6 +465,14 @@ function updateAdvancedImportOptions() {
     opt.disabled = !advanced;
   });
   if (!advanced && sel.selectedOptions.length && sel.selectedOptions[0].disabled) {
+    // The workspace's default is an advanced-only strategy (e.g. full,
+    // cull_ready) but advanced mode is off, so we have to hide it in the
+    // dropdown. Fall the visual selection back to __none__ but remember
+    // that this fallback isn't a user choice — otherwise startImport
+    // would post after_import: null and silently downgrade the workspace
+    // default to import-only. The flag is cleared as soon as the user
+    // actively interacts with the select.
+    _afterImportHidingDefault = true;
     sel.value = '__none__';
   }
 }
@@ -482,6 +490,16 @@ window.addEventListener('devmodechange', updateAdvancedImportOptions);
 // fall back to the endpoint's "key omitted → apply workspace default"
 // branch, which is what the user actually expects.
 let _afterImportConfigLoaded = false;
+
+// True when updateAdvancedImportOptions() has visually reset the select
+// to __none__ solely because the workspace's stored default is an
+// advanced-only strategy (full / cull_ready) and advanced mode is off.
+// In that state the __none__ display is a UI artifact, not a user
+// choice, so startImport() must omit the after_import key and let the
+// server apply the workspace default rather than posting an explicit
+// null (which would run import-only). Cleared as soon as the user
+// actively changes the select.
+let _afterImportHidingDefault = false;
 
 function showError(msg) {
   const el = document.getElementById('importError');
@@ -773,7 +791,7 @@ async function startImport() {
     body.folder_template = (document.getElementById('folderTemplate').value || '').trim();
     body.file_types = document.getElementById('fileTypes').value;
   }
-  if (_afterImportConfigLoaded) {
+  if (_afterImportConfigLoaded && !_afterImportHidingDefault) {
     body.after_import = selectedAfterImport();
   }
   document.getElementById('btnStart').disabled = true;
@@ -974,6 +992,15 @@ async function initImportPage() {
   const def = pipelineCfg.default_strategy;
   sel.value = def ? def : '__none__';
   if (sel.selectedIndex === -1) sel.value = '__none__';
+  // updateAdvancedImportOptions() may flip _afterImportHidingDefault
+  // when the resolved default is an advanced-only strategy the current
+  // mode hides. Wire the change listener first so a user-driven change
+  // afterwards (advanced toggle keeps it, explicit dropdown pick clears
+  // it) is always tracked.
+  sel.addEventListener('change', () => {
+    _afterImportHidingDefault = false;
+  });
+  _afterImportHidingDefault = false;
   updateAdvancedImportOptions();
   // Only mark the resolved default as trustworthy when BOTH config
   // fetches actually succeeded. Otherwise the select value reflects the

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -145,6 +145,7 @@ body { display: flex; flex-direction: column; height: 100vh; }
       <h3>After import</h3>
       <div class="row">
         <select id="afterImportSelect" style="max-width:280px;">
+          <option id="afterImportHiddenDefault" value="__hidden_default__" hidden disabled></option>
           <option value="__none__">None — import only</option>
           <option value="identify">Identify birds</option>
           <option value="quick_look">Quick look (thumbnails + previews)</option>
@@ -453,7 +454,20 @@ function selectImportBrowserFolder() {
 
 function selectedAfterImport() {
   const v = document.getElementById('afterImportSelect').value;
-  return v === '__none__' ? null : v;
+  // __hidden_default__ is a display-only placeholder — the request path
+  // omits after_import in that state, so callers never read this value.
+  if (v === '__none__' || v === '__hidden_default__') return null;
+  return v;
+}
+
+function retireHiddenDefaultOption(sel) {
+  const placeholder = document.getElementById('afterImportHiddenDefault');
+  if (!placeholder) return;
+  placeholder.hidden = true;
+  placeholder.disabled = true;
+  placeholder.textContent = '';
+  delete placeholder.dataset.maskedValue;
+  if (sel && sel.value === '__hidden_default__') sel.value = '__none__';
 }
 
 function updateAdvancedImportOptions() {
@@ -464,16 +478,41 @@ function updateAdvancedImportOptions() {
     opt.hidden = !advanced;
     opt.disabled = !advanced;
   });
-  if (!advanced && sel.selectedOptions.length && sel.selectedOptions[0].disabled) {
-    // The workspace's default is an advanced-only strategy (e.g. full,
-    // cull_ready) but advanced mode is off, so we have to hide it in the
-    // dropdown. Fall the visual selection back to __none__ but remember
-    // that this fallback isn't a user choice — otherwise startImport
-    // would post after_import: null and silently downgrade the workspace
-    // default to import-only. The flag is cleared as soon as the user
-    // actively interacts with the select.
+  const placeholder = document.getElementById('afterImportHiddenDefault');
+  if (advanced) {
+    // Advanced mode is back on — reveal whichever advanced strategy the
+    // placeholder was masking so the visible selection matches what
+    // Start Import will send, then retire the placeholder.
+    if (placeholder && sel.value === '__hidden_default__') {
+      const masked = placeholder.dataset.maskedValue;
+      sel.value = masked || '__none__';
+      _afterImportHidingDefault = false;
+    }
+    retireHiddenDefaultOption(sel);
+    return;
+  }
+  const current = sel.selectedOptions[0];
+  const currentIsHiddenAdvanced =
+    !!(current && current.disabled && current.hasAttribute('data-advanced-strategy'));
+  if (currentIsHiddenAdvanced && placeholder) {
+    // The workspace's default is an advanced-only strategy (full,
+    // cull_ready) but advanced mode is off. If we silently fell the
+    // display back to __none__, startImport() would omit after_import so
+    // the server still runs the hidden default while the dropdown reads
+    // "None — import only" — the exact mismatch the reviewer flagged.
+    // Instead, surface an honest placeholder that names the masked
+    // strategy so the visible selection tells the truth about what a
+    // Start Import will do.
+    const maskedLabel = (current.textContent || '').trim();
+    placeholder.textContent =
+      'Workspace default: ' + maskedLabel + ' (enable Advanced mode to change)';
+    placeholder.dataset.maskedValue = current.value;
+    placeholder.hidden = false;
+    placeholder.disabled = false;
     _afterImportHidingDefault = true;
-    sel.value = '__none__';
+    sel.value = '__hidden_default__';
+  } else if (sel.value !== '__hidden_default__') {
+    retireHiddenDefaultOption(sel);
   }
 }
 
@@ -999,6 +1038,10 @@ async function initImportPage() {
   // it) is always tracked.
   sel.addEventListener('change', () => {
     _afterImportHidingDefault = false;
+    // Once the user actively picks a real option, the "Workspace
+    // default (hidden)" placeholder is no longer relevant — retire it
+    // so it doesn't clutter the dropdown on the next open.
+    if (sel.value !== '__hidden_default__') retireHiddenDefaultOption(sel);
   });
   _afterImportHidingDefault = false;
   updateAdvancedImportOptions();

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -146,9 +146,10 @@ body { display: flex; flex-direction: column; height: 100vh; }
       <div class="row">
         <select id="afterImportSelect" style="max-width:280px;">
           <option value="__none__">None — import only</option>
+          <option value="identify">Identify birds</option>
           <option value="quick_look">Quick look (thumbnails + previews)</option>
-          <option value="cull_ready">Cull-ready (+ detect, classify, group)</option>
-          <option value="full">Full pipeline (everything)</option>
+          <option value="cull_ready" data-advanced-strategy>Cull-ready (+ quality review)</option>
+          <option value="full" data-advanced-strategy>Full pipeline (everything)</option>
         </select>
       </div>
       <div class="hint">Processing runs as its own job when the import finishes — a processing failure never touches imported photos.</div>
@@ -454,6 +455,22 @@ function selectedAfterImport() {
   const v = document.getElementById('afterImportSelect').value;
   return v === '__none__' ? null : v;
 }
+
+function updateAdvancedImportOptions() {
+  const sel = document.getElementById('afterImportSelect');
+  if (!sel) return;
+  const advanced = !!(window.isAdvancedMode && window.isAdvancedMode());
+  sel.querySelectorAll('[data-advanced-strategy]').forEach((opt) => {
+    opt.hidden = !advanced;
+    opt.disabled = !advanced;
+  });
+  if (!advanced && sel.selectedOptions.length && sel.selectedOptions[0].disabled) {
+    sel.value = '__none__';
+  }
+}
+
+window.addEventListener('advancedmodechange', updateAdvancedImportOptions);
+window.addEventListener('devmodechange', updateAdvancedImportOptions);
 
 // True once initImportPage() has resolved the workspace's after-import
 // default into the select. Until then, the select still shows its HTML
@@ -957,6 +974,7 @@ async function initImportPage() {
   const def = pipelineCfg.default_strategy;
   sel.value = def ? def : '__none__';
   if (sel.selectedIndex === -1) sel.value = '__none__';
+  updateAdvancedImportOptions();
   // Only mark the resolved default as trustworthy when BOTH config
   // fetches actually succeeded. Otherwise the select value reflects the
   // HTML placeholder rather than the workspace default, and startImport

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -5013,9 +5013,20 @@ function _stageStateFor(stage) {
   if (_runningStages[stage.suffix]) return 'running';
   if (_stageOutcomes[stage.suffix]) return _stageOutcomes[stage.suffix];
 
-  // User-toggled skip overrides anything the server-side plan returned —
-  // matches the user's mental model that toggling a stage off is the
-  // strongest signal of "do not run this".
+  var fromPlan = _pipelinePlan && _pipelinePlan.stages
+    ? _pipelinePlan.stages[stage.suffix] : null;
+
+  // Plan wins on 'will-run': /api/pipeline/plan expands ``strategy`` the
+  // same way /api/jobs/pipeline does, so when it says a stage will run,
+  // the actual job WILL run it — even if the stage's checkbox is off.
+  // The identify preset auto-unchecks Group but its species-review
+  // branch still runs regroup_stage and rewrites the review cache;
+  // without this the pill lies about what pressing Start would do.
+  if (fromPlan && fromPlan.state === 'will-run') return 'will-run';
+
+  // Otherwise user-toggled skip overrides the plan — matches the user's
+  // mental model that toggling a stage off is the strongest signal of
+  // "do not run this".
   if (stage.enable) {
     var cb = document.getElementById(stage.enable);
     if (cb && !cb.checked) return 'will-skip';
@@ -5023,7 +5034,6 @@ function _stageStateFor(stage) {
   // Stages with no plan entry (Scan in non-import modes) default to
   // "will-run" — they always run when the pipeline starts.
   if (!_pipelinePlan) return 'will-run';
-  var fromPlan = _pipelinePlan.stages && _pipelinePlan.stages[stage.suffix];
   if (!fromPlan) return 'will-run';
   return fromPlan.state || 'will-run';
 }

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -909,10 +909,11 @@ body { padding-bottom: 36px; }
     <span style="margin-left:auto;display:inline-flex;align-items:center;gap:6px;font-size:12px;color:var(--text-secondary);">
       Strategy
       <select id="strategySelect" onchange="applyStrategyPreset()" style="font-size:12px;background:var(--bg-tertiary);color:var(--text-primary);border:1px solid var(--border-secondary);border-radius:4px;padding:3px 6px;">
-        <option value="__custom__" selected>Custom (use toggles)</option>
-        <option value="full">Full pipeline</option>
-        <option value="cull_ready">Cull-ready</option>
+        <option value="identify" selected>Identify birds</option>
         <option value="quick_look">Quick look</option>
+        <option value="__custom__" data-advanced-strategy>Custom (use toggles)</option>
+        <option value="full" data-advanced-strategy>Full pipeline</option>
+        <option value="cull_ready" data-advanced-strategy>Cull-ready</option>
       </select>
     </span>
   </div>
@@ -970,7 +971,7 @@ body { padding-bottom: 36px; }
   </div>
 
   <!-- Card 6: Extract Features -->
-  <div class="stage-card" id="card-extract" data-testid="stage-card">
+  <div class="stage-card" id="card-extract" data-testid="stage-card" data-advanced-stage>
     <div class="stage-header" onclick="toggleCard('extract')">
       <span class="stage-num" id="numExtract">6</span>
       <input type="checkbox" class="stage-enable" id="enableExtract" checked
@@ -1033,7 +1034,7 @@ body { padding-bottom: 36px; }
   </div>
 
   <!-- Card 7: Eye Keypoints (optional, off by default until weights downloaded) -->
-  <div class="stage-card" id="card-eyekeypoints" data-testid="stage-card">
+  <div class="stage-card" id="card-eyekeypoints" data-testid="stage-card" data-advanced-stage>
     <div class="stage-header" onclick="toggleCard('eyekeypoints')">
       <span class="stage-num" id="numEyeKeypoints">7</span>
       <input type="checkbox" class="stage-enable" id="enableEyeKeypoints" checked
@@ -1065,7 +1066,7 @@ body { padding-bottom: 36px; }
   </div>
 
   <!-- Card 8: Group & Score -->
-  <div class="stage-card" id="card-group" data-testid="stage-card">
+  <div class="stage-card" id="card-group" data-testid="stage-card" data-advanced-stage>
     <div class="stage-header" onclick="toggleCard('group')">
       <span class="stage-num" id="numGroup">8</span>
       <input type="checkbox" class="stage-enable" id="enableGroup" checked
@@ -1328,6 +1329,9 @@ document.addEventListener('DOMContentLoaded', initPipelinePage);
 // Render pills + plan summary immediately from default toggle state, so the
 // page isn't blank while the page-init API call is in flight.
 document.addEventListener('DOMContentLoaded', refreshPipelineUI);
+document.addEventListener('DOMContentLoaded', updateAdvancedPipelineOptions);
+window.addEventListener('advancedmodechange', updateAdvancedPipelineOptions);
+window.addEventListener('devmodechange', updateAdvancedPipelineOptions);
 
 // -- New images (Stage 1 third option) --
 var newImagesSnapshotId = null;
@@ -1633,6 +1637,7 @@ function applyStrategyPreset() {
   var sel = document.getElementById('strategySelect');
   if (!sel || sel.value === '__custom__') { refreshPipelineUI(); return; }
   var presets = {
+    identify:   { classify: true,  extract: false, eyes: false, group: false },
     full:       { classify: true,  extract: true,  eyes: true,  group: true  },
     cull_ready: { classify: true,  extract: false, eyes: false, group: true  },
     quick_look: { classify: false, extract: false, eyes: false, group: false },
@@ -1659,6 +1664,23 @@ function applyStrategyPreset() {
     gCb.disabled = false;
   }
   refreshPipelineUI();
+}
+
+function updateAdvancedPipelineOptions() {
+  var sel = document.getElementById('strategySelect');
+  if (!sel) return;
+  var advanced = !!(window.isAdvancedMode && window.isAdvancedMode());
+  sel.querySelectorAll('[data-advanced-strategy]').forEach(function(opt) {
+    opt.hidden = !advanced;
+    opt.disabled = !advanced;
+  });
+  document.querySelectorAll('[data-advanced-stage]').forEach(function(card) {
+    card.style.display = advanced ? '' : 'none';
+  });
+  if (!advanced && sel.selectedOptions.length && sel.selectedOptions[0].disabled) {
+    sel.value = 'identify';
+  }
+  applyStrategyPreset();
 }
 
 var _sourceMode = 'folders'; // 'folders', 'import', 'collection', or 'new_images'

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -5174,6 +5174,16 @@ function _buildPlanBody() {
   body.skip_eye_keypoints  = !document.getElementById('enableEyeKeypoints').checked;
   body.skip_regroup        = !document.getElementById('enableGroup').checked;
 
+  // Mirror the strategy field startPipeline() sends so /api/pipeline/plan
+  // expands the preset with the same rules /api/jobs/pipeline does. The
+  // identify preset sets skip_regroup=true but flags review_mode="species";
+  // without the strategy the plan reports Group as "Disabled" even though
+  // the actual run prepares species review results.
+  var planStrategySel = document.getElementById('strategySelect');
+  if (planStrategySel && planStrategySel.value && planStrategySel.value !== '__custom__') {
+    body.strategy = planStrategySel.value;
+  }
+
   // Preview size is a workspace/library setting. Omit preview_max_size so
   // the backend planner and job both use the same workspace-effective value.
 

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -2399,8 +2399,9 @@ function renderResults() {
 
 function renderPhotoCard(p, encIdx, burstIdx) {
   var label = (p.label || '').toLowerCase();
-  var q = p.quality_composite || 0;
-  var qPct = Math.round(q * 100);
+  var hasQuality = hasQualityScore(p);
+  var q = hasQuality ? Number(p.quality_composite) : null;
+  var qPct = hasQuality ? Math.round(q * 100) : 0;
   var thumbUrl = window.vireoThumbnailUrl ? window.vireoThumbnailUrl(p) : '/thumbnails/' + p.id + '.jpg';
   var html = '<div class="photo-card ' + label + '" data-photo-id="' + p.id + '">';
   html += '<img src="' + escapeAttr(thumbUrl) + '" loading="lazy" alt="" onclick="openInspect(' + p.id + ')">';
@@ -2411,10 +2412,30 @@ function renderPhotoCard(p, encIdx, burstIdx) {
   if (encIdx != null && burstIdx != null) {
     html += '<button class="detach-btn" onclick="event.stopPropagation();detachPhoto(' + encIdx + ',' + burstIdx + ',' + p.id + ')" title="Detach photo" style="position:absolute;top:2px;right:2px;">&times;</button>';
   }
-  html += '<div class="photo-score-bar"><div class="photo-score-fill" style="width:' + qPct + '%"></div></div>';
-  html += '<div class="photo-info">' + escapeHtml(p.filename || '') + ' &middot; Q=' + q.toFixed(2) + '</div>';
+  if (hasQuality) {
+    html += '<div class="photo-score-bar"><div class="photo-score-fill" style="width:' + qPct + '%"></div></div>';
+    html += '<div class="photo-info">' + escapeHtml(p.filename || '') + ' &middot; Q=' + q.toFixed(2) + '</div>';
+  } else {
+    html += '<div class="photo-info">' + escapeHtml(p.filename || '') + '</div>';
+  }
   html += '</div>';
   return html;
+}
+
+function hasQualityScore(photo) {
+  return photo && photo.quality_composite != null && isFinite(Number(photo.quality_composite));
+}
+
+function hasQualityResults() {
+  if (!pipelineResults || pipelineResults.review_mode === 'species') return false;
+  return (pipelineResults.photos || []).some(hasQualityScore);
+}
+
+function updatePipelineReviewSidebarVisibility() {
+  var ss = document.getElementById('sidebarScoring');
+  if (ss) ss.style.display = hasQualityResults() ? '' : 'none';
+  var sg = document.getElementById('sidebarGrouping');
+  if (sg) sg.style.display = '';
 }
 
 function toggleEncounter(idx) {
@@ -2855,7 +2876,7 @@ function openInspect(photoId) {
   inspectPhotoId = photoId;
 
   var label = (photo.label || '').toLowerCase();
-  var q = photo.quality_composite || 0;
+  var q = hasQualityScore(photo) ? Number(photo.quality_composite) : null;
 
   // Score components
   var scores = [
@@ -2903,19 +2924,21 @@ function openInspect(photoId) {
   html += buildSpeciesPredictionsHtml(photo, buildBurstConsensus(encPhotos), 'Encounter consensus', minConfidence / 100);
 
   // Score waterfall
-  html += '<div class="score-waterfall">';
-  html += '<div style="font-size:13px;font-weight:600;margin-bottom:8px;">Quality Score: ' + q.toFixed(3) + '</div>';
-  scores.forEach(function(s) {
-    var val = photo[s.key] || 0;
-    var weighted = val * s.weight;
-    var pct = Math.round(val * 100);
-    html += '<div class="score-waterfall-row">';
-    html += '<span class="score-wf-label">' + s.name + ' (' + (s.weight*100) + '%)</span>';
-    html += '<div class="score-wf-bar-track"><div class="score-wf-bar-fill ' + s.cls + '" style="width:' + pct + '%"></div></div>';
-    html += '<span class="score-wf-val">' + val.toFixed(3) + ' (' + weighted.toFixed(3) + ')</span>';
+  if (q !== null) {
+    html += '<div class="score-waterfall">';
+    html += '<div style="font-size:13px;font-weight:600;margin-bottom:8px;">Quality Score: ' + q.toFixed(3) + '</div>';
+    scores.forEach(function(s) {
+      var val = photo[s.key] || 0;
+      var weighted = val * s.weight;
+      var pct = Math.round(val * 100);
+      html += '<div class="score-waterfall-row">';
+      html += '<span class="score-wf-label">' + s.name + ' (' + (s.weight*100) + '%)</span>';
+      html += '<div class="score-wf-bar-track"><div class="score-wf-bar-fill ' + s.cls + '" style="width:' + pct + '%"></div></div>';
+      html += '<span class="score-wf-val">' + val.toFixed(3) + ' (' + weighted.toFixed(3) + ')</span>';
+      html += '</div>';
+    });
     html += '</div>';
-  });
-  html += '</div>';
+  }
 
   // Encounter context filmstrip
   if (enc) {
@@ -3093,8 +3116,7 @@ function computeReviewNow() {
     document.getElementById('summaryBar').style.display = '';
     updateSummaryBar(data.summary);
     document.getElementById('filterBar').style.display = '';
-    document.getElementById('sidebarScoring').style.display = '';
-    document.getElementById('sidebarGrouping').style.display = '';
+    updatePipelineReviewSidebarVisibility();
     restorePipelineReviewViewState();
     renderResults();
     openRequestedGroupReviewFromUrl();
@@ -3143,11 +3165,7 @@ function loadPipelinePageInit() {
       document.getElementById('confSliderVal').textContent = minConfidence + '%';
     }
 
-    // Show sidebar sections
-    var ss = document.getElementById('sidebarScoring');
-    if (ss) ss.style.display = '';
-    var sg = document.getElementById('sidebarGrouping');
-    if (sg) sg.style.display = '';
+    updatePipelineReviewSidebarVisibility();
 
     // Show summary bar and populate
     var sb = document.getElementById('summaryBar');
@@ -4546,7 +4564,7 @@ function buildSpeciesPredictionsHtml(photo, consensusRows, consensusTitleText, t
 function buildPipelineMetadataHtml(photo) {
   var enc = pipelineResults.encounters[grmState.encIdx];
   var label = (photo.label || '').toLowerCase();
-  var q = photo.quality_composite || 0;
+  var q = hasQualityScore(photo) ? Number(photo.quality_composite) : null;
 
   var html = '';
 
@@ -4594,19 +4612,21 @@ function buildPipelineMetadataHtml(photo) {
     {name: 'Area', key: 'area_score', weight: 0.10, cls: 'area'},
     {name: 'Noise', key: 'noise_score', weight: 0.10, cls: 'noise'},
   ];
-  html += '<div class="score-waterfall">';
-  html += '<div style="font-size:13px;font-weight:600;margin-bottom:8px;">Quality Score: ' + q.toFixed(3) + '</div>';
-  scores.forEach(function(s) {
-    var val = photo[s.key] || 0;
-    var weighted = val * s.weight;
-    var pct = Math.round(val * 100);
-    html += '<div class="score-waterfall-row">';
-    html += '<span class="score-wf-label">' + s.name + ' (' + (s.weight*100) + '%)</span>';
-    html += '<div class="score-wf-bar-track"><div class="score-wf-bar-fill ' + s.cls + '" style="width:' + pct + '%"></div></div>';
-    html += '<span class="score-wf-val">' + val.toFixed(3) + ' (' + weighted.toFixed(3) + ')</span>';
+  if (q !== null) {
+    html += '<div class="score-waterfall">';
+    html += '<div style="font-size:13px;font-weight:600;margin-bottom:8px;">Quality Score: ' + q.toFixed(3) + '</div>';
+    scores.forEach(function(s) {
+      var val = photo[s.key] || 0;
+      var weighted = val * s.weight;
+      var pct = Math.round(val * 100);
+      html += '<div class="score-waterfall-row">';
+      html += '<span class="score-wf-label">' + s.name + ' (' + (s.weight*100) + '%)</span>';
+      html += '<div class="score-wf-bar-track"><div class="score-wf-bar-fill ' + s.cls + '" style="width:' + pct + '%"></div></div>';
+      html += '<span class="score-wf-val">' + val.toFixed(3) + ' (' + weighted.toFixed(3) + ')</span>';
+      html += '</div>';
+    });
     html += '</div>';
-  });
-  html += '</div>';
+  }
 
   // Raw feature table
   html += '<table class="feature-table">';

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -2435,7 +2435,13 @@ function updatePipelineReviewSidebarVisibility() {
   var ss = document.getElementById('sidebarScoring');
   if (ss) ss.style.display = hasQualityResults() ? '' : 'none';
   var sg = document.getElementById('sidebarGrouping');
-  if (sg) sg.style.display = '';
+  // Species-only review has no burst/quality/keep/reject output, and
+  // /api/pipeline/regroup-live always runs the full pipeline — nudging a
+  // grouping slider here would clobber the all-REVIEW cache with quality
+  // triage results, reintroducing the culling pipeline that identify mode
+  // is meant to skip. Hide the grouping sidebar in that mode; users who
+  // want to change grouping can switch to advanced mode and rerun.
+  if (sg) sg.style.display = (pipelineResults && pipelineResults.review_mode === 'species') ? 'none' : '';
 }
 
 function toggleEncounter(idx) {

--- a/vireo/tests/test_config_schema.py
+++ b/vireo/tests/test_config_schema.py
@@ -348,6 +348,7 @@ def test_validate_nullable_enum_accepts_null():
 
     assert validate_value("pipeline.default_strategy", None) is None
     assert validate_value("pipeline.default_strategy", "") is None
+    assert validate_value("pipeline.default_strategy", "identify") == "identify"
     assert validate_value("pipeline.default_strategy", "full") == "full"
 
 

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -2459,6 +2459,23 @@ def test_pipeline_strategy_expands_flags(app_and_db):
         assert cfg["skip_regroup"] is True
 
 
+def test_pipeline_identify_strategy_keeps_classify_only(app_and_db, monkeypatch):
+    app, _ = app_and_db
+    col_id = _make_collection(app)
+    _fake_active_model(monkeypatch)
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/pipeline", json={
+            "collection_id": col_id, "strategy": "identify",
+        })
+        assert resp.status_code == 200
+        cfg = _job_config(client, resp.get_json()["job_id"])
+        assert cfg["strategy"] == "identify"
+        assert cfg["skip_classify"] is False
+        assert cfg["skip_extract_masks"] is True
+        assert cfg["skip_regroup"] is True
+        assert cfg["miss_enabled"] is False
+
+
 def test_pipeline_cull_ready_pins_miss_enabled_false(app_and_db, monkeypatch):
     # quick_look alone can't prove miss_enabled reached PipelineParams:
     # it also sets skip_classify=True, and the misses stage is downstream
@@ -2509,8 +2526,7 @@ def test_pipeline_null_strategy_400(app_and_db):
 
 
 def test_pipeline_none_string_strategy_400(app_and_db):
-    # The literal string "none" is not a valid strategy name either
-    # (STRATEGIES only holds full / cull_ready / quick_look).
+    # The literal string "none" is not a valid strategy name either.
     app, _ = app_and_db
     col_id = _make_collection(app)
     with app.test_client() as client:

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -2474,6 +2474,11 @@ def test_pipeline_identify_strategy_keeps_classify_only(app_and_db, monkeypatch)
         assert cfg["skip_extract_masks"] is True
         assert cfg["skip_regroup"] is True
         assert cfg["miss_enabled"] is False
+        # Only identify opts into the species-only save path — the flag
+        # that gates regroup_stage's ``run_species_review_pipeline`` call.
+        # Without it, a Custom body posting ``skip_regroup: true`` would
+        # incorrectly land there too.
+        assert cfg["review_mode"] == "species"
 
 
 def test_pipeline_cull_ready_pins_miss_enabled_false(app_and_db, monkeypatch):
@@ -2564,6 +2569,31 @@ def test_pipeline_explicit_flags_beat_strategy(app_and_db, monkeypatch):
         cfg = _job_config(client, resp.get_json()["job_id"])
         assert cfg["skip_regroup"] is True
         assert cfg["skip_classify"] is False
+        # Full's ``review_mode`` is None. Pinning ``skip_regroup=True`` on
+        # top of it must NOT bleed the identify preset's species-only
+        # save path in — the regroup stage should skip cleanly instead of
+        # overwriting the workspace cache with all-REVIEW output.
+        assert cfg.get("review_mode") is None
+
+
+def test_pipeline_skip_regroup_without_strategy_has_no_review_mode(
+    app_and_db, monkeypatch,
+):
+    # No strategy at all + ``skip_regroup: true`` — the exact shape the
+    # reviewer flagged: an API client refreshing classifications without
+    # touching grouping. The species-only cache write must not fire, so
+    # ``review_mode`` must be None in the resulting job config.
+    app, _ = app_and_db
+    col_id = _make_collection(app)
+    _fake_active_model(monkeypatch)
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/pipeline", json={
+            "collection_id": col_id, "skip_regroup": True,
+        })
+        assert resp.status_code == 200
+        cfg = _job_config(client, resp.get_json()["job_id"])
+        assert cfg["skip_regroup"] is True
+        assert cfg.get("review_mode") is None
 
 
 # ---------------------------------------------------------------------------

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -420,6 +420,30 @@ def test_run_full_pipeline(tmp_path):
     assert s["keep_count"] + s["review_count"] + s["reject_count"] == 6
 
 
+def test_run_species_review_pipeline_labels_all_review_without_scores(tmp_path):
+    """Identify-only results support review without pretending to cull."""
+    from pipeline import (
+        load_photo_features,
+        run_species_review_pipeline,
+        serialize_results,
+    )
+
+    db, ids = _setup_db_with_photos(tmp_path)
+    photos = load_photo_features(db)
+
+    results = run_species_review_pipeline(photos)
+    serialized = serialize_results(results)
+
+    assert serialized["review_mode"] == "species"
+    assert serialized["summary"]["total_photos"] == 6
+    assert serialized["summary"]["review_count"] == 6
+    assert serialized["summary"]["keep_count"] == 0
+    assert serialized["summary"]["reject_count"] == 0
+    assert {p["label"] for p in serialized["photos"]} == {"REVIEW"}
+    assert all("quality_composite" not in p for p in serialized["photos"])
+    assert serialized["encounters"][0]["species_predictions"]
+
+
 # -- serialize_results + save/load --
 
 

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -1326,6 +1326,39 @@ def test_save_results_preserves_miss_computed_at_across_reflow(tmp_path):
     assert loaded["miss_computed_at"] == "2026-04-22T12:00:00.000000+00:00"
 
 
+def test_save_results_preserve_miss_marker_false_drops_existing(tmp_path):
+    """When called with preserve_miss_marker=False, save_results must
+    drop any prior miss_computed_at marker instead of carrying it
+    forward. The identify/species-only pipeline uses this so Pipeline
+    Review doesn't render misses from an earlier full run as if this
+    pass produced them."""
+    from pipeline import (
+        load_photo_features,
+        load_results,
+        run_full_pipeline,
+        save_results,
+        save_results_raw,
+    )
+
+    db, ids = _setup_db_with_photos(tmp_path)
+    photos = load_photo_features(db)
+    results = run_full_pipeline(photos)
+
+    cache_dir = str(tmp_path)
+    save_results(results, cache_dir, workspace_id=1)
+
+    raw = load_results(cache_dir, workspace_id=1)
+    raw["miss_computed_at"] = "2026-04-22T12:00:00.000000+00:00"
+    save_results_raw(raw, cache_dir, workspace_id=1)
+
+    fresh = run_full_pipeline(photos)
+    assert "miss_computed_at" not in fresh
+    save_results(fresh, cache_dir, workspace_id=1, preserve_miss_marker=False)
+
+    loaded = load_results(cache_dir, workspace_id=1)
+    assert "miss_computed_at" not in loaded
+
+
 def test_save_results_new_marker_overrides_existing(tmp_path):
     """When the caller's results dict does carry miss_computed_at (e.g.
     a fresh full pipeline run restamping the marker), it must win over

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -10743,11 +10743,16 @@ def test_miss_enabled_false_param_short_circuits_before_compute(
 
 
 def test_identify_run_prepares_species_review_cache(tmp_path, monkeypatch):
-    """skip_regroup + classify still writes species review results."""
+    """Identify preset (skip_regroup + classify + review_mode=species)
+    writes species review results."""
     runner, result, spy_calls, job = _run_pipeline_for_miss_tests(
         tmp_path, monkeypatch,
         pipeline_cfg={"miss_enabled": True},
-        params_extra={"skip_regroup": True, "miss_enabled": False},
+        params_extra={
+            "skip_regroup": True,
+            "miss_enabled": False,
+            "review_mode": "species",
+        },
     )
     assert result["stages"]["review"] == {"review_count": 1}
     assert spy_calls == []
@@ -10759,6 +10764,35 @@ def test_identify_run_prepares_species_review_cache(tmp_path, monkeypatch):
         "status": "completed",
         "summary": "Review results ready",
     } in regroup_steps
+
+
+def test_classify_only_skip_regroup_does_not_write_species_cache(
+    tmp_path, monkeypatch,
+):
+    """Advanced/Custom classify-only path: skip_regroup=True with classify
+    on but no ``review_mode`` opt-in must SKIP regroup entirely rather than
+    fall through to the identify preset's species-review save. Otherwise a
+    user who just disabled Group & Score to refresh classifications would
+    silently see the workspace cache overwritten with all-REVIEW output —
+    the culling-pipeline downgrade the reviewer flagged."""
+    runner, result, spy_calls, job = _run_pipeline_for_miss_tests(
+        tmp_path, monkeypatch,
+        pipeline_cfg={"miss_enabled": True},
+        params_extra={
+            "skip_regroup": True,
+            "miss_enabled": False,
+            # review_mode intentionally left at its default (None) — this
+            # is the shape /api/jobs/pipeline gets from a Custom-strategy
+            # body that ticks off Group without setting a strategy name.
+        },
+    )
+    # No "review" summary got written — species-review pipeline never ran.
+    assert "review" not in result["stages"]
+    assert _last_stages(runner)["regroup"]["status"] == "skipped"
+    regroup_steps = [
+        kw for (_, step, kw) in runner.step_updates if step == "regroup"
+    ]
+    assert {"status": "completed", "summary": "Skipped"} in regroup_steps
 
 
 def test_miss_enabled_true_param_overrides_disabled_workspace(

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -10664,6 +10664,15 @@ def _run_pipeline_for_miss_tests(tmp_path, monkeypatch, *, pipeline_cfg,
         },
     )
     monkeypatch.setattr(
+        pipeline_mod, "run_species_review_pipeline",
+        lambda photos, config=None, emit_trace=False: {
+            "review_mode": "species",
+            "summary": {"review_count": len(photos)},
+            "photos": photos,
+            "encounters": [],
+        },
+    )
+    monkeypatch.setattr(
         pipeline_mod, "save_results", lambda results, cache_dir, ws: None,
     )
     monkeypatch.setattr(
@@ -10731,6 +10740,25 @@ def test_miss_enabled_false_param_short_circuits_before_compute(
         kw for (_, step, kw) in runner.step_updates if step == "misses"
     ]
     assert {"status": "completed", "summary": "Skipped"} in miss_steps
+
+
+def test_identify_run_prepares_species_review_cache(tmp_path, monkeypatch):
+    """skip_regroup + classify still writes species review results."""
+    runner, result, spy_calls, job = _run_pipeline_for_miss_tests(
+        tmp_path, monkeypatch,
+        pipeline_cfg={"miss_enabled": True},
+        params_extra={"skip_regroup": True, "miss_enabled": False},
+    )
+    assert result["stages"]["review"] == {"review_count": 1}
+    assert spy_calls == []
+    assert _last_stages(runner)["regroup"]["status"] == "completed"
+    regroup_steps = [
+        kw for (_, step, kw) in runner.step_updates if step == "regroup"
+    ]
+    assert {
+        "status": "completed",
+        "summary": "Review results ready",
+    } in regroup_steps
 
 
 def test_miss_enabled_true_param_overrides_disabled_workspace(

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -10673,7 +10673,7 @@ def _run_pipeline_for_miss_tests(tmp_path, monkeypatch, *, pipeline_cfg,
         },
     )
     monkeypatch.setattr(
-        pipeline_mod, "save_results", lambda results, cache_dir, ws: None,
+        pipeline_mod, "save_results", lambda *a, **kw: None,
     )
     monkeypatch.setattr(
         pipeline_mod, "load_photo_features",

--- a/vireo/tests/test_pipeline_plan.py
+++ b/vireo/tests/test_pipeline_plan.py
@@ -1972,6 +1972,44 @@ def test_regroup_plan_will_skip_when_disabled(tmp_path):
     assert plan["stages"]["Group"]["state"] == "will-skip"
 
 
+def test_regroup_plan_will_run_species_review_for_identify_preset(tmp_path):
+    """The identify preset sets ``skip_regroup=True`` but flags
+    ``review_mode="species"``, and ``regroup_stage`` (pipeline_job.py) then
+    runs the species-review pipeline and overwrites the workspace cache. The
+    plan must NOT report "Disabled" here — that lies about the work the
+    next press performs (and hides that identify wipes the existing full
+    Group cache/fingerprint on save).
+    """
+    from pipeline_plan import compute_plan
+    db, _ = _make_db(tmp_path)
+    plan = compute_plan(
+        db,
+        _params(skip_regroup=True, review_mode="species"),
+        str(tmp_path / "test.db"),
+    )
+    group = plan["stages"]["Group"]
+    assert group["state"] == "will-run", group
+    assert "species review" in group["summary"].lower(), group
+
+
+def test_regroup_plan_species_review_ignored_when_classify_also_disabled(tmp_path):
+    """species review only runs when classify runs (regroup_stage's
+    species branch requires ``not skip_classify``). If a caller sends
+    ``review_mode="species"`` alongside ``skip_classify=True``, the actual
+    job skips grouping — the plan must too.
+    """
+    from pipeline_plan import compute_plan
+    db, _ = _make_db(tmp_path)
+    plan = compute_plan(
+        db,
+        _params(
+            skip_regroup=True, skip_classify=True, review_mode="species",
+        ),
+        str(tmp_path / "test.db"),
+    )
+    assert plan["stages"]["Group"]["state"] == "will-skip"
+
+
 def test_regroup_plan_done_prior_when_cache_exists_and_no_upstream_work(tmp_path, monkeypatch):
     """The other headline bug: Group & Score had no signal at all and
     always said "Will run." When the cache exists and no upstream stage
@@ -2177,6 +2215,48 @@ def test_api_pipeline_plan_returns_per_stage_state(app_and_db):
     assert data["stages"]["Extract"]["state"] == "will-skip"
     assert data["stages"]["EyeKeypoints"]["state"] == "will-skip"
     assert data["stages"]["Group"]["state"] == "will-skip"
+
+
+def test_api_pipeline_plan_expands_identify_strategy_to_species_review(app_and_db):
+    """Frontend sends the strategy name so the plan endpoint expands it the
+    same way /api/jobs/pipeline does. Before this route knew about the
+    ``identify`` preset, the plan reported Group as "Disabled — stage will
+    be skipped" because the frontend sent ``skip_regroup=true`` without the
+    ``review_mode`` that identify actually runs — a lie about the plan
+    summary for the default workflow.
+    """
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post(
+        "/api/pipeline/plan",
+        json={
+            "strategy": "identify",
+            # Mirror what applyStrategyPreset() sets when identify is picked:
+            # classify on, extract/eyes/group off.
+            "skip_classify": False,
+            "skip_extract_masks": True,
+            "skip_eye_keypoints": True,
+            "skip_regroup": True,
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    group = data["stages"]["Group"]
+    assert group["state"] == "will-run", group
+    assert "species review" in group["summary"].lower(), group
+
+
+def test_api_pipeline_plan_rejects_unknown_strategy(app_and_db):
+    """A bad strategy name must 400 — otherwise the plan silently falls back
+    to the raw skip flags and disagrees with what /api/jobs/pipeline would
+    do (which 400s the same input)."""
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post(
+        "/api/pipeline/plan",
+        json={"strategy": "does_not_exist"},
+    )
+    assert resp.status_code == 400
 
 
 def test_api_pipeline_plan_collection_scope(app_and_db):

--- a/vireo/tests/test_pipeline_plan.py
+++ b/vireo/tests/test_pipeline_plan.py
@@ -2246,6 +2246,83 @@ def test_api_pipeline_plan_expands_identify_strategy_to_species_review(app_and_d
     assert "species review" in group["summary"].lower(), group
 
 
+def test_api_pipeline_plan_strategy_only_body_merges_skip_flags(app_and_db):
+    """A body of just ``{"strategy": "quick_look"}`` (no explicit skip
+    flags) must plan the same run ``/api/jobs/pipeline`` would run — every
+    stage that quick_look disables must report skipped/disabled, not the
+    ``skip_* = false`` defaults the raw ``PipelinePlanParams`` would use.
+
+    Before the plan route merged the full strategy expansion, it copied
+    only ``review_mode`` from the expansion and left every ``skip_*``
+    field at its default False, so an API caller sending strategy-only
+    got a plan that promised Classify/Extract/Group work the actual
+    strategy job would skip.
+    """
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post(
+        "/api/pipeline/plan",
+        json={"strategy": "quick_look"},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    # quick_look: skip_classify + skip_extract + skip_eyes + skip_regroup
+    for stage in ("Classify", "Extract", "EyeKeypoints", "Group"):
+        assert data["stages"][stage]["state"] == "will-skip", (stage, data)
+
+
+def test_api_pipeline_plan_strategy_only_identify_runs_species_review(app_and_db):
+    """Strategy-only identify must still surface the species-review branch.
+
+    Pairs with the quick_look case above: identify sets skip_regroup=True
+    *and* review_mode="species", and the plan must reflect that the Group
+    stage will prepare species review even though skip_regroup came from
+    the expansion (not an explicit body key).
+    """
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post(
+        "/api/pipeline/plan",
+        json={"strategy": "identify"},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    group = data["stages"]["Group"]
+    assert group["state"] == "will-run", group
+    assert "species review" in group["summary"].lower(), group
+    # Extract/EyeKeypoints must still report skipped — the strategy's
+    # skip flags applied even though the body sent only ``strategy``.
+    assert data["stages"]["Extract"]["state"] == "will-skip", data
+    assert data["stages"]["EyeKeypoints"]["state"] == "will-skip", data
+
+
+def test_api_pipeline_plan_explicit_body_key_wins_over_strategy(app_and_db):
+    """Strategy expansion supplies *defaults*: an explicit body key must
+    still override, mirroring ``/api/jobs/pipeline``. Without this an
+    Advanced/Custom caller can't pin one flag on top of a preset.
+
+    quick_look sets ``skip_regroup=True`` — a body that pins
+    ``skip_regroup=False`` alongside the strategy must produce a Group
+    plan for a real run, not the "Disabled" summary skip_regroup=True
+    would emit. The summary text distinguishes the two branches so the
+    assertion is robust to unrelated environmental reasons a stage might
+    also report will-skip (missing models, no eligible photos, etc.).
+    """
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post(
+        "/api/pipeline/plan",
+        json={"strategy": "quick_look", "skip_regroup": False},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    group = data["stages"]["Group"]
+    # skip_regroup=True would produce "Disabled — stage will be skipped"
+    # (pipeline_plan._regroup_plan). Explicit False must route around
+    # that branch entirely.
+    assert "disabled" not in group["summary"].lower(), group
+
+
 def test_api_pipeline_plan_rejects_unknown_strategy(app_and_db):
     """A bad strategy name must 400 — otherwise the plan silently falls back
     to the raw skip flags and disagrees with what /api/jobs/pipeline would

--- a/vireo/tests/test_pipeline_plan.py
+++ b/vireo/tests/test_pipeline_plan.py
@@ -1972,15 +1972,26 @@ def test_regroup_plan_will_skip_when_disabled(tmp_path):
     assert plan["stages"]["Group"]["state"] == "will-skip"
 
 
-def test_regroup_plan_will_run_species_review_for_identify_preset(tmp_path):
+def test_regroup_plan_will_run_species_review_for_identify_preset(
+    tmp_path, monkeypatch,
+):
     """The identify preset sets ``skip_regroup=True`` but flags
     ``review_mode="species"``, and ``regroup_stage`` (pipeline_job.py) then
     runs the species-review pipeline and overwrites the workspace cache. The
     plan must NOT report "Disabled" here — that lies about the work the
     next press performs (and hides that identify wipes the existing full
     Group cache/fingerprint on save).
+
+    Requires a downloaded/active model: ``/api/jobs/pipeline`` auto-flips
+    ``skip_classify`` on installs without one, and the species-review
+    branch can't run then. The plan mirrors that no-model degradation —
+    see ``test_regroup_plan_species_review_skipped_when_no_active_model``.
     """
     from pipeline_plan import compute_plan
+    import models as models_mod
+    monkeypatch.setattr(models_mod, "get_active_model", lambda: {
+        "id": "m1", "name": "BioCLIP-2", "downloaded": True,
+    })
     db, _ = _make_db(tmp_path)
     plan = compute_plan(
         db,
@@ -2004,6 +2015,59 @@ def test_regroup_plan_species_review_ignored_when_classify_also_disabled(tmp_pat
         db,
         _params(
             skip_regroup=True, skip_classify=True, review_mode="species",
+        ),
+        str(tmp_path / "test.db"),
+    )
+    assert plan["stages"]["Group"]["state"] == "will-skip"
+
+
+def test_regroup_plan_species_review_skipped_when_no_active_model(
+    tmp_path, monkeypatch,
+):
+    """No downloaded/active model → ``/api/jobs/pipeline`` calls
+    ``_apply_no_model_auto_skip`` and flips ``skip_classify`` +
+    ``skip_regroup`` to True, so ``regroup_stage`` skips and no
+    species-review cache is prepared. The plan must mirror that
+    degradation instead of promising "Will prepare species review" for
+    a run that will only show the no-model warning.
+    """
+    from pipeline_plan import compute_plan
+    import models as models_mod
+    # No downloaded model, no active model — the plan-side auto-skip
+    # gate should trip. The `_make_db` fixture already ships no models,
+    # but the dev's real ~/.vireo/models.json could bleed in without
+    # this monkeypatch.
+    monkeypatch.setattr(models_mod, "get_models", lambda: [])
+    monkeypatch.setattr(models_mod, "get_active_model", lambda: None)
+    db, _ = _make_db(tmp_path)
+    plan = compute_plan(
+        db,
+        _params(skip_regroup=True, review_mode="species"),
+        str(tmp_path / "test.db"),
+    )
+    group = plan["stages"]["Group"]
+    assert group["state"] == "will-skip", group
+    assert "disabled" in group["summary"].lower(), group
+
+
+def test_regroup_plan_species_review_skipped_when_selected_model_not_downloaded(
+    tmp_path, monkeypatch,
+):
+    """The auto-skip in ``/api/jobs/pipeline`` also trips when every
+    requested ``model_ids`` entry is missing its download. The plan
+    must not advertise species review in that case either.
+    """
+    from pipeline_plan import compute_plan
+    import models as models_mod
+    monkeypatch.setattr(models_mod, "get_models", lambda: [
+        {"id": "m1", "name": "BioCLIP-2", "downloaded": False},
+    ])
+    monkeypatch.setattr(models_mod, "get_active_model", lambda: None)
+    db, _ = _make_db(tmp_path)
+    plan = compute_plan(
+        db,
+        _params(
+            skip_regroup=True, review_mode="species", model_ids=["m1"],
         ),
         str(tmp_path / "test.db"),
     )
@@ -2217,15 +2281,25 @@ def test_api_pipeline_plan_returns_per_stage_state(app_and_db):
     assert data["stages"]["Group"]["state"] == "will-skip"
 
 
-def test_api_pipeline_plan_expands_identify_strategy_to_species_review(app_and_db):
+def test_api_pipeline_plan_expands_identify_strategy_to_species_review(
+    app_and_db, monkeypatch,
+):
     """Frontend sends the strategy name so the plan endpoint expands it the
     same way /api/jobs/pipeline does. Before this route knew about the
     ``identify`` preset, the plan reported Group as "Disabled — stage will
     be skipped" because the frontend sent ``skip_regroup=true`` without the
     ``review_mode`` that identify actually runs — a lie about the plan
     summary for the default workflow.
+
+    An active model must resolve for the plan to promise species review —
+    on no-model installs the job auto-skips; see the paired plan-side
+    ``test_regroup_plan_species_review_skipped_when_no_active_model``.
     """
     app, _ = app_and_db
+    import models as models_mod
+    monkeypatch.setattr(models_mod, "get_active_model", lambda: {
+        "id": "m1", "name": "BioCLIP-2", "downloaded": True,
+    })
     client = app.test_client()
     resp = client.post(
         "/api/pipeline/plan",
@@ -2271,7 +2345,9 @@ def test_api_pipeline_plan_strategy_only_body_merges_skip_flags(app_and_db):
         assert data["stages"][stage]["state"] == "will-skip", (stage, data)
 
 
-def test_api_pipeline_plan_strategy_only_identify_runs_species_review(app_and_db):
+def test_api_pipeline_plan_strategy_only_identify_runs_species_review(
+    app_and_db, monkeypatch,
+):
     """Strategy-only identify must still surface the species-review branch.
 
     Pairs with the quick_look case above: identify sets skip_regroup=True
@@ -2280,6 +2356,10 @@ def test_api_pipeline_plan_strategy_only_identify_runs_species_review(app_and_db
     the expansion (not an explicit body key).
     """
     app, _ = app_and_db
+    import models as models_mod
+    monkeypatch.setattr(models_mod, "get_active_model", lambda: {
+        "id": "m1", "name": "BioCLIP-2", "downloaded": True,
+    })
     client = app.test_client()
     resp = client.post(
         "/api/pipeline/plan",
@@ -2294,6 +2374,28 @@ def test_api_pipeline_plan_strategy_only_identify_runs_species_review(app_and_db
     # skip flags applied even though the body sent only ``strategy``.
     assert data["stages"]["Extract"]["state"] == "will-skip", data
     assert data["stages"]["EyeKeypoints"]["state"] == "will-skip", data
+
+
+def test_api_pipeline_plan_identify_no_model_mirrors_job_auto_skip(app_and_db):
+    """On installs with no active model, ``/api/jobs/pipeline`` calls
+    ``_apply_no_model_auto_skip`` and flips ``skip_classify`` +
+    ``skip_regroup`` to True, so the identify run only shows the
+    no-model warning and skips regroup. The plan endpoint must mirror
+    that degradation instead of promising "Will prepare species review"
+    for the default workflow on a fresh install.
+    """
+    app, _ = app_and_db
+    # `app_and_db` already redirects models.DEFAULT_MODELS_DIR/CONFIG_PATH
+    # to tmp_path, so `get_active_model()` returns None here without any
+    # extra monkeypatching — a clean fresh install.
+    client = app.test_client()
+    resp = client.post(
+        "/api/pipeline/plan",
+        json={"strategy": "identify"},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["stages"]["Group"]["state"] == "will-skip", data
 
 
 def test_api_pipeline_plan_explicit_body_key_wins_over_strategy(app_and_db):

--- a/vireo/tests/test_process_strategies.py
+++ b/vireo/tests/test_process_strategies.py
@@ -17,6 +17,12 @@ def test_full_skips_nothing():
     flags = resolve_strategy("full")
     assert not any(v for k, v in flags.items() if k.startswith("skip_"))
     assert flags["miss_enabled"] is True
+    # ``review_mode`` distinguishes the identify preset's species-only
+    # save path from a generic classify-only run. Full processing must
+    # never trigger it, otherwise a caller who pinned ``skip_regroup=True``
+    # onto a full-strategy run would silently downgrade the workspace
+    # cache to all-REVIEW output.
+    assert flags["review_mode"] is None
 
 
 def test_cull_ready_skips_expensive_extras():
@@ -27,6 +33,7 @@ def test_cull_ready_skips_expensive_extras():
     # classify and regroup stay on: review pages need predictions + encounters
     assert flags["skip_classify"] is False
     assert flags["skip_regroup"] is False
+    assert flags["review_mode"] is None
 
 
 def test_identify_keeps_classify_but_skips_quality_stack():
@@ -36,6 +43,11 @@ def test_identify_keeps_classify_but_skips_quality_stack():
     assert flags["skip_eye_keypoints"] is True
     assert flags["skip_regroup"] is True
     assert flags["miss_enabled"] is False
+    # Only the identify preset flips this on; regroup_stage keys the
+    # species-only cache write off exactly this value so generic
+    # ``skip_regroup=True`` requests skip the stage instead of writing
+    # all-REVIEW output over the workspace cache.
+    assert flags["review_mode"] == "species"
 
 
 def test_quick_look_is_thumbs_and_previews_only():
@@ -45,6 +57,7 @@ def test_quick_look_is_thumbs_and_previews_only():
     assert flags["skip_eye_keypoints"] is True
     assert flags["skip_regroup"] is True
     assert flags["miss_enabled"] is False
+    assert flags["review_mode"] is None
 
 
 def test_unknown_strategy_raises():

--- a/vireo/tests/test_process_strategies.py
+++ b/vireo/tests/test_process_strategies.py
@@ -5,12 +5,12 @@ from process_strategies import STRATEGIES, resolve_strategy
 
 def test_known_strategies():
     # The whitelist is deliberately narrow: only *processing* presets.
-    # The design doc's "None" / import-only choice is NOT a fourth
+    # The design doc's "None" / import-only choice is NOT another
     # entry here — it lives at the import→process boundary (workspace
     # default in Task 1.5, chaining hook in PR 3). Adding an entry like
     # "none" here would make the process-job API accept it and enqueue
     # a no-op run instead of letting the chaining hook short-circuit.
-    assert set(STRATEGIES) == {"full", "cull_ready", "quick_look"}
+    assert set(STRATEGIES) == {"identify", "full", "cull_ready", "quick_look"}
 
 
 def test_full_skips_nothing():
@@ -27,6 +27,15 @@ def test_cull_ready_skips_expensive_extras():
     # classify and regroup stay on: review pages need predictions + encounters
     assert flags["skip_classify"] is False
     assert flags["skip_regroup"] is False
+
+
+def test_identify_keeps_classify_but_skips_quality_stack():
+    flags = resolve_strategy("identify")
+    assert flags["skip_classify"] is False
+    assert flags["skip_extract_masks"] is True
+    assert flags["skip_eye_keypoints"] is True
+    assert flags["skip_regroup"] is True
+    assert flags["miss_enabled"] is False
 
 
 def test_quick_look_is_thumbs_and_previews_only():


### PR DESCRIPTION
## Summary
- Adds an identify-only processing strategy that keeps species classification and review results while skipping experimental quality/culling stages by default.
- Renames Developer Mode to Advanced Mode and hides full/cull/custom processing controls plus quality stage cards behind it.
- Updates Pipeline Review to avoid showing fake quality scores for identify-only results.

## Validation
- pytest vireo/tests/test_process_strategies.py vireo/tests/test_config_schema.py::test_validate_nullable_enum_accepts_null vireo/tests/test_jobs_api.py::test_pipeline_identify_strategy_keeps_classify_only vireo/tests/test_pipeline.py::test_run_species_review_pipeline_labels_all_review_without_scores vireo/tests/test_pipeline_job.py::test_identify_run_prepares_species_review_cache vireo/tests/test_app.py::test_import_page_returns_200 vireo/tests/test_app.py::test_process_page_has_no_import_source tests/test_workspaces.py::test_create_workspace_accepts_valid_default_strategy tests/test_workspaces.py::test_workspace_default_strategy_unknown_400
- python -m py_compile vireo/process_strategies.py vireo/pipeline.py vireo/pipeline_job.py vireo/config_schema.py && git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **Identify birds** preset for workspace and pipeline workflows.
  * Introduced an advanced review path that prepares species-only review results when using the identify preset.
  * Updated the review screens to hide irrelevant sections when quality scores or grouping details aren’t available.

* **Bug Fixes**
  * Improved strategy handling so defaults and manual selections stay in sync.
  * Ensured pipeline review mode is preserved across planning, execution, and saved results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->