### PR TITLE
Add combinable highlights curation filters

### DIFF
--- a/tests/e2e/test_highlights_initial_scope.py
+++ b/tests/e2e/test_highlights_initial_scope.py
@@ -224,6 +224,7 @@ def test_highlights_curation_filter_controls_combine(live_server, page):
     data = live_server["data"]
     _seed_quality_scores_and_species(db, data)
     db.add_species_highlight("Red-tailed Hawk", data["photos"][0])
+    db.add_species_highlight("American Robin", data["photos"][3])
     db.set_species_representative("American Robin", data["photos"][3])
 
     page.goto(f"{live_server['url']}/highlights", timeout=5000)
@@ -239,6 +240,7 @@ def test_highlights_curation_filter_controls_combine(live_server, page):
         )
     ):
         page.locator("#highlightSelectionFilter").select_option("yes")
+    expect(page.locator(".bucket-title")).to_have_count(2)
 
     with page.expect_response(
         lambda response: (

--- a/tests/e2e/test_highlights_initial_scope.py
+++ b/tests/e2e/test_highlights_initial_scope.py
@@ -91,9 +91,9 @@ def test_initial_load_matches_default_workspace_scope(live_server, page):
     # a per-card .card-species label.
     bucket_titles = page.locator(".bucket-title").all_inner_texts()
     species_text = {t.strip() for title in bucket_titles for t in [title]}
-    # bucket-title text may include a trailing badge (e.g. "Confirmed"); match
+    # bucket-title text may include a trailing badge (e.g. "Keyword confirmed"); match
     # by substring so we tolerate either "Red-tailed Hawk" or
-    # "Red-tailed Hawk Confirmed".
+    # "Red-tailed Hawk Keyword confirmed".
     has_hawk = any("Red-tailed Hawk" in t for t in species_text)
     has_robin = any("American Robin" in t for t in species_text)
     assert has_hawk and has_robin, (
@@ -219,6 +219,40 @@ def test_highlights_species_search_filters_buckets(live_server, page):
     )
 
 
+def test_highlights_curation_filter_controls_combine(live_server, page):
+    db = live_server["db"]
+    data = live_server["data"]
+    _seed_quality_scores_and_species(db, data)
+    db.add_species_highlight("Red-tailed Hawk", data["photos"][0])
+    db.set_species_representative("American Robin", data["photos"][3])
+
+    page.goto(f"{live_server['url']}/highlights", timeout=5000)
+    expect(page.locator(".highlights-card").first).to_be_visible(timeout=5000)
+    expect(page.locator("label[for='confirmationFilter']")).to_have_text(
+        "Species keyword"
+    )
+
+    with page.expect_response(
+        lambda response: (
+            "/api/highlights?" in response.url
+            and "highlight_selection=yes" in response.url
+        )
+    ):
+        page.locator("#highlightSelectionFilter").select_option("yes")
+
+    with page.expect_response(
+        lambda response: (
+            "/api/highlights?" in response.url
+            and "highlight_selection=yes" in response.url
+            and "species_representative=no" in response.url
+        )
+    ):
+        page.locator("#representativeFilter").select_option("no")
+
+    expect(page.locator(".bucket-title")).to_have_count(1)
+    expect(page.locator(".bucket-title").first).to_contain_text("Red-tailed Hawk")
+
+
 def test_highlights_general_search_filters_by_filename_folder_and_keyword(live_server, page):
     db = live_server["db"]
     data = live_server["data"]
@@ -313,16 +347,16 @@ def test_ordered_highlight_updates_top_photo_timestamp(live_server):
 
 
 def test_highlights_search_recomputes_bucket_accepted_status(live_server):
-    """Filtering a mixed bucket down to only confirmed photos must flip
+    """Filtering a mixed bucket down to keyword-confirmed photos must flip
     ``is_accepted`` to True so the bucket loses the candidate badge and the
-    Confirmed-first sort places it above unconfirmed rows."""
+    confirmed-keywords-first sort places it above prediction-only rows."""
     db = live_server["db"]
     data = live_server["data"]
     _seed_quality_scores_and_species(db, data)
 
     # Add a prediction-only photo that lands in the same "Red-tailed Hawk"
     # bucket (predicted confidence above the default 0.70 threshold) so the
-    # bucket is a mix of confirmed (keyword-tagged) and unconfirmed photos.
+    # bucket mixes keyword-confirmed and prediction-only photos.
     pid = db.add_photo(
         folder_id=data["folders"][0],
         filename="predicted-hawk.jpg",
@@ -351,14 +385,14 @@ def test_highlights_search_recomputes_bucket_accepted_status(live_server):
 
     base = live_server["url"]
 
-    # Without a filter, the mixed bucket is unconfirmed at the bucket level.
+    # Without a filter, the mixed bucket is not fully keyword-confirmed.
     with urlopen(f"{base}/api/highlights?scope=workspace") as resp:
         payload = json.load(resp)
     hawk = next(b for b in payload["buckets"] if b["species"] == "Red-tailed Hawk")
     assert hawk["is_accepted"] is False
     assert hawk["certainty"] != "confirmed"
 
-    # Filtering by filename to only include a confirmed (keyword-tagged) photo
+    # Filtering by filename to only include a keyword-confirmed photo
     # must recompute ``is_accepted`` from the filtered photos.
     with urlopen(f"{base}/api/highlights?scope=workspace&q=hawk1") as resp:
         payload = json.load(resp)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -343,7 +343,7 @@ def _bucket_best_score(photos):
 
 
 def _apply_highlight_preferences(db, buckets):
-    preferences = db.get_species_representatives()
+    preferences = db.get_species_representatives(eligible_only=True)
     for bucket in buckets:
         preferred_id = preferences.get(bucket["species"])
         applied = False

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -353,6 +353,9 @@ def _apply_highlight_preferences(db, buckets):
             applied = applied or is_rep
         top = bucket["photos"][0] if bucket["photos"] else {}
         bucket["preferred_photo_id"] = preferred_id
+        # Species-level state stays true even when the representative photo is
+        # outside the current folder or search result.
+        bucket["has_species_representative"] = preferred_id is not None
         bucket["has_preferred_photo"] = applied
         bucket["best_quality"] = top.get("quality_score")
         # Rank by the highest-scored photo in the bucket, not photos[0].
@@ -368,6 +371,9 @@ def _apply_ordered_highlights(db, buckets):
     highlights = db.get_species_highlights()
     for bucket in buckets:
         ranks = highlights.get(bucket["species"], {})
+        # Species-level state stays true even when every selected highlight is
+        # outside the current folder or search result.
+        bucket["has_highlight_selection"] = bool(ranks)
         photos = bucket.get("photos") or []
         matched = False
         for p in photos:
@@ -448,6 +454,13 @@ def _highlight_confidence_label(confidence, is_accepted):
 def _normalize_highlight_confirmation_filter(value):
     value = (value or "all").strip().lower()
     if value not in {"all", "confirmed", "unconfirmed"}:
+        return "all"
+    return value
+
+
+def _normalize_highlight_presence_filter(value):
+    value = (value or "all").strip().lower()
+    if value not in {"all", "yes", "no"}:
         return "all"
     return value
 
@@ -658,6 +671,38 @@ def _filter_highlight_sections(
         if _highlight_photo_matches_query(p, query, match_case, whole_word)
     ]
     return filtered_buckets, unidentified
+
+
+def _filter_highlight_curation_state(
+    buckets,
+    unidentified_photos,
+    highlight_filter="all",
+    representative_filter="all",
+):
+    highlight_filter = _normalize_highlight_presence_filter(highlight_filter)
+    representative_filter = _normalize_highlight_presence_filter(
+        representative_filter
+    )
+
+    def matches(bucket, filter_value, field):
+        if filter_value == "all":
+            return True
+        return bool(bucket.get(field)) == (filter_value == "yes")
+
+    filtered = [
+        bucket for bucket in buckets
+        if matches(bucket, highlight_filter, "has_highlight_selection")
+        and matches(
+            bucket,
+            representative_filter,
+            "has_species_representative",
+        )
+    ]
+    # These two states only apply to named species. Unidentified photos have
+    # neither a species highlight list nor a species representative assignment.
+    if highlight_filter != "all" or representative_filter != "all":
+        unidentified_photos = []
+    return filtered, unidentified_photos
 
 
 # Maximum number of bound parameters per SQL statement. SQLite's
@@ -7612,6 +7657,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         search_match_case=False,
         search_whole_word=False,
         confirmation_filter="all",
+        highlight_filter="all",
+        representative_filter="all",
     ):
         folders = db.get_folders_with_quality_data()
         if scope == "workspace":
@@ -7622,6 +7669,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         species_filter = (species_filter or "").strip()
         confirmation_filter = _normalize_highlight_confirmation_filter(
             confirmation_filter
+        )
+        highlight_filter = _normalize_highlight_presence_filter(highlight_filter)
+        representative_filter = _normalize_highlight_presence_filter(
+            representative_filter
         )
 
         candidates = db.get_highlights_candidates(folder_id, min_quality=min_quality)
@@ -7660,6 +7711,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         )
         _apply_ordered_highlights(db, buckets)
         _apply_highlight_preferences(db, buckets)
+        buckets, unidentified_photos = _filter_highlight_curation_state(
+            buckets,
+            unidentified_photos,
+            highlight_filter,
+            representative_filter,
+        )
 
         def limited_bucket(bucket):
             photos = bucket["photos"]
@@ -7696,6 +7753,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "eligible": eligible_count,
                 "limit_per_bucket": limit_per_bucket,
                 "confirmation": confirmation_filter,
+                "highlight_selection": highlight_filter,
+                "species_representative": representative_filter,
                 "search": (search_query or "").strip(),
             },
             "scope": "workspace" if folder_id is None else "folder",
