### PR TITLE
Restore import source photo counts

### DIFF
--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -17,6 +17,38 @@ def test_import_source_browse_button_adds_source_folder(live_server, page):
     expect(source_list).to_contain_text("/tmp/card-b")
 
 
+def test_import_source_browse_button_shows_quick_photo_count(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/import")
+    page.evaluate(
+        """
+        () => {
+          const originalFetch = window.fetch.bind(window);
+          window.fetch = (input, init) => {
+            const target = typeof input === 'string' ? input : input.url;
+            if (target && target.indexOf('/api/import/folder-preview') === 0) {
+              return Promise.resolve(new Response(JSON.stringify({
+                total_count: 42,
+                total_size: 0,
+                type_breakdown: {'.jpg': 42},
+                duplicate_count: 0,
+                files: [],
+              }), {status: 200, headers: {'Content-Type': 'application/json'}}));
+            }
+            return originalFetch(input, init);
+          };
+          window.pickDirectory = async () => ['/tmp/card-a'];
+        }
+        """
+    )
+
+    page.locator("[data-testid='import-source-browse-btn']").click()
+
+    source_list = page.locator("#sourceList")
+    expect(source_list).to_contain_text("/tmp/card-a")
+    expect(source_list.locator(".source-meta")).to_have_text("42 photos")
+
+
 def test_import_destination_browse_button_sets_destination(live_server, page):
     url = live_server["url"]
     page.goto(f"{url}/import")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -12940,12 +12940,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         body = request.get_json(silent=True) or {}
         folders = body.get("folders", [])
         file_types = body.get("file_types", [])
+        summary_only = bool(body.get("summary_only"))
         if not folders:
             return json_error("folders required", 400)
 
         from ingest import discover_source_files
 
         all_files = []
+        type_breakdown = {}
+        total_size = 0
         multi_source = len(folders) > 1
 
         # Compute unique display names for each source folder.
@@ -12970,6 +12973,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             discovered = discover_source_files(folder, file_types=file_types if file_types else "both", recursive=body.get("recursive", True))
             for f in discovered:
                 stat = f.stat()
+                ext = f.suffix.lower()
+                type_breakdown[ext] = type_breakdown.get(ext, 0) + 1
+                total_size += stat.st_size
+                if summary_only:
+                    continue
                 # Determine subfolder relative to the source root
                 try:
                     rel = f.parent.relative_to(folder)
@@ -12986,21 +12994,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     "filename": f.name,
                     "subfolder": subfolder,
                     "size": stat.st_size,
-                    "extension": f.suffix.lower(),
+                    "extension": ext,
                     "mtime": stat.st_mtime,
                     "thumb_url": "/api/import/folder-preview/thumbnail?path=" + quote(str(f)),
                 })
 
