### PR TITLE
Fix multiselect keyword fill suggestions

### DIFF
--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -4739,7 +4739,7 @@ async function loadSelectionKeywordSuggestions(ids) {
       body: JSON.stringify({photo_ids: ids}),
     }, { toast: false });
     if (seq !== selectionKeywordRequestSeq) return;
-    renderSelectionKeywordSuggestions(data.keywords || data.suggestions || [], data.selected_count || ids.length);
+    renderSelectionKeywordSuggestions(data.suggestions || [], data.selected_count || ids.length);
   } catch(e) {
     if (seq === selectionKeywordRequestSeq && list) {
       list.innerHTML = '<div class="selection-empty">Could not load keyword suggestions.</div>';


### PR DESCRIPTION
Fixes the Browse multi-select keyword fill panel so it renders only partial keyword suggestions from the API instead of every keyword on selected photos.

This prevents a filled keyword from remaining visible after it has been added to the missing photos; the richer keywords payload remains available to API callers.

Validation:
- pytest 'tests/e2e/test_browse_single_select.py::test_multiselect_offers_partial_keyword_fill[chromium]' -q\n- pytest vireo/tests/test_app.py::test_selection_keyword_suggestions_return_partial_keywords vireo/tests/test_app.py::test_selection_keyword_suggestions_chunks_large_selection vireo/tests/test_app.py::test_batch_keyword_route_accepts_existing_keyword_id -q