### PR TITLE
Add species representatives and ordered highlights

### DIFF
--- a/tests/e2e/test_lifelist_add_verify.py
+++ b/tests/e2e/test_lifelist_add_verify.py
@@ -1,4 +1,4 @@
-"""E2E verification for the "Add to Life List" surfaces (lightbox + browse menu).
+"""E2E verification for species representative surfaces (lightbox + browse menu).
 
 Seed (from conftest.seed_e2e_data): photos[0]=hawk1 tagged "Red-tailed Hawk",
 photos[3]=robin1 tagged "American Robin"; the other three carry predictions but
@@ -9,7 +9,7 @@ import re
 from playwright.sync_api import expect
 
 
-def test_browse_menu_add_to_life_list_sets_representative(live_server, page):
+def test_browse_menu_sets_representative(live_server, page):
     url = live_server["url"]
     hawk = live_server["data"]["photos"][0]
     page.goto(f"{url}/browse")
@@ -20,7 +20,7 @@ def test_browse_menu_add_to_life_list_sets_representative(live_server, page):
 
     menu = page.locator(".vireo-ctx-menu")
     expect(menu).to_be_visible()
-    item = menu.locator(".vireo-ctx-item", has_text="Add to Life List — Red-tailed Hawk")
+    item = menu.locator(".vireo-ctx-item", has_text="Set Representative — Red-tailed Hawk")
     expect(item).to_be_visible()
 
     # The menu handler is fire-and-forget (safeFetch(...).then(...)); wait for
@@ -40,7 +40,11 @@ def test_browse_menu_add_to_life_list_sets_representative(live_server, page):
         }""",
         hawk,
     )
-    assert life_list == [{"species": "Red-tailed Hawk", "is_current_photo": True}], life_list
+    assert life_list == [{
+        "species": "Red-tailed Hawk",
+        "is_current_photo": True,
+        "is_species_representative": True,
+    }], life_list
 
 
 def test_browse_menu_hidden_for_photo_without_species(live_server, page):
@@ -54,12 +58,12 @@ def test_browse_menu_hidden_for_photo_without_species(live_server, page):
 
     menu = page.locator(".vireo-ctx-menu")
     expect(menu).to_be_visible()
-    expect(menu.locator(".vireo-ctx-item", has_text="Add to Life List")).to_have_count(0)
+    expect(menu.locator(".vireo-ctx-item", has_text="Set Representative")).to_have_count(0)
 
 
 def test_browse_menu_hidden_for_rejected_photo(live_server, page):
     """A species-tagged photo that has been rejected must not surface an
-    "Add to Life List" menu item — the server backstop
+    "Set Representative" menu item — the server backstop
     (_photo_can_be_life_list_preference) rejects flag='rejected', so offering
     it in the menu would only ever produce an error toast."""
     url = live_server["url"]
@@ -86,7 +90,7 @@ def test_browse_menu_hidden_for_rejected_photo(live_server, page):
 
     menu = page.locator(".vireo-ctx-menu")
     expect(menu).to_be_visible()
-    expect(menu.locator(".vireo-ctx-item", has_text="Add to Life List")).to_have_count(0)
+    expect(menu.locator(".vireo-ctx-item", has_text="Set Representative")).to_have_count(0)
 
 
 def test_browse_menu_disabled_for_multi_select(live_server, page):
@@ -104,7 +108,7 @@ def test_browse_menu_disabled_for_multi_select(live_server, page):
     hawk_card.click(button="right")
     menu = page.locator(".vireo-ctx-menu")
     expect(menu).to_be_visible()
-    item = menu.locator(".vireo-ctx-item", has_text="Add to Life List")
+    item = menu.locator(".vireo-ctx-item", has_text="Set Representative")
     expect(item).to_be_visible()
     assert "vireo-ctx-disabled" in (item.get_attribute("class") or "")
     assert item.get_attribute("title") == "Select a single photo"
@@ -120,11 +124,11 @@ def test_lightbox_panel_add_and_flip_to_selected(live_server, page):
 
     panel = page.locator("#lifeListLightboxPanel")
     expect(panel).to_be_visible()
-    add_btn = panel.locator("button", has_text="Add to Life List")
+    add_btn = panel.locator("button", has_text="Set Representative")
     expect(add_btn).to_be_visible()
     add_btn.click()
 
-    selected = panel.locator("button", has_text="Life List photo")
+    selected = panel.locator("button.primary", has_text="Representative")
     expect(selected).to_be_visible()
     assert re.search(r"\bprimary\b", selected.get_attribute("class") or "")
 
@@ -132,7 +136,7 @@ def test_lightbox_panel_add_and_flip_to_selected(live_server, page):
 def test_lightbox_panel_hides_after_current_photo_rejected(live_server, page):
     """When the currently-open photo is rejected via lightbox flag controls,
     _photo_can_be_life_list_preference stops accepting it on the server. The
-    panel must refresh so "Add to Life List" stops offering clicks that would
+    panel must refresh so "Set Representative" stops offering clicks that would
     be guaranteed 4xxs."""
     url = live_server["url"]
     page.goto(f"{url}/life-list")
@@ -143,7 +147,7 @@ def test_lightbox_panel_hides_after_current_photo_rejected(live_server, page):
 
     panel = page.locator("#lifeListLightboxPanel")
     expect(panel).to_be_visible()
-    expect(panel.locator("button", has_text="Add to Life List")).to_be_visible()
+    expect(panel.locator("button", has_text="Set Representative")).to_be_visible()
 
     # Reject via the same code path the lightbox flag chips call.
     page.evaluate("() => _lbApplyFlag(_lightboxCurrentId, 'rejected')")

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -1362,6 +1362,39 @@ def test_move_folders_moves_photo_preferences(db_with_workspace):
     assert db.get_species_highlights() == {}
 
 
+def test_move_folders_reranks_species_highlights_on_collision(db):
+    """Moving highlights into a target that already has ranks for the same
+    species must append after the target's max rank so `ORDER BY rank`
+    keeps the target's curated order first."""
+    ws1 = db.create_workspace("Source")
+    ws2 = db.create_workspace("Target")
+
+    src_folder = db.add_folder("/src", name="src")
+    tgt_folder = db.add_folder("/tgt", name="tgt")
+    db.add_workspace_folder(ws1, src_folder)
+    db.add_workspace_folder(ws2, tgt_folder)
+
+    src_photo = db.add_photo(folder_id=src_folder, filename="src.jpg",
+                             extension=".jpg", file_size=100, file_mtime=1.0)
+    tgt_photo = db.add_photo(folder_id=tgt_folder, filename="tgt.jpg",
+                             extension=".jpg", file_size=100, file_mtime=2.0)
+
+    db.set_active_workspace(ws1)
+    db.add_species_highlight("Robin", src_photo)
+    db.set_active_workspace(ws2)
+    db.add_species_highlight("Robin", tgt_photo)
+
+    result = db.move_folders_to_workspace(ws1, ws2, [src_folder])
+    assert result["species_highlights_moved"] == 1
+
+    db.set_active_workspace(ws2)
+    # Both photos are in the Robin bucket, with distinct ranks; the target's
+    # original rank-1 stays first because moved rows append after it.
+    assert db.get_species_highlights("Robin") == {
+        "Robin": {tgt_photo: 1, src_photo: 2},
+    }
+
+
 def test_move_folders_collections_stay_behind(db_with_workspace):
     """Collections in the source workspace are NOT moved."""
     db, ws1, folder_id, photo_id = db_with_workspace

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -1340,22 +1340,26 @@ def test_move_folders_moves_pending_changes(db_with_workspace):
 
 
 def test_move_folders_moves_photo_preferences(db_with_workspace):
-    """Representative Life List / Highlights choices follow moved photos."""
+    """Representative choices and ordered highlights follow moved photos."""
     db, ws1, folder_id, photo_id = db_with_workspace
     db.set_photo_preference("life_list", "Robin", photo_id)
     db.set_photo_preference("highlights", "Robin", photo_id)
+    db.add_species_highlight("Robin", photo_id)
 
     ws2 = db.create_workspace("Target")
     result = db.move_folders_to_workspace(ws1, ws2, [folder_id])
 
     assert result["photo_preferences_moved"] == 2
+    assert result["species_highlights_moved"] == 1
     db.set_active_workspace(ws2)
     assert db.get_photo_preferences("life_list") == {"Robin": photo_id}
     assert db.get_photo_preferences("highlights") == {"Robin": photo_id}
+    assert db.get_species_highlights() == {"Robin": {photo_id: 1}}
 
     db.set_active_workspace(ws1)
     assert db.get_photo_preferences("life_list") == {}
     assert db.get_photo_preferences("highlights") == {}
+    assert db.get_species_highlights() == {}
 
 
 def test_move_folders_collections_stay_behind(db_with_workspace):

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -323,15 +323,46 @@ def _apply_preferred_photo(photos, preferred_photo_id, marker_key):
 
 
 def _apply_highlight_preferences(db, buckets):
-    preferences = db.get_photo_preferences("highlights")
+    preferences = db.get_species_representatives()
     for bucket in buckets:
         preferred_id = preferences.get(bucket["species"])
-        applied = _apply_preferred_photo(
-            bucket["photos"], preferred_id, "is_highlights_photo"
-        )
+        applied = False
+        for photo in bucket.get("photos") or []:
+            is_rep = preferred_id is not None and photo.get("id") == preferred_id
+            photo["is_species_representative"] = is_rep
+            applied = applied or is_rep
         best = bucket["photos"][0] if bucket["photos"] else {}
         bucket["preferred_photo_id"] = preferred_id
         bucket["has_preferred_photo"] = applied
+        bucket["best_quality"] = best.get("quality_score")
+        bucket["best_score"] = best.get("highlight_score")
+        bucket["best_timestamp"] = best.get("timestamp")
+
+
+def _apply_ordered_highlights(db, buckets):
+    highlights = db.get_species_highlights()
+    for bucket in buckets:
+        ranks = highlights.get(bucket["species"], {})
+        for p in bucket.get("photos") or []:
+            rank = ranks.get(p.get("id"))
+            p["is_highlighted"] = rank is not None
+            p["highlight_rank"] = rank
+        if ranks:
+            bucket["photos"].sort(
+                key=lambda p: (
+                    0 if p.get("is_highlighted") else 1,
+                    p.get("highlight_rank") if p.get("highlight_rank") is not None else 10**9,
+                    -(p.get("highlight_score") or 0),
+                    -(p.get("predicted_confidence") or 0),
+                    -(p.get("quality_score") or 0),
+                    -(p.get("rating") or 0),
+                    p.get("id", 0),
+                )
+            )
+        best = bucket["photos"][0] if bucket.get("photos") else {}
+        bucket["highlight_count"] = sum(
+            1 for p in bucket.get("photos") or [] if p.get("is_highlighted")
+        )
         bucket["best_quality"] = best.get("quality_score")
         bucket["best_score"] = best.get("highlight_score")
         bucket["best_timestamp"] = best.get("timestamp")
@@ -3695,16 +3726,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         keywords = db.get_photo_keywords(photo_id)
         result["keywords"] = [dict(k) for k in keywords]
 
-        # Life-list block: the photo's eligible species plus whether this photo
-        # is the current representative for each, so the shared lightbox and
-        # browse context menu can offer "Add to Life List" and show the honest
-        # selected state without page-local data. Empty when the photo has no
-        # lifelist species (built from the same eligibility rule as the list).
-        life_list_prefs = db.get_photo_preferences("life_list")
+        # Representative block: the photo's eligible species plus whether this
+        # photo is the current one-photo species representative. Keep the
+        # legacy ``life_list`` key because shared lightbox/menu code reads it.
+        representatives = db.get_species_representatives()
         result["life_list"] = [
-            {"species": s, "is_current_photo": life_list_prefs.get(s) == photo_id}
+            {
+                "species": s,
+                "is_current_photo": representatives.get(s) == photo_id,
+                "is_species_representative": representatives.get(s) == photo_id,
+            }
             for s in db.get_photo_life_list_species(photo_id)
         ]
+        result["species_representatives"] = result["life_list"]
 
         # Location section: pre-resolved leaf + parent chain so the photo
         # detail panel can render the filled state without a second roundtrip.
@@ -7036,8 +7070,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         species = body.get("species", "")
         purpose = purpose.strip() if isinstance(purpose, str) else ""
         species = species.strip() if isinstance(species, str) else ""
-        if purpose not in {"life_list", "highlights"}:
-            return None, "purpose must be life_list or highlights"
+        if purpose not in {"species_representative", "life_list", "highlights"}:
+            return None, "purpose must be species_representative"
         if not species:
             return None, "species required"
 
@@ -7050,6 +7084,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         return {
             "purpose": purpose,
+            "canonical_purpose": "species_representative",
             "species": species,
             "photo_id": photo_id,
         }, None
@@ -7085,9 +7120,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         return False
 
     def _photo_can_be_preference(db, purpose, species, photo_id):
-        if purpose == "life_list":
-            return _photo_can_be_life_list_preference(db, species, photo_id)
-        return _photo_can_be_highlights_preference(db, species, photo_id)
+        return _photo_can_be_life_list_preference(db, species, photo_id)
 
     @app.route("/api/photo-preferences", methods=["POST"])
     def api_photo_preferences_set():
@@ -7105,9 +7138,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error(
                 "photo_id is not eligible for that purpose/species", 400,
             )
-        db.set_photo_preference(
-            parsed["purpose"], parsed["species"], parsed["photo_id"]
-        )
+        db.set_species_representative(parsed["species"], parsed["photo_id"])
         return jsonify({"ok": True, **parsed})
 
     @app.route("/api/photo-preferences", methods=["DELETE"])
@@ -7117,12 +7148,78 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         parsed, error = _parse_photo_preference_body(body, require_photo=False)
         if error:
             return json_error(error)
-        db.clear_photo_preference(parsed["purpose"], parsed["species"])
+        db.clear_species_representative(parsed["species"])
         return jsonify({
             "ok": True,
-            "purpose": parsed["purpose"],
+            "purpose": parsed["canonical_purpose"],
             "species": parsed["species"],
         })
+
+    def _parse_species_highlight_body(body, require_direction=False):
+        species = body.get("species", "")
+        species = species.strip() if isinstance(species, str) else ""
+        if not species:
+            return None, "species required"
+        photo_id = body.get("photo_id")
+        if isinstance(photo_id, bool) or not isinstance(photo_id, int):
+            return None, "photo_id must be an integer"
+        parsed = {"species": species, "photo_id": photo_id}
+        if require_direction:
+            direction = body.get("direction", "")
+            direction = direction.strip().lower() if isinstance(direction, str) else ""
+            if direction not in {"up", "down"}:
+                return None, "direction must be up or down"
+            parsed["direction"] = direction
+        return parsed, None
+
+    @app.route("/api/species-highlights", methods=["POST"])
+    def api_species_highlights_add():
+        db = _get_db()
+        body = request.get_json(silent=True) or {}
+        parsed, error = _parse_species_highlight_body(body)
+        if error:
+            return json_error(error)
+        error, status = _validate_highlight_photo_ids(db, [parsed["photo_id"]])
+        if error:
+            return json_error(error, status)
+        if not _photo_can_be_highlights_preference(
+            db, parsed["species"], parsed["photo_id"]
+        ):
+            return json_error(
+                "photo_id is not eligible as a highlight for that species", 400,
+            )
+        rank = db.add_species_highlight(parsed["species"], parsed["photo_id"])
+        return jsonify({"ok": True, **parsed, "rank": rank})
+
+    @app.route("/api/species-highlights", methods=["DELETE"])
+    def api_species_highlights_remove():
+        db = _get_db()
+        body = request.get_json(silent=True) or {}
+        parsed, error = _parse_species_highlight_body(body)
+        if error:
+            return json_error(error)
+        error, status = _validate_highlight_photo_ids(db, [parsed["photo_id"]])
+        if error:
+            return json_error(error, status)
+        removed = db.remove_species_highlight(parsed["species"], parsed["photo_id"])
+        return jsonify({"ok": True, **parsed, "removed": removed})
+
+    @app.route("/api/species-highlights/order", methods=["PATCH", "POST"])
+    def api_species_highlights_order():
+        db = _get_db()
+        body = request.get_json(silent=True) or {}
+        parsed, error = _parse_species_highlight_body(body, require_direction=True)
+        if error:
+            return json_error(error)
+        error, status = _validate_highlight_photo_ids(db, [parsed["photo_id"]])
+        if error:
+            return json_error(error, status)
+        ok = db.move_species_highlight(
+            parsed["species"], parsed["photo_id"], parsed["direction"]
+        )
+        if not ok:
+            return json_error("highlight not found", 404)
+        return jsonify({"ok": True, **parsed})
 
     def _build_highlights_payload(
         db,
@@ -7184,6 +7281,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             search_match_case,
             search_whole_word,
         )
