### PR TITLE
Extract photo color label routes into domain layers

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -86,6 +86,7 @@ from render_source import (
 )
 from schema import ensure_schema
 from web.pages import pages_blueprint
+from web.photo_labels import create_photo_labels_blueprint
 from web.system import system_blueprint
 from web.workspaces import create_workspace_blueprint
 from werkzeug.exceptions import BadRequest
@@ -4493,16 +4494,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             )
         )
 
-    @app.route("/api/photos/color_labels")
-    def api_photos_color_labels():
-        db = _get_db()
-        ids_str = request.args.get("ids", "")
-        if not ids_str:
-            return jsonify({})
-        photo_ids = [int(x) for x in ids_str.split(",") if x.strip().isdigit()]
-        labels = db.get_color_labels_for_photos(photo_ids)
-        return jsonify(labels)
-
     @app.route("/api/photos/<int:photo_id>")
     def api_photo_detail(photo_id):
         db = _get_db()
@@ -5225,32 +5216,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             [{"photo_id": photo_id, "old_value": old_value, "new_value": new_value}],
         )
         return jsonify({"ok": True, "wildlife_excluded": excluded})
-
-    @app.route("/api/photos/<int:photo_id>/color_label", methods=["POST"])
-    def api_set_color_label(photo_id):
-        db = _get_db()
-        body = request.get_json(silent=True) or {}
-        color = body.get("color")
-        if color is not None and color not in db.VALID_COLOR_LABELS:
-            return json_error(f"color must be one of {db.VALID_COLOR_LABELS}")
-        # Existence + workspace checks mirror the rating/flag endpoints. A
-        # stale id from an open browse tab would otherwise hit the
-        # photo_color_labels FK and 500.
-        if db.get_photo(photo_id) is None:
-            return json_error("not found", 404)
-        try:
-            db._verify_photo_in_workspace(photo_id)
-        except ValueError as e:
-            return json_error(str(e), 403)
-        old_color = db.get_color_label(photo_id) or ''
-        new_color = color or ''
-        if color:
-            db.set_color_label(photo_id, color)
-        else:
-            db.remove_color_label(photo_id)
-        db.record_edit('color_label', f'Set color to {color or "none"}', new_color,
-                       [{'photo_id': photo_id, 'old_value': old_color, 'new_value': new_color}])
-        return jsonify({"ok": True})
 
     @app.route("/api/photos/<int:photo_id>/edit-recipe", methods=["GET"])
     def api_get_photo_edit_recipe(photo_id):
@@ -6912,41 +6877,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 for pid in photo_ids
             },
         })
-
-    @app.route("/api/batch/color_label", methods=["POST"])
-    def api_batch_color_label():
-        db = _get_db()
-        body = request.get_json(silent=True) or {}
-        photo_ids = body.get("photo_ids", [])
-        color = body.get("color")
-        if color is not None and color not in db.VALID_COLOR_LABELS:
-            return json_error(f"color must be one of {db.VALID_COLOR_LABELS}")
-        if not photo_ids:
-            return json_error("photo_ids required")
-        # Filter to photos that exist AND are visible in the active workspace
-        # (mirrors api_batch_rating's stale-id filtering). Stale ids would
-        # otherwise hit the photo_color_labels FK and abort the batch with a
-        # 500 partway through.
-        photos_map = db.get_photos_by_ids(photo_ids)
-        ws_folder_ids = {
-            r["folder_id"] for r in db.conn.execute(
-                "SELECT folder_id FROM workspace_folders WHERE workspace_id = ?",
-                (db._ws_id(),),
-            )
-        }
-        valid_ids = list(dict.fromkeys(
-            pid for pid in photo_ids
-            if pid in photos_map and photos_map[pid]["folder_id"] in ws_folder_ids
-        ))
-        old_labels = db.get_color_labels_for_photos(valid_ids)
-        new_color = color or ''
-        db.batch_set_color_label(valid_ids, color)
-        items = [{'photo_id': pid, 'old_value': old_labels.get(pid, ''), 'new_value': new_color}
-                 for pid in valid_ids]
-        if items:
-            db.record_edit('color_label', f'Set color to {color or "none"} on {len(valid_ids)} photos',
-                           new_color, items, is_batch=True)
-        return jsonify({"ok": True, "updated": len(valid_ids)})
 
     @app.route("/api/batch/keyword", methods=["POST"])
     def api_batch_keyword():
@@ -23158,6 +23088,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         os.makedirs(originals_dir, exist_ok=True)
         img.save(cache_path, format="JPEG", quality=quality)
         return send_file(cache_path, mimetype="image/jpeg")
