### PR TITLE
Extract photo rating and flag review layers

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -87,6 +87,7 @@ from render_source import (
 from schema import ensure_schema
 from web.pages import pages_blueprint
 from web.photo_labels import create_photo_labels_blueprint
+from web.photo_review import create_photo_review_blueprint
 from web.system import system_blueprint
 from web.workspaces import create_workspace_blueprint
 from werkzeug.exceptions import BadRequest
@@ -5162,42 +5163,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
     # -- Edit API routes --
 
-    @app.route("/api/photos/<int:photo_id>/rating", methods=["POST"])
-    def api_set_rating(photo_id):
-        db = _get_db()
-        body = request.get_json(silent=True) or {}
-        rating = body.get("rating", 0)
-        if isinstance(rating, bool) or not isinstance(rating, int) or rating < 0 or rating > 5:
-            return json_error("rating must be an integer 0-5")
-        old = db.get_photo(photo_id)
-        old_rating = old["rating"] if old else 0
-        try:
-            db.update_photo_rating(photo_id, rating)
-        except ValueError as e:
-            return json_error(str(e), 403)
-        db.queue_change(photo_id, "rating", str(rating))
-        db.record_edit('rating', f'Set rating to {rating}', str(rating),
-                       [{'photo_id': photo_id, 'old_value': str(old_rating), 'new_value': str(rating)}])
-        return jsonify({"ok": True})
-
-    @app.route("/api/photos/<int:photo_id>/flag", methods=["POST"])
-    def api_set_flag(photo_id):
-        db = _get_db()
-        body = request.get_json(silent=True) or {}
-        flag = body.get("flag", "none")
-        if flag not in ("none", "flagged", "rejected"):
-            return json_error("flag must be 'none', 'flagged', or 'rejected'")
-        old = db.get_photo(photo_id)
-        old_flag = old["flag"] if old else "none"
-        try:
-            db.update_photo_flag(photo_id, flag)
-        except ValueError as e:
-            return json_error(str(e), 403)
-        db.queue_flag_change_if_enabled(photo_id, flag)
-        db.record_edit('flag', f'Set flag to {flag}', flag,
-                       [{'photo_id': photo_id, 'old_value': old_flag, 'new_value': flag}])
-        return jsonify({"ok": True})
-
     @app.route("/api/photos/<int:photo_id>/wildlife_excluded", methods=["POST"])
     def api_set_wildlife_excluded(photo_id):
         db = _get_db()
@@ -6762,55 +6727,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         })
 
     # -- Batch operations --
-
-    @app.route("/api/batch/rating", methods=["POST"])
-    def api_batch_rating():
-        db = _get_db()
-        body = request.get_json(silent=True) or {}
-        photo_ids = body.get("photo_ids", [])
-        rating = body.get("rating", 0)
-        if isinstance(rating, bool) or not isinstance(rating, int) or rating < 0 or rating > 5:
-            return json_error("rating must be an integer 0-5")
-        if not photo_ids:
-            return json_error("photo_ids required")
-        photos_map = db.get_photos_by_ids(photo_ids)
-        old_values = {pid: photos_map[pid]["rating"] for pid in photo_ids if pid in photos_map}
-        valid_ids = list(old_values.keys())
-        try:
-            db.batch_update_photo_rating(valid_ids, rating)
-        except ValueError as e:
-            return json_error(str(e), 403)
-        for pid in valid_ids:
-            db.queue_change(pid, "rating", str(rating))
-        items = [{'photo_id': pid, 'old_value': str(old_values[pid]), 'new_value': str(rating)} for pid in old_values]
-        db.record_edit('rating', f'Set rating to {rating} on {len(photo_ids)} photos',
-                       str(rating), items, is_batch=True)
-        return jsonify({"ok": True, "updated": len(old_values)})
-
-    @app.route("/api/batch/flag", methods=["POST"])
-    def api_batch_flag():
-        db = _get_db()
-        body = request.get_json(silent=True) or {}
-        photo_ids = body.get("photo_ids", [])
-        flag = body.get("flag", "none")
-        if flag not in ("none", "flagged", "rejected"):
-            return json_error("flag must be 'none', 'flagged', or 'rejected'")
-        if not photo_ids:
-            return json_error("photo_ids required")
-        photos_map = db.get_photos_by_ids(photo_ids)
-        old_values = {pid: photos_map[pid]["flag"] for pid in photo_ids if pid in photos_map}
-        valid_ids = list(old_values.keys())
-        try:
-            db.batch_update_photo_flag(valid_ids, flag)
-        except ValueError as e:
-            return json_error(str(e), 403)
-        for pid in valid_ids:
-            db.queue_flag_change_if_enabled(pid, flag, _commit=False)
-        db.conn.commit()
-        items = [{'photo_id': pid, 'old_value': old_values[pid], 'new_value': flag} for pid in old_values]
-        db.record_edit('flag', f'Set flag to {flag} on {len(photo_ids)} photos',
-                       flag, items, is_batch=True)
-        return jsonify({"ok": True, "updated": len(old_values)})
 
     @app.route("/api/batch/best-batch-flags", methods=["POST"])
     def api_batch_best_batch_flags():