+        _apply_ordered_highlights(db, buckets)
         _apply_highlight_preferences(db, buckets)
 
         def limited_bucket(bucket):
@@ -7308,21 +7406,47 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "quality_score": photo.get("quality_score"),
                 "highlight_score": photo.get("highlight_score"),
                 "reasons": photo.get("reasons") or [],
-                "is_life_list_photo": bool(photo.get("is_life_list_photo")),
+                "is_species_representative": bool(
+                    photo.get("is_species_representative")
+                ),
+                "is_life_list_photo": bool(photo.get("is_species_representative")),
+                "is_highlighted": bool(photo.get("is_highlighted")),
+                "highlight_rank": photo.get("highlight_rank"),
             }
 
         species_entries = []
         distinct_photo_ids = set()
-        life_list_preferences = db.get_photo_preferences("life_list")
+        representatives = db.get_species_representatives()
+        highlights_by_species = db.get_species_highlights()
         for species, entry in buckets.items():
             photos = entry["photos"]
             distinct_photo_ids.update(p["id"] for p in photos)
             timestamps = [p["timestamp"] for p in photos if p.get("timestamp")]
             _highlight_score_bucket(photos)
-            preferred_id = life_list_preferences.get(species)
+            preferred_id = representatives.get(species)
+            highlight_ranks = highlights_by_species.get(species, {})
+            for photo in photos:
+                rank = highlight_ranks.get(photo["id"])
+                photo["is_highlighted"] = rank is not None
+                photo["highlight_rank"] = rank
             preferred_applied = _apply_preferred_photo(
-                photos, preferred_id, "is_life_list_photo"
+                photos, preferred_id, "is_species_representative"
             )
+            best_source = "representative" if preferred_applied else "algorithm"
+            if not preferred_applied and highlight_ranks:
+                valid_highlights = [
+                    (highlight_ranks[p["id"]], p["id"])
+                    for p in photos
+                    if p["id"] in highlight_ranks
+                ]
+                if valid_highlights:
+                    _, highlight_id = min(valid_highlights)
+                    for idx, photo in enumerate(photos):
+                        if photo["id"] == highlight_id:
+                            if idx:
+                                photos.insert(0, photos.pop(idx))
+                            best_source = "highlight"
+                            break
             top = photos if photo_limit is None else photos[:photo_limit]
             species_entries.append({
                 "species": species,
@@ -7334,6 +7458,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "locations": locations_by_species.get(species, []),
                 "preferred_photo_id": preferred_id,
                 "has_preferred_photo": preferred_applied,
+                "best_source": best_source,
                 "best": compact(top[0]) if top else None,
                 "photos": [compact(p) for p in top],
             })
@@ -7819,6 +7944,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             _request_bool_arg("q_match_case"),
             _request_bool_arg("q_whole_word"),
         )
+        _apply_ordered_highlights(db, buckets)
         _apply_highlight_preferences(db, buckets)
         if species == "__unidentified__":
             photos = unidentified_photos

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -7867,6 +7867,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             (ws_id, *photo_ids),
         ).fetchall()
         highlight_renames = {}
+        hl_prev_by_pid = {}
         for row in highlight_rows:
             old_species_name = row["species"]
             if old_species_name == species:
@@ -7874,8 +7875,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             highlight_renames.setdefault(old_species_name, []).append(
                 row["photo_id"]
             )
+            hl_prev_by_pid.setdefault(row["photo_id"], []).append(
+                old_species_name
+            )
         preference_rows = db.conn.execute(
-            f"""SELECT species, photo_id FROM photo_preferences
+            f"""SELECT species, photo_id, purpose FROM photo_preferences
                 WHERE workspace_id = ?
                   AND photo_id IN ({placeholders})
                   AND purpose IN (
@@ -7884,6 +7888,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             (ws_id, *photo_ids),
         ).fetchall()
         preference_renames = {}
+        pref_prev_by_pid = {}
         for row in preference_rows:
             old_species_name = row["species"]
             if old_species_name == species:
@@ -7891,6 +7896,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             preference_renames.setdefault(old_species_name, []).append(
                 row["photo_id"]
             )
+            pref_prev_by_pid.setdefault(row["photo_id"], []).append({
+                "purpose": row["purpose"],
+                "species": old_species_name,
+            })
         try:
             kid = db.add_keyword(species, is_species=True, _commit=False)
             items = []
@@ -7925,7 +7934,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 _queue_keyword_add(pid, species, workspace_id=ws_id, _commit=False)
                 old_value = str(old_primary["id"]) if old_primary else ""
                 old_keyword_ids = [old["id"] for old in old_rows]
-                if pred is not None or len(old_keyword_ids) > 1:
+                hl_prev = hl_prev_by_pid.get(pid) or []
+                pref_prev = pref_prev_by_pid.get(pid) or []
+                needs_payload = (
+                    pred is not None
+                    or len(old_keyword_ids) > 1
+                    or hl_prev
+                    or pref_prev
+                )
+                if needs_payload:
                     old_payload = {
                         "keyword_id": old_value,
                         "keyword_ids": old_keyword_ids,
@@ -7935,6 +7952,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                             "prediction_id": pred["id"],
                             "prediction_status": pred["status"],
                         })
