### PR TITLE
Fix pipeline and import e2e regressions

### DIFF
--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -297,6 +297,7 @@ function addSource() {
 
 async function browseForSource() {
   if (typeof pickDirectory === 'function') {
+    const seqBeforePicker = browserSeq;
     const result = await pickDirectory('Select source folders', { multiple: true });
     if (result) {
       const paths = Array.isArray(result) ? result : [result];
@@ -304,12 +305,17 @@ async function browseForSource() {
       return;
     }
     if (typeof isTauri === 'function' && isTauri()) return;
+    if (browserSeq !== seqBeforePicker) {
+      openImportFolderBrowser('source', { skipInitialBrowse: true });
+      return;
+    }
   }
   openImportFolderBrowser('source');
 }
 
 async function browseForDestination() {
   if (typeof pickDirectory === 'function') {
+    const seqBeforePicker = browserSeq;
     const result = await pickDirectory('Select archive folder');
     if (result) {
       const path = Array.isArray(result) ? result[0] : result;
@@ -317,11 +323,15 @@ async function browseForDestination() {
       return;
     }
     if (typeof isTauri === 'function' && isTauri()) return;
+    if (browserSeq !== seqBeforePicker) {
+      openImportFolderBrowser('destination', { skipInitialBrowse: true });
+      return;
+    }
   }
   openImportFolderBrowser('destination');
 }
 
-function openImportFolderBrowser(mode) {
+function openImportFolderBrowser(mode, opts = {}) {
   browserMode = mode === 'destination' ? 'destination' : 'source';
   const overlay = document.getElementById('importFolderBrowser');
   document.getElementById('folderBrowserTitle').textContent =
@@ -344,7 +354,7 @@ function openImportFolderBrowser(mode) {
   const startPath = browserMode === 'destination'
     ? (document.getElementById('destInput').value || '').trim()
     : '';
-  browseImportFolderTo(startPath || null);
+  if (!opts.skipInitialBrowse) browseImportFolderTo(startPath || null);
 }
 
 function closeImportFolderBrowser() {

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -909,9 +909,9 @@ body { padding-bottom: 36px; }
     <span style="margin-left:auto;display:inline-flex;align-items:center;gap:6px;font-size:12px;color:var(--text-secondary);">
       Strategy
       <select id="strategySelect" onchange="applyStrategyPreset()" style="font-size:12px;background:var(--bg-tertiary);color:var(--text-primary);border:1px solid var(--border-secondary);border-radius:4px;padding:3px 6px;">
-        <option value="identify" selected>Identify birds</option>
+        <option value="__custom__" selected>Custom (use toggles)</option>
+        <option value="identify">Identify birds</option>
         <option value="quick_look">Quick look</option>
-        <option value="__custom__" data-advanced-strategy>Custom (use toggles)</option>
         <option value="full" data-advanced-strategy>Full pipeline</option>
         <option value="cull_ready" data-advanced-strategy>Cull-ready</option>
       </select>
@@ -1673,9 +1673,6 @@ function updateAdvancedPipelineOptions() {
   sel.querySelectorAll('[data-advanced-strategy]').forEach(function(opt) {
     opt.hidden = !advanced;
     opt.disabled = !advanced;
-  });
-  document.querySelectorAll('[data-advanced-stage]').forEach(function(card) {
-    card.style.display = advanced ? '' : 'none';
   });
   if (!advanced && sel.selectedOptions.length && sel.selectedOptions[0].disabled) {
     sel.value = 'identify';


### PR DESCRIPTION
Fixes the Pipeline page default state so visible stage toggles drive the initial plan, keeping Extract, Eye Keypoints, and Group visible and runnable unless the user chooses a preset. Prevents the import folder browser fallback from overwriting an explicit navigation, which restores synthetic Volumes selection. Validated with `python -m pytest tests/e2e/test_pipeline.py -q` and `python -m pytest tests/e2e/test_import_page.py -q`.