### PR TITLE
Guard species confirmation requests

### DIFF
--- a/tests/e2e/test_pipeline_review_species.py
+++ b/tests/e2e/test_pipeline_review_species.py
@@ -222,6 +222,67 @@ def test_predictionless_pipeline_encounter_can_add_species(live_server, page):
     assert {r["id"] for r in rows} == set(photo_ids)
 
 
+def test_pipeline_review_species_confirm_ignores_duplicate_inflight_clicks(live_server, page):
+    photo_ids = live_server["data"]["photos"][:2]
+    _write_confirmation_pipeline_cache(live_server, photo_ids)
+
+    page.goto(f"{live_server['url']}/pipeline/review")
+
+    page.evaluate(
+        """
+        () => {
+          window.__speciesPosts = [];
+          const originalSafeFetch = window.safeFetch;
+          window.safeFetch = (url, opts, cfg) => {
+            if (String(url).includes('/api/encounters/species')) {
+              window.__speciesPosts.push(JSON.parse(opts.body));
+              return new Promise(resolve => {
+                window.__resolveSpeciesPost = () => resolve({
+                  ok: true,
+                  species: 'American Robin',
+                  keyword_id: 123,
+                  photo_count: 1,
+                  skipped_photo_ids: [],
+                  low_confidence_photo_ids: [],
+                });
+              });
+            }
+            return originalSafeFetch(url, opts, cfg);
+          };
+        }
+        """
+    )
+
+    post_count = page.evaluate(
+        """
+        () => {
+          const event = { stopPropagation() {} };
+          window.__confirmPromises = [
+            confirmSpecies(event, 1, null, null),
+            confirmSpecies(event, 1, null, null),
+          ];
+          return window.__speciesPosts.length;
+        }
+        """
+    )
+
+    assert post_count == 1
+    expect(
+        page.locator('[data-species-widget="1"][data-enc="1"] .species-confirm-btn').first
+    ).to_be_disabled()
+
+    page.evaluate("() => window.__resolveSpeciesPost()")
+    page.evaluate("() => Promise.all(window.__confirmPromises)")
+
+    posts = page.evaluate("() => window.__speciesPosts")
+    assert len(posts) == 1
+    assert posts[0]["species"] == "American Robin"
+    assert posts[0]["photo_ids"] == [photo_ids[1]]
+    expect(
+        page.locator('[data-species-widget="1"][data-enc="1"] .species-confirm-btn')
+    ).to_have_count(0)
+
+
 def test_species_name_arg_keeps_nullish_values_empty(live_server, page):
     page.goto(f"{live_server['url']}/pipeline/review")
 

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -843,6 +843,14 @@ input[type="range"]::-moz-range-thumb {
   border-color: var(--accent);
   color: var(--accent);
 }
