### PR TITLE
Apply batch review actions to selections

### DIFF
--- a/tests/e2e/test_burst_group_context_menu.py
+++ b/tests/e2e/test_burst_group_context_menu.py
@@ -280,6 +280,52 @@ def test_burst_multi_selected_cards_drag_together(live_server, page):
     assert abs(offsets["a"]["ty"]) > 0
 
 
+def test_burst_multi_selected_reject_shortcut_applies_to_selection(live_server, page):
+    """X in the review burst modal rejects every selected card."""
+    n = _seed_burst_group(live_server["db"])
+    if n < 2:
+        pytest.skip("need at least 2 burst cards")
+
+    url = live_server["url"]
+    page.goto(f"{url}/review")
+    page.wait_for_load_state("networkidle")
+    _open_burst_modal(page)
+
+    cards = page.locator("#grmOverlay .grm-card[data-photo-id]")
+    first_pid = cards.nth(0).get_attribute("data-photo-id")
+    second_pid = cards.nth(1).get_attribute("data-photo-id")
+    assert first_pid and second_pid
+
+    page.evaluate(
+        """() => {
+          grmState.picks.clear();
+          grmState.rejects.clear();
+          grmState.selected = null;
+          grmState.selectedIds.clear();
+          grmState.selectionAnchor = null;
+          renderGroupModal();
+        }"""
+    )
+
+    page.locator(f'#grmOverlay .grm-card[data-photo-id="{first_pid}"]').click()
+    page.locator(f'#grmOverlay .grm-card[data-photo-id="{second_pid}"]').click(modifiers=["Meta"])
+    selected = page.evaluate("Array.from(grmState.selectedIds).map(String).sort()")
+    assert selected == sorted([first_pid, second_pid])
+
+    page.keyboard.press("x")
+
+    state = page.evaluate(
+        """() => ({
+          rejects: Array.from(grmState.rejects).map(String).sort(),
+          picks: Array.from(grmState.picks).map(String).sort(),
+          selected: Array.from(grmState.selectedIds).map(String).sort(),
+        })"""
+    )
+    assert state["rejects"] == sorted([first_pid, second_pid])
+    assert not set(state["picks"]).intersection({first_pid, second_pid})
+    assert state["selected"] == sorted([first_pid, second_pid])
+
+
 def test_burst_loupe_drag_offsets_selected_cards_only(live_server, page):
     """Dragging the right preview should nudge only the selected burst cards."""
     n = _seed_burst_group(live_server["db"])

