### PR TITLE
Keep external links out of Vireo webview

### DIFF
--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -8488,6 +8488,11 @@ function showToast(msg, type) {
 function openExternalLink(event, url) {
   if (event) event.preventDefault();
   function fallbackOpen() {
+    // In the desktop app, falling back to window.location.href navigates the
+    // WKWebView itself, which makes external sites look like they opened inside
+    // Vireo. If the native opener fails, leave the app in place and let the
+    // caller surface the link/error instead.
+    if (typeof isTauri === 'function' && isTauri()) return false;
     var opened = null;
     try {
       opened = window.open('about:blank', '_blank');

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -7685,6 +7685,27 @@ def test_native_import_commands_route_to_import_page():
     assert "case 'import_folder':\n        nativeMenuRoute('/import');" in navbar
 
 
+def test_external_link_fallback_does_not_navigate_tauri_webview():
+    """If the native browser opener fails, don't load iNat inside Vireo."""
+    import os
+
+    repo_root = os.path.normpath(
+        os.path.join(os.path.dirname(__file__), "..", "..")
+    )
+    navbar_path = os.path.join(repo_root, "vireo", "templates", "_navbar.html")
+
+    with open(navbar_path, encoding="utf-8") as f:
+        navbar = f.read()
+
+    fallback_start = navbar.index("function fallbackOpen()")
+    location_fallback = navbar.index("window.location.href = url", fallback_start)
+    tauri_guard = navbar.index(
+        "if (typeof isTauri === 'function' && isTauri()) return false;",
+        fallback_start,
+    )
+    assert tauri_guard < location_fallback
+
+
 def test_pipeline_plan_accepts_folder_scope(app_and_db):
     """The Process page's folder scope must produce truthful readiness
     pills: the plan is computed over the folders' subtree photos, not the


### PR DESCRIPTION
## Summary
- Prevent desktop fallback handling for external links from navigating the Tauri WKWebView.
- Add a regression test covering the iNaturalist/external-link fallback ordering.

## Tests
- pytest vireo/tests/test_app.py::test_external_link_fallback_does_not_navigate_tauri_webview vireo/tests/test_config.py::test_open_in_browser_round_trip vireo/tests/test_config.py::test_open_in_browser_default_is_false