+
+    app.register_blueprint(create_photo_labels_blueprint(_get_db, json_error))
 
     # --- /api/v1/* aliases over the stable subset of /api/* ---
     # These are the endpoints advertised to external callers in docs/headless-api.md.

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -7073,69 +7073,40 @@ class Database:
             self.conn.rollback()
             raise
 
-    VALID_COLOR_LABELS = ('red', 'yellow', 'green', 'blue', 'purple')
+    from repositories.photo_labels import VALID_COLOR_LABELS
 
     def set_color_label(self, photo_id, color):
         """Set a color label for a photo in the active workspace."""
-        if color not in self.VALID_COLOR_LABELS:
-            raise ValueError(f"Invalid color label: {color}. Must be one of {self.VALID_COLOR_LABELS}")
-        self.conn.execute(
-            "INSERT OR REPLACE INTO photo_color_labels (photo_id, workspace_id, color) VALUES (?, ?, ?)",
-            (photo_id, self._ws_id(), color),
-        )
-        self.conn.commit()
+        self._photo_label_repository().set(photo_id, color)
 
     def remove_color_label(self, photo_id):
         """Remove the color label for a photo in the active workspace."""
-        self.conn.execute(
-            "DELETE FROM photo_color_labels WHERE photo_id = ? AND workspace_id = ?",
-            (photo_id, self._ws_id()),
-        )
-        self.conn.commit()
+        self._photo_label_repository().remove(photo_id)
 
     def get_color_label(self, photo_id):
         """Return the color label for a photo in the active workspace, or None."""
-        row = self.conn.execute(
-            "SELECT color FROM photo_color_labels WHERE photo_id = ? AND workspace_id = ?",
-            (photo_id, self._ws_id()),
-        ).fetchone()
-        return row['color'] if row else None
+        return self._photo_label_repository().get(photo_id)
 
     def get_color_labels_for_photos(self, photo_ids):
         """Return a dict of {photo_id: color} for the active workspace."""
-        if not photo_ids:
-            return {}
-        out = {}
-        for chunk in _chunks(photo_ids):
-            placeholders = ",".join("?" for _ in chunk)
-            rows = self.conn.execute(
-                f"SELECT photo_id, color FROM photo_color_labels WHERE workspace_id = ? AND photo_id IN ({placeholders})",
-                [self._ws_id()] + list(chunk),
-            ).fetchall()
-            out.update({row['photo_id']: row['color'] for row in rows})
-        return out
+        return self._photo_label_repository().get_for_photos(photo_ids)
+
+    def filter_photo_ids_in_workspace(self, photo_ids):
+        """Return existing, active-workspace photo IDs in input order."""
+        return self._photo_label_repository().visible_photo_ids(photo_ids)
 
     def batch_set_color_label(self, photo_ids, color):
         """Set or remove color label for multiple photos in the active workspace."""
-        if not photo_ids:
-            return
-        ws_id = self._ws_id()
-        if color is None:
-            for chunk in _chunks(photo_ids):
-                placeholders = ",".join("?" for _ in chunk)
-                self.conn.execute(
-                    f"DELETE FROM photo_color_labels WHERE workspace_id = ? AND photo_id IN ({placeholders})",
-                    [ws_id] + list(chunk),
-                )
-        else:
-            if color not in self.VALID_COLOR_LABELS:
-                raise ValueError(f"Invalid color label: {color}. Must be one of {self.VALID_COLOR_LABELS}")
-            for pid in photo_ids:
-                self.conn.execute(
-                    "INSERT OR REPLACE INTO photo_color_labels (photo_id, workspace_id, color) VALUES (?, ?, ?)",
-                    (pid, ws_id, color),
-                )
-        self.conn.commit()
+        self._photo_label_repository().set_many(photo_ids, color)
+
+    def _photo_label_repository(self):
+        from repositories.photo_labels import PhotoLabelRepository
+
+        return PhotoLabelRepository(
+            self.conn,
+            self._ws_id(),
+            chunk_size=_SQLITE_PARAM_CHUNK_SIZE,
+        )
 
     def get_photo_edit_recipe(self, photo_id, verify_workspace=False):
         """Return the normalized edit recipe dict for a photo, or None."""

