### PR TITLE
Fix rapid review E2E navigation timeout

### DIFF
--- a/tests/e2e/test_pipeline_rapid_review.py
+++ b/tests/e2e/test_pipeline_rapid_review.py
@@ -135,10 +135,18 @@ def _mock_pipeline_rapid_review(
     )
 
 
+def _goto_rapid_review(live_server, page, path="/pipeline/rapid-review"):
+    # Rapid Review is ready for these tests after DOMContentLoaded; the page
+    # then hydrates from mocked API calls and image routes. Waiting for the
+    # browser load event couples the tests to nonessential resources and can
+    # timeout under the full E2E suite.
+    page.goto(f"{live_server['url']}{path}", wait_until="domcontentloaded")
+
+
 def test_rapid_review_decision_keys_advance_through_queue(live_server, page):
     _mock_pipeline_rapid_review(page)
 
-    page.goto(f"{live_server['url']}/pipeline/rapid-review")
+    _goto_rapid_review(live_server, page)
 
     expect(page.locator("#filename")).to_have_text("a.jpg")
     expect(page.locator("#applyBtn")).to_be_enabled()
@@ -159,7 +167,7 @@ def test_rapid_review_decision_keys_advance_through_queue(live_server, page):
 def test_rapid_review_pick_key_ignores_legacy_pipeline_nav_shortcut(live_server, page):
     _mock_pipeline_rapid_review(page)
 
-    page.goto(f"{live_server['url']}/pipeline/rapid-review")
+    _goto_rapid_review(live_server, page)
     page.wait_for_function(
         """() => window.Keymap
           && window.Keymap.getScope() === 'pipeline_rapid_review'
@@ -193,7 +201,7 @@ def test_rapid_review_honors_remapped_decision_shortcuts(live_server, page):
         },
     )
 
-    page.goto(f"{live_server['url']}/pipeline/rapid-review")
+    _goto_rapid_review(live_server, page)
     page.wait_for_function(
         """() => window._vireoShortcuts
           && window._vireoShortcuts.pipeline_rapid_review
@@ -220,7 +228,7 @@ def test_rapid_review_honors_remapped_decision_shortcuts(live_server, page):
 def test_rapid_review_keeps_apply_disabled_when_state_load_fails(live_server, page):
     _mock_pipeline_rapid_review(page, state_ok=False)
 
-    page.goto(f"{live_server['url']}/pipeline/rapid-review")
+    _goto_rapid_review(live_server, page)
 
     expect(page.locator("#filename")).to_have_text("a.jpg")
     expect(page.locator("#applyBtn")).to_be_disabled()
@@ -234,7 +242,7 @@ def test_rapid_review_keeps_apply_disabled_when_state_load_fails(live_server, pa
 def test_rapid_review_apply_button_summarizes_pending_writes(live_server, page):
     _mock_pipeline_rapid_review(page)
 
-    page.goto(f"{live_server['url']}/pipeline/rapid-review")
+    _goto_rapid_review(live_server, page)
 
     # Species tagging now covers EVERY frame in the burst (not just picks), so
     # with a pre-filled species and no frames yet carrying the keyword, Apply
@@ -274,7 +282,7 @@ def test_rapid_review_species_edit_refreshes_existing_keyword_state(live_server,
         state_photos={"1": {"flag": "flagged", "has_species_keyword": True}},
     )
 
-    page.goto(f"{live_server['url']}/pipeline/rapid-review")
+    _goto_rapid_review(live_server, page)
     expect(page.locator("#applyBtn")).to_have_text("Apply: no DB changes")
 
     page.locator("#speciesInput").fill("New bird")
@@ -316,7 +324,7 @@ def test_rapid_review_rewrites_all_burst_labels_before_saving_cache(live_server,
         save_payloads=save_payloads,
     )
 
-    page.goto(f"{live_server['url']}/pipeline/rapid-review")
+    _goto_rapid_review(live_server, page)
     expect(page.locator("#applyBtn")).to_be_enabled()
 
     with page.expect_response("**/api/pipeline/save-cache"):
@@ -360,7 +368,7 @@ def test_rapid_review_preserves_burst_override_species_on_apply_next(live_server
         },
     )
 
-    page.goto(f"{live_server['url']}/pipeline/rapid-review")
+    _goto_rapid_review(live_server, page)
     expect(page.locator("#speciesInput")).to_have_value("Encounter bird")
     page.locator("#speciesInput").fill("New encounter bird")
 
@@ -390,7 +398,7 @@ def test_rapid_review_default_queue_excludes_fully_confirmed_bursts(live_server,
     }
     _mock_pipeline_rapid_review(page, results=results)
 
-    page.goto(f"{live_server['url']}/pipeline/rapid-review")
+    _goto_rapid_review(live_server, page)
 
     expect(page.locator("#queueFilter")).to_have_value("needs-species")
     expect(page.locator("#queueCount")).to_contain_text("Needs species: 1 of 2 bursts")
@@ -421,7 +429,7 @@ def test_rapid_review_deep_link_opens_filtered_out_burst_via_all(live_server, pa
     }
     _mock_pipeline_rapid_review(page, results=results)
 
-    page.goto(f"{live_server['url']}/pipeline/rapid-review?enc=0&burst=0")
+    _goto_rapid_review(live_server, page, "/pipeline/rapid-review?enc=0&burst=0")
 
     expect(page.locator("#queueFilter")).to_have_value("all")
     expect(page.locator("#burstTitle")).to_have_text("Encounter 1, Burst 1")
@@ -447,7 +455,7 @@ def test_rapid_review_needs_species_includes_mixed_burst(live_server, page):
     }
     _mock_pipeline_rapid_review(page, results=results)
 
