### PR TITLE
Import page: destination folder-structure preview + drop staging vestige

### DIFF
--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -160,6 +160,94 @@ def test_import_preview_passes_verify_by_hash_to_duplicate_check(live_server, pa
     assert body["verify_by_hash"] is True
 
 
+def test_import_preview_shows_destination_folder_structure(live_server, page):
+    """Copy-mode preview surfaces the destination folder structure (new vs
+    existing folders) and a managed-archive callout, wired to
+    /api/import/destination-preview. Skipped duplicates are excluded so the
+    folder counts match the files that will actually land."""
+    url = live_server["url"]
+    captured = {}
+
+    def folder_preview(route):
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "files": [
+                    {"path": "/tmp/card-a/IMG_0001.jpg"},
+                    {"path": "/tmp/card-a/IMG_0002.jpg"},
+                ],
+            }),
+        )
+
+    def check_duplicates(route):
+        frame = (
+            "data: " + json.dumps({
+                "duplicates": ["/tmp/card-a/IMG_0002.jpg"],
+                "checked": 2, "total": 2,
+            }) + "\n\n"
+            + "data: " + json.dumps({
+                "done": True, "duplicate_count": 1, "checked": 2, "total": 2,
+            }) + "\n\n"
+        )
+        route.fulfill(
+            status=200, content_type="text/event-stream", body=frame,
+        )
+
+    def destination_preview(route):
+        captured["body"] = json.loads(route.request.post_data or "{}")
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "folders": [
+                    {"path": "2026/2026-07-01",
+                     "full_path": "/archive/2026/2026-07-01",
+                     "count": 1, "exists": False},
+                    {"path": "2026/2026-07-02",
+                     "full_path": "/archive/2026/2026-07-02",
+                     "count": 1, "exists": True},
+                ],
+                "total_photos": 2,
+                "total_folders": 2,
+                "new_folders": 1,
+                "existing_folders": 1,
+                "managed_archive": {"path": "/archive", "photo_count": 1284},
+            }),
+        )
+
+    page.route("**/api/import/folder-preview", folder_preview)
+    page.route("**/api/import/check-duplicates", check_duplicates)
+    page.route("**/api/import/destination-preview", destination_preview)
+    page.goto(f"{url}/import")
+
+    page.locator("#modeCopy").check()
+    page.locator("#sourceInput").fill("/tmp/card-a")
+    page.locator("#btnAddSource").click()
+    page.locator("#destInput").fill("/archive")
+    page.locator("#btnPreview").click()
+
+    structure = page.locator("#destStructure")
+    expect(structure).to_be_visible()
+    expect(structure).to_contain_text(
+        "2 photos → 2 folders (1 new, 1 existing)"
+    )
+    expect(structure).to_contain_text("Merging into a managed archive at")
+    expect(structure).to_contain_text("/archive")
+    expect(structure).to_contain_text("1284 photos already cataloged")
+    expect(structure).to_contain_text("2026/2026-07-01")
+    expect(structure).to_contain_text("new")
+    expect(structure).to_contain_text("existing")
+
+    # The structure block is only made visible after destination-preview
+    # resolves, so captured["body"] is populated by the time we get here.
+    # The skipped duplicate is excluded from the structure preview so the
+    # new/existing folder counts reflect the copy set, not every file found.
+    assert captured["body"]["exclude_paths"] == ["/tmp/card-a/IMG_0002.jpg"]
+    assert captured["body"]["destination"] == "/archive"
+    assert captured["body"]["file_types"] == "both"
+
+
 def test_import_copy_start_sends_restored_options(live_server, page):
     url = live_server["url"]
     captured = {}

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -46,6 +46,20 @@ body { display: flex; flex-direction: column; height: 100vh; }
 }
 .input-fixed { max-width: 240px; flex: 0 1 240px; }
 .preview-summary { font-size: 12px; color: var(--text-secondary); margin-top: 6px; }