@@ -23095,6 +23011,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         return send_file(cache_path, mimetype="image/jpeg")
 
     app.register_blueprint(create_photo_labels_blueprint(_get_db, json_error))
+    app.register_blueprint(create_photo_review_blueprint(_get_db, json_error))
 
     # --- /api/v1/* aliases over the stable subset of /api/* ---
     # These are the endpoints advertised to external callers in docs/headless-api.md.

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -6989,12 +6989,9 @@ class Database:
                 lists, or from undo/redo where the edit history is already
                 workspace-scoped.
         """
-        if verify_workspace:
-            self._verify_photo_in_workspace(photo_id)
-        self.conn.execute(
-            "UPDATE photos SET rating = ? WHERE id = ?", (rating, photo_id)
+        self._photo_review_repository().set_rating(
+            photo_id, rating, verify_workspace=verify_workspace
         )
-        self.conn.commit()
 
     def batch_update_photo_rating(self, photo_ids, rating, verify_workspace=True):
         """Set rating for multiple photos in a single transaction.
@@ -7003,28 +7000,9 @@ class Database:
             verify_workspace: when True, raises ValueError if any photo is
                 not in the active workspace.
         """
-        if not photo_ids:
-            return
-        if verify_workspace:
-            for pid in photo_ids:
-                self._verify_photo_in_workspace(pid)
-        # Chunked: a select-all on a large library exceeds SQLite's
-        # bound-parameter cap (999 on legacy builds) in one IN clause.
-        # Rolled back on error: sqlite3 leaves earlier DML pending in
-        # the open transaction after an exception, so a subsequent
-        # unrelated commit() on this connection would persist a
-        # half-applied batch.
-        try:
-            for chunk in _chunks(photo_ids):
-                placeholders = ",".join("?" for _ in chunk)
-                self.conn.execute(
-                    f"UPDATE photos SET rating = ? WHERE id IN ({placeholders})",
-                    [rating] + list(chunk),
-                )
-            self.conn.commit()
-        except Exception:
-            self.conn.rollback()
-            raise
+        self._photo_review_repository().set_ratings(
+            photo_ids, rating, verify_workspace=verify_workspace
+        )
 
     def update_photo_flag(self, photo_id, flag, verify_workspace=True):
         """Set photo flag ('none', 'flagged', 'rejected').
@@ -7033,10 +7011,9 @@ class Database:
             verify_workspace: when True (the default), raises ValueError if
                 the photo is not in the active workspace's folders.
         """
-        if verify_workspace:
-            self._verify_photo_in_workspace(photo_id)
-        self.conn.execute("UPDATE photos SET flag = ? WHERE id = ?", (flag, photo_id))
-        self.conn.commit()
+        self._photo_review_repository().set_flag(
+            photo_id, flag, verify_workspace=verify_workspace
+        )
 
     def update_photo_wildlife_excluded(self, photo_id, excluded, verify_workspace=True):
         """Set whether a photo is excluded from wildlife detection/classification."""
@@ -7055,23 +7032,18 @@ class Database:
             verify_workspace: when True, raises ValueError if any photo is
                 not in the active workspace.
         """
-        if not photo_ids:
-            return
-        if verify_workspace:
-            for pid in photo_ids:
-                self._verify_photo_in_workspace(pid)
-        # Chunked + rolled back on error: see batch_update_photo_rating.
-        try:
-            for chunk in _chunks(photo_ids):
-                placeholders = ",".join("?" for _ in chunk)
-                self.conn.execute(
-                    f"UPDATE photos SET flag = ? WHERE id IN ({placeholders})",
-                    [flag] + list(chunk),
-                )
-            self.conn.commit()
-        except Exception:
-            self.conn.rollback()
-            raise
+        self._photo_review_repository().set_flags(
+            photo_ids, flag, verify_workspace=verify_workspace
+        )
+
+    def _photo_review_repository(self):
+        from repositories.photo_review import PhotoReviewRepository
+
+        return PhotoReviewRepository(
+            self.conn,
+            self._active_workspace_id,
+            chunk_size=_SQLITE_PARAM_CHUNK_SIZE,
+        )
 
     from repositories.photo_labels import VALID_COLOR_LABELS
 