+                    if hl_prev or pref_prev:
+                        old_payload["curation"] = {
+                            "hl_prev": hl_prev,
+                            "pref_prev": pref_prev,
+                        }
                     old_value = json.dumps(old_payload, sort_keys=True)
                 items.append({
                     "photo_id": pid,

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -7874,6 +7874,23 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             highlight_renames.setdefault(old_species_name, []).append(
                 row["photo_id"]
             )
+        preference_rows = db.conn.execute(
+            f"""SELECT species, photo_id FROM photo_preferences
+                WHERE workspace_id = ?
+                  AND photo_id IN ({placeholders})
+                  AND purpose IN (
+                      'species_representative', 'life_list', 'highlights'
+                  )""",
+            (ws_id, *photo_ids),
+        ).fetchall()
+        preference_renames = {}
+        for row in preference_rows:
+            old_species_name = row["species"]
+            if old_species_name == species:
+                continue
+            preference_renames.setdefault(old_species_name, []).append(
+                row["photo_id"]
+            )
         try:
             kid = db.add_keyword(species, is_species=True, _commit=False)
             items = []
@@ -7927,6 +7944,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
             for old_species_name, pids in highlight_renames.items():
                 db.rename_species_highlights_species(
+                    old_species_name,
+                    species,
+                    [(pid, ws_id) for pid in pids],
+                    _commit=False,
+                )
+            for old_species_name, pids in preference_renames.items():
+                db.rename_photo_preferences_species(
                     old_species_name,
                     species,
                     [(pid, ws_id) for pid in pids],

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -7102,7 +7102,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         purpose = purpose.strip() if isinstance(purpose, str) else ""
         species = species.strip() if isinstance(species, str) else ""
         if purpose not in {"species_representative", "life_list", "highlights"}:
-            return None, "purpose must be species_representative"
+            return None, (
+                "purpose must be one of species_representative, "
+                "life_list, or highlights"
+            )
         if not species:
             return None, "species required"
 
@@ -7860,46 +7863,57 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         top_predictions = _highlight_top_predictions(db, photo_ids)
         ws_id = db._ws_id()
-        placeholders = ",".join("?" for _ in photo_ids)
-        highlight_rows = db.conn.execute(
-            f"""SELECT species, photo_id FROM species_highlights
-                WHERE workspace_id = ? AND photo_id IN ({placeholders})""",
-            (ws_id, *photo_ids),
-        ).fetchall()
+        # Chunk both lookups: photo_ids has no upstream cap
+        # (_parse_highlight_photo_ids just parses the list), so a bulk
+        # relabel of >999 photos would blow SQLITE_MAX_VARIABLE_NUMBER
+        # on the legacy builds this file already guards against.
         highlight_renames = {}
         hl_prev_by_pid = {}
-        for row in highlight_rows:
-            old_species_name = row["species"]
-            if old_species_name == species:
-                continue
-            highlight_renames.setdefault(old_species_name, []).append(
-                row["photo_id"]
-            )
-            hl_prev_by_pid.setdefault(row["photo_id"], []).append(
-                old_species_name
-            )
-        preference_rows = db.conn.execute(
-            f"""SELECT species, photo_id, purpose FROM photo_preferences
-                WHERE workspace_id = ?
-                  AND photo_id IN ({placeholders})
-                  AND purpose IN (
-                      'species_representative', 'life_list', 'highlights'
-                  )""",
-            (ws_id, *photo_ids),
-        ).fetchall()
+        for chunk in _chunked(photo_ids):
+            placeholders = ",".join("?" for _ in chunk)
+            rows = db.conn.execute(
+                f"""SELECT species, photo_id, rank FROM species_highlights
+                    WHERE workspace_id = ? AND photo_id IN ({placeholders})""",
+                (ws_id, *chunk),
+            ).fetchall()
+            for row in rows:
+                old_species_name = row["species"]
+                if old_species_name == species:
+                    continue
+                highlight_renames.setdefault(old_species_name, []).append(
+                    row["photo_id"]
+                )
+                # Snapshot the original rank so undo can restore each
+                # highlighted photo at its original position instead of
+                # dumping it at MAX(rank)+1 (see _restore_relabel_curation).
+                hl_prev_by_pid.setdefault(row["photo_id"], []).append({
+                    "species": old_species_name,
+                    "rank": row["rank"],
+                })
         preference_renames = {}
         pref_prev_by_pid = {}
-        for row in preference_rows:
-            old_species_name = row["species"]
-            if old_species_name == species:
-                continue
-            preference_renames.setdefault(old_species_name, []).append(
-                row["photo_id"]
-            )
-            pref_prev_by_pid.setdefault(row["photo_id"], []).append({
-                "purpose": row["purpose"],
-                "species": old_species_name,
-            })
+        for chunk in _chunked(photo_ids):
+            placeholders = ",".join("?" for _ in chunk)
+            rows = db.conn.execute(
+                f"""SELECT species, photo_id, purpose FROM photo_preferences
+                    WHERE workspace_id = ?
+                      AND photo_id IN ({placeholders})
+                      AND purpose IN (
+                          'species_representative', 'life_list', 'highlights'
+                      )""",
+                (ws_id, *chunk),
+            ).fetchall()
+            for row in rows:
+                old_species_name = row["species"]
+                if old_species_name == species:
+                    continue
+                preference_renames.setdefault(old_species_name, []).append(
+                    row["photo_id"]
+                )
+                pref_prev_by_pid.setdefault(row["photo_id"], []).append({
+                    "purpose": row["purpose"],
+                    "species": old_species_name,
+                })
         try:
             kid = db.add_keyword(species, is_species=True, _commit=False)
             items = []

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -7878,6 +7878,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # on the legacy builds this file already guards against.
         highlight_renames = {}
         hl_prev_by_pid = {}
+        # Photos that already had a `(species=<target>, photo_id)` row in
+        # species_highlights before the relabel. rename_species_highlights_species
+        # skips inserting a duplicate for these, so the destination row is
+        # pre-existing and undo must not delete it.
+        hl_dst_preexisting = set()
         for chunk in _chunked(photo_ids):
             placeholders = ",".join("?" for _ in chunk)
             rows = db.conn.execute(
@@ -7888,6 +7893,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             for row in rows:
                 old_species_name = row["species"]
                 if old_species_name == species:
+                    hl_dst_preexisting.add(row["photo_id"])
                     continue
                 highlight_renames.setdefault(old_species_name, []).append(
                     row["photo_id"]
@@ -7899,8 +7905,32 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     "species": old_species_name,
                     "rank": row["rank"],
                 })
+        # Backfill dst_existed onto each entry now that the target-species
+        # pass has finished (row order within the query is unspecified).
+        for pid, entries in hl_prev_by_pid.items():
+            dst = pid in hl_dst_preexisting
+            for entry in entries:
+                entry["dst_existed"] = dst
         preference_renames = {}
         pref_prev_by_pid = {}
+        # Purposes that already have a row at (new_species, purpose) — for
+        # any photo. rename_photo_preferences_species uses INSERT OR IGNORE,
+        # so when the destination slot is already taken (either by this
+        # photo or a different one), the relabel does not create a new
+        # destination row for this photo and undo must not attempt to
+        # delete it. Un-gating the old-species restore from a destination
+        # row lookup lets undo recover representatives even when the
+        # relabel collided with another photo holding the slot.
+        pref_dst_taken = {
+            r["purpose"] for r in db.conn.execute(
+                """SELECT purpose FROM photo_preferences
+                   WHERE workspace_id = ? AND species = ?
+                     AND purpose IN (
+                         'species_representative', 'life_list', 'highlights'
+                     )""",
+                (ws_id, species),
+            ).fetchall()
+        }
         for chunk in _chunked(photo_ids):
             placeholders = ",".join("?" for _ in chunk)
             rows = db.conn.execute(
@@ -7922,6 +7952,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 pref_prev_by_pid.setdefault(row["photo_id"], []).append({
                     "purpose": row["purpose"],
                     "species": old_species_name,
+                    "dst_existed": row["purpose"] in pref_dst_taken,
                 })
         try:
             kid = db.add_keyword(species, is_species=True, _commit=False)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -365,11 +365,20 @@ def _apply_ordered_highlights(db, buckets):
     highlights = db.get_species_highlights()
     for bucket in buckets:
         ranks = highlights.get(bucket["species"], {})
-        for p in bucket.get("photos") or []:
+        photos = bucket.get("photos") or []
+        matched = False
+        for p in photos:
             rank = ranks.get(p.get("id"))
             p["is_highlighted"] = rank is not None
             p["highlight_rank"] = rank
-        if ranks:
+            if rank is not None:
+                matched = True
+        # Only re-sort when at least one visible photo actually maps to a
+        # stored highlight rank. `ranks` is workspace-scoped, so a folder
+        # or search view of the same species can be truthy here while none
+        # of its photos are highlights — re-sorting then discards the
+        # picked-first order that _highlight_score_bucket already applied.
+        if matched:
             bucket["photos"].sort(
                 key=lambda p: (
                     0 if p.get("is_highlighted") else 1,

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5142,10 +5142,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 and (new_row["is_species"] == 1 or new_row["type"] == "taxonomy")
             )
             if old_is_species_keyword and new_is_species_keyword:
+                pairs = [
+                    (row["photo_id"], row["workspace_id"]) for row in affected
+                ]
                 db.rename_photo_preferences_species(
                     old_name,
                     new_name,
-                    [(row["photo_id"], row["workspace_id"]) for row in affected],
+                    pairs,
+                )
+                db.rename_species_highlights_species(
+                    old_name,
+                    new_name,
+                    pairs,
                 )
             for row in affected:
                 _queue_keyword_remove(row["photo_id"], old_name, workspace_id=row["workspace_id"])
@@ -7852,6 +7860,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         top_predictions = _highlight_top_predictions(db, photo_ids)
         ws_id = db._ws_id()
+        placeholders = ",".join("?" for _ in photo_ids)
+        highlight_rows = db.conn.execute(
+            f"""SELECT species, photo_id FROM species_highlights
+                WHERE workspace_id = ? AND photo_id IN ({placeholders})""",
+            (ws_id, *photo_ids),
+        ).fetchall()
+        highlight_renames = {}
+        for row in highlight_rows:
+            old_species_name = row["species"]
+            if old_species_name == species:
+                continue
+            highlight_renames.setdefault(old_species_name, []).append(
+                row["photo_id"]
+            )
         try:
             kid = db.add_keyword(species, is_species=True, _commit=False)
             items = []
@@ -7902,6 +7924,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     "old_value": old_value,
                     "new_value": str(kid),
                 })
+
+            for old_species_name, pids in highlight_renames.items():
+                db.rename_species_highlights_species(
+                    old_species_name,
+                    species,
+                    [(pid, ws_id) for pid in pids],
+                    _commit=False,
+                )
 
             action_type = (
                 "species_replace"

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -7119,7 +7119,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return None, "species required"
 
         photo_id = body.get("photo_id")
-        if require_photo:
+        # Ordered highlights are per-photo (multiple photos per species),
+        # so photo_id is always required for purpose=highlights — even on
+        # DELETE, where representative purposes let it be omitted to clear
+        # the whole species preference.
+        needs_photo = require_photo or purpose == "highlights"
+        if needs_photo:
             if isinstance(photo_id, bool) or not isinstance(photo_id, int):
                 return None, "photo_id must be an integer"
         else:
@@ -7127,7 +7132,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         return {
             "purpose": purpose,
-            "canonical_purpose": "species_representative",
+            "canonical_purpose": (
+                "highlights" if purpose == "highlights"
+                else "species_representative"
+            ),
             "species": species,
             "photo_id": photo_id,
         }, None
@@ -7163,6 +7171,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         return False
 
     def _photo_can_be_preference(db, purpose, species, photo_id):
+        # Ordered highlights use their own (stricter) eligibility check —
+        # the photo must appear in the workspace's highlight buckets for
+        # this species. Representative-style purposes (species_representative,
+        # life_list) only require the photo to carry the species keyword.
+        if purpose == "highlights":
+            return _photo_can_be_highlights_preference(db, species, photo_id)
         return _photo_can_be_life_list_preference(db, species, photo_id)
 
     @app.route("/api/photo-preferences", methods=["POST"])
@@ -7181,6 +7195,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error(
                 "photo_id is not eligible for that purpose/species", 400,
             )
+        # Route legacy `purpose=highlights` writes to the ordered-highlights
+        # table so a cached Highlights page or older client doesn't silently
+        # overwrite the species representative instead.
+        if parsed["purpose"] == "highlights":
+            rank = db.add_species_highlight(
+                parsed["species"], parsed["photo_id"]
+            )
+            return jsonify({"ok": True, **parsed, "rank": rank})
         db.set_species_representative(parsed["species"], parsed["photo_id"])
         return jsonify({"ok": True, **parsed})
 
@@ -7191,6 +7213,21 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         parsed, error = _parse_photo_preference_body(body, require_photo=False)
         if error:
             return json_error(error)
+        # See the POST handler: `purpose=highlights` targets one row in the
+        # ordered-highlights table, so it needs a photo_id (enforced by
+        # _parse_photo_preference_body) and routes to remove_species_highlight
+        # rather than clearing all representative rows for the species.
+        if parsed["purpose"] == "highlights":
+            removed = db.remove_species_highlight(
+                parsed["species"], parsed["photo_id"]
+            )
+            return jsonify({
+                "ok": True,
+                "purpose": parsed["canonical_purpose"],
+                "species": parsed["species"],
+                "photo_id": parsed["photo_id"],
+                "removed": removed,
+            })
         db.clear_species_representative(parsed["species"])
         return jsonify({
             "ok": True,

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -9985,6 +9985,110 @@ class Database:
             self.conn.commit()
         return cur.rowcount
 
+    def rename_species_highlights_species(
+        self, old_species, new_species, photo_workspace_pairs=None, _commit=True,
+    ):
+        """Rename ordered species-highlight rows to a new species bucket.
+
+        Companion to :meth:`rename_photo_preferences_species` for the
+        ``species_highlights`` table. The rows carry a per-species ``rank``,
+        so we can't just rewrite the ``species`` column — a bucket may
+        already exist for ``new_species`` with its own ranks. Instead, each
+        moved row is deleted from the old bucket and inserted at the end
+        of the new bucket (``MAX(rank) + 1``) while preserving its
+        old-bucket order. Rows whose photo already appears in the new
+        bucket are dropped rather than duplicated.
+
+        When ``photo_workspace_pairs`` is provided, only rows matching
+        those ``(photo_id, workspace_id)`` pairs are moved (used by
+        ``api_update_keyword`` so we only rebucket highlights for photos
+        actually tagged with the renamed keyword). When omitted, all
+        workspaces are rebucketed.
+
+        Returns the count of highlight rows that landed in the new bucket
+        (excludes rows dropped as duplicates).
+        """
+        if not old_species or not new_species or old_species == new_species:
+            return 0
+
+        if photo_workspace_pairs is not None:
+            by_ws = {}
+            seen = set()
+            for photo_id, workspace_id in photo_workspace_pairs:
+                key = (photo_id, workspace_id)
+                if key in seen:
+                    continue
+                seen.add(key)
+                by_ws.setdefault(workspace_id, []).append(photo_id)
+            workspace_scopes = list(by_ws.items())
+        else:
+            workspace_ids = [
+                r["workspace_id"] for r in self.conn.execute(
+                    """SELECT DISTINCT workspace_id
+                       FROM species_highlights
+                       WHERE species = ?""",
+                    (old_species,),
+                ).fetchall()
+            ]
+            workspace_scopes = [(ws, None) for ws in workspace_ids]
+
+        moved = 0
+        for workspace_id, photo_ids in workspace_scopes:
+            if photo_ids is None:
+                src_rows = self.conn.execute(
+                    """SELECT photo_id
+                       FROM species_highlights
+                       WHERE workspace_id = ? AND species = ?
+                       ORDER BY rank, created_at, photo_id""",
+                    (workspace_id, old_species),
+                ).fetchall()
+            else:
+                placeholders = ",".join("?" for _ in photo_ids)
+                src_rows = self.conn.execute(
+                    f"""SELECT photo_id
+                        FROM species_highlights
+                        WHERE workspace_id = ? AND species = ?
+                          AND photo_id IN ({placeholders})
+                        ORDER BY rank, created_at, photo_id""",
+                    (workspace_id, old_species, *photo_ids),
+                ).fetchall()
+            if not src_rows:
+                continue
+            existing = {
+                r["photo_id"] for r in self.conn.execute(
+                    """SELECT photo_id FROM species_highlights
+                       WHERE workspace_id = ? AND species = ?""",
+                    (workspace_id, new_species),
+                ).fetchall()
+            }
+            next_rank = int(self.conn.execute(
+                """SELECT COALESCE(MAX(rank), 0) AS max_rank
+                   FROM species_highlights
+                   WHERE workspace_id = ? AND species = ?""",
+                (workspace_id, new_species),
+            ).fetchone()["max_rank"] or 0) + 1
+            for r in src_rows:
+                pid = r["photo_id"]
+                self.conn.execute(
+                    """DELETE FROM species_highlights
+                       WHERE workspace_id = ? AND species = ? AND photo_id = ?""",
+                    (workspace_id, old_species, pid),
+                )
+                if pid in existing:
+                    continue
+                self.conn.execute(
+                    """INSERT INTO species_highlights
+                           (workspace_id, species, photo_id, rank,
+                            created_at, updated_at)
+                       VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))""",
+                    (workspace_id, new_species, pid, next_rank),
+                )
+                next_rank += 1
+                moved += 1
+        if _commit:
+            self.conn.commit()
+        return moved
+
     def get_folders_with_quality_data(self):
         """Return folders with at least one scored photo in their subtree.
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -12574,7 +12574,16 @@ class Database:
             return
         hl_prev = curation.get("hl_prev") or []
         pref_prev = curation.get("pref_prev") or []
-        for old_species in hl_prev:
+        for hl in hl_prev:
+            # Newer relabels record {species, rank}; entries from older
+            # relabels (before PR #1161 landed rank capture) are plain
+            # species-name strings and fall back to append-at-end.
+            if isinstance(hl, dict):
+                old_species = hl.get("species")
+                target_rank = hl.get("rank")
+            else:
+                old_species = hl
+                target_rank = None
             if not old_species or old_species == new_species:
                 continue
             self.conn.execute(
@@ -12589,18 +12598,29 @@ class Database:
             ).fetchone()
             if existing:
                 continue
-            next_rank = int(self.conn.execute(
-                """SELECT COALESCE(MAX(rank), 0) AS max_rank
-                   FROM species_highlights
-                   WHERE workspace_id = ? AND species = ?""",
-                (workspace_id, old_species),
-            ).fetchone()["max_rank"] or 0) + 1
+            if target_rank is None:
+                rank = int(self.conn.execute(
+                    """SELECT COALESCE(MAX(rank), 0) AS max_rank
+                       FROM species_highlights
+                       WHERE workspace_id = ? AND species = ?""",
+                    (workspace_id, old_species),
+                ).fetchone()["max_rank"] or 0) + 1
+            else:
+                try:
+                    rank = int(target_rank)
+                except (TypeError, ValueError):
+                    rank = int(self.conn.execute(
+                        """SELECT COALESCE(MAX(rank), 0) AS max_rank
+                           FROM species_highlights
+                           WHERE workspace_id = ? AND species = ?""",
+                        (workspace_id, old_species),
+                    ).fetchone()["max_rank"] or 0) + 1
             self.conn.execute(
                 """INSERT INTO species_highlights
                        (workspace_id, species, photo_id, rank,
                         created_at, updated_at)
                    VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))""",
-                (workspace_id, old_species, photo_id, next_rank),
+                (workspace_id, old_species, photo_id, rank),
             )
         for pref in pref_prev:
             if not isinstance(pref, dict):
@@ -12642,7 +12662,13 @@ class Database:
             return
         hl_prev = curation.get("hl_prev") or []
         pref_prev = curation.get("pref_prev") or []
-        for old_species in hl_prev:
+        for hl in hl_prev:
+            # Accept both new dict form ({species, rank}) and legacy
+            # string form for compatibility with older edit-history rows.
+            if isinstance(hl, dict):
+                old_species = hl.get("species")
+            else:
+                old_species = hl
             if not old_species or old_species == new_species:
                 continue
             src = self.conn.execute(

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -11271,6 +11271,23 @@ class Database:
                                 photo_id, "keyword_remove", old_name,
                                 _commit=False,
                             )
+                    # Migrate curated species state (representatives and
+                    # ordered highlights) alongside the replaced species
+                    # tag. Without this, a photo highlighted or set as
+                    # representative under the old species keeps rows in
+                    # species_highlights / photo_preferences under a name
+                    # it no longer carries, so it stops driving Highlights
+                    # and Life List for the new species. Mirrors the
+                    # migration in api_highlights_relabel.
+                    for old_name in old_species:
+                        self.rename_species_highlights_species(
+                            old_name, species, [(photo_id, ws)],
+                            _commit=False,
+                        )
+                        self.rename_photo_preferences_species(
+                            old_name, species, [(photo_id, ws)],
+                            _commit=False,
+                        )
                 self.tag_photo(photo_id, kid, _commit=False)
                 self.queue_change(photo_id, "keyword_add", species, _commit=False)
                 affected.append({

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2169,19 +2169,49 @@ class Database:
                     [source_ws_id] + chunk,
                 )
 
-                cur = self.conn.execute(
-                    f"""INSERT OR IGNORE INTO species_highlights
-                          (workspace_id, species, photo_id, rank,
-                           created_at, updated_at)
-                        SELECT ?, species, photo_id, rank, created_at, updated_at
+                # Append moved highlights after the target workspace's
+                # existing rows per species. Preserving the source `rank`
+                # verbatim would collide with the target's ranks (rank is
+                # not part of the PK), corrupting the curated order the
+                # target uses in `ORDER BY rank, created_at, photo_id`.
+                src_highlights = self.conn.execute(
+                    f"""SELECT species, photo_id, rank, created_at, updated_at
                         FROM species_highlights
                         WHERE workspace_id = ?
                           AND photo_id IN (
                               SELECT id FROM photos WHERE folder_id IN ({placeholders})
-                          )""",
-                    [target_ws_id, source_ws_id] + chunk,
-                )
-                species_highlights_moved += cur.rowcount
+                          )
+                        ORDER BY species, rank, created_at, photo_id""",
+                    [source_ws_id] + chunk,
+                ).fetchall()
+                by_species = {}
+                for src_row in src_highlights:
+                    by_species.setdefault(src_row["species"], []).append(src_row)
+                for sp, sp_rows in by_species.items():
+                    next_rank = int(self.conn.execute(
+                        """SELECT COALESCE(MAX(rank), 0) AS max_rank
+                           FROM species_highlights
+                           WHERE workspace_id = ? AND species = ?""",
+                        (target_ws_id, sp),
+                    ).fetchone()["max_rank"] or 0) + 1
+                    for src_row in sp_rows:
+                        cur = self.conn.execute(
+                            """INSERT OR IGNORE INTO species_highlights
+                                   (workspace_id, species, photo_id, rank,
+                                    created_at, updated_at)
+                               VALUES (?, ?, ?, ?, ?, ?)""",
+                            (
+                                target_ws_id,
+                                sp,
+                                src_row["photo_id"],
+                                next_rank,
+                                src_row["created_at"],
+                                src_row["updated_at"],
+                            ),
+                        )
+                        if cur.rowcount:
+                            species_highlights_moved += 1
+                            next_rank += 1
                 self.conn.execute(
                     f"""DELETE FROM species_highlights
                         WHERE workspace_id = ?

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -12324,6 +12324,17 @@ class Database:
                     self.remove_pending_changes(pid, 'keyword_add', kw['name'])
                 if entry['action_type'] == 'keyword_add':
                     self._restore_edit_prediction_status(old_meta)
+                    # Predicted-only relabels (no prior species tag)
+                    # record their action as `keyword_add` but still
+                    # carry a `curation` payload when the photo held
+                    # highlight/representative rows under other species.
+                    # Restore those rows here too, mirroring the
+                    # `species_replace` undo path.
+                    if kw:
+                        self._restore_relabel_curation(
+                            entry['workspace_id'], pid, kw['name'],
+                            old_meta.get('curation'),
+                        )
                 if entry['action_type'] == 'prediction_accept' and old_val:
                     pred_id = self._edit_prediction_id(old_meta, old_val)
                     if pred_id is None:
@@ -12473,6 +12484,15 @@ class Database:
                     self.queue_change(pid, 'keyword_add', kw['name'])
                 if entry['action_type'] == 'keyword_add':
                     self._reject_edit_prediction(old_meta)
+                    # Mirror of the `keyword_add` undo branch: predicted-
+                    # only relabels record curation on `keyword_add`, so
+                    # redo must re-apply it here rather than only in
+                    # `species_replace`.
+                    if kw:
+                        self._reapply_relabel_curation(
+                            entry['workspace_id'], pid, kw['name'],
+                            old_meta.get('curation'),
+                        )
                 if entry['action_type'] == 'prediction_accept' and item['old_value']:
                     pred_id = self._edit_prediction_id(old_meta, item['old_value'])
                     if pred_id is None:
@@ -12575,22 +12595,31 @@ class Database:
         hl_prev = curation.get("hl_prev") or []
         pref_prev = curation.get("pref_prev") or []
         for hl in hl_prev:
-            # Newer relabels record {species, rank}; entries from older
-            # relabels (before PR #1161 landed rank capture) are plain
-            # species-name strings and fall back to append-at-end.
+            # Newer relabels record {species, rank, dst_existed}; entries
+            # from older relabels (before PR #1161 landed rank capture)
+            # are plain species-name strings and fall back to
+            # append-at-end with dst_existed=False.
             if isinstance(hl, dict):
                 old_species = hl.get("species")
                 target_rank = hl.get("rank")
+                dst_existed = bool(hl.get("dst_existed", False))
             else:
                 old_species = hl
                 target_rank = None
+                dst_existed = False
             if not old_species or old_species == new_species:
                 continue
-            self.conn.execute(
-                """DELETE FROM species_highlights
-                   WHERE workspace_id = ? AND species = ? AND photo_id = ?""",
-                (workspace_id, new_species, photo_id),
-            )
+            if not dst_existed:
+                # Only delete the destination row when the relabel
+                # actually created it. If the photo was already
+                # highlighted at `new_species` before the relabel,
+                # rename_species_highlights_species skipped inserting a
+                # duplicate — undo must not remove the pre-existing row.
+                self.conn.execute(
+                    """DELETE FROM species_highlights
+                       WHERE workspace_id = ? AND species = ? AND photo_id = ?""",
+                    (workspace_id, new_species, photo_id),
+                )
             existing = self.conn.execute(
                 """SELECT 1 FROM species_highlights
                    WHERE workspace_id = ? AND species = ? AND photo_id = ?""",
@@ -12627,22 +12656,27 @@ class Database:
                 continue
             purpose = pref.get("purpose")
             old_species = pref.get("species")
+            dst_existed = bool(pref.get("dst_existed", False))
             if not purpose or not old_species or old_species == new_species:
                 continue
-            row = self.conn.execute(
-                """SELECT 1 FROM photo_preferences
-                   WHERE workspace_id = ? AND purpose = ?
-                     AND species = ? AND photo_id = ?""",
-                (workspace_id, purpose, new_species, photo_id),
-            ).fetchone()
-            if not row:
-                continue
-            self.conn.execute(
-                """DELETE FROM photo_preferences
-                   WHERE workspace_id = ? AND purpose = ?
-                     AND species = ? AND photo_id = ?""",
-                (workspace_id, purpose, new_species, photo_id),
-            )
+            # Only delete the (new_species, purpose) row when the relabel
+            # created it. When the destination slot was already taken
+            # before the relabel — either by this photo or a different
+            # one — rename_photo_preferences_species's INSERT OR IGNORE
+            # was ignored and no new row was written for this photo, so
+            # undo must leave the destination alone.
+            if not dst_existed:
+                self.conn.execute(
+                    """DELETE FROM photo_preferences
+                       WHERE workspace_id = ? AND purpose = ?
+                         AND species = ? AND photo_id = ?""",
+                    (workspace_id, purpose, new_species, photo_id),
+                )
+            # Restore the old-species preference unconditionally. The
+            # previous gate on finding a `(new_species, purpose,
+            # photo_id)` row skipped restore when the relabel collided
+            # with a different photo holding the destination slot,
+            # stranding the old species' representative.
             self.conn.execute(
                 """INSERT OR IGNORE INTO photo_preferences
                        (workspace_id, purpose, species, photo_id,

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -478,6 +478,12 @@ class Database:
         # SELECT 1 LIMIT 1 short-circuit) — matches ensure_default_workspace
         # above.
         self.ensure_default_genre_keywords()
+        # Idempotent, one-shot: seed species_highlights from legacy
+        # photo_preferences rows with purpose='highlights' so upgraded
+        # DBs don't lose their prior Highlights picks the first time the
+        # ordered-highlights UI reads only species_highlights. Gated by
+        # db_meta so it runs at most once per DB.
+        self.backfill_species_highlights_from_legacy_preferences()
         # Restore last-used workspace, or fall back to Default
         last = self.conn.execute(
             "SELECT id FROM workspaces ORDER BY CASE WHEN last_opened_at IS NULL THEN 0 ELSE 1 END DESC, last_opened_at DESC, id ASC LIMIT 1"
@@ -2330,6 +2336,68 @@ class Database:
                 "INSERT INTO keywords (name, type, is_species) VALUES (?, 'genre', 0)",
                 (name,),
             )
+        self.conn.commit()
+
+    _SPECIES_HIGHLIGHTS_BACKFILL_KEY = "species_highlights_from_preferences_backfill"
+
+    def backfill_species_highlights_from_legacy_preferences(self):
+        """One-shot backfill: seed ``species_highlights`` from legacy
+        ``photo_preferences`` rows with ``purpose='highlights'``.
+
+        Before ordered highlights existed, a "Highlights" pick was stored
+        as a single ``photo_preferences`` row per (workspace, species).
+        The new Highlights UI reads exclusively from ``species_highlights``,
+        so upgraded databases would lose those picks — the pill/rank
+        indicators and bucket ordering would not surface the old choice
+        until the user manually re-added it. This copies each legacy pick
+        into ``species_highlights`` at the end of any existing bucket
+        (rank = MAX(rank) + 1) so pre-existing curated order is preserved
+        and the legacy pick still appears as a highlight.
+
+        Gated by a ``db_meta`` marker so it runs exactly once per DB.
+        """
+        marker = self.conn.execute(
+            "SELECT value FROM db_meta WHERE key = ?",
+            (self._SPECIES_HIGHLIGHTS_BACKFILL_KEY,),
+        ).fetchone()
+        if marker is not None:
+            return
+        try:
+            rows = self.conn.execute(
+                """SELECT workspace_id, species, photo_id
+                   FROM photo_preferences
+                   WHERE purpose = 'highlights'"""
+            ).fetchall()
+        except sqlite3.OperationalError:
+            rows = []
+        for row in rows:
+            ws = row["workspace_id"]
+            sp = row["species"]
+            pid = row["photo_id"]
+            existing = self.conn.execute(
+                """SELECT 1 FROM species_highlights
+                   WHERE workspace_id = ? AND species = ? AND photo_id = ?""",
+                (ws, sp, pid),
+            ).fetchone()
+            if existing:
+                continue
+            next_rank = int(self.conn.execute(
+                """SELECT COALESCE(MAX(rank), 0) AS max_rank
+                   FROM species_highlights
+                   WHERE workspace_id = ? AND species = ?""",
+                (ws, sp),
+            ).fetchone()["max_rank"] or 0) + 1
+            self.conn.execute(
+                """INSERT INTO species_highlights
+                       (workspace_id, species, photo_id, rank,
+                        created_at, updated_at)
+                   VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))""",
+                (ws, sp, pid, next_rank),
+            )
+        self.conn.execute(
+            "INSERT INTO db_meta(key, value) VALUES (?, '1')",
+            (self._SPECIES_HIGHLIGHTS_BACKFILL_KEY,),
+        )
         self.conn.commit()
 
     def migrate_legacy_keyword_types(self):
@@ -12330,12 +12398,14 @@ class Database:
                 old_meta = self._edit_old_value_meta(old_val)
                 new_kid = int(item['new_value']) if item['new_value'] else None
                 old_kids = old_meta.get("keyword_ids") or []
+                new_kw_name = None
                 if new_kid:
                     self.untag_photo(pid, new_kid)
                     new_kw = self.conn.execute(
                         "SELECT name FROM keywords WHERE id = ?", (new_kid,)
                     ).fetchone()
                     if new_kw:
+                        new_kw_name = new_kw['name']
                         cancelled = self.remove_pending_changes(
                             pid, 'keyword_add', new_kw['name']
                         )
@@ -12352,6 +12422,16 @@ class Database:
                         )
                         if cancelled == 0:
                             self.queue_change(pid, 'keyword_add', old_kw['name'])
+                # Restore any species_highlights / photo_preferences rows the
+                # original relabel migrated to `new_kw_name`. Without this,
+                # the photo is back in its old species bucket but the
+                # curated Highlight/Representative rows stay stranded under
+                # the new species. See PR #1161.
+                if new_kw_name:
+                    self._restore_relabel_curation(
+                        entry['workspace_id'], pid, new_kw_name,
+                        old_meta.get('curation'),
+                    )
                 self._restore_edit_prediction_status(old_meta)
 
     def _apply_redo(self, entry, items):
@@ -12445,6 +12525,7 @@ class Database:
                 old_meta = self._edit_old_value_meta(item['old_value'])
                 new_kid = int(new_val) if new_val else None
                 old_kids = old_meta.get("keyword_ids") or []
+                new_kw_name = None
                 for old_kid in old_kids:
                     self.untag_photo(pid, old_kid)
                     old_kw = self.conn.execute(
@@ -12462,12 +12543,168 @@ class Database:
                         "SELECT name FROM keywords WHERE id = ?", (new_kid,)
                     ).fetchone()
                     if new_kw:
+                        new_kw_name = new_kw['name']
                         cancelled = self.remove_pending_changes(
                             pid, 'keyword_remove', new_kw['name']
                         )
                         if cancelled == 0:
                             self.queue_change(pid, 'keyword_add', new_kw['name'])
+                if new_kw_name:
+                    self._reapply_relabel_curation(
+                        entry['workspace_id'], pid, new_kw_name,
+                        old_meta.get('curation'),
+                    )
                 self._reject_edit_prediction(old_meta)
+
+    def _restore_relabel_curation(
+        self, workspace_id, photo_id, new_species, curation,
+    ):
+        """Undo the curation migration performed by ``api_highlights_relabel``.
+
+        For each ``species_highlights`` row the relabel moved from an old
+        species bucket to ``new_species``, delete the row at ``new_species``
+        and re-insert it at the end of the old bucket (unless the photo
+        already appears there). For each ``photo_preferences`` row moved
+        by the relabel, delete the row at ``(new_species, purpose)`` and
+        re-insert it at ``(old_species, purpose)``. Best-effort: if the
+        target row no longer exists (state has changed since the relabel),
+        the corresponding restore is a no-op.
+        """
+        if not curation:
+            return
+        hl_prev = curation.get("hl_prev") or []
+        pref_prev = curation.get("pref_prev") or []
+        for old_species in hl_prev:
+            if not old_species or old_species == new_species:
+                continue
+            self.conn.execute(
+                """DELETE FROM species_highlights
+                   WHERE workspace_id = ? AND species = ? AND photo_id = ?""",
+                (workspace_id, new_species, photo_id),
+            )
+            existing = self.conn.execute(
+                """SELECT 1 FROM species_highlights
+                   WHERE workspace_id = ? AND species = ? AND photo_id = ?""",
+                (workspace_id, old_species, photo_id),
+            ).fetchone()
+            if existing:
+                continue
+            next_rank = int(self.conn.execute(
+                """SELECT COALESCE(MAX(rank), 0) AS max_rank
+                   FROM species_highlights
+                   WHERE workspace_id = ? AND species = ?""",
+                (workspace_id, old_species),
+            ).fetchone()["max_rank"] or 0) + 1
+            self.conn.execute(
+                """INSERT INTO species_highlights
+                       (workspace_id, species, photo_id, rank,
+                        created_at, updated_at)
+                   VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))""",
+                (workspace_id, old_species, photo_id, next_rank),
+            )
+        for pref in pref_prev:
+            if not isinstance(pref, dict):
+                continue
+            purpose = pref.get("purpose")
+            old_species = pref.get("species")
+            if not purpose or not old_species or old_species == new_species:
+                continue
+            row = self.conn.execute(
+                """SELECT 1 FROM photo_preferences
+                   WHERE workspace_id = ? AND purpose = ?
+                     AND species = ? AND photo_id = ?""",
+                (workspace_id, purpose, new_species, photo_id),
+            ).fetchone()
+            if not row:
+                continue
+            self.conn.execute(
+                """DELETE FROM photo_preferences
+                   WHERE workspace_id = ? AND purpose = ?
+                     AND species = ? AND photo_id = ?""",
+                (workspace_id, purpose, new_species, photo_id),
+            )
+            self.conn.execute(
+                """INSERT OR IGNORE INTO photo_preferences
+                       (workspace_id, purpose, species, photo_id,
+                        created_at, updated_at)
+                   VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))""",
+                (workspace_id, purpose, old_species, photo_id),
+            )
+
+    def _reapply_relabel_curation(
+        self, workspace_id, photo_id, new_species, curation,
+    ):
+        """Redo the curation migration reversed by
+        :meth:`_restore_relabel_curation`. Moves rows from each recorded
+        old species back onto ``new_species``.
+        """
+        if not curation:
+            return
+        hl_prev = curation.get("hl_prev") or []
+        pref_prev = curation.get("pref_prev") or []
+        for old_species in hl_prev:
+            if not old_species or old_species == new_species:
+                continue
+            src = self.conn.execute(
+                """SELECT 1 FROM species_highlights
+                   WHERE workspace_id = ? AND species = ? AND photo_id = ?""",
+                (workspace_id, old_species, photo_id),
+            ).fetchone()
+            if not src:
+                continue
+            self.conn.execute(
+                """DELETE FROM species_highlights
+                   WHERE workspace_id = ? AND species = ? AND photo_id = ?""",
+                (workspace_id, old_species, photo_id),
+            )
+            existing = self.conn.execute(
+                """SELECT 1 FROM species_highlights
+                   WHERE workspace_id = ? AND species = ? AND photo_id = ?""",
+                (workspace_id, new_species, photo_id),
+            ).fetchone()
+            if existing:
+                continue
+            next_rank = int(self.conn.execute(
+                """SELECT COALESCE(MAX(rank), 0) AS max_rank
+                   FROM species_highlights
+                   WHERE workspace_id = ? AND species = ?""",
+                (workspace_id, new_species),
+            ).fetchone()["max_rank"] or 0) + 1
+            self.conn.execute(
+                """INSERT INTO species_highlights
+                       (workspace_id, species, photo_id, rank,
+                        created_at, updated_at)
+                   VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))""",
+                (workspace_id, new_species, photo_id, next_rank),
+            )
+        for pref in pref_prev:
+            if not isinstance(pref, dict):
+                continue
+            purpose = pref.get("purpose")
+            old_species = pref.get("species")
+            if not purpose or not old_species or old_species == new_species:
+                continue
+            row = self.conn.execute(
+                """SELECT 1 FROM photo_preferences
+                   WHERE workspace_id = ? AND purpose = ?
+                     AND species = ? AND photo_id = ?""",
+                (workspace_id, purpose, old_species, photo_id),
+            ).fetchone()
+            if not row:
+                continue
+            self.conn.execute(
+                """DELETE FROM photo_preferences
+                   WHERE workspace_id = ? AND purpose = ?
+                     AND species = ? AND photo_id = ?""",
+                (workspace_id, purpose, old_species, photo_id),
+            )
+            self.conn.execute(
+                """INSERT OR IGNORE INTO photo_preferences
+                       (workspace_id, purpose, species, photo_id,
+                        created_at, updated_at)
+                   VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))""",
+                (workspace_id, purpose, new_species, photo_id),
+            )
 
     def _edit_old_value_meta(self, old_value):
         """Parse edit item old_value, including newer JSON metadata payloads."""

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -10141,15 +10141,26 @@ class Database:
                     (workspace_id, old_species),
                 ).fetchall()
             else:
-                placeholders = ",".join("?" for _ in photo_ids)
-                src_rows = self.conn.execute(
-                    f"""SELECT photo_id
-                        FROM species_highlights
-                        WHERE workspace_id = ? AND species = ?
-                          AND photo_id IN ({placeholders})
-                        ORDER BY rank, created_at, photo_id""",
-                    (workspace_id, old_species, *photo_ids),
-                ).fetchall()
+                # Chunk the IN(...) clause: photo_ids can carry every photo
+                # tagged with the renamed keyword in this workspace, which on
+                # legacy SQLite builds (SQLITE_MAX_VARIABLE_NUMBER=999) blows
+                # the parameter cap once a species passes ~997 tagged photos.
+                # Chunk in memory then re-sort so the rebucket order matches
+                # the single-query path.
+                raw_rows = []
+                for chunk in _chunks(photo_ids):
+                    placeholders = ",".join("?" for _ in chunk)
+                    raw_rows.extend(self.conn.execute(
+                        f"""SELECT photo_id, rank, created_at
+                            FROM species_highlights
+                            WHERE workspace_id = ? AND species = ?
+                              AND photo_id IN ({placeholders})""",
+                        (workspace_id, old_species, *chunk),
+                    ).fetchall())
+                raw_rows.sort(
+                    key=lambda r: (r["rank"], r["created_at"], r["photo_id"])
+                )
+                src_rows = raw_rows
             if not src_rows:
                 continue
             existing = {

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -856,6 +856,16 @@ class Database:
                 PRIMARY KEY (workspace_id, purpose, species)
             );
 
+            CREATE TABLE IF NOT EXISTS species_highlights (
+                workspace_id  INTEGER NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+                species       TEXT NOT NULL,
+                photo_id      INTEGER NOT NULL REFERENCES photos(id) ON DELETE CASCADE,
+                rank          INTEGER NOT NULL,
+                created_at    TEXT DEFAULT (datetime('now')),
+                updated_at    TEXT DEFAULT (datetime('now')),
+                PRIMARY KEY (workspace_id, species, photo_id)
+            );
+
             CREATE TABLE IF NOT EXISTS preview_cache (
                 photo_id INTEGER NOT NULL,
                 size INTEGER NOT NULL,
@@ -938,6 +948,10 @@ class Database:
                 ON photo_color_labels(workspace_id);
             CREATE INDEX IF NOT EXISTS idx_photo_preferences_photo
                 ON photo_preferences(photo_id);
+            CREATE INDEX IF NOT EXISTS idx_species_highlights_photo
+                ON species_highlights(photo_id);
+            CREATE INDEX IF NOT EXISTS idx_species_highlights_rank
+                ON species_highlights(workspace_id, species, rank);
             CREATE INDEX IF NOT EXISTS preview_cache_last_access
                 ON preview_cache(last_access_at);
             CREATE INDEX IF NOT EXISTS idx_offline_originals_status
@@ -2005,10 +2019,10 @@ class Database:
         """Move folders and their workspace-scoped data to another workspace.
 
         Moves: workspace_folders rows, pending_changes, prediction_review,