--- a/vireo/repositories/photo_labels.py
+++ b/vireo/repositories/photo_labels.py
@@ -1,0 +1,98 @@
+"""Persistence for workspace-scoped photo color labels."""
+
+
+VALID_COLOR_LABELS = ("red", "yellow", "green", "blue", "purple")
+
+
+class PhotoLabelRepository:
+    def __init__(self, conn, workspace_id, *, chunk_size=800):
+        self.conn = conn
+        self.workspace_id = workspace_id
+        self.chunk_size = chunk_size
+
+    def get(self, photo_id):
+        row = self.conn.execute(
+            "SELECT color FROM photo_color_labels "
+            "WHERE photo_id = ? AND workspace_id = ?",
+            (photo_id, self.workspace_id),
+        ).fetchone()
+        return row["color"] if row else None
+
+    def get_for_photos(self, photo_ids):
+        if not photo_ids:
+            return {}
+        labels = {}
+        for chunk in self._chunks(photo_ids):
+            placeholders = ",".join("?" for _ in chunk)
+            rows = self.conn.execute(
+                "SELECT photo_id, color FROM photo_color_labels "
+                f"WHERE workspace_id = ? AND photo_id IN ({placeholders})",
+                [self.workspace_id, *chunk],
+            ).fetchall()
+            labels.update({row["photo_id"]: row["color"] for row in rows})
+        return labels
+
+    def visible_photo_ids(self, photo_ids):
+        """Return existing, workspace-visible IDs in caller order, deduplicated."""
+        requested = list(dict.fromkeys(photo_ids))
+        visible = set()
+        for chunk in self._chunks(requested):
+            placeholders = ",".join("?" for _ in chunk)
+            rows = self.conn.execute(
+                "SELECT p.id FROM photos p "
+                "JOIN workspace_folders wf ON wf.folder_id = p.folder_id "
+                f"WHERE wf.workspace_id = ? AND p.id IN ({placeholders})",
+                [self.workspace_id, *chunk],
+            ).fetchall()
+            visible.update(row["id"] for row in rows)
+        return [photo_id for photo_id in requested if photo_id in visible]
+
+    def set(self, photo_id, color):
+        if color not in VALID_COLOR_LABELS:
+            raise ValueError(
+                f"Invalid color label: {color}. Must be one of {VALID_COLOR_LABELS}"
+            )
+        self.conn.execute(
+            "INSERT OR REPLACE INTO photo_color_labels "
+            "(photo_id, workspace_id, color) VALUES (?, ?, ?)",
+            (photo_id, self.workspace_id, color),
+        )
+        self.conn.commit()
+
+    def remove(self, photo_id):
+        self.conn.execute(
+            "DELETE FROM photo_color_labels "
+            "WHERE photo_id = ? AND workspace_id = ?",
+            (photo_id, self.workspace_id),
+        )
+        self.conn.commit()
+
+    def set_many(self, photo_ids, color):
+        if not photo_ids:
+            return
+        if color is not None and color not in VALID_COLOR_LABELS:
+            raise ValueError(
+                f"Invalid color label: {color}. Must be one of {VALID_COLOR_LABELS}"
+            )
+        if color is None:
+            for chunk in self._chunks(photo_ids):
+                placeholders = ",".join("?" for _ in chunk)
+                self.conn.execute(
+                    "DELETE FROM photo_color_labels "
+                    f"WHERE workspace_id = ? AND photo_id IN ({placeholders})",
+                    [self.workspace_id, *chunk],
+                )
+        else:
+            self.conn.executemany(
+                "INSERT OR REPLACE INTO photo_color_labels "
+                "(photo_id, workspace_id, color) VALUES (?, ?, ?)",
+                [(photo_id, self.workspace_id, color) for photo_id in photo_ids],
+            )
+        self.conn.commit()
+
+    def _chunks(self, values):
+        values = list(values)
+        return (
+            values[index:index + self.chunk_size]
+            for index in range(0, len(values), self.chunk_size)
+        )

--- a/vireo/services/__init__.py
+++ b/vireo/services/__init__.py
@@ -1,0 +1,1 @@
+"""Domain services coordinating Vireo workflows."""

--- a/vireo/services/photo_labels.py
+++ b/vireo/services/photo_labels.py
@@ -1,0 +1,55 @@
+"""Photo color-label workflow coordination."""
+
+
+class PhotoLabelService:
+    def __init__(self, db):
+        self.db = db
+
+    def labels_for_photos(self, photo_ids):
+        return self.db.get_color_labels_for_photos(photo_ids)
+
+    def set_label(self, photo_id, color):
+        photo = self.db.get_photo(photo_id)
+        if photo is None:
+            raise LookupError("not found")
+        self.db._verify_photo_in_workspace(photo_id)
+
+        old_color = self.db.get_color_label(photo_id) or ""
+        new_color = color or ""
+        if color:
+            self.db.set_color_label(photo_id, color)
+        else:
+            self.db.remove_color_label(photo_id)
+        self.db.record_edit(
+            "color_label",
+            f'Set color to {color or "none"}',
+            new_color,
+            [{
+                "photo_id": photo_id,
+                "old_value": old_color,
+                "new_value": new_color,
+            }],
+        )
+
+    def set_labels(self, photo_ids, color):
+        valid_ids = self.db.filter_photo_ids_in_workspace(photo_ids)
+        old_labels = self.db.get_color_labels_for_photos(valid_ids)
+        new_color = color or ""
+        self.db.batch_set_color_label(valid_ids, color)
+        items = [
+            {
+                "photo_id": photo_id,
+                "old_value": old_labels.get(photo_id, ""),
+                "new_value": new_color,
+            }
+            for photo_id in valid_ids
+        ]
+        if items:
+            self.db.record_edit(
+                "color_label",
+                f'Set color to {color or "none"} on {len(valid_ids)} photos',
+                new_color,
+                items,
+                is_batch=True,
+            )
+        return len(valid_ids)