--- a/vireo/repositories/photo_review.py
+++ b/vireo/repositories/photo_review.py
@@ -1,0 +1,79 @@
+"""Persistence for workspace-scoped photo ratings and flags."""
+
+
+class PhotoReviewRepository:
+    def __init__(self, conn, workspace_id, *, chunk_size=800):
+        self.conn = conn
+        self.workspace_id = workspace_id
+        self.chunk_size = chunk_size
+
+    def set_rating(self, photo_id, rating, *, verify_workspace=True):
+        if verify_workspace:
+            self._verify_photo(photo_id)
+        self.conn.execute(
+            "UPDATE photos SET rating = ? WHERE id = ?", (rating, photo_id)
+        )
+        self.conn.commit()
+
+    def set_ratings(self, photo_ids, rating, *, verify_workspace=True):
+        self._set_many(
+            photo_ids,
+            "rating",
+            rating,
+            verify_workspace=verify_workspace,
+        )
+
+    def set_flag(self, photo_id, flag, *, verify_workspace=True):
+        if verify_workspace:
+            self._verify_photo(photo_id)
+        self.conn.execute(
+            "UPDATE photos SET flag = ? WHERE id = ?", (flag, photo_id)
+        )
+        self.conn.commit()
+
+    def set_flags(self, photo_ids, flag, *, verify_workspace=True):
+        self._set_many(
+            photo_ids,
+            "flag",
+            flag,
+            verify_workspace=verify_workspace,
+        )
+
+    def _set_many(self, photo_ids, column, value, *, verify_workspace):
+        if not photo_ids:
+            return
+        if verify_workspace:
+            for photo_id in photo_ids:
+                self._verify_photo(photo_id)
+        try:
+            for chunk in self._chunks(photo_ids):
+                placeholders = ",".join("?" for _ in chunk)
+                self.conn.execute(
+                    f"UPDATE photos SET {column} = ? WHERE id IN ({placeholders})",
+                    [value, *chunk],
+                )
+            self.conn.commit()
+        except Exception:
+            self.conn.rollback()
+            raise
+
+    def _verify_photo(self, photo_id):
+        if self.workspace_id is None:
+            raise RuntimeError("No active workspace set")
+        row = self.conn.execute(
+            "SELECT 1 FROM photos p "
+            "JOIN workspace_folders wf ON wf.folder_id = p.folder_id "
+            "WHERE p.id = ? AND wf.workspace_id = ?",
+            (photo_id, self.workspace_id),
+        ).fetchone()
+        if row is None:
+            raise ValueError(
+                f"Photo {photo_id} does not belong to the active workspace"
+            )
+
+    def _chunks(self, values):
+        values = list(values)
+        return (
+            values[index:index + self.chunk_size]
+            for index in range(0, len(values), self.chunk_size)
+        )