-        and photo_preferences. Detections and predictions are global (no
-        workspace_id), so they follow the folder via workspace_folders
-        membership rather than being reassigned. Collections and edit_history
-        stay behind.
+        photo_preferences, and species_highlights. Detections and predictions
+        are global (no workspace_id), so they follow the folder via
+        workspace_folders membership rather than being reassigned. Collections
+        and edit_history stay behind.
 
         Returns:
             dict with keys: folders_moved, pending_changes_moved,
@@ -2030,11 +2044,12 @@ class Database:
                 )
 
         if not folder_ids:
-            return {
-                "folders_moved": 0,
-                "pending_changes_moved": 0,
-                "photo_preferences_moved": 0,
-            }
+                return {
+                    "folders_moved": 0,
+                    "pending_changes_moved": 0,
+                    "photo_preferences_moved": 0,
+                    "species_highlights_moved": 0,
+                }
 
         selected_folder_ids = set(folder_ids)
         source_folder_paths = {
@@ -2128,6 +2143,7 @@ class Database:
             # for the same (purpose, species), keep the target value and drop
             # the now-stale source row.
             photo_preferences_moved = 0
+            species_highlights_moved = 0
             for chunk in _chunks(moved_folder_ids):
                 placeholders = ",".join("?" for _ in chunk)
                 cur = self.conn.execute(
@@ -2146,6 +2162,28 @@ class Database:
                 photo_preferences_moved += cur.rowcount
                 self.conn.execute(
                     f"""DELETE FROM photo_preferences
+                        WHERE workspace_id = ?
+                          AND photo_id IN (
+                              SELECT id FROM photos WHERE folder_id IN ({placeholders})
+                          )""",
+                    [source_ws_id] + chunk,
+                )
+
+                cur = self.conn.execute(
+                    f"""INSERT OR IGNORE INTO species_highlights
+                          (workspace_id, species, photo_id, rank,
+                           created_at, updated_at)
+                        SELECT ?, species, photo_id, rank, created_at, updated_at
+                        FROM species_highlights
+                        WHERE workspace_id = ?
+                          AND photo_id IN (
+                              SELECT id FROM photos WHERE folder_id IN ({placeholders})
+                          )""",
+                    [target_ws_id, source_ws_id] + chunk,
+                )
+                species_highlights_moved += cur.rowcount
+                self.conn.execute(
+                    f"""DELETE FROM species_highlights
                         WHERE workspace_id = ?
                           AND photo_id IN (
                               SELECT id FROM photos WHERE folder_id IN ({placeholders})
@@ -2191,6 +2229,7 @@ class Database:
             "folders_moved": len(folder_ids),
             "pending_changes_moved": pending_changes_moved,
             "photo_preferences_moved": photo_preferences_moved,
+            "species_highlights_moved": species_highlights_moved,
         }
 
     def ensure_default_workspace(self):
@@ -9711,6 +9750,32 @@ class Database:
         ).fetchall()
         return {r["species"]: r["photo_id"] for r in rows}
 
+    def get_species_representatives(self):
+        """Return representative photo preferences with legacy fallback.
+
+        ``species_representative`` is the canonical purpose. Existing
+        ``life_list`` and ``highlights`` rows are still read as fallbacks so
+        older libraries keep their explicit curation choices.
+        """
+        ws = self._ws_id()
+        rows = self.conn.execute(
+            """SELECT species, photo_id, purpose
+               FROM photo_preferences
+               WHERE workspace_id = ?
+                 AND purpose IN ('species_representative', 'life_list', 'highlights')
+               ORDER BY species,
+                        CASE purpose
+                          WHEN 'species_representative' THEN 0
+                          WHEN 'life_list' THEN 1
+                          ELSE 2
+                        END""",
+            (ws,),
+        ).fetchall()
+        result = {}
+        for r in rows:
+            result.setdefault(r["species"], r["photo_id"])
+        return result
+
     def set_photo_preference(self, purpose, species, photo_id, _commit=True):
         """Set the preferred photo for a species/purpose in this workspace."""
         ws = self._ws_id()
@@ -9726,6 +9791,12 @@ class Database:
         if _commit:
             self.conn.commit()
 
+    def set_species_representative(self, species, photo_id, _commit=True):
+        """Set the one-photo representative for a species in this workspace."""
+        self.set_photo_preference(
+            "species_representative", species, photo_id, _commit=_commit
+        )
+
     def clear_photo_preference(self, purpose, species, _commit=True):
         """Clear the preferred photo for a species/purpose in this workspace."""
         ws = self._ws_id()
@@ -9736,6 +9807,127 @@ class Database:
         )
         if _commit:
             self.conn.commit()
+
+    def clear_species_representative(self, species, _commit=True):
+        """Clear canonical and legacy representative preferences for a species."""
+        ws = self._ws_id()
+        self.conn.execute(
+            """DELETE FROM photo_preferences
+               WHERE workspace_id = ?
+                 AND species = ?
+                 AND purpose IN ('species_representative', 'life_list', 'highlights')""",
+            (ws, species),
+        )
+        if _commit:
+            self.conn.commit()
+
+    def get_species_highlights(self, species=None):
+        """Return ordered highlighted photo ids for the active workspace.
+
+        Result shape is ``{species: {photo_id: rank}}``.
+        """
+        ws = self._ws_id()
+        if species:
+            rows = self.conn.execute(
+                """SELECT species, photo_id, rank
+                   FROM species_highlights
+                   WHERE workspace_id = ? AND species = ?
+                   ORDER BY rank, created_at, photo_id""",
+                (ws, species),
+            ).fetchall()
+        else:
+            rows = self.conn.execute(
+                """SELECT species, photo_id, rank
+                   FROM species_highlights
+                   WHERE workspace_id = ?
+                   ORDER BY species, rank, created_at, photo_id""",
+                (ws,),
+            ).fetchall()
+        result = {}
+        for r in rows:
+            result.setdefault(r["species"], {})[r["photo_id"]] = r["rank"]
+        return result
+
+    def add_species_highlight(self, species, photo_id, _commit=True):
+        """Add a photo to a species' ordered highlights, appending if new."""
+        ws = self._ws_id()
+        row = self.conn.execute(
+            """SELECT rank FROM species_highlights
+               WHERE workspace_id = ? AND species = ? AND photo_id = ?""",
+            (ws, species, photo_id),
+        ).fetchone()
+        if row:
+            self.conn.execute(
+                """UPDATE species_highlights
+                   SET updated_at = datetime('now')
+                   WHERE workspace_id = ? AND species = ? AND photo_id = ?""",
+                (ws, species, photo_id),
+            )
+            if _commit:
+                self.conn.commit()
+            return row["rank"]
+        max_rank = self.conn.execute(
+            """SELECT COALESCE(MAX(rank), 0) AS max_rank
+               FROM species_highlights
+               WHERE workspace_id = ? AND species = ?""",
+            (ws, species),
+        ).fetchone()["max_rank"]
+        rank = int(max_rank or 0) + 1
+        self.conn.execute(
+            """INSERT INTO species_highlights
+                   (workspace_id, species, photo_id, rank, created_at, updated_at)
+               VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))""",
+            (ws, species, photo_id, rank),
+        )
+        if _commit:
+            self.conn.commit()
+        return rank
+
+    def remove_species_highlight(self, species, photo_id, _commit=True):
+        """Remove a photo from a species' ordered highlights."""
+        ws = self._ws_id()
+        cur = self.conn.execute(
+            """DELETE FROM species_highlights
+               WHERE workspace_id = ? AND species = ? AND photo_id = ?""",
+            (ws, species, photo_id),
+        )
+        if _commit:
+            self.conn.commit()
+        return cur.rowcount
+
+    def move_species_highlight(self, species, photo_id, direction, _commit=True):
+        """Move a highlighted photo one step up/down within its species."""
+        ws = self._ws_id()
+        rows = self.conn.execute(
+            """SELECT photo_id
+               FROM species_highlights
+               WHERE workspace_id = ? AND species = ?
+               ORDER BY rank, created_at, photo_id""",
+            (ws, species),
+        ).fetchall()
+        ids = [r["photo_id"] for r in rows]
+        if photo_id not in ids:
+            return False
+        idx = ids.index(photo_id)
+        if direction == "up":
+            new_idx = max(0, idx - 1)
+        elif direction == "down":
+            new_idx = min(len(ids) - 1, idx + 1)
+        else:
+            return False
+        if new_idx == idx:
+            return True
+        ids.insert(new_idx, ids.pop(idx))
+        for rank, pid in enumerate(ids, start=1):
+            self.conn.execute(
+                """UPDATE species_highlights
+                   SET rank = ?, updated_at = datetime('now')
+                   WHERE workspace_id = ? AND species = ? AND photo_id = ?""",
+                (rank, ws, species, pid),
+            )
+        if _commit:
+            self.conn.commit()
+        return True
 
     def rename_photo_preferences_species(
         self, old_species, new_species, photo_workspace_pairs=None, _commit=True,

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3570,11 +3570,11 @@ var _lbEditRecipeWriteSeqByPhoto = {};
 var _lbPhotoDataByPhoto = {};
 var _lbRenderVersionByPhoto = {};
 
-// --- Life List: "Add to Life List" panel, shared across every page's lightbox.
+// --- Species Representative panel, shared across every page's lightbox.
 // Driven by the `life_list` block on GET /api/photos/<id> (cached in
 // _lbPhotoDataByPhoto), so the action works wherever a photo is opened — not
 // just on the /life-list page. Each eligible species gets its own row; the
-// button reflects real state (representative → selected, disabled star).
+// button reflects real state.
 function _lbEnsureLifeListPanel() {
   var actions = document.getElementById('lightboxActions');
   if (!actions) return null;
@@ -3611,9 +3611,9 @@ function _lbRenderLifeListPanel(photoId) {
     if (entry.is_current_photo) {
       btn.className = 'primary';
       btn.disabled = true;
-      btn.textContent = '★ Life List photo';
+      btn.textContent = 'Representative';
     } else {
-      btn.textContent = 'Add to Life List';
+      btn.textContent = 'Set Representative';
     }
     btn.addEventListener('click', function(event) {
       event.stopPropagation();
@@ -3632,7 +3632,7 @@ async function setLifeListPhoto(species, photoId, button) {
     await window.safeFetch('/api/photo-preferences', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ purpose: 'life_list', species: species, photo_id: photoId }),
+      body: JSON.stringify({ purpose: 'species_representative', species: species, photo_id: photoId }),
     });
     // Re-read this photo's block so the panel shows the honest new state, and
     // refresh the lightbox's cache so re-renders stay consistent.
@@ -3646,7 +3646,7 @@ async function setLifeListPhoto(species, photoId, button) {
       detail: { species: species, photoId: photoId },
     }));
     if (typeof showToast === 'function') {
-      showToast('Life List photo set for ' + species, 'success');
+      showToast('Species representative set for ' + species, 'success');
     }
   } finally {
     if (button) button.disabled = false;
@@ -3660,8 +3660,8 @@ document.addEventListener('lightbox:photochanged', function(event) {
   if (pid != null) _lbRenderLifeListPanel(pid);
 });
 
-// A photo's flag decides its life-list eligibility (a rejected photo can't be a
-// Life List photo, per _photo_can_be_life_list_preference). The cached
+// A photo's flag decides representative eligibility (a rejected photo can't be
+// a representative, per _photo_can_be_life_list_preference). The cached
 // `life_list` block goes stale the moment the user changes the flag from the
 // lightbox, so re-fetch it and re-render — this hides the panel when the photo
 // becomes rejected and re-shows it when the flag is cleared again.

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -7114,12 +7114,10 @@ function buildPhotoContextMenu(photoIds) {
   ]);
 }
 
-// "Add to Life List" context-menu items. A photo is a lifelist representative
-// per species keyword, so one item per eligible species (the same species
-// names shown on the card). Fire-and-forget: it sets the representative and
-// toasts; the server (_photo_can_be_life_list_preference) is the backstop for
-// a stale menu. Disabled for a multi-selection because crowning one shot from
-// many is ambiguous; hidden entirely when nothing selected has a species.
+// "Set Representative" context-menu items. One photo can represent each
+// species in the active workspace. Disabled for a multi-selection because
+// crowning one shot from many is ambiguous; hidden entirely when nothing
+// selected has a species.
 // Rejected photos are excluded here too \u2014 they'd fail the server backstop
 // (`_photo_can_be_life_list_preference` rejects `flag = 'rejected'`) and only
 // produce an error toast, so don't offer the action in the first place.
@@ -7132,14 +7130,14 @@ function buildLifeListMenuItems(photoIds) {
   });
   if (!anyEligible) return [];
   if (photoIds.length !== 1) {
-    return [{ label: 'Add to Life List', disabled: true,
+    return [{ label: 'Set Representative', disabled: true,
               disabledHint: 'Select a single photo' }];
   }
   var photo = photos.find(function(p) { return p.id === photoIds[0]; });
   if (!_lifeListEligibleClient(photo)) return [];
   return (photo.species || []).map(function(sp) {
     return {
-      label: 'Add to Life List \u2014 ' + sp,
+      label: 'Set Representative \u2014 ' + sp,
       onClick: function() { addPhotoToLifeList(sp, photoIds[0]); },
     };
   });
@@ -7148,12 +7146,12 @@ function buildLifeListMenuItems(photoIds) {
 function addPhotoToLifeList(species, photoId) {
   if (!species || !photoId) return;
   safeFetch('/api/photo-preferences', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ purpose: 'life_list', species: species, photo_id: photoId }),
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ purpose: 'species_representative', species: species, photo_id: photoId }),
   }).then(function() {
     if (typeof showToast === 'function') {
-      showToast('Life List photo set for ' + species, 'success');
+      showToast('Species representative set for ' + species, 'success');
     }
   });
 }

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -42,7 +42,8 @@
   html[data-advanced-mode="true"] .highlights-card.best-card { border-color:var(--accent); }
   .best-ribbon { position:absolute; top:6px; left:6px; padding:2px 6px; border-radius:999px; background:var(--accent); color:var(--accent-text); font-size:10px; font-weight:700; text-transform:uppercase; letter-spacing:0.5px; }
   .highlight-order { position:absolute; top:6px; right:6px; display:flex; gap:4px; opacity:0; transition:opacity .12s; }
