### PR TITLE
Use JPEG fallback for failed RAW edits

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -21107,17 +21107,23 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # this often means rawpy.postprocess() failed and we fell back to
             # the embedded JPEG, which can be a few pixels shy of the full
             # sensor area. Re-extracting would yield the same fallback image,
-            # just slower — so trust the wc when it is within 1% of the
-            # believed dims. This tolerance is RAW-only: for JPEG/PNG/etc.,
-            # the wc being smaller means the cap downsized it, and re-extracting
-            # WILL produce more pixels.
+            # just slower — so trust the wc when BOTH axes are within 1% of
+            # the believed dims. A long-edge-only check would silently accept
+            # an embedded JPEG whose long edge is full but whose short edge is
+            # substantially truncated (e.g. 6000x3376 for a 6000x4000 source),
+            # then apply the edit recipe to a cropped image. This tolerance is
+            # RAW-only: for JPEG/PNG/etc., the wc being smaller means the cap
+            # downsized it, and re-extracting WILL produce more pixels.
             from image_loader import RAW_EXTENSIONS
             ext = os.path.splitext(photo["filename"])[1].lower()
-            if ext in RAW_EXTENSIONS and wc_w and wc_h:
-                wc_long = max(wc_w, wc_h)
-                orig_long = max(orig_w, orig_h)
-                if orig_long and wc_long >= orig_long * 0.99:
-                    return wc_path
+            if (
+                ext in RAW_EXTENSIONS
+                and wc_w and wc_h
+                and orig_w and orig_h
+                and wc_w >= orig_w * 0.99
+                and wc_h >= orig_h * 0.99
+            ):
+                return wc_path
             return None
 
         trusted_wc_path = _trusted_full_res_working_copy_path()

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -62,6 +62,9 @@ from render_source import (
 from render_source import (
     image_is_smaller_than_expected as _image_is_smaller_than_expected,
 )
+from render_source import (
+    image_size_after_exif_orientation as _image_size_after_exif_orientation,
+)
 from render_source import path_satisfies_recipe_render as _path_satisfies_recipe_render
 from render_source import (
     recipe_render_source as _recipe_render_source,
@@ -21090,10 +21093,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 return None
             from PIL import Image as _PILImage
 
-            from render_source import image_size_after_exif_orientation
             try:
                 with _PILImage.open(wc_path) as _wc_img:
-                    wc_w, wc_h = image_size_after_exif_orientation(_wc_img)
+                    wc_w, wc_h = _image_size_after_exif_orientation(_wc_img)
             except Exception:
                 wc_w = wc_h = 0
             # Compare in display-orientation space: ``extract_working_copy``

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -21185,17 +21185,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     folder["path"], using_offline_cache,
                 )
                 image_ext = os.path.splitext(image_path)[1].lower()
-                if (
+                source_failure_current = (
                     primary_is_raw
-                    and trusted_wc_path
-                    and not os.path.exists(image_path)
-                ):
-                    image_path = trusted_wc_path
-                elif companion_source and image_ext not in RAW_EXTENSIONS:
-                    image_path = companion_source
-                elif (
-                    primary_is_raw
-                    and companion_source
                     and _has_current_working_copy_failure(
                         photo,
                         vireo_dir,
@@ -21203,6 +21194,23 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         live_source_path=image_path,
                         folder_path=folder["path"],
                     )
+                )
+                if (
+                    primary_is_raw
+                    and trusted_wc_path
+                    and not companion_source
+                    and (
+                        not os.path.exists(image_path)
+                        or source_failure_current
+                    )
+                ):
+                    image_path = trusted_wc_path
+                elif companion_source and image_ext not in RAW_EXTENSIONS:
+                    image_path = companion_source
+                elif (
+                    primary_is_raw
+                    and companion_source
+                    and source_failure_current
                 ):
                     # Mirror _recipe_render_source: when scanner has marked
                     # this RAW as failed for the current mtime, route the

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -21089,13 +21089,22 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if not os.path.exists(wc_path):
                 return None
             from PIL import Image as _PILImage
+
+            from render_source import image_size_after_exif_orientation
             try:
                 with _PILImage.open(wc_path) as _wc_img:
-                    wc_w, wc_h = _wc_img.size
+                    wc_w, wc_h = image_size_after_exif_orientation(_wc_img)
             except Exception:
                 wc_w = wc_h = 0
-            orig_w = photo["width"] or 0
-            orig_h = photo["height"] or 0
+            # Compare in display-orientation space: ``extract_working_copy``
+            # writes the EXIF-transposed JPEG (e.g. 4000x6000 for a portrait
+            # RAW), while ``photo["width"]/height`` are the sensor axes
+            # (6000x4000). Comparing raw sensor axes rejects a valid
+            # full-resolution WC for portrait RAWs and either 500s or forces
+            # a redundant re-decode. ``_recipe_source_dimensions`` swaps the
+            # sensor axes when EXIF Orientation indicates it, matching what
+            # ``load_image`` returns.
+            orig_w, orig_h = _recipe_source_dimensions(photo)
             # Trust the wc when it meets/exceeds the believed original dims,
             # or when those dims are unknown (no basis to declare the wc stale
             # and a speculative RAW re-extract would just thrash the disk).

--- a/vireo/render_source.py
+++ b/vireo/render_source.py
@@ -257,6 +257,19 @@ def working_copy_satisfies_recipe_render(
         required_w = orig_render_w
         required_h = orig_render_h
     wc_render_w, wc_render_h = rendered_recipe_dimensions(wc_w, wc_h, recipe)
+    # ``load_image(..., max_size=max_size)`` caps the long edge at ``max_size``
+    # and scales the short edge proportionally. Compare what it would actually
+    # produce from this working copy, not the raw WC render dims: a 6000x3376
+    # embedded preview for a 6000x4000 source clears an unscaled compare
+    # against 1024x683 (both axes exceed it), but a max_size=1024 render of
+    # that WC is 1024x576 — its short edge falls short and the truncated
+    # preview would otherwise get cached through the failed-RAW fallback.
+    if max_size:
+        wc_render_long = max(wc_render_w, wc_render_h)
+        if wc_render_long > max_size:
+            wc_scale = max_size / wc_render_long
+            wc_render_w = wc_render_w * wc_scale
+            wc_render_h = wc_render_h * wc_scale
     return not is_undersized(
         wc_render_w, wc_render_h, required_w, required_h,
         abs_slack=0, rel_slack=rel_slack,

--- a/vireo/render_source.py
+++ b/vireo/render_source.py
@@ -125,15 +125,27 @@ def scaled_recipe_source_dimensions(photo, max_size=None, exif_data=_UNSET):
     return width, height
 
 
-def rendered_recipe_long_edge(width, height, recipe):
-    """Return the rendered long edge after right-angle rotation and crop."""
+def rendered_recipe_dimensions(width, height, recipe):
+    """Return the rendered ``(width, height)`` after right-angle rotation and crop.
+
+    Kept in floats to match the multiplicative crop shape callers use, and to
+    let :func:`working_copy_satisfies_recipe_render` compare each axis
+    separately — a long-edge-only compare accepts a truncated short edge
+    (e.g. 6000x3376 for a 6000x4000 source) which drops content.
+    """
     rotation = (recipe or {}).get("rotation", 0)
     if rotation in (90, 270):
         width, height = height, width
     crop = (recipe or {}).get("crop") if recipe else None
     if crop:
-        return max(float(crop["w"]) * width, float(crop["h"]) * height)
-    return max(width, height)
+        return float(crop["w"]) * width, float(crop["h"]) * height
+    return float(width), float(height)
+
+
+def rendered_recipe_long_edge(width, height, recipe):
+    """Return the rendered long edge after right-angle rotation and crop."""
+    w, h = rendered_recipe_dimensions(width, height, recipe)
+    return max(w, h)
 
 
 def image_size_after_exif_orientation(img):
@@ -207,10 +219,16 @@ def working_copy_satisfies_recipe_render(
 ):
     """Return True when the working copy is large enough for this recipe render.
 
-    The working copy qualifies when its rendered long edge (after the recipe's
-    rotation/crop) covers ``min(max_size, original render long edge)`` — for a
-    typical capped request that's just ``max_size``, but a native-resolution
+    The working copy qualifies when its rendered dimensions (after the recipe's
+    rotation/crop) cover the rendered original scaled to ``max_size`` on both
+    axes — for a typical capped request that's just ``max_size`` on the long
+    edge with the short edge scaled proportionally, but a native-resolution
     request (the editor's 100% zoom) needs the full original.
+
+    Both axes are compared. A long-edge-only check accepts a working copy whose
+    short edge is truncated (e.g. a failed RAW decode's 6000x3376 embedded
+    preview for a 6000x4000 source) and silently drops that lost short-edge
+    content into the cached edit render.
     """
     wc_rel = photo_value(photo, "working_copy_path")
     if not wc_rel:
@@ -227,12 +245,22 @@ def working_copy_satisfies_recipe_render(
     original_w, original_h = recipe_source_dimensions(photo)
     if original_w <= 0 or original_h <= 0:
         return False
-    original_render_long = rendered_recipe_long_edge(original_w, original_h, recipe)
-    required_long = (
-        min(max_size, original_render_long) if max_size else original_render_long
+    orig_render_w, orig_render_h = rendered_recipe_dimensions(
+        original_w, original_h, recipe,
     )
-    wc_render_long = rendered_recipe_long_edge(wc_w, wc_h, recipe)
-    return wc_render_long >= required_long * (1.0 - rel_slack)
+    orig_render_long = max(orig_render_w, orig_render_h)
+    if max_size and orig_render_long > max_size:
+        scale = max_size / orig_render_long
+        required_w = orig_render_w * scale
+        required_h = orig_render_h * scale
+    else:
+        required_w = orig_render_w
+        required_h = orig_render_h
+    wc_render_w, wc_render_h = rendered_recipe_dimensions(wc_w, wc_h, recipe)
+    return not is_undersized(
+        wc_render_w, wc_render_h, required_w, required_h,
+        abs_slack=0, rel_slack=rel_slack,
+    )
 
 
 def path_satisfies_recipe_render(path, photo, recipe, max_size):

--- a/vireo/render_source.py
+++ b/vireo/render_source.py
@@ -202,7 +202,9 @@ def companion_image_can_replace_raw_result(
     )
 
 
-def working_copy_satisfies_recipe_render(photo, recipe, max_size, vireo_dir):
+def working_copy_satisfies_recipe_render(
+    photo, recipe, max_size, vireo_dir, *, rel_slack=0.0,
+):
     """Return True when the working copy is large enough for this recipe render.
 
     The working copy qualifies when its rendered long edge (after the recipe's
@@ -230,7 +232,7 @@ def working_copy_satisfies_recipe_render(photo, recipe, max_size, vireo_dir):
         min(max_size, original_render_long) if max_size else original_render_long
     )
     wc_render_long = rendered_recipe_long_edge(wc_w, wc_h, recipe)
-    return wc_render_long >= required_long
+    return wc_render_long >= required_long * (1.0 - rel_slack)
 
 
 def path_satisfies_recipe_render(path, photo, recipe, max_size):
@@ -306,18 +308,19 @@ def recipe_render_source(photo, recipe, max_size, vireo_dir, folders):
                 return wc_path, True
         return "", False
 
-    companion_path = photo_value(photo, "companion_path")
     original_abs = os.path.join(folder_path, photo_value(photo, "filename"))
+    source_failure_current = primary_is_raw and has_current_working_copy_failure(
+        photo,
+        vireo_dir,
+        trust_existing_working_copy=False,
+        live_source_path=original_abs,
+        folder_path=folder_path,
+    )
+    companion_path = photo_value(photo, "companion_path")
     allow_companion = (
         not primary_is_raw
         or not os.path.exists(original_abs)
-        or has_current_working_copy_failure(
-            photo,
-            vireo_dir,
-            trust_existing_working_copy=False,
-            live_source_path=original_abs,
-            folder_path=folder_path,
-        )
+        or source_failure_current
     )
     if companion_path and allow_companion:
         companion = os.path.join(folder_path, companion_path)
@@ -325,6 +328,12 @@ def recipe_render_source(photo, recipe, max_size, vireo_dir, folders):
             companion, photo, recipe, max_size,
         ):
             return companion, True
+    if source_failure_current and working_copy_satisfies_recipe_render(
+        photo, recipe, max_size, vireo_dir, rel_slack=0.01,
+    ):
+        wc_path = os.path.join(vireo_dir, wc_rel)
+        if os.path.exists(wc_path):
+            return wc_path, True
     if not os.path.exists(original_abs) and wc_rel:
         wc_path = os.path.join(vireo_dir, wc_rel)
         if os.path.exists(wc_path):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1204,6 +1204,59 @@ def test_original_trusts_raw_working_copy_even_when_smaller_than_stored_dims(app
         assert resp.data == f.read()
 
 
+def test_original_does_not_trust_raw_working_copy_with_truncated_short_edge(app_and_db):
+    """A RAW working copy whose short edge is substantially truncated must NOT
+    be served as full-res.
+
+    A failed libraw decode can leave an embedded JPEG whose long edge matches
+    the sensor but whose short edge is significantly smaller (e.g. 6000x3376
+    for a 6000x4000 source). A long-edge-only tolerance accepted that WC and
+    served it as the full-resolution original, silently dropping the missing
+    short-edge content. The trust check must reject it on the short edge so
+    the endpoint tries to recover the true full-res instead.
+    """
+    import config as cfg
+
+    app, db = app_and_db
+    client = app.test_client()
+
+    cfg.save({**cfg.DEFAULTS, "working_copy_max_size": 0})
+
+    photos = db.get_photos()
+    pid = photos[0]["id"]
+
+    db.conn.execute(
+        "UPDATE photos SET filename=?, extension=?, width=6000, height=4000 WHERE id=?",
+        ("DSC_0001.NEF", ".nef", pid),
+    )
+    db.conn.commit()
+
+    from PIL import Image
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    working_dir = os.path.join(vireo_dir, "working")
+    os.makedirs(working_dir, exist_ok=True)
+    wc_path = os.path.join(working_dir, f"{pid}.jpg")
+    # Long edge matches sensor (6000) but short edge is ~15% short — the
+    # kind of truncated embedded JPEG rawpy hands back when demosaic fails.
+    Image.new("RGB", (6000, 3376), color=(200, 100, 50)).save(wc_path, "JPEG")
+    db.conn.execute(
+        "UPDATE photos SET working_copy_path=? WHERE id=?",
+        (f"working/{pid}.jpg", pid),
+    )
+    db.conn.commit()
+
+    resp = client.get(f"/photos/{pid}/original")
+
+    # Whatever the endpoint decides to do downstream (re-extract, 500, serve
+    # a companion), it must not have returned the truncated WC as-is.
+    with open(wc_path, "rb") as f:
+        truncated_bytes = f.read()
+    if resp.status_code == 200:
+        assert resp.data != truncated_bytes, (
+            "endpoint trusted a short-edge-truncated RAW working copy as full-res"
+        )
+
+
 def test_edited_original_uses_working_copy_after_current_raw_failure(
     client_with_photo, monkeypatch,
 ):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1266,7 +1266,9 @@ def test_edited_original_uses_working_copy_after_current_raw_failure(
     resp = client.get(f"/photos/{photo_id}/original")
 
     assert resp.status_code == 200, resp.get_data(as_text=True)
-    assert loaded_paths == [wc_path]
+    assert [os.path.normpath(path) for path in loaded_paths] == [
+        os.path.normpath(wc_path)
+    ]
 
 
 def test_original_reextracts_stale_capped_jpeg_wc_after_cap_raised(app_and_db, tmp_path):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1204,6 +1204,71 @@ def test_original_trusts_raw_working_copy_even_when_smaller_than_stored_dims(app
         assert resp.data == f.read()
 
 
+def test_edited_original_uses_working_copy_after_current_raw_failure(
+    client_with_photo, monkeypatch,
+):
+    """An unsupported edited RAW should render from its JPEG working copy.
+
+    Nikon HE* RAWs can fail libraw demosaic and only leave a near-full embedded
+    JPEG working copy. Once that source failure is recorded for the current
+    mtime, the edited original route should apply the crop to the JPEG instead
+    of returning a permanent 500.
+    """
+    import image_loader
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    folder = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (photo_id,),
+    ).fetchone()
+    raw_path = os.path.join(folder["path"], "bad.NEF")
+    with open(raw_path, "wb") as f:
+        f.write(b"unsupported raw")
+
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    working_dir = os.path.join(vireo_dir, "working")
+    os.makedirs(working_dir, exist_ok=True)
+    wc_path = os.path.join(working_dir, f"{photo_id}.jpg")
+    Image.new("RGB", (792, 594), color=(80, 120, 160)).save(wc_path, "JPEG")
+
+    mtime = os.path.getmtime(raw_path)
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='bad.NEF', extension='.nef',
+               width=800, height=600,
+               file_mtime=?,
+               working_copy_path=?,
+               working_copy_failed_at=datetime('now'),
+               working_copy_failed_mtime=?,
+               working_copy_failed_source='source'
+           WHERE id=?""",
+        (mtime, f"working/{photo_id}.jpg", mtime, photo_id),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(
+        photo_id,
+        {"crop": {"x": 0, "y": 0, "w": 0.5, "h": 1}},
+    )
+
+    loaded_paths = []
+    original_load_image = image_loader.load_image
+
+    def tracking_load_image(file_path, max_size=1024, **kwargs):
+        loaded_paths.append(str(file_path))
+        if str(file_path).lower().endswith(".nef"):
+            raise AssertionError("edited original retried failed RAW")
+        return original_load_image(file_path, max_size=max_size, **kwargs)
+
+    monkeypatch.setattr(image_loader, "load_image", tracking_load_image)
+
+    resp = client.get(f"/photos/{photo_id}/original")
+
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    assert loaded_paths == [wc_path]
+
+
 def test_original_reextracts_stale_capped_jpeg_wc_after_cap_raised(app_and_db, tmp_path):
     """Stale working copies generated under a smaller cap must be re-extracted
     after the cap is raised — the endpoint must not trust the wc just

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1257,6 +1257,60 @@ def test_original_does_not_trust_raw_working_copy_with_truncated_short_edge(app_
         )
 
 
+def test_original_trusts_portrait_raw_working_copy_with_transposed_dims(app_and_db):
+    """Portrait RAWs store sensor axes while extract_working_copy writes the
+    EXIF-transposed JPEG, so the trust check must compare in display-orientation
+    space.
+
+    For a portrait RAW with sensor 6000x4000 and EXIF Orientation 6, the
+    working copy lands as 4000x6000 on disk. Comparing raw sensor axes
+    (``wc_w >= orig_w`` where wc_w=4000 and orig_w=6000) rejects a legitimate
+    full-resolution WC and forces a redundant re-extract or a 500. The trust
+    check must normalize both sides to display orientation.
+    """
+    import json
+
+    import config as cfg
+
+    app, db = app_and_db
+    client = app.test_client()
+
+    cfg.save({**cfg.DEFAULTS, "working_copy_max_size": 0})
+
+    photos = db.get_photos()
+    pid = photos[0]["id"]
+
+    exif = json.dumps({"EXIF": {"Orientation": 6}})
+    db.conn.execute(
+        "UPDATE photos SET filename=?, extension=?, width=6000, height=4000, "
+        "exif_data=? WHERE id=?",
+        ("DSC_0001.NEF", ".nef", exif, pid),
+    )
+    db.conn.commit()
+
+    from PIL import Image
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    working_dir = os.path.join(vireo_dir, "working")
+    os.makedirs(working_dir, exist_ok=True)
+    wc_path = os.path.join(working_dir, f"{pid}.jpg")
+    # extract_working_copy writes the EXIF-transposed JPEG: for a portrait
+    # source with sensor 6000x4000 the WC on disk is 4000x6000 (display).
+    Image.new("RGB", (4000, 6000), color=(90, 130, 200)).save(wc_path, "JPEG")
+    db.conn.execute(
+        "UPDATE photos SET working_copy_path=? WHERE id=?",
+        (f"working/{pid}.jpg", pid),
+    )
+    db.conn.commit()
+
+    resp = client.get(f"/photos/{pid}/original")
+
+    assert resp.status_code == 200
+    # The endpoint must have trusted and served the WC directly — comparing
+    # sensor vs display would have rejected it and either 500'd or re-extracted.
+    with open(wc_path, "rb") as f:
+        assert resp.data == f.read()
+
+
 def test_edited_original_uses_working_copy_after_current_raw_failure(
     client_with_photo, monkeypatch,
 ):

--- a/vireo/tests/test_render_source.py
+++ b/vireo/tests/test_render_source.py
@@ -116,3 +116,113 @@ def test_scaled_recipe_source_dimensions_scales_long_edge():
     photo = {"width": 6000, "height": 4000, "exif_data": None}
     assert rs.scaled_recipe_source_dimensions(photo, 3000) == (3000, 2000)
     assert rs.scaled_recipe_source_dimensions(photo, None) == (6000, 4000)
+
+
+def test_rendered_recipe_dimensions_no_recipe():
+    assert rs.rendered_recipe_dimensions(6000, 4000, None) == (6000.0, 4000.0)
+
+
+def test_rendered_recipe_dimensions_swaps_for_right_angle_rotation():
+    assert rs.rendered_recipe_dimensions(6000, 4000, {"rotation": 90}) == (4000.0, 6000.0)
+    assert rs.rendered_recipe_dimensions(6000, 4000, {"rotation": 270}) == (4000.0, 6000.0)
+
+
+def test_rendered_recipe_dimensions_applies_crop_after_rotation():
+    # 90° rotation swaps to (4000, 6000), then a 0.5x0.5 crop yields (2000, 3000).
+    result = rs.rendered_recipe_dimensions(
+        6000, 4000, {"rotation": 90, "crop": {"w": 0.5, "h": 0.5}},
+    )
+    assert result == (2000.0, 3000.0)
+
+
+def test_rendered_recipe_long_edge_matches_max_of_dimensions():
+    # Regression guard: long-edge helper must agree with both-axis helper.
+    for recipe in (
+        None,
+        {"rotation": 90},
+        {"rotation": 180, "crop": {"w": 0.5, "h": 0.75}},
+    ):
+        w, h = rs.rendered_recipe_dimensions(6000, 4000, recipe)
+        assert rs.rendered_recipe_long_edge(6000, 4000, recipe) == max(w, h)
+
+
+def _wc_photo(tmp_path, wc_size, orig_w, orig_h):
+    """Build a photo dict backed by a real JPEG on disk at ``wc_size``."""
+    wc_rel = "wc.jpg"
+    _img(*wc_size).save(str(tmp_path / wc_rel), "JPEG")
+    return {
+        "working_copy_path": wc_rel,
+        "width": orig_w,
+        "height": orig_h,
+        "exif_data": None,
+        "filename": "IMG.NEF",
+    }
+
+
+def test_working_copy_satisfies_recipe_render_full_size_wc_passes(tmp_path):
+    photo = _wc_photo(tmp_path, (6000, 4000), 6000, 4000)
+    assert rs.working_copy_satisfies_recipe_render(
+        photo, recipe=None, max_size=None, vireo_dir=str(tmp_path),
+    ) is True
+
+
+def test_working_copy_satisfies_recipe_render_rejects_short_edge_truncated(tmp_path):
+    # A failed-RAW embedded JPEG at 6000x3376 covers the long edge of a
+    # 6000x4000 source but loses ~15% of the short-edge content. A long-edge-
+    # only check would accept it; the both-axis check must reject it.
+    photo = _wc_photo(tmp_path, (6000, 3376), 6000, 4000)
+    assert rs.working_copy_satisfies_recipe_render(
+        photo, recipe=None, max_size=None, vireo_dir=str(tmp_path),
+    ) is False
+
+
+def test_working_copy_satisfies_recipe_render_short_edge_within_rel_slack(tmp_path):
+    # 1% rel_slack: 5940 is >= 6000*0.99 and 3960 is >= 4000*0.99, so it passes.
+    photo = _wc_photo(tmp_path, (5940, 3960), 6000, 4000)
+    assert rs.working_copy_satisfies_recipe_render(
+        photo, recipe=None, max_size=None, vireo_dir=str(tmp_path),
+        rel_slack=0.01,
+    ) is True
+    # But a WC whose short edge falls below rel_slack must still be rejected.
+    truncated = _wc_photo(tmp_path, (5940, 3376), 6000, 4000)
+    assert rs.working_copy_satisfies_recipe_render(
+        truncated, recipe=None, max_size=None, vireo_dir=str(tmp_path),
+        rel_slack=0.01,
+    ) is False
+
+
+def test_working_copy_satisfies_recipe_render_scales_by_max_size(tmp_path):
+    # For a max_size=3000 request over a 6000x4000 source, the required
+    # rendered dims are (3000, 2000). A 3000x2000 wc satisfies; a 3000x1688
+    # (short-edge truncated after scaling) wc does not.
+    ok = _wc_photo(tmp_path, (3000, 2000), 6000, 4000)
+    assert rs.working_copy_satisfies_recipe_render(
+        ok, recipe=None, max_size=3000, vireo_dir=str(tmp_path),
+    ) is True
+    truncated = _wc_photo(tmp_path, (3000, 1688), 6000, 4000)
+    assert rs.working_copy_satisfies_recipe_render(
+        truncated, recipe=None, max_size=3000, vireo_dir=str(tmp_path),
+    ) is False
+
+
+def test_working_copy_satisfies_recipe_render_respects_recipe_rotation(tmp_path):
+    # A 90° rotation swaps axes: a wc that looks correct pre-rotation but is
+    # short on the post-rotation axis must be rejected on both axes.
+    truncated = _wc_photo(tmp_path, (6000, 3376), 6000, 4000)
+    assert rs.working_copy_satisfies_recipe_render(
+        truncated, recipe={"rotation": 90}, max_size=None,
+        vireo_dir=str(tmp_path),
+    ) is False
+
+
+def test_working_copy_satisfies_recipe_render_missing_wc_path(tmp_path):
+    photo = {
+        "working_copy_path": "does-not-exist.jpg",
+        "width": 6000,
+        "height": 4000,
+        "exif_data": None,
+        "filename": "IMG.NEF",
+    }
+    assert rs.working_copy_satisfies_recipe_render(
+        photo, recipe=None, max_size=None, vireo_dir=str(tmp_path),
+    ) is False

--- a/vireo/tests/test_render_source.py
+++ b/vireo/tests/test_render_source.py
@@ -226,3 +226,23 @@ def test_working_copy_satisfies_recipe_render_missing_wc_path(tmp_path):
     assert rs.working_copy_satisfies_recipe_render(
         photo, recipe=None, max_size=None, vireo_dir=str(tmp_path),
     ) is False
+
+
+def test_working_copy_satisfies_recipe_render_scales_wc_before_compare(tmp_path):
+    # ``load_image(..., max_size=1024)`` caps the long edge and scales the
+    # short edge proportionally. A 6000x3376 embedded preview vs a 1024px
+    # target renders as 1024x576 — its short edge falls short of the
+    # required 1024x683. Without scaling the WC render dims before the
+    # compare, 6000 >= 1024 and 3376 >= 683 both pass and the failed-RAW
+    # fallback would cache the truncated preview.
+    truncated = _wc_photo(tmp_path, (6000, 3376), 6000, 4000)
+    assert rs.working_copy_satisfies_recipe_render(
+        truncated, recipe=None, max_size=1024, vireo_dir=str(tmp_path),
+        rel_slack=0.01,
+    ) is False
+    # A full-resolution WC still passes the capped-request compare.
+    full = _wc_photo(tmp_path, (6000, 4000), 6000, 4000)
+    assert rs.working_copy_satisfies_recipe_render(
+        full, recipe=None, max_size=1024, vireo_dir=str(tmp_path),
+        rel_slack=0.01,
+    ) is True

--- a/vireo/tests/test_thumbnails.py
+++ b/vireo/tests/test_thumbnails.py
@@ -527,7 +527,9 @@ def test_generate_all_uses_near_full_working_copy_after_current_raw_failure(
 
     assert result["generated"] == 1
     assert result["failed"] == 0
-    assert loaded_paths == [str(wc_path)]
+    assert [os.path.normpath(path) for path in loaded_paths] == [
+        os.path.normpath(str(wc_path))
+    ]
     row = db.conn.execute(
         "SELECT thumb_path FROM photos WHERE id=?", (photo_id,),
     ).fetchone()

--- a/vireo/tests/test_thumbnails.py
+++ b/vireo/tests/test_thumbnails.py
@@ -457,10 +457,16 @@ def test_generate_all_does_not_record_thumb_path_on_failure(tmp_path, monkeypatc
     assert row["thumb_path"] is None
 
 
-def test_generate_all_skips_current_raw_marker_after_crop_rejects_working_copy(
+def test_generate_all_uses_near_full_working_copy_after_current_raw_failure(
     tmp_path, monkeypatch,
 ):
-    """Batch thumbnails must not retry a RAW that has a current source failure."""
+    """Edited HE/unsupported RAW thumbnails should fall back to the JPEG copy.
+
+    A Nikon HE* embedded/working JPEG can be a few pixels smaller than the
+    RAW's nominal dimensions. Once the RAW source is marked failed for the
+    current mtime, the thumbnail path should use that JPEG when it can satisfy
+    the cropped render instead of leaving the photo permanently thumbnail-less.
+    """
     import thumbnails as thumbnails_mod
     from db import Database
 
@@ -473,7 +479,7 @@ def test_generate_all_skips_current_raw_marker_after_crop_rejects_working_copy(
     working_dir = vireo_dir / "working"
     working_dir.mkdir(parents=True)
     wc_path = working_dir / "1.jpg"
-    Image.new("RGB", (200, 150), color="red").save(wc_path, "JPEG")
+    Image.new("RGB", (792, 594), color="red").save(wc_path, "JPEG")
 
     db = Database(str(vireo_dir / "test.db"))
     fid = db.add_folder(str(photos_dir), name="photos")
@@ -504,21 +510,28 @@ def test_generate_all_skips_current_raw_marker_after_crop_rejects_working_copy(
         {"crop": {"x": 0, "y": 0, "w": 0.5, "h": 1}},
     )
 
-    def fail_if_called(*_args, **_kwargs):
-        raise AssertionError("batch thumbnail generation retried failed RAW")
+    loaded_paths = []
+    original_load_image = thumbnails_mod.load_image
 
-    monkeypatch.setattr(thumbnails_mod, "generate_thumbnail", fail_if_called)
+    def tracking_load_image(file_path, max_size=1024, **kwargs):
+        loaded_paths.append(str(file_path))
+        if str(file_path).lower().endswith(".nef"):
+            raise AssertionError("batch thumbnail generation retried failed RAW")
+        return original_load_image(file_path, max_size=max_size, **kwargs)
+
+    monkeypatch.setattr(thumbnails_mod, "load_image", tracking_load_image)
 
     result = thumbnails_mod.generate_all(
         db, str(vireo_dir / "thumbnails"), vireo_dir=str(vireo_dir),
     )
 
-    assert result["generated"] == 0
-    assert result["failed"] == 1
+    assert result["generated"] == 1
+    assert result["failed"] == 0
+    assert loaded_paths == [str(wc_path)]
     row = db.conn.execute(
         "SELECT thumb_path FROM photos WHERE id=?", (photo_id,),
     ).fetchone()
-    assert row["thumb_path"] is None
+    assert row["thumb_path"] == f"{photo_id}.jpg"
 
 
 def test_backfill_thumb_paths_sets_path_for_existing_files(tmp_path):


### PR DESCRIPTION
This updates edited RAW rendering to fall back to a usable JPEG when the RAW source has already failed decoding for the current file mtime. It keeps full-size RAW+JPEG sidecars preferred, then uses a near-full working or embedded JPEG with a small tolerance so Nikon HE* files can still be cropped and thumbnailed. The root cause was libraw failing to demosaic HE* NEFs while Vireo rejected the embedded JPEG as slightly undersized. Validated with targeted thumbnail/photo API coverage and the full photo API test file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RAW image fallback behavior when the original source is unavailable or has failed.
  * Prevented undersized working copies from being treated as full-resolution originals.
  * Improved dimension checks for rotated, cropped, portrait, and preview images.
  * Ensured valid working copies can still power edited originals and thumbnails after a current RAW failure.
* **Tests**
  * Added coverage for RAW fallback, orientation handling, rendering dimensions, cropping, scaling, and thumbnail generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->