### PR TITLE
Fix photo deletion cleanup and new image counts

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2034,11 +2034,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if db is not None:
             db.conn.close()
 
+    def _reraise_fatal_cleanup_error(exc):
+        if isinstance(exc, (KeyboardInterrupt, GeneratorExit)):
+            raise exc
+
     def _cleanup_cached_files_for_deleted_photos(files):
-        from preview_cache import cleanup_cached_files_for_deleted_photos
-        cleanup_cached_files_for_deleted_photos(
-            app.config["THUMB_CACHE_DIR"], files,
-        )
+        try:
+            from preview_cache import cleanup_cached_files_for_deleted_photos
+            cleanup_cached_files_for_deleted_photos(
+                app.config["THUMB_CACHE_DIR"], files,
+            )
+        except BaseException as exc:
+            _reraise_fatal_cleanup_error(exc)
+            log.exception("Failed to clean cached files after delete")
 
     @app.before_request
     def _enforce_api_v1_token():
@@ -6124,7 +6132,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         # Run the deferred non-DB side effects only after the outer
         # transaction committed successfully.
-        db.prune_pipeline_cache_for_ids(result["ids"])
+        try:
+            db.prune_pipeline_cache_for_ids(result["ids"])
+        except BaseException as exc:
+            _reraise_fatal_cleanup_error(exc)
+            log.exception("Failed to prune pipeline cache after delete")
         _cleanup_cached_files_for_deleted_photos(result["files"])
 
         trashed = 0
@@ -6148,7 +6160,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                             from send2trash import send2trash as _trash
                             _trash(filepath)
                             trashed += 1
-                        except Exception as send_err:
+                        except BaseException as send_err:
+                            _reraise_fatal_cleanup_error(send_err)
                             # send2trash implements the platform trash spec on
                             # Linux/Windows; the AppleScript Finder fallback only
                             # helps on macOS. Off-mac, report the real send2trash

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -7027,7 +7027,9 @@ class Database:
                 self._active_workspace_id,
                 ids,
             )
-        except Exception:
+        except BaseException as exc:
+            if isinstance(exc, (KeyboardInterrupt, GeneratorExit)):
+                raise
             log.exception("Failed to prune pipeline cache after delete")
 
     def delete_photos(self, photo_ids, include_companions=False, commit=True):
