### PR TITLE
Add Windows 11 public beta support

### DIFF
--- a/.github/ISSUE_TEMPLATE/windows-public-beta.yml
+++ b/.github/ISSUE_TEMPLATE/windows-public-beta.yml
@@ -1,0 +1,48 @@
+name: Windows public beta problem
+description: Report a Vireo installation, update, storage, integration, or workflow problem on Windows 11.
+title: "Windows: "
+labels:
+  - windows
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please use Help → Report an Issue when Vireo can open; its diagnostic bundle redacts catalog paths and credentials.
+  - type: input
+    id: version
+    attributes:
+      label: Vireo version
+      placeholder: 0.19.0
+    validations:
+      required: true
+  - type: input
+    id: windows-build
+    attributes:
+      label: Windows edition and build
+      placeholder: Windows 11 24H2, build 26100
+    validations:
+      required: true
+  - type: dropdown
+    id: storage
+    attributes:
+      label: Photo storage involved
+      options:
+        - Local NTFS drive
+        - Removable drive or memory card
+        - Mapped network drive
+        - Universal Naming Convention (UNC) network path
+        - No photo storage involved
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: Include the action, expected result, actual result, and whether originals remained intact.
+    validations:
+      required: true
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostic details
+      description: Attach the downloaded diagnostic JSON or paste relevant log lines after checking them for information you do not want to share.

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -537,10 +537,10 @@ jobs:
         if: runner.os == 'Windows' && (startsWith(github.ref, 'refs/tags/v') || inputs.tag_name != '' || inputs.sign_windows_candidate)
         shell: pwsh
         env:
-          TAURI_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: |
-          if (-not $env:TAURI_PRIVATE_KEY) { throw "TAURI_SIGNING_PRIVATE_KEY is required" }
+          if (-not $env:TAURI_SIGNING_PRIVATE_KEY) { throw "TAURI_SIGNING_PRIVATE_KEY is required" }
           Get-ChildItem signed-windows -Recurse -File |
             Where-Object { $_.Extension -in '.exe', '.msi' } |
             ForEach-Object {
@@ -640,6 +640,11 @@ jobs:
       - name: Collect release files
         run: |
           mkdir -p release-files
+          # Drop the signing-input artifact so it can't be scooped into the
+          # release. Its installers share filenames with the SignPath-signed
+          # outputs and would otherwise overwrite them (or leave signed .sig
+          # sidecars paired with unsigned installer bytes).
+          rm -rf artifacts/vireo-windows-installers-unsigned
           # Regular installers (unique names across platforms)
           find artifacts -type f \( \
             -name "*.dmg" -o \

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -640,11 +640,14 @@ jobs:
       - name: Collect release files
         run: |
           mkdir -p release-files
-          # Drop the signing-input artifact so it can't be scooped into the
-          # release. Its installers share filenames with the SignPath-signed
-          # outputs and would otherwise overwrite them (or leave signed .sig
-          # sidecars paired with unsigned installer bytes).
+          # Drop every unsigned Windows signing-input artifact so it can't be
+          # scooped into the release. The unsigned installers share filenames
+          # with the SignPath-signed outputs and would otherwise overwrite them
+          # (or leave signed .sig sidecars paired with unsigned installer
+          # bytes); the unsigned raw binaries (vireo.exe, vireo-server-*.exe)
+          # would ship alongside the signed installers.
           rm -rf artifacts/vireo-windows-installers-unsigned
+          rm -rf artifacts/vireo-windows-binaries-unsigned
           # Regular installers (unique names across platforms)
           find artifacts -type f \( \
             -name "*.dmg" -o \

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -10,6 +10,11 @@ on:
         description: "Release tag (e.g. v0.1.0). Leave blank for artifact-only build."
         required: false
         type: string
+      sign_windows_candidate:
+        description: "Sign and verify Windows artifacts without publishing a release."
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -357,17 +362,13 @@ jobs:
           npx tauri build --target ${{ matrix.rust-target }} --bundles deb,appimage 2>&1
           echo "=== Tauri build finished at $(date -u) ==="
 
-      # Windows: no signing needed, use tauri-action.
-      # continue-on-error because Tauri can exit non-zero AFTER producing
-      # valid installers (e.g. cosmetic post-bundle steps fail). We tolerate
-      # that here, then the "Verify Windows installers" step below re-asserts
-      # that real artifacts exist — so a genuinely broken build (no installer
-      # produced) still fails the job loudly instead of silently shipping
-      # nothing through the release step's `if: always()`.
-      - name: Build Tauri app (Windows)
+      # Manual artifact builds remain unsigned unless a signed release candidate
+      # is requested. Tagged releases and signed candidates use the split
+      # build/sign/bundle flow below so the app and sidecar are signed before
+      # they are embedded in either installer.
+      - name: Build Tauri app (Windows internal artifact)
         id: build_windows
-        if: runner.os == 'Windows'
-        continue-on-error: true
+        if: runner.os == 'Windows' && !(startsWith(github.ref, 'refs/tags/v') || inputs.tag_name != '' || inputs.sign_windows_candidate)
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -377,16 +378,92 @@ jobs:
           tauriScript: npx tauri
           args: --target ${{ matrix.rust-target }}
 
-      # Fail loud if the Windows build produced no installer. This step has NO
-      # continue-on-error, so an empty bundle dir fails the job — the only thing
-      # we suppress above is Tauri's non-zero-but-successful exit, not a build
-      # that genuinely produced nothing to ship.
+      - name: Validate SignPath signing configuration
+        if: runner.os == 'Windows' && (startsWith(github.ref, 'refs/tags/v') || inputs.tag_name != '' || inputs.sign_windows_candidate)
+        shell: bash
+        env:
+          SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
+          SIGNPATH_ORGANIZATION_ID: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+          SIGNPATH_PROJECT_SLUG: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+          SIGNPATH_POLICY_SLUG: ${{ vars.SIGNPATH_POLICY_SLUG }}
+          SIGNPATH_ARTIFACT_CONFIGURATION_SLUG: ${{ vars.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG }}
+          WINDOWS_SIGNING_PUBLISHER: ${{ vars.WINDOWS_SIGNING_PUBLISHER }}
+        run: |
+          if [ "${{ inputs.sign_windows_candidate }}" = "true" ] && [ -z "${{ inputs.tag_name }}" ] && [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "::error::Signed Windows release candidates may only be built from the protected main branch"
+            exit 1
+          fi
+          for name in SIGNPATH_API_TOKEN SIGNPATH_ORGANIZATION_ID SIGNPATH_PROJECT_SLUG SIGNPATH_POLICY_SLUG SIGNPATH_ARTIFACT_CONFIGURATION_SLUG WINDOWS_SIGNING_PUBLISHER; do
+            if [ -z "${!name}" ]; then
+              echo "::error::$name is required for a signed Windows release or release candidate"
+              exit 1
+            fi
+          done
+
+      - name: Build Windows application binaries for signing
+        if: runner.os == 'Windows' && (startsWith(github.ref, 'refs/tags/v') || inputs.tag_name != '' || inputs.sign_windows_candidate)
+        shell: bash
+        run: |
+          cd src-tauri
+          npx tauri build --target ${{ matrix.rust-target }} --no-bundle
+
+      - name: Stage unsigned Windows application binaries
+        if: runner.os == 'Windows' && (startsWith(github.ref, 'refs/tags/v') || inputs.tag_name != '' || inputs.sign_windows_candidate)
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force windows-binaries-unsigned | Out-Null
+          Copy-Item "src-tauri/target/${{ matrix.rust-target }}/release/vireo.exe" windows-binaries-unsigned
+          Copy-Item "src-tauri/binaries/vireo-server-${{ matrix.rust-target }}.exe" windows-binaries-unsigned
+
+      - name: Upload Windows application binaries for signing
+        id: upload_windows_binaries
+        if: runner.os == 'Windows' && (startsWith(github.ref, 'refs/tags/v') || inputs.tag_name != '' || inputs.sign_windows_candidate)
+        uses: actions/upload-artifact@v4
+        with:
+          name: vireo-windows-binaries-unsigned
+          path: windows-binaries-unsigned/*
+          retention-days: 1
+
+      - name: Sign Windows application binaries with SignPath
+        if: runner.os == 'Windows' && (startsWith(github.ref, 'refs/tags/v') || inputs.tag_name != '' || inputs.sign_windows_candidate)
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+          signing-policy-slug: ${{ vars.SIGNPATH_POLICY_SLUG }}
+          artifact-configuration-slug: ${{ vars.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG }}
+          github-artifact-id: ${{ steps.upload_windows_binaries.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: windows-binaries-signed
+
+      - name: Install and verify signed Windows application binaries
+        if: runner.os == 'Windows' && (startsWith(github.ref, 'refs/tags/v') || inputs.tag_name != '' || inputs.sign_windows_candidate)
+        shell: pwsh
+        run: |
+          ./scripts/verify_windows_signatures.ps1 -Root windows-binaries-signed -ExpectedPublisher '${{ vars.WINDOWS_SIGNING_PUBLISHER }}'
+          $app = Get-ChildItem windows-binaries-signed -Recurse -Filter "vireo.exe" | Select-Object -First 1 -ExpandProperty FullName
+          $sidecar = Get-ChildItem windows-binaries-signed -Recurse -Filter "vireo-server-${{ matrix.rust-target }}.exe" | Select-Object -First 1 -ExpandProperty FullName
+          if (-not $app -or -not $sidecar) { throw "SignPath output is missing an application binary" }
+          Copy-Item $app "src-tauri/target/${{ matrix.rust-target }}/release/vireo.exe" -Force
+          Copy-Item $sidecar "src-tauri/binaries/vireo-server-${{ matrix.rust-target }}.exe" -Force
+
+      - name: Bundle signed Windows application
+        if: runner.os == 'Windows' && (startsWith(github.ref, 'refs/tags/v') || inputs.tag_name != '' || inputs.sign_windows_candidate)
+        shell: bash
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          cd src-tauri
+          npx tauri bundle --target ${{ matrix.rust-target }} --bundles nsis,msi
+
+      # Fail loudly if the Windows build produced no installer.
       - name: Verify Windows installers
         if: runner.os == 'Windows'
         shell: bash
         env:
           BUNDLE_DIR: src-tauri/target/${{ matrix.rust-target }}/release/bundle
-          BUILD_OUTCOME: ${{ steps.build_windows.outcome }}
         run: |
           echo "Searching for installers under: $BUNDLE_DIR"
 
@@ -409,11 +486,78 @@ jobs:
             echo "  $f ($(du -h "$f" | cut -f1))"
           done
 
-          # If Tauri itself reported failure AND yet we have installers, surface
-          # it as a warning so the cosmetic post-bundle failure stays visible.
-          if [[ "$BUILD_OUTCOME" == "failure" ]]; then
-            echo "::warning::Tauri build step reported failure but valid installers were produced (tolerated post-bundle error). Review the build log above."
-          fi
+      - name: Smoke-test unsigned Windows internal artifact
+        if: runner.os == 'Windows' && !(startsWith(github.ref, 'refs/tags/v') || inputs.tag_name != '' || inputs.sign_windows_candidate)
+        shell: pwsh
+        run: |
+          $installer = Get-ChildItem "src-tauri/target/${{ matrix.rust-target }}/release/bundle" -Recurse -Filter "*-setup.exe" | Select-Object -First 1 -ExpandProperty FullName
+          if (-not $installer) { throw "NSIS setup executable not found" }
+          ./scripts/windows_package_smoke.ps1 -Installer $installer
+
+      - name: Stage unsigned Windows installers
+        if: runner.os == 'Windows' && (startsWith(github.ref, 'refs/tags/v') || inputs.tag_name != '' || inputs.sign_windows_candidate)
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force windows-installers-unsigned | Out-Null
+          Get-ChildItem "src-tauri/target/${{ matrix.rust-target }}/release/bundle" -Recurse -File |
+            Where-Object { $_.Extension -in '.exe', '.msi' } |
+            Copy-Item -Destination windows-installers-unsigned
+
+      - name: Upload unsigned Windows signing input
+        id: upload_windows_installers
+        if: runner.os == 'Windows' && (startsWith(github.ref, 'refs/tags/v') || inputs.tag_name != '' || inputs.sign_windows_candidate)
+        uses: actions/upload-artifact@v4
+        with:
+          name: vireo-windows-installers-unsigned
+          path: windows-installers-unsigned/*
+          retention-days: 1
+
+      - name: Sign Windows installers with SignPath
+        if: runner.os == 'Windows' && (startsWith(github.ref, 'refs/tags/v') || inputs.tag_name != '' || inputs.sign_windows_candidate)
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+          signing-policy-slug: ${{ vars.SIGNPATH_POLICY_SLUG }}
+          artifact-configuration-slug: ${{ vars.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG }}
+          github-artifact-id: ${{ steps.upload_windows_installers.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: signed-windows
+
+      - name: Verify signed Windows artifacts
+        if: runner.os == 'Windows' && (startsWith(github.ref, 'refs/tags/v') || inputs.tag_name != '' || inputs.sign_windows_candidate)
+        shell: pwsh
+        run: |
+          ./scripts/verify_windows_signatures.ps1 -Root signed-windows -ExpectedPublisher '${{ vars.WINDOWS_SIGNING_PUBLISHER }}'
+
+      # Authenticode changes the installer bytes, invalidating the updater
+      # signatures Tauri created before SignPath. Sign the final bytes again.
+      - name: Sign final Windows updater artifacts
+        if: runner.os == 'Windows' && (startsWith(github.ref, 'refs/tags/v') || inputs.tag_name != '' || inputs.sign_windows_candidate)
+        shell: pwsh
+        env:
+          TAURI_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          if (-not $env:TAURI_PRIVATE_KEY) { throw "TAURI_SIGNING_PRIVATE_KEY is required" }
+          Get-ChildItem signed-windows -Recurse -File |
+            Where-Object { $_.Extension -in '.exe', '.msi' } |
+            ForEach-Object {
+              Remove-Item "$($_.FullName).sig" -ErrorAction SilentlyContinue
+              npx tauri signer sign $_.FullName
+              if ($LASTEXITCODE -ne 0 -or -not (Test-Path "$($_.FullName).sig")) {
+                throw "Failed to create updater signature for $($_.Name)"
+              }
+            }
+
+      - name: Smoke-test signed Windows artifact
+        if: runner.os == 'Windows' && (startsWith(github.ref, 'refs/tags/v') || inputs.tag_name != '' || inputs.sign_windows_candidate)
+        shell: pwsh
+        run: |
+          $installer = Get-ChildItem signed-windows -Recurse -Filter "*-setup.exe" | Select-Object -First 1 -ExpandProperty FullName
+          if (-not $installer) { throw "Signed NSIS setup executable not found" }
+          ./scripts/windows_package_smoke.ps1 -Installer $installer -RequireSignature
 
       # ── Dump resource monitor (Linux only) ─────────────────
       - name: Dump resource monitor log
@@ -426,6 +570,7 @@ jobs:
 
       # ── Upload artifacts ──────────────────────────────────
       - name: Upload build artifacts
+        if: runner.os != 'Windows'
         uses: actions/upload-artifact@v4
         with:
           name: vireo-${{ matrix.label }}
@@ -444,12 +589,34 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
+      - name: Upload unsigned Windows CI artifacts
+        if: runner.os == 'Windows' && !(startsWith(github.ref, 'refs/tags/v') || inputs.tag_name != '' || inputs.sign_windows_candidate)
+        uses: actions/upload-artifact@v4
+        with:
+          name: vireo-${{ matrix.label }}
+          path: |
+            src-tauri/target/${{ matrix.rust-target }}/release/bundle/**/*.msi
+            src-tauri/target/${{ matrix.rust-target }}/release/bundle/**/*.exe
+            src-tauri/target/${{ matrix.rust-target }}/release/bundle/**/*.exe.sig
+            src-tauri/target/${{ matrix.rust-target }}/release/bundle/**/*.msi.sig
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload signed Windows artifacts
+        if: runner.os == 'Windows' && (startsWith(github.ref, 'refs/tags/v') || inputs.tag_name != '' || inputs.sign_windows_candidate)
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.sign_windows_candidate && inputs.tag_name == '' && 'vireo-windows-x86_64-signed-candidate' || 'vireo-windows-x86_64' }}
+          path: signed-windows/**/*
+          if-no-files-found: error
+          retention-days: 30
+
   # ── Release job ─────────────────────────────────────────
   release:
     needs: build
     runs-on: ubuntu-latest
-    # Run even if some builds failed — release whatever succeeded
-    if: always() && (startsWith(github.ref, 'refs/tags/v') || github.event.inputs.tag_name != '')
+    # Every platform, including signed Windows artifacts, must succeed.
+    if: needs.build.result == 'success' && (startsWith(github.ref, 'refs/tags/v') || github.event.inputs.tag_name != '')
 
     steps:
       - name: Checkout repository
@@ -503,6 +670,8 @@ jobs:
           done
 
           ls -lh release-files/
+
+          (cd release-files && sha256sum $(find . -maxdepth 1 -type f ! -name 'SHA256SUMS.txt' -printf '%f\n' | sort) > SHA256SUMS.txt)
 
       - name: Generate update manifest
         run: python3 scripts/generate_update_manifest.py "${{ steps.tag.outputs.tag }}" release-files

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -258,7 +258,11 @@ jobs:
         run: ruff check vireo/ tests/
 
   e2e-smoke:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     needs: changes
     timeout-minutes: 20
 
@@ -277,10 +281,15 @@ jobs:
           python-version: "3.14"
 
       - name: Install Vireo and Chromium
+        shell: bash
         if: needs.changes.outputs.python == 'true'
         run: |
           pip install -e ".[dev]"
-          python -m playwright install --with-deps chromium
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            python -m playwright install --with-deps chromium
+          else
+            python -m playwright install chromium
+          fi
 
       - name: Run critical browser journeys
         if: needs.changes.outputs.python == 'true'
@@ -295,7 +304,11 @@ jobs:
           tests/e2e/test_browser_security.py::test_browser_transport_authenticates_internal_mutations
 
   rust:
-    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     needs: changes
     timeout-minutes: 20
 

--- a/.signpath/README.md
+++ b/.signpath/README.md
@@ -1,0 +1,36 @@
+# SignPath release configuration
+
+Windows public-beta tags require the SignPath Foundation open-source project
+to be approved and the SignPath GitHub App to have repository access.
+
+Configure these repository values:
+
+- Secret `SIGNPATH_API_TOKEN`
+- Variable `SIGNPATH_ORGANIZATION_ID`
+- Variable `SIGNPATH_PROJECT_SLUG`
+- Variable `SIGNPATH_POLICY_SLUG`
+- Variable `SIGNPATH_ARTIFACT_CONFIGURATION_SLUG`
+- Variable `WINDOWS_SIGNING_PUBLISHER` containing the expected certificate
+  subject text
+
+The artifact configuration must sign flat portable executable inputs. The
+workflow submits two requests: first `Vireo.exe` and `vireo-server.exe`, then
+the NSIS and MSI installers produced from those signed binaries. It regenerates
+the adjacent Tauri updater `.sig` files after installer signing because
+Authenticode changes installer bytes.
+The signing policy must accept tagged builds and explicitly requested signed
+release-candidate builds from GitHub-hosted runners on protected repository
+branches. Restrict manual workflow dispatch to trusted maintainers in GitHub
+and SignPath. The workflow rejects a signed Windows build when configuration is
+absent, a signature is invalid, the publisher differs, or the timestamp is
+missing.
+
+Unsigned artifacts remain available only from manually dispatched internal
+builds and must not be described as supported beta releases.
+
+To certify a build before publishing, manually run **Build & Release** from the
+protected `main` branch, leave `tag_name` blank, and enable
+`sign_windows_candidate`. This uses the repository version, signs and
+smoke-tests the Windows application and installers, and retains the signed
+candidate artifact for 30 days. It does not create a tag or GitHub release and
+does not update the website.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Vireo are documented in this file.
 
 ## Unreleased
 
+### Added
+- **Windows 11 public beta.** Windows releases now include ExifTool, report
+  optional integration readiness, support long-path-aware packaging, require
+  signed release installers, and run Windows browser, native-shell, installer,
+  updater, and uninstall-preservation gates before publication.
+
 ### Fixed
 - Miss detection now aligns its default no-subject threshold with the default
   detector confidence floor, avoiding "no subject" misses for photos whose

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ For downloads, system requirements, and user documentation, visit [vireo.photo](
 
 AI models are downloaded automatically on first use.
 
+64-bit Windows 11 is available as a public beta with CPU inference support. See
+[the Windows support guide](docs/WINDOWS_SUPPORT.md) for optional integrations,
+storage coverage, and troubleshooting.
+
 ## Developing from source
 
 ### Requirements

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -52,9 +52,17 @@ git tag v0.2.0
 git push origin v0.2.0
 ```
 
-This builds for macOS (ARM64 + x86_64), Windows, and Linux, then creates a draft GitHub Release with all installers attached. Review the draft and publish when ready.
+This builds for macOS ARM64, Windows x64, and Linux x64, then creates a
+public GitHub Release with all installers attached. The release job
+runs only when every platform build succeeds.
 
 To trigger manually without a tag, use the "Run workflow" button on the Actions tab.
+Manual runs without a tag produce unsigned internal Windows artifacts by
+default. Enable `sign_windows_candidate` to sign, verify, smoke-test, and retain
+a candidate for 30 days without creating a public release. Tagged Windows
+releases and signed candidates require the SignPath repository values
+documented in `.signpath/README.md`; missing or invalid Authenticode signatures
+block the build.
 
 ### Signed Mac build (notarized)
 
@@ -81,6 +89,7 @@ This builds the sidecar, signs it, builds the Tauri app, signs the .app bundle, 
 |----------|-----------|----------|
 | macOS | `.dmg` | `src-tauri/target/release/bundle/dmg/` |
 | macOS | `.app` | `src-tauri/target/release/bundle/macos/` |
+| Windows | `.exe` | `src-tauri/target/release/bundle/nsis/` |
 | Windows | `.msi` | `src-tauri/target/release/bundle/msi/` |
 | Linux | `.AppImage` | `src-tauri/target/release/bundle/appimage/` |
 | Linux | `.deb` | `src-tauri/target/release/bundle/deb/` |

--- a/docs/DEV_NOTES.md
+++ b/docs/DEV_NOTES.md
@@ -43,7 +43,7 @@ This script:
 4. Runs E2E tests
 5. **Without `--publish`**: builds the Python sidecar via PyInstaller, builds the Tauri app (`.dmg` on Mac)
 6. Commits the version bump
-7. **With `--publish`**: tags, pushes — CI then builds all platforms and creates a draft GitHub Release (no local build)
+7. **With `--publish`**: tags, pushes — CI then builds all platforms and creates a public GitHub Release (no local build)
 
 ### Manual steps (if you prefer)
 
@@ -62,7 +62,10 @@ git tag v0.3.0
 git push origin v0.3.0
 ```
 
-This produces `.dmg` (macOS ARM + Intel), `.msi` (Windows), `.AppImage` and `.deb` (Linux) as a draft GitHub Release.
+This produces `.dmg` (macOS ARM), signed `.exe` and `.msi` installers
+(Windows x64), and `.AppImage` and `.deb` packages (Linux x64) as a
+public GitHub Release. Windows signing configuration is documented
+in `.signpath/README.md`.
 
 ## Version Management
 

--- a/docs/WINDOWS_SUPPORT.md
+++ b/docs/WINDOWS_SUPPORT.md
@@ -1,0 +1,65 @@
+# Windows 11 Public Beta
+
+Vireo supports 64-bit Windows 11 as a public beta. The Windows build runs the
+same local application and machine-learning models as the macOS and Linux builds.
+CPU inference is the guaranteed configuration; CUDA and DirectML are not part
+of the support commitment yet.
+
+## Included components
+
+- The installer includes the 64-bit ExifTool distribution used for photo
+  dates, GPS, camera data, and metadata repair.
+- The installer checks for and can bootstrap the Microsoft Edge WebView2
+  runtime used by the desktop interface.
+- Vireo enables long-path awareness. Windows must also have **Enable Win32
+  long paths** turned on for deeply nested libraries; Settings reports when
+  that system policy is disabled.
+- Uninstalling Vireo removes the application but preserves `.vireo` under the
+  user's home directory, including the catalog, settings, downloaded models,
+  and logs. XMP files and photos are never application-owned and are not
+  removed.
+
+## Optional integrations
+
+Vireo detects standard Windows installation locations and also accepts an
+explicit executable path under Settings → Paths.
+
+- Darktable and `darktable-cli` are required only for Darktable development.
+- Adobe DNG Converter is required only for Nikon High Efficiency NEF
+  conversion.
+- Lightroom Classic is required only for Lightroom catalog workflows.
+- Remote import, archive, and move require both the Windows OpenSSH Client
+  optional feature and a user-installed GNU rsync. Vireo tests both programs
+  before enabling a transfer and preserves originals after any failed or
+  unverified transfer.
+
+## Supported storage
+
+The beta covers local NTFS libraries, removable exFAT media, and mounted Server
+Message Block (SMB) shares through drive-letter or Universal Naming Convention
+(UNC) paths. Windows symlinks are processed when
+the current account has permission, but enabling Developer Mode is not a
+requirement. A disconnected drive, locked file, read-only destination, or
+failed verification must produce an error and leave the original untouched.
+
+## Reporting a Windows problem
+
+Use Help → Report an Issue and mention that the problem occurred on Windows.
+The diagnostic bundle includes Windows build, architecture, WebView2 version,
+inference provider, dependency readiness, and filesystem type. Tokens,
+configured executable paths, and catalog photo paths are redacted.
+
+## Release certification
+
+Every Windows beta release must pass the automated Windows Python, browser,
+Rust, sidecar, installer, signature, updater, and uninstall-preservation
+checks. Before publishing, certify the release on a clean 64-bit Windows 11
+virtual machine and a physical Windows 11 machine with local and removable or
+network storage.
+
+The manual journey covers fresh install, JPEG and supported RAW imports, model
+download, CPU classification, process/review/cull/browse/edit/export,
+duplicates, map, iNaturalist, Lightroom import, Darktable, DNG conversion,
+local and remote moves, publishing, update from the previous beta, and
+uninstall. Do not publish with a confirmed Windows startup, updater, data-loss,
+or core-workflow blocker.

--- a/scripts/build_sidecar.py
+++ b/scripts/build_sidecar.py
@@ -12,6 +12,7 @@ import platform
 import shutil
 import subprocess
 import sys
+from pathlib import Path
 
 
 def sign_binary(binary_path, entitlements_path=None):
@@ -121,6 +122,18 @@ def main():
         "--hidden-import", "onnxruntime",
         "--hidden-import", "tokenizers",
     ]
+
+    if platform.system() == "Windows":
+        # ExifTool is the metadata backbone, not an optional integration.  A
+        # Windows desktop install cannot assume it exists on PATH, so include
+        # the pinned, checksum-verified official distribution in the one-file
+        # sidecar.  metadata.py resolves it from PyInstaller's _MEIPASS.
+        from fetch_exiftool import fetch
+
+        exiftool_dir = fetch(Path(repo_root) / "build" / "vendor" / "exiftool")
+        pyinstaller_args += [
+            "--add-data", f"{exiftool_dir}{sep}vendor/exiftool",
+        ]
 
     if args.ci:
         # Exclude packages that bloat the binary but aren't needed at runtime

--- a/scripts/fetch_exiftool.py
+++ b/scripts/fetch_exiftool.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Fetch the pinned 64-bit Windows ExifTool distribution for packaging.
+
+The archive is intentionally downloaded only on Windows release builders.  It
+is verified against the checksum published by exiftool.org before extraction;
+an upstream replacement at the same URL therefore fails the build instead of
+silently entering a Vireo installer.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+import tempfile
+import urllib.request
+import zipfile
+from pathlib import Path
+
+VERSION = "13.59"
+SHA256 = "44b512b25af500724ba579d0a53c8fc5851628b692dd5e5d94ae4a15c2cba9ec"
+URL = (
+    "https://sourceforge.net/projects/exiftool/files/"
+    f"exiftool-{VERSION}_64.zip/download"
+)
+
+
+def fetch(destination: Path) -> Path:
+    executable = destination / "exiftool.exe"
+    support_dir = destination / "exiftool_files"
+    if executable.is_file() and support_dir.is_dir():
+        return destination
+
+    with tempfile.TemporaryDirectory(prefix="vireo-exiftool-") as tmp:
+        archive = Path(tmp) / "exiftool.zip"
+        request = urllib.request.Request(URL, headers={"User-Agent": "Vireo build"})
+        with urllib.request.urlopen(request, timeout=120) as response, archive.open("wb") as out:
+            shutil.copyfileobj(response, out)
+
+        digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+        if digest != SHA256:
+            raise RuntimeError(
+                f"ExifTool {VERSION} checksum mismatch: expected {SHA256}, got {digest}"
+            )
+
+        extracted = Path(tmp) / "extracted"
+        with zipfile.ZipFile(archive) as bundle:
+            bundle.extractall(extracted)
+
+        roots = [path for path in extracted.iterdir() if path.is_dir()]
+        if len(roots) != 1:
+            raise RuntimeError("Unexpected ExifTool archive layout")
+        source = roots[0]
+        source_exe = source / "exiftool(-k).exe"
+        source_support = source / "exiftool_files"
+        if not source_exe.is_file() or not source_support.is_dir():
+            raise RuntimeError("ExifTool archive is missing its executable or support directory")
+
+        if destination.exists():
+            shutil.rmtree(destination)
+        destination.mkdir(parents=True)
+        shutil.copy2(source_exe, executable)
+        shutil.copytree(source_support, support_dir)
+        (destination / "VERSION.txt").write_text(
+            f"ExifTool {VERSION}\nSource: {URL}\nSHA-256: {SHA256}\n",
+            encoding="utf-8",
+        )
+
+    return destination
+
+
+if __name__ == "__main__":
+    root = Path(__file__).resolve().parents[1]
+    result = fetch(root / "build" / "vendor" / "exiftool")
+    print(result)

--- a/scripts/verify_windows_signatures.ps1
+++ b/scripts/verify_windows_signatures.ps1
@@ -1,0 +1,23 @@
+param(
+  [Parameter(Mandatory = $true)][string]$Root,
+  [Parameter(Mandatory = $true)][string]$ExpectedPublisher
+)
+
+$ErrorActionPreference = "Stop"
+$artifacts = Get-ChildItem -Path $Root -Recurse -File |
+  Where-Object { $_.Extension -in ".exe", ".msi" }
+if (-not $artifacts) { throw "No Windows executable artifacts found below $Root" }
+
+foreach ($artifact in $artifacts) {
+  $signature = Get-AuthenticodeSignature -FilePath $artifact.FullName
+  if ($signature.Status -ne "Valid") {
+    throw "$($artifact.Name) signature is $($signature.Status)"
+  }
+  if (-not $signature.SignerCertificate.Subject.Contains($ExpectedPublisher)) {
+    throw "$($artifact.Name) publisher '$($signature.SignerCertificate.Subject)' does not contain '$ExpectedPublisher'"
+  }
+  if (-not $signature.TimeStamperCertificate) {
+    throw "$($artifact.Name) has no timestamp certificate"
+  }
+  Write-Host "Verified $($artifact.Name): $($signature.SignerCertificate.Subject)"
+}

--- a/scripts/windows_package_smoke.ps1
+++ b/scripts/windows_package_smoke.ps1
@@ -1,0 +1,145 @@
+param(
+  [Parameter(Mandatory = $true)][string]$Installer,
+  [switch]$RequireSignature
+)
+
+$ErrorActionPreference = "Stop"
+
+function Assert-Signed([string]$Path) {
+  $signature = Get-AuthenticodeSignature -FilePath $Path
+  if ($signature.Status -ne "Valid") {
+    throw "Invalid Authenticode signature for $Path ($($signature.Status))"
+  }
+  if (-not $signature.TimeStamperCertificate) {
+    throw "Missing Authenticode timestamp for $Path"
+  }
+}
+
+function Wait-Vireo([string]$RuntimePath) {
+  for ($i = 0; $i -lt 60; $i++) {
+    Start-Sleep -Seconds 1
+    if (-not (Test-Path $RuntimePath)) { continue }
+    try {
+      $candidate = Get-Content $RuntimePath -Raw | ConvertFrom-Json
+      $health = Invoke-RestMethod `
+        -Uri "http://127.0.0.1:$($candidate.port)/api/v1/health" `
+        -Headers @{ "X-Vireo-Token" = $candidate.token } `
+        -TimeoutSec 2
+      if ($health.service -eq "vireo") { return $candidate }
+    } catch { }
+  }
+  throw "Packaged Vireo backend did not become healthy"
+}
+
+function Stop-Vireo($Runtime, $AppProcess) {
+  try {
+    Invoke-RestMethod -Method Post `
+      -Uri "http://127.0.0.1:$($Runtime.port)/api/v1/shutdown" `
+      -Headers @{ "X-Vireo-Token" = $Runtime.token } `
+      -TimeoutSec 5 | Out-Null
+  } catch {
+    Write-Warning "Graceful backend shutdown failed: $_"
+  }
+  Start-Sleep -Seconds 1
+  if (-not $AppProcess.HasExited) {
+    Stop-Process -Id $AppProcess.Id -Force -ErrorAction SilentlyContinue
+  }
+}
+
+$installerPath = (Resolve-Path $Installer).Path
+if ($RequireSignature) { Assert-Signed $installerPath }
+
+$stateDir = Join-Path $HOME ".vireo"
+$preserveMarker = Join-Path $stateDir "windows-smoke-preserve.txt"
+New-Item -ItemType Directory -Force -Path $stateDir | Out-Null
+Set-Content -Path $preserveMarker -Value "must survive uninstall"
+
+$install = Start-Process -FilePath $installerPath -ArgumentList "/S" -Wait -PassThru
+if ($install.ExitCode -ne 0) { throw "Installer exited $($install.ExitCode)" }
+
+$searchRoots = @(
+  (Join-Path $env:LOCALAPPDATA "Programs\Vireo"),
+  (Join-Path $env:LOCALAPPDATA "Vireo"),
+  (Join-Path $env:ProgramFiles "Vireo")
+)
+$appExe = $null
+foreach ($root in $searchRoots) {
+  if (Test-Path $root) {
+    $appExe = Get-ChildItem -Path $root -Filter "Vireo.exe" -Recurse -File |
+      Select-Object -First 1 -ExpandProperty FullName
+    if ($appExe) { break }
+  }
+}
+if (-not $appExe) { throw "Installed Vireo.exe was not found" }
+if ($RequireSignature) {
+  Assert-Signed $appExe
+  $installedSidecar = Get-ChildItem -Path (Split-Path $appExe -Parent) -Filter "vireo-server.exe" -Recurse -File |
+    Select-Object -First 1 -ExpandProperty FullName
+  if (-not $installedSidecar) { throw "Installed vireo-server.exe was not found" }
+  Assert-Signed $installedSidecar
+}
+
+$app = Start-Process -FilePath $appExe -PassThru
+$runtimePath = Join-Path $stateDir "runtime.json"
+$runtime = Wait-Vireo $runtimePath
+$headers = @{ "X-Vireo-Token" = $runtime.token; "Content-Type" = "application/json" }
+
+# Exercise a real filesystem journey through the packaged sidecar.
+$fixtureDir = Join-Path $env:TEMP "vireo-windows-smoke-library"
+Remove-Item $fixtureDir -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Force -Path $fixtureDir | Out-Null
+Add-Type -AssemblyName System.Drawing
+$bitmap = New-Object System.Drawing.Bitmap 32, 32
+$fixturePhoto = Join-Path $fixtureDir "windows-smoke.jpg"
+$bitmap.Save($fixturePhoto, [System.Drawing.Imaging.ImageFormat]::Jpeg)
+$bitmap.Dispose()
+
+$scan = Invoke-RestMethod -Method Post `
+  -Uri "http://127.0.0.1:$($runtime.port)/api/jobs/scan" `
+  -Headers $headers `
+  -Body (@{ root = $fixtureDir } | ConvertTo-Json) `
+  -TimeoutSec 10
+if (-not $scan.job_id) { throw "Packaged scan did not return a job id" }
+$job = $null
+for ($i = 0; $i -lt 90; $i++) {
+  Start-Sleep -Seconds 1
+  $job = Invoke-RestMethod `
+    -Uri "http://127.0.0.1:$($runtime.port)/api/jobs/$($scan.job_id)" `
+    -Headers $headers `
+    -TimeoutSec 5
+  if ($job.status -in "completed", "failed", "cancelled") { break }
+}
+if ($job.status -ne "completed") { throw "Packaged scan ended with status $($job.status)" }
+$photos = Invoke-RestMethod `
+  -Uri "http://127.0.0.1:$($runtime.port)/api/v1/photos" `
+  -Headers $headers `
+  -TimeoutSec 5
+if (-not ($photos.photos | Where-Object { $_.filename -eq "windows-smoke.jpg" })) {
+  throw "Scanned fixture did not appear in the catalog"
+}
+
+# Restart and prove that the catalog survives the native shell lifecycle.
+Stop-Vireo $runtime $app
+$app = Start-Process -FilePath $appExe -PassThru
+$runtime = Wait-Vireo $runtimePath
+$headers = @{ "X-Vireo-Token" = $runtime.token }
+$photos = Invoke-RestMethod `
+  -Uri "http://127.0.0.1:$($runtime.port)/api/v1/photos" `
+  -Headers $headers `
+  -TimeoutSec 5
+if (-not ($photos.photos | Where-Object { $_.filename -eq "windows-smoke.jpg" })) {
+  throw "Catalog fixture did not survive restart"
+}
+Stop-Vireo $runtime $app
+
+$installRoot = Split-Path $appExe -Parent
+$uninstaller = Get-ChildItem -Path $installRoot -Filter "uninstall*.exe" -File |
+  Select-Object -First 1 -ExpandProperty FullName
+if (-not $uninstaller) { throw "Vireo uninstaller was not found" }
+$uninstall = Start-Process -FilePath $uninstaller -ArgumentList "/S" -Wait -PassThru
+if ($uninstall.ExitCode -ne 0) { throw "Uninstaller exited $($uninstall.ExitCode)" }
+if (-not (Test-Path $preserveMarker)) {
+  throw "Uninstall removed Vireo user data"
+}
+
+Write-Host "Windows packaged-app smoke test passed"

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -10,5 +10,8 @@ fn main() {
     {
         std::env::set_var("TAURI_CONFIG", r#"{"bundle":{"externalBin":[]}}"#);
     }
-    tauri_build::build()
+    let windows = tauri_build::WindowsAttributes::new()
+        .app_manifest(include_str!("windows-app-manifest.xml"));
+    let attributes = tauri_build::Attributes::new().windows_attributes(windows);
+    tauri_build::try_build(attributes).expect("failed to run Tauri build script")
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -203,11 +203,16 @@ pub fn run() {
                             "Vireo: Incompatible database at {}: {}",
                             db_path, reason
                         );
+                        let log_dir = app
+                            .path()
+                            .app_log_dir()
+                            .map(|path| path.display().to_string())
+                            .unwrap_or_else(|_| "the Vireo application log directory".into());
                         app.handle()
                             .dialog()
                             .message(format!(
-                                "Vireo can't open the database at:\n\n{}\n\nIt's from an incompatible older version of Vireo. To start fresh, move this file aside (for example, rename it with a `.bak` suffix) and relaunch.\n\nDetails: {}",
-                                db_path, reason
+                                "Vireo can't open the database at:\n\n{}\n\nIt's from an incompatible older version of Vireo. To start fresh, move this file aside (for example, rename it with a `.bak` suffix) and relaunch.\n\nDetails: {}\n\nLogs: {}",
+                                db_path, reason, log_dir
                             ))
                             .title("Incompatible Vireo Database")
                             .kind(MessageDialogKind::Error)
@@ -221,13 +226,18 @@ pub fn run() {
                         // into a blank window — the user otherwise has no idea
                         // why Vireo didn't open.
                         let reason = e.to_string();
+                        let log_dir = app
+                            .path()
+                            .app_log_dir()
+                            .map(|path| path.display().to_string())
+                            .unwrap_or_else(|_| "the Vireo application log directory".into());
                         log::error!("Failed to start sidecar: {}", reason);
                         eprintln!("Vireo: Failed to start Python backend: {}", reason);
                         app.handle()
                             .dialog()
                             .message(format!(
-                                "Vireo couldn't start its backend.\n\nDetails: {}\n\nTry relaunching. If the problem persists, check Vireo's log file for more information.",
-                                reason
+                                "Vireo couldn't start its backend.\n\nDetails: {}\n\nTry relaunching. If the problem persists, check the logs at:\n{}",
+                                reason, log_dir
                             ))
                             .title("Vireo Couldn't Start")
                             .kind(MessageDialogKind::Error)

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -447,6 +447,7 @@ pub fn build_menu(app: &AppHandle) -> tauri::Result<tauri::menu::Menu<tauri::Wry
         .build()?;
 
     // -- Window menu --
+    #[allow(unused_mut)]
     let mut window_builder = SubmenuBuilder::new(app, "Window").minimize().maximize();
 
     #[cfg(target_os = "macos")]
@@ -493,6 +494,7 @@ pub fn build_menu(app: &AppHandle) -> tauri::Result<tauri::menu::Menu<tauri::Wry
     let help_menu = help_builder.build()?;
 
     // -- Assemble --
+    #[allow(unused_mut)]
     let mut builder = MenuBuilder::new(app);
 
     #[cfg(target_os = "macos")]

--- a/src-tauri/src/sidecar.rs
+++ b/src-tauri/src/sidecar.rs
@@ -420,6 +420,7 @@ pub fn start_sidecar(app: &AppHandle) -> Result<SidecarState, SidecarStartError>
         format!("/opt/homebrew/bin:/usr/local/bin:{}", path)
     };
 
+    #[allow(unused_mut)]
     let mut cmd = app.shell().sidecar("vireo-server").map_err(|e| {
         SidecarStartError::Generic(format!("Failed to create sidecar command: {}", e))
     })?;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -49,6 +49,16 @@
       "signingIdentity": null,
       "providerShortName": null,
       "minimumSystemVersion": "11.0"
+    },
+    "windows": {
+      "webviewInstallMode": {
+        "type": "downloadBootstrapper",
+        "silent": true
+      },
+      "allowDowngrades": false,
+      "nsis": {
+        "installMode": "currentUser"
+      }
     }
   },
   "plugins": {

--- a/src-tauri/windows-app-manifest.xml
+++ b/src-tauri/windows-app-manifest.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+        type="win32"
+        name="Microsoft.Windows.Common-Controls"
+        version="6.0.0.0"
+        processorArchitecture="*"
+        publicKeyToken="6595b64144ccf1df"
+        language="*" />
+    </dependentAssembly>
+  </dependency>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </windowsSettings>
+  </application>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+</assembly>

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -56,6 +56,7 @@ from preview_cache import (
 from preview_cache import (
     reconcile_preview_cache,
 )
+from proc import no_window_kwargs
 from render_source import (
     companion_image_can_replace_raw_result as _companion_image_can_replace_raw_result,
 )
@@ -1144,6 +1145,7 @@ def _trash_via_finder(filepath):
         ],
         capture_output=True,
         text=True,
+        **no_window_kwargs(),
     )
     if result.returncode != 0:
         raise OSError(result.stderr.strip() or f"Finder trash failed ({result.returncode})")
@@ -2099,11 +2101,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             rsync_bin = None
         if not rsync_bin:
             return None, None, json_error(
-                "No GNU rsync found for remote archiving — macOS's "
-                "built-in rsync can't drive rsync-over-SSH. Install GNU "
-                "rsync (e.g. `brew install rsync`) or set its path under "
+                "No usable GNU rsync was found for remote archiving. Install "
+                "GNU rsync for your platform or set its executable under "
                 "Settings → Paths."
             )
+        ssh_bin = move_mod.resolve_ssh_bin(effective_cfg.get("ssh_bin", "") or "")
+        if not ssh_bin:
+            return None, None, json_error(
+                "OpenSSH Client was not found. On Windows, install the OpenSSH "
+                "Client optional feature or set ssh.exe under Settings → Paths."
+            )
+        remote_archive_config["target"] = dict(remote_archive_config["target"])
+        remote_archive_config["target"]["ssh_bin"] = ssh_bin
         return remote_archive_config, rsync_bin, None
 
     def _coerce_collection_id(raw):
@@ -5645,6 +5654,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     check=False,
                     capture_output=True,
                     text=True,
+                    **no_window_kwargs(),
                 )
             elif sys.platform.startswith("win"):
                 # explorer.exe's exit status is not a reliable success signal
@@ -5663,6 +5673,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         check=False,
                         capture_output=True,
                         text=True,
+                        **no_window_kwargs(),
                     )
                 else:
                     if not os.path.isfile(path):
@@ -5673,6 +5684,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         check=False,
                         capture_output=True,
                         text=True,
+                        **no_window_kwargs(),
                     )
             else:
                 # xdg-open on a file has inconsistent behavior across desktops
@@ -5699,6 +5711,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     check=False,
                     capture_output=True,
                     text=True,
+                    **no_window_kwargs(),
                 )
             # explorer.exe's exit status is not a reliable success signal:
             # `explorer /select,<path>` (and `explorer <folder>`) routinely
@@ -10630,8 +10643,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         import shutil
 
+        from metadata import exiftool_status as get_exiftool_status
+
+        exiftool_probe = get_exiftool_status()
         exiftool_status = {
-            "installed": shutil.which("exiftool") is not None,
+            "installed": exiftool_probe["available"],
+            "version": exiftool_probe["version"],
+            "bundled": bool(
+                sys.platform.startswith("win") and exiftool_probe["available"]
+            ),
             "brew_available": shutil.which("brew") is not None,
         }
 
@@ -10759,13 +10779,30 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
     @app.route("/api/system/install-exiftool", methods=["POST"])
     def api_install_exiftool():
-        """Install exiftool via Homebrew."""
-        import shutil
+        """Install ExifTool where Vireo can safely automate installation."""
         import subprocess
 
-        if shutil.which("exiftool"):
+        from metadata import exiftool_status
+
+        status = exiftool_status()
+        if status["available"]:
             return jsonify({"success": True, "message": "exiftool is already installed"})
 
+        if sys.platform.startswith("win"):
+            return jsonify({
+                "success": False,
+                "error": (
+                    "The Windows desktop build includes ExifTool. Repair or reinstall "
+                    "Vireo if the bundled copy is unavailable."
+                ),
+            })
+        if sys.platform != "darwin":
+            return jsonify({
+                "success": False,
+                "error": "Install ExifTool with your Linux package manager, then restart Vireo.",
+            })
+
+        import shutil
         if not shutil.which("brew"):
             return jsonify({
                 "success": False,
@@ -10776,6 +10813,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             result = subprocess.run(
                 ["brew", "install", "exiftool"],
                 capture_output=True, text=True, timeout=300,
+                **no_window_kwargs(),
             )
             if result.returncode == 0:
                 return jsonify({"success": True, "message": "exiftool installed successfully"})
@@ -11654,17 +11692,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 result = subprocess.run(
                     ["open", "-a", app_bundle] + file_paths,
                     capture_output=True, text=True, timeout=30,
+                    **no_window_kwargs(),
                 )
                 if result.returncode != 0:
                     err = (result.stderr or result.stdout or "open failed").strip()
                     log.warning("open -a %s failed: %s", app_bundle, err)
                     return json_error(err, 500)
             elif editor_path:
-                subprocess.Popen([editor_path] + file_paths)
+                subprocess.Popen([editor_path] + file_paths, **no_window_kwargs())
             elif sys.platform == "darwin":
                 result = subprocess.run(
                     ["open"] + file_paths,
                     capture_output=True, text=True, timeout=30,
+                    **no_window_kwargs(),
                 )
                 if result.returncode != 0:
                     err = (result.stderr or result.stdout or "open failed").strip()
@@ -11675,7 +11715,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     os.startfile(fp)
             else:
                 for fp in file_paths:
-                    subprocess.Popen(["xdg-open", fp])
+                    subprocess.Popen(["xdg-open", fp], **no_window_kwargs())
         except Exception as e:
             log.warning("Failed to open external editor: %s", e)
             return json_error(str(e), 500)
@@ -14118,6 +14158,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def api_system_info():
         """Return system information: ONNX Runtime, hardware."""
         info = _runtime_execution_info()
+        import config as cfg
+        from platform_support import platform_support_info
+
+        try:
+            effective = _get_db().get_effective_config(cfg.load())
+        except Exception:
+            effective = cfg.load()
+        info["platform_support"] = platform_support_info(effective)
 
         # "installed" requires both module AND weights — module-only
         # lets classify silently fall back to full-image classification.
@@ -15137,12 +15185,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             try:
                 if sys.platform == "darwin":
                     proc = subprocess.run(["open", "-R", "--", path],
-                                          timeout=5, check=False)
+                                          timeout=5, check=False,
+                                          **no_window_kwargs())
                 elif sys.platform.startswith("win"):
                     # Folder reveal opens the folder itself (no /select,)
                     # so the user sees its contents.
                     proc = subprocess.run(["explorer", path],
-                                          timeout=5, check=False)
+                                          timeout=5, check=False,
+                                          **no_window_kwargs())
                 else:
                     # xdg-open doesn't honor `--`; abspath guarantees a
                     # leading slash so a crafted leading-dash path can't
@@ -15150,6 +15200,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     proc = subprocess.run(
                         ["xdg-open", os.path.abspath(path)],
                         timeout=5, check=False,
+                        **no_window_kwargs(),
                     )
                 # check=False returns a CompletedProcess for every exit
                 # code; classify non-zero as failed so the UI doesn't
@@ -16299,14 +16350,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 effective_cfg.get("rsync_bin", "") or "")
             if not rsync_bin:
                 return json_error(
-                    "No GNU rsync found for remote moves — macOS's "
-                    "built-in rsync can't drive rsync-over-SSH. Install GNU "
-                    "rsync (e.g. `brew install rsync`) or set its path under "
+                    "No usable GNU rsync was found for remote moves. Install "
+                    "GNU rsync for your platform or set its executable under "
                     "Settings → Paths."
+                )
+            ssh_bin = move_mod.resolve_ssh_bin(
+                effective_cfg.get("ssh_bin", "") or "")
+            if not ssh_bin:
+                return json_error(
+                    "OpenSSH Client was not found. Install the Windows "
+                    "OpenSSH Client optional feature or configure ssh.exe in Settings."
                 )
             try:
                 remote = move_mod.build_remote_move_spec(
-                    target, subpath, rsync_bin)
+                    target, subpath, rsync_bin, ssh_bin)
             except ValueError as exc:
                 return json_error(str(exc))
             # Pass the mount path as `destination` for informational use; the
@@ -16488,8 +16545,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             target = cfg.get_remote_target(remote_target_id)
             if not target:
                 return json_error("Remote target not found", status=404)
+            effective_cfg = _get_db().get_effective_config(cfg.load())
+            ssh_bin = move_mod.resolve_ssh_bin(
+                effective_cfg.get("ssh_bin", "") or "")
+            if not ssh_bin:
+                return json_error(
+                    "OpenSSH Client was not found. Install it or configure ssh.exe in Settings."
+                )
+            target = dict(target)
+            target["ssh_bin"] = ssh_bin
             try:
-                spec = move_mod.build_remote_move_spec(target, subpath, "")
+                spec = move_mod.build_remote_move_spec(target, subpath, "", ssh_bin)
             except ValueError as exc:
                 return json_error(str(exc))
             # The NAS path is POSIX, so the preview/probe path must join with
@@ -16566,10 +16632,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         rsync_bin = move_mod.resolve_rsync_bin(
             effective_cfg.get("rsync_bin", "") or "")
         usable = bool(rsync_bin and move_mod.is_gnu_rsync(rsync_bin))
+        ssh_bin = move_mod.resolve_ssh_bin(
+            effective_cfg.get("ssh_bin", "") or "")
         return jsonify({
             "targets": cfg.get_remote_targets(),
             "rsync_available": usable,
             "rsync_bin": rsync_bin if usable else None,
+            "ssh_available": bool(ssh_bin),
+            "ssh_bin": ssh_bin,
+            "remote_available": bool(usable and ssh_bin),
         })
 
     @app.route("/api/remote-targets/test", methods=["POST"])
@@ -16591,11 +16662,21 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # Apple openrsync resolves but can't drive SSH — treat as unusable.
         if rsync_bin and not move_mod.is_gnu_rsync(rsync_bin):
             rsync_bin = ""
+        ssh_bin = move_mod.resolve_ssh_bin(
+            effective_cfg.get("ssh_bin", "") or "")
+        target["ssh_bin"] = ssh_bin
         res = move_mod.test_remote_connection(target, rsync_bin)
         mount = target.get("mount_path")
         res["mount_path"] = mount
         res["mount_present"] = bool(mount and os.path.isdir(mount))
         res["rsync_bin"] = rsync_bin or None
+        res["ssh_bin"] = ssh_bin
+        if not ssh_bin:
+            res["ok"] = False
+            res["message"] = (
+                "OpenSSH Client was not found. Install the Windows optional "
+                "feature or configure ssh.exe under Settings → Paths."
+            )
         return jsonify(res)
 
     @app.route("/api/jobs/import-full", methods=["POST"])
@@ -18205,8 +18286,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if isinstance(obj, dict):
                 out = {}
                 for k, v in obj.items():
-                    if any(s in k.lower() for s in ("token", "key", "secret", "password")):
+                    key = k.lower()
+                    if any(s in key for s in ("token", "secret", "password")) or key.endswith("_key"):
                         out[k] = "[REDACTED]"
+                    elif any(s in key for s in ("path", "root", "_bin", "directory", "editor")):
+                        out[k] = "[REDACTED_PATH]" if v else v
                     else:
                         out[k] = _redact(v)
                 return out
@@ -18215,6 +18299,54 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return obj
 
         sanitized_config = _redact(cfg.load())
+
+        # Exact catalog roots are private and can also appear in logs. Issue
+        # reports retain the diagnostic message while replacing those values;
+        # the user can paste a path into the description when it is relevant.
+        private_paths = []
+        if db is not None:
+            with contextlib.suppress(Exception):
+                private_paths = [
+                    row[0] for row in db.conn.execute("SELECT path FROM folders")
+                    if row[0]
+                ]
+
+        def _sanitize_text(value):
+            text = str(value)
+            for private_path in sorted(private_paths, key=len, reverse=True):
+                text = text.replace(private_path, "[PHOTO_PATH]")
+            home = os.path.expanduser("~")
+            if home:
+                text = text.replace(home, "~")
+            return text
+
+        def _sanitize_private_values(value):
+            if isinstance(value, dict):
+                return {key: _sanitize_private_values(item) for key, item in value.items()}
+            if isinstance(value, list):
+                return [_sanitize_private_values(item) for item in value]
+            if isinstance(value, str):
+                return _sanitize_text(value)
+            return value
+
+        sanitized_logs = _sanitize_private_values(
+            app._log_broadcaster.get_recent(200)
+        )
+
+        try:
+            from platform_support import filesystem_type, platform_support_info
+
+            filesystems = sorted({
+                kind for path in private_paths
+                if (kind := filesystem_type(path))
+            })
+            support_info = _redact(platform_support_info(cfg.load()))
+        except Exception:
+            filesystems = []
+            support_info = {}
+        execution_info = {}
+        with contextlib.suppress(Exception):
+            execution_info = _runtime_execution_info()
 
         # --- Build the bundle ---
         from datetime import datetime
@@ -18227,15 +18359,19 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "platform": platform.platform(),
                 "python": sys.version,
                 "architecture": platform.machine(),
+                "inference_device": execution_info.get("device"),
+                "inference_providers": execution_info.get("onnxruntime_providers", []),
+                "platform_support": support_info,
+                "library_filesystems": filesystems,
             },
-            "logs": app._log_broadcaster.get_recent(200),
+            "logs": sanitized_logs,
             "app_state": {
                 "workspace": ws_name,
                 "folders": folder_count,
                 "photos": photo_count,
                 "predictions": pred_count,
             },
-            "recent_jobs": recent_jobs,
+            "recent_jobs": _sanitize_private_values(_redact(recent_jobs)),
             "config": sanitized_config,
         }
 

--- a/vireo/capture_time.py
+++ b/vireo/capture_time.py
@@ -295,7 +295,10 @@ def adjust_capture_time(
     cancel_check=None,
 ):
     """Apply a capture-time correction to selected photos via ExifTool."""
-    if shutil.which("exiftool") is None:
+    from metadata import find_exiftool
+
+    exiftool = find_exiftool() or shutil.which("exiftool")
+    if exiftool is None:
         raise RuntimeError("exiftool is not installed")
 
     target_minutes, manual_shift, target_offset_str = _normalize_inputs(
@@ -350,7 +353,7 @@ def adjust_capture_time(
                 progress_callback(index, total, photo["filename"])
             continue
 
-        cmd = ["exiftool"]
+        cmd = [exiftool]
         if not keep_backups:
             cmd.append("-overwrite_original")
         if photo_shift:

--- a/vireo/config.py
+++ b/vireo/config.py
@@ -37,6 +37,9 @@ DEFAULTS = {
     # then a few known install paths) via move.resolve_rsync_bin(). Local
     # moves are unaffected and keep using whatever `rsync` is on PATH.
     "rsync_bin": "",
+    # Optional explicit Windows OpenSSH path. Empty uses PATH and then the
+    # standard Windows optional-feature location.
+    "ssh_bin": "",
     # Saved remote (NAS) destinations for folder moves over SSH. Each entry:
     #   {"id", "name", "host", "user", "port", "ssh_key",
     #    "remote_path", "mount_path", "bwlimit_kbps"}

--- a/vireo/config_schema.py
+++ b/vireo/config_schema.py
@@ -306,6 +306,13 @@ SCHEMA = {
                 "macOS ships openrsync, which can't do rsync-over-SSH. "
                 "Leave empty to auto-detect.",
     },
+    "ssh_bin": {
+        "type": "path",
+        "category": "Paths", "scope": "global",
+        "label": "OpenSSH client path (remote moves)",
+        "desc": "Optional path to ssh.exe for remote import, archive, and moves. "
+                "Leave empty to auto-detect Windows OpenSSH or PATH.",
+    },
 
     # --- Integrations -----------------------------------------------------
     "inat_token": {

--- a/vireo/develop.py
+++ b/vireo/develop.py
@@ -60,6 +60,18 @@ def find_darktable(configured_path):
     found = shutil.which("darktable-cli")
     if found:
         return os.path.realpath(found)
+    if os.name == "nt":
+        candidates = []
+        for env_var in ("PROGRAMFILES", "PROGRAMFILES(X86)", "PROGRAMW6432"):
+            base = os.environ.get(env_var)
+            if base:
+                candidates.extend([
+                    os.path.join(base, "darktable", "bin", "darktable-cli.exe"),
+                    os.path.join(base, "darktable", "darktable-cli.exe"),
+                ])
+        for candidate in candidates:
+            if os.path.isfile(candidate):
+                return os.path.realpath(candidate)
     return None
 
 

--- a/vireo/metadata.py
+++ b/vireo/metadata.py
@@ -9,6 +9,7 @@ import logging
 import shutil
 import subprocess
 import sys
+from pathlib import Path
 
 try:
     from .proc import no_window_kwargs
@@ -22,6 +23,27 @@ _BATCH_SIZE = 100
 _EXIFTOOL_TIMEOUT = 120
 _MAX_TIMEOUT_SPLIT_ATTEMPTS = 16
 _TIMEOUT = object()
+
+
+def find_exiftool() -> str | None:
+    """Resolve ExifTool, preferring Vireo's packaged Windows copy.
+
+    PyInstaller extracts bundled data below ``sys._MEIPASS``.  Keeping the
+    support directory next to the executable is required by the official
+    Windows distribution.  Development installs continue to use PATH.
+    """
+    bundle_root = getattr(sys, "_MEIPASS", None)
+    if bundle_root:
+        bundled = Path(bundle_root) / "vendor" / "exiftool" / "exiftool.exe"
+        if bundled.is_file():
+            return str(bundled)
+    try:
+        return shutil.which("exiftool")
+    except (AttributeError, OSError):
+        # Defensive for restricted Windows runtimes where executable lookup
+        # itself is unavailable. Callers that execute the fallback still
+        # receive the normal FileNotFoundError handling.
+        return None
 
 
 def _exiftool_install_hint() -> str:
@@ -57,7 +79,7 @@ def exiftool_status():
     PATH-only check would render broken installs as a healthy green state
     while every scan loses capture date, GPS, and camera info.
     """
-    path = shutil.which("exiftool")
+    path = find_exiftool()
     if not path:
         return {
             "available": False,
@@ -72,7 +94,7 @@ def exiftool_status():
     error = None
     try:
         result = subprocess.run(
-            ["exiftool", "-ver"],
+            [path, "-ver"],
             capture_output=True,
             text=True,
             timeout=10,
@@ -137,7 +159,8 @@ def _run_exiftool(file_paths, extra_args=None):
     if not file_paths:
         return []
 
-    cmd = ["exiftool", "-G", "-json", "-n"]
+    exiftool = find_exiftool() or "exiftool"
+    cmd = [exiftool, "-G", "-json", "-n"]
     if extra_args:
         cmd.extend(extra_args)
     cmd.append("--")

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -13,6 +13,11 @@ import tempfile
 import threading
 import time
 
+try:
+    from .proc import no_window_kwargs
+except ImportError:
+    from proc import no_window_kwargs
+
 log = logging.getLogger(__name__)
 
 # How long the remote verification rsync (a --checksum dry-run over SSH) may
@@ -96,7 +101,7 @@ def sanitize_subpath(subpath):
     return "/".join(parts)
 
 
-def build_remote_move_spec(target, subpath, rsync_bin):
+def build_remote_move_spec(target, subpath, rsync_bin, ssh_bin=""):
     """Build the ``remote`` dict ``move_folder`` expects from a config target.
 
     ``target`` is a validated dict from ``config.get_remote_target`` (host,
@@ -119,6 +124,7 @@ def build_remote_move_spec(target, subpath, rsync_bin):
         "ssh_key": target.get("ssh_key", ""),
         "bwlimit_kbps": target.get("bwlimit_kbps", 0),
         "rsync_bin": rsync_bin,
+        "ssh_bin": resolve_ssh_bin(ssh_bin or target.get("ssh_bin", "")),
         "ssh_dest_base": ssh_base,
         "mount_dest_base": mount_base,
     }
@@ -269,6 +275,16 @@ def _platform_rsync_candidates():
     found = shutil.which("rsync")
     if found:
         cands.append(found)
+    if os.name == "nt":
+        for env_var in ("PROGRAMFILES", "PROGRAMFILES(X86)", "PROGRAMW6432"):
+            base = os.environ.get(env_var)
+            if base:
+                cands.append(os.path.join(base, "cwRsync", "bin", "rsync.exe"))
+        system_drive = os.environ.get("SYSTEMDRIVE", "C:")
+        cands.extend([
+            os.path.join(system_drive + os.sep, "msys64", "usr", "bin", "rsync.exe"),
+            os.path.join(system_drive + os.sep, "cygwin64", "bin", "rsync.exe"),
+        ])
     cands.append("/usr/bin/rsync")
     return tuple(cands)
 
@@ -306,6 +322,22 @@ def resolve_rsync_bin(configured=""):
     return None
 
 
+def resolve_ssh_bin(configured=""):
+    """Resolve OpenSSH without requiring it to be on a GUI process's PATH."""
+    candidates = [configured, os.environ.get("VIREO_SSH_BIN"), shutil.which("ssh")]
+    if os.name == "nt":
+        system_root = os.environ.get("SYSTEMROOT", r"C:\Windows")
+        candidates.append(os.path.join(system_root, "System32", "OpenSSH", "ssh.exe"))
+    for candidate in candidates:
+        if candidate and _is_executable_file(os.path.abspath(candidate)):
+            return os.path.abspath(candidate)
+    return None
+
+
+def _ssh_command(remote):
+    return remote.get("ssh_bin") or resolve_ssh_bin() or "ssh"
+
+
 def is_gnu_rsync(rsync_bin):
     """True if ``rsync_bin`` looks like GNU rsync (not Apple openrsync).
 
@@ -315,7 +347,8 @@ def is_gnu_rsync(rsync_bin):
     """
     try:
         out = subprocess.run([rsync_bin, "--version"], capture_output=True,
-                             text=True, timeout=10).stdout.lower()
+                             text=True, timeout=10,
+                             **no_window_kwargs()).stdout.lower()
     except (OSError, subprocess.SubprocessError):
         return False
     return "openrsync" not in out and "rsync" in out
@@ -350,7 +383,7 @@ def _ssh_rsh_string(remote):
     ``shlex.join`` so a key path like ``/Users/me/My Keys/id_ed25519`` (or a
     port flag carrying any whitespace) survives the round-trip intact.
     """
-    return shlex.join(["ssh"] + ssh_base_args(remote))
+    return shlex.join([_ssh_command(remote)] + ssh_base_args(remote))
 
 
 def _ssh_target(remote):
@@ -404,10 +437,11 @@ def _remote_mkdir_p(remote, path):
     Returns ``(True, "")`` on success or ``(False, detail)`` where
     ``detail`` is a short message suitable for surfacing to the user.
     """
-    cmd = (["ssh"] + ssh_base_args(remote) + [_ssh_target(remote)]
+    cmd = ([_ssh_command(remote)] + ssh_base_args(remote) + [_ssh_target(remote)]
            + [f"mkdir -p {shlex.quote(path)}"])
     try:
-        r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=30,
+                           **no_window_kwargs())
     except (OSError, subprocess.SubprocessError) as exc:
         return False, str(exc)
     if r.returncode != 0:
@@ -433,10 +467,11 @@ def _remote_dir_exists(remote, path):
     couldn't complete the session — so any other return code (255 or
     otherwise unexpected) is bucketed with the OSError/SubprocessError path.
     """
-    cmd = (["ssh"] + ssh_base_args(remote)
+    cmd = ([_ssh_command(remote)] + ssh_base_args(remote)
            + [_ssh_target(remote), f"test -d {shlex.quote(path)}"])
     try:
-        rc = subprocess.run(cmd, capture_output=True, timeout=30).returncode
+        rc = subprocess.run(cmd, capture_output=True, timeout=30,
+                            **no_window_kwargs()).returncode
     except (OSError, subprocess.SubprocessError):
         return None
     if rc == 0:
@@ -458,10 +493,11 @@ def _remote_free_bytes(remote, path):
     GNU, BusyBox, and Synology's df all honor it. ``path`` must exist on
     the remote (probe the configured base, not a not-yet-created leaf).
     """
-    cmd = (["ssh"] + ssh_base_args(remote) + [_ssh_target(remote)]
+    cmd = ([_ssh_command(remote)] + ssh_base_args(remote) + [_ssh_target(remote)]
            + [f"df -Pk {shlex.quote(path)}"])
     try:
-        r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=30,
+                           **no_window_kwargs())
     except (OSError, subprocess.SubprocessError):
         return None
     if r.returncode != 0:
@@ -486,11 +522,12 @@ def remote_preflight(remote, dest_path, file_cap=1000):
         ``find | head | wc -l`` so a huge tree can't hang the probe.
     """
     target = _ssh_target(remote)
-    base = ["ssh"] + ssh_base_args(remote) + [target]
+    base = [_ssh_command(remote)] + ssh_base_args(remote) + [target]
     q = shlex.quote(dest_path)
     probe = base + [f"if [ -d {q} ]; then echo EXISTS; else echo NOPE; fi"]
     try:
-        r = subprocess.run(probe, capture_output=True, text=True, timeout=30)
+        r = subprocess.run(probe, capture_output=True, text=True, timeout=30,
+                           **no_window_kwargs())
     except (OSError, subprocess.SubprocessError) as exc:
         return (False, 0, False, False, str(exc))
     if r.returncode != 0:
@@ -501,7 +538,8 @@ def remote_preflight(remote, dest_path, file_cap=1000):
     cnt_cmd = base + [
         f"find {q} -type f 2>/dev/null | head -n {file_cap + 1} | wc -l"]
     try:
-        c = subprocess.run(cnt_cmd, capture_output=True, text=True, timeout=120)
+        c = subprocess.run(cnt_cmd, capture_output=True, text=True, timeout=120,
+                           **no_window_kwargs())
         n = int((c.stdout or "0").strip() or 0)
     except (OSError, subprocess.SubprocessError, ValueError):
         return (True, 0, False, True, None)
@@ -528,10 +566,10 @@ def test_remote_connection(remote, rsync_bin):
               "rsync_ok": bool(rsync_bin), "remote_rsync_ok": False,
               "message": ""}
     target = _ssh_target(remote)
-    base = ["ssh"] + ssh_base_args(remote) + [target]
+    base = [_ssh_command(remote)] + ssh_base_args(remote) + [target]
     try:
         r = subprocess.run(base + ["echo vireo_ok"], capture_output=True,
-                           text=True, timeout=20)
+                           text=True, timeout=20, **no_window_kwargs())
     except (OSError, subprocess.SubprocessError) as exc:
         result["message"] = f"SSH connection failed: {exc}"
         return result
@@ -545,7 +583,7 @@ def test_remote_connection(remote, rsync_bin):
     try:
         w = subprocess.run(
             base + [f"test -d {rp} && test -w {rp} && echo WRITABLE"],
-            capture_output=True, text=True, timeout=20)
+            capture_output=True, text=True, timeout=20, **no_window_kwargs())
     except (OSError, subprocess.SubprocessError) as exc:
         result["message"] = f"SSH connection failed: {exc}"
         return result
@@ -559,8 +597,8 @@ def test_remote_connection(remote, rsync_bin):
     if not rsync_bin:
         result["message"] = (
             "SSH and the remote path are reachable, but no GNU rsync was "
-            "found for the transfer (macOS's built-in rsync can't do this). "
-            "Install GNU rsync or set its path under Settings → Paths.")
+            "found for the transfer. Install GNU rsync for your platform or "
+            "set its path under Settings → Paths.")
         return result
     # Probe the REMOTE rsync. `rsync --version` is cheap and side-effect-free;
     # any non-zero exit (or a missing binary, which the remote shell reports
@@ -571,7 +609,7 @@ def test_remote_connection(remote, rsync_bin):
     try:
         rr = subprocess.run(
             base + ["rsync --version 2>/dev/null | head -n 1"],
-            capture_output=True, text=True, timeout=20)
+            capture_output=True, text=True, timeout=20, **no_window_kwargs())
     except (OSError, subprocess.SubprocessError) as exc:
         result["message"] = (
             f"SSH and the remote path are reachable, but couldn't probe the "
@@ -614,7 +652,8 @@ def _remote_verify_complete(rsync_bin, src_path, rsync_target, remote):
            src_path + "/", rsync_target + "/"]
     try:
         proc = subprocess.run(cmd, capture_output=True, text=True,
-                              timeout=REMOTE_VERIFY_TIMEOUT)
+                              timeout=REMOTE_VERIFY_TIMEOUT,
+                              **no_window_kwargs())
     except subprocess.TimeoutExpired:
         return ("__ERROR__", f"verification timed out after "
                 f"{REMOTE_VERIFY_TIMEOUT // 60} minutes")
@@ -679,7 +718,8 @@ def remote_verify_files(rsync_bin, src_specs, rsync_target, remote,
     cmd += [rsync_target + "/" if dest_is_dir else rsync_target]
     try:
         proc = subprocess.run(cmd, capture_output=True, text=True,
-                              timeout=REMOTE_VERIFY_TIMEOUT)
+                              timeout=REMOTE_VERIFY_TIMEOUT,
+                              **no_window_kwargs())
     except subprocess.TimeoutExpired:
         return ("__ERROR__", f"verification timed out after "
                 f"{REMOTE_VERIFY_TIMEOUT // 60} minutes")
@@ -760,6 +800,7 @@ def _run_rsync_streamed(src_path, dest_spec, rsync_flags, total_files,
     try:
         proc = subprocess.Popen(
             cmd, stdout=stdout_arg, stderr=subprocess.PIPE, text=True,
+            **no_window_kwargs(),
         )
     except BaseException:
         # Popen can raise after os.openpty() succeeded (bad rsync_bin,
@@ -894,7 +935,8 @@ def _find_remote_content_conflict(rsync_bin, src_path, rsync_target, remote):
            src_path + "/", rsync_target + "/"]
     try:
         proc = subprocess.run(cmd, capture_output=True, text=True,
-                              timeout=REMOTE_VERIFY_TIMEOUT)
+                              timeout=REMOTE_VERIFY_TIMEOUT,
+                              **no_window_kwargs())
     except subprocess.TimeoutExpired:
         return ("__ERROR__", f"conflict check timed out after "
                 f"{REMOTE_VERIFY_TIMEOUT // 60} minutes")
@@ -1917,9 +1959,8 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
             remote_rsync = remote.get("rsync_bin")
             if not remote_rsync:
                 return {"moved": 0, "errors": [
-                    "No GNU rsync binary available for remote moves. macOS's "
-                    "built-in rsync can't do this — set the GNU rsync path "
-                    "in Settings."
+                    "No usable GNU rsync binary is available for remote moves. "
+                    "Install it or set the GNU rsync path in Settings."
                 ]}
             conflict = _find_remote_content_conflict(
                 remote_rsync, src_path, rsync_target, remote)
@@ -1998,9 +2039,8 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
         rsync_bin = remote.get("rsync_bin")
         if not rsync_bin:
             return {"moved": 0, "errors": [
-                "No GNU rsync binary available for remote moves. macOS's "
-                "built-in rsync can't do this — set the GNU rsync path in "
-                "Settings."
+                "No usable GNU rsync binary is available for remote moves. "
+                "Install it or set the GNU rsync path in Settings."
             ]}
         extra_args = [
             "-e", _ssh_rsh_string(remote),

--- a/vireo/new_images.py
+++ b/vireo/new_images.py
@@ -387,6 +387,23 @@ class NewImagesCache:
         """
         key = (db_path, workspace_id)
         with self._lock:
+            # Race guard: a worker finishing between the caller's
+            # ``cache.get()`` (which returned None) and this call would
+            # write the result to ``_entries`` and then clear
+            # ``_inflight`` — under separate lock acquires — so by the
+            # time we arrive both are visible but the ``_inflight`` slot
+            # is gone. Without this check we would spawn a redundant walk
+            # that duplicates the just-finished one. If a fresh entry is
+            # already cached, return an already-set event so the caller's
+            # follow-up ``cache.get()`` picks it up.
+            entry = self._entries.get(key)
+            if entry is not None:
+                _result, set_at = entry
+                if time.monotonic() - set_at <= self._ttl:
+                    done = threading.Event()
+                    done.set()
+                    return done
+
             err_entry = self._errors.get(key)
             if err_entry is not None:
                 _err_msg, set_at = err_entry

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -1269,12 +1269,10 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                     rsync_bin = ""
                                 if not rsync_bin:
                                     _bail_storage(
-                                        "No GNU rsync found for the remote "
-                                        "archive — macOS's built-in rsync "
-                                        "can't drive rsync-over-SSH. Install "
-                                        "GNU rsync (e.g. `brew install "
-                                        "rsync`) or set its path under "
-                                        "Settings → Paths."
+                                        "No usable GNU rsync was found for the "
+                                        "remote archive. Install GNU rsync for "
+                                        "your platform or set its executable "
+                                        "under Settings → Paths."
                                     )
                                     return
                                 conn = move_mod.test_remote_connection(

--- a/vireo/platform_support.py
+++ b/vireo/platform_support.py
@@ -1,0 +1,230 @@
+"""Platform capability discovery used by Settings and support diagnostics."""
+
+from __future__ import annotations
+
+import contextlib
+import ctypes
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from develop import find_darktable, find_dng_converter
+from metadata import exiftool_status
+from move import is_gnu_rsync, resolve_rsync_bin
+from proc import no_window_kwargs
+
+
+def _program_files_candidates(*relative_parts: str) -> list[str]:
+    candidates = []
+    for env_var in ("PROGRAMFILES", "PROGRAMFILES(X86)", "PROGRAMW6432"):
+        base = os.environ.get(env_var)
+        if base:
+            candidate = os.path.join(base, *relative_parts)
+            if candidate not in candidates:
+                candidates.append(candidate)
+    return candidates
+
+
+def find_lightroom() -> str | None:
+    if os.name != "nt":
+        return None
+    candidates = []
+    for base in _program_files_candidates("Adobe"):
+        root = Path(base)
+        with contextlib.suppress(OSError):
+            for child in root.glob("Adobe Lightroom Classic*"):
+                candidates.extend(child.glob("lightroom.exe"))
+                candidates.extend(child.glob("Lightroom.exe"))
+    for candidate in candidates:
+        if candidate.is_file():
+            return str(candidate.resolve())
+    return None
+
+
+def find_ssh(configured: str = "") -> str | None:
+    if configured and os.path.isfile(configured):
+        return os.path.abspath(configured)
+    found = shutil.which("ssh")
+    if found:
+        return os.path.abspath(found)
+    if os.name == "nt":
+        system_root = os.environ.get("SYSTEMROOT", r"C:\Windows")
+        candidate = os.path.join(system_root, "System32", "OpenSSH", "ssh.exe")
+        if os.path.isfile(candidate):
+            return candidate
+    return None
+
+
+def _probe(binary: str | None, args: list[str]) -> tuple[bool, str | None]:
+    if not binary:
+        return False, None
+    try:
+        result = subprocess.run(
+            [binary, *args],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            **no_window_kwargs(),
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return False, str(exc)
+    detail = (result.stdout or result.stderr or "").strip().splitlines()
+    return result.returncode == 0, (detail[0] if detail else None)
+
+
+def windows_long_path_status() -> dict:
+    if os.name != "nt":
+        return {"state": "not_applicable", "enabled": True, "detail": "Not Windows"}
+    try:
+        import winreg
+
+        with winreg.OpenKey(
+            winreg.HKEY_LOCAL_MACHINE,
+            r"SYSTEM\CurrentControlSet\Control\FileSystem",
+        ) as key:
+            value, _kind = winreg.QueryValueEx(key, "LongPathsEnabled")
+        enabled = bool(value)
+        return {
+            "state": "ready" if enabled else "warning",
+            "enabled": enabled,
+            "detail": (
+                "Windows long paths are enabled"
+                if enabled
+                else "Enable Win32 long paths in Windows policy before importing deeply nested libraries"
+            ),
+        }
+    except OSError as exc:
+        return {"state": "warning", "enabled": False, "detail": str(exc)}
+
+
+def webview2_version() -> str | None:
+    if os.name != "nt":
+        return None
+    try:
+        import winreg
+
+        roots = (
+            (winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients"),
+            (winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\Microsoft\EdgeUpdate\Clients"),
+            (winreg.HKEY_CURRENT_USER, r"Software\Microsoft\EdgeUpdate\Clients"),
+        )
+        for hive, root_name in roots:
+            with contextlib.suppress(OSError), winreg.OpenKey(hive, root_name) as root:
+                index = 0
+                while True:
+                    try:
+                        child_name = winreg.EnumKey(root, index)
+                    except OSError:
+                        break
+                    index += 1
+                    with contextlib.suppress(OSError), winreg.OpenKey(root, child_name) as child:
+                        product_name, _kind = winreg.QueryValueEx(child, "name")
+                        if "webview2" not in str(product_name).lower():
+                            continue
+                        version, _kind = winreg.QueryValueEx(child, "pv")
+                        if version:
+                            return str(version)
+    except ImportError:
+        pass
+    return None
+
+
+def filesystem_type(path: str) -> str | None:
+    """Return the Windows volume filesystem without exposing the input path."""
+    if os.name != "nt" or not path:
+        return None
+    root = os.path.splitdrive(os.path.abspath(path))[0] + "\\"
+    if path.startswith("\\\\"):
+        parts = path.strip("\\").split("\\")
+        if len(parts) >= 2:
+            root = f"\\\\{parts[0]}\\{parts[1]}\\"
+    fs_name = ctypes.create_unicode_buffer(64)
+    try:
+        ok = ctypes.windll.kernel32.GetVolumeInformationW(
+            root, None, 0, None, None, None, fs_name, len(fs_name)
+        )
+    except (AttributeError, OSError):
+        return None
+    return fs_name.value if ok else None
+
+
+def dependency_readiness(config: dict | None = None) -> dict:
+    config = config or {}
+    exif = exiftool_status()
+    darktable = find_darktable(config.get("darktable_bin", ""))
+    dng = find_dng_converter(config.get("dng_converter_bin", ""))
+    ssh = find_ssh(config.get("ssh_bin", ""))
+    ssh_ok, ssh_detail = _probe(ssh, ["-V"])
+    rsync = resolve_rsync_bin(config.get("rsync_bin", ""))
+    rsync_ok = bool(rsync and is_gnu_rsync(rsync))
+    remote_ready = ssh_ok and rsync_ok
+
+    return {
+        "exiftool": {
+            "required": True,
+            "state": "ready" if exif["available"] else ("misconfigured" if exif["path"] else "missing"),
+            **exif,
+        },
+        "darktable": {
+            "required": False,
+            "state": "ready" if darktable else "missing",
+            "path": darktable,
+            "hint": "Install Darktable or configure darktable-cli under Settings → Paths.",
+        },
+        "dng_converter": {
+            "required": False,
+            "state": "ready" if dng else "missing",
+            "path": dng,
+            "hint": "Install Adobe DNG Converter or configure its executable under Settings → Paths.",
+        },
+        "lightroom": {
+            "required": False,
+            "state": "ready" if (lightroom := find_lightroom()) else "missing",
+            "path": lightroom,
+            "hint": "Lightroom Classic is optional; catalog import remains available when installed.",
+        },
+        "openssh": {
+            "required": False,
+            "state": "ready" if ssh_ok else ("misconfigured" if ssh else "missing"),
+            "path": ssh,
+            "version": ssh_detail,
+            "hint": "Install the Windows OpenSSH Client optional feature or configure ssh.exe.",
+        },
+        "rsync": {
+            "required": False,
+            "state": "ready" if rsync_ok else ("misconfigured" if rsync else "missing"),
+            "path": rsync,
+            "hint": "Install GNU rsync and configure its executable under Settings → Paths.",
+        },
+        "remote_transfer": {
+            "required": False,
+            "state": "ready" if remote_ready else "unavailable",
+            "hint": "Remote import, archive, and move require both OpenSSH Client and GNU rsync.",
+        },
+    }
+
+
+def platform_support_info(config: dict | None = None) -> dict:
+    windows_release = platform.release() if os.name == "nt" else None
+    windows_build = platform.version() if os.name == "nt" else None
+    windows_11 = False
+    if os.name == "nt":
+        with contextlib.suppress(ValueError, IndexError):
+            windows_11 = int((windows_build or "").split(".")[-1]) >= 22000
+        windows_11 = windows_11 or windows_release == "11"
+    return {
+        "support_tier": (
+            "public_beta" if windows_11 else "unsupported"
+        ) if os.name == "nt" else "supported",
+        "platform": sys.platform,
+        "windows_release": windows_release,
+        "windows_build": windows_build,
+        "architecture": platform.machine(),
+        "guaranteed_inference": "CPUExecutionProvider" if os.name == "nt" else None,
+        "webview2_version": webview2_version(),
+        "long_paths": windows_long_path_status(),
+        "dependencies": dependency_readiness(config),
+    }

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -929,7 +929,7 @@
     <div class="setting-row">
       <div class="setting-label">
         Adobe DNG Converter path
-        <small>Leave empty to auto-detect the macOS app bundle or PATH. Required only when DNG conversion is enabled.</small>
+        <small>Leave empty to auto-detect the Windows installation, macOS app bundle, or PATH. Required only when DNG conversion is enabled.</small>
       </div>
       <div style="display:flex;align-items:center;gap:6px;">
         <input type="text" id="cfgDngConverterBin" placeholder="auto-detect"
@@ -970,6 +970,17 @@
         <small id="exiftoolDetail">Reads capture date, GPS, and camera info during scans.</small>
       </div>
       <span class="setting-value" id="exiftoolStatus">-</span>
+    </div>
+    <div class="setting-row" id="windowsSupportRow" style="display:none;">
+      <div class="setting-label">
+        Windows support
+        <small id="windowsSupportDetail">Checking platform readiness...</small>
+      </div>
+      <span class="setting-value" id="windowsSupportStatus">-</span>
+    </div>
+    <div id="dependencyReadiness" style="display:none;margin-top:10px;">
+      <div style="font-size:11px;font-weight:600;color:var(--text-dim);text-transform:uppercase;letter-spacing:.05em;margin-bottom:6px;">Integration readiness</div>
+      <div id="dependencyReadinessRows"></div>
     </div>
   </div>
 
@@ -2181,9 +2192,51 @@ async function loadSystemInfo() {
       mdStatus.style.color = 'var(--danger)';
       mdDetail.textContent = d.megadetector_detail;
     }
+    renderPlatformReadiness(d.platform_support || null);
   } catch(e) {}
   loadExiftoolStatus();
   loadPipelineModels();
+}
+
+function renderPlatformReadiness(support) {
+  if (!support) return;
+  var row = document.getElementById('windowsSupportRow');
+  if (support.platform === 'win32') {
+    row.style.display = '';
+    var status = document.getElementById('windowsSupportStatus');
+    var detail = document.getElementById('windowsSupportDetail');
+    var supported = support.support_tier === 'public_beta';
+    status.textContent = supported ? 'Public beta' : 'Unsupported Windows version';
+    status.style.color = supported ? 'var(--warning)' : 'var(--danger)';
+    var bits = ['Windows ' + (support.windows_release || '11'), support.architecture || 'x64', 'CPU inference supported'];
+    if (support.webview2_version) bits.push('WebView2 ' + support.webview2_version);
+    if (support.long_paths && !support.long_paths.enabled) {
+      bits.push('Long paths need Windows policy');
+      status.textContent = 'Action needed';
+      status.style.color = 'var(--danger)';
+    }
+    detail.textContent = bits.join(' · ');
+  }
+
+  var deps = support.dependencies || {};
+  var names = {
+    exiftool: 'ExifTool', darktable: 'Darktable', dng_converter: 'Adobe DNG Converter',
+    lightroom: 'Lightroom Classic', openssh: 'OpenSSH Client', rsync: 'GNU rsync',
+    remote_transfer: 'Remote transfers'
+  };
+  var keys = Object.keys(names).filter(function(key) { return deps[key]; });
+  if (!keys.length) return;
+  document.getElementById('dependencyReadiness').style.display = '';
+  document.getElementById('dependencyReadinessRows').innerHTML = keys.map(function(key) {
+    var dep = deps[key];
+    var ready = dep.state === 'ready';
+    var color = ready ? 'var(--accent)' : (dep.required ? 'var(--danger)' : 'var(--warning)');
+    var label = ready ? 'Ready' : (dep.state === 'misconfigured' ? 'Needs repair' : 'Unavailable');
+    var detail = dep.path || dep.hint || '';
+    return '<div class="setting-row"><div class="setting-label">' + escapeHtml(names[key]) +
+      '<small>' + escapeHtml(detail) + '</small></div><span class="setting-value" style="color:' +
+      color + ';">' + label + '</span></div>';
+  }).join('');
 }
 
 // exiftool is the metadata backbone for every scan; a missing binary

--- a/vireo/tests/test_develop.py
+++ b/vireo/tests/test_develop.py
@@ -195,6 +195,21 @@ def test_find_darktable_resolves_symlink(tmp_path):
         assert develop.find_darktable("") == str(real)
 
 
+def test_find_darktable_detects_standard_windows_install(monkeypatch, tmp_path):
+    import develop
+
+    binary = tmp_path / "darktable" / "bin" / "darktable-cli.exe"
+    binary.parent.mkdir(parents=True)
+    binary.write_bytes(b"exe")
+    monkeypatch.setattr(develop.os, "name", "nt")
+    monkeypatch.setenv("PROGRAMFILES", str(tmp_path))
+    monkeypatch.delenv("PROGRAMFILES(X86)", raising=False)
+    monkeypatch.delenv("PROGRAMW6432", raising=False)
+    monkeypatch.setattr(develop.shutil, "which", lambda _name: None)
+
+    assert develop.find_darktable("") == str(binary.resolve())
+
+
 def test_is_nikon_high_efficiency_nef_from_metadata(tmp_path):
     """ExifTool NEFCompression values 13/14 are Nikon HE/HE*."""
     import develop

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -636,6 +636,8 @@ def test_install_exiftool_endpoint_exists(app_and_db, monkeypatch):
     """Install-exiftool endpoint should exist and return JSON."""
     import shutil
     import subprocess
+    import sys
+    monkeypatch.setattr(sys, "platform", "darwin")
     original_which = shutil.which
     monkeypatch.setattr(shutil, "which", lambda cmd: "/usr/local/bin/brew" if cmd == "brew" else (None if cmd == "exiftool" else original_which(cmd)))
     monkeypatch.setattr(subprocess, "run", lambda *a, **kw: type("R", (), {"returncode": 0, "stderr": ""})())
@@ -650,6 +652,8 @@ def test_install_exiftool_endpoint_exists(app_and_db, monkeypatch):
 def test_install_exiftool_fails_without_brew(app_and_db, monkeypatch):
     """Install endpoint should fail gracefully when brew is not available."""
     import shutil
+    import sys
+    monkeypatch.setattr(sys, "platform", "darwin")
     original_which = shutil.which
     monkeypatch.setattr(shutil, "which", lambda cmd: None if cmd in ("brew", "exiftool") else original_which(cmd))
     app, _ = app_and_db

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -2248,6 +2248,12 @@ def _save_remote_target(monkeypatch, tmp_path, **overrides):
     # check so happy-path tests don't depend on a real GNU rsync being
     # installed in the CI environment.
     monkeypatch.setattr(move_mod, "is_gnu_rsync", lambda _rb: True)
+    # The remote-archive preflight also probes for an OpenSSH client
+    # (added for Windows). Stub so happy-path tests don't require ssh
+    # in the CI environment.
+    monkeypatch.setattr(
+        move_mod, "resolve_ssh_bin", lambda configured="": "/usr/bin/ssh",
+    )
     return entry
 
 

--- a/vireo/tests/test_metadata.py
+++ b/vireo/tests/test_metadata.py
@@ -17,6 +17,18 @@ requires_exiftool = pytest.mark.skipif(
 )
 
 
+def test_find_exiftool_prefers_pyinstaller_bundle(monkeypatch, tmp_path):
+    import metadata
+
+    bundled = tmp_path / "vendor" / "exiftool" / "exiftool.exe"
+    bundled.parent.mkdir(parents=True)
+    bundled.write_bytes(b"exe")
+    monkeypatch.setattr(metadata.sys, "_MEIPASS", str(tmp_path), raising=False)
+    monkeypatch.setattr(metadata.shutil, "which", lambda _name: "/path/exiftool")
+
+    assert metadata.find_exiftool() == str(bundled)
+
+
 def _create_jpg_with_exif(path):
     """Create a JPEG with EXIF data via PIL's native Exif support."""
     img = Image.new('RGB', (200, 100), color='green')

--- a/vireo/tests/test_platform_support.py
+++ b/vireo/tests/test_platform_support.py
@@ -1,0 +1,64 @@
+import os
+from types import SimpleNamespace
+
+import platform_support
+
+
+def test_dependency_readiness_requires_both_remote_tools(monkeypatch):
+    monkeypatch.setattr(
+        platform_support,
+        "exiftool_status",
+        lambda: {"available": True, "path": "exiftool", "version": "13", "error": None, "hint": ""},
+    )
+    monkeypatch.setattr(platform_support, "find_darktable", lambda _path: None)
+    monkeypatch.setattr(platform_support, "find_dng_converter", lambda _path: None)
+    monkeypatch.setattr(platform_support, "find_lightroom", lambda: None)
+    monkeypatch.setattr(platform_support, "find_ssh", lambda _path="": "ssh.exe")
+    monkeypatch.setattr(platform_support, "_probe", lambda _binary, _args: (True, "OpenSSH_9"))
+    monkeypatch.setattr(platform_support, "resolve_rsync_bin", lambda _path="": None)
+
+    readiness = platform_support.dependency_readiness({})
+
+    assert readiness["exiftool"]["state"] == "ready"
+    assert readiness["openssh"]["state"] == "ready"
+    assert readiness["rsync"]["state"] == "missing"
+    assert readiness["remote_transfer"]["state"] == "unavailable"
+
+
+def test_filesystem_type_is_not_probed_off_windows(monkeypatch):
+    monkeypatch.setattr(platform_support.os, "name", "posix")
+    monkeypatch.setattr(
+        platform_support.ctypes,
+        "windll",
+        SimpleNamespace(kernel32=SimpleNamespace()),
+        raising=False,
+    )
+    assert platform_support.filesystem_type("/photos") is None
+
+
+def test_program_files_candidates_are_deduplicated(monkeypatch, tmp_path):
+    monkeypatch.setenv("PROGRAMFILES", str(tmp_path))
+    monkeypatch.setenv("PROGRAMW6432", str(tmp_path))
+    monkeypatch.delenv("PROGRAMFILES(X86)", raising=False)
+    assert platform_support._program_files_candidates("Adobe") == [
+        os.path.join(str(tmp_path), "Adobe")
+    ]
+
+
+def test_windows_11_build_is_public_beta(monkeypatch):
+    monkeypatch.setattr(platform_support.os, "name", "nt")
+    monkeypatch.setattr(platform_support.platform, "release", lambda: "11")
+    monkeypatch.setattr(platform_support.platform, "version", lambda: "10.0.26100")
+    monkeypatch.setattr(platform_support.platform, "machine", lambda: "AMD64")
+    monkeypatch.setattr(platform_support, "dependency_readiness", lambda _config: {})
+    monkeypatch.setattr(platform_support, "webview2_version", lambda: "1.0")
+    monkeypatch.setattr(
+        platform_support,
+        "windows_long_path_status",
+        lambda: {"state": "ready", "enabled": True},
+    )
+
+    info = platform_support.platform_support_info({})
+
+    assert info["support_tier"] == "public_beta"
+    assert info["guaranteed_inference"] == "CPUExecutionProvider"

--- a/vireo/tests/test_report.py
+++ b/vireo/tests/test_report.py
@@ -1,5 +1,7 @@
 """Tests for the issue-reporting endpoint."""
 
+import json
+import logging
 import os
 import sys
 
@@ -121,6 +123,33 @@ class TestReportIssue:
         assert config_in_report.get("inat_token") == "[REDACTED]"
         # Non-sensitive values should not be redacted
         assert config_in_report.get("classification_threshold") == current["classification_threshold"]
+
+    def test_catalog_paths_are_redacted_without_destroying_log_shape(self, app_and_db):
+        """Diagnostics preserve structured logs but never include photo roots."""
+        import config as cfg
+
+        app, _db = app_and_db
+        current = cfg.load()
+        current["scan_roots"] = ["/photos/2024"]
+        current["darktable_bin"] = "/Applications/darktable-cli"
+        current["report_url"] = ""
+        cfg.save(current)
+        app._log_broadcaster.emit(logging.LogRecord(
+            "vireo.test", logging.INFO, __file__, 1,
+            "Scanning /photos/2024/bird1.jpg", (), None,
+        ))
+
+        with app.test_client() as client:
+            response = client.post(
+                "/api/report-issue", json={"description": "path redaction"}
+            )
+        diagnostics = response.get_json()["diagnostics"]
+        serialized = json.dumps(diagnostics)
+
+        assert "/photos/2024" not in serialized
+        assert "[PHOTO_PATH]" in serialized
+        assert isinstance(diagnostics["logs"][-1], dict)
+        assert diagnostics["config"]["scan_roots"] == "[REDACTED_PATH]"
 
     def test_report_with_bad_url_returns_download_fallback(self, client):
         """If the report URL is unreachable, fall back to download."""

--- a/website/src/pages/docs.astro
+++ b/website/src/pages/docs.astro
@@ -29,7 +29,7 @@ for (const entry of helpData) {
 
       <div class="docs-step">
         <h3>1. Install Vireo</h3>
-        <p>Download the installer for your platform from the <a href={`${base}download/`}>download page</a> and run it. On macOS, drag Vireo to your Applications folder. On Windows, run the setup wizard. On Linux, install the .deb package.</p>
+        <p>Download the installer for your platform from the <a href={`${base}download/`}>download page</a> and run it. On macOS, drag Vireo to your Applications folder. On Windows 11, run the public-beta setup wizard. On Linux, install the .deb package.</p>
       </div>
 
       <div class="docs-step">

--- a/website/src/pages/download.astro
+++ b/website/src/pages/download.astro
@@ -9,6 +9,13 @@ const releaseUrl = (v: string) => `https://github.com/jss367/vireo/releases/down
 const macosArm64Version = '0.18.0';
 const windowsVersion = '0.18.0';
 const linuxVersion = '0.18.0';
+
+// The Windows 11 public beta ships as the first SignPath-signed build.
+// Until the download link points at that signed build, the older Windows
+// installer (v0.18.0) is still what users get — don't advertise it as
+// the beta. Flip this to `true` in the same change that bumps
+// `windowsVersion` to the signed beta release.
+const windowsBetaAvailable = windowsVersion !== '0.18.0';
 ---
 
 <Base title="Download — Vireo" description="Download Vireo for macOS, Windows, or Linux. Free, open source, no account required.">
@@ -33,7 +40,7 @@ const linuxVersion = '0.18.0';
           label="Download for Windows"
           href={`${releaseUrl(windowsVersion)}/Vireo_${windowsVersion}_x64-setup.exe`}
           version={windowsVersion}
-          note="Windows 11 public beta"
+          note={windowsBetaAvailable ? 'Windows 11 public beta' : undefined}
         />
         <DownloadButton
           platform="linux"
@@ -78,11 +85,19 @@ const linuxVersion = '0.18.0';
             <li>2 GB disk space (more for larger AI models)</li>
             <li>CPU inference is fully supported</li>
           </ul>
-          <p class="sysreq__note">
-            Windows 11 support is in public beta. ExifTool is included. Darktable, Lightroom, Adobe DNG Converter,
-            and remote-transfer tools are optional and detected from your Windows installation.
-            <a href="https://github.com/jss367/vireo/blob/main/docs/WINDOWS_SUPPORT.md" target="_blank" rel="noopener">Read the Windows support guide</a>.
-          </p>
+          {windowsBetaAvailable ? (
+            <p class="sysreq__note">
+              Windows 11 support is in public beta. ExifTool is included. Darktable, Lightroom, Adobe DNG Converter,
+              and remote-transfer tools are optional and detected from your Windows installation.
+              <a href="https://github.com/jss367/vireo/blob/main/docs/WINDOWS_SUPPORT.md" target="_blank" rel="noopener">Read the Windows support guide</a>.
+            </p>
+          ) : (
+            <p class="sysreq__note">
+              Windows 11 support is preparing for public beta. The download above is the previous Windows build;
+              the signed public beta will appear here once released.
+              <a href="https://github.com/jss367/vireo/blob/main/docs/WINDOWS_SUPPORT.md" target="_blank" rel="noopener">Read the Windows support guide</a>.
+            </p>
+          )}
         </div>
         <div class="sysreq__card">
           <h3>Linux</h3>

--- a/website/src/pages/download.astro
+++ b/website/src/pages/download.astro
@@ -33,7 +33,7 @@ const linuxVersion = '0.18.0';
           label="Download for Windows"
           href={`${releaseUrl(windowsVersion)}/Vireo_${windowsVersion}_x64-setup.exe`}
           version={windowsVersion}
-          note="Not actively supported"
+          note="Windows 11 public beta"
         />
         <DownloadButton
           platform="linux"
@@ -72,14 +72,16 @@ const linuxVersion = '0.18.0';
         <div class="sysreq__card">
           <h3>Windows</h3>
           <ul>
-            <li>Windows 10 (64-bit) or later</li>
+            <li>Windows 11 (64-bit)</li>
             <li>x86-64 processor</li>
             <li>4 GB RAM minimum</li>
             <li>2 GB disk space (more for larger AI models)</li>
+            <li>CPU inference is fully supported</li>
           </ul>
           <p class="sysreq__note">
-            Windows is not actively supported at the moment. The installer is available but you may encounter issues.
-            <a href="https://github.com/jss367/vireo/issues/334" target="_blank" rel="noopener">Upvote this issue</a> if you'd like Windows support prioritized.
+            Windows 11 support is in public beta. ExifTool is included. Darktable, Lightroom, Adobe DNG Converter,
+            and remote-transfer tools are optional and detected from your Windows installation.
+            <a href="https://github.com/jss367/vireo/blob/main/docs/WINDOWS_SUPPORT.md" target="_blank" rel="noopener">Read the Windows support guide</a>.
           </p>
         </div>
         <div class="sysreq__card">


### PR DESCRIPTION
## Summary

- promote Windows 11 x64 CPU builds to a documented public beta with bundled ExifTool, platform-aware dependency detection, readiness reporting, safer subprocess handling, and Windows diagnostics
- add native Windows manifest/runtime recovery behavior plus installer, startup, restart, persistence, shutdown, and uninstall smoke coverage
- make Windows release builds blocking and Authenticode-sign the app, Python sidecar, NSIS installer, and MSI installer through SignPath
- add a protected signed release-candidate mode that retains verified artifacts without creating a tag, public release, or website update
- expand Windows CI, issue reporting, support documentation, website messaging, and the Windows issue template

## User impact

Windows 11 x64 users receive the same core workflows as other supported platforms, with CPU inference guaranteed and optional third-party integrations clearly diagnosed. Remote operations remain unavailable until both Windows OpenSSH and GNU rsync pass executable probes. Failed file and transfer operations preserve originals.

## Validation

- full Python suite: 4,495 passed, 78 skipped
- focused Windows/platform suite after the final workflow changes: 61 passed
- Ruff: passed
- Rust formatting and `cargo check`: passed
- Rust tests: 20 passed
- Playwright/static website build: passed
- GitHub Actions workflow validation with actionlint: passed
- ExifTool 13.59 download checksum and extraction: verified
- `git diff --check`: passed

## Release prerequisites

- SignPath open-source approval, GitHub App installation, signing policy, secret, and repository variables still need to be configured.
- A signed candidate must be certified on a clean Windows 11 x64 virtual machine and a physical machine with NTFS plus removable or network storage before announcing the beta.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows 11 64-bit public beta support with CPU inference.
  * Windows installers now bundle ExifTool and support long paths, WebView2 setup, and current-user installation.
  * Added support guidance for remote transfers, storage formats, optional integrations, and troubleshooting.
  * Added Windows integration-readiness details and improved startup error messages with log locations.

* **Bug Fixes**
  * Improved Windows detection for Darktable, ExifTool, OpenSSH, and remote transfer tools.
  * Enhanced diagnostic redaction to protect private paths.

* **Documentation**
  * Updated download pages, setup instructions, release documentation, changelog, and issue reporting guidance.

* **Tests**
  * Expanded smoke testing across Windows, macOS, and Linux.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->