### PR TITLE
Remove Destination card and browse sources from Process page

### DIFF
--- a/tests/e2e/test_pipeline.py
+++ b/tests/e2e/test_pipeline.py
@@ -8,7 +8,7 @@ def test_pipeline_page_loads_with_stages(live_server, page):
     url = live_server["url"]
     page.goto(f"{url}/pipeline")
     stages = page.locator("[data-testid='stage-card']")
-    expect(stages).to_have_count(8)
+    expect(stages).to_have_count(7)
 
 
 def test_pipeline_start_button_disabled_without_folders(live_server, page):
@@ -18,153 +18,67 @@ def test_pipeline_start_button_disabled_without_folders(live_server, page):
     expect(btn).to_be_disabled()
 
 
-def test_pipeline_destination_points_imports_to_import_page(live_server, page):
+def test_pipeline_has_no_destination_card(live_server, page):
+    """The Destination card left with the import/process split — Process
+    never copies files, so the page must not offer a destination or any
+    of the legacy copy controls."""
     url = live_server["url"]
     page.goto(f"{url}/pipeline")
-    page.click("#card-destination .stage-header")
-    dest_card = page.locator("#card-destination")
-    expect(dest_card).to_contain_text("Copying cards or folders into the archive now happens on the")
-    expect(dest_card.locator("a[href='/import']")).to_contain_text("Import")
+    expect(page.locator("#card-destination")).to_have_count(0)
+    for testid in (
+        "file-copying-section",
+        "copy-photos-toggle",
+        "destination-section",
+        "custom-template-input",
+        "preview-folders-btn",
+        "workspace-new",
+        "workspace-current",
+    ):
+        expect(page.locator(f"[data-testid='{testid}']")).to_have_count(0)
 
 
-def test_pipeline_legacy_copy_controls_stay_hidden(live_server, page):
+def test_pipeline_source_points_imports_to_import_page(live_server, page):
     url = live_server["url"]
     page.goto(f"{url}/pipeline")
-    page.click("#card-destination .stage-header")
-    expect(page.locator("[data-testid='file-copying-section']")).to_be_hidden()
-    expect(page.locator("[data-testid='copy-photos-toggle']")).to_be_hidden()
-    expect(page.locator("[data-testid='destination-section']")).to_be_hidden()
+    hint = page.locator("[data-testid='source-import-hint']")
+    expect(hint).to_contain_text("Adding new photos to your library happens on the")
+    expect(hint.locator("a[href='/import']")).to_contain_text("Import")
 
 
-def test_pipeline_collection_source_dims_import(live_server, page):
+def test_pipeline_has_no_source_browse_controls(live_server, page):
+    """Arbitrary-path sources left with the import/process split: the
+    Source card offers only workspace folders and collections, so the
+    Browse button, the type-a-path input, and the folder-browser modal
+    must all be gone."""
+    url = live_server["url"]
+    page.goto(f"{url}/pipeline")
+    expect(page.locator("[data-testid='source-browse-btn']")).to_have_count(0)
+    expect(page.locator("#cfgSourceInput")).to_have_count(0)
+    expect(page.locator("#folderBrowserOverlay")).to_have_count(0)
+
+
+def test_pipeline_collection_source_dims_folders(live_server, page):
     url = live_server["url"]
     page.goto(f"{url}/pipeline")
     page.click("[data-testid='source-collection']")
-    import_body = page.locator("#sourceImportBody")
-    expect(import_body).to_have_class(re.compile("dimmed"))
+    folders_body = page.locator("#sourceImportBody")
+    expect(folders_body).to_have_class(re.compile("dimmed"))
 
 
-def test_pipeline_import_source_dims_collection(live_server, page):
+def test_pipeline_folders_source_dims_collection(live_server, page):
     url = live_server["url"]
     page.goto(f"{url}/pipeline")
     page.click("[data-testid='source-collection']")
     collection_body = page.locator("[data-testid='collection-section']")
     expect(collection_body).not_to_have_class(re.compile("dimmed"))
-    page.click("[data-testid='source-import']")
+    page.click("[data-testid='source-folders-option']")
     expect(collection_body).to_have_class(re.compile("dimmed"))
 
 
-def test_pipeline_source_browse_button_adds_source_folder(live_server, page):
-    url = live_server["url"]
-    page.route(
-        "**/api/import/folder-preview",
-        lambda route: route.fulfill(
-            status=200,
-            content_type="application/json",
-            body=json.dumps({
-                "total_count": 0,
-                "total_size": 0,
-                "type_breakdown": {},
-                "duplicate_count": 0,
-                "files": [],
-            }),
-        ),
-    )
-    page.goto(f"{url}/pipeline")
-    page.evaluate("window.pickDirectory = async () => ['/tmp/vireo-source']")
-
-    browse_btn = page.locator("[data-testid='source-browse-btn']")
-    expect(browse_btn).to_be_visible()
-    browse_btn.click()
-
-    expect(page.locator("#sourceFolderList")).to_contain_text("/tmp/vireo-source")
-    assert page.evaluate("_sourceMode") == "import"
-
-
-def test_pipeline_import_source_start_posts_source_folders(live_server, page):
-    """Import mode (source folders added via Browse/type) must enable Start
-    and POST /api/jobs/pipeline with `sources` = the folder list — not
-    fall through to collection scope and send `collection_id`.
-
-    Regression test for a bug where startPipeline() only special-cased
-    'folders' and 'new_images', so 'import' mode was treated as a
-    collection: Start stayed disabled unless a collection was selected,
-    and if one was, the request POSTed that collection_id instead of the
-    previewed source paths.
-    """
-    url = live_server["url"]
-    page.route(
-        "**/api/import/folder-preview",
-        lambda route: route.fulfill(
-            status=200,
-            content_type="application/json",
-            body=json.dumps({
-                "total_count": 1,
-                "total_size": 1000,
-                "type_breakdown": {".jpg": 1},
-                "duplicate_count": 0,
-                "files": [{
-                    "path": "/tmp/vireo-source/hawk.jpg",
-                    "size": 1000,
-                    "mtime": 1.0,
-                    "duplicate": False,
-                }],
-            }),
-        ),
-    )
-    pipeline_payloads = []
-
-    def capture_pipeline(route):
-        pipeline_payloads.append(route.request.post_data_json)
-        route.fulfill(
-            status=200,
-            content_type="application/json",
-            body=json.dumps({"job_id": "job-abc"}),
-        )
-
-    page.route("**/api/jobs/pipeline", capture_pipeline)
-
-    page.goto(f"{url}/pipeline")
-    page.evaluate("window.pickDirectory = async () => ['/tmp/vireo-source']")
-
-    page.locator("[data-testid='source-browse-btn']").click()
-    expect(page.locator("#sourceFolderList")).to_contain_text("/tmp/vireo-source")
-    assert page.evaluate("_sourceMode") == "import"
-
-    start_btn = page.locator("[data-testid='start-pipeline-btn']")
-    expect(start_btn).to_be_enabled()
-
-    # Turn Classify off so Start doesn't wait on the plan-refresh gate —
-    # the wiring under test is source scope, not classify gating.
-    page.uncheck("#enableClassify")
-    expect(start_btn).to_be_enabled()
-
-    start_btn.click()
-
-    for _ in range(50):
-        if pipeline_payloads:
-            break
-        page.wait_for_timeout(100)
-    assert pipeline_payloads, "expected /api/jobs/pipeline to be POSTed"
-    body = pipeline_payloads[0]
-    assert body.get("sources") == ["/tmp/vireo-source"], (
-        f"expected sources=['/tmp/vireo-source'], got body={body!r}"
-    )
-    assert "collection_id" not in body, (
-        f"import mode must not POST collection_id, got body={body!r}"
-    )
-    assert "folder_ids" not in body, (
-        f"import mode must not POST folder_ids, got body={body!r}"
-    )
-
-
-def test_pipeline_import_mode_switches_to_folders_on_checkbox(live_server, page):
-    """P2 regression: with a workspace folder checkbox available, checking
-    it while in `_sourceMode === 'import'` must switch mode back to
-    `'folders'`. Otherwise `updateStartButton()` keeps gating on
-    `_sourceFolders` and `startPipeline()` POSTs the stale `sources` list
-    instead of the `folder_ids` the user just picked.
-    """
+def test_pipeline_folder_selection_posts_folder_ids(live_server, page):
+    """Switching back from collection mode and checking a workspace folder
+    must make Start POST `folder_ids` — not the previously selected
+    collection scope."""
     url = live_server["url"]
     page.route(
         re.compile(r"/api/workspaces/\d+/folders$"),
@@ -180,20 +94,6 @@ def test_pipeline_import_mode_switches_to_folders_on_checkbox(live_server, page)
                     "workspace_photo_count": 5,
                 },
             ]),
-        ),
-    )
-    page.route(
-        "**/api/import/folder-preview",
-        lambda route: route.fulfill(
-            status=200,
-            content_type="application/json",
-            body=json.dumps({
-                "total_count": 0,
-                "total_size": 0,
-                "type_breakdown": {},
-                "duplicate_count": 0,
-                "files": [],
-            }),
         ),
     )
     pipeline_payloads = []
@@ -209,19 +109,17 @@ def test_pipeline_import_mode_switches_to_folders_on_checkbox(live_server, page)
     page.route("**/api/jobs/pipeline", capture_pipeline)
 
     page.goto(f"{url}/pipeline")
-    page.evaluate("window.pickDirectory = async () => ['/tmp/vireo-source']")
+    page.click("[data-testid='source-collection']")
+    assert page.evaluate("_sourceMode") == "collection"
 
-    page.locator("[data-testid='source-browse-btn']").click()
-    assert page.evaluate("_sourceMode") == "import"
-
-    # Wait for the workspace folder list to render, then check the folder.
+    # Return to folders scope, then check a workspace folder.
+    page.click("[data-testid='source-folders-option']")
+    assert page.evaluate("_sourceMode") == "folders"
     folder_cb = page.locator("#folderScopeList input[type='checkbox']").first
     expect(folder_cb).to_be_visible()
     folder_cb.check()
 
-    assert page.evaluate("_sourceMode") == "folders"
-
-    # Start now uses folder_ids, not sources.
+    # Start posts folder_ids, not a collection scope.
     page.uncheck("#enableClassify")
     start_btn = page.locator("[data-testid='start-pipeline-btn']")
     expect(start_btn).to_be_enabled()
@@ -236,113 +134,12 @@ def test_pipeline_import_mode_switches_to_folders_on_checkbox(live_server, page)
     assert body.get("folder_ids") == [42], (
         f"expected folder_ids=[42], got body={body!r}"
     )
+    assert "collection_id" not in body, (
+        f"folders mode must not POST collection_id, got body={body!r}"
+    )
     assert "sources" not in body, (
         f"folders mode must not POST sources, got body={body!r}"
     )
-
-
-def test_pipeline_removing_last_import_source_restores_folder_mode(live_server, page):
-    """P2 regression: removing the last import source folder must switch
-    `_sourceMode` back to `'folders'`. Otherwise Start stays stuck
-    disabled with `_sourceMode === 'import'` and an empty source list,
-    even if workspace-folder checkboxes are still ticked.
-    """
-    url = live_server["url"]
-    page.route(
-        "**/api/import/folder-preview",
-        lambda route: route.fulfill(
-            status=200,
-            content_type="application/json",
-            body=json.dumps({
-                "total_count": 0,
-                "total_size": 0,
-                "type_breakdown": {},
-                "duplicate_count": 0,
-                "files": [],
-            }),
-        ),
-    )
-    page.goto(f"{url}/pipeline")
-    page.evaluate("window.pickDirectory = async () => ['/tmp/vireo-source']")
-
-    page.locator("[data-testid='source-browse-btn']").click()
-    expect(page.locator("#sourceFolderList")).to_contain_text("/tmp/vireo-source")
-    assert page.evaluate("_sourceMode") == "import"
-
-    page.locator("#sourceFolderList button:has-text('Remove')").first.click()
-
-    assert page.evaluate("_sourceMode") == "folders"
-    expect(page.locator("#sourceFolderList")).to_be_empty()
-
-
-def test_pipeline_source_browse_reselect_restores_import_mode(live_server, page):
-    """P2 regression: after adding a source path, reverting to
-    workspace-folder scope, then using Browse to pick that same source
-    path again must switch `_sourceMode` back to `'import'`. Otherwise
-    Start posts `folder_ids` instead of the previewed `sources`, and
-    the UI still shows the source path row but Start would execute a
-    different scope than the plan describes.
-    """
-    url = live_server["url"]
-    page.route(
-        re.compile(r"/api/workspaces/\d+/folders$"),
-        lambda route: route.fulfill(
-            status=200,
-            content_type="application/json",
-            body=json.dumps([
-                {
-                    "id": 42,
-                    "path": "/library",
-                    "parent_id": None,
-                    "photo_count": 5,
-                    "workspace_photo_count": 5,
-                },
-            ]),
-        ),
-    )
-    page.route(
-        "**/api/import/folder-preview",
-        lambda route: route.fulfill(
-            status=200,
-            content_type="application/json",
-            body=json.dumps({
-                "total_count": 0,
-                "total_size": 0,
-                "type_breakdown": {},
-                "duplicate_count": 0,
-                "files": [],
-            }),
-        ),
-    )
-    page.goto(f"{url}/pipeline")
-    page.evaluate("window.pickDirectory = async () => ['/tmp/vireo-source']")
-
-    page.locator("[data-testid='source-browse-btn']").click()
-    expect(page.locator("#sourceFolderList")).to_contain_text("/tmp/vireo-source")
-    assert page.evaluate("_sourceMode") == "import"
-
-    folder_cb = page.locator("#folderScopeList input[type='checkbox']").first
-    expect(folder_cb).to_be_visible()
-    folder_cb.check()
-    assert page.evaluate("_sourceMode") == "folders"
-
-    # Re-pick the already-added path via Browse. Without the fix
-    # `added` stays false so the mode/render/refresh block is skipped
-    # and mode stays 'folders'.
-    page.locator("[data-testid='source-browse-btn']").click()
-    assert page.evaluate("_sourceMode") == "import"
-
-
-def test_pipeline_source_browse_cancel_keeps_workspace_folder_mode(live_server, page):
-    url = live_server["url"]
-    page.goto(f"{url}/pipeline")
-    assert page.evaluate("_sourceMode") == "folders"
-    page.evaluate("window.pickDirectory = async () => null")
-
-    page.locator("[data-testid='source-browse-btn']").click()
-
-    assert page.evaluate("_sourceMode") == "folders"
-    expect(page.locator("#sourceFolderList")).to_be_empty()
 
 
 def test_pipeline_source_card_expanded_by_default(live_server, page):
