### PR TITLE
Restore import page options

### DIFF
--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -228,6 +228,48 @@ def test_import_copy_start_sends_restored_options(live_server, page):
     assert body["file_types"] == [".jpg", ".nef"]
     assert body["skip_duplicates"] is False
     assert body["verify_by_hash"] is True
+    # The After Import dropdown was untouched, and this is a new-workspace
+    # import — the client must omit after_import so the server resolves the
+    # default against the newly-created workspace instead of leaking the
+    # previously-active workspace's pipeline.default_strategy.
+    assert "after_import" not in body
+
+
+def test_import_new_workspace_forwards_explicit_after_import(live_server, page):
+    """When the user actively picks a strategy for a new-workspace import,
+    the client must forward that pick — only the untouched-dropdown case is
+    omitted so the server can apply the new workspace's default."""
+    url = live_server["url"]
+    captured = {}
+
+    def start_import(route):
+        captured["body"] = json.loads(route.request.post_data or "{}")
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "job_id": "import-test",
+                "workspace": {"id": 23, "name": "Serengeti"},
+            }),
+        )
+
+    page.route("**/api/jobs/import-photos", start_import)
+    page.goto(f"{url}/import")
+
+    page.locator("#modeCopy").check()
+    page.locator("#sourceInput").fill("/tmp/card-a")
+    page.locator("#btnAddSource").click()
+    page.locator("#workspaceNew").check()
+    page.locator("#newWorkspaceName").fill("Serengeti")
+    page.locator("#destInput").fill("/tmp/archive")
+    page.locator("#afterImportSelect").select_option("identify")
+
+    page.locator("#btnStart").click()
+    expect(page.locator("#progressCard")).to_be_visible()
+
+    body = captured["body"]
+    assert body["new_workspace_name"] == "Serengeti"
+    assert body["after_import"] == "identify"
 
 
 def test_import_browse_button_opens_folder_browser_fallback(live_server, page):

--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -110,6 +110,56 @@ def test_import_custom_extensions_feed_preview(live_server, page):
     assert body["file_types"] == [".jpg", ".nef"]
 
 
+def test_import_preview_passes_verify_by_hash_to_duplicate_check(live_server, page):
+    """The preview and the actual import must use the same duplicate mode so
+    the counts don't disagree for renamed / metadata-colliding files."""
+    url = live_server["url"]
+    page.goto(f"{url}/import")
+    page.evaluate(
+        """
+        () => {
+          const originalFetch = window.fetch.bind(window);
+          window.__dupBody = null;
+          window.fetch = (input, init) => {
+            const target = typeof input === 'string' ? input : input.url;
+            if (target && target.indexOf('/api/import/folder-preview') === 0) {
+              return Promise.resolve(new Response(JSON.stringify({
+                total_count: 1,
+                total_size: 0,
+                type_breakdown: {'.jpg': 1},
+                duplicate_count: 0,
+                files: [{path: '/tmp/card-a/IMG_0001.jpg'}],
+              }), {status: 200, headers: {'Content-Type': 'application/json'}}));
+            }
+            if (target && target.indexOf('/api/import/check-duplicates') === 0) {
+              window.__dupBody = JSON.parse(init.body);
+              const frame = 'data: ' + JSON.stringify({
+                done: true, duplicate_count: 0, checked: 1, total: 1,
+              }) + '\\n\\n';
+              return Promise.resolve(new Response(frame, {
+                status: 200,
+                headers: {'Content-Type': 'text/event-stream'},
+              }));
+            }
+            return originalFetch(input, init);
+          };
+        }
+        """
+    )
+
+    page.locator("#modeCopy").check()
+    page.locator("#sourceInput").fill("/tmp/card-a")
+    page.locator("#btnAddSource").click()
+    page.locator("#chkSkipDuplicates").check()
+    page.locator("#chkVerifyByHash").check()
+    page.locator("#btnPreview").click()
+    page.wait_for_function("window.__dupBody !== null")
+
+    body = page.evaluate("window.__dupBody")
+    assert body["paths"] == ["/tmp/card-a/IMG_0001.jpg"]
+    assert body["verify_by_hash"] is True
+
+
 def test_import_copy_start_sends_restored_options(live_server, page):
     url = live_server["url"]
     captured = {}

--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -272,6 +272,64 @@ def test_import_new_workspace_forwards_explicit_after_import(live_server, page):
     assert body["after_import"] == "identify"
 
 
+def test_import_new_workspace_shows_target_default_in_after_import_display(
+    live_server, page
+):
+    """When 'New workspace' is picked and the After Import dropdown is
+    untouched, the visible label must describe what the server will
+    actually do — the global default that the freshly-created workspace
+    inherits — rather than leaking the currently-active workspace's
+    (possibly-overridden) prefilled selection."""
+    url = live_server["url"]
+
+    def config_route(route):
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "pipeline": {"default_strategy": "identify"},
+            }),
+        )
+
+    def active_workspace_route(route):
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "id": 1,
+                "name": "Existing",
+                "config_overrides": {
+                    "pipeline": {"default_strategy": "quick_look"},
+                },
+            }),
+        )
+
+    page.route("**/api/config", config_route)
+    page.route("**/api/workspaces/active", active_workspace_route)
+    page.goto(f"{url}/import")
+
+    # Before touching workspaceNew, the dropdown reflects the CURRENT
+    # workspace's default (quick_look) — the source of the misleading
+    # signal that this fix addresses.
+    expect(page.locator("#afterImportSelect")).to_have_value("quick_look")
+
+    page.locator("#workspaceNew").check()
+
+    # After switching to new-workspace mode, the visible selection swaps
+    # to a placeholder that names the GLOBAL default (identify) — matching
+    # what the server will actually apply to the freshly-created workspace.
+    expect(page.locator("#afterImportSelect")).to_have_value("__hidden_default__")
+    placeholder = page.locator("#afterImportHiddenDefault")
+    expect(placeholder).to_contain_text("New workspace default")
+    expect(placeholder).to_contain_text("Identify birds")
+
+    # Switching back to current-workspace mode without touching the
+    # dropdown restores the current workspace's default rather than
+    # sticking on the placeholder.
+    page.locator("#workspaceCurrent").check()
+    expect(page.locator("#afterImportSelect")).to_have_value("quick_look")
+
+
 def test_import_browse_button_opens_folder_browser_fallback(live_server, page):
     url = live_server["url"]
     page.goto(f"{url}/import")

--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -507,6 +507,24 @@ def test_use_staging_as_import_source_forces_copy_mode(live_server, page):
     expect(page.locator("#destCard")).to_be_visible()
 
 
+def test_import_menu_deep_link_opens_copy_mode_with_source_picker(live_server, page):
+    # File > Import Folder... in the native menu routes to
+    # /import?mode=copy&pick=source so the two File-menu import commands stay
+    # distinct actions. In browser mode pickDirectory() returns null, so the
+    # in-page folder browser must open instead of the native dialog.
+    url = live_server["url"]
+    page.goto(f"{url}/import?mode=copy&pick=source")
+
+    expect(page.locator("#modeCopy")).to_be_checked()
+    expect(page.locator("#destCard")).to_be_visible()
+    expect(page.locator("[data-testid='import-folder-browser']")).to_have_class(
+        re.compile(r"\bopen\b"))
+    expect(page.locator("#folderBrowserTitle")).to_have_text("Select Source Folders")
+    # pick is a one-shot trigger: it must be stripped from the URL so a manual
+    # reload doesn't reopen the picker, while the mode param survives.
+    page.wait_for_url(f"{url}/import?mode=copy")
+
+
 def test_import_folder_browser_escape_closes_modal(live_server, page):
     url = live_server["url"]
     page.goto(f"{url}/import")

--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -1,3 +1,4 @@
+import json
 import re
 
 from playwright.sync_api import expect
