### PR TITLE
Add global species photo actions

### DIFF
--- a/tests/e2e/test_lightbox_context_menu.py
+++ b/tests/e2e/test_lightbox_context_menu.py
@@ -71,6 +71,84 @@ def test_lightbox_right_click_opens_menu(live_server, page):
     assert menu.locator(".vireo-ctx-chip").count() > 5
 
 
+def test_lightbox_menu_sets_species_representative(live_server, page):
+    """The shared lightbox menu can set the current photo as representative."""
+    url = live_server["url"]
+    hawk = live_server["data"]["photos"][0]
+    _open_lightbox(page, url)
+    page.wait_for_function(
+        """() => {
+            const id = window._lightboxCurrentId;
+            const data = window._lbPhotoDataByPhoto && window._lbPhotoDataByPhoto[String(id)];
+            return data && data.life_list && data.life_list.length > 0;
+        }""",
+        timeout=3000,
+    )
+
+    _fire_contextmenu_on_lightbox(page)
+    item = page.locator(
+        ".vireo-ctx-item",
+        has_text="Set Representative — Red-tailed Hawk",
+    )
+    expect(item).to_be_visible()
+    with page.expect_response(
+        lambda r: "/api/photo-preferences" in r.url and r.status == 200
+    ):
+        item.click()
+
+    life_list = page.evaluate(
+        """async (pid) => {
+            const r = await fetch('/api/photos/' + pid);
+            const d = await r.json();
+            return d.life_list;
+        }""",
+        hawk,
+    )
+    assert life_list[0]["is_current_photo"] is True
+    assert life_list[0]["is_species_representative"] is True
+
+
+def test_lightbox_menu_adds_species_highlight(live_server, page):
+    """The shared lightbox menu can add the current photo to Highlights."""
+    db = live_server["db"]
+    url = live_server["url"]
+    hawk = live_server["data"]["photos"][0]
+    db.conn.execute("UPDATE photos SET quality_score = 0.9 WHERE id = ?", (hawk,))
+    db.conn.commit()
+
+    _open_lightbox(page, url)
+    page.wait_for_function(
+        """() => {
+            const id = window._lightboxCurrentId;
+            const data = window._lbPhotoDataByPhoto && window._lbPhotoDataByPhoto[String(id)];
+            return data && data.highlight_list && data.highlight_list.length > 0;
+        }""",
+        timeout=3000,
+    )
+
+    _fire_contextmenu_on_lightbox(page)
+    item = page.locator(
+        ".vireo-ctx-item",
+        has_text="Add to Highlights — Red-tailed Hawk",
+    )
+    expect(item).to_be_visible()
+    with page.expect_response(
+        lambda r: "/api/species-highlights" in r.url and r.status == 200
+    ):
+        item.click()
+
+    highlight_list = page.evaluate(
+        """async (pid) => {
+            const r = await fetch('/api/photos/' + pid);
+            const d = await r.json();
+            return d.highlight_list;
+        }""",
+        hawk,
+    )
+    assert highlight_list[0]["is_highlighted"] is True
+    assert highlight_list[0]["highlight_rank"] == 1
+
+
 def test_lightbox_overlay_toggles_persist_and_context_restores(live_server, page):
     """Lightbox overlay visibility toggles persist and stay recoverable.
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -400,18 +400,24 @@ def _apply_ordered_highlights(db, buckets):
 
 
 def _photo_highlight_entries(db, photo_id):
-    """Return highlight-eligible species entries for one visible photo."""
-    candidates = db.get_highlights_candidates(None, min_quality=0.0)
+    """Return highlight-eligible species entries for one visible photo.
+
+    Restricts both the candidate scan and the species-highlights lookup to
+    the requested photo so the photo-detail endpoint doesn't rebuild every
+    workspace bucket for each call (browse detail, lightbox, batch actions).
+    """
+    candidates = db.get_highlights_candidates(
+        None, min_quality=0.0, photo_id=photo_id
+    )
     buckets, _unidentified = _collect_highlight_buckets(
         candidates, confidence_threshold=0.0
     )
-    highlights = db.get_species_highlights()
     entries = []
     for bucket in buckets:
         species = bucket.get("species")
         if not species:
             continue
-        ranks = highlights.get(species, {})
+        ranks = db.get_species_highlights(species).get(species, {})
         for photo in bucket.get("photos") or []:
             if photo.get("id") != photo_id:
                 continue

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -399,6 +399,33 @@ def _apply_ordered_highlights(db, buckets):
         bucket["best_timestamp"] = best.get("timestamp")
 
 
+def _photo_highlight_entries(db, photo_id):
+    """Return highlight-eligible species entries for one visible photo."""
+    candidates = db.get_highlights_candidates(None, min_quality=0.0)
+    buckets, _unidentified = _collect_highlight_buckets(
+        candidates, confidence_threshold=0.0
+    )
+    highlights = db.get_species_highlights()
+    entries = []
+    for bucket in buckets:
+        species = bucket.get("species")
+        if not species:
+            continue
+        ranks = highlights.get(species, {})
+        for photo in bucket.get("photos") or []:
+            if photo.get("id") != photo_id:
+                continue
+            rank = ranks.get(photo_id)
+            entries.append({
+                "species": species,
+                "is_highlighted": rank is not None,
+                "highlight_rank": rank,
+                "is_confirmed": bool(photo.get("has_accepted_species")),
+            })
+            break
+    return entries
+
+
 def _highlight_confidence_label(confidence, is_accepted):
     if is_accepted:
         return "confirmed"
@@ -3771,6 +3798,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             for s in db.get_photo_life_list_species(photo_id)
         ]
         result["species_representatives"] = result["life_list"]
+        result["highlight_list"] = _photo_highlight_entries(db, photo_id)
 
         # Location section: pre-resolved leaf + parent chain so the photo
         # detail panel can render the filled state without a second roundtrip.

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -9487,12 +9487,15 @@ class Database:
                 result.setdefault(r["photo_id"], []).append(r["name"])
         return result
 
-    def get_highlights_candidates(self, folder_id, min_quality=0.0):
+    def get_highlights_candidates(self, folder_id, min_quality=0.0, photo_id=None):
         """Return photos eligible for highlights selection.
 
         When ``folder_id`` is an int, returns photos in that folder and its
         descendant folders. When ``folder_id`` is ``None``, returns photos
