### PR TITLE
Show representative badges across photo views

### DIFF
--- a/tests/e2e/test_lifelist_add_verify.py
+++ b/tests/e2e/test_lifelist_add_verify.py
@@ -46,6 +46,13 @@ def test_browse_menu_sets_representative(live_server, page):
         "is_species_representative": True,
     }], life_list
 
+    expect(card.locator(".representative-badge", has_text="Representative")).to_be_visible()
+    card.click(button="right")
+    item = page.locator(".vireo-ctx-menu .vireo-ctx-item", has_text="Set Representative — Red-tailed Hawk")
+    expect(item).to_be_visible()
+    assert "vireo-ctx-disabled" in (item.get_attribute("class") or "")
+    assert item.get_attribute("title") == "Already representative"
+
 
 def test_browse_menu_hidden_for_photo_without_species(live_server, page):
     url = live_server["url"]

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -21261,7 +21261,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if row:
                 species_kid = row["id"]
 
-        representatives = db.get_species_representatives()
+        # Gate the badge on the same eligibility rules the shared payload
+        # attachers use, so a stale preference row (photo later rejected or
+        # no longer carrying the species keyword) doesn't light up the modal
+        # while browse/highlights hide it.
+        representatives = db.get_species_representatives(eligible_only=True)
         photos = {}
         for pid in photo_ids:
             # Same workspace guard the apply endpoint uses, so a malicious

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3014,7 +3014,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if isinstance(pid, int) and not isinstance(pid, bool):
                 ids.append(pid)
         species_map = db.get_species_keywords_for_photos(ids)
-        representatives = db.get_species_representatives()
+        # Gate representatives on current DB eligibility so a stale preference
+        # row (photo later rejected, folder removed from workspace, or species
+        # keyword untagged) doesn't light up a Representative badge on views
+        # whose photo dicts lack the `flag` column (notably /api/predictions,
+        # whose SELECT only pulls filename/timestamp from photos). The
+        # in-loop `p.get("flag") == "rejected"` shortcut still short-circuits
+        # rejected photos for views that DO include flag, so this only shifts
+        # behavior for the payloads that were previously reading raw prefs.
+        representatives = db.get_species_representatives(eligible_only=True)
         for p in photo_dicts:
             pid = p.get("photo_id", p.get("id"))
             if p.get("flag") == "rejected":

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3252,6 +3252,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 f, r = flag_map.get(p["id"], ("none", 0))
                 p["flag"] = f
                 p["rating"] = r
+            # Overlay representative state onto the cached results so
+            # pipeline cards render the badge after a page reload. The
+            # cache is written before eligibility runs (and by pipeline
+            # runs that predate the badge), so is_species_representative
+            # is otherwise absent and every card renders unbadged even
+            # when the DB says the photo is the species rep. The flag
+            # overlay above is what makes this call correct — the shared
+            # attacher short-circuits rejected photos, and the overlay
+            # ensures p["flag"] reflects the live DB, not a stale cache.
+            _attach_species_representatives(db, results["photos"])
 
         effective_cfg = db.get_effective_config(cfg.load())
         pipeline_cfg = effective_cfg.get("pipeline", {})

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3004,6 +3004,38 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             p["species"] = species_map.get(p["id"], [])
         return photo_dicts
 
+    def _attach_species_representatives(db, photo_dicts):
+        """Attach species representative state to photo dicts (in-place)."""
+        if not photo_dicts:
+            return photo_dicts
+        ids = []
+        for p in photo_dicts:
+            pid = p.get("photo_id", p.get("id"))
+            if isinstance(pid, int) and not isinstance(pid, bool):
+                ids.append(pid)
+        species_map = db.get_species_keywords_for_photos(ids)
+        representatives = db.get_species_representatives()
+        for p in photo_dicts:
+            pid = p.get("photo_id", p.get("id"))
+            if p.get("flag") == "rejected":
+                species = []
+            else:
+                species = species_map.get(pid, [])
+            entries = [
+                {
+                    "species": s,
+                    "is_current_photo": representatives.get(s) == pid,
+                    "is_species_representative": representatives.get(s) == pid,
+                }
+                for s in species
+            ]
+            p["life_list"] = entries
+            p["species_representatives"] = entries
+            p["is_species_representative"] = any(
+                entry["is_species_representative"] for entry in entries
+            )
+        return photo_dicts
+
     def _attach_detections(db, photo_dicts):
         """Attach detection bounding boxes to a list of photo dicts (in-place).
 
@@ -3054,6 +3086,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         recipe_map = db.get_photo_edit_recipes(sorted({pid for _, pid in refs}))
         for photo, pid in refs:
             photo["edit_recipe"] = recipe_map.get(pid)
+        _attach_species_representatives(db, [photo for photo, _pid in refs])
         return payload
 
     def _request_flag_filter():
@@ -3124,6 +3157,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         photo_dicts = [dict(p) for p in photos]
         _attach_species(db, photo_dicts)
+        _attach_species_representatives(db, photo_dicts)
         _attach_detections(db, photo_dicts)
         _attach_edit_recipes(db, photo_dicts)
         collection_dicts = []
@@ -4394,6 +4428,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         photo_dicts = [dict(p) for p in photos]
         _attach_species(db, photo_dicts)
+        _attach_species_representatives(db, photo_dicts)
         _attach_detections(db, photo_dicts)
         _attach_edit_recipes(db, photo_dicts)
 
@@ -4608,6 +4643,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if photo:
                 photos.append(dict(photo))
         _attach_species(db, photos)
+        _attach_species_representatives(db, photos)
         _attach_detections(db, photos)
         return jsonify({"photos": photos})
 
@@ -7989,6 +8025,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         total = db.count_collection_photos(collection_id)
         photo_dicts = [dict(p) for p in photos]
         _attach_species(db, photo_dicts)
+        _attach_species_representatives(db, photo_dicts)
         _attach_detections(db, photo_dicts)
         _attach_edit_recipes(db, photo_dicts)
         return jsonify(
@@ -9867,6 +9904,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # Enrich predictions and attach alternatives
         results = []
         pred_dicts = [dict(p) for p in preds]
+        _attach_species_representatives(db, pred_dicts)
         recipes_by_photo = db.get_photo_edit_recipes({
             p.get("photo_id") for p in pred_dicts if p.get("photo_id") is not None
         })
@@ -10527,6 +10565,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def _attach_miss_edit_recipes(db, grouped):
         for category in ("no_subject", "clipped", "oof"):
             photos = [dict(p) for p in grouped.get(category, [])]
+            _attach_species_representatives(db, photos)
             _attach_edit_recipes(db, photos)
             grouped[category] = photos
         return grouped
@@ -10547,6 +10586,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if category not in ("no_subject", "clipped", "oof"):
                 return jsonify({"error": "invalid category"}), 400
             photos = [dict(p) for p in db.list_misses(category=category, since=since)]
+            _attach_species_representatives(db, photos)
             _attach_edit_recipes(db, photos)
             return jsonify({"photos": photos, "category": category})
         grouped = {
@@ -21196,7 +21236,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         consensus species keyword applied.
 
         Body: {photo_ids: [int], species: str}
-        Returns: {photos: {pid: {flag, has_species_keyword}}, species_kid: int|None}
+        Returns: {photos: {pid: {flag, has_species_keyword,
+                  is_species_representative}}, species_kid: int|None}
         """
         db = _get_db()
         body = request.get_json(silent=True) or {}
