### PR TITLE
Add lightbox UI toggle shortcut

### DIFF
--- a/tests/e2e/test_keymap.py
+++ b/tests/e2e/test_keymap.py
@@ -299,6 +299,7 @@ def test_shortcuts_sheet_lists_misses_and_shared_hotkeys(live_server, page):
     assert {"key": "Escape", "label": "Clear selection"} in groups["Misses"]
     assert {"key": "?", "label": "Open keyboard shortcuts"} in groups["Global"]
     assert {"key": "Alt+U", "label": "Clear pick/reject flag"} in groups["Lightbox"]
+    assert {"key": "H", "label": "Toggle UI controls"} in groups["Lightbox"]
 
 
 def test_question_mark_opens_shortcuts_sheet_over_lightbox(live_server, page):

--- a/tests/e2e/test_lightbox_context_menu.py
+++ b/tests/e2e/test_lightbox_context_menu.py
@@ -197,6 +197,20 @@ def test_lightbox_overlay_toggles_persist_and_context_restores(live_server, page
     assert page.evaluate("localStorage.getItem('vireo.lb.infoVisible')") == "0"
     assert page.evaluate("localStorage.getItem('vireo.lb.chromeVisible')") == "0"
 
+    page.keyboard.press("h")
+    page.wait_for_function(
+        "!document.getElementById('lightboxOverlay').classList.contains('lb-hide-chrome')",
+        timeout=2000,
+    )
+    assert page.evaluate("localStorage.getItem('vireo.lb.chromeVisible')") == "1"
+
+    page.keyboard.press("h")
+    page.wait_for_function(
+        "document.getElementById('lightboxOverlay').classList.contains('lb-hide-chrome')",
+        timeout=2000,
+    )
+    assert page.evaluate("localStorage.getItem('vireo.lb.chromeVisible')") == "0"
+
     _fire_contextmenu_on_lightbox(page)
     menu = page.locator(".vireo-ctx-menu")
     expect(menu).to_be_visible()

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2472,6 +2472,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     # workspace overrides. Gated by a marker so it runs once; re-saved
     # legacy values are preserved on subsequent boots.
     cfg.migrate_legacy_miss_thresholds(init_db)
+    # One-time resolution of the browse.toggle_ui="h" default clashing with
+    # any pre-existing browse binding on ``h``. Writes an explicit "" so the
+    # user's existing action keeps working; they can re-bind toggle_ui from
+    # the shortcuts editor.
+    cfg.migrate_toggle_ui_h_conflict()
     init_db.create_default_collections_for_all_workspaces()
 
     # Wildlife backfill timing:

--- a/vireo/config.py
+++ b/vireo/config.py
@@ -293,6 +293,7 @@ def set(key, value):
 # 25% via the slider) keeps that setting on future loads.
 
 MIGRATION_MISS_THRESHOLDS = "miss_thresholds_2026_05"
+MIGRATION_TOGGLE_UI_H_CONFLICT = "toggle_ui_h_conflict_2026_07"
 
 _LEGACY_MISS_DET_CONFIDENCE = 0.25
 _LEGACY_MISS_DET_CONFIDENCE_BURST = 0.15
@@ -355,6 +356,50 @@ def migrate_legacy_miss_thresholds(db=None):
             if ws_rewrites:
                 rewrote = True
         applied.append(MIGRATION_MISS_THRESHOLDS)
+        raw["_migrations_applied"] = applied
+        save(raw)
+        return rewrote
+
+
+def migrate_toggle_ui_h_conflict():
+    """One-time resolution of the browse.toggle_ui="h" default vs. a user
+    binding that already uses ``h``.
+
+    ``h`` was newly added as the default binding for the lightbox
+    "toggle UI controls" action. For an install that had already customized
+    another browse action to ``h`` (for example ``browse.flag: "h"``),
+    ``load()`` would deep-merge the new default in and produce two browse
+    bindings on the same key. The lightbox key handler checks ``toggle_ui``
+    before flag/reject/unflag, so ``h`` would silently start toggling the
+    chrome instead of firing the user's existing binding.
+
+    This migration inspects the raw on-disk config. If the user has a
+    ``keyboard_shortcuts.browse`` block that already binds ``h`` to some
+    other action AND does NOT already have an explicit ``toggle_ui``
+    setting, it writes ``browse.toggle_ui: ""`` to disk so the effective
+    config leaves the user's existing binding alone. Users can pick a
+    non-conflicting key from the shortcuts editor to re-enable it.
+    Gated by a marker so it runs at most once per install; a user who
+    later explicitly rebinds ``toggle_ui`` keeps that setting.
+    """
+    with _lock:
+        raw = _read_raw()
+        applied = _migrations_applied(raw)
+        if MIGRATION_TOGGLE_UI_H_CONFLICT in applied:
+            return False
+        rewrote = False
+        shortcuts = raw.get("keyboard_shortcuts")
+        if isinstance(shortcuts, dict):
+            browse = shortcuts.get("browse")
+            if isinstance(browse, dict) and "toggle_ui" not in browse:
+                for action, key in browse.items():
+                    if action == "toggle_ui":
+                        continue
+                    if isinstance(key, str) and key.lower() == "h":
+                        browse["toggle_ui"] = ""
+                        rewrote = True
+                        break
+        applied.append(MIGRATION_TOGGLE_UI_H_CONFLICT)
         raw["_migrations_applied"] = applied
         save(raw)
         return rewrote

--- a/vireo/config.py
+++ b/vireo/config.py
@@ -200,6 +200,7 @@ DEFAULTS = {
             "compare": "c",
             "zoom": "z",
             "toggle_boxes": "b",
+            "toggle_ui": "h",
         },
     },
 }

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3109,7 +3109,14 @@ window.NAV_ALL_PAGES = [
       if (action === 'unflag') return browse2.unflag || browseDefaults2.unflag || SC_DEFAULTS.lightbox.unflag;
       if (action === 'zoom') return browse2.zoom || browseDefaults2.zoom || SC_DEFAULTS.lightbox.zoom;
       if (action === 'toggle_boxes') return browse2.toggle_boxes || browseDefaults2.toggle_boxes || SC_DEFAULTS.lightbox.toggle_boxes;
-      if (action === 'toggle_ui') return browse2.toggle_ui || browseDefaults2.toggle_ui || SC_DEFAULTS.lightbox.toggle_ui;
+      if (action === 'toggle_ui') {
+        // Presence-checked so an explicit '' (migrated on install to resolve
+        // a pre-existing 'h' binding conflict) reads as Unassigned instead
+        // of silently falling through to the 'h' default.
+        if ('toggle_ui' in browse2) return browse2.toggle_ui;
+        if ('toggle_ui' in browseDefaults2) return browseDefaults2.toggle_ui;
+        return SC_DEFAULTS.lightbox.toggle_ui;
+      }
     }
     var values = (shortcuts && shortcuts[ctx]) || {};
     var defaults = SC_DEFAULTS[ctx] || {};
