### PR TITLE
Recognize smart-apostrophe species keywords

### DIFF
--- a/vireo/db.py
+++ b/vireo/db.py
@@ -70,6 +70,41 @@ def _nfc(name: str) -> str:
     return unicodedata.normalize("NFC", name)
 
 
+_TAXON_LOOKUP_TRANSLATION = str.maketrans({
+    "’": "'",
+    "‘": "'",
+    "`": "'",
+    "´": "'",
+    "ʼ": "'",
+    "ʹ": "'",
+    "‛": "'",
+    "“": '"',
+    "”": '"',
+    "„": '"',
+    "‟": '"',
+    "‐": "-",
+    "‑": "-",
+    "‒": "-",
+    "–": "-",
+    "—": "-",
+    "―": "-",
+})
+
+
+def _taxon_lookup_variants(name: str) -> list[str]:
+    """Return ordered taxon-name variants for punctuation-tolerant lookup."""
+    stripped = str(name).strip()
+    variants = []
+    for variant in (
+        stripped,
+        unicodedata.normalize("NFKC", stripped).translate(_TAXON_LOOKUP_TRANSLATION),
+    ):
+        collapsed = " ".join(variant.split())
+        if collapsed and collapsed not in variants:
+            variants.append(collapsed)
+    return variants
+
+
 def _path_for_subtree_match(value: str) -> str:
     """Normalize a stored path for platform-neutral subtree prefix matching."""
     return value.replace("\\", "/").rstrip("/")
@@ -8042,6 +8077,28 @@ class Database:
             return name.title()
         return name
 