+.dest-structure { margin-top: 8px; }
+.dest-structure .structure-headline { font-size: 12px; color: var(--text-primary); font-weight: 600; }
+.managed-archive-callout {
+  font-size: 12px; color: var(--text-secondary); margin-top: 6px;
+  padding: 8px 10px; border-radius: 6px; overflow-wrap: anywhere;
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 35%, transparent);
+}
+.structure-table { width: 100%; border-collapse: collapse; font-size: 12px; margin-top: 8px; }
+.structure-table td { padding: 3px 8px; border-bottom: 1px solid var(--border-primary); color: var(--text-primary); }
+.structure-table td.num { text-align: right; color: var(--text-secondary); font-variant-numeric: tabular-nums; white-space: nowrap; }
+.structure-table td.tag { text-align: right; white-space: nowrap; }
+.tag-new { color: var(--success, #2da44e); }
+.tag-existing { color: var(--text-secondary); }
 .progress-bar { height: 8px; background: var(--bg-tertiary); border-radius: 4px; overflow: hidden; }
 .progress-bar > div { height: 100%; background: var(--accent); width: 0; transition: width 0.2s; }
 .folder-progress { width: 100%; border-collapse: collapse; font-size: 12px; margin-top: 8px; }
@@ -215,9 +229,7 @@ body { display: flex; flex-direction: column; height: 100vh; }
         <div class="option-stack">
           <label><input type="checkbox" id="chkSkipDuplicates" checked> Skip duplicates</label>
           <label><input type="checkbox" id="chkVerifyByHash"> Verify copied files with full content hashes</label>
-          <label><input type="checkbox" id="chkLocalProcessing" disabled> Use local staging while processing</label>
         </div>
-        <div class="hint">Local staging is temporarily unavailable in the split Import flow; old staging folders can still be recovered above.</div>
       </div>
     </div>
 
@@ -242,6 +254,7 @@ body { display: flex; flex-direction: column; height: 100vh; }
         <button class="btn btn-primary" id="btnStart" onclick="startImport()">Start import</button>
       </div>
       <div class="preview-summary" id="previewSummary"></div>
+      <div id="destStructure" class="dest-structure" style="display:none;"></div>
       <div id="importError"></div>
     </div>
 
@@ -327,6 +340,7 @@ function updateImportMode() {
   document.getElementById('btnPreview').textContent =
     copyMode ? 'Check for duplicates' : 'Preview import';
   document.getElementById('previewSummary').textContent = '';
+  hideDestStructure();
   showError('');
   updateFileTypeControls();
   updateWorkspaceMode();
@@ -1216,8 +1230,111 @@ function useStagingAsImportSource(result) {
   document.getElementById('sourceCard').scrollIntoView({ behavior: 'smooth', block: 'start' });
 }
 
+function hideDestStructure() {
+  const el = document.getElementById('destStructure');
+  if (!el) return;
+  el.style.display = 'none';
+  el.innerHTML = '';
+}
+
+// Resolve the absolute local path files will be cataloged at, for the
+// destination-structure preview. Local mode: the destination field. Remote
+// (SSH) mode: the target's local mount path joined with the subpath — the
+// same path the import job catalogs at (mount_final). Returns '' when the
+// path isn't known/absolute yet, in which case the structure preview is
+// skipped (the duplicate summary still stands).
+function resolvedCopyDestination() {
+  if (importRemoteTargetId()) {
+    const t = importRemoteTarget();
+    if (!t || !t.mount_path || !importIsAbsolutePath(t.mount_path)) return '';
+    const sub = normalizeRemoteSubpath(document.getElementById('remoteSubpath').value);
+    if (sub.error) return '';
+    const base = t.mount_path.replace(/\/+$/, '');
+    return sub.value ? base + '/' + sub.value : base;
+  }
+  const local = (document.getElementById('destInput').value || '').trim();
+  return importIsAbsolutePath(local) ? local : '';
+}
+
+// Preview the destination folder structure (new vs existing folders) and,
+// when the destination sits in a folder Vireo already manages, a callout
+// naming that archive and how many photos it already holds. Best-effort:
+// any failure leaves the destination unknown and simply shows nothing, so
+// the duplicate summary above is never clobbered. ``excludePaths`` are the
+// source files that will be skipped as duplicates — excluding them keeps the
+// new/existing folder counts matching the files that actually land.
+async function renderDestStructure(excludePaths) {
+  hideDestStructure();
+  const destination = resolvedCopyDestination();
+  if (!destination) return;
+  let data;
+  try {
+    const resp = await fetch('/api/import/destination-preview', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sources: sources,
+        destination: destination,
+        folder_template: (document.getElementById('folderTemplate').value || '').trim(),
+        file_types: selectedFileTypes(),
+        recursive: document.getElementById('chkRecursive').checked,
+        exclude_paths: excludePaths || [],
+      }),
+    });
+    if (!resp.ok) return;
+    data = await resp.json();
+  } catch (e) {
+    return;  // structure preview is optional; keep the summary intact
+  }
+  const el = document.getElementById('destStructure');
+  const folders = data.folders || [];
+  if (!folders.length && !data.managed_archive) return;
+
+  const headline = document.createElement('div');
+  headline.className = 'structure-headline';
+  headline.textContent = data.total_photos + ' photos → ' + data.total_folders +
+    ' folder' + (data.total_folders === 1 ? '' : 's') +
+    ' (' + data.new_folders + ' new, ' + data.existing_folders + ' existing)';
+  el.appendChild(headline);
+
+  if (data.managed_archive) {
+    const callout = document.createElement('div');
+    callout.className = 'managed-archive-callout';
+    const label = document.createElement('span');
+    label.textContent = 'Merging into a managed archive at ';
+    const path = document.createElement('span');
+    path.style.fontFamily = 'monospace';
+    path.textContent = data.managed_archive.path;
+    const tail = document.createElement('span');
+    tail.textContent = ' — ' + data.managed_archive.photo_count +
+      ' photo' + (data.managed_archive.photo_count === 1 ? '' : 's') +
+      ' already cataloged there.';
+    callout.append(label, path, tail);
+    el.appendChild(callout);
+  }
+
+  const table = document.createElement('table');
+  table.className = 'structure-table';
+  folders.forEach((f) => {
+    const tr = document.createElement('tr');
+    const name = document.createElement('td');
+    name.textContent = f.path === '.' ? '(archive root)' : f.path;
+    const count = document.createElement('td');
+    count.className = 'num';
+    count.textContent = f.count + ' photo' + (f.count === 1 ? '' : 's');
+    const tag = document.createElement('td');
+    tag.className = 'tag ' + (f.exists ? 'tag-existing' : 'tag-new');
+    tag.textContent = f.exists ? 'existing' : 'new';
+    tr.append(name, count, tag);
+    table.appendChild(tr);
+  });
+  el.appendChild(table);
+  el.style.display = '';
+}
+
 async function previewImport() {
   showError('');
+  hideDestStructure();
   if (!sources.length) { showError('Add at least one source folder.'); return; }
   const copyMode = selectedImportMode() === 'copy';
   const fileTypes = copyMode ? selectedFileTypes() : 'both';
@@ -1247,10 +1364,13 @@ async function previewImport() {
     }
     if (!document.getElementById('chkSkipDuplicates').checked) {
       summary.textContent = files.length + ' files found · duplicates will be copied';
+      // No dedup gate, so every discovered file lands — pass no exclusions
+      // so the folder-structure counts match the full copy set.
+      await renderDestStructure([]);
       return;
     }
     summary.textContent = files.length + ' files found — checking for duplicates…';
-    // check-duplicates streams results; count flagged paths as they arrive.
+    // check-duplicates streams results; collect flagged paths as they arrive.
     // Pass verify_by_hash so the preview and the import agree on which files
     // are duplicates — otherwise a renamed/metadata-colliding file counted
     // as "to copy" in the preview would be skipped by the hash-based import.
@@ -1266,7 +1386,7 @@ async function previewImport() {
     const reader = dupResp.body.getReader();
     const decoder = new TextDecoder();
     let buffer = '';
-    let dupCount = 0;
+    const duplicatePaths = [];
     for (;;) {
       const r = await reader.read();
       if (r.done) break;
@@ -1278,13 +1398,18 @@ async function previewImport() {
         if (!m) continue;
         try {
           const d = JSON.parse(m[1]);
-          if (d.duplicates) dupCount += d.duplicates.length;
+          if (d.duplicates) duplicatePaths.push(...d.duplicates);
         } catch (e) { /* partial frame */ }
       }
     }
+    const dupCount = duplicatePaths.length;
     summary.textContent = files.length + ' files found · ' + dupCount +
       ' already in your library (will be skipped) · ' +
       (files.length - dupCount) + ' to copy';
+    // Skipped duplicates aren't copied, so exclude them from the
+    // folder-structure preview — the new/existing folder counts must
+    // reflect the files that will actually land in the archive.
+    await renderDestStructure(duplicatePaths);
   } catch (e) {
     summary.textContent = '';
     showError(String(e.message || e));


### PR DESCRIPTION
Closes two gaps in the menu-reached import flow that remained after the import/process split (from the earlier lost-functionality audit — items 9 and 7).

## Item 9 — Folder-structure preview (built)

Wires the already-existing `/api/import/destination-preview` endpoint into the copy-mode preview. After the duplicate check runs, the Import page now shows:

- **Headline:** `N photos → M folders (X new, Y existing)`
- **Managed-archive callout** when the destination sits inside a folder Vireo already catalogs — names the archive path and how many photos are already there, framing the import as a merge rather than a fresh copy.
- **Per-folder table** tagging each destination folder `new` / `existing`.

Correctness: skipped duplicates are passed as `exclude_paths`, so the new/existing folder counts reflect the files that *actually land*, not everything discovered (UI-transparency rule). Works for local destinations and SSH remote targets (resolves the mount path). Best-effort — a missing/unresolvable destination just hides the block and leaves the duplicate summary intact.

## Item 7 — Local staging (resolved by removal, not rebuild)

Removed the disabled **"Use local staging while processing"** checkbox and its *"temporarily unavailable"* hint.

The import/process split **deliberately eliminated** local staging: working copies live locally under `~/.vireo`, so processing never touches the remote/slow archive — "the remote case stops needing local staging too" (`docs/plans/2026-07-04-import-process-split-design.md:118-127`; `import_job.py:13-15` states there is "no staging tree"). The disabled control implied a feature was returning that the architecture had intentionally removed, which violated the No-black-boxes rule.

The orphaned-staging **recovery** card (cleans up real leftover dirs from the retired flow) is untouched.

> If per-run local staging is ever genuinely wanted again, that's a re-architecture against the current split and should be scoped separately.

## Testing

- New e2e `test_import_preview_shows_destination_folder_structure` drives a real browser through `folder-preview → check-duplicates → destination-preview` and asserts the counts, the managed-archive callout, and that skipped duplicates are excluded from the structure counts.
- `tests/e2e/test_import_page.py`: **17/17 pass** (deterministic order + isolation).
- Core suite (`test_workspaces`, `test_db`, `test_app`, `test_photos_api`, `test_edits_api`, `test_jobs_api`, `test_darktable_api`, `test_config`): **1504 passed, 14 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)