-  .highlights-card:hover .highlight-order { opacity:1; }
+  .highlights-card:hover .highlight-order,
+  .highlights-card:focus-within .highlight-order { opacity:1; }
   .highlight-order button { padding:2px 6px; border-radius:999px; border:1px solid rgba(255,255,255,.45); background:rgba(0,0,0,.62); color:#fff; font-size:10px; cursor:pointer; }
   .highlight-order button:hover { border-color:#fff; }
   .highlights-card img { width:100%; aspect-ratio:3/2; object-fit:cover; display:block; background:var(--bg-tertiary); }

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -40,6 +40,10 @@
   .highlights-card:hover { border-color:var(--accent); }
   .highlights-card.best-card { border-color:var(--accent); }
   .best-ribbon { position:absolute; top:6px; left:6px; padding:2px 6px; border-radius:999px; background:var(--accent); color:var(--accent-text); font-size:10px; font-weight:700; text-transform:uppercase; letter-spacing:0.5px; }
+  .highlight-order { position:absolute; top:6px; right:6px; display:flex; gap:4px; opacity:0; transition:opacity .12s; }
+  .highlights-card:hover .highlight-order { opacity:1; }
+  .highlight-order button { padding:2px 6px; border-radius:999px; border:1px solid rgba(255,255,255,.45); background:rgba(0,0,0,.62); color:#fff; font-size:10px; cursor:pointer; }
+  .highlight-order button:hover { border-color:#fff; }
   .highlights-card img { width:100%; aspect-ratio:3/2; object-fit:cover; display:block; background:var(--bg-tertiary); }
   .card-info { padding:6px 8px; font-size:11px; color:var(--text-secondary); display:flex; flex-wrap:wrap; align-items:center; justify-content:flex-end; gap:4px; min-height:28px; }
   .card-chip { padding:1px 5px; border-radius:999px; background:var(--bg-tertiary); white-space:nowrap; }
@@ -361,13 +365,26 @@ function renderCard(p, idx) {
     return '<span class="card-chip reason">' + escapeAttr(r) + '</span>';
   }).join('');
   var title = (p.reasons || []).join(', ');
-  var ribbon = p.is_highlights_photo
-    ? '<div class="best-ribbon">Highlight</div>'
-    : (idx === 0 ? '<div class="best-ribbon">Best</div>' : '');
+  var ribbon = p.is_highlighted
+    ? '<div class="best-ribbon">Highlight ' + escapeAttr(p.highlight_rank || '') + '</div>'
+    : (p.is_species_representative
+      ? '<div class="best-ribbon">Representative</div>'
+      : (idx === 0 ? '<div class="best-ribbon">Best</div>' : ''));
+  var rep = p.is_species_representative
+    ? '<span class="card-chip reason">Representative</span>'
+    : '';
+  var order = p.is_highlighted
+    ? '<div class="highlight-order">'
+      + '<button type="button" data-highlight-order="up" data-photo-id="' + p.id + '" data-species="' + escapeAttr(photoSpeciesName(p)) + '">Up</button>'
+      + '<button type="button" data-highlight-order="down" data-photo-id="' + p.id + '" data-species="' + escapeAttr(photoSpeciesName(p)) + '">Down</button>'
+      + '<button type="button" data-highlight-remove="1" data-photo-id="' + p.id + '" data-species="' + escapeAttr(photoSpeciesName(p)) + '">Remove</button>'
+      + '</div>'
+    : '';
   return '<div class="highlights-card' + (idx === 0 ? ' best-card' : '') + '" data-photo-id="' + p.id + '" title="' + escapeAttr(title) + '">'
     + ribbon
+    + order
     + '<img src="' + thumbSrc + '" alt="' + escapeAttr(p.filename) + '" loading="lazy">'
-    + '<div class="card-info"><span class="card-chip score">' + formatScore(p.highlight_score) + '</span>' + conf + reasons + '</div>'
+    + '<div class="card-info"><span class="card-chip score">' + formatScore(p.highlight_score) + '</span>' + conf + rep + reasons + '</div>'
     + '</div>';
 }
 
@@ -382,6 +399,21 @@ function attachCardClicks(container, photoSet) {
       if (window.openLightbox && photo) {
         activeLightboxPhotoId = pid;
         openLightbox(pid, photo.filename, photoSet);
+      }
+    });
+  });
+}
+
+function attachHighlightOrderButtons(container) {
+  container.querySelectorAll('[data-highlight-order], [data-highlight-remove]').forEach(function(btn) {
+    btn.addEventListener('click', function(event) {
+      event.stopPropagation();
+      var species = btn.getAttribute('data-species');
+      var photoId = parseInt(btn.getAttribute('data-photo-id'));
+      if (btn.hasAttribute('data-highlight-remove')) {
+        removeSpeciesHighlight(species, photoId, btn);
+      } else {
+        moveSpeciesHighlight(species, photoId, btn.getAttribute('data-highlight-order'), btn);
       }
     });
   });
@@ -503,20 +535,70 @@ async function submitSpeciesModal() {
   }
 }
 
