### PR TITLE
Add highlights search and sort options

### DIFF
--- a/tests/e2e/test_highlights_initial_scope.py
+++ b/tests/e2e/test_highlights_initial_scope.py
@@ -267,6 +267,62 @@ def test_highlights_preference_updates_top_photo_timestamp(live_server):
     assert hawk["best_timestamp"] == "2024-03-10T08:02:00"
 
 
+def test_highlights_search_recomputes_bucket_accepted_status(live_server):
+    """Filtering a mixed bucket down to only confirmed photos must flip
+    ``is_accepted`` to True so the bucket loses the candidate badge and the
+    Confirmed-first sort places it above unconfirmed rows."""
+    db = live_server["db"]
+    data = live_server["data"]
+    _seed_quality_scores_and_species(db, data)
+
+    # Add a prediction-only photo that lands in the same "Red-tailed Hawk"
+    # bucket (predicted confidence above the default 0.70 threshold) so the
+    # bucket is a mix of confirmed (keyword-tagged) and unconfirmed photos.
+    pid = db.add_photo(
+        folder_id=data["folders"][0],
+        filename="predicted-hawk.jpg",
+        extension=".jpg",
+        file_size=1000,
+        file_mtime=1.0,
+        timestamp="2024-03-10T08:05:00",
+    )
+    db.conn.execute("UPDATE photos SET quality_score = 0.7 WHERE id = ?", (pid,))
+    det_id = db.save_detections(
+        pid,
+        [{
+            "box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+            "confidence": 0.95,
+            "category": "animal",
+        }],
+        detector_model="test-detector",
+    )[0]
+    db.add_prediction(
+        detection_id=det_id,
+        species="Red-tailed Hawk",
+        confidence=0.9,
+        model="BioCLIP-2",
+    )
+    db.conn.commit()
+
+    base = live_server["url"]
+
+    # Without a filter, the mixed bucket is unconfirmed at the bucket level.
+    with urlopen(f"{base}/api/highlights?scope=workspace") as resp:
+        payload = json.load(resp)
+    hawk = next(b for b in payload["buckets"] if b["species"] == "Red-tailed Hawk")
+    assert hawk["is_accepted"] is False
+    assert hawk["certainty"] != "confirmed"
+
+    # Filtering by filename to only include a confirmed (keyword-tagged) photo
+    # must recompute ``is_accepted`` from the filtered photos.
+    with urlopen(f"{base}/api/highlights?scope=workspace&q=hawk1") as resp:
+        payload = json.load(resp)
+    hawk = next(b for b in payload["buckets"] if b["species"] == "Red-tailed Hawk")
+    assert hawk["photo_count"] == 1
+    assert hawk["is_accepted"] is True
+    assert hawk["certainty"] == "confirmed"
+
+
 def test_highlights_lightbox_reject_advances_and_can_restore(live_server, page):
     db = live_server["db"]
     data = live_server["data"]

