### PR TITLE
Fix Highlights pick ordering refresh

### DIFF
--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2461,9 +2461,10 @@ class Database:
                        updated_at = excluded.updated_at""",
                 (row["species"], row["photo_id"], order),
             )
-        self.conn.execute(
-            "INSERT INTO db_meta(key, value) VALUES (?, '1')",
-            (self._SPECIES_REPRESENTATIVES_BACKFILL_KEY,),
+        self.set_meta(
+            self._SPECIES_REPRESENTATIVES_BACKFILL_KEY,
+            "1",
+            _commit=False,
         )
         self.conn.commit()
 

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -1383,11 +1383,13 @@ document.addEventListener('lightbox:flagchanged', function(e) {
     var isUnidentified = hit.bucket === null;
     var target = isUnidentified ? currentData.unidentified : hit.bucket;
     if (!target) { render(); return; }
-    // Render once immediately so the Pick badge/outline appears without
-    // waiting for the refetch's network round-trip; render again after the
-    // refetch so the reordered bucket window replaces the stale one.
-    render();
-    refetchBucketFromZero(target, isUnidentified).then(render);
+    // Render after the authoritative refetch settles so the Pick badge/outline
+    // and the bucket ordering become visible together. Rendering before the
+    // refetch exposes a transient stale order: tests and collection saves can
+    // observe the picked class while the photo is still in its old position.
+    refetchBucketFromZero(target, isUnidentified)
+      .then(render)
+      .catch(function() { render(); });
   }
 });
 


### PR DESCRIPTION
## Summary
- Wait for the authoritative Highlights bucket refetch before rendering pick/unpick changes from the lightbox.
- This keeps the pick badge and backend score-bonus ordering visible at the same time, avoiding a transient stale order.
- Make the species representative backfill marker write idempotent so duplicate marker races do not fail CI or startup backfills.

## Validation
- pytest tests/e2e/test_highlights_initial_scope.py::test_highlights_lightbox_pick_applies_backend_score_bonus -q
- pytest tests/e2e/test_highlights_initial_scope.py -q -k "lightbox_pick"
- pytest vireo/tests/test_life_list.py::test_highlights_picks_sort_before_higher_scored_unflagged vireo/tests/test_life_list.py::test_highlights_bucket_best_score_ignores_pick_promotion vireo/tests/test_app.py::test_highlights_expose_pre_pick_base_score vireo/tests/test_app.py::test_highlights_bucket_returns_full_bucket_ordering_keys -q
- pytest tests/e2e/test_highlights_initial_scope.py -q
- pytest vireo/tests/test_life_list.py -q