### PR TITLE
Fix burst Open in Browse action

### DIFF
--- a/tests/e2e/test_burst_group_confirm_split.py
+++ b/tests/e2e/test_burst_group_confirm_split.py
@@ -152,6 +152,13 @@ def _open_burst_modal(page, live_server):
     expect(page.locator("#grmApplyBtn")).to_be_enabled()
 
 
+def _dispatch_contextmenu(locator):
+    locator.evaluate(
+        "el => el.dispatchEvent(new MouseEvent('contextmenu', "
+        "{clientX: 100, clientY: 100, bubbles: true, cancelable: true}))"
+    )
+
+
 def _photo_flags(live_server, photo_ids):
     db = live_server["db"]
     placeholders = ",".join("?" for _ in photo_ids)
@@ -185,6 +192,36 @@ def _tag_all(live_server, photo_ids, species):
     for pid in photo_ids:
         db.tag_photo(pid, kid)
     return kid
+
+
+def test_pipeline_burst_context_open_browse_falls_back_to_current_window(live_server, page):
+    """Open in Browse Mode must still navigate when window.open is ignored."""
+    photo_ids = live_server["data"]["photos"][0:3]
+    _write_single_burst_cache(live_server, photo_ids)
+
+    _open_burst_modal(page, live_server)
+    cards = page.locator("#grmOverlay .grm-card[data-photo-id]")
+    assert cards.count() >= 2
+    target = cards.nth(1)
+    target_pid = target.get_attribute("data-photo-id")
+    assert target_pid
+
+    page.evaluate("() => { window.open = () => null; }")
+    _dispatch_contextmenu(target)
+
+    selected = page.evaluate("String(grmState.selected)")
+    assert selected == target_pid
+
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+    menu.locator(".vireo-ctx-item", has_text="Open in Browse Mode").click()
+
+    page.wait_for_function(
+        "expectedPid => location.pathname === '/browse'"
+        " && new URLSearchParams(location.search).get('photo_id') === expectedPid",
+        arg=target_pid,
+        timeout=5000,
+    )
 
 
 def test_smart_default_flags_checked_when_moves_pending(live_server, page):

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -2137,7 +2137,13 @@ function sendReport() {
     if (typeof isTauri === 'function' && isTauri()) {
       window.location.href = url;
     } else {
-      window.open(url, '_blank', 'noopener');
+      var opened = window.open('about:blank', '_blank');
+      if (!opened) {
+        window.location.href = url;
+        return;
+      }
+      try { opened.opener = null; } catch (e) {}
+      opened.location = url;
     }
   };
 })();

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -5869,6 +5869,15 @@ document.addEventListener('contextmenu', function(e) {
   var pid = parseInt(card.dataset.photoId, 10);
   if (!pid) return;
   e.preventDefault();
+  if (card.classList.contains('grm-card') && typeof grmState !== 'undefined' && grmState) {
+    grmState.selected = pid;
+    if (!grmState.selectedIds) grmState.selectedIds = new Set();
+    if (!grmState.selectedIds.has(pid)) {
+      grmState.selectedIds = new Set([pid]);
+    }
+    grmState.selectionAnchor = pid;
+    renderGroupModal();
+  }
   if (typeof openContextMenu === 'function') {
     openContextMenu(e, buildPipelinePhotoContextMenu(pid));
   } else {

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -5870,6 +5870,7 @@ document.addEventListener('contextmenu', function(e) {
   if (!pid) return;
   e.preventDefault();
   if (card.classList.contains('grm-card') && typeof grmState !== 'undefined' && grmState) {
+    var prevSelected = grmState.selected;
     grmState.selected = pid;
     if (!grmState.selectedIds) grmState.selectedIds = new Set();
     if (!grmState.selectedIds.has(pid)) {
@@ -5877,6 +5878,11 @@ document.addEventListener('contextmenu', function(e) {
     }
     grmState.selectionAnchor = pid;
     renderGroupModal();
+    // Keep the right-hand loupe in sync with the newly selected card so it
+    // doesn't stay on the previous photo if the user dismisses the menu.
+    if (prevSelected !== pid && typeof grmRefreshSelectedLoupe === 'function') {
+      grmRefreshSelectedLoupe();
+    }
   }
   if (typeof openContextMenu === 'function') {
     openContextMenu(e, buildPipelinePhotoContextMenu(pid));


### PR DESCRIPTION
Fixes the burst-review Open in Browse Mode path so it no longer appears to do nothing when the browser or webview ignores a new-window open. The Pipeline Review burst context menu now syncs the active GRM selection to the right-clicked frame before running menu actions. The shared Browse opener now falls back to same-window navigation if a new tab cannot be opened. Validated with the burst confirm/split E2E suite, targeted burst context menu checks, and git diff --check.