### PR TITLE
Classify no-detection photos with full-image fallback

### DIFF
--- a/vireo/db.py
+++ b/vireo/db.py
@@ -5144,6 +5144,133 @@ class Database:
         ).fetchone()
         return row["n"] or 0
 
+    def count_full_image_fallback_photos(
+        self, photo_ids=None, detector_model="megadetector-v6",
+    ):
+        """Count photos eligible for full-image fallback classification.
+
+        These are photos in the active workspace where the detector has
+        successfully run and found no boxes. Photos with any real detector row,
+        including below-threshold noise, are excluded to match the pipeline's
+        current runtime fallback gate.
+        """
+        ws = self._ws_id()
+        scope_sql, scope_params = self._scope_clause(photo_ids)
+        row = self.conn.execute(
+            f"""SELECT COUNT(*) AS n
+                  FROM photos p
+                  JOIN workspace_folders wf
+                    ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
+                  JOIN detector_runs dr
+                    ON dr.photo_id = p.id
+                   AND dr.detector_model = ?
+                   AND dr.box_count = 0
+                 WHERE NOT EXISTS (
+                         SELECT 1 FROM detections d
+                          WHERE d.photo_id = p.id
+                            AND d.detector_model != 'full-image'
+                       ){scope_sql}""",
+            (ws, detector_model, *scope_params),
+        ).fetchone()
+        return row["n"] or 0
+
+    def count_full_image_classify_pending_pairs(
+        self, classifier_model, labels_fingerprint,
+        photo_ids=None, detector_model="megadetector-v6",
+    ):
+        """Count fallback photos lacking a classifier run for (model, fp)."""
+        ws = self._ws_id()
+        scope_sql, scope_params = self._scope_clause(photo_ids)
+        row = self.conn.execute(
+            f"""WITH full_anchor AS (
+                    SELECT photo_id, MIN(id) AS detection_id
+                      FROM detections
+                     WHERE detector_model = 'full-image'
+                     GROUP BY photo_id
+                  ),
+                  fallback AS (
+                    SELECT p.id AS photo_id, fa.detection_id
+                      FROM photos p
+                      JOIN workspace_folders wf
+                        ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
+                      JOIN detector_runs dr
+                        ON dr.photo_id = p.id
+                       AND dr.detector_model = ?
+                       AND dr.box_count = 0
+                      LEFT JOIN full_anchor fa ON fa.photo_id = p.id
+                     WHERE NOT EXISTS (
+                             SELECT 1 FROM detections d
+                              WHERE d.photo_id = p.id
+                                AND d.detector_model != 'full-image'
+                           ){scope_sql}
+                  )
+                SELECT COUNT(*) AS pending
+                  FROM fallback f
+                  LEFT JOIN classifier_runs cr
+                    ON cr.detection_id = f.detection_id
+                   AND cr.classifier_model = ?
+                   AND cr.labels_fingerprint = ?
+                 WHERE f.detection_id IS NULL
+                    OR cr.detection_id IS NULL""",
+            (
+                ws, detector_model, *scope_params,
+                classifier_model, labels_fingerprint,
+            ),
+        ).fetchone()
+        return row["pending"] or 0
+
+    def count_full_image_classify_stale(
+        self, classifier_model, labels_fingerprint,
+        photo_ids=None, detector_model="megadetector-v6",
+    ):
+        """Count fallback anchors with stale runs and no current run."""
+        ws = self._ws_id()
+        scope_sql, scope_params = self._scope_clause(photo_ids)
+        row = self.conn.execute(
+            f"""WITH full_anchor AS (
+                    SELECT photo_id, MIN(id) AS detection_id
+                      FROM detections
+                     WHERE detector_model = 'full-image'
+                     GROUP BY photo_id
+                  ),
+                  fallback AS (
+                    SELECT p.id AS photo_id, fa.detection_id
+                      FROM photos p
+                      JOIN workspace_folders wf
+                        ON wf.folder_id = p.folder_id AND wf.workspace_id = ?
+                      JOIN detector_runs dr
+                        ON dr.photo_id = p.id
+                       AND dr.detector_model = ?
+                       AND dr.box_count = 0
+                      JOIN full_anchor fa ON fa.photo_id = p.id
+                     WHERE NOT EXISTS (
+                             SELECT 1 FROM detections d
+                              WHERE d.photo_id = p.id
+                                AND d.detector_model != 'full-image'
+                           ){scope_sql}
+                  )
+                SELECT COUNT(*) AS n
+                  FROM fallback f
+                 WHERE EXISTS (
+                         SELECT 1 FROM classifier_runs cr_stale
+                          WHERE cr_stale.detection_id = f.detection_id
+                            AND cr_stale.classifier_model = ?
+                            AND cr_stale.labels_fingerprint != ?
+                       )
+                   AND NOT EXISTS (
+                         SELECT 1 FROM classifier_runs cr_cur
+                          WHERE cr_cur.detection_id = f.detection_id
+                            AND cr_cur.classifier_model = ?
+                            AND cr_cur.labels_fingerprint = ?
+                       )""",
+            (
+                ws, detector_model, *scope_params,
+                classifier_model, labels_fingerprint,
+                classifier_model, labels_fingerprint,
+            ),
+        ).fetchone()
+        return row["n"] or 0
+
     def get_classification_inventory(self, workspace_id, min_conf=None,
                                      median_sample_per_pair=2000):
         """Per-(model × fingerprint) coverage stats for ``workspace_id``.
@@ -10868,18 +10995,18 @@ class Database:
 
     def count_classifier_runs(self, photo_ids, classifier_model, labels_fingerprint):
         """Count distinct photos in `photo_ids` that have at least one