@@ -360,61 +157,6 @@ def test_pipeline_stage_cards_collapse_expand(live_server, page):
     expect(source_card).not_to_have_class(re.compile("expanded"))
     page.click("#card-source .stage-header")
     expect(source_card).to_have_class(re.compile("expanded"))
-
-
-def test_pipeline_folder_template_hidden_on_process_page(live_server, page):
-    url = live_server["url"]
-    page.goto(f"{url}/pipeline")
-    page.click("#card-destination .stage-header")
-    template = page.locator("#cfgFolderTemplate")
-    expect(template).to_be_hidden()
-
-
-def test_pipeline_custom_template_hidden_on_process_page(live_server, page):
-    url = live_server["url"]
-    page.goto(f"{url}/pipeline")
-    page.click("#card-destination .stage-header")
-    custom_input = page.locator("[data-testid='custom-template-input']")
-    expect(custom_input).to_be_hidden()
-
-
-def test_pipeline_destination_preview_button_hidden_on_process_page(live_server, page):
-    url = live_server["url"]
-    page.goto(f"{url}/pipeline")
-    page.click("#card-destination .stage-header")
-    btn = page.locator("[data-testid='preview-folders-btn']")
-    expect(btn).to_be_hidden()
-
-
-def test_pipeline_duplicate_summary_reframed_when_merging(live_server, page):
-    """With a managed archive in play, the duplicate summary reads as an
-    archive merge (already-in-archive + new-will-be-merged), not the generic
-    'already imported' wording."""
-    url = live_server["url"]
-    page.goto(f"{url}/pipeline")
-    # Managed-merge framing.
-    page.evaluate(
-        "window._managedArchive = {path: '/arch/USA', photo_count: 10};"
-        "updateDuplicateSummary({done: true, duplicate_count: 2, total: 5});"
-    )
-    dup = page.locator("#previewSummary .dup-status")
-    expect(dup).to_contain_text("already in your library")
-    expect(dup).to_contain_text("will be skipped")
-    expect(dup).to_contain_text("3 new")
-    expect(dup).to_contain_text("will be merged")
-
-
-def test_pipeline_duplicate_summary_generic_when_fresh(live_server, page):
-    """No managed archive -> today's exact 'already imported' wording."""
-    url = live_server["url"]
-    page.goto(f"{url}/pipeline")
-    page.evaluate(
-        "window._managedArchive = null;"
-        "updateDuplicateSummary({done: true, duplicate_count: 2, total: 5});"
-    )
-    dup = page.locator("#previewSummary .dup-status")
-    expect(dup).to_contain_text("already imported")
-    expect(dup).not_to_contain_text("this archive")
 
 
 def test_pipeline_section_headers_visible(live_server, page):
@@ -440,63 +182,6 @@ def test_pipeline_status_pills_visible_for_processing_stages(live_server, page):
     expect(page.locator("#pillClassify")).to_contain_text("Already done")
     # Extract has no seeded masks → "Will run".
     expect(page.locator("#pillExtract")).to_contain_text("Will run")
-
-
-def test_pipeline_import_plan_waits_for_folder_preview_scope(live_server, page):
-    url = live_server["url"]
-    page.goto(f"{url}/pipeline")
-    expect(page.locator("#pillClassify")).to_contain_text("Already done")
-
-    stale_plan_route = []
-
-    def hold_stale_plan(route):
-        stale_plan_route.append(route)
-
-    page.route("**/api/pipeline/plan", hold_stale_plan)
-    page.evaluate("setTimeout(refreshPipelinePlan, 0)")
-    for _ in range(50):
-        if stale_plan_route:
-            break
-        page.wait_for_timeout(100)
-    assert stale_plan_route
-
-    folder_preview_route = []
-    page.route("**/api/import/folder-preview", lambda route: folder_preview_route.append(route))
-    page.fill("#cfgSourceInput", "/Volumes/Photography/Raw Files/USA/2026/2026-05-30")
-    page.press("#cfgSourceInput", "Enter")
-    stale_plan_route[0].fulfill(
-        status=200,
-        content_type="application/json",
-        body=json.dumps({
-            "stages": {
-                "Previews": {"state": "done-prior", "summary": "stale"},
-                "Classify": {"state": "done-prior", "summary": "stale"},
-                "Extract": {"state": "done-prior", "summary": "stale"},
-                "EyeKeypoints": {"state": "done-prior", "summary": "stale"},
-                "Group": {"state": "done-prior", "summary": "stale"},
-            },
-            "scope": {"collection_id": None, "photo_count": None, "new_count": 0, "known_count": 0},
-        }),
-    )
-
-    expect(page.locator("[data-testid='pipeline-plan-summary'] .plan-loading")).to_be_visible()
-    expect(page.locator("#pillClassify")).not_to_contain_text("Already done")
-    for _ in range(50):
-        if folder_preview_route:
-            break
-        page.wait_for_timeout(100)
-    assert folder_preview_route
-    folder_preview_route[0].fulfill(
-        status=200,
-        content_type="application/json",
-        body=json.dumps({
-            "total_count": 0,
-            "total_size": 0,
-            "type_breakdown": {},
-            "duplicate_count": 0,
-            "files": [],
-        }),
-    )
 
 
 def test_pipeline_reclassify_flips_classify_pill_to_will_run(live_server, page):

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3434,7 +3434,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "results_cache_info": results_cache_info,
             "review_readiness": review_readiness,
             "workspace_overrides": ws_overrides,
-            "recent_destinations": effective_cfg.get("ingest", {}).get("recent_destinations", []),
         })
 
     @app.route("/api/pipeline/plan", methods=["POST"])

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -412,16 +412,6 @@ body { padding-bottom: 36px; }
   letter-spacing: 1px;
 }
 