@@ -7720,6 +7779,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             search_match_case=_request_bool_arg("q_match_case"),
             search_whole_word=_request_bool_arg("q_whole_word"),
             confirmation_filter=request.args.get("confirmation") or "all",
+            highlight_filter=request.args.get("highlight_selection") or "all",
+            representative_filter=(
+                request.args.get("species_representative") or "all"
+            ),
         )
         return jsonify(payload)
 
@@ -8433,6 +8496,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         )
         _apply_ordered_highlights(db, buckets)
         _apply_highlight_preferences(db, buckets)
+        buckets, unidentified_photos = _filter_highlight_curation_state(
+            buckets,
+            unidentified_photos,
+            request.args.get("highlight_selection") or "all",
+            request.args.get("species_representative") or "all",
+        )
         if species == "__unidentified__":
             photos = unidentified_photos
             label = "Unidentified"

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -368,7 +368,7 @@ def _apply_highlight_preferences(db, buckets):
 
 
 def _apply_ordered_highlights(db, buckets):
-    highlights = db.get_species_highlights()
+    highlights = db.get_species_highlights(eligible_only=True)
     for bucket in buckets:
         ranks = highlights.get(bucket["species"], {})
         # Species-level state stays true even when every selected highlight is

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -9885,21 +9885,46 @@ class Database:
         ).fetchall()
         return {r["species"]: r["photo_id"] for r in rows}
 
