### PR TITLE
Add shared search match options

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -32,6 +32,7 @@ from db import (
     Database,
     IncompatibleDatabaseError,
     commit_with_retry,
+    text_search_match,
 )
 from flask import (
     Flask,
@@ -2752,6 +2753,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             raise ValueError("flag must be 'none', 'flagged', or 'rejected'")
         return flag
 
+    def _request_bool_arg(name):
+        raw = request.args.get(name, "")
+        return str(raw).strip().lower() in {"1", "true", "yes", "on"}
+
     @app.route("/api/browse/init")
     def api_browse_init():
         """Combined endpoint for browse page initial load — one request instead of five."""
@@ -3371,6 +3376,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         date_from = request.args.get("date_from", None)
         date_to = request.args.get("date_to", None)
         keyword = request.args.get("keyword", None)
+        keyword_match_case = _request_bool_arg("keyword_match_case")
+        keyword_whole_word = _request_bool_arg("keyword_whole_word")
         color_label = request.args.get("color_label", None)
         try:
             flag = _request_flag_filter()
@@ -3386,6 +3393,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             date_from=date_from,
             date_to=date_to,
             keyword=keyword,
+            keyword_match_case=keyword_match_case,
+            keyword_whole_word=keyword_whole_word,
             color_label=color_label,
             flag=flag,
         )
@@ -3400,6 +3409,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 date_from=date_from,
                 date_to=date_to,
                 keyword=keyword,
+                keyword_match_case=keyword_match_case,
+                keyword_whole_word=keyword_whole_word,
                 color_label=color_label,
                 flag=flag,
             )
@@ -3428,6 +3439,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         date_from = request.args.get("date_from", None)
         date_to = request.args.get("date_to", None)
         keyword = request.args.get("keyword", None)
+        keyword_match_case = _request_bool_arg("keyword_match_case")
+        keyword_whole_word = _request_bool_arg("keyword_whole_word")
         color_label = request.args.get("color_label", None)
         try:
             flag = _request_flag_filter()
@@ -3441,6 +3454,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             date_from=date_from,
             date_to=date_to,
             keyword=keyword,
+            keyword_match_case=keyword_match_case,
+            keyword_whole_word=keyword_whole_word,
             color_label=color_label,
             flag=flag,
         )
@@ -3455,6 +3470,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         folder_id = request.args.get("folder_id", None, type=int)
         rating_min = request.args.get("rating_min", None, type=int)
         keyword = request.args.get("keyword", None)
+        keyword_match_case = _request_bool_arg("keyword_match_case")
+        keyword_whole_word = _request_bool_arg("keyword_whole_word")
         color_label = request.args.get("color_label", None)
         try:
             flag = _request_flag_filter()
@@ -3462,6 +3479,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error(str(e), 400)
         data = db.get_calendar_data(
             year=year, folder_id=folder_id, rating_min=rating_min, keyword=keyword,
+            keyword_match_case=keyword_match_case,
+            keyword_whole_word=keyword_whole_word,
             color_label=color_label, flag=flag,
         )
         return jsonify(data)
@@ -3474,6 +3493,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         date_from = request.args.get("date_from", None)
         date_to = request.args.get("date_to", None)
         keyword = request.args.get("keyword", None)
+        keyword_match_case = _request_bool_arg("keyword_match_case")
+        keyword_whole_word = _request_bool_arg("keyword_whole_word")
         collection_id = request.args.get("collection_id", None, type=int)
         color_label = request.args.get("color_label", None)
         try:
@@ -3487,6 +3508,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 date_from=date_from,
                 date_to=date_to,
                 keyword=keyword,
+                keyword_match_case=keyword_match_case,
+                keyword_whole_word=keyword_whole_word,
                 collection_id=collection_id,
                 color_label=color_label,
                 flag=flag,
@@ -3779,6 +3802,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         date_from = request.args.get("date_from", None)
         date_to = request.args.get("date_to", None)
         keyword = request.args.get("keyword", None)
+        keyword_match_case = _request_bool_arg("keyword_match_case")
+        keyword_whole_word = _request_bool_arg("keyword_whole_word")
         species = request.args.get("species", None)
 
         photos = db.get_geolocated_photos(
@@ -3787,6 +3812,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             date_from=date_from,
             date_to=date_to,
             keyword=keyword,
+            keyword_match_case=keyword_match_case,
+            keyword_whole_word=keyword_whole_word,
             species=species,
         )
 
@@ -6956,6 +6983,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         confidence_threshold=0.70,
         limit_per_bucket=20,
         species_filter="",
+        species_match_case=False,
+        species_whole_word=False,
         confirmation_filter="all",
     ):
         folders = db.get_folders_with_quality_data()
@@ -6964,7 +6993,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         elif folder_id is None and folders:
             folder_id = folders[0]["id"]  # Most recent
         limit_per_bucket = max(1, min(int(limit_per_bucket), 100))
-        species_filter = (species_filter or "").strip().lower()
+        species_filter = (species_filter or "").strip()
         confirmation_filter = _normalize_highlight_confirmation_filter(
             confirmation_filter
         )
@@ -6981,9 +7010,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         _apply_highlight_preferences(db, buckets)
         if species_filter:
             buckets = [
-                b for b in buckets if species_filter in b["species"].lower()
+                b for b in buckets
+                if text_search_match(
+                    b["species"],
+                    species_filter,
+                    species_match_case,
+                    species_whole_word,
+                )
             ]
-            if "unidentified".find(species_filter) < 0:
+            if not text_search_match(
+                "unidentified",
+                species_filter,
+                species_match_case,
+                species_whole_word,
+            ):
                 unidentified_photos = []
 
         def limited_bucket(bucket):
@@ -7038,6 +7078,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             ),
             limit_per_bucket=request.args.get("limit_per_bucket", 20, type=int),
             species_filter=request.args.get("species") or "",
+            species_match_case=_request_bool_arg("species_match_case"),
+            species_whole_word=_request_bool_arg("species_whole_word"),
             confirmation_filter=request.args.get("confirmation") or "all",
         )
         return jsonify(payload)
@@ -18921,7 +18963,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     @app.route("/api/species/search")
     def api_species_search():
         """Search species names from active label sets for autocomplete."""
-        q = request.args.get("q", "").strip().lower()
+        q = request.args.get("q", "").strip()
+        match_case = _request_bool_arg("match_case")
+        whole_word = _request_bool_arg("whole_word")
         if len(q) < 2:
             return jsonify([])
 
@@ -18939,9 +18983,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         name = line.strip()
                         if not name:
                             continue
-                        name_lower = name.lower()
-                        if q in name_lower and name_lower not in seen:
-                            seen.add(name_lower)
+                        name_key = name.casefold()
+                        if (
+                            text_search_match(name, q, match_case, whole_word)
+                            and name_key not in seen
+                        ):
+                            seen.add(name_key)
                             matches.append(name)
                             if len(matches) >= 20:
                                 break
@@ -18953,12 +19000,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # Also search existing species keywords in the database
         db = _get_db()
         kw_rows = db.conn.execute(
-            "SELECT name FROM keywords WHERE is_species = 1 AND LOWER(name) LIKE ?",
-            (f"%{q}%",),
+            """SELECT name FROM keywords
+               WHERE is_species = 1
+                 AND vireo_keyword_text_match(name, ?, ?, ?)""",
+            (q, 1 if match_case else 0, 1 if whole_word else 0),
         ).fetchall()
         for row in kw_rows:
-            if row["name"].lower() not in seen:
-                seen.add(row["name"].lower())
+            name_key = row["name"].casefold()
+            if name_key not in seen:
+                seen.add(name_key)
                 matches.append(row["name"])
 
         return jsonify(matches[:20])
@@ -19819,6 +19869,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         date_from = request.args.get("date_from", None)
         date_to = request.args.get("date_to", None)
         keyword = request.args.get("keyword", None)
+        keyword_match_case = _request_bool_arg("keyword_match_case")
+        keyword_whole_word = _request_bool_arg("keyword_whole_word")
         color_label = request.args.get("color_label", None)
         collection_id = request.args.get("collection_id", None, type=int)
         try:
@@ -19854,6 +19906,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 date_from=date_from,
                 date_to=date_to,
                 keyword=keyword,
+                keyword_match_case=keyword_match_case,
+                keyword_whole_word=keyword_whole_word,
                 color_label=color_label,
                 flag=flag,
             )

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -87,16 +87,57 @@ def _escape_like(s: str) -> str:
     return s.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