--- a/vireo/services/photo_review.py
+++ b/vireo/services/photo_review.py
@@ -1,0 +1,98 @@
+"""Photo rating and flag workflow coordination."""
+
+
+class PhotoReviewService:
+    def __init__(self, db):
+        self.db = db
+
+    def set_rating(self, photo_id, rating):
+        old = self.db.get_photo(photo_id)
+        old_rating = old["rating"] if old else 0
+        self.db.update_photo_rating(photo_id, rating)
+        self.db.queue_change(photo_id, "rating", str(rating))
+        self.db.record_edit(
+            "rating",
+            f"Set rating to {rating}",
+            str(rating),
+            [{
+                "photo_id": photo_id,
+                "old_value": str(old_rating),
+                "new_value": str(rating),
+            }],
+        )
+
+    def set_flag(self, photo_id, flag):
+        old = self.db.get_photo(photo_id)
+        old_flag = old["flag"] if old else "none"
+        self.db.update_photo_flag(photo_id, flag)
+        self.db.queue_flag_change_if_enabled(photo_id, flag)
+        self.db.record_edit(
+            "flag",
+            f"Set flag to {flag}",
+            flag,
+            [{
+                "photo_id": photo_id,
+                "old_value": old_flag,
+                "new_value": flag,
+            }],
+        )
+
+    def set_ratings(self, photo_ids, rating):
+        photos_map = self.db.get_photos_by_ids(photo_ids)
+        old_values = {
+            photo_id: photos_map[photo_id]["rating"]
+            for photo_id in photo_ids
+            if photo_id in photos_map
+        }
+        valid_ids = list(old_values)
+        self.db.batch_update_photo_rating(valid_ids, rating)
+        for photo_id in valid_ids:
+            self.db.queue_change(photo_id, "rating", str(rating))
+        items = [
+            {
+                "photo_id": photo_id,
+                "old_value": str(old_values[photo_id]),
+                "new_value": str(rating),
+            }
+            for photo_id in old_values
+        ]
+        self.db.record_edit(
+            "rating",
+            f"Set rating to {rating} on {len(photo_ids)} photos",
+            str(rating),
+            items,
+            is_batch=True,
+        )
+        return len(old_values)
+
+    def set_flags(self, photo_ids, flag):
+        photos_map = self.db.get_photos_by_ids(photo_ids)
+        old_values = {
+            photo_id: photos_map[photo_id]["flag"]
+            for photo_id in photo_ids
+            if photo_id in photos_map
+        }
+        valid_ids = list(old_values)
+        self.db.batch_update_photo_flag(valid_ids, flag)
+        for index, photo_id in enumerate(valid_ids):
+            self.db.queue_flag_change_if_enabled(
+                photo_id,
+                flag,
+                _commit=index == len(valid_ids) - 1,
+            )
+        items = [
+            {
+                "photo_id": photo_id,
+                "old_value": old_values[photo_id],
+                "new_value": flag,
+            }
+            for photo_id in old_values
+        ]
+        self.db.record_edit(
+            "flag",
+            f"Set flag to {flag} on {len(photo_ids)} photos",
+            flag,
+            items,
+            is_batch=True,
+        )
+        return len(old_values)

--- a/vireo/tests/test_edits_api.py
+++ b/vireo/tests/test_edits_api.py
@@ -79,6 +79,85 @@ def test_color_label_routes_are_owned_by_domain_blueprint(app_and_db):
     }
 
 