+    def _lookup_taxon_id_for_keyword(self, name):
+        """Return the local taxa.id matching a keyword name, if any."""
+        for variant in _taxon_lookup_variants(name):
+            taxon = self.conn.execute(
+                """SELECT t.id FROM taxa t
+                   WHERE t.common_name = ? COLLATE NOCASE
+                      OR t.name = ? COLLATE NOCASE
+                   LIMIT 1""",
+                (variant, variant),
+            ).fetchone()
+            if taxon:
+                return taxon["id"]
+            taxon = self.conn.execute(
+                """SELECT t.taxon_id AS id FROM taxa_common_names t
+                   WHERE t.name = ? COLLATE NOCASE
+                   LIMIT 1""",
+                (variant,),
+            ).fetchone()
+            if taxon:
+                return taxon["id"]
+        return None
+
     def add_keyword(self, name, parent_id=None, is_species=False, kw_type=None, _commit=True):
         """Insert a keyword. Returns existing id if duplicate (case-insensitive).
 
@@ -8110,14 +8167,14 @@ class Database:
         if parent_id is None:
             if kw_type is None:
                 existing = self.conn.execute(
-                    f"SELECT id FROM keywords WHERE name = ? COLLATE NOCASE "
+                    f"SELECT id, type FROM keywords WHERE name = ? COLLATE NOCASE "
                     f"AND parent_id IS NULL "
                     f"ORDER BY {type_priority_case}, id ASC LIMIT 1",
                     (name,),
                 ).fetchone()
             else:
                 existing = self.conn.execute(
-                    "SELECT id FROM keywords WHERE name = ? COLLATE NOCASE "
+                    "SELECT id, type FROM keywords WHERE name = ? COLLATE NOCASE "
                     "AND parent_id IS NULL AND type IN (?, 'general') "
                     "ORDER BY (type = ?) DESC, id ASC LIMIT 1",
                     (name, kw_type, kw_type),
@@ -8125,19 +8182,30 @@ class Database:
         else:
             if kw_type is None:
                 existing = self.conn.execute(
-                    f"SELECT id FROM keywords WHERE name = ? COLLATE NOCASE "
+                    f"SELECT id, type FROM keywords WHERE name = ? COLLATE NOCASE "
                     f"AND parent_id = ? "
                     f"ORDER BY {type_priority_case}, id ASC LIMIT 1",
                     (name, parent_id),
                 ).fetchone()
             else:
                 existing = self.conn.execute(
-                    "SELECT id FROM keywords WHERE name = ? COLLATE NOCASE "
+                    "SELECT id, type FROM keywords WHERE name = ? COLLATE NOCASE "
                     "AND parent_id = ? AND type IN (?, 'general') "
                     "ORDER BY (type = ?) DESC, id ASC LIMIT 1",
                     (name, parent_id, kw_type, kw_type),
                 ).fetchone()
         if existing:
+            if kw_type is None and not is_species and existing["type"] == "general":
+                taxon_id = self._lookup_taxon_id_for_keyword(name)
+                if taxon_id:
+                    self.conn.execute(
+                        "UPDATE keywords SET is_species = 1, type = 'taxonomy', "
+                        "taxon_id = COALESCE(taxon_id, ?) "
+                        "WHERE id = ? AND type = 'general'",
+                        (taxon_id, existing["id"]),
+                    )
+                    if _commit:
+                        self.conn.commit()
             # Promote an unset row to taxonomy when this call indicates a
             # species. Restrict to 'general' (the legacy default for unknown
             # rows) so a deliberate user type — 'individual', 'location',
@@ -8194,24 +8262,9 @@ class Database:
             if is_species:
                 kw_type = 'taxonomy'
             else:
-                # Check if name matches a known taxon (common name or scientific name)
-                taxon = self.conn.execute(
-                    """SELECT t.id FROM taxa t
-                       WHERE t.common_name = ? COLLATE NOCASE
-                          OR t.name = ? COLLATE NOCASE
-                       LIMIT 1""",
-                    (name, name),
-                ).fetchone()
-                if not taxon:
-                    taxon = self.conn.execute(
-                        """SELECT t.taxon_id AS id FROM taxa_common_names t
-                           WHERE t.name = ? COLLATE NOCASE
-                           LIMIT 1""",
-                        (name,),
-                    ).fetchone()
-                if taxon:
+                taxon_id = self._lookup_taxon_id_for_keyword(name)
+                if taxon_id:
                     kw_type = 'taxonomy'
-                    taxon_id = taxon["id"]
 
         cur = self.conn.execute(
             "INSERT INTO keywords (name, parent_id, is_species, type, taxon_id) VALUES (?, ?, ?, ?, ?)",
@@ -9684,25 +9737,12 @@ class Database:
             ).fetchone()
             if current is not None and new_name != current["name"]:
                 cur_type = current["type"]
-                taxon = self.conn.execute(
-                    """SELECT t.id FROM taxa t
-                       WHERE t.common_name = ? COLLATE NOCASE
-                          OR t.name = ? COLLATE NOCASE
-                       LIMIT 1""",
-                    (new_name, new_name),
-                ).fetchone()
-                if not taxon:
-                    taxon = self.conn.execute(
-                        """SELECT t.taxon_id AS id FROM taxa_common_names t
-                           WHERE t.name = ? COLLATE NOCASE
-                           LIMIT 1""",
-                        (new_name,),
-                    ).fetchone()
+                taxon_id = self._lookup_taxon_id_for_keyword(new_name)
 
                 if cur_type == 'general':
                     # Only promote to taxonomy if a match exists; otherwise
                     # leave type/taxon_id alone.
-                    if taxon:
+                    if taxon_id:
                         updates.setdefault('type', 'taxonomy')
                         # Gate taxon_id on the EFFECTIVE type so an
                         # explicit non-taxonomy type kwarg (e.g.
@@ -9711,16 +9751,16 @@ class Database:
                         # for the auto-promoted case: type='taxonomy'
                         # backed by a matched taxon implies is_species=1.
                         if updates.get('type') == 'taxonomy':
-                            updates.setdefault('taxon_id', taxon["id"])
+                            updates.setdefault('taxon_id', taxon_id)
                             updates['is_species'] = 1
-                elif (cur_type == 'taxonomy' and taxon
+                elif (cur_type == 'taxonomy' and taxon_id
                       and updates.get('type', 'taxonomy') == 'taxonomy'):
                     # Already taxonomy: refresh taxon_id only if the new
                     # name matches a (possibly different) taxon AND the
                     # effective type stays 'taxonomy' (caller may demote
                     # to 'location' etc.). If no match, leave the existing
                     # link in place.
-                    updates.setdefault('taxon_id', taxon["id"])
+                    updates.setdefault('taxon_id', taxon_id)
                 # Other manual types ('location', 'people', etc.) are
                 # preserved — user intent wins.
 

--- a/vireo/taxonomy.py
+++ b/vireo/taxonomy.py
@@ -22,6 +22,7 @@ import logging
 import os
 import ssl
 import time
+import unicodedata
 import urllib.request
 import zipfile
 from datetime import date
@@ -261,8 +262,28 @@ class Taxonomy:
 
     @staticmethod
     def _normalize(name):
-        """Normalize a name for lookup: lowercase, strip hyphens and extra spaces."""
-        return name.lower().strip().replace("-", " ").replace("  ", " ")
+        """Normalize a name for lookup: lowercase, fold punctuation, collapse spaces."""
+        text = unicodedata.normalize("NFKC", name).casefold().strip()
+        text = text.translate(str.maketrans({
+            "’": "'",
+            "‘": "'",
+            "`": "'",
+            "´": "'",
+            "ʼ": "'",
+            "ʹ": "'",
+            "‛": "'",
+            "“": '"',
+            "”": '"',
+            "„": '"',
+            "‟": '"',
+            "‐": "-",
+            "‑": "-",
+            "‒": "-",
+            "–": "-",
+            "—": "-",
+            "―": "-",
+        }))
+        return " ".join(text.replace("-", " ").split())
 
     def lookup(self, name):
         """Look up a taxon by common name or scientific name.

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -4652,6 +4652,47 @@ def test_add_keyword_auto_detects_taxonomy_via_alt_common_name(tmp_path):
     assert row["taxon_id"] == 1
 
 
