### PR TITLE
Fix import folder browser volume test

### DIFF
--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -146,6 +146,10 @@ def test_import_folder_browser_selects_volumes_from_synthetic_root(live_server, 
     page.evaluate(
         """
         () => {
+          Object.defineProperty(navigator, 'userAgent', {
+            value: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/120 Safari/537.36',
+            configurable: true,
+          });
           const originalFetch = window.fetch.bind(window);
           window.fetch = (input, init) => {
             const target = typeof input === 'string' ? input : input.url;
@@ -172,8 +176,18 @@ def test_import_folder_browser_selects_volumes_from_synthetic_root(live_server, 
     select_btn = page.locator("#folderBrowserSelectBtn")
     expect(select_btn).to_be_disabled()
 
-    items.nth(0).click(modifiers=["Control"])
-    items.nth(1).click(modifiers=["Control"])
+    items.nth(0).evaluate(
+        """el => el.dispatchEvent(new MouseEvent('click', {
+          bubbles: true,
+          ctrlKey: true,
+        }))"""
+    )
+    items.nth(1).evaluate(
+        """el => el.dispatchEvent(new MouseEvent('click', {
+          bubbles: true,
+          ctrlKey: true,
+        }))"""
+    )
 
     expect(select_btn).to_be_enabled()
     expect(select_btn).to_have_text("Add 2 Folders")


### PR DESCRIPTION
This fixes the import page synthetic Volumes regression test so it reliably exercises the non-macOS /api/volumes branch.

The test now overrides navigator.userAgent and dispatches ctrlKey click events directly, avoiding host-specific macOS Control-click behavior.

Validated with `pytest -q tests/e2e/test_import_page.py::test_import_folder_browser_selects_volumes_from_synthetic_root --browser chromium` and `pytest -q tests/e2e/test_import_page.py --browser chromium`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end coverage for importing folders from the volumes root.
  * Improved simulation of Chrome-like browser behavior and multi-select interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->