@@ -21220,6 +21261,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if row:
                 species_kid = row["id"]
 
+        representatives = db.get_species_representatives()
         photos = {}
         for pid in photo_ids:
             # Same workspace guard the apply endpoint uses, so a malicious
@@ -21236,6 +21278,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             photos[pid] = {
                 "flag": row["flag"] or "none",
                 "has_species_keyword": has_kw,
+                "is_species_representative": bool(
+                    species and representatives.get(species) == pid
+                ),
             }
         return jsonify({"photos": photos, "species_kid": species_kid})
 
@@ -21634,6 +21679,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     photo_dicts.append(dict(photos_map[pid]))
                     sims_by_pid[pid] = round(sim, 4)
             _attach_species(db, photo_dicts)
+            _attach_species_representatives(db, photo_dicts)
             _attach_detections(db, photo_dicts)
             _attach_edit_recipes(db, photo_dicts)
             results = [

--- a/vireo/new_images.py
+++ b/vireo/new_images.py
@@ -398,6 +398,26 @@ class NewImagesCache:
                 # Backoff window elapsed — let a fresh attempt run.
                 del self._errors[key]
 
+            # Skip the spawn if a fresh, complete walk already sits in the
+            # cache. Without this, a caller that saw an empty cache moments
+            # ago can race the in-flight worker's finally block: worker
+            # populates the cache, then clears its in-flight slot; the
+            # caller then arrives here and sees no in-flight, so we'd fan
+            # out a second walk over the same directories. All async walks
+            # run with sample_limit=None (so sample_complete=True), so
+            # gating on that flag is a precise "a completed walk exists"
+            # check — sync ``get_new_images_for_workspace`` writes at
+            # sample_limit=5 (sample_complete potentially False) and must
+            # still fall through to spawn a real walk.
+            entry = self._entries.get(key)
+            if entry is not None:
+                cached_result, set_at = entry
+                if (time.monotonic() - set_at <= self._ttl
+                        and cached_result.get("sample_complete")):
+                    done = threading.Event()
+                    done.set()
+                    return done
+
             generation = self._generations.get(key, 0)
             existing = self._inflight.get(key)
             if existing is not None:

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -4916,6 +4916,27 @@ async function batchSetRating(rating) {
   showUndoToast();
 }
 
+// Server-side representative eligibility (see get_species_representatives)
+// hides rejected photos. Mirror that here so the grid badge and the shared
+// representative context menu ("Already representative" hint on the current
+// entry) don't keep treating a just-rejected photo as still representative
+// until a reload. Un-rejecting is left as-is: the client can't know whether
+// the DB preference still points at this photo, so the badge stays hidden
+// until the page reloads rather than lighting up incorrectly.
+function _clearRepresentativeStateIfIneligible(photoId, flag) {
+  if (flag !== 'rejected') return;
+  var p = photos.find(function(x) { return x.id === photoId; });
+  if (!p) return;
+  if (p.is_species_representative) p.is_species_representative = false;
+  if (Array.isArray(p.life_list)) {
+    p.life_list.forEach(function(entry) {
+      if (!entry) return;
+      if (entry.is_current_photo) entry.is_current_photo = false;
+      if (entry.is_species_representative) entry.is_species_representative = false;
+    });
+  }
+}
+
 async function batchSetFlag(flag) {
   var ids = getActiveSelection();
   try {
@@ -4927,6 +4948,7 @@ async function batchSetFlag(flag) {
   ids.forEach(function(id) {
     var p = photos.find(function(x) { return x.id === id; });
     if (p) p.flag = flag;
+    _clearRepresentativeStateIfIneligible(id, flag);
   });
   refreshGridCards(ids);
   if (selectedPhotoId != null && ids.indexOf(selectedPhotoId) !== -1) {
@@ -5947,6 +5969,7 @@ async function setFlag(flag) {
     });
     var p = photos.find(function(x) { return x.id === photoId; });
     if (p) p.flag = flag;
+    _clearRepresentativeStateIfIneligible(photoId, flag);
     refreshGridCards([photoId]);
     if (selectedPhotoId === photoId) updateDetailFlagButtons(flag);
     scheduleCollectionCountsRefresh();
@@ -7111,6 +7134,7 @@ async function setFlagFor(photoId, flag) {
   } catch(e) { return false; }
   var p = photos.find(function(x) { return x.id === photoId; });
   if (p) p.flag = flag;
+  _clearRepresentativeStateIfIneligible(photoId, flag);
   refreshGridCards([photoId]);
   _refreshInspectorAfterSinglePhotoEdit(photoId, function() { updateDetailFlagButtons(flag); });
   scheduleCollectionCountsRefresh();

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -4872,6 +4872,7 @@ async function removeSelectionKeyword(keywordId) {
       body: JSON.stringify({photo_ids: ids, keyword_id: keywordId}),
     });
   } catch(e) { return; }
+  _clearRepresentativeStateAfterKeywordRemoval(ids, removedName);
   selectionKeywordKey = '';
   loadSelectionKeywordSuggestions(getActiveSelection());
   loadKeywords();
@@ -4935,6 +4936,48 @@ function _clearRepresentativeStateIfIneligible(photoId, flag) {
       if (entry.is_species_representative) entry.is_species_representative = false;
     });
   }