-/* Destination card sections */
-.dest-section {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  margin-top: 8px;
-}
-.dest-option {
-  padding: 4px 0;
-}
 /* Pipeline action bar */
 .pipeline-action-bar {
   margin-top: 8px;
@@ -450,116 +440,9 @@ body { padding-bottom: 36px; }
 }
 .view-results-btn:hover { background: var(--accent-hover, #5AF0DA); }
 
-/* Folder tags (multi-folder input) */
-.folder-tag {
-  display: inline-flex; align-items: center; gap: 6px;
-  background: var(--bg-tertiary); border: 1px solid var(--border-secondary);
-  border-radius: 4px; padding: 4px 8px; margin: 2px; font-size: 12px;
-  font-family: monospace; color: var(--text-secondary);
-}
-.folder-tag-remove {
-  cursor: pointer; color: var(--text-ghost); font-size: 14px;
-}
-.folder-tag-remove:hover { color: var(--warning); }
-
 /* Stage enable/disable checkboxes */
 .stage-enable {
   accent-color: var(--accent); margin-right: 4px;
-}
-
-/* ---------- Folder Browser Modal ---------- */
-.folder-browser-overlay {
-  display: none;
-  position: fixed;
-  inset: 0;
-  z-index: 10000;
-  background: rgba(0,0,0,0.6);
-}
-.folder-browser-overlay.active { display: flex; align-items: center; justify-content: center; }
-.folder-browser-panel {
-  background: var(--bg-secondary);
-  border-radius: 8px;
-  width: 540px;
-  max-height: 80vh;
-  display: flex;
-  flex-direction: column;
-  color: var(--text-primary);
-  box-shadow: 0 8px 32px rgba(0,0,0,0.4);
-}
-.folder-browser-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 16px 20px 12px;
-  border-bottom: 1px solid var(--border-color);
-}
-.folder-browser-header h3 { margin: 0; font-size: 15px; }
-.folder-browser-close {
-  background: none; border: none; color: var(--text-muted);
-  font-size: 20px; cursor: pointer; padding: 0 4px;
-}
-.folder-browser-close:hover { color: var(--text-primary); }
-.folder-browser-shortcuts {
-  display: flex; gap: 6px; padding: 10px 20px;
-  border-bottom: 1px solid var(--border-color);
-}
-.folder-browser-shortcuts button {
-  font-size: 12px; padding: 4px 10px; border-radius: 4px;
-  background: var(--bg-tertiary); border: 1px solid var(--border-color);
-  color: var(--text-secondary); cursor: pointer;
-}
-.folder-browser-shortcuts button:hover { color: var(--text-primary); border-color: var(--accent); }
-.folder-browser-breadcrumb {
-  padding: 8px 20px; font-size: 12px; color: var(--text-muted);
-  display: flex; flex-wrap: wrap; gap: 2px; align-items: center;
-}
-.folder-browser-breadcrumb span { cursor: pointer; color: var(--accent); }
-.folder-browser-breadcrumb span:hover { text-decoration: underline; }
-.folder-browser-breadcrumb span.current { color: var(--text-primary); cursor: default; }
-.folder-browser-breadcrumb span.current:hover { text-decoration: none; }
-.folder-browser-list {
-  flex: 1; overflow-y: auto; padding: 4px 0; min-height: 200px;
-  user-select: none;
-}
-.folder-browser-item {
-  display: flex; align-items: center; gap: 8px;
-  padding: 6px 20px; cursor: pointer; font-size: 13px;
-}
-.folder-browser-item:hover { background: var(--bg-tertiary); }
-.folder-browser-item.selected { background: color-mix(in srgb, var(--accent) 15%, transparent); }
-.folder-browser-item-name {
-  flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-}
-.folder-browser-count {
-  font-size: 11px; color: var(--text-muted); margin-left: 8px;
-  font-variant-numeric: tabular-nums; flex-shrink: 0;
-}
-.folder-browser-empty {
-  padding: 20px; text-align: center; color: var(--text-muted); font-size: 13px;
-}
-.folder-browser-error {
-  padding: 12px 20px; color: #e55; font-size: 12px;
-}
-.folder-browser-loading {
-  padding: 20px; text-align: center; color: var(--text-muted); font-size: 13px;
-}
-.folder-browser-footer {
-  display: flex; justify-content: space-between; align-items: center;
-  padding: 12px 20px; border-top: 1px solid var(--border-color);
-}
-.folder-browser-path {
-  font-size: 11px; color: var(--text-muted); flex: 1; min-width: 0;
-  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-  margin-right: 12px;
-}
-.folder-browser-footer .btn { margin-left: 6px; }
-.folder-browser-new-folder {
-  display: flex; gap: 6px; padding: 6px 20px; align-items: center;
-}
-.folder-browser-new-folder input {
-  flex: 1; font-size: 13px; padding: 4px 8px; border-radius: 4px;
-  border: 1px solid var(--border-color); background: var(--bg-primary);
-  color: var(--text-primary); font-family: inherit;
 }
 
 /* Preview panel */
@@ -719,7 +602,7 @@ body { padding-bottom: 36px; }
     <div class="stage-body">
       <div class="source-choice">
         <div class="source-option" id="sourceOptionFolders">
-          <div class="source-option-header" onclick="selectSourceMode('folders')" data-testid="source-import">
+          <div class="source-option-header" onclick="selectSourceMode('folders')" data-testid="source-folders-option">
             <input type="radio" name="sourceMode" value="folders" id="radioFolders" checked data-testid="source-folders">
             <label for="radioFolders" style="cursor:pointer;font-weight:600;font-size:13px;">Workspace Folders</label>
           </div>
@@ -728,15 +611,6 @@ body { padding-bottom: 36px; }
               <div class="setting-item">
                 <div class="setting-label">Folders <span style="font-weight:400;color:var(--text-dim);">(each includes its subfolders)</span></div>
                 <div id="folderScopeList" style="display:flex;flex-direction:column;gap:2px;max-height:220px;overflow-y:auto;font-size:12px;"></div>
-                <div style="display:flex;flex-direction:column;gap:6px;margin-top:8px;">
-                  <button class="btn btn-primary" type="button" onclick="browseForFolder()"
-                          style="white-space:nowrap;align-self:flex-start;"
-                          data-testid="source-browse-btn">Browse&hellip;</button>
-                  <input type="text" class="setting-input" id="cfgSourceInput"
-                         placeholder="or type a path and press Enter"
-                         onkeydown="if(event.key==='Enter'){event.preventDefault();addSourceFolder();}">
-                </div>
-                <div id="sourceFolderList" style="margin-top:6px;"></div>
               </div>
             </div>
           </div>
@@ -777,6 +651,11 @@ body { padding-bottom: 36px; }
         </div>
       </div>
 
+      <div class="hint" style="font-size:12px;color:var(--text-secondary);line-height:1.4;margin-top:12px;" data-testid="source-import-hint">
+        Adding new photos to your library happens on the
+        <a href="/import" style="color:var(--accent);">Import</a> page.
+        Process only works on photos already in the active workspace.
+      </div>
       <div class="progress-wrap" id="progressSource" style="display:none;">
         <div class="progress-bar-track"><div class="progress-bar-fill" id="fillSource"></div></div>
         <div class="progress-text" id="textSource"></div>
@@ -785,82 +664,13 @@ body { padding-bottom: 36px; }
     </div>
   </div>
 
-  <!-- Card 2: Destination -->
-  <div class="stage-card" id="card-destination" data-testid="stage-card">
-    <div class="stage-header" onclick="toggleCard('destination')">
-      <span class="stage-num" id="numDestination">2</span>
-      <span class="stage-name">Destination</span>
-      <span class="stage-summary" id="summaryDestination"></span>
-      <span class="stage-chevron">&#9656;</span>
-    </div>
-    <div class="stage-body">
-      <!-- Section 1: Workspace -->
-      <div class="setting-label">Workspace</div>
-      <div class="dest-section">
-        <div class="dest-option">
-          <label style="cursor:pointer;display:flex;align-items:center;gap:8px;">
-            <input type="radio" name="destWorkspace" value="current" id="radioWsCurrent" checked
-                   onchange="onDestWorkspaceChange()" style="accent-color:var(--accent);" data-testid="workspace-current">
-            <span style="font-size:13px;font-weight:600;">Current workspace</span>
-            <span style="font-size:13px;color:var(--text-dim);" id="lblCurrentWsName"></span>
-          </label>
-        </div>
-        <div class="dest-option">
-          <label style="cursor:pointer;display:flex;align-items:center;gap:8px;">
-            <input type="radio" name="destWorkspace" value="new" id="radioWsNew"
-                   onchange="onDestWorkspaceChange()" style="accent-color:var(--accent);" data-testid="workspace-new">
-            <span style="font-size:13px;font-weight:600;">New workspace</span>
-          </label>
-          <div id="newWsNameRow" style="display:none;margin-top:8px;margin-left:24px;">
-            <input type="text" class="setting-select" id="destNewWsName"
-                   placeholder="e.g. Kenya 2025" style="font-family:inherit;max-width:300px;"
-                   oninput="updateStartButton()" data-testid="new-workspace-name">
-            <div class="dest-error" id="destWsError" style="display:none;color:var(--error,#f66);font-size:12px;margin-top:4px;" data-testid="workspace-name-error"></div>
-          </div>
-        </div>
-        <div id="destWsNewImagesNote" style="display:none;margin-top:6px;font-size:12px;color:var(--text-dim);" data-testid="workspace-new-images-note">
-          Processing new images uses the current workspace — the snapshot is scoped to it.
-        </div>
-      </div>
-
-      <div style="border-top:1px solid var(--border-primary,#14374E);margin:16px 0;"></div>
-      <div class="setting-label">Importing photos</div>
-      <div class="hint" style="font-size:12px;color:var(--text-secondary);line-height:1.4;">
-        Copying cards or folders into the archive now happens on the
-        <a href="/import" style="color:var(--accent);">Import</a> page.
-        Process only works on photos already in the active workspace.
-      </div>
-      <div id="destCopySection" data-testid="file-copying-section" style="display:none;">
-        <input type="checkbox" id="chkCopyPhotos" data-testid="copy-photos-toggle">
-        <div id="copyOnlyFields" data-testid="destination-section" style="display:none;">
-          <input type="text" id="cfgDestination">
-          <select id="cfgDestMode"><option value="local">Local path</option></select>
-          <input type="checkbox" id="chkSkipDuplicates" checked>
-          <input type="checkbox" id="chkVerifyByHash">
-          <input type="checkbox" id="chkLocalProcessing" data-testid="local-processing-toggle">
-          <select id="cfgFolderTemplate"><option value="%Y/%Y-%m-%d">Year / Date</option></select>
-          <input type="text" id="cfgCustomTemplate" data-testid="custom-template-input">
-          <button id="btnPreviewFolders" data-testid="preview-folders-btn">Preview folder structure</button>
-          <span id="previewFoldersHint"></span>
-          <div id="folderPreviewResults" data-testid="folder-preview-results" style="display:none;">
-            <div id="folderPreviewManagedArchive" data-testid="managed-archive-callout" style="display:none;"></div>
-            <div id="folderPreviewSummary"></div>
-            <div id="folderPreviewList"></div>
-            <div id="folderPreviewStale" style="display:none;"></div>
-          </div>
-        </div>
-      </div>
-
-    </div>
-  </div>
-
   <div class="stage-section-header">Indexing<span class="stage-section-sub">always runs</span></div>
 
-  <!-- Card 3: Scan & Import -->
+  <!-- Card 2: Scan & Index -->
   <div class="stage-card" id="card-scan" data-testid="stage-card">
     <div class="stage-header" onclick="toggleCard('scan')">
-      <span class="stage-num" id="numScan">3</span>
-      <span class="stage-name">Scan &amp; Import</span>
+      <span class="stage-num" id="numScan">2</span>
+      <span class="stage-name">Scan &amp; Index</span>
       <span class="stage-status-pill" id="pillScan"></span>
       <span class="stage-summary" id="summaryScan"></span>
       <span class="stage-chevron">&#9656;</span>
@@ -877,10 +687,10 @@ body { padding-bottom: 36px; }
     </div>
   </div>
 
-  <!-- Card 4: Thumbnails & Previews -->
+  <!-- Card 3: Thumbnails & Previews -->
   <div class="stage-card" id="card-previews" data-testid="stage-card">
     <div class="stage-header" onclick="toggleCard('previews')">
-      <span class="stage-num" id="numPreviews">4</span>
+      <span class="stage-num" id="numPreviews">3</span>
       <span class="stage-name">Thumbnails &amp; Previews</span>
       <span class="stage-status-pill" id="pillPreviews"></span>
       <span class="stage-summary" id="summaryPreviews"></span>
@@ -918,10 +728,10 @@ body { padding-bottom: 36px; }
     </span>
   </div>
 
-  <!-- Card 5: Classify -->
+  <!-- Card 4: Classify -->
   <div class="stage-card" id="card-classify" data-testid="stage-card">
     <div class="stage-header" onclick="toggleCard('classify')">
-      <span class="stage-num" id="numClassify">5</span>
+      <span class="stage-num" id="numClassify">4</span>
       <input type="checkbox" class="stage-enable" id="enableClassify" checked
              onchange="onStageToggle('classify')" onclick="event.stopPropagation()">
       <span class="stage-name">Classify</span>
@@ -970,10 +780,10 @@ body { padding-bottom: 36px; }
     </div>
   </div>
 
-  <!-- Card 6: Extract Features -->
+  <!-- Card 5: Extract Features -->
   <div class="stage-card" id="card-extract" data-testid="stage-card" data-advanced-stage>
     <div class="stage-header" onclick="toggleCard('extract')">
-      <span class="stage-num" id="numExtract">6</span>
+      <span class="stage-num" id="numExtract">5</span>
       <input type="checkbox" class="stage-enable" id="enableExtract" checked
              onchange="onStageToggle('extract')" onclick="event.stopPropagation()">
       <span class="stage-name">Extract Features</span>
@@ -1033,10 +843,10 @@ body { padding-bottom: 36px; }
     </div>
   </div>
 
-  <!-- Card 7: Eye Keypoints (optional, off by default until weights downloaded) -->
+  <!-- Card 6: Eye Keypoints (optional, off by default until weights downloaded) -->
   <div class="stage-card" id="card-eyekeypoints" data-testid="stage-card" data-advanced-stage>
     <div class="stage-header" onclick="toggleCard('eyekeypoints')">
-      <span class="stage-num" id="numEyeKeypoints">7</span>
+      <span class="stage-num" id="numEyeKeypoints">6</span>
       <input type="checkbox" class="stage-enable" id="enableEyeKeypoints" checked
              onchange="onStageToggle('eyekeypoints')" onclick="event.stopPropagation()">
       <span class="stage-name">Eye Keypoints (optional)</span>
@@ -1065,10 +875,10 @@ body { padding-bottom: 36px; }
     </div>
   </div>
 
-  <!-- Card 8: Group & Score -->
+  <!-- Card 7: Group & Score -->
   <div class="stage-card" id="card-group" data-testid="stage-card" data-advanced-stage>
     <div class="stage-header" onclick="toggleCard('group')">
-      <span class="stage-num" id="numGroup">8</span>
+      <span class="stage-num" id="numGroup">7</span>
       <input type="checkbox" class="stage-enable" id="enableGroup" checked
              onchange="onStageToggle('group')" onclick="event.stopPropagation()">
       <span class="stage-name">Group &amp; Score</span>
@@ -1236,36 +1046,12 @@ function initPipelinePage() {
       if (typeof updateSamVariantWarning === 'function') {
         updateSamVariantWarning(data.sam_variant_warning || null);
       }
-
-      // Populate recent destinations
-      var recents = data.recent_destinations || [];
-      if (recents.length > 0) {
-        var container = document.getElementById('recentDestList');
-        recents.forEach(function(path) {
-          var name = path.split('/').filter(Boolean).slice(-1)[0] || path;
-          var btn = document.createElement('button');
-          btn.className = 'btn btn-secondary';
-          btn.style.cssText = 'font-size:11px;padding:2px 8px;';
-          btn.title = path;
-          btn.textContent = name;
-          btn.addEventListener('click', function() { selectRecentDestination(path); });
-          container.appendChild(btn);
-        });
-        document.getElementById('recentDestinations').style.display = '';
-      }
     })
     .catch(function(e) {
       console.error('Failed to load pipeline page data:', e);
     });
 
-  // Load active workspace name for Destination card
-  safeFetch('/api/workspaces/active', {}, { toast: false }).then(function(ws) {
-    if (ws && ws.name) {
-      document.getElementById('lblCurrentWsName').textContent = '(' + ws.name + ')';
-    }
-  });
-
-  // Load collections, models, labels, volumes in parallel
+  // Load collections, models, and labels in parallel
   loadFolderScopeList();
   loadCollections();
   // Models and labels populate the pickers the plan endpoint reads from,
@@ -1277,8 +1063,6 @@ function initPipelinePage() {
     applyClassifyQueryParams();
     refreshPipelinePlan();
   });
-  loadVolumes();
-  loadRemoteTargets();
 
   // Pre-fill folders from query params (e.g., from audit panel)
   var urlParams = new URLSearchParams(window.location.search);
@@ -1503,19 +1287,6 @@ async function loadCollections() {
   } catch(e) {}
 }
 
-// -- Card 2: Destination --
-var _destWorkspaceMode = 'current'; // 'current' or 'new'
-
-function onDestWorkspaceChange() {
-  _destWorkspaceMode = document.getElementById('radioWsNew').checked ? 'new' : 'current';
-  document.getElementById('newWsNameRow').style.display = _destWorkspaceMode === 'new' ? '' : 'none';
-  document.getElementById('destWsError').style.display = 'none';
-  if (_destWorkspaceMode === 'new') {
-    document.getElementById('destNewWsName').focus();
-  }
-  updateStartButton();
-}
-
 // -- Card 1: Source --
 var _prefillFolderPaths = [];
 