--- a/tests/e2e/test_highlights_initial_scope.py
+++ b/tests/e2e/test_highlights_initial_scope.py
@@ -211,6 +211,62 @@ def test_highlights_general_search_filters_by_filename_folder_and_keyword(live_s
     expect(page.locator(".highlights-card img")).to_have_attribute("alt", "hawk2.jpg")
 
 
+def test_highlights_unidentified_search_includes_low_confidence_predictions(live_server):
+    db = live_server["db"]
+    data = live_server["data"]
+    _seed_quality_scores_and_species(db, data)
+
+    pid = db.add_photo(
+        folder_id=data["folders"][0],
+        filename="low-conf-bird.jpg",
+        extension=".jpg",
+        file_size=1000,
+        file_mtime=1.0,
+        timestamp="2024-03-10T08:03:00",
+    )
+    db.conn.execute("UPDATE photos SET quality_score = 0.65 WHERE id = ?", (pid,))
+    det_id = db.save_detections(
+        pid,
+        [{
+            "box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+            "confidence": 0.95,
+            "category": "animal",
+        }],
+        detector_model="test-detector",
+    )[0]
+    db.add_prediction(
+        detection_id=det_id,
+        species="Low-confidence Sparrow",
+        confidence=0.55,
+        model="BioCLIP-2",
+    )
+    db.conn.commit()
+
+    base = live_server["url"]
+    with urlopen(f"{base}/api/highlights?scope=workspace&q=unidentified") as resp:
+        payload = json.load(resp)
+
+    filenames = {p["filename"] for p in payload["unidentified"]["photos"]}
+    assert "low-conf-bird.jpg" in filenames
+
+
+def test_highlights_preference_updates_top_photo_timestamp(live_server):
+    db = live_server["db"]
+    data = live_server["data"]
+    _seed_quality_scores_and_species(db, data)
+
+    preferred = data["photos"][2]
+    db.set_photo_preference("highlights", "Red-tailed Hawk", preferred)
+
+    base = live_server["url"]
+    with urlopen(f"{base}/api/highlights?scope=workspace") as resp:
+        payload = json.load(resp)
+
+    hawk = next(b for b in payload["buckets"] if b["species"] == "Red-tailed Hawk")
+    assert hawk["photos"][0]["id"] == preferred
+    assert hawk["best_timestamp"] == "2024-03-10T08:02:00"
+
+
 def test_highlights_lightbox_reject_advances_and_can_restore(live_server, page):
     db = live_server["db"]
     data = live_server["data"]

--- a/tests/e2e/test_highlights_initial_scope.py
+++ b/tests/e2e/test_highlights_initial_scope.py
@@ -175,6 +175,42 @@ def test_highlights_species_search_filters_buckets(live_server, page):
     )
 
 
+def test_highlights_general_search_filters_by_filename_folder_and_keyword(live_server, page):
+    db = live_server["db"]
+    data = live_server["data"]
+    _seed_quality_scores_and_species(db, data)
+
+    perch_kid = db.add_keyword("Perched portrait")
+    db.tag_photo(data["photos"][1], perch_kid)
+    db.conn.commit()
+
+    page.goto(f"{live_server['url']}/highlights", timeout=5000)
+    expect(page.locator(".highlights-card").first).to_be_visible(timeout=5000)
+
+    search = page.locator("#highlightSearch")
+    with page.expect_response(
+        lambda r: "/api/highlights?" in r.url and "q=hawk1" in r.url.lower()
+    ):
+        search.fill("hawk1")
+    expect(page.locator(".highlights-card")).to_have_count(1)
+    expect(page.locator(".highlights-card img")).to_have_attribute("alt", "hawk1.jpg")
+
+    with page.expect_response(
+        lambda r: "/api/highlights?" in r.url and "q=yard" in r.url.lower()
+    ):
+        search.fill("yard")
+    expect(page.locator(".bucket-title")).to_have_count(1)
+    expect(page.locator(".bucket-title").first).to_contain_text("American Robin")
+    expect(page.locator(".highlights-card")).to_have_count(2)
+
+    with page.expect_response(
+        lambda r: "/api/highlights?" in r.url and "q=perched" in r.url.lower()
+    ):
+        search.fill("perched")
+    expect(page.locator(".highlights-card")).to_have_count(1)
+    expect(page.locator(".highlights-card img")).to_have_attribute("alt", "hawk2.jpg")
+
+
 def test_highlights_lightbox_reject_advances_and_can_restore(live_server, page):
     db = live_server["db"]
     data = live_server["data"]

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -511,6 +511,12 @@ def _refresh_highlight_bucket_metadata(bucket):
         if confidences else None
     )
     best = photos[0] if photos else {}