-        across every folder visible in the active workspace.
+        across every folder visible in the active workspace. When
+        ``photo_id`` is set, the result is additionally restricted to that
+        single photo so the photo-detail endpoint can compute its highlight
+        eligibility without rebuilding every workspace bucket.
 
         Each row carries:
           * ``species`` — accepted species keyword (NULL if none accepted)
@@ -9515,6 +9518,12 @@ class Database:
             placeholders = ",".join("?" for _ in subtree)
             folder_filter = f"AND p.folder_id IN ({placeholders})"
             folder_params = tuple(subtree)
+        if photo_id is None:
+            photo_filter = ""
+            photo_params = ()
+        else:
+            photo_filter = "AND p.id = ?"
+            photo_params = (photo_id,)
         rows = self.conn.execute(
             f"""SELECT p.id, p.folder_id, p.filename, p.extension,
                       p.timestamp, p.width, p.height, p.rating, p.flag,
@@ -9583,11 +9592,12 @@ class Database:
                ) kw ON kw.photo_id = p.id
                WHERE wf.workspace_id = ?
                  {folder_filter}
+                 {photo_filter}
                  AND p.quality_score IS NOT NULL
                  AND p.quality_score >= ?
                  AND (p.flag IS NULL OR p.flag != 'rejected')
                ORDER BY p.quality_score DESC""",
-            (ws, ws, *folder_params, min_quality),
+            (ws, ws, *folder_params, *photo_params, min_quality),
         ).fetchall()
         return rows
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -9521,9 +9521,24 @@ class Database:
         if photo_id is None:
             photo_filter = ""
             photo_params = ()