@@ -1573,10 +1344,10 @@ async function loadFolderScopeList() {
       cb.checked = prefillRootIds.has(f.id);
       cb.onchange = function() {
         // Checking a workspace-folder box is a switch to workspace-folder
-        // scope: if we're still in 'import' mode from a previously typed/
-        // browsed source path, updateStartButton() and startPipeline()
-        // would keep gating on _sourceFolders and POST the stale sources
-        // list instead of the folder_ids the user just picked.
+        // scope: if we're still in collection or new-images mode,
+        // updateStartButton() and startPipeline() would keep gating on the
+        // previous scope and POST it instead of the folder_ids the user
+        // just picked.
         if (cb.checked && _sourceMode !== 'folders') selectSourceMode('folders');
         updateSourceSummary();
         updateStartButton();
@@ -1610,23 +1381,6 @@ function updateSourceSummary() {
   if (_sourceMode === 'folders') {
     var n = selectedFolderIds().length;
     el.textContent = n ? (n + ' folder(s) selected') : '';
-  } else if (_sourceMode === 'import') {
-    if (!_sourceFolders.length) {
-      el.textContent = '';
-    } else if (_previewLoading) {
-      el.textContent = 'Loading preview...';
-    } else if (_previewData && Array.isArray(_previewData.files)) {
-      var total = _previewData.files.length;
-      var selected = 0;
-      _previewData.files.forEach(function(f) {
-        if (_previewSelected[f.path]) selected++;
-      });
-      el.textContent = selected === total
-        ? (total + ' photo' + (total === 1 ? '' : 's') + ' ready')
-        : (selected + ' of ' + total + ' photos selected');
-    } else {
-      el.textContent = 'Preview pending';
-    }
   }
 }
 
@@ -1680,30 +1434,14 @@ function updateAdvancedPipelineOptions() {
   applyStrategyPreset();
 }
 
-var _sourceMode = 'folders'; // 'folders', 'import', 'collection', or 'new_images'
-var _copyMode = false;
-var _folderPreviewShown = false;
-var _sourceWasReady = false;
-var _sourceFolders = [];
+var _sourceMode = 'folders'; // 'folders', 'collection', or 'new_images'
 
-// -- Import preview state --
-var _previewData = null;       // response from /api/import/folder-preview
+// -- Preview panel state --
+var _previewData = null;       // response from the preview endpoint
 var _previewSelected = {};     // { filePath: true/false }
-var _previewLoading = false;   // true while import/new-images preview scope is unresolved
+var _previewLoading = false;   // true while the new-images preview scope is unresolved
 var _previewAbort = null;      // AbortController for in-flight request
-var _duplicateResults = {};    // path -> true for duplicates (cache)
-var _duplicateCheckAbort = null;  // AbortController for in-flight check
-// Set from the last destination-preview when the destination is (or sits
-// inside) an existing Vireo-managed archive: { path, photo_count }. null
-// otherwise. Used to reframe the destination preview + duplicate summary as
-// a merge into an existing archive rather than a fresh copy.
-var _managedArchive = null;
 var _thumbSchedulerCancel = null; // cancels the current thumbnail pump on re-render
-
-function includeSubfoldersEnabled() {
-  var cb = document.getElementById('chkIncludeSubfolders');
-  return cb ? cb.checked : true;
-}
 
 function fetchFolderPreview() {
   if (_previewAbort) _previewAbort.abort();
@@ -1737,51 +1475,6 @@ function fetchFolderPreview() {
         _previewData = data;
         _previewSelected = {};
         data.files.forEach(function(f) {
-          _previewSelected[f.path] = !f.duplicate;
-        });
-        renderPreview();
-      })
-      .catch(function(err) {
-        if (err.name === 'AbortError') return;
-        showPreviewError('Failed to load preview: ' + err.message);
-      });
-    return;
-  }
-
-  // Import preview mode is a compatibility path for source folders chosen
-  // directly from Process. Importing/archive copies still live on /import.
-  if (_sourceMode === 'import') {
-    var folders = _sourceFolders;
-    if (!folders.length) {
-      showPreviewPlaceholder();
-      return;
-    }
-    var fileTypes = getIngestFileTypes();
-    if (!fileTypes.length) {
-      showPreviewPlaceholder();
-      return;
-    }
-    showPreviewLoading();
-    _previewAbort = new AbortController();
-    fetch('/api/import/folder-preview', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        folders: folders,
-        file_types: fileTypes,
-        recursive: includeSubfoldersEnabled(),
-      }),
-      signal: _previewAbort.signal,
-    })
-      .then(function(r) {
-        if (!r.ok) throw new Error('HTTP ' + r.status);
-        return r.json();
-      })
-      .then(function(data) {
-        _previewData = data;
-        _previewSelected = {};
-        _duplicateResults = {};
-        (data.files || []).forEach(function(f) {
           _previewSelected[f.path] = !f.duplicate;
         });
         renderPreview();
@@ -1852,8 +1545,6 @@ function showPreviewLoading() {
   updateSamVariantWarning(null);
   refreshPipelineUI();
   updateSourceSummary();
-  // Cancel any in-flight duplicate check when preview context changes
-  if (_duplicateCheckAbort) { _duplicateCheckAbort.abort(); _duplicateCheckAbort = null; }
   if (_thumbSchedulerCancel) { _thumbSchedulerCancel(); _thumbSchedulerCancel = null; }
 }
 
@@ -1962,213 +1653,9 @@ function renderPreview() {
   setupThumbnailObserver();
   updatePreviewCounts();
   updateSourceSummary();
-  // Reapply cached duplicate markers after DOM rebuild
-  if (Object.keys(_duplicateResults).length > 0) applyDuplicateVisuals();
-  // Preview content drives the import-mode plan (which paths are selected).
+  // Preview content drives the run scope (which paths are selected).
   // Refresh debounced — folder-level and select-all checkboxes call us in
   // bursts, and we'd rather not POST to /api/pipeline/plan on every click.
-  schedulePlanRefresh();
-}
-
-function checkForDuplicates() {
-  // Abort any in-flight check
-  if (_duplicateCheckAbort) _duplicateCheckAbort.abort();
-
-  if (!_previewData || !_previewData.files.length) return;
-  var skipDuplicates = document.getElementById('chkSkipDuplicates');
-  if (!_copyMode) return;
-  if (skipDuplicates && !skipDuplicates.checked) return;
-
-  _duplicateResults = {};
-  _duplicateCheckAbort = new AbortController();
-
-  // Only send selected files: deselected files are excluded from import and
-  // should not influence which other files are flagged as run-duplicates,
-  // matching the behaviour of the actual import step (exclude_paths applied
-  // before duplicate filtering).
-  var paths = _previewData.files
-    .filter(function(f) { return _previewSelected[f.path] !== false; })
-    .map(function(f) { return f.path; });
-
-  if (!paths.length) {
-    applyDuplicateVisuals();
-    var summary = document.getElementById('previewSummary');
-    var ds = summary ? summary.querySelector('.dup-status') : null;
-    if (ds) ds.remove();
-    return;
-  }
-
-  fetch('/api/import/check-duplicates', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      paths: paths,
-      verify_by_hash: !!((document.getElementById('chkVerifyByHash') || {}).checked),
-    }),
-    signal: _duplicateCheckAbort.signal,
-  }).then(function(response) {
-    if (!response.ok) return;
-    var reader = response.body.getReader();
-    var decoder = new TextDecoder();
-    var buffer = '';
-
-    function read() {
-      reader.read().then(function(result) {
-        if (result.done) return;
-        buffer += decoder.decode(result.value, { stream: true });
-        var parts = buffer.split('\n\n');
-        buffer = parts.pop();
-        parts.forEach(function(part) {
-          var match = part.match(/^data: (.+)$/m);
-          if (!match) return;
-          try { var data = JSON.parse(match[1]); } catch(e) { return; }
-          if (data.duplicates) {
-            data.duplicates.forEach(function(p) {
-              _duplicateResults[p] = true;
-            });
-          }
-          // Only update UI if the user still wants to skip duplicates
-          var stillSkip = document.getElementById('chkSkipDuplicates');
-          if (!stillSkip || stillSkip.checked) {
-            if (data.duplicates) applyDuplicateVisuals();
-            updateDuplicateSummary(data);
-            // Newly-discovered hash duplicates change the import scope —
-            // ingest() will skip those files, so the plan must shift them
-            // from "new" to "already known". Debounced via
-            // schedulePlanRefresh so the burst of SSE batches collapses
-            // into a single plan POST.
-            if (data.duplicates && data.duplicates.length) {
-              schedulePlanRefresh();
-            }
-          }
-        });
-        read();
-      }).catch(function() {});
-    }
-    read();
-  }).catch(function() {});
-}
-
-function applyDuplicateVisuals() {
-  var skipCb = document.getElementById('chkSkipDuplicates');
-  var skipChecked = !skipCb || skipCb.checked;
-  var grid = document.getElementById('previewGrid');
-  var thumbs = grid.querySelectorAll('.preview-thumb');
-  thumbs.forEach(function(el) {
-    var path = el.dataset.path;
-    var isDup = _duplicateResults[path];
-    if (isDup && skipChecked) {
-      el.classList.add('duplicate');
-      if (!el.querySelector('.duplicate-badge')) {
-        var badge = document.createElement('span');
-        badge.className = 'duplicate-badge';
-        badge.textContent = 'DUPLICATE';
-        el.appendChild(badge);
-      }
-    } else {
-      el.classList.remove('duplicate');
-      var badge = el.querySelector('.duplicate-badge');
-      if (badge) badge.remove();
-    }
-  });
-}
-
-function updateDuplicateSummary(data) {
-  var summary = document.getElementById('previewSummary');
-  if (!summary) return;
-  // Remove any existing duplicate status
-  var existing = summary.querySelector('.dup-status');
-  if (existing) existing.remove();
-
-  var span = document.createElement('span');
-  span.className = 'stat dup-status';
-  span.title = duplicateMethodNote();
-  if (data.done) {
-    if (data.duplicate_count > 0) {
-      if (_managedArchive) {
-        // Merging into an existing archive: frame duplicates as already
-        // living in the catalog (they'll be skipped), and \u2014 when we can
-        // reliably derive it \u2014 how many are genuinely new (will be merged).
-        // The duplicate check is catalog-global (matches ingest's global
-        // skip), so a match may live in a different archive \u2014 hence
-        // "in your library", not "in this archive". The count is still
-        // correct for the skip/merge framing.
-        span.innerHTML = '<span class="stat-value">' + data.duplicate_count
-          + '</span> already in your library (will be skipped)';
-        if (typeof data.total === 'number' && data.total >= data.duplicate_count) {
-          var newCount = data.total - data.duplicate_count;
-          span.innerHTML += ', <span class="stat-value">' + newCount
-            + '</span> new (will be merged)';
-        }
-      } else {
-        span.innerHTML = '<span class="stat-value">' + data.duplicate_count + '</span> already imported';
-      }
-    }
-    // If 0 duplicates, show nothing
-  } else {
-    span.textContent = 'Checking duplicates\u2026 ' + data.checked + '/' + data.total;
-  }
-  if (span.innerHTML || span.textContent) summary.appendChild(span);
-}
-
-function duplicateMethodNote() {
-  // Keep the summary honest about HOW duplicates were identified — the
-  // two modes can disagree on edge cases (e.g. renamed copies).
-  var verify = document.getElementById('chkVerifyByHash');
-  return verify && verify.checked
-    ? 'matched by content hash'
-    : 'matched by filename, size & capture time';
-}
-
-function onVerifyByHashToggle() {
-  // The two modes can classify files differently, so cached results are
-  // stale the moment the mode changes: drop them and re-scan.
-  if (_duplicateCheckAbort) { _duplicateCheckAbort.abort(); _duplicateCheckAbort = null; }
-  _duplicateResults = {};
-  applyDuplicateVisuals();
-  var summary = document.getElementById('previewSummary');
-  var existing = summary ? summary.querySelector('.dup-status') : null;
-  if (existing) existing.remove();
-  var skipDuplicates = document.getElementById('chkSkipDuplicates');
-  if (!skipDuplicates || skipDuplicates.checked) {
-    checkForDuplicates();
-  }
-  schedulePlanRefresh();
-}
-
-function onSkipDuplicatesToggle() {
-  var skipDuplicates = document.getElementById('chkSkipDuplicates');
-  var checked = !skipDuplicates || skipDuplicates.checked;
-  if (!checked) {
-    // Abort any in-flight check so SSE callbacks stop updating the UI
-    if (_duplicateCheckAbort) { _duplicateCheckAbort.abort(); _duplicateCheckAbort = null; }
-    // Remove visuals and summary before clearing cache
-    applyDuplicateVisuals();
-    var summary = document.getElementById('previewSummary');
-    var existing = summary.querySelector('.dup-status');
-    if (existing) existing.remove();
-    _duplicateResults = {};
-  } else if (Object.keys(_duplicateResults).length > 0) {
-    applyDuplicateVisuals();
-    var dupCount = Object.keys(_duplicateResults).length;
-    var summary = document.getElementById('previewSummary');
-    var existing = summary.querySelector('.dup-status');
-    if (existing) existing.remove();
-    if (dupCount > 0) {
-      var span = document.createElement('span');
-      span.className = 'stat dup-status';
-      span.title = duplicateMethodNote();
-      span.innerHTML = _managedArchive
-        ? '<span class="stat-value">' + dupCount + '</span> already in your library (will be skipped)'
-        : '<span class="stat-value">' + dupCount + '</span> already imported';
-      summary.appendChild(span);
-    }
-  } else {
-    checkForDuplicates();
-  }
-  // Toggling the gate flips whether known-by-hash files count as
-  // "new" (gate off → ingest will copy them) or "known" (gate on →
-  // ingest will skip them). Either way the plan changes; refresh it.
   schedulePlanRefresh();
 }
 
@@ -2272,464 +1759,21 @@ function formatBytes(bytes) {
   return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
 }
 
