### PR TITLE
Disable text correction in Vireo inputs

### DIFF
--- a/tests/e2e/test_browse_search_empty_state.py
+++ b/tests/e2e/test_browse_search_empty_state.py
@@ -10,6 +10,11 @@ def test_keyword_search_empty_state_and_clear(live_server, page):
     cards.first.wait_for(state="visible")
 
     search = page.locator("#searchInput")
+    expect(search).to_have_attribute("autocomplete", "off")
+    expect(search).to_have_attribute("autocorrect", "off")
+    expect(search).to_have_attribute("autocapitalize", "none")
+    expect(search).to_have_attribute("spellcheck", "false")
+
     search.fill("definitely-no-such-photo")
 
     expect(page.locator("#emptyState")).to_be_visible()

--- a/tests/e2e/test_page_loads.py
+++ b/tests/e2e/test_page_loads.py
@@ -62,3 +62,16 @@ def test_text_inputs_disable_os_correction_app_wide(live_server, page):
         }"""
     )
     _expect_text_correction_disabled(page.locator("#dynamicTextInput"))
+
+    # A password input flipped to text at runtime (Settings "Show" buttons)
+    # should also receive the correction opt-out.
+    page.evaluate(
+        """() => {
+            const input = document.createElement('input');
+            input.type = 'password';
+            input.id = 'flippedPasswordInput';
+            document.body.appendChild(input);
+            input.type = 'text';
+        }"""
+    )
+    _expect_text_correction_disabled(page.locator("#flippedPasswordInput"))

--- a/tests/e2e/test_page_loads.py
+++ b/tests/e2e/test_page_loads.py
@@ -37,3 +37,28 @@ def test_page_loads_within_timeout(live_server, page, path):
     assert response.status == 200
     # Page should have rendered — title or body content present
     expect(page.locator("body")).not_to_be_empty()
+
+
+def _expect_text_correction_disabled(locator):
+    expect(locator).to_have_attribute("autocomplete", "off")
+    expect(locator).to_have_attribute("autocorrect", "off")
+    expect(locator).to_have_attribute("autocapitalize", "none")
+    expect(locator).to_have_attribute("spellcheck", "false")
+
+
+def test_text_inputs_disable_os_correction_app_wide(live_server, page):
+    """Text/search fields should not let browser or OS autocorrect alter queries."""
+    url = live_server["url"]
+    page.goto(f"{url}/edit")
+
+    _expect_text_correction_disabled(page.locator("#editorSearchInput"))
+
+    page.evaluate(
+        """() => {
+            const input = document.createElement('input');
+            input.type = 'text';
+            input.id = 'dynamicTextInput';
+            document.body.appendChild(input);
+        }"""
+    )
+    _expect_text_correction_disabled(page.locator("#dynamicTextInput"))

--- a/vireo/static/vireo-utils.js
+++ b/vireo/static/vireo-utils.js
@@ -17,6 +17,48 @@ function escapeAttr(str) {
     .replace(/>/g, '&gt;');
 }
 
+var VireoTextInputs = (function() {
+  var selector = 'input[type="text"], input[type="search"], input:not([type]), textarea';
+
+  function disableCorrection(el) {
+    if (!el || !el.setAttribute) return;
+    el.setAttribute('autocomplete', 'off');
+    el.setAttribute('autocorrect', 'off');
+    el.setAttribute('autocapitalize', 'none');
+    el.setAttribute('spellcheck', 'false');
+  }
+
+  function apply(root) {
+    if (!root || !root.querySelectorAll) return;
+    if (root.matches && root.matches(selector)) disableCorrection(root);
+    root.querySelectorAll(selector).forEach(disableCorrection);
+  }
+
+  function start() {
+    apply(document);
+    if (!window.MutationObserver || !document.body) return;
+    var observer = new MutationObserver(function(records) {
+      records.forEach(function(record) {
+        record.addedNodes.forEach(function(node) {
+          if (node.nodeType === 1) apply(node);
+        });
+      });
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start);
+  } else {
+    start();
+  }
+
+  return {
+    apply: apply,
+    disableCorrection: disableCorrection,
+  };
+})();
+
 var VireoTextSearch = (function() {
   function isWordChar(ch) {
     return !!ch && (/[0-9]/.test(ch) || ch.toLowerCase() !== ch.toUpperCase());

--- a/vireo/static/vireo-utils.js
+++ b/vireo/static/vireo-utils.js
@@ -39,12 +39,21 @@ var VireoTextInputs = (function() {
     if (!window.MutationObserver || !document.body) return;
     var observer = new MutationObserver(function(records) {
       records.forEach(function(record) {
+        if (record.type === 'attributes') {
+          if (record.target && record.target.nodeType === 1) apply(record.target);
+          return;
+        }
         record.addedNodes.forEach(function(node) {
           if (node.nodeType === 1) apply(node);
         });
       });
     });
-    observer.observe(document.body, { childList: true, subtree: true });
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['type'],
+    });
   }
 
   if (document.readyState === 'loading') {

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1385,7 +1385,9 @@ body {
     <!-- Filter Bar -->
     <div class="filter-bar">
       <div class="search-control">
-        <input type="text" id="searchInput" placeholder="Search keywords or filenames..." onkeydown="if(event.key==='Enter')applySearchFilterNow()" oninput="scheduleSearchFilter()">
+        <input type="text" id="searchInput" placeholder="Search keywords or filenames..."
+               autocomplete="off" autocorrect="off" autocapitalize="none" spellcheck="false"
+               onkeydown="if(event.key==='Enter')applySearchFilterNow()" oninput="scheduleSearchFilter()">
         <button id="keywordMatchCaseBtn" class="search-option-btn" type="button" aria-pressed="false" onclick="toggleKeywordSearchOption('match_case')" title="Match case">Aa</button>
         <button id="keywordWholeWordBtn" class="search-option-btn" type="button" aria-pressed="false" onclick="toggleKeywordSearchOption('whole_word')" title="Match whole word">ab</button>
       </div>
@@ -1646,7 +1648,8 @@ body {
         <div id="locationFilled" class="single-only" hidden></div>
         <div id="locationEmpty">
           <div class="keyword-autocomplete">
-            <input type="text" id="locationInput" class="add-kw-input" placeholder="📍 Add location..." autocomplete="off">
+            <input type="text" id="locationInput" class="add-kw-input" placeholder="📍 Add location..."
+                   autocomplete="off" autocorrect="off" autocapitalize="none" spellcheck="false">
             <div class="keyword-suggestion-list location-keyword-suggestion-list" id="locationKeywordSuggestions" role="listbox"></div>
           </div>
           <div id="locationExifSuggestion" class="location-suggestion" hidden></div>
@@ -1658,7 +1661,8 @@ body {
         <div class="detail-section-title">Keywords</div>
         <div id="detailKeywords" class="single-only"></div>
         <div class="keyword-autocomplete">
-          <input class="add-kw-input" id="addKeywordInput" placeholder="Add keyword..." autocomplete="off">
+          <input class="add-kw-input" id="addKeywordInput" placeholder="Add keyword..."
+                 autocomplete="off" autocorrect="off" autocapitalize="none" spellcheck="false">
           <div class="keyword-suggestion-list" id="addKeywordSuggestions" role="listbox"></div>
         </div>
       </div>
@@ -1717,7 +1721,8 @@ body {
   <div class="modal">
     <h3 id="batchKeywordTitle">Add Keyword</h3>
     <div class="keyword-autocomplete">
-      <input class="modal-input" id="batchKeywordInput" placeholder="Keyword name" autocomplete="off">
+      <input class="modal-input" id="batchKeywordInput" placeholder="Keyword name"
+             autocomplete="off" autocorrect="off" autocapitalize="none" spellcheck="false">
       <div class="keyword-suggestion-list" id="batchKeywordSuggestions" role="listbox"></div>
     </div>
     <div class="modal-actions">


### PR DESCRIPTION
Disables browser and macOS text correction across Vireo text, search, untyped input, and textarea fields so partial bird/species names are not rewritten while filtering or editing. Adds a shared utility that applies the correction opt-out on page load and to dynamically inserted controls, while keeping explicit Browse attributes for the affected lookup fields. Adds e2e coverage for Browse search attributes and app-wide dynamic input handling.\n\nValidation: pytest tests/e2e/test_page_loads.py tests/e2e/test_browse_search_empty_state.py