+            bp_filter = ""
+            bp_params = ()
+            tp_filter = ""
+            tp_params = ()
+            kw_filter = ""
+            kw_params = ()
         else:
             photo_filter = "AND p.id = ?"
             photo_params = (photo_id,)
+            # Push the single-photo predicate into every derived subquery so
+            # SQLite never materializes workspace-wide keyword/prediction
+            # aggregations just to discard them at the outer join.
+            bp_filter = "AND pk.photo_id = ?"
+            bp_params = (photo_id,)
+            tp_filter = "AND d.photo_id = ?"
+            tp_params = (photo_id,)
+            kw_filter = "WHERE pk.photo_id = ?"
+            kw_params = (photo_id,)
         rows = self.conn.execute(
             f"""SELECT p.id, p.folder_id, p.filename, p.extension,
                       p.timestamp, p.width, p.height, p.rating, p.flag,
@@ -9553,7 +9568,8 @@ class Database:
                               ) AS rn
                        FROM photo_keywords pk
                        JOIN keywords k ON k.id = pk.keyword_id
-                       WHERE k.is_species = 1 OR k.type = 'taxonomy'
+                       WHERE (k.is_species = 1 OR k.type = 'taxonomy')
+                         {bp_filter}
                    ) WHERE rn = 1
                ) bp ON bp.photo_id = p.id
                LEFT JOIN (
@@ -9581,6 +9597,7 @@ class Database:
                              ORDER BY pr2.created_at DESC, pr2.id DESC
                              LIMIT 1
                          )
+                         {tp_filter}
                    ) WHERE rn = 1
                ) tp ON tp.photo_id = p.id
                LEFT JOIN (
@@ -9588,6 +9605,7 @@ class Database:
                           group_concat(DISTINCT k.name) AS keyword_names
                    FROM photo_keywords pk
                    JOIN keywords k ON k.id = pk.keyword_id
+                   {kw_filter}
                    GROUP BY pk.photo_id
                ) kw ON kw.photo_id = p.id
                WHERE wf.workspace_id = ?
@@ -9597,7 +9615,16 @@ class Database:
                  AND p.quality_score >= ?
                  AND (p.flag IS NULL OR p.flag != 'rejected')
                ORDER BY p.quality_score DESC""",
-            (ws, ws, *folder_params, *photo_params, min_quality),
+            (
+                *bp_params,
+                ws,
+                *tp_params,
+                *kw_params,
+                ws,
+                *folder_params,
+                *photo_params,
+                min_quality,
+            ),
         ).fetchall()
         return rows
 

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3657,6 +3657,204 @@ async function setLifeListPhoto(species, photoId, button) {
     if (button) button.disabled = false;
   }
 }