-function addSourceFolder() {
-  var input = document.getElementById('cfgSourceInput');
-  if (!input) return;
-  var val = input.value.trim();
-  if (!val) return;
-  // Adding a path the user has already typed once is still an unambiguous
-  // "use this import source" signal. If we early-returned on the duplicate
-  // the mode/render/preview refresh below would be skipped, leaving Start
-  // gated by folder_ids after the user switched back to workspace-folder
-  // scope. Fall through so the mode always re-syncs to 'import'.
-  var alreadyPresent = _sourceFolders.indexOf(val) !== -1;
-  if (!alreadyPresent) _sourceFolders.push(val);
-  input.value = '';
-  var switched = _sourceMode !== 'import';
-  if (switched) selectSourceMode('import');
-  if (!alreadyPresent) {
-    renderSourceFolders();
-    if (!switched) fetchFolderPreview();
-  }
-  updateStartButton();
-}
-
-function renderSourceFolders() {
-  var list = document.getElementById('sourceFolderList');
-  if (!list) return;
-  list.innerHTML = '';
-  _sourceFolders.forEach(function(path, idx) {
-    var row = document.createElement('div');
-    row.style.cssText = 'display:flex;align-items:center;gap:6px;color:var(--text-secondary);font-size:12px;';
-    var text = document.createElement('span');
-    text.style.cssText = 'font-family:monospace;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;';
-    text.textContent = path;
-    var remove = document.createElement('button');
-    remove.type = 'button';
-    remove.className = 'btn btn-secondary';
-    remove.style.cssText = 'font-size:11px;padding:2px 6px;';
-    remove.textContent = 'Remove';
-    remove.onclick = function() {
-      _sourceFolders.splice(idx, 1);
-      renderSourceFolders();
-      // Removing the last import source leaves _sourceMode stuck at
-      // 'import' with an empty list, so Start stays disabled even if
-      // workspace folder checkboxes are still ticked. Fall back to
-      // 'folders' scope so the previously-checked folders take over.
-      if (_sourceFolders.length === 0 && _sourceMode === 'import') {
-        selectSourceMode('folders');
-      }
-      fetchFolderPreview();
-      updateStartButton();
-    };
-    row.appendChild(text);
-    row.appendChild(remove);
-    list.appendChild(row);
-  });
-}
-
-/* ---------- Remote (SSH) archive targets ----------
-   Mirrors the Move page's saved-remote-target picker: the archive
-   destination becomes a saved SSH target plus a required subpath naming
-   the archive folder under it. Requires local processing (files are
-   staged locally, then rsynced over SSH by the archive stage). */
-var _remoteTargets = [];
-var _rsyncAvailable = false;
-
-async function loadRemoteTargets() {
-  try {
-    var data = await safeFetch('/api/remote-targets', {}, { toast: false });
-    _remoteTargets = (data && data.targets) || [];
-    _rsyncAvailable = !!(data && data.rsync_available);
-  } catch (e) {
-    _remoteTargets = [];
-    _rsyncAvailable = false;
-  }
-  var sel = document.getElementById('cfgDestMode');
-  if (!sel) return;
-  // Rebuild remote options, keeping the "Local path" option at index 0.
-  while (sel.options.length > 1) sel.remove(1);
-  _remoteTargets.forEach(function(t) {
-    var opt = document.createElement('option');
-    opt.value = 'remote:' + t.id;
-    opt.textContent = t.name + ' — ' + t.user + '@' + t.host + ' (SSH)';
-    sel.appendChild(opt);
-  });
-}
-
-// The remote target id when the destination mode is a remote target, else ''.
-function pipelineRemoteTargetId() {
-  var el = document.getElementById('cfgDestMode');
-  var v = el ? el.value : 'local';
-  return v.indexOf('remote:') === 0 ? v.slice(7) : '';
-}
-
-function pipelineRemoteTarget() {
-  var id = pipelineRemoteTargetId();
-  if (!id) return null;
-  return _remoteTargets.find(function(t) { return t.id === id; }) || null;
-}
-
-function onDestModeChange() {
-  var remoteId = pipelineRemoteTargetId();
-  document.getElementById('destLocalRows').style.display = remoteId ? 'none' : '';
-  document.getElementById('destRemoteRows').style.display = remoteId ? '' : 'none';
-  // SSH targets require the local staging flow: photos can't be processed
-  // in place over SSH, so the archive stage rsyncs the staged tree to the
-  // NAS. Lock the toggle on so its state always matches what the job does.
-  var lp = document.getElementById('chkLocalProcessing');
-  var note = document.getElementById('remoteLocalProcessingNote');
-  if (remoteId) {
-    if (lp) { lp.checked = true; lp.disabled = true; }
-    if (note) note.style.display = '';
-  } else {
-    if (lp) lp.disabled = false;
-    if (note) note.style.display = 'none';
-  }
-  updateRemoteDestPreview();
-  markFolderPreviewStale();
-  updateStartButton();
-  schedulePlanRefresh();
-}
-
-// Normalize a remote-target subpath the same way move.py sanitize_subpath
-// does (see move.html's copy of this helper): trim, fold backslashes,
-// reject absolute paths and '..' traversal, drop empty/'.' segments.
-// Sharing the backend's rules means the path the UI previews is the path
-// the archive will actually write — a UI-transparency requirement.
-function normalizeRemoteSubpath(raw) {
-  var trimmed = (raw || '').trim();
-  if (!trimmed) return {value: '', error: ''};
-  var s = trimmed.replace(/\\/g, '/');
-  if (s.charAt(0) === '/' || /^[A-Za-z]:/.test(s)) {
-    return {value: '', error: 'Subpath must be relative.'};
-  }
-  var parts = [];
-  var segs = s.split('/');
-  for (var i = 0; i < segs.length; i++) {
-    var seg = segs[i];
-    if (seg === '' || seg === '.') continue;
-    if (seg === '..') return {value: '', error: "Subpath may not contain '..'."};
-    parts.push(seg);
-  }
-  return {value: parts.join('/'), error: ''};
-}
-
-// True if `p` looks absolute on either backend OS (POSIX, Windows drive,
-// or UNC). Used to warn before the backend refuses a relative mount path.
-function _isAbsolutePath(p) {
-  if (!p) return false;
-  return p.charAt(0) === '/' || /^[A-Za-z]:[\\\/]/.test(p) || /^\\\\/.test(p);
-}
-
-// Mirror move.py rsync_dest_spec(): bracket IPv6-literal hosts so the
-// preview shows the exact spec rsync will be handed.
-function rsyncDestSpec(user, host, path) {
-  var hostToken = host && host.indexOf(':') !== -1 ? '[' + host + ']' : host;
-  return user + '@' + hostToken + ':' + path;
-}
-
-function _remoteDestWarn(text) {
-  var d = document.createElement('div');
-  d.style.color = 'var(--warning,#f0ad4e)';
-  d.textContent = text;
-  return d;
-}
-
-function updateRemoteDestPreview() {
-  var el = document.getElementById('remoteDestPreview');
-  if (!el) return;
-  el.textContent = '';
-  var t = pipelineRemoteTarget();
-  if (!t) return;
-  var subResult = normalizeRemoteSubpath(
-    document.getElementById('cfgRemoteSubpath').value);
-  if (subResult.error) {
-    el.appendChild(_remoteDestWarn('⚠ ' + subResult.error));
-  } else if (!subResult.value) {
-    var hint = document.createElement('div');
-    hint.textContent = 'Name the archive folder under ' + t.remote_path
-      + ' — e.g. 2026/kenya-trip.';
-    el.appendChild(hint);
-  } else {
-    var line = document.createElement('div');
-    line.textContent = 'Staged locally, then archived over SSH to: ';
-    var span = document.createElement('span');
-    span.style.fontFamily = 'monospace';
-    span.textContent = rsyncDestSpec(
-      t.user, t.host, t.remote_path.replace(/\/+$/, '') + '/' + subResult.value);
-    line.appendChild(span);
-    el.appendChild(line);
-  }
-  if (!_rsyncAvailable) {
-    el.appendChild(_remoteDestWarn('⚠ No GNU rsync found — remote archiving '
-      + 'needs it. Install GNU rsync or set its path under Settings → Paths.'));
-  }
-  if (!t.mount_path) {
-    el.appendChild(_remoteDestWarn('⚠ This target has no local mount path, so '
-      + 'archived photos couldn’t stay in your library. Add one in Settings → '
-      + 'Remote targets.'));
-  } else if (!_isAbsolutePath(t.mount_path)) {
-    el.appendChild(_remoteDestWarn('⚠ This target’s local mount path must be '
-      + 'absolute (e.g. "/Volumes/Photos"). Fix it under Settings → Remote '
-      + 'targets.'));
-  }
-}
-
-// True when the remote archive selection is complete and usable. Mirrors
-// the backend's POST validation so Start is only enabled for a request
-// that would be accepted.
-function remoteArchiveSelectionReady() {
-  var t = pipelineRemoteTarget();
-  if (!t || !_rsyncAvailable) return false;
-  if (!t.mount_path || !_isAbsolutePath(t.mount_path)) return false;
-  var subResult = normalizeRemoteSubpath(
-    document.getElementById('cfgRemoteSubpath').value);
-  return !subResult.error && !!subResult.value;
-}
-
-function onCopyModeChange() {
-  _copyMode = document.getElementById('chkCopyPhotos').checked;
-  var copyFields = document.getElementById('copyOnlyFields');
-
-  if (_copyMode) {
-    copyFields.style.display = '';
-    checkForDuplicates();
-  } else {
-    copyFields.style.display = 'none';
-    _folderPreviewShown = false;
-    document.getElementById('folderPreviewResults').style.display = 'none';
-    // Clear duplicate state when copy mode is disabled
-    if (_duplicateCheckAbort) { _duplicateCheckAbort.abort(); _duplicateCheckAbort = null; }
-    applyDuplicateVisuals();
-    var summary = document.getElementById('previewSummary');
-    var dupStatus = summary ? summary.querySelector('.dup-status') : null;
-    if (dupStatus) dupStatus.remove();
-    _duplicateResults = {};
-  }
-  updateStartButton();
-  // Toggling copy mode flips whether _buildPlanBody sends
-  // hash_duplicate_paths (only sent when _copyMode is on with skip
-  // duplicates checked and cached results exist). Without this refresh,
-  // pills keep showing the prior mode's run estimate until some other
-  // UI action triggers a plan fetch — exactly the staleness the
-  // CORE_PHILOSOPHY transparency rule prohibits.
-  schedulePlanRefresh();
-}
-
-function getSelectedFolderTemplate() {
-  var sel = document.getElementById('cfgFolderTemplate');
-  if (sel.value === '__custom__') {
-    return document.getElementById('cfgCustomTemplate').value.trim() || '%Y/%Y-%m-%d';
-  }
-  return sel.value;
-}
-
-function onFolderTemplateChange() {
-  var sel = document.getElementById('cfgFolderTemplate');
-  var customRow = document.getElementById('customTemplateRow');
-  customRow.style.display = sel.value === '__custom__' ? '' : 'none';
-
-  // Auto-refresh if preview is already showing
-  if (_folderPreviewShown) {
-    previewDestinationFolders();
-  }
-}
-
-async function previewDestinationFolders() {
-  var btn = document.getElementById('btnPreviewFolders');
-  var hint = document.getElementById('previewFoldersHint');
-  var resultsDiv = document.getElementById('folderPreviewResults');
-  var summaryDiv = document.getElementById('folderPreviewSummary');
-  var listDiv = document.getElementById('folderPreviewList');
-  var staleDiv = document.getElementById('folderPreviewStale');
-
-  btn.disabled = true;
-  btn.textContent = 'Loading...';
-  hint.textContent = '';
-  staleDiv.style.display = 'none';
-
-  var sources = _sourceFolders.length > 0 ? _sourceFolders : [];
-  var destination = document.getElementById('cfgDestination').value.trim();
-
-  try {
-    var data = await safeFetch('/api/import/destination-preview', {
-      method: 'POST',
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify(function() {
-        var req = {
-          sources: sources,
-          destination: destination,
-          folder_template: getSelectedFolderTemplate(),
-          file_types: getIngestFileTypes(),
-          recursive: includeSubfoldersEnabled(),
-        };
-        if (_previewData && _previewSelected) {
-          var excluded = [];
-          _previewData.files.forEach(function(f) {
-            if (!_previewSelected[f.path]) excluded.push(f.path);
-          });
-          if (excluded.length > 0) req.exclude_paths = excluded;
-        }
-        return req;
-      }()),
-    }, { toast: false });
-
-    if (data.error) {
-      hint.textContent = data.error;
-      btn.textContent = 'Preview folder structure';
-      btn.disabled = false;
-      return;
-    }
-
-    // Render summary
-    var newCount = data.new_folders;
-    var existCount = data.existing_folders;
-    var parts = [data.total_photos + ' photo' + (data.total_photos !== 1 ? 's' : '')];
-    parts.push(data.total_folders + ' folder' + (data.total_folders !== 1 ? 's' : ''));
-    var detail = [];
-    if (newCount > 0) detail.push(newCount + ' new folder' + (newCount !== 1 ? 's' : ''));
-    if (existCount > 0) detail.push(existCount + ' existing folder' + (existCount !== 1 ? 's' : ''));
-    summaryDiv.textContent = parts.join(' \u2192 ') + (detail.length ? ' (' + detail.join(', ') + ')' : '');
-
-    // Render folder list
-    listDiv.innerHTML = data.folders.map(function(f) {
-      var tag = f.exists
-        ? '<span style="font-size:10px;padding:1px 5px;border-radius:3px;background:var(--accent);color:#fff;margin-left:6px;white-space:nowrap;">Existing folder</span>'
-        : '<span style="font-size:10px;padding:1px 5px;border-radius:3px;background:var(--success,#28a745);color:#fff;margin-left:6px;white-space:nowrap;">New folder</span>';
-      var fullPath = f.full_path || (f.path === '.' ? destination : destination.replace(/\/$/, '') + '/' + f.path);
-      return '<div style="padding:3px 0;display:flex;align-items:center;gap:4px;">'
-        + '<span title="' + escapeAttr(fullPath) + '" style="font-family:monospace;color:var(--text-secondary);min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">' + escapeHtml(fullPath) + '</span>'
-        + tag
-        + '<span style="color:var(--text-dim);margin-left:auto;">' + f.count + ' photo' + (f.count !== 1 ? 's' : '') + '</span>'
-        + '</div>';
-    }).join('');
-
-    // Managed-archive callout: when the destination is (or sits inside) an
-    // existing Vireo-managed archive, say so plainly so the dialog never
-    // presents an existing archive as an empty/new destination.
-    _managedArchive = data.managed_archive || null;
-    renderManagedArchiveCallout();
-
-    resultsDiv.style.display = '';
-    _folderPreviewShown = true;
-    btn.textContent = 'Refresh preview';
-    btn.disabled = false;
-
-  } catch(e) {
-    hint.textContent = 'Preview failed';
-    btn.textContent = 'Preview folder structure';
-    btn.disabled = false;
-  }
-}
-
-// Render (or hide) the "destination is an existing managed archive" callout
-// based on _managedArchive. Built with textContent so the archive path is
-// never interpreted as HTML.
-function renderManagedArchiveCallout() {
-  var el = document.getElementById('folderPreviewManagedArchive');
-  if (!el) return;
-  if (!_managedArchive || !_managedArchive.path) {
-    el.textContent = '';
-    el.style.display = 'none';
-    return;
-  }
-  var count = _managedArchive.photo_count || 0;
-  el.textContent = '';
-
-  var lead = document.createElement('span');
-  lead.textContent = 'Destination is an existing Vireo archive (';
-  el.appendChild(lead);
-
-  var pathEl = document.createElement('code');
-  pathEl.style.fontFamily = 'monospace';
-  pathEl.textContent = _managedArchive.path;
-  el.appendChild(pathEl);
-
-  var mid = document.createElement('span');
-  mid.textContent = ', ' + count.toLocaleString() + ' photo' + (count === 1 ? '' : 's')
-    + '). New files will be merged in.';
-  el.appendChild(mid);
-
-  el.style.display = '';
-}
-
-function markFolderPreviewStale() {
-  if (!_folderPreviewShown) return;
-  // A source/destination change invalidates the managed-archive verdict — drop
-  // it so the duplicate summary doesn't keep merge-framing against a stale
-  // destination, and hide the callout so it never asserts an "existing archive"
-  // for a path that may no longer be the destination. The amber "click Refresh"
-  // banner below still prompts the user; the callout is recomputed on refresh.
-  _managedArchive = null;
-  renderManagedArchiveCallout();
-  var stale = document.getElementById('folderPreviewStale');
-  if (!stale) return;
-  stale.style.display = '';
-  var btn = document.getElementById('btnPreviewFolders');
-  if (!btn) return;
-  btn.textContent = 'Refresh preview';
-  // Only enable if prerequisites are still met (sources + a LOCAL
-  // destination — the preview can't walk an SSH target).
-  var hasSources = _sourceFolders.length > 0;
-  var hasDest = !pipelineRemoteTargetId()
-    && document.getElementById('cfgDestination').value.trim();
-  btn.disabled = !(hasSources && hasDest);
-}
-
 async function selectSourceMode(mode) {
-  // Cancel any in-flight duplicate scan before switching context
-  if (_duplicateCheckAbort) { _duplicateCheckAbort.abort(); _duplicateCheckAbort = null; }
   _sourceMode = mode;
   var isFolders = (mode === 'folders');
-  document.getElementById('radioFolders').checked = isFolders || mode === 'import';
+  document.getElementById('radioFolders').checked = isFolders;
   document.getElementById('radioCollection').checked = (mode === 'collection');
   var newImgRadio = document.getElementById('radioNewImages');
   if (newImgRadio) newImgRadio.checked = (mode === 'new_images');
 
-  var importBody = document.getElementById('sourceImportBody');
+  var foldersBody = document.getElementById('sourceImportBody');
   var collBody = document.getElementById('sourceCollectionBody');
   var newImgBody = document.getElementById('sourceNewImagesBody');
 
-  if (isFolders || mode === 'import') {
-    importBody.classList.remove('dimmed');
-    collBody.classList.add('dimmed');
-    if (newImgBody) newImgBody.classList.add('dimmed');
-  } else if (mode === 'collection') {
-    importBody.classList.add('dimmed');
-    collBody.classList.remove('dimmed');
-    if (newImgBody) newImgBody.classList.add('dimmed');
-  } else if (mode === 'new_images') {
-    importBody.classList.add('dimmed');
-    collBody.classList.add('dimmed');
-    if (newImgBody) newImgBody.classList.remove('dimmed');
-  }
-
-  // Snapshot IDs are scoped to the workspace they were captured in, so the
-  // "New workspace" destination would produce a 404 at lookup time. Lock the
-  // destination to the current workspace while new-images mode is active.
-  // Folder IDs are likewise workspace-local (workspace_folders is the guard
-  // both on the plan route and /api/jobs/pipeline), so activating an empty
-  // "New workspace" would make the selected folder_ids foreign to the run's
-  // workspace. Lock destination to Current for folder scope for the same
-  // reason.
-  // Apply the destination lock and button state BEFORE any async snapshot
-  // POST — callers don't await this function, so a click on Start during
-  // the POST's network round-trip would otherwise see stale state.
-  var wsNewRadio = document.getElementById('radioWsNew');
-  var wsCurrentRadio = document.getElementById('radioWsCurrent');
-  var wsNewNote = document.getElementById('destWsNewImagesNote');
-  if (mode === 'new_images' || mode === 'folders') {
-    if (wsNewRadio) wsNewRadio.disabled = true;
-    if (wsCurrentRadio && !wsCurrentRadio.checked) {
-      wsCurrentRadio.checked = true;
-      onDestWorkspaceChange();
-    }
-    if (wsNewNote) wsNewNote.style.display = mode === 'new_images' ? '' : 'none';
-  } else {
-    if (wsNewRadio) wsNewRadio.disabled = false;
-    if (wsNewNote) wsNewNote.style.display = 'none';
-  }
+  foldersBody.classList.toggle('dimmed', !isFolders);
+  collBody.classList.toggle('dimmed', mode !== 'collection');
+  if (newImgBody) newImgBody.classList.toggle('dimmed', mode !== 'new_images');
 
   // With new-images mode selected but no snapshot yet, updateStartButton()
   // correctly disables Start (gate on `newImagesSnapshotId`). Call it now
@@ -2810,70 +1854,6 @@ function onCollectionChange() {
   schedulePlanRefresh();
 }
 
-async function loadVolumes() {
-  try {
-    var volumes = await safeFetch('/api/volumes', {}, { toast: false });
-    var dl = document.getElementById('volumeDatalist');
-    if (dl) {
-      volumes.forEach(function(v) {
-        dl.innerHTML += '<option value="' + escapeHtml(v.path) + '">' + escapeHtml(v.name) + '</option>';
-      });
-    }
-  } catch(e) {}
-}
-
-function onGroupToggle(group) {
-  var parentId = group === 'standard' ? 'chkStandard' : 'chkRaw';
-  var checked = document.getElementById(parentId).checked;
-  var children = document.querySelectorAll('input[data-group="' + group + '"]');
-  children.forEach(function(cb) { cb.checked = checked; });
-  updateStartButton();
-  fetchFolderPreview();
-  markFolderPreviewStale();
-}
-
-function onExtToggle(group) {
-  var parentId = group === 'standard' ? 'chkStandard' : 'chkRaw';
-  var children = document.querySelectorAll('input[data-group="' + group + '"]');
-  var allChecked = true;
-  var anyChecked = false;
-  children.forEach(function(cb) {
-    if (cb.checked) anyChecked = true;
-    else allChecked = false;
-  });
-  var parent = document.getElementById(parentId);
-  parent.checked = allChecked;
-  parent.indeterminate = anyChecked && !allChecked;
-  updateStartButton();
-  fetchFolderPreview();
-  markFolderPreviewStale();
-}
-
-function getIngestFileTypes() {
-  var exts = [];
-  var stdMap = {'.jpg': ['.jpg', '.jpeg'], '.png': ['.png'], '.tiff': ['.tiff', '.tif'], '.bmp': ['.bmp'], '.webp': ['.webp']};
-  var standardInputs = document.querySelectorAll('input[data-group="standard"]');
-  var rawInputs = document.querySelectorAll('input[data-group="raw"]');
-  if (!standardInputs.length && !rawInputs.length) {
-    // Match the backend default (discover_source_files file_types="both"
-    // = SUPPORTED_EXTENSIONS in image_loader). Returning only the
-    // raster set here would silently drop RAW-only sources during
-    // preview and start.
-    return [
-      '.jpg', '.jpeg', '.png', '.tiff', '.tif', '.bmp', '.webp',
-      '.nef', '.cr2', '.cr3', '.arw', '.raf', '.dng', '.rw2', '.orf',
-    ];
-  }
-  document.querySelectorAll('input[data-group="standard"]:checked').forEach(function(cb) {
-    var ext = cb.getAttribute('data-ext');
-    (stdMap[ext] || [ext]).forEach(function(e) { exts.push(e); });
-  });
-  document.querySelectorAll('input[data-group="raw"]:checked').forEach(function(cb) {
-    exts.push(cb.getAttribute('data-ext'));
-  });
-  return exts;
-}
-
 function updateStartButton() {
   var btn = document.getElementById('btnStartPipeline');
   var actionStatus = document.getElementById('pipelineActionStatus');
@@ -2905,13 +1885,6 @@ function updateStartButton() {
 
   if (_sourceMode === 'folders') {
     btn.disabled = selectedFolderIds().length === 0;
-  } else if (_sourceMode === 'import') {
-    // Import-source mode: at least one source folder is required. The
-    // per-file preview may still be resolving; we don't block Start on
-    // that (matches new_images), but startPipeline() will pass the
-    // deselected paths through as exclude_paths so the run scope
-    // matches the plan the user saw.
-    btn.disabled = _sourceFolders.length === 0;
   } else if (_sourceMode === 'new_images') {
     btn.disabled = !newImagesSnapshotId;
   } else {
@@ -2919,17 +1892,8 @@ function updateStartButton() {
     btn.disabled = !collId;
   }
 
-  // Destination card validation
-  if (!btn.disabled) {
-    if (_destWorkspaceMode === 'new') {
-      var wsName = document.getElementById('destNewWsName').value.trim();
-      if (!wsName) btn.disabled = true;
-    }
-  }
-
-  // Snapshot whether source + destination are configured *before* the
-  // classify gates below. The stage-1 "complete" indicator and the
-  // auto-expand of the destination card key off this; if we let the
+  // Snapshot whether the source is configured *before* the classify gates
+  // below. The stage-1 "complete" indicator keys off this; if we let the
   // classify gate (which can flip while a plan refresh is pending) drive
   // the source indicator, the source stage flickers between complete and
   // incomplete every time the plan refetches.
@@ -2968,26 +1932,14 @@ function updateStartButton() {
     }
   }
 
-  // Update preview button state
-  var previewBtn = document.getElementById('btnPreviewFolders');
-  var previewHint = document.getElementById('previewFoldersHint');
-  if (previewBtn) {
-    previewBtn.disabled = true;
-    if (previewHint) previewHint.textContent = '';
-  }
-
-  // Update stage 1 indicator and auto-expand stage 2 when source is ready
-  // (sourceReady was captured above, before the classify gates).
+  // Update stage 1 indicator when the source is ready (sourceReady was
+  // captured above, before the classify gates).
   var numSource = document.getElementById('numSource');
   if (sourceReady) {
     numSource.classList.add('complete');
-    if (!_sourceWasReady) {
-      document.getElementById('card-destination').classList.add('expanded');
-    }
   } else {
     numSource.className = 'stage-num';
   }
-  _sourceWasReady = sourceReady;
 }
 
 // -- Stage enable/disable dependency chain --
@@ -3153,45 +2105,6 @@ async function startPipeline() {
   var _prevErrBanner = document.getElementById('pipelineErrorBanner');
   if (_prevErrBanner) _prevErrBanner.style.display = 'none';
 
-  // Create new workspace if requested
-  if (_destWorkspaceMode === 'new') {
-    var wsName = document.getElementById('destNewWsName').value.trim();
-    if (!wsName) {
-      document.getElementById('destWsError').textContent = 'Name is required';
-      document.getElementById('destWsError').style.display = '';
-      _pipelineRunning = false;
-      _pipelineCancelling = false;
-      return;
-    }
-    try {
-      var wsData = await safeFetch('/api/workspaces', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({ name: wsName })
-      }, { toast: false });
-      // Activate the new workspace
-      await safeFetch('/api/workspaces/' + wsData.id + '/activate', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({ current_path: window.location.pathname })
-      });
-      if (window.vireoEditNav) window.vireoEditNav.clearWorkspaceScopedCursors();
-      // Update the navbar workspace display ('wsCurrentName' is the
-      // navbar's actual element — the old 'wsDropdownBtn' id never
-      // existed, so the navbar kept showing the previous workspace for
-      // the whole run).
-      var wsBtn = document.getElementById('wsCurrentName');
-      if (wsBtn) wsBtn.textContent = wsName;
-      document.getElementById('lblCurrentWsName').textContent = '(' + wsName + ')';
-    } catch(e) {
-      document.getElementById('destWsError').textContent = e.message || 'Failed to create workspace';
-      document.getElementById('destWsError').style.display = '';
-      _pipelineRunning = false;
-      _pipelineCancelling = false;
-      return;
-    }
-  }
-
   var btn = document.getElementById('btnStartPipeline');
   btn.textContent = 'Stop Pipeline';
   btn.onclick = stopPipeline;
@@ -3211,34 +2124,8 @@ async function startPipeline() {
     // its active-workspace subtree and pins the run to an ad-hoc
     // collection (import/process split PR 1).
     body.folder_ids = selectedFolderIds();
-  } else if (_sourceMode === 'import') {
-    // Import-source mode on the Process page: scope = the user-typed
-    // source directory list. Mirrors the shape _buildPlanBody() uses
-    // (deselected preview files land in exclude_paths) so the run
-    // matches the plan the user saw. Without this branch startPipeline
-    // fell through to collection scope and POSTed collection_id from
-    // whatever was in the picker, which could execute a completely
-    // different scope than the one the plan described.
-    body.sources = _sourceFolders.slice();
-    body.recursive = includeSubfoldersEnabled();
-    var importFileTypes = getIngestFileTypes();
-    if (importFileTypes && importFileTypes.length) {
-      body.file_types = importFileTypes;
-    }
-    if (_previewData && _previewSelected) {
-      var excludedImportPaths = [];
-      _previewData.files.forEach(function(f) {
-        if (!_previewSelected[f.path]) excludedImportPaths.push(f.path);
-      });
-      if (excludedImportPaths.length > 0) {
-        body.exclude_paths = excludedImportPaths;
-      }
-    }
   } else if (_sourceMode === 'new_images') {
     body.source_snapshot_id = newImagesSnapshotId;
-    delete body.source;
-    delete body.sources;
-    delete body.file_types;
     // Honor per-file deselections from the preview grid — otherwise the
     // user can uncheck photos and still see them run through the pipeline.
     if (_previewData && _previewSelected) {
@@ -3304,14 +2191,10 @@ async function startPipeline() {
   }
 
   // Reset all stage cards to pending state
-  ['Source', 'Destination', 'Scan', 'Previews', 'Classify', 'Extract', 'Group'].forEach(function(name) {
+  ['Source', 'Scan', 'Previews', 'Classify', 'Extract', 'Group'].forEach(function(name) {
     var numEl = document.getElementById('num' + name);
     if (numEl) numEl.className = 'stage-num';
   });
-
-  // Destination is a config-only card — mark complete immediately since
-  // workspace creation and copy settings are already resolved at this point.
-  document.getElementById('numDestination').classList.add('complete');
 
   try {
     var data = await safeFetch('/api/jobs/pipeline', {
@@ -3387,9 +2270,10 @@ async function startPipeline() {
   }
 }
 
-// Map pipeline stage names to UI card element suffixes
+// Map pipeline stage names to UI card element suffixes. Stages with no
+// card here (e.g. the import job's storage/archive stages) are ignored by
+// _updatePipelineStageUI.
 var _stageToCard = {
-  storage: 'Destination',
   ingest: 'Source',
   scan: 'Scan',
   thumbnails: 'Previews',
@@ -3399,7 +2283,6 @@ var _stageToCard = {
   extract_masks: 'Extract',
   eye_keypoints: 'EyeKeypoints',
   regroup: 'Group',
-  archive: 'Destination',
 };
 
 // Reverse of _stageToCard: cardSuffix -> [backend stage names]. Used by
@@ -3647,7 +2530,7 @@ function _onPipelineComplete(result) {
       actionStatus.textContent = 'Pipeline cancelled.';
       actionStatus.className = 'status-msg';
     }
-    ['Source', 'Destination', 'Scan', 'Previews', 'Classify', 'Extract', 'EyeKeypoints', 'Group'].forEach(function(cardSuffix) {
+    ['Source', 'Scan', 'Previews', 'Classify', 'Extract', 'EyeKeypoints', 'Group'].forEach(function(cardSuffix) {
       if (_runningStages[cardSuffix]) {
         delete _runningStages[cardSuffix];
         // Record a real 'cancelled' outcome so later refreshPipelineUI
@@ -3671,7 +2554,7 @@ function _onPipelineComplete(result) {
   if (_sourceMode === 'collection') {
     document.getElementById('txtSource').textContent = 'Collection selected';
   } else {
-    document.getElementById('txtSource').textContent = _sourceFolders.length + ' folder(s)';
+    updateSourceSummary();
   }
   // If the ingest progress bar was shown (copy mode), finalize it
   // only on a successful pipeline run. On failure, leave the bar at
@@ -4882,7 +3765,7 @@ var _planDebounceTimer = null;
 var _planRefreshPending = false;
 
 var _STAGES = [
-  { suffix: 'Scan',         label: 'Scan & Import',          enable: null },
+  { suffix: 'Scan',         label: 'Scan & Index',           enable: null },
   { suffix: 'Previews',     label: 'Thumbnails & Previews',  enable: null },
   { suffix: 'Classify',     label: 'Classify',               enable: 'enableClassify' },
   { suffix: 'Extract',      label: 'Extract Features',       enable: 'enableExtract' },
@@ -5138,13 +4021,6 @@ function _buildPlanBody() {
   if (_sourceMode === 'folders') {
     var folderIds = selectedFolderIds();
     if (folderIds.length) body.folder_ids = folderIds;
-  } else if (_sourceMode === 'import'
-             && _previewData && _previewData.files && _previewSelected) {
-    var importPaths = [];
-    _previewData.files.forEach(function(f) {
-      if (_previewSelected[f.path]) importPaths.push(f.path);
-    });
-    body.source_paths = importPaths;
   } else if (_sourceMode === 'collection') {
     var picker = document.getElementById('collectionPicker');
     var cid = picker && picker.value ? parseInt(picker.value, 10) : NaN;
@@ -5214,9 +4090,6 @@ function _buildPlanBody() {
 }
 
 function _planIsWaitingForImportPreview() {
-  if (_sourceMode === 'import') {
-    return _sourceFolders.length > 0 && (_previewLoading || !_previewData);
-  }
   if (_sourceMode === 'new_images') {
     return newImagesSnapshotId !== null && (_previewLoading || !_previewData);
   }
@@ -5289,467 +4162,8 @@ function updateCardStates() {
   refreshPipelineUI();
 }
 
-/* ---------- Native folder picker (Tauri only) ---------- */
-(function() {
-  if (typeof isTauri === 'function' && isTauri()) {
-    document.querySelectorAll('.tauri-only').forEach(function(el) {
-      el.style.display = '';
-    });
-  }
-})();
-
-async function browseForFolder() {
-  if (typeof pickDirectory === 'function') {
-    var result = await pickDirectory('Select photo folders', { multiple: true });
-    if (result) {
-      var paths = Array.isArray(result) ? result : [result];
-      var validPicks = paths.filter(function(p) { return !!p; });
-      if (!validPicks.length) return;
-      var added = false;
-      validPicks.forEach(function(path) {
-        if (_sourceFolders.indexOf(path) === -1) {
-          _sourceFolders.push(path);
-          added = true;
-        }
-      });
-      // Picking a source path with Browse is a clear "use this import
-      // source" action, so the mode/render/preview refresh must run even
-      // when every picked path was already in _sourceFolders — otherwise
-      // the mode stays 'folders' and Start posts folder_ids instead of
-      // the previewed sources list.
-      var switched = _sourceMode !== 'import';
-      if (switched) selectSourceMode('import');
-      if (added) {
-        renderSourceFolders();
-        if (!switched) fetchFolderPreview();
-      }
-      updateStartButton();
-      return;
-    }
-  }
-  openFolderBrowser('source');
-}
-
-async function browseForDestination() {
-  if (typeof pickDirectory === 'function') {
-    var path = await pickDirectory('Select destination folder');
-    if (path) {
-      document.getElementById('cfgDestination').value = path;
-      updateStartButton();
-      markFolderPreviewStale();
-      return;
-    }
-  }
-  openFolderBrowser('destination');
-}
-
-// ---------- Folder Browser ----------
-var _fbCurrentPath = '';
-var _fbSelectedDir = '';
-var _fbSelectedDirs = []; // source mode: all selected paths; destination mode: at most one
-var _fbSelectAnchorPath = ''; // source mode: anchor for shift-click range selection
-var _fbMode = 'destination'; // 'source' or 'destination'
-var _fbCountsAbort = null;
-var _fbCountCache = {}; // key: "path|ext1,ext2" -> count (session-scoped)
-var _fbBrowseToken = 0; // incremented on every browseTo to stamp stale responses
-
-function openFolderBrowser(mode) {
-  _fbMode = mode || 'destination';
-  document.getElementById('fbTitle').textContent = _fbMode === 'source' ? 'Select Source Folders' : 'Select Destination Folder';
-  var overlay = document.getElementById('folderBrowserOverlay');
-  overlay.classList.add('active');
-  document.body.style.overflow = 'hidden';
-  // Close on clicking the backdrop
-  overlay.onclick = function(e) {
-    if (e.target === overlay) closeFolderBrowser();
-  };
-  // Start at home directory
-  browseTo(null);
-  // Close on Escape — remove previous listener to prevent accumulation
-  if (overlay._escHandler) {
-    document.removeEventListener('keydown', overlay._escHandler);
-  }
-  overlay._escHandler = function(e) {
-    if (e.key === 'Escape') closeFolderBrowser();
-  };
-  document.addEventListener('keydown', overlay._escHandler);
-}
-
-function closeFolderBrowser() {
-  var overlay = document.getElementById('folderBrowserOverlay');
-  overlay.classList.remove('active');
-  document.body.style.overflow = '';
-  cancelNewFolder();
-  if (overlay._escHandler) {
-    document.removeEventListener('keydown', overlay._escHandler);
-    overlay._escHandler = null;
-  }
-}
-
-function browseTo(path) {
-  var listEl = document.getElementById('fbList');
-  listEl.innerHTML = '<div class="folder-browser-loading">Loading\u2026</div>';
-  // Clear _fbCurrentPath before the async fetch resolves so New Folder
-  // cannot target the previous location's path if the user clicks it
-  // while the new browse is still in flight. updateNewFolderButton()
-  // re-disables the button until the fetch sets _fbCurrentPath again.
-  _fbCurrentPath = '';
-  updateNewFolderButton();
-  _fbSelectedDir = '';
-  _fbSelectedDirs = [];
-  _fbSelectAnchorPath = '';
-  document.getElementById('fbSelectedPath').textContent = '';
-  updateFbSelectButtonLabel();
-  cancelNewFolder();
-  // Invalidate any in-flight photo-count request so its results don't
-  // land in a now-stale list.
-  _fbBrowseToken += 1;
-  if (_fbCountsAbort) { _fbCountsAbort.abort(); _fbCountsAbort = null; }
-
-  var url = '/api/browse';
-  if (path === '__pictures__') {
-    url = '/api/browse?path=' + encodeURIComponent(_fbHomePath + '/Pictures');
-  } else if (path === '__volumes__') {
-    // Windows has no single "volumes root" directory — drives live at C:\,
-    // D:\, etc. /api/volumes enumerates them via the Win32 API; render the
-    // drive list directly as a synthetic listing the user can drill into.
-    if (navigator.userAgent.indexOf('Win') >= 0) {
-      fetch('/api/volumes').then(function(r) {
-        if (!r.ok) return r.json().then(function(d) { throw new Error(d.error || 'Failed to enumerate volumes'); });
-        return r.json();
-      }).then(function(volumes) {
-        _fbCurrentPath = '';
-        _fbSelectedDir = '';
-        _fbSelectedDirs = [];
-        _fbSelectAnchorPath = '';
-        document.getElementById('fbSelectedPath').textContent = '';
-        updateFbSelectButtonLabel();
-        updateNewFolderButton();
-        var bc = document.getElementById('fbBreadcrumb');
-        bc.innerHTML = '<span class="current">Volumes</span>';
-        bc.onclick = null;
-        // Skip recursive photo counts on the synthetic drive-root list:
-        // /api/volumes includes the system drive, and counting it would
-        // recursively walk all of C:\ before the user has picked anything.
-        // Counts resume once the user drills into a specific drive.
-        renderFolderList(volumes, { skipCounts: true });
-      }).catch(function(err) {
-        listEl.innerHTML = '<div class="folder-browser-error">' + escapeHtml(err.message) + '</div>';
-      });
-      return;
-    }
-    var volDir = navigator.userAgent.indexOf('Mac') >= 0 ? '/Volumes' : '/media';
-    url = '/api/browse?path=' + encodeURIComponent(volDir);
-  } else if (path) {
-    url = '/api/browse?path=' + encodeURIComponent(path);
-  }
-
-  fetch(url).then(function(r) {
-    if (!r.ok) return r.json().then(function(d) { throw new Error(d.error || 'Failed to browse'); });
-    return r.json();
-  }).then(function(data) {
-    _fbCurrentPath = data.path;
-    updateNewFolderButton();
-    if (!path) _fbHomePath = data.path;
-    // Implicit fallback: selectFolder() uses _fbSelectedDir when the user
-    // hits Select without clicking any subfolder. Keep _fbSelectedDirs empty
-    // so the first cmd/shift-click starts from a clean slate instead of
-    // silently including the unhighlighted parent folder.
-    _fbSelectedDir = data.path;
-    _fbSelectedDirs = [];
-    _fbSelectAnchorPath = '';
-    document.getElementById('fbSelectedPath').textContent = data.path;
-    updateFbSelectButtonLabel();
-    renderBreadcrumb(data.path);
-    // Drilling into a Windows drive root (e.g. C:\, D:/) lists top-level
-    // system directories like Users, Windows, Program Files. Recursive
-    // photo counts on those would scan the entire volume and hang the
-    // UI/server, so skip counts here and resume once the user drills in
-    // one more level. The synthetic Volumes list is handled separately
-    // (with skipCounts:true) above; this guard covers the post-drill
-    // path that /api/browse renders.
-    var isWindowsDriveRoot = /^[A-Za-z]:[\\\/]?$/.test(data.path || '');
-    renderFolderList(data.dirs, { skipCounts: isWindowsDriveRoot });
-  }).catch(function(err) {
-    listEl.innerHTML = '<div class="folder-browser-error">' + escapeHtml(err.message) + '</div>';
-  });
-}
-
-function renderBreadcrumb(path) {
-  var el = document.getElementById('fbBreadcrumb');
-  var parts = path.split('/').filter(Boolean);
-  var html = '<span data-browse="/">/</span>';
-  var accum = '';
-  for (var i = 0; i < parts.length; i++) {
-    accum += '/' + parts[i];
-    if (i === parts.length - 1) {
-      html += ' <span class="current">' + escapeHtml(parts[i]) + '</span>';
-    } else {
-      html += ' <span data-browse="' + escapeAttr(accum) + '">' + escapeHtml(parts[i]) + '</span> /';
-    }
-  }
-  el.innerHTML = html;
-  el.onclick = function(e) {
-    var target = e.target.closest('[data-browse]');
-    if (target) browseTo(target.getAttribute('data-browse'));
-  };
-}
-
-function renderFolderList(dirs, opts) {
-  var listEl = document.getElementById('fbList');
-  if (!dirs.length) {
-    listEl.innerHTML = '<div class="folder-browser-empty">No subfolders</div>';
-    return;
-  }
-  var html = '';
-  for (var i = 0; i < dirs.length; i++) {
-    html += '<div class="folder-browser-item" data-path="' + escapeAttr(dirs[i].path) + '">' +
-            '<span class="folder-browser-item-name">\uD83D\uDCC1 ' + escapeHtml(dirs[i].name) + '</span>' +
-            '<span class="folder-browser-count" data-count-path="' + escapeAttr(dirs[i].path) + '"></span>' +
-            '</div>';
-  }
-  listEl.innerHTML = html;
-  // In source mode, asynchronously fetch recursive photo counts for each
-  // subfolder so users can see which ones contain photos. Callers can pass
-  // skipCounts to avoid this for synthetic listings (e.g. Windows drive
-  // roots) where counting would recursively walk an entire volume.
-  if (_fbMode === 'source' && !(opts && opts.skipCounts)) {
-    fetchFolderCounts(dirs.map(function(d) { return d.path; }));
-  }
-  // Event delegation: click to select, double-click to drill in.
-  // In source mode, shift-click extends a range and cmd/ctrl-click toggles.
-  listEl.onclick = function(e) {
-    var item = e.target.closest('.folder-browser-item');
-    if (!item) return;
-    var items = listEl.querySelectorAll('.folder-browser-item');
-    var path = item.getAttribute('data-path');
-    var isSource = _fbMode === 'source';
-    var shift = isSource && e.shiftKey;
-    var toggle = isSource && (e.metaKey || e.ctrlKey);
-
-    if (shift && _fbSelectAnchorPath) {
-      var anchorIdx = -1, clickIdx = -1;
-      for (var i = 0; i < items.length; i++) {
-        var p = items[i].getAttribute('data-path');
-        if (p === _fbSelectAnchorPath) anchorIdx = i;
-        if (p === path) clickIdx = i;
-      }
-      if (anchorIdx === -1) anchorIdx = clickIdx;
-      var lo = Math.min(anchorIdx, clickIdx);
-      var hi = Math.max(anchorIdx, clickIdx);
-      _fbSelectedDirs = [];
-      for (var j = lo; j <= hi; j++) {
-        _fbSelectedDirs.push(items[j].getAttribute('data-path'));
-      }
-    } else if (toggle) {
-      var idx = _fbSelectedDirs.indexOf(path);
-      if (idx === -1) _fbSelectedDirs.push(path);
-      else _fbSelectedDirs.splice(idx, 1);
-      _fbSelectAnchorPath = path;
-    } else {
-      _fbSelectedDirs = [path];
-      _fbSelectAnchorPath = path;
-    }
-
-    var sel = {};
-    for (var k = 0; k < _fbSelectedDirs.length; k++) sel[_fbSelectedDirs[k]] = true;
-    for (var m = 0; m < items.length; m++) {
-      if (sel[items[m].getAttribute('data-path')]) items[m].classList.add('selected');
-      else items[m].classList.remove('selected');
-    }
-
-    _fbSelectedDir = _fbSelectedDirs.length ? _fbSelectedDirs[_fbSelectedDirs.length - 1] : '';
-    var label = document.getElementById('fbSelectedPath');
-    if (_fbMode === 'source' && _fbSelectedDirs.length > 1) {
-      label.textContent = _fbSelectedDirs.length + ' folders selected';
-    } else {
-      label.textContent = _fbSelectedDir;
-    }
-    updateFbSelectButtonLabel();
-  };
-  listEl.ondblclick = function(e) {
-    var item = e.target.closest('.folder-browser-item');
-    if (item) browseTo(item.getAttribute('data-path'));
-  };
-}
-
-function updateFbSelectButtonLabel() {
-  var btn = document.getElementById('fbSelectBtn');
-  if (!btn) return;
-  if (_fbMode === 'source' && _fbSelectedDirs.length > 1) {
-    btn.textContent = 'Select ' + _fbSelectedDirs.length + ' folders';
-  } else {
-    btn.textContent = 'Select';
-  }
-}
-
-function applyCount(path, count) {
-  // Hide zero counts to reduce visual noise; show formatted number otherwise.
-  if (!count) return;
-  // Iterate rather than use a CSS selector so paths containing quotes,
-  // backslashes, or other special chars match correctly.
-  var badges = document.getElementsByClassName('folder-browser-count');
-  var label = count.toLocaleString() + (count === 1 ? ' photo' : ' photos');
-  for (var i = 0; i < badges.length; i++) {
-    if (badges[i].getAttribute('data-count-path') === path) {
-      badges[i].textContent = label;
-    }
-  }
-}
-
-function fetchFolderCounts(paths) {
-  if (!paths || !paths.length) return;
-  var fileTypes = getIngestFileTypes();
-  if (!fileTypes.length) return;
-  var cacheKey = fileTypes.slice().sort().join(',');
-  var token = _fbBrowseToken;
-
-  // Serve cached counts immediately, collect uncached paths.
-  var uncached = [];
-  for (var i = 0; i < paths.length; i++) {
-    var p = paths[i];
-    var key = p + '|' + cacheKey;
-    if (Object.prototype.hasOwnProperty.call(_fbCountCache, key)) {
-      applyCount(p, _fbCountCache[key]);
-    } else {
-      uncached.push(p);
-    }
-  }
-  if (!uncached.length) return;
-
-  _fbCountsAbort = new AbortController();
-  fetch('/api/browse/photo-counts', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ paths: uncached, file_types: fileTypes }),
-    signal: _fbCountsAbort.signal,
-  })
-    .then(function(r) { return r.ok ? r.json() : null; })
-    .then(function(data) {
-      if (!data || token !== _fbBrowseToken) return; // stale response
-      var counts = data.counts || {};
-      for (var p in counts) {
-        if (!Object.prototype.hasOwnProperty.call(counts, p)) continue;
-        _fbCountCache[p + '|' + cacheKey] = counts[p];
-        applyCount(p, counts[p]);
-      }
-    })
-    .catch(function(err) { if (err.name !== 'AbortError') { /* silent */ } });
-}
-
-function selectFolder() {
-  var previewScheduledByModeSwitch = false;
-  if (_fbMode === 'source') {
-    var picks = _fbSelectedDirs.length ? _fbSelectedDirs : (_fbSelectedDir ? [_fbSelectedDir] : []);
-    if (!picks.length) return;
-    var added = false;
-    picks.forEach(function(path) {
-      if (path && _sourceFolders.indexOf(path) === -1) {
-        _sourceFolders.push(path);
-        added = true;
-      }
-    });
-    // Selecting source paths in the folder browser is an unambiguous
-    // "use these import sources" action, so the mode switch has to run
-    // even when every pick was already in _sourceFolders — otherwise a
-    // user who reverted to workspace-folder scope and then re-picked the
-    // same imported path would stay stuck in 'folders' mode with Start
-    // POSTing folder_ids instead of sources.
-    var switched = _sourceMode !== 'import';
-    if (switched) {
-      selectSourceMode('import');
-      previewScheduledByModeSwitch = true;
-    }
-    if (added) renderSourceFolders();
-  } else {
-    if (!_fbSelectedDir) return;
-    document.getElementById('cfgDestination').value = _fbSelectedDir;
-    markFolderPreviewStale();
-  }
-  updateStartButton();
-  if (!previewScheduledByModeSwitch) fetchFolderPreview();
-  closeFolderBrowser();
-}
-
-function showNewFolderInput() {
-  document.getElementById('fbNewFolderRow').style.display = 'flex';
-  document.getElementById('fbNewFolderInput').value = '';
-  document.getElementById('fbNewFolderInput').focus();
-}
-
-function cancelNewFolder() {
-  document.getElementById('fbNewFolderRow').style.display = 'none';
-  document.getElementById('fbNewFolderInput').value = '';
-}
-
-function updateNewFolderButton() {
-  // The synthetic Windows Volumes listing leaves _fbCurrentPath empty —
-  // letting users click New Folder there would POST mkdir to '/<name>'
-  // (the current drive root on Windows) instead of a real selected path.
-  var btn = document.getElementById('fbNewFolderBtn');
-  if (!btn) return;
-  btn.disabled = !_fbCurrentPath;
-  btn.style.opacity = _fbCurrentPath ? '' : '0.5';
-  btn.title = _fbCurrentPath ? '' : 'Open a drive to create folders inside it';
-}
-
-function createNewFolder() {
-  var name = document.getElementById('fbNewFolderInput').value.trim();
-  if (!name) return;
-  if (!_fbCurrentPath) {
-    alert('Open a drive before creating a folder.');
-    return;
-  }
-  var newPath = _fbCurrentPath.replace(/\/+$/, '') + '/' + name;
-  fetch('/api/browse/mkdir', {
-    method: 'POST',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({path: newPath})
-  }).then(function(r) {
-    if (!r.ok) return r.json().then(function(d) { throw new Error(d.error || 'Failed to create folder'); });
-    return r.json();
-  }).then(function(data) {
-    cancelNewFolder();
-    browseTo(data.path);
-  }).catch(function(err) {
-    alert('Error: ' + err.message);
-  });
-}
-
-var _fbHomePath = '';
 
 </script>
-
-<!-- Folder Browser Modal -->
-<div class="folder-browser-overlay" id="folderBrowserOverlay">
-  <div class="folder-browser-panel">
-    <div class="folder-browser-header">
-      <h3 id="fbTitle">Select Destination Folder</h3>
-      <button class="folder-browser-close" onclick="closeFolderBrowser()">&times;</button>
-    </div>
-    <div class="folder-browser-shortcuts">
-      <button onclick="browseTo(null)">Home</button>
-      <button onclick="browseTo('__pictures__')">Pictures</button>
-      <button onclick="browseTo('__volumes__')">Volumes</button>
-    </div>
-    <div class="folder-browser-breadcrumb" id="fbBreadcrumb"></div>
-    <div id="fbNewFolderRow" class="folder-browser-new-folder" style="display:none;">
-      <input type="text" id="fbNewFolderInput" placeholder="New folder name"
-             onkeydown="if(event.key==='Enter'){createNewFolder();} if(event.key==='Escape'){cancelNewFolder();}">
-      <button class="btn btn-secondary" onclick="createNewFolder()" style="font-size:12px;padding:4px 10px;">Create</button>
-      <button class="btn btn-secondary" onclick="cancelNewFolder()" style="font-size:12px;padding:4px 10px;">Cancel</button>
-    </div>
-    <div class="folder-browser-list" id="fbList"></div>
-    <div class="folder-browser-footer">
-      <button id="fbNewFolderBtn" class="btn btn-secondary" onclick="showNewFolderInput()" style="font-size:12px;flex-shrink:0;">New Folder</button>
-      <div style="display:flex;align-items:center;flex:1;min-width:0;margin-left:12px;">
-        <span class="folder-browser-path" id="fbSelectedPath"></span>
-        <button class="btn btn-secondary" onclick="closeFolderBrowser()" style="font-size:12px;flex-shrink:0;">Cancel</button>
-        <button class="btn btn-primary" id="fbSelectBtn" onclick="selectFolder()" style="font-size:12px;flex-shrink:0;">Select</button>
-      </div>
-    </div>
-  </div>
-</div>
 
 </body>
 </html>

--- a/vireo/testing/userfirst/scenarios/scan.py
+++ b/vireo/testing/userfirst/scenarios/scan.py
@@ -1,9 +1,8 @@
-"""Scenario: visit the pipeline (scan/import) page.
+"""Scenario: visit the pipeline (process) page.
 
 Verifies that /pipeline renders, the stage cards are present (Source,
-Destination, Scan & Import, etc.), and the "Start Pipeline" button exists.
-We do not trigger an actual scan because that requires real photo files and
-ML models.
+Scan & Index, etc.), and the "Start Pipeline" button exists. We do not
+trigger an actual scan because that requires real photo files and ML models.
 """
 
 
@@ -11,13 +10,14 @@ def run(session):
     session.goto("/pipeline")
     session.screenshot("pipeline-initial")
 
-    # Stage cards should be present (at least the first 3: Source, Destination, Scan & Import)
+    # Stage cards should be present (at least Source, Scan & Index, Previews)
     stage_count = session.eval(
         "document.querySelectorAll('.stage-card').length"
     )
     session.assert_that(stage_count >= 3, f"expected at least 3 stage cards, got {stage_count}")
 
-    # Stage names should include Source, Destination, Scan & Import
+    # Stage names should include Source and Scan & Index. Destination was
+    # removed in the import/process split — copying files is Import's job.
     stage_names = session.eval(
         """Array.from(document.querySelectorAll('.stage-name')).map(el => el.textContent.trim())"""
     )
@@ -26,12 +26,12 @@ def run(session):
         f"expected 'Source' in stage names, got {stage_names!r}",
     )
     session.assert_that(
-        "Destination" in stage_names,
-        f"expected 'Destination' in stage names, got {stage_names!r}",
+        "Destination" not in stage_names,
+        f"'Destination' should be gone from the process page, got {stage_names!r}",
     )
     session.assert_that(
-        "Scan & Import" in stage_names,
-        f"expected 'Scan & Import' in stage names, got {stage_names!r}",
+        "Scan & Index" in stage_names,
+        f"expected 'Scan & Index' in stage names, got {stage_names!r}",
     )
 
     # The "Start Pipeline" button should exist

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -2258,11 +2258,12 @@ def test_pipeline_page_init_api(app_and_db):
     assert data['total_photos'] == 3
 
 
-def test_pipeline_page_init_includes_recent_destinations(app_and_db):
-    """page-init response includes recent_destinations from ingest config."""
+def test_pipeline_page_init_omits_recent_destinations(app_and_db):
+    """recent_destinations left page-init with the Destination card: the
+    process page no longer copies files anywhere, so leaking the import
+    history here would just invite the UI to grow a destination again."""
     import config as cfg
     app, _ = app_and_db
-    # Write config with recent_destinations
     config = cfg.load()
     config.setdefault("ingest", {})["recent_destinations"] = ["/photos/out1", "/photos/out2"]
     cfg.save(config)
@@ -2270,8 +2271,7 @@ def test_pipeline_page_init_includes_recent_destinations(app_and_db):
         resp = c.get("/api/pipeline/page-init")
         assert resp.status_code == 200
         data = resp.get_json()
-        assert "recent_destinations" in data
-        assert data["recent_destinations"] == ["/photos/out1", "/photos/out2"]
+        assert "recent_destinations" not in data
 
 
 def test_templates_jinja_free_except_includes():


### PR DESCRIPTION
## What changed

Import/process split cleanup for the Process page (`/pipeline`). Process never copies files anymore, so:

- **Destination card removed** entirely — including the current/new workspace choice and the hidden legacy copy/remote/folder-template controls. Runs always target the current workspace, which the folder/snapshot scopes already required (the card locked itself to "Current" in those modes anyway).
- **Browse… button and type-a-path input removed** from the Source card, along with the whole `'import'` source mode. The Source card now offers exactly what's in the workspace: the folder checklist (with photo counts) and the collections dropdown, plus the New-images card when available. A hint links photo ingestion to the Import page.
- **Dead code deleted** (~1,900 lines net): folder-browser modal + CSS, duplicate-check SSE machinery, remote-target/rsync destination preview, destination folder-structure preview, volume datalist and recent-destinations loading (some of this referenced DOM elements that no longer existed and would have thrown if reached).
- **Cards renumbered 1–7**; "Scan & Import" renamed to "Scan & Index".
- **Backend**: `recent_destinations` dropped from `/api/pipeline/page-init` — its only consumer was the removed UI (the Import page reads it from ingest config via its own endpoint). `/api/jobs/pipeline` still accepts `sources` for other callers; untouched.
- **Tests**: destination/browse e2e tests replaced with absence assertions, a Source-card import-hint test, and a folders-scope POST test; userfirst scan scenario updated.

## Test results

- Backend suite (workspaces, db, app, photos, edits, jobs, darktable, config): **1500 passed, 14 skipped**
- `tests/e2e/test_pipeline.py`: **27 passed**
- Adjacent e2e (new-images pipeline, page loads, navigation, import page): **58 passed**
- Verified visually in a real browser: Source card shows workspace folders + collection dropdown, no Destination card, stages numbered 1–7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)