-async function setPhotoPreference(purpose, species, photoId, button) {
-  if (!purpose || !species || !photoId) return;
+async function setSpeciesRepresentative(species, photoId, button) {
+  if (!species || !photoId) return;
   if (button) button.disabled = true;
   try {
     await safeFetch('/api/photo-preferences', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ purpose: purpose, species: species, photo_id: photoId }),
+      body: JSON.stringify({ purpose: 'species_representative', species: species, photo_id: photoId }),
     });
     await loadHighlights();
     updateHighlightsLightboxControls(activeLightboxPhotoId);
     if (typeof showToast === 'function') {
-      showToast(purpose === 'life_list' ? 'Life List photo set' : 'Highlights photo set', 'success');
+      showToast('Species representative set', 'success');
     }
+  } finally {
+    if (button) button.disabled = false;
+  }
+}
+
+async function addSpeciesHighlight(species, photoId, button) {
+  if (!species || !photoId) return;
+  if (button) button.disabled = true;
+  try {
+    await safeFetch('/api/species-highlights', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ species: species, photo_id: photoId }),
+    });
+    await loadHighlights();
+    updateHighlightsLightboxControls(activeLightboxPhotoId);
+    if (typeof showToast === 'function') showToast('Added to Highlights', 'success');
+  } finally {
+    if (button) button.disabled = false;
+  }
+}
+
+async function removeSpeciesHighlight(species, photoId, button) {
+  if (!species || !photoId) return;
+  if (button) button.disabled = true;
+  try {
+    await safeFetch('/api/species-highlights', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ species: species, photo_id: photoId }),
+    });
+    await loadHighlights();
+    updateHighlightsLightboxControls(activeLightboxPhotoId);
+    if (typeof showToast === 'function') showToast('Removed from Highlights', 'success');
+  } finally {
+    if (button) button.disabled = false;
+  }
+}
+
+async function moveSpeciesHighlight(species, photoId, direction, button) {
+  if (!species || !photoId || !direction) return;
+  if (button) button.disabled = true;
+  try {
+    await safeFetch('/api/species-highlights/order', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ species: species, photo_id: photoId, direction: direction }),
+    });
+    await loadHighlights();
+    updateHighlightsLightboxControls(activeLightboxPhotoId);
   } finally {
     if (button) button.disabled = false;
   }
@@ -534,6 +616,7 @@ function renderBucket(bucket) {
     : '<span class="bucket-badge ' + badgeClass + '">' + badgeText + '</span>';
   var meta = bucket.photo_count + ' photo' + (bucket.photo_count === 1 ? '' : 's')
     + ' · best ' + formatScore(bucket.best_score);
+  if (bucket.highlight_count) meta += ' · ' + bucket.highlight_count + ' highlighted';
   if (!bucket.is_accepted && bucket.avg_confidence != null) meta += ' · ID ' + formatPercent(bucket.avg_confidence);
   var expandBtn = '';
   // Show the affordance whenever photos are hidden (more loaded than one row)
@@ -648,6 +731,7 @@ function render() {
     }
     attachCardClicks(section, photoSet);
   });
+  attachHighlightOrderButtons(content);
 
   // Expand buttons
   content.querySelectorAll('.bucket-expand').forEach(function(btn) {
@@ -822,12 +906,18 @@ function updateHighlightsLightboxControls(photoId) {
   if (photo) {
     var highlightSpecies = photoSpeciesName(photo);
     if (highlightSpecies) {
-      html += '<button data-lb-action="set-highlight"'
-        + (photo.is_highlights_photo ? ' class="primary"' : '') + '>'
-        + (photo.is_highlights_photo ? 'Highlights Photo' : 'Use as Highlights') + '</button>';
+      if (photo.is_highlighted) {
+        html += '<button class="primary" data-lb-action="remove-highlight">Highlighted</button>';
+        html += '<button data-lb-action="highlight-up">Move Up</button>';
+        html += '<button data-lb-action="highlight-down">Move Down</button>';
+      } else {
+        html += '<button data-lb-action="add-highlight">Add to Highlights</button>';
+      }
     }
     if (photo.has_accepted_species && photo.species) {
-      html += '<button data-lb-action="set-life-list">Use as Life List</button>';
+      html += '<button data-lb-action="set-representative"'
+        + (photo.is_species_representative ? ' class="primary"' : '') + '>'
+        + (photo.is_species_representative ? 'Representative' : 'Set Representative') + '</button>';
     }
     if (photo.is_confirmable_prediction) {
       html += '<button class="primary" data-lb-action="confirm">Confirm</button>';
@@ -848,10 +938,16 @@ function updateHighlightsLightboxControls(photoId) {
         return;
       } else if (action === 'confirm') {
         confirmPhotoIds([photo.id], btn);
-      } else if (action === 'set-highlight') {
-        setPhotoPreference('highlights', photoSpeciesName(photo), photo.id, btn);
-      } else if (action === 'set-life-list') {
-        setPhotoPreference('life_list', photo.species, photo.id, btn);
+      } else if (action === 'add-highlight') {
+        addSpeciesHighlight(photoSpeciesName(photo), photo.id, btn);
+      } else if (action === 'remove-highlight') {
+        removeSpeciesHighlight(photoSpeciesName(photo), photo.id, btn);
+      } else if (action === 'highlight-up') {
+        moveSpeciesHighlight(photoSpeciesName(photo), photo.id, 'up', btn);
+      } else if (action === 'highlight-down') {
+        moveSpeciesHighlight(photoSpeciesName(photo), photo.id, 'down', btn);
+      } else if (action === 'set-representative') {
+        setSpeciesRepresentative(photo.species, photo.id, btn);
       } else {
         var modalTitle = (photo.is_confirmable_prediction || photo.has_accepted_species)
           ? 'Change species'

--- a/vireo/templates/life_list.html
+++ b/vireo/templates/life_list.html
@@ -321,7 +321,7 @@ function renderCard(entry) {
   return '<div class="species-card" data-species="' + escapeAttr(entry.species) + '" title="'
     + escapeAttr((entry.locations || []).join(', ')) + '">'
     + '<div class="lifer-number">#' + entry.number + '</div>'
-    + (best && best.is_life_list_photo ? '<div class="lifelist-ribbon">Life List</div>' : '')
+    + (best && best.is_species_representative ? '<div class="lifelist-ribbon">Representative</div>' : '')
     + (best ? '<img src="' + escapeAttr(thumb) + '" data-photo-id="' + escapeAttr(best.id) + '" alt="' + escapeAttr(best.filename) + '" loading="lazy">' : '')
     + '<div class="species-info">'
     + '<div class="species-name">' + escapeAttr(entry.species) + '</div>'
@@ -374,7 +374,7 @@ function render() {
       if (entry && entry.best && window.openLightbox) {
         // The lightbox set is this species' top photos so the user can
         // flip through their best shots of the lifer. The shared lightbox
-        // panel (see _navbar.html) renders its own "Add to Life List" control.
+        // panel (see _navbar.html) renders its own representative control.
         openLightbox(entry.best.id, entry.best.filename, entry.photos || [entry.best]);
       }
     });
@@ -488,7 +488,7 @@ async function startPublishSite() {
   }
 }
 
-// The "Add to Life List" lightbox panel is shared (see _navbar.html) and
+// The representative lightbox panel is shared (see _navbar.html) and
 // works on every page. When it changes a representative photo, it dispatches
 // `lifelist:changed`; refresh this page's grid + ribbons in response.
 document.addEventListener('lifelist:changed', function() {

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -3303,6 +3303,21 @@ def test_rename_keyword_updates_photo_preferences(app_and_db):
     assert db.get_photo_preferences("highlights") == {"NewBird": p1}
 
 
+def test_rename_keyword_updates_species_representative(app_and_db):
+    """species_representative preferences follow species keyword renames."""
+    app, db = app_and_db
+    client = app.test_client()
+    kid = db.add_keyword("OldBird", is_species=True)
+    p1 = db.conn.execute("SELECT id FROM photos LIMIT 1").fetchone()["id"]
+    db.tag_photo(p1, kid)
+    db.set_photo_preference("species_representative", "OldBird", p1)
+
+    resp = client.put(f"/api/keywords/{kid}", json={"name": "NewBird"})
+    assert resp.status_code == 200
+
+    assert db.get_photo_preferences("species_representative") == {"NewBird": p1}
+
+
 def test_rename_keyword_photo_preferences_keep_existing_target(app_and_db):
     """Renaming into an existing preference keeps the target preference."""
     app, db = app_and_db
@@ -5589,6 +5604,57 @@ def test_highlights_relabel_undo_restores_curation(app_and_db):
     hl_redo = db.get_species_highlights()
     assert pid in (hl_redo.get("Golden Eagle") or {})
     assert "Bald Eagle" not in hl_redo
+
+
+def test_highlights_relabel_undo_preserves_original_rank(app_and_db):
+    """Undoing a relabel puts the highlighted photo back at its original
+    rank rather than dumping it at MAX(rank)+1 of the old bucket, so
+    curated order survives a round-trip through undo."""
+    app, db = app_and_db
+    client = app.test_client()
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES ('/hrrank', 'hrrank', 'ok')"
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO workspace_folders (workspace_id, folder_id) VALUES (?, ?)",
+        (db._ws_id(), fid),
+    )
+    old_kid = db.add_keyword("Old Rank Bird", is_species=True)
+    db.add_keyword("New Rank Bird", is_species=True)
+    p1 = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+        "VALUES (?, 'rank-1.jpg', 0.9, 'none')",
+        (fid,),
+    ).lastrowid
+    p2 = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+        "VALUES (?, 'rank-2.jpg', 0.9, 'none')",
+        (fid,),
+    ).lastrowid
+    db.tag_photo(p1, old_kid)
+    db.tag_photo(p2, old_kid)
+    db.add_species_highlight("Old Rank Bird", p1)
+    db.add_species_highlight("Old Rank Bird", p2)
+
+    # Sanity: original ranks are 1 (p1) and 2 (p2).
+    assert db.get_species_highlights("Old Rank Bird") == {
+        "Old Rank Bird": {p1: 1, p2: 2}
+    }
+
+    resp = client.post(
+        "/api/highlights/relabel",
+        json={"photo_ids": [p1], "species": "New Rank Bird"},
+    )
+    assert resp.status_code == 200
+
+    undone = db.undo_last_edit()
+    assert undone is not None
+
+    restored = db.get_species_highlights("Old Rank Bird")["Old Rank Bird"]
+    # Before the fix, p1 landed at rank 3 (MAX(rank)+1) and appeared
+    # after p2 in the ordered list.
+    assert restored[p1] == 1
+    assert restored[p2] == 2
 
 
 def test_backfill_species_highlights_from_legacy_preferences(tmp_path):

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -5702,6 +5702,168 @@ def test_highlights_relabel_undo_preserves_original_rank(app_and_db):
     assert restored[p2] == 2
 
 
+def test_highlights_relabel_prediction_only_undo_restores_curation(app_and_db):
+    """Predicted-only relabels record `keyword_add`, not `species_replace`,
+    but can still carry a `curation` payload when the photo already held a
+    representative or highlight under another species. Undo/redo must
+    move those rows back and forth just like the `species_replace` case."""
+    app, db = app_and_db
+    client = app.test_client()
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES ('/hrpo', 'hrpo', 'ok')"
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO workspace_folders (workspace_id, folder_id) VALUES (?, ?)",
+        (db._ws_id(), fid),
+    )
+    db.add_keyword("New Species", is_species=True)
+    pid = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+        "VALUES (?, 'pred-cur.jpg', 0.9, 'none')",
+        (fid,),
+    ).lastrowid
+    # No prior species tag: only representative + highlight rows exist
+    # for an unrelated species. This is what makes the relabel record as
+    # `keyword_add` (has_old_species stays False) rather than
+    # `species_replace`.
+    db.set_species_representative("Predicted Bird", pid)
+    db.add_species_highlight("Predicted Bird", pid)
+    det = db.save_detections(
+        pid,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2}, "confidence": 0.9}],
+        detector_model="MDV6",
+    )[0]
+    db.add_prediction(det, "Predicted Bird", 0.88, "m")
+    db.conn.commit()
+
+    resp = client.post(
+        "/api/highlights/relabel",
+        json={"photo_ids": [pid], "species": "New Species"},
+    )
+    assert resp.status_code == 200
+    assert db.get_edit_history(limit=1)[0]["action_type"] == "keyword_add"
+    assert db.get_species_representatives().get("New Species") == pid
+    assert pid in (db.get_species_highlights("New Species") or {}).get(
+        "New Species", {}
+    )
+
+    undone = db.undo_last_edit()
+    assert undone is not None
+    assert undone["action_type"] == "keyword_add"
+    reps = db.get_species_representatives()
+    assert reps.get("Predicted Bird") == pid
+    assert "New Species" not in reps
+    hl = db.get_species_highlights()
+    assert pid in (hl.get("Predicted Bird") or {})
+    assert "New Species" not in hl
+
+    redone = db.redo_last_undo()
+    assert redone is not None
+    assert redone["action_type"] == "keyword_add"
+    reps_redo = db.get_species_representatives()
+    assert reps_redo.get("New Species") == pid
+    assert "Predicted Bird" not in reps_redo
+    hl_redo = db.get_species_highlights()
+    assert pid in (hl_redo.get("New Species") or {})
+    assert "Predicted Bird" not in hl_redo
+
+
+def test_highlights_relabel_undo_preserves_existing_destination_highlight(app_and_db):
+    """When a photo is highlighted under both the old and new species,
+    the relabel drops the old-bucket row and leaves the pre-existing
+    destination row alone. Undo must not delete that destination row —
+    it wasn't created by the relabel."""
+    app, db = app_and_db
+    client = app.test_client()
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES ('/hrdst', 'hrdst', 'ok')"
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO workspace_folders (workspace_id, folder_id) VALUES (?, ?)",
+        (db._ws_id(), fid),
+    )
+    old_kid = db.add_keyword("Both Bird A", is_species=True)
+    db.add_keyword("Both Bird B", is_species=True)
+    pid = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+        "VALUES (?, 'both.jpg', 0.9, 'none')",
+        (fid,),
+    ).lastrowid
+    db.tag_photo(pid, old_kid)
+    # Highlighted under both species before the relabel.
+    db.add_species_highlight("Both Bird A", pid)
+    db.add_species_highlight("Both Bird B", pid)
+
+    resp = client.post(
+        "/api/highlights/relabel",
+        json={"photo_ids": [pid], "species": "Both Bird B"},
+    )
+    assert resp.status_code == 200
+    # Old-bucket row dropped; destination row retained.
+    assert db.get_species_highlights("Both Bird A") == {}
+    assert pid in (db.get_species_highlights("Both Bird B") or {}).get(
+        "Both Bird B", {}
+    )
+
+    undone = db.undo_last_edit()
+    assert undone is not None
+    hl = db.get_species_highlights()
+    # Old bucket restored AND destination row survives — before the fix
+    # the undo deleted the pre-existing (Both Bird B, pid) row.
+    assert pid in (hl.get("Both Bird A") or {})
+    assert pid in (hl.get("Both Bird B") or {})
+
+
+def test_highlights_relabel_undo_restores_representative_over_collision(app_and_db):
+    """When the destination species already has a different representative,
+    rename_photo_preferences_species's INSERT OR IGNORE is ignored and no
+    row for our photo is written at the new species, but the old-species
+    row is still deleted. Undo must restore the old-species representative
+    even though there's no destination row for this photo to key off of."""
+    app, db = app_and_db
+    client = app.test_client()
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES ('/hrcol', 'hrcol', 'ok')"
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO workspace_folders (workspace_id, folder_id) VALUES (?, ?)",
+        (db._ws_id(), fid),
+    )
+    old_kid = db.add_keyword("Rep Old", is_species=True)
+    db.add_keyword("Rep New", is_species=True)
+    p_moving = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+        "VALUES (?, 'moving.jpg', 0.9, 'none')",
+        (fid,),
+    ).lastrowid
+    p_incumbent = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+        "VALUES (?, 'incumbent.jpg', 0.9, 'none')",
+        (fid,),
+    ).lastrowid
+    db.tag_photo(p_moving, old_kid)
+    db.set_species_representative("Rep Old", p_moving)
+    db.set_species_representative("Rep New", p_incumbent)
+
+    resp = client.post(
+        "/api/highlights/relabel",
+        json={"photo_ids": [p_moving], "species": "Rep New"},
+    )
+    assert resp.status_code == 200
+    reps_after = db.get_species_representatives()
+    # Old-species rep dropped; Rep New keeps its original incumbent.
+    assert "Rep Old" not in reps_after
+    assert reps_after.get("Rep New") == p_incumbent
+
+    undone = db.undo_last_edit()
+    assert undone is not None
+    reps = db.get_species_representatives()
+    # Before the fix, the old-species representative stayed stranded
+    # because the destination row for p_moving never existed at "Rep New".
+    assert reps.get("Rep Old") == p_moving
+    assert reps.get("Rep New") == p_incumbent
+
+
 def test_backfill_species_highlights_from_legacy_preferences(tmp_path):
     """On upgraded databases, legacy photo_preferences rows with
     purpose='highlights' should seed species_highlights so pre-existing

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -3455,6 +3455,47 @@ def test_rename_keyword_species_highlights_dedupe_existing_photo(app_and_db):
     }
 
 
+def test_rename_species_highlights_species_chunks_scoped_photo_ids(
+    app_and_db, monkeypatch,
+):
+    """rename_species_highlights_species must chunk the IN(...) clause when
+    called with more photos than SQLite's bound-parameter cap. Without the
+    chunk, an unbounded IN clause on legacy SQLite builds
+    (SQLITE_MAX_VARIABLE_NUMBER=999) raises OperationalError and strands the
+    highlight rows under the renamed species."""
+    from vireo import db as db_module
+
+    _app, db = app_and_db
+    ws = db._ws_id()
+    kid_old = db.add_keyword("OldBird", is_species=True)
+    fid = db.add_folder("/renamed", name="renamed")
+    db.add_workspace_folder(ws, fid)
+
+    # Seed enough photos+highlight rows to exceed the shrunk parameter cap
+    # in a single un-chunked query.
+    monkeypatch.setattr(db_module, "_SQLITE_PARAM_CHUNK_SIZE", 3)
+    photo_ids = []
+    for i in range(7):
+        pid = db.add_photo(
+            folder_id=fid, filename=f"p{i}.jpg", extension=".jpg",
+            file_size=1, file_mtime=float(i),
+        )
+        db.tag_photo(pid, kid_old)
+        db.add_species_highlight("OldBird", pid)
+        photo_ids.append(pid)
+
+    pairs = [(pid, ws) for pid in photo_ids]
+    moved = db.rename_species_highlights_species("OldBird", "NewBird", pairs)
+
+    assert moved == len(photo_ids)
+    assert db.get_species_highlights("OldBird") == {}
+    highlights = db.get_species_highlights("NewBird")
+    # Ranks preserve the original bucket order (1..N).
+    assert highlights == {
+        "NewBird": {pid: rank for rank, pid in enumerate(photo_ids, start=1)}
+    }
+
+
 def test_apply_ordered_highlights_preserves_order_when_no_visible_match():
     """When a species has highlights elsewhere in the workspace but none are
     present in the current bucket, _apply_ordered_highlights must not re-sort

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -3407,6 +3407,51 @@ def test_rename_keyword_species_highlights_dedupe_existing_photo(app_and_db):
     }
 
 
