### PR TITLE
Fix external upload page links

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,6 +5,12 @@
   "windows": [
     "main"
   ],
+  "remote": {
+    "urls": [
+      "http://127.0.0.1:*/*",
+      "http://localhost:*/*"
+    ]
+  },
   "permissions": [
     "core:default",
     {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -93,6 +93,19 @@ fn set_job_progress(
         .map_err(|e| e.to_string())
 }
 
+#[tauri::command]
+fn open_external_url(app: tauri::AppHandle, url: String) -> Result<(), String> {
+    let url = url.trim();
+    let lower = url.to_ascii_lowercase();
+    if !(lower.starts_with("https://") || lower.starts_with("http://")) {
+        return Err("Only http and https URLs can be opened externally".to_string());
+    }
+
+    app.opener()
+        .open_url(url, None::<&str>)
+        .map_err(|e| e.to_string())
+}
+
 /// Build the logging plugin used in BOTH dev and release builds.
 ///
 /// Previously logging was only initialized under `cfg!(debug_assertions)`, so
@@ -311,6 +324,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             get_server_port,
             set_job_progress,
+            open_external_url,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/vireo/static/tauri-bridge.js
+++ b/vireo/static/tauri-bridge.js
@@ -108,14 +108,21 @@ async function openExternal(url) {
   }
   if (isTauri()) {
     try {
-      await window.__TAURI_INTERNALS__.invoke('plugin:opener|open_url', { url: url, with: null });
+      await window.__TAURI_INTERNALS__.invoke('open_external_url', { url: url });
       logInfo('openExternal: opened ' + url);
       return true;
     } catch (e) {
-      // Surface the *real* opener error (e.g. ForbiddenUrl from a missing
-      // capability scope) to the log file so this stops being a silent no-op.
-      logError('openExternal failed for ' + url + ': ' + (e && e.message ? e.message : e));
-      return false;
+      logWarn('openExternal command failed for ' + url + ': ' + (e && e.message ? e.message : e));
+      try {
+        await window.__TAURI_INTERNALS__.invoke('plugin:opener|open_url', { url: url, with: null });
+        logInfo('openExternal: opened ' + url + ' via opener plugin fallback');
+        return true;
+      } catch (fallbackError) {
+        // Surface the *real* opener error (e.g. ForbiddenUrl from a missing
+        // capability scope) to the log file so this stops being a silent no-op.
+        logError('openExternal failed for ' + url + ': ' + (fallbackError && fallbackError.message ? fallbackError.message : fallbackError));
+        return false;
+      }
     }
   }
   // Browser fallback. We deliberately omit the 'noopener' window feature: with

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -8203,8 +8203,39 @@ function showToast(msg, type) {
 // navigation. Use on <a> tags as: onclick="return openExternalLink(event, this.href)".
 function openExternalLink(event, url) {
   if (event) event.preventDefault();
+  function fallbackOpen() {
+    var opened = null;
+    try {
+      opened = window.open('about:blank', '_blank');
+    } catch(e) {}
+    if (opened) {
+      try { opened.opener = null; } catch(e) {}
+      opened.location = url;
+      return true;
+    }
+    if (!opened && url) {
+      try {
+        window.location.href = url;
+        return true;
+      } catch(e) {}
+    }
+    return false;
+  }
+
+  if (typeof openExternal !== 'function') {
+    if (!fallbackOpen()) showToast('Could not open link: ' + url, 'error');
+    return false;
+  }
+
   openExternal(url).then(function(ok) {
     if (!ok) showToast('Could not open link: ' + url, 'error');
+  }).catch(function(e) {
+    if (!fallbackOpen()) {
+      showToast('Could not open link: ' + url, 'error');
+    }
+    if (typeof logError === 'function') {
+      logError('openExternalLink failed for ' + url + ': ' + (e && e.message ? e.message : e));
+    }
   });
   return false;
 }

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -8228,7 +8228,13 @@ function openExternalLink(event, url) {
   }
 
   openExternal(url).then(function(ok) {
-    if (!ok) showToast('Could not open link: ' + url, 'error');
+    // openExternal catches Tauri command/opener failures internally and
+    // resolves `false` rather than rejecting, so the .catch() below never runs
+    // in the packaged-desktop failure path (ACL denial, opener error, popup
+    // block). Try fallbackOpen here too so the click doesn't silently die.
+    if (!ok && !fallbackOpen()) {
+      showToast('Could not open link: ' + url, 'error');
+    }
   }).catch(function(e) {
     if (!fallbackOpen()) {
       showToast('Could not open link: ' + url, 'error');


### PR DESCRIPTION
## Summary
- Add a guarded Tauri command for opening external http/https URLs in the system browser.
- Permit Vireo's main Tauri capability from loopback Flask origins so packaged desktop webviews can invoke the opener path.
- Update the web bridge and shared link handler so failed or missing bridge wiring no longer turns iNaturalist upload links into no-ops.

## Verification
- node --check vireo/static/tauri-bridge.js
- git diff --check
- python -m json.tool src-tauri/capabilities/default.json
- cargo check passed with a temporary placeholder sidecar because this workspace does not include src-tauri/binaries/vireo-server-aarch64-apple-darwin.