+    # Filtering can drop the unconfirmed photos from a mixed bucket, leaving
+    # only confirmed ones — recompute so the "candidate" badge and the
+    # `confirmed` sort match what the row now actually contains.
+    bucket["is_accepted"] = bool(photos) and all(
+        p.get("has_accepted_species") for p in photos
+    )
     bucket["avg_confidence"] = avg_confidence
     bucket["certainty"] = _highlight_confidence_label(
         avg_confidence, bucket.get("is_accepted")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -386,6 +386,10 @@ def _collect_highlight_buckets(
         photo = {
             "id": r["id"],
             "filename": r["filename"],
+            "timestamp": r.get("timestamp"),
+            "folder_name": r.get("folder_name"),
+            "folder_path": r.get("folder_path"),
+            "keyword_names": r.get("keyword_names") or "",
             "rating": r.get("rating") or 0,
             "flag": r.get("flag") or "none",
             "quality_score": r.get("quality_score"),
@@ -460,6 +464,94 @@ def _collect_highlight_buckets(
         reverse=True,
     )
     return buckets, unidentified_photos
+
+
+def _highlight_search_fields(photo):
+    return [
+        photo.get("filename") or "",
+        photo.get("folder_name") or "",
+        photo.get("folder_path") or "",
+        photo.get("keyword_names") or "",
+        photo.get("species") or "",
+        photo.get("predicted_species") or "",
+        (
+            "unidentified"
+            if not photo.get("species") and not photo.get("predicted_species")
+            else ""
+        ),
+    ]
+
+
+def _highlight_photo_matches_query(
+    photo,
+    query,
+    match_case=False,
+    whole_word=False,
+):
+    tokens = str(query or "").split()
+    if not tokens:
+        return True
+    fields = _highlight_search_fields(photo)
+    return all(
+        any(
+            text_search_match(field, token, match_case, whole_word)
+            for field in fields
+        )
+        for token in tokens
+    )
+
+
+def _refresh_highlight_bucket_metadata(bucket):
+    photos = bucket.get("photos") or []
+    confidences = [
+        p.get("predicted_confidence")
+        for p in photos
+        if p.get("predicted_confidence") is not None
+    ]
+    avg_confidence = (
+        round(sum(confidences) / len(confidences), 4)
+        if confidences else None
+    )
+    best = photos[0] if photos else {}
+    bucket["avg_confidence"] = avg_confidence
+    bucket["certainty"] = _highlight_confidence_label(
+        avg_confidence, bucket.get("is_accepted")
+    )
+    bucket["photo_count"] = len(photos)
+    bucket["best_quality"] = best.get("quality_score")
+    bucket["best_score"] = best.get("highlight_score")
+    bucket["best_timestamp"] = best.get("timestamp")
+    return bucket
+
+
+def _filter_highlight_sections(
+    buckets,
+    unidentified_photos,
+    query,
+    match_case=False,
+    whole_word=False,
+):
+    query = (query or "").strip()
+    if not query:
+        for bucket in buckets:
+            _refresh_highlight_bucket_metadata(bucket)
+        return buckets, unidentified_photos
+
+    filtered_buckets = []
+    for bucket in buckets:
+        photos = [
+            p for p in (bucket.get("photos") or [])
+            if _highlight_photo_matches_query(p, query, match_case, whole_word)
+        ]
+        if photos:
+            updated = {**bucket, "photos": photos}
+            filtered_buckets.append(_refresh_highlight_bucket_metadata(updated))
+
+    unidentified = [
+        p for p in unidentified_photos
+        if _highlight_photo_matches_query(p, query, match_case, whole_word)
+    ]
+    return filtered_buckets, unidentified
 
 
 # Maximum number of bound parameters per SQL statement. SQLite's
@@ -7022,6 +7114,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         species_filter="",
         species_match_case=False,
         species_whole_word=False,
+        search_query="",
+        search_match_case=False,
+        search_whole_word=False,
         confirmation_filter="all",
     ):
         folders = db.get_folders_with_quality_data()
@@ -7044,7 +7139,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         eligible_count = sum(b["photo_count"] for b in buckets) + len(
             unidentified_photos
         )
-        _apply_highlight_preferences(db, buckets)
         if species_filter:
             buckets = [
                 b for b in buckets
@@ -7062,6 +7156,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 species_whole_word,
             ):
                 unidentified_photos = []
+
+        buckets, unidentified_photos = _filter_highlight_sections(
+            buckets,
+            unidentified_photos,
+            search_query,
+            search_match_case,
+            search_whole_word,
+        )
+        _apply_highlight_preferences(db, buckets)
 
         def limited_bucket(bucket):
             photos = bucket["photos"]
@@ -7098,6 +7201,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "eligible": eligible_count,
                 "limit_per_bucket": limit_per_bucket,
                 "confirmation": confirmation_filter,
+                "search": (search_query or "").strip(),
             },
             "scope": "workspace" if folder_id is None else "folder",
         }
