### PR TITLE
Add bird search to photo editor

### DIFF
--- a/tests/e2e/test_photo_editor_search.py
+++ b/tests/e2e/test_photo_editor_search.py
@@ -15,3 +15,29 @@ def test_photo_editor_search_opens_matching_species(live_server, page):
     expect(page).to_have_url(f"{url}/edit/{robin_id}")
     expect(page.locator("#editorFilename")).to_have_text("robin1.jpg")
     expect(page.locator("#editorSearchStatus")).to_have_text("1 match")
+
+
+def test_photo_editor_clear_search_invalidates_pending_response(live_server, page):
+    """Clearing search should ignore an older in-flight search response."""
+    url = live_server["url"]
+    held_routes = []
+
+    def hold_photo_ids(route):
+        held_routes.append(route)
+
+    page.route("**/api/photos/ids?*", hold_photo_ids)
+    page.goto(f"{url}/edit")
+
+    page.locator("#editorSearchInput").fill("American Robin")
+    for _ in range(20):
+        if held_routes:
+            break
+        page.wait_for_timeout(100)
+    assert held_routes, "search request was not issued"
+
+    page.locator("#editorSearchInput").fill("")
+    held_routes[0].continue_()
+
+    expect(page).to_have_url(f"{url}/edit")
+    expect(page.locator("#editorFilename")).to_have_text("No photo to edit")
+    expect(page.locator("#editorSearchStatus")).to_have_text("")

