### PR TITLE
Show picked flags in highlights

### DIFF
--- a/tests/e2e/test_highlights_initial_scope.py
+++ b/tests/e2e/test_highlights_initial_scope.py
@@ -344,6 +344,61 @@ def test_highlights_lightbox_pick_hidden_photo_promotes_to_visible(live_server, 
     expect(promoted.locator(".pick-flag-badge")).to_be_visible()
 
 
+def test_highlights_lightbox_pick_keeps_curated_highlight_first(live_server, page):
+    """Picking an unhighlighted photo must not demote a stored species highlight.
+
+    Regression for Codex feedback on PR #1176: the client-side re-sort ran a
+    picked-first ordering that ignored ``is_highlighted``/``highlight_rank``,
+    so pressing ``P`` on an unhighlighted photo in a curated bucket shoved
+    the stored highlight out of its top slot — changing the visible slice
+    and the Save-as-Collection payload — until a full reload restored the
+    server's ``_apply_ordered_highlights`` ordering.
+    """
+    db = live_server["db"]
+    data = live_server["data"]
+    _seed_quality_scores_and_species(db, data)
+
+    # photos[1] is a lower-quality hawk than photos[0]; without the stored
+    # highlight it would sort second. Marking it a species highlight promotes
+    # it to the top of the bucket via _apply_ordered_highlights.
+    highlighted_id = data["photos"][1]
+    unhighlighted_id = data["photos"][0]
+    db.add_species_highlight("Red-tailed Hawk", highlighted_id)
+
+    page.goto(f"{live_server['url']}/highlights", timeout=5000)
+    hawk_section = page.locator("section.bucket").filter(has_text="Red-tailed Hawk")
+    expect(hawk_section.locator(".highlights-card").first).to_be_visible(timeout=5000)
+
+    first_card = hawk_section.locator(".highlights-card").nth(0)
+    assert int(first_card.get_attribute("data-photo-id")) == highlighted_id
+
+    # Open the lightbox on the unhighlighted card and pick it.
+    unhighlighted_card = hawk_section.locator(
+        f'.highlights-card[data-photo-id="{unhighlighted_id}"]'
+    )
+    unhighlighted_card.click()
+    page.wait_for_function(
+        "document.getElementById('lightboxOverlay').classList.contains('active')",
+        timeout=3000,
+    )
+    page.wait_for_function(
+        "pid => _lightboxCurrentId === pid",
+        arg=unhighlighted_id,
+        timeout=3000,
+    )
+    page.keyboard.press("p")
+    assert _wait_for_flag(db, unhighlighted_id, "flagged") == "flagged"
+
+    # The stored highlight must still lead the bucket; the newly-picked
+    # photo must NOT have jumped ahead of it.
+    picked_card = hawk_section.locator(
+        f'.highlights-card[data-photo-id="{unhighlighted_id}"]'
+    )
+    expect(picked_card).to_have_class(re.compile(r"\bpick-flag-card\b"), timeout=5000)
+    still_first = hawk_section.locator(".highlights-card").nth(0)
+    assert int(still_first.get_attribute("data-photo-id")) == highlighted_id
+
+
 def test_highlights_species_search_filters_buckets(live_server, page):
     db = live_server["db"]
     data = live_server["data"]

--- a/tests/e2e/test_highlights_initial_scope.py
+++ b/tests/e2e/test_highlights_initial_scope.py
@@ -480,6 +480,106 @@ def test_highlights_lightbox_pick_applies_backend_score_bonus(live_server, page)
     assert updated_ids[2] == upper_unhighlighted
 
 
+def test_highlights_lightbox_pick_refetches_paged_bucket(live_server, page):
+    """Picking in a bucket with `has_more` must refetch, not just resort locally.
+
+    Regression for Codex feedback on PR #1176 (line 1308): when a bucket
+    still has ``has_more=true``, the client's loaded window is a subset of
+    the server's ordered list. A local resort of that slice can't reconcile
+    a pick that promotes a preloaded-but-hidden photo into the window (or
+    demotes a visible one past it), and ``loadMoreBucket`` uses
+    ``target.photos.length`` as its next offset — so it would either append
+    duplicates for photos still at the same server offset or skip photos
+    that newly entered the first page.
+    """
+    db = live_server["db"]
+    data = live_server["data"]
+    _seed_quality_scores_and_species(db, data)
+
+    hawk_kid = db.conn.execute(
+        "SELECT id FROM keywords WHERE name = ?", ("Red-tailed Hawk",)
+    ).fetchone()["id"]
+    folder_id = data["folders"][0]
+
+    # loadHighlights sends limit_per_bucket = max(20, perRowSlider). Seed
+    # >20 hawks total so the initial hawk bucket comes back with
+    # has_more=true (3 seeded hawks + 25 extras = 28 > 20).
+    extras = []
+    for i in range(25):
+        pid = db.add_photo(
+            folder_id=folder_id,
+            filename=f"pageable-hawk-{i}.jpg",
+            extension=".jpg",
+            file_size=1000,
+            file_mtime=1.0,
+            timestamp=f"2024-03-11T09:{i:02d}:00",
+        )
+        db.conn.execute(
+            "UPDATE photos SET quality_score = ? WHERE id = ?",
+            (0.5 - i * 0.005, pid),
+        )
+        db.conn.execute(
+            "INSERT OR IGNORE INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+            (pid, hawk_kid),
+        )
+        extras.append(pid)
+    db.conn.commit()
+
+    page.goto(f"{live_server['url']}/highlights", timeout=5000)
+    hawk_section = page.locator("section.bucket").filter(has_text="Red-tailed Hawk")
+    expect(hawk_section.locator(".highlights-card").first).to_be_visible(timeout=5000)
+
+    # Sanity: 28 hawks total, 20 loaded → has_more should be true.
+    has_more = page.evaluate(
+        "() => currentData.buckets.find(b => b.species === 'Red-tailed Hawk').has_more"
+    )
+    assert has_more is True
+
+    # Pick a photo from within the loaded window.
+    first_card = hawk_section.locator(".highlights-card").nth(0)
+    first_pid = int(first_card.get_attribute("data-photo-id"))
+    first_card.click()
+    page.wait_for_function(
+        "document.getElementById('lightboxOverlay').classList.contains('active')",
+        timeout=3000,
+    )
+    page.wait_for_function(
+        "pid => _lightboxCurrentId === pid",
+        arg=first_pid,
+        timeout=3000,
+    )
+
+    # The pick must trigger a refetch from offset=0 against the bucket
+    # endpoint, not just a local reorder.
+    with page.expect_response(
+        lambda r: (
+            "/api/highlights/bucket" in r.url
+            and "offset=0" in r.url
+            and "species=Red-tailed" in r.url
+        ),
+        timeout=5000,
+    ):
+        page.keyboard.press("p")
+
+    assert _wait_for_flag(db, first_pid, "flagged") == "flagged"
+
+    # Load the rest of the bucket via the Load-more path. If the refetch
+    # aligned the client window with the server's post-bonus ordering, the
+    # combined set is duplicate-free and covers every hawk.
+    page.evaluate(
+        "async () => { while (currentData.buckets.find(b => b.species === 'Red-tailed Hawk').has_more) "
+        "{ await loadMoreBucket('Red-tailed Hawk', false); } }"
+    )
+    all_ids = page.evaluate(
+        "() => currentData.buckets.find(b => b.species === 'Red-tailed Hawk').photos.map(p => p.id)"
+    )
+    assert len(all_ids) == len(set(all_ids)), (
+        f"Duplicate photo IDs after Load-more: {all_ids}"
+    )
+    # 3 seeded hawks + 25 extras = 28 unique hawks in the bucket.
+    assert len(all_ids) == 28
+
+
 def test_highlights_species_search_filters_buckets(live_server, page):
     db = live_server["db"]
     data = live_server["data"]

--- a/tests/e2e/test_highlights_initial_scope.py
+++ b/tests/e2e/test_highlights_initial_scope.py
@@ -648,6 +648,150 @@ def test_highlights_lightbox_pick_refetches_paged_bucket(live_server, page):
     assert len(all_ids) == 28
 
 
+def test_highlights_lightbox_repick_after_eviction_restores_photo(live_server, page):
+    """Re-picking from the lightbox after the photo was evicted from the
+    loaded window must reload highlights, not silently no-op.
+
+    Regression for Codex feedback on PR #1176 (line 1288): the lightbox
+    ``flagchanged`` handler bailed on ``if (!hit) return;`` whenever the
+    photo wasn't in any bucket's loaded window. That happens when a photo
+    is only in the loaded slice because ``picked_first`` promoted it — a
+    prior unpick's ``refetchBucketFromZero`` then replaces the bucket with
+    a server prefix that no longer contains the photo. Pressing ``P``
+    again from the still-open lightbox left the photo flagged on the
+    backend but absent from the visible Highlights grid (and the
+    Save-as-Collection payload) until a full reload.
+    """
+    db = live_server["db"]
+    data = live_server["data"]
+    _seed_quality_scores_and_species(db, data)
+
+    hawk_kid = db.conn.execute(
+        "SELECT id FROM keywords WHERE name = ?", ("Red-tailed Hawk",)
+    ).fetchone()["id"]
+    folder_id = data["folders"][0]
+
+    # Seed 25 extra hawks (3 seeded + 25 = 28 > 20) with very low quality
+    # scores so the loaded window's first 20 tail hawks all outrank the
+    # low_hawk below. That guarantees low_hawk is only visible because
+    # picked_first promotes it.
+    for i in range(25):
+        pid = db.add_photo(
+            folder_id=folder_id,
+            filename=f"filler-hawk-{i}.jpg",
+            extension=".jpg",
+            file_size=1000,
+            file_mtime=1.0,
+            timestamp=f"2024-03-11T09:{i:02d}:00",
+        )
+        db.conn.execute(
+            "UPDATE photos SET quality_score = ? WHERE id = ?",
+            (0.7 - i * 0.01, pid),
+        )
+        db.conn.execute(
+            "INSERT OR IGNORE INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+            (pid, hawk_kid),
+        )
+
+    # The eviction target: a hawk with a much lower base score than every
+    # other hawk. Without picked_first it sits at the bottom of the
+    # sorted-by-score list, past the initial 20-photo window.
+    low_hawk = db.add_photo(
+        folder_id=folder_id,
+        filename="low-score-hawk.jpg",
+        extension=".jpg",
+        file_size=1000,
+        file_mtime=1.0,
+        timestamp="2024-03-11T10:00:00",
+    )
+    db.conn.execute(
+        "UPDATE photos SET quality_score = 0.05, flag = 'flagged' WHERE id = ?",
+        (low_hawk,),
+    )
+    db.conn.execute(
+        "INSERT OR IGNORE INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (low_hawk, hawk_kid),
+    )
+    db.conn.commit()
+
+    page.goto(f"{live_server['url']}/highlights", timeout=5000)
+    hawk_section = page.locator("section.bucket").filter(has_text="Red-tailed Hawk")
+    expect(hawk_section.locator(".highlights-card").first).to_be_visible(timeout=5000)
+
+    # Initial load: picked_first promotes low_hawk into bucket.photos even
+    # though its base score would otherwise put it past position 20.
+    def _bucket_has_photo(pid):
+        return page.evaluate(
+            "pid => {"
+            "  const b = currentData.buckets.find(x => x.species === 'Red-tailed Hawk');"
+            "  return !!(b && b.photos.some(p => p.id === pid));"
+            "}",
+            pid,
+        )
+
+    assert _bucket_has_photo(low_hawk) is True
+
+    # Open the lightbox on the picked low_hawk. `attachCardClicks` only
+    # wires the visible slice, so drive the lightbox directly with the
+    # bucket's photo list.
+    low_card = hawk_section.locator(
+        f'.highlights-card[data-photo-id="{low_hawk}"]'
+    )
+    if low_card.count() > 0:
+        low_card.click()
+    else:
+        page.evaluate(
+            "pid => {"
+            "  const b = currentData.buckets.find(x => x.species === 'Red-tailed Hawk');"
+            "  openLightbox(pid, '', b.photos);"
+            "}",
+            low_hawk,
+        )
+    page.wait_for_function(
+        "document.getElementById('lightboxOverlay').classList.contains('active')",
+        timeout=3000,
+    )
+    page.wait_for_function(
+        "pid => _lightboxCurrentId === pid",
+        arg=low_hawk,
+        timeout=3000,
+    )
+
+    # Unpick from the lightbox. The refetch that fires after this must
+    # drop low_hawk out of the loaded window (no picked_first bonus and
+    # a much lower score than every other hawk).
+    page.keyboard.press("u")
+    assert _wait_for_flag(db, low_hawk, "none") == "none"
+    page.wait_for_function(
+        "pid => {"
+        "  const b = currentData.buckets.find(x => x.species === 'Red-tailed Hawk');"
+        "  return !!(b && !b.photos.some(p => p.id === pid));"
+        "}",
+        arg=low_hawk,
+        timeout=5000,
+    )
+    assert _bucket_has_photo(low_hawk) is False
+    assert page.evaluate("() => _lightboxCurrentId") == low_hawk
+
+    # Re-pick from the still-open lightbox. Before the fix, the handler
+    # would bail because the photo is no longer in any bucket's loaded
+    # window; with the fix, it falls back to loadHighlights() so
+    # picked_first promotes low_hawk back into the visible grid.
+    page.keyboard.press("p")
+    assert _wait_for_flag(db, low_hawk, "flagged") == "flagged"
+    page.wait_for_function(
+        "pid => {"
+        "  const b = currentData.buckets.find(x => x.species === 'Red-tailed Hawk');"
+        "  return !!(b && b.photos.some(p => p.id === pid && p.flag === 'flagged'));"
+        "}",
+        arg=low_hawk,
+        timeout=5000,
+    )
+    restored = page.locator(f'.highlights-card[data-photo-id="{low_hawk}"]')
+    expect(restored).to_be_visible(timeout=5000)
+    expect(restored).to_have_class(re.compile(r"\bpick-flag-card\b"))
+
+
 def test_highlights_species_search_filters_buckets(live_server, page):
     db = live_server["db"]
     data = live_server["data"]

--- a/tests/e2e/test_highlights_initial_scope.py
+++ b/tests/e2e/test_highlights_initial_scope.py
@@ -480,6 +480,74 @@ def test_highlights_lightbox_pick_applies_backend_score_bonus(live_server, page)
     assert updated_ids[2] == upper_unhighlighted
 
 
+def test_highlights_lightbox_pick_refreshes_bucket_best_timestamp(live_server, page):
+    """Picking a photo that becomes ``bucket.photos[0]`` must refresh
+    ``bucket.best_timestamp`` so ``sortedBuckets()`` ('Newest top photo' /
+    'Oldest top photo') doesn't rank the species by the pre-pick top
+    photo's timestamp until reload.
+
+    Regression for Codex feedback on PR #1176 (line 873): the client-side
+    pick handler only refreshed ``best_score`` after re-sorting. A pick
+    that promoted an older/newer photo to ``photos[0]`` left
+    ``best_timestamp`` pointing at the previous top photo, so a reload
+    would rank the species differently in the timestamp-based sorts.
+    """
+    db = live_server["db"]
+    data = live_server["data"]
+    _seed_quality_scores_and_species(db, data)
+
+    # Seeded quality scores put hawk1 (2024-03-10T08:00:00) at photos[0]
+    # via _highlight_score_bucket. Picking hawk3 (2024-03-10T08:02:00)
+    # promotes it to photos[0] under picked_first ordering.
+    hawk1_id = data["photos"][0]
+    hawk3_id = data["photos"][2]
+
+    page.goto(f"{live_server['url']}/highlights", timeout=5000)
+    hawk_section = page.locator("section.bucket").filter(has_text="Red-tailed Hawk")
+    expect(hawk_section.locator(".highlights-card").first).to_be_visible(timeout=5000)
+
+    initial = page.evaluate(
+        "() => {"
+        "  const b = currentData.buckets.find(x => x.species === 'Red-tailed Hawk');"
+        "  return { first: b.photos[0].id, ts: b.best_timestamp };"
+        "}"
+    )
+    assert initial["first"] == hawk1_id
+    assert initial["ts"] == "2024-03-10T08:00:00"
+
+    hawk3_card = hawk_section.locator(
+        f'.highlights-card[data-photo-id="{hawk3_id}"]'
+    )
+    hawk3_card.click()
+    page.wait_for_function(
+        "document.getElementById('lightboxOverlay').classList.contains('active')",
+        timeout=3000,
+    )
+    page.wait_for_function(
+        "pid => _lightboxCurrentId === pid",
+        arg=hawk3_id,
+        timeout=3000,
+    )
+    page.keyboard.press("p")
+    assert _wait_for_flag(db, hawk3_id, "flagged") == "flagged"
+
+    page.wait_for_function(
+        "() => {"
+        "  const b = currentData.buckets.find(x => x.species === 'Red-tailed Hawk');"
+        "  return b && b.photos[0] && b.photos[0].flag === 'flagged';"
+        "}",
+        timeout=5000,
+    )
+    after = page.evaluate(
+        "() => {"
+        "  const b = currentData.buckets.find(x => x.species === 'Red-tailed Hawk');"
+        "  return { first: b.photos[0].id, ts: b.best_timestamp };"
+        "}"
+    )
+    assert after["first"] == hawk3_id
+    assert after["ts"] == "2024-03-10T08:02:00"
+
+
 def test_highlights_lightbox_pick_refetches_paged_bucket(live_server, page):
     """Picking in a bucket with `has_more` must refetch, not just resort locally.
 

--- a/tests/e2e/test_highlights_initial_scope.py
+++ b/tests/e2e/test_highlights_initial_scope.py
@@ -215,6 +215,57 @@ def test_highlights_picked_photos_show_flag_marker(live_server, page):
     expect(card.locator(".pick-flag-badge")).to_have_text("Pick")
 
 
+def test_highlights_lightbox_pick_updates_card_without_reload(live_server, page):
+    """Picking/unpicking from the lightbox must refresh the card DOM in place.
+
+    Regression for Codex feedback on PR #1176: the highlights
+    ``lightbox:flagchanged`` handler only reacted to ``rejected`` (and
+    previously-rejected) transitions, so the new Pick badge/outline never
+    appeared or disappeared until a full reload.
+    """
+    db = live_server["db"]
+    data = live_server["data"]
+    _seed_quality_scores_and_species(db, data)
+
+    page.goto(f"{live_server['url']}/highlights", timeout=5000)
+    hawk_section = page.locator("section.bucket").filter(has_text="Red-tailed Hawk")
+    first_card = hawk_section.locator(".highlights-card").nth(0)
+    expect(first_card).to_be_visible(timeout=5000)
+    first_pid = int(first_card.get_attribute("data-photo-id"))
+
+    # Nothing picked yet — the badge/class must be absent.
+    expect(first_card).not_to_have_class(re.compile(r"\bpick-flag-card\b"))
+    expect(
+        page.locator(f'.highlights-card[data-photo-id="{first_pid}"] .pick-flag-badge')
+    ).to_have_count(0)
+
+    first_card.click()
+    page.wait_for_function(
+        "document.getElementById('lightboxOverlay').classList.contains('active')",
+        timeout=3000,
+    )
+    page.wait_for_function(
+        "pid => _lightboxCurrentId === pid",
+        arg=first_pid,
+        timeout=3000,
+    )
+
+    page.keyboard.press("p")
+
+    assert _wait_for_flag(db, first_pid, "flagged") == "flagged"
+    refreshed = page.locator(f'.highlights-card[data-photo-id="{first_pid}"]')
+    expect(refreshed).to_have_class(re.compile(r"\bpick-flag-card\b"), timeout=5000)
+    expect(refreshed.locator(".pick-flag-badge")).to_be_visible()
+
+    # Clearing the pick from the lightbox must also refresh the card DOM.
+    page.keyboard.press("u")
+
+    assert _wait_for_flag(db, first_pid, "none") == "none"
+    cleared = page.locator(f'.highlights-card[data-photo-id="{first_pid}"]')
+    expect(cleared).not_to_have_class(re.compile(r"\bpick-flag-card\b"), timeout=5000)
+    expect(cleared.locator(".pick-flag-badge")).to_have_count(0)
+
+
 def test_highlights_species_search_filters_buckets(live_server, page):
     db = live_server["db"]
     data = live_server["data"]

--- a/tests/e2e/test_highlights_initial_scope.py
+++ b/tests/e2e/test_highlights_initial_scope.py
@@ -199,6 +199,22 @@ def test_highlights_best_ui_is_advanced_only(live_server, page):
     )
 
 
+def test_highlights_picked_photos_show_flag_marker(live_server, page):
+    db = live_server["db"]
+    data = live_server["data"]
+    _seed_quality_scores_and_species(db, data)
+    picked_id = data["photos"][0]
+    db.update_photo_flag(picked_id, "flagged")
+
+    page.goto(f"{live_server['url']}/highlights", timeout=5000)
+
+    card = page.locator(f'.highlights-card[data-photo-id="{picked_id}"]')
+    expect(card).to_be_visible(timeout=5000)
+    expect(card).to_have_class(re.compile(r"\bpick-flag-card\b"))
+    expect(card.locator(".pick-flag-badge")).to_be_visible()
+    expect(card.locator(".pick-flag-badge")).to_have_text("Pick")
+
+
 def test_highlights_species_search_filters_buckets(live_server, page):
     db = live_server["db"]
     data = live_server["data"]

--- a/tests/e2e/test_highlights_initial_scope.py
+++ b/tests/e2e/test_highlights_initial_scope.py
@@ -399,6 +399,87 @@ def test_highlights_lightbox_pick_keeps_curated_highlight_first(live_server, pag
     assert int(still_first.get_attribute("data-photo-id")) == highlighted_id
 
 
+def test_highlights_lightbox_pick_applies_backend_score_bonus(live_server, page):
+    """Picking must apply the backend's pick bonus before client-side re-sort.
+
+    Regression for Codex feedback on PR #1176 (thread on line 881): the
+    client sort compares cached ``highlight_score`` values, but the backend
+    bakes a ``+0.08`` bonus into ``highlight_score`` for flagged photos in
+    ``_highlight_score_bucket`` before ordering. In a curated bucket with a
+    stored species highlight, unhighlighted photos are ordered by
+    ``highlight_score``. Without the bonus adjustment, picking an
+    unhighlighted photo whose score is within 0.08 of the next one leaves
+    it behind in the client slice, while a reload would promote it — so the
+    visible slice (and the Save-as-Collection payload derived from it)
+    diverges from what the backend would produce.
+    """
+    db = live_server["db"]
+    data = live_server["data"]
+    _seed_quality_scores_and_species(db, data)
+
+    # Seeded quality scores: hawks are photos[0]=0.90, photos[1]=0.85,
+    # photos[2]=0.80. With no other subject metrics populated,
+    # highlight_score == quality_score in _highlight_score_bucket.
+    highlighted_id = data["photos"][0]  # promoted to top by the stored highlight
+    upper_unhighlighted = data["photos"][1]  # score 0.85 — the pick target
+    lower_unhighlighted = data["photos"][2]  # score 0.80
+
+    # Reduce the gap between the two unhighlighted hawks so the +0.08 bonus
+    # is enough to flip their order, but small enough that a stale cached
+    # score would still leave lower_unhighlighted second.
+    db.conn.execute(
+        "UPDATE photos SET quality_score = ? WHERE id = ?",
+        (0.83, lower_unhighlighted),
+    )
+    db.conn.commit()
+
+    db.add_species_highlight("Red-tailed Hawk", highlighted_id)
+
+    page.goto(f"{live_server['url']}/highlights", timeout=5000)
+    hawk_section = page.locator("section.bucket").filter(has_text="Red-tailed Hawk")
+    expect(hawk_section.locator(".highlights-card").first).to_be_visible(timeout=5000)
+
+    # Initial order: [highlighted, upper_unhighlighted(0.85), lower_unhighlighted(0.83)].
+    initial_ids = hawk_section.locator(".highlights-card").evaluate_all(
+        "cards => cards.map(c => Number(c.getAttribute('data-photo-id')))"
+    )
+    assert initial_ids[0] == highlighted_id
+    assert initial_ids[1] == upper_unhighlighted
+    assert initial_ids[2] == lower_unhighlighted
+
+    # Open the lightbox on the lower unhighlighted card and pick it. The
+    # backend would add +0.08 to its highlight_score (0.83 -> 0.91),
+    # promoting it above upper_unhighlighted (0.85).
+    lower_card = hawk_section.locator(
+        f'.highlights-card[data-photo-id="{lower_unhighlighted}"]'
+    )
+    lower_card.click()
+    page.wait_for_function(
+        "document.getElementById('lightboxOverlay').classList.contains('active')",
+        timeout=3000,
+    )
+    page.wait_for_function(
+        "pid => _lightboxCurrentId === pid",
+        arg=lower_unhighlighted,
+        timeout=3000,
+    )
+    page.keyboard.press("p")
+    assert _wait_for_flag(db, lower_unhighlighted, "flagged") == "flagged"
+
+    # The picked photo must jump ahead of the higher-scored unhighlighted
+    # photo — mirroring what a full reload would render.
+    picked_card = hawk_section.locator(
+        f'.highlights-card[data-photo-id="{lower_unhighlighted}"]'
+    )
+    expect(picked_card).to_have_class(re.compile(r"\bpick-flag-card\b"), timeout=5000)
+    updated_ids = hawk_section.locator(".highlights-card").evaluate_all(
+        "cards => cards.map(c => Number(c.getAttribute('data-photo-id')))"
+    )
+    assert updated_ids[0] == highlighted_id
+    assert updated_ids[1] == lower_unhighlighted
+    assert updated_ids[2] == upper_unhighlighted
+
+
 def test_highlights_species_search_filters_buckets(live_server, page):
     db = live_server["db"]
     data = live_server["data"]

--- a/tests/e2e/test_highlights_initial_scope.py
+++ b/tests/e2e/test_highlights_initial_scope.py
@@ -266,6 +266,84 @@ def test_highlights_lightbox_pick_updates_card_without_reload(live_server, page)
     expect(cleared.locator(".pick-flag-badge")).to_have_count(0)
 
 
+def test_highlights_lightbox_pick_hidden_photo_promotes_to_visible(live_server, page):
+    """Picking a preloaded-but-hidden photo from the lightbox must promote it
+    into the visible slice, not leave it hidden until a reload.
+
+    Regression for Codex feedback on PR #1176: the ``lightbox:flagchanged``
+    handler only mutated ``pickedPhoto.flag`` and rerendered the existing
+    array order. So a photo picked from beyond the ``perRow`` slice (the
+    backend preloads up to 20 per bucket but the grid shows 5 by default)
+    kept its new Pick badge invisible until a full refetch, even though the
+    server's ``picked_first`` sort would have promoted it.
+    """
+    db = live_server["db"]
+    data = live_server["data"]
+    _seed_quality_scores_and_species(db, data)
+
+    hawk_kid = db.conn.execute(
+        "SELECT id FROM keywords WHERE name = ?", ("Red-tailed Hawk",)
+    ).fetchone()["id"]
+    folder_id = data["folders"][0]
+    extras = []
+    for i in range(8):
+        pid = db.add_photo(
+            folder_id=folder_id,
+            filename=f"extra-hawk-{i}.jpg",
+            extension=".jpg",
+            file_size=1000,
+            file_mtime=1.0,
+            timestamp=f"2024-03-11T08:{i:02d}:00",
+        )
+        db.conn.execute(
+            "UPDATE photos SET quality_score = ? WHERE id = ?",
+            (0.5 - i * 0.01, pid),
+        )
+        db.conn.execute(
+            "INSERT OR IGNORE INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+            (pid, hawk_kid),
+        )
+        extras.append(pid)
+    db.conn.commit()
+
+    page.goto(f"{live_server['url']}/highlights", timeout=5000)
+    hawk_section = page.locator("section.bucket").filter(has_text="Red-tailed Hawk")
+    expect(hawk_section.locator(".highlights-card").first).to_be_visible(timeout=5000)
+
+    visible_ids = hawk_section.locator(".highlights-card").evaluate_all(
+        "cards => cards.map(c => Number(c.getAttribute('data-photo-id')))"
+    )
+    # perRow default is 5; extra hawks (8) plus seeded hawks (3) = 11 in the
+    # bucket, so at least one preloaded photo is hidden past the slice.
+    assert len(visible_ids) == 5
+    hidden_pid = next(pid for pid in extras if pid not in set(visible_ids))
+
+    # Open the lightbox on the first visible card so `_lightboxPhotoList` is
+    # populated with the full bucket, then jump to the hidden photo.
+    hawk_section.locator(".highlights-card").nth(0).click()
+    page.wait_for_function(
+        "document.getElementById('lightboxOverlay').classList.contains('active')",
+        timeout=3000,
+    )
+    page.evaluate(
+        "pid => openLightbox(pid, '', _lightboxPhotoList)",
+        hidden_pid,
+    )
+    page.wait_for_function(
+        "pid => _lightboxCurrentId === pid",
+        arg=hidden_pid,
+        timeout=3000,
+    )
+
+    page.keyboard.press("p")
+
+    assert _wait_for_flag(db, hidden_pid, "flagged") == "flagged"
+    promoted = page.locator(f'.highlights-card[data-photo-id="{hidden_pid}"]')
+    expect(promoted).to_be_visible(timeout=5000)
+    expect(promoted).to_have_class(re.compile(r"\bpick-flag-card\b"))
+    expect(promoted.locator(".pick-flag-badge")).to_be_visible()
+
+
 def test_highlights_species_search_filters_buckets(live_server, page):
     db = live_server["db"]
     data = live_server["data"]

--- a/tests/e2e/test_highlights_initial_scope.py
+++ b/tests/e2e/test_highlights_initial_scope.py
@@ -648,6 +648,114 @@ def test_highlights_lightbox_pick_refetches_paged_bucket(live_server, page):
     assert len(all_ids) == 28
 
 
+def test_highlights_lightbox_pick_preserves_loaded_window(live_server, page):
+    """Picking must refetch only the currently-loaded window, not inflate it.
+
+    Regression for Codex feedback on PR #1176 (line 907): the refetch
+    forced ``targetLen = Math.max(500, currentLen)`` on every lightbox
+    pick/unpick. For an unexpanded bucket with the default 20-row initial
+    load, that silently pulled the bucket up to 500 photos in one request;
+    the next "Load more" click then used ``target.photos.length`` (now 500)
+    as its offset and appended photos 500-999, so the expanded grid — and
+    the Save-as-Collection payload — suddenly included hundreds of photos
+    the user never paged through, and each pick downloaded far more data
+    than necessary.
+    """
+    db = live_server["db"]
+    data = live_server["data"]
+    _seed_quality_scores_and_species(db, data)
+
+    hawk_kid = db.conn.execute(
+        "SELECT id FROM keywords WHERE name = ?", ("Red-tailed Hawk",)
+    ).fetchone()["id"]
+    folder_id = data["folders"][0]
+
+    # 3 seeded + 25 extras = 28 hawks; the initial /api/highlights load
+    # caps at 20 per bucket, so has_more starts true and the loaded window
+    # is exactly 20.
+    for i in range(25):
+        pid = db.add_photo(
+            folder_id=folder_id,
+            filename=f"windowed-hawk-{i}.jpg",
+            extension=".jpg",
+            file_size=1000,
+            file_mtime=1.0,
+            timestamp=f"2024-03-11T09:{i:02d}:00",
+        )
+        db.conn.execute(
+            "UPDATE photos SET quality_score = ? WHERE id = ?",
+            (0.5 - i * 0.005, pid),
+        )
+        db.conn.execute(
+            "INSERT OR IGNORE INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+            (pid, hawk_kid),
+        )
+    db.conn.commit()
+
+    page.goto(f"{live_server['url']}/highlights", timeout=5000)
+    hawk_section = page.locator("section.bucket").filter(has_text="Red-tailed Hawk")
+    expect(hawk_section.locator(".highlights-card").first).to_be_visible(timeout=5000)
+
+    initial = page.evaluate(
+        "() => {"
+        "  const b = currentData.buckets.find(x => x.species === 'Red-tailed Hawk');"
+        "  return { len: b.photos.length, hasMore: b.has_more };"
+        "}"
+    )
+    assert initial["len"] == 20
+    assert initial["hasMore"] is True
+
+    first_card = hawk_section.locator(".highlights-card").nth(0)
+    first_pid = int(first_card.get_attribute("data-photo-id"))
+    first_card.click()
+    page.wait_for_function(
+        "document.getElementById('lightboxOverlay').classList.contains('active')",
+        timeout=3000,
+    )
+    page.wait_for_function(
+        "pid => _lightboxCurrentId === pid",
+        arg=first_pid,
+        timeout=3000,
+    )
+
+    # Capture the refetch request URL to prove the limit matches the loaded
+    # window (20), not the old 500 floor.
+    with page.expect_response(
+        lambda r: (
+            "/api/highlights/bucket" in r.url
+            and "offset=0" in r.url
+            and "species=Red-tailed" in r.url
+        ),
+        timeout=5000,
+    ) as refetch:
+        page.keyboard.press("p")
+
+    assert _wait_for_flag(db, first_pid, "flagged") == "flagged"
+    assert "limit=20" in refetch.value.url, (
+        f"refetch limit must match loaded window (20); got {refetch.value.url}"
+    )
+    assert "limit=500" not in refetch.value.url
+
+    # After the refetch, the client-side loaded window must still be 20 —
+    # not silently expanded to 28 (the whole bucket). has_more must remain
+    # true so the Load-more path still targets offset=20 next.
+    page.wait_for_function(
+        "() => {"
+        "  const b = currentData.buckets.find(x => x.species === 'Red-tailed Hawk');"
+        "  return b && b.photos.length === 20 && b.photos[0].flag === 'flagged';"
+        "}",
+        timeout=5000,
+    )
+    after = page.evaluate(
+        "() => {"
+        "  const b = currentData.buckets.find(x => x.species === 'Red-tailed Hawk');"
+        "  return { len: b.photos.length, hasMore: b.has_more };"
+        "}"
+    )
+    assert after["len"] == 20
+    assert after["hasMore"] is True
+
+
 def test_highlights_lightbox_repick_after_eviction_restores_photo(live_server, page):
     """Re-picking from the lightbox after the photo was evicted from the
     loaded window must reload highlights, not silently no-op.

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -8341,12 +8341,21 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         chunk = photos[offset: offset + limit]
         _attach_edit_recipes(db, chunk)
+        # Include the full-bucket ordering keys so a client refetch of a
+        # paged bucket (has_more still true after the loaded window) can
+        # keep bucket.best_score / best_timestamp anchored to the actual
+        # tail. Recomputing them from only the loaded slice would drop
+        # a large species below its true Recommended/Best sort position
+        # when the highest-scored photo lives past the loaded window.
+        top = photos[0] if photos else {}
         return jsonify({
             "species": label,
             "photos": chunk,
             "photo_count": len(photos),
             "loaded_count": min(len(photos), offset + len(chunk)),
             "has_more": offset + len(chunk) < len(photos),
+            "best_score": _bucket_best_score(photos),
+            "best_timestamp": top.get("timestamp") if top else None,
         })
 
     @app.route("/api/highlights/save", methods=["POST"])

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -263,12 +263,19 @@ def _highlight_score_bucket(photos, picked_first=False):
             score = p.get("quality_score") if p.get("quality_score") is not None else 0.0
 
         rating = p.get("rating") or 0
-        if p.get("flag") == "flagged":
-            score += 0.08
         if rating >= 4:
             score += 0.04 + 0.02 * (rating - 4)
         elif rating == 3:
             score += 0.015
+        # Baseline BEFORE the pick bonus, so the client can recompute
+        # highlight_score on a lightbox pick/unpick via clamp(base + bonus)
+        # instead of subtracting the bonus from the already-clamped value —
+        # which loses precision when the raw score exceeded 1.0 pre-clamp
+        # (e.g. base 0.97 → cached 1.0 → subtract 0.08 → 0.92, but the
+        # correct unpicked value is 0.97).
+        base_score_pre_pick = score
+        if p.get("flag") == "flagged":
+            score += 0.08
 
         reasons = []
         if p.get("flag") == "flagged":
@@ -294,6 +301,9 @@ def _highlight_score_bucket(photos, picked_first=False):
             reasons.append("legacy quality")
 
         p["highlight_score"] = round(max(0.0, min(1.0, score)), 4)
+        p["highlight_base_score"] = round(
+            max(0.0, min(1.0, base_score_pre_pick)), 4
+        )
         p["score_parts"] = {
             "focus": round(focus, 3),
             "exposure": round(exposure, 3),

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -850,11 +850,27 @@ function findHighlightPhotoWithContainer(photoId) {
   for (var i = 0; i < buckets.length; i++) {
     var photos = buckets[i].photos || [];
     var match = photos.find(function(p) { return p.id === photoId; });
-    if (match) return { photo: match, photos: photos };
+    if (match) return { photo: match, photos: photos, bucket: buckets[i] };
   }
   var unid = currentData.unidentified && currentData.unidentified.photos || [];
   var match = unid.find(function(p) { return p.id === photoId; });
-  return match ? { photo: match, photos: unid } : null;
+  return match ? { photo: match, photos: unid, bucket: null } : null;
+}
+
+// Mirrors backend `_bucket_best_score`: max highlight_score across the
+// bucket, or null if empty. Called after applyPickBonusOnFlagChange so
+// sortedBuckets() ('Recommended first' / 'Best photo first') doesn't
+// keep the bucket at its pre-pick position — a reload would order it by
+// the post-bonus best.
+function recomputeBucketBestScore(bucket) {
+  if (!bucket || !Array.isArray(bucket.photos)) return;
+  var best = null;
+  for (var i = 0; i < bucket.photos.length; i++) {
+    var s = bucket.photos[i].highlight_score;
+    if (typeof s !== 'number') continue;
+    if (best === null || s > best) best = s;
+  }
+  bucket.best_score = best;
 }
 
 // Backend `_highlight_score_bucket` adds this bonus to `highlight_score`
@@ -1290,6 +1306,7 @@ document.addEventListener('lightbox:flagchanged', function(e) {
     applyPickBonusOnFlagChange(hit.photo, prev, next);
     hit.photo.flag = next;
     sortBucketAfterFlagChange(hit.photos);
+    recomputeBucketBestScore(hit.bucket);
     render();
   }
 });

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -886,9 +886,11 @@ function refreshBucketOrderingKeys(bucket) {
 // rather than mirror `_highlight_score_bucket` / `_apply_ordered_highlights` /
 // `_apply_highlight_preferences` in JS (repeatedly getting it wrong on subtle
 // edge cases), let the server compute the authoritative order and copy it
-// back. Pages in 500-row chunks up to the currently-loaded length because the
-// endpoint clamps `limit` to 500 — a single fetch with limit>500 would drop
-// cards from an expanded bucket (>500 loaded) and shrink Save-as-Collection.
+// back. Pages in up-to-500-row chunks so the final iteration only asks for
+// the remainder of the loaded window (`targetLen - offset`) — a full 500-row
+// last page would silently expand the loaded slice past what the user
+// actually loaded (e.g. 520 loaded would become 1000). The endpoint clamps
+// `limit` to 500, so the per-request cap is preserved automatically.
 // Returns a promise so callers can await the refresh before rendering.
 async function refetchBucketFromZero(target, isUnidentified) {
   if (!target) return;
@@ -905,7 +907,7 @@ async function refetchBucketFromZero(target, isUnidentified) {
     // the endpoint returns the right bucket, not whatever the search box holds.
     params.set('species', speciesKey);
     params.set('offset', offset);
-    params.set('limit', 500);
+    params.set('limit', Math.min(500, targetLen - offset));
     var page = await safeFetch('/api/highlights/bucket?' + params);
     if (!page || !Array.isArray(page.photos)) return;
     lastPage = page;

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -858,18 +858,30 @@ function findHighlightPhotoWithContainer(photoId) {
 }
 
 // Backend `_highlight_score_bucket` adds this bonus to `highlight_score`
-// when flag === 'flagged' before sorting (see vireo/app.py). Client-cached
-// scores already include or exclude the bonus depending on the flag at load
-// time, so a lightbox pick/unpick must apply the same delta before re-
-// sorting — otherwise a stale cached score can keep the wrong photo in the
-// visible slice (and in the Save-as-Collection payload derived from it).
+// when flag === 'flagged' before clamping to [0, 1] (see vireo/app.py).
+// The API also sends `highlight_base_score`: the same computation with the
+// pick bonus omitted, clamped and rounded. On a lightbox pick/unpick we
+// recompute `highlight_score = clamp(base + bonus_if_flagged)` from that
+// baseline so the client mirrors what a reload would produce — subtracting
+// the bonus from the already-clamped cached score would under-count when
+// the raw pre-clamp score exceeded 1.0 (e.g. base 0.97 → cached 1.0 →
+// subtract 0.08 → 0.92, but the correct unpicked value is 0.97).
 var PICK_HIGHLIGHT_SCORE_BONUS = 0.08;
 
 function applyPickBonusOnFlagChange(photo, previousFlag, nextFlag) {
-  if (!photo || typeof photo.highlight_score !== 'number') return;
+  if (!photo) return;
   var wasFlagged = previousFlag === 'flagged';
   var isFlagged = nextFlag === 'flagged';
   if (wasFlagged === isFlagged) return;
+  if (typeof photo.highlight_base_score === 'number') {
+    var next = photo.highlight_base_score + (isFlagged ? PICK_HIGHLIGHT_SCORE_BONUS : 0);
+    photo.highlight_score = Math.max(0, Math.min(1, next));
+    return;
+  }
+  // Fallback for payloads that predate highlight_base_score — apply the
+  // delta to the cached (clamped) score. Ordering may drift by up to the
+  // bonus in the rare case where the raw score exceeded 1.0 pre-clamp.
+  if (typeof photo.highlight_score !== 'number') return;
   var delta = isFlagged ? PICK_HIGHLIGHT_SCORE_BONUS : -PICK_HIGHLIGHT_SCORE_BONUS;
   photo.highlight_score = Math.max(0, Math.min(1, photo.highlight_score + delta));
 }

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -857,12 +857,16 @@ function findHighlightPhotoWithContainer(photoId) {
   return match ? { photo: match, photos: unid, bucket: null } : null;
 }
 
-// Mirrors backend `_bucket_best_score`: max highlight_score across the
-// bucket, or null if empty. Called after applyPickBonusOnFlagChange so
-// sortedBuckets() ('Recommended first' / 'Best photo first') doesn't
-// keep the bucket at its pre-pick position — a reload would order it by
-// the post-bonus best.
-function recomputeBucketBestScore(bucket) {
+// Re-derive the bucket-level keys that sortedBuckets() reads so a
+// client-side pick change orders species the same way a reload would.
+// `best_score` mirrors backend `_bucket_best_score` (max highlight_score
+// across the bucket, or null if empty) so 'Recommended first' / 'Best
+// photo first' don't anchor to the pre-pick max. `best_timestamp`
+// mirrors the backend's `top.get("timestamp")` on photos[0] so 'Newest
+// top photo' / 'Oldest top photo' don't rank the species by whichever
+// photo led before the pick — a pick that promotes a photo to
+// photos[0] must move its timestamp with it.
+function refreshBucketOrderingKeys(bucket) {
   if (!bucket || !Array.isArray(bucket.photos)) return;
   var best = null;
   for (var i = 0; i < bucket.photos.length; i++) {
@@ -871,6 +875,8 @@ function recomputeBucketBestScore(bucket) {
     if (best === null || s > best) best = s;
   }
   bucket.best_score = best;
+  var top = bucket.photos[0];
+  bucket.best_timestamp = top ? (top.timestamp || null) : null;
 }
 
 // Backend `_highlight_score_bucket` adds this bonus to `highlight_score`
@@ -929,7 +935,7 @@ async function refetchBucketFromZero(bucket, isUnidentified) {
   target.loaded_count = data.loaded_count;
   target.has_more = data.has_more;
   if (typeof data.photo_count === 'number') target.photo_count = data.photo_count;
-  recomputeBucketBestScore(target);
+  refreshBucketOrderingKeys(target);
 }
 
 // Sort a bucket's photos to match the backend's ordering after a client-side
@@ -1348,7 +1354,7 @@ document.addEventListener('lightbox:flagchanged', function(e) {
       return;
     }
     sortBucketAfterFlagChange(hit.photos);
-    recomputeBucketBestScore(hit.bucket);
+    refreshBucketOrderingKeys(hit.bucket);
     render();
   }
 });

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -857,12 +857,38 @@ function findHighlightPhotoWithContainer(photoId) {
   return match ? { photo: match, photos: unid } : null;
 }
 
-// Mirror the server-side `_highlight_score_bucket(..., picked_first=True)` sort
-// so a client-side pick change moves the photo into the same slot the backend
-// would place it on a reload. Without this, a picked photo hidden past the
-// perRow slice would keep its Pick badge invisible until a refetch.
-function sortBucketPicksFirst(photos) {
+// Sort a bucket's photos to match the backend's ordering after a client-side
+// flag mutation. If any visible photo maps to a stored species highlight the
+// backend runs `_apply_ordered_highlights` after `_highlight_score_bucket`,
+// which places highlighted photos (by highlight_rank) ahead of unhighlighted
+// ones regardless of flag; otherwise only `_highlight_score_bucket(...,
+// picked_first=True)` applies and flagged photos lead. Without this dispatch,
+// picking an unhighlighted photo in a curated bucket would demote the stored
+// highlight until reload — changing the visible slice and the Save-as-
+// Collection payload that reads from it.
+function sortBucketAfterFlagChange(photos) {
   if (!photos || photos.length < 2) return;
+  var hasHighlights = photos.some(function(p) { return p.is_highlighted; });
+  if (hasHighlights) {
+    photos.sort(function(a, b) {
+      var ah = a.is_highlighted ? 0 : 1;
+      var bh = b.is_highlighted ? 0 : 1;
+      if (ah !== bh) return ah - bh;
+      var ar = a.highlight_rank != null ? a.highlight_rank : Number.MAX_SAFE_INTEGER;
+      var br = b.highlight_rank != null ? b.highlight_rank : Number.MAX_SAFE_INTEGER;
+      if (ar !== br) return ar - br;
+      var as = a.highlight_score || 0, bs = b.highlight_score || 0;
+      if (as !== bs) return bs - as;
+      var ac = a.predicted_confidence || 0, bc = b.predicted_confidence || 0;
+      if (ac !== bc) return bc - ac;
+      var aq = a.quality_score || 0, bq = b.quality_score || 0;
+      if (aq !== bq) return bq - aq;
+      var art = a.rating || 0, brt = b.rating || 0;
+      if (art !== brt) return brt - art;
+      return (a.id || 0) - (b.id || 0);
+    });
+    return;
+  }
   photos.sort(function(a, b) {
     var ap = a.flag === 'flagged' ? 1 : 0;
     var bp = b.flag === 'flagged' ? 1 : 0;
@@ -1222,9 +1248,10 @@ document.addEventListener('lightbox:flagchanged', function(e) {
     // Pick/Unpick from the lightbox: the badge/outline are derived from
     // p.flag inside renderCard, and the visible row is a slice(0, perRow)
     // of bucket.photos, so we must both mutate the flag AND re-sort the
-    // containing bucket to match the backend's picked_first ordering —
+    // containing bucket to match what the backend would render on reload —
     // otherwise a photo picked from the preloaded-but-hidden tail would
-    // keep its Pick badge invisible until a full refetch.
+    // keep its Pick badge invisible, or a pick in a curated bucket would
+    // shove a stored highlight out of the visible slice.
     var prev = detail.previousFlag || 'none';
     var next = detail.flag || 'none';
     if (prev === next) return;
@@ -1232,7 +1259,7 @@ document.addEventListener('lightbox:flagchanged', function(e) {
     var hit = findHighlightPhotoWithContainer(detail.photoId);
     if (!hit) return;
     hit.photo.flag = next;
-    sortBucketPicksFirst(hit.photos);
+    sortBucketAfterFlagChange(hit.photos);
     render();
   }
 });

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -857,26 +857,34 @@ function findHighlightPhotoWithContainer(photoId) {
   return match ? { photo: match, photos: unid, bucket: null } : null;
 }
 
-// Re-derive the bucket-level keys that sortedBuckets() reads so a
-// client-side pick change orders species the same way a reload would.
-// `best_score` mirrors backend `_bucket_best_score` (max highlight_score
-// across the bucket, or null if empty) so 'Recommended first' / 'Best
-// photo first' don't anchor to the pre-pick max. `best_timestamp`
-// mirrors the backend's `top.get("timestamp")` on photos[0] so 'Newest
-// top photo' / 'Oldest top photo' don't rank the species by whichever
-// photo led before the pick — a pick that promotes a photo to
-// photos[0] must move its timestamp with it.
-function refreshBucketOrderingKeys(bucket) {
-  if (!bucket || !Array.isArray(bucket.photos)) return;
-  var best = null;
-  for (var i = 0; i < bucket.photos.length; i++) {
-    var s = bucket.photos[i].highlight_score;
-    if (typeof s !== 'number') continue;
-    if (best === null || s > best) best = s;
+// Copy the authoritative full-bucket ordering keys from a bucket-endpoint
+// page onto the client-side bucket so sortedBuckets() ranks species the
+// same way a reload would. Prefer the endpoint's `best_score` /
+// `best_timestamp` (computed over the entire filtered bucket) over
+// recomputing from `bucket.photos`, because a paged refetch (has_more
+// still true) only loads a prefix — recomputing would drop a species
+// below its true Recommended/Best position when the highest-scored photo
+// lives past the loaded window. Falls back to a local scan only if the
+// endpoint didn't return the keys (older server, defensive).
+function applyBucketOrderingKeysFromPage(bucket, page) {
+  if (!bucket) return;
+  if (page && Object.prototype.hasOwnProperty.call(page, 'best_score')) {
+    bucket.best_score = page.best_score;
+  } else if (Array.isArray(bucket.photos)) {
+    var best = null;
+    for (var i = 0; i < bucket.photos.length; i++) {
+      var s = bucket.photos[i].highlight_score;
+      if (typeof s !== 'number') continue;
+      if (best === null || s > best) best = s;
+    }
+    bucket.best_score = best;
   }
-  bucket.best_score = best;
-  var top = bucket.photos[0];
-  bucket.best_timestamp = top ? (top.timestamp || null) : null;
+  if (page && Object.prototype.hasOwnProperty.call(page, 'best_timestamp')) {
+    bucket.best_timestamp = page.best_timestamp;
+  } else {
+    var top = Array.isArray(bucket.photos) ? bucket.photos[0] : null;
+    bucket.best_timestamp = top ? (top.timestamp || null) : null;
+  }
 }
 
 // Refetch a bucket (or the unidentified section) from offset 0 so the loaded
@@ -920,7 +928,7 @@ async function refetchBucketFromZero(target, isUnidentified) {
   target.loaded_count = allPhotos.length;
   target.has_more = !!lastPage.has_more;
   if (typeof lastPage.photo_count === 'number') target.photo_count = lastPage.photo_count;
-  refreshBucketOrderingKeys(target);
+  applyBucketOrderingKeysFromPage(target, lastPage);
 }
 
 function lightboxIsOpenOnPhoto(photoId) {

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -1189,6 +1189,19 @@ document.addEventListener('lightbox:flagchanged', function(e) {
     rejectedFromGrid.delete(detail.photoId);
     delete rejectedAtLoadSeq[detail.photoId];
     loadHighlights();
+  } else {
+    // Pick/Unpick from the lightbox: the badge/outline are derived from
+    // p.flag inside renderCard, so the already-rendered card DOM stays
+    // stale until the model is updated and re-rendered. Only re-render
+    // when the transition actually crosses the 'flagged' boundary.
+    var prev = detail.previousFlag || 'none';
+    var next = detail.flag || 'none';
+    if (prev === next) return;
+    if (prev !== 'flagged' && next !== 'flagged') return;
+    var pickedPhoto = findHighlightPhoto(detail.photoId);
+    if (!pickedPhoto) return;
+    pickedPhoto.flag = next;
+    render();
   }
 });
 

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -40,8 +40,11 @@
   .highlights-card:hover { border-color:var(--accent); }
   .highlights-card.highlight-card,
   html[data-advanced-mode="true"] .highlights-card.best-card { border-color:var(--accent); }
+  .highlights-card.pick-flag-card { border-color:var(--accent); box-shadow:0 0 0 2px color-mix(in srgb, var(--accent) 50%, transparent); }
   .best-ribbon { position:absolute; top:6px; left:6px; padding:2px 6px; border-radius:999px; background:var(--accent); color:var(--accent-text); font-size:10px; font-weight:700; text-transform:uppercase; letter-spacing:0.5px; }
+  .pick-flag-badge { position:absolute; top:6px; right:6px; z-index:2; padding:3px 8px; border-radius:999px; background:var(--accent); color:var(--accent-text); border:1px solid color-mix(in srgb, var(--accent-text) 65%, transparent); box-shadow:0 1px 6px rgba(0,0,0,0.45); font-size:10px; font-weight:800; text-transform:uppercase; letter-spacing:0.5px; pointer-events:none; }
   .highlight-order { position:absolute; top:6px; right:6px; display:flex; gap:4px; opacity:0; transition:opacity .12s; }
+  .pick-flag-card .highlight-order { top:34px; }
   .highlights-card:hover .highlight-order,
   .highlights-card:focus-within .highlight-order { opacity:1; }
   .highlight-order button { padding:2px 6px; border-radius:999px; border:1px solid rgba(255,255,255,.45); background:rgba(0,0,0,.62); color:#fff; font-size:10px; cursor:pointer; }
@@ -403,6 +406,9 @@ function renderCard(p, idx) {
     : (p.is_species_representative
       ? '<div class="best-ribbon">Representative</div>'
       : (advanced && idx === 0 ? '<div class="best-ribbon">Best</div>' : ''));
+  var flagBadge = p.flag === 'flagged'
+    ? '<div class="pick-flag-badge" title="Flagged as pick">Pick</div>'
+    : '';
   var rep = p.is_species_representative
     ? '<span class="card-chip reason">Representative</span>'
     : '';
@@ -416,8 +422,10 @@ function renderCard(p, idx) {
   return '<div class="highlights-card'
     + (p.is_highlighted ? ' highlight-card' : '')
     + (idx === 0 ? ' best-card' : '')
+    + (p.flag === 'flagged' ? ' pick-flag-card' : '')
     + '" data-photo-id="' + p.id + '" title="' + escapeAttr(title) + '">'
     + ribbon
+    + flagBadge
     + order
     + '<img src="' + thumbSrc + '" alt="' + escapeAttr(p.filename) + '" loading="lazy">'
     + '<div class="card-info">' + scoreChip + conf + rep + reasons + '</div>'

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -902,6 +902,36 @@ function applyPickBonusOnFlagChange(photo, previousFlag, nextFlag) {
   photo.highlight_score = Math.max(0, Math.min(1, photo.highlight_score + delta));
 }
 
+// Refetch a bucket (or the unidentified section) from offset 0 so the loaded
+// window matches the backend's post-pick ordering. Used when `has_more` is
+// true — a client-only resort of the loaded slice can't be trusted because
+// the picked-first bonus can push a previously-visible photo past the loaded
+// window or promote a hidden one into it, and `loadMoreBucket` uses
+// `photos.length` as its next offset. That would append duplicates and skip
+// photos that newly entered the first page. Returns a promise so callers can
+// await the refresh before rendering.
+async function refetchBucketFromZero(bucket, isUnidentified) {
+  var target = bucket;
+  if (!target) return;
+  var currentLen = Array.isArray(target.photos) ? target.photos.length : 0;
+  var params = requestScopeParams();
+  var speciesKey = isUnidentified ? '__unidentified__' : target.species;
+  appendHighlightFilterParams(params);
+  // appendHighlightFilterParams may set 'species' for the species-search
+  // filter; force it back to the target species/unidentified sentinel so
+  // the endpoint returns the right bucket, not whatever the search box holds.
+  params.set('species', speciesKey);
+  params.set('offset', 0);
+  params.set('limit', Math.max(500, currentLen));
+  var data = await safeFetch('/api/highlights/bucket?' + params);
+  if (!data || !Array.isArray(data.photos)) return;
+  target.photos = data.photos;
+  target.loaded_count = data.loaded_count;
+  target.has_more = data.has_more;
+  if (typeof data.photo_count === 'number') target.photo_count = data.photo_count;
+  recomputeBucketBestScore(target);
+}
+
 // Sort a bucket's photos to match the backend's ordering after a client-side
 // flag mutation. If any visible photo maps to a stored species highlight the
 // backend runs `_apply_ordered_highlights` after `_highlight_score_bucket`,
@@ -1305,6 +1335,18 @@ document.addEventListener('lightbox:flagchanged', function(e) {
     if (!hit) return;
     applyPickBonusOnFlagChange(hit.photo, prev, next);
     hit.photo.flag = next;
+    // When the bucket has `has_more`, the loaded window is a subset of
+    // the server's ordered list. A local resort of that window can't
+    // reconcile a pick that promotes a hidden photo into the slice or
+    // demotes a visible one past it, and `loadMoreBucket` would then
+    // append duplicates / skip newly-first-page photos. Refetch instead
+    // so pagination stays aligned with the server's picked-first order.
+    var isUnidentified = hit.bucket === null;
+    var target = isUnidentified ? currentData.unidentified : hit.bucket;
+    if (target && target.has_more) {
+      refetchBucketFromZero(target, isUnidentified).then(render);
+      return;
+    }
     sortBucketAfterFlagChange(hit.photos);
     recomputeBucketBestScore(hit.bucket);
     render();

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -879,111 +879,46 @@ function refreshBucketOrderingKeys(bucket) {
   bucket.best_timestamp = top ? (top.timestamp || null) : null;
 }
 
-// Backend `_highlight_score_bucket` adds this bonus to `highlight_score`
-// when flag === 'flagged' before clamping to [0, 1] (see vireo/app.py).
-// The API also sends `highlight_base_score`: the same computation with the
-// pick bonus omitted, clamped and rounded. On a lightbox pick/unpick we
-// recompute `highlight_score = clamp(base + bonus_if_flagged)` from that
-// baseline so the client mirrors what a reload would produce — subtracting
-// the bonus from the already-clamped cached score would under-count when
-// the raw pre-clamp score exceeded 1.0 (e.g. base 0.97 → cached 1.0 →
-// subtract 0.08 → 0.92, but the correct unpicked value is 0.97).
-var PICK_HIGHLIGHT_SCORE_BONUS = 0.08;
-
-function applyPickBonusOnFlagChange(photo, previousFlag, nextFlag) {
-  if (!photo) return;
-  var wasFlagged = previousFlag === 'flagged';
-  var isFlagged = nextFlag === 'flagged';
-  if (wasFlagged === isFlagged) return;
-  if (typeof photo.highlight_base_score === 'number') {
-    var next = photo.highlight_base_score + (isFlagged ? PICK_HIGHLIGHT_SCORE_BONUS : 0);
-    photo.highlight_score = Math.max(0, Math.min(1, next));
-    return;
-  }
-  // Fallback for payloads that predate highlight_base_score — apply the
-  // delta to the cached (clamped) score. Ordering may drift by up to the
-  // bonus in the rare case where the raw score exceeded 1.0 pre-clamp.
-  if (typeof photo.highlight_score !== 'number') return;
-  var delta = isFlagged ? PICK_HIGHLIGHT_SCORE_BONUS : -PICK_HIGHLIGHT_SCORE_BONUS;
-  photo.highlight_score = Math.max(0, Math.min(1, photo.highlight_score + delta));
-}
-
 // Refetch a bucket (or the unidentified section) from offset 0 so the loaded
-// window matches the backend's post-pick ordering. Used when `has_more` is
-// true — a client-only resort of the loaded slice can't be trusted because
-// the picked-first bonus can push a previously-visible photo past the loaded
-// window or promote a hidden one into it, and `loadMoreBucket` uses
-// `photos.length` as its next offset. That would append duplicates and skip
-// photos that newly entered the first page. Returns a promise so callers can
-// await the refresh before rendering.
-async function refetchBucketFromZero(bucket, isUnidentified) {
-  var target = bucket;
+// window matches the backend's post-pick ordering. A pick mutates
+// highlight_score (the +0.08 bonus, clamped to [0, 1]) and can flip ordering
+// against representatives, curated species_highlights, or the has_more tail;
+// rather than mirror `_highlight_score_bucket` / `_apply_ordered_highlights` /
+// `_apply_highlight_preferences` in JS (repeatedly getting it wrong on subtle
+// edge cases), let the server compute the authoritative order and copy it
+// back. Pages in 500-row chunks up to the currently-loaded length because the
+// endpoint clamps `limit` to 500 — a single fetch with limit>500 would drop
+// cards from an expanded bucket (>500 loaded) and shrink Save-as-Collection.
+// Returns a promise so callers can await the refresh before rendering.
+async function refetchBucketFromZero(target, isUnidentified) {
   if (!target) return;
   var currentLen = Array.isArray(target.photos) ? target.photos.length : 0;
-  var params = requestScopeParams();
   var speciesKey = isUnidentified ? '__unidentified__' : target.species;
-  appendHighlightFilterParams(params);
-  // appendHighlightFilterParams may set 'species' for the species-search
-  // filter; force it back to the target species/unidentified sentinel so
-  // the endpoint returns the right bucket, not whatever the search box holds.
-  params.set('species', speciesKey);
-  params.set('offset', 0);
-  params.set('limit', Math.max(500, currentLen));
-  var data = await safeFetch('/api/highlights/bucket?' + params);
-  if (!data || !Array.isArray(data.photos)) return;
-  target.photos = data.photos;
-  target.loaded_count = data.loaded_count;
-  target.has_more = data.has_more;
-  if (typeof data.photo_count === 'number') target.photo_count = data.photo_count;
-  refreshBucketOrderingKeys(target);
-}
-
-// Sort a bucket's photos to match the backend's ordering after a client-side
-// flag mutation. If any visible photo maps to a stored species highlight the
-// backend runs `_apply_ordered_highlights` after `_highlight_score_bucket`,
-// which places highlighted photos (by highlight_rank) ahead of unhighlighted
-// ones regardless of flag; otherwise only `_highlight_score_bucket(...,
-// picked_first=True)` applies and flagged photos lead. Without this dispatch,
-// picking an unhighlighted photo in a curated bucket would demote the stored
-// highlight until reload — changing the visible slice and the Save-as-
-// Collection payload that reads from it.
-function sortBucketAfterFlagChange(photos) {
-  if (!photos || photos.length < 2) return;
-  var hasHighlights = photos.some(function(p) { return p.is_highlighted; });
-  if (hasHighlights) {
-    photos.sort(function(a, b) {
-      var ah = a.is_highlighted ? 0 : 1;
-      var bh = b.is_highlighted ? 0 : 1;
-      if (ah !== bh) return ah - bh;
-      var ar = a.highlight_rank != null ? a.highlight_rank : Number.MAX_SAFE_INTEGER;
-      var br = b.highlight_rank != null ? b.highlight_rank : Number.MAX_SAFE_INTEGER;
-      if (ar !== br) return ar - br;
-      var as = a.highlight_score || 0, bs = b.highlight_score || 0;
-      if (as !== bs) return bs - as;
-      var ac = a.predicted_confidence || 0, bc = b.predicted_confidence || 0;
-      if (ac !== bc) return bc - ac;
-      var aq = a.quality_score || 0, bq = b.quality_score || 0;
-      if (aq !== bq) return bq - aq;
-      var art = a.rating || 0, brt = b.rating || 0;
-      if (art !== brt) return brt - art;
-      return (a.id || 0) - (b.id || 0);
-    });
-    return;
+  var targetLen = Math.max(500, currentLen);
+  var allPhotos = [];
+  var lastPage = null;
+  for (var offset = 0; offset < targetLen; offset += 500) {
+    var params = requestScopeParams();
+    appendHighlightFilterParams(params);
+    // appendHighlightFilterParams may set 'species' for the species-search
+    // filter; force it back to the target species/unidentified sentinel so
+    // the endpoint returns the right bucket, not whatever the search box holds.
+    params.set('species', speciesKey);
+    params.set('offset', offset);
+    params.set('limit', 500);
+    var page = await safeFetch('/api/highlights/bucket?' + params);
+    if (!page || !Array.isArray(page.photos)) return;
+    lastPage = page;
+    if (page.photos.length === 0) break;
+    allPhotos = allPhotos.concat(page.photos);
+    if (!page.has_more) break;
   }
-  photos.sort(function(a, b) {
-    var ap = a.flag === 'flagged' ? 1 : 0;
-    var bp = b.flag === 'flagged' ? 1 : 0;
-    if (ap !== bp) return bp - ap;
-    var ah = a.highlight_score || 0, bh = b.highlight_score || 0;
-    if (ah !== bh) return bh - ah;
-    var ac = a.predicted_confidence || 0, bc = b.predicted_confidence || 0;
-    if (ac !== bc) return bc - ac;
-    var aq = a.quality_score || 0, bq = b.quality_score || 0;
-    if (aq !== bq) return bq - aq;
-    var ar = a.rating || 0, br = b.rating || 0;
-    if (ar !== br) return br - ar;
-    return (a.id || 0) - (b.id || 0);
-  });
+  if (!lastPage) return;
+  target.photos = allPhotos;
+  target.loaded_count = allPhotos.length;
+  target.has_more = !!lastPage.has_more;
+  if (typeof lastPage.photo_count === 'number') target.photo_count = lastPage.photo_count;
+  refreshBucketOrderingKeys(target);
 }
 
 function lightboxIsOpenOnPhoto(photoId) {
@@ -1326,36 +1261,30 @@ document.addEventListener('lightbox:flagchanged', function(e) {
     delete rejectedAtLoadSeq[detail.photoId];
     loadHighlights();
   } else {
-    // Pick/Unpick from the lightbox: the badge/outline are derived from
-    // p.flag inside renderCard, and the visible row is a slice(0, perRow)
-    // of bucket.photos, so we must both mutate the flag AND re-sort the
-    // containing bucket to match what the backend would render on reload —
-    // otherwise a photo picked from the preloaded-but-hidden tail would
-    // keep its Pick badge invisible, or a pick in a curated bucket would
-    // shove a stored highlight out of the visible slice.
+    // Pick/Unpick from the lightbox: the visible row is a slice(0, perRow)
+    // of bucket.photos, and the backend applies the +0.08 highlight_score
+    // bonus + picked_first ordering + `_apply_ordered_highlights` +
+    // `_apply_highlight_preferences` before serving that ordering. Rather
+    // than mirror all of that in JS (which has already produced a stream
+    // of ordering bugs against representatives, curated highlights, the
+    // score clamp, best_timestamp, and the has_more offset), refetch the
+    // bucket authoritatively so the client window is always what a full
+    // reload would produce.
     var prev = detail.previousFlag || 'none';
     var next = detail.flag || 'none';
     if (prev === next) return;
     if (prev !== 'flagged' && next !== 'flagged') return;
     var hit = findHighlightPhotoWithContainer(detail.photoId);
     if (!hit) return;
-    applyPickBonusOnFlagChange(hit.photo, prev, next);
+    // Mutate the shared photo reference immediately so any UI that reads
+    // photo.flag between now and the refetch resolving (e.g. the still-open
+    // lightbox controls) reflects the new pick state; the refetch then
+    // replaces the bucket's photo array with the server-authoritative order.
     hit.photo.flag = next;
-    // When the bucket has `has_more`, the loaded window is a subset of
-    // the server's ordered list. A local resort of that window can't
-    // reconcile a pick that promotes a hidden photo into the slice or
-    // demotes a visible one past it, and `loadMoreBucket` would then
-    // append duplicates / skip newly-first-page photos. Refetch instead
-    // so pagination stays aligned with the server's picked-first order.
     var isUnidentified = hit.bucket === null;
     var target = isUnidentified ? currentData.unidentified : hit.bucket;
-    if (target && target.has_more) {
-      refetchBucketFromZero(target, isUnidentified).then(render);
-      return;
-    }
-    sortBucketAfterFlagChange(hit.photos);
-    refreshBucketOrderingKeys(hit.bucket);
-    render();
+    if (!target) { render(); return; }
+    refetchBucketFromZero(target, isUnidentified).then(render);
   }
 });
 

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -229,6 +229,11 @@ var lastHighlightReject = null;
 // out-of-band (another tab, Undo panel), which it must be trusted to include.
 var highlightsLoadSeq = 0;
 var rejectedAtLoadSeq = {};
+// Per-bucket monotonic counter for refetchBucketFromZero. Rapid Pick/Unpick
+// cycles on the same bucket can leave two /api/highlights/bucket refetches in
+// flight; without a stamp, an older response can arrive after a newer one and
+// overwrite the fresher photos/ordering keys.
+var bucketRefetchSeq = {};
 
 function escapeAttr(s) {
   if (s === null || s === undefined) return '';
@@ -911,6 +916,10 @@ async function refetchBucketFromZero(target, isUnidentified) {
   var speciesKey = isUnidentified ? '__unidentified__' : target.species;
   var targetLen = currentLen;
   if (targetLen <= 0) return;
+  // Stamp this refetch so a slower earlier one for the same bucket can't
+  // clobber a newer response (Pick → Unpick before the first GET resolves).
+  var seq = (bucketRefetchSeq[speciesKey] || 0) + 1;
+  bucketRefetchSeq[speciesKey] = seq;
   var allPhotos = [];
   var lastPage = null;
   for (var offset = 0; offset < targetLen; offset += 500) {
@@ -923,6 +932,7 @@ async function refetchBucketFromZero(target, isUnidentified) {
     params.set('offset', offset);
     params.set('limit', Math.min(500, targetLen - offset));
     var page = await safeFetch('/api/highlights/bucket?' + params);
+    if (bucketRefetchSeq[speciesKey] !== seq) return;
     if (!page || !Array.isArray(page.photos)) return;
     lastPage = page;
     if (page.photos.length === 0) break;
@@ -930,6 +940,7 @@ async function refetchBucketFromZero(target, isUnidentified) {
     if (!page.has_more) break;
   }
   if (!lastPage) return;
+  if (bucketRefetchSeq[speciesKey] !== seq) return;
   target.photos = allPhotos;
   target.loaded_count = allPhotos.length;
   target.has_more = !!lastPage.has_more;

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -857,6 +857,23 @@ function findHighlightPhotoWithContainer(photoId) {
   return match ? { photo: match, photos: unid } : null;
 }
 
+// Backend `_highlight_score_bucket` adds this bonus to `highlight_score`
+// when flag === 'flagged' before sorting (see vireo/app.py). Client-cached
+// scores already include or exclude the bonus depending on the flag at load
+// time, so a lightbox pick/unpick must apply the same delta before re-
+// sorting — otherwise a stale cached score can keep the wrong photo in the
+// visible slice (and in the Save-as-Collection payload derived from it).
+var PICK_HIGHLIGHT_SCORE_BONUS = 0.08;
+
+function applyPickBonusOnFlagChange(photo, previousFlag, nextFlag) {
+  if (!photo || typeof photo.highlight_score !== 'number') return;
+  var wasFlagged = previousFlag === 'flagged';
+  var isFlagged = nextFlag === 'flagged';
+  if (wasFlagged === isFlagged) return;
+  var delta = isFlagged ? PICK_HIGHLIGHT_SCORE_BONUS : -PICK_HIGHLIGHT_SCORE_BONUS;
+  photo.highlight_score = Math.max(0, Math.min(1, photo.highlight_score + delta));
+}
+
 // Sort a bucket's photos to match the backend's ordering after a client-side
 // flag mutation. If any visible photo maps to a stored species highlight the
 // backend runs `_apply_ordered_highlights` after `_highlight_score_bucket`,
@@ -1258,6 +1275,7 @@ document.addEventListener('lightbox:flagchanged', function(e) {
     if (prev !== 'flagged' && next !== 'flagged') return;
     var hit = findHighlightPhotoWithContainer(detail.photoId);
     if (!hit) return;
+    applyPickBonusOnFlagChange(hit.photo, prev, next);
     hit.photo.flag = next;
     sortBucketAfterFlagChange(hit.photos);
     render();

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -1285,7 +1285,17 @@ document.addEventListener('lightbox:flagchanged', function(e) {
     if (prev === next) return;
     if (prev !== 'flagged' && next !== 'flagged') return;
     var hit = findHighlightPhotoWithContainer(detail.photoId);
-    if (!hit) return;
+    if (!hit) {
+      // Eviction path: a prior unpick's refetchBucketFromZero can drop a
+      // photo out of the loaded window when it was only visible because
+      // picked_first promoted it. If the lightbox is still open on that
+      // photo and the user re-picks, we no longer have a bucket reference
+      // for a targeted refetch — reload everything so the fresh
+      // picked_first ordering brings the photo back into a bucket window
+      // (and the Save-as-Collection payload).
+      loadHighlights();
+      return;
+    }
     // Mutate the shared photo reference immediately so any UI that reads
     // photo.flag between now and the refetch resolving (e.g. the still-open
     // lightbox controls) reflects the new pick state; the refetch then

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -899,12 +899,18 @@ function applyBucketOrderingKeysFromPage(bucket, page) {
 // last page would silently expand the loaded slice past what the user
 // actually loaded (e.g. 520 loaded would become 1000). The endpoint clamps
 // `limit` to 500, so the per-request cap is preserved automatically.
+// Refetch size mirrors the user's currently loaded window (`currentLen`) —
+// forcing it up to 500 would silently expand an unexpanded 20-row bucket to
+// 500 rows, and the next "Load more" (which offsets by `target.photos.length`)
+// would then start at 500 and render up to 1000 cards the user never paged
+// through, plus bloat every pick's Save-as-Collection payload.
 // Returns a promise so callers can await the refresh before rendering.
 async function refetchBucketFromZero(target, isUnidentified) {
   if (!target) return;
   var currentLen = Array.isArray(target.photos) ? target.photos.length : 0;
   var speciesKey = isUnidentified ? '__unidentified__' : target.species;
-  var targetLen = Math.max(500, currentLen);
+  var targetLen = currentLen;
+  if (targetLen <= 0) return;
   var allPhotos = [];
   var lastPage = null;
   for (var offset = 0; offset < targetLen; offset += 500) {
@@ -1304,6 +1310,10 @@ document.addEventListener('lightbox:flagchanged', function(e) {
     var isUnidentified = hit.bucket === null;
     var target = isUnidentified ? currentData.unidentified : hit.bucket;
     if (!target) { render(); return; }
+    // Render once immediately so the Pick badge/outline appears without
+    // waiting for the refetch's network round-trip; render again after the
+    // refetch so the reordered bucket window replaces the stale one.
+    render();
     refetchBucketFromZero(target, isUnidentified).then(render);
   }
 });

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -840,14 +840,43 @@ function render() {
 }
 
 function findHighlightPhoto(photoId) {
+  var hit = findHighlightPhotoWithContainer(photoId);
+  return hit ? hit.photo : null;
+}
+
+function findHighlightPhotoWithContainer(photoId) {
   if (!currentData || photoId == null) return null;
   var buckets = currentData.buckets || [];
   for (var i = 0; i < buckets.length; i++) {
-    var match = (buckets[i].photos || []).find(function(p) { return p.id === photoId; });
-    if (match) return match;
+    var photos = buckets[i].photos || [];
+    var match = photos.find(function(p) { return p.id === photoId; });
+    if (match) return { photo: match, photos: photos };
   }
   var unid = currentData.unidentified && currentData.unidentified.photos || [];
-  return unid.find(function(p) { return p.id === photoId; }) || null;
+  var match = unid.find(function(p) { return p.id === photoId; });
+  return match ? { photo: match, photos: unid } : null;
+}
+
+// Mirror the server-side `_highlight_score_bucket(..., picked_first=True)` sort
+// so a client-side pick change moves the photo into the same slot the backend
+// would place it on a reload. Without this, a picked photo hidden past the
+// perRow slice would keep its Pick badge invisible until a refetch.
+function sortBucketPicksFirst(photos) {
+  if (!photos || photos.length < 2) return;
+  photos.sort(function(a, b) {
+    var ap = a.flag === 'flagged' ? 1 : 0;
+    var bp = b.flag === 'flagged' ? 1 : 0;
+    if (ap !== bp) return bp - ap;
+    var ah = a.highlight_score || 0, bh = b.highlight_score || 0;
+    if (ah !== bh) return bh - ah;
+    var ac = a.predicted_confidence || 0, bc = b.predicted_confidence || 0;
+    if (ac !== bc) return bc - ac;
+    var aq = a.quality_score || 0, bq = b.quality_score || 0;
+    if (aq !== bq) return bq - aq;
+    var ar = a.rating || 0, br = b.rating || 0;
+    if (ar !== br) return br - ar;
+    return (a.id || 0) - (b.id || 0);
+  });
 }
 
 function lightboxIsOpenOnPhoto(photoId) {
@@ -1191,16 +1220,19 @@ document.addEventListener('lightbox:flagchanged', function(e) {
     loadHighlights();
   } else {
     // Pick/Unpick from the lightbox: the badge/outline are derived from
-    // p.flag inside renderCard, so the already-rendered card DOM stays
-    // stale until the model is updated and re-rendered. Only re-render
-    // when the transition actually crosses the 'flagged' boundary.
+    // p.flag inside renderCard, and the visible row is a slice(0, perRow)
+    // of bucket.photos, so we must both mutate the flag AND re-sort the
+    // containing bucket to match the backend's picked_first ordering —
+    // otherwise a photo picked from the preloaded-but-hidden tail would
+    // keep its Pick badge invisible until a full refetch.
     var prev = detail.previousFlag || 'none';
     var next = detail.flag || 'none';
     if (prev === next) return;
     if (prev !== 'flagged' && next !== 'flagged') return;
-    var pickedPhoto = findHighlightPhoto(detail.photoId);
-    if (!pickedPhoto) return;
-    pickedPhoto.flag = next;
+    var hit = findHighlightPhotoWithContainer(detail.photoId);
+    if (!hit) return;
+    hit.photo.flag = next;
+    sortBucketPicksFirst(hit.photos);
     render();
   }
 });

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -5153,6 +5153,77 @@ def test_highlights_expose_pre_pick_base_score(app_and_db):
     assert photos[unpicked_id]["highlight_base_score"] == 0.60
 
 
+def test_highlights_bucket_returns_full_bucket_ordering_keys(app_and_db):
+    """/api/highlights/bucket returns full-bucket best_score/best_timestamp
+    so a client refetch of a paged bucket doesn't shrink the ordering
+    keys to just the loaded window.
+
+    Regression for Codex feedback on PR #1176 (line 923): after a
+    lightbox pick, the client calls refetchBucketFromZero to mirror the
+    server's post-pick order. When has_more is still true (large bucket
+    with a low limit) the response was only the first page, so the
+    client recomputed bucket.best_score from that partial slice — if the
+    highest-scored photo lives past the loaded window, the bucket's
+    Recommended/Best sort key would silently shrink and the species
+    would drop below its true position until a full reload.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES ('/pg', 'pg', 'ok')"
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO workspace_folders (workspace_id, folder_id) VALUES (?, ?)",
+        (db._ws_id(), fid),
+    )
+    kw = db.conn.execute(
+        "INSERT INTO keywords (name, type, is_species) VALUES ('Robin', 'taxonomy', 1)"
+    ).lastrowid
+    # Three photos; the highest-scored one (0.9) sits at offset 2 so
+    # a limit=1 request would miss it and a naive client recompute
+    # from the loaded window would land on 0.7, not 0.9.
+    photo_ids = []
+    for filename, quality, ts in [
+        ("hi.jpg", 0.7, 3000),
+        ("mid.jpg", 0.5, 2000),
+        ("top.jpg", 0.9, 1000),
+    ]:
+        pid = db.conn.execute(
+            "INSERT INTO photos (folder_id, filename, quality_score, flag, timestamp) "
+            "VALUES (?, ?, ?, 'none', ?)",
+            (fid, filename, quality, ts),
+        ).lastrowid
+        db.conn.execute(
+            "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+            (pid, kw),
+        )
+        photo_ids.append(pid)
+    db.conn.commit()
+
+    resp = client.get(
+        "/api/highlights/bucket",
+        query_string={
+            "folder_id": fid,
+            "species": "Robin",
+            "offset": 0,
+            "limit": 1,
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    # Only the first page came back...
+    assert data["has_more"] is True
+    assert len(data["photos"]) == 1
+    # ...but the ordering keys reflect the ENTIRE filtered bucket, so
+    # the client can copy them onto bucket.best_score / best_timestamp
+    # without shrinking the sort key to whatever the loaded window
+    # happens to hold.
+    assert data["best_score"] == 0.9
+    # best_timestamp mirrors the backend `top.get("timestamp")` on
+    # photos[0] of the full ordered bucket, not the loaded slice.
+    assert data["best_timestamp"] == data["photos"][0]["timestamp"]
+
+
 def test_highlights_bucket_mixed_accepted_predicted_is_not_accepted(app_and_db):
     """A bucket whose photos are a mix of accepted-tag and prediction-only
     must report is_accepted=False. The "Confirmed" badge means the whole

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -5100,6 +5100,59 @@ def test_highlights_buckets_by_accepted_species(app_and_db):
     assert qs == sorted(qs, reverse=True)
 
 
+def test_highlights_expose_pre_pick_base_score(app_and_db):
+    """Each photo carries `highlight_base_score` = pre-pick-bonus baseline.
+
+    Regression for Codex feedback on PR #1176 (line 874): the client-side
+    lightbox pick handler must recompute highlight_score without losing
+    precision to clamping. A flagged photo whose raw score is 0.97 gets
+    +0.08 → 1.05, clamped and cached as highlight_score=1.0; subtracting
+    the bonus on unpick would give 0.92 while the correct value is 0.97.
+    Exposing the pre-bonus baseline lets the client compute the exact same
+    value the backend would on a full reload.
+    """
+    app, db = app_and_db
+    client = app.test_client()
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES ('/b', 'b', 'ok')"
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO workspace_folders (workspace_id, folder_id) VALUES (?, ?)",
+        (db._ws_id(), fid),
+    )
+    robin_kw = db.conn.execute(
+        "INSERT INTO keywords (name, type, is_species) VALUES ('Robin', 'taxonomy', 1)"
+    ).lastrowid
+    picked_id = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+        "VALUES (?, 'picked.jpg', 0.97, 'flagged')",
+        (fid,),
+    ).lastrowid
+    unpicked_id = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+        "VALUES (?, 'unpicked.jpg', 0.60, 'none')",
+        (fid,),
+    ).lastrowid
+    for pid in (picked_id, unpicked_id):
+        db.conn.execute(
+            "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+            (pid, robin_kw),
+        )
+    db.conn.commit()
+
+    resp = client.get(f"/api/highlights?folder_id={fid}")
+    assert resp.status_code == 200
+    photos = {p["id"]: p for p in resp.get_json()["buckets"][0]["photos"]}
+    # Picked photo: 0.97 + 0.08 = 1.05, clamped to 1.0 for highlight_score.
+    # highlight_base_score keeps the pre-bonus 0.97 so the client can
+    # reverse the pick without under-counting.
+    assert photos[picked_id]["highlight_score"] == 1.0
+    assert photos[picked_id]["highlight_base_score"] == 0.97
+    # Unpicked photo: no bonus, so base == score.
+    assert photos[unpicked_id]["highlight_score"] == 0.60
+    assert photos[unpicked_id]["highlight_base_score"] == 0.60
+
+
 def test_highlights_bucket_mixed_accepted_predicted_is_not_accepted(app_and_db):
     """A bucket whose photos are a mix of accepted-tag and prediction-only
     must report is_accepted=False. The "Confirmed" badge means the whole

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -2505,21 +2505,25 @@ def test_rsync_streamed_runs_as_long_as_it_progresses(monkeypatch):
     import move as move_mod
 
     def _fake_popen(*_a, **_k):
-        # 8 files, one every 0.1s = 0.8s total — well past the 0.3s stall
-        # window, but never idle for 0.3s, so the watchdog must not fire.
-        return _FakeProc(_StreamingStdout(n=8, gap=0.1))
+        # 12 files, one every 0.1s = 1.2s total — comfortably past the
+        # 1.0s stall window, so the runtime exceeds it and the watchdog
+        # would fire if progress didn't reset the clock. The 10x gap of
+        # per-file jitter margin (0.1s emit vs 1.0s window) keeps the
+        # test robust against CI runner scheduling stalls that pushed
+        # the previous 0.1s-vs-0.3s spacing over the edge on macOS.
+        return _FakeProc(_StreamingStdout(n=12, gap=0.1))
 
     monkeypatch.setattr(move_mod.subprocess, "Popen", _fake_popen)
 
     seen = []
     rc, stderr, timed_out = move_mod._run_rsync_streamed(
-        "/src", "/dst", ["--ignore-existing"], 8,
+        "/src", "/dst", ["--ignore-existing"], 12,
         lambda cur, tot, name, phase: seen.append(name),
-        stall_timeout=0.3,
+        stall_timeout=1.0,
     )
     assert timed_out is False
     assert rc == 0
-    assert len(seen) == 8  # progress reported for every transferred file
+    assert len(seen) == 12  # progress reported for every transferred file
 
 
 @pytest.mark.skipif(not hasattr(os, "openpty"), reason="pty is POSIX-only")


### PR DESCRIPTION
Highlights cards now make picked photos obvious with a persistent Pick badge and stronger accent outline. The highlight ordering controls are offset on picked cards so they do not overlap the badge. Added Playwright coverage that verifies a flagged highlight renders the picked marker.\n\nValidation: pytest tests/e2e/test_highlights_initial_scope.py -q