@@ -7699,7 +7706,11 @@ document.addEventListener('keydown', function(e) {
       return;
     }
   }
-  var uiKey = (window._vireoShortcuts && window._vireoShortcuts.browse && window._vireoShortcuts.browse.toggle_ui) || 'h';
+  // Presence check: `''` means the migration blanked this to avoid stealing
+  // an existing user binding on 'h'. Only fall back to the 'h' default when
+  // the key is genuinely absent from config (shortcuts not yet loaded).
+  var browseSc = window._vireoShortcuts && window._vireoShortcuts.browse;
+  var uiKey = browseSc && 'toggle_ui' in browseSc ? browseSc.toggle_ui : 'h';
   if (matchesShortcut(e, uiKey)) {
     var tagUi = e.target && e.target.tagName;
     var editableUi = tagUi === 'INPUT' || tagUi === 'TEXTAREA' || tagUi === 'SELECT' ||

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3028,6 +3028,7 @@ window.NAV_ALL_PAGES = [
       zoom_out: 'Zoom out',
       fit: 'Fit to screen',
       toggle_boxes: 'Toggle detection boxes',
+      toggle_ui: 'Toggle UI controls',
       fullscreen: 'Enter fullscreen',
       close_return: 'Close and return',
     },
@@ -3059,6 +3060,7 @@ window.NAV_ALL_PAGES = [
       flag: 'p', reject: 'x', unflag: 'u',
       undo: 'ctrl+z', redo: 'ctrl+shift+z', select_all: 'ctrl+a', compare: 'c', zoom: 'z',
       toggle_boxes: 'b',
+      toggle_ui: 'h',
     },
     misses: {
       next: 'j',
@@ -3082,6 +3084,7 @@ window.NAV_ALL_PAGES = [
       zoom_out: '-',
       fit: '0',
       toggle_boxes: 'b',
+      toggle_ui: 'h',
       fullscreen: 'f',
       close_return: 'g',
     },
@@ -3106,6 +3109,7 @@ window.NAV_ALL_PAGES = [
       if (action === 'unflag') return browse2.unflag || browseDefaults2.unflag || SC_DEFAULTS.lightbox.unflag;
       if (action === 'zoom') return browse2.zoom || browseDefaults2.zoom || SC_DEFAULTS.lightbox.zoom;
       if (action === 'toggle_boxes') return browse2.toggle_boxes || browseDefaults2.toggle_boxes || SC_DEFAULTS.lightbox.toggle_boxes;
+      if (action === 'toggle_ui') return browse2.toggle_ui || browseDefaults2.toggle_ui || SC_DEFAULTS.lightbox.toggle_ui;
     }
     var values = (shortcuts && shortcuts[ctx]) || {};
     var defaults = SC_DEFAULTS[ctx] || {};
@@ -7690,6 +7694,18 @@ document.addEventListener('keydown', function(e) {
       (e.target && e.target.isContentEditable);
     if (!editable2) {
       toggleLightboxBoxes();
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      return;
+    }
+  }
+  var uiKey = (window._vireoShortcuts && window._vireoShortcuts.browse && window._vireoShortcuts.browse.toggle_ui) || 'h';
+  if (matchesShortcut(e, uiKey)) {
+    var tagUi = e.target && e.target.tagName;
+    var editableUi = tagUi === 'INPUT' || tagUi === 'TEXTAREA' || tagUi === 'SELECT' ||
+      (e.target && e.target.isContentEditable);
+    if (!editableUi) {
+      toggleLightboxChrome();
       e.preventDefault();
       e.stopImmediatePropagation();
       return;

--- a/vireo/templates/shortcuts.html
+++ b/vireo/templates/shortcuts.html
@@ -118,6 +118,7 @@ var SHORTCUT_LABELS = {
     compare: 'Compare selected photos',
     zoom: 'Toggle zoom (lightbox)',
     toggle_boxes: 'Toggle detection boxes (lightbox)',
+    toggle_ui: 'Toggle UI controls (lightbox)',
     color_red: 'Color label: Red',
     color_yellow: 'Color label: Yellow',
     color_green: 'Color label: Green',
@@ -142,7 +143,7 @@ var SHORTCUT_DEFAULTS = {
     rate_4: '4', rate_5: '5',
     flag: 'p', reject: 'x', unflag: 'u',
     undo: 'ctrl+z', select_all: 'ctrl+a', compare: 'c', zoom: 'z',
-    toggle_boxes: 'b',
+    toggle_boxes: 'b', toggle_ui: 'h',
     color_red: '6', color_yellow: '7', color_green: '8', color_blue: '9',
   },
 };

--- a/vireo/templates/shortcuts.html
+++ b/vireo/templates/shortcuts.html
@@ -163,7 +163,11 @@ function renderShortcutsEditor() {
       'style="background:none;border:1px solid var(--text-ghost);color:var(--text-dim);border-radius:4px;padding:2px 10px;font-size:11px;cursor:pointer;">Reset All</button></div>';
     for (var action in labels) {
       if (action === '_title') continue;
-      var current = values[action] || defaults[action] || '';
+      // Presence-checked so an explicit '' (e.g. server-side migration
+      // resolved a conflicting default) renders as "Unassigned" instead of
+      // silently falling through to the default key. Otherwise the button
+      // shows the default keycap but the binding does nothing.
+      var current = (action in values) ? values[action] : (defaults[action] || '');
       var isDefault = current === defaults[action];
       var conflict = findConflict(ctx, action, current);
       html += '<div class="shortcut-row">';
@@ -286,11 +290,15 @@ function saveShortcuts() {
 // Load config and init editor
 safeFetch('/api/config', {}, { toast: false }).then(function(cfg) {
   currentShortcuts = (cfg && cfg.keyboard_shortcuts) || JSON.parse(JSON.stringify(SHORTCUT_DEFAULTS));
-  // Ensure all default keys exist (for newly added shortcuts)
+  // Ensure all default keys exist (for newly added shortcuts). Presence
+  // check on the action: if the server-side config already includes the
+  // action with an explicit empty string (e.g. a conflict-resolution
+  // migration blanked it), preserve that so we don't silently re-inject
+  // the default and clobber the user's other binding on save.
   for (var ctx in SHORTCUT_DEFAULTS) {
     if (!currentShortcuts[ctx]) currentShortcuts[ctx] = {};
     for (var action in SHORTCUT_DEFAULTS[ctx]) {
-      if (!currentShortcuts[ctx][action]) currentShortcuts[ctx][action] = SHORTCUT_DEFAULTS[ctx][action];
+      if (!(action in currentShortcuts[ctx])) currentShortcuts[ctx][action] = SHORTCUT_DEFAULTS[ctx][action];
       if (ctx === 'navigation' && isBareShortcut(currentShortcuts[ctx][action])) {
         currentShortcuts[ctx][action] = '';
       }

--- a/vireo/tests/test_config.py
+++ b/vireo/tests/test_config.py
@@ -587,6 +587,133 @@ def test_migrate_legacy_miss_thresholds_rewrites_workspace_overrides(
     assert custom_overrides["pipeline"]["miss_det_confidence_burst"] == 0.18
 
 
+def test_migrate_toggle_ui_h_conflict_blanks_when_h_taken(tmp_path, monkeypatch):
+    """A user upgrading with `browse.flag` already bound to `h` gets
+    `browse.toggle_ui` blanked to `""` so the newly added default doesn't
+    silently steal their existing binding."""
+    import config as cfg
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    _write_raw(cfg.CONFIG_PATH, {
+        "keyboard_shortcuts": {
+            "browse": {
+                "flag": "h",
+                "reject": "x",
+            },
+        },
+    })
+
+    assert cfg.migrate_toggle_ui_h_conflict() is True
+    raw = _read_raw(cfg.CONFIG_PATH)
+    assert raw["keyboard_shortcuts"]["browse"]["toggle_ui"] == ""
+    assert raw["keyboard_shortcuts"]["browse"]["flag"] == "h"
+    assert cfg.MIGRATION_TOGGLE_UI_H_CONFLICT in raw["_migrations_applied"]
+
+
+def test_migrate_toggle_ui_h_conflict_case_insensitive(tmp_path, monkeypatch):
+    """A saved config that spells the key `H` still triggers the conflict —
+    `matchesShortcut` lower-cases the event key, so the collision is real."""
+    import config as cfg
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    _write_raw(cfg.CONFIG_PATH, {
+        "keyboard_shortcuts": {
+            "browse": {
+                "unflag": "H",
+            },
+        },
+    })
+
+    assert cfg.migrate_toggle_ui_h_conflict() is True
+    raw = _read_raw(cfg.CONFIG_PATH)
+    assert raw["keyboard_shortcuts"]["browse"]["toggle_ui"] == ""
+
+
+def test_migrate_toggle_ui_h_conflict_no_conflict_leaves_defaults(
+    tmp_path, monkeypatch
+):
+    """No user binding uses `h` — nothing to rewrite. The default merged in
+    from DEFAULTS stays as `h`."""
+    import config as cfg
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    _write_raw(cfg.CONFIG_PATH, {
+        "keyboard_shortcuts": {
+            "browse": {
+                "flag": "p",
+                "reject": "x",
+            },
+        },
+    })
+
+    assert cfg.migrate_toggle_ui_h_conflict() is False
+    raw = _read_raw(cfg.CONFIG_PATH)
+    # Only the migration marker was added — no toggle_ui override written.
+    assert "toggle_ui" not in raw["keyboard_shortcuts"]["browse"]
+    assert cfg.MIGRATION_TOGGLE_UI_H_CONFLICT in raw["_migrations_applied"]
+    # And the effective config still fills in the DEFAULTS binding.
+    assert cfg.load()["keyboard_shortcuts"]["browse"]["toggle_ui"] == "h"
+
+
+def test_migrate_toggle_ui_h_conflict_preserves_explicit_user_setting(
+    tmp_path, monkeypatch
+):
+    """A user who already set `browse.toggle_ui` explicitly (even to `h`) is
+    left alone — the migration only fills the gap when no explicit choice
+    exists, so it never overrides a deliberate binding."""
+    import config as cfg
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    _write_raw(cfg.CONFIG_PATH, {
+        "keyboard_shortcuts": {
+            "browse": {
+                "flag": "h",
+                "toggle_ui": "h",
+            },
+        },
+    })
+
+    assert cfg.migrate_toggle_ui_h_conflict() is False
+    raw = _read_raw(cfg.CONFIG_PATH)
+    assert raw["keyboard_shortcuts"]["browse"]["toggle_ui"] == "h"
+
+
+def test_migrate_toggle_ui_h_conflict_is_one_time(tmp_path, monkeypatch):
+    """Once the marker is set, a later re-conflict (e.g. user rebinds another
+    action to `h` and clears their `toggle_ui`) is NOT touched — respecting
+    the user's explicit choice on subsequent boots."""
+    import config as cfg
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    _write_raw(cfg.CONFIG_PATH, {
+        "keyboard_shortcuts": {
+            "browse": {
+                "flag": "h",
+            },
+        },
+    })
+    assert cfg.migrate_toggle_ui_h_conflict() is True
+
+    # User later reverts their toggle_ui override (by removing it from disk)
+    # and picks another binding for `h` — a second migration run must not
+    # silently rewrite anything.
+    raw = _read_raw(cfg.CONFIG_PATH)
+    raw["keyboard_shortcuts"]["browse"].pop("toggle_ui", None)
+    raw["keyboard_shortcuts"]["browse"]["unflag"] = "h"
+    _write_raw(cfg.CONFIG_PATH, raw)
+
+    assert cfg.migrate_toggle_ui_h_conflict() is False
+    raw = _read_raw(cfg.CONFIG_PATH)
+    assert "toggle_ui" not in raw["keyboard_shortcuts"]["browse"]
+    assert raw["keyboard_shortcuts"]["browse"]["unflag"] == "h"
+
+
+def test_migrate_toggle_ui_h_conflict_no_config_file(tmp_path, monkeypatch):
+    """Fresh install with no config.json — nothing to rewrite; only the
+    marker gets stamped so future boots skip the check."""
+    import config as cfg
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+
+    assert cfg.migrate_toggle_ui_h_conflict() is False
+    raw = _read_raw(cfg.CONFIG_PATH)
+    assert cfg.MIGRATION_TOGGLE_UI_H_CONFLICT in raw["_migrations_applied"]
+
+
 def test_default_subject_types_includes_taxonomy_individual_genre(tmp_path, monkeypatch):
     """Default subject_types is the set of keyword types that count as
     'identifying' a photo — taxonomy + individual + genre by default."""

--- a/vireo/tests/test_config.py
+++ b/vireo/tests/test_config.py
@@ -112,6 +112,7 @@ def test_keyboard_shortcut_defaults_include_rapid_review():
     assert shortcuts["pipeline_rapid_review"]["reject"] == "x"
     assert shortcuts["pipeline_rapid_review"]["zoom"] == "z"
     assert shortcuts["browse"]["compare"] == "c"
+    assert shortcuts["browse"]["toggle_ui"] == "h"
 
 
 def test_working_copy_defaults(tmp_path, monkeypatch):


### PR DESCRIPTION
Adds a default h shortcut for toggling Vireo lightbox UI controls so users can recover after hiding the chrome. The shortcut is shown in the keyboard shortcuts sheet and is configurable from the shortcuts editor. The existing context-menu recovery path remains covered. Validated with focused config, keymap, and lightbox e2e tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `H` keyboard shortcut to show or hide lightbox UI controls.
  * Added “Toggle UI controls (lightbox)” to the keyboard shortcuts editor and cheat sheet.
  * Shortcut changes persist and respect customized key bindings.

* **Bug Fixes**
  * Improved lightbox shortcut behavior and state restoration when using the context menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->