### PR TITLE
Show filenames on highlights cards

### DIFF
--- a/tests/e2e/test_highlights_initial_scope.py
+++ b/tests/e2e/test_highlights_initial_scope.py
@@ -274,6 +274,7 @@ def test_highlights_general_search_filters_by_filename_folder_and_keyword(live_s
         search.fill("hawk1")
     expect(page.locator(".highlights-card")).to_have_count(1)
     expect(page.locator(".highlights-card img")).to_have_attribute("alt", "hawk1.jpg")
+    expect(page.locator(".highlights-card .card-filename")).to_have_text("hawk1.jpg")
 
     with page.expect_response(
         lambda r: "/api/highlights?" in r.url and "q=yard" in r.url.lower()

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -47,7 +47,8 @@
   .highlight-order button { padding:2px 6px; border-radius:999px; border:1px solid rgba(255,255,255,.45); background:rgba(0,0,0,.62); color:#fff; font-size:10px; cursor:pointer; }
   .highlight-order button:hover { border-color:#fff; }
   .highlights-card img { width:100%; aspect-ratio:3/2; object-fit:cover; display:block; background:var(--bg-tertiary); }
-  .card-info { padding:6px 8px; font-size:11px; color:var(--text-secondary); display:flex; flex-wrap:wrap; align-items:center; justify-content:flex-end; gap:4px; min-height:28px; }
+  .card-filename { padding:6px 8px 0; color:var(--text-primary); font-size:12px; line-height:1.35; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+  .card-info { padding:4px 8px 6px; font-size:11px; color:var(--text-secondary); display:flex; flex-wrap:wrap; align-items:center; justify-content:flex-end; gap:4px; min-height:26px; }
   .card-chip { padding:1px 5px; border-radius:999px; background:var(--bg-tertiary); white-space:nowrap; }
   .card-chip.score { color:var(--text-primary); font-weight:600; }
   .card-chip.conf { color:var(--text-secondary); }
@@ -438,6 +439,7 @@ function renderCard(p, idx) {
     + ribbon
     + order
     + '<img src="' + thumbSrc + '" alt="' + escapeAttr(p.filename) + '" loading="lazy">'
+    + '<div class="card-filename" title="' + escapeAttr(p.filename) + '">' + escapeAttr(p.filename) + '</div>'
     + '<div class="card-info">' + scoreChip + conf + rep + reasons + '</div>'
     + '</div>';
 }


### PR DESCRIPTION
Adds a visible filename line beneath each thumbnail in the Highlights view, with truncation for long names. Keeps the existing metadata chips below the filename and preserves advanced-mode behavior. Adds an e2e assertion that the filename appears on a filtered highlights card. Validation: python -m pytest tests/e2e/test_highlights_initial_scope.py::test_highlights_general_search_filters_by_filename_folder_and_keyword