### PR TITLE
Improve Compare model review controls

### DIFF
--- a/tests/e2e/test_compare_page.py
+++ b/tests/e2e/test_compare_page.py
@@ -23,6 +23,26 @@ def test_compare_page_filters_conflicts_without_crashing(live_server, page):
     expect(page.locator("#filterRow .active")).to_contain_text("Matches")
 
 
+def test_compare_page_exposes_disagreement_filters_and_sorts(live_server, page):
+    page.goto(f"{live_server['url']}/compare")
+
+    expect(page.locator("#sortRow")).to_be_visible()
+    expect(page.locator("#excludeRow")).to_be_visible()
+    expect(page.locator("#filterRow")).to_contain_text("Models disagree")
+    expect(page.locator("#filterRow")).to_contain_text("Keyword vs models")
+    expect(page.locator("#excludeRow")).to_contain_text("Hide rejects")
+    expect(page.locator("#excludeRow")).to_contain_text("Hide picks")
+
+    page.locator("#sortRow button", has_text="Model disagreement").click()
+    expect(page.locator("#sortRow .active")).to_contain_text("Model disagreement")
+
+    page.locator("#excludeRow button", has_text="Hide rejects").click()
+    expect(page.locator("#excludeRow .active")).to_contain_text("Hide rejects")
+
+    page.locator("#filterRow button", has_text="Keyword vs models").click()
+    expect(page.locator("#filterRow .active")).to_contain_text("Keyword vs models")
+
+
 def test_compare_page_thumbnail_opens_lightbox(live_server, page):
     page.goto(f"{live_server['url']}/compare")
 

--- a/tests/e2e/test_compare_page.py
+++ b/tests/e2e/test_compare_page.py
@@ -1,6 +1,34 @@
 from playwright.sync_api import expect
 
 
+def test_compare_keyword_conflict_filter_includes_non_top_predictions(live_server, page):
+    from labels_fingerprint import TOL_SENTINEL
+
+    db = live_server["db"]
+    photo_id = live_server["data"]["photos"][0]
+    det_id = db.conn.execute(
+        "SELECT id FROM detections WHERE photo_id = ? ORDER BY id LIMIT 1",
+        (photo_id,),
+    ).fetchone()["id"]
+    db.add_prediction(
+        detection_id=det_id,
+        species="Cooper's Hawk",
+        confidence=0.41,
+        model="BioCLIP-2",
+        category="conflict",
+        labels_fingerprint=TOL_SENTINEL,
+    )
+    db.conn.commit()
+
+    page.goto(f"{live_server['url']}/compare")
+    page.locator("#filterRow button", has_text="Keyword vs models").click()
+
+    row = page.locator(f'tr[data-photo-id="{photo_id}"]')
+    expect(row).to_be_visible()
+    expect(row).to_contain_text("Cooper's Hawk")
+    expect(row.locator(".signal-pill.hot")).to_contain_text("Keyword")
+
+
 def test_compare_page_shows_keyword_workflow(live_server, page):
     page.goto(f"{live_server['url']}/compare")
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -8437,12 +8437,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         taxonomy = load_local_taxonomy()
 
         def summarize_photo(row):
+            row_keys = row.keys()
+            def row_bool(key):
+                return bool(row[key]) if key in row_keys else False
+
             return {
                 "photo_id": row["id"],
                 "filename": row["filename"],
                 "timestamp": row["timestamp"],
                 "rating": row["rating"],
                 "flag": row["flag"],
+                "wildlife_excluded": row_bool("wildlife_excluded"),
+                "miss_no_subject": row_bool("miss_no_subject"),
+                "miss_clipped": row_bool("miss_clipped"),
+                "miss_oof": row_bool("miss_oof"),
                 "width": row["width"],
                 "height": row["height"],
                 "edit_recipe": edit_recipes_by_photo.get(row["id"]),

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -4445,7 +4445,7 @@ class Database:
                     timestamp, width, height, rating, flag, thumb_path, sharpness,
                     subject_sharpness, subject_size, quality_score,
                     latitude, longitude, companion_path, working_copy_path,
-                    wildlife_excluded"""
+                    wildlife_excluded, miss_no_subject, miss_clipped, miss_oof"""
 
     # Columns for single-photo detail queries (includes exif_data JSON +
     # eye-focus fields consumed by the review lightbox's crosshair overlay)

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1223,19 +1223,18 @@ class Database:
         # and misses.py both reference these; without the fallback ALTER, any
         # DB created before the miss-classifier feature fails every photo-list
         # query with "no such column".
-        for _miss_col in ("miss_no_subject", "miss_clipped", "miss_oof"):
+        for column, column_type in (
+            ("miss_no_subject", "INTEGER"),
+            ("miss_clipped", "INTEGER"),
+            ("miss_oof", "INTEGER"),
+            ("miss_computed_at", "TEXT"),
+        ):
             try:
-                self.conn.execute(f"SELECT {_miss_col} FROM photos LIMIT 0")
+                self.conn.execute(f"SELECT {column} FROM photos LIMIT 0")
             except sqlite3.OperationalError:
                 self.conn.execute(
-                    f"ALTER TABLE photos ADD COLUMN {_miss_col} INTEGER"
+                    f"ALTER TABLE photos ADD COLUMN {column} {column_type}"
                 )
-        try:
-            self.conn.execute("SELECT miss_computed_at FROM photos LIMIT 0")
-        except sqlite3.OperationalError:
-            self.conn.execute(
-                "ALTER TABLE photos ADD COLUMN miss_computed_at TEXT"
-            )
         # Migration: integrity-verification markers. hash_checked_at is when
         # the file's content was last re-hashed against photos.file_hash;
         # hash_status records the verdict ('ok', 'modified', 'corrupt',

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -1219,6 +1219,23 @@ class Database:
                 "ALTER TABLE photos "
                 "ADD COLUMN wildlife_excluded INTEGER NOT NULL DEFAULT 0"
             )