-        non-full-image detection above the active workspace's
-        ``detector_confidence`` threshold with a classifier_runs row
-        matching the given (classifier_model, labels_fingerprint).
+        runtime-classifiable target with a classifier_runs row matching the
+        given (classifier_model, labels_fingerprint).
 
         Used by the streaming pipeline's classify stage to pre-flight how
         many photos will hit the cache vs. require fresh inference.
 
         Mirrors the runtime gate's photo selection (see pipeline_job.py,
         the ``primary_det = photo_dets[0]`` block in the classify loop):
-        full-image rows are excluded and below-threshold detections are
-        ignored, so prior full-image classifier_runs and low-confidence
-        secondary boxes don't inflate the cached_estimate. May still
+        above-threshold real detections count normally, and photos where
+        MegaDetector ran with ``box_count=0`` count through their synthetic
+        full-image anchor. Below-threshold real detections are ignored because
+        the pipeline still skips them instead of falling back. May still
         overcount for photos with multiple above-threshold non-full-image
         detections where a non-primary one happens to carry the matching
         run key — exact mirroring would require a window function over
@@ -10908,6 +11035,33 @@ class Database:
                 f"  AND d.detector_confidence >= ? "
                 f"  AND d.photo_id IN ({placeholders})",
                 [classifier_model, labels_fingerprint, min_conf, *chunk],
+            ).fetchall()
+            for r in rows:
+                matched.add(r["photo_id"])
+            rows = self.conn.execute(
+                f"""WITH full_anchor AS (
+                        SELECT photo_id, MIN(id) AS detection_id
+                          FROM detections
+                         WHERE detector_model = 'full-image'
+                           AND photo_id IN ({placeholders})
+                         GROUP BY photo_id
+                      )
+                    SELECT DISTINCT fa.photo_id
+                      FROM full_anchor fa
+                      JOIN detector_runs dr
+                        ON dr.photo_id = fa.photo_id
+                       AND dr.detector_model = 'megadetector-v6'
+                       AND dr.box_count = 0
+                      JOIN classifier_runs cr
+                        ON cr.detection_id = fa.detection_id
+                       AND cr.classifier_model = ?
+                       AND cr.labels_fingerprint = ?
+                     WHERE NOT EXISTS (
+                             SELECT 1 FROM detections d
+                              WHERE d.photo_id = fa.photo_id
+                                AND d.detector_model != 'full-image'
+                           )""",
+                [*chunk, classifier_model, labels_fingerprint],
             ).fetchall()
             for r in rows:
                 matched.add(r["photo_id"])

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -3512,6 +3512,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 # (all detected photos) would incorrectly delete detections for
                 # photos that weren't reached if the job was aborted mid-classify.
                 first_model_photo_ids: set = set()
+                fresh_full_image_ids_by_photo: dict = {}
 
                 from datetime import datetime as dt
 
@@ -3833,6 +3834,9 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 }
                                 full_image_fallback = True
                                 full_image_fallbacks += 1
+                                fresh_full_image_ids_by_photo.setdefault(
+                                    photo["id"], set(),
+                                ).add(full_det_id)
 
                             # Classifier-run gate: skip work when this exact
                             # (detection, classifier_model, labels_fingerprint)