--- a/tests/e2e/test_pipeline_rapid_review.py
+++ b/tests/e2e/test_pipeline_rapid_review.py
@@ -886,6 +886,96 @@ def test_classic_pipeline_review_group_shortcuts_do_not_flag_prior_single_photo(
     assert stale_flag_payloads == []
 
 
+def test_classic_pipeline_review_group_reject_shortcut_applies_to_multiselection(live_server, page):
+    image_body = base64.b64decode(_PNG_1X1)
+    results = {
+        "photos": [
+            {"id": 1, "filename": "burst-a.jpg", "label": "REVIEW", "quality_composite": 0.3, "subject_tenengrad": 10},
+            {"id": 2, "filename": "burst-b.jpg", "label": "REVIEW", "quality_composite": 0.6, "subject_tenengrad": 20},
+            {"id": 3, "filename": "burst-c.jpg", "label": "REVIEW", "quality_composite": 0.9, "subject_tenengrad": 30},
+        ],
+        "encounters": [
+            {
+                "photo_ids": [1, 2, 3],
+                "photo_count": 3,
+                "burst_count": 1,
+                "species": ["Test bird"],
+                "bursts": [{"photo_ids": [1, 2, 3]}],
+            }
+        ],
+        "summary": {
+            "total_photos": 3,
+            "encounter_count": 1,
+            "burst_count": 1,
+            "keep_count": 0,
+            "review_count": 3,
+            "reject_count": 0,
+        },
+    }
+
+    page.route(
+        "**/api/pipeline/page-init",
+        lambda route: route.fulfill(
+            json={
+                "results": results,
+                "workspace_overrides": {},
+                "review_readiness": {"state": "ready", "total_photos": 3},
+            }
+        ),
+    )
+    page.route(
+        "**/api/pipeline/group/state",
+        lambda route: route.fulfill(
+            json={
+                "photos": {
+                    "1": {"flag": "none", "has_species_keyword": False},
+                    "2": {"flag": "none", "has_species_keyword": False},
+                    "3": {"flag": "none", "has_species_keyword": False},
+                },
+                "species_kid": None,
+            }
+        ),
+    )
+    page.route("**/thumbnails/*.jpg", lambda route: route.fulfill(body=image_body, content_type="image/png"))
+    page.route("**/photos/*/preview?*", lambda route: route.fulfill(body=image_body, content_type="image/png"))
+    page.route("**/photos/*/original", lambda route: route.fulfill(body=image_body, content_type="image/png"))
+
+    page.goto(f"{live_server['url']}/pipeline/review")
+    page.locator(".photo-card[data-photo-id='1'] img").click()
+    expect(page.locator("#grmOverlay")).to_have_class(re.compile(r"\bopen\b"))
+    expect(page.locator("#grmTitle")).to_have_text("Review Burst Group")
+    expect(page.locator("#grmApplyBtn")).to_be_enabled()
+
+    page.evaluate(
+        """() => {
+          grmState.picks.clear();
+          grmState.rejects.clear();
+          grmState.selected = null;
+          grmState.selectedIds.clear();
+          grmState.selectionAnchor = null;
+          renderGroupModal();
+        }"""
+    )
+
+    page.locator('#grmOverlay .grm-card[data-photo-id="1"]').click()
+    page.locator('#grmOverlay .grm-card[data-photo-id="2"]').click(modifiers=["Meta"])
+    page.keyboard.press("x")
+
+    expect(page.locator("#grmCount")).to_have_text("0 picks, 2 rejects, 1 unsorted")
+    state = page.evaluate(
+        """() => ({
+          rejects: Array.from(grmState.rejects).sort(),
+          picks: Array.from(grmState.picks).sort(),
+          selected: Array.from(grmState.selectedIds).sort(),
+          touched: Array.from(grmState.touched || []).sort(),
+        })"""
+    )
+    assert state["rejects"] == [1, 2]
+    assert not set(state["picks"]).intersection({1, 2})
+    assert state["selected"] == [1, 2]
+    assert state["touched"] == [1, 2]
+
+
 def test_rapid_review_apply_tags_all_burst_frames_via_encounters_species(live_server, page):
     # A multi-frame burst where only ONE frame is a pick. Species tagging must
     # cover EVERY frame (matching the pipeline decision / the grid), so the

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -5753,61 +5753,100 @@ function _grmMarkTouched(photoId) {
   if (photoId) grmState.touched.add(photoId);
 }
 
-function grmMoveUp() {
-  if (!grmState.selected) return;
-  _grmMarkTouched(grmState.selected);
-  var zone = _grmGetZone(grmState.selected);
-  if (zone === 'rejects') {
-    grmState.rejects.delete(grmState.selected);
-  } else if (zone === 'candidates') {
-    grmState.picks.add(grmState.selected);
+function _grmActionTargetIds() {
+  var visible = {};
+  _grmVisibleItems().forEach(function(p) { visible[p.id] = true; });
+  var ids = [];
+  if (grmState.selectedIds && grmState.selectedIds.size) {
+    grmState.selectedIds.forEach(function(id) {
+      var photoId = parseInt(id, 10);
+      if (visible[photoId] && ids.indexOf(photoId) === -1) ids.push(photoId);
+    });
   }
+  if (!ids.length && grmState.selected) {
+    var selectedId = parseInt(grmState.selected, 10);
+    if (visible[selectedId]) ids.push(selectedId);
+  }
+  return ids;
+}
+
+function _grmMarkTouchedMany(photoIds) {
+  photoIds.forEach(function(photoId) { _grmMarkTouched(photoId); });
+}
+
+function grmMoveUp() {
+  var ids = _grmActionTargetIds();
+  if (!ids.length) return;
+  _grmMarkTouchedMany(ids);
+  ids.forEach(function(photoId) {
+    var zone = _grmGetZone(photoId);
+    if (zone === 'rejects') {
+      grmState.rejects.delete(photoId);
+    } else if (zone === 'candidates') {
+      grmState.picks.add(photoId);
+    }
+  });
   renderGroupModal();
 }
 
 function grmMoveDown() {
-  if (!grmState.selected) return;
-  _grmMarkTouched(grmState.selected);
-  var zone = _grmGetZone(grmState.selected);
-  if (zone === 'picks') {
-    grmState.picks.delete(grmState.selected);
-  } else if (zone === 'candidates') {
-    grmState.rejects.add(grmState.selected);
-  }
+  var ids = _grmActionTargetIds();
+  if (!ids.length) return;
+  _grmMarkTouchedMany(ids);
+  ids.forEach(function(photoId) {
+    var zone = _grmGetZone(photoId);
+    if (zone === 'picks') {
+      grmState.picks.delete(photoId);
+    } else if (zone === 'candidates') {
+      grmState.rejects.add(photoId);
+    }
+  });
   renderGroupModal();
 }
 
 function grmMovePick() {
-  if (!grmState.selected) return;
-  _grmMarkTouched(grmState.selected);
-  grmState.rejects.delete(grmState.selected);
-  grmState.picks.add(grmState.selected);
+  var ids = _grmActionTargetIds();
+  if (!ids.length) return;
+  _grmMarkTouchedMany(ids);
+  ids.forEach(function(photoId) {
+    grmState.rejects.delete(photoId);
+    grmState.picks.add(photoId);
+  });
   renderGroupModal();
 }
 
 function grmMoveReject() {
-  if (!grmState.selected) return;
-  _grmMarkTouched(grmState.selected);
-  grmState.picks.delete(grmState.selected);
-  grmState.rejects.add(grmState.selected);
+  var ids = _grmActionTargetIds();
+  if (!ids.length) return;
+  _grmMarkTouchedMany(ids);
+  ids.forEach(function(photoId) {
+    grmState.picks.delete(photoId);
+    grmState.rejects.add(photoId);
+  });
   renderGroupModal();
 }
 
 function grmMoveCandidate() {
-  if (!grmState.selected) return;
-  _grmMarkTouched(grmState.selected);
-  grmState.picks.delete(grmState.selected);
-  grmState.rejects.delete(grmState.selected);
+  var ids = _grmActionTargetIds();
+  if (!ids.length) return;
+  _grmMarkTouchedMany(ids);
+  ids.forEach(function(photoId) {
+    grmState.picks.delete(photoId);
+    grmState.rejects.delete(photoId);
+  });
   renderGroupModal();
 }
 
 function grmRemoveFromGroup() {
   if (grmState && grmState.allowRemove === false) return;
-  if (!grmState.selected) return;
-  _grmMarkTouched(grmState.selected);
-  grmState.removed.add(grmState.selected);
-  grmState.picks.delete(grmState.selected);
-  grmState.rejects.delete(grmState.selected);
+  var ids = _grmActionTargetIds();
+  if (!ids.length) return;
+  _grmMarkTouchedMany(ids);
+  ids.forEach(function(photoId) {
+    grmState.removed.add(photoId);
+    grmState.picks.delete(photoId);
+    grmState.rejects.delete(photoId);
+  });
   grmState.selected = null;
   if (grmState.selectedIds) grmState.selectedIds.clear();
   grmState.selectionAnchor = null;

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1522,10 +1522,10 @@ document.addEventListener('contextmenu', function(e) {
  * names, different closest() matches.
  *
  * Critical: grmMovePick / grmMoveReject / grmMoveCandidate / grmRemoveFromGroup
- * all operate on grmState.selected. On right-click we force the clicked card
- * to be the primary selection before opening the menu. If the clicked card is
- * already part of a multi-selection, preserve that set so drag alignment state
- * is not lost.
+ * all operate on the active selection. On right-click we force the clicked
+ * card to be the primary selection before opening the menu. If the clicked
+ * card is already part of a multi-selection, preserve that set so drag
+ * alignment state and batch actions are not lost.
  */
 function buildBurstGroupContextMenu(photoId, filename) {
   var rateChip = function(n) {
@@ -2722,62 +2722,97 @@ function _grmGetZone(photoId) {
   return 'candidates';
 }
 
-function grmMoveUp() {
-  if (!grmState.selected) return;
-  var zone = _grmGetZone(grmState.selected);
-  if (zone === 'rejects') {
-    // rejects → candidates
-    grmState.rejects.delete(grmState.selected);
-  } else if (zone === 'candidates') {
-    // candidates → picks
-    grmState.picks.add(grmState.selected);
+function _grmActionTargetIds() {
+  var visible = {};
+  _grmVisibleItems().forEach(function(it) { visible[it.photo_id] = true; });
+  var ids = [];
+  if (grmState.selectedIds && grmState.selectedIds.size) {
+    grmState.selectedIds.forEach(function(id) {
+      var photoId = parseInt(id, 10);
+      if (visible[photoId] && ids.indexOf(photoId) === -1) ids.push(photoId);
+    });
   }
-  // already in picks — do nothing
+  if (!ids.length && grmState.selected) {
+    var selectedId = parseInt(grmState.selected, 10);
+    if (visible[selectedId]) ids.push(selectedId);
+  }
+  return ids;
+}
+
+function grmMoveUp() {
+  var ids = _grmActionTargetIds();
+  if (!ids.length) return;
+  ids.forEach(function(photoId) {
+    var zone = _grmGetZone(photoId);
+    if (zone === 'rejects') {
+      // rejects → candidates
+      grmState.rejects.delete(photoId);
+    } else if (zone === 'candidates') {
+      // candidates → picks
+      grmState.picks.add(photoId);
+    }
+    // already in picks — do nothing
+  });
   renderGroupModal();
 }
 
 function grmMoveDown() {
-  if (!grmState.selected) return;
-  var zone = _grmGetZone(grmState.selected);
-  if (zone === 'picks') {
-    // picks → candidates
-    grmState.picks.delete(grmState.selected);
-  } else if (zone === 'candidates') {
-    // candidates → rejects
-    grmState.rejects.add(grmState.selected);
-  }
-  // already in rejects — do nothing
+  var ids = _grmActionTargetIds();
+  if (!ids.length) return;
+  ids.forEach(function(photoId) {
+    var zone = _grmGetZone(photoId);
+    if (zone === 'picks') {
+      // picks → candidates
+      grmState.picks.delete(photoId);
+    } else if (zone === 'candidates') {
+      // candidates → rejects
+      grmState.rejects.add(photoId);
+    }
+    // already in rejects — do nothing
+  });
   renderGroupModal();
 }
 
 function grmMovePick() {
-  if (!grmState.selected) return;
-  grmState.rejects.delete(grmState.selected);
-  grmState.picks.add(grmState.selected);
+  var ids = _grmActionTargetIds();
+  if (!ids.length) return;
+  ids.forEach(function(photoId) {
+    grmState.rejects.delete(photoId);
+    grmState.picks.add(photoId);
+  });
   renderGroupModal();
 }
 
 function grmMoveReject() {
-  if (!grmState.selected) return;
-  grmState.picks.delete(grmState.selected);
-  grmState.rejects.add(grmState.selected);
+  var ids = _grmActionTargetIds();
+  if (!ids.length) return;
+  ids.forEach(function(photoId) {
+    grmState.picks.delete(photoId);
+    grmState.rejects.add(photoId);
+  });
   renderGroupModal();
 }
 
 function grmMoveCandidate() {
-  if (!grmState.selected) return;
-  grmState.picks.delete(grmState.selected);
-  grmState.rejects.delete(grmState.selected);
+  var ids = _grmActionTargetIds();
+  if (!ids.length) return;
+  ids.forEach(function(photoId) {
+    grmState.picks.delete(photoId);
+    grmState.rejects.delete(photoId);
+  });
   renderGroupModal();
 }
 
 function grmRemoveFromGroup() {
-  if (!grmState.selected) return;
-  // Find the prediction id
-  var item = grmState.items.find(function(it) { return it.photo_id === grmState.selected; });
-  if (item) grmState.removed.add(item.id);
-  grmState.picks.delete(grmState.selected);
-  grmState.rejects.delete(grmState.selected);
+  var ids = _grmActionTargetIds();
+  if (!ids.length) return;
+  ids.forEach(function(photoId) {
+    // Find the prediction id
+    var item = grmState.items.find(function(it) { return it.photo_id === photoId; });
+    if (item) grmState.removed.add(item.id);
+    grmState.picks.delete(photoId);
+    grmState.rejects.delete(photoId);
+  });
   grmState.selected = null;
   if (grmState.selectedIds) grmState.selectedIds.clear();
   grmState.selectionAnchor = null;
@@ -2873,6 +2908,8 @@ document.addEventListener('keydown', function(e) {
   if (e.key === ' ') { grmMoveCandidate(); e.preventDefault(); return; }
   if (e.key === '1') { grmSnapOneToOne(); e.preventDefault(); return; }
   if (e.key && e.key.toLowerCase() === 'z') { grmToggleLoupeOneToOne(); e.preventDefault(); return; }
+  if (e.key && e.key.toLowerCase() === 'p' && !e.ctrlKey && !e.metaKey && !e.altKey) { grmMovePick(); e.preventDefault(); return; }
+  if (e.key && e.key.toLowerCase() === 'x' && !e.ctrlKey && !e.metaKey && !e.altKey) { grmMoveReject(); e.preventDefault(); return; }
 });
 
 </script>


### PR DESCRIPTION
## Summary
- Applies group review pick, reject, candidate, and remove actions to every selected photo instead of only the active card.
- Adds P/X shortcut handling in classify review and preserves pipeline review touched-state for batch decisions.
- Covers the multi-selected X flow in both review and pipeline review Playwright tests.

## Tests
- python -m pytest tests/e2e/test_burst_group_context_menu.py
- python -m pytest tests/e2e/test_pipeline_rapid_review.py::test_classic_pipeline_review_single_photo_opens_review_modal tests/e2e/test_pipeline_rapid_review.py::test_classic_pipeline_review_group_shortcuts_do_not_flag_prior_single_photo tests/e2e/test_pipeline_rapid_review.py::test_classic_pipeline_review_group_reject_shortcut_applies_to_multiselection
- git diff --check