+        # Migration: miss-classifier columns. PHOTO_COLS/get_collection_photos
+        # and misses.py both reference these; without the fallback ALTER, any
+        # DB created before the miss-classifier feature fails every photo-list
+        # query with "no such column".
+        for _miss_col in ("miss_no_subject", "miss_clipped", "miss_oof"):
+            try:
+                self.conn.execute(f"SELECT {_miss_col} FROM photos LIMIT 0")
+            except sqlite3.OperationalError:
+                self.conn.execute(
+                    f"ALTER TABLE photos ADD COLUMN {_miss_col} INTEGER"
+                )
+        try:
+            self.conn.execute("SELECT miss_computed_at FROM photos LIMIT 0")
+        except sqlite3.OperationalError:
+            self.conn.execute(
+                "ALTER TABLE photos ADD COLUMN miss_computed_at TEXT"
+            )
         # Migration: integrity-verification markers. hash_checked_at is when
         # the file's content was last re-hashed against photos.file_hash;
         # hash_status records the verdict ('ok', 'modified', 'corrupt',

--- a/vireo/templates/compare.html
+++ b/vireo/templates/compare.html
@@ -18,7 +18,7 @@ body { padding-bottom: 36px; }
   padding: 12px 16px;
   margin-bottom: 14px;
   display: grid;
-  grid-template-columns: minmax(180px, 1.2fr) repeat(2, minmax(160px, 0.9fr)) minmax(180px, 1fr);
+  grid-template-columns: minmax(180px, 1.1fr) repeat(2, minmax(150px, 0.85fr)) minmax(150px, 0.8fr) minmax(180px, 1fr);
   gap: 12px;
   align-items: end;
 }
@@ -69,6 +69,8 @@ body { padding-bottom: 36px; }
 }
 
 .filter-row,
+.sort-row,
+.exclude-row,
 .batch-row {
   display: flex;
   flex-wrap: wrap;
@@ -77,6 +79,8 @@ body { padding-bottom: 36px; }
   margin-bottom: 12px;
 }
 .filter-btn,