@@ -4045,22 +4049,29 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         # whose boxes didn't change — the common reclassify case.
                         # Compare against the ids THIS run actually re-detected
                         # (detect_state["detections"] is the in-memory map
-                        # _detect_batch built); a photo that came back empty has
-                        # no entry, so its pre-run rows are all stale and get
-                        # purged (write_detection_batch([]) already cleared them at
-                        # the data layer — this is the belt-and-suspenders pass and
-                        # cross-model cleanup). A photo re-detected with the same
-                        # boxes has its ids in the fresh set, so they survive.
+                        # _detect_batch built). A no-detection photo may also
+                        # have a freshly used synthetic full-image anchor from
+                        # the fallback path; preserve that id so the purge does
+                        # not cascade-delete the new fallback prediction. Other
+                        # pre-run rows on empty photos are stale and get purged
+                        # (write_detection_batch([]) already cleared the
+                        # MegaDetector rows at the data layer — this is the
+                        # belt-and-suspenders pass and cross-model cleanup). A
+                        # photo re-detected with the same boxes has its ids in
+                        # the fresh set, so they survive.
                         fresh_by_photo = detect_state["detections"]
                         stale_ids = [
                             det_id
                             for photo_id, id_set in pre_ids.items()
                             if photo_id in purge_ids
                             for det_id in id_set
-                            if det_id not in {
-                                d["id"]
-                                for d in fresh_by_photo.get(photo_id, [])
-                            }
+                            if det_id not in (
+                                {
+                                    d["id"]
+                                    for d in fresh_by_photo.get(photo_id, [])
+                                }
+                                | fresh_full_image_ids_by_photo.get(photo_id, set())
+                            )
                         ]
                         if stale_ids:
                             getattr(

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -3496,6 +3496,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 total = len(photos)
 
                 total_predictions_stored = 0
+                total_full_image_fallbacks = 0
                 total_failed = 0
                 total_skipped_existing = 0
                 # Track unique photo IDs that failed in any model so the rollup
@@ -3661,6 +3662,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     raw_results: list = []
                     failed = 0
                     skipped_existing = 0
+                    full_image_fallbacks = 0
                     stages["classify"].setdefault("cached", 0)
                     stages["classify"].setdefault("seen", 0)
                     # Photos that iterated past the inner abort check IN THIS spec.
@@ -3756,16 +3758,17 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             # never completed (e.g. mid-batch exception, or the
                             # detect stage was skipped for an already-detected
                             # non-reclassify run — in which case the DB holds the
-                            # authoritative rows). Photos with no detections get
-                            # skipped entirely; pipeline classify is detection-
-                            # driven and won't synthesize full-image boxes.
+                            # authoritative rows). If MegaDetector produced no
+                            # real rows at all, synthesize a full-image anchor so
+                            # classifiers still get one attempt and future reruns
+                            # can hit classifier_runs for that attempt.
+                            full_image_fallback = False
                             if photo["id"] in cached_detections:
                                 # cached_detections from _detect_batch can include
                                 # full-image rows when an earlier pass synthesized
                                 # them (legacy db state); filter to match the
-                                # fallback-query branch below so primary_det never
-                                # lands on a full-image box. Pipeline classify is
-                                # detection-driven and won't classify full-image.
+                                # fallback-query branch below so primary_det only
+                                # lands on a real detector box.
                                 photo_dets = [
                                     d for d in cached_detections[photo["id"]]
                                     if d.get("detector_model") != "full-image"
@@ -3786,7 +3789,50 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 ]
                             primary_det = photo_dets[0] if photo_dets else None
                             if primary_det is None:
-                                continue
+                                # Distinguish "no eligible detection at the
+                                # workspace threshold" from "MegaDetector found
+                                # nothing at all." Weak raw detections keep the
+                                # existing behavior for now; true no-detection
+                                # photos get full-image classification.
+                                raw_real_dets = [
+                                    d for d in thread_db.get_detections(
+                                        photo["id"], min_conf=0,
+                                    )
+                                    if d["detector_model"] != "full-image"
+                                ]
+                                if raw_real_dets:
+                                    continue
+
+                                existing_full = thread_db.get_detections(
+                                    photo["id"],
+                                    detector_model="full-image",
+                                    min_conf=0,
+                                )
+                                if existing_full and not params.reclassify:
+                                    full_det_id = existing_full[0]["id"]
+                                else:
+                                    full_det_ids = thread_db.save_detections(
+                                        photo["id"],
+                                        [{
+                                            "box": {"x": 0, "y": 0, "w": 1, "h": 1},
+                                            "confidence": 0,
+                                            "category": "animal",
+                                        }],
+                                        detector_model="full-image",
+                                    )
+                                    full_det_id = full_det_ids[0]
+                                primary_det = {
+                                    "id": full_det_id,
+                                    "box_x": 0,
+                                    "box_y": 0,
+                                    "box_w": 1,
+                                    "box_h": 1,
+                                    "confidence": 0,
+                                    "category": "animal",
+                                    "detector_model": "full-image",
+                                }
+                                full_image_fallback = True
+                                full_image_fallbacks += 1
 
                             # Classifier-run gate: skip work when this exact
                             # (detection, classifier_model, labels_fingerprint)
@@ -3851,7 +3897,8 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                     # instead of stranding the detection.
 
                             img, folder_path, image_path = _prepare_image(
-                                photo, folders, primary_det,
+                                photo, folders,
+                                None if full_image_fallback else primary_det,
                             )
                             if img is None:
                                 failed += 1
@@ -3958,6 +4005,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     )
                     preds = group_result["predictions_stored"]
                     total_predictions_stored += preds