@@ -7117,6 +7221,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             species_filter=request.args.get("species") or "",
             species_match_case=_request_bool_arg("species_match_case"),
             species_whole_word=_request_bool_arg("species_whole_word"),
+            search_query=request.args.get("q") or "",
+            search_match_case=_request_bool_arg("q_match_case"),
+            search_whole_word=_request_bool_arg("q_whole_word"),
             confirmation_filter=request.args.get("confirmation") or "all",
         )
         return jsonify(payload)
@@ -7684,6 +7791,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         candidates = db.get_highlights_candidates(folder_id, min_quality=min_quality)
         buckets, unidentified_photos = _collect_highlight_buckets(
             candidates, confidence_threshold, confirmation_filter
+        )
+        buckets, unidentified_photos = _filter_highlight_sections(
+            buckets,
+            unidentified_photos,
+            request.args.get("q") or "",
+            _request_bool_arg("q_match_case"),
+            _request_bool_arg("q_whole_word"),
         )
         _apply_highlight_preferences(db, buckets)
         if species == "__unidentified__":

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -331,6 +331,7 @@ def _apply_highlight_preferences(db, buckets):
         bucket["has_preferred_photo"] = applied
         bucket["best_quality"] = best.get("quality_score")
         bucket["best_score"] = best.get("highlight_score")
+        bucket["best_timestamp"] = best.get("timestamp")
 
 
 def _highlight_confidence_label(confidence, is_accepted):
