### PR TITLE
Fix Browse photo deep links

### DIFF
--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -44,6 +44,52 @@ def test_browse_lightbox_arrows_navigate(live_server, page):
     expect(counter).to_contain_text("1 /")
 
 
+def test_browse_photo_id_deep_link_loads_target_folder_first_page(live_server, page):
+    """Open in Browse must find a target that is not on global Browse page 1."""
+    db = live_server["db"]
+    folder_a, folder_b = live_server["data"]["folders"]
+    target_id = live_server["data"]["photos"][3]  # first photo in folder_b
+
+    for idx in range(60):
+        db.add_photo(
+            folder_id=folder_a,
+            filename=f"older-{idx:02d}.jpg",
+            extension=".jpg",
+            file_size=1000,
+            file_mtime=10 + idx,
+            timestamp=f"2024-01-{(idx % 28) + 1:02d}T00:00:00",
+        )
+
+    page.goto(f"{live_server['url']}/browse?photo_id={target_id}")
+
+    target_card = page.locator(f'.grid-card[data-id="{target_id}"]')
+    expect(target_card).to_be_visible(timeout=5000)
+    assert page.evaluate("window.activeFolderId") == folder_b
+
+
+def test_browse_photo_id_deep_link_loads_target_after_first_folder_page(live_server, page):
+    """Open in Browse must page within the target folder without freezing."""
+    db = live_server["db"]
+    _, folder_b = live_server["data"]["folders"]
+    target_id = live_server["data"]["photos"][4]  # robin2 in folder_b
+
+    for idx in range(60):
+        db.add_photo(
+            folder_id=folder_b,
+            filename=f"yard-before-{idx:02d}.jpg",
+            extension=".jpg",
+            file_size=1000,
+            file_mtime=10 + idx,
+            timestamp=f"2024-06-14T10:{idx % 60:02d}:00",
+        )
+
+    page.goto(f"{live_server['url']}/browse?photo_id={target_id}")
+
+    target_card = page.locator(f'.grid-card[data-id="{target_id}"]')
+    expect(target_card).to_be_visible(timeout=5000)
+    assert page.evaluate("window.loading") is False
+
+
 def test_browse_lightbox_arrows_preserve_one_to_one_zoom(live_server, page):
     """Navigating from a 1:1 lightbox view keeps the next photo at 1:1."""
     url = live_server["url"]

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2972,9 +2972,47 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         default_per_page = cfg.load().get("photos_per_page", 50)
         per_page = max(1, min(request.args.get("per_page", default_per_page, type=int), _MAX_PER_PAGE))
         sort = request.args.get("sort", "date")
+        folder_id = request.args.get("folder_id", None, type=int)
+        rating_min = request.args.get("rating_min", None, type=int)
+        date_from = request.args.get("date_from", None)
+        date_to = request.args.get("date_to", None)
+        keyword = request.args.get("keyword", None)
+        keyword_match_case = _request_bool_arg("keyword_match_case")
+        keyword_whole_word = _request_bool_arg("keyword_whole_word")
+        color_label = request.args.get("color_label", None)
+        try:
+            flag = _request_flag_filter()
+        except ValueError as e:
+            return json_error(str(e), 400)
 
-        photos = db.get_photos(page=page, per_page=per_page, sort=sort)
-        total = db.count_photos()
+        photos = db.get_photos(
+            folder_id=folder_id,
+            page=page,
+            per_page=per_page,
+            sort=sort,
+            rating_min=rating_min,
+            date_from=date_from,
+            date_to=date_to,
+            keyword=keyword,
+            keyword_match_case=keyword_match_case,
+            keyword_whole_word=keyword_whole_word,
+            color_label=color_label,
+            flag=flag,
+        )
+        if not any([folder_id, rating_min, date_from, date_to, keyword, color_label, flag]):
+            total = db.count_photos()
+        else:
+            total = db.count_filtered_photos(
+                folder_id=folder_id,
+                rating_min=rating_min,
+                date_from=date_from,
+                date_to=date_to,
+                keyword=keyword,
+                keyword_match_case=keyword_match_case,
+                keyword_whole_word=keyword_whole_word,
+                color_label=color_label,
+                flag=flag,
+            )
         folders = db.get_folder_tree()
         keywords = db.get_keyword_tree()
         collections = db.get_collections()

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -7452,12 +7452,12 @@ document.addEventListener('contextmenu', function(e) {
       deepLinkLoaded = true;
     }
 
-    // Keep loading pages until we find the photo or run out
-    var el = document.querySelector('.grid-card[data-id="' + photoId + '"]');
-    while (!el && !allLoaded) {
-      await loadPhotos();
-      el = document.querySelector('.grid-card[data-id="' + photoId + '"]');
-    }
+    // Keep loading pages until we find the photo or run out. The setup guard
+    // above intentionally blocks IntersectionObserver-driven loads, but
+    // loadPhotos() also honors it; clear it before this explicit paging pass
+    // or a target beyond the first page spins in a resolved Promise loop.
+    loading = false;
+    var el = await loadUntilPhotoRendered(photoId);
 
     // Update folder tree active state
     document.querySelectorAll('#folderTree .tree-item').forEach(function(el) {

--- a/vireo/tests/test_collections_api.py
+++ b/vireo/tests/test_collections_api.py
@@ -118,6 +118,23 @@ def test_browse_init_marks_manual_photo_targets(app_and_db):
     assert by_name["Smart"]["can_add_photos"] is False
 
 
+def test_browse_init_honors_folder_filter(app_and_db):
+    """Deep-linked Browse loads the target folder's first page, not global page 1."""
+    app, db = app_and_db
+    client = app.test_client()
+
+    january = db.conn.execute(
+        "SELECT id FROM folders WHERE name = 'January'"
+    ).fetchone()["id"]
+
+    resp = client.get(f"/api/browse/init?folder_id={january}&per_page=10")
+    assert resp.status_code == 200
+    data = resp.get_json()
+
+    assert data["total"] == 1
+    assert [p["filename"] for p in data["photos"]] == ["bird2.jpg"]
+
+
 def test_collection_photo_ids_returns_all_matching_ids(app_and_db):
     """Collection select-all support returns all matching IDs without pagination."""
     app, db = app_and_db


### PR DESCRIPTION
## Summary
Fixes Browse photo deep links by making `/api/browse/init` honor the same filters as `/api/photos`, including `folder_id`.
Also clears the setup-only loading guard before the deep-link fallback paging pass so a target beyond the first loaded page cannot spin the WebView in a resolved Promise/querySelector loop.
Adds API and Playwright regressions for folder-filtered initialization, global-page misses, and targets after the first folder page.

## Tests
- `python -m pytest tests/e2e/test_browse_lightbox.py -q`
- `python -m pytest vireo/tests/test_collections_api.py::test_browse_init_marks_manual_photo_targets vireo/tests/test_collections_api.py::test_browse_init_honors_folder_filter -q`