### PR TITLE
Run Missing Originals checks in background

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3727,6 +3727,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def api_folders_check_health():
         db = _get_db()
         changed = db.check_folder_health()
+        # A folder flipping ok→missing turns every one of its photos into a
+        # ghost, and missing→ok resurrects them. Either transition would
+        # otherwise be masked by a ready /api/photos/missing cache until the
+        # next full scan.
+        if changed:
+            _invalidate_missing_originals_cache()
         missing = db.get_missing_folders()
         return jsonify({
             "changed": changed,
@@ -3842,6 +3848,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             cascaded = db.relocate_folder(folder_id, new_path)
         except ValueError as e:
             return json_error(str(e), 409)
+
+        # Relocation rewrites folders.path (and can merge/delete rows via the
+        # missing→existing branch). A ready /api/photos/missing cache would
+        # otherwise keep offering the pre-relocation ghost rows for removal
+        # even though the originals just came back online at the new path.
+        _invalidate_missing_originals_cache()
 
         import config as cfg
         from export import relocate_developed_dir
@@ -13787,7 +13799,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             thread_db = Database(db_path)
             thread_db.set_active_workspace(active_ws)
             # Check folder health before scanning to prevent duplicate imports
-            thread_db.check_folder_health()
+            if thread_db.check_folder_health():
+                _invalidate_missing_originals_cache()
 
             # Accumulator so multi-root progress doesn't rewind at each
             # root boundary. scanner.scan() reports (current, total) local
@@ -15885,7 +15898,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             thread_db = Database(db_path)
             thread_db.set_active_workspace(active_ws)
             # Check folder health before scanning to prevent duplicate imports
-            thread_db.check_folder_health()
+            if thread_db.check_folder_health():
+                _invalidate_missing_originals_cache()
             job["_start_time"] = time.time()
 
             scan_target = str(Path(source))  # normalize (strips trailing slash)
@@ -16306,7 +16320,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
             thread_db = Database(db_path)
             thread_db.set_active_workspace(active_ws)
-            thread_db.check_folder_health()
+            if thread_db.check_folder_health():
+                _invalidate_missing_originals_cache()
             effective_cfg = thread_db.get_effective_config(cfg.load())
             pipeline_cfg = effective_cfg.get("pipeline", {})
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3333,6 +3333,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # scan would; letting them run concurrently can double the filesystem
         # load on slow NAS/SMB libraries.
         "new_images_walk",
+        # Folder-scoped and workspace-wide missing-originals scans have
+        # distinct cache keys, so the same-key in-flight coalescing does
+        # not catch a workspace scan started while a folder scan is
+        # running (or vice versa). Treat any in-flight
+        # missing_originals_scan as heavy work so automatic reruns
+        # don't kick off a second filesystem walk over the same tree.
+        "missing_originals_scan",
     }
 
     def _utc_iso_now():
@@ -3847,6 +3854,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # Clean up cached files alongside the cascaded photo rows so preview
         # files don't get orphaned on disk (untracked by preview_cache).
         _cleanup_cached_files_for_deleted_photos(result.get("files", []))
+        # The cascaded row deletion here is the same shape as any other
+        # photo-removal path: without invalidation, a ready
+        # /api/photos/missing cache could keep listing ghosts from the
+        # now-deleted folder (offered up for removal a second time in
+        # the modal) until the next scan runs.
+        _invalidate_missing_originals_cache()
         # Don't leak the internal file list to the API response — keep the
         # shape callers expect.
         return jsonify({"deleted_photos": result["deleted_photos"]})

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -31,6 +31,7 @@ from db import (
     KEYWORD_TYPES,
     Database,
     IncompatibleDatabaseError,
+    MissingPhotosCancelled,
     commit_with_retry,
     text_search_match,
 )
@@ -3447,11 +3448,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "folder_id": folder_id,
             }
 
-    def _build_missing_originals_rows(db, folder_id=None, progress_callback=None):
+    def _build_missing_originals_rows(
+        db,
+        folder_id=None,
+        progress_callback=None,
+        cancel_callback=None,
+    ):
         thumb_dir = app.config["THUMB_CACHE_DIR"]
         vireo_dir = os.path.dirname(thumb_dir)
         preview_dir = os.path.join(vireo_dir, "previews")
         working_dir = os.path.join(vireo_dir, "working")
+
+        def check_cancelled():
+            if cancel_callback is not None and cancel_callback():
+                raise MissingPhotosCancelled("missing originals scan cancelled")
 
         # Index preview cache once. The endpoint is polled from the navbar,
         # so per-photo `glob(preview_dir, f"{pid}_*.jpg")` was O(missing ×
@@ -3459,15 +3469,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # listdir and check the set in O(1) per row.
         preview_pids: set[int] = set()
         try:
-            for name in os.listdir(preview_dir):
-                # Match `{id}.jpg` (legacy full preview) or `{id}_{size}.jpg`
-                # (sized variant). Anything else is not part of the per-photo
-                # cache and should be ignored.
-                if not name.endswith(".jpg"):
-                    continue
-                head = name[:-4].split("_", 1)[0]
-                if head.isdigit():
-                    preview_pids.add(int(head))
+            check_cancelled()
+            with os.scandir(preview_dir) as it:
+                for entry in it:
+                    check_cancelled()
+                    name = entry.name
+                    # Match `{id}.jpg` (legacy full preview) or `{id}_{size}.jpg`
+                    # (sized variant). Anything else is not part of the per-photo
+                    # cache and should be ignored.
+                    if not name.endswith(".jpg"):
+                        continue
+                    head = name[:-4].split("_", 1)[0]
+                    if head.isdigit():
+                        preview_pids.add(int(head))
         except FileNotFoundError:
             pass  # cache dir hasn't been created yet — no previews
 
@@ -3475,7 +3489,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         for row in db.get_missing_photos(
             folder_id=folder_id,
             progress_callback=progress_callback,
+            cancel_callback=cancel_callback,
         ):
+            check_cancelled()
             pid = row["id"]
             src = os.path.join(row["folder_path"], row["filename"])
             stem, _ext = os.path.splitext(src)
@@ -3654,15 +3670,23 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         "phase": job["progress"]["phase"],
                     })
 
+                def cancel_check():
+                    return runner.is_cancelled(job["id"])
+
                 photos = _build_missing_originals_rows(
                     thread_db,
                     folder_id=folder_id,
                     progress_callback=progress,
+                    cancel_callback=cancel_check,
                 )
+                if cancel_check():
+                    return {"cancelled": True, "scope": scope_label}
                 checked_at = _utc_iso_now()
                 stale = False
                 with app._missing_originals_lock:
                     current_gen = app._missing_originals_generation.get(key, 0)
+                    if cancel_check():
+                        return {"cancelled": True, "scope": scope_label}
                     if current_gen != scan_generation:
                         # A batch delete (or other invalidation) fired
                         # while this scan was walking the disk. Its photo
@@ -3685,6 +3709,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     "scope": scope_label,
                     "stale": stale,
                 }
+            except MissingPhotosCancelled:
+                raise
             except Exception as exc:
                 checked_at = _utc_iso_now()
                 with app._missing_originals_lock:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3394,7 +3394,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             entry = app._missing_originals_cache.get(key)
             inflight = app._missing_originals_inflight.get(key)
             err = app._missing_originals_errors.get(key)
-            if entry is not None:
+            # An error recorded after the last cached scan means a later
+            # refresh failed. Returning the pre-refresh photo list as a
+            # fresh "ready" result would hide the failure — and worse,
+            # let the user delete rows whose originals may have been
+            # restored between scans. When a scan is in flight the UI
+            # already shows "pending", so still surface the stale
+            # entry then; otherwise prefer the error state.
+            cache_superseded_by_error = (
+                entry is not None
+                and err is not None
+                and not inflight
+                and err["set_at"] > entry["set_at"]
+            )
+            if entry is not None and not cache_superseded_by_error:
                 status = "pending" if inflight else "ready"
                 photos = entry["photos"]
                 checked_at = entry["checked_at"]
@@ -14137,6 +14150,22 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         root_errors.append(cache_msg)
                         if cache_msg not in job["errors"]:
                             job["errors"].append(cache_msg)
+                    # scanner.scan touches disk and may add or remove
+                    # photo rows; a ready Missing Originals payload
+                    # computed before the scan can now be stale (e.g.
+                    # user restored an original before running "Rescan
+                    # this Folder"). The pre-scan health-check
+                    # invalidation only fires when a folder flips
+                    # missing/ok, so also drop the cache once the scan
+                    # itself has run — even on partial failure, since
+                    # rows are committed incrementally.
+                    try:
+                        _invalidate_missing_originals_cache()
+                    except Exception:
+                        log.exception(
+                            "Failed to invalidate missing-originals cache for %s",
+                            root,
+                        )
                     advance_scan_acc()
 
             if cancelled or cancel_check():

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -17059,9 +17059,31 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 vireo_dir=vireo_dir,
                 thumb_cache_dir=thumb_cache_dir,
             )
-            result = run_import_job(job, runner, db_path, active_ws, params)
-            _chain_after_import(job, result)
-            return result
+            try:
+                result = run_import_job(
+                    job, runner, db_path, active_ws, params,
+                )
+                _chain_after_import(job, result)
+                return result
+            finally:
+                # run_import_job can flip destination folders from
+                # ``missing`` to ``ok`` and re-scans landed files, so a
+                # ready /api/photos/missing cache computed before the
+                # import can now list rows whose originals are back on
+                # disk. The other scan/import paths (rescan-this-folder,
+                # import-in-place) already invalidate the cache after
+                # they touch disk; do the same here so the banner/modal
+                # stop offering ghosts for photos this job just restored,
+                # even if the job failed part-way (rows land
+                # incrementally). Best-effort: never let a cache-drop
+                # failure mask the underlying import result.
+                try:
+                    _invalidate_missing_originals_cache()
+                except Exception:
+                    log.exception(
+                        "Failed to invalidate missing-originals cache "
+                        "after import-photos job",
+                    )
 
         job_id = runner.start(
             "import", work, config=job_config, workspace_id=active_ws,

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -12653,11 +12653,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         from audit import import_untracked
 
         vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
-        import_untracked(
-            db, paths,
-            vireo_dir=vireo_dir,
-            thumb_cache_dir=app.config["THUMB_CACHE_DIR"],
-        )
+        try:
+            import_untracked(
+                db, paths,
+                vireo_dir=vireo_dir,
+                thumb_cache_dir=app.config["THUMB_CACHE_DIR"],
+            )
+        finally:
+            try:
+                _invalidate_missing_originals_cache()
+            except Exception:
+                log.exception(
+                    "Failed to invalidate missing-originals cache after audit import"
+                )
         # Audit import calls scanner.scan just like the standalone scan/import
         # paths above. Without ExifTool the newly imported photos still lose
         # capture date, GPS, and camera info; the frontend renders any warning

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -19026,6 +19026,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return run_pipeline_job(
                 job, runner, db_path, workspace_id, params,
                 thumb_cache_dir=app.config["THUMB_CACHE_DIR"],
+                missing_originals_invalidator=_invalidate_missing_originals_cache,
             )
 
         job_config = {
@@ -19707,6 +19708,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return run_pipeline_job(
                 job, runner, db_path, active_ws, params,
                 thumb_cache_dir=app.config["THUMB_CACHE_DIR"],
+                missing_originals_invalidator=_invalidate_missing_originals_cache,
             )
 
         # Enqueue rather than start directly: when SLOT_CAP is 1 and

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3791,6 +3791,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         ws_id = db._active_workspace_id
         deleted = 0
         skipped = 0
+        folder_online_cache = {}
         for raw_id in photo_ids:
             try:
                 pid = int(raw_id)
@@ -3808,7 +3809,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if not row:
                 skipped += 1
                 continue
-            src = os.path.join(row["folder_path"], row["filename"])
+            folder_path = row["folder_path"]
+            folder_online = folder_online_cache.get(folder_path)
+            if folder_online is None:
+                folder_online = os.path.isdir(folder_path)
+                folder_online_cache[folder_path] = folder_online
+            if not folder_online:
+                # Folder is currently unreachable — we can't tell whether
+                # the original was restored before the mount went offline,
+                # so skip the sidecar (a valid original could have a
+                # matching .xmp we would wrongly delete once the volume
+                # comes back).
+                skipped += 1
+                continue
+            src = os.path.join(folder_path, row["filename"])
             if os.path.exists(src):
                 # Original came back — refuse to touch the sidecar.
                 skipped += 1
@@ -3867,8 +3881,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         ws_id = db._active_workspace_id
         confirmed_ids = []
         restored_ids = []
+        folder_offline_ids = []
         skipped = 0
         sidecar_targets = []
+        folder_online_cache = {}
         for raw_id in photo_ids:
             try:
                 pid = int(raw_id)
@@ -3886,7 +3902,22 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if not row:
                 skipped += 1
                 continue
-            src = os.path.join(row["folder_path"], row["filename"])
+            folder_path = row["folder_path"]
+            folder_online = folder_online_cache.get(folder_path)
+            if folder_online is None:
+                folder_online = os.path.isdir(folder_path)
+                folder_online_cache[folder_path] = folder_online
+            if not folder_online:
+                # The parent folder/NAS mount is currently unreachable, so
+                # ``os.path.exists(src)`` would return False for every row
+                # regardless of whether the original was restored before
+                # the volume went offline. Deleting under that ambiguity
+                # would remove valid Vireo rows; leave the decision for a
+                # later scan (once folder health flips or the volume comes
+                # back) instead.
+                folder_offline_ids.append(pid)
+                continue
+            src = os.path.join(folder_path, row["filename"])
             if os.path.exists(src):
                 # Original is back on disk — the cached "missing" verdict
                 # was stale. Keep the Vireo row (and its sidecar).
@@ -3934,13 +3965,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # deletion is also the one the banner will keep serving until the
         # next scan. Dropping it now forces a fresh check the next time
         # the banner/modal asks, so the restored photos stop appearing
-        # as ghosts.
-        if restored_ids and deleted_count == 0:
+        # as ghosts. Do the same when we deferred rows because a folder
+        # was offline: the cache is unreliable evidence for those IDs and
+        # the next scan (or health flip) needs to replace it.
+        if deleted_count == 0 and (restored_ids or folder_offline_ids):
             _invalidate_missing_originals_cache()
 
         return jsonify({
             "deleted": deleted_count,
             "restored": restored_ids,
+            "folder_offline": folder_offline_ids,
             "skipped": skipped,
             "sidecars_deleted": sidecars_deleted,
             "sidecars_skipped": sidecars_skipped,

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3501,19 +3501,31 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         token = object()
         suppressed_reason = None
         reuse_existing = False
+        fresh_cache = False
         with app._missing_originals_lock:
             inflight = app._missing_originals_inflight.get(key)
             if inflight:
                 reuse_existing = True
+            entry = app._missing_originals_cache.get(key)
+            if (
+                not reuse_existing
+                and automatic
+                and entry is not None
+                and now - entry["set_at"] <= _MISSING_ORIGINALS_STALE_SECONDS
+            ):
+                fresh_cache = True
             err = app._missing_originals_errors.get(key)
             if (
                 not reuse_existing
+                and not fresh_cache
                 and automatic
                 and err is not None
                 and now < err["backoff_until"]
             ):
                 suppressed_reason = "backoff"
         if reuse_existing:
+            return _missing_originals_payload(db, folder_id)
+        if fresh_cache:
             return _missing_originals_payload(db, folder_id)
         if automatic and suppressed_reason is None and _missing_originals_heavy_job_active():
             suppressed_reason = "heavy_job_active"

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3853,7 +3853,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             folder_path = row["folder_path"]
             folder_online = folder_online_cache.get(folder_path)
             if folder_online is None:
-                folder_online = os.path.isdir(folder_path)
+                # Match /api/photos/missing/remove: a path that stats as a
+                # directory but can't be enumerated (NAS/share ACL denial,
+                # missing search permission) makes ``os.path.exists(src)``
+                # unreliable for every child, so we'd otherwise unlink
+                # sidecars belonging to originals we couldn't actually
+                # verify were missing.
+                folder_online = False
+                if os.path.isdir(folder_path):
+                    try:
+                        with os.scandir(folder_path):
+                            folder_online = True
+                    except OSError:
+                        folder_online = False
                 folder_online_cache[folder_path] = folder_online
             if not folder_online:
                 # Folder is currently unreachable — we can't tell whether

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3353,6 +3353,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # missing-originals timer fire during verification would
         # double the I/O on those slow volumes.
         "verify-hashes",
+        # The startup working-copy backfill job walks the same source
+        # trees and additionally performs RAW decode + JPEG encode
+        # work per file, so overlapping it with an automatic Missing
+        # Originals scan can double the source-volume I/O on large
+        # legacy RAW libraries over NAS/SMB.
+        "working_copy_backfill",
     }
 
     def _utc_iso_now():

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4072,13 +4072,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # change invalidates the old key and would silently regress export
         # to RAW until the user re-developed.
         old_row = db.conn.execute(
-            "SELECT path FROM folders WHERE id = ?", (folder_id,)
+            "SELECT path, status FROM folders WHERE id = ?", (folder_id,)
         ).fetchone()
         old_path = old_row["path"] if old_row else ""
 
         try:
             cascaded = db.relocate_folder(folder_id, new_path)
         except ValueError as e:
+            if old_row and old_row["status"] == "missing":
+                current_row = db.conn.execute(
+                    "SELECT status FROM folders WHERE id = ?", (folder_id,)
+                ).fetchone()
+                if current_row and current_row["status"] == "ok":
+                    _invalidate_missing_originals_cache()
             return json_error(str(e), 409)
 
         # Relocation rewrites folders.path (and can merge/delete rows via the

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2425,6 +2425,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 changed = health_db.check_folder_health()
                 if changed:
                     log.info("Folder health check: %d folder(s) changed status", changed)
+                    # A background ok↔missing flip would otherwise leave a
+                    # ready /api/photos/missing cache serving the pre-flip
+                    # photo list: the modal/banner could offer to delete
+                    # rows whose folder just went offline, or hide ghosts
+                    # from a folder that just came back, until a later
+                    # rescan replaced the entry.
+                    _invalidate_missing_originals_cache()
             except Exception:
                 log.debug("Folder health check failed", exc_info=True)
             _time.sleep(600)  # 10 minutes

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3347,6 +3347,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # missing_originals_scan as heavy work so automatic reruns
         # don't kick off a second filesystem walk over the same tree.
         "missing_originals_scan",
+        # audit.verify_hashes walks every workspace source file and
+        # hashes readable ones — the same NAS/SMB trees a Missing
+        # Originals scan touches. Letting the 30-minute automatic
+        # missing-originals timer fire during verification would
+        # double the I/O on those slow volumes.
+        "verify-hashes",
     }
 
     def _utc_iso_now():
@@ -3805,6 +3811,124 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             else:
                 skipped += 1
         return jsonify({"deleted": deleted, "skipped": skipped})
+
+    @app.route("/api/photos/missing/remove", methods=["POST"])
+    def api_photos_missing_remove():
+        """Delete Vireo rows for photos whose originals are still gone.
+
+        Body: ``{"photo_ids": [int, ...], "delete_sidecars": bool,
+        "mode": "vireo"|"disk"|"disk_permanent"}``.
+
+        A ready ``/api/photos/missing`` cache is served for up to
+        ``_MISSING_ORIGINALS_STALE_SECONDS`` (30 min) without a filesystem
+        recheck, so a photo whose original came back between the last
+        scan and the user clicking Remove would otherwise be deleted
+        from Vireo by trusting the cache. This endpoint pre-checks each
+        photo's source on disk in the active workspace and only forwards
+        the still-missing IDs to the shared batch-delete implementation.
+        Sidecar cleanup follows the same guard, so a restored original
+        never loses its ``.xmp`` either.
+
+        Response: ``{deleted, restored: [ids], skipped, sidecars_deleted,
+        sidecars_skipped, mode}``. ``restored`` lets the client show which
+        photos were saved from the cache-driven delete so the modal can
+        surface them (e.g. via toast) instead of silently discarding the
+        request.
+        """
+        body = request.get_json(silent=True) or {}
+        photo_ids = body.get("photo_ids") or []
+        if not isinstance(photo_ids, list):
+            return json_error("photo_ids must be a list")
+        delete_sidecars = bool(body.get("delete_sidecars"))
+        mode = body.get("mode", "vireo")
+        if mode not in ("vireo", "disk", "disk_permanent"):
+            return json_error(
+                "mode must be 'vireo', 'disk', or 'disk_permanent'"
+            )
+
+        db = _get_db()
+        ws_id = db._active_workspace_id
+        confirmed_ids = []
+        restored_ids = []
+        skipped = 0
+        sidecar_targets = []
+        for raw_id in photo_ids:
+            try:
+                pid = int(raw_id)
+            except (TypeError, ValueError):
+                skipped += 1
+                continue
+            row = db.conn.execute(
+                """SELECT p.filename, f.path AS folder_path
+                   FROM photos p
+                   JOIN folders f ON p.folder_id = f.id
+                   JOIN workspace_folders wf ON wf.folder_id = f.id
+                   WHERE p.id = ? AND wf.workspace_id = ?""",
+                (pid, ws_id),
+            ).fetchone()
+            if not row:
+                skipped += 1
+                continue
+            src = os.path.join(row["folder_path"], row["filename"])
+            if os.path.exists(src):
+                # Original is back on disk — the cached "missing" verdict
+                # was stale. Keep the Vireo row (and its sidecar).
+                restored_ids.append(pid)
+                continue
+            confirmed_ids.append(pid)
+            if delete_sidecars:
+                sidecar_targets.append(src)
+
+        sidecars_deleted = 0
+        sidecars_skipped = 0
+        if delete_sidecars:
+            for src in sidecar_targets:
+                stem, _ = os.path.splitext(src)
+                removed_one = False
+                for candidate in (stem + ".xmp", stem + ".XMP",
+                                  src + ".xmp", src + ".XMP"):
+                    if os.path.isfile(candidate):
+                        try:
+                            os.remove(candidate)
+                            removed_one = True
+                        except OSError as e:
+                            log.warning(
+                                "Failed to delete sidecar %s: %s", candidate, e
+                            )
+                if removed_one:
+                    sidecars_deleted += 1
+                else:
+                    sidecars_skipped += 1
+
+        deleted_count = 0
+        if confirmed_ids:
+            try:
+                result = _run_batch_delete(
+                    db, confirmed_ids, mode, include_companions=False,
+                )
+            except ValueError as exc:
+                return json_error(str(exc))
+            deleted_count = int(result.get("deleted") or 0)
+            if deleted_count:
+                _invalidate_missing_originals_cache()
+
+        # A cache invalidation is still worth doing when everything came
+        # back online: the ready payload we just refused to trust for
+        # deletion is also the one the banner will keep serving until the
+        # next scan. Dropping it now forces a fresh check the next time
+        # the banner/modal asks, so the restored photos stop appearing
+        # as ghosts.
+        if restored_ids and deleted_count == 0:
+            _invalidate_missing_originals_cache()
+
+        return jsonify({
+            "deleted": deleted_count,
+            "restored": restored_ids,
+            "skipped": skipped,
+            "sidecars_deleted": sidecars_deleted,
+            "sidecars_skipped": sidecars_skipped,
+            "mode": mode,
+        })
 
     @app.route("/api/folders/<int:folder_id>", methods=["GET"])
     def api_folder_get(folder_id):

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -16231,6 +16231,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 # scanner.scan commits photo rows incrementally, so even a mid-scan
                 # failure can leave DB state that invalidates cached new-image counts.
                 _invalidate_new_images_after_scan(thread_db, scan_target)
+                # scanner.scan touches disk and may reconcile ghost rows
+                # (e.g. a user restored an original before running import).
+                # The pre-scan health-check invalidation only fires when a
+                # folder flips missing/ok, so also drop the missing-originals
+                # cache once the scan itself has run — even on partial
+                # failure, since rows are committed incrementally.
+                try:
+                    _invalidate_missing_originals_cache()
+                except Exception:
+                    log.exception(
+                        "Failed to invalidate missing-originals cache after import scan of %s",
+                        scan_target,
+                    )
             scan_count = job["progress"].get("total", 0)
             scan_summary = f"{scan_count} photos"
             metadata_warning = _scan_metadata_warning()
@@ -16646,6 +16659,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         root_errors.append(msg)
                         if msg not in job["errors"]:
                             job["errors"].append(msg)
+                    # scanner.scan touches disk and may reconcile ghost rows
+                    # (e.g. a user restored an original before running
+                    # import-in-place). The pre-scan health-check invalidation
+                    # only fires when a folder flips missing/ok, so also drop
+                    # the missing-originals cache once the scan itself has
+                    # run — even on partial failure, since rows are committed
+                    # incrementally.
+                    try:
+                        _invalidate_missing_originals_cache()
+                    except Exception:
+                        log.exception(
+                            "Failed to invalidate missing-originals cache after in-place import scan of %s",
+                            source,
+                        )
                     advance_scan_acc()
 
             indexed = len(photo_ids)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3642,8 +3642,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         scope_label = "workspace" if folder_id is None else f"folder #{folder_id}"
 
         def work(job):
-            thread_db = Database(db_file)
+            thread_db = None
             try:
+                thread_db = Database(db_file)
                 if ws_id is not None:
                     thread_db.set_active_workspace(ws_id)
 
@@ -3727,7 +3728,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         }
                 raise
             finally:
-                thread_db.close()
+                if thread_db is not None:
+                    thread_db.close()
                 with app._missing_originals_lock:
                     if app._missing_originals_inflight.get(key) in (
                         token,

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -12374,6 +12374,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         result = db.delete_photos(photo_ids)
         _cleanup_cached_files_for_deleted_photos(result.get("files", []))
+        if result.get("deleted"):
+            _invalidate_missing_originals_cache(db._active_workspace_id)
         return jsonify({"ok": True, "removed": result.get("deleted", 0)})
 
     @app.route("/api/audit/import-untracked", methods=["POST"])
@@ -14549,10 +14551,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if trashed_pids:
             try:
                 all_files = []
+                deleted_rows = 0
                 for chunk in _chunked(trashed_pids):
                     result = db.delete_photos(chunk)
                     all_files.extend(result.get("files", []))
+                    deleted_rows += result.get("deleted", 0)
                 _cleanup_cached_files_for_deleted_photos(all_files)
+                if deleted_rows:
+                    _invalidate_missing_originals_cache(db._active_workspace_id)
             except Exception:
                 # Files are already in Trash; if the row delete fails we
                 # surface a 500 so the caller knows reconciliation is

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -15371,6 +15371,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 destination=destination,
                 progress_cb=progress_cb,
             )
+            if int(result.get("moved") or 0) > 0:
+                try:
+                    _invalidate_missing_originals_cache()
+                except Exception:
+                    log.exception(
+                        "Failed to invalidate missing-originals cache "
+                        "after move-photos job",
+                    )
 
             if rule_id:
                 thread_db.touch_move_rule(rule_id)
@@ -15916,6 +15924,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                             f"; cleanup failed: {cleanup_error}"
                             if cleanup_error else ""
                         )