@@ -411,6 +412,7 @@ def _collect_highlight_buckets(
             "predicted_species": r.get("predicted_species"),
             "predicted_confidence": predicted_conf,
             "has_accepted_species": accepted is not None,
+            "is_unidentified": species is None,
             "is_confirmable_prediction": (
                 accepted is None
                 and species is not None
@@ -474,11 +476,7 @@ def _highlight_search_fields(photo):
         photo.get("keyword_names") or "",
         photo.get("species") or "",
         photo.get("predicted_species") or "",
-        (
-            "unidentified"
-            if not photo.get("species") and not photo.get("predicted_species")
-            else ""
-        ),
+        "unidentified" if photo.get("is_unidentified") else "",
     ]
 
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -9379,6 +9379,7 @@ class Database:
         rows = self.conn.execute(
             f"""SELECT p.id, p.folder_id, p.filename, p.extension,
                       p.timestamp, p.width, p.height, p.rating, p.flag,
+                      f.name AS folder_name, f.path AS folder_path,
                       p.thumb_path, p.quality_score, p.subject_sharpness,
                       p.subject_size, p.sharpness, p.phash_crop,
                       p.mask_path, p.subject_tenengrad, p.bg_tenengrad,
@@ -9390,7 +9391,8 @@ class Database:
                       bp.species,
                       tp.prediction_id,
                       tp.predicted_species,
-                      tp.predicted_confidence
+                      tp.predicted_confidence,
+                      kw.keyword_names
                FROM photos p
                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
                JOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')
@@ -9433,6 +9435,13 @@ class Database:
                          )
                    ) WHERE rn = 1
                ) tp ON tp.photo_id = p.id
+               LEFT JOIN (
+                   SELECT pk.photo_id,
+                          group_concat(DISTINCT k.name) AS keyword_names
+                   FROM photo_keywords pk
+                   JOIN keywords k ON k.id = pk.keyword_id
+                   GROUP BY pk.photo_id
+               ) kw ON kw.photo_id = p.id
                WHERE wf.workspace_id = ?
                  {folder_filter}
                  AND p.quality_score IS NOT NULL

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -97,6 +97,14 @@
     <select id="folderSelect"></select>
   </div>
   <div class="control-group">
+    <label for="highlightSearch">Search</label>
+    <div class="search-control">
+      <input type="search" id="highlightSearch" placeholder="Name, filename, folder">
+      <button id="highlightSearchMatchCaseBtn" class="search-option-btn" type="button" aria-pressed="false" onclick="VireoTextSearch.toggle('highlightSearch', 'match_case', debounceLoad)" title="Match case">Aa</button>
+      <button id="highlightSearchWholeWordBtn" class="search-option-btn" type="button" aria-pressed="false" onclick="VireoTextSearch.toggle('highlightSearch', 'whole_word', debounceLoad)" title="Match whole word">ab</button>
+    </div>
+  </div>
+  <div class="control-group">
     <label for="speciesSearch">Species</label>
     <div class="search-control">
       <input type="search" id="speciesSearch" placeholder="Cardinal">
@@ -134,6 +142,12 @@
       <option value="fewest">Fewest photos</option>
       <option value="most">Most photos</option>
       <option value="worst">Worst photo first</option>
+      <option value="species_asc">Species A-Z</option>
+      <option value="species_desc">Species Z-A</option>
+      <option value="newest">Newest top photo</option>
+      <option value="oldest">Oldest top photo</option>
+      <option value="confidence">Highest ID confidence</option>
+      <option value="confirmed">Confirmed first</option>
     </select>
   </div>
   <button class="save-btn" id="saveBtn" onclick="showSaveModal()">Save as Collection</button>
@@ -235,11 +249,18 @@ function requestScopeParams() {
   return params;
 }
 
-async function loadHighlights() {
-  var params = requestScopeParams();
-  var folderSelect = document.getElementById('folderSelect');
+function appendHighlightFilterParams(params) {
+  var search = document.getElementById('highlightSearch').value.trim();
   var speciesSearch = document.getElementById('speciesSearch').value.trim();
-  params.set('limit_per_bucket', Math.max(20, parseInt(document.getElementById('perRowSlider').value)));
+  if (search) {
+    params.set('q', search);
+    VireoTextSearch.appendParams(
+      params,
+      VireoTextSearch.readOptions('highlightSearch'),
+      'q_match_case',
+      'q_whole_word'
+    );
+  }
   if (speciesSearch) {
     params.set('species', speciesSearch);
     VireoTextSearch.appendParams(
@@ -249,6 +270,13 @@ async function loadHighlights() {
       'species_whole_word'
     );
   }
+}
+
+async function loadHighlights() {
+  var params = requestScopeParams();
+  var folderSelect = document.getElementById('folderSelect');
+  params.set('limit_per_bucket', Math.max(20, parseInt(document.getElementById('perRowSlider').value)));
+  appendHighlightFilterParams(params);
 
   // Capture the issue-time sequence so the prune below can tell rejections that
   // happened after this request was sent (response is stale for them) from
@@ -290,10 +318,28 @@ async function loadHighlights() {
 function sortedBuckets() {
   var sort = document.getElementById('sortSelect').value;
   var buckets = (currentData.buckets || []).slice();
+  function compareTimestamp(a, b, newest) {
+    var ta = a.best_timestamp || '';
+    var tb = b.best_timestamp || '';
+    if (!ta && !tb) return 0;
+    if (!ta) return 1;
+    if (!tb) return -1;
+    return newest ? String(tb).localeCompare(String(ta)) : String(ta).localeCompare(String(tb));
+  }
   buckets.sort(function(a, b) {
     if (sort === 'most') return b.photo_count - a.photo_count;
     if (sort === 'best') return (b.best_score || 0) - (a.best_score || 0);
     if (sort === 'worst') return (a.best_score || 0) - (b.best_score || 0);
+    if (sort === 'species_asc') return String(a.species || '').localeCompare(String(b.species || ''));
+    if (sort === 'species_desc') return String(b.species || '').localeCompare(String(a.species || ''));
+    if (sort === 'newest') return compareTimestamp(a, b, true);
+    if (sort === 'oldest') return compareTimestamp(a, b, false);
+    if (sort === 'confidence') return (b.avg_confidence || 0) - (a.avg_confidence || 0);
+    if (sort === 'confirmed') {
+      var status = Number(!!b.is_accepted) - Number(!!a.is_accepted);
+      if (status) return status;
+      return (b.best_score || 0) - (a.best_score || 0);
+    }
     return a.photo_count - b.photo_count; // 'fewest' default
   });
   return buckets;
@@ -550,6 +596,8 @@ async function loadMoreBucket(species, isUnidentified) {
   var target = isUnidentified ? currentData.unidentified : (currentData.buckets || []).find(function(b) { return b.species === species; });
   if (!target || !target.has_more) return;
   params.set('species', isUnidentified ? '__unidentified__' : species);
+  appendHighlightFilterParams(params);
+  params.set('species', isUnidentified ? '__unidentified__' : species);
   params.set('offset', target.photos.length);
   params.set('limit', 500);
   var data = await safeFetch('/api/highlights/bucket?' + params);
@@ -575,9 +623,10 @@ function render() {
   controls.style.display = '';
 
   var buckets = sortedBuckets();
+  var search = document.getElementById('highlightSearch').value.trim();
   var speciesSearch = document.getElementById('speciesSearch').value.trim();
   var confirmation = document.getElementById('confirmationFilter').value;
-  var filterLabel = speciesSearch ? ' matching' : '';
+  var filterLabel = (search || speciesSearch) ? ' matching' : '';
   if (confirmation === 'confirmed') filterLabel += ' confirmed';
   if (confirmation === 'unconfirmed') filterLabel += ' unconfirmed';
   meta.textContent = buckets.length + filterLabel + ' species · '
@@ -838,6 +887,9 @@ document.getElementById('qualitySlider').addEventListener('input', function() {
 });
 document.getElementById('confidenceSlider').addEventListener('input', function() {
   document.getElementById('confidenceValue').textContent = (this.value / 100).toFixed(2);
+  debounceLoad();
+});
+document.getElementById('highlightSearch').addEventListener('input', function() {
   debounceLoad();
 });
 document.getElementById('speciesSearch').addEventListener('input', function() {

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -8923,6 +8923,9 @@ def test_get_highlights_candidates(tmp_path):
     assert scores == sorted(scores, reverse=True)
     # Each result should have species field (may be None for unclassified)
     assert all("species" in dict(r) for r in results)
+    assert all("folder_name" in dict(r) for r in results)
+    assert all("folder_path" in dict(r) for r in results)
+    assert all("keyword_names" in dict(r) for r in results)
 
 
 def test_get_highlights_candidates_includes_descendants(tmp_path):


### PR DESCRIPTION
Adds a broad Highlights search filter that matches filename, folder, keyword, accepted species, predicted species, and unidentified photos while preserving the existing species-only filter.
Adds row sort options for species name, newest/oldest top photo, ID confidence, and confirmed-first ordering, and keeps filtered load-more requests consistent with the visible result set.
Updates highlights candidate data and regression coverage for filename, folder, and keyword search.

Validation: python -m pytest tests/e2e/test_highlights_initial_scope.py -q; python -m pytest vireo/tests/test_db.py -k highlights -q; python -m ruff check vireo/app.py vireo/db.py tests/e2e/test_highlights_initial_scope.py vireo/tests/test_db.py; python -m py_compile vireo/app.py vireo/db.py.