### PR TITLE
Show collection on jobs page

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -17935,6 +17935,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "source": None,
             "sources": None,
             "collection_id": collection_id,
+            "collection_name": next(
+                (
+                    c["name"]
+                    for c in thread_db.get_collections()
+                    if c["id"] == collection_id
+                ),
+                None,
+            ),
             "destination": None,
             "local_processing": False,
             "strategy": strategy_name,
@@ -18522,17 +18530,29 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if pending_folder_collection is not None:
             from datetime import datetime as _dt
 
+            collection_name = "Process {} {}".format(
+                pending_folder_collection["leaf"],
+                _dt.now().strftime("%Y-%m-%d %H:%M"),
+            )
             collection_id = db.add_collection(
-                "Process {} {}".format(
-                    pending_folder_collection["leaf"],
-                    _dt.now().strftime("%Y-%m-%d %H:%M"),
-                ),
+                collection_name,
                 json.dumps([{
                     "field": "photo_ids",
                     "value": pending_folder_collection["photo_ids"],
                 }]),
             )
             params.collection_id = collection_id
+        elif collection_id is not None:
+            collection_name = next(
+                (
+                    c["name"]
+                    for c in db.get_collections()
+                    if c["id"] == collection_id
+                ),
+                None,
+            )
+        else:
+            collection_name = None
 
         # Auto-skip classify stages if no model is available. Shared with
         # the after-import chaining hook so a chained run and a manually
@@ -18603,6 +18623,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "source": source,
             "sources": sources,
             "collection_id": collection_id,
+            "collection_name": collection_name,
             "destination": destination,
             "local_processing": local_processing,
             "strategy": strategy_name,

--- a/vireo/templates/jobs.html
+++ b/vireo/templates/jobs.html
@@ -116,7 +116,7 @@
 .job-detail-status.failed { background: color-mix(in srgb, var(--danger) 20%, transparent); color: var(--danger); }
 .job-detail-meta {
   font-size: 12px; color: var(--text-muted); display: flex; gap: 16px;
-  padding: 8px 24px; border-bottom: 1px solid var(--border-subtle);
+  flex-wrap: wrap; padding: 8px 24px; border-bottom: 1px solid var(--border-subtle);
 }
 .btn-cancel {
   font-size: 12px; padding: 4px 12px; border-radius: 4px; cursor: pointer;
@@ -341,6 +341,19 @@
     return Math.max(0, Math.min(100, Math.round((info.current / info.total) * 100)));
   }
 
