### PR TITLE
Add bulk keyword removal in browse

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5066,7 +5066,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
     @app.route("/api/selection/keyword-suggestions", methods=["POST"])
     def api_selection_keyword_suggestions():
-        """Return selected keywords that are present on some, but not all photos."""
+        """Return selected keywords and which selected photos carry each one."""
         db = _get_db()
         body = request.get_json(silent=True) or {}
         raw_ids = body.get("photo_ids", [])
@@ -5120,26 +5120,35 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             )
             entry["photo_ids"].add(row["photo_id"])
 
-        suggestions = []
+        keywords = []
         for entry in by_keyword.values():
             count = len(entry["photo_ids"])
             missing_count = selected_count - count
-            if 0 < count < selected_count:
-                missing_photo_ids = [
-                    pid for pid in photo_ids if pid not in entry["photo_ids"]
-                ]
-                suggestions.append({
-                    "id": entry["id"],
-                    "name": entry["name"],
-                    "type": entry["type"],
-                    "count": count,
-                    "missing_count": missing_count,
-                    "missing_photo_ids": missing_photo_ids,
-                })
-        suggestions.sort(
+            present_photo_ids = [
+                pid for pid in photo_ids if pid in entry["photo_ids"]
+            ]
+            missing_photo_ids = [
+                pid for pid in photo_ids if pid not in entry["photo_ids"]
+            ]
+            item = {
+                "id": entry["id"],
+                "name": entry["name"],
+                "type": entry["type"],
+                "count": count,
+                "missing_count": missing_count,
+                "present_photo_ids": present_photo_ids,
+                "missing_photo_ids": missing_photo_ids,
+            }
+            keywords.append(item)
+        keywords.sort(
             key=lambda item: (-item["count"], item["name"].lower(), item["id"])
         )
-        return jsonify({"selected_count": selected_count, "suggestions": suggestions})
+        suggestions = [item for item in keywords if 0 < item["count"] < selected_count]
+        return jsonify({
+            "selected_count": selected_count,
+            "keywords": keywords,
+            "suggestions": suggestions,
+        })
 
     @app.route("/api/keywords/<int:keyword_id>", methods=["PUT"])
     def api_update_keyword(keyword_id):
@@ -6257,6 +6266,73 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             db.record_edit('keyword_add', f'Added "{name}" to {len(added_ids)} photos',
                            str(kid), items, is_batch=True)
         return jsonify({"ok": True, "updated": len(added_ids)})
+
+    @app.route("/api/batch/keyword-remove", methods=["POST"])
+    def api_batch_keyword_remove():
+        db = _get_db()
+        body = request.get_json(silent=True) or {}
+        photo_ids = body.get("photo_ids", [])
+        keyword_id = body.get("keyword_id")
+        if not isinstance(photo_ids, list) or not photo_ids:
+            return json_error("photo_ids required")
+        if isinstance(keyword_id, bool) or not isinstance(keyword_id, int):
+            return json_error("keyword_id must be an integer")
+
+        clean_ids = []
+        seen = set()
+        for raw in photo_ids:
+            if isinstance(raw, bool) or not isinstance(raw, int):
+                return json_error("photo_ids must be integers")
+            if raw not in seen:
+                clean_ids.append(raw)
+                seen.add(raw)
+        if not clean_ids:
+            return json_error("photo_ids required")
+
+        keyword_row = db.conn.execute(
+            "SELECT id, name FROM keywords WHERE id = ?", (keyword_id,)
+        ).fetchone()
+        if keyword_row is None:
+            return json_error("keyword not found", 404)
+
+        for pid in clean_ids:
+            if not db._photo_in_workspace(pid):
+                return json_error(
+                    f"Photo {pid} does not belong to the active workspace", 403
+                )
+
+        tagged_ids = []
+        batch_size = 800
+        for i in range(0, len(clean_ids), batch_size):
+            chunk = clean_ids[i:i + batch_size]
+            placeholders = ",".join("?" for _ in chunk)
+            rows = db.conn.execute(
+                f"""SELECT photo_id FROM photo_keywords
+                    WHERE keyword_id = ? AND photo_id IN ({placeholders})""",
+                [keyword_id] + chunk,
+            ).fetchall()
+            tagged_ids.extend(row["photo_id"] for row in rows)
+
+        tagged_set = set(tagged_ids)
+        removed_ids = [pid for pid in clean_ids if pid in tagged_set]
+        name = keyword_row["name"]
+        for pid in removed_ids:
+            db.untag_photo(pid, keyword_id)
+            _queue_keyword_remove(pid, name)
+
+        items = [
+            {"photo_id": pid, "old_value": str(keyword_id), "new_value": ""}
+            for pid in removed_ids
+        ]
+        if items:
+            db.record_edit(
+                "keyword_remove",
+                f'Removed "{name}" from {len(removed_ids)} photos',
+                str(keyword_id),
+                items,
+                is_batch=True,
+            )
+        return jsonify({"ok": True, "updated": len(removed_ids)})
 
     def _run_batch_delete(
         db, photo_ids, mode="vireo", include_companions=False, paths=None,

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -12558,7 +12558,18 @@ class Database:
                 kw = self.conn.execute("SELECT name FROM keywords WHERE id = ?",
                                        (int(entry['new_value']),)).fetchone()
                 if kw:
-                    self.remove_pending_changes(pid, 'keyword_remove', kw['name'])
+                    # Symmetric with `_queue_keyword_remove`: the original
+                    # remove either queued a `keyword_remove` or, when a
+                    # not-yet-synced `keyword_add` was pending, cancelled
+                    # that add. Reversing needs to restore whichever side
+                    # the remove touched — otherwise an add → remove → undo
+                    # flow leaves the tag on the photo with no pending
+                    # sidecar write, and the restored keyword never syncs.
+                    cancelled = self.remove_pending_changes(
+                        pid, 'keyword_remove', kw['name']
+                    )
+                    if cancelled == 0:
+                        self.queue_change(pid, 'keyword_add', kw['name'])
             elif entry['action_type'] == 'species_replace':
                 # Atomic swap: the edit replaced old_value's species with
                 # new_value's. Undo untags the new species and retags the
@@ -12696,7 +12707,14 @@ class Database:
                 kw = self.conn.execute("SELECT name FROM keywords WHERE id = ?",
                                        (int(entry['new_value']),)).fetchone()
                 if kw:
-                    self.queue_change(pid, 'keyword_remove', kw['name'])
+                    # Mirror the undo path: if undo re-queued a
+                    # `keyword_add`, redo should cancel it rather than
+                    # stack a conflicting `keyword_remove` alongside it.
+                    cancelled = self.remove_pending_changes(
+                        pid, 'keyword_add', kw['name']
+                    )
+                    if cancelled == 0:
+                        self.queue_change(pid, 'keyword_remove', kw['name'])
             elif entry['action_type'] == 'species_replace':
                 # Re-apply the swap: untag old, retag new, mirror pending queue.
                 old_meta = self._edit_old_value_meta(item['old_value'])

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -410,6 +410,22 @@ body {
   cursor: pointer;
 }
 .selection-keyword-add:hover { filter: brightness(1.05); }
+.selection-keyword-actions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+.selection-keyword-remove {
+  flex-shrink: 0;
+  background: var(--bg-primary);
+  color: var(--danger);
+  border: 1px solid color-mix(in srgb, var(--danger) 60%, var(--border-secondary));
+  border-radius: 4px;
+  padding: 5px 8px;
+  font-size: 12px;
+  cursor: pointer;
+}
+.selection-keyword-remove:hover { background: color-mix(in srgb, var(--danger) 12%, var(--bg-primary)); }
 .selection-empty {
   color: var(--text-muted);
   font-size: 12px;
@@ -1859,6 +1875,7 @@ var selectedPhotos = new Set(); // multi-select
 var selectionKeywordRequestSeq = 0;
 var selectionKeywordKey = '';
 var selectionKeywordMissingById = {};
+var selectionKeywordPresentById = {};
 var showDetectionBoxes = false;
 var cardFields = ["filename", "rating", "flag", "color_label", "sharpness"]; // default, overridden by config
 var inatSubmitted = {};  // {photo_id: true}
@@ -4425,6 +4442,7 @@ function updateSelectionPanel(ids) {
     panel.classList.add('hidden');
     selectionKeywordKey = '';
     selectionKeywordMissingById = {};
+    selectionKeywordPresentById = {};
     selectionKeywordRequestSeq++;
     var list = document.getElementById('selectionKeywordSuggestions');
     if (list) list.innerHTML = '';
@@ -4460,6 +4478,7 @@ function updateSelectionPanel(ids) {
   if (ids.length > 1000) {
     selectionKeywordKey = selectionIdsKey(ids);
     selectionKeywordMissingById = {};
+    selectionKeywordPresentById = {};
     selectionKeywordRequestSeq++;
     var list = document.getElementById('selectionKeywordSuggestions');
     if (list) {
@@ -4668,7 +4687,7 @@ async function loadSelectionKeywordSuggestions(ids) {
       body: JSON.stringify({photo_ids: ids}),
     }, { toast: false });
     if (seq !== selectionKeywordRequestSeq) return;
-    renderSelectionKeywordSuggestions(data.suggestions || []);
+    renderSelectionKeywordSuggestions(data.keywords || data.suggestions || [], data.selected_count || ids.length);
   } catch(e) {
     if (seq === selectionKeywordRequestSeq && list) {
       list.innerHTML = '<div class="selection-empty">Could not load keyword suggestions.</div>';
@@ -4676,26 +4695,37 @@ async function loadSelectionKeywordSuggestions(ids) {
   }
 }
 
-function renderSelectionKeywordSuggestions(suggestions) {
+function renderSelectionKeywordSuggestions(keywords, selectedCount) {
   var list = document.getElementById('selectionKeywordSuggestions');
   if (!list) return;
-  if (!suggestions.length) {
+  if (!keywords.length) {
     selectionKeywordMissingById = {};
-    list.innerHTML = '<div class="selection-empty">No partial keywords in this selection.</div>';
+    selectionKeywordPresentById = {};
+    list.innerHTML = '<div class="selection-empty">No keywords on selected photos.</div>';
     return;
   }
 
   var html = '';
   selectionKeywordMissingById = {};
-  suggestions.slice(0, 8).forEach(function(k) {
+  selectionKeywordPresentById = {};
+  keywords.forEach(function(k) {
     var missing = k.missing_count || 0;
+    var count = k.count || 0;
     selectionKeywordMissingById[String(k.id)] = k.missing_photo_ids || [];
+    selectionKeywordPresentById[String(k.id)] = k.present_photo_ids || [];
+    var actions = '';
+    if (missing > 0) {
+      actions += '<button class="selection-keyword-add" onclick="applySelectionKeyword(' + k.id + ')" title="Add this keyword to the selected photos missing it">Add to ' + missing + '</button>';
+    }
+    if (count > 0) {
+      actions += '<button class="selection-keyword-remove" onclick="removeSelectionKeyword(' + k.id + ')" title="Remove this keyword from selected photos that have it">Remove from ' + count + '</button>';
+    }
     html += '<div class="selection-keyword-row">' +
       '<div style="min-width:0;">' +
         '<div class="selection-keyword-name">' + escapeHtml(k.name) + '</div>' +
-        '<div class="selection-keyword-meta">On ' + k.count + ', missing from ' + missing + '</div>' +
+        '<div class="selection-keyword-meta">On ' + count + ' of ' + selectedCount + (missing ? ', missing from ' + missing : '') + '</div>' +
       '</div>' +
-      '<button class="selection-keyword-add" onclick="applySelectionKeyword(' + k.id + ')" title="Add this keyword to the selected photos missing it">Add to ' + missing + '</button>' +
+      '<div class="selection-keyword-actions">' + actions + '</div>' +
     '</div>';
   });
   list.innerHTML = html;
@@ -4706,6 +4736,25 @@ async function applySelectionKeyword(keywordId) {
   if (!ids.length) return;
   try {
     await safeFetch('/api/batch/keyword', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({photo_ids: ids, keyword_id: keywordId}),
+    });
+  } catch(e) { return; }
+  selectionKeywordKey = '';
+  loadSelectionKeywordSuggestions(getActiveSelection());
+  loadKeywords();
+  scheduleCollectionCountsRefresh();
+  refreshActiveCollectionAfterMembershipChange();
+  refreshPendingSyncBanner();
+  showUndoToast();
+}
+
+async function removeSelectionKeyword(keywordId) {
+  var ids = selectionKeywordPresentById[String(keywordId)] || [];
+  if (!ids.length) return;
+  try {
+    await safeFetch('/api/batch/keyword-remove', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({photo_ids: ids, keyword_id: keywordId}),

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2714,25 +2714,41 @@ function refreshActiveCollectionAfterMembershipChange() {
 // they stay in the grid and in the selection until the user manually
 // changes filters. Two paths can drive the current keyword filter — the
 // keyword tree (via `activeKeyword`) or the search box text (via
-// `appendKeywordSearchParams`) — so check both. If the search query
-// still matches the removed keyword name under the current match_case /
-// whole_word settings, the untagged photos may no longer belong in the
-// grid; reloading is safe either way (a photo still matching via
-// another keyword or filename token just comes back).
+// `appendKeywordSearchParams`) — so check both. Reloading is safe either
+// way (a photo still matching via another keyword or filename token
+// just comes back on the next fetch).
 function refreshActiveKeywordAfterRemoval(removedName) {
   if (!removedName) return;
   if (activeKeyword && activeKeyword === removedName) {
     reloadBrowseResults();
     return;
   }
+  // While a collection is active, `refreshActiveCollectionAfterMembershipChange`
+  // has already reloaded via `filterByCollection`. Collections ignore the
+  // search input, so any stale `#searchInput` text is not driving the
+  // current grid. Calling `reloadBrowseResults` here would run
+  // `resetAndLoad`, which clears `activeCollectionId` and drops the user
+  // into the global keyword search.
+  if (activeCollectionId) return;
   var searchInput = document.getElementById('searchInput');
   var query = searchInput ? searchInput.value.trim() : '';
   if (!query) return;
-  if (VireoTextSearch.matchesFields(
-    removedName,
-    query,
-    { matchCase: keywordSearchMatchCase, wholeWord: keywordSearchWholeWord }
-  )) {
+  // The backend keyword filter tokenizes `keyword=<query>` and satisfies
+  // each token independently — a token can match via a different keyword
+  // or the filename. So a photo can appear in the grid because
+  // `removedName` satisfied one token while other tokens matched
+  // elsewhere. Reload whenever any query token still matches the removed
+  // keyword name; requiring the whole query to match would miss those
+  // multi-token cases.
+  var opts = {
+    matchCase: keywordSearchMatchCase,
+    wholeWord: keywordSearchWholeWord,
+  };
+  var tokens = query.split(/\s+/);
+  var anyTokenMatches = tokens.some(function(token) {
+    return token && VireoTextSearch.tokenMatches(removedName, token, opts);
+  });
+  if (anyTokenMatches) {
     reloadBrowseResults();
   }
 }

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1876,6 +1876,7 @@ var selectionKeywordRequestSeq = 0;
 var selectionKeywordKey = '';
 var selectionKeywordMissingById = {};
 var selectionKeywordPresentById = {};
+var selectionKeywordNameById = {};
 var showDetectionBoxes = false;
 var cardFields = ["filename", "rating", "flag", "color_label", "sharpness"]; // default, overridden by config
 var inatSubmitted = {};  // {photo_id: true}
@@ -2706,6 +2707,17 @@ function scheduleCollectionCountsRefresh() {
 function refreshActiveCollectionAfterMembershipChange() {
   if (!activeCollectionId) return;
   filterByCollection(activeCollectionId, { preserveAnchor: false });
+}
+
+// When bulk-removing the keyword that currently drives the filter, the
+// photos we just untagged no longer match the query. Without this reload
+// they stay in the grid and in the selection until the user manually
+// changes filters. `filterByKeyword` uses `activeKeyword` as the source
+// of truth, so trigger the same reload path.
+function refreshActiveKeywordAfterRemoval(removedName) {
+  if (!activeKeyword || !removedName) return;
+  if (activeKeyword !== removedName) return;
+  reloadBrowseResults();
 }
 
 function refreshBrowseSidebarCounts() {
@@ -4443,6 +4455,7 @@ function updateSelectionPanel(ids) {
     selectionKeywordKey = '';
     selectionKeywordMissingById = {};
     selectionKeywordPresentById = {};
+    selectionKeywordNameById = {};
     selectionKeywordRequestSeq++;
     var list = document.getElementById('selectionKeywordSuggestions');
     if (list) list.innerHTML = '';
@@ -4479,6 +4492,7 @@ function updateSelectionPanel(ids) {
     selectionKeywordKey = selectionIdsKey(ids);
     selectionKeywordMissingById = {};
     selectionKeywordPresentById = {};
+    selectionKeywordNameById = {};
     selectionKeywordRequestSeq++;
     var list = document.getElementById('selectionKeywordSuggestions');
     if (list) {
@@ -4701,6 +4715,7 @@ function renderSelectionKeywordSuggestions(keywords, selectedCount) {
   if (!keywords.length) {
     selectionKeywordMissingById = {};
     selectionKeywordPresentById = {};
+    selectionKeywordNameById = {};
     list.innerHTML = '<div class="selection-empty">No keywords on selected photos.</div>';
     return;
   }
@@ -4708,11 +4723,13 @@ function renderSelectionKeywordSuggestions(keywords, selectedCount) {
   var html = '';
   selectionKeywordMissingById = {};
   selectionKeywordPresentById = {};
+  selectionKeywordNameById = {};
   keywords.forEach(function(k) {
     var missing = k.missing_count || 0;
     var count = k.count || 0;
     selectionKeywordMissingById[String(k.id)] = k.missing_photo_ids || [];
     selectionKeywordPresentById[String(k.id)] = k.present_photo_ids || [];
+    selectionKeywordNameById[String(k.id)] = k.name;
     var actions = '';
     if (missing > 0) {
       actions += '<button class="selection-keyword-add" onclick="applySelectionKeyword(' + k.id + ')" title="Add this keyword to the selected photos missing it">Add to ' + missing + '</button>';
@@ -4753,6 +4770,7 @@ async function applySelectionKeyword(keywordId) {
 async function removeSelectionKeyword(keywordId) {
   var ids = selectionKeywordPresentById[String(keywordId)] || [];
   if (!ids.length) return;
+  var removedName = selectionKeywordNameById[String(keywordId)] || null;
   try {
     await safeFetch('/api/batch/keyword-remove', {
       method: 'POST',
@@ -4765,6 +4783,7 @@ async function removeSelectionKeyword(keywordId) {
   loadKeywords();
   scheduleCollectionCountsRefresh();
   refreshActiveCollectionAfterMembershipChange();
+  refreshActiveKeywordAfterRemoval(removedName);
   refreshPendingSyncBanner();
   showUndoToast();
 }

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2712,12 +2712,29 @@ function refreshActiveCollectionAfterMembershipChange() {
 // When bulk-removing the keyword that currently drives the filter, the
 // photos we just untagged no longer match the query. Without this reload
 // they stay in the grid and in the selection until the user manually
-// changes filters. `filterByKeyword` uses `activeKeyword` as the source
-// of truth, so trigger the same reload path.
+// changes filters. Two paths can drive the current keyword filter — the
+// keyword tree (via `activeKeyword`) or the search box text (via
+// `appendKeywordSearchParams`) — so check both. If the search query
+// still matches the removed keyword name under the current match_case /
+// whole_word settings, the untagged photos may no longer belong in the
+// grid; reloading is safe either way (a photo still matching via
+// another keyword or filename token just comes back).
 function refreshActiveKeywordAfterRemoval(removedName) {
-  if (!activeKeyword || !removedName) return;
-  if (activeKeyword !== removedName) return;
-  reloadBrowseResults();
+  if (!removedName) return;
+  if (activeKeyword && activeKeyword === removedName) {
+    reloadBrowseResults();
+    return;
+  }
+  var searchInput = document.getElementById('searchInput');
+  var query = searchInput ? searchInput.value.trim() : '';
+  if (!query) return;
+  if (VireoTextSearch.matchesFields(
+    removedName,
+    query,
+    { matchCase: keywordSearchMatchCase, wholeWord: keywordSearchWholeWord }
+  )) {
+    reloadBrowseResults();
+  }
 }
 
 function refreshBrowseSidebarCounts() {

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -4471,6 +4471,84 @@ def test_batch_keyword_remove_route_removes_existing_keyword_id(app_and_db):
     assert [row["photo_id"] for row in tagged_after_undo] == [ids[0]]
 
 
+def test_batch_keyword_remove_undo_restores_pending_add(app_and_db):
+    """Add → bulk remove → undo must leave a pending sidecar write.
+
+    Bulk remove of a not-yet-synced pending add cancels the pending
+    `keyword_add` (via `_queue_keyword_remove`) instead of queuing a
+    `keyword_remove`. Undoing the recorded `keyword_remove` retags the
+    photo but must also re-queue the `keyword_add` so the restored
+    keyword is actually written back to the sidecar; otherwise the tag
+    silently diverges from disk.
+    """
+    app, db = app_and_db
+    photo_id = db.conn.execute(
+        "SELECT id FROM photos ORDER BY filename LIMIT 1"
+    ).fetchone()["id"]
+    sparrow_id = db.conn.execute(
+        "SELECT id FROM keywords WHERE name = 'Sparrow'"
+    ).fetchone()["id"]
+    client = app.test_client()
+
+    add_resp = client.post(
+        "/api/batch/keyword",
+        json={"photo_ids": [photo_id], "keyword_id": sparrow_id},
+        content_type="application/json",
+    )
+    assert add_resp.status_code == 200
+    pending_add = db.conn.execute(
+        """SELECT photo_id FROM pending_changes
+           WHERE change_type = 'keyword_add' AND value = 'Sparrow'"""
+    ).fetchall()
+    assert [row["photo_id"] for row in pending_add] == [photo_id]
+
+    remove_resp = client.post(
+        "/api/batch/keyword-remove",
+        json={"photo_ids": [photo_id], "keyword_id": sparrow_id},
+        content_type="application/json",
+    )
+    assert remove_resp.status_code == 200
+    pending_after_remove = db.conn.execute(
+        """SELECT change_type FROM pending_changes
+           WHERE photo_id = ? AND value = 'Sparrow'""",
+        (photo_id,),
+    ).fetchall()
+    assert pending_after_remove == []
+
+    undo_resp = client.post("/api/undo")
+    assert undo_resp.status_code == 200
+    tagged = db.conn.execute(
+        "SELECT 1 FROM photo_keywords WHERE photo_id = ? AND keyword_id = ?",
+        (photo_id, sparrow_id),
+    ).fetchone()
+    assert tagged is not None, "undo should restore the Sparrow tag"
+    pending_after_undo = db.conn.execute(
+        """SELECT change_type, value FROM pending_changes
+           WHERE photo_id = ? AND value = 'Sparrow'""",
+        (photo_id,),
+    ).fetchall()
+    assert [(row["change_type"], row["value"]) for row in pending_after_undo] == [
+        ("keyword_add", "Sparrow"),
+    ]
+
+    redo_resp = client.post("/api/redo")
+    assert redo_resp.status_code == 200
+    tagged_after_redo = db.conn.execute(
+        "SELECT 1 FROM photo_keywords WHERE photo_id = ? AND keyword_id = ?",
+        (photo_id, sparrow_id),
+    ).fetchone()
+    assert tagged_after_redo is None, "redo should re-remove the Sparrow tag"
+    pending_after_redo = db.conn.execute(
+        """SELECT change_type FROM pending_changes
+           WHERE photo_id = ? AND value = 'Sparrow'""",
+        (photo_id,),
+    ).fetchall()
+    assert pending_after_redo == [], (
+        "redo of the cancel-a-pending-add remove must leave no pending "
+        "change — mirroring the original bulk remove that cancelled the add"
+    )
+
+
 def test_batch_keyword_route_chunks_large_existing_keyword_lookup(app_and_db):
     """Large batch keyword adds must not exceed SQLite's variable limit."""
     app, db = app_and_db

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -4351,6 +4351,11 @@ def test_selection_keyword_suggestions_return_partial_keywords(app_and_db):
     assert by_name["Sparrow"]["count"] == 1
     assert by_name["Sparrow"]["missing_count"] == 2
 
+    keywords_by_name = {item["name"]: item for item in data["keywords"]}
+    assert keywords_by_name["Cardinal"]["present_photo_ids"] == [ids[0]]
+    assert sorted(keywords_by_name["Cardinal"]["missing_photo_ids"]) == sorted(ids[1:])
+    assert keywords_by_name["Sparrow"]["present_photo_ids"] == [ids[1]]
+
 
 def test_selection_keyword_suggestions_chunks_large_selection(app_and_db):
     """Large selection suggestions must not exceed SQLite's variable limit."""
@@ -4410,6 +4415,50 @@ def test_batch_keyword_route_accepts_existing_keyword_id(app_and_db):
         (cardinal_id,),
     ).fetchall()
     assert [row["photo_id"] for row in tagged] == sorted(ids)
+
+    undo_resp = client.post("/api/undo")
+    assert undo_resp.status_code == 200
+    tagged_after_undo = db.conn.execute(
+        """SELECT photo_id FROM photo_keywords
+           WHERE keyword_id = ?
+           ORDER BY photo_id""",
+        (cardinal_id,),
+    ).fetchall()
+    assert [row["photo_id"] for row in tagged_after_undo] == [ids[0]]
+
+
+def test_batch_keyword_remove_route_removes_existing_keyword_id(app_and_db):
+    """Selected-keyword removal should only affect selected photos that have it."""
+    app, db = app_and_db
+    rows = db.conn.execute(
+        "SELECT id, filename FROM photos ORDER BY filename"
+    ).fetchall()
+    ids = [row["id"] for row in rows]
+    cardinal_id = db.conn.execute(
+        "SELECT id FROM keywords WHERE name = 'Cardinal'"
+    ).fetchone()["id"]
+    client = app.test_client()
+
+    resp = client.post(
+        "/api/batch/keyword-remove",
+        json={"photo_ids": ids, "keyword_id": cardinal_id},
+        content_type="application/json",
+    )
+
+    assert resp.status_code == 200
+    assert resp.get_json()["updated"] == 1
+    tagged = db.conn.execute(
+        """SELECT photo_id FROM photo_keywords
+           WHERE keyword_id = ?""",
+        (cardinal_id,),
+    ).fetchall()
+    assert tagged == []
+
+    pending = db.conn.execute(
+        """SELECT photo_id, change_type, value FROM pending_changes
+           WHERE change_type = 'keyword_remove' AND value = 'Cardinal'"""
+    ).fetchall()
+    assert [row["photo_id"] for row in pending] == [ids[0]]
 
     undo_resp = client.post("/api/undo")
     assert undo_resp.status_code == 200


### PR DESCRIPTION
## Summary

- Lists every keyword present across a Browse multi-selection, with add-to-missing and remove-from-present actions.

- Adds a batch keyword removal API that records undo history and pending sync changes, with focused tests for the expanded keyword payload and undoable removal.
## Validation

- pytest vireo/tests/test_app.py -k "selection_keyword_suggestions or batch_keyword_route_accepts_existing_keyword_id or batch_keyword_remove_route"

- python -m py_compile vireo/app.py && git diff --check