+def test_apply_ordered_highlights_preserves_order_when_no_visible_match():
+    """When a species has highlights elsewhere in the workspace but none are
+    present in the current bucket, _apply_ordered_highlights must not re-sort
+    the bucket. Re-sorting would drop the picked-first order that
+    _highlight_score_bucket already applied on the visible photos."""
+    from app import _apply_ordered_highlights
+
+    class FakeDb:
+        def get_species_highlights(self):
+            return {"Robin": {999: 1}}
+
+    original = [
+        {"id": 1, "highlight_score": 0.4, "flag": "flagged"},
+        {"id": 2, "highlight_score": 0.9, "flag": "none"},
+    ]
+    buckets = [{"species": "Robin", "photos": list(original)}]
+    _apply_ordered_highlights(FakeDb(), buckets)
+    assert [p["id"] for p in buckets[0]["photos"]] == [1, 2]
+    assert all(p["is_highlighted"] is False for p in buckets[0]["photos"])
+    assert all(p["highlight_rank"] is None for p in buckets[0]["photos"])
+
+
+def test_apply_ordered_highlights_resorts_when_visible_match():
+    """When at least one visible photo is a stored highlight, the bucket must
+    be re-sorted so the highlighted photo leads and follows the stored rank."""
+    from app import _apply_ordered_highlights
+
+    class FakeDb:
+        def get_species_highlights(self):
+            return {"Robin": {2: 1}}
+
+    buckets = [{
+        "species": "Robin",
+        "photos": [
+            {"id": 1, "highlight_score": 0.9, "flag": "flagged"},
+            {"id": 2, "highlight_score": 0.4, "flag": "none"},
+        ],
+    }]
+    _apply_ordered_highlights(FakeDb(), buckets)
+    order = [p["id"] for p in buckets[0]["photos"]]
+    assert order == [2, 1]
+    marks = {p["id"]: p["is_highlighted"] for p in buckets[0]["photos"]}
+    assert marks == {1: False, 2: True}
+
+
 def test_rename_homonym_non_species_keyword_leaves_species_preferences(app_and_db):
     """Renaming an unrelated same-name keyword must not rewrite species prefs."""
     app, db = app_and_db

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -3321,6 +3321,77 @@ def test_rename_keyword_photo_preferences_keep_existing_target(app_and_db):
     assert db.get_photo_preferences("life_list") == {"NewBird": p_new}
 
 
+def test_rename_keyword_updates_species_highlights(app_and_db):
+    """Ordered species highlights follow species-keyword renames."""
+    app, db = app_and_db
+    client = app.test_client()
+    kid = db.add_keyword("OldBird", is_species=True)
+    rows = db.conn.execute("SELECT id FROM photos ORDER BY id LIMIT 2").fetchall()
+    p1, p2 = rows[0]["id"], rows[1]["id"]
+    db.tag_photo(p1, kid)
+    db.tag_photo(p2, kid)
+    db.add_species_highlight("OldBird", p1)
+    db.add_species_highlight("OldBird", p2)
+
+    resp = client.put(f"/api/keywords/{kid}", json={"name": "NewBird"})
+    assert resp.status_code == 200
+
+    assert db.get_species_highlights("OldBird") == {}
+    highlights = db.get_species_highlights("NewBird")
+    assert highlights == {"NewBird": {p1: 1, p2: 2}}
+
+
+def test_rename_keyword_species_highlights_merge_into_existing_target(app_and_db):
+    """Renaming into an existing highlights bucket appends after the target's rows."""
+    app, db = app_and_db
+    client = app.test_client()
+    kid_old = db.add_keyword("OldBird", is_species=True)
+    kid_new = db.add_keyword("NewBird", is_species=True)
+    rows = db.conn.execute("SELECT id FROM photos ORDER BY id LIMIT 3").fetchall()
+    p_target = rows[0]["id"]
+    p_moving_a = rows[1]["id"]
+    p_moving_b = rows[2]["id"]
+    db.tag_photo(p_target, kid_new)
+    db.tag_photo(p_moving_a, kid_old)
+    db.tag_photo(p_moving_b, kid_old)
+    db.add_species_highlight("NewBird", p_target)
+    db.add_species_highlight("OldBird", p_moving_a)
+    db.add_species_highlight("OldBird", p_moving_b)
+
+    resp = client.put(f"/api/keywords/{kid_old}", json={"name": "NewBird"})
+    assert resp.status_code == 200
+
+    assert db.get_species_highlights("OldBird") == {}
+    assert db.get_species_highlights("NewBird") == {
+        "NewBird": {p_target: 1, p_moving_a: 2, p_moving_b: 3}
+    }
+
+
+def test_rename_keyword_species_highlights_dedupe_existing_photo(app_and_db):
+    """A photo already highlighted under the target species keeps its target rank."""
+    app, db = app_and_db
+    client = app.test_client()
+    kid_old = db.add_keyword("OldBird", is_species=True)
+    kid_new = db.add_keyword("NewBird", is_species=True)
+    rows = db.conn.execute("SELECT id FROM photos ORDER BY id LIMIT 2").fetchall()
+    p_target = rows[0]["id"]
+    p_shared = rows[1]["id"]
+    db.tag_photo(p_target, kid_new)
+    db.tag_photo(p_shared, kid_old)
+    db.tag_photo(p_shared, kid_new)
+    db.add_species_highlight("NewBird", p_target)
+    db.add_species_highlight("NewBird", p_shared)
+    db.add_species_highlight("OldBird", p_shared)
+
+    resp = client.put(f"/api/keywords/{kid_old}", json={"name": "NewBird"})
+    assert resp.status_code == 200
+
+    assert db.get_species_highlights("OldBird") == {}
+    assert db.get_species_highlights("NewBird") == {
+        "NewBird": {p_target: 1, p_shared: 2}
+    }
+
+
 def test_rename_homonym_non_species_keyword_leaves_species_preferences(app_and_db):
     """Renaming an unrelated same-name keyword must not rewrite species prefs."""
     app, db = app_and_db
@@ -5349,6 +5420,85 @@ def test_highlights_relabel_unidentified_sets_species(app_and_db):
     )
     assert resp.status_code == 200
     assert "Song Sparrow" in {kw["name"] for kw in db.get_photo_keywords(pid)}
+
+
+def test_highlights_relabel_moves_species_highlights_to_new_bucket(app_and_db):
+    """Relabel migrates ordered species_highlights rows to the new species."""
+    app, db = app_and_db
+    client = app.test_client()
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES ('/hrh', 'hrh', 'ok')"
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO workspace_folders (workspace_id, folder_id) VALUES (?, ?)",
+        (db._ws_id(), fid),
+    )
+    old_kid = db.add_keyword("Bald Eagle", is_species=True)
+    p1 = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+        "VALUES (?, 'h1.jpg', 0.8, 'none')",
+        (fid,),
+    ).lastrowid
+    p2 = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+        "VALUES (?, 'h2.jpg', 0.8, 'none')",
+        (fid,),
+    ).lastrowid
+    db.tag_photo(p1, old_kid)
+    db.tag_photo(p2, old_kid)
+    db.add_species_highlight("Bald Eagle", p1)
+    db.add_species_highlight("Bald Eagle", p2)
+
+    resp = client.post(
+        "/api/highlights/relabel",
+        json={"photo_ids": [p1, p2], "species": "Golden Eagle"},
+    )
+    assert resp.status_code == 200
+
+    assert db.get_species_highlights("Bald Eagle") == {}
+    assert db.get_species_highlights("Golden Eagle") == {
+        "Golden Eagle": {p1: 1, p2: 2}
+    }
+
+
+def test_highlights_relabel_merges_into_existing_new_species_bucket(app_and_db):
+    """Relabel appends after rows already present in the destination bucket."""
+    app, db = app_and_db
+    client = app.test_client()
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES ('/hrm', 'hrm', 'ok')"
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO workspace_folders (workspace_id, folder_id) VALUES (?, ?)",
+        (db._ws_id(), fid),
+    )
+    db.add_keyword("Bald Eagle", is_species=True)
+    new_kid = db.add_keyword("Golden Eagle", is_species=True)
+    p_dest = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+        "VALUES (?, 'dest.jpg', 0.8, 'none')",
+        (fid,),
+    ).lastrowid
+    p_moving = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+        "VALUES (?, 'moving.jpg', 0.8, 'none')",
+        (fid,),
+    ).lastrowid
+    db.tag_photo(p_dest, new_kid)
+    db.tag_photo(p_moving, db.add_keyword("Bald Eagle", is_species=True))
+    db.add_species_highlight("Golden Eagle", p_dest)
+    db.add_species_highlight("Bald Eagle", p_moving)
+
+    resp = client.post(
+        "/api/highlights/relabel",
+        json={"photo_ids": [p_moving], "species": "Golden Eagle"},
+    )
+    assert resp.status_code == 200
+
+    assert db.get_species_highlights("Bald Eagle") == {}
+    assert db.get_species_highlights("Golden Eagle") == {
+        "Golden Eagle": {p_dest: 1, p_moving: 2}
+    }
 
 
 def test_highlights_accepted_species_wins_over_higher_confidence_prediction(app_and_db):

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -1615,6 +1615,54 @@ def test_replace_prediction_keywords_updates_grouped_photos(app_and_db):
         )
 
 
+def test_replace_prediction_keywords_migrates_species_curation(app_and_db):
+    """Replacing species via prediction moves ordered highlights and
+    representative preferences from the old species to the new one.
+    Without this migration, a curated photo silently loses its
+    Highlights/Life-List position when its species is swapped."""
+    app, db = app_and_db
+    photo_id = db.conn.execute(
+        "SELECT id FROM photos ORDER BY id LIMIT 1"
+    ).fetchone()["id"]
+    old_kid = db.add_keyword("Old Species", is_species=True)
+    db.tag_photo(photo_id, old_kid)
+    db.add_species_highlight("Old Species", photo_id)
+    db.set_species_representative("Old Species", photo_id)
+
+    det_id = db.save_detections(photo_id, [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.3},
+         "confidence": 0.9, "category": "animal"},
+    ], detector_model="MDV6")[0]
+    db.add_prediction(det_id, "New Species", 0.95, "model-a")
+    pred = db.conn.execute(
+        """SELECT id FROM predictions
+           WHERE detection_id = ? AND classifier_model = ?""",
+        (det_id, "model-a"),
+    ).fetchone()
+
+    resp = app.test_client().post(
+        f"/api/predictions/{pred['id']}/replace-keywords"
+    )
+    assert resp.status_code == 200
+
+    ws_id = db._ws_id()
+    highlights = db.conn.execute(
+        """SELECT species FROM species_highlights
+           WHERE workspace_id = ? AND photo_id = ?""",
+        (ws_id, photo_id),
+    ).fetchall()
+    assert [r["species"] for r in highlights] == ["New Species"]
+
+    prefs = db.conn.execute(
+        """SELECT purpose, species FROM photo_preferences
+           WHERE workspace_id = ? AND photo_id = ?""",
+        (ws_id, photo_id),
+    ).fetchall()
+    assert {(p["purpose"], p["species"]) for p in prefs} == {
+        ("species_representative", "New Species"),
+    }
+
+
 def test_api_predictions_include_bounding_box(app_and_db):
     """GET /api/predictions should return bounding box data from detections."""
     app, db = app_and_db

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -5535,6 +5535,113 @@ def test_highlights_relabel_migrates_species_representative(app_and_db):
     assert "Bald Eagle" not in reps
 
 