+.species-confirm-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.species-confirm-btn:disabled:hover {
+  border-color: var(--border-primary);
+  color: var(--text-dim);
+}
 
 /* Species dropdown */
 .species-dropdown {
@@ -3608,6 +3616,22 @@ function refreshMissesReviewBtn() {
 // -- Species confirmation --
 
 var activeDropdown = null;
+var speciesConfirmInFlight = {};
+
+function speciesConfirmPhotoKey(photoIds) {
+  return 'photos:' + (photoIds || []).slice().sort(function(a, b) { return a - b; }).join(',');
+}
+
+function speciesConfirmPendingFor(enc, burstIdx) {
+  if (!enc) return false;
+  var photoIds = null;
+  if (burstIdx != null && enc.bursts && enc.bursts[burstIdx]) {
+    photoIds = enc.bursts[burstIdx].photo_ids;
+  } else {
+    photoIds = enc.photo_ids;
+  }
+  return !!speciesConfirmInFlight[speciesConfirmPhotoKey(photoIds)];
+}
 
 function renderSpeciesWidget(enc, encIdx, level, burstIdx, pos) {
   // level: 'encounter' or 'burst'
@@ -3636,16 +3660,19 @@ function renderSpeciesWidget(enc, encIdx, level, burstIdx, pos) {
   }
 
   var hasCandidate = !!candidateSpecies;
+  var isPending = speciesConfirmPendingFor(enc, burstIdx);
   var cls = isConfirmed ? 'confirmed' : (hasCandidate ? 'unconfirmed' : 'missing');
   var badge = isConfirmed ? '&#10003;' : (hasCandidate ? '?' : '+');
   var widgetCls = level === 'burst' ? 'burst-species-widget' : 'species-widget';
 
   var idKey = (burstIdx != null ? burstIdx : 'enc') + '_' + pos;
   var html = '<span class="' + widgetCls + '" data-species-widget="1" data-level="' + level + '" data-enc="' + encIdx + '" data-burst="' + (burstIdx != null ? burstIdx : '') + '" data-pos="' + pos + '">';
-  html += '<span class="species-name ' + cls + '" title="' + (hasCandidate ? 'Change species' : 'Add species') + '" onclick="toggleSpeciesDropdown(event, ' + encIdx + ',' + (burstIdx != null ? burstIdx : 'null') + ',\'' + pos + '\')">' + escapeHtml(displayName) + '</span>';
+  html += '<span class="species-name ' + cls + '" title="' + (isPending ? 'Confirming species...' : (hasCandidate ? 'Change species' : 'Add species')) + '"'
+    + (isPending ? '' : ' onclick="toggleSpeciesDropdown(event, ' + encIdx + ',' + (burstIdx != null ? burstIdx : 'null') + ',\'' + pos + '\')"')
+    + '>' + escapeHtml(displayName) + '</span>';
   html += '<span class="species-badge ' + cls + '">' + badge + '</span>';
   if (!isConfirmed && hasCandidate) {
-    html += '<button class="species-confirm-btn" onclick="confirmSpecies(event, ' + encIdx + ',' + (burstIdx != null ? burstIdx : 'null') + ',null)" title="Confirm as ' + escapeHtml(displayName) + '">&#10003;</button>';
+    html += '<button class="species-confirm-btn" onclick="confirmSpecies(event, ' + encIdx + ',' + (burstIdx != null ? burstIdx : 'null') + ',null)" title="' + (isPending ? 'Confirming species...' : 'Confirm as ' + escapeHtml(displayName)) + '"' + (isPending ? ' disabled aria-busy="true"' : '') + '>&#10003;</button>';
   }
 
   // Dropdown — bottom-bar widget opens upward to stay inside the card
@@ -3683,6 +3710,7 @@ function renderSpeciesWidget(enc, encIdx, level, burstIdx, pos) {
 
 function toggleSpeciesDropdown(event, encIdx, burstIdx, pos) {
   event.stopPropagation();
+  if (pipelineResults && pipelineResults.encounters && speciesConfirmPendingFor(pipelineResults.encounters[encIdx], burstIdx)) return;
   pos = pos || 'top';
   var id = 'spDrop_' + encIdx + '_' + (burstIdx != null ? burstIdx : 'enc') + '_' + pos;
   var el = document.getElementById(id);
@@ -3845,7 +3873,7 @@ function refreshAfterSpeciesConfirm(encIdx, burstIdx, forceFullRender) {
 }
 
 async function confirmSpecies(event, encIdx, burstIdx, speciesName) {
-  event.stopPropagation();
+  if (event && event.stopPropagation) event.stopPropagation();
   closeAllDropdowns();
 
   // /api/encounters/species reloads and rewrites the saved cache on the
@@ -3879,6 +3907,10 @@ async function confirmSpecies(event, encIdx, burstIdx, speciesName) {
   } else {
     photoIds = enc.photo_ids;
   }
+  var pendingKey = speciesConfirmPhotoKey(photoIds);
+  if (speciesConfirmInFlight[pendingKey]) return;
+  speciesConfirmInFlight[pendingKey] = true;
+  rerenderSpeciesWidgets(encIdx, burstIdx);
 
   var body = { species: speciesName, photo_ids: photoIds };
   if (burstIdx != null) body.burst_index = burstIdx;
@@ -3893,9 +3925,15 @@ async function confirmSpecies(event, encIdx, burstIdx, speciesName) {
       body: JSON.stringify(body),
     });
   } catch (e) {
+    delete speciesConfirmInFlight[pendingKey];
+    rerenderSpeciesWidgets(encIdx, burstIdx);
     return;
   }
-  if (!resp || !resp.ok) return;
+  delete speciesConfirmInFlight[pendingKey];
+  if (!resp || !resp.ok) {
+    rerenderSpeciesWidgets(encIdx, burstIdx);
+    return;
+  }
 
   // Prefer the server's encounter list — the endpoint may auto-detach a burst
   // into a new or adjacent encounter when its confirmed species differs from


### PR DESCRIPTION
## Summary
- Adds a photo-set keyed in-flight guard for pipeline review species confirmations.
- Rerenders duplicate top/bottom species controls as disabled while the POST is pending.
- Adds an E2E regression that keeps the first confirmation unresolved and verifies a duplicate call does not post.

## Tests
- pytest tests/e2e/test_pipeline_review_species.py::test_pipeline_review_species_confirm_ignores_duplicate_inflight_clicks -q
- pytest tests/e2e/test_pipeline_review_species.py::test_predictionless_pipeline_encounter_can_add_species tests/e2e/test_pipeline_review_species.py::test_species_name_arg_keeps_nullish_values_empty tests/e2e/test_pipeline_review_species.py::test_pipeline_review_species_confirm_ignores_duplicate_inflight_clicks -q
- git diff --check