@@ -60,6 +61,123 @@ def test_import_destination_browse_button_sets_destination(live_server, page):
     browse_btn.click()
 
     expect(page.locator("#destInput")).to_have_value("/tmp/archive")
+
+
+def test_import_custom_extensions_feed_preview(live_server, page):
+    url = live_server["url"]
+    page.goto(f"{url}/import")
+    page.evaluate(
+        """
+        () => {
+          const originalFetch = window.fetch.bind(window);
+          window.__previewBody = null;
+          window.fetch = (input, init) => {
+            const target = typeof input === 'string' ? input : input.url;
+            if (target && target.indexOf('/api/import/folder-preview') === 0) {
+              window.__previewBody = JSON.parse(init.body);
+              return Promise.resolve(new Response(JSON.stringify({
+                total_count: 0,
+                total_size: 0,
+                type_breakdown: {},
+                duplicate_count: 0,
+                files: [],
+              }), {status: 200, headers: {'Content-Type': 'application/json'}}));
+            }
+            return originalFetch(input, init);
+          };
+        }
+        """
+    )
+
+    page.locator("#modeCopy").check()
+    page.locator("#sourceInput").fill("/tmp/card-a")
+    page.locator("#btnAddSource").click()
+    page.locator("#fileTypePreset").select_option("custom")
+    page.evaluate(
+        """
+        () => {
+          document.querySelectorAll('.file-ext').forEach(el => { el.checked = false; });
+          document.querySelector('.file-ext[value=".jpg"]').checked = true;
+          document.querySelector('.file-ext[value=".nef"]').checked = true;
+        }
+        """
+    )
+    page.locator("#btnPreview").click()
+    page.wait_for_function("window.__previewBody !== null")
+
+    body = page.evaluate("window.__previewBody")
+    assert body["folders"] == ["/tmp/card-a"]
+    assert body["file_types"] == [".jpg", ".nef"]
+
+
+def test_import_copy_start_sends_restored_options(live_server, page):
+    url = live_server["url"]
+    captured = {}
+
+    def remote_targets(route):
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "rsync_available": True,
+                "targets": [{
+                    "id": "nas1",
+                    "name": "Photo NAS",
+                    "user": "photo",
+                    "host": "nas.local",
+                    "remote_path": "/srv/photos",
+                    "mount_path": "/Volumes/photos",
+                }],
+            }),
+        )
+
+    def start_import(route):
+        captured["body"] = json.loads(route.request.post_data or "{}")
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "job_id": "import-test",
+                "workspace": {"id": 22, "name": "Kenya 2026"},
+            }),
+        )
+
+    page.route("**/api/remote-targets", remote_targets)
+    page.route("**/api/jobs/import-photos", start_import)
+    page.goto(f"{url}/import")
+
+    page.locator("#modeCopy").check()
+    page.locator("#sourceInput").fill("/tmp/card-a")
+    page.locator("#btnAddSource").click()
+    page.locator("#workspaceNew").check()
+    page.locator("#newWorkspaceName").fill("Kenya 2026")
+    page.locator("#destMode").select_option("remote:nas1")
+    page.locator("#remoteSubpath").fill("2026/kenya")
+    page.locator("#fileTypePreset").select_option("custom")
+    page.evaluate(
+        """
+        () => {
+          document.querySelectorAll('.file-ext').forEach(el => { el.checked = false; });
+          document.querySelector('.file-ext[value=".jpg"]').checked = true;
+          document.querySelector('.file-ext[value=".nef"]').checked = true;
+        }
+        """
+    )
+    page.locator("#chkSkipDuplicates").uncheck()
+    page.locator("#chkVerifyByHash").check()
+
+    page.locator("#btnStart").click()
+    expect(page.locator("#progressCard")).to_be_visible()
+
+    body = captured["body"]
+    assert body["sources"] == ["/tmp/card-a"]
+    assert body["new_workspace_name"] == "Kenya 2026"
+    assert body["remote_target_id"] == "nas1"
+    assert body["remote_subpath"] == "2026/kenya"
+    assert "destination" not in body
+    assert body["file_types"] == [".jpg", ".nef"]
+    assert body["skip_duplicates"] is False
+    assert body["verify_by_hash"] is True
 
 
 def test_import_browse_button_opens_folder_browser_fallback(live_server, page):

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -17391,6 +17391,29 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         except Exception as e:
             return None, None, json_error(str(e))
 
+    def _validate_after_import(value):
+        """Return a JSON error response for a bad after_import spec, else None.
+
+        Shared by both import endpoints: the type check rejects non-string,
+        non-null bodies and resolve_strategy() rejects unknown names, so
+        chained processing can't fail hours later on a typo the enqueue
+        step could have caught.
+        """
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            return json_error(
+                "after_import must be a strategy name or null, got "
+                f"{type(value).__name__}"
+            )
+        from process_strategies import resolve_strategy
+
+        try:
+            resolve_strategy(value)
+        except ValueError as e:
+            return json_error(str(e))
+        return None
+
     @app.route("/api/jobs/import-in-place", methods=["POST"])
     def api_job_import_in_place():
         """Import existing folders without copying files.
@@ -17421,33 +17444,36 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         recursive = bool(body.get("recursive", True))
         db = _get_db()
-        if "after_import" in body:
+        # Preflight an explicit after_import before creating a workspace so
+        # a bad value doesn't leave an orphan Card Import behind. The
+        # omitted branch has to wait until AFTER the workspace switch — see
+        # below.
+        explicit_after_import = "after_import" in body
+        if explicit_after_import:
             after_import = body.get("after_import")
-        else:
-            import config as cfg
-
-            effective_cfg = db.get_effective_config(cfg.load())
-            after_import = (
-                effective_cfg.get("pipeline", {}).get("default_strategy")
-            )
-        if after_import is not None:
-            if not isinstance(after_import, str):
-                return json_error(
-                    "after_import must be a strategy name or null, got "
-                    f"{type(after_import).__name__}"
-                )
-            from process_strategies import resolve_strategy
-
-            try:
-                resolve_strategy(after_import)
-            except ValueError as e:
-                return json_error(str(e))
+            err = _validate_after_import(after_import)
+            if err is not None:
+                return err
 
         active_ws, created_workspace, workspace_err = (
             _prepare_import_workspace(db, body)
         )
         if workspace_err is not None:
             return workspace_err
+
+        # Resolve the omitted-default AFTER the workspace switch. Reading
+        # pipeline.default_strategy off the previously-active workspace
+        # would leak that workspace's override into a new-workspace import.
+        if not explicit_after_import:
+            import config as cfg
+
+            effective_cfg = db.get_effective_config(cfg.load())
+            after_import = (
+                effective_cfg.get("pipeline", {}).get("default_strategy")
+            )
+            err = _validate_after_import(after_import)
+            if err is not None:
+                return err
 
         runner = app._job_runner
         thumb_cache_dir = app.config["THUMB_CACHE_DIR"]
@@ -17884,27 +17910,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # omitted -> default from the workspace's pipeline.default_strategy
         # (nullable, same vocabulary). Stored in the job config for the
         # PR 3 chaining hook; the import job itself never reads it.
-        if "after_import" in body:
+        # Preflight an explicit value before creating a workspace so a bad
+        # string doesn't leave an orphan Archive Import behind.
+        explicit_after_import = "after_import" in body
+        if explicit_after_import:
             after_import = body.get("after_import")
-        else:
-            import config as cfg
-
-            effective_cfg = db.get_effective_config(cfg.load())
-            after_import = (
-                effective_cfg.get("pipeline", {}).get("default_strategy")
-            )
-        if after_import is not None:
-            if not isinstance(after_import, str):
-                return json_error(
-                    "after_import must be a strategy name or null, got "
-                    f"{type(after_import).__name__}"
-                )
-            from process_strategies import resolve_strategy
-
-            try:
-                resolve_strategy(after_import)
-            except ValueError as e:
-                return json_error(str(e))
+            err = _validate_after_import(after_import)
+            if err is not None:
+                return err
 
         file_types = body.get("file_types", "both")
         skip_duplicates = bool(body.get("skip_duplicates", True))
@@ -17916,6 +17929,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         )
         if workspace_err is not None:
             return workspace_err
+
+        # Resolve the omitted-default AFTER the workspace switch. Reading
+        # pipeline.default_strategy off the previously-active workspace
+        # would leak that workspace's override into a new-workspace import.
+        if not explicit_after_import:
+            import config as cfg
+
+            effective_cfg = db.get_effective_config(cfg.load())
+            after_import = (
+                effective_cfg.get("pipeline", {}).get("default_strategy")
+            )
+            err = _validate_after_import(after_import)
+            if err is not None:
+                return err
 
         runner = app._job_runner
         thumb_cache_dir = app.config["THUMB_CACHE_DIR"]

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -17363,6 +17363,34 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error(str(exc), status=409)
         return jsonify(result)
 
+    def _prepare_import_workspace(db, body):
+        """Return the workspace id an import should write to.
+
+        `new_workspace_name` mirrors the normal workspace creation route
+        so import-to-new-workspace jobs get default collections and do not
+        inherit stale per-workspace caches from a reused SQLite rowid.
+        """
+        if "new_workspace_name" not in body:
+            return db._active_workspace_id, None, None
+        raw_name = body.get("new_workspace_name")
+        if not isinstance(raw_name, str):
+            return None, None, json_error("new_workspace_name must be a string")
+        name = raw_name.strip()
+        if not name:
+            return None, None, json_error("new_workspace_name is required")
+        try:
+            from datetime import datetime
+
+            ws_id = db.create_workspace(name)
+            _invalidate_missing_originals_cache(workspace_ids=[ws_id])
+            db.create_default_collections(workspace_id=ws_id)
+            db.set_active_workspace(ws_id)
+            db.update_workspace(ws_id, last_opened_at=datetime.now().isoformat())
+            ws = db.get_workspace(ws_id)
+            return ws_id, dict(ws) if ws else {"id": ws_id, "name": name}, None
+        except Exception as e:
+            return None, None, json_error(str(e))
+
     @app.route("/api/jobs/import-in-place", methods=["POST"])
     def api_job_import_in_place():
         """Import existing folders without copying files.