@@ -12128,16 +12130,14 @@ class Database:
         decides how to handle zero-file snapshots (the pipeline short-circuits).
         """
         ws_id = self._ws_id()
+        unique_paths = sorted(set(file_paths or []))
         cur = self.conn.execute(
             "INSERT INTO new_image_snapshots (workspace_id, created_at, file_count) "
             "VALUES (?, datetime('now'), ?)",
-            (ws_id, len(file_paths)),
+            (ws_id, len(unique_paths)),
         )
         snap_id = cur.lastrowid
-        if file_paths:
-            # De-duplicate in case the caller passed repeats; PK would reject them
-            # but sending a clean set keeps executemany cheap.
-            unique_paths = sorted(set(file_paths))
+        if unique_paths:
             self.conn.executemany(
                 "INSERT INTO new_image_snapshot_files (snapshot_id, file_path) VALUES (?, ?)",
                 [(snap_id, p) for p in unique_paths],

--- a/vireo/image_loader.py
+++ b/vireo/image_loader.py
@@ -260,8 +260,12 @@ def safe_iter_dir(top, onerror=None):
             onerror(exc)
         return
     skipped = []
+    seen = set()
     with scandir_it:
         for entry in scandir_it:
+            if entry.name in seen:
+                continue
+            seen.add(entry.name)
             if is_excluded_scan_dir(entry.name):
                 skipped.append(entry.name)
                 continue
@@ -311,9 +315,13 @@ def safe_scan_walk(top, onerror=None):
     dirs = []
     nondirs = []
     skipped = []
+    seen = set()
     with scandir_it:
         for entry in scandir_it:
             name = entry.name
+            if name in seen:
+                continue
+            seen.add(name)
             # Name-based exclusion catches direct bundle entries
             # (``Photos Library.photoslibrary``) without any stat.
             if is_excluded_scan_dir(name):

--- a/vireo/new_images.py
+++ b/vireo/new_images.py
@@ -130,6 +130,7 @@ def count_new_images_for_workspace(db, workspace_id, sample_limit=5,
     total = 0
     files_checked = 0
     last_emitted = 0
+    seen_new_paths = set()
 
     def _maybe_emit():
         nonlocal last_emitted
@@ -197,6 +198,10 @@ def count_new_images_for_workspace(db, workspace_id, sample_limit=5,
                 if ext in _JPEG_EXTS and (dirpath, Path(name).stem) in known_raw_stems:
                     _maybe_emit()
                     continue
+                if full in seen_new_paths:
+                    _maybe_emit()
+                    continue
+                seen_new_paths.add(full)
                 root_new += 1
                 total += 1
                 if sample_limit is None or len(sample) < sample_limit:

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -10463,6 +10463,18 @@ def test_create_and_get_new_images_snapshot(tmp_path):
     assert sorted(snap["file_paths"]) == sorted(paths)
 
 
+def test_create_new_images_snapshot_file_count_matches_unique_paths(tmp_path):
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    paths = ["/tmp/a/IMG_001.JPG", "/tmp/a/IMG_001.JPG", "/tmp/b/IMG_002.JPG"]
+
+    snap_id = db.create_new_images_snapshot(paths)
+    snap = db.get_new_images_snapshot(snap_id)
+
+    assert snap["file_count"] == 2
+    assert snap["file_paths"] == ["/tmp/a/IMG_001.JPG", "/tmp/b/IMG_002.JPG"]
+
+
 def test_get_snapshot_from_different_workspace_returns_none(tmp_path):
     from db import Database
     db = Database(str(tmp_path / "test.db"))

--- a/vireo/tests/test_delete_api.py
+++ b/vireo/tests/test_delete_api.py
@@ -1,4 +1,5 @@
 """Tests for photo deletion API and database cleanup."""
+import builtins
 import json
 import os
 
@@ -178,6 +179,76 @@ def test_api_batch_delete_vireo_mode(app_and_db):
     client = app.test_client()
     photos = db.get_photos()
     pid = photos[0]["id"]
+
+    resp = client.post("/api/batch/delete", json={
+        "photo_ids": [pid],
+        "mode": "vireo",
+    })
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is True
+    assert data["deleted"] == 1
+    assert db.get_photo(pid) is None
+
+
+def test_api_batch_delete_tolerates_pipeline_prune_system_exit(app_and_db, monkeypatch):
+    """A packaged-app lazy import failure must not strand the delete request."""
+    from db import Database
+
+    app, db = app_and_db
+    client = app.test_client()
+    pid = db.get_photos()[0]["id"]
+
+    def fail_prune(self, ids):
+        raise SystemExit("packaged executable was moved")
+
+    monkeypatch.setattr(Database, "prune_pipeline_cache_for_ids", fail_prune)
+
+    resp = client.post("/api/batch/delete", json={
+        "photo_ids": [pid],
+        "mode": "vireo",
+    })
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is True
+    assert data["deleted"] == 1
+    assert db.get_photo(pid) is None
+
+
+def test_delete_photos_tolerates_pipeline_import_system_exit(app_and_db, monkeypatch):
+    """Direct DB deletes should also treat pipeline cache pruning as optional."""
+    app, db = app_and_db
+    pid = db.get_photos()[0]["id"]
+    real_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name == "pipeline":
+            raise SystemExit("packaged executable was moved")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+    result = db.delete_photos([pid])
+
+    assert result["deleted"] == 1
+    assert db.get_photo(pid) is None
+
+
+def test_api_batch_delete_tolerates_cache_cleanup_system_exit(app_and_db, monkeypatch):
+    """Preview/thumbnail cleanup failures should not prevent a delete response."""
+    app, db = app_and_db
+    client = app.test_client()
+    pid = db.get_photos()[0]["id"]
+    real_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name == "preview_cache":
+            raise SystemExit("packaged executable was moved")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
 
     resp = client.post("/api/batch/delete", json={
         "photo_ids": [pid],

--- a/vireo/tests/test_image_loader.py
+++ b/vireo/tests/test_image_loader.py
@@ -807,6 +807,53 @@ def test_safe_iter_dir_skips_bundle_children_and_yields_paths(tmp_path):
     assert "LibraryAlias" not in names
 
 
+def test_safe_iter_dir_deduplicates_duplicate_scandir_entries(tmp_path, monkeypatch):
+    """Some SMB mounts can return duplicate names from one ``scandir`` call."""
+    import image_loader
+    from image_loader import safe_iter_dir
+
+    root = tmp_path / "photos"
+    root.mkdir()
+    (root / "real.jpg").write_bytes(b"")
+
+    real_scandir = image_loader.os.scandir
+
+    class FakeScandir:
+        def __init__(self, entries):
+            self.entries = entries
+
+        def __iter__(self):
+            return iter(self.entries)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    def fake_scandir(path):
+        if path == str(root):
+            return FakeScandir([
+                SimpleNamespace(
+                    name="real.jpg",
+                    path=str(root / "real.jpg"),
+                    is_symlink=lambda: False,
+                    is_dir=lambda follow_symlinks=True: False,
+                ),
+                SimpleNamespace(
+                    name="real.jpg",
+                    path=str(root / "real.jpg"),
+                    is_symlink=lambda: False,
+                    is_dir=lambda follow_symlinks=True: False,
+                ),
+            ])
+        return real_scandir(path)
+
+    monkeypatch.setattr(image_loader.os, "scandir", fake_scandir)
+
+    assert [p.name for p in safe_iter_dir(str(root))] == ["real.jpg"]
+
+
 def test_safe_iter_dir_surfaces_permission_errors_via_onerror(tmp_path):
     """Mirrors ``safe_scan_walk``: a directory the kernel refuses to
     open is reported via the callback, not swallowed. Scanner's
