### PR TITLE
Add pipeline review scope filter

### DIFF
--- a/tests/e2e/test_pipeline_review_species.py
+++ b/tests/e2e/test_pipeline_review_species.py
@@ -250,6 +250,7 @@ def test_pipeline_review_scope_control_loads_workspace_and_collection(live_serve
     _write_predictionless_pipeline_cache(live_server, cached_ids)
 
     payloads = []
+    flag_payloads = []
 
     page.route(
         "**/api/collections",
@@ -265,6 +266,13 @@ def test_pipeline_review_scope_control_loads_workspace_and_collection(live_serve
         route.fulfill(json=_review_result_for_ids(live_server, ids))
 
     page.route("**/api/pipeline/regroup-live", regroup_live)
+    page.route(
+        "**/api/photos/*/flag",
+        lambda route: (
+            flag_payloads.append(route.request.post_data_json),
+            route.fulfill(json={"ok": True}),
+        ),
+    )
 
     page.goto(f"{live_server['url']}/pipeline/review")
 
@@ -278,6 +286,13 @@ def test_pipeline_review_scope_control_loads_workspace_and_collection(live_serve
     expect(page.locator("#statTotalPhotos")).to_have_text("1")
     assert payloads[-1]["collection_id"] == 123
     assert payloads[-1]["save_cache"] is False
+
+    page.evaluate(
+        "(photoId) => window.setFlagFor(photoId, 'flagged')",
+        collection_ids[0],
+    )
+    page.wait_for_timeout(100)
+    assert flag_payloads == []
 
 
 def test_pipeline_review_sidebar_collapses_and_persists(live_server, page):

--- a/tests/e2e/test_pipeline_review_species.py
+++ b/tests/e2e/test_pipeline_review_species.py
@@ -141,6 +141,57 @@ def _write_confirmation_pipeline_cache(live_server, photo_ids):
         json.dump(cache, f)
 
 
+def _review_result_for_ids(live_server, photo_ids):
+    db = live_server["db"]
+    placeholders = ",".join("?" for _ in photo_ids)
+    rows = db.conn.execute(
+        f"SELECT id, filename, timestamp FROM photos WHERE id IN ({placeholders}) ORDER BY id",
+        photo_ids,
+    ).fetchall()
+    photos = [
+        {
+            "id": row["id"],
+            "filename": row["filename"],
+            "timestamp": row["timestamp"],
+            "label": "REVIEW",
+            "quality_composite": 0.5,
+            "flag": "none",
+            "rating": 0,
+        }
+        for row in rows
+    ]
+    ids = [p["id"] for p in photos]
+    return {
+        "photos": photos,
+        "encounters": [
+            {
+                "photo_ids": ids,
+                "photo_count": len(ids),
+                "burst_count": 1 if ids else 0,
+                "time_range": [
+                    photos[0]["timestamp"] if photos else None,
+                    photos[-1]["timestamp"] if photos else None,
+                ],
+                "species": [],
+                "species_predictions": [],
+                "species_confirmed": False,
+                "confirmed_species": None,
+                "bursts": [{"photo_ids": ids, "species_predictions": []}]
+                if ids else [],
+            }
+        ] if ids else [],
+        "summary": {
+            "total_photos": len(ids),
+            "encounter_count": 1 if ids else 0,
+            "burst_count": 1 if ids else 0,
+            "keep_count": 0,
+            "review_count": len(ids),
+            "reject_count": 0,
+            "rarity_protected": 0,
+        },
+    }
+
+
 def test_predictionless_pipeline_encounter_can_add_species(live_server, page):
     photo_ids = live_server["data"]["photos"][1:3]
     _write_predictionless_pipeline_cache(live_server, photo_ids)
@@ -176,6 +227,57 @@ def test_species_name_arg_keeps_nullish_values_empty(live_server, page):
 
     assert page.evaluate("speciesNameArg(null)") == "''"
     assert page.evaluate("speciesNameArg(undefined)") == "''"
+
+
+def test_pipeline_review_explains_partial_cache(live_server, page):
+    photo_ids = live_server["data"]["photos"][1:3]
+    _write_predictionless_pipeline_cache(live_server, photo_ids)
+
+    page.goto(f"{live_server['url']}/pipeline/review")
+
+    banner = page.locator("[data-testid='pipeline-review-cache-scope']")
+    expect(banner).to_be_visible()
+    expect(banner).to_contain_text(
+        f"Showing {len(photo_ids)} of {len(live_server['data']['photos'])}"
+    )
+    expect(banner).to_contain_text("selected folders")
+
+
+def test_pipeline_review_scope_control_loads_workspace_and_collection(live_server, page):
+    all_ids = live_server["data"]["photos"]
+    cached_ids = all_ids[1:3]
+    collection_ids = [all_ids[0]]
+    _write_predictionless_pipeline_cache(live_server, cached_ids)
+
+    payloads = []
+
+    page.route(
+        "**/api/collections",
+        lambda route: route.fulfill(
+            json=[{"id": 123, "name": "Selected Birds", "photo_count": 1}]
+        ),
+    )
+
+    def regroup_live(route):
+        body = route.request.post_data_json
+        payloads.append(body)
+        ids = collection_ids if body.get("collection_id") == 123 else all_ids
+        route.fulfill(json=_review_result_for_ids(live_server, ids))
+
+    page.route("**/api/pipeline/regroup-live", regroup_live)
+
+    page.goto(f"{live_server['url']}/pipeline/review")
+
+    page.locator("[data-testid='pipeline-review-scope']").select_option("workspace")
+    expect(page.locator("#statTotalPhotos")).to_have_text(str(len(all_ids)))
+    assert payloads[-1]["save_cache"] is False
+    assert "collection_id" not in payloads[-1]
+
+    page.locator("[data-testid='pipeline-review-scope']").select_option("collection")
+    page.locator("[data-testid='pipeline-review-collection']").select_option("123")
+    expect(page.locator("#statTotalPhotos")).to_have_text("1")
+    assert payloads[-1]["collection_id"] == 123
+    assert payloads[-1]["save_cache"] is False
 
 
 def test_pipeline_review_sidebar_collapses_and_persists(live_server, page):

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2831,8 +2831,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         total_photos = db.count_photos()
 
         import config as cfg
-        from pipeline import compute_review_readiness, load_results
+        from pipeline import (
+            compute_group_fingerprint,
+            compute_review_readiness,
+            load_results,
+            prune_missing_photos,
+        )
         cache_dir = os.path.dirname(db_path)
+        prune_missing_photos(cache_dir, db._active_workspace_id, db)
         results = load_results(cache_dir, db._active_workspace_id)
         if results and results.get("photos"):
             photo_ids = [p["id"] for p in results["photos"]]
@@ -2853,6 +2859,36 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         effective_cfg = db.get_effective_config(cfg.load())
         pipeline_cfg = effective_cfg.get("pipeline", {})
+
+        results_cache_info = None
+        if results is not None:
+            cached_photo_ids = {
+                p.get("id")
+                for p in results.get("photos", [])
+                if p.get("id") is not None
+            }
+            row = db.conn.execute(
+                "SELECT last_group_fingerprint FROM workspaces WHERE id = ?",
+                (db._active_workspace_id,),
+            ).fetchone()
+            last_group_fp = row["last_group_fingerprint"] if row else None
+            current_group_fp = compute_group_fingerprint(effective_cfg)
+            if not last_group_fp:
+                fp_status = "untracked"
+            elif last_group_fp == current_group_fp:
+                fp_status = "current"
+            else:
+                fp_status = "outdated"
+            results_cache_info = {
+                "workspace_photo_count": total_photos,
+                "cached_photo_count": len(cached_photo_ids),
+                "missing_photo_count": max(
+                    total_photos - len(cached_photo_ids), 0,
+                ),
+                "is_partial": len(cached_photo_ids) < total_photos,
+                "group_fingerprint_status": fp_status,
+                "review_mode": results.get("review_mode"),
+            }
 
         # Variant must match the active DINOv2 variant so embedding coverage
         # reflects what /api/pipeline/regroup-live would actually consume —
@@ -2906,6 +2942,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "mask_variant_coverage": db.mask_variant_coverage(),
             "sam_variant_warning": db.sam_variant_rerun_warning(sam2_variant),
             "results": results,
+            "results_cache_info": results_cache_info,
             "review_readiness": review_readiness,
             "workspace_overrides": ws_overrides,
             "recent_destinations": effective_cfg.get("ingest", {}).get("recent_destinations", []),
@@ -19147,6 +19184,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         collection_id = _coerce_collection_id(body.get("collection_id"))
         if collection_id is False:
             return json_error("collection_id must be an integer")
+        photo_ids = body.get("photo_ids")
+        if photo_ids is not None:
+            if not isinstance(photo_ids, list):
+                return json_error("photo_ids must be a list")
+            for pid in photo_ids:
+                if isinstance(pid, bool) or not isinstance(pid, int):
+                    return json_error("photo_ids entries must be integers")
+            if collection_id is not None:
+                return json_error("photo_ids cannot be combined with collection_id")
+        save_cache = body.get("save_cache", True)
+        if not isinstance(save_cache, bool):
+            return json_error("save_cache must be boolean")
 
         import config as cfg
 
@@ -19158,7 +19207,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # We re-group to have the full photo dicts with numpy arrays
         # (the cached JSON doesn't have embeddings)
         photos = load_photo_features(
-            db, collection_id=collection_id, config=effective_cfg
+            db,
+            collection_id=collection_id,
+            config=effective_cfg,
+            photo_ids=photo_ids,
         )
         if not photos:
             return json_error("No photos with pipeline features", 404)
@@ -19178,7 +19230,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if existing and existing.get("miss_computed_at"):
             results["miss_computed_at"] = existing["miss_computed_at"]
 
-        if collection_id is None:
+        if save_cache and collection_id is None and photo_ids is None:
             save_results(results, cache_dir, db._active_workspace_id)
 
         serialized = serialize_results(results)
@@ -19210,6 +19262,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         collection_id = _coerce_collection_id(body.get("collection_id"))
         if collection_id is False:
             return json_error("collection_id must be an integer")
+        photo_ids = body.get("photo_ids")
+        if photo_ids is not None:
+            if not isinstance(photo_ids, list):
+                return json_error("photo_ids must be a list")
+            for pid in photo_ids:
+                if isinstance(pid, bool) or not isinstance(pid, int):
+                    return json_error("photo_ids entries must be integers")
+            if collection_id is not None:
+                return json_error("photo_ids cannot be combined with collection_id")
+        save_cache = body.get("save_cache", True)
+        if not isinstance(save_cache, bool):
+            return json_error("save_cache must be boolean")
 
         import config as cfg
 
@@ -19218,7 +19282,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         pipeline_cfg = {**effective_cfg.get("pipeline", {}), **overrides}
 
         photos = load_photo_features(
-            db, collection_id=collection_id, config=effective_cfg
+            db,
+            collection_id=collection_id,
+            config=effective_cfg,
+            photo_ids=photo_ids,
         )
         if not photos:
             return json_error("No photos with pipeline features", 404)
@@ -19236,7 +19303,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if existing and existing.get("miss_computed_at"):
             results["miss_computed_at"] = existing["miss_computed_at"]
 
-        if collection_id is None:
+        if save_cache and collection_id is None and photo_ids is None:
             save_results(results, cache_dir, db._active_workspace_id)
 
         serialized = serialize_results(results)

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -3161,6 +3161,25 @@ function cloneReviewData(data) {
   return data ? JSON.parse(JSON.stringify(data)) : null;
 }
 
+// Workspace/Collection scope shows a *view* of the pipeline for a different
+// photo set — the result lives in `pipelineResults` alongside the persisted
+// cache, but writing it back to /api/pipeline/save-cache (or triggering any
+// server endpoint that rewrites the cache: detach-burst, detach-photo,
+// /api/encounters/species) would clobber the workspace's saved review with
+// this scoped subset. Callers use this to short-circuit those flows so
+// editing is confined to the Latest review scope.
+function isScopedReviewView() {
+  return reviewScopeMode && reviewScopeMode !== 'cache';
+}
+
+function notifyReadOnlyScopedView() {
+  var label = reviewScopeMode === 'collection' ? 'Collection' : 'Workspace';
+  showToast(
+    label + ' scope is view-only. Switch to Latest review to make changes.',
+    'warning'
+  );
+}
+
 function setReviewScopeStatus(text, isError) {
   var el = document.getElementById('reviewScopeStatus');
   if (!el) return;
@@ -3209,6 +3228,14 @@ function loadReviewScopeCollections() {
 }
 
 function reviewScopePayload(config) {
+  // Latest review scope: send the pre-scope request shape (config only) so
+  // the backend defaults save_cache=true with no photo_ids filter and
+  // slider tuning persists to the saved cache. Adding photo_ids here (as
+  // an earlier revision did) blocks the save branch in
+  // api_pipeline_reflow/regroup_live and drops slider changes on reload.
+  if (reviewScopeMode === 'cache') {
+    return { config: config || {} };
+  }
   var body = {
     config: config || {},
     save_cache: false,
@@ -3216,10 +3243,6 @@ function reviewScopePayload(config) {
   if (reviewScopeMode === 'collection') {
     if (!reviewScopeCollectionId) return null;
     body.collection_id = parseInt(reviewScopeCollectionId, 10);
-  } else if (reviewScopeMode === 'cache') {
-    var source = pipelineResults || cachedPipelineResults;
-    body.photo_ids = ((source && source.photos) || []).map(function(p) { return p.id; });
-    if (!body.photo_ids.length) return null;
   }
   return body;
 }
@@ -3263,6 +3286,12 @@ function scopedCacheInfoFor(data) {
 
 function loadReviewScopeResults() {
   updateReviewScopeControls();
+  // Bump the request sequence up front so that any scope fetch still in
+  // flight from a prior scope choice is invalidated regardless of which
+  // branch we take here. Otherwise a Workspace/Collection request that
+  // resolves after the user switches back to Latest review could pass its
+  // .then() guard and replace the cached view with stale scoped results.
+  var seq = ++reviewScopeRequestSeq;
   if (reviewScopeMode === 'cache') {
     if (cachedPipelineResults) {
       applyReviewResults(
@@ -3278,7 +3307,6 @@ function loadReviewScopeResults() {
     setReviewScopeStatus('Select one');
     return;
   }
-  var seq = ++reviewScopeRequestSeq;
   setReviewScopeStatus('Loading...');
   safeFetch('/api/pipeline/regroup-live', {
     method: 'POST',
@@ -3730,6 +3758,16 @@ async function confirmSpecies(event, encIdx, burstIdx, speciesName) {
   event.stopPropagation();
   closeAllDropdowns();
 
+  // /api/encounters/species reloads and rewrites the saved cache on the
+  // server, so calling it from a Workspace/Collection scope view would
+  // overwrite the persisted review with only the scoped photo set. Block
+  // it here — the inline species chip/dropdown buttons that call us have
+  // no scope awareness of their own.
+  if (isScopedReviewView()) {
+    notifyReadOnlyScopedView();
+    return;
+  }
+
   var enc = pipelineResults.encounters[encIdx];
   if (!enc) return;
 
@@ -3825,6 +3863,10 @@ async function confirmSpecies(event, encIdx, burstIdx, speciesName) {
 async function clearBurstOverride(event, encIdx, burstIdx) {
   event.stopPropagation();
   closeAllDropdowns();
+  if (isScopedReviewView()) {
+    notifyReadOnlyScopedView();
+    return;
+  }
   var enc = pipelineResults.encounters[encIdx];
   if (!enc || !enc.bursts || !enc.bursts[burstIdx]) return;
   enc.bursts[burstIdx].species_override = null;
@@ -3871,6 +3913,10 @@ function undoLastAction() {
 }
 
 async function detachBurst(encIdx, burstIdx) {
+  if (isScopedReviewView()) {
+    notifyReadOnlyScopedView();
+    return;
+  }
   // Save state for undo
   var snapshot = JSON.parse(JSON.stringify(pipelineResults));
 
@@ -3901,6 +3947,10 @@ async function detachBurst(encIdx, burstIdx) {
 }
 
 async function detachPhoto(encIdx, burstIdx, photoId) {
+  if (isScopedReviewView()) {
+    notifyReadOnlyScopedView();
+    return;
+  }
   var snapshot = JSON.parse(JSON.stringify(pipelineResults));
 
   var resp = await safeFetch('/api/pipeline/detach-photo', {
@@ -4626,6 +4676,19 @@ function grmUpdateApplyLabel() {
   if (checks.flags && diff.detachNew > 0) parts.push('Detach ' + diff.detachNew);
   btn.textContent = parts.length ? parts.join(' · ') + ' & Close' : 'Apply and close';
   btn.title = grmApplyTitle(diff, checks, checks.species ? tagCount : 0);
+
+  // In Workspace/Collection scope the current pipelineResults are a *view*
+  // over a different photo set — committing them would overwrite the
+  // workspace's saved review cache with just this scoped subset (both via
+  // the client save-cache POST and the server-side cache rewrite inside
+  // /api/encounters/species). Keep the modal browsable but block Apply.
+  if (isScopedReviewView()) {
+    btn.disabled = true;
+    btn.style.opacity = '0.5';
+    btn.style.cursor = 'not-allowed';
+    btn.textContent = 'Read-only in scope view';
+    btn.title = 'Switch Scope to "Latest review" to save picks, rejects, or species confirmations.';
+  }
 }
 
 // Diff the current modal zones against the DB snapshot we opened with.
@@ -5752,6 +5815,16 @@ async function grmApply() {
   // error after retry) must not let Apply clear flags.
   if (!grmState.seeded) {
     console.warn('grmApply called before /group/state seed completed; ignoring.');
+    return;
+  }
+  // Scoped-view guard: grmApply POSTs pipelineResults to /api/pipeline/save-cache
+  // (line ~5921) and confirms species via /api/encounters/species, which
+  // reloads and rewrites the saved cache server-side — either path would
+  // clobber the workspace's persisted review with this scoped subset.
+  // grmUpdateApplyLabel keeps the button visibly disabled here; this is
+  // defense in depth against a stray click while still seeded.
+  if (isScopedReviewView()) {
+    notifyReadOnlyScopedView();
     return;
   }
   if (grmState.applying) return;

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -2713,16 +2713,24 @@ function doReflow() {
     if (noBodyIndicator) noBodyIndicator.style.display = 'none';
     return;
   }
+  // Tag this request with the scope request sequence so a scope switch (or
+  // a newer slider request) invalidates its response. Without this, a tune
+  // fired in Workspace/Collection scope that resolves after the user
+  // switches back to Latest review would replace the cached view with
+  // stale scoped data (and scopedCacheInfoFor would recompute against the
+  // now-current scope).
+  var seq = ++reviewScopeRequestSeq;
   safeFetch('/api/pipeline/reflow', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify(body),
   }, { toast: false })
   .then(function(data) {
-    if (data.error) return;
-    applyReviewResults(data, scopedCacheInfoFor(data));
     var indicator = document.getElementById('reflowIndicator');
     if (indicator) indicator.style.display = 'none';
+    if (seq !== reviewScopeRequestSeq) return;
+    if (!data || data.error) return;
+    applyReviewResults(data, scopedCacheInfoFor(data));
   })
   .catch(function() {
     var indicator = document.getElementById('reflowIndicator');
@@ -2738,16 +2746,18 @@ function doRegroupLive() {
     if (noBodyIndicator) noBodyIndicator.style.display = 'none';
     return;
   }
+  var seq = ++reviewScopeRequestSeq;
   safeFetch('/api/pipeline/regroup-live', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify(body),
   }, { toast: false })
   .then(function(data) {
-    if (data.error) return;
-    applyReviewResults(data, scopedCacheInfoFor(data));
     var indicator = document.getElementById('reflowIndicator');
     if (indicator) indicator.style.display = 'none';
+    if (seq !== reviewScopeRequestSeq) return;
+    if (!data || data.error) return;
+    applyReviewResults(data, scopedCacheInfoFor(data));
   })
   .catch(function() {
     var indicator = document.getElementById('reflowIndicator');
@@ -3284,6 +3294,20 @@ function scopedCacheInfoFor(data) {
   };
 }
 
+// Sync cachedPipelineResults with the current view when we're in Latest
+// review scope. cachedPipelineResults was originally only written at page
+// init / computeReviewNow; without this, slider tunes, GRM apply, species
+// confirmation, and detach — all of which mutate pipelineResults and save
+// the cache while in Latest scope — would be lost the next time the user
+// switched to Workspace/Collection and back, and a later save-cache from
+// that stale view would overwrite the newer saved review on disk.
+function refreshLatestScopeSnapshotIfCurrent() {
+  if (reviewScopeMode !== 'cache') return;
+  if (!pipelineResults) return;
+  cachedPipelineResults = cloneReviewData(pipelineResults);
+  cachedResultsCacheInfo = cloneReviewData(resultsCacheInfo);
+}
+
 function loadReviewScopeResults() {
   updateReviewScopeControls();
   // Bump the request sequence up front so that any scope fetch still in
@@ -3325,6 +3349,11 @@ function loadReviewScopeResults() {
 
 function onReviewScopeModeChange(mode) {
   if (['cache', 'workspace', 'collection'].indexOf(mode) === -1) return;
+  // Capture the current Latest-review state before switching away so a later
+  // return to Latest restores the post-mutation view. Must run before
+  // reviewScopeMode changes so refreshLatestScopeSnapshotIfCurrent still
+  // matches on the outgoing (cache) mode.
+  refreshLatestScopeSnapshotIfCurrent();
   reviewScopeMode = mode;
   updateReviewScopeControls();
   loadReviewScopeResults();

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -166,6 +166,28 @@
   cursor: pointer;
   padding: 0 4px;
 }
+.cache-scope-banner {
+  display: none;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 14px;
+  padding: 10px 14px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--warning);
+  border-radius: 6px;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.45;
+}
+.cache-scope-banner strong {
+  color: var(--text-primary);
+  font-weight: 700;
+}
+.cache-scope-banner a {
+  margin-left: auto;
+  color: var(--accent);
+  white-space: nowrap;
+}
 
 /* Filter bar */
 .filter-bar {
@@ -221,6 +243,34 @@
   display: none;
 }
 .species-filter-clear:hover { color: var(--text-primary); }
+.scope-filter-wrap {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: 8px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+.scope-filter-wrap select {
+  padding: 5px 8px;
+  border-radius: 6px;
+  border: 1px solid var(--border-primary);
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 12px;
+  outline: none;
+  cursor: pointer;
+}
+.scope-filter-wrap select:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+.scope-filter-wrap select:focus { border-color: var(--accent); }
+.scope-status {
+  min-width: 70px;
+  color: var(--text-dim);
+  font-size: 11px;
+}
 .confidence-slider-wrap {
   display: flex;
   align-items: center;
@@ -1405,6 +1455,10 @@ input[type="range"]::-moz-range-thumb {
       <a href="/pipeline" class="degraded-banner-link">Open Pipeline</a>
       <button class="degraded-banner-close" onclick="dismissDegradedBanner()" aria-label="Dismiss">&times;</button>
     </div>
+    <div class="cache-scope-banner" id="cacheScopeBanner" data-testid="pipeline-review-cache-scope">
+      <span id="cacheScopeBannerText"></span>
+      <a href="/pipeline">Open Process</a>
+    </div>
 
     <!-- Summary bar (hidden until data loads) -->
     <div class="summary-bar" id="summaryBar" style="display:none">
@@ -1480,6 +1534,18 @@ input[type="range"]::-moz-range-thumb {
       <div class="species-filter-wrap">
         <input type="text" id="speciesFilterInput" placeholder="Filter by species..." oninput="setSpeciesFilter(this.value)">
         <button class="species-filter-clear" id="speciesFilterClear" onclick="clearSpeciesFilter()" title="Clear filter">&times;</button>
+      </div>
+      <div class="scope-filter-wrap" title="Choose which photos are included in this review view">
+        <label for="reviewScopeSelect">Scope:</label>
+        <select id="reviewScopeSelect" onchange="onReviewScopeModeChange(this.value)" data-testid="pipeline-review-scope">
+          <option value="cache">Latest review</option>
+          <option value="workspace">Workspace</option>
+          <option value="collection">Collection</option>
+        </select>
+        <select id="reviewScopeCollectionSelect" onchange="onReviewScopeCollectionChange(this.value)" style="display:none;max-width:180px;" data-testid="pipeline-review-collection">
+          <option value="">Select collection...</option>
+        </select>
+        <span class="scope-status" id="reviewScopeStatus"></span>
       </div>
       <div class="encounter-sort-wrap" title="Order encounters are listed in">
         <label for="encounterSortSelect">Sort:</label>
@@ -1633,6 +1699,13 @@ var workspaceOverrides = null;
 // (regroup-live doesn't return readiness, but the missing-features set is
 // unchanged by computing the cache).
 var reviewReadiness = null;
+var resultsCacheInfo = null;
+var cachedPipelineResults = null;
+var cachedResultsCacheInfo = null;
+var reviewScopeMode = 'cache';
+var reviewScopeCollectionId = null;
+var reviewScopeCollections = [];
+var reviewScopeRequestSeq = 0;
 // Survives re-renders so confirming/filtering doesn't re-expand collapsed
 // encounters. Keyed by the encounter's full sorted photo_id set so that
 // detach/regroup (which change composition) naturally invalidate the key
@@ -2609,16 +2682,20 @@ function onGroupingChange(slider) {
 
 function doReflow() {
   var config = getScoringConfig();
+  var body = reviewScopePayload(config);
+  if (!body) {
+    var noBodyIndicator = document.getElementById('reflowIndicator');
+    if (noBodyIndicator) noBodyIndicator.style.display = 'none';
+    return;
+  }
   safeFetch('/api/pipeline/reflow', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({config: config}),
+    body: JSON.stringify(body),
   }, { toast: false })
   .then(function(data) {
     if (data.error) return;
-    pipelineResults = data;
-    renderResults();
-    updateSummaryBar(data.summary);
+    applyReviewResults(data, scopedCacheInfoFor(data));
     var indicator = document.getElementById('reflowIndicator');
     if (indicator) indicator.style.display = 'none';
   })
@@ -2630,16 +2707,20 @@ function doReflow() {
 
 function doRegroupLive() {
   var config = Object.assign({}, getGroupingConfig(), getScoringConfig());
+  var body = reviewScopePayload(config);
+  if (!body) {
+    var noBodyIndicator = document.getElementById('reflowIndicator');
+    if (noBodyIndicator) noBodyIndicator.style.display = 'none';
+    return;
+  }
   safeFetch('/api/pipeline/regroup-live', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({config: config}),
+    body: JSON.stringify(body),
   }, { toast: false })
   .then(function(data) {
     if (data.error) return;
-    pipelineResults = data;
-    renderResults();
-    updateSummaryBar(data.summary);
+    applyReviewResults(data, scopedCacheInfoFor(data));
     var indicator = document.getElementById('reflowIndicator');
     if (indicator) indicator.style.display = 'none';
   })
@@ -3033,6 +3114,175 @@ function dismissDegradedBanner() {
   document.getElementById('degradedBanner').style.display = 'none';
 }
 
+function renderCacheScopeBanner(info) {
+  var banner = document.getElementById('cacheScopeBanner');
+  var text = document.getElementById('cacheScopeBannerText');
+  if (!banner || !text) return;
+  banner.style.display = 'none';
+  if (!info || !info.is_partial) return;
+
+  var shown = info.cached_photo_count || 0;
+  var total = info.workspace_photo_count || 0;
+  var missing = info.missing_photo_count || Math.max(total - shown, 0);
+  text.innerHTML = '<strong>Showing ' + shown + ' of ' + total
+    + ' active workspace photo' + (total === 1 ? '' : 's') + '.</strong> '
+    + missing + ' photo' + (missing === 1 ? '' : 's')
+    + ' are not in this review cache. This usually means the last Process run '
+    + 'was scoped to selected folders, a collection, new images, or deselected photos.';
+  banner.style.display = 'flex';
+}
+
+function cloneReviewData(data) {
+  return data ? JSON.parse(JSON.stringify(data)) : null;
+}
+
+function setReviewScopeStatus(text, isError) {
+  var el = document.getElementById('reviewScopeStatus');
+  if (!el) return;
+  el.textContent = text || '';
+  el.style.color = isError ? 'var(--danger)' : 'var(--text-dim)';
+}
+
+function updateReviewScopeControls() {
+  var scopeSel = document.getElementById('reviewScopeSelect');
+  var collectionSel = document.getElementById('reviewScopeCollectionSelect');
+  if (scopeSel) scopeSel.value = reviewScopeMode;
+  if (collectionSel) {
+    collectionSel.style.display = reviewScopeMode === 'collection' ? '' : 'none';
+    collectionSel.value = reviewScopeCollectionId || '';
+  }
+}
+
+function updateReviewScopeStatusFromResults(data) {
+  var n = data && data.summary ? data.summary.total_photos : null;
+  if (n == null) {
+    setReviewScopeStatus('');
+    return;
+  }
+  setReviewScopeStatus(n + ' photo' + (n === 1 ? '' : 's'));
+}
+
+function populateReviewScopeCollections(collections) {
+  reviewScopeCollections = Array.isArray(collections) ? collections : [];
+  var sel = document.getElementById('reviewScopeCollectionSelect');
+  if (!sel) return;
+  sel.innerHTML = '<option value="">Select collection...</option>';
+  reviewScopeCollections.forEach(function(c) {
+    var opt = document.createElement('option');
+    opt.value = String(c.id);
+    var count = c.photo_count != null ? ' (' + c.photo_count + ')' : '';
+    opt.textContent = c.name + count;
+    sel.appendChild(opt);
+  });
+  updateReviewScopeControls();
+}
+
+function loadReviewScopeCollections() {
+  safeFetch('/api/collections', {}, { toast: false })
+    .then(populateReviewScopeCollections)
+    .catch(function() { populateReviewScopeCollections([]); });
+}
+
+function reviewScopePayload(config) {
+  var body = {
+    config: config || {},
+    save_cache: false,
+  };
+  if (reviewScopeMode === 'collection') {
+    if (!reviewScopeCollectionId) return null;
+    body.collection_id = parseInt(reviewScopeCollectionId, 10);
+  } else if (reviewScopeMode === 'cache') {
+    var source = pipelineResults || cachedPipelineResults;
+    body.photo_ids = ((source && source.photos) || []).map(function(p) { return p.id; });
+    if (!body.photo_ids.length) return null;
+  }
+  return body;
+}
+
+function applyReviewResults(data, info) {
+  if (!data || !data.encounters) return;
+  var empty = document.getElementById('emptyState');
+  if (empty) empty.style.display = 'none';
+  pipelineResults = data;
+  resultsCacheInfo = info || null;
+  collapsedEncounters = new Set();
+  updatePipelineReviewSidebarVisibility();
+  var sb = document.getElementById('summaryBar');
+  if (sb) sb.style.display = '';
+  updateSummaryBar(data.summary);
+  var fb = document.getElementById('filterBar');
+  if (fb) fb.style.display = '';
+  applyPipelineReviewToolbarState();
+  renderResults();
+  checkPendingSync();
+  refreshMissesReviewBtn();
+  renderDegradedBanner(reviewReadiness && reviewReadiness.enhancing_missing);
+  renderCacheScopeBanner(resultsCacheInfo);
+  updateReviewScopeStatusFromResults(data);
+}
+
+function scopedCacheInfoFor(data) {
+  var workspaceTotal = reviewReadiness ? reviewReadiness.total_photos : (
+    data && data.summary ? data.summary.total_photos : 0
+  );
+  var shown = data && data.summary ? data.summary.total_photos : 0;
+  return {
+    workspace_photo_count: workspaceTotal,
+    cached_photo_count: shown,
+    missing_photo_count: Math.max(workspaceTotal - shown, 0),
+    is_partial: reviewScopeMode === 'cache' && shown < workspaceTotal,
+    group_fingerprint_status: 'view',
+    review_mode: data ? data.review_mode || null : null,
+  };
+}
+
+function loadReviewScopeResults() {
+  updateReviewScopeControls();
+  if (reviewScopeMode === 'cache') {
+    if (cachedPipelineResults) {
+      applyReviewResults(
+        cloneReviewData(cachedPipelineResults),
+        cloneReviewData(cachedResultsCacheInfo)
+      );
+    }
+    return;
+  }
+
+  var body = reviewScopePayload(Object.assign({}, getGroupingConfig(), getScoringConfig()));
+  if (!body) {
+    setReviewScopeStatus('Select one');
+    return;
+  }
+  var seq = ++reviewScopeRequestSeq;
+  setReviewScopeStatus('Loading...');
+  safeFetch('/api/pipeline/regroup-live', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(body),
+  }, { toast: false })
+  .then(function(data) {
+    if (seq !== reviewScopeRequestSeq || !data || data.error) return;
+    applyReviewResults(data, scopedCacheInfoFor(data));
+  })
+  .catch(function(e) {
+    if (seq !== reviewScopeRequestSeq) return;
+    setReviewScopeStatus((e && e.message) || 'Could not load', true);
+  });
+}
+
+function onReviewScopeModeChange(mode) {
+  if (['cache', 'workspace', 'collection'].indexOf(mode) === -1) return;
+  reviewScopeMode = mode;
+  updateReviewScopeControls();
+  loadReviewScopeResults();
+}
+
+function onReviewScopeCollectionChange(value) {
+  reviewScopeCollectionId = value || null;
+  updateReviewScopeControls();
+  loadReviewScopeResults();
+}
+
 function renderEmptyState(readiness) {
   var heading = document.getElementById('emptyStateHeading');
   var body = document.getElementById('emptyStateBody');
@@ -3111,24 +3361,30 @@ function computeReviewNow() {
     }
     // Hide empty state, render results inline
     document.getElementById('emptyState').style.display = 'none';
-    pipelineResults = data;
+    resultsCacheInfo = {
+      workspace_photo_count: reviewReadiness ? reviewReadiness.total_photos : data.summary.total_photos,
+      cached_photo_count: data.summary.total_photos,
+      missing_photo_count: Math.max(
+        (reviewReadiness ? reviewReadiness.total_photos : data.summary.total_photos)
+          - data.summary.total_photos,
+        0
+      ),
+      is_partial: false,
+      group_fingerprint_status: 'current',
+      review_mode: data.review_mode || null
+    };
+    cachedPipelineResults = cloneReviewData(data);
+    cachedResultsCacheInfo = cloneReviewData(resultsCacheInfo);
     // Parity with initPipelineReviewPage's happy path:
-    collapsedEncounters = new Set();
     if (workspaceOverrides && workspaceOverrides.review_min_confidence != null) {
       minConfidence = workspaceOverrides.review_min_confidence;
       document.getElementById('confSlider').value = minConfidence;
       document.getElementById('confSliderVal').textContent = minConfidence + '%';
     }
-    document.getElementById('summaryBar').style.display = '';
-    updateSummaryBar(data.summary);
-    document.getElementById('filterBar').style.display = '';
-    updatePipelineReviewSidebarVisibility();
     restorePipelineReviewViewState();
-    renderResults();
+    applyReviewResults(data, resultsCacheInfo);
     openRequestedGroupReviewFromUrl();
-    checkPendingSync();
-    refreshMissesReviewBtn();
-    renderDegradedBanner(reviewReadiness && reviewReadiness.enhancing_missing);
+    loadReviewScopeCollections();
   }).catch(function() {
     // safeFetch toasts the error; re-enable the button so the user can retry.
     if (btn) { btn.disabled = false; btn.textContent = 'Compute results now'; }
@@ -3162,8 +3418,9 @@ function loadPipelinePageInit() {
     var empty = document.getElementById('emptyState');
     if (empty) empty.style.display = 'none';
 
-    pipelineResults = data.results;
-    collapsedEncounters = new Set();
+    resultsCacheInfo = data.results_cache_info || null;
+    cachedPipelineResults = cloneReviewData(data.results);
+    cachedResultsCacheInfo = cloneReviewData(resultsCacheInfo);
 
     if (data.workspace_overrides && data.workspace_overrides.review_min_confidence != null) {
       minConfidence = data.workspace_overrides.review_min_confidence;
@@ -3171,23 +3428,10 @@ function loadPipelinePageInit() {
       document.getElementById('confSliderVal').textContent = minConfidence + '%';
     }
 
-    updatePipelineReviewSidebarVisibility();
-
-    // Show summary bar and populate
-    var sb = document.getElementById('summaryBar');
-    if (sb) sb.style.display = '';
-    updateSummaryBar(data.results.summary);
-
-    // Show filter bar
-    var fb = document.getElementById('filterBar');
-    if (fb) fb.style.display = '';
-
     restorePipelineReviewViewState();
-    renderResults();
+    applyReviewResults(data.results, resultsCacheInfo);
     openRequestedGroupReviewFromUrl();
-    checkPendingSync();
-    refreshMissesReviewBtn();
-    renderDegradedBanner(data.review_readiness && data.review_readiness.enhancing_missing);
+    loadReviewScopeCollections();
   });
 }
 

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -2959,6 +2959,10 @@ function setPipelineReviewFlag(photoId, flag) {
   if (flag !== 'flagged' && flag !== 'rejected' && flag !== 'none') return Promise.resolve();
   photoId = parseInt(photoId, 10);
   if (!photoId) return Promise.resolve();
+  if (isScopedReviewView()) {
+    notifyReadOnlyScopedView();
+    return Promise.resolve();
+  }
 
   return safeFetch('/api/photos/' + photoId + '/flag', {
     method: 'POST',
@@ -2973,6 +2977,7 @@ function setPipelineReviewFlag(photoId, flag) {
     }
     var msg = flag === 'flagged' ? 'Marked as pick' : (flag === 'rejected' ? 'Marked as reject' : 'Flag cleared');
     showToast(msg, 'success');
+    refreshLatestScopeSnapshotIfCurrent();
   });
 }
 
@@ -3277,6 +3282,7 @@ function applyReviewResults(data, info) {
   renderDegradedBanner(reviewReadiness && reviewReadiness.enhancing_missing);
   renderCacheScopeBanner(resultsCacheInfo);
   updateReviewScopeStatusFromResults(data);
+  refreshLatestScopeSnapshotIfCurrent();
 }
 
 function scopedCacheInfoFor(data) {
@@ -3887,6 +3893,7 @@ async function confirmSpecies(event, encIdx, burstIdx, speciesName) {
   }
   refreshAfterSpeciesConfirm(encIdx, burstIdx, forceFullRender);
   checkPendingSync();
+  refreshLatestScopeSnapshotIfCurrent();
 }
 
 async function clearBurstOverride(event, encIdx, burstIdx) {
@@ -3907,6 +3914,7 @@ async function clearBurstOverride(event, encIdx, burstIdx) {
   });
   renderResults();
   updateSummaryBar(refreshLocalSummaryCounts());
+  refreshLatestScopeSnapshotIfCurrent();
 }
 
 // -- Detach & Undo --
@@ -3960,6 +3968,7 @@ async function detachBurst(encIdx, burstIdx) {
   if (resp.summary) pipelineResults.summary = resp.summary;
   renderResults();
   updateSummaryBar(pipelineResults.summary);
+  refreshLatestScopeSnapshotIfCurrent();
 
   showUndo('Burst detached from encounter', function() {
     // Restore from snapshot
@@ -3972,6 +3981,7 @@ async function detachBurst(encIdx, burstIdx) {
     });
     renderResults();
     updateSummaryBar(pipelineResults.summary);
+    refreshLatestScopeSnapshotIfCurrent();
   });
 }
 
@@ -3993,6 +4003,7 @@ async function detachPhoto(encIdx, burstIdx, photoId) {
   if (resp.summary) pipelineResults.summary = resp.summary;
   renderResults();
   updateSummaryBar(pipelineResults.summary);
+  refreshLatestScopeSnapshotIfCurrent();
 
   showUndo('Photo detached from burst', function() {
     pipelineResults = snapshot;
@@ -4003,6 +4014,7 @@ async function detachPhoto(encIdx, burstIdx, photoId) {
     });
     renderResults();
     updateSummaryBar(pipelineResults.summary);
+    refreshLatestScopeSnapshotIfCurrent();
   });
 }
 
@@ -6060,6 +6072,7 @@ async function grmApply() {
       clearBrowseBurstHandoff();
     }
 
+    refreshLatestScopeSnapshotIfCurrent();
     closeGroupReview();
     // Clear the species input for next use
     document.getElementById('grmSpecies').value = '';

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -3169,6 +3169,46 @@ def test_pipeline_regroup_live_view_scope_does_not_overwrite_cache(setup):
         assert _json.load(f) == original_cache
 
 
+def test_pipeline_regroup_live_default_persists_cache(setup):
+    """Latest-review-scope slider tunes (no photo_ids, no save_cache flag)
+    must persist to the saved cache so a reload restores the user's
+    latest review adjustments. This is the pre-scope-switcher default
+    behavior; the client's reviewScopePayload sends the same body shape
+    when scope == 'cache'."""
+    app, db_path = setup
+    p1, _p2 = _seed_workspace_with_masks(db_path)
+
+    import json as _json
+
+    from db import Database
+    db = Database(db_path)
+    ws = db._active_workspace_id
+    db.close()
+    cache_path = os.path.join(
+        os.path.dirname(db_path), f"pipeline_results_ws{ws}.json"
+    )
+    original_cache = {
+        "encounters": [],
+        "photos": [{"id": p1, "filename": "a.jpg", "label": "REVIEW"}],
+        "summary": {"total_photos": 1},
+    }
+    with open(cache_path, "w") as f:
+        _json.dump(original_cache, f)
+
+    with app.test_client() as c:
+        resp = c.post("/api/pipeline/regroup-live", json={"config": {}})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["summary"]["total_photos"] == 2
+
+    with open(cache_path) as f:
+        saved = _json.load(f)
+    # The default request shape must have overwritten the partial cache
+    # with the fresh workspace-wide regroup result.
+    assert saved != original_cache
+    assert saved["summary"]["total_photos"] == 2
+
+
 def test_pipeline_page_init_state_ready_folds_blocking_gaps_into_enhancing(setup, tmp_path):
     """When the grouping cache is on disk but mask coverage is below the
     25% threshold, compute_review_readiness returns missing_required=["masks"]

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -3105,6 +3105,70 @@ def test_pipeline_page_init_review_readiness_state_ready_when_cache_exists(setup
         assert "embeddings" in data["review_readiness"]["enhancing_missing"]
 
 
+def test_pipeline_page_init_reports_partial_review_cache(setup):
+    """page-init tells the review UI when cached results cover only a subset."""
+    app, db_path = setup
+    p1, _p2 = _seed_workspace_with_masks(db_path)
+
+    import json as _json
+
+    from db import Database
+    db = Database(db_path)
+    ws = db._active_workspace_id
+    db.close()
+    cache_path = os.path.join(
+        os.path.dirname(db_path), f"pipeline_results_ws{ws}.json"
+    )
+    with open(cache_path, "w") as f:
+        _json.dump({
+            "encounters": [],
+            "photos": [{"id": p1, "filename": "a.jpg", "label": "REVIEW"}],
+            "summary": {"total_photos": 1},
+        }, f)
+
+    with app.test_client() as c:
+        resp = c.get("/api/pipeline/page-init")
+        assert resp.status_code == 200
+        info = resp.get_json()["results_cache_info"]
+        assert info["workspace_photo_count"] == 2
+        assert info["cached_photo_count"] == 1
+        assert info["missing_photo_count"] == 1
+        assert info["is_partial"] is True
+        assert info["group_fingerprint_status"] == "untracked"
+
+
+def test_pipeline_regroup_live_view_scope_does_not_overwrite_cache(setup):
+    """Review-page scope changes can compute all-workspace results as a view."""
+    app, db_path = setup
+    p1, _p2 = _seed_workspace_with_masks(db_path)
+
+    import json as _json
+
+    from db import Database
+    db = Database(db_path)
+    ws = db._active_workspace_id
+    db.close()
+    cache_path = os.path.join(
+        os.path.dirname(db_path), f"pipeline_results_ws{ws}.json"
+    )
+    original_cache = {
+        "encounters": [],
+        "photos": [{"id": p1, "filename": "a.jpg", "label": "REVIEW"}],
+        "summary": {"total_photos": 1},
+    }
+    with open(cache_path, "w") as f:
+        _json.dump(original_cache, f)
+
+    with app.test_client() as c:
+        resp = c.post("/api/pipeline/regroup-live", json={"save_cache": False})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["summary"]["total_photos"] == 2
+
+    with open(cache_path) as f:
+        assert _json.load(f) == original_cache
+
+
 def test_pipeline_page_init_state_ready_folds_blocking_gaps_into_enhancing(setup, tmp_path):
     """When the grouping cache is on disk but mask coverage is below the
     25% threshold, compute_review_readiness returns missing_required=["masks"]


### PR DESCRIPTION
Adds a Scope control to Pipeline Review so reviewers can switch between the latest saved review, all workspace photos, and a selected collection. Exposes review-cache coverage metadata and shows a partial-cache banner when the latest saved review excludes active workspace photos. Extends live regroup/reflow APIs with view-only photo and cache-save controls so scoped review changes do not overwrite the saved cache. Tests cover cache coverage metadata, view-only regroup behavior, and browser scope switching for workspace and collection views.