@@ -17415,8 +17443,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             except ValueError as e:
                 return json_error(str(e))
 
+        active_ws, created_workspace, workspace_err = (
+            _prepare_import_workspace(db, body)
+        )
+        if workspace_err is not None:
+            return workspace_err
+
         runner = app._job_runner
-        active_ws = db._active_workspace_id
         thumb_cache_dir = app.config["THUMB_CACHE_DIR"]
         vireo_dir = os.path.dirname(thumb_cache_dir)
 
@@ -17644,11 +17677,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "recursive": recursive,
             "after_import": after_import,
             "mode": "in_place",
+            "workspace_id": active_ws,
+            "created_workspace": created_workspace,
         }
         job_id = runner.start(
             "import-in-place", work, config=job_config, workspace_id=active_ws,
         )
-        return jsonify({"job_id": job_id})
+        response = {"job_id": job_id}
+        if created_workspace is not None:
+            response["workspace"] = created_workspace
+        return jsonify(response)
 
     @app.route("/api/jobs/import-photos", methods=["POST"])
     def api_job_import_photos():
@@ -17873,8 +17911,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         verify_by_hash = bool(body.get("verify_by_hash", False))
         recursive = bool(body.get("recursive", True))
 
+        active_ws, created_workspace, workspace_err = (
+            _prepare_import_workspace(db, body)
+        )
+        if workspace_err is not None:
+            return workspace_err
+
         runner = app._job_runner
-        active_ws = db._active_workspace_id
         thumb_cache_dir = app.config["THUMB_CACHE_DIR"]
         vireo_dir = os.path.dirname(thumb_cache_dir)
 
@@ -17909,6 +17952,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "after_import": after_import,
             "remote_target_id": remote_target_id or None,
             "remote_subpath": remote_subpath or None,
+            "workspace_id": active_ws,
+            "created_workspace": created_workspace,
         }
 
         def _chain_after_import(job, result):
@@ -18011,7 +18056,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         job_id = runner.start(
             "import", work, config=job_config, workspace_id=active_ws,
         )