+window.setLifeListPhoto = setLifeListPhoto;
+
+function _lifeListEntriesFromPhotoLike(photo) {
+  if (!photo) return [];
+  if (Array.isArray(photo.life_list)) {
+    return photo.life_list.filter(function(entry) {
+      return entry && entry.species;
+    });
+  }
+  if (Array.isArray(photo.species)) {
+    if (photo.flag === 'rejected') return [];
+    return photo.species.filter(Boolean).map(function(species) {
+      return { species: species, is_current_photo: false, is_species_representative: false };
+    });
+  }
+  if (typeof photo.species === 'string' && photo.species && photo.flag !== 'rejected') {
+    return [{ species: photo.species, is_current_photo: false, is_species_representative: false }];
+  }
+  return [];
+}
+
+function _lifeListMenuEntriesForPhotoId(photoId, opts) {
+  opts = opts || {};
+  var photo = null;
+  if (typeof opts.getPhoto === 'function') {
+    photo = opts.getPhoto(photoId);
+  }
+  if (!photo && opts.photoById) {
+    photo = opts.photoById[String(photoId)] || opts.photoById[photoId];
+  }
+  return _lifeListEntriesFromPhotoLike(photo);
+}
+
+async function chooseSpeciesRepresentativeForPhoto(photoId) {
+  if (!photoId) return;
+  var data;
+  try {
+    data = await window.safeFetch('/api/photos/' + photoId);
+  } catch (err) {
+    return;
+  }
+  var entries = _lifeListEntriesFromPhotoLike(data);
+  if (!entries.length) {
+    if (typeof showToast === 'function') {
+      showToast('No eligible species keyword on this photo', 'warning');
+    }
+    return;
+  }
+  var entry = entries[0];
+  if (entries.length > 1) {
+    var names = entries.map(function(e) { return e.species; });
+    var choice = window.prompt('Set as representative for which species?\n' + names.join('\n'), names[0]);
+    if (!choice) return;
+    entry = entries.find(function(e) { return e.species === choice; }) || { species: choice };
+  }
+  await setLifeListPhoto(entry.species, photoId);
+}
+window.chooseSpeciesRepresentativeForPhoto = chooseSpeciesRepresentativeForPhoto;
+
+window.buildSpeciesRepresentativeMenuItems = function(photoIds, opts) {
+  opts = opts || {};
+  photoIds = (photoIds || []).filter(function(id) { return id != null; });
+  if (!photoIds.length) return [];
+  if (photoIds.length !== 1) {
+    var anyEligible = photoIds.some(function(id) {
+      return _lifeListMenuEntriesForPhotoId(id, opts).length > 0;
+    });
+    if (!anyEligible && !opts.showFetchFallback) return [];
+    return [{
+      label: 'Set Representative',
+      disabled: true,
+      disabledHint: 'Select a single photo',
+    }];
+  }
+  var photoId = photoIds[0];
+  var entries = _lifeListMenuEntriesForPhotoId(photoId, opts);
+  if (entries.length) {
+    return entries.map(function(entry) {
+      return {
+        label: 'Set Representative \u2014 ' + entry.species,
+        disabled: !!entry.is_current_photo,
+        disabledHint: entry.is_current_photo ? 'Already representative' : undefined,
+        onClick: function() { setLifeListPhoto(entry.species, photoId); },
+      };
+    });
+  }
+  if (!opts.showFetchFallback) return [];
+  return [{
+    label: 'Set Representative\u2026',
+    onClick: function() { chooseSpeciesRepresentativeForPhoto(photoId); },
+  }];
+};
+
+function _highlightEntriesFromPhotoLike(photo) {
+  if (!photo) return [];
+  if (Array.isArray(photo.highlight_list)) {
+    return photo.highlight_list.filter(function(entry) {
+      return entry && entry.species;
+    });
+  }
+  return [];
+}
+
+function _highlightMenuEntriesForPhotoId(photoId, opts) {
+  opts = opts || {};
+  var photo = null;
+  if (typeof opts.getPhoto === 'function') {
+    photo = opts.getPhoto(photoId);
+  }
+  if (!photo && opts.photoById) {
+    photo = opts.photoById[String(photoId)] || opts.photoById[photoId];
+  }
+  return _highlightEntriesFromPhotoLike(photo);
+}
+
+async function setSpeciesHighlightFromMenu(species, photoId) {
+  if (!species || !photoId) return;
+  await window.safeFetch('/api/species-highlights', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ species: species, photo_id: photoId }),
+  });
+  try {
+    var fresh = await window.safeFetch('/api/photos/' + photoId, {}, { toast: false });
+    if (fresh && typeof _lbPhotoDataByPhoto !== 'undefined') {
+      _lbPhotoDataByPhoto[String(photoId)] = fresh;
+    }
+  } catch (e) {}
+  document.dispatchEvent(new CustomEvent('highlights:changed', {
+    detail: { species: species, photoId: photoId },
+  }));
+  if (typeof window.loadHighlights === 'function') {
+    await window.loadHighlights();
+    if (typeof window.updateHighlightsLightboxControls === 'function') {
+      window.updateHighlightsLightboxControls(photoId);
+    }
+  }
+  if (typeof showToast === 'function') {
+    showToast('Added to Highlights', 'success');
+  }
+}
+window.setSpeciesHighlightFromMenu = setSpeciesHighlightFromMenu;
+
+async function chooseSpeciesHighlightForPhoto(photoId) {
+  if (!photoId) return;
+  var data;
+  try {
+    data = await window.safeFetch('/api/photos/' + photoId);
+  } catch (err) {
+    return;
+  }
+  var entries = _highlightEntriesFromPhotoLike(data);
+  if (!entries.length) {
+    if (typeof showToast === 'function') {
+      showToast('No eligible highlight species on this photo', 'warning');
+    }
+    return;
+  }
+  var entry = entries[0];
+  if (entries.length > 1) {
+    var names = entries.map(function(e) { return e.species; });
+    var choice = window.prompt('Add as a highlight for which species?\n' + names.join('\n'), names[0]);
+    if (!choice) return;
+    entry = entries.find(function(e) { return e.species === choice; }) || { species: choice };
+  }
+  await setSpeciesHighlightFromMenu(entry.species, photoId);
+}
+window.chooseSpeciesHighlightForPhoto = chooseSpeciesHighlightForPhoto;
+
+window.buildSpeciesHighlightMenuItems = function(photoIds, opts) {
+  opts = opts || {};
+  photoIds = (photoIds || []).filter(function(id) { return id != null; });
+  if (!photoIds.length) return [];
+  if (photoIds.length !== 1) {
+    return [{
+      label: 'Add to Highlights',
+      disabled: true,
+      disabledHint: 'Select a single photo',
+    }];
+  }
+  var photoId = photoIds[0];
+  var entries = _highlightMenuEntriesForPhotoId(photoId, opts);
+  if (entries.length) {
+    return entries.map(function(entry) {
+      return {
+        label: (entry.is_highlighted ? 'Highlighted' : 'Add to Highlights') + ' \u2014 ' + entry.species,
+        disabled: !!entry.is_highlighted,
+        disabledHint: entry.is_highlighted ? 'Already highlighted' : undefined,
+        onClick: function() { setSpeciesHighlightFromMenu(entry.species, photoId); },
+      };
+    });
+  }
+  if (!opts.showFetchFallback) return [];
+  return [{
+    label: 'Add to Highlights\u2026',
+    onClick: function() { chooseSpeciesHighlightForPhoto(photoId); },
+  }];
+};
 
 document.addEventListener('lightbox:photochanged', function(event) {
   var pid = event.detail ? event.detail.photoId : null;
@@ -6828,6 +7026,17 @@ function buildLightboxContextMenu(pid) {
     onClick: function() {
       window.location.href = '/browse?photo_id=' + encodeURIComponent(pid);
     } });
+  if (typeof window.buildSpeciesHighlightMenuItems === 'function') {
+    items = items.concat(window.buildSpeciesHighlightMenuItems([pid], {
+      photoById: _lbPhotoDataByPhoto,
+      showFetchFallback: true,
+    }));
+  }
+  if (typeof window.buildSpeciesRepresentativeMenuItems === 'function') {
+    items = items.concat(window.buildSpeciesRepresentativeMenuItems([pid], {
+      photoById: _lbPhotoDataByPhoto,
+    }));
+  }
 
   if (has('findSimilar')) {
     items.push({ label: 'Find Similar',

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -7107,53 +7107,17 @@ function buildPhotoContextMenu(photoIds) {
     { separator: true },
     { label: 'Add Keyword\u2026', onClick: function() { batchAddKeyword(); } },
     { label: 'Add to Collection\u2026', onClick: function() { addToCollection(); } },
-  ]).concat(buildLifeListMenuItems(photoIds)).concat([
+  ]).concat(window.buildSpeciesHighlightMenuItems(photoIds, {
+    showFetchFallback: true,
+  })).concat(window.buildSpeciesRepresentativeMenuItems(photoIds, {
+    getPhoto: function(id) {
+      return photos.find(function(p) { return p.id === id; });
+    },
+  })).concat([
     { label: 'Adjust Capture Time\u2026', onClick: function() { openCaptureTimeModal(); } },
     { separator: true },
     { label: 'Delete', onClick: function() { batchDelete(); } },
   ]);
-}
-
-// "Set Representative" context-menu items. One photo can represent each
-// species in the active workspace. Disabled for a multi-selection because
-// crowning one shot from many is ambiguous; hidden entirely when nothing
-// selected has a species.
-// Rejected photos are excluded here too \u2014 they'd fail the server backstop
-// (`_photo_can_be_life_list_preference` rejects `flag = 'rejected'`) and only
-// produce an error toast, so don't offer the action in the first place.
-function _lifeListEligibleClient(p) {
-  return !!(p && p.species && p.species.length && p.flag !== 'rejected');
-}
-function buildLifeListMenuItems(photoIds) {
-  var anyEligible = photoIds.some(function(id) {
-    return _lifeListEligibleClient(photos.find(function(x) { return x.id === id; }));
-  });
-  if (!anyEligible) return [];
-  if (photoIds.length !== 1) {
-    return [{ label: 'Set Representative', disabled: true,
-              disabledHint: 'Select a single photo' }];
-  }
-  var photo = photos.find(function(p) { return p.id === photoIds[0]; });
-  if (!_lifeListEligibleClient(photo)) return [];
-  return (photo.species || []).map(function(sp) {
-    return {
-      label: 'Set Representative \u2014 ' + sp,
-      onClick: function() { addPhotoToLifeList(sp, photoIds[0]); },
-    };
-  });
-}
-
-function addPhotoToLifeList(species, photoId) {
-  if (!species || !photoId) return;
-  safeFetch('/api/photo-preferences', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ purpose: 'species_representative', species: species, photo_id: photoId }),
-  }).then(function() {
-    if (typeof showToast === 'function') {
-      showToast('Species representative set for ' + species, 'success');
-    }
-  });
 }
 
 // Document-level delegation: grids re-render on sort/filter/scroll, so

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -1284,6 +1284,15 @@ function buildMissContextMenu(photoId, cat, idx) {
       onClick: function() { openPhotoInBrowse(photoId); } },
     { label: 'Open in Lightbox',
       onClick: function() { openMiss(cat, idx); } },
