### PR TITLE
Prioritize picked photos in highlights

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -195,8 +195,13 @@ def _highlight_area_score(subject_size):
     return min(1.0, math.sqrt(subject_size) * 2.0)
 
 
-def _highlight_score_bucket(photos):
-    """Attach highlight scores and compact reason labels to one species bucket."""
+def _highlight_score_bucket(photos, picked_first=False):
+    """Attach highlight scores and compact reason labels to one species bucket.
+
+    picked_first promotes flagged photos above unflagged ones regardless of
+    score — desired on the Highlights page, but off by default so callers
+    like the Life List keep selecting the highest-scored photo.
+    """
     subject_values = [p.get("subject_tenengrad") for p in photos]
     eye_values = [p.get("eye_tenengrad") for p in photos if p.get("eye_tenengrad") is not None]
     bg_values = [p.get("bg_tenengrad") for p in photos]
@@ -297,7 +302,7 @@ def _highlight_score_bucket(photos):
 
     photos.sort(
         key=lambda p: (
-            1 if p.get("flag") == "flagged" else 0,
+            (1 if p.get("flag") == "flagged" else 0) if picked_first else 0,
             p.get("highlight_score") or 0,
             p.get("predicted_confidence") or 0,
             p.get("quality_score") or 0,
@@ -430,7 +435,7 @@ def _collect_highlight_buckets(
     buckets = []
     for species, entry in bucket_map.items():
         photos = entry["photos"]
-        _highlight_score_bucket(photos)
+        _highlight_score_bucket(photos, picked_first=True)
         confidences = [
             p["predicted_confidence"]
             for p in photos
@@ -454,7 +459,7 @@ def _collect_highlight_buckets(
             "photos": photos,
         })
 
-    _highlight_score_bucket(unidentified_photos)
+    _highlight_score_bucket(unidentified_photos, picked_first=True)
     buckets.sort(
         key=lambda b: (
             b.get("best_score") or 0,

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -328,6 +328,17 @@ def _apply_preferred_photo(photos, preferred_photo_id, marker_key):
     return False
 
 
+def _bucket_best_score(photos):
+    """Return the highest highlight_score in a bucket, or None if empty.
+
+    Used to rank buckets on the Highlights page. Reads the max across all
+    photos so a pick-first (or user-preferred) reorder at photos[0] can't
+    demote a species by anchoring the bucket score to a lower-scored photo.
+    """
+    scores = [p.get("highlight_score") for p in photos if p.get("highlight_score") is not None]
+    return max(scores) if scores else None
+
+
 def _apply_highlight_preferences(db, buckets):
     preferences = db.get_photo_preferences("highlights")
     for bucket in buckets:
@@ -335,11 +346,16 @@ def _apply_highlight_preferences(db, buckets):
         applied = _apply_preferred_photo(
             bucket["photos"], preferred_id, "is_highlights_photo"
         )
-        best = bucket["photos"][0] if bucket["photos"] else {}
+        top = bucket["photos"][0] if bucket["photos"] else {}
         bucket["preferred_photo_id"] = preferred_id
         bucket["has_preferred_photo"] = applied
-        bucket["best_quality"] = best.get("quality_score")
-        bucket["best_score"] = best.get("highlight_score")
+        bucket["best_quality"] = top.get("quality_score")
+        # Rank by the highest-scored photo in the bucket, not photos[0].
+        # A picked (or manually preferred) photo may sit at photos[0] with a
+        # lower highlight_score; using its score for bucket ranking would
+        # demote the whole species below buckets with worse actual best
+        # photos.
+        bucket["best_score"] = _bucket_best_score(bucket["photos"])
 
 
 def _highlight_confidence_label(confidence, is_accepted):
@@ -445,7 +461,7 @@ def _collect_highlight_buckets(
             round(sum(confidences) / len(confidences), 4)
             if confidences else None
         )
-        best = photos[0] if photos else {}
+        top = photos[0] if photos else {}
         buckets.append({
             "species": species,
             "is_accepted": entry["is_accepted"],
@@ -454,8 +470,8 @@ def _collect_highlight_buckets(
             ),
             "avg_confidence": avg_confidence,
             "photo_count": len(photos),
-            "best_quality": best.get("quality_score"),
-            "best_score": best.get("highlight_score"),
+            "best_quality": top.get("quality_score"),
+            "best_score": _bucket_best_score(photos),
             "photos": photos,
         })
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -297,6 +297,7 @@ def _highlight_score_bucket(photos):
 
     photos.sort(
         key=lambda p: (
+            1 if p.get("flag") == "flagged" else 0,
             p.get("highlight_score") or 0,
             p.get("predicted_confidence") or 0,
             p.get("quality_score") or 0,

--- a/vireo/tests/test_life_list.py
+++ b/vireo/tests/test_life_list.py
@@ -176,6 +176,19 @@ def test_highlights_photo_preference_overrides_best_photo(life_app):
     assert cardinal["has_preferred_photo"] is True
 
 
+def test_highlights_picks_sort_before_higher_scored_unflagged(life_app):
+    app, db, ids = life_app
+    db.update_photo_flag(ids["p1"], "flagged")
+
+    data = app.test_client().get("/api/highlights?scope=workspace").get_json()
+    cardinal = next(
+        b for b in data["buckets"] if b["species"] == "Northern Cardinal"
+    )
+    assert [p["id"] for p in cardinal["photos"][:2]] == [ids["p1"], ids["p2"]]
+    assert cardinal["photos"][0]["flag"] == "flagged"
+    assert cardinal["photos"][1]["flag"] == "none"
+
+
 def test_life_order_numbering_and_dates(life_app):
     app, _, _ = life_app
     data = _get_life_list(app)

--- a/vireo/tests/test_life_list.py
+++ b/vireo/tests/test_life_list.py
@@ -129,6 +129,20 @@ def test_best_photo_is_highest_scored(life_app):
     assert [p["id"] for p in cardinal["photos"]] == [ids["p2"], ids["p1"]]
 
 
+def test_life_list_best_ignores_pick_when_no_preference(life_app):
+    """Life List ranking must stay score-driven — the Highlights-only
+    picked-first ordering must not leak into `_build_life_list_payload`."""
+    app, db, ids = life_app
+    # p1's quality_score (0.5) is lower than p2's (0.9). Flagging p1
+    # must NOT promote it above p2 on the Life List.
+    db.update_photo_flag(ids["p1"], "flagged")
+
+    data = _get_life_list(app)
+    cardinal = _entry(data, "Northern Cardinal")
+    assert cardinal["best"]["id"] == ids["p2"]
+    assert [p["id"] for p in cardinal["photos"]] == [ids["p2"], ids["p1"]]
+
+
 def test_life_list_photo_preference_overrides_best_photo(life_app):
     app, _, ids = life_app
     client = app.test_client()

--- a/vireo/tests/test_life_list.py
+++ b/vireo/tests/test_life_list.py
@@ -203,6 +203,30 @@ def test_highlights_picks_sort_before_higher_scored_unflagged(life_app):
     assert cardinal["photos"][1]["flag"] == "none"
 
 
+def test_highlights_bucket_best_score_ignores_pick_promotion(life_app):
+    """Picking a lower-scored photo must not demote the whole species bucket.
+
+    The Highlights UI ranks buckets by ``best_score`` for the default
+    "Best photo first" sort. A pick moves the flagged photo to
+    ``photos[0]`` for display, but ``best_score`` must still reflect the
+    highest-scored photo in the bucket so the species isn't pushed down
+    below buckets whose actual best photo is worse.
+    """
+    app, db, ids = life_app
+    db.update_photo_flag(ids["p1"], "flagged")
+
+    data = app.test_client().get("/api/highlights?scope=workspace").get_json()
+    cardinal = next(
+        b for b in data["buckets"] if b["species"] == "Northern Cardinal"
+    )
+    picked = next(p for p in cardinal["photos"] if p["id"] == ids["p1"])
+    unpicked = next(p for p in cardinal["photos"] if p["id"] == ids["p2"])
+    # Sanity: p1 (picked) really is the lower-scored photo, so photos[0]'s
+    # score would demote the bucket if best_score anchored to it.
+    assert picked["highlight_score"] < unpicked["highlight_score"]
+    assert cardinal["best_score"] == unpicked["highlight_score"]
+
+
 def test_life_order_numbering_and_dates(life_app):
     app, _, _ = life_app
     data = _get_life_list(app)


### PR DESCRIPTION
## Summary

Highlights now sort picked photos ahead of unflagged photos within each species bucket, while still using the existing highlight score and quality signals to order photos inside each group. Rejected photos were already excluded from Highlights, and this preserves that behavior. Added a regression test covering a lower-scored picked photo beating a higher-scored unflagged photo.

## Validation

- `pytest vireo/tests/test_life_list.py`