--- a/vireo/tests/test_edits_api.py
+++ b/vireo/tests/test_edits_api.py
@@ -47,6 +47,38 @@ def test_batch_color_label(app_and_db):
     assert db.get_color_label(pids[1]) == 'green'
 
 
+def test_get_color_labels(app_and_db):
+    """GET /api/photos/color_labels returns labels keyed by photo id."""
+    app, db = app_and_db
+    client = app.test_client()
+    photos = db.get_photos()
+    pids = [photo['id'] for photo in photos[:2]]
+    db.set_color_label(pids[0], 'purple')
+
+    resp = client.get(
+        f'/api/photos/color_labels?ids={pids[0]},{pids[1]},not-an-id'
+    )
+
+    assert resp.status_code == 200
+    assert resp.get_json() == {str(pids[0]): 'purple'}
+
+
+def test_color_label_routes_are_owned_by_domain_blueprint(app_and_db):
+    """The extracted route group must not drift back into the app module."""
+    app, _ = app_and_db
+    endpoints = {
+        rule.rule: rule.endpoint
+        for rule in app.url_map.iter_rules()
+        if 'color_label' in rule.rule
+    }
+
+    assert endpoints == {
+        '/api/batch/color_label': 'photo_labels.set_labels',
+        '/api/photos/<int:photo_id>/color_label': 'photo_labels.set_label',
+        '/api/photos/color_labels': 'photo_labels.get_labels',
+    }
+
+
 def test_set_rating(app_and_db):
     """POST /api/photos/<id>/rating updates rating and queues pending change."""
     app, db = app_and_db

--- a/vireo/web/photo_labels.py
+++ b/vireo/web/photo_labels.py
@@ -1,0 +1,50 @@
+"""Workspace-scoped photo color-label endpoints."""
+
+from flask import Blueprint, jsonify, request
+from repositories.photo_labels import VALID_COLOR_LABELS
+from services.photo_labels import PhotoLabelService
+
+
+def create_photo_labels_blueprint(get_db, json_error):
+    blueprint = Blueprint("photo_labels", __name__)
+
+    @blueprint.get("/api/photos/color_labels")
+    def get_labels():
+        ids_str = request.args.get("ids", "")
+        if not ids_str:
+            return jsonify({})
+        photo_ids = [
+            int(value)
+            for value in ids_str.split(",")
+            if value.strip().isdigit()
+        ]
+        labels = PhotoLabelService(get_db()).labels_for_photos(photo_ids)
+        return jsonify(labels)
+
+    @blueprint.post("/api/photos/<int:photo_id>/color_label")
+    def set_label(photo_id):
+        body = request.get_json(silent=True) or {}
+        color = body.get("color")
+        if color is not None and color not in VALID_COLOR_LABELS:
+            return json_error(f"color must be one of {VALID_COLOR_LABELS}")
+        try:
+            PhotoLabelService(get_db()).set_label(photo_id, color)
+        except LookupError:
+            return json_error("not found", 404)
+        except ValueError as exc:
+            return json_error(str(exc), 403)
+        return jsonify({"ok": True})
+
+    @blueprint.post("/api/batch/color_label")
+    def set_labels():
+        body = request.get_json(silent=True) or {}
+        photo_ids = body.get("photo_ids", [])
+        color = body.get("color")
+        if color is not None and color not in VALID_COLOR_LABELS:
+            return json_error(f"color must be one of {VALID_COLOR_LABELS}")
+        if not photo_ids:
+            return json_error("photo_ids required")
+        updated = PhotoLabelService(get_db()).set_labels(photo_ids, color)
+        return jsonify({"ok": True, "updated": updated})
+
+    return blueprint


### PR DESCRIPTION
Extracts the existing photo color-label route group from the legacy application module into a focused Flask blueprint. Moves workflow coordination into a photo-label service and workspace-scoped SQL into a repository while retaining Database compatibility methods. Preserves all existing URLs, response shapes, status codes, workspace isolation, edit history, the route-contract snapshot, and /api/v1 behavior. Validated with 4,492 Python tests, Ruff, seven critical Playwright journeys, focused contract tests, and the enforced 100,000-photo performance benchmark.