+                    total_full_image_fallbacks += full_image_fallbacks
                     total_failed += failed
                     total_skipped_existing += skipped_existing
                     models_succeeded += 1
@@ -4031,6 +4079,8 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     parts = [f"{preds} predictions"]
                     if skipped_existing:
                         parts.append(f"{skipped_existing} cached")
+                    if full_image_fallbacks:
+                        parts.append(f"{full_image_fallbacks} full-image fallback")
                     if failed:
                         parts.append(f"{failed} failed")
                     runner.update_step(
@@ -4075,6 +4125,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     "detected": detect_state["total_detected"],
                     "failed": total_failed,
                     "already_classified": total_skipped_existing,
+                    "full_image_fallbacks": total_full_image_fallbacks,
                     "model_count": len(resolved_specs_local),
                     "models_succeeded": models_succeeded,
                     "models_skipped": len(skipped_model_names),

--- a/vireo/pipeline_plan.py
+++ b/vireo/pipeline_plan.py
@@ -266,11 +266,13 @@ def _classify_plan(db, params, photo_ids, new_count=0):
     det_counts = db.count_primary_detections_in_scope(photo_ids)
     total_dets = det_counts["total_dets"]
     photos_with_dets = det_counts["photos_with_dets"]
+    full_image_fallbacks = db.count_full_image_fallback_photos(photo_ids)
+    classifiable_units = total_dets + full_image_fallbacks
 
     unblocked_count = sum(
         1 for m in models if not label_resolution[m["id"]].get("blocked")
     )
-    eligible = total_dets * unblocked_count
+    eligible = classifiable_units * unblocked_count
 
     # Every selected model is blocked on missing labels and can't run
     # label-free (Tree of Life). The classify stage cannot do any work for
@@ -298,7 +300,7 @@ def _classify_plan(db, params, photo_ids, new_count=0):
         }
 
     stale_total = 0
-    if total_dets > 0 and not params.reclassify:
+    if classifiable_units > 0 and not params.reclassify:
         for m in models:
             info = label_resolution[m["id"]]
             if info.get("blocked"):
@@ -309,11 +311,16 @@ def _classify_plan(db, params, photo_ids, new_count=0):
                 labels_fingerprint=fp,
                 photo_ids=photo_ids,
             )
+            stale_total += db.count_full_image_classify_stale(
+                classifier_model=m["name"],
+                labels_fingerprint=fp,
+                photo_ids=photo_ids,
+            )
     # Reclassify is a user override, not a settings-change signal.
     fingerprint_outdated = stale_total > 0 and not params.reclassify
     fingerprint_reason = "label_set_changed" if fingerprint_outdated else None
 
-    if total_dets == 0:
+    if classifiable_units == 0:
         # Mixed shape with no detections cached yet: some selected models
         # can run (label-free, or have labels) and others are blocked on
         # missing labels. The earlier unblocked_count==0 guard doesn't fire
@@ -339,6 +346,7 @@ def _classify_plan(db, params, photo_ids, new_count=0):
                     "blocked_models": blocked_now,
                     "total_dets": 0,
                     "photos_with_dets": 0,
+                    "full_image_fallbacks": 0,
                     "models": [m["name"] for m in models],
                     "pending": 0,
                     "eligible": 0,