-        return jsonify({"job_id": job_id})
+        response = {"job_id": job_id}
+        if created_workspace is not None:
+            response["workspace"] = created_workspace
+        return jsonify(response)
 
     @app.route("/api/jobs/sync", methods=["POST"])
     def api_job_sync():

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -2461,9 +2461,10 @@ class Database:
                        updated_at = excluded.updated_at""",
                 (row["species"], row["photo_id"], order),
             )
-        self.conn.execute(
-            "INSERT INTO db_meta(key, value) VALUES (?, '1')",
-            (self._SPECIES_REPRESENTATIVES_BACKFILL_KEY,),
+        self.set_meta(
+            self._SPECIES_REPRESENTATIVES_BACKFILL_KEY,
+            "1",
+            _commit=False,
         )
         self.conn.commit()
 

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -8832,7 +8832,11 @@ window.handleNativeMenuCommand = async function(command) {
         nativeMenuRoute('/import');
         break;
       case 'import_folder':
-        nativeMenuRoute('/import');
+        // Unlike import_photos (which lands on the Import page default),
+        // Import Folder... deep-links into Copy-to-archive with the source
+        // folder picker open — the two File-menu commands must stay
+        // distinct actions.
+        nativeMenuRoute('/import?mode=copy&pick=source');
         break;
       case 'export_selected':
         if (typeof openExportModal === 'function') openExportModal();

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -1383,11 +1383,13 @@ document.addEventListener('lightbox:flagchanged', function(e) {
     var isUnidentified = hit.bucket === null;
     var target = isUnidentified ? currentData.unidentified : hit.bucket;
     if (!target) { render(); return; }
-    // Render once immediately so the Pick badge/outline appears without
-    // waiting for the refetch's network round-trip; render again after the
-    // refetch so the reordered bucket window replaces the stale one.
-    render();
-    refetchBucketFromZero(target, isUnidentified).then(render);
+    // Render after the authoritative refetch settles so the Pick badge/outline
+    // and the bucket ordering become visible together. Rendering before the
+    // refetch exposes a transient stale order: tests and collection saves can
+    // observe the picked class while the photo is still in its old position.
+    refetchBucketFromZero(target, isUnidentified)
+      .then(render)
+      .catch(function() { render(); });
   }
 });
 

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -935,13 +935,16 @@ function applyBucketOrderingKeysFromPage(bucket, page) {
 // 500 rows, and the next "Load more" (which offsets by `target.photos.length`)
 // would then start at 500 and render up to 1000 cards the user never paged
 // through, plus bloat every pick's Save-as-Collection payload.
-// Returns a promise so callers can await the refresh before rendering.
+// Returns a promise resolving to true only when this call actually wrote to
+// `target.photos` — a superseded (older) refetch resolves to false so its
+// caller can skip rendering the stale locally-mutated flag against the old
+// bucket order and let the winning refetch's render fire instead.
 async function refetchBucketFromZero(target, isUnidentified) {
-  if (!target) return;
+  if (!target) return true;
   var currentLen = Array.isArray(target.photos) ? target.photos.length : 0;
   var speciesKey = isUnidentified ? '__unidentified__' : target.species;
   var targetLen = currentLen;
-  if (targetLen <= 0) return;
+  if (targetLen <= 0) return true;
   // Stamp this refetch so a slower earlier one for the same bucket can't
   // clobber a newer response (Pick → Unpick before the first GET resolves).
   var seq = (bucketRefetchSeq[speciesKey] || 0) + 1;
@@ -958,20 +961,21 @@ async function refetchBucketFromZero(target, isUnidentified) {
     params.set('offset', offset);
     params.set('limit', Math.min(500, targetLen - offset));
     var page = await safeFetch('/api/highlights/bucket?' + params);
-    if (bucketRefetchSeq[speciesKey] !== seq) return;
-    if (!page || !Array.isArray(page.photos)) return;
+    if (bucketRefetchSeq[speciesKey] !== seq) return false;
+    if (!page || !Array.isArray(page.photos)) return true;
     lastPage = page;
     if (page.photos.length === 0) break;
     allPhotos = allPhotos.concat(page.photos);
     if (!page.has_more) break;
   }
-  if (!lastPage) return;
-  if (bucketRefetchSeq[speciesKey] !== seq) return;
+  if (!lastPage) return true;
+  if (bucketRefetchSeq[speciesKey] !== seq) return false;
   target.photos = allPhotos;
   target.loaded_count = allPhotos.length;
   target.has_more = !!lastPage.has_more;
   if (typeof lastPage.photo_count === 'number') target.photo_count = lastPage.photo_count;
   applyBucketOrderingKeysFromPage(target, lastPage);
+  return true;
 }
 
 function lightboxIsOpenOnPhoto(photoId) {
@@ -1388,7 +1392,7 @@ document.addEventListener('lightbox:flagchanged', function(e) {
     // refetch exposes a transient stale order: tests and collection saves can
     // observe the picked class while the photo is still in its old position.
     refetchBucketFromZero(target, isUnidentified)
-      .then(render)
+      .then(function(applied) { if (applied) render(); })
       .catch(function() { render(); });
   }
 });

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -352,6 +352,10 @@ function updateWorkspaceMode() {
   const newMode = !!document.getElementById('workspaceNew')?.checked;
   const row = document.getElementById('newWorkspaceRow');
   if (row) row.style.display = newMode ? '' : 'none';
+  // Flipping between "current workspace" and "new workspace" changes
+  // which default (workspace-scoped vs global) the server will resolve
+  // after_import against, so the After Import display must resync.
+  updateAdvancedImportOptions();
 }
 
 function importRemoteTargetId() {
@@ -874,6 +878,15 @@ function retireHiddenDefaultOption(sel) {
   if (sel && sel.value === '__hidden_default__') sel.value = '__none__';
 }
 
+function afterImportOptionLabel(strategy) {
+  const sel = document.getElementById('afterImportSelect');
+  const value = strategy || '__none__';
+  if (!sel) return strategy || 'None — import only';
+  const opt = Array.from(sel.options).find(
+    (o) => o.value === value && o.id !== 'afterImportHiddenDefault');
+  return opt ? (opt.textContent || '').trim() : (strategy || 'None — import only');
+}
+
 function updateAdvancedImportOptions() {
   const sel = document.getElementById('afterImportSelect');
   if (!sel) return;
@@ -883,22 +896,58 @@ function updateAdvancedImportOptions() {
     opt.disabled = !advanced;
   });
   const placeholder = document.getElementById('afterImportHiddenDefault');
-  if (advanced) {
-    // Advanced mode is back on — reveal whichever advanced strategy the
-    // placeholder was masking so the visible selection matches what
-    // Start Import will send, then retire the placeholder.
-    if (placeholder && sel.value === '__hidden_default__') {
-      const masked = placeholder.dataset.maskedValue;
-      sel.value = masked || '__none__';
-      _afterImportHidingDefault = false;
-    }
+  if (!placeholder) return;
+
+  // Once the user actively picks an option, that pick is authoritative
+  // and no placeholder mode should override it.
+  if (_afterImportUserTouched) {
     retireHiddenDefaultOption(sel);
+    _afterImportHidingDefault = false;
     return;
   }
+
+  const newMode = !!document.getElementById('workspaceNew')?.checked;
+
+  // "New workspace" untouched: startImport() omits after_import so the
+  // server resolves it against the freshly-created workspace (which
+  // inherits the GLOBAL default, since a brand-new workspace has no
+  // overrides yet). The visible dropdown, prefilled from the currently-
+  // active workspace's default, would otherwise lie about what the
+  // server is going to do — show a placeholder that names the real
+  // target strategy.
+  if (newMode && _afterImportConfigLoaded) {
+    const label = afterImportOptionLabel(_globalDefaultStrategy);
+    placeholder.textContent =
+      'New workspace default: ' + label + ' (applied to the new workspace)';
+    placeholder.dataset.maskedValue = _globalDefaultStrategy || '';
+    placeholder.hidden = false;
+    placeholder.disabled = false;
+    _afterImportHidingDefault = true;
+    sel.value = '__hidden_default__';
+    return;
+  }
+
+  // Not new-workspace mode: the visible selection should track the
+  // workspace's own default (or the HTML fallback if config didn't
+  // load). Re-derive it every call so switching workspaceNew off
+  // restores the workspace default rather than sticking on whatever
+  // placeholder we were showing.
+  const wsDef = _afterImportConfigLoaded
+    ? (_workspaceDefaultStrategy || '__none__')
+    : '__none__';
+  sel.value = wsDef;
+  if (sel.selectedIndex === -1) sel.value = '__none__';
+
+  if (advanced) {
+    retireHiddenDefaultOption(sel);
+    _afterImportHidingDefault = false;
+    return;
+  }
+
   const current = sel.selectedOptions[0];
   const currentIsHiddenAdvanced =
     !!(current && current.disabled && current.hasAttribute('data-advanced-strategy'));
-  if (currentIsHiddenAdvanced && placeholder) {
+  if (currentIsHiddenAdvanced) {
     // The workspace's default is an advanced-only strategy (full,
     // cull_ready) but advanced mode is off. If we silently fell the
     // display back to __none__, startImport() would omit after_import so
@@ -915,8 +964,9 @@ function updateAdvancedImportOptions() {
     placeholder.disabled = false;
     _afterImportHidingDefault = true;
     sel.value = '__hidden_default__';
-  } else if (sel.value !== '__hidden_default__') {
+  } else {
     retireHiddenDefaultOption(sel);
+    _afterImportHidingDefault = false;
   }
 }
 
@@ -955,6 +1005,23 @@ let _afterImportHidingDefault = false;
 // (including "None — import only") flips this flag and gets forwarded
 // verbatim.
 let _afterImportUserTouched = false;
+
+// The unscoped global pipeline.default_strategy from /api/config, captured
+// during initImportPage. A brand-new workspace has no config_overrides yet,
+// so this is the strategy the server will apply when the new-workspace
+// import path omits `after_import`. Used to populate the honest "New
+// workspace default: X" placeholder so the visible dropdown selection
+// isn't misled by whatever was prefilled from the currently-active
+// workspace's (possibly-overridden) default.
+let _globalDefaultStrategy = null;
+
+// The effective pipeline.default_strategy for the CURRENTLY-active
+// workspace (global config merged with the workspace's overrides). Used
+// so updateAdvancedImportOptions() can re-derive the visible dropdown
+// selection when the user toggles "New workspace" off without touching
+// the dropdown — the underlying target reverts to the current workspace's
+// default rather than sticking on whatever placeholder was showing.
+let _workspaceDefaultStrategy = null;
 
 function showError(msg) {
   const el = document.getElementById('importError');
@@ -1512,6 +1579,14 @@ async function initImportPage() {
   const def = pipelineCfg.default_strategy;
   sel.value = def ? def : '__none__';
   if (sel.selectedIndex === -1) sel.value = '__none__';
+  // Capture the unscoped global default so the "New workspace default"
+  // placeholder can name the strategy the server will actually apply
+  // to a freshly-created workspace (which starts with no overrides).
+  _globalDefaultStrategy = (cfg && cfg.pipeline && cfg.pipeline.default_strategy) || null;
+  // Capture the effective (workspace-scoped) default so switching out of
+  // "New workspace" mode without touching the dropdown restores this
+  // value rather than sticking on the placeholder.
+  _workspaceDefaultStrategy = def || null;
   // updateAdvancedImportOptions() may flip _afterImportHidingDefault
   // when the resolved default is an advanced-only strategy the current
   // mode hides. Wire the change listener first so a user-driven change
@@ -1526,12 +1601,15 @@ async function initImportPage() {
     if (sel.value !== '__hidden_default__') retireHiddenDefaultOption(sel);
   });
   _afterImportHidingDefault = false;
-  updateAdvancedImportOptions();
   // Only mark the resolved default as trustworthy when BOTH config
   // fetches actually succeeded. Otherwise the select value reflects the
   // HTML placeholder rather than the workspace default, and startImport
   // should omit the key so the server applies pipeline.default_strategy.
+  // Set this BEFORE the initial updateAdvancedImportOptions() call so
+  // that call can use _workspaceDefaultStrategy to derive the visible
+  // dropdown value.
   _afterImportConfigLoaded = cfgOk && overridesOk;
+  updateAdvancedImportOptions();
   loadImportRemoteTargets();
   loadOrphanedStaging();
   updateImportMode();

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -944,6 +944,18 @@ let _afterImportConfigLoaded = false;
 // actively changes the select.
 let _afterImportHidingDefault = false;
 
+// True once the user actively picks something in the After Import
+// dropdown. Until then the visible selection is whatever
+// initImportPage() prefilled from the CURRENTLY-active workspace's
+// default — which is the wrong basis for a new-workspace import, where
+// the server should apply the new workspace's (or global) default
+// instead. startImport() omits the after_import key for new-workspace
+// imports that this flag hasn't been set on, so the resolution happens
+// server-side after the workspace switch. An explicit user pick
+// (including "None — import only") flips this flag and gets forwarded
+// verbatim.
+let _afterImportUserTouched = false;
+
 function showError(msg) {
   const el = document.getElementById('importError');
   el.textContent = msg;
@@ -1272,7 +1284,19 @@ async function startImport() {
     body.skip_duplicates = document.getElementById('chkSkipDuplicates').checked;
     body.verify_by_hash = document.getElementById('chkVerifyByHash').checked;
   }
-  if (_afterImportConfigLoaded && !_afterImportHidingDefault) {
+  // For new-workspace imports where the user hasn't touched the After
+  // Import dropdown, the visible selection was prefilled from the
+  // currently-active workspace's default — posting it would make the
+  // server apply that old default instead of the new workspace's (or
+  // global) one. Omit the key so the server resolves it against the
+  // freshly-created workspace after the switch.
+  const newWorkspaceUntouched =
+    !!body.new_workspace_name && !_afterImportUserTouched;
+  if (
+    _afterImportConfigLoaded
+    && !_afterImportHidingDefault
+    && !newWorkspaceUntouched
+  ) {
     body.after_import = selectedAfterImport();
   }
   document.getElementById('btnStart').disabled = true;
@@ -1486,6 +1510,7 @@ async function initImportPage() {
   // it) is always tracked.
   sel.addEventListener('change', () => {
     _afterImportHidingDefault = false;
+    _afterImportUserTouched = true;
     // Once the user actively picks a real option, the "Workspace
     // default (hidden)" placeholder is no longer relevant — retire it
     // so it doesn't clutter the dropdown on the next open.

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -29,6 +29,22 @@ body { display: flex; flex-direction: column; height: 100vh; }
 .source-item button { background: none; border: none; color: var(--danger); cursor: pointer; font-size: 14px; }
 .source-meta { color: var(--text-secondary); white-space: nowrap; }
 .hint { font-size: 11px; color: var(--text-secondary); }
+.section-divider { border-top: 1px solid var(--border-primary); margin-top: 12px; padding-top: 12px; }
+.option-stack { display: flex; flex-direction: column; gap: 8px; margin: 6px 0 8px; }
+.option-stack label { font-size: 12px; color: var(--text-primary); }
+.extension-grid {
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(86px, 1fr));
+  gap: 6px 10px; width: 100%; margin: 4px 0 8px;
+}
+.extension-grid label {
+  background: var(--bg-tertiary); border: 1px solid var(--border-secondary);
+  border-radius: 4px; padding: 5px 8px; color: var(--text-primary);
+}
+.remote-preview {
+  font-size: 11px; color: var(--text-secondary); overflow-wrap: anywhere;
+  margin-top: 4px; width: 100%;
+}
+.input-fixed { max-width: 240px; flex: 0 1 240px; }
 .preview-summary { font-size: 12px; color: var(--text-secondary); margin-top: 6px; }
 .progress-bar { height: 8px; background: var(--bg-tertiary); border-radius: 4px; overflow: hidden; }
 .progress-bar > div { height: 100%; background: var(--accent); width: 0; transition: width 0.2s; }
@@ -117,18 +133,64 @@ body { display: flex; flex-direction: column; height: 100vh; }
       <div class="source-list" id="sourceList"></div>
       <div class="row" style="margin-top:8px;">
         <label><input type="checkbox" id="chkRecursive" checked onchange="refreshSourceCounts()"> Include subfolders</label>
-        <label id="fileTypesWrap">File types
-          <select id="fileTypes" style="min-width:100px;" onchange="refreshSourceCounts()">
+      </div>
+      <div id="fileTypesWrap" class="section-divider" style="display:none;">
+        <div class="row">
+          <label>File types</label>
+          <select id="fileTypePreset" class="input-fixed" onchange="updateFileTypeControls(); refreshSourceCounts();">
             <option value="both" selected>RAW + JPEG</option>
             <option value="raw">RAW only</option>
             <option value="jpeg">JPEG only</option>
+            <option value="custom">Choose extensions</option>
           </select>
-        </label>
+        </div>
+        <div id="customFileTypes" style="display:none;">
+          <div class="hint">Standard formats</div>
+          <div class="extension-grid">
+            <label><input type="checkbox" class="file-ext standard-ext" value=".jpg" checked onchange="refreshSourceCounts()"> JPG</label>
+            <label><input type="checkbox" class="file-ext standard-ext" value=".jpeg" checked onchange="refreshSourceCounts()"> JPEG</label>
+            <label><input type="checkbox" class="file-ext standard-ext" value=".png" checked onchange="refreshSourceCounts()"> PNG</label>
+            <label><input type="checkbox" class="file-ext standard-ext" value=".tif" checked onchange="refreshSourceCounts()"> TIF</label>
+            <label><input type="checkbox" class="file-ext standard-ext" value=".tiff" checked onchange="refreshSourceCounts()"> TIFF</label>
+            <label><input type="checkbox" class="file-ext standard-ext" value=".bmp" checked onchange="refreshSourceCounts()"> BMP</label>
+            <label><input type="checkbox" class="file-ext standard-ext" value=".webp" checked onchange="refreshSourceCounts()"> WebP</label>
+          </div>
+          <div class="hint">RAW formats</div>
+          <div class="extension-grid">
+            <label><input type="checkbox" class="file-ext raw-ext" value=".nef" checked onchange="refreshSourceCounts()"> NEF</label>
+            <label><input type="checkbox" class="file-ext raw-ext" value=".cr2" checked onchange="refreshSourceCounts()"> CR2</label>
+            <label><input type="checkbox" class="file-ext raw-ext" value=".cr3" checked onchange="refreshSourceCounts()"> CR3</label>
+            <label><input type="checkbox" class="file-ext raw-ext" value=".arw" checked onchange="refreshSourceCounts()"> ARW</label>
+            <label><input type="checkbox" class="file-ext raw-ext" value=".raf" checked onchange="refreshSourceCounts()"> RAF</label>
+            <label><input type="checkbox" class="file-ext raw-ext" value=".dng" checked onchange="refreshSourceCounts()"> DNG</label>
+            <label><input type="checkbox" class="file-ext raw-ext" value=".rw2" checked onchange="refreshSourceCounts()"> RW2</label>
+            <label><input type="checkbox" class="file-ext raw-ext" value=".orf" checked onchange="refreshSourceCounts()"> ORF</label>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="card" id="workspaceCard">
+      <h3>Workspace</h3>
+      <div class="option-stack">
+        <label><input type="radio" name="workspaceMode" value="current" id="workspaceCurrent" checked onchange="updateWorkspaceMode()"> Current workspace <span class="hint" id="activeWorkspaceName"></span></label>
+        <label><input type="radio" name="workspaceMode" value="new" id="workspaceNew" onchange="updateWorkspaceMode()"> New workspace</label>
+      </div>
+      <div class="row" id="newWorkspaceRow" style="display:none;">
+        <label>Workspace name</label>
+        <input type="text" id="newWorkspaceName" class="input-fixed" placeholder="New workspace">
       </div>
     </div>
 
     <div class="card" id="destCard">
       <h3>Destination</h3>
+      <div class="row">
+        <label>Archive destination</label>
+        <select id="destMode" class="input-fixed" onchange="onImportDestModeChange()">
+          <option value="local" selected>Local path</option>
+        </select>
+      </div>
+      <div id="destLocalRows">
       <div class="row">
         <button class="btn btn-primary" id="btnBrowseDestination" data-testid="import-destination-browse-btn" onclick="browseForDestination()">Browse...</button>
         <input type="text" id="destInput" list="recentDestinations"
@@ -136,10 +198,26 @@ body { display: flex; flex-direction: column; height: 100vh; }
                value="">
         <datalist id="recentDestinations"></datalist>
       </div>
+      </div>
+      <div id="destRemoteRows" style="display:none;">
+        <div class="row">
+          <label>Remote subpath</label>
+          <input type="text" id="remoteSubpath" class="input-fixed" placeholder="2026/trip" oninput="updateRemoteDestPreview()">
+        </div>
+        <div class="remote-preview" id="remoteDestPreview"></div>
+      </div>
       <div class="row">
         <label>Folder template</label>
         <input type="text" id="folderTemplate" value="%Y/%Y-%m-%d" style="max-width:200px;flex:0 1 auto;">
         <span class="hint">strftime of each photo's capture time, e.g. %Y/%Y-%m-%d</span>
+      </div>
+      <div class="section-divider">
+        <div class="option-stack">
+          <label><input type="checkbox" id="chkSkipDuplicates" checked> Skip duplicates</label>
+          <label><input type="checkbox" id="chkVerifyByHash"> Verify copied files with full content hashes</label>
+          <label><input type="checkbox" id="chkLocalProcessing" disabled> Use local staging while processing</label>
+        </div>
+        <div class="hint">Local staging is temporarily unavailable in the split Import flow; old staging folders can still be recovered above.</div>
       </div>
     </div>
 
@@ -233,6 +311,8 @@ let browserEscHandler = null;
 let browserSelectedPaths = [];
 let browserSelectAnchorPath = '';
 let activeImportMode = 'in_place';
+let importRemoteTargets = [];
+let importRsyncAvailable = false;
 
 function selectedImportMode() {
   const checked = document.querySelector('input[name="importMode"]:checked');
@@ -248,7 +328,148 @@ function updateImportMode() {
     copyMode ? 'Check for duplicates' : 'Preview import';
   document.getElementById('previewSummary').textContent = '';
   showError('');
+  updateFileTypeControls();
+  updateWorkspaceMode();
+  onImportDestModeChange();
   refreshSourceCounts();
+}
+
+function selectedFileTypes() {
+  const preset = document.getElementById('fileTypePreset').value;
+  if (preset !== 'custom') return preset;
+  return Array.from(document.querySelectorAll('.file-ext:checked'))
+    .map(el => el.value);
+}
+
+function updateFileTypeControls() {
+  const preset = document.getElementById('fileTypePreset');
+  const custom = document.getElementById('customFileTypes');
+  if (!preset || !custom) return;
+  custom.style.display = preset.value === 'custom' ? '' : 'none';
+}
+
+function updateWorkspaceMode() {
+  const newMode = !!document.getElementById('workspaceNew')?.checked;
+  const row = document.getElementById('newWorkspaceRow');
+  if (row) row.style.display = newMode ? '' : 'none';
+}
+
+function importRemoteTargetId() {
+  const el = document.getElementById('destMode');
+  const v = el ? el.value : 'local';
+  return v.indexOf('remote:') === 0 ? v.slice(7) : '';
+}
+
+function importRemoteTarget() {
+  const id = importRemoteTargetId();
+  if (!id) return null;
+  return importRemoteTargets.find(t => t.id === id) || null;
+}
+
+function normalizeRemoteSubpath(raw) {
+  const trimmed = (raw || '').trim();
+  if (!trimmed) return {value: '', error: ''};
+  const s = trimmed.replace(/\\/g, '/');
+  if (s.charAt(0) === '/' || /^[A-Za-z]:/.test(s)) {
+    return {value: '', error: 'Subpath must be relative.'};
+  }
+  const parts = [];
+  for (const seg of s.split('/')) {
+    if (seg === '' || seg === '.') continue;
+    if (seg === '..') return {value: '', error: "Subpath may not contain '..'."};
+    parts.push(seg);
+  }
+  return {value: parts.join('/'), error: ''};
+}
+
+function importIsAbsolutePath(p) {
+  if (!p) return false;
+  return p.charAt(0) === '/' || /^[A-Za-z]:[\\\/]/.test(p) || /^\\\\/.test(p);
+}
+
+function rsyncDestSpec(user, host, path) {
+  const hostToken = host && host.indexOf(':') !== -1 ? '[' + host + ']' : host;
+  return user + '@' + hostToken + ':' + path;
+}
+
+function remotePreviewWarn(text) {
+  const d = document.createElement('div');
+  d.style.color = 'var(--warning,#bf8700)';
+  d.textContent = text;
+  return d;
+}
+
+function updateRemoteDestPreview() {
+  const el = document.getElementById('remoteDestPreview');
+  if (!el) return;
+  el.textContent = '';
+  const t = importRemoteTarget();
+  if (!t) return;
+  const subResult = normalizeRemoteSubpath(document.getElementById('remoteSubpath').value);
+  if (subResult.error) {
+    el.appendChild(remotePreviewWarn('Warning: ' + subResult.error));
+  } else if (!subResult.value) {
+    const hint = document.createElement('div');
+    hint.textContent = 'Name the archive folder under ' + t.remote_path + ', e.g. 2026/kenya-trip.';
+    el.appendChild(hint);
+  } else {
+    const line = document.createElement('div');
+    line.textContent = 'Archive over SSH to: ';
+    const span = document.createElement('span');
+    span.style.fontFamily = 'monospace';
+    span.textContent = rsyncDestSpec(
+      t.user, t.host, t.remote_path.replace(/\/+$/, '') + '/' + subResult.value);
+    line.appendChild(span);
+    el.appendChild(line);
+  }
+  if (!importRsyncAvailable) {
+    el.appendChild(remotePreviewWarn('Warning: no GNU rsync found. Install GNU rsync or set its path under Settings > Paths.'));
+  }
+  if (!t.mount_path) {
+    el.appendChild(remotePreviewWarn('Warning: this target needs a local mount path for cataloging. Add one under Settings > Remote targets.'));
+  } else if (!importIsAbsolutePath(t.mount_path)) {
+    el.appendChild(remotePreviewWarn('Warning: this target local mount path must be absolute.'));
+  }
+}
+
+function remoteArchiveSelectionReady() {
+  const t = importRemoteTarget();
+  if (!t || !importRsyncAvailable) return false;
+  if (!t.mount_path || !importIsAbsolutePath(t.mount_path)) return false;
+  const subResult = normalizeRemoteSubpath(document.getElementById('remoteSubpath').value);
+  return !subResult.error && !!subResult.value;
+}
+
+function onImportDestModeChange() {
+  const remoteId = importRemoteTargetId();
+  const localRows = document.getElementById('destLocalRows');
+  const remoteRows = document.getElementById('destRemoteRows');
+  if (localRows) localRows.style.display = remoteId ? 'none' : '';
+  if (remoteRows) remoteRows.style.display = remoteId ? '' : 'none';
+  updateRemoteDestPreview();
+}
+
+async function loadImportRemoteTargets() {
+  try {
+    const resp = await fetch('/api/remote-targets');
+    if (!resp.ok) throw new Error('remote targets unavailable');
+    const data = await resp.json();
+    importRemoteTargets = (data && data.targets) || [];
+    importRsyncAvailable = !!(data && data.rsync_available);
+  } catch (e) {
+    importRemoteTargets = [];
+    importRsyncAvailable = false;
+  }
+  const sel = document.getElementById('destMode');
+  if (!sel) return;
+  while (sel.options.length > 1) sel.remove(1);
+  importRemoteTargets.forEach((t) => {
+    const opt = document.createElement('option');
+    opt.value = 'remote:' + t.id;
+    opt.textContent = t.name + ' - ' + t.user + '@' + t.host + ' (SSH)';
+    sel.appendChild(opt);
+  });
+  onImportDestModeChange();
 }
 
 function importEscapeHtml(s) {
@@ -293,7 +514,7 @@ function renderSources() {
 function selectedSourceCountOptions() {
   const copyMode = selectedImportMode() === 'copy';
   return {
-    file_types: copyMode ? document.getElementById('fileTypes').value : 'both',
+    file_types: copyMode ? selectedFileTypes() : 'both',
     recursive: document.getElementById('chkRecursive').checked,
   };
 }
@@ -920,6 +1141,11 @@ async function previewImport() {
   showError('');
   if (!sources.length) { showError('Add at least one source folder.'); return; }
   const copyMode = selectedImportMode() === 'copy';
+  const fileTypes = copyMode ? selectedFileTypes() : 'both';
+  if (copyMode && Array.isArray(fileTypes) && !fileTypes.length) {
+    showError('Choose at least one file extension.');
+    return;
+  }
   const summary = document.getElementById('previewSummary');
   summary.textContent = 'Discovering files…';
   try {
@@ -928,7 +1154,7 @@ async function previewImport() {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         folders: sources,
-        file_types: copyMode ? document.getElementById('fileTypes').value : 'both',
+        file_types: fileTypes,
         recursive: document.getElementById('chkRecursive').checked,
       }),
     });
@@ -938,6 +1164,10 @@ async function previewImport() {
     if (!files.length) { summary.textContent = 'No importable files found.'; return; }
     if (!copyMode) {
       summary.textContent = files.length + ' files found · originals will stay in place';
+      return;
+    }
+    if (!document.getElementById('chkSkipDuplicates').checked) {
+      summary.textContent = files.length + ' files found · duplicates will be copied';
       return;
     }
     summary.textContent = files.length + ' files found — checking for duplicates…';
@@ -1002,16 +1232,39 @@ async function startImport() {
   showError('');
   if (!sources.length) { showError('Add at least one source folder.'); return; }
   const copyMode = selectedImportMode() === 'copy';
-  const destination = (document.getElementById('destInput').value || '').trim();
-  if (copyMode && !destination) { showError('Choose a destination folder.'); return; }
   const body = {
     sources: sources,
     recursive: document.getElementById('chkRecursive').checked,
   };
+  if (document.getElementById('workspaceNew').checked) {
+    const name = (document.getElementById('newWorkspaceName').value || '').trim();
+    if (!name) { showError('Name the new workspace.'); return; }
+    body.new_workspace_name = name;
+  }
   if (copyMode) {
-    body.destination = destination;
+    const fileTypes = selectedFileTypes();
+    if (Array.isArray(fileTypes) && !fileTypes.length) {
+      showError('Choose at least one file extension.');
+      return;
+    }
+    const remoteId = importRemoteTargetId();
+    if (remoteId) {
+      if (!remoteArchiveSelectionReady()) {
+        showError('Choose a usable remote target and relative subpath.');
+        return;
+      }
+      body.remote_target_id = remoteId;
+      body.remote_subpath = normalizeRemoteSubpath(
+        document.getElementById('remoteSubpath').value).value;
+    } else {
+      const destination = (document.getElementById('destInput').value || '').trim();
+      if (!destination) { showError('Choose a destination folder.'); return; }
+      body.destination = destination;
+    }
     body.folder_template = (document.getElementById('folderTemplate').value || '').trim();
-    body.file_types = document.getElementById('fileTypes').value;
+    body.file_types = fileTypes;
+    body.skip_duplicates = document.getElementById('chkSkipDuplicates').checked;
+    body.verify_by_hash = document.getElementById('chkVerifyByHash').checked;
   }
   if (_afterImportConfigLoaded && !_afterImportHidingDefault) {
     body.after_import = selectedAfterImport();
@@ -1025,6 +1278,10 @@ async function startImport() {
     });
     const data = await resp.json();
     if (!resp.ok) throw new Error(data.error || 'import failed to start');
+    if (data.workspace && data.workspace.name) {
+      const activeName = document.getElementById('activeWorkspaceName');
+      if (activeName) activeName.textContent = '(' + data.workspace.name + ')';
+    }
     activeJobId = data.job_id;
     document.getElementById('progressCard').style.display = '';
     document.getElementById('resultCard').style.display = 'none';
@@ -1186,6 +1443,8 @@ async function initImportPage() {
     const resp = await fetch('/api/workspaces/active');
     if (resp.ok) {
       const ws = await resp.json();
+      const activeName = document.getElementById('activeWorkspaceName');
+      if (activeName && ws.name) activeName.textContent = '(' + ws.name + ')';
       const raw = ws.config_overrides;
       overrides = typeof raw === 'string' ? JSON.parse(raw) : (raw || {});
       overridesOk = true;
@@ -1233,6 +1492,7 @@ async function initImportPage() {
   // HTML placeholder rather than the workspace default, and startImport
   // should omit the key so the server applies pipeline.default_strategy.
   _afterImportConfigLoaded = cfgOk && overridesOk;
+  loadImportRemoteTargets();
   loadOrphanedStaging();
   updateImportMode();
 }

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -1172,10 +1172,16 @@ async function previewImport() {
     }
     summary.textContent = files.length + ' files found — checking for duplicates…';
     // check-duplicates streams results; count flagged paths as they arrive.
+    // Pass verify_by_hash so the preview and the import agree on which files
+    // are duplicates — otherwise a renamed/metadata-colliding file counted
+    // as "to copy" in the preview would be skipped by the hash-based import.
     const dupResp = await fetch('/api/import/check-duplicates', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ paths: files.map(f => f.path) }),
+      body: JSON.stringify({
+        paths: files.map(f => f.path),
+        verify_by_hash: document.getElementById('chkVerifyByHash').checked,
+      }),
     });
     if (!dupResp.ok) throw new Error('duplicate check failed');
     const reader = dupResp.body.getReader();

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -1444,6 +1444,15 @@ function renderModelWarning(res) {
 }
 
 async function initImportPage() {
+  // Native menu deep link: File > Import Folder... routes here as
+  // /import?mode=copy&pick=source so it lands in Copy-to-archive with the
+  // source picker open, while File > Import Photos... gets the page
+  // default (Add in place).
+  const menuParams = new URLSearchParams(window.location.search);
+  if (menuParams.get('mode') === 'copy') {
+    const copyRadio = document.getElementById('modeCopy');
+    if (copyRadio) copyRadio.checked = true;
+  }
   // Volume suggestions for the source input.
   try {
     const resp = await fetch('/api/volumes');
@@ -1526,6 +1535,16 @@ async function initImportPage() {
   loadImportRemoteTargets();
   loadOrphanedStaging();
   updateImportMode();
+  if (menuParams.get('pick') === 'source') {
+    // One-shot trigger: strip it from the URL so a manual reload doesn't
+    // reopen the picker, then open it (native dialog in Tauri, in-page
+    // folder browser otherwise).
+    menuParams.delete('pick');
+    const qs = menuParams.toString();
+    history.replaceState(
+      null, '', window.location.pathname + (qs ? '?' + qs : ''));
+    browseForSource();
+  }
 }
 initImportPage();
 </script>

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -10181,7 +10181,11 @@ def test_native_import_commands_route_to_import_page():
 
     assert "ids::NAV_IMPORT => Some(\"/import\")" in menu
     assert "case 'import_photos':\n        nativeMenuRoute('/import');" in navbar
-    assert "case 'import_folder':\n        nativeMenuRoute('/import');" in navbar
+    # Import Folder... must stay a distinct action from Import Photos...:
+    # it deep-links into Copy-to-archive with the source picker open.
+    assert (
+        "nativeMenuRoute('/import?mode=copy&pick=source');" in navbar
+    )
 
 
 def test_native_shell_owns_external_navigation_policy():

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -3383,6 +3383,49 @@ def test_import_photos_after_import_defaults_from_workspace(
     assert config["after_import"] == "cull_ready"
 
 
+def test_import_photos_new_workspace_ignores_old_default_strategy(
+        app_and_db, tmp_path):
+    """Regression: an omitted after_import must resolve against the TARGET
+    workspace's effective config, not the caller's previously-active one.
+    Otherwise a stale pipeline.default_strategy override on the old
+    workspace silently chains onto a fresh-workspace import."""
+    app, db = app_and_db
+    client = app.test_client()
+    old_ws = db._active_workspace_id
+    db.update_workspace(old_ws, config_overrides={
+        "pipeline": {"default_strategy": "cull_ready"},
+    })
+    resp = client.post("/api/jobs/import-photos", json={
+        "sources": [_import_card(tmp_path)],
+        "destination": str(tmp_path / "archive"),
+        "new_workspace_name": "Fresh Archive",
+    })
+    assert resp.status_code == 200, resp.get_json()
+    config = _job_config(client, resp.get_json()["job_id"])
+    assert config["workspace_id"] != old_ws
+    assert config["after_import"] is None
+
+
+def test_import_in_place_new_workspace_ignores_old_default_strategy(
+        app_and_db, tmp_path):
+    """Same regression as above, exercised through the in-place endpoint —
+    both routes call _prepare_import_workspace so both had the bug."""
+    app, db = app_and_db
+    client = app.test_client()
+    old_ws = db._active_workspace_id
+    db.update_workspace(old_ws, config_overrides={
+        "pipeline": {"default_strategy": "cull_ready"},
+    })
+    resp = client.post("/api/jobs/import-in-place", json={
+        "sources": [_import_card(tmp_path)],
+        "new_workspace_name": "Fresh In-Place",
+    })
+    assert resp.status_code == 200, resp.get_json()
+    config = _job_config(client, resp.get_json()["job_id"])
+    assert config["workspace_id"] != old_ws
+    assert config["after_import"] is None
+
+
 def test_import_photos_validation_400s(app_and_db, tmp_path):
     app, _ = app_and_db
     client = app.test_client()

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -3293,6 +3293,27 @@ def test_import_in_place_no_destination_required(app_and_db, tmp_path):
     assert result["after_import_skipped"] == "import-only"
 
 
+def test_import_in_place_can_target_new_workspace(app_and_db, tmp_path):
+    app, db = app_and_db
+    client = app.test_client()
+    old_ws = db._active_workspace_id
+
+    resp = client.post("/api/jobs/import-in-place", json={
+        "sources": [_import_card(tmp_path)],
+        "after_import": None,
+        "new_workspace_name": "Card Import",
+    })
+    assert resp.status_code == 200, resp.get_json()
+    data = resp.get_json()
+    assert data["workspace"]["name"] == "Card Import"
+
+    config = _job_config(client, data["job_id"])
+    assert config["workspace_id"] != old_ws
+    assert config["created_workspace"]["name"] == "Card Import"
+    active = client.get("/api/workspaces/active").get_json()
+    assert active["id"] == config["workspace_id"]
+
+
 def test_import_photos_null_after_import_is_import_only(app_and_db, tmp_path):
     """after_import: null means import-only (PR 3's hook short-circuits) —
     same nullable vocabulary as pipeline.default_strategy."""
@@ -3306,6 +3327,28 @@ def test_import_photos_null_after_import_is_import_only(app_and_db, tmp_path):
     assert resp.status_code == 200, resp.get_json()
     config = _job_config(client, resp.get_json()["job_id"])
     assert config["after_import"] is None
+
+
+def test_import_photos_can_target_new_workspace(app_and_db, tmp_path):
+    app, db = app_and_db
+    client = app.test_client()
+    old_ws = db._active_workspace_id
+
+    resp = client.post("/api/jobs/import-photos", json={
+        "sources": [_import_card(tmp_path)],
+        "destination": str(tmp_path / "archive"),
+        "after_import": None,
+        "new_workspace_name": "Archive Import",
+    })
+    assert resp.status_code == 200, resp.get_json()
+    data = resp.get_json()
+    assert data["workspace"]["name"] == "Archive Import"
+
+    config = _job_config(client, data["job_id"])
+    assert config["workspace_id"] != old_ws
+    assert config["created_workspace"]["name"] == "Archive Import"
+    active = client.get("/api/workspaces/active").get_json()
+    assert active["id"] == config["workspace_id"]
 
 
 @pytest.mark.parametrize("bad", ["yolo", "none"])


### PR DESCRIPTION
Restores Import page controls for per-extension copy selection, skip-duplicates, full-hash verification, saved SSH archive destinations, and new-workspace imports. Adds server-side support for import jobs to create, activate, and queue against a new workspace while preserving default collection setup and cache invalidation. Leaves local staging visible but disabled because the split Import backend still blocks that retired processing path. Validated with `pytest tests/e2e/test_import_page.py -q` and `pytest vireo/tests/test_jobs_api.py -k "import_photos or import_in_place" -q`.

**Also fixes the File-menu import routing defect from the same audit (item #3):** `File > Import Photos...` and `File > Import Folder...` were two menu items dispatching the identical action (`nativeMenuRoute('/import')`, landing on the Add-in-place default). `Import Folder...` now deep-links to `/import?mode=copy&pick=source` — Copy-to-archive preselected with the source folder picker open (native dialog in Tauri, in-page browser otherwise); the one-shot `pick` param is stripped from the URL so a reload doesn't reopen the picker. `Import Photos...` keeps the plain Import page. Covered by a new Playwright test and an updated navbar-routing unit test, plus manual browser verification of the dispatch path, reload, Escape, and garbage-param cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added customizable file-type selection for imports, including standard and RAW extensions.
  - Added remote archive destinations with subpath validation and live previews.
  - Added copy-mode options to skip duplicates and verify files using full hashes.
  - Imports can now create and switch to a new workspace.
- **Bug Fixes**
  - Improved import validation to prevent invalid settings from creating incomplete import state.
  - Fixed default post-import behavior when switching workspaces.
  - Improved highlights lightbox updates to avoid premature refreshes.
- **Tests**
  - Added coverage for import previews, duplicate checks, remote destinations, and new workspace workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
