### PR TITLE
Disable current representative menu action

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4654,19 +4654,24 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         result["keywords"] = [dict(k) for k in keywords]
 
         # Representative block: the photo's eligible species plus whether this
-        # photo is one of the shared species representatives. Keep the
-        # legacy ``life_list`` key because shared lightbox/menu code reads it.
+        # photo is the primary species representative. Only the primary (item 0
+        # of get_species_representative_lists, which sorts newest-selection
+        # first) flips these flags — secondary reps stay false so shared UI
+        # code (context menus, panel buttons) can still offer to promote them
+        # via set_species_representative's re-select-to-newest behavior.
+        # Keep the legacy ``life_list`` key because shared lightbox/menu code
+        # reads it.
         representatives = db.get_species_representative_lists()
         life_list_species = db.get_photo_life_list_species(photo_id)
-        representative_sets = {
-            species: set(representatives.get(species) or [])
-            for species in life_list_species
+        primary_by_species = {
+            species: (photo_ids[0] if photo_ids else None)
+            for species, photo_ids in representatives.items()
         }
         result["life_list"] = [
             {
                 "species": s,
-                "is_current_photo": photo_id in representative_sets[s],
-                "is_species_representative": photo_id in representative_sets[s],
+                "is_current_photo": photo_id == primary_by_species.get(s),
+                "is_species_representative": photo_id == primary_by_species.get(s),
             }
             for s in life_list_species
         ]

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4661,7 +4661,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # via set_species_representative's re-select-to-newest behavior.
         # Keep the legacy ``life_list`` key because shared lightbox/menu code
         # reads it.
-        representatives = db.get_species_representative_lists()
+        representatives = db.get_species_representative_lists(eligible_only=True)
         life_list_species = db.get_photo_life_list_species(photo_id)
         primary_by_species = {
             species: (photo_ids[0] if photo_ids else None)

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3752,7 +3752,7 @@ window.buildSpeciesRepresentativeMenuItems = function(photoIds, opts) {
   var entries = _lifeListMenuEntriesForPhotoId(photoId, opts);
   if (entries.length) {
     return entries.map(function(entry) {
-      var isCurrent = !!(entry.is_current_photo || entry.is_species_representative);
+      var isCurrent = !!entry.is_current_photo;
       return {
         label: 'Set Representative \u2014 ' + entry.species,
         disabled: isCurrent,

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3752,8 +3752,11 @@ window.buildSpeciesRepresentativeMenuItems = function(photoIds, opts) {
   var entries = _lifeListMenuEntriesForPhotoId(photoId, opts);
   if (entries.length) {
     return entries.map(function(entry) {
+      var isCurrent = !!(entry.is_current_photo || entry.is_species_representative);
       return {
         label: 'Set Representative \u2014 ' + entry.species,
+        disabled: isCurrent,
+        disabledHint: isCurrent ? 'Already representative' : null,
         onClick: function() { setLifeListPhoto(entry.species, photoId); },
       };
     });

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -642,6 +642,31 @@ def test_photo_detail_life_list_marks_only_primary_of_multiple_reps(app_and_db):
     ]
 
 
+def test_photo_detail_life_list_uses_primary_eligible_rep(app_and_db):
+    """If the newest representative is ineligible, the older eligible rep is
+    current so detail menus do not offer a redundant representative action."""
+    app, db = app_and_db
+    client = app.test_client()
+    photos = db.get_photos()
+    p1, p2 = photos[0]["id"], photos[1]["id"]
+    kid = db.add_keyword("American Robin", is_species=True)
+    db.tag_photo(p1, kid)
+    db.tag_photo(p2, kid)
+    db.set_species_representative("American Robin", p1)
+    db.set_species_representative("American Robin", p2)
+    db.update_photo_flag(p2, "rejected")
+
+    data = client.get(f"/api/photos/{p1}").get_json()
+
+    assert data["life_list"] == [
+        {
+            "species": "American Robin",
+            "is_current_photo": True,
+            "is_species_representative": True,
+        }
+    ]
+
+
 def test_photo_detail_life_list_excludes_non_species_keyword(app_and_db):
     """Plain (non-species) keywords never produce a lifelist entry."""
     app, db = app_and_db

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -607,6 +607,41 @@ def test_photo_detail_life_list_current_false_when_other_photo_is_rep(app_and_db
     ]
 
 
+def test_photo_detail_life_list_marks_only_primary_of_multiple_reps(app_and_db):
+    """Secondary reps report is_current_photo=False so the lightbox lifelist
+    panel renders "Set Representative" (re-selecting promotes them) and the
+    shared context menu doesn't disable the item for a secondary rep."""
+    app, db = app_and_db
+    client = app.test_client()
+    photos = db.get_photos()
+    p1, p2 = photos[0]["id"], photos[1]["id"]
+    kid = db.add_keyword("American Robin", is_species=True)
+    db.tag_photo(p1, kid)
+    db.tag_photo(p2, kid)
+    # p1 selected first, then p2 — get_species_representative_lists is
+    # newest-first, so p2 is the primary (index 0) and p1 is secondary.
+    db.set_species_representative("American Robin", p1)
+    db.set_species_representative("American Robin", p2)
+
+    primary = client.get(f"/api/photos/{p2}").get_json()
+    secondary = client.get(f"/api/photos/{p1}").get_json()
+
+    assert primary["life_list"] == [
+        {
+            "species": "American Robin",
+            "is_current_photo": True,
+            "is_species_representative": True,
+        }
+    ]
+    assert secondary["life_list"] == [
+        {
+            "species": "American Robin",
+            "is_current_photo": False,
+            "is_species_representative": False,
+        }
+    ]
+
+
 def test_photo_detail_life_list_excludes_non_species_keyword(app_and_db):
     """Plain (non-species) keywords never produce a lifelist entry."""
     app, db = app_and_db


### PR DESCRIPTION
## Summary
- Disable the shared Set Representative context-menu item when the selected photo is already the species representative.
- Preserve the existing menu label while adding the disabled state and tooltip expected by Browse and lightbox callers.

## Validation
- pytest tests/e2e/test_lifelist_add_verify.py --browser chromium
- pytest tests/e2e/test_lightbox_context_menu.py --browser chromium
- pytest tests/e2e/test_highlights_initial_scope.py::test_highlights_lightbox_pick_applies_backend_score_bonus --browser chromium
- git diff --check