+.sort-btn,
+.exclude-btn,
 .batch-btn,
 .inline-btn {
   background: var(--bg-tertiary);
@@ -90,6 +94,20 @@ body { padding-bottom: 36px; }
 .filter-btn.active {
   color: var(--accent);
   border-color: var(--accent);
+}
+.sort-btn.active {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.exclude-btn.active {
+  color: var(--warning);
+  border-color: var(--warning);
+}
+.row-label {
+  width: 100%;
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: uppercase;
 }
 .batch-btn:disabled {
   opacity: 0.4;
@@ -162,6 +180,7 @@ body { padding-bottom: 36px; }
 .select-col { width: 30px; }
 .photo-col { min-width: 220px; }
 .keyword-col { min-width: 220px; }
+.signal-col { min-width: 190px; }
 .model-col { min-width: 250px; }
 
 .photo-cell {
@@ -211,6 +230,7 @@ body { padding-bottom: 36px; }
 }
 .keyword-pill,
 .status-pill,
+.signal-pill,
 .category-pill {
   display: inline-flex;
   align-items: center;
@@ -233,6 +253,27 @@ body { padding-bottom: 36px; }
 .category-pill.conflict { color: var(--warning); border-color: color-mix(in srgb, var(--warning) 55%, var(--border-primary)); }
 .category-pill.new { color: var(--text-primary); }
 .category-pill.missing_prediction { color: var(--text-muted); }
+.signal-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+.signal-pill {
+  color: var(--text-muted);
+}
+.signal-pill.hot {
+  color: var(--warning);
+  border-color: color-mix(in srgb, var(--warning) 55%, var(--border-primary));
+}
+.signal-pill.match {
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--border-primary));
+}
+.signal-note {
+  margin-top: 5px;
+  color: var(--text-muted);
+  font-size: 11px;
+}
 
 .pred {
   padding: 7px 0;
@@ -297,6 +338,12 @@ body { padding-bottom: 36px; }
       </select>
     </div>
     <div class="control">
+      <label for="sortMode">Sort</label>
+      <select id="sortMode" onchange="setSort(this.value)">
+        <option value="review_priority">Review priority</option>
+      </select>
+    </div>
+    <div class="control">
       <label for="compareSearch">Search</label>
       <div class="search-control">
         <input id="compareSearch" type="search" placeholder="Filename, keyword, species" oninput="renderCompare()">
@@ -308,6 +355,8 @@ body { padding-bottom: 36px; }
 
   <div id="summaryGrid" class="summary-grid" style="display:none;"></div>
   <div id="taxonomyNote" class="taxonomy-note">Taxonomy data is unavailable. Compare can confirm exact keyword matches, but broader/refinement/conflict labels are limited.</div>
+  <div id="sortRow" class="sort-row" style="display:none;"></div>
+  <div id="excludeRow" class="exclude-row" style="display:none;"></div>
   <div id="filterRow" class="filter-row" style="display:none;"></div>
   <div id="batchRow" class="batch-row" style="display:none;">
     <span id="batchCount" class="batch-count">0 selected</span>
@@ -325,10 +374,27 @@ body { padding-bottom: 36px; }
 <script>
 var compareData = null;
 var activeFilter = 'needs_review';
+var activeSort = 'review_priority';
+var excludeState = {
+  rejected: false,
+  picks: false,
+  unflagged: false,
+  not_wildlife: false,
+  misses: false,
+};
 var selectedRows = new Set();
 var loadingSeq = 0;
+var signalCache = new Map();
 
 var FILTERS = [
+  { id: 'model_disagreement', label: 'Models disagree' },
+  { id: 'strong_model_disagreement', label: 'Strong model disagreement' },
+  { id: 'keyword_model_conflict', label: 'Keyword vs models' },
+  { id: 'strong_keyword_model_conflict', label: 'Strong keyword conflict' },
+  { id: 'consensus_conflict', label: 'Model consensus conflicts' },
+  { id: 'all_models_agree', label: 'Shown models agree' },
+  { id: 'missing_visible_model', label: 'Missing shown model' },
+  { id: 'two_models', label: 'Two+ model predictions' },
   { id: 'needs_review', label: 'Needs review' },
   { id: 'conflict', label: 'Conflicts' },
   { id: 'refinement', label: 'Refinements' },
@@ -338,6 +404,26 @@ var FILTERS = [
   { id: 'match', label: 'Matches' },
   { id: 'reviewed', label: 'Reviewed' },
   { id: 'all', label: 'All' },
+];
+
+var SORTS = [
+  { id: 'review_priority', label: 'Review priority' },
+  { id: 'model_disagreement', label: 'Model disagreement' },
+  { id: 'keyword_disagreement', label: 'Keyword disagreement' },
+  { id: 'consensus_conflict', label: 'Consensus conflict' },
+  { id: 'top_confidence', label: 'Top confidence' },
+  { id: 'low_confidence', label: 'Low confidence' },
+  { id: 'filename', label: 'Filename' },
+  { id: 'newest', label: 'Newest' },
+  { id: 'oldest', label: 'Oldest' },
+];
+
+var EXCLUDES = [
+  { id: 'rejected', label: 'Hide rejects' },
+  { id: 'picks', label: 'Hide picks' },
+  { id: 'unflagged', label: 'Hide unflagged' },
+  { id: 'not_wildlife', label: 'Hide not wildlife' },
+  { id: 'misses', label: 'Hide marked misses' },
 ];
 
 var CATEGORY_ORDER = {
@@ -388,6 +474,8 @@ async function loadComparison() {
   if (!collId) {
     compareData = null;
     document.getElementById('summaryGrid').style.display = 'none';
+    document.getElementById('sortRow').style.display = 'none';
+    document.getElementById('excludeRow').style.display = 'none';
     document.getElementById('filterRow').style.display = 'none';
     document.getElementById('batchRow').style.display = 'none';
     content.innerHTML = '<div class="compare-empty">Select a collection to compare keywords and predictions.</div>';
@@ -401,6 +489,7 @@ async function loadComparison() {
     if (seq !== loadingSeq) return;
     compareData = data;
     populateModelSelects(data.models || []);
+    populateSortSelect();
     activeFilter = data.summary && data.summary.needs_review > 0 ? 'needs_review' : 'all';
     renderCompare();
   } catch(e) {
@@ -424,6 +513,15 @@ function populateModelSelects(models) {
   b.value = models.indexOf(oldB) >= 0 ? oldB : '';
 }
 
+function populateSortSelect() {
+  var sel = document.getElementById('sortMode');
+  if (!sel) return;
+  sel.innerHTML = SORTS.map(function(s) {
+    return '<option value="' + escapeAttr(s.id) + '">' + escapeHtml(s.label) + '</option>';
+  }).join('');
+  sel.value = activeSort;
+}
+
 function visibleModels() {
   if (!compareData) return [];
   var a = document.getElementById('modelA').value;
@@ -436,7 +534,10 @@ function visibleModels() {
 
 function renderCompare() {
   if (!compareData) return;
+  signalCache = new Map();
   renderSummary();
+  renderSorts();
+  renderExcludes();
   renderFilters();
   renderTaxonomyNote();
   var rows = filteredRows();
@@ -449,10 +550,13 @@ function renderCompare() {
 
 function renderSummary() {
   var s = compareData.summary || {};
+  var signals = signalSummary();
   var items = [
     ['photos', 'Photos'],
     ['models', 'Models'],
     ['needs_review', 'Needs review'],
+    ['model_disagreements', 'Models disagree', signals.model_disagreements],
+    ['keyword_model_conflicts', 'Keyword vs models', signals.keyword_model_conflicts],
     ['conflicts', 'Conflicts'],
     ['refinements', 'Refinements'],
     ['broader', 'Broader'],
@@ -461,8 +565,9 @@ function renderSummary() {
   ];
   document.getElementById('summaryGrid').style.display = '';
   document.getElementById('summaryGrid').innerHTML = items.map(function(item) {
+    var value = item.length > 2 ? item[2] : (s[item[0]] || 0);
     return '<div class="summary-item"><span class="summary-value">' +
-      escapeHtml(s[item[0]] || 0) + '</span><span class="summary-label">' +
+      escapeHtml(value) + '</span><span class="summary-label">' +
       escapeHtml(item[1]) + '</span></div>';
   }).join('');
 }
@@ -476,18 +581,51 @@ function renderTaxonomyNote() {
 
 function filterCount(filter) {
   return (compareData.photos || []).filter(function(photo) {
+    if (!photoMatchesExclusions(photo)) return false;
     return photoMatchesFilter(photo, filter.id);
   }).length;
+}
+
+function renderSorts() {
+  var row = document.getElementById('sortRow');
+  row.style.display = '';
+  row.innerHTML = '<span class="row-label">Sort by</span>' + SORTS.map(function(s) {
+    var cls = s.id === activeSort ? 'sort-btn active' : 'sort-btn';
+    return '<button class="' + cls + '" onclick="setSort(\'' + s.id + '\')">' +
+      escapeHtml(s.label) + '</button>';
+  }).join('');
+  var select = document.getElementById('sortMode');
+  if (select) select.value = activeSort;
+}
+
+function renderExcludes() {
+  var row = document.getElementById('excludeRow');
+  row.style.display = '';
+  row.innerHTML = '<span class="row-label">Exclude</span>' + EXCLUDES.map(function(f) {
+    var cls = excludeState[f.id] ? 'exclude-btn active' : 'exclude-btn';
+    return '<button class="' + cls + '" onclick="toggleExclude(\'' + f.id + '\')">' +
+      escapeHtml(f.label) + ' <span>' + exclusionCount(f.id) + '</span></button>';
+  }).join('');
 }
 
 function renderFilters() {
   var row = document.getElementById('filterRow');
   row.style.display = '';
-  row.innerHTML = FILTERS.map(function(f) {
+  row.innerHTML = '<span class="row-label">Filter</span>' + FILTERS.map(function(f) {
     var cls = f.id === activeFilter ? 'filter-btn active' : 'filter-btn';
     return '<button class="' + cls + '" onclick="setFilter(\'' + f.id + '\')">' +
       escapeHtml(f.label) + ' <span>' + filterCount(f) + '</span></button>';
   }).join('');
+}
+
+function toggleExclude(id) {
+  excludeState[id] = !excludeState[id];
+  renderCompare();
+}
+
+function setSort(sort) {
+  activeSort = sort;
+  renderCompare();
 }
 
 function setFilter(filter) {
@@ -504,14 +642,47 @@ function hasReviewedPrediction(photo) {
 }
 
 function photoMatchesFilter(photo, filter) {
+  var signal = photoSignal(photo);
   if (filter === 'all') return true;
+  if (filter === 'model_disagreement') return signal.model_disagreement_score > 0;
+  if (filter === 'strong_model_disagreement') return signal.model_disagreement_score >= 70;
+  if (filter === 'keyword_model_conflict') return signal.keyword_conflict_count > 0;
+  if (filter === 'strong_keyword_model_conflict') return signal.keyword_conflict_score >= 100 || signal.max_keyword_conflict_confidence >= 0.75;
+  if (filter === 'consensus_conflict') return signal.consensus_count >= 2 && signal.keyword_conflict_count > 0;
+  if (filter === 'all_models_agree') return signal.top_prediction_count >= 2 && signal.unique_top_species_count === 1 && signal.missing_visible_model_count === 0;
+  if (filter === 'missing_visible_model') return signal.missing_visible_model_count > 0;
+  if (filter === 'two_models') return signal.top_prediction_count >= 2;
   if (filter === 'needs_review') return !!photo.needs_review;
   if (filter === 'reviewed') return hasReviewedPrediction(photo);
   return photo.row_category === filter;
 }
 
+function photoMatchesExclusions(photo) {
+  var flag = photo.flag || 'none';
+  if (excludeState.rejected && flag === 'rejected') return false;
+  if (excludeState.picks && flag === 'flagged') return false;
+  if (excludeState.unflagged && (!flag || flag === 'none')) return false;
+  if (excludeState.not_wildlife && photo.wildlife_excluded) return false;
+  if (excludeState.misses && (photo.miss_no_subject || photo.miss_clipped || photo.miss_oof)) return false;
+  return true;
+}
+
+function exclusionCount(id) {
+  return (compareData.photos || []).filter(function(photo) {
+    var flag = photo.flag || 'none';
+    if (id === 'rejected') return flag === 'rejected';
+    if (id === 'picks') return flag === 'flagged';
+    if (id === 'unflagged') return !flag || flag === 'none';
+    if (id === 'not_wildlife') return !!photo.wildlife_excluded;
+    if (id === 'misses') return !!(photo.miss_no_subject || photo.miss_clipped || photo.miss_oof);
+    return false;
+  }).length;
+}
+
 function searchableFields(photo) {
   var parts = [photo.filename, photo.row_label];
+  var signal = photoSignal(photo);
+  parts.push(signal.model_disagreement_label, signal.keyword_disagreement_label, signal.consensus_species);
   (photo.keywords || []).forEach(function(k) { parts.push(k.name, k.type); });
   Object.keys(photo.predictions || {}).forEach(function(model) {
     parts.push(model);
@@ -525,12 +696,58 @@ function searchableFields(photo) {
 function filteredRows() {
   var q = document.getElementById('compareSearch').value.trim();
   var searchOptions = VireoTextSearch.readOptions('compareSearch');
-  return (compareData.photos || []).filter(function(photo) {
+  var rows = (compareData.photos || []).filter(function(photo) {
+    if (!photoMatchesExclusions(photo)) return false;
     if (!photoMatchesFilter(photo, activeFilter)) return false;
     if (q && !VireoTextSearch.matchesFields(searchableFields(photo), q, searchOptions)) return false;
     return true;
   });
+  return sortRows(rows);
 }
+
+function sortRows(rows) {
+  return rows.slice().sort(function(a, b) {
+    var sa = photoSignal(a);
+    var sb = photoSignal(b);
+    if (activeSort === 'model_disagreement') {
+      return desc(sa.model_disagreement_score, sb.model_disagreement_score)
+        || desc(sa.top_prediction_count, sb.top_prediction_count)
+        || desc(sa.max_confidence, sb.max_confidence)
+        || textAsc(a.filename, b.filename);
+    }
+    if (activeSort === 'keyword_disagreement') {
+      return desc(sa.keyword_conflict_score, sb.keyword_conflict_score)
+        || desc(sa.max_keyword_conflict_confidence, sb.max_keyword_conflict_confidence)
+        || desc(CATEGORY_ORDER[a.row_category] || 0, CATEGORY_ORDER[b.row_category] || 0)
+        || textAsc(a.filename, b.filename);
+    }
+    if (activeSort === 'consensus_conflict') {
+      return desc(sa.consensus_count >= 2 && sa.keyword_conflict_count > 0 ? 1 : 0, sb.consensus_count >= 2 && sb.keyword_conflict_count > 0 ? 1 : 0)
+        || desc(sa.consensus_count, sb.consensus_count)
+        || desc(sa.keyword_conflict_score, sb.keyword_conflict_score)
+        || textAsc(a.filename, b.filename);
+    }
+    if (activeSort === 'top_confidence') {
+      return desc(sa.max_confidence, sb.max_confidence) || textAsc(a.filename, b.filename);
+    }
+    if (activeSort === 'low_confidence') {
+      return asc(sa.min_confidence || 999, sb.min_confidence || 999) || textAsc(a.filename, b.filename);
+    }
+    if (activeSort === 'filename') return textAsc(a.filename, b.filename);
+    if (activeSort === 'newest') return textDesc(a.timestamp || '', b.timestamp || '') || textAsc(a.filename, b.filename);
+    if (activeSort === 'oldest') return textAsc(a.timestamp || '', b.timestamp || '') || textAsc(a.filename, b.filename);
+    return desc(a.needs_review ? 1 : 0, b.needs_review ? 1 : 0)
+      || desc(CATEGORY_ORDER[a.row_category] || 0, CATEGORY_ORDER[b.row_category] || 0)
+      || desc(sa.keyword_conflict_score, sb.keyword_conflict_score)
+      || desc(sa.model_disagreement_score, sb.model_disagreement_score)
+      || textAsc(a.filename, b.filename);
+  });
+}
+
+function desc(a, b) { return (b || 0) - (a || 0); }
+function asc(a, b) { return (a || 0) - (b || 0); }
+function textAsc(a, b) { return String(a || '').localeCompare(String(b || '')); }
+function textDesc(a, b) { return String(b || '').localeCompare(String(a || '')); }
 
 function renderTable(rows) {
   var content = document.getElementById('compareContent');
@@ -548,6 +765,7 @@ function renderTable(rows) {
     '<th class="select-col"><input type="checkbox" onchange="toggleAllRows(this.checked)"></th>' +
     '<th class="photo-col">Photo</th>' +
     '<th>Status</th>' +
+    '<th class="signal-col">Signals</th>' +
     '<th class="keyword-col">Current keywords</th>';
   models.forEach(function(m) {
     html += '<th class="model-col">' + escapeHtml(m) + '</th>';
@@ -561,6 +779,7 @@ function renderTable(rows) {
       '<td>' + renderPhotoCell(photo) + '</td>' +
       '<td><span class="category-pill ' + escapeAttr(photo.row_category) + '">' +
       escapeHtml(photo.row_label) + '</span></td>' +
+      '<td>' + renderSignalCell(photo) + '</td>' +
       '<td>' + renderKeywordCell(photo) + '</td>';
     models.forEach(function(m) {
       html += '<td>' + renderPredictionCell(photo, m) + '</td>';
@@ -571,6 +790,146 @@ function renderTable(rows) {
   content.innerHTML = html;
 }
 
+function normalizedSpecies(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function usablePrediction(pred) {
+  return pred && pred.status !== 'rejected';
+}
+
+function bestPredictionForModel(photo, model) {
+  var preds = ((photo.predictions || {})[model] || []).filter(usablePrediction);
+  if (!preds.length) return null;
+  return preds.slice().sort(function(a, b) {
+    return desc(a.confidence, b.confidence) || textAsc(a.species, b.species);
+  })[0];
+}
+
+function photoSignal(photo) {
+  var cacheKey = photo.photo_id + '|' + visibleModels().join('|');
+  if (signalCache.has(cacheKey)) return signalCache.get(cacheKey);
+  var models = visibleModels();
+  var topPreds = [];
+  var missing = 0;
+  var keywordConflictScore = 0;
+  var keywordConflictCount = 0;
+  var maxKeywordConflictConfidence = 0;
+  var keywordSupportScore = 0;
+  var maxConfidence = 0;
+  var minConfidence = null;
+
+  models.forEach(function(model) {
+    var best = bestPredictionForModel(photo, model);
+    if (!best) {
+      missing += 1;
+      return;
+    }
+    var conf = best.confidence || 0;
+    topPreds.push({ model: model, species: best.species || '', confidence: conf, pred: best });
+    maxConfidence = Math.max(maxConfidence, conf);
+    minConfidence = minConfidence === null ? conf : Math.min(minConfidence, conf);
+    if (best.category === 'conflict') {
+      keywordConflictCount += 1;
+      keywordConflictScore += conf;
+      maxKeywordConflictConfidence = Math.max(maxKeywordConflictConfidence, conf);
+    } else if (best.category === 'match' || best.category === 'refinement') {
+      keywordSupportScore += conf;
+    }
+  });
+
+  var speciesGroups = {};
+  topPreds.forEach(function(item) {
+    var key = normalizedSpecies(item.species);
+    if (!speciesGroups[key]) speciesGroups[key] = { species: item.species, count: 0, confidence: 0, max_confidence: 0 };
+    speciesGroups[key].count += 1;
+    speciesGroups[key].confidence += item.confidence;
+    speciesGroups[key].max_confidence = Math.max(speciesGroups[key].max_confidence, item.confidence);
+  });
+  var groupList = Object.keys(speciesGroups).map(function(key) { return speciesGroups[key]; });
+  groupList.sort(function(a, b) {
+    return desc(a.count, b.count) || desc(a.confidence, b.confidence) || textAsc(a.species, b.species);
+  });
+
+  var disagreementPair = null;
+  var modelDisagreementScore = 0;
+  for (var i = 0; i < topPreds.length; i++) {
+    for (var j = i + 1; j < topPreds.length; j++) {
+      if (normalizedSpecies(topPreds[i].species) === normalizedSpecies(topPreds[j].species)) continue;
+      var pairScore = Math.min(topPreds[i].confidence || 0, topPreds[j].confidence || 0) * 100;
+      if (!disagreementPair || pairScore > modelDisagreementScore) {
+        modelDisagreementScore = pairScore;
+        disagreementPair = [topPreds[i], topPreds[j]];
+      }
+    }
+  }
+
+  var signal = {
+    top_prediction_count: topPreds.length,
+    unique_top_species_count: groupList.length,
+    missing_visible_model_count: missing,
+    model_disagreement_score: modelDisagreementScore,
+    model_disagreement_pair: disagreementPair,
+    keyword_conflict_count: keywordConflictCount,
+    keyword_conflict_score: keywordConflictScore * 100,
+    max_keyword_conflict_confidence: maxKeywordConflictConfidence,
+    keyword_support_score: keywordSupportScore * 100,
+    consensus_species: groupList.length ? groupList[0].species : '',
+    consensus_count: groupList.length ? groupList[0].count : 0,
+    max_confidence: maxConfidence,
+    min_confidence: minConfidence,
+  };
+  signal.model_disagreement_label = disagreementPair
+    ? disagreementPair[0].species + ' vs ' + disagreementPair[1].species
+    : '';
+  signal.keyword_disagreement_label = keywordConflictCount
+    ? keywordConflictCount + ' model conflict' + (keywordConflictCount === 1 ? '' : 's')
+    : '';
+  signalCache.set(cacheKey, signal);
+  return signal;
+}
+
+function signalSummary() {
+  var result = {
+    model_disagreements: 0,
+    keyword_model_conflicts: 0,
+  };
+  (compareData.photos || []).forEach(function(photo) {
+    var signal = photoSignal(photo);
+    if (signal.model_disagreement_score > 0) result.model_disagreements += 1;
+    if (signal.keyword_conflict_count > 0) result.keyword_model_conflicts += 1;
+  });
+  return result;
+}
+
+function renderSignalCell(photo) {
+  var signal = photoSignal(photo);
+  var pills = [];
+  if (signal.model_disagreement_score > 0) {
+    pills.push('<span class="signal-pill hot" title="' + escapeAttr(signal.model_disagreement_label) +
+      '">Models ' + Math.round(signal.model_disagreement_score) + '</span>');
+  }
+  if (signal.keyword_conflict_count > 0) {
+    pills.push('<span class="signal-pill hot" title="Cumulative confidence from model predictions that conflict with the current species keyword">' +
+      'Keyword ' + Math.round(signal.keyword_conflict_score) + '</span>');
+  }
+  if (signal.consensus_count >= 2) {
+    pills.push('<span class="signal-pill match" title="' + escapeAttr(signal.consensus_species) +
+      '">' + signal.consensus_count + ' agree</span>');
+  }
+  if (signal.missing_visible_model_count > 0) {
+    pills.push('<span class="signal-pill">' + signal.missing_visible_model_count + ' missing</span>');
+  }
+  if (!pills.length) {
+    return '<span class="empty-cell">No comparison signal</span>';
+  }
+  var detail = [];
+  if (signal.model_disagreement_label) detail.push(signal.model_disagreement_label);
+  if (signal.consensus_count >= 2 && signal.consensus_species) detail.push('Consensus: ' + signal.consensus_species);
+  return '<div class="signal-list">' + pills.join('') + '</div>' +
+    (detail.length ? '<div class="signal-note">' + escapeHtml(detail.join(' · ')) + '</div>' : '');
+}
+
 function renderPhotoCell(photo) {
   var meta = [];
   var thumbUrl = window.vireoThumbnailUrl
@@ -579,6 +938,8 @@ function renderPhotoCell(photo) {
   if (photo.timestamp) meta.push(photo.timestamp.replace('T', ' ').substring(0, 16));
   if (photo.rating) meta.push(photo.rating + ' star' + (photo.rating === 1 ? '' : 's'));
   if (photo.flag && photo.flag !== 'none') meta.push(photo.flag);
+  if (photo.wildlife_excluded) meta.push('not wildlife');
+  if (photo.miss_no_subject || photo.miss_clipped || photo.miss_oof) meta.push('marked miss');
   return '<div class="photo-cell">' +
     '<button type="button" class="photo-thumb-button" title="View larger" onclick="openCompareLightbox(' +
     photo.photo_id + ')"><img src="' + escapeAttr(thumbUrl) + '" loading="lazy" alt="' +

--- a/vireo/templates/compare.html
+++ b/vireo/templates/compare.html
@@ -822,6 +822,21 @@ function photoSignal(photo) {
   var minConfidence = null;
 
   models.forEach(function(model) {
+    var preds = ((photo.predictions || {})[model] || []).filter(usablePrediction);
+    if (!preds.length) {
+      missing += 1;
+      return;
+    }
+    preds.forEach(function(pred) {
+      var predConf = pred.confidence || 0;
+      if (pred.category === 'conflict') {
+        keywordConflictCount += 1;
+        keywordConflictScore += predConf;
+        maxKeywordConflictConfidence = Math.max(maxKeywordConflictConfidence, predConf);
+      } else if (pred.category === 'match' || pred.category === 'refinement') {
+        keywordSupportScore += predConf;
+      }
+    });
     var best = bestPredictionForModel(photo, model);
     if (!best) {
       missing += 1;
@@ -831,13 +846,6 @@ function photoSignal(photo) {
     topPreds.push({ model: model, species: best.species || '', confidence: conf, pred: best });
     maxConfidence = Math.max(maxConfidence, conf);
     minConfidence = minConfidence === null ? conf : Math.min(minConfidence, conf);
-    if (best.category === 'conflict') {
-      keywordConflictCount += 1;
-      keywordConflictScore += conf;
-      maxKeywordConflictConfidence = Math.max(maxKeywordConflictConfidence, conf);
-    } else if (best.category === 'match' || best.category === 'refinement') {
-      keywordSupportScore += conf;
-    }
   });
 
   var speciesGroups = {};

--- a/vireo/templates/compare.html
+++ b/vireo/templates/compare.html
@@ -657,25 +657,27 @@ function photoMatchesFilter(photo, filter) {
   return photo.row_category === filter;
 }
 
-function photoMatchesExclusions(photo) {
+function matchesExclusion(photo, id) {
   var flag = photo.flag || 'none';
-  if (excludeState.rejected && flag === 'rejected') return false;
-  if (excludeState.picks && flag === 'flagged') return false;
-  if (excludeState.unflagged && (!flag || flag === 'none')) return false;
-  if (excludeState.not_wildlife && photo.wildlife_excluded) return false;
-  if (excludeState.misses && (photo.miss_no_subject || photo.miss_clipped || photo.miss_oof)) return false;
+  if (id === 'rejected') return flag === 'rejected';
+  if (id === 'picks') return flag === 'flagged';
+  if (id === 'unflagged') return !flag || flag === 'none';
+  if (id === 'not_wildlife') return !!photo.wildlife_excluded;
+  if (id === 'misses') return !!(photo.miss_no_subject || photo.miss_clipped || photo.miss_oof);
+  return false;
+}
+
+function photoMatchesExclusions(photo) {
+  for (var i = 0; i < EXCLUDES.length; i += 1) {
+    var id = EXCLUDES[i].id;
+    if (excludeState[id] && matchesExclusion(photo, id)) return false;
+  }
   return true;
 }
 
 function exclusionCount(id) {
   return (compareData.photos || []).filter(function(photo) {
-    var flag = photo.flag || 'none';
-    if (id === 'rejected') return flag === 'rejected';
-    if (id === 'picks') return flag === 'flagged';
-    if (id === 'unflagged') return !flag || flag === 'none';
-    if (id === 'not_wildlife') return !!photo.wildlife_excluded;
-    if (id === 'misses') return !!(photo.miss_no_subject || photo.miss_clipped || photo.miss_oof);
-    return false;
+    return matchesExclusion(photo, id);
   }).length;
 }
 

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -1497,6 +1497,35 @@ def test_compare_predictions_api(app_and_db):
         assert "confidence" in model_preds[0]
 
 
+def test_compare_predictions_api_exposes_miss_flags(app_and_db):
+    """Miss flags on a photo must reach the compare payload so the
+    'Hide marked misses' exclusion and 'marked miss' badge can work."""
+    app, db = app_and_db
+
+    photos = db.conn.execute("SELECT id FROM photos ORDER BY id").fetchall()
+    p_miss = photos[0]["id"]
+    p_clean = photos[1]["id"]
+    db.conn.execute(
+        "UPDATE photos SET miss_no_subject=1, miss_clipped=1, miss_oof=1 WHERE id=?",
+        (p_miss,),
+    )
+    db.conn.commit()
+
+    rules = json.dumps([{"field": "photo_ids", "value": [p_miss, p_clean]}])
+    cid = db.add_collection("Miss Flag Collection", rules)
+
+    resp = app.test_client().get(f"/api/predictions/compare?collection_id={cid}")
+    assert resp.status_code == 200
+    by_id = {row["photo_id"]: row for row in resp.get_json()["photos"]}
+
+    assert by_id[p_miss]["miss_no_subject"] is True
+    assert by_id[p_miss]["miss_clipped"] is True
+    assert by_id[p_miss]["miss_oof"] is True
+    assert by_id[p_clean]["miss_no_subject"] is False
+    assert by_id[p_clean]["miss_clipped"] is False
+    assert by_id[p_clean]["miss_oof"] is False
+
+
 def test_compare_ignores_resolved_predictions_for_needs_review(app_and_db):
     """A resolved conflict plus a pending match should not stay in review."""
     app, db = app_and_db

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -4121,6 +4121,43 @@ def test_migration_from_legacy_embedding_columns(tmp_path):
     assert rows[0]["embedding"] == b'\x01\x02\x03'
 
 
+def test_migration_adds_missing_miss_classifier_columns(tmp_path):
+    """DBs created before the miss-classifier columns existed must have
+    miss_no_subject/miss_clipped/miss_oof/miss_computed_at added on open —
+    otherwise PHOTO_COLS-based queries fail with 'no such column'."""
+    from db import Database
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    fid = db.add_folder('/photos', name='photos')
+    db.add_photo(folder_id=fid, filename='a.jpg', extension='.jpg',
+                 file_size=1, file_mtime=1.0)
+
+    # Simulate a pre-miss-classifier DB by dropping the columns and
+    # closing. Reopening must trigger the ALTER TABLE fallback.
+    for col in ("miss_no_subject", "miss_clipped", "miss_oof",
+                "miss_computed_at"):
+        db.conn.execute(f"ALTER TABLE photos DROP COLUMN {col}")
+    db.conn.commit()
+    db.conn.close()
+
+    db2 = Database(db_path)
+    cols = {row[1] for row in db2.conn.execute("PRAGMA table_info(photos)")}
+    for expected in (
+        "miss_no_subject", "miss_clipped", "miss_oof", "miss_computed_at"
+    ):
+        assert expected in cols, f"migration failed to add {expected}"
+
+    # PHOTO_COLS-based queries must succeed against the migrated DB.
+    row = db2.conn.execute(
+        f"SELECT {Database.PHOTO_COLS} FROM photos"
+    ).fetchone()
+    assert row is not None
+    assert row["miss_no_subject"] is None
+    assert row["miss_clipped"] is None
+    assert row["miss_oof"] is None
+
+
 # -- Edit history --
 
 

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -9951,6 +9951,57 @@ def test_miss_columns_present(tmp_path):
     }
 
 
+def test_migration_adds_miss_columns_to_existing_photos_table(tmp_path):
+    from db import Database
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    folder_id = db.add_folder("/photos", name="photos")
+    db.add_photo(
+        folder_id=folder_id,
+        filename="legacy.jpg",
+        extension=".jpg",
+        file_size=100,
+        file_mtime=1.0,
+    )
+
+    missing_cols = {
+        "miss_no_subject", "miss_clipped", "miss_oof", "miss_computed_at",
+    }
+    rows = db.conn.execute("PRAGMA table_info(photos)").fetchall()
+    keep = [row for row in rows if row["name"] not in missing_cols]
+    definitions = []
+    for row in keep:
+        definition = f'"{row["name"]}" {row["type"]}'
+        if row["pk"]:
+            definition += " PRIMARY KEY"
+        if row["notnull"]:
+            definition += " NOT NULL"
+        if row["dflt_value"] is not None:
+            definition += f' DEFAULT {row["dflt_value"]}'
+        definitions.append(definition)
+    column_list = ", ".join(f'"{row["name"]}"' for row in keep)
+
+    db.conn.execute("ALTER TABLE photos RENAME TO photos_current")
+    db.conn.execute(f"CREATE TABLE photos ({', '.join(definitions)})")
+    db.conn.execute(
+        f"INSERT INTO photos ({column_list}) SELECT {column_list} FROM photos_current"
+    )
+    db.conn.execute("DROP TABLE photos_current")
+    db.conn.commit()
+    db.conn.close()
+
+    db2 = Database(db_path)
+    cols = {row["name"] for row in db2.conn.execute("PRAGMA table_info(photos)")}
+    assert missing_cols.issubset(cols)
+
+    photos = db2.get_photos()
+    assert len(photos) == 1
+    assert photos[0]["miss_no_subject"] is None
+    assert photos[0]["miss_clipped"] is None
+    assert photos[0]["miss_oof"] is None
+
+
 def test_list_misses_returns_flagged_photos_only(tmp_path):
     from db import Database
     db = Database(str(tmp_path / "m.db"))

--- a/vireo/tests/test_new_images_api.py
+++ b/vireo/tests/test_new_images_api.py
@@ -119,7 +119,11 @@ def test_api_new_images_returns_pending_when_walk_is_slow(app_and_db, monkeypatc
         assert data["new_count"] is None
         assert data["workspace_id"] == ws_id
         # The endpoint must have actually kicked off the background compute.
-        assert started.is_set()
+        # The worker thread opens its own DB before calling the walk fn, so
+        # on loaded CI runners it can still be inside Database.__init__ when
+        # the endpoint's 500ms wait times out and returns pending. Give the
+        # worker a bounded moment to actually reach slow_count.
+        assert started.wait(timeout=2.0)
     finally:
         # Let the background thread finish before pytest tears down tmp_path,
         # otherwise it walks a deleted directory tree.
@@ -639,7 +643,7 @@ def test_post_snapshot_reuses_walk_across_polls(app_and_db, monkeypatch):
             # First POST kicks off the walk; walk is blocked in-flight.
             first = client.post("/api/workspaces/active/new-images/snapshot")
             assert first.status_code == 202
-            assert started.is_set()
+            assert started.wait(timeout=2.0)
             calls_after_first = call_count["n"]
 
             # A poll arriving before the walk finishes must coalesce, not
@@ -784,7 +788,7 @@ def test_post_snapshot_surfaces_async_error_without_retry_loop(
         with app.test_client() as client:
             first = client.post("/api/workspaces/active/new-images/snapshot")
             assert first.status_code == 202
-            assert started.is_set()
+            assert started.wait(timeout=2.0)
             assert call_count["n"] == 1
 
             release.set()
@@ -925,7 +929,7 @@ def test_post_snapshot_returns_pending_when_cache_is_incomplete(app_and_db, monk
             # show real numbers instead of an opaque spinner.
             assert "files_checked" in body
             assert "new_count_so_far" in body
-            assert started.is_set()
+            assert started.wait(timeout=2.0)
     finally:
         release.set()
 
@@ -1013,7 +1017,7 @@ def test_post_snapshot_registers_ephemeral_job_when_walk_needed(
         with app.test_client() as client:
             resp = client.post("/api/workspaces/active/new-images/snapshot")
             assert resp.status_code == 202
-            assert started.is_set()
+            assert started.wait(timeout=2.0)
             deadline = time.monotonic() + 2.0
             walk_jobs = []
             while time.monotonic() < deadline:


### PR DESCRIPTION
Adds Compare page signal scoring for model-vs-model and keyword-vs-model disagreement, with new sort/filter controls and combinable exclusions for rejected, picked, unflagged, not-wildlife, and miss-marked photos. Extends the compare API payload with those photo metadata flags using backwards-compatible reads. Adds E2E coverage for the new controls. Validated with `python -m pytest tests/test_compare.py vireo/tests/test_compare.py tests/e2e/test_compare_page.py -q`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a **Signals** column to the Compare Keywords page.
  - Added sorting, filtering, and exclusion controls for model disagreements, keyword conflicts, missing predictions, and related signals.
  - Photo rows now display indicators for excluded wildlife and marked misses.
  - Compare results include additional miss-detection information.

- **Tests**
  - Added coverage for signal controls, sorting, exclusions, and miss flags in compare results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->