+def test_photo_review_routes_are_owned_by_domain_blueprint(app_and_db):
+    """Rating and flag routes stay outside the legacy app module."""
+    app, _ = app_and_db
+    review_routes = {
+        "/api/photos/<int:photo_id>/rating",
+        "/api/photos/<int:photo_id>/flag",
+        "/api/batch/rating",
+        "/api/batch/flag",
+    }
+    endpoints = {
+        rule.rule: rule.endpoint
+        for rule in app.url_map.iter_rules()
+        if rule.rule in review_routes
+    }
+
+    assert endpoints == {
+        "/api/photos/<int:photo_id>/rating": "photo_review.set_rating",
+        "/api/photos/<int:photo_id>/flag": "photo_review.set_flag",
+        "/api/batch/rating": "photo_review.set_ratings",
+        "/api/batch/flag": "photo_review.set_flags",
+    }
+
+
+def test_photo_review_routes_preserve_workspace_isolation(app_and_db):
+    """Individual and batch review edits reject hidden photos atomically."""
+    app, db = app_and_db
+    visible_id = db.get_photos()[0]["id"]
+    active_workspace_id = db._active_workspace_id
+    other_workspace_id = db.create_workspace("Other review workspace")
+    db.set_active_workspace(other_workspace_id)
+    folder_id = db.add_folder("/photos/other-review", name="other-review")
+    hidden_id = db.add_photo(
+        folder_id=folder_id,
+        filename="hidden-review.jpg",
+        extension=".jpg",
+        file_size=10,
+        file_mtime=1.0,
+    )
+    db.set_active_workspace(active_workspace_id)
+    client = app.test_client()
+
+    for field, value in (("rating", 4), ("flag", "flagged")):
+        individual = client.post(
+            f"/api/photos/{hidden_id}/{field}", json={field: value}
+        )
+        assert individual.status_code == 403
+
+        batch = client.post(
+            f"/api/batch/{field}",
+            json={"photo_ids": [visible_id, hidden_id], field: value},
+        )
+        assert batch.status_code == 403
+
+    assert db.get_photo(visible_id)["rating"] == 3
+    assert db.get_photo(visible_id)["flag"] == "none"
+    assert db.get_photo(hidden_id)["rating"] == 0
+    assert db.get_photo(hidden_id)["flag"] == "none"
+
+
+def test_photo_review_batches_skip_stale_ids_and_keep_requested_history_count(
+    app_and_db,
+):
+    """Batch review edits retain their stale-ID and audit-description contract."""
+    app, db = app_and_db
+    photo_id = db.get_photos()[0]["id"]
+    client = app.test_client()
+
+    response = client.post(
+        "/api/batch/rating",
+        json={"photo_ids": [photo_id, 999999], "rating": 2},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {"ok": True, "updated": 1}
+    assert db.get_photo(photo_id)["rating"] == 2
+    history = db.get_edit_history()
+    assert history[0]["description"] == "Set rating to 2 on 2 photos"
+
+
 def test_set_rating(app_and_db):
     """POST /api/photos/<id>/rating updates rating and queues pending change."""
     app, db = app_and_db

--- a/vireo/web/photo_review.py
+++ b/vireo/web/photo_review.py
@@ -1,0 +1,76 @@
+"""Workspace-scoped photo rating and flag endpoints."""
+
+from flask import Blueprint, jsonify, request
+from services.photo_review import PhotoReviewService
+
+VALID_FLAGS = ("none", "flagged", "rejected")
+
+
+def create_photo_review_blueprint(get_db, json_error):
+    blueprint = Blueprint("photo_review", __name__)
+
+    @blueprint.post("/api/photos/<int:photo_id>/rating")
+    def set_rating(photo_id):
+        body = request.get_json(silent=True) or {}
+        rating = body.get("rating", 0)
+        if (
+            isinstance(rating, bool)
+            or not isinstance(rating, int)
+            or rating < 0
+            or rating > 5
+        ):
+            return json_error("rating must be an integer 0-5")
+        try:
+            PhotoReviewService(get_db()).set_rating(photo_id, rating)
+        except ValueError as exc:
+            return json_error(str(exc), 403)
+        return jsonify({"ok": True})
+
+    @blueprint.post("/api/photos/<int:photo_id>/flag")
+    def set_flag(photo_id):
+        body = request.get_json(silent=True) or {}
+        flag = body.get("flag", "none")
+        if flag not in VALID_FLAGS:
+            return json_error("flag must be 'none', 'flagged', or 'rejected'")
+        try:
+            PhotoReviewService(get_db()).set_flag(photo_id, flag)
+        except ValueError as exc:
+            return json_error(str(exc), 403)
+        return jsonify({"ok": True})
+
+    @blueprint.post("/api/batch/rating")
+    def set_ratings():
+        body = request.get_json(silent=True) or {}
+        photo_ids = body.get("photo_ids", [])
+        rating = body.get("rating", 0)
+        if (
+            isinstance(rating, bool)
+            or not isinstance(rating, int)
+            or rating < 0
+            or rating > 5
+        ):
+            return json_error("rating must be an integer 0-5")
+        if not photo_ids:
+            return json_error("photo_ids required")
+        try:
+            updated = PhotoReviewService(get_db()).set_ratings(photo_ids, rating)
+        except ValueError as exc:
+            return json_error(str(exc), 403)
+        return jsonify({"ok": True, "updated": updated})
+
+    @blueprint.post("/api/batch/flag")
+    def set_flags():
+        body = request.get_json(silent=True) or {}
+        photo_ids = body.get("photo_ids", [])
+        flag = body.get("flag", "none")
+        if flag not in VALID_FLAGS:
+            return json_error("flag must be 'none', 'flagged', or 'rejected'")
+        if not photo_ids:
+            return json_error("photo_ids required")
+        try:
+            updated = PhotoReviewService(get_db()).set_flags(photo_ids, flag)
+        except ValueError as exc:
+            return json_error(str(exc), 403)
+        return jsonify({"ok": True, "updated": updated})
+
+    return blueprint


### PR DESCRIPTION
## Summary

Extracts individual and batch photo rating and flag routes into a dedicated blueprint, service, and repository while retaining `Database` as a compatibility façade.
Preserves URLs, validation, response shapes, status codes, workspace isolation, XMP queue behavior, edit history, and the existing route-contract snapshot.
Adds focused regression coverage for blueprint ownership, atomic workspace rejection, stale batch IDs, and audit descriptions.

## Validation

`pytest -q` (4,501 passed, 78 skipped); `ruff check vireo/ tests/`; route-contract test; seven critical Playwright journeys; and `python scripts/benchmark_library.py --photos 100000 --enforce`.