--- a/tests/e2e/test_photo_editor_search.py
+++ b/tests/e2e/test_photo_editor_search.py
@@ -43,6 +43,41 @@ def test_photo_editor_clear_search_invalidates_pending_response(live_server, pag
     expect(page.locator("#editorSearchStatus")).to_have_text("")
 
 
+def test_photo_editor_search_invalidates_pending_response_when_query_changes(live_server, page):
+    """Typing a new query while a prior search is in flight discards the older response."""
+    url = live_server["url"]
+    hawk_id = live_server["data"]["photos"][0]
+    held_routes = []
+
+    def hold(route):
+        held_routes.append(route)
+
+    page.goto(f"{url}/edit/{hawk_id}")
+    expect(page.locator("#editorFilename")).to_have_text("hawk1.jpg")
+
+    page.route("**/api/photos/ids?*", hold)
+
+    page.locator("#editorSearchInput").fill("American Robin")
+    for _ in range(20):
+        if held_routes:
+            break
+        page.wait_for_timeout(100)
+    assert held_routes, "first search request was not issued"
+
+    # Replace the query while the robin response is still held. The seq must
+    # be bumped now, not only when the next debounced search fires 300ms later.
+    page.locator("#editorSearchInput").fill("zzzz-no-match")
+
+    held_routes[0].continue_()
+
+    # Give the stale response a chance to (incorrectly) navigate or restatus.
+    page.wait_for_timeout(300)
+
+    expect(page).to_have_url(f"{url}/edit/{hawk_id}")
+    expect(page.locator("#editorFilename")).to_have_text("hawk1.jpg")
+    expect(page.locator("#editorSearchStatus")).not_to_have_text("1 match")
+
+
 def test_photo_editor_search_confirms_dirty_edits_from_in_flight_search(live_server, page):
     """Edits made while a search is in flight must not be silently discarded."""
     url = live_server["url"]

--- a/tests/e2e/test_photo_editor_search.py
+++ b/tests/e2e/test_photo_editor_search.py
@@ -41,3 +41,50 @@ def test_photo_editor_clear_search_invalidates_pending_response(live_server, pag
     expect(page).to_have_url(f"{url}/edit")
     expect(page.locator("#editorFilename")).to_have_text("No photo to edit")
     expect(page.locator("#editorSearchStatus")).to_have_text("")
+
+
+def test_photo_editor_search_confirms_dirty_edits_from_in_flight_search(live_server, page):
+    """Edits made while a search is in flight must not be silently discarded."""
+    url = live_server["url"]
+    hawk_id = live_server["data"]["photos"][0]
+    held_routes = []
+
+    def hold(route):
+        held_routes.append(route)
+
+    page.goto(f"{url}/edit/{hawk_id}")
+    expect(page.locator("#editorFilename")).to_have_text("hawk1.jpg")
+
+    page.route("**/api/photos/ids?*", hold)
+
+    page.locator("#editorSearchInput").fill("American Robin")
+    for _ in range(20):
+        if held_routes:
+            break
+        page.wait_for_timeout(100)
+    assert held_routes, "search request was not issued"
+
+    # Dirty the recipe while the search is in flight.
+    exposure = page.locator("#exposureRange")
+    exposure.evaluate("(el) => { el.value = '1.2'; el.dispatchEvent(new Event('input')); }")
+
+    dialogs = []
+
+    def on_dialog(dialog):
+        dialogs.append(dialog.message)
+        dialog.dismiss()
+
+    page.once("dialog", on_dialog)
+
+    held_routes[0].continue_()
+
+    # The confirm must be shown, and dismissing it keeps us on the current
+    # (dirty) photo instead of navigating to a search match.
+    for _ in range(20):
+        if dialogs:
+            break
+        page.wait_for_timeout(100)
+    assert dialogs, "expected a discard confirmation for dirty in-flight edits"
+    assert "Discard" in dialogs[0]
+    expect(page).to_have_url(f"{url}/edit/{hawk_id}")
+    expect(page.locator("#editorFilename")).to_have_text("hawk1.jpg")

--- a/tests/e2e/test_photo_editor_search.py
+++ b/tests/e2e/test_photo_editor_search.py
@@ -1,0 +1,17 @@
+from playwright.sync_api import expect
+
+
+def test_photo_editor_search_opens_matching_species(live_server, page):
+    """Typing a species name on /edit opens a matching photo for editing."""
+    url = live_server["url"]
+    robin_id = live_server["data"]["photos"][3]
+
+    page.goto(f"{url}/edit")
+    expect(page.locator("#editorFilename")).to_have_text("No photo to edit")
+
+    with page.expect_response("**/api/photos/ids?*"):
+        page.locator("#editorSearchInput").fill("American Robin")
+
+    expect(page).to_have_url(f"{url}/edit/{robin_id}")
+    expect(page.locator("#editorFilename")).to_have_text("robin1.jpg")
+    expect(page.locator("#editorSearchStatus")).to_have_text("1 match")

--- a/tests/e2e/test_photo_editor_search.py
+++ b/tests/e2e/test_photo_editor_search.py
@@ -155,3 +155,52 @@ def test_photo_editor_search_confirms_dirty_edits_from_in_flight_search(live_ser
     assert "Discard" in dialogs[0]
     expect(page).to_have_url(f"{url}/edit/{hawk_id}")
     expect(page.locator("#editorFilename")).to_have_text("hawk1.jpg")
+    # Dismissing the discard prompt must leave the editor visibly untouched:
+    # the "N matches" status and the nav position/list must NOT already
+    # describe the search target, since we haven't navigated to it.
+    expect(page.locator("#editorSearchStatus")).not_to_have_text("1 match")
+
+
+def test_photo_editor_search_revert_to_in_flight_query_refetches(live_server, page):
+    """Reverting to the in-flight query after an intermediate keystroke must refetch."""
+    url = live_server["url"]
+    robin_id = live_server["data"]["photos"][3]
+    held_routes = []
+
+    def hold(route):
+        held_routes.append(route)
+
+    page.goto(f"{url}/edit")
+    page.route("**/api/photos/ids?*", hold)
+
+    # First search fires the debounce and its response is held.
+    page.locator("#editorSearchInput").fill("American Robin")
+    for _ in range(20):
+        if held_routes:
+            break
+        page.wait_for_timeout(100)
+    assert held_routes, "first search request was not issued"
+
+    # Type a different query — this bumps the seq and invalidates the held
+    # response — then quickly revert to the original query before the 300ms
+    # debounce fires. Without the revert-refetch fix, scheduleEditorSearch
+    # would early-return on the same-query check and no replacement fetch
+    # would be dispatched, leaving the UI stranded at "Searching...".
+    page.locator("#editorSearchInput").fill("American Robins")
+    page.locator("#editorSearchInput").fill("American Robin")
+
+    # Wait for a second (replacement) fetch to be issued.
+    for _ in range(20):
+        if len(held_routes) >= 2:
+            break
+        page.wait_for_timeout(100)
+    assert len(held_routes) >= 2, "replacement search after revert was not issued"
+
+    # Release both responses. The first (invalidated) must be ignored; the
+    # replacement must apply and navigate to the robin.
+    held_routes[0].continue_()
+    held_routes[1].continue_()
+
+    expect(page).to_have_url(f"{url}/edit/{robin_id}")
+    expect(page.locator("#editorFilename")).to_have_text("robin1.jpg")
+    expect(page.locator("#editorSearchStatus")).to_have_text("1 match")

--- a/tests/e2e/test_photo_editor_search.py
+++ b/tests/e2e/test_photo_editor_search.py
@@ -78,6 +78,38 @@ def test_photo_editor_search_invalidates_pending_response_when_query_changes(liv
     expect(page.locator("#editorSearchStatus")).not_to_have_text("1 match")
 
 
+def test_photo_editor_search_trailing_space_applies_in_flight_response(live_server, page):
+    """Whitespace-only input changes must not invalidate an in-flight search."""
+    url = live_server["url"]
+    robin_id = live_server["data"]["photos"][3]
+    held_routes = []
+
+    def hold(route):
+        held_routes.append(route)
+
+    page.goto(f"{url}/edit")
+    page.route("**/api/photos/ids?*", hold)
+
+    page.locator("#editorSearchInput").fill("American Robin")
+    for _ in range(20):
+        if held_routes:
+            break
+        page.wait_for_timeout(100)
+    assert held_routes, "search request was not issued"
+
+    # Add a trailing space while the response is held. The trimmed query is
+    # unchanged, so the in-flight response must still apply — bumping the
+    # seq here would strand the UI at "Searching..." because the debounced
+    # replacement would early-return on the same-query check.
+    page.locator("#editorSearchInput").fill("American Robin ")
+
+    held_routes[0].continue_()
+
+    expect(page).to_have_url(f"{url}/edit/{robin_id}")
+    expect(page.locator("#editorFilename")).to_have_text("robin1.jpg")
+    expect(page.locator("#editorSearchStatus")).to_have_text("1 match")
+
+
 def test_photo_editor_search_confirms_dirty_edits_from_in_flight_search(live_server, page):
     """Edits made while a search is in flight must not be silently discarded."""
     url = live_server["url"]

--- a/vireo/templates/photo_editor.html
+++ b/vireo/templates/photo_editor.html
@@ -2404,7 +2404,12 @@ async function runEditorSearch(opts) {
     if (window.vireoEditNav) window.vireoEditNav.setList(ids, target);
     setSearchStatus(ids.length.toLocaleString() + ' match' + (ids.length === 1 ? '' : 'es'));
     updateNavControls();
-    if (target !== current) await loadPhoto(target);
+    if (target !== current) {
+      // Dirty state can change during the fetch above; re-check so edits
+      // made mid-request are not silently discarded when we navigate.
+      if (isEditorDirty() && !window.confirm('Discard unsaved edits to this photo?')) return;
+      await loadPhoto(target);
+    }
   } catch (e) {
     if (seq !== editorState.searchSeq) return;
     setSearchStatus(e.message || 'Search failed', true);

--- a/vireo/templates/photo_editor.html
+++ b/vireo/templates/photo_editor.html
@@ -2339,6 +2339,12 @@ function setSearchStatus(text, isError) {
 
 function scheduleEditorSearch() {
   if (editorState.searchTimer) clearTimeout(editorState.searchTimer);
+  var input = document.getElementById('editorSearchInput');
+  if (!input || !input.value.trim()) {
+    editorState.searchTimer = null;
+    clearEditorSearchResults();
+    return;
+  }
   editorState.searchTimer = setTimeout(function() {
     editorState.searchTimer = null;
     runEditorSearch();
@@ -2346,6 +2352,7 @@ function scheduleEditorSearch() {
 }
 
 function clearEditorSearchResults() {
+  editorState.searchSeq++;
   editorState.searchQuery = '';
   editorState.navIds = (editorState.baseNavIds || []).slice();
   if (window.vireoEditNav) window.vireoEditNav.setList(editorState.navIds, editorState.photoId);

--- a/vireo/templates/photo_editor.html
+++ b/vireo/templates/photo_editor.html
@@ -31,14 +31,49 @@ body {
   min-height: 52px;
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 10px;
   padding: 10px 14px;
   border-bottom: 1px solid var(--border-primary);
   background: var(--bg-secondary);
 }
+.editor-search {
+  min-width: 220px;
+  flex: 0 1 300px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 6px;
+  align-items: center;
+}
+.editor-search input {
+  min-width: 0;
+  width: 100%;
+  height: 32px;
+  border: 1px solid var(--border-secondary);
+  border-radius: 4px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  padding: 0 9px;
+  font-size: 12px;
+}
+.editor-search input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+.editor-search-status {
+  grid-column: 1 / -1;
+  min-height: 13px;
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 13px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.editor-search-status.error { color: var(--danger); }
 .editor-title {
   min-width: 0;
-  flex: 1;
+  flex: 1 1 180px;
 }
 .editor-title strong,
 .editor-title span {
@@ -402,6 +437,14 @@ body {
     border-right: 0;
     border-bottom: 1px solid var(--border-primary);
   }
+  .editor-search {
+    flex-basis: 100%;
+    order: 2;
+  }
+  .editor-title {
+    flex-basis: 100%;
+    order: 3;
+  }
   #editorImg {
     max-width: calc(100vw - 32px);
     max-height: 70vh;
@@ -419,6 +462,11 @@ body {
       <button class="editor-btn" id="prevBtn" type="button" onclick="editorNav(-1)" title="Previous photo (←)" hidden>‹ Prev</button>
       <button class="editor-btn" id="nextBtn" type="button" onclick="editorNav(1)" title="Next photo (→)" hidden>Next ›</button>
       <span class="editor-navpos" id="editorNavPos"></span>
+      <div class="editor-search" role="search">
+        <input id="editorSearchInput" type="search" placeholder="Find bird or filename..." autocomplete="off" aria-label="Find bird or filename" oninput="scheduleEditorSearch()" onkeydown="if(event.key==='Enter'){event.preventDefault(); runEditorSearch({immediate:true});}">
+        <button class="editor-btn" type="button" onclick="runEditorSearch({immediate:true})">Search</button>
+        <span class="editor-search-status" id="editorSearchStatus" role="status" aria-live="polite"></span>
+      </div>
       <div class="editor-title">
         <strong id="editorFilename">Loading photo...</strong>
         <span id="editorSubhead">Non-destructive editor</span>
@@ -656,9 +704,13 @@ var editorState = {
   zoomMode: 'fit',
   cropAspect: null,
   navIds: [],
+  baseNavIds: [],
   loadSeq: 0,
   loading: false,
   histogramTimer: null,
+  searchTimer: null,
+  searchSeq: 0,
+  searchQuery: '',
   suppressUnloadPrompt: false,
 };
 
@@ -2278,6 +2330,80 @@ function updateNavControls() {
   if (pos) pos.textContent = hasNav ? (idx + 1) + ' / ' + ids.length : '';
 }
 
+function setSearchStatus(text, isError) {
+  var el = document.getElementById('editorSearchStatus');
+  if (!el) return;
+  el.textContent = text || '';
+  el.classList.toggle('error', !!isError);
+}
+
+function scheduleEditorSearch() {
+  if (editorState.searchTimer) clearTimeout(editorState.searchTimer);
+  editorState.searchTimer = setTimeout(function() {
+    editorState.searchTimer = null;
+    runEditorSearch();
+  }, 300);
+}
+
+function clearEditorSearchResults() {
+  editorState.searchQuery = '';
+  editorState.navIds = (editorState.baseNavIds || []).slice();
+  if (window.vireoEditNav) window.vireoEditNav.setList(editorState.navIds, editorState.photoId);
+  setSearchStatus('');
+  updateNavControls();
+}
+
+async function runEditorSearch(opts) {
+  opts = opts || {};
+  if (editorState.searchTimer) {
+    clearTimeout(editorState.searchTimer);
+    editorState.searchTimer = null;
+  }
+  var input = document.getElementById('editorSearchInput');
+  var q = input ? input.value.trim() : '';
+  if (!q) {
+    clearEditorSearchResults();
+    return;
+  }
+  if (q === editorState.searchQuery && !opts.immediate) return;
+  if (isEditorDirty()) {
+    setSearchStatus('Save or discard this photo before searching.', true);
+    return;
+  }
+
+  var seq = ++editorState.searchSeq;
+  editorState.searchQuery = q;
+  setSearchStatus('Searching...');
+  try {
+    var params = new URLSearchParams();
+    params.set('keyword', q);
+    params.set('sort', 'name');
+    var data = await safeFetch('/api/photos/ids?' + params.toString(), {}, {toast: false});
+    if (seq !== editorState.searchSeq) return;
+    var ids = (data.photo_ids || [])
+      .map(function(id) { return Number(id); })
+      .filter(function(id) { return Number.isFinite(id) && id > 0; });
+    if (!ids.length) {
+      editorState.navIds = [];
+      if (window.vireoEditNav) window.vireoEditNav.setList([], null);
+      setSearchStatus('No matches for "' + q + '".', true);
+      updateNavControls();
+      return;
+    }
+
+    editorState.navIds = ids;
+    var current = Number(editorState.photoId);
+    var target = ids.indexOf(current) === -1 ? ids[0] : current;
+    if (window.vireoEditNav) window.vireoEditNav.setList(ids, target);
+    setSearchStatus(ids.length.toLocaleString() + ' match' + (ids.length === 1 ? '' : 'es'));
+    updateNavControls();
+    if (target !== current) await loadPhoto(target);
+  } catch (e) {
+    if (seq !== editorState.searchSeq) return;
+    setSearchStatus(e.message || 'Search failed', true);
+  }
+}
+
 function editorNav(delta) {
   var ids = editorState.navIds || [];
   var idx = ids.indexOf(Number(editorState.photoId));
@@ -2334,6 +2460,10 @@ async function loadPhoto(photoId, opts) {
   editorState.recipe = {};
   var saveBtn = document.getElementById('saveBtn');
   if (saveBtn) saveBtn.disabled = true;
+  ['copySettingsBtn', 'beforeBtn', 'fitBtn', 'actualBtn'].forEach(function(id) {
+    var b = document.getElementById(id);
+    if (b) b.disabled = false;
+  });
   editorState.showBefore = false;
   editorState.cropAspect = null;
   updateAspectButtons();
@@ -2428,6 +2558,7 @@ async function initEditor() {
   setZoomMode('fit');
   loadPresets();
   if (window.vireoEditNav) editorState.navIds = window.vireoEditNav.getList() || [];
+  editorState.baseNavIds = (editorState.navIds || []).slice();
   var match = window.location.pathname.match(/\/edit\/(\d+)/);
   var photoId = match
     ? Number(match[1])

--- a/vireo/templates/photo_editor.html
+++ b/vireo/templates/photo_editor.html
@@ -2340,6 +2340,10 @@ function setSearchStatus(text, isError) {
 function scheduleEditorSearch() {
   if (editorState.searchTimer) clearTimeout(editorState.searchTimer);
   var input = document.getElementById('editorSearchInput');
+  // Bump the sequence the moment the input changes so any in-flight response
+  // for the previous query fails the seq guard in runEditorSearch, instead
+  // of racing the 300ms debounce and applying/navigating to stale matches.
+  editorState.searchSeq++;
   if (!input || !input.value.trim()) {
     editorState.searchTimer = null;
     clearEditorSearchResults();

--- a/vireo/templates/photo_editor.html
+++ b/vireo/templates/photo_editor.html
@@ -2339,16 +2339,25 @@ function setSearchStatus(text, isError) {
 
 function scheduleEditorSearch() {
   if (editorState.searchTimer) clearTimeout(editorState.searchTimer);
+  editorState.searchTimer = null;
   var input = document.getElementById('editorSearchInput');
-  // Bump the sequence the moment the input changes so any in-flight response
-  // for the previous query fails the seq guard in runEditorSearch, instead
-  // of racing the 300ms debounce and applying/navigating to stale matches.
-  editorState.searchSeq++;
-  if (!input || !input.value.trim()) {
-    editorState.searchTimer = null;
+  var q = input ? input.value.trim() : '';
+  if (!q) {
     clearEditorSearchResults();
     return;
   }
+  if (q === editorState.searchQuery) {
+    // Trimmed query is unchanged (e.g. typing a trailing space after
+    // "American Robin"), so any in-flight fetch is still relevant. Bumping
+    // the seq here would invalidate that response while the debounced
+    // replacement runEditorSearch would early-return on the same-query
+    // check, leaving the UI stuck at "Searching...".
+    return;
+  }
+  // Query actually changed — bump the sequence so any in-flight response for
+  // the previous query fails the seq guard in runEditorSearch, instead of
+  // racing the 300ms debounce and applying stale matches.
+  editorState.searchSeq++;
   editorState.searchTimer = setTimeout(function() {
     editorState.searchTimer = null;
     runEditorSearch();

--- a/vireo/templates/photo_editor.html
+++ b/vireo/templates/photo_editor.html
@@ -711,6 +711,11 @@ var editorState = {
   searchTimer: null,
   searchSeq: 0,
   searchQuery: '',
+  // Seq under which the current `searchQuery` was dispatched. When the input
+  // is retyped back to `searchQuery` after an intermediate keystroke bumped
+  // `searchSeq`, this mismatch tells us the in-flight response was already
+  // invalidated so a replacement fetch is required.
+  searchQuerySeq: 0,
   suppressUnloadPrompt: false,
 };
 
@@ -2346,17 +2351,21 @@ function scheduleEditorSearch() {
     clearEditorSearchResults();
     return;
   }
-  if (q === editorState.searchQuery) {
-    // Trimmed query is unchanged (e.g. typing a trailing space after
-    // "American Robin"), so any in-flight fetch is still relevant. Bumping
-    // the seq here would invalidate that response while the debounced
-    // replacement runEditorSearch would early-return on the same-query
-    // check, leaving the UI stuck at "Searching...".
+  if (q === editorState.searchQuery &&
+      editorState.searchQuerySeq === editorState.searchSeq) {
+    // Trimmed query unchanged since our last dispatch AND that dispatch is
+    // still current (e.g. typing a trailing space after "American Robin"),
+    // so its in-flight response will still pass the seq guard. Bumping the
+    // seq here would invalidate it while the debounced replacement would
+    // early-return on the same-query check, leaving the UI stuck at
+    // "Searching...".
     return;
   }
-  // Query actually changed — bump the sequence so any in-flight response for
-  // the previous query fails the seq guard in runEditorSearch, instead of
-  // racing the 300ms debounce and applying stale matches.
+  // Either the trimmed query actually changed, or the previously-dispatched
+  // fetch has been invalidated by an intermediate keystroke (user typed a
+  // different query then reverted before the debounce fired). In both cases
+  // bump the seq so any in-flight response fails the seq guard, then debounce
+  // a replacement fetch.
   editorState.searchSeq++;
   editorState.searchTimer = setTimeout(function() {
     editorState.searchTimer = null;
@@ -2367,6 +2376,7 @@ function scheduleEditorSearch() {
 function clearEditorSearchResults() {
   editorState.searchSeq++;
   editorState.searchQuery = '';
+  editorState.searchQuerySeq = 0;
   editorState.navIds = (editorState.baseNavIds || []).slice();
   if (window.vireoEditNav) window.vireoEditNav.setList(editorState.navIds, editorState.photoId);
   setSearchStatus('');
@@ -2385,7 +2395,15 @@ async function runEditorSearch(opts) {
     clearEditorSearchResults();
     return;
   }
-  if (q === editorState.searchQuery && !opts.immediate) return;
+  if (q === editorState.searchQuery && !opts.immediate &&
+      editorState.searchQuerySeq === editorState.searchSeq) {
+    // Same trimmed query as our last dispatch and that dispatch is still
+    // current (nothing invalidated it) — no need to refire. If the seqs no
+    // longer match, `scheduleEditorSearch` bumped the seq because an
+    // intermediate keystroke invalidated the in-flight response, so we must
+    // fall through to dispatch a replacement.
+    return;
+  }
   if (isEditorDirty()) {
     setSearchStatus('Save or discard this photo before searching.', true);
     return;
@@ -2393,6 +2411,7 @@ async function runEditorSearch(opts) {
 
   var seq = ++editorState.searchSeq;
   editorState.searchQuery = q;
+  editorState.searchQuerySeq = seq;
   setSearchStatus('Searching...');
   try {
     var params = new URLSearchParams();
@@ -2411,16 +2430,22 @@ async function runEditorSearch(opts) {
       return;
     }
 
-    editorState.navIds = ids;
     var current = Number(editorState.photoId);
     var target = ids.indexOf(current) === -1 ? ids[0] : current;
+    // Dirty state can change during the fetch above. Run the confirm before
+    // any nav/status mutation so a dismissed prompt leaves the editor
+    // untouched — otherwise the navIds/nav position/status would already
+    // describe the search target while the still-loaded dirty photo isn't in
+    // ids, leaving the editor visibly inconsistent.
+    if (target !== current && isEditorDirty() &&
+        !window.confirm('Discard unsaved edits to this photo?')) {
+      return;
+    }
+    editorState.navIds = ids;
     if (window.vireoEditNav) window.vireoEditNav.setList(ids, target);
     setSearchStatus(ids.length.toLocaleString() + ' match' + (ids.length === 1 ? '' : 'es'));
     updateNavControls();
     if (target !== current) {
-      // Dirty state can change during the fetch above; re-check so edits
-      // made mid-request are not silently discarded when we navigate.
-      if (isEditorDirty() && !window.confirm('Discard unsaved edits to this photo?')) return;
       await loadPhoto(target);
     }
   } catch (e) {

--- a/vireo/tests/test_new_images_cache.py
+++ b/vireo/tests/test_new_images_cache.py
@@ -121,7 +121,7 @@ def test_kickoff_compute_drops_stale_error_when_generation_changes():
         raise RuntimeError("disk unreachable")
 
     event = cache.kickoff_compute(DB, 1, compute)
-    assert event.wait(timeout=2.0), "background compute did not finish"
+    assert event.wait(timeout=10.0), "background compute did not finish"
 
     assert cache.get_recent_error(DB, 1) is None, (
         "stale error must be dropped when the generation moved during compute"
@@ -138,7 +138,7 @@ def test_kickoff_compute_records_error_when_generation_unchanged():
         raise RuntimeError("disk unreachable")
 
     event = cache.kickoff_compute(DB, 1, compute)
-    assert event.wait(timeout=2.0)
+    assert event.wait(timeout=10.0)
 
     err = cache.get_recent_error(DB, 1)
     assert err is not None and "disk unreachable" in err
@@ -153,7 +153,7 @@ def test_kickoff_compute_clears_prior_error_on_success():
         raise RuntimeError("transient")
 
     event = cache.kickoff_compute(DB, 1, boom)
-    assert event.wait(timeout=2.0)
+    assert event.wait(timeout=10.0)
     assert cache.get_recent_error(DB, 1) is not None
 
     # The error sits in the backoff window and would normally suppress the
@@ -167,7 +167,7 @@ def test_kickoff_compute_clears_prior_error_on_success():
         return {"new_count": 3}
 
     event = cache.kickoff_compute(DB, 1, ok)
-    assert event.wait(timeout=2.0)
+    assert event.wait(timeout=10.0)
     assert cache.get(DB, 1) == {"new_count": 3}
     assert cache.get_recent_error(DB, 1) is None
 
@@ -186,7 +186,7 @@ def test_invalidate_workspaces_clears_recent_error():
         raise RuntimeError("disk unreachable")
 
     event = cache.kickoff_compute(DB, 1, boom)
-    assert event.wait(timeout=2.0)
+    assert event.wait(timeout=10.0)
     assert cache.get_recent_error(DB, 1) is not None
 
     # Invalidation simulates a finished scan or workspace folder change.
@@ -202,7 +202,7 @@ def test_invalidate_workspaces_clears_recent_error():
         return {"new_count": 4}
 
     event = cache.kickoff_compute(DB, 1, ok)
-    assert event.wait(timeout=2.0)
+    assert event.wait(timeout=10.0)
     assert cache.get(DB, 1) == {"new_count": 4}
 
 
@@ -214,8 +214,8 @@ def test_invalidate_workspaces_clears_error_only_for_targeted_keys():
     def boom():
         raise RuntimeError("disk unreachable")
 
-    cache.kickoff_compute(DB, 1, boom).wait(timeout=2.0)
-    cache.kickoff_compute(DB, 2, boom).wait(timeout=2.0)
+    cache.kickoff_compute(DB, 1, boom).wait(timeout=10.0)
+    cache.kickoff_compute(DB, 2, boom).wait(timeout=10.0)
     assert cache.get_recent_error(DB, 1) is not None
     assert cache.get_recent_error(DB, 2) is not None
 
@@ -240,11 +240,11 @@ def test_kickoff_compute_reuses_in_flight_for_current_generation():
         return {"new_count": 3}
 
     e1 = cache.kickoff_compute(DB, 1, slow_compute)
-    assert started.wait(timeout=2.0)
+    assert started.wait(timeout=10.0)
     e2 = cache.kickoff_compute(DB, 1, slow_compute)
     assert e1 is e2, "concurrent kickoff for same generation must reuse in-flight"
     proceed.set()
-    assert e1.wait(timeout=2.0)
+    assert e1.wait(timeout=10.0)
     assert call_count[0] == 1
 
 
@@ -269,7 +269,7 @@ def test_kickoff_compute_coalesces_stale_generation_into_deferred_rerun():
         return {"new_count": 999}  # stale value — must be dropped
 
     e1 = cache.kickoff_compute(DB, 1, stale_compute)
-    assert stale_started.wait(timeout=2.0)
+    assert stale_started.wait(timeout=10.0)
 
     # Invalidation advances the generation while the compute is still running.
     cache.invalidate_workspaces(DB, [1])
@@ -297,8 +297,8 @@ def test_kickoff_compute_coalesces_stale_generation_into_deferred_rerun():
     # Release the stale thread; the deferred rerun fires asynchronously after
     # its finally block runs.
     stale_proceed.set()
-    assert e1.wait(timeout=2.0)
-    assert fresh_called.wait(timeout=2.0), (
+    assert e1.wait(timeout=10.0)
+    assert fresh_called.wait(timeout=10.0), (
         "deferred rerun must spawn fresh compute after stale finishes"
     )
 
@@ -330,7 +330,7 @@ def test_kickoff_compute_coalesces_repeated_invalidations_into_single_rerun():
         return {"new_count": 0}
 
     cache.kickoff_compute(DB, 1, stale_compute)
-    assert stale_started.wait(timeout=2.0)
+    assert stale_started.wait(timeout=10.0)
 
     # Several rounds of invalidation + kickoff with different compute_fns;
     # only the last one's result should ultimately land in the cache.
@@ -387,7 +387,7 @@ def test_kickoff_compute_stale_thread_clears_inflight_slot_for_rerun():
         return {"new_count": 1}
 
     cache.kickoff_compute(DB, 1, stale_compute)
-    assert stale_started.wait(timeout=2.0)
+    assert stale_started.wait(timeout=10.0)
     cache.invalidate_workspaces(DB, [1])
 
     rerun_done = threading.Event()
@@ -399,7 +399,7 @@ def test_kickoff_compute_stale_thread_clears_inflight_slot_for_rerun():
     cache.kickoff_compute(DB, 1, rerun_compute)
     stale_proceed.set()
 
-    assert rerun_done.wait(timeout=2.0), (
+    assert rerun_done.wait(timeout=10.0), (
         "rerun must run after stale thread finishes and frees the in-flight slot"
     )
 


### PR DESCRIPTION
Adds a search control to the photo editor so users can find photos by bird/species keyword or filename and jump straight into editing. Matching search results become the editor Prev/Next list, which keeps navigation scoped to the selected bird. Also covers opening /edit with no current photo by searching directly into a matching photo.

Validation: python -m pytest tests/e2e/test_photo_editor_search.py -q; python -m pytest tests/e2e/test_page_loads.py -q.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added species search to the photo editor, with matching results, result counts, and navigation updates.
  * Search supports debounced typing, immediate searches on Enter or button click, and clearing to restore the full photo list.
  * Added responsive search layout and accessible live status updates.

* **Bug Fixes**
  * Prevented stale search results from replacing newer searches or cleared results.
  * Added protection against navigating away from unsaved edits without confirmation.

* **Tests**
  * Added end-to-end coverage for search, stale responses, clearing, and unsaved changes.
  * Improved reliability of background-processing tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->