+  ].concat(
+    typeof window.buildSpeciesHighlightMenuItems === 'function'
+      ? window.buildSpeciesHighlightMenuItems([photoId], { showFetchFallback: true })
+      : []
+  ).concat(
+    typeof window.buildSpeciesRepresentativeMenuItems === 'function'
+      ? window.buildSpeciesRepresentativeMenuItems([photoId], { showFetchFallback: true })
+      : []
+  ).concat([
     { separator: true },
     { label: 'Flag as Pick',
       onClick: function() { flagFocusedMiss(photoId, 'flagged'); } },
@@ -1291,7 +1300,7 @@ function buildMissContextMenu(photoId, cat, idx) {
       onClick: function() { flagFocusedMiss(photoId, 'rejected'); } },
     { label: 'Unmark Missed', disabled: previewActive,
       onClick: function() { unflagMiss(cat, photoId); } },
-  ];
+  ]);
 }
 
 document.addEventListener('contextmenu', function(e) {

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -5856,7 +5856,15 @@ function buildPipelinePhotoContextMenu(photoId) {
       label: 'Open in Browse Mode',
       onClick: function() { window.openInBrowse(photoId); },
     },
-  ];
+  ].concat(
+    typeof window.buildSpeciesHighlightMenuItems === 'function'
+      ? window.buildSpeciesHighlightMenuItems([photoId], { showFetchFallback: true })
+      : []
+  ).concat(
+    typeof window.buildSpeciesRepresentativeMenuItems === 'function'
+      ? window.buildSpeciesRepresentativeMenuItems([photoId], { showFetchFallback: true })
+      : []
+  );
 }
 
 /* --- Right-click menu ---

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1490,6 +1490,16 @@ function buildReviewCardContextMenu(pred) {
     label: 'Open in Lightbox',
     onClick: function() { openReviewLightbox(photoId, pred.filename); },
   });
+  if (typeof window.buildSpeciesHighlightMenuItems === 'function') {
+    items = items.concat(window.buildSpeciesHighlightMenuItems([photoId], {
+      showFetchFallback: true,
+    }));
+  }
+  if (typeof window.buildSpeciesRepresentativeMenuItems === 'function') {
+    items = items.concat(window.buildSpeciesRepresentativeMenuItems([photoId], {
+      showFetchFallback: true,
+    }));
+  }
   items.push({
     label: window.VIREO_REVEAL_LABEL,
     onClick: function() { revealReviewPhoto(photoId); },
@@ -1554,6 +1564,15 @@ function buildBurstGroupContextMenu(photoId, filename) {
     ] },
     { separator: true },
     { label: 'Open in Lightbox',        onClick: function() { openReviewLightbox(photoId, filename); } },
+  ].concat(
+    typeof window.buildSpeciesHighlightMenuItems === 'function'
+      ? window.buildSpeciesHighlightMenuItems([photoId], { showFetchFallback: true })
+      : []
+  ).concat(
+    typeof window.buildSpeciesRepresentativeMenuItems === 'function'
+      ? window.buildSpeciesRepresentativeMenuItems([photoId], { showFetchFallback: true })
+      : []
+  ).concat([
     { label: window.VIREO_REVEAL_LABEL, onClick: function() { revealReviewPhoto(photoId); } },
     { label: 'Copy Path',               onClick: function() { copyReviewPhotoPath(photoId); } },
     { separator: true },
@@ -1587,7 +1606,7 @@ function buildBurstGroupContextMenu(photoId, filename) {
           window.open(url, '_blank', 'noopener');
         }
       } },
-  ].concat(
+  ]).concat(
     typeof window.buildOpenInEditorMenuItems === 'function'
       ? window.buildOpenInEditorMenuItems([photoId])
       : []

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -9012,6 +9012,28 @@ def test_get_highlights_candidates_workspace_wide(tmp_path):
     assert filenames == {"day1.jpg", "day2.jpg"}
 
 
+def test_get_highlights_candidates_photo_id_restricts_query(tmp_path):
+    """photo_id filter returns only that photo's row, ignoring workspace peers."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    f = db.add_folder('/shoot', name='shoot')
+    p1 = db.add_photo(folder_id=f, filename='a.jpg', extension='.jpg',
+                      file_size=100, file_mtime=1.0)
+    p2 = db.add_photo(folder_id=f, filename='b.jpg', extension='.jpg',
+                      file_size=100, file_mtime=2.0)
+    db.conn.execute("UPDATE photos SET quality_score = 0.8 WHERE id IN (?, ?)",
+                    (p1, p2))
+    db.conn.commit()
+
+    only = db.get_highlights_candidates(folder_id=None, min_quality=0.0,
+                                        photo_id=p1)
+    assert [r["id"] for r in only] == [p1]
+
+    # Non-existent id yields no rows without erroring.
+    assert db.get_highlights_candidates(folder_id=None, min_quality=0.0,
+                                        photo_id=999999) == []
+
+
 def test_get_highlights_candidates_workspace_wide_isolates_workspaces(tmp_path):
     """folder_id=None must not leak photos from folders in other workspaces."""
     from db import Database


### PR DESCRIPTION
Adds shared context-menu actions for setting species representatives and adding species Highlights from photo surfaces across Browse, Lightbox, Review, Burst Review, Misses, and Pipeline Review. Exposes highlight eligibility in photo detail responses so those menus can use the same backend validation as the Highlights page. Reuses existing representative and ordered-highlight APIs, preserving stricter highlight eligibility and single-photo behavior. Validated with targeted lightbox/life-list e2e tests, the photo detail API suite, broader context-menu e2e coverage, and diff whitespace checks.