+  function jobConfig(job) {
+    return job && job.config && typeof job.config === 'object' ? job.config : {};
+  }
+
+  function jobCollectionText(job) {
+    var cfg = jobConfig(job);
+    if (cfg.collection_name) return 'Collection: ' + cfg.collection_name;
+    if (cfg.collection_id !== undefined && cfg.collection_id !== null && cfg.collection_id !== '') {
+      return 'Collection #' + cfg.collection_id;
+    }
+    return '';
+  }
+
   function renderJobCard(job, options) {
     options = options || {};
     // Queued pipelines are "live" for UI purposes: they have a real
@@ -380,6 +393,10 @@
     html += '<div class="job-detail-meta">';
     html += '<span>Started: ' + new Date(job.started_at).toLocaleTimeString() + '</span>';
     html += '<span>Elapsed: ' + elapsed + '</span>';
+    var collectionText = jobCollectionText(job);
+    if (collectionText) {
+      html += '<span>' + esc(collectionText) + '</span>';
+    }
     var visibleProgress = activeProgress(job.progress);
     if (visibleProgress) {
       html += '<span>' + esc(visibleProgress.label) + ': ' + progressPct(visibleProgress) + '%</span>';
@@ -673,6 +690,7 @@
     }
     var detail = '';
     var visibleProgress = activeProgress(j.progress);
+    var collectionText = jobCollectionText(j);
     if (j.status === 'running' && j.progress && j.progress.phase) {
       detail = esc(j.progress.phase);
       if (visibleProgress && visibleProgress.phase) {
@@ -684,6 +702,9 @@
       detail = '<span style="color:var(--danger);">' + esc(j.errors[0]).substring(0, 60) + '</span>';
     } else if (j.duration) {
       detail = formatElapsed(j.duration);
+    }
+    if (collectionText) {
+      detail = detail ? detail + ' &middot; ' + esc(collectionText) : esc(collectionText);
     }
     var pct = 0;
     if (visibleProgress) {

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -684,6 +684,36 @@ def test_pipeline_job_with_collection_returns_job_id(app_and_db):
         assert data["job_id"].startswith("pipeline-")
 
 
+def test_pipeline_job_config_includes_collection_name(app_and_db, monkeypatch):
+    """Collection-scoped jobs carry the collection name for the Jobs page."""
+    import json
+
+    import pipeline_job
+    from db import Database
+
+    app, _ = app_and_db
+    db = Database(app.config["DB_PATH"])
+    db.set_active_workspace(db._active_workspace_id)
+    col_id = db.add_collection("Costa Rica selects", json.dumps([]))
+
+    def fake_run(job, runner, db_path, workspace_id, params, thumb_cache_dir=None):
+        return {"ok": True}
+
+    monkeypatch.setattr(pipeline_job, "run_pipeline_job", fake_run)
+
+    with app.test_client() as client:
+        resp = client.post("/api/jobs/pipeline", json={
+            "collection_id": col_id,
+            "skip_classify": True,
+            "skip_extract_masks": True,
+            "skip_regroup": True,
+        })
+        assert resp.status_code == 200
+        cfg = _job_config(client, resp.get_json()["job_id"])
+        assert cfg["collection_id"] == col_id
+        assert cfg["collection_name"] == "Costa Rica selects"
+
+
 def test_pipeline_auto_skips_classify_when_no_model(app_and_db):
     """Pipeline should auto-skip classify/extract/regroup when no model is available."""
     import json

--- a/vireo/tests/test_pipeline_plan.py
+++ b/vireo/tests/test_pipeline_plan.py
@@ -1987,8 +1987,8 @@ def test_regroup_plan_will_run_species_review_for_identify_preset(
     branch can't run then. The plan mirrors that no-model degradation —
     see ``test_regroup_plan_species_review_skipped_when_no_active_model``.
     """
-    from pipeline_plan import compute_plan
     import models as models_mod
+    from pipeline_plan import compute_plan
     monkeypatch.setattr(models_mod, "get_active_model", lambda: {
         "id": "m1", "name": "BioCLIP-2", "downloaded": True,
     })
@@ -2031,8 +2031,8 @@ def test_regroup_plan_species_review_skipped_when_no_active_model(
     degradation instead of promising "Will prepare species review" for
     a run that will only show the no-model warning.
     """
-    from pipeline_plan import compute_plan
     import models as models_mod
+    from pipeline_plan import compute_plan
     # No downloaded model, no active model — the plan-side auto-skip
     # gate should trip. The `_make_db` fixture already ships no models,
     # but the dev's real ~/.vireo/models.json could bleed in without
@@ -2057,8 +2057,8 @@ def test_regroup_plan_species_review_skipped_when_selected_model_not_downloaded(
     requested ``model_ids`` entry is missing its download. The plan
     must not advertise species review in that case either.
     """
-    from pipeline_plan import compute_plan
     import models as models_mod
+    from pipeline_plan import compute_plan
     monkeypatch.setattr(models_mod, "get_models", lambda: [
         {"id": "m1", "name": "BioCLIP-2", "downloaded": False},
     ])


### PR DESCRIPTION
## Summary
Show collection context on the Jobs page for collection-scoped pipeline runs, including both active jobs and history rows.
Pipeline enqueue now snapshots the collection name into job config so the UI can display readable context even after later collection changes.
Added a regression test for collection name metadata.

## Validation
- python -m pytest vireo/tests/test_jobs_api.py::test_pipeline_job_config_includes_collection_name vireo/tests/test_jobs_api.py::test_pipeline_job_with_collection_returns_job_id -q
- python -m py_compile vireo/app.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Jobs now show a collection label in the UI when available.
  * Collection information is now included alongside job details and run parameters.

* **Bug Fixes**
  * Improved collection handling so jobs can resolve a collection name from an existing collection ID.
  * Pending-folder runs now create and store a collection name automatically before job submission.

* **Tests**
  * Added coverage to verify job configuration includes the expected collection name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->