### PR TITLE
Fix process review loupe browse action

### DIFF
--- a/tests/e2e/test_burst_group_confirm_split.py
+++ b/tests/e2e/test_burst_group_confirm_split.py
@@ -224,6 +224,30 @@ def test_pipeline_burst_context_open_browse_falls_back_to_current_window(live_se
     )
 
 
+def test_pipeline_burst_loupe_context_open_browse_uses_selected_photo(live_server, page):
+    """Right-clicking the Process Review loupe should target its selected photo."""
+    photo_ids = live_server["data"]["photos"][0:3]
+    _write_single_burst_cache(live_server, photo_ids)
+
+    _open_burst_modal(page, live_server)
+    selected_pid = page.evaluate("String(grmState.selected)")
+    assert selected_pid and selected_pid != "null"
+
+    page.evaluate("() => { window.open = () => null; }")
+    _dispatch_contextmenu(page.locator("#grmLoupePhoto"))
+
+    menu = page.locator(".vireo-ctx-menu")
+    expect(menu).to_be_visible()
+    menu.locator(".vireo-ctx-item", has_text="Open in Browse Mode").click()
+
+    page.wait_for_function(
+        "expectedPid => location.pathname === '/browse'"
+        " && new URLSearchParams(location.search).get('photo_id') === expectedPid",
+        arg=selected_pid,
+        timeout=5000,
+    )
+
+
 def test_smart_default_flags_checked_when_moves_pending(live_server, page):
     """Moving a frame to rejects pre-checks "Apply picks/rejects" via the smart
     default; "Confirm species" stays unchecked because the species field is

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -5973,17 +5973,52 @@ function buildPipelinePhotoContextMenu(photoId) {
   );
 }
 
-/* --- Right-click menu ---
- * Catches contextmenu on photo cards (main grid) and grm-cards (group review
- * modal). Browse opens in a new tab (browser) or navigates in place (Tauri app
- * window) via openInBrowse, so the user reaches the photo either way. */
-document.addEventListener('contextmenu', function(e) {
+function pipelineContextPhotoIdFromEvent(e) {
   var card = e.target.closest('.photo-card[data-photo-id], .grm-card[data-photo-id]');
-  if (!card) return;
-  var pid = parseInt(card.dataset.photoId, 10);
-  if (!pid) return;
+  if (card) {
+    var cardPid = parseInt(card.dataset.photoId, 10);
+    if (cardPid) {
+      return {
+        photoId: cardPid,
+        card: card,
+      };
+    }
+  }
+
+  // The burst-review loupe is an image too, but it is not nested in a
+  // data-photo-id card. Resolve it through the modal's current selection so
+  // the same context menu actions work on the large preview.
+  var loupe = e.target.closest('#grmLoupeImg, #grmLoupePhoto');
+  var overlay = document.getElementById('grmOverlay');
+  if (
+    loupe &&
+    overlay &&
+    overlay.classList.contains('open') &&
+    typeof grmState !== 'undefined' &&
+    grmState &&
+    grmState.selected
+  ) {
+    return {
+      photoId: parseInt(grmState.selected, 10),
+      card: null,
+    };
+  }
+
+  return null;
+}
+
+/* --- Right-click menu ---
+ * Catches contextmenu on photo cards (main grid), grm-cards (group review
+ * modal), and the group-review loupe preview. Browse opens in a new tab
+ * (browser) or navigates in place (Tauri app window) via openInBrowse, so the
+ * user reaches the photo either way. */
+document.addEventListener('contextmenu', function(e) {
+  var target = pipelineContextPhotoIdFromEvent(e);
+  if (!target) return;
+  var pid = target.photoId;
+  var card = target.card;
   e.preventDefault();
-  if (card.classList.contains('grm-card') && typeof grmState !== 'undefined' && grmState) {
+  if (card && card.classList.contains('grm-card') && typeof grmState !== 'undefined' && grmState) {
     var prevSelected = grmState.selected;
     grmState.selected = pid;
     if (!grmState.selectedIds) grmState.selectedIds = new Set();


### PR DESCRIPTION
Fixes the Process Review burst loupe context menu so right-clicking the large preview resolves to the currently selected photo. The root cause was that the loupe image is not inside a data-photo-id card, so the existing context handler ignored that surface while card right-clicks worked. This adds a focused regression test that opens Browse Mode from the loupe and confirms it lands on the selected photo, including the window.open fallback path. Validated with focused burst context-menu and browse-mode e2e tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the right-click context menu in Group Review’s loupe preview so actions apply to the currently selected photo.
  * “Open in Browse Mode” now navigates to the correct selected photo when launched from the loupe.
  * Preserved context-menu behavior for thumbnails and photo cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->