+}
+
+function _keywordNameFromCache(keywordId) {
+  if (!Array.isArray(keywordAutocompleteCache)) return null;
+  for (var i = 0; i < keywordAutocompleteCache.length; i++) {
+    var k = keywordAutocompleteCache[i];
+    if (k && k.id === keywordId) return k.name;
+  }
+  return null;
+}
+
+// Server-side eligibility requires the photo to still carry the species
+// keyword, so removing a species keyword drops the photo from the eligible
+// representative set. Mirror that locally: strip life_list entries whose
+// species matches the removed keyword name and recompute the badge flag.
+// The context menu reads photo.life_list too, so this also stops the shared
+// "Already representative" hint from lingering on a photo the DB no longer
+// counts. Non-species keywords never appear in life_list, so the filter
+// no-ops for those. If the cache lookup fails to resolve the name, we
+// leave state alone rather than clearing the wrong entry.
+function _clearRepresentativeStateAfterKeywordRemoval(photoIds, keywordName) {
+  if (!Array.isArray(photoIds) || !photoIds.length) return;
+  if (!keywordName) return;
+  var touched = [];
+  photoIds.forEach(function(id) {
+    var p = photos.find(function(x) { return x.id === id; });
+    if (!p || !Array.isArray(p.life_list)) return;
+    var next = p.life_list.filter(function(entry) {
+      return !entry || entry.species !== keywordName;
+    });
+    if (next.length !== p.life_list.length) {
+      p.life_list = next;
+      var isRep = next.some(function(entry) {
+        return entry && entry.is_species_representative;
+      });
+      if (p.is_species_representative !== isRep) {
+        p.is_species_representative = isRep;
+      }
+      touched.push(id);
+    }
+  });
+  if (touched.length) refreshGridCards(touched);
 }
 
 async function batchSetFlag(flag) {
@@ -6237,6 +6280,10 @@ async function removeKeyword(photoId, keywordId) {
     await safeFetch('/api/photos/' + photoId + '/keywords/' + keywordId, {
       method: 'DELETE',
     });
+    _clearRepresentativeStateAfterKeywordRemoval(
+      [photoId],
+      _keywordNameFromCache(keywordId),
+    );
     loadDetail(photoId);
     loadKeywords();
     scheduleCollectionCountsRefresh();

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -267,6 +267,19 @@ body {
   border-radius: 3px;
   pointer-events: none;
 }
+.representative-badge {
+  position: absolute;
+  top: 6px;
+  left: 6px;
+  background: var(--accent);
+  color: var(--accent-text);
+  font-size: 10px;
+  font-weight: 700;
+  padding: 2px 6px;
+  border-radius: 999px;
+  text-transform: uppercase;
+  pointer-events: none;
+}
 .grid-card-info {
   padding: 8px 10px;
 }
@@ -2259,6 +2272,7 @@ function renderPhotoCard(p, idx) {
   }
   var inatBadge = inatSubmitted[String(p.id)] ? '<span class="inat-badge">iNat</span>' : '';
   var wildlifeBadge = p.wildlife_excluded ? '<span class="no-wildlife-badge">No Wildlife</span>' : '';
+  var representativeBadge = p.is_species_representative ? '<span class="representative-badge">Representative</span>' : '';
 
   // Species badges on image overlay (only when NOT in cardFields — if in cardFields, rendered below)
   var speciesBadgeHtml = '';
@@ -2283,6 +2297,7 @@ function renderPhotoCard(p, idx) {
       boxHtml +
       inatBadge +
       wildlifeBadge +
+      representativeBadge +
       speciesBadgeHtml +
     '</div>' +
     '<div class="grid-card-info">' +
@@ -2391,9 +2406,50 @@ function refreshGridCards(photoIds) {
       } else if (!shouldShow && existing) {
         existing.remove();
       }
+      var rep = wrap.querySelector('.representative-badge');
+      if (p.is_species_representative && !rep) {
+        wrap.insertAdjacentHTML('beforeend', '<span class="representative-badge">Representative</span>');
+      } else if (!p.is_species_representative && rep) {
+        rep.remove();
+      }
     }
   });
 }