+def test_add_keyword_auto_detects_taxonomy_with_smart_apostrophe(tmp_path):
+    """Smart-apostrophe user text matches straight-apostrophe taxa names."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    db.conn.execute(
+        "INSERT INTO taxa (id, name, common_name, rank) "
+        "VALUES (1, 'Sayornis saya', ?, 'species')",
+        ("Say's Phoebe",),
+    )
+    db.conn.commit()
+
+    kid = db.add_keyword("Say’s phoebe")
+    row = db.conn.execute(
+        "SELECT type, is_species, taxon_id FROM keywords WHERE id = ?", (kid,)
+    ).fetchone()
+    assert row["type"] == "taxonomy"
+    assert row["is_species"] == 1
+    assert row["taxon_id"] == 1
+
+
+def test_add_keyword_promotes_existing_general_smart_apostrophe_taxon(tmp_path):
+    """A legacy general row is promoted when auto-detect can now resolve it."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    kid = db.add_keyword("Say’s phoebe")
+    db.conn.execute(
+        "INSERT INTO taxa (id, name, common_name, rank) "
+        "VALUES (1, 'Sayornis saya', ?, 'species')",
+        ("Say's Phoebe",),
+    )
+    db.conn.commit()
+
+    assert db.add_keyword("Say’s phoebe") == kid
+    row = db.conn.execute(
+        "SELECT type, is_species, taxon_id FROM keywords WHERE id = ?", (kid,)
+    ).fetchone()
+    assert row["type"] == "taxonomy"
+    assert row["is_species"] == 1
+    assert row["taxon_id"] == 1
+
+
 def test_add_keyword_no_auto_detect_for_general(tmp_path):
     """add_keyword defaults to general when name doesn't match a taxon."""
     from db import Database

--- a/vireo/tests/test_taxonomy.py
+++ b/vireo/tests/test_taxonomy.py
@@ -117,6 +117,38 @@ def test_lookup_case_insensitive():
         assert tax.lookup("Song Sparrow") is not None
 
 
+def test_lookup_normalizes_smart_apostrophes():
+    """Smart quotes from photo apps match straight-apostrophe taxonomy names."""
+    from taxonomy import Taxonomy
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tax_path = _create_mock_taxonomy(tmpdir)
+        tax = Taxonomy(tax_path)
+
+        result = tax.lookup("Lincoln’s Sparrow")
+        assert result is not None
+        assert result["scientific_name"] == "Melospiza lincolnii"
+
+
+def test_mark_species_keywords_normalizes_smart_apostrophes(tmp_path):
+    """Startup species marking retypes smart-apostrophe XMP keywords."""
+    from taxonomy import Taxonomy
+
+    tax_path = _create_mock_taxonomy(str(tmp_path))
+    tax = Taxonomy(tax_path)
+    db = Database(str(tmp_path / "test.db"))
+    kid = db.add_keyword("Lincoln’s Sparrow")
+
+    updated = db.mark_species_keywords(tax)
+    assert updated == 1
+
+    row = db.conn.execute(
+        "SELECT is_species, type FROM keywords WHERE id = ?", (kid,)
+    ).fetchone()
+    assert row["is_species"] == 1
+    assert row["type"] == "taxonomy"
+
+
 def test_lookup_scientific_name():
     """Lookup works for scientific names too."""
     from taxonomy import Taxonomy


### PR DESCRIPTION
## Summary
Normalize taxonomy keyword matching so smart apostrophes and related punctuation from photo metadata match straight-apostrophe taxonomy names. This lets hand-entered XMP keywords like `Say’s phoebe` resolve as taxonomy/wildlife instead of staying general keywords.

## Validation
- `pytest vireo/tests/test_taxonomy.py`
- `pytest vireo/tests/test_db.py -k "add_keyword or mark_species_keywords"`
- `pytest vireo/tests/test_taxonomy.py vireo/tests/test_db.py -k "smart_apostrophe or add_keyword or mark_species_keywords"`
- dry run on a temp copy of `~/.vireo/vireo.db` promoted `Say’s phoebe` to taxonomy/species