-    page.goto(f"{live_server['url']}/pipeline/rapid-review")
+    _goto_rapid_review(live_server, page)
 
     expect(page.locator("#queueCount")).to_contain_text("Needs species: 1 of 1 bursts")
     expect(page.locator(".reason-chip", has_text="No species")).to_be_visible()
@@ -473,7 +481,7 @@ def test_rapid_review_needs_species_ignores_rejected_untagged_photos(live_server
     }
     _mock_pipeline_rapid_review(page, results=results)
 
-    page.goto(f"{live_server['url']}/pipeline/rapid-review")
+    _goto_rapid_review(live_server, page)
 
     expect(page.locator("#queueCount")).to_contain_text("Needs species: 0 of 1 bursts")
     expect(page.locator("#burstSubtitle")).to_have_text("0 matching bursts")
@@ -503,7 +511,7 @@ def test_rapid_review_apply_next_skips_bursts_outside_active_queue(live_server, 
     }
     _mock_pipeline_rapid_review(page, results=results)
 
-    page.goto(f"{live_server['url']}/pipeline/rapid-review")
+    _goto_rapid_review(live_server, page)
     expect(page.locator("#filename")).to_have_text("first.jpg")
     page.locator("#speciesInput").fill("Test bird")
     page.keyboard.press("p")
@@ -539,7 +547,7 @@ def test_rapid_review_rebases_active_session_after_apply_rebuild(live_server, pa
         apply_photos={"1": {"flag": "flagged", "has_species_keyword": True}},
     )
 
-    page.goto(f"{live_server['url']}/pipeline/rapid-review")
+    _goto_rapid_review(live_server, page)
     expect(page.locator("#applyBtn")).to_be_enabled()
     expect(page.locator("#filename")).to_have_text("first.jpg")
     page.locator("#speciesInput").fill("Test bird")
@@ -578,7 +586,7 @@ def test_rapid_review_filter_change_prompts_with_staged_decisions(live_server, p
     }
     _mock_pipeline_rapid_review(page, results=results, save_payloads=save_payloads)
 
-    page.goto(f"{live_server['url']}/pipeline/rapid-review")
+    _goto_rapid_review(live_server, page)
     expect(page.locator("#applyBtn")).to_be_enabled()
     page.keyboard.press("x")
     page.locator("#queueFilter").select_option("all")
@@ -615,7 +623,7 @@ def test_rapid_review_click_main_image_opens_original_at_one_to_one(live_server,
         original_content_type="image/svg+xml",
     )
 
-    page.goto(f"{live_server['url']}/pipeline/rapid-review")
+    _goto_rapid_review(live_server, page)
     img = page.locator("#currentPhoto")
     stage = page.locator("#photoStage")
 
@@ -1010,7 +1018,7 @@ def test_rapid_review_apply_tags_all_burst_frames_via_encounters_species(live_se
         species_payloads=species_payloads,
     )
 
-    page.goto(f"{live_server['url']}/pipeline/rapid-review")
+    _goto_rapid_review(live_server, page)
     expect(page.locator("#applyBtn")).to_be_enabled()
     # Pick only the first frame; the other two stay unsorted.
     page.keyboard.press("p")