+
+document.addEventListener('lifelist:changed', function(e) {
+  var detail = e && e.detail ? e.detail : {};
+  var species = detail.species;
+  var photoId = detail.photoId;
+  if (!species || !photoId) return;
+  var changed = [];
+  photos.forEach(function(p) {
+    var entries = Array.isArray(p.life_list) ? p.life_list : [];
+    var touched = false;
+    entries.forEach(function(entry) {
+      if (!entry || entry.species !== species) return;
+      var isCurrent = p.id === photoId;
+      if (entry.is_current_photo !== isCurrent || entry.is_species_representative !== isCurrent) {
+        entry.is_current_photo = isCurrent;
+        entry.is_species_representative = isCurrent;
+        touched = true;
+      }
+    });
+    if (p.id === photoId && !entries.some(function(entry) { return entry && entry.species === species; })) {
+      entries.push({species: species, is_current_photo: true, is_species_representative: true});
+      p.life_list = entries;
+      touched = true;
+    }
+    var isRep = entries.some(function(entry) {
+      return entry && entry.is_species_representative;
+    });
+    if (p.is_species_representative !== isRep) {
+      p.is_species_representative = isRep;
+      touched = true;
+    }
+    if (touched) changed.push(p.id);
+  });
+  if (changed.length) refreshGridCards(changed);
+});
 
 function getGridCard(photoId) {
   return document.querySelector('.grid-card[data-id="' + photoId + '"]');

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2669,6 +2669,7 @@ async function loadKeywords() {
 }
 
 function renderKeywordTree(keywords) {
+  _rememberKeywordNames(keywords);
   var byParent = {};
   keywords.forEach(function(k) {
     var pid = k.parent_id || 'root';
@@ -4938,7 +4939,26 @@ function _clearRepresentativeStateIfIneligible(photoId, flag) {
   }
 }
 
+// Every render path that has (keywordId, name) pairs feeds this map so the
+// single-photo remove path can resolve the name even before the autocomplete
+// field is ever opened. keywordAutocompleteCache starts as null and only
+// populates after that field renders, so on a fresh Browse page the previous
+// lookup returned null and _clearRepresentativeStateAfterKeywordRemoval
+// no-oped — the grid badge/context-menu state stayed stale until reload.
+var _keywordNamesById = {};
+function _rememberKeywordNames(keywords) {
+  if (!Array.isArray(keywords)) return;
+  keywords.forEach(function(k) {
+    if (k && typeof k.id === 'number' && typeof k.name === 'string') {
+      _keywordNamesById[k.id] = k.name;
+    }
+  });
+}
+
 function _keywordNameFromCache(keywordId) {
+  if (Object.prototype.hasOwnProperty.call(_keywordNamesById, keywordId)) {
+    return _keywordNamesById[keywordId];
+  }
   if (!Array.isArray(keywordAutocompleteCache)) return null;
   for (var i = 0; i < keywordAutocompleteCache.length; i++) {
     var k = keywordAutocompleteCache[i];
@@ -5670,6 +5690,7 @@ function renderDetail(photo) {
   // Keywords
   var kwTypeIcons = {general:'●', taxonomy:'🌿', individual:'👤', location:'📍', genre:'🎭'};
   var kwTypeLabels = {general:'General', taxonomy:'Taxonomy', individual:'Individual', location:'Location', genre:'Genre'};
+  _rememberKeywordNames(photo.keywords || []);
   var kwHtml = '';
   (photo.keywords || []).forEach(function(k) {
     var ktype = k.type || 'general';

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -207,6 +207,18 @@
     height: 8px;
     border-radius: 50%;
   }
+  .miss-card-representative {
+    position: absolute;
+    bottom: 6px;
+    left: 6px;
+    padding: 2px 6px;
+    background: var(--accent);
+    color: var(--accent-text);
+    border-radius: 999px;
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+  }
 
   .miss-card-unflag {
     position: absolute;
@@ -888,6 +900,7 @@ function renderCard(cat, p, idx) {
           '<span class="dot cat-' + cat + '"></span>' +
           escapeHtml(CATEGORY_LABELS[cat]) +
         '</span>' +
+        (p.is_species_representative ? '<span class="miss-card-representative">Representative</span>' : '') +
         '<button class="miss-card-unflag" ' +
           'title="Unflag as miss (U)" ' +
           'data-testid="miss-unflag-' + cat + '-' + p.id + '" ' +

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -1585,6 +1585,25 @@ document.addEventListener('lifelist:changed', function(e) {
   if (changed) render();
 });
 
+// Reject via the shared lightbox does NOT route through flagFocusedMiss /
+// bulkFlagSelection: handleMissesLightboxFlagShortcut only intercepts
+// flag === 'none' (unflag-as-miss), and every other flag lands in _lbApplyFlag's
+// generic /api/photos/<id>/flag fallback because misses.html doesn't define
+// window.setFlagFor / setReviewFlag. That path never clears the local
+// representative state, so a card whose rep badge was rendered stays showing
+// "Representative" after a lightbox reject until the next loadMisses().
+// _lbApplyFlag emits lightbox:flagchanged with the settled flag; listen here
+// and reuse the same clearing helper the keyboard/bulk reject paths use.
+document.addEventListener('lightbox:flagchanged', function(e) {
+  var detail = e && e.detail ? e.detail : {};
+  var photoId = detail.photoId;
+  var flag = detail.flag;
+  if (photoId == null || flag !== 'rejected') return;
+  if (_clearMissRepresentativeStateIfIneligible([photoId], flag)) {
+    render();
+  }
+});
+
 /* ---------- Boot ---------- */
 installMissSliderHandlers();
 loadMissConfig().then(loadMisses);

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -1504,6 +1504,50 @@ function extendSelectionByFocus(delta) {
   if (newP) setSelected(newP.id, true);
 }
 
+// setLifeListPhoto (miss card context menu / shared lightbox action) only emits
+// a lifelist:changed event and updates its own caches; without this listener
+// the Misses cards keep the pre-change value of p.is_species_representative, so
+// the newly assigned photo stays un-badged and any previously visible former
+// representative keeps its badge until a full reload. Walk missesData across
+// all categories in place, flip the species entry's flags, and rerender.
+document.addEventListener('lifelist:changed', function(e) {
+  var detail = e && e.detail ? e.detail : {};
+  var species = detail.species;
+  var photoId = detail.photoId;
+  if (!species || !photoId) return;
+  var changed = false;
+  CATEGORY_ORDER.forEach(function(cat) {
+    var photos = missesData[cat] || [];
+    photos.forEach(function(p) {
+      var entries = Array.isArray(p.life_list) ? p.life_list : [];
+      var touched = false;
+      entries.forEach(function(entry) {
+        if (!entry || entry.species !== species) return;
+        var isCurrent = p.id === photoId;
+        if (entry.is_current_photo !== isCurrent || entry.is_species_representative !== isCurrent) {
+          entry.is_current_photo = isCurrent;
+          entry.is_species_representative = isCurrent;
+          touched = true;
+        }
+      });
+      if (p.id === photoId && !entries.some(function(entry) { return entry && entry.species === species; })) {
+        entries.push({species: species, is_current_photo: true, is_species_representative: true});
+        p.life_list = entries;
+        touched = true;
+      }
+      var isRep = entries.some(function(entry) {
+        return entry && entry.is_species_representative;
+      });
+      if (p.is_species_representative !== isRep) {
+        p.is_species_representative = isRep;
+        touched = true;
+      }
+      if (touched) changed = true;
+    });
+  });
+  if (changed) render();
+});
+
 /* ---------- Boot ---------- */
 installMissSliderHandlers();
 loadMissConfig().then(loadMisses);

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -1048,6 +1048,38 @@ async function bulkReject(cat, e) {
   loadMisses();
 }
 
+// Server-side representative eligibility (see get_species_representatives)
+// hides rejected photos. Both flag paths below intentionally leave the card
+// rendered until the next loadMisses() so keyboard navigation stays put, but
+// without clearing rep state here the "Representative" badge and the shared
+// context menu's Already-representative hint keep treating the just-rejected
+// card as current until that later refetch. Walk missesData across all
+// categories in place — same shape the lifelist:changed listener uses.
+function _clearMissRepresentativeStateIfIneligible(photoIds, flag) {
+  if (flag !== 'rejected') return false;
+  var ids = photoIds instanceof Set ? photoIds : new Set(photoIds || []);
+  if (!ids.size) return false;
+  var changed = false;
+  CATEGORY_ORDER.forEach(function(cat) {
+    var photos = missesData[cat] || [];
+    photos.forEach(function(p) {
+      if (!ids.has(p.id)) return;
+      if (p.is_species_representative) {
+        p.is_species_representative = false;
+        changed = true;
+      }
+      if (Array.isArray(p.life_list)) {
+        p.life_list.forEach(function(entry) {
+          if (!entry) return;
+          if (entry.is_current_photo) { entry.is_current_photo = false; changed = true; }
+          if (entry.is_species_representative) { entry.is_species_representative = false; changed = true; }
+        });
+      }
+    });
+  });
+  return changed;
+}
+
 /* ---------- Per-card flag/reject (keyboard) ----------
  * Mirrors the bulk-reject behavior: sets the photo's flag without removing
  * the card from the list, so j/k navigation stays continuous. The card will
@@ -1064,6 +1096,9 @@ async function flagFocusedMiss(photoId, flag) {
   } catch (err) {
     if (typeof showToast === 'function') showToast('Flag update failed', 'error');
     return;
+  }
+  if (_clearMissRepresentativeStateIfIneligible([photoId], flag)) {
+    render();
   }
   if (typeof showToast === 'function') {
     var label = flag === 'flagged' ? 'Flagged' : flag === 'rejected' ? 'Rejected' : 'Cleared';
@@ -1091,11 +1126,13 @@ async function bulkFlagSelection(flag) {
     if (typeof showToast === 'function') showToast('Bulk flag failed', 'error');
     return;
   }
+  var repChanged = _clearMissRepresentativeStateIfIneligible(ids, flag);
   if (typeof showToast === 'function') {
     var verb = flag === 'flagged' ? 'Flagged' : flag === 'rejected' ? 'Rejected' : 'Cleared';
     showToast(verb + ' ' + ids.length + ' photo' + (ids.length === 1 ? '' : 's'), 'success');
   }
   clearSelection();
+  if (repChanged) render();
 }
 
 /* Bulk unflag-as-miss across the selection. Each photo can be flagged in

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -447,6 +447,18 @@
   color: var(--accent-text);
   font-weight: 600;
 }
+.photo-representative {
+  position: absolute;
+  bottom: 24px;
+  right: 6px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  font-size: 9px;
+  background: var(--accent);
+  color: var(--accent-text);
+  font-weight: 700;
+  text-transform: uppercase;
+}
 .photo-score-bar {
   height: 3px;
   background: var(--bg-tertiary);
@@ -1082,6 +1094,18 @@ input[type="range"]::-moz-range-thumb {
 .grm-card-species { color: var(--text-primary); font-weight: 600; }
 .grm-card-scores { color: var(--text-dim); }
 .grm-card-scores .score-val { color: var(--text-secondary); }
+.grm-card-representative {
+  position: absolute;
+  bottom: 4px;
+  right: 4px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: var(--accent);
+  color: var(--accent-text);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
 
 .grm-footer {
   padding: 12px 20px;
@@ -2553,6 +2577,7 @@ function renderPhotoCard(p, encIdx, burstIdx) {
   html += '<img src="' + escapeAttr(thumbUrl) + '" loading="lazy" alt="" onclick="openInspect(' + p.id + ')">';
   if (visibleLabel) html += '<span class="photo-label ' + visibleLabelClass + '">' + visibleLabel + '</span>';
   if (p.rarity_protected) html += '<span class="photo-rarity">protected</span>';
+  if (p.is_species_representative) html += '<span class="photo-representative">Representative</span>';
   if (p.flag === 'flagged') html += '<span class="photo-flag-badge flag-flagged">P</span>';
   else if (p.flag === 'rejected') html += '<span class="photo-flag-badge flag-rejected">X</span>';
   if (encIdx != null && burstIdx != null) {
@@ -4560,6 +4585,9 @@ function renderGroupModal() {
     var kwHtml = hasKw
       ? '<span class="grm-card-kw-badge" title="Species keyword already applied" style="position:absolute;top:4px;right:4px;background:var(--accent);color:var(--accent-text);font-size:10px;font-weight:600;padding:2px 6px;border-radius:3px;letter-spacing:0.04em;">TAG</span>'
       : '';
+    var repHtml = dbSt.is_species_representative
+      ? '<span class="grm-card-representative">Representative</span>'
+      : '';
 
     var nat = grmNaturalDims(p);
     var imgStyle = 'width:' + nat.w + 'px;height:' + nat.h + 'px;';
@@ -4575,6 +4603,7 @@ function renderGroupModal() {
           ' onload="grmCardImgLoaded(this)" loading="lazy" draggable="false">' +
         flagHtml +
         kwHtml +
+        repHtml +
       '</div>' +
       '<div class="grm-card-info">' +
         '<div class="grm-card-species">' + escapeHtml(p.filename || '') + '</div>' +

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -3050,7 +3050,25 @@ function setPipelineReviewFlag(photoId, flag) {
     body: JSON.stringify({ flag: flag }),
   }).then(function() {
     var photo = findPhotoInResults(photoId);
-    if (photo) photo.flag = flag;
+    if (photo) {
+      photo.flag = flag;
+      // Rejected photos lose representative eligibility server-side
+      // (get_species_representatives(eligible_only=True) filters them out),
+      // so drop the cached representative fields — the pipeline grid renders
+      // the Representative badge from photo.is_species_representative and
+      // would otherwise keep displaying it on a photo that's just been
+      // rejected via the inspect shortcut or the shared lightbox reject.
+      if (flag === 'rejected') {
+        if (photo.is_species_representative) photo.is_species_representative = false;
+        if (Array.isArray(photo.life_list)) {
+          photo.life_list.forEach(function(entry) {
+            if (!entry) return;
+            if (entry.is_current_photo) entry.is_current_photo = false;
+            if (entry.is_species_representative) entry.is_species_representative = false;
+          });
+        }
+      }
+    }
     renderResults();
     if (inspectPhotoId === photoId && document.getElementById('inspectOverlay').classList.contains('open')) {
       openInspect(photoId);

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -6059,12 +6059,29 @@ async function grmApply() {
 
     // Sync the in-memory pipeline cache's per-photo `flag` with what the
     // server just wrote, so the badges in the main grid (which read p.flag)
-    // refresh without a full reload.
+    // refresh without a full reload. Rejected photos also lose eligibility
+    // as species representatives (get_species_representatives(eligible_only)
+    // filters them out), so clear the cached representative fields too — the
+    // main pipeline grid renders its Representative badge from
+    // p.is_species_representative and would otherwise keep displaying it on
+    // a rejected photo until a full reload.
     if (applyResp && applyResp.photos) {
       Object.keys(applyResp.photos).forEach(function(pidStr) {
         var pid = parseInt(pidStr, 10);
         var p = photoMap[pid];
-        if (p) p.flag = applyResp.photos[pidStr].flag;
+        if (!p) return;
+        var newFlag = applyResp.photos[pidStr].flag;
+        p.flag = newFlag;
+        if (newFlag === 'rejected') {
+          if (p.is_species_representative) p.is_species_representative = false;
+          if (Array.isArray(p.life_list)) {
+            p.life_list.forEach(function(entry) {
+              if (!entry) return;
+              if (entry.is_current_photo) entry.is_current_photo = false;
+              if (entry.is_species_representative) entry.is_species_representative = false;
+            });
+          }
+        }
       });
     }
 

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -6235,6 +6235,68 @@ async function grmApply() {
   }
 }
 
+// setLifeListPhoto (card context menu / shared lightbox action) only emits a
+// lifelist:changed event and updates its own caches. Without this listener the
+// pipeline cards keep the pre-change value of p.is_species_representative, so
+// the newly assigned photo stays un-badged and any previously visible former
+// representative keeps its badge until a full reload. Walk pipelineResults.photos
+// in place and flip the species entry's flags, then rerender the grid. If the
+// burst modal happens to be open on the matching species, also update its
+// dbState so the modal's Representative badge stays honest.
+document.addEventListener('lifelist:changed', function(e) {
+  var detail = e && e.detail ? e.detail : {};
+  var species = detail.species;
+  var photoId = detail.photoId;
+  if (!species || !photoId) return;
+  if (!pipelineResults || !Array.isArray(pipelineResults.photos)) return;
+  var changed = false;
+  pipelineResults.photos.forEach(function(p) {
+    var entries = Array.isArray(p.life_list) ? p.life_list : [];
+    var touched = false;
+    entries.forEach(function(entry) {
+      if (!entry || entry.species !== species) return;
+      var isCurrent = p.id === photoId;
+      if (entry.is_current_photo !== isCurrent || entry.is_species_representative !== isCurrent) {
+        entry.is_current_photo = isCurrent;
+        entry.is_species_representative = isCurrent;
+        touched = true;
+      }
+    });
+    if (p.id === photoId && !entries.some(function(entry) { return entry && entry.species === species; })) {
+      entries.push({species: species, is_current_photo: true, is_species_representative: true});
+      p.life_list = entries;
+      touched = true;
+    }
+    var isRep = entries.some(function(entry) {
+      return entry && entry.is_species_representative;
+    });
+    if (p.is_species_representative !== isRep) {
+      p.is_species_representative = isRep;
+      touched = true;
+    }
+    if (touched) changed = true;
+  });
+  if (grmState && grmState.dbState && grmState.keywordStateSpecies === species) {
+    Object.keys(grmState.dbState).forEach(function(pidStr) {
+      var pid = parseInt(pidStr, 10);
+      var st = grmState.dbState[pid];
+      if (!st) return;
+      var next = (pid === photoId);
+      if (st.is_species_representative !== next) {
+        st.is_species_representative = next;
+        changed = true;
+      }
+    });
+  }
+  if (changed) {
+    renderResults();
+    if (typeof renderGroupModal === 'function') {
+      var overlay = document.getElementById('grmOverlay');
+      if (overlay && overlay.classList.contains('open')) renderGroupModal();
+    }
+  }
+});
+
 initPipelineReviewPage();
 </script>
 </body>

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -4673,12 +4673,16 @@ function grmRefreshSpeciesKeywordState() {
     if (grmState.sessionId !== sessionId) return;
     if (token !== _grmSpeciesRefetchToken) return;
     var fresh = (data && data.photos) || {};
-    // Only update the keyword field — the flag field is owned by the user's
+    // Only update DB-owned fields — the flag field is owned by the user's
     // in-modal moves at this point and would be wrong to overwrite from DB.
+    // The representative field is species-scoped, so it has to move with
+    // the typed species or the badge would show the previous species'
+    // representative state on the newly typed one.
     Object.keys(fresh).forEach(function(pidStr) {
       var pid = parseInt(pidStr, 10);
       if (!grmState.dbState[pid]) grmState.dbState[pid] = { flag: 'none' };
       grmState.dbState[pid].has_species_keyword = !!fresh[pidStr].has_species_keyword;
+      grmState.dbState[pid].is_species_representative = !!fresh[pidStr].is_species_representative;
     });
     grmState.keywordStateSpecies = species;
     renderGroupModal();

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -2952,6 +2952,49 @@ document.addEventListener('keydown', function(e) {
   if (e.key && e.key.toLowerCase() === 'x' && !e.ctrlKey && !e.metaKey && !e.altKey) { grmMoveReject(); e.preventDefault(); return; }
 });
 
+// setLifeListPhoto (card context menu / shared lightbox action) only emits a
+// lifelist:changed event and updates its own caches; without this listener the
+// Review cards keep the pre-change value of pred.is_species_representative, so
+// the newly assigned photo stays un-badged and any previously visible former
+// representative keeps its badge until a full reload. Walk allPredictions
+// (predictions is a filtered .slice() over the same object references, so
+// updating in place propagates) and flip the species entry's flags, then
+// re-render.
+document.addEventListener('lifelist:changed', function(e) {
+  var detail = e && e.detail ? e.detail : {};
+  var species = detail.species;
+  var photoId = detail.photoId;
+  if (!species || !photoId) return;
+  var changed = false;
+  allPredictions.forEach(function(pred) {
+    var entries = Array.isArray(pred.life_list) ? pred.life_list : [];
+    var touched = false;
+    entries.forEach(function(entry) {
+      if (!entry || entry.species !== species) return;
+      var isCurrent = pred.photo_id === photoId;
+      if (entry.is_current_photo !== isCurrent || entry.is_species_representative !== isCurrent) {
+        entry.is_current_photo = isCurrent;
+        entry.is_species_representative = isCurrent;
+        touched = true;
+      }
+    });
+    if (pred.photo_id === photoId && !entries.some(function(entry) { return entry && entry.species === species; })) {
+      entries.push({species: species, is_current_photo: true, is_species_representative: true});
+      pred.life_list = entries;
+      touched = true;
+    }
+    var isRep = entries.some(function(entry) {
+      return entry && entry.is_species_representative;
+    });
+    if (pred.is_species_representative !== isRep) {
+      pred.is_species_representative = isRep;
+      touched = true;
+    }
+    if (touched) changed = true;
+  });
+  if (changed) renderAll();
+});
+
 </script>
 
 <!-- Group Review Modal -->

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -164,6 +164,10 @@
     aspect-ratio: 3/2;
     object-fit: cover;
   }
+  .card > .card-img-wrap > img {
+    aspect-ratio: 3/2;
+    object-fit: cover;
+  }
   .card-body { padding: 12px 14px; }
   .card-filename {
     font-size: 12px;
@@ -199,6 +203,19 @@
     margin-left: 6px;
     background: var(--bg-tertiary, #14374E);
     color: var(--info);
+  }
+  .representative-badge {
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    padding: 2px 6px;
+    border-radius: 999px;
+    background: var(--accent);
+    color: var(--accent-text);
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    pointer-events: none;
   }
 
   /* Existing keywords */
@@ -1277,6 +1294,9 @@ function renderPredictionCard(pred) {
   var imgStyle = hasBox ? 'cursor:pointer;object-fit:contain;' : 'cursor:pointer;';
   var imgTag = '<img src="' + thumbUrl + '" loading="lazy" alt="' + escapeAttr(pred.filename || '') +
     '" style="' + imgStyle + '" data-photo-id="' + pred.photo_id + '" data-filename="' + escapeAttr(pred.filename || '') + '">';
+  var representativeBadge = pred.is_species_representative
+    ? '<span class="representative-badge">Representative</span>'
+    : '';
 
   var imgHtml;
   if (hasBox) {
@@ -1286,13 +1306,14 @@ function renderPredictionCard(pred) {
     var bWidth = (pred.box_w * 100).toFixed(2) + '%';
     var bHeight = (pred.box_h * 100).toFixed(2) + '%';
     imgHtml = '<div class="card-img-wrap">' + imgTag +
+      representativeBadge +
       '<div class="detection-box" data-photo-id="' + pred.photo_id + '" style="' + (hideDetectionOverlay ? 'display:none;' : '') + 'left:' + bLeft + ';top:' + bTop +
       ';width:' + bWidth + ';height:' + bHeight + ';border-color:' + color + ';">' +
       '<span class="detection-label" style="background:' + color +
       ';color:#0A1F2E;">' + escapeHtml(displaySpecies) + ' ' + confPct + '%</span>' +
       '</div></div>';
   } else {
-    imgHtml = imgTag;
+    imgHtml = '<div class="card-img-wrap">' + imgTag + representativeBadge + '</div>';
   }
 
   return '<div class="' + cardClass + '" data-pred-id="' + pred.id + '">' +

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -1417,12 +1417,44 @@ function setReviewRating(photoId, rating) {
   }, { toast: false }).catch(function() {});
 }
 
+// Server-side representative eligibility (see get_species_representatives)
+// hides rejected photos. Mirror that here so a card loaded with the badge
+// stops rendering Representative the moment the user rejects it from the
+// same page — without the walk below, pred.is_species_representative stays
+// true until a full reload. Un-rejecting is intentionally left alone: the
+// client can't know whether the DB preference still points at this photo,
+// so the badge stays hidden until reload rather than lighting up incorrectly.
+function _clearPredictionRepresentativeStateIfIneligible(photoId, flag) {
+  if (flag !== 'rejected') return false;
+  var changed = false;
+  allPredictions.forEach(function(pred) {
+    if (!pred || pred.photo_id !== photoId) return;
+    if (pred.is_species_representative) {
+      pred.is_species_representative = false;
+      changed = true;
+    }
+    if (Array.isArray(pred.life_list)) {
+      pred.life_list.forEach(function(entry) {
+        if (!entry) return;
+        if (entry.is_current_photo) { entry.is_current_photo = false; changed = true; }
+        if (entry.is_species_representative) { entry.is_species_representative = false; changed = true; }
+      });
+    }
+  });
+  return changed;
+}
+
 function setReviewFlag(photoId, flag) {
   return safeFetch('/api/batch/flag', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ photo_ids: [photoId], flag: flag }),
-  }, { toast: false }).then(function() { return true; }).catch(function() { return false; });
+  }, { toast: false }).then(function() {
+    if (_clearPredictionRepresentativeStateIfIneligible(photoId, flag)) {
+      renderAll();
+    }
+    return true;
+  }).catch(function() { return false; });
 }
 
 function revealReviewPhoto(photoId) {

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -29,6 +29,29 @@ def test_api_photos_includes_edit_recipe(app_and_db):
     assert listed[photo["id"]]["edit_recipe"] == {"version": 1, "rotation": 90}
 
 
+def test_api_photos_marks_species_representative(app_and_db):
+    """List payloads expose representative state for card views and menus."""
+    app, db = app_and_db
+    photo = db.get_photos()[0]
+    kid = db.add_keyword("American Robin", is_species=True)
+    db.tag_photo(photo["id"], kid)
+    db.set_species_representative("American Robin", photo["id"])
+
+    client = app.test_client()
+    resp = client.get("/api/photos")
+    assert resp.status_code == 200
+    listed = {p["id"]: p for p in resp.get_json()["photos"]}
+
+    assert listed[photo["id"]]["is_species_representative"] is True
+    assert listed[photo["id"]]["life_list"] == [
+        {
+            "species": "American Robin",
+            "is_current_photo": True,
+            "is_species_representative": True,
+        }
+    ]
+
+
 def test_api_photos_pagination(app_and_db):
     """GET /api/photos supports pagination."""
     app, _ = app_and_db

--- a/vireo/tests/test_pipeline_group_apply.py
+++ b/vireo/tests/test_pipeline_group_apply.py
@@ -335,3 +335,56 @@ def test_state_endpoint_ignores_homonym_non_species_keyword(app_and_db):
     # reported, or it's a different id from the individual.
     assert data['species_kid'] != individual_kid
     assert data['photos'][str(pid)]['has_species_keyword'] is False
+
+
+def test_state_endpoint_gates_representative_on_current_eligibility(app_and_db):
+    """A stored representative preference that's now stale (photo rejected or
+    no longer carrying the species keyword) must NOT be reported as the
+    representative on the group modal, matching how browse/highlights hide it.
+    """
+    app, db = app_and_db
+    pids = _photo_ids(db)
+    live_id, rejected_id, untagged_id = pids[0], pids[1], pids[2]
+
+    # One species per photo so each failure mode is independently observable.
+    kid_live = db.add_keyword('Coyote Live', is_species=True)
+    kid_rejected = db.add_keyword('Coyote Rejected', is_species=True)
+    kid_untagged = db.add_keyword('Coyote Untagged', is_species=True)
+    db.tag_photo(live_id, kid_live)
+    db.tag_photo(rejected_id, kid_rejected)
+    db.tag_photo(untagged_id, kid_untagged)
+    db.set_species_representative('Coyote Live', live_id)
+    db.set_species_representative('Coyote Rejected', rejected_id)
+    db.set_species_representative('Coyote Untagged', untagged_id)
+
+    # Make each stale in one of the two ways the shared payload attachers
+    # already filter on. The preference rows themselves remain intact.
+    db.update_photo_flag(rejected_id, 'rejected')
+    db.untag_photo(untagged_id, kid_untagged)
+
+    client = app.test_client()
+
+    # Eligible representative still lights up.
+    resp = client.post('/api/pipeline/group/state', json={
+        'photo_ids': [live_id],
+        'species': 'Coyote Live',
+    })
+    assert resp.status_code == 200
+    assert resp.get_json()['photos'][str(live_id)]['is_species_representative'] is True
+
+    # Rejected photo whose preference row still points at it does NOT.
+    resp = client.post('/api/pipeline/group/state', json={
+        'photo_ids': [rejected_id],
+        'species': 'Coyote Rejected',
+    })
+    assert resp.status_code == 200
+    assert resp.get_json()['photos'][str(rejected_id)]['is_species_representative'] is False
+
+    # Photo whose preference row still points at it but that no longer carries
+    # the stored species keyword also does NOT.
+    resp = client.post('/api/pipeline/group/state', json={
+        'photo_ids': [untagged_id],
+        'species': 'Coyote Untagged',
+    })
+    assert resp.status_code == 200
+    assert resp.get_json()['photos'][str(untagged_id)]['is_species_representative'] is False

--- a/vireo/tests/test_predictions_api.py
+++ b/vireo/tests/test_predictions_api.py
@@ -379,3 +379,51 @@ def test_accept_alternative_prediction(app_and_db):
     keywords = db.get_photo_keywords(photos[0]['id'])
     kw_names = {k['name'] for k in keywords}
     assert 'Sparrow' in kw_names
+
+
+def test_list_predictions_gates_representative_on_current_eligibility(app_and_db):
+    """A stale representative preference must not light up the Review-card
+    badge for a photo that is now rejected or no longer carries the stored
+    species keyword. get_predictions() only pulls filename/timestamp from
+    photos, so _attach_species_representatives can't see p.flag on prediction
+    dicts — this test protects the eligible-representative lookup that
+    replaces the missing-column check.
+    """
+    app, db = app_and_db
+    photos = _seed_predictions(db)
+
+    live_pid = photos[0]['id']
+    rejected_pid = photos[1]['id']
+    det_untagged = _make_detection(db, photos[2]['id'])
+    db.add_prediction(detection_id=det_untagged, species='Coyote Untagged',
+                      confidence=0.90, model='test-model', category='new',
+                      group_id=None)
+
+    # Tag each photo with its own species so failure modes are independent.
+    kid_live = db.add_keyword('Coyote Live', is_species=True)
+    kid_rejected = db.add_keyword('Coyote Rejected', is_species=True)
+    kid_untagged = db.add_keyword('Coyote Untagged', is_species=True)
+    db.tag_photo(live_pid, kid_live)
+    db.tag_photo(rejected_pid, kid_rejected)
+    db.tag_photo(photos[2]['id'], kid_untagged)
+    db.set_species_representative('Coyote Live', live_pid)
+    db.set_species_representative('Coyote Rejected', rejected_pid)
+    db.set_species_representative('Coyote Untagged', photos[2]['id'])
+
+    # Make each stale in one of the two ways the eligibility gate covers.
+    # Preference rows themselves remain intact (undo-friendly).
+    db.update_photo_flag(rejected_pid, 'rejected')
+    db.untag_photo(photos[2]['id'], kid_untagged)
+
+    client = app.test_client()
+    resp = client.get('/api/predictions')
+    assert resp.status_code == 200
+    by_photo = {p['photo_id']: p for p in resp.get_json()}
+
+    # Eligible representative still lights up on the review card.
+    assert by_photo[live_pid]['is_species_representative'] is True
+    # Rejected photo no longer counts as a representative even though the
+    # preference row still points at it.
+    assert by_photo[rejected_pid]['is_species_representative'] is False
+    # Photo whose species keyword was untagged no longer counts either.
+    assert by_photo[photos[2]['id']]['is_species_representative'] is False


### PR DESCRIPTION
Adds representative state to shared photo, prediction, misses, and pipeline review payloads so card views can tell when a photo is already the species representative. Renders compact Representative badges in Browse, Review, Misses, Pipeline Review, and the pipeline group modal, and keeps Browse cards/menu state current after setting a representative. Validation: python -m py_compile vireo/app.py; pytest vireo/tests/test_photos_api.py -q; pytest tests/e2e/test_lifelist_add_verify.py -q; git diff --check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added “Representative” badges to browse, review, pipeline review, and misses photo cards.
  - Representative status now updates automatically when lifelist data changes.
  - Rejected or no-longer-eligible photos no longer display representative status.
  - The representative action is disabled for photos already marked as representative.

- **Bug Fixes**
  - Improved representative status accuracy across photo listings, predictions, and review workflows.

- **Tests**
  - Added coverage verifying representative badges, eligibility rules, and rejected-photo behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->