### PR TITLE
Promote representatives to top highlights

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -7338,9 +7338,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         db.set_species_representative(
             parsed["species"], parsed["photo_id"], _commit=False
         )
-        rank = db.promote_species_highlight(
-            parsed["species"], parsed["photo_id"], _commit=False
-        )
+        # Only promote to `species_highlights` when the photo is actually a
+        # Highlights candidate. Otherwise the row is invisible on the
+        # Highlights page (which filters by quality_score) — the user could
+        # neither see it nor remove it.
+        rank = None
+        if _photo_can_be_highlights_preference(
+            db, parsed["species"], parsed["photo_id"]
+        ):
+            rank = db.promote_species_highlight(
+                parsed["species"], parsed["photo_id"], _commit=False
+            )
         db.conn.commit()
         return jsonify({"ok": True, **parsed, "highlight_rank": rank})
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -7335,8 +7335,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 parsed["species"], parsed["photo_id"]
             )
             return jsonify({"ok": True, **parsed, "rank": rank})
-        db.set_species_representative(parsed["species"], parsed["photo_id"])
-        return jsonify({"ok": True, **parsed})
+        db.set_species_representative(
+            parsed["species"], parsed["photo_id"], _commit=False
+        )
+        rank = db.promote_species_highlight(
+            parsed["species"], parsed["photo_id"], _commit=False
+        )
+        db.conn.commit()
+        return jsonify({"ok": True, **parsed, "highlight_rank": rank})
 
     @app.route("/api/photo-preferences", methods=["DELETE"])
     def api_photo_preferences_clear():

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -9981,6 +9981,39 @@ class Database:
             self.conn.commit()
         return rank
 
+    def promote_species_highlight(self, species, photo_id, _commit=True):
+        """Add a photo to a species' ordered highlights at rank 1."""
+        ws = self._ws_id()
+        rows = self.conn.execute(
+            """SELECT photo_id
+               FROM species_highlights
+               WHERE workspace_id = ? AND species = ?
+               ORDER BY rank, created_at, photo_id""",
+            (ws, species),
+        ).fetchall()
+        ids = [r["photo_id"] for r in rows if r["photo_id"] != photo_id]
+        ids.insert(0, photo_id)
+
+        self.conn.execute(
+            """INSERT INTO species_highlights
+                   (workspace_id, species, photo_id, rank, created_at, updated_at)
+               VALUES (?, ?, ?, 1, datetime('now'), datetime('now'))
+               ON CONFLICT(workspace_id, species, photo_id) DO UPDATE SET
+                   rank = excluded.rank,
+                   updated_at = excluded.updated_at""",
+            (ws, species, photo_id),
+        )
+        for rank, pid in enumerate(ids, start=1):
+            self.conn.execute(
+                """UPDATE species_highlights
+                   SET rank = ?, updated_at = datetime('now')
+                   WHERE workspace_id = ? AND species = ? AND photo_id = ?""",
+                (rank, ws, species, pid),
+            )
+        if _commit:
+            self.conn.commit()
+        return 1
+
     def remove_species_highlight(self, species, photo_id, _commit=True):
         """Remove a photo from a species' ordered highlights."""
         ws = self._ws_id()

--- a/vireo/tests/test_life_list.py
+++ b/vireo/tests/test_life_list.py
@@ -193,6 +193,25 @@ def test_representative_preference_promotes_existing_highlight_to_top(life_app):
     }
 
 
+def test_representative_preference_skips_highlight_when_ineligible(life_app):
+    # p3 (sparrow) is life-list eligible but has no quality_score, so it
+    # can't appear in Highlights. Setting it as representative must not
+    # create an invisible species_highlights row the user can't see or
+    # remove from the Highlights page.
+    app, db, ids = life_app
+
+    resp = app.test_client().post("/api/photo-preferences", json={
+        "purpose": "species_representative",
+        "species": "House Sparrow",
+        "photo_id": ids["p3"],
+    })
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["highlight_rank"] is None
+
+    assert db.get_species_highlights("House Sparrow") == {}
+
+
 def test_life_list_photo_preference_must_match_species(life_app):
     app, _, ids = life_app
     resp = app.test_client().post("/api/photo-preferences", json={

--- a/vireo/tests/test_life_list.py
+++ b/vireo/tests/test_life_list.py
@@ -144,7 +144,7 @@ def test_life_list_best_ignores_pick_when_no_preference(life_app):
 
 
 def test_life_list_photo_preference_overrides_best_photo(life_app):
-    app, _, ids = life_app
+    app, db, ids = life_app
     client = app.test_client()
     resp = client.post("/api/photo-preferences", json={
         "purpose": "life_list",
@@ -161,6 +161,36 @@ def test_life_list_photo_preference_overrides_best_photo(life_app):
     assert cardinal["has_preferred_photo"] is True
     assert cardinal["best_source"] == "representative"
     assert [p["id"] for p in cardinal["photos"][:2]] == [ids["p1"], ids["p2"]]
+    assert db.get_species_highlights("Northern Cardinal") == {
+        "Northern Cardinal": {ids["p1"]: 1},
+    }
+
+    highlights = client.get("/api/highlights?scope=workspace").get_json()
+    cardinal_highlights = next(
+        b for b in highlights["buckets"] if b["species"] == "Northern Cardinal"
+    )
+    assert cardinal_highlights["photos"][0]["id"] == ids["p1"]
+    assert cardinal_highlights["photos"][0]["is_highlighted"] is True
+    assert cardinal_highlights["photos"][0]["highlight_rank"] == 1
+
+
+def test_representative_preference_promotes_existing_highlight_to_top(life_app):
+    app, db, ids = life_app
+    db.add_species_highlight("Northern Cardinal", ids["p1"])
+    db.add_species_highlight("Northern Cardinal", ids["p2"])
+
+    resp = app.test_client().post("/api/photo-preferences", json={
+        "purpose": "species_representative",
+        "species": "Northern Cardinal",
+        "photo_id": ids["p2"],
+    })
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["highlight_rank"] == 1
+
+    assert db.get_species_highlights("Northern Cardinal") == {
+        "Northern Cardinal": {ids["p2"]: 1, ids["p1"]: 2},
+    }
 
 
 def test_life_list_photo_preference_must_match_species(life_app):


### PR DESCRIPTION
## Summary
- Promote a newly selected species representative to rank 1 in that species' ordered highlights.
- Preserve existing highlights by shifting them down, and move an existing highlighted representative to the top without duplicating it.
- Add Life List/Highlights tests covering the new promotion behavior.

## Validation
- python -m pytest vireo/tests/test_life_list.py -q
- python -m pytest vireo/tests/test_app.py -q -k "photo_preferences or species_highlights or highlights_relabel or backfill_species_highlights or highlights_accepted_species_wins or highlights_scope_workspace or highlights_get_empty or highlights_buckets"