+                    )
+            if result.get("ok"):
+                try:
+                    _invalidate_missing_originals_cache()
+                except Exception:
+                    log.exception(
+                        "Failed to invalidate missing-originals cache "
+                        "after move-folder job",
                     )
             return result
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3657,7 +3657,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     job["progress"]["current"] = current
                     job["progress"]["total"] = total
                     job["progress"]["current_file"] = current_folder
-                    job["progress"]["phase"] = (
+                    phase = (
                         f"{folders_checked:,} folders checked, "
                         f"{current:,} photos considered, "
                         f"{missing_found:,} missing"
@@ -3668,7 +3668,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         "current_file": current_folder,
                         "folders_checked": folders_checked,
                         "missing_found": missing_found,
-                        "phase": job["progress"]["phase"],
+                        "phase": phase,
                     })
 
                 def cancel_check():

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3488,32 +3488,43 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 return True
         return False
 
-    def _invalidate_missing_originals_cache():
-        """Drop cached Missing Originals results for every workspace on
-        this app's database.
+    def _invalidate_missing_originals_cache(workspace_ids=None):
+        """Drop cached Missing Originals results for this app's database.
 
         Photos are shared across workspaces (a folder can be linked into
-        more than one), so removing a row must clear every workspace
-        cache that could still list it — scoping to the active
-        workspace lets other workspaces keep serving stale ready
-        payloads until their next scan.
+        more than one), so a photo-row removal must clear every
+        workspace cache that could still list it — scoping to the
+        active workspace lets other workspaces keep serving stale
+        ready payloads until their next scan.
+
+        ``workspace_ids`` narrows the invalidation to those workspace
+        ids. Use it on workspace create/delete to clear entries that
+        could otherwise be served to a later workspace that reuses a
+        SQLite rowid.
         """
+        ws_filter = None if workspace_ids is None else {int(w) for w in workspace_ids}
         with app._missing_originals_lock:
             for store in (
                 app._missing_originals_cache,
                 app._missing_originals_errors,
             ):
                 for key in list(store.keys()):
-                    if key[0] == db_path:
-                        store.pop(key, None)
+                    if key[0] != db_path:
+                        continue
+                    if ws_filter is not None and key[1] not in ws_filter:
+                        continue
+                    store.pop(key, None)
             # Bump generation for every in-flight scan under this DB so
             # its completion path refuses to write its stale
             # pre-invalidation snapshot back into the cache.
             for key in list(app._missing_originals_inflight.keys()):
-                if key[0] == db_path:
-                    app._missing_originals_generation[key] = (
-                        app._missing_originals_generation.get(key, 0) + 1
-                    )
+                if key[0] != db_path:
+                    continue
+                if ws_filter is not None and key[1] not in ws_filter:
+                    continue
+                app._missing_originals_generation[key] = (
+                    app._missing_originals_generation.get(key, 0) + 1
+                )
 
     def _start_missing_originals_scan(db, folder_id=None, automatic=False):
         key = _missing_originals_key(db, folder_id)
@@ -8415,6 +8426,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return err
         try:
             ws_id = db.create_workspace(name, config_overrides=config_overrides)
+            # SQLite can reuse the rowid of a deleted workspace here, so a
+            # ready Missing Originals payload cached under the old
+            # workspace could otherwise be served to this fresh workspace
+            # until its own scan overwrites the entry — mirroring the
+            # new-images cache guard in db.create_workspace.
+            _invalidate_missing_originals_cache(workspace_ids=[ws_id])
             # Seed the standard smart collections (All Photos, Flagged, etc.).
             # Startup only seeds the active workspace, so without this a
             # workspace created via the API never gets defaults until it's
@@ -8464,6 +8481,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if ws_id == db._active_workspace_id:
             return json_error("Cannot delete the active workspace. Switch first.")
         db.delete_workspace(ws_id)
+        # Drop this workspace's cached Missing Originals payload so a
+        # later workspace that reuses this SQLite rowid can't be served
+        # the deleted workspace's ghost photos / folder paths.
+        _invalidate_missing_originals_cache(workspace_ids=[ws_id])
         return jsonify({"ok": True})
 
     @app.route("/api/workspaces/<int:ws_id>/activate", methods=["POST"])

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3924,6 +3924,21 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         skipped = 0
         sidecar_targets = []
         folder_online_cache = {}
+
+        def folder_accessible(folder_path):
+            cached = folder_online_cache.get(folder_path)
+            if cached is not None:
+                return cached
+            accessible = False
+            if os.path.isdir(folder_path):
+                try:
+                    with os.scandir(folder_path):
+                        accessible = True
+                except OSError:
+                    accessible = False
+            folder_online_cache[folder_path] = accessible
+            return accessible
+
         for raw_id in photo_ids:
             try:
                 pid = int(raw_id)
@@ -3942,11 +3957,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 skipped += 1
                 continue
             folder_path = row["folder_path"]
-            folder_online = folder_online_cache.get(folder_path)
-            if folder_online is None:
-                folder_online = os.path.isdir(folder_path)
-                folder_online_cache[folder_path] = folder_online
-            if not folder_online:
+            if not folder_accessible(folder_path):
                 # The parent folder/NAS mount is currently unreachable, so
                 # ``os.path.exists(src)`` would return False for every row
                 # regardless of whether the original was restored before

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -8527,12 +8527,21 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not db.get_folder(folder_id):
             return json_error("Folder not found", 404)
         db.add_workspace_folder(ws_id, folder_id)
+        # A newly linked folder can introduce ghosts (or resolve them if it
+        # was previously offline). The missing-originals cache is keyed by
+        # workspace, so leaving a stale ready payload here would keep serving
+        # the old membership's answer until the next scan.
+        _invalidate_missing_originals_cache()
         return jsonify({"ok": True})
 
     @app.route("/api/workspaces/<int:ws_id>/folders/<int:folder_id>", methods=["DELETE"])
     def api_remove_workspace_folder(ws_id, folder_id):
         db = _get_db()
         db.remove_workspace_folder_tree(ws_id, folder_id)
+        # Unlinking a folder tree removes photos from the workspace's scope;
+        # the cached ready payload would otherwise keep listing ghosts from
+        # the now-detached folders until a manual rescan.
+        _invalidate_missing_originals_cache()
         return jsonify({"ok": True})
 
     @app.route("/api/workspaces/<int:ws_id>/move-folders", methods=["POST"])
@@ -8567,6 +8576,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         try:
             result = db.move_folders_to_workspace(ws_id, target_ws_id, folder_ids)
             result["target_workspace_id"] = target_ws_id
+            # Moving folders changes membership on both source and target
+            # workspaces, so any cached missing-originals payloads for either
+            # side would go stale.
+            _invalidate_missing_originals_cache()
             return jsonify(result)
         except ValueError as e:
             return json_error(str(e))

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2461,6 +2461,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     app._missing_originals_cache = {}
     app._missing_originals_inflight = {}
     app._missing_originals_errors = {}
+    # Monotonic per-key counter bumped whenever the cache is invalidated
+    # while a scan is in flight. Each scan snapshots this at start; if the
+    # counter has advanced by the time it finishes, the scan's results are
+    # from a pre-invalidation view of the library and must be discarded so
+    # deleted photos don't reappear in the banner/modal.
+    app._missing_originals_generation = {}
 
     # Self-healing background backfill of missing working copies. RAW (and
     # oversized JPEG) imports need a JPEG working copy at
@@ -3480,6 +3486,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 for key in list(store.keys()):
                     if key[1] == workspace_id:
                         store.pop(key, None)
+            # Bump generation for every in-flight scan touching this
+            # workspace so its completion path refuses to write its stale
+            # pre-invalidation snapshot back into the cache.
+            for key in list(app._missing_originals_inflight.keys()):
+                if key[1] == workspace_id:
+                    app._missing_originals_generation[key] = (
+                        app._missing_originals_generation.get(key, 0) + 1
+                    )
 
     def _start_missing_originals_scan(db, folder_id=None, automatic=False):
         key = _missing_originals_key(db, folder_id)
@@ -3510,12 +3524,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if suppressed_reason == "heavy_job_active":
                 payload["status"] = "skipped"
             return payload
+        scan_generation = 0
         with app._missing_originals_lock:
             inflight = app._missing_originals_inflight.get(key)
             if inflight:
                 reuse_existing = True
             else:
                 app._missing_originals_inflight[key] = token
+                scan_generation = app._missing_originals_generation.get(key, 0)
         if reuse_existing:
             return _missing_originals_payload(db, folder_id)
 
@@ -3559,30 +3575,44 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     progress_callback=progress,
                 )
                 checked_at = _utc_iso_now()
+                stale = False
                 with app._missing_originals_lock:
-                    app._missing_originals_cache[key] = {
-                        "photos": photos,
-                        "checked_at": checked_at,
-                        "set_at": time.monotonic(),
-                    }
-                    app._missing_originals_errors.pop(key, None)
+                    current_gen = app._missing_originals_generation.get(key, 0)
+                    if current_gen != scan_generation:
+                        # A batch delete (or other invalidation) fired
+                        # while this scan was walking the disk. Its photo
+                        # list reflects the pre-delete library, so writing
+                        # it back would resurrect just-removed photos in
+                        # the banner. Drop the result and let the next
+                        # scan recompute.
+                        stale = True
+                    else:
+                        app._missing_originals_cache[key] = {
+                            "photos": photos,
+                            "checked_at": checked_at,
+                            "set_at": time.monotonic(),
+                        }
+                        app._missing_originals_errors.pop(key, None)
                 return {
                     "missing_count": len(photos),
                     "checked_at": checked_at,
                     "scope": scope_label,
+                    "stale": stale,
                 }
             except Exception as exc:
                 checked_at = _utc_iso_now()
                 with app._missing_originals_lock:
-                    app._missing_originals_errors[key] = {
-                        "error": str(exc) or exc.__class__.__name__,
-                        "checked_at": checked_at,
-                        "set_at": time.monotonic(),
-                        "backoff_until": (
-                            time.monotonic()
-                            + _MISSING_ORIGINALS_BACKOFF_SECONDS
-                        ),
-                    }
+                    current_gen = app._missing_originals_generation.get(key, 0)
+                    if current_gen == scan_generation:
+                        app._missing_originals_errors[key] = {
+                            "error": str(exc) or exc.__class__.__name__,
+                            "checked_at": checked_at,
+                            "set_at": time.monotonic(),
+                            "backoff_until": (
+                                time.monotonic()
+                                + _MISSING_ORIGINALS_BACKOFF_SECONDS
+                            ),
+                        }
                 raise
             finally:
                 thread_db.close()

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3329,6 +3329,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         "batch-delete",
         "duplicate-scan",
         "offline-cache",
+        # Navbar's new-images probe walks the same folders a missing-originals
+        # scan would; letting them run concurrently can double the filesystem
+        # load on slow NAS/SMB libraries.
+        "new_images_walk",
     }
 
     def _utc_iso_now():

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2457,6 +2457,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     # over large network volumes. Values are per-spawn dicts; a new walk
     # replaces the key wholesale, so readers never see torn state.
     app._new_images_walk_progress = {}
+    app._missing_originals_lock = threading.Lock()
+    app._missing_originals_cache = {}
+    app._missing_originals_inflight = {}
+    app._missing_originals_errors = {}
 
     # Self-healing background backfill of missing working copies. RAW (and
     # oversized JPEG) imports need a JPEG working copy at
@@ -3296,33 +3300,105 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         missing = db.get_missing_folders()
         return jsonify([dict(f) for f in missing])
 
-    @app.route("/api/photos/missing")
-    def api_photos_missing():
-        """Return photos whose original file is gone but the folder remains.
+    _MISSING_ORIGINALS_STALE_SECONDS = 30 * 60
+    _MISSING_ORIGINALS_BACKOFF_SECONDS = 30 * 60
+    _MISSING_ORIGINALS_HEAVY_JOB_TYPES = {
+        "scan",
+        "pipeline",
+        "thumbnails",
+        "previews",
+        "move-photos",
+        "move-folder",
+        "sync",
+        "classify",
+        "cull",
+        "develop",
+        "extract-masks",
+        "regroup",
+        "import",
+        "import-full",
+        "import-in-place",
+        "ingest",
+        "import-photos",
+        "batch-delete",
+        "duplicate-scan",
+        "offline-cache",
+    }
 
