### PR TITLE
Fix RAW crop fallback to working copy

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -78,6 +78,9 @@ from render_source import (
 from render_source import (
     scaled_recipe_source_dimensions as _scaled_recipe_source_dimensions,
 )
+from render_source import (
+    working_copy_path_if_satisfies as _working_copy_path_if_satisfies,
+)
 from werkzeug.exceptions import BadRequest
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
@@ -17572,7 +17575,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # decode (the working copy was extracted from the embedded JPEG
         # at scan time).
         import config as cfg
-        from thumbnails import generate_thumbnail
+        from thumbnails import (
+            _retry_thumbnail_with_working_copy,
+            generate_thumbnail,
+        )
         vireo_dir = os.path.dirname(thumb_dir)
         # Look up the photo's folder path directly rather than via
         # ``get_folder_tree()``: the tree filter excludes folders whose
@@ -17679,6 +17685,23 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         )
                         if result:
                             source = companion_abs
+            if (
+                not result
+                and recipe
+                and os.path.splitext(source)[1].lower() in RAW_EXTENSIONS
+            ):
+                result = _retry_thumbnail_with_working_copy(
+                    db,
+                    photo,
+                    source,
+                    thumb_dir,
+                    thumb_size,
+                    cfg.load().get("thumbnail_quality", 85),
+                    recipe,
+                    vireo_dir,
+                )
+                if result:
+                    source = result
         except Exception:
             log.exception(
                 "Thumbnail self-heal failed for photo %s (source=%s)",
@@ -21295,6 +21318,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     img = load_image(companion_abs, max_size=load_max_size)
                     if img is not None:
                         canonical = companion_abs
+            if img is None:
+                wc_path = _working_copy_path_if_satisfies(
+                    photo, recipe, size, vireo_dir, rel_slack=0.01,
+                )
+                if wc_path and os.path.abspath(wc_path) != os.path.abspath(canonical):
+                    log.info(
+                        "RAW decode failed for photo %s preview at size=%s; "
+                        "falling back to JPEG working copy",
+                        photo_id, size,
+                    )
+                    _record_working_copy_failure(db, photo, canonical)
+                    img = load_image(wc_path, max_size=load_max_size)
+                    if img is not None:
+                        canonical = wc_path
         if img is None:
             _record_working_copy_failure(db, photo, canonical)
             return "Could not load image", 500

--- a/vireo/render_source.py
+++ b/vireo/render_source.py
@@ -276,6 +276,23 @@ def working_copy_satisfies_recipe_render(
     )
 
 
+def working_copy_path_if_satisfies(
+    photo, recipe, max_size, vireo_dir, *, rel_slack=0.0,
+):
+    """Return the working-copy path when it can satisfy this recipe render."""
+    wc_rel = photo_value(photo, "working_copy_path")
+    if not wc_rel or not vireo_dir:
+        return None
+    wc_path = wc_rel if os.path.isabs(wc_rel) else os.path.join(vireo_dir, wc_rel)
+    if not os.path.exists(wc_path):
+        return None
+    if not working_copy_satisfies_recipe_render(
+        photo, recipe, max_size, vireo_dir, rel_slack=rel_slack,
+    ):
+        return None
+    return wc_path
+
+
 def path_satisfies_recipe_render(path, photo, recipe, max_size):
     """Return True when the file at ``path`` is large enough for this render."""
     original_w, original_h = recipe_source_dimensions(photo)
@@ -372,8 +389,10 @@ def recipe_render_source(photo, recipe, max_size, vireo_dir, folders):
     if source_failure_current and working_copy_satisfies_recipe_render(
         photo, recipe, max_size, vireo_dir, rel_slack=0.01,
     ):
-        wc_path = os.path.join(vireo_dir, wc_rel)
-        if os.path.exists(wc_path):
+        wc_path = working_copy_path_if_satisfies(
+            photo, recipe, max_size, vireo_dir, rel_slack=0.01,
+        )
+        if wc_path:
             return wc_path, True
     if not os.path.exists(original_abs) and wc_rel:
         wc_path = os.path.join(vireo_dir, wc_rel)

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -2484,6 +2484,74 @@ def test_cropped_thumbnail_uses_companion_before_raw_failure_marker(
         assert img.size == (267, 400)
 
 
+def test_cropped_thumbnail_uses_working_copy_on_first_raw_decode_failure(
+    client_with_photo, monkeypatch,
+):
+    import io
+    import os
+
+    import thumbnails
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    folder = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (photo_id,),
+    ).fetchone()
+    raw_path = os.path.join(folder["path"], "DSC_7062.NEF")
+    with open(raw_path, "wb") as f:
+        f.write(b"unsupported raw")
+
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    working_dir = os.path.join(vireo_dir, "working")
+    os.makedirs(working_dir, exist_ok=True)
+    wc_path = os.path.join(working_dir, f"{photo_id}.jpg")
+    Image.new("RGB", (800, 600), (30, 120, 200)).save(wc_path, "JPEG")
+    mtime = os.path.getmtime(raw_path)
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='DSC_7062.NEF', extension='.nef',
+               companion_path=NULL,
+               working_copy_path=?,
+               width=800, height=600,
+               file_mtime=?,
+               working_copy_failed_at=NULL,
+               working_copy_failed_mtime=NULL,
+               working_copy_failed_source=NULL
+           WHERE id=?""",
+        (f"working/{photo_id}.jpg", mtime, photo_id),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(
+        photo_id,
+        {"crop": {"x": 0, "y": 0, "w": 0.5, "h": 1}},
+    )
+
+    original_load_image = thumbnails.load_image
+    loaded_paths = []
+
+    def tracking_load_image(file_path, max_size=1024, **kwargs):
+        loaded_paths.append(str(file_path))
+        if str(file_path).lower().endswith(".nef"):
+            return None
+        return original_load_image(file_path, max_size=max_size, **kwargs)
+
+    monkeypatch.setattr(thumbnails, "load_image", tracking_load_image)
+
+    rendered = client.get(f"/thumbnails/{photo_id}.jpg")
+
+    assert rendered.status_code == 200, rendered.get_data(as_text=True)
+    assert loaded_paths == [raw_path, wc_path]
+    with Image.open(io.BytesIO(rendered.data)) as img:
+        assert img.size == (267, 400)
+    row = db.conn.execute(
+        "SELECT working_copy_failed_source FROM photos WHERE id=?",
+        (photo_id,),
+    ).fetchone()
+    assert row["working_copy_failed_source"] == "source"
+
+
 def test_thumbnail_falls_back_when_raw_short_edge_is_smaller(
     client_with_photo, monkeypatch,
 ):
@@ -3668,6 +3736,73 @@ def test_preview_falls_back_to_companion_on_first_raw_decode_failure(
     # The failed RAW decode must stamp the source marker so subsequent
     # requests skip the slow RAW retry and _recipe_render_source selects
     # the companion directly.
+    row = db.conn.execute(
+        "SELECT working_copy_failed_source FROM photos WHERE id=?",
+        (photo_id,),
+    ).fetchone()
+    assert row["working_copy_failed_source"] == "source"
+
+
+def test_preview_falls_back_to_working_copy_on_first_raw_decode_failure(
+    client_with_photo, monkeypatch,
+):
+    import io
+    import os
+
+    import image_loader
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    folder = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id WHERE p.id=?",
+        (photo_id,),
+    ).fetchone()
+    raw_path = os.path.join(folder["path"], "DSC_7062.NEF")
+    with open(raw_path, "wb") as f:
+        f.write(b"unsupported raw")
+
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    working_dir = os.path.join(vireo_dir, "working")
+    os.makedirs(working_dir, exist_ok=True)
+    wc_path = os.path.join(working_dir, f"{photo_id}.jpg")
+    Image.new("RGB", (800, 600), (30, 120, 200)).save(wc_path, "JPEG")
+    mtime = os.path.getmtime(raw_path)
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='DSC_7062.NEF', extension='.nef',
+               companion_path=NULL,
+               working_copy_path=?,
+               width=800, height=600,
+               file_mtime=?,
+               working_copy_failed_at=NULL,
+               working_copy_failed_mtime=NULL,
+               working_copy_failed_source=NULL
+           WHERE id=?""",
+        (f"working/{photo_id}.jpg", mtime, photo_id),
+    )
+    db.conn.commit()
+    db.set_photo_edit_recipe(
+        photo_id,
+        {"crop": {"x": 0, "y": 0, "w": 0.5, "h": 1}},
+    )
+
+    original_load_image = image_loader.load_image
+    loaded_paths = []
+
+    def tracking_load_image(file_path, max_size=1024, **kwargs):
+        loaded_paths.append(str(file_path))
+        if str(file_path).lower().endswith(".nef"):
+            return None
+        return original_load_image(file_path, max_size=max_size, **kwargs)
+
+    monkeypatch.setattr(image_loader, "load_image", tracking_load_image)
+
+    resp = app.test_client().get(f"/photos/{photo_id}/preview?size=1920")
+
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    assert loaded_paths == [raw_path, wc_path]
+    with Image.open(io.BytesIO(resp.data)) as img:
+        assert img.size == (400, 600)
     row = db.conn.execute(
         "SELECT working_copy_failed_source FROM photos WHERE id=?",
         (photo_id,),

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -2542,7 +2542,10 @@ def test_cropped_thumbnail_uses_working_copy_on_first_raw_decode_failure(
     rendered = client.get(f"/thumbnails/{photo_id}.jpg")
 
     assert rendered.status_code == 200, rendered.get_data(as_text=True)
-    assert loaded_paths == [raw_path, wc_path]
+    assert [os.path.normpath(path) for path in loaded_paths] == [
+        os.path.normpath(raw_path),
+        os.path.normpath(wc_path),
+    ]
     with Image.open(io.BytesIO(rendered.data)) as img:
         assert img.size == (267, 400)
     row = db.conn.execute(
@@ -3800,7 +3803,10 @@ def test_preview_falls_back_to_working_copy_on_first_raw_decode_failure(
     resp = app.test_client().get(f"/photos/{photo_id}/preview?size=1920")
 
     assert resp.status_code == 200, resp.get_data(as_text=True)
-    assert loaded_paths == [raw_path, wc_path]
+    assert [os.path.normpath(path) for path in loaded_paths] == [
+        os.path.normpath(raw_path),
+        os.path.normpath(wc_path),
+    ]
     with Image.open(io.BytesIO(resp.data)) as img:
         assert img.size == (400, 600)
     row = db.conn.execute(

--- a/vireo/thumbnails.py
+++ b/vireo/thumbnails.py
@@ -24,6 +24,9 @@ from render_source import (
 from render_source import (
     scaled_recipe_source_dimensions as _scaled_recipe_source_dimensions,
 )
+from render_source import (
+    working_copy_path_if_satisfies as _working_copy_path_if_satisfies,
+)
 
 log = logging.getLogger(__name__)
 
@@ -114,6 +117,47 @@ def _retry_thumbnail_with_companion(
     return generate_thumbnail(
         photo_id,
         companion_abs,
+        cache_dir,
+        size=size,
+        quality=quality,
+        **recipe_kwargs,
+    )
+
+
+def _retry_thumbnail_with_working_copy(
+    db, photo, source_path, cache_dir, size, quality, recipe, vireo_dir,
+):
+    if not photo or not recipe or not vireo_dir:
+        return None
+    if os.path.splitext(source_path or "")[1].lower() not in RAW_EXTENSIONS:
+        return None
+    wc_path = _working_copy_path_if_satisfies(
+        photo, recipe, size, vireo_dir, rel_slack=0.01,
+    )
+    if not wc_path or os.path.abspath(wc_path) == os.path.abspath(source_path):
+        return None
+    photo_id = _photo_value(photo, "id")
+    log.info(
+        "Thumbnail RAW decode failed for photo %s; falling back to JPEG "
+        "working copy",
+        photo_id,
+    )
+    file_mtime = _photo_value(photo, "file_mtime")
+    if file_mtime is not None and photo_id is not None and hasattr(db, "conn"):
+        with contextlib.suppress(Exception):
+            db.conn.execute(
+                "UPDATE photos SET"
+                " working_copy_failed_at=datetime('now'),"
+                " working_copy_failed_mtime=?,"
+                " working_copy_failed_source='source'"
+                " WHERE id=?",
+                (file_mtime, photo_id),
+            )
+            db.conn.commit()
+    recipe_kwargs = {"recipe": recipe, "native_size": _recipe_source_dimensions(photo)}
+    return generate_thumbnail(
+        photo_id,
+        wc_path,
         cache_dir,
         size=size,
         quality=quality,
@@ -323,6 +367,21 @@ def generate_all(db, cache_dir, progress_callback=None, config=None, vireo_dir=N
                 thumb_quality,
                 recipe,
                 folders.get(source_photo["folder_id"]),
+            )
+        if (
+            result_path is None
+            and recipe
+            and os.path.splitext(source_path)[1].lower() in RAW_EXTENSIONS
+        ):
+            result_path = _retry_thumbnail_with_working_copy(
+                db,
+                source_photo,
+                source_path,
+                cache_dir,
+                thumb_size,
+                thumb_quality,
+                recipe,
+                vireo_dir,
             )
         if result_path is not None:
             generated += 1


### PR DESCRIPTION
## Summary
Fix cropped RAW thumbnail and preview rendering so a failed first RAW decode can fall back to a sufficient JPEG working copy when no companion JPEG is available.
This prevents saved crops on files like DSC_7062.NEF from turning into broken question-mark images in Browse after the edit cache is invalidated.
The change centralizes working-copy eligibility and uses it from preview rendering, on-demand thumbnail self-heal, and batch thumbnail generation.

## Tests
- python -m pytest vireo/tests/test_render_source.py -q
- python -m pytest vireo/tests/test_photos_api.py -q