### PR TITLE
Fix multi-species prediction matching

### DIFF
--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -83,16 +83,17 @@ def test_compare_prediction_to_keywords_conflict_with_shared_rank():
     assert result["shared_rank"] == "genus"
 
 
-def test_compare_prediction_to_keywords_conflict_outranks_refinement():
-    # Prediction refines "Sparrow" but conflicts with "Red-tailed Hawk".
-    # The most severe relationship (conflict) must win regardless of the
-    # order keywords are evaluated in, so the row stays in the review flow.
+def test_compare_prediction_to_keywords_refinement_outranks_conflict():
+    # Prediction refines "Sparrow" and conflicts with "Red-tailed Hawk".
+    # A supported relationship (refinement) with any existing species keyword
+    # means the photo already backs the prediction, so refinement wins over
+    # the conflict regardless of the order keywords are evaluated in.
     result = compare_prediction_to_keywords(
         "White-crowned Sparrow",
         ["Sparrow", "Red-tailed Hawk"],
         FakeTaxonomy(),
     )
-    assert result["category"] == "conflict"
+    assert result["category"] == "refinement"
 
     # Same keywords, reversed order — result must be stable.
     reversed_result = compare_prediction_to_keywords(
@@ -100,19 +101,19 @@ def test_compare_prediction_to_keywords_conflict_outranks_refinement():
         ["Red-tailed Hawk", "Sparrow"],
         FakeTaxonomy(),
     )
-    assert reversed_result["category"] == "conflict"
+    assert reversed_result["category"] == "refinement"
 
 
-def test_compare_prediction_to_keywords_match_does_not_hide_conflict():
-    # An exact match must not short-circuit the scan: a contradictory
-    # species keyword on the same photo still has to surface as a conflict
-    # so the row stays in the review flow.
+def test_compare_prediction_to_keywords_match_outranks_conflict():
+    # An exact match with any existing species keyword means the prediction
+    # is already supported by the photo, so a contradictory sibling keyword
+    # on the same photo does not downgrade it to a conflict.
     result = compare_prediction_to_keywords(
         "Red-tailed Hawk",
         ["Red-tailed Hawk", "White-crowned Sparrow"],
         FakeTaxonomy(),
     )
-    assert result["category"] == "conflict"
+    assert result["category"] == "match"
 
     # Order must not matter.
     reversed_result = compare_prediction_to_keywords(
@@ -120,7 +121,7 @@ def test_compare_prediction_to_keywords_match_does_not_hide_conflict():
         ["White-crowned Sparrow", "Red-tailed Hawk"],
         FakeTaxonomy(),
     )
-    assert reversed_result["category"] == "conflict"
+    assert reversed_result["category"] == "match"
 
 
 def test_compare_prediction_to_keywords_pure_match():

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -8879,9 +8879,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             row_category = pending_category or highest_category
             photo["row_category"] = row_category
             photo["row_label"] = labels[row_category]