-    def get_species_representatives(self):
+    def get_species_representatives(self, eligible_only=False):
         """Return representative photo preferences with legacy fallback.
 
         ``species_representative`` is the canonical purpose. Existing
         ``life_list`` and ``highlights`` rows are still read as fallbacks so
         older libraries keep their explicit curation choices.
+
+        When ``eligible_only`` is true, omit preferences whose photo is
+        rejected, unavailable to the workspace, or no longer carries the
+        stored species keyword. The preference row remains intact for undo.
         """
         ws = self._ws_id()
+        eligibility_joins = ""
+        eligibility_filter = ""
+        if eligible_only:
+            eligibility_joins = """
+               JOIN photos p ON p.id = pp.photo_id
+               JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+                AND wf.workspace_id = pp.workspace_id
+               JOIN folders f ON f.id = p.folder_id
+                AND f.status IN ('ok', 'partial')"""
+            eligibility_filter = """
+                 AND COALESCE(p.flag, 'none') != 'rejected'
+                 AND EXISTS (
+                     SELECT 1
+                     FROM photo_keywords pk
+                     JOIN keywords k ON k.id = pk.keyword_id
+                      AND (k.is_species = 1 OR k.type = 'taxonomy')
+                     WHERE pk.photo_id = pp.photo_id
+                       AND k.name = pp.species
+                 )"""
         rows = self.conn.execute(
-            """SELECT species, photo_id, purpose
-               FROM photo_preferences
-               WHERE workspace_id = ?
-                 AND purpose IN ('species_representative', 'life_list', 'highlights')
-               ORDER BY species,
-                        CASE purpose
+            f"""SELECT pp.species, pp.photo_id, pp.purpose
+               FROM photo_preferences pp
+               {eligibility_joins}
+               WHERE pp.workspace_id = ?
+                 AND pp.purpose IN ('species_representative', 'life_list', 'highlights')
+                 {eligibility_filter}
+               ORDER BY pp.species,
+                        CASE pp.purpose
                           WHEN 'species_representative' THEN 0
                           WHEN 'life_list' THEN 1
                           ELSE 2
@@ -9977,7 +10002,39 @@ class Database:
                     AND f.status IN ('ok', 'partial')"""
             eligibility_filter = """
                  AND p.quality_score IS NOT NULL
-                 AND COALESCE(p.flag, 'none') != 'rejected'"""
+                 AND COALESCE(p.flag, 'none') != 'rejected'
+                 AND sh.species = COALESCE(
+                     (
+                         SELECT k.name
+                         FROM photo_keywords pk
+                         JOIN keywords k ON k.id = pk.keyword_id
+                          AND (k.is_species = 1 OR k.type = 'taxonomy')
+                         WHERE pk.photo_id = sh.photo_id
+                         ORDER BY pk.rowid DESC
+                         LIMIT 1
+                     ),
+                     (
+                         SELECT pr.species
+                         FROM detections d
+                         JOIN predictions pr ON pr.detection_id = d.id
+                         LEFT JOIN prediction_review pr_rev
+                          ON pr_rev.prediction_id = pr.id
+                         AND pr_rev.workspace_id = sh.workspace_id
+                         WHERE d.photo_id = sh.photo_id
+                           AND pr.species IS NOT NULL
+                           AND COALESCE(pr_rev.status, 'pending') != 'rejected'
+                           AND pr.labels_fingerprint = (
+                               SELECT pr2.labels_fingerprint
+                               FROM predictions pr2
+                               WHERE pr2.detection_id = pr.detection_id
+                                 AND pr2.classifier_model = pr.classifier_model
+                               ORDER BY pr2.created_at DESC, pr2.id DESC
+                               LIMIT 1
+                           )
+                         ORDER BY pr.confidence DESC, pr.id DESC
+                         LIMIT 1
+                     )
+                 )"""
         if species:
             rows = self.conn.execute(
                 f"""SELECT sh.species, sh.photo_id, sh.rank

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -9956,26 +9956,46 @@ class Database:
         if _commit:
             self.conn.commit()
 
-    def get_species_highlights(self, species=None):
+    def get_species_highlights(self, species=None, eligible_only=False):
         """Return ordered highlighted photo ids for the active workspace.
+
+        When ``eligible_only`` is true, omit rejected photos and photos that
+        are no longer eligible for the Highlights page. Stored rows are kept
+        intact so un-rejecting a photo restores its selection.
 
         Result shape is ``{species: {photo_id: rank}}``.
         """
         ws = self._ws_id()
+        eligibility_joins = ""
+        eligibility_filter = ""
+        if eligible_only:
+            eligibility_joins = """
+                   JOIN photos p ON p.id = sh.photo_id
+                   JOIN workspace_folders wf ON wf.folder_id = p.folder_id
+                    AND wf.workspace_id = sh.workspace_id
+                   JOIN folders f ON f.id = p.folder_id
+                    AND f.status IN ('ok', 'partial')"""
+            eligibility_filter = """
+                 AND p.quality_score IS NOT NULL
+                 AND COALESCE(p.flag, 'none') != 'rejected'"""
         if species:
             rows = self.conn.execute(
-                """SELECT species, photo_id, rank
-                   FROM species_highlights
-                   WHERE workspace_id = ? AND species = ?
-                   ORDER BY rank, created_at, photo_id""",
+                f"""SELECT sh.species, sh.photo_id, sh.rank
+                   FROM species_highlights sh
+                   {eligibility_joins}
+                   WHERE sh.workspace_id = ? AND sh.species = ?
+                   {eligibility_filter}
+                   ORDER BY sh.rank, sh.created_at, sh.photo_id""",
                 (ws, species),
             ).fetchall()
         else:
             rows = self.conn.execute(
-                """SELECT species, photo_id, rank
-                   FROM species_highlights
-                   WHERE workspace_id = ?
-                   ORDER BY species, rank, created_at, photo_id""",
+                f"""SELECT sh.species, sh.photo_id, sh.rank
+                   FROM species_highlights sh
+                   {eligibility_joins}
+                   WHERE sh.workspace_id = ?
+                   {eligibility_filter}
+                   ORDER BY sh.species, sh.rank, sh.created_at, sh.photo_id""",
                 (ws,),
             ).fetchall()
         result = {}

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -119,11 +119,27 @@
     </div>
   </div>
   <div class="control-group">
-    <label for="confirmationFilter">Status</label>
-    <select id="confirmationFilter">
-      <option value="all">All</option>
-      <option value="confirmed">Confirmed only</option>
-      <option value="unconfirmed">Unconfirmed only</option>
+    <label for="confirmationFilter">Species keyword</label>
+    <select id="confirmationFilter" title="Whether the species keyword has been confirmed on the photo">
+      <option value="all">Any</option>
+      <option value="confirmed">Confirmed</option>
+      <option value="unconfirmed">Not confirmed</option>
+    </select>
+  </div>
+  <div class="control-group">
+    <label for="highlightSelectionFilter">Highlight chosen</label>
+    <select id="highlightSelectionFilter" title="Whether this species has at least one chosen highlight">
+      <option value="all">Any</option>
+      <option value="yes">Yes</option>
+      <option value="no">No</option>
+    </select>
+  </div>
+  <div class="control-group">
+    <label for="representativeFilter">Representative set</label>
+    <select id="representativeFilter" title="Whether this species has a representative photo set">
+      <option value="all">Any</option>
+      <option value="yes">Yes</option>
+      <option value="no">No</option>
     </select>
   </div>
   <div class="control-group">
@@ -153,7 +169,7 @@
       <option value="newest">Newest top photo</option>
       <option value="oldest">Oldest top photo</option>
       <option value="confidence">Highest ID confidence</option>
-      <option value="confirmed">Confirmed first</option>
+      <option value="confirmed">Confirmed keywords first</option>
     </select>
   </div>
   <button class="save-btn" id="saveBtn" onclick="showSaveModal()">Save as Collection</button>
@@ -252,6 +268,8 @@ function requestScopeParams() {
   params.set('min_quality', (parseInt(document.getElementById('qualitySlider').value) / 100).toFixed(2));
   params.set('confidence_threshold', (parseInt(document.getElementById('confidenceSlider').value) / 100).toFixed(2));
   params.set('confirmation', document.getElementById('confirmationFilter').value || 'all');
+  params.set('highlight_selection', document.getElementById('highlightSelectionFilter').value || 'all');
+  params.set('species_representative', document.getElementById('representativeFilter').value || 'all');
   return params;
 }
 
@@ -480,7 +498,7 @@ async function unidPhotoIds() {
 function photoCurrentLabel(photo) {
   if (!photo) return '';
   if (photo.has_accepted_species && photo.species) {
-    return 'Confirmed: ' + photo.species;
+    return 'Keyword confirmed: ' + photo.species;
   }
   if (photo.predicted_species) {
     var conf = photo.predicted_confidence != null
@@ -508,7 +526,7 @@ async function confirmPhotoIds(photoIds, button) {
       body: JSON.stringify({ photo_ids: photoIds }),
     });
     await loadHighlights();
-    if (typeof showToast === 'function') showToast('Prediction confirmed', 'success');
+    if (typeof showToast === 'function') showToast('Species keyword confirmed', 'success');
   } finally {
     if (button) button.disabled = false;
   }
@@ -646,9 +664,9 @@ function renderBucket(bucket) {
   var visible = expanded ? bucket.photos : bucket.photos.slice(0, perRow);
   var remaining = bucket.photo_count - visible.length;
   var badgeClass = bucket.is_accepted ? 'accepted' : (bucket.certainty === 'likely' ? 'likely' : 'candidate');
-  var badgeText = bucket.is_accepted ? 'Confirmed' : (bucket.certainty === 'likely' ? 'Likely ID' : 'Top candidates');
+  var badgeText = bucket.is_accepted ? 'Keyword confirmed' : (bucket.certainty === 'likely' ? 'Likely ID' : 'Top candidates');
   var badge = bucket.is_accepted
-    ? '<span class="bucket-badge accepted">Confirmed</span>'
+    ? '<span class="bucket-badge accepted">Keyword confirmed</span>'
     : '<span class="bucket-badge ' + badgeClass + '">' + badgeText + '</span>';
   var meta = bucket.photo_count + ' photo' + (bucket.photo_count === 1 ? '' : 's');
   if (bucket.highlight_count) meta += ' · ' + bucket.highlight_count + ' highlighted';
@@ -668,7 +686,7 @@ function renderBucket(bucket) {
   var actions = '<div class="bucket-actions">';
   if (!bucket.is_accepted) {
     actions += '<button class="bucket-action primary" data-action="confirm-bucket" data-species="'
-      + escapeAttr(bucket.species) + '">Confirm</button>';
+      + escapeAttr(bucket.species) + '">Confirm keyword</button>';
   }
   actions += '<button class="bucket-action" data-action="change-bucket" data-species="'
     + escapeAttr(bucket.species) + '">Change</button></div>';
@@ -745,9 +763,15 @@ function render() {
   var search = document.getElementById('highlightSearch').value.trim();
   var speciesSearch = document.getElementById('speciesSearch').value.trim();
   var confirmation = document.getElementById('confirmationFilter').value;
+  var highlightSelection = document.getElementById('highlightSelectionFilter').value;
+  var representative = document.getElementById('representativeFilter').value;
   var filterLabel = (search || speciesSearch) ? ' matching' : '';
-  if (confirmation === 'confirmed') filterLabel += ' confirmed';
-  if (confirmation === 'unconfirmed') filterLabel += ' unconfirmed';
+  if (confirmation === 'confirmed') filterLabel += ' with confirmed keywords';
+  if (confirmation === 'unconfirmed') filterLabel += ' without confirmed keywords';
+  if (highlightSelection === 'yes') filterLabel += ' with highlights chosen';
+  if (highlightSelection === 'no') filterLabel += ' without highlights chosen';
+  if (representative === 'yes') filterLabel += ' with representatives set';
+  if (representative === 'no') filterLabel += ' without representatives set';
   meta.textContent = buckets.length + filterLabel + ' species · '
     + currentData.meta.eligible + ' of '
     + currentData.meta.total_in_scope + ' photos scored';
@@ -1028,6 +1052,16 @@ document.getElementById('speciesSearch').addEventListener('input', function() {
   debounceLoad();
 });
 document.getElementById('confirmationFilter').addEventListener('change', function() {
+  expandedBuckets.clear();
+  unidentifiedExpanded = false;
+  loadHighlights();
+});
+document.getElementById('highlightSelectionFilter').addEventListener('change', function() {
+  expandedBuckets.clear();
+  unidentifiedExpanded = false;
+  loadHighlights();
+});
+document.getElementById('representativeFilter').addEventListener('change', function() {
   expandedBuckets.clear();
   unidentifiedExpanded = false;
   loadHighlights();

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -765,14 +765,14 @@ function render() {
   var confirmation = document.getElementById('confirmationFilter').value;
   var highlightSelection = document.getElementById('highlightSelectionFilter').value;
   var representative = document.getElementById('representativeFilter').value;
-  var filterLabel = (search || speciesSearch) ? ' matching' : '';
+  var filterLabel = (search || speciesSearch) ? ' matching species' : ' species';
   if (confirmation === 'confirmed') filterLabel += ' with confirmed keywords';
   if (confirmation === 'unconfirmed') filterLabel += ' without confirmed keywords';
   if (highlightSelection === 'yes') filterLabel += ' with highlights chosen';
   if (highlightSelection === 'no') filterLabel += ' without highlights chosen';
   if (representative === 'yes') filterLabel += ' with representatives set';
   if (representative === 'no') filterLabel += ' without representatives set';
-  meta.textContent = buckets.length + filterLabel + ' species · '
+  meta.textContent = buckets.length + filterLabel + ' · '
     + currentData.meta.eligible + ' of '
     + currentData.meta.total_in_scope + ' photos scored';
 

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -1149,6 +1149,21 @@ async function doSave(mode) {
   closeSaveModal();
 }
 
+// True when a rejection needs a reload rather than just a local prune: an
+// active yes/no curation filter treats the rejected photo's highlight or
+// representative role as an active bucket signal, and the eligible-only
+// query on the server would drop it. If we only prune locally the bucket
+// keeps its stale has_highlight_selection / has_species_representative
+// state and stays visible under the wrong filter.
+function curationFilterAffectedByReject(photo) {
+  if (!photo) return false;
+  var highlightFilter = document.getElementById('highlightSelectionFilter').value || 'all';
+  var repFilter = document.getElementById('representativeFilter').value || 'all';
+  if (highlightFilter !== 'all' && photo.is_highlighted) return true;
+  if (repFilter !== 'all' && photo.is_species_representative) return true;
+  return false;
+}
+
 // Drop a photo from the in-memory model after it is rejected, so the grid
 // matches the backend query (which excludes rejected photos). Returns true if
 // anything changed.
@@ -1206,7 +1221,18 @@ document.addEventListener('lightbox:flagchanged', function(e) {
     // it (a reload issued afterward already reflects the rejection server-side).
     rejectedFromGrid.add(detail.photoId);
     rejectedAtLoadSeq[detail.photoId] = highlightsLoadSeq;
-    if (removeRejectedPhotoFromModel(detail.photoId)) render();
+    // A curation filter set to yes/no may need to hide the bucket when the
+    // rejected photo is the last highlight or the species representative:
+    // eligible_only server-side drops that stored row, but the local prune
+    // path leaves has_highlight_selection / has_species_representative
+    // stale. Reload authoritatively so the visible buckets match the
+    // backend's filter state.
+    if (photo && curationFilterAffectedByReject(photo)) {
+      removeRejectedPhotoFromModel(detail.photoId);
+      loadHighlights();
+    } else if (removeRejectedPhotoFromModel(detail.photoId)) {
+      render();
+    }
   } else if (rejectedFromGrid.has(detail.photoId)) {
     // A previously-rejected photo was un-rejected — it re-qualifies for
     // highlights, so refetch to restore it (and the Save-as-Collection list)

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -3573,7 +3573,8 @@ def test_apply_ordered_highlights_preserves_order_when_no_visible_match():
     from app import _apply_ordered_highlights
 
     class FakeDb:
-        def get_species_highlights(self):
+        def get_species_highlights(self, eligible_only=False):
+            assert eligible_only is True
             return {"Robin": {999: 1}}
 
     original = [
@@ -3593,7 +3594,8 @@ def test_apply_ordered_highlights_resorts_when_visible_match():
     from app import _apply_ordered_highlights
 
     class FakeDb:
-        def get_species_highlights(self):
+        def get_species_highlights(self, eligible_only=False):
+            assert eligible_only is True
             return {"Robin": {2: 1}}
 
     buckets = [{
@@ -5393,6 +5395,7 @@ def test_highlights_curation_filters_combine_independently(app_and_db):
     )
 
     photo_ids = {}
+    keyword_ids = {}
     for index, species in enumerate(("Alpha Bird", "Beta Bird", "Gamma Bird", "Delta Bird")):
         keyword_id = db.conn.execute(
             "INSERT INTO keywords (name, type, is_species) VALUES (?, 'taxonomy', 1)",
@@ -5408,6 +5411,17 @@ def test_highlights_curation_filters_combine_independently(app_and_db):
             (photo_id, keyword_id),
         )
         photo_ids[species] = photo_id
+        keyword_ids[species] = keyword_id
+
+    alpha_alternate = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+        "VALUES (?, 'alpha-alternate.jpg', 0.65, 'none')",
+        (fid,),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (alpha_alternate, keyword_ids["Alpha Bird"]),
+    )
     db.conn.commit()
 
     # Alpha has only a highlight, Beta only a representative, Gamma has both,
@@ -5435,6 +5449,20 @@ def test_highlights_curation_filters_combine_independently(app_and_db):
         highlight_selection="no",
         species_representative="no",
     ) == {"Delta Bird"}
+
+    # Rejecting Alpha's selected photo leaves another eligible Alpha photo in
+    # the bucket. The stored rank is retained for undo, but it must not make the
+    # active-selection filter report that Alpha still has a chosen highlight.
+    db.update_photo_flag(photo_ids["Alpha Bird"], "rejected")
+    assert species_for(highlight_selection="yes") == {"Gamma Bird"}
+    assert species_for(
+        highlight_selection="no", species_representative="no"
+    ) == {"Alpha Bird", "Delta Bird"}
+    assert db.get_species_highlights("Alpha Bird") == {
+        "Alpha Bird": {photo_ids["Alpha Bird"]: 1}
+    }
+    db.update_photo_flag(photo_ids["Alpha Bird"], "none")
+    assert species_for(highlight_selection="yes") == {"Alpha Bird", "Gamma Bird"}
 
     response = client.get(
         "/api/highlights",

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -5422,6 +5422,15 @@ def test_highlights_curation_filters_combine_independently(app_and_db):
         "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
         (alpha_alternate, keyword_ids["Alpha Bird"]),
     )
+    beta_alternate = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+        "VALUES (?, 'beta-alternate.jpg', 0.6, 'none')",
+        (fid,),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (beta_alternate, keyword_ids["Beta Bird"]),
+    )
     db.conn.commit()
 
     # Alpha has only a highlight, Beta only a representative, Gamma has both,
@@ -5464,6 +5473,17 @@ def test_highlights_curation_filters_combine_independently(app_and_db):
     db.update_photo_flag(photo_ids["Alpha Bird"], "none")
     assert species_for(highlight_selection="yes") == {"Alpha Bird", "Gamma Bird"}
 
+    # Representative preferences follow the same active-state rule while
+    # keeping their stored row available for an un-reject.
+    db.update_photo_flag(photo_ids["Beta Bird"], "rejected")
+    assert species_for(species_representative="yes") == {"Gamma Bird"}
+    assert db.get_species_representatives() == {
+        "Beta Bird": photo_ids["Beta Bird"],
+        "Gamma Bird": photo_ids["Gamma Bird"],
+    }
+    db.update_photo_flag(photo_ids["Beta Bird"], "none")
+    assert species_for(species_representative="yes") == {"Beta Bird", "Gamma Bird"}
+
     response = client.get(
         "/api/highlights",
         query_string={
@@ -5474,6 +5494,65 @@ def test_highlights_curation_filters_combine_independently(app_and_db):
     )
     assert response.get_json()["meta"]["highlight_selection"] == "all"
     assert response.get_json()["meta"]["species_representative"] == "all"
+
+
+def test_highlights_curation_filter_ignores_rejected_selected_prediction(app_and_db):
+    app, db = app_and_db
+    client = app.test_client()
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES ('/pred-filter', 'pred-filter', 'ok')"
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO workspace_folders (workspace_id, folder_id) VALUES (?, ?)",
+        (db._ws_id(), fid),
+    )
+
+    photo_ids = []
+    prediction_ids = []
+    for index in range(2):
+        photo_id = db.conn.execute(
+            "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+            "VALUES (?, ?, ?, 'none')",
+            (fid, f"predicted-{index}.jpg", 0.9 - index * 0.1),
+        ).lastrowid
+        detection_id = db.conn.execute(
+            "INSERT INTO detections (photo_id, detector_confidence) VALUES (?, 0.95)",
+            (photo_id,),
+        ).lastrowid
+        prediction_id = db.conn.execute(
+            "INSERT INTO predictions "
+            "(detection_id, classifier_model, labels_fingerprint, species, confidence) "
+            "VALUES (?, 'test-model', 'test-labels', 'Prediction Bird', ?)",
+            (detection_id, 0.95 - index * 0.05),
+        ).lastrowid
+        photo_ids.append(photo_id)
+        prediction_ids.append(prediction_id)
+    db.conn.commit()
+    db.add_species_highlight("Prediction Bird", photo_ids[0])
+
+    response = client.get(
+        "/api/highlights",
+        query_string={"folder_id": fid, "highlight_selection": "yes"},
+    )
+    assert {b["species"] for b in response.get_json()["buckets"]} == {
+        "Prediction Bird"
+    }
+
+    # Rejecting the selected photo's prediction removes that photo from the
+    # species bucket, but the second prediction keeps the species visible.
+    db.update_prediction_status(prediction_ids[0], "rejected")
+    response = client.get(
+        "/api/highlights",
+        query_string={"folder_id": fid, "highlight_selection": "yes"},
+    )
+    assert response.get_json()["buckets"] == []
+    response = client.get(
+        "/api/highlights",
+        query_string={"folder_id": fid, "highlight_selection": "no"},
+    )
+    assert {b["species"] for b in response.get_json()["buckets"]} == {
+        "Prediction Bird"
+    }
 
 
 def test_highlights_predictions_above_threshold_populate_buckets(app_and_db):

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -5229,8 +5229,8 @@ def test_highlights_buckets_by_accepted_species(app_and_db):
 
 def test_highlights_bucket_mixed_accepted_predicted_is_not_accepted(app_and_db):
     """A bucket whose photos are a mix of accepted-tag and prediction-only
-    must report is_accepted=False. The "Confirmed" badge means the whole
-    row is confirmed, not just some of it (UI transparency rule)."""
+    must report is_accepted=False. The "Keyword confirmed" badge means every
+    photo in the row is keyword-confirmed, not just some of it."""
     app, db = app_and_db
     client = app.test_client()
     fid = db.conn.execute(
@@ -5379,6 +5379,73 @@ def test_highlights_confirmation_filter_splits_confirmed_and_unconfirmed(app_and
     data = resp.get_json()
     assert data["photo_count"] == 1
     assert data["photos"][0]["id"] == predicted_pid
+
+
+def test_highlights_curation_filters_combine_independently(app_and_db):
+    app, db = app_and_db
+    client = app.test_client()
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES ('/curated', 'curated', 'ok')"
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO workspace_folders (workspace_id, folder_id) VALUES (?, ?)",
+        (db._ws_id(), fid),
+    )
+
+    photo_ids = {}
+    for index, species in enumerate(("Alpha Bird", "Beta Bird", "Gamma Bird", "Delta Bird")):
+        keyword_id = db.conn.execute(
+            "INSERT INTO keywords (name, type, is_species) VALUES (?, 'taxonomy', 1)",
+            (species,),
+        ).lastrowid
+        photo_id = db.conn.execute(
+            "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+            "VALUES (?, ?, ?, 'none')",
+            (fid, f"{index}.jpg", 0.9 - index * 0.1),
+        ).lastrowid
+        db.conn.execute(
+            "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+            (photo_id, keyword_id),
+        )
+        photo_ids[species] = photo_id
+    db.conn.commit()
+
+    # Alpha has only a highlight, Beta only a representative, Gamma has both,
+    # and Delta has neither. Every pair of filters should intersect cleanly.
+    db.add_species_highlight("Alpha Bird", photo_ids["Alpha Bird"])
+    db.set_species_representative("Beta Bird", photo_ids["Beta Bird"])
+    db.add_species_highlight("Gamma Bird", photo_ids["Gamma Bird"])
+    db.set_species_representative("Gamma Bird", photo_ids["Gamma Bird"])
+
+    def species_for(**filters):
+        response = client.get(
+            "/api/highlights",
+            query_string={"folder_id": fid, **filters},
+        )
+        assert response.status_code == 200
+        return {bucket["species"] for bucket in response.get_json()["buckets"]}
+
+    assert species_for(highlight_selection="yes") == {"Alpha Bird", "Gamma Bird"}
+    assert species_for(species_representative="yes") == {"Beta Bird", "Gamma Bird"}
+    assert species_for(
+        highlight_selection="yes", species_representative="yes"
+    ) == {"Gamma Bird"}
+    assert species_for(
+        confirmation="confirmed",
+        highlight_selection="no",
+        species_representative="no",
+    ) == {"Delta Bird"}
+
+    response = client.get(
+        "/api/highlights",
+        query_string={
+            "folder_id": fid,
+            "highlight_selection": "not-a-filter",
+            "species_representative": "not-a-filter",
+        },
+    )
+    assert response.get_json()["meta"]["highlight_selection"] == "all"
+    assert response.get_json()["meta"]["species_representative"] == "all"
 
 
 def test_highlights_predictions_above_threshold_populate_buckets(app_and_db):


### PR DESCRIPTION
Adds independent filters for species keyword confirmation, chosen highlights, and representative assignments, allowing any combination on the Highlights page.

Clarifies ambiguous confirmation labels and keeps highlight and representative state species-level even when the selected photo is outside the current folder or search slice.

Validated with 281 application tests, 12 Highlights browser tests, Ruff, and diff checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Highlights filters for “Highlight chosen” and “Representative set,” including combined filtering.
  - Added clear yes/no filter states and updated result summaries to reflect active selections.
  - Updated terminology to “Keyword confirmed” and “Confirm keyword” throughout the Highlights interface.

- **Bug Fixes**
  - Improved filtering behavior for unidentified photos and mixed confirmation states.
  - Corrected bucket status and confirmation indicators to reflect whether all keywords are confirmed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->