@@ -372,6 +380,7 @@ def _classify_plan(db, params, photo_ids, new_count=0):
             "detail": {
                 "total_dets": 0,
                 "photos_with_dets": 0,
+                "full_image_fallbacks": 0,
                 "models": [m["name"] for m in models],
                 "pending": new_count,
                 "eligible": new_count,
@@ -393,9 +402,14 @@ def _classify_plan(db, params, photo_ids, new_count=0):
             continue
         fp = info["fingerprint"]
         if params.reclassify:
-            pending = total_dets
+            pending = classifiable_units
         else:
             pending = db.count_primary_classify_pending_pairs(
+                classifier_model=m["name"],
+                labels_fingerprint=fp,
+                photo_ids=photo_ids,
+            )
+            pending += db.count_full_image_classify_pending_pairs(
                 classifier_model=m["name"],
                 labels_fingerprint=fp,
                 photo_ids=photo_ids,
@@ -441,12 +455,13 @@ def _classify_plan(db, params, photo_ids, new_count=0):
                 "summary": (
                     f"Will run on {new_count} new "
                     f"photo{_plural(new_count)} "
-                    f"({total_dets} existing detection"
-                    f"{_plural(total_dets)} already classified)"
+                    f"({classifiable_units} existing target"
+                    f"{_plural(classifiable_units)} already classified)"
                 ),
                 "detail": {
                     "total_dets": total_dets,
                     "photos_with_dets": photos_with_dets,
+                    "full_image_fallbacks": full_image_fallbacks,
                     "models": [m["name"] for m in models],
                     "pending": new_count,
                     "eligible": eligible + new_count,
@@ -459,13 +474,14 @@ def _classify_plan(db, params, photo_ids, new_count=0):
         return {
             "state": "done-prior",
             "summary": (
-                f"Already classified — {total_dets} "
-                f"detection{_plural(total_dets)} across "
+                f"Already classified — {classifiable_units} "
+                f"target{_plural(classifiable_units)} across "
                 f"{len(models)} model{_plural(len(models))}"
             ),
             "detail": {
                 "total_dets": total_dets,
                 "photos_with_dets": photos_with_dets,
+                "full_image_fallbacks": full_image_fallbacks,
                 "models": [m["name"] for m in models],
                 "pending": 0,
                 "eligible": eligible,
@@ -478,8 +494,8 @@ def _classify_plan(db, params, photo_ids, new_count=0):
     if params.reclassify:
         summary = (
             f"Re-classify — {pending_total} "
-            f"detection-model pair{_plural(pending_total)} "
-            f"({total_dets} detection{_plural(total_dets)} × "
+            f"target-model pair{_plural(pending_total)} "
+            f"({classifiable_units} target{_plural(classifiable_units)} × "
             f"{len(models)} model{_plural(len(models))})"
         )
     else:
@@ -509,6 +525,7 @@ def _classify_plan(db, params, photo_ids, new_count=0):
         "per_model": pending_per_model,
         "total_dets": total_dets,
         "photos_with_dets": photos_with_dets,
+        "full_image_fallbacks": full_image_fallbacks,
         "pending": pending_total + new_count,
         "eligible": eligible + new_count,
         "stale": stale_total,

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -2603,6 +2603,110 @@ def test_pipeline_model_ids_back_compat_with_model_id(tmp_path, monkeypatch):
     )
 
 
+def test_pipeline_classifies_full_image_when_detector_finds_nothing(
+    tmp_path, monkeypatch
+):
+    """Pipeline classify should not strand photos where MegaDetector ran and
+    found no subject. It should classify the full image once, persist the
+    synthetic anchor, and use classifier_runs on the next pass.
+    """
+    import classifier as classifier_mod
+    import classify_job
+    import config as cfg
+    import detector
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    photo_id = db.add_photo(
+        folder_id, "empty.jpg", ".jpg", 100, 1_000_000.0,
+    )
+    _drop_jpeg(folder_path, "empty.jpg")
+    col_id = db.add_collection(
+        "No detections",
+        json.dumps([{"field": "photo_ids", "value": [photo_id]}]),
+    )
+
+    _setup_fake_downloaded_model(tmp_path, monkeypatch)
+    monkeypatch.setattr(detector, "ensure_megadetector_weights", lambda **_k: None)
+    monkeypatch.setattr(classify_job, "detect_animals", lambda _path: [])
+    monkeypatch.setattr(classify_job, "get_primary_detection", lambda _dets: None)
+
+    classify_calls = []
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def classify_batch_with_embedding(self, images, threshold=0):
+            import numpy as np
+
+            classify_calls.append(len(images))
+            return [
+                (
+                    [{"species": "Full-image Robin", "score": 0.91}],
+                    np.zeros(512, dtype=np.float32),
+                )
+                for _ in images
+            ]
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    params = PipelineParams(
+        collection_id=col_id,
+        model_id="bioclip-vit-b-16",
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    first = run_pipeline_job(
+        _make_job(), FakeRunner(), db_path, ws_id, params,
+    )
+    assert first["stages"]["detect"] == {
+        "total": 1,
+        "detected": 0,
+        "processed": 1,
+    }
+    assert first["stages"]["classify"]["full_image_fallbacks"] == 1
+    assert classify_calls == [1]
+
+    check = Database(db_path)
+    check.set_active_workspace(ws_id)
+    full = check.get_detections(
+        photo_id, detector_model="full-image", min_conf=0,
+    )
+    assert len(full) == 1
+    pred = check.get_predictions_for_detection(
+        full[0]["id"],
+        classifier_model="BioCLIP",
+        min_classifier_conf=0,
+    )
+    assert len(pred) == 1
+    assert pred[0]["species"] == "Full-image Robin"
+    assert (
+        "BioCLIP", pred[0]["labels_fingerprint"],
+    ) in check.get_classifier_run_keys(full[0]["id"])
+
+    # Rerun: detector_run + full-image classifier_run should make this a
+    # metadata/cache pass, not another model inference.
+    second = run_pipeline_job(
+        _make_job(), FakeRunner(), db_path, ws_id, params,
+    )
+    assert second["stages"]["classify"]["full_image_fallbacks"] == 1
+    assert classify_calls == [1]
+    full_after = check.get_detections(
+        photo_id, detector_model="full-image", min_conf=0,
+    )
+    assert [d["id"] for d in full_after] == [full[0]["id"]]
+
+
 def test_pipeline_redownloads_taxonomy_when_existing_file_is_corrupt(
     tmp_path, monkeypatch
 ):
@@ -5021,30 +5125,27 @@ def test_pipeline_classify_stores_predictions_with_detection_id(
         "its prediction is not reachable via the predictions→detections join."
     )
 
-    # photo_without_det must NOT have a prediction or a detection row. The
-    # pipeline classify stage is detection-driven: photos without a real
-    # MegaDetector hit are skipped, not classified against a synthetic
-    # full-image box (earlier versions did that, but it broke
-    # extract_masks_stage and caused multi-model duplicate inserts).
+    # photo_without_det should now have a full-image prediction anchored to a
+    # synthetic full-image detection. That preserves the non-NULL detection_id
+    # invariant while still letting no-detection photos be classified and cached.
     no_det_preds = db.conn.execute(
-        """SELECT pr.id FROM predictions pr
-           LEFT JOIN detections d ON d.id = pr.detection_id
-           WHERE d.photo_id = ? OR pr.detection_id IS NULL""",
+        """SELECT pr.id, d.detector_model
+             FROM predictions pr
+             JOIN detections d ON d.id = pr.detection_id
+            WHERE d.photo_id = ?""",
         (photo_without_det,),
     ).fetchall()
-    assert not no_det_preds, (
-        f"Pipeline wrote predictions for photo_without_det: {[dict(r) for r in no_det_preds]}. "
-        "Photos without a MegaDetector detection must be skipped by the "
-        "pipeline classify stage."
+    assert [r["detector_model"] for r in no_det_preds] == ["full-image"], (
+        "No-detection photos should be classified against a synthetic "
+        f"full-image anchor, got: {[dict(r) for r in no_det_preds]}"
     )
     leftover_dets = db.conn.execute(
         "SELECT id, detector_model FROM detections WHERE photo_id = ?",
         (photo_without_det,),
     ).fetchall()
-    assert not leftover_dets, (
-        f"Pipeline created spurious detection rows for photo_without_det: "
-        f"{[dict(r) for r in leftover_dets]}. No synthetic detections should "
-        "be inserted — the photo should just be skipped."
+    assert [r["detector_model"] for r in leftover_dets] == ["full-image"], (
+        "No-detection photos should get exactly one synthetic full-image "
+        f"detection anchor, got: {[dict(r) for r in leftover_dets]}"
     )
 
 
@@ -5745,7 +5846,25 @@ def test_pipeline_detect_runs_once_before_any_classifier_loads(
                           det_conf_threshold=None, already_detected_ids=None,
                           cached_detections=None):
         events.append(("detect", [p["id"] for p in batch]))
-        return {}, 0, {p["id"] for p in batch}
+        det_map = {}
+        for p in batch:
+            det_id = db_.save_detections(
+                p["id"],
+                [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+                  "confidence": 0.9, "category": "animal"}],
+                detector_model="megadetector-v6",
+            )[0]
+            det_map[p["id"]] = [{
+                "id": det_id,
+                "box_x": 0.1,
+                "box_y": 0.1,
+                "box_w": 0.5,
+                "box_h": 0.5,
+                "confidence": 0.9,
+                "category": "animal",
+                "detector_model": "megadetector-v6",
+            }]
+        return det_map, len(det_map), {p["id"] for p in batch}
 
     monkeypatch.setattr(classify_job, "_detect_batch", fake_detect_batch)
 
@@ -5756,6 +5875,16 @@ def test_pipeline_detect_runs_once_before_any_classifier_loads(
         def encode_image(self, *args, **kwargs):
             import numpy as np
             return np.zeros(512, dtype=np.float32)
+
+        def classify_batch_with_embedding(self, images, threshold=0):
+            import numpy as np
+            return [
+                (
+                    [{"species": "Test species", "score": 0.9}],
+                    np.zeros(512, dtype=np.float32),
+                )
+                for _ in images
+            ]
 
     monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
 

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -2706,6 +2706,35 @@ def test_pipeline_classifies_full_image_when_detector_finds_nothing(
     )
     assert [d["id"] for d in full_after] == [full[0]["id"]]
 
+    # Forced reclassify should infer again, but the stale-detection purge must
+    # treat the synthetic full-image anchor as fresh. Otherwise the purge
+    # cascades through predictions.detection_id and deletes the new result.
+    reclassify_params = PipelineParams(
+        collection_id=col_id,
+        model_id="bioclip-vit-b-16",
+        reclassify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+    third = run_pipeline_job(
+        _make_job(), FakeRunner(), db_path, ws_id, reclassify_params,
+    )
+    assert third["stages"]["classify"]["full_image_fallbacks"] == 1
+    assert classify_calls == [1, 1]
+    verify = Database(db_path)
+    verify.set_active_workspace(ws_id)
+    full_reclassified = verify.get_detections(
+        photo_id, detector_model="full-image", min_conf=0,
+    )
+    assert [d["id"] for d in full_reclassified] == [full[0]["id"]]
+    pred_after_reclassify = verify.get_predictions_for_detection(
+        full[0]["id"],
+        classifier_model="BioCLIP",
+        min_classifier_conf=0,
+    )
+    assert len(pred_after_reclassify) == 1
+    assert pred_after_reclassify[0]["species"] == "Full-image Robin"
+
 
 def test_pipeline_redownloads_taxonomy_when_existing_file_is_corrupt(
     tmp_path, monkeypatch

--- a/vireo/tests/test_pipeline_plan.py
+++ b/vireo/tests/test_pipeline_plan.py
@@ -207,6 +207,33 @@ def test_count_real_detections_scopes_to_photo_ids(tmp_path):
     assert counts == {"total_dets": 0, "photos_with_dets": 0}
 
 
+def test_full_image_fallback_classify_counts_track_run_keys(tmp_path):
+    db, folder_id = _make_db(tmp_path)
+    pid_empty = db.add_photo(
+        folder_id=folder_id, filename="empty.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    db.record_detector_run(pid_empty, "megadetector-v6", box_count=0)
+
+    pid_weak, _ = _add_photo_with_detection(db, folder_id, "weak.jpg", conf=0.05)
+    db.record_detector_run(pid_weak, "megadetector-v6", box_count=1)
+
+    assert db.count_full_image_fallback_photos() == 1
+    assert db.count_full_image_classify_pending_pairs("BioCLIP-2", "fp1") == 1
+
+    full_det_id = db.save_detections(
+        pid_empty,
+        [{"box": {"x": 0, "y": 0, "w": 1, "h": 1},
+          "confidence": 0, "category": "animal"}],
+        detector_model="full-image",
+    )[0]
+    assert db.count_full_image_classify_pending_pairs("BioCLIP-2", "fp1") == 1
+
+    db.record_classifier_run(full_det_id, "BioCLIP-2", "fp1", prediction_count=1)
+    assert db.count_full_image_classify_pending_pairs("BioCLIP-2", "fp1") == 0
+    assert db.count_classifier_runs([pid_empty, pid_weak], "BioCLIP-2", "fp1") == 1
+
+
 def test_count_classify_pending_excludes_recorded_runs(tmp_path):
     """The pending-pair count must mirror the classify gate exactly: a
     detection with a classifier_runs row for (model, fp) is done.
@@ -1005,6 +1032,74 @@ def test_classify_plan_exposes_pending_and_eligible_no_detections(tmp_path, monk
     detail = plan["stages"]["Classify"]["detail"]
     assert detail["eligible"] == 0
     assert detail["pending"] == 0
+
+
+def test_classify_plan_counts_full_image_fallback_pending(tmp_path, monkeypatch):
+    from pipeline_plan import compute_plan
+
+    db, folder_id = _make_db(tmp_path)
+    pid = db.add_photo(
+        folder_id=folder_id, filename="empty.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    db.record_detector_run(pid, "megadetector-v6", box_count=0)
+
+    import labels as labels_mod
+    import models as models_mod
+
+    monkeypatch.setattr(models_mod, "get_models", lambda: [
+        {"id": "m1", "name": "BioCLIP-2",
+         "model_str": "hf-hub:imageomics/bioclip-2",
+         "model_type": "bioclip", "downloaded": True,
+         "weights_path": _tol_weights(tmp_path)},
+    ])
+    monkeypatch.setattr(labels_mod, "get_active_labels", lambda: [])
+    monkeypatch.setattr(labels_mod, "get_saved_labels", lambda: [])
+
+    plan = compute_plan(db, _params(model_ids=["m1"]), str(tmp_path / "test.db"))
+    classify = plan["stages"]["Classify"]
+    assert classify["state"] == "will-run"
+    assert classify["detail"]["full_image_fallbacks"] == 1
+    assert classify["detail"]["eligible"] == 1
+    assert classify["detail"]["pending"] == 1
+
+
+def test_classify_plan_done_prior_for_full_image_fallback(tmp_path, monkeypatch):
+    from labels_fingerprint import TOL_SENTINEL
+    from pipeline_plan import compute_plan
+
+    db, folder_id = _make_db(tmp_path)
+    pid = db.add_photo(
+        folder_id=folder_id, filename="empty.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    db.record_detector_run(pid, "megadetector-v6", box_count=0)
+    full_det_id = db.save_detections(
+        pid,
+        [{"box": {"x": 0, "y": 0, "w": 1, "h": 1},
+          "confidence": 0, "category": "animal"}],
+        detector_model="full-image",
+    )[0]
+    db.record_classifier_run(full_det_id, "BioCLIP-2", TOL_SENTINEL, 1)
+
+    import labels as labels_mod
+    import models as models_mod
+
+    monkeypatch.setattr(models_mod, "get_models", lambda: [
+        {"id": "m1", "name": "BioCLIP-2",
+         "model_str": "hf-hub:imageomics/bioclip-2",
+         "model_type": "bioclip", "downloaded": True,
+         "weights_path": _tol_weights(tmp_path)},
+    ])
+    monkeypatch.setattr(labels_mod, "get_active_labels", lambda: [])
+    monkeypatch.setattr(labels_mod, "get_saved_labels", lambda: [])
+
+    plan = compute_plan(db, _params(model_ids=["m1"]), str(tmp_path / "test.db"))
+    classify = plan["stages"]["Classify"]
+    assert classify["state"] == "done-prior"
+    assert classify["detail"]["full_image_fallbacks"] == 1
+    assert classify["detail"]["eligible"] == 1
+    assert classify["detail"]["pending"] == 0
 
 
 def test_classify_plan_exposes_pending_and_eligible_blocked_only(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- classify photos with no MegaDetector boxes by creating a synthetic `full-image` detection anchor and running the selected classifier models on the whole image
- record and reuse `classifier_runs` for those fallback anchors so rerunning the same job skips inference instead of reprocessing the photo
- update pipeline planning/status counts so no-detection fallback work appears as pending/done classifier work without inflating real detection, mask, or extraction scope

## Root Cause
The streaming pipeline was detection-driven: if MegaDetector produced no above-threshold primary detection, the classifier stage skipped the photo. Detector attempts were recorded, but there was no classifier attempt/result for true no-box photos, leaving Compare with photos that had no associated prediction.

## Validation
- `pytest -q vireo/tests/test_pipeline_plan.py`
- `pytest -q vireo/tests/test_pipeline_job.py`