-            photo["needs_review"] = row_category in {
-                "conflict", "refinement", "broader", "new",
-            } and pending_category is not None
+            # Any pending prediction means the user hasn't decided yet, so
+            # the photo still needs review — including pending "match"
+            # predictions, which classify_job stores deliberately when a
+            # multi-species sidecar makes a photo-level match ambiguous
+            # (see _store_pending_detection_prediction / auto_accept=False).
+            photo["needs_review"] = pending_category is not None
             if photo["needs_review"]:
                 summary["needs_review"] += 1
 

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -1405,21 +1405,39 @@ def _can_auto_accept_detection_prediction(prediction, category, existing_keyword
     """Return True when a photo-level match is unambiguous for one detection.
 
     A photo may carry taxonomy-hierarchy keywords (e.g. ``Aves`` alongside
-    ``Robin``) without adding a second species. Those ancestors/duplicates are
-    folded into the matched species; only keywords that resolve to a distinct
-    species (``sibling``, ``unrelated``, or an unknown relationship) force the
-    detection back into pending review.
+    ``Robin``) without adding a second species: ancestors of the matched
+    prediction are just broader labels for the same taxon. A single
+    descendant is also fine — it just refines the prediction to a specific
+    species. But multiple *distinct* descendants (e.g. the prediction is
+    ``Sparrow`` and the sidecar has ``White-crowned Sparrow`` +
+    ``Golden-crowned Sparrow``) describe more than one species and must go
+    through review, even though ``categorize()`` still returns ``"match"``
+    because each keyword is a descendant of the prediction.
+
+    Descendants only fold into the same species when they resolve to one
+    another (a species and its own subspecies, for example); any pair that
+    is ``sibling``/``unrelated`` means genuinely distinct species and
+    forces the detection back to pending review.
     """
     if category != "match":
         return False
     taxa = _recognized_taxon_keywords(existing_keywords, tax)
     if not tax or not hasattr(tax, "relationship"):
         return len(taxa) <= 1
+    descendants = []
     for kw in taxa:
         rel = tax.relationship(kw, prediction)
-        if rel in ("same", "ancestor", "descendant"):
+        if rel in ("same", "ancestor"):
+            continue
+        if rel == "descendant":
+            descendants.append(kw)
             continue
         return False
+    for i, a in enumerate(descendants):
+        for b in descendants[i + 1:]:
+            rel = tax.relationship(a, b)
+            if rel not in ("same", "ancestor", "descendant"):
+                return False
     return True
 
 

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -1401,11 +1401,26 @@ def _categorize_detection_prediction(prediction, existing_keywords, tax):
     return categorize(prediction, existing_keywords, tax)
 
 
-def _can_auto_accept_detection_prediction(category, existing_keywords, tax):
-    """Return True when a photo-level match is unambiguous for one detection."""
+def _can_auto_accept_detection_prediction(prediction, category, existing_keywords, tax):
+    """Return True when a photo-level match is unambiguous for one detection.
+
+    A photo may carry taxonomy-hierarchy keywords (e.g. ``Aves`` alongside
+    ``Robin``) without adding a second species. Those ancestors/duplicates are
+    folded into the matched species; only keywords that resolve to a distinct
+    species (``sibling``, ``unrelated``, or an unknown relationship) force the
+    detection back into pending review.
+    """
     if category != "match":
         return False
-    return len(_recognized_taxon_keywords(existing_keywords, tax)) <= 1
+    taxa = _recognized_taxon_keywords(existing_keywords, tax)
+    if not tax or not hasattr(tax, "relationship"):
+        return len(taxa) <= 1
+    for kw in taxa:
+        rel = tax.relationship(kw, prediction)
+        if rel in ("same", "ancestor", "descendant"):
+            continue
+        return False
+    return True
 
 
 def _store_pending_detection_prediction(
@@ -1545,7 +1560,7 @@ def _store_grouped_predictions(
                     item["prediction"], existing, tax,
                 )
                 auto_accept = _can_auto_accept_detection_prediction(
-                    category, existing, tax,
+                    item["prediction"], category, existing, tax,
                 )
 
             if auto_accept:
@@ -1599,7 +1614,7 @@ def _store_grouped_predictions(
                         item["prediction"], existing, tax,
                     )
                     auto_accept = _can_auto_accept_detection_prediction(
-                        category, existing, tax,
+                        item["prediction"], category, existing, tax,
                     )
 
                 if auto_accept:

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -1451,6 +1451,16 @@ def _store_pending_detection_prediction(
                     individual=individual,
                     labels_fingerprint=labels_fingerprint,
                 )
+            else:
+                # Cached prediction may still carry group metadata from an
+                # earlier grouped burst; if the current run decided this
+                # detection is not group-reviewable, drop the stale group_id
+                # so ungrouping actually takes effect on reuse.
+                db.clear_prediction_group_info(
+                    detection_id=item["detection_id"],
+                    model=model_name,
+                    labels_fingerprint=labels_fingerprint,
+                )
             return
 
     db.add_prediction(

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -1370,6 +1370,121 @@ def _store_match_prediction(
     )
 
 
+def _recognized_taxon_keywords(keywords, tax):
+    """Return XMP keywords that the loaded taxonomy recognizes as taxa."""
+    if not tax or not hasattr(tax, "is_taxon"):
+        return []
+    taxa = []
+    seen = set()
+    for kw in keywords or []:
+        if not kw or not tax.is_taxon(kw):
+            continue
+        key = kw.strip().lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        taxa.append(kw)
+    return taxa
+
+
+def _categorize_detection_prediction(prediction, existing_keywords, tax):
+    """Categorize one detection prediction against its photo-level keywords.
+
+    Photo keywords are not detection-scoped, so this only describes whether
+    the prediction agrees with the photo's species set. The caller separately
+    decides whether a photo-level match is specific enough to auto-accept.
+    """
+    if not tax:
+        return "new"
+    from compare import categorize
+
+    return categorize(prediction, existing_keywords, tax)
+
+
+def _can_auto_accept_detection_prediction(category, existing_keywords, tax):
+    """Return True when a photo-level match is unambiguous for one detection."""
+    if category != "match":
+        return False
+    return len(_recognized_taxon_keywords(existing_keywords, tax)) <= 1
+
+
+def _store_pending_detection_prediction(
+    db,
+    item,
+    model_name,
+    labels_fingerprint,
+    category,
+    tax=None,
+    group_id=None,
+    vote_count=None,
+    total_votes=None,
+    individual=None,
+):
+    tax_hierarchy = item.get("taxonomy") or (
+        tax.get_hierarchy(item["prediction"]) if tax else {}
+    )
+    if item.get("_existing"):
+        existing_row = db.conn.execute(
+            """SELECT id FROM predictions
+               WHERE detection_id = ? AND classifier_model = ?
+                 AND labels_fingerprint = ? AND species IS ?""",
+            (
+                item["detection_id"],
+                model_name,
+                labels_fingerprint,
+                item["prediction"],
+            ),
+        ).fetchone()
+        db.reconcile_match_review_state(
+            item["detection_id"], model_name, labels_fingerprint,
+            item["prediction"], category,
+        )
+        if existing_row is not None:
+            if group_id is not None:
+                db.update_prediction_group_info(
+                    detection_id=item["detection_id"],
+                    model=model_name,
+                    group_id=group_id,
+                    vote_count=vote_count,
+                    total_votes=total_votes,
+                    individual=individual,
+                    labels_fingerprint=labels_fingerprint,
+                )
+            return
+
+    db.add_prediction(
+        detection_id=item["detection_id"],
+        species=item["prediction"],
+        confidence=round(item["confidence"], 4),
+        model=model_name,
+        category=category,
+        group_id=group_id,
+        vote_count=vote_count,
+        total_votes=total_votes,
+        individual=individual,
+        taxonomy=tax_hierarchy,
+        labels_fingerprint=labels_fingerprint,
+    )
+    db.reconcile_match_review_state(
+        item["detection_id"], model_name, labels_fingerprint,
+        item["prediction"], category,
+    )
+    for alt in item.get("alternatives", []):
+        alt_tax = alt.get("taxonomy") or (
+            tax.get_hierarchy(alt["species"]) if tax else {}
+        )
+        db.add_prediction(
+            detection_id=item["detection_id"],
+            species=alt["species"],
+            confidence=round(alt["confidence"], 4),
+            model=model_name,
+            category=category,
+            status="alternative",
+            taxonomy=alt_tax,
+            labels_fingerprint=labels_fingerprint,
+        )
+
+
 def _store_grouped_predictions(
     raw_results, job_id, model_name, grouping_window, similarity_threshold, tax, db,
     labels_fingerprint="legacy",
@@ -1385,7 +1500,6 @@ def _store_grouped_predictions(
     Returns:
         dict with predictions_stored, burst_groups, already_labeled counts.
     """
-    from compare import categorize
     from grouping import (
         consensus_prediction,
         group_by_timestamp,
@@ -1408,56 +1522,30 @@ def _store_grouped_predictions(
             folder_path = item["folder_path"]
 
             category = "new"
+            auto_accept = False
             if tax:
                 xmp_path = os.path.join(
                     folder_path,
                     os.path.splitext(photo["filename"])[0] + ".xmp",
                 )
                 existing = read_keywords(xmp_path)
-                category = categorize(item["prediction"], existing, tax)
+                category = _categorize_detection_prediction(
+                    item["prediction"], existing, tax,
+                )
+                auto_accept = _can_auto_accept_detection_prediction(
+                    category, existing, tax,
+                )
 
-            if category == "match":
+            if auto_accept:
                 _store_match_prediction(
                     db, item, model_name, labels_fingerprint, tax,
                 )
                 skipped_match += 1
                 continue
 
-            tax_hierarchy = item.get("taxonomy") or (
-                tax.get_hierarchy(item["prediction"]) if tax else {}
+            _store_pending_detection_prediction(
+                db, item, model_name, labels_fingerprint, category, tax,
             )
-            db.add_prediction(
-                detection_id=item["detection_id"],
-                species=item["prediction"],
-                confidence=round(item["confidence"], 4),
-                model=model_name,
-                category=category,
-                taxonomy=tax_hierarchy,
-                labels_fingerprint=labels_fingerprint,
-            )
-            # If this detection was a cached 'match', its auto-accepted
-            # review row would otherwise survive the now non-match reuse
-            # (add_prediction's default pending never overwrites it) and
-            # keep it out of the queue. Downgrade it back to pending.
-            db.reconcile_match_review_state(
-                item["detection_id"], model_name, labels_fingerprint,
-                item["prediction"], category,
-            )
-            # Store alternative predictions
-            for alt in item.get("alternatives", []):
-                alt_tax = alt.get("taxonomy") or (
-                    tax.get_hierarchy(alt["species"]) if tax else {}
-                )
-                db.add_prediction(
-                    detection_id=item["detection_id"],
-                    species=alt["species"],
-                    confidence=round(alt["confidence"], 4),
-                    model=model_name,
-                    category=category,
-                    status="alternative",
-                    taxonomy=alt_tax,
-                    labels_fingerprint=labels_fingerprint,
-                )
             predictions_stored += 1
         else:
             group_count += 1
@@ -1473,91 +1561,58 @@ def _store_grouped_predictions(
             if not cons:
                 continue
 
-            representative = group[0]
-            category = "new"
-            if tax:
-                xmp_path = os.path.join(
-                    representative["folder_path"],
-                    os.path.splitext(representative["photo"]["filename"])[0] + ".xmp",
-                )
-                existing = read_keywords(xmp_path)
-                category = categorize(cons["prediction"], existing, tax)
+            group_species = {
+                (item.get("prediction") or "").strip().lower()
+                for item in group
+                if item.get("prediction")
+            }
+            group_reviewable = len(group_species) == 1
+            individual_json = (
+                json.dumps(cons["individual_predictions"])
+                if group_reviewable
+                else None
+            )
+            stored_in_group = 0
+            for item in group:
+                photo = item["photo"]
+                category = "new"
+                auto_accept = False
+                if tax:
+                    xmp_path = os.path.join(
+                        item["folder_path"],
+                        os.path.splitext(photo["filename"])[0] + ".xmp",
+                    )
+                    existing = read_keywords(xmp_path)
+                    category = _categorize_detection_prediction(
+                        item["prediction"], existing, tax,
+                    )
+                    auto_accept = _can_auto_accept_detection_prediction(
+                        category, existing, tax,
+                    )
 
-            if category == "match":
-                cons_hierarchy = (
-                    tax.get_hierarchy(cons["prediction"]) if tax else {}
-                )
-                for item in group:
+                if auto_accept:
                     _store_match_prediction(
                         db, item, model_name, labels_fingerprint, tax,
-                        species=cons["prediction"],
-                        confidence=cons["confidence"],
-                        taxonomy=cons_hierarchy,
                         store_alternatives=False,
                     )
-                skipped_match += len(group)
-                continue
+                    skipped_match += 1
+                    continue
 
-            individual_json = json.dumps(cons["individual_predictions"])
-            rep_tax = group[0].get("taxonomy")
-            cons_hierarchy = rep_tax or (
-                tax.get_hierarchy(cons["prediction"]) if tax else {}
-            )
-
-            # Drop any stale auto-accept from a prior 'match' pass first, so
-            # the update_prediction_group_info upsert below re-inserts a
-            # fresh pending row (its ON CONFLICT keeps the existing status)
-            # and the burst re-enters review. A prior match pass cached every
-            # detection under the consensus species, so reconcile that same
-            # species (not each frame's own prediction) or the downgrade
-            # misses a dissenting frame's cached row and it stays hidden.
-            for item in group:
-                db.reconcile_match_review_state(
-                    item["detection_id"], model_name, labels_fingerprint,
-                    cons["prediction"], category,
+                _store_pending_detection_prediction(
+                    db,
+                    item,
+                    model_name,
+                    labels_fingerprint,
+                    category,
+                    tax,
+                    group_id=gid if group_reviewable else None,
+                    vote_count=cons["vote_count"] if group_reviewable else None,
+                    total_votes=cons["total_votes"] if group_reviewable else None,
+                    individual=individual_json,
                 )
+                stored_in_group += 1
 
-            for item in group:
-                if item.get("_existing"):
-                    db.update_prediction_group_info(
-                        detection_id=item["detection_id"],
-                        model=model_name,
-                        group_id=gid,
-                        vote_count=cons["vote_count"],
-                        total_votes=cons["total_votes"],
-                        individual=individual_json,
-                        labels_fingerprint=labels_fingerprint,
-                    )
-                else:
-                    db.add_prediction(
-                        detection_id=item["detection_id"],
-                        species=item["prediction"],
-                        confidence=round(item["confidence"], 4),
-                        model=model_name,
-                        category=category,
-                        group_id=gid,
-                        vote_count=cons["vote_count"],
-                        total_votes=cons["total_votes"],
-                        individual=individual_json,
-                        taxonomy=item.get("taxonomy") or cons_hierarchy,
-                        labels_fingerprint=labels_fingerprint,
-                    )
-                    # Store alternative predictions for this group member
-                    for alt in item.get("alternatives", []):
-                        alt_tax = alt.get("taxonomy") or (
-                            tax.get_hierarchy(alt["species"]) if tax else {}
-                        )
-                        db.add_prediction(
-                            detection_id=item["detection_id"],
-                            species=alt["species"],
-                            confidence=round(alt["confidence"], 4),
-                            model=model_name,
-                            category=category,
-                            status="alternative",
-                            taxonomy=alt_tax,
-                            labels_fingerprint=labels_fingerprint,
-                        )
-            predictions_stored += len(group)
+            predictions_stored += stored_in_group
 
     singles = len([g for g in groups if len(g) == 1])
     grouped_photos = sum(len(g) for g in groups if len(g) > 1)

--- a/vireo/classify_job.py
+++ b/vireo/classify_job.py
@@ -1438,6 +1438,7 @@ def _store_pending_detection_prediction(
         db.reconcile_match_review_state(
             item["detection_id"], model_name, labels_fingerprint,
             item["prediction"], category,
+            auto_accept=False,
         )
         if existing_row is not None:
             if group_id is not None:
@@ -1468,6 +1469,7 @@ def _store_pending_detection_prediction(
     db.reconcile_match_review_state(
         item["detection_id"], model_name, labels_fingerprint,
         item["prediction"], category,
+        auto_accept=False,
     )
     for alt in item.get("alternatives", []):
         alt_tax = alt.get("taxonomy") or (

--- a/vireo/compare.py
+++ b/vireo/compare.py
@@ -13,6 +13,13 @@ _CATEGORY_PRIORITY = {
 }
 
 
+_CATEGORIZE_PRIORITY = {
+    "match": 3,
+    "refinement": 2,
+    "disagreement": 1,
+}
+
+
 def categorize(prediction, existing_keywords, taxonomy):
     """Categorize a prediction relative to existing keywords using taxonomy.
 
@@ -26,6 +33,14 @@ def categorize(prediction, existing_keywords, taxonomy):
         'new' — no existing species keywords found
         'refinement' — prediction is more specific than an existing keyword
         'disagreement' — prediction differs from existing species keyword
+
+    ``existing_keywords`` is a set, so iteration order is not deterministic.
+    A short-circuit on the first taxon-recognizing keyword would let an
+    ancestor (``Aves``) hide an exact match (``Robin``) purely because the
+    set happened to iterate the ancestor first, sending an already-labeled
+    photo through review. Iterating every taxon and picking the highest
+    priority makes the result depend on the taxa, not on iteration order,
+    and mirrors ``compare_prediction_to_keywords``'s tie-break rule.
     """
     # Filter existing keywords to just those recognized as taxa
     existing_taxa = []
@@ -39,25 +54,33 @@ def categorize(prediction, existing_keywords, taxonomy):
     if not existing_taxa:
         return "new"
 
-    # Check each existing taxon against the prediction
+    best = None
     for taxon_kw in existing_taxa:
         rel = taxonomy.relationship(taxon_kw, prediction)
 
         if rel is None:
             log.warning("Prediction '%s' not found in taxonomy", prediction)
-            return "disagreement"
+            category = "disagreement"
         elif rel == "same":
-            return "match"
+            category = "match"
         elif rel == "ancestor":
             # Existing is broader, prediction is more specific → refinement
-            return "refinement"
+            category = "refinement"
         elif rel == "descendant":
             # Existing is more specific, prediction is broader — unusual but treat as match
-            return "match"
-        # 'sibling' and 'unrelated' fall through to check remaining taxa
+            category = "match"
+        else:
+            # 'sibling' and 'unrelated' don't decide on their own — keep looking
+            continue
+
+        if (
+            best is None
+            or _CATEGORIZE_PRIORITY[category] > _CATEGORIZE_PRIORITY[best]
+        ):
+            best = category
 
     # No existing taxon matched/contained the prediction
-    return "disagreement"
+    return best or "disagreement"
 
 
 def _taxon_rank_map(taxon):

--- a/vireo/compare.py
+++ b/vireo/compare.py
@@ -5,11 +5,11 @@ import logging
 log = logging.getLogger(__name__)
 
 _CATEGORY_PRIORITY = {
-    "conflict": 50,
+    "match": 50,
     "refinement": 40,
     "broader": 30,
     "new": 20,
-    "match": 10,
+    "conflict": 10,
 }
 
 
@@ -182,7 +182,11 @@ def compare_prediction_to_keywords(prediction, existing_species, taxonomy):
                 "shared_rank": shared,
             }
 
-        if best is None or _CATEGORY_PRIORITY[result["category"]] > _CATEGORY_PRIORITY[best["category"]]:
+        if (
+            best is None
+            or _CATEGORY_PRIORITY[result["category"]]
+            > _CATEGORY_PRIORITY[best["category"]]
+        ):
             best = result
 
     return best or {

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -10097,6 +10097,7 @@ class Database:
         labels_fingerprint,
         species,
         category,
+        auto_accept=True,
     ):
         """Re-sync a cached prediction's category and auto-review on reuse.
 
@@ -10109,6 +10110,13 @@ class Database:
         it out of the queue until a full reclassify/clear is forced.  Only the
         marked auto-review row is safe to drop here; explicit user decisions
         from before a temporary XMP match must remain intact.
+
+        ``auto_accept`` is False when the caller has decided this reuse must
+        stay pending even though ``category`` is still ``match`` — e.g. the
+        XMP later gained a second recognized taxon, so a single-species match
+        is now ambiguous.  Without dropping the marker in that case,
+        ``status='accepted'`` from the earlier unambiguous run would keep the
+        detection hidden from the queue.
 
         The persisted ``category`` is always refreshed to the current value:
         ``add_prediction`` is INSERT-OR-IGNORE so it never updates it on
@@ -10126,7 +10134,7 @@ class Database:
         if row is None:
             return
         pred_id = row["id"]
-        if row["category"] == "match" and category != "match":
+        if row["category"] == "match" and (category != "match" or not auto_accept):
             self.conn.execute(
                 "DELETE FROM prediction_review "
                 "WHERE prediction_id = ? AND workspace_id = ? "

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -10682,6 +10682,57 @@ class Database:
         rows = self.conn.execute(sql, params).fetchall()
         return [(row["photo_id"], row["embedding"]) for row in rows]
 
+    def clear_prediction_group_info(self, detection_id, model,
+                                    labels_fingerprint=None):
+        """Drop stale group metadata from the cached prediction's review row.
+
+        Used when a cached prediction that previously belonged to a
+        reviewable burst is reused under a run where the burst is no longer
+        group-reviewable (mixed species, singleton, etc.), so the caller
+        would otherwise pass ``group_id=None`` to
+        ``update_prediction_group_info`` and skip it. Without this, the old
+        ``group_id`` / ``individual`` / vote counts stay attached and group
+        actions retag the whole stale burst together.
+
+        Only updates an existing ``prediction_review`` row — never inserts
+        one — so the "absence == pending" invariant that ``add_prediction``
+        enforces for un-reviewed detections stays intact.
+        """
+        ws = self._ws_id()
+        if labels_fingerprint is not None:
+            row = self.conn.execute(
+                """SELECT pr.id FROM predictions pr
+                   LEFT JOIN prediction_review pr_rev
+                     ON pr_rev.prediction_id = pr.id AND pr_rev.workspace_id = ?
+                   WHERE pr.detection_id = ? AND pr.classifier_model = ?
+                     AND pr.labels_fingerprint = ?
+                     AND COALESCE(pr_rev.status, 'pending') != 'alternative'
+                   ORDER BY pr.confidence DESC LIMIT 1""",
+                (ws, detection_id, model, labels_fingerprint),
+            ).fetchone()
+        else:
+            row = self.conn.execute(
+                """SELECT pr.id FROM predictions pr
+                   LEFT JOIN prediction_review pr_rev
+                     ON pr_rev.prediction_id = pr.id AND pr_rev.workspace_id = ?
+                   WHERE pr.detection_id = ? AND pr.classifier_model = ?
+                     AND COALESCE(pr_rev.status, 'pending') != 'alternative'
+                   ORDER BY pr.confidence DESC LIMIT 1""",
+                (ws, detection_id, model),
+            ).fetchone()
+        if not row:
+            return
+        self.conn.execute(
+            """UPDATE prediction_review
+                  SET individual  = NULL,
+                      group_id    = NULL,
+                      vote_count  = NULL,
+                      total_votes = NULL
+                WHERE prediction_id = ? AND workspace_id = ?""",
+            (row["id"], ws),
+        )
+        commit_with_retry(self.conn)
+
     def update_prediction_group_info(self, detection_id, model, group_id,
                                      vote_count, total_votes, individual,
                                      labels_fingerprint=None):

--- a/vireo/templates/compare.html
+++ b/vireo/templates/compare.html
@@ -920,12 +920,12 @@ function photoReviewStatus(photo) {
 
   var category = pendingCategory || highestCategory;
   if (!category) category = sawLowConflict ? 'low_conflict' : 'missing_prediction';
-  var needsReview = !!pendingCategory && {
-    conflict: true,
-    refinement: true,
-    broader: true,
-    new: true,
-  }[pendingCategory] === true;
+  // Any pending prediction means the user hasn't decided yet — including
+  // pending "match" predictions kept deliberately for ambiguous multi-species
+  // photo-level matches by classify_job. Excluding "match" here would hide
+  // those from the Needs review count/filter even though the backend
+  // deliberately kept them pending for review.
+  var needsReview = !!pendingCategory;
   return {
     category: category,
     label: CATEGORY_LABELS[category] || category,

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -1527,7 +1527,7 @@ def test_compare_predictions_api_exposes_miss_flags(app_and_db):
 
 
 def test_compare_ignores_resolved_predictions_for_needs_review(app_and_db):
-    """A resolved conflict plus a pending match should not stay in review."""
+    """When every prediction on a photo is already reviewed, no needs_review."""
     app, db = app_and_db
     photo_id = db.conn.execute(
         "SELECT id FROM photos ORDER BY id LIMIT 1"
@@ -1544,15 +1544,55 @@ def test_compare_ignores_resolved_predictions_for_needs_review(app_and_db):
     db.add_prediction(
         det_ids[0], "Blue Jay", 0.95, "model-a", status="accepted",
     )
-    db.add_prediction(det_ids[1], "Cardinal", 0.92, "model-b")
+    db.add_prediction(
+        det_ids[1], "Cardinal", 0.92, "model-b", status="accepted",
+    )
 
     resp = app.test_client().get(f"/api/predictions/compare?collection_id={cid}")
 
     assert resp.status_code == 200
     row = resp.get_json()["photos"][0]
-    assert row["row_category"] == "match"
+    # Both predictions are already reviewed (accepted). The row falls back
+    # to the highest-priority category among all predictions, but nothing is
+    # pending so it must not appear in the Needs review count/filter.
+    assert row["row_category"] == "conflict"
     assert row["needs_review"] is False
     assert resp.get_json()["summary"]["needs_review"] == 0
+
+
+def test_compare_flags_pending_match_as_needs_review(app_and_db):
+    """A pending match prediction must still surface in the needs-review
+    count/filter.
+
+    classify_job stores a pending prediction with ``category="match"`` when a
+    photo-level match is ambiguous (e.g. multiple recognized species keywords
+    in the sidecar), and expects Compare to route the user to it. Before this
+    fix, ``/api/predictions/compare`` excluded ``match`` from ``needs_review``,
+    so those deliberately-pending detections disappeared from the queue.
+    """
+    app, db = app_and_db
+    photo_id = db.conn.execute(
+        "SELECT id FROM photos ORDER BY id LIMIT 1"
+    ).fetchone()["id"]
+    species_id = db.add_keyword("Cardinal", is_species=True)
+    db.tag_photo(photo_id, species_id)
+    rules = json.dumps([{"field": "photo_ids", "value": [photo_id]}])
+    cid = db.add_collection("Pending Match", rules)
+
+    det_ids = db.save_detections(photo_id, [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.3},
+         "confidence": 0.9, "category": "animal"},
+    ], detector_model="MDV6")
+    db.add_prediction(det_ids[0], "Cardinal", 0.92, "model-a")
+
+    resp = app.test_client().get(f"/api/predictions/compare?collection_id={cid}")
+
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    row = payload["photos"][0]
+    assert row["row_category"] == "match"
+    assert row["needs_review"] is True
+    assert payload["summary"]["needs_review"] == 1
 
 
 def test_replace_prediction_keywords_updates_grouped_photos(app_and_db):

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -1825,6 +1825,180 @@ def test_hierarchy_keyword_still_auto_accepts_single_species_match(
     assert [r["species"] for r in accepted] == ["Robin"]
 
 
+def test_multiple_distinct_descendants_stay_pending(tmp_path, monkeypatch):
+    """A photo-level ``match`` on a broad prediction that has two unrelated
+    descendant keywords in the sidecar describes multiple species and must
+    NOT be auto-accepted.
+
+    Concretely: prediction ``Sparrow`` with sidecar ``White-crowned Sparrow``
+    + ``Golden-crowned Sparrow``. ``categorize()`` returns ``match`` because
+    each keyword is a descendant of the prediction, but folding both under
+    "same species" would hide a genuinely multi-species photo from review.
+    Descendants only fold in when they resolve to one another (species +
+    subspecies); sibling descendants must force pending review.
+    """
+    import classify_job
+    from db import Database
+    from xmp import write_sidecar
+
+    monkeypatch.setattr("compare.categorize", lambda *_a, **_k: "match")
+
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder(str(tmp_path))
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(
+        folder_id, "a.jpg", extension=".jpg", file_size=100, file_mtime=1.0
+    )
+    det_id = db.save_detections(
+        photo_id,
+        [{"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}],
+        detector_model="MDV6",
+    )[0]
+    write_sidecar(
+        tmp_path / "a.xmp",
+        {"White-crowned Sparrow", "Golden-crowned Sparrow"},
+        set(),
+    )
+
+    class Tax:
+        _species = {
+            "Sparrow",
+            "White-crowned Sparrow",
+            "Golden-crowned Sparrow",
+        }
+
+        def is_taxon(self, name):
+            return name in self._species
+
+        def relationship(self, existing, prediction):
+            if existing == prediction:
+                return "same"
+            descendants_of_sparrow = {
+                "White-crowned Sparrow", "Golden-crowned Sparrow",
+            }
+            if (
+                existing in descendants_of_sparrow
+                and prediction == "Sparrow"
+            ):
+                return "descendant"
+            if (
+                existing == "Sparrow"
+                and prediction in descendants_of_sparrow
+            ):
+                return "ancestor"
+            if existing in descendants_of_sparrow and prediction in descendants_of_sparrow:
+                return "sibling"
+            return "unrelated"
+
+        def get_hierarchy(self, _species):
+            return {}
+
+    result = classify_job._store_grouped_predictions(
+        raw_results=[{
+            "photo": {
+                "id": photo_id, "filename": "a.jpg",
+                "folder_id": folder_id, "timestamp": None, "burst_id": None,
+            },
+            "folder_path": str(tmp_path),
+            "detection_id": det_id,
+            "prediction": "Sparrow",
+            "confidence": 0.88,
+            "alternatives": [],
+            "taxonomy": {},
+            "timestamp": None,
+        }],
+        job_id="job-abc",
+        model_name="bioclip-2",
+        grouping_window=0,
+        similarity_threshold=0.99,
+        tax=Tax(),
+        db=db,
+        labels_fingerprint="fp-active",
+    )
+
+    assert result["predictions_stored"] == 1
+    assert result["already_labeled"] == 0
+    rows = db.get_predictions(photo_ids=[photo_id])
+    assert len(rows) == 1
+    assert rows[0]["species"] == "Sparrow"
+    assert rows[0]["category"] == "match"
+    assert rows[0]["status"] == "pending"
+    assert not db.get_predictions(photo_ids=[photo_id], status="accepted")
+
+
+def test_single_descendant_still_auto_accepts_match(tmp_path, monkeypatch):
+    """A photo-level match on a broad prediction with a single descendant
+    keyword (e.g. prediction ``Sparrow`` + sidecar ``White-crowned Sparrow``)
+    still auto-accepts — only one species is asserted.
+    """
+    import classify_job
+    from db import Database
+    from xmp import write_sidecar
+
+    monkeypatch.setattr("compare.categorize", lambda *_a, **_k: "match")
+
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder(str(tmp_path))
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(
+        folder_id, "a.jpg", extension=".jpg", file_size=100, file_mtime=1.0
+    )
+    det_id = db.save_detections(
+        photo_id,
+        [{"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}],
+        detector_model="MDV6",
+    )[0]
+    write_sidecar(tmp_path / "a.xmp", {"White-crowned Sparrow"}, set())
+
+    class Tax:
+        def is_taxon(self, name):
+            return name in {"Sparrow", "White-crowned Sparrow"}
+
+        def relationship(self, existing, prediction):
+            if existing == prediction:
+                return "same"
+            if existing == "White-crowned Sparrow" and prediction == "Sparrow":
+                return "descendant"
+            if existing == "Sparrow" and prediction == "White-crowned Sparrow":
+                return "ancestor"
+            return "unrelated"
+
+        def get_hierarchy(self, _species):
+            return {}
+
+    result = classify_job._store_grouped_predictions(
+        raw_results=[{
+            "photo": {
+                "id": photo_id, "filename": "a.jpg",
+                "folder_id": folder_id, "timestamp": None, "burst_id": None,
+            },
+            "folder_path": str(tmp_path),
+            "detection_id": det_id,
+            "prediction": "Sparrow",
+            "confidence": 0.88,
+            "alternatives": [],
+            "taxonomy": {},
+            "timestamp": None,
+        }],
+        job_id="job-abc",
+        model_name="bioclip-2",
+        grouping_window=0,
+        similarity_threshold=0.99,
+        tax=Tax(),
+        db=db,
+        labels_fingerprint="fp-active",
+    )
+
+    assert result["already_labeled"] == 1
+    assert result["predictions_stored"] == 0
+    accepted = db.get_predictions(photo_ids=[photo_id], status="accepted")
+    assert [r["species"] for r in accepted] == ["Sparrow"]
+
+
 @pytest.mark.parametrize("manual_status", ["accepted", "rejected"])
 def test_match_flip_preserves_manual_review_on_reuse(
     tmp_path, monkeypatch, manual_status

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -1599,6 +1599,91 @@ def test_match_then_unmatch_reenters_pending_on_reuse(tmp_path, monkeypatch):
     assert rows["Sparrow"]["status"] == "alternative"   # still nested
 
 
+def test_match_becoming_multispecies_clears_stale_auto_accept(tmp_path, monkeypatch):
+    """A previously auto-accepted single-species match must re-enter the
+    pending queue when the sidecar later gains a second recognized taxon.
+
+    Run 1: XMP has one recognized taxon -> single-species match ->
+    ``_can_auto_accept_detection_prediction`` returns True ->
+    ``_store_match_prediction`` writes the ``AUTO_MATCH_REVIEW_MARKER``
+    review row so the detection stays out of the queue.
+
+    Run 2 (non-reclassify, cache reused via ``_existing=True``): the sidecar
+    now has two recognized taxa. The prediction still matches, so
+    ``category`` remains ``"match"``, but auto-accept flips off. The pending
+    path must drop the stale marker so ``status='accepted'`` no longer hides
+    the detection from review.
+    """
+    import classify_job
+    from db import Database
+    from xmp import write_sidecar
+
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder(str(tmp_path))
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(
+        folder_id, "a.jpg", extension=".jpg", file_size=100, file_mtime=1.0
+    )
+    det_id = db.save_detections(
+        photo_id,
+        [{"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}],
+        detector_model="MDV6",
+    )[0]
+
+    class Tax:
+        def is_taxon(self, name):
+            return name in {"Robin", "Sparrow"}
+
+        def get_hierarchy(self, _species):
+            return {}
+
+    monkeypatch.setattr("compare.categorize", lambda *_a, **_k: "match")
+
+    def run(extra):
+        return classify_job._store_grouped_predictions(
+            raw_results=[{
+                "photo": {
+                    "id": photo_id, "filename": "a.jpg",
+                    "folder_id": folder_id, "timestamp": None, "burst_id": None,
+                },
+                "folder_path": str(tmp_path),
+                "detection_id": det_id,
+                "prediction": "Robin",
+                "confidence": 0.88,
+                "alternatives": [],
+                "taxonomy": {},
+                "timestamp": None,
+                **extra,
+            }],
+            job_id="job-abc",
+            model_name="bioclip-2",
+            grouping_window=0,
+            similarity_threshold=0.99,
+            tax=Tax(),
+            db=db,
+            labels_fingerprint="fp-active",
+        )
+
+    # Run 1: sole recognized taxon matches -> auto-accepted, out of queue.
+    write_sidecar(tmp_path / "a.xmp", {"Robin"}, set())
+    run({})
+    accepted = db.get_predictions(photo_ids=[photo_id], status="accepted")
+    assert [r["species"] for r in accepted] == ["Robin"]
+
+    # Run 2: sidecar now has a second recognized taxon. Category stays
+    # "match" but the match is no longer unambiguous -> pending path.
+    write_sidecar(tmp_path / "a.xmp", {"Robin", "Sparrow"}, set())
+    run({"_existing": True})
+
+    row = db.get_predictions(photo_ids=[photo_id])[0]
+    assert row["species"] == "Robin"
+    assert row["category"] == "match"
+    assert row["status"] == "pending"        # stale auto-accept cleared
+    assert not db.get_predictions(photo_ids=[photo_id], status="accepted")
+
+
 def test_multi_species_xmp_does_not_auto_accept_detection_match(tmp_path):
     """Photo-level multi-species matches stay pending for detection review."""
     import classify_job

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -1349,7 +1349,7 @@ def test_store_grouped_predictions_persists_match_for_cache(tmp_path, monkeypatc
 
 
 def test_store_grouped_predictions_persists_group_match_for_cache(tmp_path, monkeypatch):
-    """Already-labeled burst groups cache consensus species per detection."""
+    """Already-labeled burst groups cache each detection's own species."""
     from datetime import datetime
 
     import classify_job
@@ -1424,14 +1424,14 @@ def test_store_grouped_predictions_persists_group_match_for_cache(tmp_path, monk
     ).fetchall()
     assert {(r["detection_id"], r["species"], r["category"]) for r in rows} == {
         (det_ids[0], "Robin", "match"),
-        (det_ids[1], "Robin", "match"),
+        (det_ids[1], "Sparrow", "match"),
     }
 
 
 def test_group_match_drops_per_frame_alternatives(tmp_path, monkeypatch):
-    """Burst match caches only the consensus species — per-frame alternatives
+    """Burst match caches only each member's primary species; alternatives
     are dropped so a high-confidence dissenting runner-up can't outrank the
-    consensus primary via get_predictions_for_detection's confidence ordering.
+    accepted primary via get_predictions_for_detection's confidence ordering.
     """
     from datetime import datetime
 
@@ -1599,6 +1599,76 @@ def test_match_then_unmatch_reenters_pending_on_reuse(tmp_path, monkeypatch):
     assert rows["Sparrow"]["status"] == "alternative"   # still nested
 
 
+def test_multi_species_xmp_does_not_auto_accept_detection_match(tmp_path):
+    """Photo-level multi-species matches stay pending for detection review."""
+    import classify_job
+    from db import Database
+    from xmp import write_sidecar
+
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder(str(tmp_path))
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(
+        folder_id, "a.jpg", extension=".jpg", file_size=100, file_mtime=1.0
+    )
+    det_id = db.save_detections(
+        photo_id,
+        [{"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}],
+        detector_model="MDV6",
+    )[0]
+    write_sidecar(
+        tmp_path / "a.xmp",
+        {"Robin", "Sparrow", "Wildlife"},
+        set(),
+    )
+
+    class Tax:
+        def is_taxon(self, name):
+            return name in {"Robin", "Sparrow"}
+
+        def relationship(self, existing, prediction):
+            if existing == prediction:
+                return "same"
+            return "unrelated"
+
+        def get_hierarchy(self, _species):
+            return {}
+
+    result = classify_job._store_grouped_predictions(
+        raw_results=[{
+            "photo": {
+                "id": photo_id, "filename": "a.jpg",
+                "folder_id": folder_id, "timestamp": None, "burst_id": None,
+            },
+            "folder_path": str(tmp_path),
+            "detection_id": det_id,
+            "prediction": "Robin",
+            "confidence": 0.88,
+            "alternatives": [],
+            "taxonomy": {},
+            "timestamp": None,
+        }],
+        job_id="job-abc",
+        model_name="bioclip-2",
+        grouping_window=0,
+        similarity_threshold=0.99,
+        tax=Tax(),
+        db=db,
+        labels_fingerprint="fp-active",
+    )
+
+    assert result["predictions_stored"] == 1
+    assert result["already_labeled"] == 0
+    rows = db.get_predictions(photo_ids=[photo_id])
+    assert len(rows) == 1
+    assert rows[0]["species"] == "Robin"
+    assert rows[0]["category"] == "match"
+    assert rows[0]["status"] == "pending"
+    assert not db.get_predictions(photo_ids=[photo_id], status="accepted")
+
+
 @pytest.mark.parametrize("manual_status", ["accepted", "rejected"])
 def test_match_flip_preserves_manual_review_on_reuse(
     tmp_path, monkeypatch, manual_status
@@ -1750,11 +1820,9 @@ def test_group_match_then_unmatch_reenters_pending_on_reuse(tmp_path, monkeypatc
 def test_mixed_group_match_then_unmatch_reenters_pending_for_dissenters(
     tmp_path, monkeypatch
 ):
-    """A mixed burst is cached as 'match' under the consensus species for
-    every detection. When it later stops matching and the cached rows are
-    reused, the downgrade must reconcile by the consensus species so the
-    dissenting frame's detection also re-enters the pending queue rather
-    than staying durably hidden as an auto-accepted match.
+    """A mixed burst caches each detection's own matched species. When it
+    later stops matching and the cached rows are reused, every detection
+    must re-enter the pending queue without grouped consensus review.
     """
     from datetime import datetime
 
@@ -1824,7 +1892,7 @@ def test_mixed_group_match_then_unmatch_reenters_pending_for_dissenters(
     run("match", {})
     accepted = db.get_predictions(photo_ids=photo_ids, status="accepted")
     assert {r["detection_id"] for r in accepted} == set(det_ids)
-    assert {r["species"] for r in accepted} == {"Robin"}
+    assert {r["species"] for r in accepted} == {"Robin", "Sparrow"}
 
     run("disagreement", {"_existing": True})
 
@@ -1833,9 +1901,12 @@ def test_mixed_group_match_then_unmatch_reenters_pending_for_dissenters(
     # Both detections, including the dissenting Sparrow frame, re-enter
     # review; none stay hidden as a stale auto-accepted match.
     assert set(by_det) == set(det_ids)
+    assert by_det[det_ids[0]]["species"] == "Robin"
+    assert by_det[det_ids[1]]["species"] == "Sparrow"
     for r in by_det.values():
         assert r["status"] == "pending"
         assert r["category"] == "disagreement"
+        assert not r["group_id"]
     assert not db.get_predictions(photo_ids=photo_ids, status="accepted")
 
 

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -1995,6 +1995,109 @@ def test_mixed_group_match_then_unmatch_reenters_pending_for_dissenters(
     assert not db.get_predictions(photo_ids=photo_ids, status="accepted")
 
 
+def test_ungrouped_burst_clears_stale_group_id_on_reuse(
+    tmp_path, monkeypatch
+):
+    """Cached predictions from a previously reviewable burst must lose their
+    ``group_id`` when the same detections are later reused outside that
+    group — e.g. the grouping window shrinks so the burst dissolves into
+    singletons. Otherwise group actions on any of the freshly-ungrouped
+    detections would retag the whole stale burst together.
+    """
+    from datetime import datetime
+
+    import classify_job
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder(str(tmp_path))
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_ids = [
+        db.add_photo(
+            folder_id, f"{i}.jpg", extension=".jpg",
+            file_size=100, file_mtime=1.0,
+        )
+        for i in range(2)
+    ]
+    det_ids = [
+        db.save_detections(
+            pid,
+            [{
+                "box": {"x": 0, "y": 0, "w": 1, "h": 1},
+                "confidence": 0.9,
+                "category": "animal",
+            }],
+            detector_model="MDV6",
+        )[0]
+        for pid in photo_ids
+    ]
+
+    class Tax:
+        def get_hierarchy(self, _species):
+            return {}
+
+    # category="new" keeps both runs on the pending path so we can watch
+    # group_id transition without the auto-accept marker interfering.
+    monkeypatch.setattr("compare.categorize", lambda *_a, **_k: "new")
+
+    def run(grouping_window, extra):
+        raw = [
+            {
+                "photo": {
+                    "id": pid, "filename": f"{i}.jpg",
+                    "folder_id": folder_id, "timestamp": None,
+                    "burst_id": None,
+                },
+                "folder_path": str(tmp_path),
+                "detection_id": did,
+                "prediction": "Robin",
+                "confidence": 0.9 - (i * 0.01),
+                "alternatives": [],
+                "taxonomy": {},
+                # Frames 5 seconds apart: grouped under a 10s window,
+                # ungrouped under a 1s window.
+                "timestamp": datetime(2024, 1, 1, 12, 0, i * 5),
+                **extra,
+            }
+            for i, (pid, did) in enumerate(
+                zip(photo_ids, det_ids, strict=True)
+            )
+        ]
+        return classify_job._store_grouped_predictions(
+            raw_results=raw, job_id="job-abc", model_name="bioclip-2",
+            grouping_window=grouping_window, similarity_threshold=0.99,
+            tax=Tax(), db=db, labels_fingerprint="fp-active",
+        )
+
+    # Run 1: 10s window groups both frames -> group_reviewable (same
+    # species) -> both detections share a burst group_id.
+    run(10, {})
+    initial = {r["detection_id"]: r
+               for r in db.get_predictions(photo_ids=photo_ids)}
+    gid_before = initial[det_ids[0]]["group_id"]
+    assert gid_before, "Run 1 should assign a burst group_id"
+    assert initial[det_ids[1]]["group_id"] == gid_before
+
+    # Run 2: cache is reused (_existing=True) with a 1s window that
+    # dissolves the burst into singletons. Each detection goes through
+    # _store_pending_detection_prediction with group_id=None; the cached
+    # rows must lose the stale group_id from Run 1.
+    run(1, {"_existing": True})
+
+    after = {r["detection_id"]: r
+             for r in db.get_predictions(photo_ids=photo_ids)}
+    for det_id in det_ids:
+        assert not after[det_id]["group_id"], (
+            f"Stale group_id survived cache reuse for detection {det_id}: "
+            f"{after[det_id]['group_id']!r}"
+        )
+        assert not after[det_id]["vote_count"]
+        assert not after[det_id]["total_votes"]
+        assert not after[det_id]["individual"]
+
+
 def test_classifier_skipped_when_run_already_recorded(tmp_path, monkeypatch):
     """If (detection, classifier_model, fingerprint) already ran, don't invoke again."""
     from db import Database

--- a/vireo/tests/test_classify_job.py
+++ b/vireo/tests/test_classify_job.py
@@ -1754,6 +1754,77 @@ def test_multi_species_xmp_does_not_auto_accept_detection_match(tmp_path):
     assert not db.get_predictions(photo_ids=[photo_id], status="accepted")
 
 
+def test_hierarchy_keyword_still_auto_accepts_single_species_match(
+    tmp_path, monkeypatch
+):
+    """An ancestor taxon keyword (e.g. ``Aves``) alongside the matched species
+    must not force the detection back into pending review — it's the same
+    species, just labeled at multiple ranks.
+    """
+    import classify_job
+    from db import Database
+    from xmp import write_sidecar
+
+    monkeypatch.setattr("compare.categorize", lambda *_a, **_k: "match")
+
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder(str(tmp_path))
+    ws = db.create_workspace("A")
+    db._active_workspace_id = ws
+    db.add_workspace_folder(ws, folder_id)
+    photo_id = db.add_photo(
+        folder_id, "a.jpg", extension=".jpg", file_size=100, file_mtime=1.0
+    )
+    det_id = db.save_detections(
+        photo_id,
+        [{"box": {"x": 0, "y": 0, "w": 1, "h": 1}, "confidence": 0.9, "category": "animal"}],
+        detector_model="MDV6",
+    )[0]
+    write_sidecar(tmp_path / "a.xmp", {"Robin", "Aves"}, set())
+
+    class Tax:
+        def is_taxon(self, name):
+            return name in {"Robin", "Aves"}
+
+        def relationship(self, existing, prediction):
+            if existing == prediction:
+                return "same"
+            if existing == "Aves" and prediction == "Robin":
+                return "ancestor"
+            return "unrelated"
+
+        def get_hierarchy(self, _species):
+            return {}
+
+    result = classify_job._store_grouped_predictions(
+        raw_results=[{
+            "photo": {
+                "id": photo_id, "filename": "a.jpg",
+                "folder_id": folder_id, "timestamp": None, "burst_id": None,
+            },
+            "folder_path": str(tmp_path),
+            "detection_id": det_id,
+            "prediction": "Robin",
+            "confidence": 0.88,
+            "alternatives": [],
+            "taxonomy": {},
+            "timestamp": None,
+        }],
+        job_id="job-abc",
+        model_name="bioclip-2",
+        grouping_window=0,
+        similarity_threshold=0.99,
+        tax=Tax(),
+        db=db,
+        labels_fingerprint="fp-active",
+    )
+
+    assert result["already_labeled"] == 1
+    assert result["predictions_stored"] == 0
+    accepted = db.get_predictions(photo_ids=[photo_id], status="accepted")
+    assert [r["species"] for r in accepted] == ["Robin"]
+
+
 @pytest.mark.parametrize("manual_status", ["accepted", "rejected"])
 def test_match_flip_preserves_manual_review_on_reuse(
     tmp_path, monkeypatch, manual_status

--- a/vireo/tests/test_compare.py
+++ b/vireo/tests/test_compare.py
@@ -143,3 +143,35 @@ def test_categorize_ignores_non_taxa():
         # "Dyke Marsh" and "0Locations" not in taxonomy -> treated as new
         result = categorize('Northern cardinal', {'Dyke Marsh', '0Locations'}, tax)
         assert result == 'new'
+
+
+def test_compare_prediction_multi_species_exact_match_beats_conflict():
+    """A prediction matching one photo species is not a conflict."""
+    from compare import compare_prediction_to_keywords
+    from taxonomy import Taxonomy
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tax = Taxonomy(_create_mock_taxonomy(tmpdir))
+        result = compare_prediction_to_keywords(
+            'Northern cardinal',
+            ['Blue jay', 'Northern cardinal'],
+            tax,
+        )
+        assert result["category"] == "match"
+        assert result["matched_keyword"] == "Northern cardinal"
+
+
+def test_compare_prediction_multi_species_refinement_beats_conflict():
+    """A supported prediction is not a conflict just because another species is present."""
+    from compare import compare_prediction_to_keywords
+    from taxonomy import Taxonomy
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tax = Taxonomy(_create_mock_taxonomy(tmpdir))
+        result = compare_prediction_to_keywords(
+            'Song sparrow',
+            ['Blue jay', 'sparrow'],
+            tax,
+        )
+        assert result["category"] == "refinement"
+        assert result["matched_keyword"] == "sparrow"

--- a/vireo/tests/test_compare.py
+++ b/vireo/tests/test_compare.py
@@ -145,6 +145,30 @@ def test_categorize_ignores_non_taxa():
         assert result == 'new'
 
 
+def test_categorize_exact_match_beats_ancestor_regardless_of_order():
+    """Exact match wins over ancestor even when the ancestor comes first.
+
+    ``read_keywords`` returns a set, so a photo tagged with both an exact
+    species keyword and a broader hierarchy ancestor (e.g. ``Song Sparrow``
+    plus ``sparrow`` family) can iterate either taxon first. If the ancestor
+    is seen first, an early-return implementation classifies the prediction
+    as ``refinement`` and the downstream auto-accept gate rejects the
+    already-labeled photo. Iterating all taxa and preferring ``match`` keeps
+    the answer stable across set iteration order.
+    """
+    from compare import categorize
+    from taxonomy import Taxonomy
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tax = Taxonomy(_create_mock_taxonomy(tmpdir))
+        # Ancestor first — this is the order that used to return 'refinement'
+        assert categorize('Song sparrow', ['sparrow', 'Song sparrow'], tax) == 'match'
+        # Exact match first — always returned 'match'
+        assert categorize('Song sparrow', ['Song sparrow', 'sparrow'], tax) == 'match'
+        # As a set — must agree regardless of hash iteration order
+        assert categorize('Song sparrow', {'sparrow', 'Song sparrow'}, tax) == 'match'
+
+
 def test_compare_prediction_multi_species_exact_match_beats_conflict():
     """A prediction matching one photo species is not a conflict."""
     from compare import compare_prediction_to_keywords


### PR DESCRIPTION
Fixes classifier storage and Compare categorization for multi-species bird photos. Grouped classifier results now preserve each detection's own species instead of writing a consensus species onto every detection, and mixed-species groups are reviewed individually rather than as one consensus batch. Compare now treats predictions that match any existing photo species keyword as supported instead of a conflict. Multi-species photo-level matches remain pending for detection review rather than being auto-accepted. Validated with `pytest -q vireo/tests/test_compare.py vireo/tests/test_classify_job.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Compare categorization now prefers exact species **matches** over **conflicts** and correctly surfaces **refinements** based on taxonomy relationships.
  - Auto-accept decisions using XMP/photo keywords and taxonomy are more accurate for multi-taxon photos, keeping ambiguous cases pending.
  - Burst/grouped detections better preserve per-detection species outcomes, applying consensus voting only when appropriate.
  - Cached results refresh more reliably, and stale group/vote metadata is cleared when reviewable grouping changes.
  - Pending “match” items are now counted as needing review in the photo review UI.
- **Tests**
  - Added/updated coverage for the revised compare and needs-review behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->