-        For each ghost row we report what cached/sidecar artifacts still exist
-        (thumb, preview, working copy, XMP) so the user can decide whether
-        anything is worth keeping before deleting the row.
+    def _utc_iso_now():
+        return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
-        Optional ``?folder_id=N`` scopes the check to that folder and its
-        descendants — the "rescan a specific folder" flow. The id must be
-        linked to the active workspace (same guard as folder rescan); an
-        unknown or foreign id returns 404 rather than silently widening to
-        the whole library.
-        """
-        db = _get_db()
+    def _parse_missing_originals_folder_id(db):
         folder_id = request.args.get("folder_id")
-        if folder_id is not None:
-            try:
-                folder_id = int(folder_id)
-            except (TypeError, ValueError):
-                return json_error("folder_id must be an integer")
-            linked = db.conn.execute(
-                "SELECT 1 FROM workspace_folders WHERE workspace_id = ? AND folder_id = ?",
-                (db._active_workspace_id, folder_id),
-            ).fetchone()
-            if not linked:
-                return json_error("folder not found", 404)
+        if request.is_json:
+            body = request.get_json(silent=True) or {}
+            if "folder_id" in body:
+                folder_id = body.get("folder_id")
+        if folder_id in (None, ""):
+            return None
+        try:
+            folder_id = int(folder_id)
+        except (TypeError, ValueError):
+            raise ValueError("folder_id must be an integer") from None
+        linked = db.conn.execute(
+            "SELECT 1 FROM workspace_folders WHERE workspace_id = ? AND folder_id = ?",
+            (db._active_workspace_id, folder_id),
+        ).fetchone()
+        if not linked:
+            raise LookupError("folder not found")
+        return folder_id
+
+    def _missing_originals_key(db, folder_id):
+        return (db._db_path, db._active_workspace_id, folder_id)
+
+    def _missing_originals_payload(db, folder_id):
+        key = _missing_originals_key(db, folder_id)
+        now = time.monotonic()
+        with app._missing_originals_lock:
+            entry = app._missing_originals_cache.get(key)
+            inflight = app._missing_originals_inflight.get(key)
+            err = app._missing_originals_errors.get(key)
+            if entry is not None:
+                status = "pending" if inflight else "ready"
+                photos = entry["photos"]
+                checked_at = entry["checked_at"]
+                stale = now - entry["set_at"] > _MISSING_ORIGINALS_STALE_SECONDS
+                error = None
+            elif inflight:
+                status = "pending"
+                photos = []
+                checked_at = None
+                stale = False
+                error = None
+            elif err is not None:
+                status = "error"
+                photos = []
+                checked_at = err["checked_at"]
+                stale = False
+                error = err["error"]
+            else:
+                status = "not_ready"
+                photos = []
+                checked_at = None
+                stale = False
+                error = None
+            backoff_seconds = 0
+            if err is not None:
+                backoff_seconds = max(0, int(err["backoff_until"] - now))
+            return {
+                "status": status,
+                "pending": bool(inflight),
+                "checked_at": checked_at,
+                "stale": stale,
+                "error": error,
+                "job_id": inflight if isinstance(inflight, str) else None,
+                "photos": photos,
+                "backoff_seconds": backoff_seconds,
+                "workspace_id": db._active_workspace_id,
+                "folder_id": folder_id,
+            }
+
+    def _build_missing_originals_rows(db, folder_id=None, progress_callback=None):
         thumb_dir = app.config["THUMB_CACHE_DIR"]
         vireo_dir = os.path.dirname(thumb_dir)
         preview_dir = os.path.join(vireo_dir, "previews")
@@ -3347,7 +3423,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             pass  # cache dir hasn't been created yet — no previews
 
         out = []
-        for row in db.get_missing_photos(folder_id=folder_id):
+        for row in db.get_missing_photos(
+            folder_id=folder_id,
+            progress_callback=progress_callback,
+        ):
             pid = row["id"]
             src = os.path.join(row["folder_path"], row["filename"])
             stem, _ext = os.path.splitext(src)
@@ -3382,7 +3461,194 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 ),
             })
         _attach_nested_edit_recipes(db, out)
-        return jsonify(out)
+        return out
+
+    def _missing_originals_heavy_job_active():
+        for job in app._job_runner.list_jobs():
+            if job.get("status") not in ("running", "queued"):
+                continue
+            if job.get("type") in _MISSING_ORIGINALS_HEAVY_JOB_TYPES:
+                return True
+        return False
+
+    def _invalidate_missing_originals_cache(workspace_id):
+        with app._missing_originals_lock:
+            for store in (
+                app._missing_originals_cache,
+                app._missing_originals_errors,
+            ):
+                for key in list(store.keys()):
+                    if key[1] == workspace_id:
+                        store.pop(key, None)
+
+    def _start_missing_originals_scan(db, folder_id=None, automatic=False):
+        key = _missing_originals_key(db, folder_id)
+        now = time.monotonic()
+        token = object()
+        suppressed_reason = None
+        reuse_existing = False
+        with app._missing_originals_lock:
+            inflight = app._missing_originals_inflight.get(key)
+            if inflight:
+                reuse_existing = True
+            err = app._missing_originals_errors.get(key)
+            if (
+                not reuse_existing
+                and automatic
+                and err is not None
+                and now < err["backoff_until"]
+            ):
+                suppressed_reason = "backoff"
+        if reuse_existing:
+            return _missing_originals_payload(db, folder_id)
+        if automatic and suppressed_reason is None and _missing_originals_heavy_job_active():
+            suppressed_reason = "heavy_job_active"
+        if suppressed_reason is not None:
+            payload = _missing_originals_payload(db, folder_id)
+            payload["suppressed"] = True
+            payload["reason"] = suppressed_reason
+            if suppressed_reason == "heavy_job_active":
+                payload["status"] = "skipped"
+            return payload
+        with app._missing_originals_lock:
+            inflight = app._missing_originals_inflight.get(key)
+            if inflight:
+                reuse_existing = True
+            else:
+                app._missing_originals_inflight[key] = token
+        if reuse_existing:
+            return _missing_originals_payload(db, folder_id)
+
+        runner = app._job_runner
+        ws_id = db._active_workspace_id
+        db_file = db._db_path
+        scope_label = "workspace" if folder_id is None else f"folder #{folder_id}"
+
+        def work(job):
+            thread_db = Database(db_file)
+            try:
+                if ws_id is not None:
+                    thread_db.set_active_workspace(ws_id)
+
+                def progress(payload):
+                    current = int(payload.get("photos_considered") or 0)
+                    total = int(payload.get("total_photos") or 0)
+                    missing_found = int(payload.get("missing_found") or 0)
+                    folders_checked = int(payload.get("folders_checked") or 0)
+                    current_folder = payload.get("current_folder") or ""
+                    job["progress"]["current"] = current
+                    job["progress"]["total"] = total
+                    job["progress"]["current_file"] = current_folder
+                    job["progress"]["phase"] = (
+                        f"{folders_checked:,} folders checked, "
+                        f"{current:,} photos considered, "
+                        f"{missing_found:,} missing"
+                    )
+                    runner.push_event(job["id"], "progress", {
+                        "current": current,
+                        "total": total,
+                        "current_file": current_folder,
+                        "folders_checked": folders_checked,
+                        "missing_found": missing_found,
+                        "phase": job["progress"]["phase"],
+                    })
+
+                photos = _build_missing_originals_rows(
+                    thread_db,
+                    folder_id=folder_id,
+                    progress_callback=progress,
+                )
+                checked_at = _utc_iso_now()
+                with app._missing_originals_lock:
+                    app._missing_originals_cache[key] = {
+                        "photos": photos,
+                        "checked_at": checked_at,
+                        "set_at": time.monotonic(),
+                    }
+                    app._missing_originals_errors.pop(key, None)
+                return {
+                    "missing_count": len(photos),
+                    "checked_at": checked_at,
+                    "scope": scope_label,
+                }
+            except Exception as exc:
+                checked_at = _utc_iso_now()
+                with app._missing_originals_lock:
+                    app._missing_originals_errors[key] = {
+                        "error": str(exc) or exc.__class__.__name__,
+                        "checked_at": checked_at,
+                        "set_at": time.monotonic(),
+                        "backoff_until": (
+                            time.monotonic()
+                            + _MISSING_ORIGINALS_BACKOFF_SECONDS
+                        ),
+                    }
+                raise
+            finally:
+                thread_db.close()
+                with app._missing_originals_lock:
+                    if app._missing_originals_inflight.get(key) in (
+                        token,
+                        job["id"],
+                    ):
+                        app._missing_originals_inflight.pop(key, None)
+
+        try:
+            job_id = runner.start(
+                "missing_originals_scan",
+                work,
+                workspace_id=ws_id,
+                config={"scope": scope_label, "folder_id": folder_id},
+                ephemeral=True,
+                counts_for_badge=False,
+            )
+        except Exception:
+            with app._missing_originals_lock:
+                if app._missing_originals_inflight.get(key) is token:
+                    app._missing_originals_inflight.pop(key, None)
+            raise
+
+        with app._missing_originals_lock:
+            if app._missing_originals_inflight.get(key) is token:
+                app._missing_originals_inflight[key] = job_id
+        payload = _missing_originals_payload(db, folder_id)
+        if payload.get("status") != "ready":
+            payload["job_id"] = job_id
+            payload["pending"] = True
+            payload["status"] = "pending"
+        return payload
+
+    @app.route("/api/photos/missing")
+    def api_photos_missing():
+        """Return cached Missing Originals scan status without filesystem work."""
+        db = _get_db()
+        try:
+            folder_id = _parse_missing_originals_folder_id(db)
+        except ValueError as exc:
+            return json_error(str(exc))
+        except LookupError:
+            return json_error("folder not found", 404)
+        return jsonify(_missing_originals_payload(db, folder_id))
+
+    @app.route("/api/photos/missing/check", methods=["POST"])
+    def api_photos_missing_check():
+        """Start or reuse a background Missing Originals scan."""
+        db = _get_db()
+        try:
+            folder_id = _parse_missing_originals_folder_id(db)
+        except ValueError as exc:
+            return json_error(str(exc))
+        except LookupError:
+            return json_error("folder not found", 404)
+        body = request.get_json(silent=True) or {}
+        automatic = bool(body.get("automatic"))
+        payload = _start_missing_originals_scan(
+            db,
+            folder_id=folder_id,
+            automatic=automatic,
+        )
+        status_code = 202 if payload.get("pending") else 200
+        return jsonify(payload), status_code
 
     @app.route("/api/folders/check-health", methods=["POST"])
     def api_folders_check_health():
@@ -6384,6 +6650,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             )
         except ValueError as exc:
             return json_error(str(exc))
+        if result.get("deleted"):
+            _invalidate_missing_originals_cache(db._active_workspace_id)
         return jsonify(result)
 
     @app.route("/api/jobs/batch-delete", methods=["POST"])
@@ -6422,7 +6690,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 })
 
             try:
-                return _run_batch_delete(
+                result = _run_batch_delete(
                     thread_db,
                     photo_ids,
                     mode,
@@ -6430,6 +6698,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     paths=paths,
                     progress_callback=progress,
                 )
+                if result.get("deleted"):
+                    _invalidate_missing_originals_cache(active_ws)
+                return result
             finally:
                 thread_db.conn.close()
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3477,20 +3477,29 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 return True
         return False
 
-    def _invalidate_missing_originals_cache(workspace_id):
+    def _invalidate_missing_originals_cache():
+        """Drop cached Missing Originals results for every workspace on
+        this app's database.
+
+        Photos are shared across workspaces (a folder can be linked into
+        more than one), so removing a row must clear every workspace
+        cache that could still list it — scoping to the active
+        workspace lets other workspaces keep serving stale ready
+        payloads until their next scan.
+        """
         with app._missing_originals_lock:
             for store in (
                 app._missing_originals_cache,
                 app._missing_originals_errors,
             ):
                 for key in list(store.keys()):
-                    if key[1] == workspace_id:
+                    if key[0] == db_path:
                         store.pop(key, None)
-            # Bump generation for every in-flight scan touching this
-            # workspace so its completion path refuses to write its stale
+            # Bump generation for every in-flight scan under this DB so
+            # its completion path refuses to write its stale
             # pre-invalidation snapshot back into the cache.
             for key in list(app._missing_originals_inflight.keys()):
-                if key[1] == workspace_id:
+                if key[0] == db_path:
                     app._missing_originals_generation[key] = (
                         app._missing_originals_generation.get(key, 0) + 1
                     )
@@ -6693,7 +6702,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         except ValueError as exc:
             return json_error(str(exc))
         if result.get("deleted"):
-            _invalidate_missing_originals_cache(db._active_workspace_id)
+            _invalidate_missing_originals_cache()
         return jsonify(result)
 
     @app.route("/api/jobs/batch-delete", methods=["POST"])
@@ -6741,7 +6750,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     progress_callback=progress,
                 )
                 if result.get("deleted"):
-                    _invalidate_missing_originals_cache(active_ws)
+                    _invalidate_missing_originals_cache()
                 return result
             finally:
                 thread_db.conn.close()
@@ -12375,7 +12384,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         result = db.delete_photos(photo_ids)
         _cleanup_cached_files_for_deleted_photos(result.get("files", []))
         if result.get("deleted"):
-            _invalidate_missing_originals_cache(db._active_workspace_id)
+            _invalidate_missing_originals_cache()
         return jsonify({"ok": True, "removed": result.get("deleted", 0)})
 
     @app.route("/api/audit/import-untracked", methods=["POST"])
@@ -14558,7 +14567,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     deleted_rows += result.get("deleted", 0)
                 _cleanup_cached_files_for_deleted_photos(all_files)
                 if deleted_rows:
-                    _invalidate_missing_originals_cache(db._active_workspace_id)
+                    _invalidate_missing_originals_cache()
             except Exception:
                 # Files are already in Trash; if the row delete fails we
                 # surface a 500 so the caller knows reconciliation is

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3541,7 +3541,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
     def _start_missing_originals_scan(db, folder_id=None, automatic=False):
         key = _missing_originals_key(db, folder_id)
-        now = time.monotonic()
+        scan_started_at = time.monotonic()
+        now = scan_started_at
         token = object()
         suppressed_reason = None
         reuse_existing = False
@@ -3551,11 +3552,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if inflight:
                 reuse_existing = True
             entry = app._missing_originals_cache.get(key)
+            # Gate on when the last scan STARTED, not when it finished. The
+            # navbar re-arms its 30-minute automatic timer from POST time,
+            # so a scan that takes real wall-clock time to walk the disk
+            # leaves ``set_at`` well under the threshold when the next tick
+            # arrives — every other automatic scan would otherwise be
+            # skipped, and deletions could stay undiscovered for nearly an
+            # hour. Legacy entries without ``started_at`` fall back to
+            # ``set_at``.
             if (
                 not reuse_existing
                 and automatic
                 and entry is not None
-                and now - entry["set_at"] <= _MISSING_ORIGINALS_STALE_SECONDS
+                and now - entry.get("started_at", entry["set_at"])
+                < _MISSING_ORIGINALS_STALE_SECONDS
             ):
                 fresh_cache = True
             err = app._missing_originals_errors.get(key)
@@ -3647,6 +3657,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                             "photos": photos,
                             "checked_at": checked_at,
                             "set_at": time.monotonic(),
+                            "started_at": scan_started_at,
                         }
                         app._missing_originals_errors.pop(key, None)
                 return {

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -19,6 +19,7 @@ _UNSET = object()  # sentinel for "not provided" vs explicit None
 AUTO_MATCH_REVIEW_MARKER = "__vireo_auto_match__"
 
 _SQLITE_PARAM_CHUNK_SIZE = 800
+_MISSING_PHOTOS_PROGRESS_INTERVAL = 200
 
 
 class IncompatibleDatabaseError(RuntimeError):
@@ -2634,6 +2635,11 @@ class Database:
         Each row carries ``folder_path``, ``timestamp``, and
         ``working_copy_path`` so the caller can render rich UI without
         joining again.
+
+        ``progress_callback`` is optional. When supplied, it receives dicts
+        containing ``folders_checked``, ``photos_considered``, ``missing_found``,
+        ``total_photos``, and ``current_folder``. Callback exceptions are
+        logged and ignored so progress reporting cannot abort detection.
         """
         params = [self._ws_id()]
         subtree_clause = ""
@@ -2690,6 +2696,28 @@ class Database:
         photos_considered = 0
         folders_checked = 0
         reported_folders = set()
+        progress_callback_enabled = True
+
+        def report_progress(current_folder):
+            nonlocal progress_callback_enabled
+            if progress_callback is None or not progress_callback_enabled:
+                return
+            try:
+                progress_callback({
+                    "folders_checked": folders_checked,
+                    "photos_considered": photos_considered,
+                    "missing_found": len(missing),
+                    "total_photos": len(rows),
+                    "current_folder": current_folder,
+                })
+            except Exception:
+                progress_callback_enabled = False
+                log.exception("Missing photos progress callback failed")
+
+        def report_photo_progress(current_folder):
+            if photos_considered % _MISSING_PHOTOS_PROGRESS_INTERVAL == 0:
+                report_progress(current_folder)
+
         for row in rows:
             fid = row["folder_id"]
             if fid not in folder_online:
@@ -2699,14 +2727,7 @@ class Database:
                 if fid not in reported_folders:
                     reported_folders.add(fid)
                     folders_checked += 1
-                    if progress_callback is not None:
-                        progress_callback({
-                            "folders_checked": folders_checked,
-                            "photos_considered": photos_considered,
-                            "missing_found": len(missing),
-                            "total_photos": len(rows),
-                            "current_folder": row["folder_path"],
-                        })
+                    report_progress(row["folder_path"])
                 continue
             if fid not in folder_names:
                 try:
@@ -2731,19 +2752,14 @@ class Database:
                 if fid not in reported_folders:
                     reported_folders.add(fid)
                     folders_checked += 1
-                    if progress_callback is not None:
-                        progress_callback({
-                            "folders_checked": folders_checked,
-                            "photos_considered": photos_considered,
-                            "missing_found": len(missing),
-                            "total_photos": len(rows),
-                            "current_folder": row["folder_path"],
-                        })
+                    report_progress(row["folder_path"])
             names = folder_names[fid]
             photos_considered += 1
             if names is None:
+                report_photo_progress(row["folder_path"])
                 continue
             if _nfc(row["filename"]) in names:
+                report_photo_progress(row["folder_path"])
                 continue
             # NFC miss: defer to the kernel for case rules. On case-insensitive
             # volumes (APFS default, NTFS) os.path.exists resolves a
@@ -2751,14 +2767,8 @@ class Database:
             # filesystems) it correctly reports the file as absent.
             if not os.path.exists(os.path.join(row["folder_path"], row["filename"])):
                 missing.append(row)
-        if progress_callback is not None:
-            progress_callback({
-                "folders_checked": folders_checked,
-                "photos_considered": photos_considered,
-                "missing_found": len(missing),
-                "total_photos": len(rows),
-                "current_folder": "",
-            })
+            report_photo_progress(row["folder_path"])
+        report_progress("")
         return missing
 
     def nearest_ancestor_folder_id(self, path, exclude_id=None):

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -55,6 +55,10 @@ class IncompatibleDatabaseError(RuntimeError):
         super().__init__(msg)
 
 
+class MissingPhotosCancelled(RuntimeError):
+    """Raised when a Missing Originals filesystem scan is cancelled."""
+
+
 def _nfc(name: str) -> str:
     """NFC-normalize a filename for byte-exact comparison against scandir output.
 
@@ -2607,7 +2611,12 @@ class Database:
             (self._ws_id(),),
         ).fetchall()
 
-    def get_missing_photos(self, folder_id=None, progress_callback=None):
+    def get_missing_photos(
+        self,
+        folder_id=None,
+        progress_callback=None,
+        cancel_callback=None,
+    ):
         """Return photos whose source file is missing from disk.
 
         Scoped to the active workspace. Skips photos in folders flagged
@@ -2640,7 +2649,15 @@ class Database:
         containing ``folders_checked``, ``photos_considered``, ``missing_found``,
         ``total_photos``, and ``current_folder``. Callback exceptions are
         logged and ignored so progress reporting cannot abort detection.
+
+        ``cancel_callback`` is optional. When supplied, it is polled between
+        filesystem operations and may abort the scan by returning true.
         """
+        def check_cancelled():
+            if cancel_callback is not None and cancel_callback():
+                raise MissingPhotosCancelled("missing photos scan cancelled")
+
+        check_cancelled()
         params = [self._ws_id()]
         subtree_clause = ""
         if folder_id is not None:
@@ -2672,6 +2689,7 @@ class Database:
                 subtree_clause = (
                     " AND f.id IN (SELECT id FROM missing_subtree_ids)"
                 )
+        check_cancelled()
         rows = self.conn.execute(
             f"""SELECT p.id, p.filename, p.extension, p.file_size,
                       p.timestamp, p.working_copy_path,
@@ -2683,6 +2701,7 @@ class Database:
                ORDER BY f.path, p.filename""",
             params,
         ).fetchall()
+        check_cancelled()
         # One readdir per folder instead of one stat per photo. On a 50k-photo
         # library across a network volume the per-photo `os.path.exists` was
         # costing minutes; a single scandir + set-membership check is orders
@@ -2719,6 +2738,7 @@ class Database:
                 report_progress(current_folder)
 
         for row in rows:
+            check_cancelled()
             fid = row["folder_id"]
             if fid not in folder_online:
                 folder_online[fid] = os.path.isdir(row["folder_path"])
@@ -2734,6 +2754,7 @@ class Database:
                     names_set: set[str] = set()
                     with os.scandir(row["folder_path"]) as it:
                         for entry in it:
+                            check_cancelled()
                             # Broken symlinks: scandir returns the basename even
                             # when the target is gone, but the prior os.path.exists
                             # check returned False. Filter them so missing
@@ -2765,9 +2786,11 @@ class Database:
             # volumes (APFS default, NTFS) os.path.exists resolves a
             # case-mismatched name; on case-sensitive volumes (most Linux
             # filesystems) it correctly reports the file as absent.
+            check_cancelled()
             if not os.path.exists(os.path.join(row["folder_path"], row["filename"])):
                 missing.append(row)
             report_photo_progress(row["folder_path"])
+        check_cancelled()
         report_progress("")
         return missing
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2606,7 +2606,7 @@ class Database:
             (self._ws_id(),),
         ).fetchall()
 
-    def get_missing_photos(self, folder_id=None):
+    def get_missing_photos(self, folder_id=None, progress_callback=None):
         """Return photos whose source file is missing from disk.
 
         Scoped to the active workspace. Skips photos in folders flagged
@@ -2687,12 +2687,26 @@ class Database:
         folder_online: dict[int, bool] = {}
         folder_names: dict[int, set[str] | None] = {}
         missing = []
+        photos_considered = 0
+        folders_checked = 0
+        reported_folders = set()
         for row in rows:
             fid = row["folder_id"]
             if fid not in folder_online:
                 folder_online[fid] = os.path.isdir(row["folder_path"])
             if not folder_online[fid]:
                 # Whole folder is offline — surfaced by missing-folders flow.
+                if fid not in reported_folders:
+                    reported_folders.add(fid)
+                    folders_checked += 1
+                    if progress_callback is not None:
+                        progress_callback({
+                            "folders_checked": folders_checked,
+                            "photos_considered": photos_considered,
+                            "missing_found": len(missing),
+                            "total_photos": len(rows),
+                            "current_folder": row["folder_path"],
+                        })
                 continue
             if fid not in folder_names:
                 try:
@@ -2714,7 +2728,19 @@ class Database:
                     # treat the same as "folder offline" so we don't bulk-flag
                     # every photo as a ghost.
                     folder_names[fid] = None
+                if fid not in reported_folders:
+                    reported_folders.add(fid)
+                    folders_checked += 1
+                    if progress_callback is not None:
+                        progress_callback({
+                            "folders_checked": folders_checked,
+                            "photos_considered": photos_considered,
+                            "missing_found": len(missing),
+                            "total_photos": len(rows),
+                            "current_folder": row["folder_path"],
+                        })
             names = folder_names[fid]
+            photos_considered += 1
             if names is None:
                 continue
             if _nfc(row["filename"]) in names:
@@ -2725,6 +2751,14 @@ class Database:
             # filesystems) it correctly reports the file as absent.
             if not os.path.exists(os.path.join(row["folder_path"], row["filename"])):
                 missing.append(row)