-        # Build summary
-        type_breakdown = {}
-        total_size = 0
-        for f in all_files:
-            ext = f["extension"]
-            type_breakdown[ext] = type_breakdown.get(ext, 0) + 1
-            total_size += f["size"]
-
         return jsonify({
-            "total_count": len(all_files),
+            "total_count": sum(type_breakdown.values()) if summary_only else len(all_files),
             "total_size": total_size,
             "type_breakdown": type_breakdown,
             "duplicate_count": 0,

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -27,6 +27,7 @@ body { display: flex; flex-direction: column; height: 100vh; }
 .source-list { display: flex; flex-direction: column; gap: 4px; margin-top: 6px; }
 .source-item { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--text-primary); background: var(--bg-tertiary); border-radius: 4px; padding: 4px 8px; }
 .source-item button { background: none; border: none; color: var(--danger); cursor: pointer; font-size: 14px; }
+.source-meta { color: var(--text-secondary); white-space: nowrap; }
 .hint { font-size: 11px; color: var(--text-secondary); }
 .preview-summary { font-size: 12px; color: var(--text-secondary); margin-top: 6px; }
 .progress-bar { height: 8px; background: var(--bg-tertiary); border-radius: 4px; overflow: hidden; }
@@ -115,9 +116,9 @@ body { display: flex; flex-direction: column; height: 100vh; }
       </div>
       <div class="source-list" id="sourceList"></div>
       <div class="row" style="margin-top:8px;">
-        <label><input type="checkbox" id="chkRecursive" checked> Include subfolders</label>
+        <label><input type="checkbox" id="chkRecursive" checked onchange="refreshSourceCounts()"> Include subfolders</label>
         <label id="fileTypesWrap">File types
-          <select id="fileTypes" style="min-width:100px;">
+          <select id="fileTypes" style="min-width:100px;" onchange="refreshSourceCounts()">
             <option value="both" selected>RAW + JPEG</option>
             <option value="raw">RAW only</option>
             <option value="jpeg">JPEG only</option>
@@ -222,6 +223,8 @@ let sources = [];
 let activeJobId = null;
 let es = null;
 let stagingResultsByPath = {};
+let sourceCounts = {};
+let sourceCountRequestSeq = 0;
 let browserMode = 'source';
 let browserPath = '';
 let browserHomePath = '';
@@ -245,6 +248,7 @@ function updateImportMode() {
     copyMode ? 'Check for duplicates' : 'Preview import';
   document.getElementById('previewSummary').textContent = '';
   showError('');
+  refreshSourceCounts();
 }
 
 function importEscapeHtml(s) {
@@ -266,14 +270,96 @@ function renderSources() {
     const span = document.createElement('span');
     span.textContent = s;
     span.style.flex = '1';
+    const meta = document.createElement('span');
+    meta.className = 'source-meta';
+    meta.textContent = sourceCounts[s] && sourceCounts[s].text
+      ? sourceCounts[s].text
+      : 'Counting photos...';
     const btn = document.createElement('button');
     btn.textContent = '×';
     btn.title = 'Remove';
-    btn.onclick = () => { sources.splice(i, 1); renderSources(); };
+    btn.onclick = () => {
+      sources.splice(i, 1);
+      delete sourceCounts[s];
+      renderSources();
+    };
     div.appendChild(span);
+    div.appendChild(meta);
     div.appendChild(btn);
     list.appendChild(div);
   });
+}
+
+function selectedSourceCountOptions() {
+  const copyMode = selectedImportMode() === 'copy';
+  return {
+    file_types: copyMode ? document.getElementById('fileTypes').value : 'both',
+    recursive: document.getElementById('chkRecursive').checked,
+  };
+}
+
+function sourceCountKey(path, options) {
+  return [
+    path,
+    options.file_types,
+    options.recursive ? 'recursive' : 'flat',
+  ].join('\n');
+}
+
+function formatPhotoCount(n) {
+  const count = Number(n || 0);
+  return count + ' photo' + (count === 1 ? '' : 's');
+}
+
+async function refreshSourceCount(path) {
+  if (!path) return;
+  const options = selectedSourceCountOptions();
+  const key = sourceCountKey(path, options);
+  const existing = sourceCounts[path];
+  if (existing && existing.key === key && existing.status === 'loaded') return;
+  const requestId = ++sourceCountRequestSeq;
+  sourceCounts[path] = {
+    key: key,
+    requestId: requestId,
+    status: 'loading',
+    text: 'Counting photos...',
+  };
+  renderSources();
+  try {
+    const resp = await fetch('/api/import/folder-preview', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        folders: [path],
+        file_types: options.file_types,
+        recursive: options.recursive,
+        summary_only: true,
+      }),
+    });
+    const data = await resp.json().catch(() => ({}));
+    const current = sourceCounts[path];
+    if (!sources.includes(path) || !current || current.requestId !== requestId) return;
+    sourceCounts[path] = {
+      key: key,
+      requestId: requestId,
+      status: resp.ok ? 'loaded' : 'error',
+      text: resp.ok ? formatPhotoCount(data.total_count) : 'Count unavailable',
+    };
+  } catch (e) {
+    const current = sourceCounts[path];
+    if (!sources.includes(path) || !current || current.requestId !== requestId) return;
+    sourceCounts[path] = {
+      key: key,
+      requestId: requestId,
+      status: 'error',
+      text: 'Count unavailable',
+    };
+  }
+  renderSources();
+}
+
+function refreshSourceCounts() {
+  sources.forEach(refreshSourceCount);
 }
 
 function addSourcePath(path) {
@@ -282,6 +368,7 @@ function addSourcePath(path) {
   if (!sources.includes(v)) {
     sources.push(v);
     renderSources();
+    refreshSourceCount(v);
     return true;
   }
   return false;

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -8707,6 +8707,30 @@ def test_api_import_folder_preview_duplicate_count_deferred(app_and_db, tmp_path
     assert data["duplicate_count"] == 0
 
 
+def test_api_import_folder_preview_summary_only_omits_file_rows(app_and_db, tmp_path):
+    """Summary-only folder preview keeps count cheap for import source rows."""
+    app, _ = app_and_db
+
+    source = tmp_path / "source_summary"
+    source.mkdir()
+    from PIL import Image
+    Image.new("RGB", (100, 100)).save(str(source / "bird1.jpg"))
+    Image.new("RGB", (100, 100)).save(str(source / "bird2.jpg"))
+    (source / "notes.txt").write_text("ignore me")
+
+    client = app.test_client()
+    resp = client.post("/api/import/folder-preview", json={
+        "folders": [str(source)],
+        "file_types": "both",
+        "summary_only": True,
+    })
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["total_count"] == 2
+    assert data["type_breakdown"][".jpg"] == 2
+    assert data["files"] == []
+
+
 def test_api_import_folder_preview_no_folders(app_and_db):
     """Folder preview returns error when no folders provided."""
     app, _ = app_and_db


### PR DESCRIPTION
## Summary
Restores the quick per-source photo count in the import source list so users see how many importable photos a selected folder contains before pressing Preview. The count uses a summary-only folder-preview request and refreshes when recursive scanning, import mode, or RAW/JPEG filters change. The root cause was that the import-page/menu rewrite kept the full Preview count but dropped the source-row count display.

## Validation
- python -m pytest tests/e2e/test_import_page.py -q
- python -m pytest vireo/tests/test_app.py -q -k "import_folder_preview"
- python -m pytest tests/e2e/test_import_page.py::test_import_source_browse_button_shows_quick_photo_count vireo/tests/test_app.py::test_api_import_folder_preview_summary_only_omits_file_rows -q