-def _keyword_token_clause(keyword):
+def _is_keyword_word_char(ch):
+    return ch.isalnum()
+
+
+def _contains_whole_keyword_token(value, token):
+    start = 0
+    while True:
+        idx = value.find(token, start)
+        if idx < 0:
+            return False
+        before = idx == 0 or not _is_keyword_word_char(value[idx - 1])
+        end = idx + len(token)
+        after = end == len(value) or not _is_keyword_word_char(value[end])
+        if before and after:
+            return True
+        start = idx + 1
+
+
+def _sqlite_keyword_text_match(value, token, match_case=0, whole_word=0):
+    if value is None or token is None:
+        return 0
+    value = str(value)
+    token = str(token)
+    if not token:
+        return 1
+    if not match_case:
+        value = value.casefold()
+        token = token.casefold()
+    if whole_word:
+        return 1 if _contains_whole_keyword_token(value, token) else 0
+    return 1 if token in value else 0
+
+
+def text_search_match(value, token, match_case=False, whole_word=False):
+    return bool(_sqlite_keyword_text_match(value, token, match_case, whole_word))
+
+
+def _keyword_token_clause(keyword, match_case=False, whole_word=False):
     """Build a WHERE clause for a multi-token keyword search.
 
     The query is split on whitespace into tokens; a photo matches only if
-    EVERY token appears (case-insensitively, as a literal substring) in the
-    photo's filename or in at least one of its keyword names. Tokens may be
-    satisfied by different keywords, so "red bill" matches a photo tagged
-    "Red-billed leiothrix" (both tokens in one keyword) as well as a photo
-    tagged both "Reddish" and "Billboard" (one token each). Tokens are escaped
-    so LIKE metacharacters (``%``/``_``) in the query match literally.
+    EVERY token appears in the photo's filename or in at least one of its
+    keyword names. By default matching is case-insensitive literal substring
+    search. ``match_case`` switches to case-sensitive search. ``whole_word``
+    requires alphanumeric boundaries, so "tern" matches "Common Tern" and
+    "tern_001.jpg" but not "Western Gull". Tokens may be satisfied by
+    different keywords, so "red bill" matches a photo tagged "Red-billed
+    leiothrix" (both tokens in one keyword) as well as a photo tagged both
+    "Reddish" and "Billboard" (one token each). In the default LIKE path,
+    tokens are escaped so LIKE metacharacters (``%``/``_``) in the query match
+    literally.
 
     Returns ``(clause_sql, params)``. The clause references the outer photos
     alias ``p``, so callers must expose the photos table as ``p``. Returns
@@ -108,7 +149,20 @@ def _keyword_token_clause(keyword):
         return None, []
     clauses = []
     params = []
+    match_case_param = 1 if match_case else 0
+    whole_word_param = 1 if whole_word else 0
     for tok in tokens:
+        if match_case or whole_word:
+            clauses.append(
+                "(vireo_keyword_text_match(p.filename, ?, ?, ?) OR EXISTS ("
+                "SELECT 1 FROM photo_keywords pk_s "
+                "JOIN keywords k_s ON k_s.id = pk_s.keyword_id "
+                "WHERE pk_s.photo_id = p.id "
+                "AND vireo_keyword_text_match(k_s.name, ?, ?, ?)))"
+            )
+            params.extend([tok, match_case_param, whole_word_param])
+            params.extend([tok, match_case_param, whole_word_param])
+            continue
         like = f"%{_escape_like(tok)}%"
         clauses.append(
             "(p.filename LIKE ? ESCAPE '\\' OR EXISTS ("
@@ -326,6 +380,12 @@ class Database:
         self.conn = None
         self.conn = sqlite3.connect(db_path, check_same_thread=False)
         self.conn.row_factory = sqlite3.Row
+        self.conn.create_function(
+            "vireo_keyword_text_match",
+            4,
+            _sqlite_keyword_text_match,
+            deterministic=True,
+        )
         self.conn.execute("PRAGMA journal_mode=WAL")
         self.conn.execute("PRAGMA foreign_keys=ON")
         self.conn.execute("PRAGMA synchronous=NORMAL")
@@ -5768,7 +5828,17 @@ class Database:
             "detected_count": detected_count,
         }
 
-    def get_calendar_data(self, year, folder_id=None, rating_min=None, keyword=None, color_label=None, flag=None):
+    def get_calendar_data(
+        self,
+        year,
+        folder_id=None,
+        rating_min=None,
+        keyword=None,
+        keyword_match_case=False,
+        keyword_whole_word=False,
+        color_label=None,
+        flag=None,
+    ):
         """Return daily photo counts for a given year, scoped to active workspace."""
         ws = self._ws_id()
         conditions = ["wf.workspace_id = ?", "p.timestamp IS NOT NULL",
@@ -5791,7 +5861,11 @@ class Database:
             conditions.append("COALESCE(p.flag, 'none') = ?")
             where_params.append(flag)
         if keyword is not None:
-            kw_clause, kw_params = _keyword_token_clause(keyword)
+            kw_clause, kw_params = _keyword_token_clause(
+                keyword,
+                match_case=keyword_match_case,
+                whole_word=keyword_whole_word,
+            )
             if kw_clause:
                 conditions.append(kw_clause)
                 where_params.extend(kw_params)
@@ -5842,6 +5916,8 @@ class Database:
         date_from=None,
         date_to=None,
         keyword=None,
+        keyword_match_case=False,
+        keyword_whole_word=False,
         color_label=None,
         flag=None,
     ):
@@ -5871,7 +5947,11 @@ class Database:
         join_clause = ("JOIN workspace_folders wf ON wf.folder_id = p.folder_id"
                        "\nJOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')")
         if keyword is not None:
-            kw_clause, kw_params = _keyword_token_clause(keyword)
+            kw_clause, kw_params = _keyword_token_clause(
+                keyword,
+                match_case=keyword_match_case,
+                whole_word=keyword_whole_word,
+            )
             if kw_clause:
                 conditions.append(kw_clause)
                 where_params.extend(kw_params)
@@ -5923,6 +6003,8 @@ class Database:
         date_from=None,
         date_to=None,
         keyword=None,
+        keyword_match_case=False,
+        keyword_whole_word=False,
         color_label=None,
         flag=None,
     ):
@@ -5952,7 +6034,11 @@ class Database:
         join_clause = ("JOIN workspace_folders wf ON wf.folder_id = p.folder_id"
                        "\nJOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')")
         if keyword is not None:
-            kw_clause, kw_params = _keyword_token_clause(keyword)
+            kw_clause, kw_params = _keyword_token_clause(
+                keyword,
+                match_case=keyword_match_case,
+                whole_word=keyword_whole_word,
+            )
             if kw_clause:
                 conditions.append(kw_clause)
                 where_params.extend(kw_params)
@@ -5993,6 +6079,8 @@ class Database:
         date_from=None,
         date_to=None,
         keyword=None,
+        keyword_match_case=False,
+        keyword_whole_word=False,
         color_label=None,
         flag=None,
     ):
@@ -6022,7 +6110,11 @@ class Database:
         join_clause = ("JOIN workspace_folders wf ON wf.folder_id = p.folder_id"
                        "\nJOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')")
         if keyword is not None:
-            kw_clause, kw_params = _keyword_token_clause(keyword)
+            kw_clause, kw_params = _keyword_token_clause(
+                keyword,
+                match_case=keyword_match_case,
+                whole_word=keyword_whole_word,
+            )
             if kw_clause:
                 conditions.append(kw_clause)
                 where_params.extend(kw_params)
@@ -6053,6 +6145,8 @@ class Database:
         date_from=None,
         date_to=None,
         keyword=None,
+        keyword_match_case=False,
+        keyword_whole_word=False,
         collection_id=None,
         color_label=None,
         flag=None,
@@ -6102,7 +6196,11 @@ class Database:
         join_clause = ("JOIN workspace_folders wf ON wf.folder_id = p.folder_id"
                        "\nJOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')")
         if keyword is not None:
-            kw_clause, kw_params = _keyword_token_clause(keyword)
+            kw_clause, kw_params = _keyword_token_clause(
+                keyword,
+                match_case=keyword_match_case,
+                whole_word=keyword_whole_word,
+            )
             if kw_clause:
                 conditions.append(kw_clause)
                 where_params.extend(kw_params)
@@ -6218,6 +6316,8 @@ class Database:
         date_from=None,
         date_to=None,
         keyword=None,
+        keyword_match_case=False,
+        keyword_whole_word=False,
         species=None,
     ):
         """Return all geolocated photos with optional species, scoped to active workspace.
@@ -6282,7 +6382,11 @@ class Database:
             f"\n{location_subquery}"
         )
         if keyword is not None:
-            kw_clause, kw_params = _keyword_token_clause(keyword)
+            kw_clause, kw_params = _keyword_token_clause(
+                keyword,
+                match_case=keyword_match_case,
+                whole_word=keyword_whole_word,
+            )
             if kw_clause:
                 conditions.append(kw_clause)
                 params.extend(kw_params)

--- a/vireo/static/help.js
+++ b/vireo/static/help.js
@@ -62,7 +62,21 @@
       return;
     }
     if (!fuse) return;
-    var hits = fuse.search(query);
+    var options = VireoTextSearch.readOptions('helpSearch');
+    var hits;
+    if (options.matchCase || options.wholeWord) {
+      hits = helpData
+        .filter(function(item) {
+          return VireoTextSearch.matchesFields(
+            [item.question, item.keywords, item.answer],
+            query,
+            options
+          );
+        })
+        .map(function(item) { return {item: item}; });
+    } else {
+      hits = fuse.search(query);
+    }
     if (hits.length === 0) {
       results.innerHTML = '<div class="help-empty">No results. Try different keywords.</div>';
       return;
@@ -75,6 +89,7 @@
   }
 
   input.addEventListener('input', onSearch);
