### PR TITLE
Make external navigation a native-shell invariant

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -30,8 +30,6 @@
     "core:tray:default",
     "core:tray:allow-set-icon",
     "core:tray:allow-set-tooltip",
-    "opener:allow-open-url",
-    "opener:allow-default-urls",
     "log:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,11 +1,13 @@
 mod config;
 mod menu;
+mod navigation;
 mod sidecar;
 mod tray;
 mod updater;
 use sidecar::{SidecarStartError, SidecarState};
-use tauri::{Manager, RunEvent};
+use tauri::webview::NewWindowResponse;
 use tauri::window::{ProgressBarState, ProgressBarStatus};
+use tauri::{Manager, RunEvent};
 use tauri_plugin_dialog::{DialogExt, MessageDialogKind};
 use tauri_plugin_opener::OpenerExt;
 
@@ -95,15 +97,7 @@ fn set_job_progress(
 
 #[tauri::command]
 fn open_external_url(app: tauri::AppHandle, url: String) -> Result<(), String> {
-    let url = url.trim();
-    let lower = url.to_ascii_lowercase();
-    if !(lower.starts_with("https://") || lower.starts_with("http://")) {
-        return Err("Only http and https URLs can be opened externally".to_string());
-    }
-
-    app.opener()
-        .open_url(url, None::<&str>)
-        .map_err(|e| e.to_string())
+    navigation::open_external_url(&app, &url)
 }
 
 /// Build the logging plugin used in BOTH dev and release builds.
@@ -143,6 +137,30 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .setup(|app| {
+            // Build the main window ourselves so the native shell, rather than
+            // scattered page JavaScript, owns the external-navigation policy.
+            // `create: false` in tauri.conf.json prevents Tauri from building
+            // this same config before setup runs.
+            let main_config = app
+                .config()
+                .app
+                .windows
+                .iter()
+                .find(|config| config.label == "main")
+                .ok_or("main window configuration is missing")?
+                .clone();
+            let navigation_app = app.handle().clone();
+            let popup_app = app.handle().clone();
+            tauri::WebviewWindowBuilder::from_config(app.handle(), &main_config)?
+                .on_navigation(move |url| {
+                    navigation::handle_navigation(&navigation_app, url)
+                })
+                .on_new_window(move |url, _features| {
+                    navigation::handle_new_window(&popup_app, &url);
+                    NewWindowResponse::Deny
+                })
+                .build()?;
+
             // Read the user's launch-time config (~/.vireo/config.json).
             // Failures fall back to defaults — see config::load_launch_config.
             let launch_cfg = config::load_launch_config();

--- a/src-tauri/src/navigation.rs
+++ b/src-tauri/src/navigation.rs
@@ -1,0 +1,238 @@
+use tauri::{Manager, Runtime, Url};
+use tauri_plugin_opener::OpenerExt;
+
+use crate::sidecar::SidecarState;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NavigationAction {
+    AllowInternal,
+    OpenExternal,
+    Block,
+}
+
+fn is_loopback_backend(url: &Url, backend_port: Option<u16>) -> bool {
+    if url.scheme() != "http" || !url.username().is_empty() || url.password().is_some() {
+        return false;
+    }
+
+    let host_is_vireo = matches!(url.host_str(), Some("localhost") | Some("127.0.0.1"));
+    if !host_is_vireo {
+        return false;
+    }
+
+    let expected_port = backend_port.or_else(|| cfg!(debug_assertions).then_some(8080));
+    url.port_or_known_default() == expected_port
+}
+
+fn classify(url: &Url, backend_port: Option<u16>) -> NavigationAction {
+    match url.scheme() {
+        // Tauri's packaged frontend is served from this private scheme. The
+        // production window uses it briefly before navigating to the sidecar.
+        "tauri"
+            if url.host_str() == Some("localhost")
+                && url.username().is_empty()
+                && url.password().is_none() =>
+        {
+            NavigationAction::AllowInternal
+        }
+        "http" if is_loopback_backend(url, backend_port) => NavigationAction::AllowInternal,
+        "http" | "https" => NavigationAction::OpenExternal,
+        _ => NavigationAction::Block,
+    }
+}
+
+fn backend_port<R: Runtime>(app: &tauri::AppHandle<R>) -> Option<u16> {
+    app.try_state::<SidecarState>().map(|state| state.port)
+}
+
+fn open_external<R: Runtime>(
+    app: &tauri::AppHandle<R>,
+    url: &Url,
+    source: &str,
+) -> Result<(), String> {
+    app.opener()
+        .open_url(url.as_str(), None::<&str>)
+        .map_err(|error| {
+            let message = error.to_string();
+            log::error!(
+                "External navigation from {} failed for {}: {}",
+                source,
+                url,
+                message
+            );
+            message
+        })?;
+    log::info!(
+        "External navigation from {} opened in browser: {}",
+        source,
+        url
+    );
+    Ok(())
+}
+
+fn surface_open_failure<R: Runtime>(app: &tauri::AppHandle<R>, url: &Url, error: &str) {
+    let Some(window) = app.get_webview_window("main") else {
+        return;
+    };
+    let url_json = serde_json::to_string(url.as_str()).unwrap_or_else(|_| "\"\"".to_string());
+    let message = format!("Vireo could not open the external URL: {error}");
+    let message_json = serde_json::to_string(&message)
+        .unwrap_or_else(|_| "\"Vireo could not open the external URL.\"".to_string());
+    let script = format!(
+        "if (window.showExternalOpenFailure) {{ window.showExternalOpenFailure({url_json}, {message_json}); }}"
+    );
+    if let Err(eval_error) = window.eval(&script) {
+        log::error!("Could not show external-open recovery UI: {}", eval_error);
+    }
+}
+
+/// Apply the native-shell navigation invariant to a main-frame navigation.
+/// Returning false prevents WKWebView/WebView2 from loading the URL.
+pub fn handle_navigation<R: Runtime>(app: &tauri::AppHandle<R>, url: &Url) -> bool {
+    match classify(url, backend_port(app)) {
+        NavigationAction::AllowInternal => {
+            log::info!("Allowed internal Vireo navigation: {}", url);
+            true
+        }
+        NavigationAction::OpenExternal => {
+            if let Err(error) = open_external(app, url, "main webview") {
+                surface_open_failure(app, url, &error);
+            }
+            false
+        }
+        NavigationAction::Block => {
+            log::warn!("Blocked unsupported webview navigation: {}", url);
+            false
+        }
+    }
+}
+
+/// Handle a `window.open` request. Vireo is intentionally single-webview:
+/// external pages go to the OS browser and no child webview is ever created.
+pub fn handle_new_window<R: Runtime>(app: &tauri::AppHandle<R>, url: &Url) {
+    match classify(url, backend_port(app)) {
+        NavigationAction::OpenExternal => {
+            if let Err(error) = open_external(app, url, "window.open") {
+                surface_open_failure(app, url, &error);
+            }
+        }
+        NavigationAction::AllowInternal => {
+            log::warn!("Blocked child Vireo webview request: {}", url);
+        }
+        NavigationAction::Block => {
+            log::warn!("Blocked unsupported child webview request: {}", url);
+        }
+    }
+}
+
+/// Canonical command implementation used by frontend-initiated external opens.
+pub fn open_external_url<R: Runtime>(
+    app: &tauri::AppHandle<R>,
+    raw_url: &str,
+) -> Result<(), String> {
+    let url = Url::parse(raw_url.trim()).map_err(|error| format!("Invalid URL: {error}"))?;
+    if !matches!(
+        classify(&url, backend_port(app)),
+        NavigationAction::OpenExternal
+    ) {
+        return Err("Only external http and https URLs can be opened".to_string());
+    }
+    open_external(app, &url, "frontend command")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{classify, NavigationAction};
+    use tauri::Url;
+
+    fn action(raw: &str, port: Option<u16>) -> NavigationAction {
+        classify(&Url::parse(raw).unwrap(), port)
+    }
+
+    #[test]
+    fn allows_packaged_assets_and_exact_backend_origin() {
+        assert_eq!(
+            action("tauri://localhost/index.html", None),
+            NavigationAction::AllowInternal
+        );
+        assert_eq!(
+            action("http://127.0.0.1:43127/browse?photo_id=1", Some(43127)),
+            NavigationAction::AllowInternal
+        );
+        assert_eq!(
+            action("http://localhost:43127/settings", Some(43127)),
+            NavigationAction::AllowInternal
+        );
+    }
+
+    #[test]
+    fn blocks_packaged_scheme_lookalikes() {
+        assert_eq!(
+            action("tauri://elsewhere/index.html", None),
+            NavigationAction::Block
+        );
+        assert_eq!(
+            action("tauri://someone@localhost/index.html", None),
+            NavigationAction::Block
+        );
+    }
+
+    #[test]
+    fn externalizes_http_and_https_websites() {
+        assert_eq!(
+            action(
+                "https://www.inaturalist.org/observations/upload",
+                Some(43127)
+            ),
+            NavigationAction::OpenExternal
+        );
+        assert_eq!(
+            action("http://example.com/help", Some(43127)),
+            NavigationAction::OpenExternal
+        );
+    }
+
+    #[test]
+    fn externalizes_wrong_ports_and_loopback_lookalikes() {
+        assert_eq!(
+            action("http://127.0.0.1:43128/browse", Some(43127)),
+            NavigationAction::OpenExternal
+        );
+        assert_eq!(
+            action("http://localhost.example.com:43127/browse", Some(43127)),
+            NavigationAction::OpenExternal
+        );
+        assert_eq!(
+            action("http://127.0.0.1.example.com:43127/browse", Some(43127)),
+            NavigationAction::OpenExternal
+        );
+    }
+
+    #[test]
+    fn rejects_user_info_on_otherwise_internal_urls() {
+        assert_eq!(
+            action("http://someone@localhost:43127/browse", Some(43127)),
+            NavigationAction::OpenExternal
+        );
+        assert_eq!(
+            action("http://someone:secret@127.0.0.1:43127/browse", Some(43127)),
+            NavigationAction::OpenExternal
+        );
+    }
+
+    #[test]
+    fn blocks_unsupported_schemes() {
+        assert_eq!(
+            action("mailto:help@example.com", Some(43127)),
+            NavigationAction::Block
+        );
+        assert_eq!(
+            action("file:///tmp/index.html", Some(43127)),
+            NavigationAction::Block
+        );
+        assert_eq!(
+            action("javascript:alert(1)", Some(43127)),
+            NavigationAction::Block
+        );
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -10,6 +10,7 @@
   "app": {
     "windows": [
       {
+        "create": false,
         "title": "Vireo",
         "width": 1280,
         "height": 800,

--- a/tests/e2e/test_external_navigation.py
+++ b/tests/e2e/test_external_navigation.py
@@ -200,6 +200,51 @@ def test_batch_quick_open_preserves_preparation_failures(live_server, page):
     )
 
 
+def test_copy_url_fallback_does_not_reuse_stale_failure_modal_value(live_server, page):
+    """Codex P2 regression: after the external-open failure modal has been shown
+    once with URL A, a subsequent copyExternalUrl(URL_B) call whose clipboard
+    write rejects must copy URL_B — not the stale value still sitting in
+    #externalOpenModalUrl."""
+    page.goto(f"{live_server['url']}/browse")
+    stale_url = "https://www.inaturalist.org/observations/upload?taxon_name=Stale"
+    fresh_url = "https://www.inaturalist.org/observations/upload?taxon_name=Fresh"
+
+    # Prime the failure modal so #externalOpenModalUrl exists with the stale URL.
+    page.evaluate("url => showExternalOpenFailure(url)", stale_url)
+    expect(page.locator("#externalOpenModalUrl")).to_have_value(stale_url)
+    page.evaluate("() => closeExternalOpenFailure()")
+
+    # Force the clipboard fallback and capture what document.execCommand would copy.
+    page.evaluate(
+        """
+        () => {
+          Object.defineProperty(navigator, 'clipboard', {
+            configurable: true,
+            value: { writeText: () => Promise.reject(new Error('denied')) }
+          });
+          window.__copyProbe = { selection: null, executed: false };
+          document.execCommand = command => {
+            if (command === 'copy') {
+              window.__copyProbe.selection = String(document.getSelection() || '');
+              window.__copyProbe.executed = true;
+            }
+            return true;
+          };
+        }
+        """
+    )
+
+    page.evaluate("url => copyExternalUrl(url)", fresh_url)
+    page.wait_for_function("window.__copyProbe.executed === true")
+
+    probe = page.evaluate("window.__copyProbe")
+    assert probe["selection"] == fresh_url, (
+        f"Expected fresh URL to be copied, got {probe['selection']!r}"
+    )
+    # Stale modal input must be left untouched — no one should be reading from it.
+    expect(page.locator("#externalOpenModalUrl")).to_have_value(stale_url)
+
+
 def test_duplicate_quick_upload_does_not_auto_open(live_server, page):
     page.goto(f"{live_server['url']}/browse")
     _mock_tauri(page)

--- a/tests/e2e/test_external_navigation.py
+++ b/tests/e2e/test_external_navigation.py
@@ -176,6 +176,30 @@ def test_batch_quick_uploads_require_explicit_per_item_open(live_server, page):
     page.wait_for_function("window.__externalTest.execCopyCalls === 1")
 
 
+def test_batch_quick_open_preserves_preparation_failures(live_server, page):
+    page.goto(f"{live_server['url']}/browse")
+    _mock_tauri(page)
+
+    failures = [
+        {"photo_id": 42, "error": "Missing GPS coordinates"},
+        {"photo_id": 43, "error": "No identifiable taxon"},
+    ]
+    page.evaluate(
+        "args => openInatQuickModal([args.item], args.failures)",
+        {"item": _item(1), "failures": failures},
+    )
+
+    # The batch had preparation failures, so the auto-open shortcut must be
+    # skipped and the modal must render both the prepared upload and the
+    # failure summary — otherwise those dropped photos are silently lost.
+    assert _open_commands(page) == []
+    expect(page.locator("#inatModal")).to_have_class("modal-overlay open")
+    expect(page.locator("#inatCards", has_text="Open Upload Page")).to_be_visible()
+    expect(page.locator("#inatCards")).to_contain_text(
+        "2 photos could not be prepared."
+    )
+
+
 def test_duplicate_quick_upload_does_not_auto_open(live_server, page):
     page.goto(f"{live_server['url']}/browse")
     _mock_tauri(page)

--- a/tests/e2e/test_external_navigation.py
+++ b/tests/e2e/test_external_navigation.py
@@ -1,0 +1,189 @@
+"""Behavioral coverage for browser and Tauri external-navigation handoffs."""
+
+from playwright.sync_api import expect
+
+INAT_URL = "https://www.inaturalist.org/observations/upload?taxon_name=Corvus"
+
+
+def _item(photo_id=1, *, url=INAT_URL, duplicate=False):
+    return {
+        "photo_id": photo_id,
+        "filename": f"photo-{photo_id}.jpg",
+        "upload_url": url,
+        "already_submitted": duplicate,
+        "existing_url": (
+            "https://www.inaturalist.org/observations/123" if duplicate else None
+        ),
+    }
+
+
+def _mock_tauri(page, *, fail_open=False):
+    page.evaluate(
+        """
+        failOpen => {
+          window.__externalTest = { invokes: [], windowOpenCalls: [] };
+          window.__TAURI_INTERNALS__ = {
+            invoke: (command, args) => {
+              window.__externalTest.invokes.push({ command, args });
+              if (failOpen && command === 'open_external_url') {
+                return Promise.reject(new Error('browser launch failed'));
+              }
+              return Promise.resolve(null);
+            }
+          };
+          window.open = (...args) => {
+            window.__externalTest.windowOpenCalls.push(args);
+            return null;
+          };
+        }
+        """,
+        fail_open,
+    )
+
+
+def _open_commands(page):
+    return page.evaluate(
+        "window.__externalTest.invokes.filter(call => "
+        "call.command === 'open_external_url')"
+    )
+
+
+def test_native_quick_open_uses_one_command_and_only_a_toast(live_server, page):
+    page.goto(f"{live_server['url']}/browse")
+    original_url = page.url
+    _mock_tauri(page)
+
+    page.evaluate("item => openInatQuickModal([item], [])", _item())
+
+    commands = _open_commands(page)
+    assert commands == [{"command": "open_external_url", "args": {"url": INAT_URL}}]
+    assert page.evaluate("window.__externalTest.windowOpenCalls") == []
+    assert page.url == original_url
+    expect(page.locator("#toastContainer")).to_contain_text(
+        "Opened iNaturalist in your browser."
+    )
+    expect(page.locator("#inatModal")).not_to_have_class("open")
+
+
+def test_native_open_failure_stays_put_and_offers_retry_and_copy(live_server, page):
+    page.goto(f"{live_server['url']}/browse")
+    original_url = page.url
+    _mock_tauri(page, fail_open=True)
+
+    page.evaluate("item => openInatQuickModal([item], [])", _item())
+
+    assert len(_open_commands(page)) == 1
+    assert page.evaluate("window.__externalTest.windowOpenCalls") == []
+    assert page.url == original_url
+    modal = page.locator("#externalOpenModal")
+    expect(modal).to_be_visible()
+    expect(modal.locator("#externalOpenModalUrl")).to_have_value(INAT_URL)
+    expect(modal.locator("#externalOpenRetryBtn")).to_be_visible()
+    expect(modal.locator("#externalOpenCopyBtn")).to_be_visible()
+    expect(modal.locator("#externalOpenCloseBtn")).to_be_visible()
+
+
+def test_browser_popup_block_never_replaces_vireo(live_server, page):
+    page.goto(f"{live_server['url']}/browse")
+    original_url = page.url
+    page.evaluate(
+        """
+        () => {
+          delete window.__TAURI_INTERNALS__;
+          window.__externalTest = { windowOpenCalls: [] };
+          window.open = (...args) => {
+            window.__externalTest.windowOpenCalls.push(args);
+            return null;
+          };
+        }
+        """
+    )
+
+    page.evaluate("url => openExternalWithRecovery(url)", INAT_URL)
+
+    assert page.url == original_url
+    assert page.evaluate("window.__externalTest.windowOpenCalls") == [
+        ["about:blank", "_blank"]
+    ]
+    expect(page.locator("#externalOpenModal")).to_be_visible()
+    expect(page.locator("#externalOpenModalUrl")).to_have_value(INAT_URL)
+
+
+def test_delegated_handler_covers_unannotated_external_links(live_server, page):
+    page.goto(f"{live_server['url']}/settings")
+    original_url = page.url
+    _mock_tauri(page)
+
+    # This link deliberately has no target=_blank or inline external handler.
+    page.locator('a[href="https://www.darktable.org/"]').click()
+    page.wait_for_function(
+        "window.__externalTest.invokes.some(call => "
+        "call.command === 'open_external_url')"
+    )
+
+    commands = _open_commands(page)
+    assert commands == [
+        {"command": "open_external_url", "args": {"url": "https://www.darktable.org/"}}
+    ]
+    assert page.url == original_url
+
+
+def test_internal_links_are_not_claimed_by_external_handler(live_server, page):
+    page.goto(f"{live_server['url']}/settings")
+    _mock_tauri(page)
+
+    assert page.evaluate("_isExternalHttpUrl('/browse')") is False
+    assert page.evaluate("_isExternalHttpUrl('https://example.com')") is True
+    assert _open_commands(page) == []
+
+
+def test_batch_quick_uploads_require_explicit_per_item_open(live_server, page):
+    page.goto(f"{live_server['url']}/browse")
+    _mock_tauri(page)
+    items = [
+        _item(1),
+        _item(
+            2,
+            url="https://www.inaturalist.org/observations/upload?taxon_name=Pica",
+        ),
+    ]
+
+    page.evaluate("items => openInatQuickModal(items, [])", items)
+
+    assert _open_commands(page) == []
+    expect(page.locator("#inatModal")).to_have_class("modal-overlay open")
+    expect(page.locator("#inatCards a", has_text="Open Upload")).to_have_count(2)
+    expect(page.locator("#inatCards button", has_text="Copy URL")).to_have_count(2)
+
+    # Copy still has a DOM fallback when clipboard permission is unavailable;
+    # batch recovery must not depend on the separate failure modal existing.
+    page.evaluate(
+        """
+        () => {
+          Object.defineProperty(navigator, 'clipboard', {
+            configurable: true,
+            value: { writeText: () => Promise.reject(new Error('denied')) }
+          });
+          window.__externalTest.execCopyCalls = 0;
+          document.execCommand = command => {
+            if (command === 'copy') window.__externalTest.execCopyCalls += 1;
+            return true;
+          };
+        }
+        """
+    )
+    page.locator("#inatCards button", has_text="Copy URL").first.click()
+    page.wait_for_function("window.__externalTest.execCopyCalls === 1")
+
+
+def test_duplicate_quick_upload_does_not_auto_open(live_server, page):
+    page.goto(f"{live_server['url']}/browse")
+    _mock_tauri(page)
+
+    page.evaluate("item => openInatQuickModal([item], [])", _item(1, duplicate=True))
+
+    assert _open_commands(page) == []
+    expect(page.locator("#inatModal")).to_have_class("modal-overlay open")
+    expect(page.locator("#inatCards")).to_contain_text("Already submitted")
+    expect(page.locator("#inatCards", has_text="Open Upload Page")).to_be_visible()
+    expect(page.locator("#inatCards button", has_text="Copy URL")).to_be_visible()

--- a/vireo/static/tauri-bridge.js
+++ b/vireo/static/tauri-bridge.js
@@ -182,20 +182,18 @@ async function copyExternalUrl(url) {
     await navigator.clipboard.writeText(url);
     copied = true;
   } catch (e) {
-    var input = document.getElementById('externalOpenModalUrl');
-    var temporaryInput = false;
-    if (!input) {
-      input = document.createElement('textarea');
-      input.value = url;
-      input.setAttribute('readonly', '');
-      input.style.cssText = 'position:fixed;left:-9999px;top:0;';
-      document.body.appendChild(input);
-      temporaryInput = true;
-    }
-    input.focus();
-    input.select();
+    // Always use a fresh throwaway textarea so non-modal callers (e.g. iNat
+    // batch Copy URL buttons) never end up selecting a stale value left in
+    // #externalOpenModalUrl from an earlier failure modal.
+    var temp = document.createElement('textarea');
+    temp.value = url;
+    temp.setAttribute('readonly', '');
+    temp.style.cssText = 'position:fixed;left:-9999px;top:0;';
+    document.body.appendChild(temp);
+    temp.focus();
+    temp.select();
     try { copied = document.execCommand('copy'); } catch (copyError) {}
-    if (temporaryInput) input.remove();
+    temp.remove();
   }
   if (typeof showToast === 'function') {
     showToast(copied ? 'URL copied.' : 'Select and copy the URL shown.', copied ? 'success' : 'warning');

--- a/vireo/static/tauri-bridge.js
+++ b/vireo/static/tauri-bridge.js
@@ -93,10 +93,10 @@ async function pickFile(opts) {
 /**
  * Open an external URL in the user's default browser.
  *
- * Inside the Tauri desktop webview a bare `window.open(url, '_blank')` is
- * silently dropped — no tab opens and no error fires — so external links must
- * be routed through the opener plugin instead. In a normal browser we fall
- * back to window.open (which also lets us detect a popup blocker).
+ * The native shell enforces the same rule independently: an external page can
+ * never replace the Vireo document or create another Vireo webview. This
+ * helper is the user-facing path because it can report opener failures and
+ * provide Retry/Copy recovery. In browser mode it opens a new tab only.
  *
  * @param {string} url - The http(s) URL to open
  * @returns {Promise<boolean>} true if the open was dispatched successfully
@@ -112,24 +112,12 @@ async function openExternal(url) {
       logInfo('openExternal: opened ' + url);
       return true;
     } catch (e) {
-      logWarn('openExternal command failed for ' + url + ': ' + (e && e.message ? e.message : e));
-      try {
-        await window.__TAURI_INTERNALS__.invoke('plugin:opener|open_url', { url: url, with: null });
-        logInfo('openExternal: opened ' + url + ' via opener plugin fallback');
-        return true;
-      } catch (fallbackError) {
-        // Surface the *real* opener error (e.g. ForbiddenUrl from a missing
-        // capability scope) to the log file so this stops being a silent no-op.
-        logError('openExternal failed for ' + url + ': ' + (fallbackError && fallbackError.message ? fallbackError.message : fallbackError));
-        return false;
-      }
+      logError('openExternal failed for ' + url + ': ' + (e && e.message ? e.message : e));
+      return false;
     }
   }
-  // Browser fallback. We deliberately omit the 'noopener' window feature: with
-  // it, window.open returns null even on a *successful* open (MDN), which would
-  // make us report a false "could not open". Instead open about:blank first so
-  // we can null the opener same-origin, then navigate — this keeps popup-block
-  // detection (a real null return) and still prevents reverse-tabnabbing.
+  // Browser mode never replaces the Vireo tab. Open a detectable blank tab,
+  // sever its opener, and navigate it only after we know it was not blocked.
   var win = window.open('about:blank', '_blank');
   if (!win) {
     logWarn('openExternal: window.open was blocked (popup blocker?) for ' + url);
@@ -139,6 +127,108 @@ async function openExternal(url) {
   win.location = url;
   return true;
 }
+
+function _ensureExternalOpenModal() {
+  var modal = document.getElementById('externalOpenModal');
+  if (modal) return modal;
+  modal = document.createElement('div');
+  modal.id = 'externalOpenModal';
+  modal.setAttribute('role', 'dialog');
+  modal.setAttribute('aria-modal', 'true');
+  modal.setAttribute('aria-labelledby', 'externalOpenModalTitle');
+  modal.style.cssText = 'display:none;position:fixed;inset:0;z-index:20000;background:rgba(0,0,0,.72);align-items:center;justify-content:center;padding:24px;';
+  modal.innerHTML =
+    '<div style="width:min(620px,100%);background:var(--bg-secondary,#20252b);border:1px solid var(--border-primary,#46515b);border-radius:8px;padding:20px;box-shadow:0 16px 50px rgba(0,0,0,.45);">' +
+      '<h3 id="externalOpenModalTitle" style="margin:0 0 10px;color:var(--text-primary,#fff);">Could not open your browser</h3>' +
+      '<p id="externalOpenModalMessage" style="margin:0 0 12px;color:var(--text-secondary,#c7ced4);line-height:1.45;">Vireo stayed on this page. Retry or copy the URL below.</p>' +
+      '<input id="externalOpenModalUrl" readonly style="box-sizing:border-box;width:100%;padding:9px 10px;background:var(--bg-primary,#15191d);color:var(--text-primary,#fff);border:1px solid var(--border-primary,#46515b);border-radius:4px;" />' +
+      '<div style="display:flex;justify-content:flex-end;gap:8px;margin-top:16px;">' +
+        '<button type="button" id="externalOpenCloseBtn" class="modal-btn modal-btn-cancel">Close</button>' +
+        '<button type="button" id="externalOpenCopyBtn" class="modal-btn">Copy URL</button>' +
+        '<button type="button" id="externalOpenRetryBtn" class="modal-btn modal-btn-primary">Retry</button>' +
+      '</div>' +
+    '</div>';
+  document.body.appendChild(modal);
+  modal.querySelector('#externalOpenCloseBtn').addEventListener('click', closeExternalOpenFailure);
+  modal.querySelector('#externalOpenCopyBtn').addEventListener('click', function() {
+    copyExternalUrl(document.getElementById('externalOpenModalUrl').value);
+  });
+  modal.querySelector('#externalOpenRetryBtn').addEventListener('click', async function() {
+    var url = document.getElementById('externalOpenModalUrl').value;
+    if (await openExternal(url)) {
+      closeExternalOpenFailure();
+      if (typeof showToast === 'function') showToast('Opened in your browser.', 'success');
+    }
+  });
+  return modal;
+}
+
+function showExternalOpenFailure(url, message) {
+  var modal = _ensureExternalOpenModal();
+  document.getElementById('externalOpenModalUrl').value = url || '';
+  document.getElementById('externalOpenModalMessage').textContent = message || 'Vireo stayed on this page. Retry or copy the URL below.';
+  modal.style.display = 'flex';
+  document.getElementById('externalOpenRetryBtn').focus();
+}
+
+function closeExternalOpenFailure() {
+  var modal = document.getElementById('externalOpenModal');
+  if (modal) modal.style.display = 'none';
+}
+
+async function copyExternalUrl(url) {
+  var copied = false;
+  try {
+    await navigator.clipboard.writeText(url);
+    copied = true;
+  } catch (e) {
+    var input = document.getElementById('externalOpenModalUrl');
+    var temporaryInput = false;
+    if (!input) {
+      input = document.createElement('textarea');
+      input.value = url;
+      input.setAttribute('readonly', '');
+      input.style.cssText = 'position:fixed;left:-9999px;top:0;';
+      document.body.appendChild(input);
+      temporaryInput = true;
+    }
+    input.focus();
+    input.select();
+    try { copied = document.execCommand('copy'); } catch (copyError) {}
+    if (temporaryInput) input.remove();
+  }
+  if (typeof showToast === 'function') {
+    showToast(copied ? 'URL copied.' : 'Select and copy the URL shown.', copied ? 'success' : 'warning');
+  }
+  return copied;
+}
+
+async function openExternalWithRecovery(url, message) {
+  var opened = await openExternal(url);
+  if (!opened) showExternalOpenFailure(url, message);
+  return opened;
+}
+
+function _isExternalHttpUrl(rawUrl) {
+  try {
+    var parsed = new URL(rawUrl, window.location.href);
+    return (parsed.protocol === 'http:' || parsed.protocol === 'https:') && parsed.origin !== window.location.origin;
+  } catch (e) {
+    return false;
+  }
+}
+
+// Catch every ordinary external anchor, including future links that forget to
+// opt into a special onclick handler. Existing explicit handlers run first and
+// preventDefault(), so this delegated fallback never opens a URL twice.
+document.addEventListener('click', function(event) {
+  if (event.defaultPrevented || event.button !== 0) return;
+  var target = event.target;
+  var anchor = target && target.closest ? target.closest('a[href]') : null;
+  if (!anchor || !_isExternalHttpUrl(anchor.href)) return;
+  event.preventDefault();
+  openExternalWithRecovery(anchor.href);
+});
 
 /**
  * Check for an available update via the Rust command.

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -7403,7 +7403,10 @@ async function submitToInatBatch(photoIds) {
 
 async function openInatQuickModal(items, failures) {
   var skipAutoOpenForDuplicate = items.length === 1 && !!items[0].already_submitted;
-  if (items.length === 1 && items[0].upload_url && !skipAutoOpenForDuplicate) {
+  var hasFailures = !!(failures && failures.length);
+  // When batch preparation left other photos in a failure state, always render
+  // the modal so the failure summary is visible instead of silently dropping it.
+  if (items.length === 1 && items[0].upload_url && !skipAutoOpenForDuplicate && !hasFailures) {
     var opened = await _inatOpenUrl(items[0].upload_url);
     if (opened) {
       showToast('Opened iNaturalist in your browser.', 'success');

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -7346,8 +7346,6 @@ async function _inatOpenUrl(url) {
     if (typeof openExternal === 'function') {
       return await openExternal(url);
     }
-    var opened = window.open(url, '_blank', 'noopener');
-    return !!opened;
   } catch(e) {}
   return false;
 }
@@ -7404,6 +7402,22 @@ async function submitToInatBatch(photoIds) {
 }
 
 async function openInatQuickModal(items, failures) {
+  var skipAutoOpenForDuplicate = items.length === 1 && !!items[0].already_submitted;
+  if (items.length === 1 && items[0].upload_url && !skipAutoOpenForDuplicate) {
+    var opened = await _inatOpenUrl(items[0].upload_url);
+    if (opened) {
+      showToast('Opened iNaturalist in your browser.', 'success');
+      return;
+    }
+    if (typeof showExternalOpenFailure === 'function') {
+      showExternalOpenFailure(
+        items[0].upload_url,
+        'Vireo could not open iNaturalist. Retry or copy the prepared upload URL below.'
+      );
+      return;
+    }
+  }
+
   if (window._inatEscToken) Keymap.popEsc(window._inatEscToken);
   window._inatEscToken = Keymap.pushEsc(function() { closeInatModal(); });
 
@@ -7418,12 +7432,6 @@ async function openInatQuickModal(items, failures) {
 
   var cancelBtn = document.querySelector('#inatActions .modal-btn-cancel');
   if (cancelBtn) cancelBtn.textContent = 'Close';
-
-  var opened = false;
-  var skipAutoOpenForDuplicate = items.length === 1 && !!items[0].already_submitted;
-  if (items.length === 1 && items[0].upload_url && !skipAutoOpenForDuplicate) {
-    opened = await _inatOpenUrl(items[0].upload_url);
-  }
 
   function _inatAlreadySubmittedWarning(item) {
     if (!item.already_submitted) return '';
@@ -7440,12 +7448,10 @@ async function openInatQuickModal(items, failures) {
         '<img class="inat-card-thumb" src="/thumbnails/' + items[0].photo_id + '.jpg" alt="">' +
         '<div style="flex:1;min-width:0;">' +
           '<div style="font-size:13px;color:var(--text-primary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">' + escapeHtml(items[0].filename) + '</div>' +
-          '<div class="inat-card-status ' + (opened ? 'success' : 'warning') + '">' +
-            (opened
-              ? 'Opened iNaturalist in your browser.'
-              : (skipAutoOpenForDuplicate
-                  ? 'Did not auto-open — this photo appears already submitted. Review the warning below before opening a new upload.'
-                  : 'iNaturalist did not visibly open. Use the link below.')) +
+          '<div class="inat-card-status warning">' +
+            (skipAutoOpenForDuplicate
+              ? 'Did not auto-open — this photo appears already submitted. Review the warning below before opening a new upload.'
+              : 'Use the prepared link below.') +
           '</div>' +
           _inatAlreadySubmittedWarning(items[0]) +
         '</div>' +
@@ -7455,6 +7461,7 @@ async function openInatQuickModal(items, failures) {
       '</div>' +
       '<div style="margin-top:12px;">' +
         '<a class="modal-btn modal-btn-primary" href="' + escapeAttr(items[0].upload_url) + '" target="_blank" rel="noopener" onclick="return openExternalLink(event, this.href)" style="display:inline-block;text-decoration:none;">Open Upload Page</a>' +
+        '<button type="button" class="modal-btn" data-external-url="' + escapeAttr(items[0].upload_url) + '" onclick="copyExternalUrl(this.getAttribute(\'data-external-url\'))" style="margin-left:8px;">Copy URL</button>' +
       '</div>' +
     '</div>';
   } else {
@@ -7466,7 +7473,10 @@ async function openInatQuickModal(items, failures) {
       html += '<div style="display:flex;flex-direction:column;gap:4px;padding:8px 0;border-top:1px solid var(--border-primary);">' +
         '<div style="display:flex;align-items:center;justify-content:space-between;gap:12px;">' +
           '<span style="font-size:13px;color:var(--text-primary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">' + escapeHtml(item.filename) + '</span>' +
-          '<a href="' + escapeAttr(item.upload_url) + '" target="_blank" rel="noopener" onclick="return openExternalLink(event, this.href)" style="color:var(--accent);font-size:12px;white-space:nowrap;">Open Upload</a>' +
+          '<span style="display:flex;align-items:center;gap:8px;white-space:nowrap;">' +
+            '<a href="' + escapeAttr(item.upload_url) + '" target="_blank" rel="noopener" onclick="return openExternalLink(event, this.href)" style="color:var(--accent);font-size:12px;">Open Upload</a>' +
+            '<button type="button" data-external-url="' + escapeAttr(item.upload_url) + '" onclick="copyExternalUrl(this.getAttribute(\'data-external-url\'))" style="border:0;background:none;color:var(--text-secondary);font-size:12px;cursor:pointer;padding:0;">Copy URL</button>' +
+          '</span>' +
         '</div>' +
         _inatAlreadySubmittedWarning(item) +
       '</div>';
@@ -8487,51 +8497,11 @@ function showToast(msg, type) {
 // navigation. Use on <a> tags as: onclick="return openExternalLink(event, this.href)".
 function openExternalLink(event, url) {
   if (event) event.preventDefault();
-  function fallbackOpen() {
-    // In the desktop app, falling back to window.location.href navigates the
-    // WKWebView itself, which makes external sites look like they opened inside
-    // Vireo. If the native opener fails, leave the app in place and let the
-    // caller surface the link/error instead.
-    if (typeof isTauri === 'function' && isTauri()) return false;
-    var opened = null;
-    try {
-      opened = window.open('about:blank', '_blank');
-    } catch(e) {}
-    if (opened) {
-      try { opened.opener = null; } catch(e) {}
-      opened.location = url;
-      return true;
-    }
-    if (!opened && url) {
-      try {
-        window.location.href = url;
-        return true;
-      } catch(e) {}
-    }
+  if (typeof openExternalWithRecovery !== 'function') {
+    showToast('Could not open link: ' + url, 'error');
     return false;
   }
-
-  if (typeof openExternal !== 'function') {
-    if (!fallbackOpen()) showToast('Could not open link: ' + url, 'error');
-    return false;
-  }
-
-  openExternal(url).then(function(ok) {
-    // openExternal catches Tauri command/opener failures internally and
-    // resolves `false` rather than rejecting, so the .catch() below never runs
-    // in the packaged-desktop failure path (ACL denial, opener error, popup
-    // block). Try fallbackOpen here too so the click doesn't silently die.
-    if (!ok && !fallbackOpen()) {
-      showToast('Could not open link: ' + url, 'error');
-    }
-  }).catch(function(e) {
-    if (!fallbackOpen()) {
-      showToast('Could not open link: ' + url, 'error');
-    }
-    if (typeof logError === 'function') {
-      logError('openExternalLink failed for ' + url + ': ' + (e && e.message ? e.message : e));
-    }
-  });
+  openExternalWithRecovery(url);
   return false;
 }
 

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -7986,25 +7986,26 @@ def test_native_import_commands_route_to_import_page():
     assert "case 'import_folder':\n        nativeMenuRoute('/import');" in navbar
 
 
-def test_external_link_fallback_does_not_navigate_tauri_webview():
-    """If the native browser opener fails, don't load iNat inside Vireo."""
+def test_native_shell_owns_external_navigation_policy():
+    """The native shell must deny external and child-webview navigation."""
     import os
 
     repo_root = os.path.normpath(
         os.path.join(os.path.dirname(__file__), "..", "..")
     )
-    navbar_path = os.path.join(repo_root, "vireo", "templates", "_navbar.html")
+    lib_path = os.path.join(repo_root, "src-tauri", "src", "lib.rs")
+    config_path = os.path.join(repo_root, "src-tauri", "tauri.conf.json")
 
-    with open(navbar_path, encoding="utf-8") as f:
-        navbar = f.read()
+    with open(lib_path, encoding="utf-8") as f:
+        lib = f.read()
+    with open(config_path, encoding="utf-8") as f:
+        config = f.read()
 
-    fallback_start = navbar.index("function fallbackOpen()")
-    location_fallback = navbar.index("window.location.href = url", fallback_start)
-    tauri_guard = navbar.index(
-        "if (typeof isTauri === 'function' && isTauri()) return false;",
-        fallback_start,
-    )
-    assert tauri_guard < location_fallback
+    assert '"create": false' in config
+    assert ".on_navigation(move |url|" in lib
+    assert "navigation::handle_navigation(&navigation_app, url)" in lib
+    assert ".on_new_window(" in lib
+    assert "NewWindowResponse::Deny" in lib
 
 
 def test_pipeline_plan_accepts_folder_scope(app_and_db):


### PR DESCRIPTION
## Summary

- Move external-navigation enforcement into the Tauri shell for both main-frame navigation and `window.open` requests.
- Route frontend external links through one native command and remove in-webview fallbacks.
- Add retry/copy recovery UI, streamlined iNaturalist quick-open feedback, and explicit batch/duplicate behavior.
- Add Rust URL-policy tests and behavioral Playwright coverage for native success/failure, browser popup blocking, delegated links, batches, and duplicates.

## Root cause

Earlier fixes repaired individual iNaturalist JavaScript paths, but authority remained split between the opener plugin, a Rust command, anchor defaults, `window.open`, and `window.location.href`. A later fallback could therefore reintroduce embedded external navigation even while earlier regression assertions still passed.

This change makes the native window the final authority: only Vireo's packaged origin and exact active loopback backend origin may load in the webview. External HTTP(S) URLs are sent to the system browser, unsupported schemes are blocked, and child webviews are always denied.

## Validation

- `cargo test --manifest-path src-tauri/Cargo.toml --no-fail-fast` — 20 passed
- `python -m pytest -q tests/e2e/test_external_navigation.py vireo/tests/test_app.py::test_native_shell_owns_external_navigation_policy` — 8 passed
- `ruff check vireo tests` — passed
- `node --check vireo/static/tauri-bridge.js` — passed
- Full Python/Playwright suite — 4,426 passed, 78 skipped; one unrelated user-first missing-asset test fails identically on clean `origin/main`
- macOS app and DMG built, signed, notarized, and accepted by Gatekeeper
- Debug native app smoke-launched against the live development server; logs confirmed the programmatically created window allowed only the expected Vireo origin

The local release packaging command finishes the signed/notarized app, DMG, and updater archive, then reports the expected missing `TAURI_SIGNING_PRIVATE_KEY` error for updater metadata signing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of external links and navigation in the desktop app.
  * Added recovery options when an external link cannot be opened, including retry, copy URL, and close controls.
  * Added copy URL actions for iNaturalist uploads.
  * Batch and duplicate uploads now avoid unintended automatic opening and provide clearer status information.

* **Bug Fixes**
  * Prevented unsupported, unsafe, or unintended navigation and popup windows.
  * Preserved the current page when external opening fails or browser popups are blocked.

* **Tests**
  * Added coverage for external navigation, upload flows, failure recovery, duplicates, and blocked popups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->