@@ -1044,6 +1091,73 @@ def test_safe_scan_walk_matches_os_walk_for_normal_trees(tmp_path):
         os.path.join("a", "mid.jpg"),
         os.path.join("a", "b", "deep.jpg"),
     }
+
+
+def test_safe_scan_walk_deduplicates_duplicate_scandir_entries(tmp_path, monkeypatch):
+    """Duplicate directory entries must not inflate new-image counts."""
+    import image_loader
+    from image_loader import safe_scan_walk
+
+    root = tmp_path / "photos"
+    root.mkdir()
+    (root / "real.jpg").write_bytes(b"")
+    (root / "sub").mkdir()
+    (root / "sub" / "deep.jpg").write_bytes(b"")
+
+    real_scandir = image_loader.os.scandir
+
+    def file_entry(path, name):
+        return SimpleNamespace(
+            name=name,
+            path=str(path / name),
+            is_symlink=lambda: False,
+            is_dir=lambda follow_symlinks=True: False,
+        )
+
+    def dir_entry(path, name):
+        return SimpleNamespace(
+            name=name,
+            path=str(path / name),
+            is_symlink=lambda: False,
+            is_dir=lambda follow_symlinks=True: True,
+        )
+
+    class FakeScandir:
+        def __init__(self, entries):
+            self.entries = entries
+
+        def __iter__(self):
+            return iter(self.entries)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    def fake_scandir(path):
+        if path == str(root):
+            return FakeScandir([
+                file_entry(root, "real.jpg"),
+                file_entry(root, "real.jpg"),
+                dir_entry(root, "sub"),
+                dir_entry(root, "sub"),
+            ])
+        if path == str(root / "sub"):
+            return FakeScandir([
+                file_entry(root / "sub", "deep.jpg"),
+                file_entry(root / "sub", "deep.jpg"),
+            ])
+        return real_scandir(path)
+
+    monkeypatch.setattr(image_loader.os, "scandir", fake_scandir)
+
+    rows = list(safe_scan_walk(str(root)))
+
+    assert [(os.path.relpath(d, str(root)), dirs, files) for d, dirs, files in rows] == [
+        (".", ["sub"], ["real.jpg"]),
+        ("sub", [], ["deep.jpg"]),
+    ]
 
 
 def test_safe_scan_walk_surfaces_permission_errors_via_onerror(tmp_path):

--- a/vireo/tests/test_new_images.py
+++ b/vireo/tests/test_new_images.py
@@ -46,6 +46,31 @@ def test_count_new_images_detects_unscanned_files(db_with_workspace):
     assert len(result["sample"]) == 2
 
 
+def test_count_new_images_deduplicates_repeated_walk_entries(
+    db_with_workspace, monkeypatch
+):
+    """SMB mounts may repeat exact names from one directory listing."""
+    import new_images
+    from new_images import count_new_images_for_workspace
+
+    db, ws_id, tmp_path = db_with_workspace
+    root = tmp_path / "USA2026"
+    photo = root / "IMG_0001.JPG"
+    _touch_image(str(photo))
+    db.add_folder(str(root), name="USA2026")
+
+    def duplicate_walk(_root):
+        yield str(root), [], ["IMG_0001.JPG", "IMG_0001.JPG", "IMG_0001.JPG"]
+
+    monkeypatch.setattr(new_images, "safe_scan_walk", duplicate_walk)
+
+    result = count_new_images_for_workspace(db, ws_id, sample_limit=None)
+
+    assert result["new_count"] == 1
+    assert result["per_root"][0]["new_count"] == 1
+    assert result["sample"] == [str(photo)]
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks required")
 def test_count_new_images_ignores_broken_symlinks(db_with_workspace):
     """A dangling *.jpg symlink must not be counted as a "new image".


### PR DESCRIPTION
Fixes a packaged-app delete failure where optional post-delete cleanup could raise SystemExit after catalog rows were already committed, preventing the disk trash step from running. Also fixes inflated new-image counts on SMB mounts that return duplicate directory entries by de-duplicating walker results, new-image paths, and snapshot metadata. Adds regression coverage for delete cleanup failures, duplicate scandir entries, new-image counting, and snapshot file counts. Validation: pytest -q vireo/tests/test_delete_api.py; pytest -q vireo/tests/test_image_loader.py -k 'safe_iter_dir or safe_scan_walk'; pytest -q vireo/tests/test_new_images.py -k 'deduplicates_repeated_walk_entries or detects_unscanned_files'; pytest -q vireo/tests/test_db.py -k 'new_images_snapshot or new_image_snapshots'.