@@ -1077,7 +1085,7 @@ def test_rapid_review_cull_only_on_confirmed_burst_skips_species_post(live_serve
     )
 
     # Deep-link forces the "all" queue so a fully-confirmed burst is reviewable.
-    page.goto(f"{live_server['url']}/pipeline/rapid-review?enc=0&burst=0")
+    _goto_rapid_review(live_server, page, "/pipeline/rapid-review?enc=0&burst=0")
     expect(page.locator("#applyBtn")).to_be_enabled()
     expect(page.locator("#filename")).to_have_text("a.jpg")
     # Species field already reflects the confirmed species; do NOT change it.
@@ -1155,7 +1163,7 @@ def test_rapid_review_confirmed_burst_with_untagged_frame_posts_species(live_ser
     )
 
     # Deep-link the "all" queue so a confirmed burst is reviewable.
-    page.goto(f"{live_server['url']}/pipeline/rapid-review?enc=0&burst=0")
+    _goto_rapid_review(live_server, page, "/pipeline/rapid-review?enc=0&burst=0")
     expect(page.locator("#applyBtn")).to_be_enabled()
     # Species field already reflects the confirmed species; leave it unchanged.
     expect(page.locator("#speciesInput")).to_have_value("Test bird")
@@ -1198,7 +1206,7 @@ def test_rapid_review_first_confirmation_and_replacement_post_species(live_serve
     }
     _mock_pipeline_rapid_review(page, results=results, species_payloads=species_payloads)
 
-    page.goto(f"{live_server['url']}/pipeline/rapid-review")
+    _goto_rapid_review(live_server, page)
     expect(page.locator("#applyBtn")).to_be_enabled()
     # "Test bird" is an unconfirmed prediction (no species_confirmed), so the
     # field pre-fills with it and applying is a first-time confirmation → posts.
@@ -1245,7 +1253,7 @@ def test_rapid_review_species_replacement_on_confirmed_burst_posts(live_server, 
         species_payloads=species_payloads,
     )
 
-    page.goto(f"{live_server['url']}/pipeline/rapid-review?enc=0&burst=0")
+    _goto_rapid_review(live_server, page, "/pipeline/rapid-review?enc=0&burst=0")
     expect(page.locator("#applyBtn")).to_be_enabled()
     expect(page.locator("#speciesInput")).to_have_value("Test bird")
     page.locator("#speciesInput").fill("Different bird")
@@ -1312,7 +1320,7 @@ def test_rapid_review_adopts_detach_restructure_without_clobbering_cache(live_se
         species_response=restructured,
     )
 
-    page.goto(f"{live_server['url']}/pipeline/rapid-review?enc=0&burst=0")
+    _goto_rapid_review(live_server, page, "/pipeline/rapid-review?enc=0&burst=0")
     expect(page.locator("#applyBtn")).to_be_enabled()
     expect(page.locator("#filename")).to_have_text("a.jpg")
     # Confirm a species that diverges from the encounter's, triggering detach.

--- a/tests/e2e/test_pipeline_rapid_review.py
+++ b/tests/e2e/test_pipeline_rapid_review.py
@@ -627,6 +627,12 @@ def test_rapid_review_click_main_image_opens_original_at_one_to_one(live_server,
     img = page.locator("#currentPhoto")
     stage = page.locator("#photoStage")
 
+    # currentPhoto() returns null until the mocked results + state responses
+    # hydrate the session, so an immediate stage.click() can fall through
+    # toggleRapidZoom() and leave .zoomed unset. Wait for the preview src to
+    # land — same hydration signal used later in this test — before clicking.
+    expect(img).to_have_attribute("src", re.compile(r"/photos/1/preview\?size=2560$"))
+
     stage.click(position={"x": 12, "y": 12})
 
     expect(stage).to_have_class(re.compile(r"\bzoomed\b"))


### PR DESCRIPTION
## Summary
- Add a Rapid Review E2E navigation helper that waits for DOMContentLoaded instead of the full browser load event.
- Route Rapid Review tests through the helper so mocked API hydration and existing assertions provide the synchronization.

## Validation
- pytest tests/e2e/test_pipeline_rapid_review.py --browser chromium -q
- pytest tests/e2e/test_pipeline_rapid_review.py::test_rapid_review_apply_button_summarizes_pending_writes --browser chromium -q