+        if progress_callback is not None:
+            progress_callback({
+                "folders_checked": folders_checked,
+                "photos_considered": photos_considered,
+                "missing_found": len(missing),
+                "total_photos": len(rows),
+                "current_folder": "",
+            })
         return missing
 
     def nearest_ancestor_folder_id(self, path, exclude_id=None):

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -651,7 +651,8 @@ def _collapse_scan_roots(paths):
 
 
 def run_pipeline_job(job, runner, db_path, workspace_id, params,
-                     thumb_cache_dir=None):
+                     thumb_cache_dir=None,
+                     missing_originals_invalidator=None):
     """Execute streaming pipeline. Called by JobRunner in a background thread.
 
     Args:
@@ -665,6 +666,12 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
             pipeline writes and invalidates the real cache even when
             ``--thumb-dir`` points outside ``dirname(db_path)/thumbnails``.
             Defaults to that convention for backward compatibility.
+        missing_originals_invalidator: optional zero-arg callable that
+            drops the Flask app's Missing Originals cache for this DB.
+            Called after every scanned root in the finally block, mirroring
+            api_job_scan / api_job_import_full so a pipeline scan that
+            touches disk doesn't leave GET /api/photos/missing serving a
+            pre-scan ghost list.
 
     Returns:
         dict with stage results, duration, and errors
@@ -2116,6 +2123,23 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 "Failed to invalidate new-images cache for %s",
                                 scanned_root,
                             )
+                        # scanner.scan touches disk and may add or remove
+                        # photo rows; a ready Missing Originals payload
+                        # computed before the pipeline scan can now be
+                        # stale (e.g. user restored an original before
+                        # running Process). Standalone scan / import jobs
+                        # already invalidate here — mirror that for
+                        # pipeline scans so GET /api/photos/missing does
+                        # not keep serving the pre-scan photo list.
+                        if missing_originals_invalidator is not None:
+                            try:
+                                missing_originals_invalidator()
+                            except Exception:
+                                log.exception(
+                                    "Failed to invalidate missing-originals "
+                                    "cache for %s",
+                                    scanned_root,
+                                )
                 scan_to_thumb.put(_SENTINEL)
                 _update_stages(runner, job["id"], stages)
 

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1107,6 +1107,14 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             )
                             unreachable += 1
                             continue
+                        # Track the repair folder so the outer finally
+                        # invalidates the Missing Originals cache for it —
+                        # scanner.scan touches the folder on disk and can
+                        # revalidate a restored original that a ready
+                        # /api/photos/missing payload still lists as a
+                        # ghost. Matches the append pattern used by the
+                        # normal ingest/scan-in-place paths below.
+                        scanned_roots.append(folder_path)
                         try:
                             # restrict_files limits discovery to the known
                             # broken photos in this folder. Without it, new

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -9975,7 +9975,18 @@ async function startMissingPhotosCheck(opts) {
 }
 
 async function checkMissingPhotos() {
-  if (_missingPhotosBannerInFlight) return;
+  if (_missingPhotosBannerInFlight) {
+    // Supersede the in-flight banner poll before returning: bump the
+    // generation counters so the still-running fetch's response is
+    // treated as stale and cannot repaint the banner or overwrite the
+    // cache with a pre-invalidation payload once it lands. Without this
+    // bump, a newer call fired after e.g. a batch-delete invalidation
+    // would return silently and the older response would pass its own
+    // ``myId`` checks and paint just-deleted photos back into view.
+    _missingPhotosCacheFetchId++;
+    _missingPhotosBannerFetchId++;
+    return;
+  }
   _missingPhotosBannerInFlight = true;
   const cacheId = ++_missingPhotosCacheFetchId;
   const myId = ++_missingPhotosBannerFetchId;

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -9908,6 +9908,9 @@ let _missingPhotosBannerFetchId = 0;
 let _missingPhotosModalFetchId = 0;
 let _missingPhotosBannerInFlight = false;
 let _missingPhotosStatusPoll = null;
+let _missingPhotosAutomaticTimer = null;
+const MISSING_PHOTOS_INITIAL_DELAY_MS = 180000;
+const MISSING_PHOTOS_AUTOMATIC_INTERVAL_MS = 30 * 60 * 1000;
 
 function _missingPhotosStatusUrl(folderId) {
   return folderId != null
@@ -9927,6 +9930,17 @@ function _scheduleMissingPhotosPoll(folderId, modal) {
     if (modal) loadMissingPhotos();
     else checkMissingPhotos();
   }, 3000);
+}
+
+function _scheduleAutomaticMissingPhotosCheck(delayMs) {
+  if (_missingPhotosAutomaticTimer !== null) clearTimeout(_missingPhotosAutomaticTimer);
+  _missingPhotosAutomaticTimer = setTimeout(async function() {
+    _missingPhotosAutomaticTimer = null;
+    try {
+      await startMissingPhotosCheck({ automatic: true });
+    } catch (e) { /* ignore */ }
+    _scheduleAutomaticMissingPhotosCheck(MISSING_PHOTOS_AUTOMATIC_INTERVAL_MS);
+  }, delayMs);
 }
 
 async function startMissingPhotosCheck(opts) {
@@ -9993,21 +10007,8 @@ function dismissMissingPhotosBanner() {
 // libraries backed by SMB/NAS volumes it can take minutes, so startup uses a
 // delayed background job and the banner only renders cached results. After the
 // initial run, keep re-arming a self-scheduling timer so a long-lived tab still
-// picks up files deleted (or previously skipped due to a heavy job) later on —
-// a bare `setTimeout` would never fire again after the first call.
-const _MISSING_ORIGINALS_INITIAL_DELAY_MS = 180000;      // ~3 min after page load
-const _MISSING_ORIGINALS_INTERVAL_MS = 30 * 60 * 1000;   // then ~every 30 min
-function _scheduleAutomaticMissingPhotosScan(delayMs) {
-  setTimeout(function() {
-    Promise.resolve()
-      .then(function() { return startMissingPhotosCheck({ automatic: true }); })
-      .catch(function() { /* ignore */ })
-      .finally(function() {
-        _scheduleAutomaticMissingPhotosScan(_MISSING_ORIGINALS_INTERVAL_MS);
-      });
-  }, delayMs);
-}
-_scheduleAutomaticMissingPhotosScan(_MISSING_ORIGINALS_INITIAL_DELAY_MS);
+// picks up files deleted, or skipped earlier because a heavy job was active.
+_scheduleAutomaticMissingPhotosCheck(MISSING_PHOTOS_INITIAL_DELAY_MS);
 
 /* ---------- New Images Banner ---------- */
 // Per-workspace dismissal: one sessionStorage key per workspace id so that

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -9985,6 +9985,15 @@ async function checkMissingPhotos() {
     // ``myId`` checks and paint just-deleted photos back into view.
     _missingPhotosCacheFetchId++;
     _missingPhotosBannerFetchId++;
+    // Bumping the generation only invalidates the older response — it
+    // does NOT send a new /api/photos/missing GET, so an already-visible
+    // banner (with the pre-invalidation count) would stay on-screen
+    // until the next 30-minute automatic tick. Schedule a follow-up
+    // poll so the banner actually catches up once the in-flight fetch
+    // clears; if it's still busy when the timer fires we'll re-enter
+    // this branch and re-arm, keeping the banner honest without
+    // aborting the in-flight request.
+    _scheduleMissingPhotosPoll(null, false);
     return;
   }
   _missingPhotosBannerInFlight = true;
@@ -10548,14 +10557,14 @@ async function runRescan() {
       }
       const label = sel.options[sel.selectedIndex]
         ? sel.options[sel.selectedIndex].textContent : '';
-      await safeFetch('/api/folders/' + fid + '/rescan', {
+      const scanRes = await safeFetch('/api/folders/' + fid + '/rescan', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ incremental: true }),
       });
       closeRescanModal();
       showToast('Rescanning “' + label + '” for new and changed photos…', 'info');
-      await reviewDeletedAfterRescan(fid, label);
+      await reviewDeletedAfterRescan(fid, label, scanRes && scanRes.job_id);
     } else {
       const res = await safeFetch('/api/jobs/scan-workspace', {
         method: 'POST',
@@ -10569,7 +10578,7 @@ async function runRescan() {
         msg += ' (' + n + ' offline folder' + (n === 1 ? '' : 's') + ' skipped)';
       }
       showToast(msg, 'info');
-      await reviewDeletedAfterRescan(null, '');
+      await reviewDeletedAfterRescan(null, '', res && res.job_id);
     }
   } catch (e) {
     // safeFetch already surfaced the error; leave the modal open to retry.
@@ -10579,10 +10588,55 @@ async function runRescan() {
   btn.disabled = false;
 }
 
+// Poll a job until it reaches a terminal state (completed / failed /
+// cancelled). Used by the rescan flow so the follow-up missing-originals
+// check doesn't race the scan itself: the scan job invalidates the
+// missing-originals cache in its per-root ``finally``, which bumps the
+// in-flight generation — a missing-originals scan started too early
+// would have its results discarded and the modal would poll to
+// ``not_ready`` instead of showing the just-computed ghosts.
+//
+// Returns true when the job reached ``completed``, false for any other
+// terminal state (or if the status endpoint stops returning the job).
+// Callers treat "unknown" the same as "done" so a lost job id doesn't
+// hang the review modal indefinitely.
+async function _awaitScanJobDone(jobId, opts) {
+  opts = opts || {};
+  const intervalMs = opts.intervalMs || 1500;
+  // Hard cap so a stuck job can never wedge the follow-up modal open.
+  // At the default 1.5s cadence this is ~10 minutes, which covers even
+  // large NAS/SMB rescans; the scan itself keeps running past the cap.
+  const maxAttempts = opts.maxAttempts || 400;
+  for (let i = 0; i < maxAttempts; i++) {
+    let job;
+    try {
+      const resp = await fetch('/api/jobs/' + encodeURIComponent(jobId));
+      if (resp.status === 404) return false;
+      if (!resp.ok) return false;
+      job = await resp.json();
+    } catch (e) {
+      return false;
+    }
+    const status = job && job.status;
+    if (status === 'completed') return true;
+    if (status === 'failed' || status === 'cancelled') return false;
+    await new Promise(function(r) { setTimeout(r, intervalMs); });
+  }
+  return false;
+}
+
 // The scan job (incremental) only adds/updates — it never removes rows for
-// files deleted on disk. So immediately after kicking it off, check for
-// missing originals in the same scope and open the review modal if any exist.
-async function reviewDeletedAfterRescan(folderId, label) {
+// files deleted on disk. So after it finishes, check for missing originals
+// in the same scope and open the review modal if any exist. We wait for
+// the scan job to reach a terminal state first because the scan's own
+// cache invalidation would otherwise bump the missing-originals scan's
+// in-flight generation mid-flight and discard the results (the modal
+// would then poll to ``not_ready``/"not checked yet" even though a full
+// filesystem walk had just completed).
+async function reviewDeletedAfterRescan(folderId, label, scanJobId) {
+  if (scanJobId) {
+    await _awaitScanJobDone(scanJobId);
+  }
   try {
     const payload = await startMissingPhotosCheck({
       folderId: folderId,

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -10635,7 +10635,25 @@ async function _awaitScanJobDone(jobId, opts) {
 // filesystem walk had just completed).
 async function reviewDeletedAfterRescan(folderId, label, scanJobId) {
   if (scanJobId) {
-    await _awaitScanJobDone(scanJobId);
+    const scanDone = await _awaitScanJobDone(scanJobId);
+    if (!scanDone) {
+      // ``_awaitScanJobDone`` returns false for terminal failures/
+      // cancels, transient ``/api/jobs/<id>`` fetch failures, and the
+      // hard polling cap (~10 min) — meaning the rescan job may still
+      // be running. Starting the missing-originals scan now would race
+      // the scan's per-root ``finally`` cache invalidation, which bumps
+      // the missing-scan in-flight generation and discards the freshly
+      // computed result — the modal would then poll to ``not_ready``
+      // even though a full filesystem walk had just completed. Defer
+      // with a toast; the banner's next automatic tick will surface any
+      // deletions once the scan actually finishes.
+      showToast(
+        'Rescan still finishing' + (label ? ' in “' + label + '”' : '')
+          + ' — deleted-photo review will run once it completes.',
+        'info',
+      );
+      return;
+    }
   }
   try {
     const payload = await startMissingPhotosCheck({

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -10775,6 +10775,19 @@ async function _deleteMissingPhotoIds(ids, deleteSidecars) {
       'info',
     );
   }
+  // The cache can't tell "original truly missing" from "folder unreachable"
+  // — if a NAS/SMB mount is currently offline every ready-cache row would
+  // look absent, so the endpoint defers those IDs. Surface that so users
+  // know why the delete didn't happen and can retry once the volume returns.
+  const folderOffline = (payload && Array.isArray(payload.folder_offline))
+    ? payload.folder_offline : [];
+  if (folderOffline.length > 0) {
+    const noun = folderOffline.length === 1 ? 'photo' : 'photos';
+    showToast(
+      `Skipped ${folderOffline.length} ${noun} whose folder is currently offline.`,
+      'warning',
+    );
+  }
   // Best-effort: refreshing the Misses page is an auxiliary UI sync. A
   // failure here must not reject the delete flow or block the caller's
   // own loadMissingPhotos() refresh.

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -10860,6 +10860,14 @@ async function _deleteMissingPhotoIds(ids, deleteSidecars) {
       'warning',
     );
   }
+  // The server just invalidated the Missing Originals cache, but callers
+  // only bump the modal/cache generation counters (via refreshMissingPhotosNow
+  // → loadMissingPhotos). A banner /api/photos/missing GET that was already
+  // in flight before this delete would still pass its own banner-generation
+  // check and repaint the pre-delete count. Route through checkMissingPhotos
+  // so the in-flight branch bumps _missingPhotosBannerFetchId and schedules
+  // a follow-up poll, and an idle banner refetches fresh state.
+  try { checkMissingPhotos(); } catch (err) { /* best-effort banner refresh */ }
   // Best-effort: refreshing the Misses page is an auxiliary UI sync. A
   // failure here must not reject the delete flow or block the caller's
   // own loadMissingPhotos() refresh.

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -10740,37 +10740,30 @@ async function removeSelectedMissingPhotos() {
 }
 
 async function _deleteMissingPhotoIds(ids, deleteSidecars) {
-  // Sidecar cleanup must run BEFORE the batch delete: the server resolves
-  // sidecar paths from the photo row's folder + filename, so once the row
-  // is gone the lookup returns nothing and the .xmp would be left behind.
-  if (deleteSidecars) {
-    // Prefer the modal's own rows: they cover ghosts that only appeared in
-    // a folder-scoped load and therefore aren't in the workspace-wide
-    // cache. Fall back to the cache for the removeOneMissingPhoto path
-    // when the modal isn't open.
-    const idSet = new Set(ids);
-    const seen = new Set();
-    const sidecarIds = [];
-    const consider = (p) => {
-      if (!p || seen.has(p.id)) return;
-      seen.add(p.id);
-      if (idSet.has(p.id) && p.has_xmp_sidecar) sidecarIds.push(p.id);
-    };
-    for (const id of ids) consider(_missingPhotosModalRows.get(id));
-    for (const p of _missingPhotosCache) consider(p);
-    if (sidecarIds.length > 0) {
-      await safeFetch('/api/photos/missing/delete-sidecars', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({photo_ids: sidecarIds}),
-      });
-    }
-  }
-  await safeFetch('/api/batch/delete', {
+  // Ready /api/photos/missing payloads are cached for up to 30 min, so a
+  // photo whose original came back after the last scan could otherwise be
+  // deleted from Vireo just by trusting the cache. The dedicated
+  // missing/remove endpoint re-checks each source on disk in the active
+  // workspace, skips any whose original is back, and only deletes the
+  // still-missing rows (plus their sidecars in the same transaction).
+  const payload = await safeFetch('/api/photos/missing/remove', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({photo_ids: ids, mode: 'vireo'}),
+    body: JSON.stringify({
+      photo_ids: ids,
+      mode: 'vireo',
+      delete_sidecars: !!deleteSidecars,
+    }),
   });
+  const restored = (payload && Array.isArray(payload.restored))
+    ? payload.restored : [];
+  if (restored.length > 0) {
+    const noun = restored.length === 1 ? 'photo' : 'photos';
+    showToast(
+      `Skipped ${restored.length} ${noun} whose original is back on disk.`,
+      'info',
+    );
+  }
   // Best-effort: refreshing the Misses page is an auxiliary UI sync. A
   // failure here must not reject the delete flow or block the caller's
   // own loadMissingPhotos() refresh.

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -9907,7 +9907,12 @@ let _missingPhotosCacheFetchId = 0;
 let _missingPhotosBannerFetchId = 0;
 let _missingPhotosModalFetchId = 0;
 let _missingPhotosBannerInFlight = false;
-let _missingPhotosStatusPoll = null;
+// Separate timer handles per target: a banner status poll firing while the
+// modal is waiting on a long scan used to cancel the modal's own poll (they
+// shared a single handle), leaving the modal stuck on "Checking missing
+// originals…" until the user closed and reopened it.
+let _missingPhotosBannerStatusPoll = null;
+let _missingPhotosModalStatusPoll = null;
 let _missingPhotosAutomaticTimer = null;
 const MISSING_PHOTOS_INITIAL_DELAY_MS = 180000;
 const MISSING_PHOTOS_AUTOMATIC_INTERVAL_MS = 30 * 60 * 1000;
@@ -9924,12 +9929,19 @@ function _missingPhotosPayloadPhotos(payload) {
 }
 
 function _scheduleMissingPhotosPoll(folderId, modal) {
-  if (_missingPhotosStatusPoll !== null) clearTimeout(_missingPhotosStatusPoll);
-  _missingPhotosStatusPoll = setTimeout(function() {
-    _missingPhotosStatusPoll = null;
-    if (modal) loadMissingPhotos();
-    else checkMissingPhotos();
-  }, 3000);
+  if (modal) {
+    if (_missingPhotosModalStatusPoll !== null) clearTimeout(_missingPhotosModalStatusPoll);
+    _missingPhotosModalStatusPoll = setTimeout(function() {
+      _missingPhotosModalStatusPoll = null;
+      loadMissingPhotos();
+    }, 3000);
+  } else {
+    if (_missingPhotosBannerStatusPoll !== null) clearTimeout(_missingPhotosBannerStatusPoll);
+    _missingPhotosBannerStatusPoll = setTimeout(function() {
+      _missingPhotosBannerStatusPoll = null;
+      checkMissingPhotos();
+    }, 3000);
+  }
 }
 
 function _scheduleAutomaticMissingPhotosCheck(delayMs) {

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -10008,6 +10008,12 @@ function dismissMissingPhotosBanner() {
 // delayed background job and the banner only renders cached results. After the
 // initial run, keep re-arming a self-scheduling timer so a long-lived tab still
 // picks up files deleted, or skipped earlier because a heavy job was active.
+//
+// Read any existing cache immediately: this app spans multiple pages, so each
+// navigation resets the delayed POST timer. Without this cheap cache-only GET,
+// a ready payload from a prior scan or another tab would stay hidden for the
+// full delay window even though showing it costs no filesystem work.
+checkMissingPhotos();
 _scheduleAutomaticMissingPhotosCheck(MISSING_PHOTOS_INITIAL_DELAY_MS);
 
 /* ---------- New Images Banner ---------- */

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -2203,7 +2203,7 @@ function sendReport() {
     <div id="missingPhotosList" style="flex:1;overflow-y:auto;"></div>
     <div class="modal-actions">
       <button class="modal-btn danger" id="missingPhotosRemoveBtn" onclick="removeSelectedMissingPhotos()" disabled>Remove selected</button>
-      <button class="modal-btn" onclick="loadMissingPhotos()">Check Again</button>
+      <button class="modal-btn" onclick="refreshMissingPhotosNow()">Check Again</button>
       <button class="modal-btn modal-btn-cancel" onclick="closeMissingPhotosModal()">Close</button>
     </div>
   </div>
@@ -9991,10 +9991,23 @@ function dismissMissingPhotosBanner() {
 
 // Missing-originals scan touches every photo's source path on disk. On large
 // libraries backed by SMB/NAS volumes it can take minutes, so startup uses a
-// delayed background job and the banner only renders cached results.
-setTimeout(function() {
-  startMissingPhotosCheck({ automatic: true }).catch(function() { /* ignore */ });
-}, 180000);
+// delayed background job and the banner only renders cached results. After the
+// initial run, keep re-arming a self-scheduling timer so a long-lived tab still
+// picks up files deleted (or previously skipped due to a heavy job) later on —
+// a bare `setTimeout` would never fire again after the first call.
+const _MISSING_ORIGINALS_INITIAL_DELAY_MS = 180000;      // ~3 min after page load
+const _MISSING_ORIGINALS_INTERVAL_MS = 30 * 60 * 1000;   // then ~every 30 min
+function _scheduleAutomaticMissingPhotosScan(delayMs) {
+  setTimeout(function() {
+    Promise.resolve()
+      .then(function() { return startMissingPhotosCheck({ automatic: true }); })
+      .catch(function() { /* ignore */ })
+      .finally(function() {
+        _scheduleAutomaticMissingPhotosScan(_MISSING_ORIGINALS_INTERVAL_MS);
+      });
+  }, delayMs);
+}
+_scheduleAutomaticMissingPhotosScan(_MISSING_ORIGINALS_INITIAL_DELAY_MS);
 
 /* ---------- New Images Banner ---------- */
 // Per-workspace dismissal: one sessionStorage key per workspace id so that

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -9893,10 +9893,10 @@ let _missingPhotosCache = [];
 // folder-scoped view.
 let _missingPhotosModalRows = new Map();
 let _missingPhotosBannerDismissedCount = 0;
-// Both the banner poll and the modal load hit /api/photos/missing and write
-// to _missingPhotosCache. A slow earlier fetch returning after a newer one
-// used to overwrite fresh state with stale results — leaving the banner
-// showing ghosts the user just deleted.
+// Both the banner and modal read cached /api/photos/missing status. A slow
+// earlier fetch returning after a newer one used to overwrite fresh state
+// with stale results — leaving the banner showing ghosts the user just
+// deleted.
 //
 // Cache writes share a single monotonic id across both flows, so only the
 // most-recently-started fetch (regardless of which flow issued it) can
@@ -9906,16 +9906,67 @@ let _missingPhotosBannerDismissedCount = 0;
 let _missingPhotosCacheFetchId = 0;
 let _missingPhotosBannerFetchId = 0;
 let _missingPhotosModalFetchId = 0;
+let _missingPhotosBannerInFlight = false;
+let _missingPhotosStatusPoll = null;
+
+function _missingPhotosStatusUrl(folderId) {
+  return folderId != null
+    ? '/api/photos/missing?folder_id=' + encodeURIComponent(folderId)
+    : '/api/photos/missing';
+}
+
+function _missingPhotosPayloadPhotos(payload) {
+  if (Array.isArray(payload)) return payload;  // legacy/test fallback
+  return (payload && Array.isArray(payload.photos)) ? payload.photos : [];
+}
+
+function _scheduleMissingPhotosPoll(folderId, modal) {
+  if (_missingPhotosStatusPoll !== null) clearTimeout(_missingPhotosStatusPoll);
+  _missingPhotosStatusPoll = setTimeout(function() {
+    _missingPhotosStatusPoll = null;
+    if (modal) loadMissingPhotos();
+    else checkMissingPhotos();
+  }, 3000);
+}
+
+async function startMissingPhotosCheck(opts) {
+  opts = opts || {};
+  const body = { automatic: !!opts.automatic };
+  if (opts.folderId != null) body.folder_id = opts.folderId;
+  const resp = await fetch('/api/photos/missing/check', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!resp.ok) throw new Error('missing originals check failed');
+  const payload = await resp.json();
+  if (payload && payload.pending) {
+    _scheduleMissingPhotosPoll(opts.folderId || null, !!opts.modal);
+  } else if (opts.automatic) {
+    checkMissingPhotos();
+  }
+  return payload;
+}
 
 async function checkMissingPhotos() {
+  if (_missingPhotosBannerInFlight) return;
+  _missingPhotosBannerInFlight = true;
   const cacheId = ++_missingPhotosCacheFetchId;
   const myId = ++_missingPhotosBannerFetchId;
   try {
     const resp = await fetch('/api/photos/missing');
     if (!resp.ok) return;
     if (myId !== _missingPhotosBannerFetchId) return;  // a newer banner poll is authoritative
-    const photos = await resp.json();
+    const payload = await resp.json();
     if (myId !== _missingPhotosBannerFetchId) return;
+    const photos = _missingPhotosPayloadPhotos(payload);
+    const ready = Array.isArray(payload) || (payload && payload.status === 'ready');
+    if (payload && payload.pending) _scheduleMissingPhotosPoll(null, false);
+    if (!ready) {
+      const banner = document.getElementById('missingPhotosBanner');
+      if (banner) banner.style.display = 'none';
+      return;
+    }
     if (cacheId === _missingPhotosCacheFetchId) _missingPhotosCache = photos;
     const banner = document.getElementById('missingPhotosBanner');
     const msg = document.getElementById('missingPhotosMsg');
@@ -9928,6 +9979,9 @@ async function checkMissingPhotos() {
       _missingPhotosBannerDismissedCount = 0;
     }
   } catch (e) { /* ignore */ }
+  finally {
+    _missingPhotosBannerInFlight = false;
+  }
 }
 
 function dismissMissingPhotosBanner() {
@@ -9935,11 +9989,12 @@ function dismissMissingPhotosBanner() {
   _missingPhotosBannerDismissedCount = _missingPhotosCache.length;
 }
 
-// Missing-originals scan touches every photo's source path on disk; on a
-// large library that's slow over a network volume. Run on load and every
-// 30 minutes — folders disappear faster than individual files do.
-checkMissingPhotos();
-setInterval(checkMissingPhotos, 1800000);
+// Missing-originals scan touches every photo's source path on disk. On large
+// libraries backed by SMB/NAS volumes it can take minutes, so startup uses a
+// delayed background job and the banner only renders cached results.
+setTimeout(function() {
+  startMissingPhotosCheck({ automatic: true }).catch(function() { /* ignore */ });
+}, 180000);
 
 /* ---------- New Images Banner ---------- */
 // Per-workspace dismissal: one sessionStorage key per workspace id so that
@@ -10486,11 +10541,13 @@ async function runRescan() {
 // missing originals in the same scope and open the review modal if any exist.
 async function reviewDeletedAfterRescan(folderId, label) {
   try {
-    const url = folderId != null
-      ? '/api/photos/missing?folder_id=' + encodeURIComponent(folderId)
-      : '/api/photos/missing';
-    const photos = await safeFetch(url, {}, { toast: false });
-    if (photos && photos.length) {
+    const payload = await startMissingPhotosCheck({
+      folderId: folderId,
+      automatic: false,
+      modal: true,
+    });
+    const photos = _missingPhotosPayloadPhotos(payload);
+    if ((payload && payload.pending) || (photos && photos.length)) {
       openMissingPhotosModal(folderId, label);
     } else {
       showToast('No deleted photos found' + (label ? ' in “' + label + '”' : '') + '.', 'info');
@@ -10516,14 +10573,29 @@ async function loadMissingPhotos() {
   const myId = ++_missingPhotosModalFetchId;
   try {
     const scoped = _missingPhotosScope.folderId != null;
-    const url = scoped
-      ? '/api/photos/missing?folder_id=' + encodeURIComponent(_missingPhotosScope.folderId)
-      : '/api/photos/missing';
+    const url = _missingPhotosStatusUrl(_missingPhotosScope.folderId);
     const resp = await fetch(url);
     if (!resp.ok) throw new Error('check failed');
     if (myId !== _missingPhotosModalFetchId) return;  // superseded by a newer modal load
-    const photos = await resp.json();
+    const payload = await resp.json();
     if (myId !== _missingPhotosModalFetchId) return;
+    const photos = _missingPhotosPayloadPhotos(payload);
+    const ready = Array.isArray(payload) || (payload && payload.status === 'ready');
+    if (payload && payload.pending) {
+      container.innerHTML = '<p style="color:var(--text-secondary);">Checking missing originals…</p>';
+      _scheduleMissingPhotosPoll(_missingPhotosScope.folderId, true);
+      return;
+    }
+    if (!ready) {
+      const err = payload && payload.error ? _escapeHtml(payload.error) : '';
+      const msg = payload && payload.status === 'error'
+        ? 'Could not check missing originals' + (err ? ': ' + err : '') + '.'
+        : 'Missing originals have not been checked yet.';
+      container.innerHTML =
+        '<p style="color:var(--text-secondary);">' + msg + '</p>' +
+        '<button class="modal-btn primary" onclick="refreshMissingPhotosNow()">Check now</button>';
+      return;
+    }
     // A folder-scoped load is a subset — don't overwrite the workspace-wide
     // banner cache with it, or the banner's dismissed-count math goes stale.
     if (!scoped && cacheId === _missingPhotosCacheFetchId) _missingPhotosCache = photos;
@@ -10574,6 +10646,24 @@ async function loadMissingPhotos() {
   }
 }
 
+async function refreshMissingPhotosNow() {
+  const container = document.getElementById('missingPhotosList');
+  const toolbar = document.getElementById('missingPhotosToolbar');
+  if (toolbar) toolbar.style.display = 'none';
+  if (container) container.innerHTML = '<p style="color:var(--text-secondary);">Starting missing originals check…</p>';
+  try {
+    await startMissingPhotosCheck({
+      folderId: _missingPhotosScope.folderId,
+      automatic: false,
+      modal: true,
+    });
+  } catch (e) {
+    if (container) container.innerHTML = '<p style="color:var(--text-secondary);">Failed to start check.</p>';
+    return;
+  }
+  loadMissingPhotos();
+}
+
 function toggleMissingPhoto(id, checked) {
   if (checked) _missingPhotosSelected.add(id);
   else _missingPhotosSelected.delete(id);
@@ -10604,7 +10694,7 @@ async function removeOneMissingPhoto(id) {
     : '\n\nThe XMP sidecar on disk will not be touched.';
   if (!confirm(`Remove this photo from Vireo?\n\nCached thumbnail/preview/working copy (if any) will also be deleted.${sidecarMsg}`)) return;
   await _deleteMissingPhotoIds([id], deleteSidecars);
-  loadMissingPhotos();
+  refreshMissingPhotosNow();
 }
 
 async function removeSelectedMissingPhotos() {
@@ -10614,7 +10704,7 @@ async function removeSelectedMissingPhotos() {
   const sidecarMsg = deleteSidecars ? '\n\nLeftover XMP sidecars will also be deleted from disk.' : '';
   if (!confirm(`Remove ${ids.length} photo${ids.length !== 1 ? 's' : ''} from Vireo?\n\nCached thumbnails/previews/working copies will be deleted.${sidecarMsg}`)) return;
   await _deleteMissingPhotoIds(ids, deleteSidecars);
-  loadMissingPhotos();
+  refreshMissingPhotosNow();
 }
 
 async function _deleteMissingPhotoIds(ids, deleteSidecars) {

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -4608,6 +4608,102 @@ def test_api_photos_missing_automatic_skips_during_heavy_job(app_and_db):
     wait_for_job_via_client(client, scan_job)
 
 
+def test_api_photos_missing_automatic_skips_during_missing_originals_scan(app_and_db):
+    """A folder-scoped scan already walking disk must suppress the automatic
+    workspace-wide check.
+
+    Regression: workspace and folder-scoped scans have distinct cache keys, so
+    the same-key in-flight coalescing does not catch them. Without treating
+    ``missing_originals_scan`` as a heavy job, the 30-minute automatic timer
+    can kick off a second walk over the same tree while a folder scan is
+    still running.
+    """
+    import threading
+    import time
+
+    app, db = app_and_db
+    client = app.test_client()
+
+    # Hold a fake missing_originals_scan job in the running queue long enough
+    # to exercise the automatic-check gate. A real folder-scoped scan would
+    # register the same job type; we don't need the actual scan logic to
+    # observe the heavy-job suppression.
+    release = threading.Event()
+
+    def _hold_running(job):
+        release.wait(timeout=5.0)
+        return {"ok": True}
+
+    scan_job = app._job_runner.start(
+        "missing_originals_scan",
+        _hold_running,
+        workspace_id=db._active_workspace_id,
+        ephemeral=True,
+    )
+    try:
+        # Give the runner a moment to move the job to "running" so
+        # _missing_originals_heavy_job_active sees it.
+        for _ in range(50):
+            jobs = app._job_runner.list_jobs()
+            if any(
+                j.get("id") == scan_job and j.get("status") in ("running", "queued")
+                for j in jobs
+            ):
+                break
+            time.sleep(0.02)
+
+        resp = client.post(
+            "/api/photos/missing/check", json={"automatic": True}
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["suppressed"] is True, data
+        assert data["reason"] == "heavy_job_active", data
+        assert data["status"] == "skipped", data
+    finally:
+        release.set()
+        wait_for_job_via_client(client, scan_job)
+
+
+def test_api_folder_delete_invalidates_missing_cache(app_and_db, tmp_path):
+    """Deleting a folder must clear the Missing Originals cache.
+
+    Regression: ``api_folder_delete`` cascades photo-row deletion but never
+    hit ``_invalidate_missing_originals_cache``. A ready payload built before
+    the delete would keep listing photos from the now-removed folder in the
+    banner/modal, offering them for removal a second time.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+
+    real_dir = tmp_path / "live"
+    real_dir.mkdir()
+    fid = db.add_folder(str(real_dir), name="live")
+    pid_ghost = db.add_photo(
+        folder_id=fid,
+        filename="ghost.NEF",
+        extension=".nef",
+        file_size=42,
+        file_mtime=2.0,
+    )
+    # Drop unrelated seed photos so the cache payload is deterministic.
+    db.delete_photos([
+        row["id"] for row in db.conn.execute(
+            "SELECT id FROM photos WHERE folder_id != ?", (fid,)
+        ).fetchall()
+    ])
+
+    cached = _run_missing_originals_check(client)
+    assert [row["id"] for row in cached["photos"]] == [pid_ghost]
+
+    resp = client.delete(f"/api/folders/{fid}")
+    assert resp.status_code == 200
+
+    payload = client.get("/api/photos/missing").get_json()
+    assert payload["status"] == "not_ready", payload
+    assert payload["photos"] == []
+
+
 def test_api_photos_missing_automatic_respects_failure_backoff(app_and_db, monkeypatch):
     """A failed manual scan suppresses automatic retries during backoff."""
     from db import Database

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -4633,6 +4633,131 @@ def test_api_photos_missing_automatic_respects_failure_backoff(app_and_db, monke
     assert data["backoff_seconds"] > 0
 
 
+def test_api_audit_remove_orphans_invalidates_missing_cache(app_and_db, tmp_path):
+    """Removing orphaned photo rows must clear the Missing Originals cache.
+
+    Regression: without invalidation, the banner and modal keep serving the
+    pre-delete cache verbatim, so a photo the user just removed via the
+    Audit page reappears in the ghost list until a later manual or
+    automatic rescan.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+
+    real_dir = tmp_path / "live"
+    real_dir.mkdir()
+    fid = db.add_folder(str(real_dir), name="live")
+    pid_ghost = db.add_photo(
+        folder_id=fid,
+        filename="ghost.NEF",
+        extension=".nef",
+        file_size=42,
+        file_mtime=2.0,
+    )
+    db.delete_photos([
+        row["id"] for row in db.conn.execute(
+            "SELECT id FROM photos WHERE folder_id != ?", (fid,)
+        ).fetchall()
+    ])
+
+    cached = _run_missing_originals_check(client)
+    assert [row["id"] for row in cached["photos"]] == [pid_ghost]
+
+    resp = client.post(
+        "/api/audit/remove-orphans", json={"photo_ids": [pid_ghost]}
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["removed"] == 1
+
+    payload = client.get("/api/photos/missing").get_json()
+    assert payload["status"] == "not_ready", payload
+    assert payload["photos"] == []
+
+
+def test_api_duplicates_delete_loser_files_invalidates_missing_cache(
+    app_and_db, monkeypatch, tmp_path,
+):
+    """Trashing duplicate losers must clear the Missing Originals cache.
+
+    Regression: the duplicate-cleanup path calls ``db.delete_photos`` after
+    trashing loser files; without invalidation, a photo removed here still
+    shows up as a ghost in the banner/modal until the next rescan.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+
+    real_dir = tmp_path / "live"
+    real_dir.mkdir()
+    fid = db.add_folder(str(real_dir), name="live")
+    winner_file = real_dir / "winner.jpg"
+    winner_file.write_bytes(b"jpeg-winner")
+    loser_file = real_dir / "loser.jpg"
+    loser_file.write_bytes(b"jpeg-loser")
+
+    # Add the photos without a hash so the ``add_photo`` auto-resolve
+    # hook doesn't reject either row on insert. We then set the shared
+    # hash + the loser's rejected flag directly, which is the exact
+    # state left behind by an earlier ``apply_duplicate_resolution``.
+    pid_winner = db.add_photo(
+        folder_id=fid, filename="winner.jpg", extension=".jpg",
+        file_size=len(b"jpeg-winner"), file_mtime=1.0,
+    )
+    pid_loser = db.add_photo(
+        folder_id=fid, filename="loser.jpg", extension=".jpg",
+        file_size=len(b"jpeg-loser"), file_mtime=2.0,
+    )
+    db.conn.execute(
+        "UPDATE photos SET file_hash='deadbeef' WHERE id IN (?, ?)",
+        (pid_winner, pid_loser),
+    )
+    db.conn.execute(
+        "UPDATE photos SET flag='rejected' WHERE id=?", (pid_loser,),
+    )
+    db.conn.commit()
+    # Make the winner the anchor row and drop unrelated seed photos so the
+    # missing-originals scan is small and deterministic.
+    db.delete_photos([
+        row["id"] for row in db.conn.execute(
+            "SELECT id FROM photos WHERE folder_id != ? AND id NOT IN (?, ?)",
+            (fid, pid_winner, pid_loser),
+        ).fetchall()
+    ])
+
+    # Introduce a ghost row so the cache actually contains something to
+    # invalidate — otherwise the "cache cleared" assertion below is
+    # trivially satisfied even without the fix.
+    pid_ghost = db.add_photo(
+        folder_id=fid, filename="ghost.NEF", extension=".nef",
+        file_size=1, file_mtime=3.0,
+    )
+    cached = _run_missing_originals_check(client)
+    assert pid_ghost in [row["id"] for row in cached["photos"]]
+
+    # Stub send2trash so the test doesn't shell out to the platform trash
+    # implementation; the endpoint's contract is "trashed then row-deleted"
+    # and only the row-delete side is what invalidates the cache.
+    import send2trash as _send2trash_mod
+
+    def fake_send2trash(path):
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            pass
+
+    monkeypatch.setattr(_send2trash_mod, "send2trash", fake_send2trash)
+
+    resp = client.post(
+        "/api/duplicates/delete-loser-files",
+        json={"photo_ids": [pid_loser]},
+    )
+    assert resp.status_code == 200, resp.get_json()
+    assert resp.get_json()["trashed"] == 1
+
+    payload = client.get("/api/photos/missing").get_json()
+    assert payload["status"] == "not_ready", payload
+    assert payload["photos"] == []
+
+
 def test_api_photos_missing_delete_sidecars(app_and_db, tmp_path):
     """POST /api/photos/missing/delete-sidecars removes orphan XMP files for ghost photos.
 

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -4704,6 +4704,110 @@ def test_api_folder_delete_invalidates_missing_cache(app_and_db, tmp_path):
     assert payload["photos"] == []
 
 
+def test_api_folder_relocate_invalidates_missing_cache(app_and_db, tmp_path):
+    """Relocating a folder must clear the Missing Originals cache.
+
+    Regression: ``api_folder_relocate`` rewrites ``folders.path`` and flips
+    status to ``ok`` (and can merge/delete rows via the missing→existing
+    branch), but never called ``_invalidate_missing_originals_cache``.
+    After moving a missing folder to a path where the originals exist, a
+    ready cached payload would keep offering the pre-relocation ghost
+    rows for removal — and the modal's remove flow would happily delete
+    photos whose originals just came back online.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+
+    # Folder exists on disk (get_missing_photos skips folders whose root
+    # is offline), but the tracked photo file isn't there — so it shows up
+    # as a ghost.
+    old_dir = tmp_path / "orig"
+    old_dir.mkdir()
+    fid = db.add_folder(str(old_dir), name="orig")
+    pid_ghost = db.add_photo(
+        folder_id=fid,
+        filename="ghost.NEF",
+        extension=".nef",
+        file_size=42,
+        file_mtime=2.0,
+    )
+    # Strip unrelated seed photos so the cached payload is deterministic.
+    db.delete_photos([
+        row["id"] for row in db.conn.execute(
+            "SELECT id FROM photos WHERE folder_id != ?", (fid,)
+        ).fetchall()
+    ])
+
+    cached = _run_missing_originals_check(client)
+    assert [row["id"] for row in cached["photos"]] == [pid_ghost], cached
+
+    # Relocate to a new path where the original actually exists.
+    new_dir = tmp_path / "moved"
+    new_dir.mkdir()
+    (new_dir / "ghost.NEF").write_bytes(b"stub")
+
+    resp = client.post(
+        f"/api/folders/{fid}/relocate",
+        json={"path": str(new_dir)},
+    )
+    assert resp.status_code == 200, resp.get_json()
+
+    # Cache must be invalidated: GET falls through to not_ready rather
+    # than serving the pre-relocate ghost payload.
+    payload = client.get("/api/photos/missing").get_json()
+    assert payload["status"] == "not_ready", payload
+    assert payload["photos"] == []
+
+
+def test_api_folders_check_health_invalidates_missing_cache(app_and_db, tmp_path):
+    """A folder health flip must clear the Missing Originals cache.
+
+    Regression: ``api_folders_check_health`` calls
+    ``db.check_folder_health`` which flips folders to/from ``missing`` as
+    disk state changes. Without invalidation, a ready cached payload
+    survives the flip: a folder going ok→missing hides the new ghosts,
+    and missing→ok keeps resurfacing photos whose originals just came
+    back.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+
+    live_dir = tmp_path / "live"
+    live_dir.mkdir()
+    fid = db.add_folder(str(live_dir), name="live")
+    (live_dir / "keep.NEF").write_bytes(b"stub")
+    db.add_photo(
+        folder_id=fid,
+        filename="keep.NEF",
+        extension=".nef",
+        file_size=len(b"stub"),
+        file_mtime=2.0,
+    )
+    db.delete_photos([
+        row["id"] for row in db.conn.execute(
+            "SELECT id FROM photos WHERE folder_id != ?", (fid,)
+        ).fetchall()
+    ])
+
+    # Prime a ready cache while the folder is healthy — no ghosts.
+    cached = _run_missing_originals_check(client)
+    assert cached["photos"] == [], cached
+
+    # Now the folder disappears from disk. The next check-health call
+    # flips its status to missing, which turns every one of its photos
+    # into a ghost. A stale cache would still say "no ghosts".
+    import shutil
+    shutil.rmtree(live_dir)
+
+    resp = client.post("/api/folders/check-health")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["changed"] >= 1
+
+    payload = client.get("/api/photos/missing").get_json()
+    assert payload["status"] == "not_ready", payload
+
+
 def test_workspace_delete_and_create_invalidate_missing_cache(app_and_db):
     """Workspace create/delete must clear their id from the missing cache.
 

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -4476,6 +4476,73 @@ def test_api_photos_missing_automatic_uses_fresh_cache(app_and_db, monkeypatch, 
     assert [row["id"] for row in data["photos"]] == [pid_ghost]
 
 
+def test_api_photos_missing_automatic_gate_uses_scan_start_time(
+    app_and_db, tmp_path
+):
+    """Automatic freshness gate must compare against scan-start, not scan-end.
+
+    Regression: the navbar re-arms its 30-minute automatic timer from POST
+    time, but the server used to gate against ``set_at`` (scan-completion
+    time). On any scan that took real wall-clock time, the next tick fired
+    with ``set_at`` under the 30-minute threshold and got skipped — actual
+    filesystem scans then ran only every second tick and deletions could
+    stay undiscovered for nearly an hour.
+    """
+    import time
+
+    from db import Database
+
+    app, db = app_and_db
+    client = app.test_client()
+
+    real_dir = tmp_path / "live"
+    real_dir.mkdir()
+    fid = db.add_folder(str(real_dir), name="live")
+    pid_ghost = db.add_photo(
+        folder_id=fid,
+        filename="ghost.NEF",
+        extension=".nef",
+        file_size=42,
+        file_mtime=2.0,
+    )
+    db.delete_photos([
+        row["id"] for row in db.conn.execute(
+            "SELECT id FROM photos WHERE folder_id != ?", (fid,)
+        ).fetchall()
+    ])
+
+    # Seed the cache to simulate a scan that started > 30 min ago but
+    # only completed recently. The old (buggy) gate would compare ``now``
+    # against ``set_at`` and treat this as fresh; the fix compares against
+    # ``started_at`` so the next automatic tick rescans as intended.
+    key = (db._db_path, db._active_workspace_id, None)
+    now = time.monotonic()
+    stale_seconds = getattr(
+        Database, "_MISSING_ORIGINALS_STALE_SECONDS", 30 * 60
+    )
+    with app._missing_originals_lock:
+        app._missing_originals_cache[key] = {
+            "photos": [],
+            "checked_at": "2026-01-01T00:00:00Z",
+            "set_at": now - 60,  # completed 1 minute ago
+            "started_at": now - (stale_seconds + 60),  # scheduled long ago
+        }
+
+    resp = client.post("/api/photos/missing/check", json={"automatic": True})
+    # A rescan was actually launched — either it finished synchronously
+    # (returning ready with the just-found ghost) or it's still pending.
+    assert resp.status_code in (200, 202)
+    data = resp.get_json()
+    if data.get("pending"):
+        wait_for_job_via_client(client, data["job_id"])
+        follow = client.get("/api/photos/missing").get_json()
+        assert follow["status"] == "ready"
+        assert [row["id"] for row in follow["photos"]] == [pid_ghost]
+    else:
+        assert data["status"] == "ready"
+        assert [row["id"] for row in data["photos"]] == [pid_ghost]
+
+
 def test_api_photos_missing_check_coalesces_duplicate_jobs(app_and_db, monkeypatch):
     """Duplicate refreshes for the same scope reuse the active background job."""
     import time

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -5121,6 +5121,73 @@ def test_api_photos_missing_delete_sidecars(app_and_db, tmp_path):
     assert decoy_xmp.exists(), "sidecar with present original must not be deleted"
 
 
+def test_api_photos_missing_remove_skips_restored_originals(app_and_db, tmp_path):
+    """POST /api/photos/missing/remove re-checks each original before deletion.
+
+    Ready /api/photos/missing payloads are cached for up to 30 minutes without
+    a filesystem recheck. If a user restores a file between the last scan and
+    clicking Remove, trusting the cache would delete a valid Vireo row. The
+    endpoint's job is to re-check per photo and refuse to delete rows whose
+    original came back.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+
+    real_dir = tmp_path / "live"
+    real_dir.mkdir()
+    # Ghost stays missing: nothing on disk for this row.
+    fid = db.add_folder(str(real_dir), name="live")
+    pid_ghost = db.add_photo(folder_id=fid, filename="ghost.NEF",
+                             extension=".nef", file_size=1, file_mtime=1.0)
+    # Restored: original file is back on disk (simulated), sidecar too.
+    pid_restored = db.add_photo(folder_id=fid, filename="restored.NEF",
+                                extension=".nef", file_size=1, file_mtime=1.0)
+    (real_dir / "restored.NEF").write_bytes(b"raw")
+    (real_dir / "restored.xmp").write_text("<x:xmpmeta/>")
+    # Ghost sidecar left on disk — should be cleaned when delete_sidecars=True.
+    (real_dir / "ghost.xmp").write_text("<x:xmpmeta/>")
+
+    resp = client.post("/api/photos/missing/remove", json={
+        "photo_ids": [pid_ghost, pid_restored],
+        "delete_sidecars": True,
+        "mode": "vireo",
+    })
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    data = resp.get_json()
+    assert data["deleted"] == 1
+    assert data["restored"] == [pid_restored]
+    assert data["skipped"] == 0
+    assert data["sidecars_deleted"] == 1
+
+    # Ghost row is gone, restored row is kept.
+    assert db.get_photo(pid_ghost) is None
+    assert db.get_photo(pid_restored) is not None
+    # Ghost sidecar was cleaned up, restored one was left alone.
+    assert not (real_dir / "ghost.xmp").exists()
+    assert (real_dir / "restored.xmp").exists()
+
+
+def test_api_photos_missing_remove_rejects_ids_outside_workspace(app_and_db, tmp_path):
+    """Unknown or out-of-workspace photo_ids must not affect anything.
+
+    Symmetry with /api/photos/missing/delete-sidecars: the endpoint resolves
+    IDs against the active workspace and refuses to touch rows or files it
+    can't own.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+
+    resp = client.post("/api/photos/missing/remove", json={
+        "photo_ids": [999_999],
+        "mode": "vireo",
+    })
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["deleted"] == 0
+    assert data["restored"] == []
+    assert data["skipped"] == 1
+
+
 def test_api_photos_missing_delete_sidecars_rejects_untracked_paths(app_and_db, tmp_path):
     """Endpoint must not delete .xmp files outside the active workspace.
 

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -4962,6 +4962,44 @@ def test_api_photos_missing_automatic_respects_failure_backoff(app_and_db, monke
     assert data["backoff_seconds"] > 0
 
 
+def test_api_photos_missing_worker_db_open_failure_clears_inflight(
+    app_and_db, monkeypatch,
+):
+    """A worker DB-open failure must not leave the scope permanently pending."""
+    import app as app_module
+
+    app, db = app_and_db
+    client = app.test_client()
+    key = (db._db_path, db._active_workspace_id, None)
+    captured = {}
+
+    real_database = app_module.Database
+
+    class FailingDatabase:
+        def __init__(self, path):
+            raise RuntimeError("open failed")
+
+    def run_with_broken_worker_db(job_type, work, **kwargs):
+        job = {"id": "missing-originals-fail", "progress": {}}
+        app_module.Database = FailingDatabase
+        try:
+            work(job)
+        except RuntimeError as exc:
+            captured["error"] = str(exc)
+        finally:
+            app_module.Database = real_database
+        return job["id"]
+
+    monkeypatch.setattr(app._job_runner, "start", run_with_broken_worker_db)
+
+    resp = client.post("/api/photos/missing/check", json={})
+    assert resp.status_code == 202, resp.get_json()
+    assert captured["error"] == "open failed"
+    with app._missing_originals_lock:
+        assert key not in app._missing_originals_inflight
+        assert app._missing_originals_errors[key]["error"] == "open failed"
+
+
 def test_get_missing_photos_honors_cancel_callback(app_and_db):
     """The low-level missing-originals walk must be cooperatively cancellable."""
     import pytest

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -17,6 +17,7 @@ def _run_missing_originals_check(client, folder_id=None):
     if folder_id is not None:
         url += f"?folder_id={folder_id}"
     payload = client.get(url).get_json()
+    assert payload["status"] == "ready"
     assert "photos" in payload
     return payload
 
@@ -4435,6 +4436,45 @@ def test_api_photos_missing_cached_result_does_not_rescan(app_and_db, monkeypatc
     assert [row["id"] for row in data["photos"]] == [pid_ghost]
 
 
+def test_api_photos_missing_automatic_uses_fresh_cache(app_and_db, monkeypatch, tmp_path):
+    """Automatic checks should not rescan when the cached result is still fresh."""
+    from db import Database
+
+    app, db = app_and_db
+    client = app.test_client()
+
+    real_dir = tmp_path / "live"
+    real_dir.mkdir()
+    fid = db.add_folder(str(real_dir), name="live")
+    pid_ghost = db.add_photo(
+        folder_id=fid,
+        filename="ghost.NEF",
+        extension=".nef",
+        file_size=42,
+        file_mtime=2.0,
+    )
+    db.delete_photos([
+        row["id"] for row in db.conn.execute(
+            "SELECT id FROM photos WHERE folder_id != ?", (fid,)
+        ).fetchall()
+    ])
+
+    cached = _run_missing_originals_check(client)
+    assert [row["id"] for row in cached["photos"]] == [pid_ghost]
+
+    def fail_scan(*_args, **_kwargs):
+        raise AssertionError("fresh automatic check must not rescan")
+
+    monkeypatch.setattr(Database, "get_missing_photos", fail_scan)
+
+    resp = client.post("/api/photos/missing/check", json={"automatic": True})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["status"] == "ready"
+    assert data["pending"] is False
+    assert [row["id"] for row in data["photos"]] == [pid_ghost]
+
+
 def test_api_photos_missing_check_coalesces_duplicate_jobs(app_and_db, monkeypatch):
     """Duplicate refreshes for the same scope reuse the active background job."""
     import time
@@ -4478,8 +4518,6 @@ def test_api_photos_missing_stale_in_flight_result_is_discarded(
     """
     import threading
 
-    from PIL import Image
-
     from db import Database
 
     app, db = app_and_db
@@ -4487,15 +4525,13 @@ def test_api_photos_missing_stale_in_flight_result_is_discarded(
 
     real_dir = tmp_path / "live"
     real_dir.mkdir()
-    Image.new("RGB", (10, 10)).save(real_dir / "here.jpg")
     fid = db.add_folder(str(real_dir), name="live")
-    db.add_photo(
-        folder_id=fid, filename="here.jpg",
-        extension=".jpg", file_size=1, file_mtime=1.0,
-    )
     pid_ghost = db.add_photo(
-        folder_id=fid, filename="ghost.NEF",
-        extension=".nef", file_size=42, file_mtime=2.0,
+        folder_id=fid,
+        filename="ghost.NEF",
+        extension=".nef",
+        file_size=42,
+        file_mtime=2.0,
     )
     # Simplify assertions by removing seed rows from other folders.
     db.delete_photos([
@@ -4535,7 +4571,9 @@ def test_api_photos_missing_stale_in_flight_result_is_discarded(
     assert delete_resp.get_json()["deleted"] == 1
 
     release.set()
-    wait_for_job_via_client(client, job_id)
+    job = wait_for_job_via_client(client, job_id)
+    assert job["status"] == "completed"
+    assert job["result"]["stale"] is True
 
     # The scan finished successfully but its results were discarded, so
     # the endpoint reports no cache — not a ready payload still holding

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -5273,6 +5273,50 @@ def test_api_audit_remove_orphans_invalidates_missing_cache(app_and_db, tmp_path
     assert payload["photos"] == []
 
 
+def test_api_audit_import_untracked_invalidates_missing_cache(
+    app_and_db, tmp_path, monkeypatch,
+):
+    """Audit imports must clear the Missing Originals cache after scanning.
+
+    Regression: ``audit.import_untracked`` runs scanner.scan over the selected
+    parent directory, so it can reconcile a restored original. Without cache
+    invalidation, the banner and modal keep serving the pre-import ghost list.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+
+    img_path = tmp_path / "shoot" / "IMG_0001.JPG"
+    img_path.parent.mkdir()
+    img_path.write_bytes(b"stub")
+
+    key = (db._db_path, db._active_workspace_id, None)
+    with app._missing_originals_lock:
+        app._missing_originals_cache[key] = {
+            "photos": [{"id": 5555, "filename": "stale.jpg"}],
+            "checked_at": "2026-01-01T00:00:00Z",
+            "set_at": 0.0,
+        }
+
+    import audit as audit_module
+    import metadata
+
+    def _stub_import_untracked(db_arg, paths, **kwargs):
+        assert db_arg._db_path == db._db_path
+        assert paths == [str(img_path)]
+
+    monkeypatch.setattr(audit_module, "import_untracked", _stub_import_untracked)
+    monkeypatch.setattr(metadata, "exiftool_available", lambda: True)
+
+    resp = client.post(
+        "/api/audit/import-untracked",
+        json={"paths": [str(img_path)]},
+    )
+    assert resp.status_code == 200, resp.get_json()
+    assert resp.get_json()["imported"] == 1
+    with app._missing_originals_lock:
+        assert key not in app._missing_originals_cache
+
+
 def test_api_duplicates_delete_loser_files_invalidates_missing_cache(
     app_and_db, monkeypatch, tmp_path,
 ):

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -4,6 +4,23 @@ import os
 from wait import wait_for_job_via_client
 
 
+def _run_missing_originals_check(client, folder_id=None):
+    body = {}
+    if folder_id is not None:
+        body["folder_id"] = folder_id
+    resp = client.post("/api/photos/missing/check", json=body)
+    assert resp.status_code in (200, 202)
+    data = resp.get_json()
+    if data.get("pending"):
+        wait_for_job_via_client(client, data["job_id"])
+    url = "/api/photos/missing"
+    if folder_id is not None:
+        url += f"?folder_id={folder_id}"
+    payload = client.get(url).get_json()
+    assert "photos" in payload
+    return payload
+
+
 def test_index_redirects_to_browse(app_and_db, monkeypatch, tmp_path):
     """GET / redirects to /browse when classification is usable (a label-free
     Tree-of-Life model needs no species list). The classification-readiness
@@ -4316,8 +4333,27 @@ def test_api_folders_check_health(app_and_db):
     assert isinstance(data["missing"], list)
 
 
+def test_api_photos_missing_uncached_is_immediate(app_and_db, monkeypatch):
+    """GET /api/photos/missing returns cache status without scanning."""
+    from db import Database
+    app, _db = app_and_db
+    client = app.test_client()
+
+    def fail_scan(*_args, **_kwargs):
+        raise AssertionError("GET /api/photos/missing must not scan")
+
+    monkeypatch.setattr(Database, "get_missing_photos", fail_scan)
+
+    resp = client.get("/api/photos/missing")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["status"] == "not_ready"
+    assert data["pending"] is False
+    assert data["photos"] == []
+
+
 def test_api_photos_missing(app_and_db, tmp_path):
-    """GET /api/photos/missing returns photos with absent source files."""
+    """Background check caches photos with absent source files."""
     from PIL import Image
     app, db = app_and_db
     client = app.test_client()
@@ -4348,12 +4384,10 @@ def test_api_photos_missing(app_and_db, tmp_path):
     # Drop an XMP sidecar next to the ghost.
     (real_dir / "ghost.xmp").write_text("<x:xmpmeta/>")
 
-    resp = client.get("/api/photos/missing")
-    assert resp.status_code == 200
-    data = resp.get_json()
-    assert isinstance(data, list)
-    assert [row["id"] for row in data] == [pid_ghost]
-    row = data[0]
+    data = _run_missing_originals_check(client)
+    assert data["status"] == "ready"
+    assert [row["id"] for row in data["photos"]] == [pid_ghost]
+    row = data["photos"][0]
     assert row["filename"] == "ghost.NEF"
     assert row["folder_path"] == str(real_dir)
     assert row["timestamp"] == "2024-03-08T10:00:00"
@@ -4361,6 +4395,122 @@ def test_api_photos_missing(app_and_db, tmp_path):
     assert row["has_preview"] is False
     assert row["has_working_copy"] is False
     assert row["has_xmp_sidecar"] is True
+
+
+def test_api_photos_missing_cached_result_does_not_rescan(app_and_db, monkeypatch, tmp_path):
+    """A cached Missing Originals result is served without filesystem work."""
+    from db import Database
+
+    app, db = app_and_db
+    client = app.test_client()
+
+    real_dir = tmp_path / "live"
+    real_dir.mkdir()
+    fid = db.add_folder(str(real_dir), name="live")
+    pid_ghost = db.add_photo(
+        folder_id=fid,
+        filename="ghost.NEF",
+        extension=".nef",
+        file_size=42,
+        file_mtime=2.0,
+    )
+    db.delete_photos([
+        row["id"] for row in db.conn.execute(
+            "SELECT id FROM photos WHERE folder_id != ?", (fid,)
+        ).fetchall()
+    ])
+
+    cached = _run_missing_originals_check(client)
+    assert [row["id"] for row in cached["photos"]] == [pid_ghost]
+
+    def fail_scan(*_args, **_kwargs):
+        raise AssertionError("cached GET must not rescan")
+
+    monkeypatch.setattr(Database, "get_missing_photos", fail_scan)
+
+    resp = client.get("/api/photos/missing")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["status"] == "ready"
+    assert [row["id"] for row in data["photos"]] == [pid_ghost]
+
+
+def test_api_photos_missing_check_coalesces_duplicate_jobs(app_and_db, monkeypatch):
+    """Duplicate refreshes for the same scope reuse the active background job."""
+    import time
+
+    from db import Database
+
+    app, db = app_and_db
+    client = app.test_client()
+
+    real_get_missing = Database.get_missing_photos
+
+    def slow_get_missing(self, *args, **kwargs):
+        time.sleep(0.2)
+        return real_get_missing(self, *args, **kwargs)
+
+    monkeypatch.setattr(Database, "get_missing_photos", slow_get_missing)
+
+    first = client.post("/api/photos/missing/check", json={})
+    second = client.post("/api/photos/missing/check", json={})
+
+    assert first.status_code == 202
+    assert second.status_code == 202
+    first_data = first.get_json()
+    second_data = second.get_json()
+    assert first_data["pending"] is True
+    assert second_data["pending"] is True
+    assert first_data["job_id"] == second_data["job_id"]
+    wait_for_job_via_client(client, first_data["job_id"])
+
+
+def test_api_photos_missing_automatic_skips_during_heavy_job(app_and_db):
+    """Automatic idle checks must not start while heavy jobs are running."""
+    import time
+
+    app, db = app_and_db
+    client = app.test_client()
+
+    scan_job = app._job_runner.start(
+        "scan",
+        lambda job: (time.sleep(0.2), {"ok": True})[1],
+        workspace_id=db._active_workspace_id,
+        ephemeral=True,
+    )
+    resp = client.post("/api/photos/missing/check", json={"automatic": True})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["suppressed"] is True
+    assert data["reason"] == "heavy_job_active"
+    assert data["status"] == "skipped"
+    wait_for_job_via_client(client, scan_job)
+
+
+def test_api_photos_missing_automatic_respects_failure_backoff(app_and_db, monkeypatch):
+    """A failed manual scan suppresses automatic retries during backoff."""
+    from db import Database
+
+    app, _db = app_and_db
+    client = app.test_client()
+
+    def fail_scan(self, *args, **kwargs):
+        raise RuntimeError("network volume unavailable")
+
+    monkeypatch.setattr(Database, "get_missing_photos", fail_scan)
+
+    started = client.post("/api/photos/missing/check", json={})
+    assert started.status_code == 202
+    job = wait_for_job_via_client(client, started.get_json()["job_id"])
+    assert job["status"] == "failed"
+
+    retry = client.post("/api/photos/missing/check", json={"automatic": True})
+    assert retry.status_code == 200
+    data = retry.get_json()
+    assert data["status"] == "error"
+    assert data["suppressed"] is True
+    assert data["reason"] == "backoff"
+    assert data["backoff_seconds"] > 0
 
 
 def test_api_photos_missing_delete_sidecars(app_and_db, tmp_path):
@@ -4465,9 +4615,8 @@ def test_api_photos_missing_detects_preview_variants(app_and_db, tmp_path):
     # Stray non-numeric filename in the cache must not crash the indexer.
     Image.new("RGB", (10, 10)).save(os.path.join(preview_dir, "stray.jpg"))
 
-    resp = client.get("/api/photos/missing")
-    assert resp.status_code == 200
-    by_id = {r["id"]: r for r in resp.get_json()}
+    payload = _run_missing_originals_check(client)
+    by_id = {r["id"]: r for r in payload["photos"]}
     assert by_id[pid_sized]["has_preview"] is True
     assert by_id[pid_legacy]["has_preview"] is True
     assert by_id[pid_no_preview]["has_preview"] is False
@@ -4505,9 +4654,7 @@ def test_api_photos_missing_reports_default_working_copy(app_and_db, tmp_path):
     Image.new("RGB", (10, 10)).save(os.path.join(working_dir, f"{pid}.jpg"))
     assert db.get_photo(pid)["working_copy_path"] is None
 
-    resp = client.get("/api/photos/missing")
-    assert resp.status_code == 200
-    data = resp.get_json()
+    data = _run_missing_originals_check(client)["photos"]
     assert len(data) == 1
     assert data[0]["has_working_copy"] is True
 
@@ -4530,9 +4677,8 @@ def test_api_photos_missing_excludes_present_files(app_and_db, tmp_path):
         ).fetchall()
     ])
 
-    resp = client.get("/api/photos/missing")
-    assert resp.status_code == 200
-    assert resp.get_json() == []
+    payload = _run_missing_originals_check(client)
+    assert payload["photos"] == []
 
 
 def test_api_folder_relocate(app_and_db, tmp_path):

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -4465,6 +4465,88 @@ def test_api_photos_missing_check_coalesces_duplicate_jobs(app_and_db, monkeypat
     wait_for_job_via_client(client, first_data["job_id"])
 
 
+def test_api_photos_missing_stale_in_flight_result_is_discarded(
+    app_and_db, monkeypatch, tmp_path
+):
+    """An invalidation mid-scan must drop the in-flight scan's stale snapshot.
+
+    Regression: when a batch delete fired while a long missing-originals
+    scan was walking the disk, the completing scan wrote its
+    pre-invalidation photo list back into the ready cache — resurrecting
+    just-deleted photos in the banner/modal until a later scan overwrote
+    them.
+    """
+    import threading
+
+    from PIL import Image
+
+    from db import Database
+
+    app, db = app_and_db
+    client = app.test_client()
+
+    real_dir = tmp_path / "live"
+    real_dir.mkdir()
+    Image.new("RGB", (10, 10)).save(real_dir / "here.jpg")
+    fid = db.add_folder(str(real_dir), name="live")
+    db.add_photo(
+        folder_id=fid, filename="here.jpg",
+        extension=".jpg", file_size=1, file_mtime=1.0,
+    )
+    pid_ghost = db.add_photo(
+        folder_id=fid, filename="ghost.NEF",
+        extension=".nef", file_size=42, file_mtime=2.0,
+    )
+    # Simplify assertions by removing seed rows from other folders.
+    db.delete_photos([
+        row["id"] for row in db.conn.execute(
+            "SELECT id FROM photos WHERE folder_id != ?", (fid,)
+        ).fetchall()
+    ])
+
+    snapshot_captured = threading.Event()
+    release = threading.Event()
+    real_get_missing = Database.get_missing_photos
+
+    def slow_get_missing(self, *args, **kwargs):
+        # Take the "pre-delete" snapshot first so the scan's result would
+        # otherwise resurrect pid_ghost, then park until the test has
+        # fired the batch delete that bumps the generation counter.
+        photos = list(real_get_missing(self, *args, **kwargs))
+        snapshot_captured.set()
+        assert release.wait(timeout=5.0)
+        return photos
+
+    monkeypatch.setattr(Database, "get_missing_photos", slow_get_missing)
+
+    started = client.post("/api/photos/missing/check", json={})
+    assert started.status_code == 202
+    job_id = started.get_json()["job_id"]
+    assert snapshot_captured.wait(timeout=5.0)
+
+    # Batch delete the ghost row. This drops it from the DB and fires
+    # _invalidate_missing_originals_cache, which bumps the in-flight
+    # scan's generation counter.
+    delete_resp = client.post(
+        "/api/batch/delete",
+        json={"photo_ids": [pid_ghost], "mode": "vireo"},
+    )
+    assert delete_resp.status_code == 200, delete_resp.get_json()
+    assert delete_resp.get_json()["deleted"] == 1
+
+    release.set()
+    wait_for_job_via_client(client, job_id)
+
+    # The scan finished successfully but its results were discarded, so
+    # the endpoint reports no cache — not a ready payload still holding
+    # the just-deleted pid_ghost.
+    resp = client.get("/api/photos/missing")
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["status"] == "not_ready", payload
+    assert payload["photos"] == []
+
+
 def test_api_photos_missing_automatic_skips_during_heavy_job(app_and_db):
     """Automatic idle checks must not start while heavy jobs are running."""
     import time

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -5149,6 +5149,89 @@ def test_import_in_place_invalidates_missing_originals_cache(
         assert key not in app._missing_originals_cache
 
 
+def test_import_photos_invalidates_missing_originals_cache(
+    app_and_db, tmp_path, monkeypatch,
+):
+    """POST /api/jobs/import-photos must drop the Missing Originals cache
+    once ``run_import_job`` finishes.
+
+    Regression: unlike scan-in-place and import-in-place, the copy-mode
+    import job (``/api/jobs/import-photos``) never invalidated the
+    missing-originals cache after ``run_import_job`` completed. That job
+    can flip destination folders from ``missing`` to ``ok`` and scans
+    landed files, so a ready ghost payload survived even after the
+    import touched disk. Verify the ``finally`` block drops the cached
+    entry — and drops it even when the import raises, since rows land
+    incrementally.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+
+    source = tmp_path / "import_src"
+    source.mkdir()
+    (source / "keep.jpg").write_bytes(b"stub")
+    destination = tmp_path / "archive"
+    destination.mkdir()
+
+    key = (db._db_path, db._active_workspace_id, None)
+
+    def _seed_cache():
+        with app._missing_originals_lock:
+            app._missing_originals_cache[key] = {
+                "photos": [{"id": 4444, "filename": "stale.jpg"}],
+                "checked_at": "2026-01-01T00:00:00Z",
+                "set_at": 0.0,
+            }
+
+    # Stub ``run_import_job`` so we exercise the endpoint's ``finally``
+    # block without depending on the real ingest+scan pipeline. The
+    # invariant under test is "cache is dropped after the job runs",
+    # not "the import succeeds"; we cover the happy path and the
+    # mid-run failure path separately.
+    import import_job as import_job_module
+
+    def _stub_run_import_job(job, runner, db_path, active_ws, params):
+        return {"ok": True, "photo_ids": []}
+
+    _seed_cache()
+    monkeypatch.setattr(
+        import_job_module, "run_import_job", _stub_run_import_job,
+    )
+    resp = client.post(
+        "/api/jobs/import-photos",
+        json={
+            "sources": [str(source)],
+            "destination": str(destination),
+            "after_import": None,
+        },
+    )
+    assert resp.status_code == 200, resp.get_json()
+    wait_for_job_via_client(client, resp.get_json()["job_id"])
+    with app._missing_originals_lock:
+        assert key not in app._missing_originals_cache
+
+    # Same invariant when the import raises: rows land incrementally,
+    # so a mid-run failure can still leave the cache stale.
+    _seed_cache()
+
+    def _boom(job, runner, db_path, active_ws, params):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(import_job_module, "run_import_job", _boom)
+    resp = client.post(
+        "/api/jobs/import-photos",
+        json={
+            "sources": [str(source)],
+            "destination": str(destination),
+            "after_import": None,
+        },
+    )
+    assert resp.status_code == 200, resp.get_json()
+    wait_for_job_via_client(client, resp.get_json()["job_id"])
+    with app._missing_originals_lock:
+        assert key not in app._missing_originals_cache
+
+
 def test_api_audit_remove_orphans_invalidates_missing_cache(app_and_db, tmp_path):
     """Removing orphaned photo rows must clear the Missing Originals cache.
 

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -4962,6 +4962,109 @@ def test_api_photos_missing_automatic_respects_failure_backoff(app_and_db, monke
     assert data["backoff_seconds"] > 0
 
 
+def test_api_photos_missing_prefers_fresher_error_over_ready_cache(app_and_db):
+    """A failed refresh must not be hidden behind an older ready cache.
+
+    Regression: after a successful scan populated the cache, a later
+    "Check now" that failed (e.g. NAS went offline) would leave the
+    ready photo list in place while recording the failure in
+    ``_missing_originals_errors``. The old ``_missing_originals_payload``
+    branch always won over the error, so ``GET /api/photos/missing``
+    would keep returning ``status: "ready"`` with the pre-failure photo
+    list — hiding the failure and letting the user act on stale ghosts
+    whose originals may have been restored between scans.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+
+    key = (db._db_path, db._active_workspace_id, None)
+    # Fresher error must supersede the cached ready payload.
+    with app._missing_originals_lock:
+        app._missing_originals_cache[key] = {
+            "photos": [{"id": 1, "filename": "ghost.jpg"}],
+            "checked_at": "2026-01-01T00:00:00Z",
+            "set_at": 1.0,
+        }
+        app._missing_originals_errors[key] = {
+            "error": "network volume unavailable",
+            "checked_at": "2026-01-01T00:05:00Z",
+            "set_at": 2.0,
+            "backoff_until": 999999.0,
+        }
+    payload = client.get("/api/photos/missing").get_json()
+    assert payload["status"] == "error", payload
+    assert payload["error"] == "network volume unavailable"
+    assert payload["photos"] == []
+
+    # An older error (already superseded by a successful cache) must
+    # not clobber the ready state — the preference only fires when
+    # the error's set_at is fresher than the cache's.
+    with app._missing_originals_lock:
+        app._missing_originals_errors[key] = {
+            "error": "old",
+            "checked_at": "2025-12-31T23:59:00Z",
+            "set_at": 0.5,
+            "backoff_until": 999999.0,
+        }
+    payload = client.get("/api/photos/missing").get_json()
+    assert payload["status"] == "ready", payload
+    assert payload["photos"] == [{"id": 1, "filename": "ghost.jpg"}]
+
+    # A fresh error alongside an in-flight scan must keep reporting
+    # "pending" so the modal doesn't flicker to an error state while
+    # the user's own refresh is still running.
+    with app._missing_originals_lock:
+        app._missing_originals_errors[key] = {
+            "error": "network volume unavailable",
+            "checked_at": "2026-01-01T00:05:00Z",
+            "set_at": 2.0,
+            "backoff_until": 999999.0,
+        }
+        app._missing_originals_inflight[key] = "job-xyz"
+    payload = client.get("/api/photos/missing").get_json()
+    assert payload["status"] == "pending", payload
+
+
+def test_scan_job_invalidates_missing_originals_cache(app_and_db, tmp_path):
+    """A rescan must clear the Missing Originals cache even when the
+    pre-scan folder-health check doesn't flip anything.
+
+    Regression: the scan work function only invalidated the cache when
+    ``check_folder_health`` returned a nonzero change count. But a
+    normal scan (e.g. Browse's "Rescan this Folder" after the user
+    restored an original) still commits photo rows and can make a
+    ready missing-originals payload stale. Without a post-scan
+    invalidation, ``GET /api/photos/missing`` would keep serving the
+    pre-scan ghost list until a separate missing-originals scan.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+
+    real_dir = tmp_path / "live"
+    real_dir.mkdir()
+    (real_dir / "keep.jpg").write_bytes(b"jpegbytes")
+    fid = db.add_folder(str(real_dir), name="live")
+
+    # Seed a stale ready cache directly (the folder is healthy, so
+    # the scan's own pre-flight would not invalidate it via the
+    # existing health-flip path).
+    key = (db._db_path, db._active_workspace_id, None)
+    with app._missing_originals_lock:
+        app._missing_originals_cache[key] = {
+            "photos": [{"id": 99, "filename": "stale.jpg"}],
+            "checked_at": "2026-01-01T00:00:00Z",
+            "set_at": 0.0,
+        }
+
+    resp = client.post(f"/api/folders/{fid}/rescan", json={})
+    assert resp.status_code == 200, resp.get_json()
+    job_id = resp.get_json()["job_id"]
+    wait_for_job_via_client(client, job_id)
+
+    with app._missing_originals_lock:
+        assert key not in app._missing_originals_cache
+
+
 def test_api_audit_remove_orphans_invalidates_missing_cache(app_and_db, tmp_path):
     """Removing orphaned photo rows must clear the Missing Originals cache.
 

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -4704,6 +4704,67 @@ def test_api_folder_delete_invalidates_missing_cache(app_and_db, tmp_path):
     assert payload["photos"] == []
 
 
+def test_workspace_delete_and_create_invalidate_missing_cache(app_and_db):
+    """Workspace create/delete must clear their id from the missing cache.
+
+    Regression: the cache key is ``(db_path, workspace_id, folder_id)``,
+    and SQLite ``INTEGER PRIMARY KEY`` can reuse the rowid of a deleted
+    workspace for the next ``create_workspace``. If the deleted workspace
+    left a ready Missing Originals payload behind, ``GET /api/photos/missing``
+    on the freshly created workspace would serve the previous workspace's
+    ghost photos and folder paths until a rescan overwrote the entry.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+
+    # Create a second workspace and give it a fake ready cache entry.
+    resp = client.post(
+        "/api/workspaces",
+        json={"name": "temp-ws"},
+    )
+    assert resp.status_code == 200
+    ws = resp.get_json()
+    ws_id = ws["id"]
+    key = (db._db_path, ws_id, None)
+    with app._missing_originals_lock:
+        app._missing_originals_cache[key] = {
+            "photos": [{"id": 99999, "filename": "ghost.jpg"}],
+            "checked_at": "2026-01-01T00:00:00Z",
+            "set_at": 0.0,
+        }
+
+    # Delete the workspace via the API and confirm the cache entry
+    # (which is keyed on this ws_id) is gone. Without invalidation on
+    # delete, a subsequent workspace that reused this rowid would still
+    # see the stale payload.
+    resp = client.delete(f"/api/workspaces/{ws_id}")
+    assert resp.status_code == 200
+    with app._missing_originals_lock:
+        assert key not in app._missing_originals_cache
+
+    # Prime a stale cache entry directly at the next id SQLite could
+    # hand out, then create a workspace to verify the create path also
+    # clears the specific workspace's key even if the store somehow
+    # retained one (e.g. a concurrent write racing between the delete
+    # invalidation and the new insert).
+    next_id_row = db.conn.execute(
+        "SELECT seq FROM sqlite_sequence WHERE name = 'workspaces'"
+    ).fetchone()
+    likely_next_id = (next_id_row["seq"] + 1) if next_id_row else ws_id + 1
+    poison_key = (db._db_path, likely_next_id, None)
+    with app._missing_originals_lock:
+        app._missing_originals_cache[poison_key] = {
+            "photos": [{"id": 42, "filename": "poison.jpg"}],
+            "checked_at": "2026-01-01T00:00:00Z",
+            "set_at": 0.0,
+        }
+    resp = client.post("/api/workspaces", json={"name": "fresh-ws"})
+    assert resp.status_code == 200
+    new_ws_id = resp.get_json()["id"]
+    with app._missing_originals_lock:
+        assert (db._db_path, new_ws_id, None) not in app._missing_originals_cache
+
+
 def test_api_photos_missing_automatic_respects_failure_backoff(app_and_db, monkeypatch):
     """A failed manual scan suppresses automatic retries during backoff."""
     from db import Database

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -4757,6 +4757,71 @@ def test_api_duplicates_delete_loser_files_invalidates_missing_cache(
     assert payload["photos"] == []
 
 
+def test_batch_delete_invalidates_missing_cache_across_workspaces(
+    app_and_db, tmp_path,
+):
+    """Deleting a photo must invalidate every workspace's Missing Originals cache.
+
+    Regression: photos are global (a folder can be linked into more than
+    one workspace), so removing a row from workspace A must clear
+    workspace B's ready cache too. Otherwise switching to B keeps serving
+    a stale payload that still lists the just-deleted photo until B's
+    next scan.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+
+    default_ws = db._active_workspace_id
+    other_ws = db.create_workspace("Other")
+
+    shared_dir = tmp_path / "shared"
+    shared_dir.mkdir()
+    fid = db.add_folder(str(shared_dir), name="shared")
+    db.add_workspace_folder(other_ws, fid)
+
+    pid_ghost = db.add_photo(
+        folder_id=fid,
+        filename="ghost.NEF",
+        extension=".nef",
+        file_size=42,
+        file_mtime=2.0,
+    )
+    db.delete_photos([
+        row["id"] for row in db.conn.execute(
+            "SELECT id FROM photos WHERE folder_id != ?", (fid,)
+        ).fetchall()
+    ])
+
+    # Populate the cache for both workspaces so there's actually
+    # something for the delete path to invalidate in each.
+    db.set_active_workspace(other_ws)
+    other_cache = _run_missing_originals_check(client)
+    assert [row["id"] for row in other_cache["photos"]] == [pid_ghost]
+
+    db.set_active_workspace(default_ws)
+    default_cache = _run_missing_originals_check(client)
+    assert [row["id"] for row in default_cache["photos"]] == [pid_ghost]
+
+    # Delete the ghost while workspace A is active.
+    resp = client.post(
+        "/api/batch/delete",
+        json={"photo_ids": [pid_ghost], "mode": "vireo"},
+    )
+    assert resp.status_code == 200, resp.get_json()
+    assert resp.get_json()["deleted"] == 1
+
+    # The active workspace's cache is gone …
+    payload = client.get("/api/photos/missing").get_json()
+    assert payload["status"] == "not_ready", payload
+    assert payload["photos"] == []
+
+    # … and so is workspace B's, even though it wasn't the caller.
+    db.set_active_workspace(other_ws)
+    payload = client.get("/api/photos/missing").get_json()
+    assert payload["status"] == "not_ready", payload
+    assert payload["photos"] == []
+
+
 def test_api_photos_missing_delete_sidecars(app_and_db, tmp_path):
     """POST /api/photos/missing/delete-sidecars removes orphan XMP files for ghost photos.
 

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -5917,6 +5917,50 @@ def test_api_folder_relocate(app_and_db, tmp_path):
     assert row["path"] == new_path
 
 
+def test_api_folder_relocate_conflict_after_revalidation_invalidates_missing_cache(
+    app_and_db, tmp_path,
+):
+    """A relocate conflict can still mutate folder health and stale the cache.
+
+    ``Database.relocate_folder`` revalidates a missing source folder whose old
+    path came back online, commits ``status='ok'``, then raises if the requested
+    new path is already tracked. The API returns 409, but the ready Missing
+    Originals cache must still be dropped because the folder is now online.
+    """
+    app, db = app_and_db
+    source_path = tmp_path / "source"
+    target_path = tmp_path / "target"
+    source_path.mkdir()
+    target_path.mkdir()
+    source_id = db.add_folder(str(source_path), name="source")
+    db.add_folder(str(target_path), name="target")
+    db.conn.execute(
+        "UPDATE folders SET status = 'missing' WHERE id = ?", (source_id,)
+    )
+    db.conn.commit()
+
+    key = (db._db_path, db._active_workspace_id, None)
+    with app._missing_originals_lock:
+        app._missing_originals_cache[key] = {
+            "photos": [{"id": 8888, "filename": "hidden.jpg"}],
+            "checked_at": "2026-01-01T00:00:00Z",
+            "set_at": 0.0,
+        }
+
+    client = app.test_client()
+    resp = client.post(
+        f"/api/folders/{source_id}/relocate",
+        json={"path": str(target_path)},
+    )
+    assert resp.status_code == 409
+    row = db.conn.execute(
+        "SELECT status FROM folders WHERE id = ?", (source_id,)
+    ).fetchone()
+    assert row["status"] == "ok"
+    with app._missing_originals_lock:
+        assert key not in app._missing_originals_cache
+
+
 def test_api_folder_relocate_rebases_configured_developed_dir(app_and_db, tmp_path):
     """POST /api/folders/<id>/relocate rebases the darktable output subdir.
 

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -5223,6 +5223,7 @@ def test_api_photos_missing_remove_skips_restored_originals(app_and_db, tmp_path
     data = resp.get_json()
     assert data["deleted"] == 1
     assert data["restored"] == [pid_restored]
+    assert data["folder_offline"] == []
     assert data["skipped"] == 0
     assert data["sidecars_deleted"] == 1
 
@@ -5232,6 +5233,79 @@ def test_api_photos_missing_remove_skips_restored_originals(app_and_db, tmp_path
     # Ghost sidecar was cleaned up, restored one was left alone.
     assert not (real_dir / "ghost.xmp").exists()
     assert (real_dir / "restored.xmp").exists()
+
+
+def test_api_photos_missing_remove_skips_offline_folder(app_and_db, tmp_path):
+    """POST /api/photos/missing/remove must not delete rows from an offline folder.
+
+    A ready ``/api/photos/missing`` cache is served for up to 30 minutes
+    without a filesystem recheck. If a NAS/SMB mount goes offline between
+    the last scan and the user clicking Remove, ``os.path.exists(src)``
+    returns False for every row — but that is evidence the folder is
+    unreachable, not that the originals are gone. If any file was
+    restored before the mount dropped, a naive "still missing" check
+    would silently delete a valid Vireo row. The endpoint must skip
+    deletion when the folder is unreachable and surface the deferred
+    IDs so the modal can explain what happened.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+
+    real_dir = tmp_path / "live"
+    real_dir.mkdir()
+    fid = db.add_folder(str(real_dir), name="live")
+    pid = db.add_photo(folder_id=fid, filename="ghost.NEF",
+                       extension=".nef", file_size=1, file_mtime=1.0)
+    # Ghost sidecar left on disk — must not be deleted while folder offline.
+    (real_dir / "ghost.xmp").write_text("<x:xmpmeta/>")
+
+    # Simulate the parent folder/NAS mount going offline by removing the
+    # folder from disk after the DB row is set up. ``os.path.isdir`` will
+    # now return False so the endpoint must treat this as ambiguous.
+    import shutil
+    shutil.rmtree(real_dir)
+
+    resp = client.post("/api/photos/missing/remove", json={
+        "photo_ids": [pid],
+        "delete_sidecars": True,
+        "mode": "vireo",
+    })
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    data = resp.get_json()
+    assert data["deleted"] == 0
+    assert data["restored"] == []
+    assert data["folder_offline"] == [pid]
+    assert data["sidecars_deleted"] == 0
+    # Row must still be present — we did not delete it.
+    assert db.get_photo(pid) is not None
+
+
+def test_api_photos_missing_delete_sidecars_skips_offline_folder(app_and_db, tmp_path):
+    """delete-sidecars must skip when the parent folder is unreachable.
+
+    Same reasoning as the /remove endpoint: an offline mount makes
+    ``os.path.exists`` uninformative, so touching the .xmp for a photo
+    whose original may have been restored risks deleting a valid sidecar.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+
+    real_dir = tmp_path / "live"
+    real_dir.mkdir()
+    fid = db.add_folder(str(real_dir), name="live")
+    pid = db.add_photo(folder_id=fid, filename="ghost.NEF",
+                       extension=".nef", file_size=1, file_mtime=1.0)
+
+    import shutil
+    shutil.rmtree(real_dir)
+
+    resp = client.post("/api/photos/missing/delete-sidecars", json={
+        "photo_ids": [pid],
+    })
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["deleted"] == 0
+    assert data["skipped"] == 1
 
 
 def test_api_photos_missing_remove_rejects_ids_outside_workspace(app_and_db, tmp_path):
@@ -5252,6 +5326,7 @@ def test_api_photos_missing_remove_rejects_ids_outside_workspace(app_and_db, tmp
     data = resp.get_json()
     assert data["deleted"] == 0
     assert data["restored"] == []
+    assert data["folder_offline"] == []
     assert data["skipped"] == 1
 
 

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -5065,6 +5065,90 @@ def test_scan_job_invalidates_missing_originals_cache(app_and_db, tmp_path):
         assert key not in app._missing_originals_cache
 
 
+def test_import_full_scan_in_place_invalidates_missing_originals_cache(
+    app_and_db, tmp_path,
+):
+    """A scan-in-place import (POST /api/jobs/import-full, copy=false) must
+    drop the Missing Originals cache once its ``do_scan`` runs.
+
+    Regression: the scan job's ``finally`` block invalidated the
+    new-images cache but not the missing-originals cache, so a ready
+    ghost payload survived even after the import touched disk. If the
+    user restored an original before running Import Photos over the
+    same folder, GET ``/api/photos/missing`` would keep serving the
+    pre-import ghost list until a separate missing-originals scan
+    replaced the entry. See Codex review on c4cc32ec.
+    """
+    from PIL import Image
+
+    app, db = app_and_db
+    client = app.test_client()
+
+    source = tmp_path / "import_src"
+    source.mkdir()
+    Image.new("RGB", (10, 10)).save(str(source / "keep.jpg"))
+
+    key = (db._db_path, db._active_workspace_id, None)
+    with app._missing_originals_lock:
+        app._missing_originals_cache[key] = {
+            "photos": [{"id": 4242, "filename": "stale.jpg"}],
+            "checked_at": "2026-01-01T00:00:00Z",
+            "set_at": 0.0,
+        }
+
+    resp = client.post("/api/jobs/import-full", json={
+        "source": str(source),
+        "copy": False,
+        "file_types": [".jpg"],
+    })
+    assert resp.status_code == 200, resp.get_json()
+    wait_for_job_via_client(client, resp.get_json()["job_id"])
+
+    with app._missing_originals_lock:
+        assert key not in app._missing_originals_cache
+
+
+def test_import_in_place_invalidates_missing_originals_cache(
+    app_and_db, tmp_path,
+):
+    """POST /api/jobs/import-in-place must drop the Missing Originals cache
+    once its ``do_scan`` runs.
+
+    Regression: the in-place import's ``finally`` block invalidated the
+    new-images cache but not the missing-originals cache, so a ready
+    ghost payload survived even after the import touched disk. If the
+    user restored an original before importing that folder in place,
+    GET ``/api/photos/missing`` would keep serving the pre-import ghost
+    list. See Codex review on c4cc32ec.
+    """
+    from PIL import Image
+
+    app, db = app_and_db
+    client = app.test_client()
+
+    source = tmp_path / "in_place_src"
+    source.mkdir()
+    Image.new("RGB", (10, 10)).save(str(source / "keep.jpg"))
+
+    key = (db._db_path, db._active_workspace_id, None)
+    with app._missing_originals_lock:
+        app._missing_originals_cache[key] = {
+            "photos": [{"id": 4343, "filename": "stale.jpg"}],
+            "checked_at": "2026-01-01T00:00:00Z",
+            "set_at": 0.0,
+        }
+
+    resp = client.post("/api/jobs/import-in-place", json={
+        "sources": [str(source)],
+        "after_import": None,
+    })
+    assert resp.status_code == 200, resp.get_json()
+    wait_for_job_via_client(client, resp.get_json()["job_id"])
+
+    with app._missing_originals_lock:
+        assert key not in app._missing_originals_cache
+
+
 def test_api_audit_remove_orphans_invalidates_missing_cache(app_and_db, tmp_path):
     """Removing orphaned photo rows must clear the Missing Originals cache.
 

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 import os
 
@@ -4739,10 +4740,8 @@ def test_api_duplicates_delete_loser_files_invalidates_missing_cache(
     import send2trash as _send2trash_mod
 
     def fake_send2trash(path):
-        try:
+        with contextlib.suppress(FileNotFoundError):
             os.remove(path)
-        except FileNotFoundError:
-            pass
 
     monkeypatch.setattr(_send2trash_mod, "send2trash", fake_send2trash)
 

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -5000,6 +5000,61 @@ def test_api_photos_missing_worker_db_open_failure_clears_inflight(
         assert app._missing_originals_errors[key]["error"] == "open failed"
 
 
+def test_api_photos_missing_progress_phase_only_sent_via_runner(
+    app_and_db, monkeypatch,
+):
+    """Missing Originals progress must not resize job["progress"] directly."""
+    from db import Database
+
+    app, _db = app_and_db
+    client = app.test_client()
+    pushed = []
+
+    class GuardedProgress(dict):
+        def __setitem__(self, key, value):
+            if key not in self:
+                raise AssertionError(f"unexpected progress key resize: {key}")
+            super().__setitem__(key, value)
+
+    def fake_missing_photos(self, folder_id=None, progress_callback=None, **kwargs):
+        if progress_callback is not None:
+            progress_callback({
+                "photos_considered": 7,
+                "total_photos": 10,
+                "missing_found": 2,
+                "folders_checked": 1,
+                "current_folder": "/photos",
+            })
+        return []
+
+    def fake_start(job_type, work, **kwargs):
+        job = {
+            "id": "missing-progress",
+            "progress": GuardedProgress({
+                "current": 0,
+                "total": 0,
+                "current_file": "",
+            }),
+        }
+        work(job)
+        return job["id"]
+
+    def fake_push_event(job_id, event_type, data):
+        pushed.append((job_id, event_type, data))
+
+    monkeypatch.setattr(Database, "get_missing_photos", fake_missing_photos)
+    monkeypatch.setattr(app._job_runner, "start", fake_start)
+    monkeypatch.setattr(app._job_runner, "push_event", fake_push_event)
+
+    resp = client.post("/api/photos/missing/check", json={})
+    assert resp.status_code == 200, resp.get_json()
+    progress_events = [data for _jid, typ, data in pushed if typ == "progress"]
+    assert progress_events
+    assert progress_events[-1]["phase"] == (
+        "1 folders checked, 7 photos considered, 2 missing"
+    )
+
+
 def test_get_missing_photos_honors_cancel_callback(app_and_db):
     """The low-level missing-originals walk must be cooperatively cancellable."""
     import pytest

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -4962,6 +4962,77 @@ def test_api_photos_missing_automatic_respects_failure_backoff(app_and_db, monke
     assert data["backoff_seconds"] > 0
 
 
+def test_get_missing_photos_honors_cancel_callback(app_and_db):
+    """The low-level missing-originals walk must be cooperatively cancellable."""
+    import pytest
+    from db import MissingPhotosCancelled
+
+    _app, db = app_and_db
+
+    with pytest.raises(MissingPhotosCancelled):
+        db.get_missing_photos(cancel_callback=lambda: True)
+
+
+def test_api_photos_missing_cancel_does_not_write_ready_cache(
+    app_and_db, monkeypatch,
+):
+    """Cancelling a Missing Originals job must stop without publishing results.
+
+    Regression: JobRunner marked the job cancelled, but the worker kept walking
+    the filesystem and could write a ready cache before terminal status flipped.
+    """
+    import threading
+    import time
+
+    from db import Database, MissingPhotosCancelled
+
+    app, db = app_and_db
+    client = app.test_client()
+    scan_entered = threading.Event()
+
+    def slow_missing_photos(
+        self,
+        folder_id=None,
+        progress_callback=None,
+        cancel_callback=None,
+    ):
+        scan_entered.set()
+        deadline = time.time() + 3.0
+        while time.time() < deadline:
+            if cancel_callback is not None and cancel_callback():
+                raise MissingPhotosCancelled("missing photos scan cancelled")
+            time.sleep(0.01)
+        return [{
+            "id": 999,
+            "folder_path": os.getcwd(),
+            "filename": "would-have-been-cached.jpg",
+            "timestamp": None,
+            "working_copy_path": None,
+        }]
+
+    monkeypatch.setattr(Database, "get_missing_photos", slow_missing_photos)
+
+    started = client.post("/api/photos/missing/check", json={})
+    assert started.status_code == 202, started.get_json()
+    job_id = started.get_json()["job_id"]
+    assert scan_entered.wait(timeout=1.0)
+
+    cancelled = client.post(f"/api/jobs/{job_id}/cancel")
+    assert cancelled.status_code == 200, cancelled.get_json()
+    assert cancelled.get_json()["cancelled"] is True
+
+    job = wait_for_job_via_client(client, job_id)
+    assert job["status"] == "cancelled"
+
+    key = (db._db_path, db._active_workspace_id, None)
+    with app._missing_originals_lock:
+        assert key not in app._missing_originals_cache
+        assert key not in app._missing_originals_errors
+        assert key not in app._missing_originals_inflight
+    payload = client.get("/api/photos/missing").get_json()
+    assert payload["status"] == "not_ready", payload
+
+
 def test_api_photos_missing_prefers_fresher_error_over_ready_cache(app_and_db):
     """A failed refresh must not be hidden behind an older ready cache.
 

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -5665,6 +5665,57 @@ def test_api_photos_missing_remove_skips_offline_folder(app_and_db, tmp_path):
     assert db.get_photo(pid) is not None
 
 
+def test_api_photos_missing_remove_skips_unreadable_folder(
+    app_and_db, tmp_path, monkeypatch,
+):
+    """A present but unreadable folder is still unverified for removal.
+
+    Regression: ``os.path.isdir`` can succeed for a NAS/local folder that the
+    process cannot traverse. In that state ``os.path.exists(child)`` may return
+    false for every original, so removal must defer instead of deleting rows.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+
+    real_dir = tmp_path / "live"
+    real_dir.mkdir()
+    fid = db.add_folder(str(real_dir), name="live")
+    pid = db.add_photo(
+        folder_id=fid,
+        filename="ghost.NEF",
+        extension=".nef",
+        file_size=1,
+        file_mtime=1.0,
+    )
+    sidecar = real_dir / "ghost.xmp"
+    sidecar.write_text("<x:xmpmeta/>")
+
+    import app as app_module
+
+    real_scandir = app_module.os.scandir
+
+    def unreadable_scandir(path):
+        if os.fspath(path) == str(real_dir):
+            raise PermissionError("permission denied")
+        return real_scandir(path)
+
+    monkeypatch.setattr(app_module.os, "scandir", unreadable_scandir)
+
+    resp = client.post("/api/photos/missing/remove", json={
+        "photo_ids": [pid],
+        "delete_sidecars": True,
+        "mode": "vireo",
+    })
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    data = resp.get_json()
+    assert data["deleted"] == 0
+    assert data["restored"] == []
+    assert data["folder_offline"] == [pid]
+    assert data["sidecars_deleted"] == 0
+    assert sidecar.exists()
+    assert db.get_photo(pid) is not None
+
+
 def test_api_photos_missing_delete_sidecars_skips_offline_folder(app_and_db, tmp_path):
     """delete-sidecars must skip when the parent folder is unreachable.
 

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -5837,6 +5837,54 @@ def test_api_photos_missing_delete_sidecars_skips_offline_folder(app_and_db, tmp
     assert data["skipped"] == 1
 
 
+def test_api_photos_missing_delete_sidecars_skips_unreadable_folder(
+    app_and_db, tmp_path, monkeypatch,
+):
+    """Present-but-unreadable folder must not have its sidecars deleted.
+
+    Regression: ``os.path.isdir`` returns True for a NAS/local folder the
+    process cannot traverse; in that state ``os.path.exists(child)`` may
+    return false for every original even though the file is still there,
+    so unlinking the paired .xmp would remove a valid sidecar. Mirrors
+    the ``/api/photos/missing/remove`` accessibility check.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+
+    real_dir = tmp_path / "live"
+    real_dir.mkdir()
+    fid = db.add_folder(str(real_dir), name="live")
+    pid = db.add_photo(
+        folder_id=fid,
+        filename="ghost.NEF",
+        extension=".nef",
+        file_size=1,
+        file_mtime=1.0,
+    )
+    sidecar = real_dir / "ghost.xmp"
+    sidecar.write_text("<x:xmpmeta/>")
+
+    import app as app_module
+
+    real_scandir = app_module.os.scandir
+
+    def unreadable_scandir(path):
+        if os.fspath(path) == str(real_dir):
+            raise PermissionError("permission denied")
+        return real_scandir(path)
+
+    monkeypatch.setattr(app_module.os, "scandir", unreadable_scandir)
+
+    resp = client.post("/api/photos/missing/delete-sidecars", json={
+        "photo_ids": [pid],
+    })
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    data = resp.get_json()
+    assert data["deleted"] == 0
+    assert data["skipped"] == 1
+    assert sidecar.exists()
+
+
 def test_api_photos_missing_remove_rejects_ids_outside_workspace(app_and_db, tmp_path):
     """Unknown or out-of-workspace photo_ids must not affect anything.
 

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -6146,6 +6146,53 @@ def test_get_missing_photos_does_not_stat_every_photo(tmp_path, monkeypatch):
     )
 
 
+def test_get_missing_photos_ignores_progress_callback_errors(tmp_path):
+    """Progress callback failures must not abort missing-original detection."""
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+
+    folder = tmp_path / "shoot"
+    folder.mkdir()
+    fid = db.add_folder(str(folder), name="shoot")
+    db.add_photo(folder_id=fid, filename="gone.jpg", extension=".jpg",
+                 file_size=1, file_mtime=1.0)
+
+    def broken_progress(_payload):
+        raise RuntimeError("progress sink unavailable")
+
+    missing = db.get_missing_photos(progress_callback=broken_progress)
+
+    assert [row["filename"] for row in missing] == ["gone.jpg"]
+
+
+def test_get_missing_photos_reports_periodic_photo_progress(tmp_path):
+    """Large single-folder scans should emit progress before the final callback."""
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    ws = db.ensure_default_workspace()
+    db.set_active_workspace(ws)
+
+    folder = tmp_path / "shoot"
+    folder.mkdir()
+    fid = db.add_folder(str(folder), name="shoot")
+    for i in range(401):
+        db.add_photo(folder_id=fid, filename=f"gone_{i:03d}.jpg",
+                     extension=".jpg", file_size=1, file_mtime=1.0)
+
+    events = []
+    missing = db.get_missing_photos(progress_callback=events.append)
+
+    assert len(missing) == 401
+    considered = [event["photos_considered"] for event in events]
+    assert 200 in considered
+    assert 400 in considered
+    assert considered[-1] == 401
+
+
 def test_get_missing_photos_handles_unicode_normalization(tmp_path):
     """A photo row stored as NFC must not be reported missing if the file
     on disk has the same visible name in NFD bytes (or vice versa).

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -696,7 +696,8 @@ def test_pipeline_job_config_includes_collection_name(app_and_db, monkeypatch):
     db.set_active_workspace(db._active_workspace_id)
     col_id = db.add_collection("Costa Rica selects", json.dumps([]))
 
-    def fake_run(job, runner, db_path, workspace_id, params, thumb_cache_dir=None):
+    def fake_run(job, runner, db_path, workspace_id, params, thumb_cache_dir=None,
+                 **_kwargs):
         return {"ok": True}
 
     monkeypatch.setattr(pipeline_job, "run_pipeline_job", fake_run)
@@ -2417,7 +2418,7 @@ def test_pipeline_remote_archive_snapshots_target_at_enqueue(
     captured = {}
 
     def fake_run(job, runner, db_path, workspace_id, params,
-                 thumb_cache_dir=None):
+                 thumb_cache_dir=None, **_kwargs):
         captured["params"] = params
         return {}
 

--- a/vireo/tests/test_move_api.py
+++ b/vireo/tests/test_move_api.py
@@ -3,6 +3,17 @@
 import os
 
 
+def _seed_missing_originals_cache(app, db):
+    key = (db._db_path, db._active_workspace_id, None)
+    with app._missing_originals_lock:
+        app._missing_originals_cache[key] = {
+            "photos": [{"id": 7777, "filename": "stale.jpg"}],
+            "checked_at": "2026-01-01T00:00:00Z",
+            "set_at": 0.0,
+        }
+    return key
+
+
 def test_move_page_returns_200(app_and_db):
     """GET /move returns 200."""
     app, _ = app_and_db
@@ -100,6 +111,38 @@ def test_move_photos_job_starts(app_and_db, tmp_path):
     assert data["job_id"].startswith("move-photos-")
 
 
+def test_move_photos_job_invalidates_missing_originals_cache(
+    app_and_db, tmp_path, monkeypatch,
+):
+    """Successful move-photo jobs must drop cached Missing Originals results."""
+    import move as move_module
+    from wait import wait_for_job_via_client
+
+    app, db = app_and_db
+    dst = tmp_path / "move_dst"
+    dst.mkdir()
+    pid = db.conn.execute("SELECT id FROM photos LIMIT 1").fetchone()["id"]
+    key = _seed_missing_originals_cache(app, db)
+
+    def fake_move_photos(db, photo_ids, destination, progress_cb=None):
+        assert photo_ids == [pid]
+        assert destination == str(dst)
+        return {"moved": 1, "errors": [], "destination_folder_id": 123}
+
+    monkeypatch.setattr(move_module, "move_photos", fake_move_photos)
+
+    client = app.test_client()
+    resp = client.post("/api/jobs/move-photos", json={
+        "photo_ids": [pid],
+        "destination": str(dst),
+    })
+    assert resp.status_code == 200, resp.get_json()
+    job = wait_for_job_via_client(client, resp.get_json()["job_id"])
+    assert job["status"] == "completed", job
+    with app._missing_originals_lock:
+        assert key not in app._missing_originals_cache
+
+
 def test_move_photos_requires_params(app_and_db):
     """POST /api/jobs/move-photos without photo_ids returns error."""
     app, _ = app_and_db
@@ -126,6 +169,47 @@ def test_move_folder_job_starts(app_and_db, tmp_path):
     data = resp.get_json()
     assert "job_id" in data
     assert data["job_id"].startswith("move-folder-")
+
+
+def test_move_folder_job_invalidates_missing_originals_cache(
+    app_and_db, tmp_path, monkeypatch,
+):
+    """Successful move-folder jobs must drop cached Missing Originals results."""
+    import move as move_module
+    from wait import wait_for_job_via_client
+
+    app, db = app_and_db
+    dst = tmp_path / "move_folder_dst"
+    dst.mkdir()
+    fid = db.get_folder_tree()[0]["id"]
+    key = _seed_missing_originals_cache(app, db)
+
+    def fake_move_folder(
+        db,
+        folder_id,
+        destination,
+        progress_cb=None,
+        developed_dir=None,
+        merge=False,
+        remote=None,
+    ):
+        assert folder_id == fid
+        assert destination == str(dst)
+        return {"moved": 1, "errors": []}
+
+    monkeypatch.setattr(move_module, "move_folder", fake_move_folder)
+
+    client = app.test_client()
+    resp = client.post("/api/jobs/move-folder", json={
+        "folder_id": fid,
+        "destination": str(dst),
+    })
+    assert resp.status_code == 200, resp.get_json()
+    job = wait_for_job_via_client(client, resp.get_json()["job_id"])
+    assert job["status"] == "completed", job
+    assert job["result"]["ok"] is True
+    with app._missing_originals_lock:
+        assert key not in app._missing_originals_cache
 
 
 def test_move_folder_failed_move_recorded_as_failed(app_and_db, tmp_path):

--- a/vireo/tests/test_pipeline_api.py
+++ b/vireo/tests/test_pipeline_api.py
@@ -2830,6 +2830,70 @@ def test_pipeline_accepts_source_snapshot_id(setup, tmp_path):
         pipeline_job.run_pipeline_job = original
 
 
+def test_pipeline_endpoint_forwards_missing_originals_invalidator(
+    setup, tmp_path,
+):
+    """POST /api/jobs/pipeline must pass the app-level Missing Originals
+    invalidator through to run_pipeline_job.
+
+    Regression: without this callback the pipeline's finally block only
+    invalidates the new-images cache, so a ready GET /api/photos/missing
+    payload can survive a scan that added or removed photo rows. See
+    Codex review on 63f6ac78. This test spies on run_pipeline_job and
+    asserts the handler forwards a callable so the pipeline_job side
+    (covered by test_pipeline_job.py) can actually fire it.
+    """
+    import threading
+
+    from db import Database
+    app, db_path = setup
+
+    # Prime a source folder so the collection-less pipeline path takes
+    # the scan branch; the spy short-circuits before scanner.scan runs.
+    folder = tmp_path / "photos"
+    folder.mkdir()
+    img_path = folder / "IMG_001.JPG"
+    Image.new("RGB", (1, 1), "white").save(str(img_path), "JPEG")
+    db = Database(db_path)
+    db.add_folder(str(folder))
+    db.conn.close()
+
+    import pipeline_job
+    original = pipeline_job.run_pipeline_job
+    captured = {}
+    called = threading.Event()
+
+    def spy_run(job, runner, db_path_arg, ws_id, params, **kwargs):
+        captured["missing_originals_invalidator"] = kwargs.get(
+            "missing_originals_invalidator"
+        )
+        called.set()
+
+    pipeline_job.run_pipeline_job = spy_run
+    try:
+        with app.test_client() as c:
+            resp = c.post("/api/jobs/pipeline", json={
+                "sources": [str(folder)],
+                "skip_classify": True,
+                "skip_extract_masks": True,
+                "skip_regroup": True,
+            })
+            assert resp.status_code == 200, resp.get_json()
+
+        assert called.wait(timeout=5.0), (
+            "run_pipeline_job spy was not invoked"
+        )
+        # The handler must forward a callable (the create_app closure's
+        # _invalidate_missing_originals_cache), not omit or None it out.
+        assert callable(captured.get("missing_originals_invalidator")), (
+            "POST /api/jobs/pipeline did not forward the "
+            "missing_originals_invalidator kwarg — pipeline scans will not "
+            "drop the GET /api/photos/missing cache after touching disk"
+        )
+    finally:
+        pipeline_job.run_pipeline_job = original
+
+
 def test_pipeline_snapshot_overrides_stale_source_paths(setup, tmp_path):
     """When a valid source_snapshot_id is present, the job overrides any
     source/sources the caller passed. The handler must not preflight-validate

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -396,6 +396,144 @@ def test_pipeline_scan_thumbnail_collection_stages(tmp_path, monkeypatch):
     assert len(photos) == 3
 
 
+def test_pipeline_scan_invokes_missing_originals_invalidator(tmp_path, monkeypatch):
+    """Pipeline scans must invalidate the Missing Originals cache too.
+
+    Regression: the standalone /api/jobs/scan and /api/jobs/import-* routes
+    already drop the cached ``GET /api/photos/missing`` payload once their
+    ``do_scan`` runs, but a Process/pipeline scan went through the same
+    scanner.scan() call in pipeline_job without wiring the invalidator.
+    If a ready ghost payload existed and the user restored or deleted an
+    original before running Process, the banner/modal continued to show
+    the pre-pipeline photo list until an unrelated Missing Originals scan
+    replaced the entry. See Codex review on 63f6ac78.
+    """
+    import config as cfg
+    from db import Database
+    from PIL import Image
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    photo_dir = tmp_path / "photos"
+    photo_dir.mkdir()
+    Image.new("RGB", (32, 32), "black").save(str(photo_dir / "keep.jpg"))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    params = PipelineParams(
+        source=str(photo_dir),
+        skip_classify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    invalidator_calls = []
+
+    def fake_invalidator():
+        invalidator_calls.append(True)
+
+    run_pipeline_job(
+        job, runner, db_path, ws_id, params,
+        missing_originals_invalidator=fake_invalidator,
+    )
+
+    # scanner.scan committed a photo row for keep.jpg, so a ready
+    # Missing Originals payload computed before this run is now
+    # potentially stale — the invalidator must fire at least once for
+    # the scanned root. Matches the try/finally in api_job_scan and
+    # api_job_import_full.
+    assert invalidator_calls, (
+        "missing_originals_invalidator was not called after the "
+        "pipeline scan touched disk"
+    )
+
+
+def test_pipeline_scan_invalidator_is_optional(tmp_path, monkeypatch):
+    """Callers that don't pass ``missing_originals_invalidator`` still work.
+
+    The parameter defaults to None so tests and any non-Flask harness can
+    call run_pipeline_job without wiring the app-level invalidator. This
+    guards the default path against a NoneType-not-callable regression.
+    """
+    import config as cfg
+    from db import Database
+    from PIL import Image
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    photo_dir = tmp_path / "photos"
+    photo_dir.mkdir()
+    Image.new("RGB", (32, 32), "black").save(str(photo_dir / "keep.jpg"))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    params = PipelineParams(
+        source=str(photo_dir),
+        skip_classify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    # No missing_originals_invalidator passed — must not raise.
+    result = run_pipeline_job(job=_make_job(), runner=FakeRunner(),
+                              db_path=db_path, workspace_id=ws_id,
+                              params=params)
+    assert isinstance(result, dict)
+
+
+def test_pipeline_scan_swallows_invalidator_exceptions(tmp_path, monkeypatch):
+    """A failing invalidator must not abort the pipeline finally block.
+
+    The finally block also invalidates the new-images cache; if the
+    missing-originals callback raised through, subsequent bookkeeping
+    (SSE sentinel, stage-status update) would be skipped and the
+    pipeline would hang. Mirror the try/except log-and-continue guard
+    already applied to invalidate_new_images_after_scan.
+    """
+    import config as cfg
+    from db import Database
+    from PIL import Image
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    photo_dir = tmp_path / "photos"
+    photo_dir.mkdir()
+    Image.new("RGB", (32, 32), "black").save(str(photo_dir / "keep.jpg"))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    params = PipelineParams(
+        source=str(photo_dir),
+        skip_classify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    def raising_invalidator():
+        raise RuntimeError("boom")
+
+    # The pipeline must finish normally even though the invalidator
+    # raised — the exception is logged and swallowed inside the finally
+    # block, same as the new-images invalidation.
+    result = run_pipeline_job(
+        _make_job(), FakeRunner(), db_path, ws_id, params,
+        missing_originals_invalidator=raising_invalidator,
+    )
+    assert isinstance(result, dict)
+
+
 def test_pipeline_stages_dict_in_progress_events(tmp_path, monkeypatch):
     """Progress events should include a 'stages' dict showing all stage statuses."""
     import config as cfg

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -454,6 +454,81 @@ def test_pipeline_scan_invokes_missing_originals_invalidator(tmp_path, monkeypat
     )
 
 
+def test_pipeline_collection_repair_scan_invokes_missing_originals_invalidator(
+    tmp_path, monkeypatch,
+):
+    """Collection-mode metadata repair scans must invalidate the cache too.
+
+    Regression: when ``skip_scan`` is on (a collection-scoped Process run)
+    and ``_find_broken_metadata_folders`` flags rows, the pipeline runs a
+    targeted ``do_scan()`` against the affected folder to repair metadata.
+    That call touches disk and can revalidate a restored original that a
+    ready ``/api/photos/missing`` payload still lists as a ghost, but the
+    repair path did not append its folder to ``scanned_roots`` — so the
+    outer finally's Missing Originals invalidation never fired for repair
+    scans. Codex review on 7fec89bd.
+    """
+    import config as cfg
+    from db import Database
+    from PIL import Image
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    photo_dir = tmp_path / "photos"
+    photo_dir.mkdir()
+    photo_path = photo_dir / "broken.jpg"
+    Image.new("RGB", (32, 32), "black").save(str(photo_path))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    folder_id = db.add_folder(str(photo_dir), name="photos")
+    photo_id = db.add_photo(
+        folder_id=folder_id,
+        filename="broken.jpg",
+        extension=".jpg",
+        file_size=os.path.getsize(photo_path),
+        file_mtime=os.path.getmtime(photo_path),
+        width=32,
+        height=32,
+    )
+    # Force _find_broken_metadata_folders to flag this row so the pipeline
+    # takes the repair branch instead of the "Skipped (using collection)"
+    # early return.
+    db.conn.execute(
+        "UPDATE photos SET timestamp=NULL WHERE id=?", (photo_id,),
+    )
+    db.conn.commit()
+
+    collection_id = db.add_collection(
+        "Repair me",
+        json.dumps([{"field": "photo_ids", "op": "in", "value": [photo_id]}]),
+    )
+
+    params = PipelineParams(
+        collection_id=collection_id,
+        skip_classify=True,
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+
+    invalidator_calls = []
+
+    def fake_invalidator():
+        invalidator_calls.append(True)
+
+    run_pipeline_job(
+        _make_job(), FakeRunner(), db_path, ws_id, params,
+        missing_originals_invalidator=fake_invalidator,
+    )
+
+    assert invalidator_calls, (
+        "missing_originals_invalidator was not called after the "
+        "collection-mode metadata repair scan"
+    )
+
+
 def test_pipeline_scan_invalidator_is_optional(tmp_path, monkeypatch):
     """Callers that don't pass ``missing_originals_invalidator`` still work.
 

--- a/vireo/tests/test_rescan_scope.py
+++ b/vireo/tests/test_rescan_scope.py
@@ -9,6 +9,7 @@ import os
 
 import pytest
 from db import Database
+from wait import wait_for_job_via_client
 
 
 def _db_with_active_ws(tmp_path):
@@ -24,6 +25,23 @@ def _add_photo_file(db, folder_dir, folder_id, name):
         folder_id=folder_id, filename=name, extension=".jpg",
         file_size=9, file_mtime=1.0,
     )
+
+
+def _run_missing_originals_check(client, folder_id=None):
+    body = {}
+    if folder_id is not None:
+        body["folder_id"] = folder_id
+    resp = client.post("/api/photos/missing/check", json=body)
+    assert resp.status_code in (200, 202)
+    data = resp.get_json()
+    if data.get("pending"):
+        wait_for_job_via_client(client, data["job_id"])
+    url = "/api/photos/missing"
+    if folder_id is not None:
+        url += f"?folder_id={folder_id}"
+    payload = client.get(url).get_json()
+    assert payload["status"] == "ready"
+    return payload["photos"]
 
 
 # ---- DB layer: get_missing_photos(folder_id=...) -------------------------
@@ -166,15 +184,15 @@ def test_missing_endpoint_scoped_by_folder(app_with_real_folders):
     client = app.test_client()
 
     # Whole-workspace: the one ghost.
-    allm = client.get("/api/photos/missing").get_json()
+    allm = _run_missing_originals_check(client)
     assert [p["id"] for p in allm] == [ids["pa"]]
 
     # Scoped to A: the ghost.
-    scoped_a = client.get(f"/api/photos/missing?folder_id={ids['fa']}").get_json()
+    scoped_a = _run_missing_originals_check(client, ids["fa"])
     assert [p["id"] for p in scoped_a] == [ids["pa"]]
 
     # Scoped to B: empty.
-    scoped_b = client.get(f"/api/photos/missing?folder_id={ids['fb']}").get_json()
+    scoped_b = _run_missing_originals_check(client, ids["fb"])
     assert scoped_b == []
 
 


### PR DESCRIPTION
## Summary
- Replace synchronous Missing Originals polling with cache-first status responses.
- Add a background Missing Originals scan job with duplicate coalescing, heavy-job gating, stale/error state, and automatic failure backoff.
- Update navbar and modal flows so page load never performs the filesystem scan, while manual refresh and explicit rescan flows can start the background check.

## Validation
- python -m py_compile vireo/app.py vireo/db.py vireo/tests/test_app.py vireo/tests/test_rescan_scope.py
- python -m pytest vireo/tests/test_app.py::test_api_photos_missing_uncached_is_immediate vireo/tests/test_app.py::test_api_photos_missing vireo/tests/test_app.py::test_api_photos_missing_cached_result_does_not_rescan vireo/tests/test_app.py::test_api_photos_missing_check_coalesces_duplicate_jobs vireo/tests/test_app.py::test_api_photos_missing_automatic_skips_during_heavy_job vireo/tests/test_app.py::test_api_photos_missing_automatic_respects_failure_backoff vireo/tests/test_app.py::test_api_photos_missing_delete_sidecars vireo/tests/test_app.py::test_api_photos_missing_delete_sidecars_rejects_untracked_paths vireo/tests/test_app.py::test_api_photos_missing_detects_preview_variants vireo/tests/test_app.py::test_api_photos_missing_reports_default_working_copy vireo/tests/test_app.py::test_api_photos_missing_excludes_present_files vireo/tests/test_rescan_scope.py vireo/tests/test_db.py -k 'get_missing_photos or test_missing_endpoint' -q
- python -m pytest vireo/tests/test_rescan_scope.py -q
- python -m pytest vireo/tests/test_app.py::test_api_photos_missing_uncached_is_immediate vireo/tests/test_app.py::test_api_photos_missing_cached_result_does_not_rescan vireo/tests/test_app.py::test_api_photos_missing_check_coalesces_duplicate_jobs vireo/tests/test_app.py::test_api_photos_missing_automatic_skips_during_heavy_job vireo/tests/test_app.py::test_api_photos_missing_automatic_respects_failure_backoff -q


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added background “Missing Originals” checks with periodic progress updates, inflight request coalescing, and clearer status metadata (ready/pending/error/not_ready + staleness/backoff).
  * Introduced APIs to start/check scans and remove missing originals, with stricter folder scoping and validation.
  * Updated the banner/modal UI flow to use consistent polling, delayed automatic checks, and a “Check now” refresh.

* **Bug Fixes**
  * Prevented stale in-flight results from overriding newer cache state after invalidations (deletes, moves, workspace changes, rescans, imports).
  * Improved error/backoff and heavy-job suppression so failures don’t repeatedly surface as outdated “ready” data.
  * Removal now re-verifies on disk, avoids deleting restored items, and defers/report issues for offline/unreachable folders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->