+  window._helpSearchRefresh = onSearch;
 
   // Open / close
   window.openHelpModal = function() {

--- a/vireo/static/vireo-base.css
+++ b/vireo/static/vireo-base.css
@@ -120,3 +120,35 @@ body {
 .status-msg.ok { color: var(--accent); }
 .status-msg.warning { color: var(--warning); }
 .status-msg.error { color: var(--danger); }
+
+/* ---------- Search Options ---------- */
+.search-control {
+  display: flex;
+  align-items: stretch;
+  min-width: 0;
+}
+.search-control input[type=text],
+.search-control input[type=search] {
+  min-width: 0;
+  flex: 1;
+  border-radius: 4px 0 0 4px;
+}
+.search-option-btn {
+  width: 30px;
+  min-width: 30px;
+  padding: 0;
+  background: var(--bg-tertiary);
+  color: var(--text-muted);
+  border: 1px solid var(--border-secondary);
+  border-left: 0;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.search-option-btn:last-child { border-radius: 0 4px 4px 0; }
+.search-option-btn:hover { color: var(--text-primary); border-color: var(--accent); }
+.search-option-btn.active {
+  background: color-mix(in srgb, var(--accent) 18%, var(--bg-tertiary));
+  color: var(--accent);
+  border-color: var(--accent);
+}

--- a/vireo/static/vireo-utils.js
+++ b/vireo/static/vireo-utils.js
@@ -41,8 +41,8 @@ var VireoTextSearch = (function() {
     var needle = String(token);
     if (!needle) return true;
     if (!options || !options.matchCase) {
-      text = text.toLocaleLowerCase();
-      needle = needle.toLocaleLowerCase();
+      text = text.toLowerCase();
+      needle = needle.toLowerCase();
     }
     if (options && options.wholeWord) {
       return containsWholeToken(text, needle);

--- a/vireo/static/vireo-utils.js
+++ b/vireo/static/vireo-utils.js
@@ -17,6 +17,100 @@ function escapeAttr(str) {
     .replace(/>/g, '&gt;');
 }
 
+var VireoTextSearch = (function() {
+  function isWordChar(ch) {
+    return !!ch && (/[0-9]/.test(ch) || ch.toLowerCase() !== ch.toUpperCase());
+  }
+
+  function containsWholeToken(value, token) {
+    var start = 0;
+    while (true) {
+      var idx = value.indexOf(token, start);
+      if (idx < 0) return false;
+      var before = idx === 0 || !isWordChar(value.charAt(idx - 1));
+      var end = idx + token.length;
+      var after = end === value.length || !isWordChar(value.charAt(end));
+      if (before && after) return true;
+      start = idx + 1;
+    }
+  }
+
+  function tokenMatches(value, token, options) {
+    if (value == null || token == null) return false;
+    var text = String(value);
+    var needle = String(token);
+    if (!needle) return true;
+    if (!options || !options.matchCase) {
+      text = text.toLocaleLowerCase();
+      needle = needle.toLocaleLowerCase();
+    }
+    if (options && options.wholeWord) {
+      return containsWholeToken(text, needle);
+    }
+    return text.indexOf(needle) !== -1;
+  }
+
+  function tokens(query) {
+    return String(query || '').trim().split(/\s+/).filter(Boolean);
+  }
+
+  function matchesFields(fields, query, options) {
+    var parts = tokens(query);
+    if (!parts.length) return true;
+    var values = Array.isArray(fields) ? fields : [fields];
+    return parts.every(function(token) {
+      return values.some(function(value) {
+        return tokenMatches(value, token, options || {});
+      });
+    });
+  }
+
+  function readOptions(prefix) {
+    var matchCase = document.getElementById(prefix + 'MatchCaseBtn');
+    var wholeWord = document.getElementById(prefix + 'WholeWordBtn');
+    return {
+      matchCase: !!(matchCase && matchCase.classList.contains('active')),
+      wholeWord: !!(wholeWord && wholeWord.classList.contains('active')),
+    };
+  }
+
+  function applyButton(button, active) {
+    if (!button) return;
+    button.classList.toggle('active', !!active);
+    button.setAttribute('aria-pressed', active ? 'true' : 'false');
+  }
+
+  function renderOptions(prefix, options) {
+    applyButton(document.getElementById(prefix + 'MatchCaseBtn'), options.matchCase);
+    applyButton(document.getElementById(prefix + 'WholeWordBtn'), options.wholeWord);
+  }
+
+  function toggle(prefix, option, onChange) {
+    var options = readOptions(prefix);
+    if (option === 'match_case') options.matchCase = !options.matchCase;
+    if (option === 'whole_word') options.wholeWord = !options.wholeWord;
+    renderOptions(prefix, options);
+    if (typeof onChange === 'function') onChange(options);
+    return options;
+  }
+
+  function appendParams(params, options, matchCaseName, wholeWordName) {
+    if (!params || !options) return;
+    if (options.matchCase) params.set(matchCaseName || 'match_case', '1');
+    if (options.wholeWord) params.set(wholeWordName || 'whole_word', '1');
+  }
+
+  return {
+    isWordChar: isWordChar,
+    tokenMatches: tokenMatches,
+    matchesFields: matchesFields,
+    readOptions: readOptions,
+    renderOptions: renderOptions,
+    toggle: toggle,
+    appendParams: appendParams,
+  };
+})();
+
 var VireoPipelineConfig = (function() {
   function defaultPipeline() {
     var defaults = window.VIREO_CONFIG_DEFAULTS;

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -143,12 +143,11 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
   padding: 16px;
   border-bottom: 1px solid var(--border-primary);
 }
+.help-search .search-control { width: 100%; }
 .help-search input {
-  width: 100%;
   padding: 10px 12px;
   font-size: 14px;
   border: 1px solid var(--border-secondary);
-  border-radius: 6px;
   background: var(--bg-input);
   color: var(--text-primary);
   outline: none;
@@ -1729,11 +1728,19 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
   max-height: 60vh; display: flex; flex-direction: column;
   box-shadow: 0 8px 32px rgba(0,0,0,0.4);
 }
+.cmd-palette .search-control {
+  border-bottom: 1px solid var(--border-primary);
+}
 .cmd-palette input {
   border: 0; outline: none; padding: 14px 16px;
   background: transparent; color: var(--text-primary);
   font-size: 15px;
-  border-bottom: 1px solid var(--border-primary);
+}
+.cmd-palette .search-option-btn {
+  background: transparent;
+  border-top: 0;
+  border-bottom: 0;
+  height: auto;
 }
 .cmd-palette-results {
   overflow-y: auto; padding: 4px 0;
@@ -1787,7 +1794,11 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
 <!-- Command palette (cmd+K) -->
 <div class="cmd-palette-overlay" id="commandPalette" hidden onclick="if(event.target===this)closeCommandPalette()">
   <div class="cmd-palette">
-    <input type="text" id="cmdPaletteInput" autocomplete="off" placeholder="Jump to page…" />
+    <div class="search-control">
+      <input type="text" id="cmdPaletteInput" autocomplete="off" placeholder="Jump to page…" />
+      <button id="cmdPaletteMatchCaseBtn" class="search-option-btn" type="button" aria-pressed="false" onclick="VireoTextSearch.toggle('cmdPalette', 'match_case', function() { window._cmdPaletteRender && window._cmdPaletteRender(document.getElementById('cmdPaletteInput').value || ''); })" title="Match case">Aa</button>
+      <button id="cmdPaletteWholeWordBtn" class="search-option-btn" type="button" aria-pressed="false" onclick="VireoTextSearch.toggle('cmdPalette', 'whole_word', function() { window._cmdPaletteRender && window._cmdPaletteRender(document.getElementById('cmdPaletteInput').value || ''); })" title="Match whole word">ab</button>
+    </div>
     <div id="cmdPaletteResults" class="cmd-palette-results"></div>
   </div>
 </div>
@@ -1858,7 +1869,11 @@ document.addEventListener('keydown', function(e) {
 <div class="help-overlay" id="helpModal">
   <div class="help-modal">
     <div class="help-search">
-      <input type="text" id="helpSearchInput" placeholder="Search help..." autocomplete="off">
+      <div class="search-control">
+        <input type="text" id="helpSearchInput" placeholder="Search help..." autocomplete="off">
+        <button id="helpSearchMatchCaseBtn" class="search-option-btn" type="button" aria-pressed="false" onclick="VireoTextSearch.toggle('helpSearch', 'match_case', window._helpSearchRefresh)" title="Match case">Aa</button>
+        <button id="helpSearchWholeWordBtn" class="search-option-btn" type="button" aria-pressed="false" onclick="VireoTextSearch.toggle('helpSearch', 'whole_word', window._helpSearchRefresh)" title="Match whole word">ab</button>
+      </div>
     </div>
     <div class="help-results" id="helpResults"></div>
   </div>
@@ -10614,15 +10629,23 @@ async function _deleteMissingPhotoIds(ids, deleteSidecars) {
     list.textContent = '';
     if (!query) {
       results = defaultSorted();
-    } else if (fuse) {
-      results = fuse.search(query).map(r => r.item);
     } else {
-      const q = query.toLowerCase();
-      results = allPages.filter(p =>
-        p.label.toLowerCase().includes(q) ||
-        p.id.includes(q) ||
-        (p.keywords || '').toLowerCase().includes(q)
-      );
+      const options = VireoTextSearch.readOptions('cmdPalette');
+      if ((options.matchCase || options.wholeWord) && window.VireoTextSearch) {
+        results = allPages.filter(p =>
+          VireoTextSearch.matchesFields(
+            [p.label, p.id, p.keywords || ''],
+            query,
+            options
+          )
+        );
+      } else if (fuse) {
+        results = fuse.search(query).map(r => r.item);
+      } else {
+        results = allPages.filter(p =>
+          VireoTextSearch.matchesFields([p.label, p.id, p.keywords || ''], query)
+        );
+      }
     }
     if (selectedIndex >= results.length) selectedIndex = 0;
     const cur = currentNavId();

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -151,6 +151,7 @@ body {
   outline: none;
 }
 .filter-bar input:focus { border-color: var(--accent); }
+.filter-bar .search-control { min-width: 240px; max-width: 420px; flex: 1 1 280px; }
 .filter-bar select {
   background: var(--bg-tertiary);
   color: var(--text-primary);
@@ -1383,7 +1384,11 @@ body {
 
     <!-- Filter Bar -->
     <div class="filter-bar">
-      <input type="text" id="searchInput" placeholder="Search keywords or filenames..." onkeydown="if(event.key==='Enter')applySearchFilterNow()" oninput="scheduleSearchFilter()">
+      <div class="search-control">
+        <input type="text" id="searchInput" placeholder="Search keywords or filenames..." onkeydown="if(event.key==='Enter')applySearchFilterNow()" oninput="scheduleSearchFilter()">
+        <button id="keywordMatchCaseBtn" class="search-option-btn" type="button" aria-pressed="false" onclick="toggleKeywordSearchOption('match_case')" title="Match case">Aa</button>
+        <button id="keywordWholeWordBtn" class="search-option-btn" type="button" aria-pressed="false" onclick="toggleKeywordSearchOption('whole_word')" title="Match whole word">ab</button>
+      </div>
       <input type="text" id="clipSearchInput" placeholder="CLIP search: describe what you see..."
              style="flex:1;min-width:200px;"
              onkeydown="if(event.key==='Enter')runClipSearch()">
@@ -1871,6 +1876,8 @@ var flagFilter = '';
 var activeFolderId = null;
 var activeKeyword = null;
 var activeCollectionId = null;
+var keywordSearchMatchCase = false;
+var keywordSearchWholeWord = false;
 var timelineMode = false;
 var calendarYear = new Date().getFullYear();
 var selectedDay = null;
@@ -3352,10 +3359,37 @@ function buildCurrentBrowseParams() {
   if (dateFrom) params.set('date_from', dateFrom);
   if (dateTo) params.set('date_to', dateTo);
 
+  appendKeywordSearchParams(params);
+  return params;
+}
+
+function appendKeywordSearchParams(params) {
   var search = document.getElementById('searchInput').value.trim();
   if (search) params.set('keyword', search);
   if (activeKeyword) params.set('keyword', activeKeyword);
-  return params;
+  if (params.has('keyword')) {
+    VireoTextSearch.appendParams(
+      params,
+      { matchCase: keywordSearchMatchCase, wholeWord: keywordSearchWholeWord },
+      'keyword_match_case',
+      'keyword_whole_word'
+    );
+  }
+}
+
+function renderKeywordSearchOptions() {
+  VireoTextSearch.renderOptions('keyword', {
+    matchCase: keywordSearchMatchCase,
+    wholeWord: keywordSearchWholeWord,
+  });
+}
+
+function toggleKeywordSearchOption(option) {
+  VireoTextSearch.toggle('keyword', option, function(options) {
+    keywordSearchMatchCase = options.matchCase;
+    keywordSearchWholeWord = options.wholeWord;
+    applySearchFilterNow();
+  });
 }
 
 async function loadPhotos(options) {
@@ -3480,9 +3514,7 @@ async function loadCalendarData() {
   if (flagFilter) params.set('flag', flagFilter);
   var colorFilter = document.getElementById('colorFilter').value;
   if (colorFilter) params.set('color_label', colorFilter);
-  var search = document.getElementById('searchInput').value.trim();
-  if (search) params.set('keyword', search);
-  if (activeKeyword) params.set('keyword', activeKeyword);
+  appendKeywordSearchParams(params);
 
   calendarData = await safeFetch('/api/photos/calendar?' + params.toString());
   renderCalendar();
@@ -3720,9 +3752,7 @@ function appendClipSearchScopeParams(params) {
   if (dateFrom) params.set('date_from', dateFrom);
   if (dateTo) params.set('date_to', dateTo);
 
-  var search = document.getElementById('searchInput').value.trim();
-  if (search) params.set('keyword', search);
-  if (activeKeyword) params.set('keyword', activeKeyword);
+  appendKeywordSearchParams(params);
 }
 
 function reloadBrowseResults() {
@@ -5679,9 +5709,7 @@ async function loadSummary() {
   var dateTo = document.getElementById('dateTo').value;
   if (dateFrom) params.set('date_from', dateFrom);
   if (dateTo) params.set('date_to', dateTo);
-  var search = document.getElementById('searchInput').value.trim();
-  if (search) params.set('keyword', search);
-  if (activeKeyword) params.set('keyword', activeKeyword);
+  appendKeywordSearchParams(params);
   if (activeCollectionId) params.set('collection_id', activeCollectionId);
 
   try {

--- a/vireo/templates/compare.html
+++ b/vireo/templates/compare.html
@@ -40,6 +40,7 @@ body { padding-bottom: 36px; }
   padding: 7px 9px;
   font-size: 13px;
 }
+.control .search-control input { width: auto; border-radius: 4px 0 0 4px; }
 
 .summary-grid {
   display: grid;
@@ -297,7 +298,11 @@ body { padding-bottom: 36px; }
     </div>
     <div class="control">
       <label for="compareSearch">Search</label>
-      <input id="compareSearch" type="search" placeholder="Filename, keyword, species" oninput="renderCompare()">
+      <div class="search-control">
+        <input id="compareSearch" type="search" placeholder="Filename, keyword, species" oninput="renderCompare()">
+        <button id="compareSearchMatchCaseBtn" class="search-option-btn" type="button" aria-pressed="false" onclick="VireoTextSearch.toggle('compareSearch', 'match_case', renderCompare)" title="Match case">Aa</button>
+        <button id="compareSearchWholeWordBtn" class="search-option-btn" type="button" aria-pressed="false" onclick="VireoTextSearch.toggle('compareSearch', 'whole_word', renderCompare)" title="Match whole word">ab</button>
+      </div>
     </div>
   </div>
 
@@ -505,7 +510,7 @@ function photoMatchesFilter(photo, filter) {
   return photo.row_category === filter;
 }
 
-function searchableText(photo) {
+function searchableFields(photo) {
   var parts = [photo.filename, photo.row_label];
   (photo.keywords || []).forEach(function(k) { parts.push(k.name, k.type); });
   Object.keys(photo.predictions || {}).forEach(function(model) {
@@ -514,14 +519,15 @@ function searchableText(photo) {
       parts.push(p.species, p.category_label, p.matched_keyword, p.status);
     });
   });
-  return parts.join(' ').toLowerCase();
+  return parts;
 }
 
 function filteredRows() {
-  var q = document.getElementById('compareSearch').value.trim().toLowerCase();
+  var q = document.getElementById('compareSearch').value.trim();
+  var searchOptions = VireoTextSearch.readOptions('compareSearch');
   return (compareData.photos || []).filter(function(photo) {
     if (!photoMatchesFilter(photo, activeFilter)) return false;
-    if (q && searchableText(photo).indexOf(q) < 0) return false;
+    if (q && !VireoTextSearch.matchesFields(searchableFields(photo), q, searchOptions)) return false;
     return true;
   });
 }

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -14,6 +14,8 @@
   .control-group input[type=range] { width:120px; }
   .control-group input[type=search], .control-group select { font-size:13px; padding:4px 8px; background:var(--bg-input); color:var(--text-primary); border:1px solid var(--border-secondary); border-radius:4px; }
   .control-group input[type=search] { width:180px; }
+  .control-group .search-control { width:240px; }
+  .control-group .search-control input[type=search] { width:auto; border-radius:4px 0 0 4px; }
   .control-value { font-size:13px; color:var(--text-primary); min-width:36px; }
   .save-btn { margin-left:auto; padding:6px 16px; background:var(--accent); color:var(--accent-text); border:none; border-radius:4px; cursor:pointer; font-size:13px; }
   .save-btn:hover { opacity:0.9; }
@@ -96,7 +98,11 @@
   </div>
   <div class="control-group">
     <label for="speciesSearch">Species</label>
-    <input type="search" id="speciesSearch" placeholder="Cardinal">
+    <div class="search-control">
+      <input type="search" id="speciesSearch" placeholder="Cardinal">
+      <button id="highlightSpeciesMatchCaseBtn" class="search-option-btn" type="button" aria-pressed="false" onclick="VireoTextSearch.toggle('highlightSpecies', 'match_case', debounceLoad)" title="Match case">Aa</button>
+      <button id="highlightSpeciesWholeWordBtn" class="search-option-btn" type="button" aria-pressed="false" onclick="VireoTextSearch.toggle('highlightSpecies', 'whole_word', debounceLoad)" title="Match whole word">ab</button>
+    </div>
   </div>
   <div class="control-group">
     <label for="confirmationFilter">Status</label>
@@ -234,7 +240,15 @@ async function loadHighlights() {
   var folderSelect = document.getElementById('folderSelect');
   var speciesSearch = document.getElementById('speciesSearch').value.trim();
   params.set('limit_per_bucket', Math.max(20, parseInt(document.getElementById('perRowSlider').value)));
-  if (speciesSearch) params.set('species', speciesSearch);
+  if (speciesSearch) {
+    params.set('species', speciesSearch);
+    VireoTextSearch.appendParams(
+      params,
+      VireoTextSearch.readOptions('highlightSpecies'),
+      'species_match_case',
+      'species_whole_word'
+    );
+  }
 
   // Capture the issue-time sequence so the prune below can tell rejections that
   // happened after this request was sent (response is stale for them) from

--- a/vireo/templates/keywords.html
+++ b/vireo/templates/keywords.html
@@ -24,6 +24,8 @@
     background: var(--bg-input); color: var(--text-primary);
     width: 220px;
   }
+  .kw-search-control { width: 280px; }
+  .kw-search-control .kw-search { width: auto; border-radius: 4px 0 0 4px; }
   .kw-search::placeholder { color: var(--text-dim); }
   .kw-search:focus { outline: none; border-color: var(--accent); }
 
@@ -177,7 +179,11 @@
 
     <!-- Toolbar -->
     <div class="kw-toolbar">
-      <input type="text" class="kw-search" id="kwSearch" placeholder="Search keywords...">
+      <div class="search-control kw-search-control">
+        <input type="text" class="kw-search" id="kwSearch" placeholder="Search keywords...">
+        <button id="kwSearchMatchCaseBtn" class="search-option-btn" type="button" aria-pressed="false" onclick="VireoTextSearch.toggle('kwSearch', 'match_case', render)" title="Match case">Aa</button>
+        <button id="kwSearchWholeWordBtn" class="search-option-btn" type="button" aria-pressed="false" onclick="VireoTextSearch.toggle('kwSearch', 'whole_word', render)" title="Match whole word">ab</button>
+      </div>
       <button class="kw-filter-btn active" data-type="all">All</button>
       <button class="kw-filter-btn" data-type="general">General</button>
       <button class="kw-filter-btn" data-type="taxonomy">Taxonomy</button>
@@ -283,8 +289,8 @@
       list = list.filter(k => (k.type || 'general') === filterType);
     }
     if (searchTerm) {
-      const s = searchTerm.toLowerCase();
-      list = list.filter(k => k.name.toLowerCase().includes(s));
+      const options = VireoTextSearch.readOptions('kwSearch');
+      list = list.filter(k => VireoTextSearch.matchesFields(k.name, searchTerm, options));
     }
     return list;
   }

--- a/vireo/templates/life_list.html
+++ b/vireo/templates/life_list.html
@@ -13,6 +13,8 @@
   .control-group label { font-size:13px; color:var(--text-secondary); white-space:nowrap; }
   .control-group input[type=search], .control-group select { font-size:13px; padding:4px 8px; background:var(--bg-input); color:var(--text-primary); border:1px solid var(--border-secondary); border-radius:4px; }
   .control-group input[type=search] { width:180px; }
+  .control-group .search-control { width:240px; }
+  .control-group .search-control input[type=search] { width:auto; border-radius:4px 0 0 4px; }
   .lifelist-actions { margin-left:auto; display:flex; gap:8px; align-items:center; }
   .publish-btn { border:1px solid var(--accent); background:transparent; color:var(--accent); border-radius:4px; padding:5px 10px; font-size:12px; cursor:pointer; }
   .publish-btn:hover { background:rgba(99, 179, 237, 0.08); }
@@ -133,7 +135,11 @@
 <div class="lifelist-controls" id="controlsBar">
   <div class="control-group">
     <label for="speciesSearch">Species</label>
-    <input type="search" id="speciesSearch" placeholder="Cardinal">
+    <div class="search-control">
+      <input type="search" id="speciesSearch" placeholder="Cardinal">
+      <button id="lifeSpeciesMatchCaseBtn" class="search-option-btn" type="button" aria-pressed="false" onclick="VireoTextSearch.toggle('lifeSpecies', 'match_case', debounceRender)" title="Match case">Aa</button>
+      <button id="lifeSpeciesWholeWordBtn" class="search-option-btn" type="button" aria-pressed="false" onclick="VireoTextSearch.toggle('lifeSpecies', 'whole_word', debounceRender)" title="Match whole word">ab</button>
+    </div>
   </div>
   <div class="control-group">
     <label for="sortSelect">Sort</label>
@@ -341,13 +347,16 @@ function render() {
   empty.style.display = 'none';
   controls.style.display = '';
 
-  var search = document.getElementById('speciesSearch').value.trim().toLowerCase();
+  var search = document.getElementById('speciesSearch').value.trim();
+  var searchOptions = VireoTextSearch.readOptions('lifeSpecies');
   var list = sortedSpecies();
   if (search) {
     list = list.filter(function(e) {
-      return e.species.toLowerCase().indexOf(search) >= 0
-        || (e.scientific_name || '').toLowerCase().indexOf(search) >= 0
-        || (e.common_name || '').toLowerCase().indexOf(search) >= 0;
+      return VireoTextSearch.matchesFields(
+        [e.species, e.scientific_name || '', e.common_name || ''],
+        search,
+        searchOptions
+      );
     });
   }
 

--- a/vireo/templates/logs.html
+++ b/vireo/templates/logs.html
@@ -35,11 +35,20 @@ body {
   border-radius: 4px; padding: 5px 10px; font-size: 12px; outline: none;
 }
 .log-toolbar input { flex: 1; max-width: 300px; }
+.log-toolbar .log-search-control { flex: 1; max-width: 360px; }
+.log-toolbar .log-search-control input { max-width: none; }
 .log-toolbar input:focus, .log-toolbar select:focus { border-color: var(--accent); }
 .log-toolbar button {
   background: var(--bg-tertiary); color: var(--text-secondary); border: none; border-radius: 4px;
   padding: 5px 12px; font-size: 12px; cursor: pointer;
 }
+.log-toolbar .search-option-btn {
+  border: 1px solid var(--border-secondary);
+  border-left: 0;
+  border-radius: 0;
+  padding: 0;
+}
+.log-toolbar .search-option-btn:last-child { border-radius: 0 4px 4px 0; }
 .log-toolbar button:hover { background: var(--border-secondary); }
 .log-toolbar label { font-size: 12px; color: var(--text-dim); display: flex; align-items: center; gap: 4px; }
 .log-toolbar input[type=checkbox] { accent-color: var(--accent); }
@@ -78,7 +87,11 @@ body {
       <option value="WARNING">WARNING+</option>
       <option value="ERROR">ERROR+</option>
     </select>
-    <input type="text" id="searchFilter" placeholder="Filter..." oninput="applyFilter()">
+    <div class="search-control log-search-control">
+      <input type="text" id="searchFilter" placeholder="Filter..." oninput="applyFilter()">
+      <button id="logSearchMatchCaseBtn" class="search-option-btn" type="button" aria-pressed="false" onclick="VireoTextSearch.toggle('logSearch', 'match_case', applyFilter)" title="Match case">Aa</button>
+      <button id="logSearchWholeWordBtn" class="search-option-btn" type="button" aria-pressed="false" onclick="VireoTextSearch.toggle('logSearch', 'whole_word', applyFilter)" title="Match whole word">ab</button>
+    </div>
     <label><input type="checkbox" id="autoScroll" checked> Auto-scroll</label>
     <button onclick="clearLogs()">Clear</button>
     <span class="log-count" id="logCount">0 lines</span>
@@ -122,7 +135,7 @@ function addLogLine(record) {
   var div = document.createElement('div');
   div.className = 'log-line level-' + record.level;
   div.dataset.level = record.level;
-  div.dataset.message = (record.message || '').toLowerCase();
+  div.dataset.message = record.message || '';
   div.innerHTML = '<span class="log-time">' + timeStr + '</span>' +
     '<span class="log-level">' + record.level + '</span>' +
     '<span class="log-logger">' + escapeHtml(record.logger || '') + '</span>' +
@@ -137,12 +150,17 @@ function addLogLine(record) {
 
 function applyFilter() {
   var minLevel = document.getElementById('levelFilter').value;
-  var search = document.getElementById('searchFilter').value.toLowerCase();
+  var search = document.getElementById('searchFilter').value.trim();
+  var searchOptions = VireoTextSearch.readOptions('logSearch');
   var minOrder = LEVEL_ORDER[minLevel] || 0;
   var lines = document.querySelectorAll('.log-line');
   lines.forEach(function(el) {
     var levelOk = (LEVEL_ORDER[el.dataset.level] || 0) >= minOrder;
-    var searchOk = !search || (el.dataset.message || '').indexOf(search) !== -1;
+    var searchOk = !search || VireoTextSearch.matchesFields(
+      el.dataset.message || '',
+      search,
+      searchOptions
+    );
     el.classList.toggle('filtered', !(levelOk && searchOk));
   });
 }

--- a/vireo/templates/map.html
+++ b/vireo/templates/map.html
@@ -46,6 +46,8 @@ body { padding-bottom: 36px; }
 
 .map-filters input[type="text"] { width: 120px; }
 .map-filters input[type="date"] { width: 130px; }
+.map-filters .search-control { width: 190px; }
+.map-filters .search-control input[type="text"] { width: auto; border-radius: 4px 0 0 4px; }
 
 .map-body {
   display: flex;
@@ -307,7 +309,11 @@ body { padding-bottom: 36px; }
     <select id="filterSpecies"><option value="">All species</option></select>
 
     <label>Keyword:</label>
-    <input type="text" id="filterKeyword" placeholder="Search...">
+    <div class="search-control">
+      <input type="text" id="filterKeyword" placeholder="Search...">
+      <button id="mapKeywordMatchCaseBtn" class="search-option-btn" type="button" aria-pressed="false" onclick="VireoTextSearch.toggle('mapKeyword', 'match_case', loadPhotos)" title="Match case">Aa</button>
+      <button id="mapKeywordWholeWordBtn" class="search-option-btn" type="button" aria-pressed="false" onclick="VireoTextSearch.toggle('mapKeyword', 'whole_word', loadPhotos)" title="Match whole word">ab</button>
+    </div>
 
     <label>From:</label>
     <input type="date" id="filterDateFrom">
@@ -568,7 +574,15 @@ async function loadPhotos() {
   if (folder) params.set('folder_id', folder);
   if (rating) params.set('rating_min', rating);
   if (species) params.set('species', species);
-  if (keyword) params.set('keyword', keyword);
+  if (keyword) {
+    params.set('keyword', keyword);
+    VireoTextSearch.appendParams(
+      params,
+      VireoTextSearch.readOptions('mapKeyword'),
+      'keyword_match_case',
+      'keyword_whole_word'
+    );
+  }
   if (dateFrom) params.set('date_from', dateFrom);
   if (dateTo) params.set('date_to', dateTo);
 

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -3389,7 +3389,7 @@ function searchSpecies(event, encIdx, burstIdx, pos) {
     var hasExact = results.some(function(name) {
       return speciesDropdownSearchOptions.matchCase
         ? name === typed
-        : name.toLocaleLowerCase() === typed.toLocaleLowerCase();
+        : name.toLowerCase() === typed.toLowerCase();
     });
     var html = '';
     if (!hasExact) {

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -194,8 +194,7 @@
   margin-left: 8px;
 }
 .species-filter-wrap input {
-  padding: 5px 26px 5px 10px;
-  border-radius: 16px;
+  padding: 5px 24px 5px 10px;
   border: 1px solid var(--border-primary);
   background: transparent;
   color: var(--text-primary);
@@ -208,7 +207,7 @@
 .species-filter-wrap input:focus { border-color: var(--accent); }
 .species-filter-clear {
   position: absolute;
-  right: 6px;
+  right: 63px;
   top: 50%;
   transform: translateY(-50%);
   background: none;
@@ -221,6 +220,8 @@
   display: none;
 }
 .species-filter-clear:hover { color: var(--text-primary); }
+.species-filter-wrap .search-control { width: 224px; }
+.species-filter-wrap .search-control input { width: auto; }
 .confidence-slider-wrap {
   display: flex;
   align-items: center;
@@ -812,13 +813,15 @@ input[type="range"]::-moz-range-thumb {
   border-bottom: 1px solid var(--border-secondary);
 }
 .species-dropdown-search input {
-  width: 100%;
   background: var(--bg-input);
   color: var(--text-primary);
   border: 1px solid var(--border-secondary);
-  border-radius: 4px;
   padding: 6px 10px;
   font-size: 12px;
+}
+.species-dropdown-search .search-control { width: 100%; }
+.species-dropdown-search .search-option-btn.active {
+  background: color-mix(in srgb, var(--accent) 18%, var(--bg-input));
 }
 
 /* Burst-level species (smaller variant) */
@@ -1478,7 +1481,11 @@ input[type="range"]::-moz-range-thumb {
       <button class="filter-btn" data-filter="REJECT" onclick="setFilter('REJECT')">Reject<span class="count" id="countReject"></span></button>
       <button class="filter-btn" id="hideConfirmedBtn" onclick="toggleHideConfirmed()" title="Hide encounters/bursts whose species has been confirmed">Hide confirmed</button>
       <div class="species-filter-wrap">
-        <input type="text" id="speciesFilterInput" placeholder="Filter by species..." oninput="setSpeciesFilter(this.value)">
+        <div class="search-control">
+          <input type="text" id="speciesFilterInput" placeholder="Filter by species..." oninput="setSpeciesFilter(this.value)">
+          <button id="speciesFilterMatchCaseBtn" class="search-option-btn" type="button" aria-pressed="false" onclick="toggleSpeciesFilterSearchOption('match_case')" title="Match case">Aa</button>
+          <button id="speciesFilterWholeWordBtn" class="search-option-btn" type="button" aria-pressed="false" onclick="toggleSpeciesFilterSearchOption('whole_word')" title="Match whole word">ab</button>
+        </div>
         <button class="species-filter-clear" id="speciesFilterClear" onclick="clearSpeciesFilter()" title="Clear filter">&times;</button>
       </div>
       <div class="encounter-sort-wrap" title="Order encounters are listed in">
@@ -1624,6 +1631,8 @@ var activeFilter = 'all';
 var minConfidence = 40;
 var speciesFilter = '';
 var speciesFilterText = '';
+var speciesFilterSearchOptions = {matchCase: false, wholeWord: false};
+var speciesDropdownSearchOptions = {matchCase: false, wholeWord: false};
 var hideConfirmed = false;
 // Captured from /api/pipeline/page-init so computeReviewNow() can apply
 // the same workspace-override logic the happy path uses on page load.
@@ -1683,6 +1692,7 @@ function persistPipelineReviewViewState() {
     window.localStorage.setItem(PIPELINE_VIEW_STATE_STORAGE_KEY, JSON.stringify({
       activeFilter: activeFilter,
       speciesFilter: speciesInput ? speciesInput.value : speciesFilterText,
+      speciesFilterSearchOptions: speciesFilterSearchOptions,
       hideConfirmed: !!hideConfirmed,
       encounterSort: encounterSort,
       thumbSize: document.getElementById('thumbSizeSlider')
@@ -1704,6 +1714,7 @@ function applyPipelineReviewToolbarState() {
   if (input) input.value = speciesFilterText || '';
   var clearBtn = document.getElementById('speciesFilterClear');
   if (clearBtn) clearBtn.style.display = speciesFilter ? 'block' : 'none';
+  VireoTextSearch.renderOptions('speciesFilter', speciesFilterSearchOptions);
 
   var sortSel = document.getElementById('encounterSortSelect');
   if (sortSel) sortSel.value = encounterSort;
@@ -1723,7 +1734,13 @@ function restorePipelineReviewViewState() {
     activeFilter = state.activeFilter;
   }
   speciesFilterText = typeof state.speciesFilter === 'string' ? state.speciesFilter : '';
-  speciesFilter = speciesFilterText.toLowerCase();
+  speciesFilter = speciesFilterText;
+  if (state.speciesFilterSearchOptions && typeof state.speciesFilterSearchOptions === 'object') {
+    speciesFilterSearchOptions = {
+      matchCase: !!state.speciesFilterSearchOptions.matchCase,
+      wholeWord: !!state.speciesFilterSearchOptions.wholeWord,
+    };
+  }
   hideConfirmed = !!state.hideConfirmed;
 
   if (PIPELINE_ENCOUNTER_SORTS.indexOf(state.encounterSort) !== -1) {
@@ -2022,11 +2039,19 @@ function _grmFinishLoupeOneToOne() {
 
 function setSpeciesFilter(val) {
   speciesFilterText = val;
-  speciesFilter = val.toLowerCase();
+  speciesFilter = val;
   var clearBtn = document.getElementById('speciesFilterClear');
   if (clearBtn) clearBtn.style.display = val ? 'block' : 'none';
   persistPipelineReviewViewState();
   renderResults();
+}
+
+function toggleSpeciesFilterSearchOption(option) {
+  VireoTextSearch.toggle('speciesFilter', option, function(options) {
+    speciesFilterSearchOptions = options;
+    persistPipelineReviewViewState();
+    renderResults();
+  });
 }
 
 function clearSpeciesFilter() {
@@ -2045,7 +2070,7 @@ function encounterMatchesSpecies(enc) {
   if (!enc.species_predictions || enc.species_predictions.length === 0) return false;
   var threshold = minConfidence / 100;
   return enc.species_predictions.some(function(sp) {
-    if (sp.species.toLowerCase().indexOf(speciesFilter) === -1) return false;
+    if (!VireoTextSearch.matchesFields(sp.species, speciesFilter, speciesFilterSearchOptions)) return false;
     return (sp.models || []).some(function(m) { return m.confidence >= threshold; });
   });
 }
@@ -3264,7 +3289,9 @@ function renderSpeciesWidget(enc, encIdx, level, burstIdx, pos) {
   // Dropdown — bottom-bar widget opens upward to stay inside the card
   var dropdownCls = 'species-dropdown' + (pos === 'bot' ? ' up' : '');
   html += '<div class="' + dropdownCls + '" id="spDrop_' + encIdx + '_' + idKey + '">';
-  html += '<div class="species-dropdown-search"><input type="text" placeholder="Search or type a new name..." oninput="searchSpecies(event, ' + encIdx + ',' + (burstIdx != null ? burstIdx : 'null') + ',\'' + pos + '\')" onkeydown="speciesInputKey(event, ' + encIdx + ',' + (burstIdx != null ? burstIdx : 'null') + ')"></div>';
+  html += '<div class="species-dropdown-search"><div class="search-control"><input type="text" placeholder="Search or type a new name..." oninput="searchSpecies(event, ' + encIdx + ',' + (burstIdx != null ? burstIdx : 'null') + ',\'' + pos + '\')" onkeydown="speciesInputKey(event, ' + encIdx + ',' + (burstIdx != null ? burstIdx : 'null') + ')">';
+  html += '<button class="search-option-btn species-dropdown-match-case' + (speciesDropdownSearchOptions.matchCase ? ' active' : '') + '" type="button" aria-pressed="' + (speciesDropdownSearchOptions.matchCase ? 'true' : 'false') + '" onclick="toggleSpeciesDropdownSearchOption(event, \'match_case\')" title="Match case">Aa</button>';
+  html += '<button class="search-option-btn species-dropdown-whole-word' + (speciesDropdownSearchOptions.wholeWord ? ' active' : '') + '" type="button" aria-pressed="' + (speciesDropdownSearchOptions.wholeWord ? 'true' : 'false') + '" onclick="toggleSpeciesDropdownSearchOption(event, \'whole_word\')" title="Match whole word">ab</button></div></div>';
 
   // "Use encounter label" option for burst level
   var encounterLabel = enc.confirmed_species || (enc.species ? enc.species[0] : null);
@@ -3325,6 +3352,31 @@ document.addEventListener('click', function(e) {
 });
 
 var _searchTimer = null;
+function renderSpeciesDropdownSearchOptions() {
+  document.querySelectorAll('.species-dropdown-match-case').forEach(function(btn) {
+    btn.classList.toggle('active', speciesDropdownSearchOptions.matchCase);
+    btn.setAttribute('aria-pressed', speciesDropdownSearchOptions.matchCase ? 'true' : 'false');
+  });
+  document.querySelectorAll('.species-dropdown-whole-word').forEach(function(btn) {
+    btn.classList.toggle('active', speciesDropdownSearchOptions.wholeWord);
+    btn.setAttribute('aria-pressed', speciesDropdownSearchOptions.wholeWord ? 'true' : 'false');
+  });
+}
+
+function toggleSpeciesDropdownSearchOption(event, option) {
+  if (event) event.stopPropagation();
+  if (option === 'match_case') {
+    speciesDropdownSearchOptions.matchCase = !speciesDropdownSearchOptions.matchCase;
+  }
+  if (option === 'whole_word') {
+    speciesDropdownSearchOptions.wholeWord = !speciesDropdownSearchOptions.wholeWord;
+  }
+  renderSpeciesDropdownSearchOptions();
+  var dropdown = event && event.target ? event.target.closest('.species-dropdown') : null;
+  var input = dropdown ? dropdown.querySelector('.species-dropdown-search input') : null;
+  if (input) input.dispatchEvent(new Event('input', {bubbles: true}));
+}
+
 function searchSpecies(event, encIdx, burstIdx, pos) {
   pos = pos || 'top';
   var q = event.target.value.trim();
@@ -3334,8 +3386,11 @@ function searchSpecies(event, encIdx, burstIdx, pos) {
   if (!q) { container.innerHTML = ''; return; }
 
   function renderInto(target, typed, results) {
-    var qLower = typed.toLowerCase();
-    var hasExact = results.some(function(name) { return name.toLowerCase() === qLower; });
+    var hasExact = results.some(function(name) {
+      return speciesDropdownSearchOptions.matchCase
+        ? name === typed
+        : name.toLocaleLowerCase() === typed.toLocaleLowerCase();
+    });
     var html = '';
     if (!hasExact) {
       html += '<div class="species-dropdown-item" data-freeform="1">'
@@ -3365,7 +3420,9 @@ function searchSpecies(event, encIdx, burstIdx, pos) {
 
   clearTimeout(_searchTimer);
   _searchTimer = setTimeout(async function() {
-    var results = await safeFetch('/api/species/search?q=' + encodeURIComponent(q), {}, { toast: false });
+    var params = new URLSearchParams({q: q});
+    VireoTextSearch.appendParams(params, speciesDropdownSearchOptions);
+    var results = await safeFetch('/api/species/search?' + params.toString(), {}, { toast: false });
     if (!results || !Array.isArray(results)) results = [];
     renderInto(container, q, results);
   }, 250);

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -1057,9 +1057,13 @@
   <div class="section" id="allSettingsSection">
     <div class="section-title" style="display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap;">
       <span>All settings</span>
-      <input type="search" id="allSettingsSearch" placeholder="Search settings…" autocomplete="off"
-             oninput="filterAllSettings()"
-             style="flex:1;min-width:200px;max-width:280px;background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border-secondary);border-radius:4px;padding:4px 10px;font-size:13px;">
+      <div class="search-control" style="flex:1;min-width:240px;max-width:340px;">
+        <input type="search" id="allSettingsSearch" placeholder="Search settings…" autocomplete="off"
+               oninput="filterAllSettings()"
+               style="background:var(--bg-input);color:var(--text-primary);border:1px solid var(--border-secondary);padding:4px 10px;font-size:13px;">
+        <button id="allSettingsMatchCaseBtn" class="search-option-btn" type="button" aria-pressed="false" onclick="VireoTextSearch.toggle('allSettings', 'match_case', filterAllSettings)" title="Match case">Aa</button>
+        <button id="allSettingsWholeWordBtn" class="search-option-btn" type="button" aria-pressed="false" onclick="VireoTextSearch.toggle('allSettings', 'whole_word', filterAllSettings)" title="Match whole word">ab</button>
+      </div>
     </div>
     <div style="font-size:12px;color:var(--text-dim);margin-bottom:10px;">
       Every Vireo setting, including ones not surfaced by the curated sections above. Edits save automatically; click Reset to revert.
@@ -3454,7 +3458,7 @@ function renderSettingRow(key) {
   } else if (!workspaceTab && hasGlobal) {
     meta += ' · default: ' + escapeHtml(formatSettingValue(defaultVal, spec, true));
   }
-  var search = (key + ' ' + spec.label + ' ' + spec.desc + ' ' + spec.category).toLowerCase();
+  var search = key + ' ' + spec.label + ' ' + spec.desc + ' ' + spec.category;
   return '<div class="setting-row-card" data-search="' + escapeAttr(search) + '" data-key="' + escapeAttr(key) + '" '
        +    'style="display:flex;align-items:flex-start;gap:10px;padding:10px 0;border-bottom:1px solid var(--border-primary);">'
        +   '<span class="provenance-dot ' + dotClass + '" title="' + escapeAttr(dotTitle) + '"></span>'
@@ -3744,10 +3748,15 @@ async function importSettingsFile(file) {
 }
 
 function filterAllSettings() {
-  var q = (document.getElementById('allSettingsSearch').value || '').trim().toLowerCase();
+  var q = (document.getElementById('allSettingsSearch').value || '').trim();
+  var searchOptions = VireoTextSearch.readOptions('allSettings');
   var rows = document.querySelectorAll('#allSettingsCategories .setting-row-card');
   rows.forEach(function(row) {
-    row.style.display = (!q || row.getAttribute('data-search').indexOf(q) !== -1) ? '' : 'none';
+    row.style.display = (!q || VireoTextSearch.matchesFields(
+      row.getAttribute('data-search') || '',
+      q,
+      searchOptions
+    )) ? '' : 'none';
   });
   document.querySelectorAll('#allSettingsCategories .setting-category').forEach(function(cat) {
     var anyVisible = false;

--- a/vireo/templates/variants.html
+++ b/vireo/templates/variants.html
@@ -33,12 +33,11 @@
   padding: 12px;
   border-bottom: 1px solid var(--border-primary);
 }
+.species-search .search-control { width: 100%; }
 .species-search input {
-  width: 100%;
   background: var(--bg-input);
   color: var(--text-primary);
   border: 1px solid var(--border-secondary);
-  border-radius: 4px;
   padding: 8px 10px;
   font-size: 13px;
   outline: none;
@@ -208,7 +207,11 @@
   <!-- Species sidebar -->
   <div class="species-sidebar">
     <div class="species-search">
-      <input type="text" id="speciesSearch" placeholder="Search species..." oninput="filterSpecies()">
+      <div class="search-control">
+        <input type="text" id="speciesSearch" placeholder="Search species..." oninput="filterSpecies()">
+        <button id="variantSpeciesMatchCaseBtn" class="search-option-btn" type="button" aria-pressed="false" onclick="VireoTextSearch.toggle('variantSpecies', 'match_case', filterSpecies)" title="Match case">Aa</button>
+        <button id="variantSpeciesWholeWordBtn" class="search-option-btn" type="button" aria-pressed="false" onclick="VireoTextSearch.toggle('variantSpecies', 'whole_word', filterSpecies)" title="Match whole word">ab</button>
+      </div>
     </div>
     <div class="species-list" id="speciesList">
       <div style="padding:20px;color:var(--text-dim);font-size:13px;">Loading species...</div>
@@ -269,15 +272,18 @@ document.getElementById('speciesList').addEventListener('click', function(e) {
 });
 
 function filterSpecies() {
-  var q = document.getElementById('speciesSearch').value.toLowerCase();
+  var q = document.getElementById('speciesSearch').value.trim();
   if (!q) {
     renderSpeciesList(allSpecies);
     return;
   }
+  var searchOptions = VireoTextSearch.readOptions('variantSpecies');
   var filtered = allSpecies.filter(function(s) {
-    return s.species.toLowerCase().indexOf(q) !== -1 ||
-           (s.taxonomy_family || '').toLowerCase().indexOf(q) !== -1 ||
-           (s.taxonomy_order || '').toLowerCase().indexOf(q) !== -1;
+    return VireoTextSearch.matchesFields(
+      [s.species, s.taxonomy_family || '', s.taxonomy_order || ''],
+      q,
+      searchOptions
+    );
   });
   renderSpeciesList(filtered);
 }

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -1338,6 +1338,27 @@ def test_species_search(app_and_db):
     names_lower = [n.lower() for n in data]
     assert any("robin" in n for n in names_lower)
 
+    db.add_keyword("Western Tanager", is_species=True)
+    db.add_keyword("Common Tern", is_species=True)
+
+    resp = client.get('/api/species/search?q=tern')
+    assert resp.status_code == 200
+    names = resp.get_json()
+    assert "Western Tanager" in names
+    assert "Common Tern" in names
+
+    resp = client.get('/api/species/search?q=tern&whole_word=1')
+    assert resp.status_code == 200
+    names = resp.get_json()
+    assert "Western Tanager" not in names
+    assert "Common Tern" in names
+
+    resp = client.get('/api/species/search?q=Tern&match_case=1')
+    assert resp.status_code == 200
+    names = resp.get_json()
+    assert "Western Tanager" not in names
+    assert "Common Tern" in names
+
     # Too short query returns empty
     resp = client.get('/api/species/search?q=r')
     assert resp.status_code == 200

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -715,6 +715,74 @@ def test_get_photos_keyword_multi_token(tmp_path):
     assert len(db.get_photo_ids(keyword='red bill')) == 2
 
 
+def test_get_photos_keyword_whole_word_excludes_embedded_token(tmp_path):
+    """Whole-word keyword search matches separators, not embedded substrings."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder('/photos', name='photos')
+    western = db.add_photo(
+        folder_id=fid, filename='western-gull.jpg', extension='.jpg',
+        file_size=100, file_mtime=1.0,
+    )
+    common = db.add_photo(
+        folder_id=fid, filename='common-tern.jpg', extension='.jpg',
+        file_size=100, file_mtime=1.0,
+    )
+    file_only = db.add_photo(
+        folder_id=fid, filename='tern_001.jpg', extension='.jpg',
+        file_size=100, file_mtime=1.0,
+    )
+    eastern = db.add_photo(
+        folder_id=fid, filename='eastern-phoebe.jpg', extension='.jpg',
+        file_size=100, file_mtime=1.0,
+    )
+    db.tag_photo(western, db.add_keyword('Western Gull'))
+    db.tag_photo(common, db.add_keyword('Common Tern'))
+    db.tag_photo(eastern, db.add_keyword('Eastern Phoebe'))
+
+    assert {
+        r['filename'] for r in db.get_photos(keyword='tern')
+    } == {'western-gull.jpg', 'common-tern.jpg', 'tern_001.jpg', 'eastern-phoebe.jpg'}
+
+    whole_word = db.get_photos(keyword='tern', keyword_whole_word=True)
+    assert {r['filename'] for r in whole_word} == {'common-tern.jpg', 'tern_001.jpg'}
+    assert db.count_filtered_photos(keyword='tern', keyword_whole_word=True) == 2
+    assert set(db.get_photo_ids(keyword='tern', keyword_whole_word=True)) == {
+        common,
+        file_only,
+    }
+
+
+def test_get_photos_keyword_match_case(tmp_path):
+    """Match-case keyword search distinguishes otherwise identical tokens."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder('/photos', name='photos')
+    db.add_photo(
+        folder_id=fid, filename='Common-Tern.jpg', extension='.jpg',
+        file_size=100, file_mtime=1.0,
+    )
+    db.add_photo(
+        folder_id=fid, filename='common-tern.jpg', extension='.jpg',
+        file_size=100, file_mtime=1.0,
+    )
+
+    assert {
+        r['filename'] for r in db.get_photos(keyword='Tern')
+    } == {'Common-Tern.jpg', 'common-tern.jpg'}
+    assert {
+        r['filename'] for r in db.get_photos(keyword='Tern', keyword_match_case=True)
+    } == {'Common-Tern.jpg'}
+    assert {
+        r['filename']
+        for r in db.get_photos(
+            keyword='Tern',
+            keyword_match_case=True,
+            keyword_whole_word=True,
+        )
+    } == {'Common-Tern.jpg'}
+
+
 def test_add_keyword_idempotent(tmp_path):
     """add_keyword returns existing id if keyword already exists."""
     from db import Database
@@ -3216,6 +3284,33 @@ def test_get_geolocated_photos_filters(tmp_path):
     results = db.get_geolocated_photos(date_from='2024-03-01')
     assert len(results) == 1
     assert results[0]['filename'] == 'b.jpg'
+
+
+def test_get_geolocated_photos_keyword_search_options(tmp_path):
+    """Map keyword filtering uses the shared whole-word and case options."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder('/photos', name='photos')
+    p1 = db.add_photo(folder_id=fid, filename='western.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+    p2 = db.add_photo(folder_id=fid, filename='tern.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+    db.conn.execute("UPDATE photos SET latitude=1.0, longitude=2.0 WHERE id IN (?,?)", (p1, p2))
+    db.conn.commit()
+    db.tag_photo(p1, db.add_keyword('Western Tanager'))
+    db.tag_photo(p2, db.add_keyword('Common Tern'))
+
+    assert {
+        r['filename'] for r in db.get_geolocated_photos(keyword='tern')
+    } == {'western.jpg', 'tern.jpg'}
+    assert {
+        r['filename']
+        for r in db.get_geolocated_photos(keyword='tern', keyword_whole_word=True)
+    } == {'tern.jpg'}
+    assert {
+        r['filename']
+        for r in db.get_geolocated_photos(keyword='Tern', keyword_match_case=True)
+    } == {'tern.jpg'}
 
 
 def test_get_geolocated_photos_with_species(tmp_path):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -70,6 +70,33 @@ def test_api_photo_ids_matches_browse_filters(app_and_db):
     assert data["total"] == len(expected)
 
 
+def test_api_photos_keyword_whole_word_option(app_and_db):
+    """Browse keyword whole-word option excludes embedded token matches."""
+    app, db = app_and_db
+    photos = db.get_photos(sort="name")
+    western_id = photos[0]["id"]
+    tern_id = photos[1]["id"]
+    db.tag_photo(western_id, db.add_keyword("Western Gull"))
+    db.tag_photo(tern_id, db.add_keyword("Common Tern"))
+
+    client = app.test_client()
+    resp = client.get("/api/photos?keyword=tern&sort=name")
+    assert resp.status_code == 200
+    names = {p["filename"] for p in resp.get_json()["photos"]}
+    assert photos[0]["filename"] in names
+    assert photos[1]["filename"] in names
+
+    resp = client.get("/api/photos?keyword=tern&keyword_whole_word=1&sort=name")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert [p["filename"] for p in data["photos"]] == [photos[1]["filename"]]
+    assert data["total"] == 1
+
+    resp = client.get("/api/photos/ids?keyword=tern&keyword_whole_word=1&sort=name")
+    assert resp.status_code == 200
+    assert resp.get_json()["photo_ids"] == [tern_id]
+
+
 def test_api_photo_search_ids_only_returns_all_matches(app_and_db, monkeypatch):
     """GET /api/photos/search?ids_only=1 returns all CLIP match IDs, not the page."""
     app, db = app_and_db

--- a/vireo/tests/test_pipeline_plan.py
+++ b/vireo/tests/test_pipeline_plan.py
@@ -1987,8 +1987,8 @@ def test_regroup_plan_will_run_species_review_for_identify_preset(
     branch can't run then. The plan mirrors that no-model degradation —
     see ``test_regroup_plan_species_review_skipped_when_no_active_model``.
     """
-    from pipeline_plan import compute_plan
     import models as models_mod
+    from pipeline_plan import compute_plan
     monkeypatch.setattr(models_mod, "get_active_model", lambda: {
         "id": "m1", "name": "BioCLIP-2", "downloaded": True,
     })
@@ -2031,8 +2031,8 @@ def test_regroup_plan_species_review_skipped_when_no_active_model(
     degradation instead of promising "Will prepare species review" for
     a run that will only show the no-model warning.
     """
-    from pipeline_plan import compute_plan
     import models as models_mod
+    from pipeline_plan import compute_plan
     # No downloaded model, no active model — the plan-side auto-skip
     # gate should trip. The `_make_db` fixture already ships no models,
     # but the dev's real ~/.vireo/models.json could bleed in without
@@ -2057,8 +2057,8 @@ def test_regroup_plan_species_review_skipped_when_selected_model_not_downloaded(
     requested ``model_ids`` entry is missing its download. The plan
     must not advertise species review in that case either.
     """
-    from pipeline_plan import compute_plan
     import models as models_mod
+    from pipeline_plan import compute_plan
     monkeypatch.setattr(models_mod, "get_models", lambda: [
         {"id": "m1", "name": "BioCLIP-2", "downloaded": False},
     ])


### PR DESCRIPTION
## Summary
Adds shared Match Case and Match Whole Word controls for local text search filters across Browse, Pipeline Review, Map, Highlights, Life List, Compare, Variants, Keywords, Settings, Logs, Help, and the command palette.
The backend now accepts matching flags for Browse-style keyword filters, Map keyword filtering, Highlights species filtering, and species autocomplete so whole-word searches like "tern" no longer match embedded text such as "Western".

## Validation
- python -m py_compile vireo/db.py vireo/app.py
- pytest vireo/tests/test_db.py::test_get_photos_keyword_whole_word_excludes_embedded_token vireo/tests/test_db.py::test_get_photos_keyword_match_case vireo/tests/test_db.py::test_get_geolocated_photos_keyword_search_options vireo/tests/test_photos_api.py::test_api_photos_keyword_whole_word_option vireo/tests/test_app.py::test_species_search
- pytest tests/e2e/test_page_loads.py