+def test_highlights_relabel_undo_restores_curation(app_and_db):
+    """Undoing a Highlights relabel restores the migrated ordered-highlight
+    row and species_representative preference back under the old species,
+    so the photo isn't stranded under the new species when the relabel
+    itself is undone. Redo re-applies the migration."""
+    app, db = app_and_db
+    client = app.test_client()
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES ('/hrundo', 'hrundo', 'ok')"
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO workspace_folders (workspace_id, folder_id) VALUES (?, ?)",
+        (db._ws_id(), fid),
+    )
+    old_kid = db.add_keyword("Bald Eagle", is_species=True)
+    db.add_keyword("Golden Eagle", is_species=True)
+    pid = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+        "VALUES (?, 'undo-cur.jpg', 0.9, 'none')",
+        (fid,),
+    ).lastrowid
+    db.tag_photo(pid, old_kid)
+    db.set_species_representative("Bald Eagle", pid)
+    db.add_species_highlight("Bald Eagle", pid)
+
+    resp = client.post(
+        "/api/highlights/relabel",
+        json={"photo_ids": [pid], "species": "Golden Eagle"},
+    )
+    assert resp.status_code == 200
+    assert db.get_species_representatives().get("Golden Eagle") == pid
+    assert pid in (db.get_species_highlights("Golden Eagle") or {}).get(
+        "Golden Eagle", {}
+    )
+
+    undone = db.undo_last_edit()
+    assert undone is not None
+    assert undone["action_type"] == "species_replace"
+    reps = db.get_species_representatives()
+    assert reps.get("Bald Eagle") == pid
+    assert "Golden Eagle" not in reps
+    hl = db.get_species_highlights()
+    assert pid in (hl.get("Bald Eagle") or {})
+    assert "Golden Eagle" not in hl
+
+    redone = db.redo_last_undo()
+    assert redone is not None
+    assert redone["action_type"] == "species_replace"
+    reps_redo = db.get_species_representatives()
+    assert reps_redo.get("Golden Eagle") == pid
+    assert "Bald Eagle" not in reps_redo
+    hl_redo = db.get_species_highlights()
+    assert pid in (hl_redo.get("Golden Eagle") or {})
+    assert "Bald Eagle" not in hl_redo
+
+
+def test_backfill_species_highlights_from_legacy_preferences(tmp_path):
+    """On upgraded databases, legacy photo_preferences rows with
+    purpose='highlights' should seed species_highlights so pre-existing
+    Highlights picks stay visible under the new ordered-highlights UI."""
+    from vireo.db import Database
+
+    db_path = tmp_path / "legacy.db"
+    db = Database(str(db_path))
+    ws_id = db._ws_id()
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES ('/legacy', 'legacy', 'ok')"
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO workspace_folders (workspace_id, folder_id) VALUES (?, ?)",
+        (ws_id, fid),
+    )
+    pid = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+        "VALUES (?, 'legacy.jpg', 0.9, 'none')",
+        (fid,),
+    ).lastrowid
+    db.conn.execute(
+        """INSERT INTO photo_preferences
+               (workspace_id, purpose, species, photo_id,
+                created_at, updated_at)
+           VALUES (?, 'highlights', 'Legacy Bird', ?,
+                   datetime('now'), datetime('now'))""",
+        (ws_id, pid),
+    )
+    # Clear the one-shot marker so re-running the backfill picks up the
+    # newly-added legacy row (simulates opening a DB that predated the
+    # ordered-highlights feature).
+    db.conn.execute(
+        "DELETE FROM db_meta WHERE key = ?",
+        (db._SPECIES_HIGHLIGHTS_BACKFILL_KEY,),
+    )
+    db.conn.commit()
+    db.backfill_species_highlights_from_legacy_preferences()
+
+    hl = db.get_species_highlights()
+    assert pid in (hl.get("Legacy Bird") or {})
+
+    # Marker set so subsequent calls are no-ops even if the row is missing.
+    marker = db.conn.execute(
+        "SELECT value FROM db_meta WHERE key = ?",
+        (db._SPECIES_HIGHLIGHTS_BACKFILL_KEY,),
+    ).fetchone()
+    assert marker is not None
+    db.close()
+
+
 def test_highlights_accepted_species_wins_over_higher_confidence_prediction(app_and_db):
     """Manual species tag is authoritative even when a high-confidence
     prediction disagrees."""

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -5501,6 +5501,40 @@ def test_highlights_relabel_merges_into_existing_new_species_bucket(app_and_db):
     }
 
 
+def test_highlights_relabel_migrates_species_representative(app_and_db):
+    """Relabel moves species_representative preferences to the new species
+    so `get_species_representatives()` returns the photo under its new bucket
+    rather than stranding it under the old species."""
+    app, db = app_and_db
+    client = app.test_client()
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES ('/hrrep', 'hrrep', 'ok')"
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO workspace_folders (workspace_id, folder_id) VALUES (?, ?)",
+        (db._ws_id(), fid),
+    )
+    old_kid = db.add_keyword("Bald Eagle", is_species=True)
+    db.add_keyword("Golden Eagle", is_species=True)
+    pid = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+        "VALUES (?, 'rep.jpg', 0.9, 'none')",
+        (fid,),
+    ).lastrowid
+    db.tag_photo(pid, old_kid)
+    db.set_species_representative("Bald Eagle", pid)
+
+    resp = client.post(
+        "/api/highlights/relabel",
+        json={"photo_ids": [pid], "species": "Golden Eagle"},
+    )
+    assert resp.status_code == 200
+
+    reps = db.get_species_representatives()
+    assert reps.get("Golden Eagle") == pid
+    assert "Bald Eagle" not in reps
+
+
 def test_highlights_accepted_species_wins_over_higher_confidence_prediction(app_and_db):
     """Manual species tag is authoritative even when a high-confidence
     prediction disagrees."""

--- a/vireo/tests/test_life_list.py
+++ b/vireo/tests/test_life_list.py
@@ -191,6 +191,88 @@ def test_clearing_representative_removes_legacy_fallbacks(life_app):
     assert cardinal["best_source"] == "algorithm"
 
 
+def test_photo_preferences_highlights_purpose_adds_ordered_highlight(life_app):
+    """POST /api/photo-preferences with purpose='highlights' must add an
+    ordered species highlight — not silently overwrite the species
+    representative. Guards against legacy clients (or a cached Highlights
+    page) whose POST would otherwise mislabel a highlight pick as the
+    canonical representative."""
+    app, db, ids = life_app
+    client = app.test_client()
+
+    resp = client.post("/api/photo-preferences", json={
+        "purpose": "highlights",
+        "species": "Northern Cardinal",
+        "photo_id": ids["p2"],
+    })
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["ok"] is True
+    assert body["purpose"] == "highlights"
+    assert body["rank"] == 1
+
+    # The photo landed in species_highlights, not in photo_preferences
+    # as a representative.
+    assert db.get_species_highlights("Northern Cardinal") == {
+        "Northern Cardinal": {ids["p2"]: 1},
+    }
+    assert db.get_photo_preferences("species_representative") == {}
+
+
+def test_photo_preferences_highlights_delete_removes_ordered_highlight(life_app):
+    """DELETE /api/photo-preferences with purpose='highlights' + photo_id
+    must remove that specific ordered highlight and leave the species
+    representative alone."""
+    app, db, ids = life_app
+    db.add_species_highlight("Northern Cardinal", ids["p1"])
+    db.set_species_representative("Northern Cardinal", ids["p2"])
+
+    resp = app.test_client().delete("/api/photo-preferences", json={
+        "purpose": "highlights",
+        "species": "Northern Cardinal",
+        "photo_id": ids["p1"],
+    })
+    assert resp.status_code == 200
+
+    assert db.get_species_highlights("Northern Cardinal") == {}
+    # The species_representative pick is untouched — DELETE with
+    # purpose=highlights must not clear the representative.
+    assert db.get_species_representatives() == {"Northern Cardinal": ids["p2"]}
+
+
+def test_photo_preferences_highlights_delete_requires_photo_id(life_app):
+    """DELETE with purpose='highlights' but no photo_id is ambiguous
+    (ordered highlights are per-photo) and must 400 rather than clearing
+    all highlights for the species."""
+    app, db, ids = life_app
+    db.add_species_highlight("Northern Cardinal", ids["p1"])
+
+    resp = app.test_client().delete("/api/photo-preferences", json={
+        "purpose": "highlights",
+        "species": "Northern Cardinal",
+    })
+    assert resp.status_code == 400
+    # The highlight is still there.
+    assert db.get_species_highlights("Northern Cardinal") == {
+        "Northern Cardinal": {ids["p1"]: 1},
+    }
+
+
+def test_photo_preferences_highlights_rejects_predicted_only_photo(life_app):
+    """Highlights eligibility is stricter than life-list eligibility: a
+    photo that lacks the accepted species keyword should be checked via
+    the highlights-bucket eligibility path, not the life-list one."""
+    app, _, ids = life_app
+    # p3 belongs to House Sparrow, not Northern Cardinal — so it is not
+    # a valid Northern Cardinal highlight.
+    resp = app.test_client().post("/api/photo-preferences", json={
+        "purpose": "highlights",
+        "species": "Northern Cardinal",
+        "photo_id": ids["p3"],
+    })
+    assert resp.status_code == 400
+
+
 def test_ordered_highlight_is_life_list_fallback(life_app):
     app, db, ids = life_app
     db.add_species_highlight("Northern Cardinal", ids["p1"])

--- a/vireo/tests/test_life_list.py
+++ b/vireo/tests/test_life_list.py
@@ -143,7 +143,9 @@ def test_life_list_photo_preference_overrides_best_photo(life_app):
     cardinal = _entry(data, "Northern Cardinal")
     assert cardinal["best"]["id"] == ids["p1"]
     assert cardinal["best"]["is_life_list_photo"] is True
+    assert cardinal["best"]["is_species_representative"] is True
     assert cardinal["has_preferred_photo"] is True
+    assert cardinal["best_source"] == "representative"
     assert [p["id"] for p in cardinal["photos"][:2]] == [ids["p1"], ids["p2"]]
 
 
@@ -157,23 +159,87 @@ def test_life_list_photo_preference_must_match_species(life_app):
     assert resp.status_code == 400
 
 
-def test_highlights_photo_preference_overrides_best_photo(life_app):
+def test_clearing_representative_removes_legacy_fallbacks(life_app):
+    app, db, ids = life_app
+    db.set_photo_preference("life_list", "Northern Cardinal", ids["p1"])
+    db.set_photo_preference("highlights", "Northern Cardinal", ids["p2"])
+
+    resp = app.test_client().delete("/api/photo-preferences", json={
+        "purpose": "species_representative",
+        "species": "Northern Cardinal",
+    })
+    assert resp.status_code == 200
+
+    assert db.get_species_representatives() == {}
+    data = _get_life_list(app)
+    cardinal = _entry(data, "Northern Cardinal")
+    assert cardinal["best"]["id"] == ids["p2"]
+    assert cardinal["best_source"] == "algorithm"
+
+
+def test_ordered_highlight_is_life_list_fallback(life_app):
+    app, db, ids = life_app
+    db.add_species_highlight("Northern Cardinal", ids["p1"])
+
+    data = _get_life_list(app)
+    cardinal = _entry(data, "Northern Cardinal")
+    assert cardinal["best"]["id"] == ids["p1"]
+    assert cardinal["best"]["is_highlighted"] is True
+    assert cardinal["best_source"] == "highlight"
+
+
+def test_species_representative_beats_ordered_highlight_for_life_list(life_app):
+    app, db, ids = life_app
+    db.add_species_highlight("Northern Cardinal", ids["p1"])
+    db.set_species_representative("Northern Cardinal", ids["p2"])
+
+    data = _get_life_list(app)
+    cardinal = _entry(data, "Northern Cardinal")
+    assert cardinal["best"]["id"] == ids["p2"]
+    assert cardinal["best"]["is_species_representative"] is True
+    assert cardinal["best_source"] == "representative"
+
+
+def test_ordered_highlights_control_highlights_bucket_order(life_app):
     app, _, ids = life_app
     client = app.test_client()
-    resp = client.post("/api/photo-preferences", json={
-        "purpose": "highlights",
+    resp = client.post("/api/species-highlights", json={
         "species": "Northern Cardinal",
         "photo_id": ids["p1"],
     })
     assert resp.status_code == 200
 
-    data = client.get("/api/highlights?scope=workspace").get_json()
+    data = client.get(
+        "/api/highlights?scope=workspace&limit_per_bucket=1"
+    ).get_json()
     cardinal = next(
         b for b in data["buckets"] if b["species"] == "Northern Cardinal"
     )
     assert cardinal["photos"][0]["id"] == ids["p1"]
-    assert cardinal["photos"][0]["is_highlights_photo"] is True
-    assert cardinal["has_preferred_photo"] is True
+    assert cardinal["photos"][0]["is_highlighted"] is True
+    assert cardinal["photos"][0]["highlight_rank"] == 1
+    assert cardinal["highlight_count"] == 1
+
+    resp = client.post("/api/species-highlights", json={
+        "species": "Northern Cardinal",
+        "photo_id": ids["p2"],
+    })
+    assert resp.status_code == 200
+    resp = client.patch("/api/species-highlights/order", json={
+        "species": "Northern Cardinal",
+        "photo_id": ids["p2"],
+        "direction": "up",
+    })
+    assert resp.status_code == 200
+
+    data = client.get(
+        "/api/highlights?scope=workspace&limit_per_bucket=1"
+    ).get_json()
+    cardinal = next(
+        b for b in data["buckets"] if b["species"] == "Northern Cardinal"
+    )
+    assert cardinal["photos"][0]["id"] == ids["p2"]
+    assert cardinal["photos"][0]["highlight_rank"] == 1
 
 
 def test_life_order_numbering_and_dates(life_app):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -526,7 +526,7 @@ def test_api_photo_detail_includes_on_disk_path(app_and_db):
 def test_photo_detail_life_list_lists_eligible_species(app_and_db):
     """GET /api/photos/<id> exposes a life_list block naming the photo's
     lifelist-eligible species so the shared lightbox / browse menu can offer
-    an 'Add to Life List' action without page-local data."""
+    a representative action without page-local data."""
     app, db = app_and_db
     client = app.test_client()
     pid = db.get_photos()[0]["id"]
@@ -535,7 +535,11 @@ def test_photo_detail_life_list_lists_eligible_species(app_and_db):
 
     data = client.get(f"/api/photos/{pid}").get_json()
     assert data["life_list"] == [
-        {"species": "American Robin", "is_current_photo": False}
+        {
+            "species": "American Robin",
+            "is_current_photo": False,
+            "is_species_representative": False,
+        }
     ]
 
 
@@ -550,7 +554,11 @@ def test_photo_detail_life_list_marks_current_representative(app_and_db):
 
     data = client.get(f"/api/photos/{pid}").get_json()
     assert data["life_list"] == [
-        {"species": "American Robin", "is_current_photo": True}
+        {
+            "species": "American Robin",
+            "is_current_photo": True,
+            "is_species_representative": True,
+        }
     ]
 
 
@@ -568,7 +576,11 @@ def test_photo_detail_life_list_current_false_when_other_photo_is_rep(app_and_db
 
     data = client.get(f"/api/photos/{p1}").get_json()
     assert data["life_list"] == [
-        {"species": "American Robin", "is_current_photo": False}
+        {
+            "species": "American Robin",
+            "is_current_photo": False,
+            "is_species_representative": False,
+        }
     ]
 
 
@@ -601,7 +613,11 @@ def test_photo_detail_life_list_includes_taxonomy_type_keyword(app_and_db):
 
     data = client.get(f"/api/photos/{pid}").get_json()
     assert data["life_list"] == [
-        {"species": "Bald Eagle", "is_current_photo": False}
+        {
+            "species": "Bald Eagle",
+            "is_current_photo": False,
+            "is_species_representative": False,
+        }
     ]
 
 


### PR DESCRIPTION
Adds workspace-scoped Species Representatives as the explicit one-photo-per-species choice, with legacy Life List/Highlights preferences preserved as representative fallbacks. Adds ordered multi-photo species highlights with add/remove/move APIs and updates Highlights, Life List, browse, and lightbox UI language around Representatives and Highlights. Life List representatives now resolve by explicit representative, then first ordered highlight, then algorithmic fallback, and workspace moves carry ordered highlights. Validated with targeted unit and E2E tests plus git diff whitespace checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Set one species representative photo from browse menus, Life List, or the lightbox.
  * Add, remove, and reorder ordered species highlights with Up/Down controls.
  * Highlights now show representative status, highlight rank, and “Best” indicators; photo details reflect representative flags.
* **Bug Fixes**
  * Preserved species representatives and ordered highlight ordering when moving folders between workspaces or renaming species.
  * Improved highlights computation (including best timestamp) and added legacy upgrade backfill for ordered highlights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->