### PR TITLE
Fix detached species labels

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -21921,8 +21921,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # too-wide range that would misplace this encounter under time sorts.
             enc["time_range"] = _compute_time_range(photos_by_id, enc["photo_ids"])
             enc["species_predictions"] = rebuild_species_predictions(results, enc["photo_ids"])
+            # No fallback: if the remaining photos have no predictions the
+            # source encounter's stale label was likely inherited from the
+            # burst we just detached, so keeping it would advertise the
+            # detached burst's species as a one-click candidate on an
+            # unrelated group of photos.
             enc["species"] = _rebuild_encounter_species_label(
-                results, enc["photo_ids"], fallback=enc.get("species")
+                results, enc["photo_ids"]
             )
             # Pair indices in trace reference the original photo composition;
             # drop it so the algorithm-trace panel renders an honest "needs
@@ -21934,8 +21939,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         # Create new encounter from detached burst
         new_enc_predictions = rebuild_species_predictions(results, detached_ids)
+        # No fallback: predictionless detached photos must not inherit the
+        # parent encounter's species — that is exactly the stale-label bug
+        # the surrounding PR is fixing.
         new_enc_species = _rebuild_encounter_species_label(
-            results, detached_ids, fallback=enc.get("species")
+            results, detached_ids
         )
         # Also refresh the detached burst's own predictions
         detached["species_predictions"] = new_enc_predictions

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -22019,7 +22019,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "species": source_override["species"],
                 "confirmed": True,
             }
-        elif enc.get("species_confirmed") and enc.get("confirmed_species"):
+        elif enc.get("confirmed_species"):
+            # Inherit the encounter's prior confirmed species by leaving the
+            # override empty. Also covers the mixed/partial state where
+            # species_confirmed is False but confirmed_species records the
+            # dominant prior species (pipeline.py builds encounter payloads
+            # this way for encounters whose photos disagree on confirmed
+            # species). A classifier-guess override here would mask that
+            # prior tag: the confirm endpoint reads species_override.species
+            # without inspecting the confirmed flag, so a later burst confirm
+            # would target the guess as previous_species instead of the real
+            # prior species and leave both keywords on the photo.
             new_burst_override = None
         else:
             new_burst_override = _candidate_species_override(new_burst_species)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1201,6 +1201,26 @@ def _compute_time_range(photos_by_id, photo_ids):
     return [min(timestamps), max(timestamps)]
 
 
+def _rebuild_encounter_species_label(results, photo_ids, fallback=None):
+    """Return the encounter-level species label for exactly photo_ids."""
+    from encounters import encounter_species_label
+
+    id_set = set(photo_ids or [])
+    photos = [p for p in results.get("photos", []) if p.get("id") in id_set]
+    name, confidence = encounter_species_label(photos)
+    if name is None and fallback is not None:
+        return list(fallback)
+    return [name, confidence]
+
+
+def _candidate_species_override(species_label):
+    """Convert a derived species label into an unconfirmed burst candidate."""
+    species = species_label[0] if species_label else None
+    if not species:
+        return None
+    return {"species": species, "confirmed": False}
+
+
 def _find_merge_target(encounters, detached_range, target_species):
     """Find an encounter index whose confirmed species matches target_species and
     whose time range is adjacent to detached_range (no other encounter sits in
@@ -1313,6 +1333,9 @@ def _auto_detach_burst_for_species(results, enc_idx, burst_idx, new_species):
         enc["photo_count"] = len(remaining)
         enc["burst_count"] = len(bursts)
         enc["species_predictions"] = rebuild_species_predictions(results, remaining)
+        enc["species"] = _rebuild_encounter_species_label(
+            results, remaining, fallback=enc.get("species")
+        )
         for b in bursts:
             b["species_predictions"] = rebuild_species_predictions(results, b["photo_ids"])
         enc["time_range"] = _compute_time_range(photos_by_id, remaining)
@@ -1333,6 +1356,9 @@ def _auto_detach_burst_for_species(results, enc_idx, burst_idx, new_species):
         target["species_predictions"] = rebuild_species_predictions(
             results, target["photo_ids"]
         )
+        target["species"] = _rebuild_encounter_species_label(
+            results, target["photo_ids"], fallback=target.get("species")
+        )
         # Same reason as above — target's trace no longer matches its photo set.
         target.pop("trace", None)
         t_min, t_max = target.get("time_range") or [None, None]
@@ -1344,8 +1370,11 @@ def _auto_detach_burst_for_species(results, enc_idx, burst_idx, new_species):
             max(maxs) if maxs else None,
         ]
     else:
+        detached_species = _rebuild_encounter_species_label(
+            results, detached_ids, fallback=enc.get("species")
+        )
         encounters.append({
-            "species": enc.get("species"),
+            "species": detached_species,
             "confirmed_species": new_species,
             "species_predictions": detached["species_predictions"],
             "species_confirmed": True,
@@ -21892,6 +21921,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # too-wide range that would misplace this encounter under time sorts.
             enc["time_range"] = _compute_time_range(photos_by_id, enc["photo_ids"])
             enc["species_predictions"] = rebuild_species_predictions(results, enc["photo_ids"])
+            enc["species"] = _rebuild_encounter_species_label(
+                results, enc["photo_ids"], fallback=enc.get("species")
+            )
             # Pair indices in trace reference the original photo composition;
             # drop it so the algorithm-trace panel renders an honest "needs
             # recompute" state instead of stale rows.
@@ -21902,13 +21934,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         # Create new encounter from detached burst
         new_enc_predictions = rebuild_species_predictions(results, detached_ids)
+        new_enc_species = _rebuild_encounter_species_label(
+            results, detached_ids, fallback=enc.get("species")
+        )
         # Also refresh the detached burst's own predictions
         detached["species_predictions"] = new_enc_predictions
+        detached_override = detached.get("species_override") or {}
+        detached_confirmed = bool(detached_override.get("confirmed"))
         new_enc = {
-            "species": enc.get("species"),
-            "confirmed_species": detached.get("species_override", {}).get("species") if detached.get("species_override") else None,
+            "species": new_enc_species,
+            "confirmed_species": detached_override.get("species") if detached_confirmed else None,
             "species_predictions": new_enc_predictions,
-            "species_confirmed": bool(detached.get("species_override", {}).get("confirmed")) if detached.get("species_override") else False,
+            "species_confirmed": detached_confirmed,
             "photo_count": len(detached_ids),
             "burst_count": 1,
             # Compute from the detached photos' timestamps. A [None, None] range
@@ -21962,6 +21999,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         burst = bursts[burst_idx]
         if photo_id not in burst["photo_ids"]:
             return json_error("photo_id not in burst")
+        source_override = burst.get("species_override") or {}
 
         # Remove photo from burst
         burst["photo_ids"].remove(photo_id)
@@ -21974,10 +22012,21 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             burst["species_predictions"] = rebuild_species_predictions(results, burst["photo_ids"])
 
         # Create new single-photo burst in the same encounter
+        new_burst_predictions = rebuild_species_predictions(results, [photo_id])
+        new_burst_species = _rebuild_encounter_species_label(results, [photo_id])
+        if source_override.get("confirmed") and source_override.get("species"):
+            new_burst_override = {
+                "species": source_override["species"],
+                "confirmed": True,
+            }
+        elif enc.get("species_confirmed") and enc.get("confirmed_species"):
+            new_burst_override = None
+        else:
+            new_burst_override = _candidate_species_override(new_burst_species)
         new_burst = {
             "photo_ids": [photo_id],
-            "species_predictions": rebuild_species_predictions(results, [photo_id]),
-            "species_override": None,
+            "species_predictions": new_burst_predictions,
+            "species_override": new_burst_override,
         }
         bursts.append(new_burst)
         enc["burst_count"] = len(bursts)

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -5148,9 +5148,33 @@ function buildBurstConsensus(photos) {
   return rows;
 }
 
-function candidateSpeciesOverrideFromConsensus(rows) {
-  var species = rows && rows.length > 0 ? rows[0].species : null;
-  return species ? { species: species, confirmed: false } : null;
+// Client mirror of encounter_species_label() (vireo/encounters.py): pick the
+// species with the highest confidence-weighted sum across all photos' top-5
+// predictions, breaking ties by first-appearance order. Used to persist an
+// unconfirmed species override for a detached single-photo burst so the
+// local save-cache path agrees with the server detach endpoint, which
+// derives the same label via _rebuild_encounter_species_label. Sorting by
+// prediction count (as buildBurstConsensus does for display) can pick a
+// different species when a lower-confidence label repeats across
+// detections/models while a higher-confidence one appears once — e.g.
+// [A .90, B .44, B .44] where the server picks A but a count sort picks B.
+function candidateSpeciesOverrideFromPhotos(photos) {
+  var weights = {};
+  var order = [];
+  (photos || []).forEach(function(p) {
+    ((p && p.species_top5) || []).forEach(function(entry) {
+      var sp = entry[0];
+      var conf = entry[1] || 0;
+      if (!(sp in weights)) { weights[sp] = 0; order.push(sp); }
+      weights[sp] += conf;
+    });
+  });
+  if (order.length === 0) return null;
+  var best = order[0];
+  for (var i = 1; i < order.length; i++) {
+    if (weights[order[i]] > weights[best]) best = order[i];
+  }
+  return { species: best, confirmed: false };
 }
 
 // Build the per-photo + consensus species prediction blocks. The per-photo
@@ -6196,7 +6220,8 @@ async function grmApply() {
         // single-photo burst must keep it (shallow clone so it doesn't alias the
         // source), or a flags-only apply would silently revert this photo to the
         // encounter species and drop the burst-specific confirmation.
-        var detachedConsensus = buildBurstConsensus(photo ? [photo] : []);
+        var detachedPhotos = photo ? [photo] : [];
+        var detachedConsensus = buildBurstConsensus(detachedPhotos);
         var sourceOverride = burst && burst.species_override;
         enc.bursts.push({
           photo_ids: [pid],
@@ -6205,7 +6230,7 @@ async function grmApply() {
             ? Object.assign({}, sourceOverride)
             : (enc.species_confirmed && enc.confirmed_species
               ? null
-              : candidateSpeciesOverrideFromConsensus(detachedConsensus)),
+              : candidateSpeciesOverrideFromPhotos(detachedPhotos)),
         });
       });
       // Recompute the shortened source burst's consensus from its remaining

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -6223,12 +6223,17 @@ async function grmApply() {
         var detachedPhotos = photo ? [photo] : [];
         var detachedConsensus = buildBurstConsensus(detachedPhotos);
         var sourceOverride = burst && burst.species_override;
+        // Match the server detach-photo elif (vireo/app.py): fall through to
+        // a null override whenever the encounter tracks any confirmed_species,
+        // including the mixed/partial state (species_confirmed=false but
+        // confirmed_species set) where a classifier-guess override would
+        // mask the real prior tag for a later burst-confirm.
         enc.bursts.push({
           photo_ids: [pid],
           species_predictions: detachedConsensus,
           species_override: sourceOverride && sourceOverride.confirmed === true
             ? Object.assign({}, sourceOverride)
-            : (enc.species_confirmed && enc.confirmed_species
+            : (enc.confirmed_species
               ? null
               : candidateSpeciesOverrideFromPhotos(detachedPhotos)),
         });

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -5148,6 +5148,11 @@ function buildBurstConsensus(photos) {
   return rows;
 }
 
+function candidateSpeciesOverrideFromConsensus(rows) {
+  var species = rows && rows.length > 0 ? rows[0].species : null;
+  return species ? { species: species, confirmed: false } : null;
+}
+
 // Build the per-photo + consensus species prediction blocks. The per-photo
 // block changes as you select different photos; the consensus block is the
 // per-species mean over the scope's frames. The title names only the scope
@@ -6191,12 +6196,16 @@ async function grmApply() {
         // single-photo burst must keep it (shallow clone so it doesn't alias the
         // source), or a flags-only apply would silently revert this photo to the
         // encounter species and drop the burst-specific confirmation.
+        var detachedConsensus = buildBurstConsensus(photo ? [photo] : []);
+        var sourceOverride = burst && burst.species_override;
         enc.bursts.push({
           photo_ids: [pid],
-          species_predictions: buildBurstConsensus(photo ? [photo] : []),
-          species_override: burst && burst.species_override
-            ? Object.assign({}, burst.species_override)
-            : null,
+          species_predictions: detachedConsensus,
+          species_override: sourceOverride && sourceOverride.confirmed === true
+            ? Object.assign({}, sourceOverride)
+            : (enc.species_confirmed && enc.confirmed_species
+              ? null
+              : candidateSpeciesOverrideFromConsensus(detachedConsensus)),
         });
       });
       // Recompute the shortened source burst's consensus from its remaining

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -3234,6 +3234,86 @@ def test_pipeline_detach_photo_partial_confirm_leaves_override_null(app_and_db):
     assert detached["species_override"] is None
 
 
+def test_pipeline_detach_burst_predictionless_does_not_inherit_parent_species(app_and_db):
+    """When the detached burst's photos have no species predictions,
+    ``encounter_species_label`` returns ``(None, 0.0)``. The new encounter
+    must remain unlabeled rather than inheriting the source encounter's
+    label — the parent species almost certainly came from the sibling
+    burst we just left behind, so advertising it as a one-click candidate
+    on the unrelated detached photos would reintroduce the stale-inherited-
+    label bug this change removes. Mirror check for the shrunken source
+    encounter when the only predicted burst is detached away from
+    unclassified siblings.
+    """
+    import json as _json
+    app, db = app_and_db
+    client = app.test_client()
+
+    cache_dir = os.path.dirname(app.config["DB_PATH"])
+    ws_id = db._active_workspace_id
+    results = {
+        "encounters": [
+            {
+                # Encounter-level label was inherited from burst [1,2] alone;
+                # burst [3] has no predictions of its own.
+                "species": ["Robin", 0.9],
+                "confirmed_species": None,
+                "species_predictions": [],
+                "species_confirmed": False,
+                "photo_count": 3,
+                "burst_count": 2,
+                "time_range": [None, None],
+                "photo_ids": [1, 2, 3],
+                "bursts": [
+                    {"photo_ids": [1, 2], "species_predictions": [], "species_override": None},
+                    {"photo_ids": [3], "species_predictions": [], "species_override": None},
+                ],
+            }
+        ],
+        "photos": [
+            {"id": 1, "label": "KEEP", "filename": "a.jpg",
+             "species_top5": [["Robin", 0.9, "m1"]]},
+            {"id": 2, "label": "KEEP", "filename": "b.jpg",
+             "species_top5": [["Robin", 0.85, "m1"]]},
+            # Photo 3 has no predictions — the burst we detach is unclassified.
+            {"id": 3, "label": "REVIEW", "filename": "c.jpg",
+             "species_top5": []},
+        ],
+        "summary": {"total_photos": 3, "encounter_count": 1, "burst_count": 2,
+                     "keep_count": 2, "review_count": 1, "reject_count": 0, "rarity_protected": 0},
+    }
+    path = os.path.join(cache_dir, f"pipeline_results_ws{ws_id}.json")
+    with open(path, "w") as f:
+        _json.dump(results, f)
+
+    resp = client.post("/api/pipeline/detach-burst",
+                       json={"encounter_index": 0, "burst_index": 1})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    # Sanity: two encounters, detached photo is on the new one.
+    assert len(data["encounters"]) == 2
+    assert data["encounters"][1]["photo_ids"] == [3]
+    # The detached encounter's photos have no predictions of their own,
+    # so its species must be [None, 0.0] — not the parent's Robin label.
+    assert data["encounters"][1]["species"] == [None, 0.0]
+
+    # Now the reverse: detach the only predicted burst and leave an
+    # encounter of unclassified photos behind. The remaining encounter
+    # must not keep the pre-detach Robin label.
+    with open(path, "w") as f:
+        _json.dump(results, f)
+    resp = client.post("/api/pipeline/detach-burst",
+                       json={"encounter_index": 0, "burst_index": 0})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    # Source encounter now holds only photo 3 (no predictions).
+    assert data["encounters"][0]["photo_ids"] == [3]
+    assert data["encounters"][0]["species"] == [None, 0.0]
+    # And the detached burst (photos 1, 2) keeps its own Robin label.
+    assert data["encounters"][1]["photo_ids"] == [1, 2]
+    assert data["encounters"][1]["species"][0] == "Robin"
+
+
 def test_pipeline_detach_burst_clears_stale_trace(app_and_db):
     """detach-burst must drop the source encounter's per-pair trace because
     pairs involving the detached photos are no longer present in the

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -3166,6 +3166,74 @@ def test_pipeline_detach_photo_confidence_weighted_override(app_and_db):
     assert detached["species_override"] == {"species": "Alpha", "confirmed": False}
 
 
+def test_pipeline_detach_photo_partial_confirm_leaves_override_null(app_and_db):
+    """When the source encounter is in the mixed/partially-confirmed state
+    (species_confirmed=False but confirmed_species set — e.g. some photos
+    confirmed as species A, others still unconfirmed), detaching a photo
+    must NOT stamp the new burst with an unconfirmed classifier-guess
+    override. The confirm endpoint reads species_override.species without
+    checking the confirmed flag, so a guess override there would be picked
+    up as previous_species on the next burst confirm — the code would then
+    try to untag the guess instead of the actual prior species, leaving
+    the photo with both the old and new species keywords. Leaving the
+    override empty makes the confirm endpoint fall back to
+    enc.confirmed_species as previous_species instead.
+    """
+    import json as _json
+    app, db = app_and_db
+    client = app.test_client()
+
+    cache_dir = os.path.dirname(app.config["DB_PATH"])
+    ws_id = db._active_workspace_id
+    results = {
+        "encounters": [
+            {
+                "species": ["Robin", 0.9],
+                # Partial-confirm state: dominant prior species is known
+                # but not all photos agree, so species_confirmed is False.
+                "confirmed_species": "Robin",
+                "species_predictions": [],
+                "species_confirmed": False,
+                "photo_count": 3,
+                "burst_count": 1,
+                "time_range": [None, None],
+                "photo_ids": [1, 2, 3],
+                "bursts": [
+                    {"photo_ids": [1, 2, 3], "species_predictions": [],
+                     "species_override": None},
+                ],
+            }
+        ],
+        "photos": [
+            {"id": 1, "label": "KEEP", "filename": "a.jpg",
+             "species_top5": [["Robin", 0.9, "m1"]]},
+            {"id": 2, "label": "KEEP", "filename": "b.jpg",
+             "species_top5": [["Robin", 0.85, "m1"]]},
+            {"id": 3, "label": "REVIEW", "filename": "c.jpg",
+             "species_top5": [["Eagle", 0.8, "m1"]]},
+        ],
+        "summary": {"total_photos": 3, "encounter_count": 1, "burst_count": 1,
+                     "keep_count": 2, "review_count": 1, "reject_count": 0,
+                     "rarity_protected": 0},
+    }
+    path = os.path.join(cache_dir, f"pipeline_results_ws{ws_id}.json")
+    with open(path, "w") as f:
+        _json.dump(results, f)
+
+    resp = client.post("/api/pipeline/detach-photo",
+                       json={"encounter_index": 0, "burst_index": 0,
+                             "photo_id": 3})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    enc = data["encounters"][0]
+    detached = enc["bursts"][1]
+    assert detached["photo_ids"] == [3]
+    # Critically: no unconfirmed "Eagle" guess should be stamped here.
+    # Otherwise the confirm endpoint would treat "Eagle" as previous_species
+    # instead of the real prior confirmed_species "Robin".
+    assert detached["species_override"] is None
+
+
 def test_pipeline_detach_burst_clears_stale_trace(app_and_db):
     """detach-burst must drop the source encounter's per-pair trace because
     pairs involving the detached photos are no longer present in the

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -2984,6 +2984,10 @@ def test_pipeline_detach_burst(app_and_db):
     assert len(data["encounters"]) == 2
     assert len(data["encounters"][0]["bursts"]) == 1
     assert data["encounters"][1]["photo_ids"] == [3]
+    assert data["encounters"][0]["species"] == ["Robin", 0.875]
+    assert data["encounters"][1]["species"] == ["Eagle", 0.8]
+    assert data["encounters"][1]["confirmed_species"] is None
+    assert data["encounters"][1]["species_confirmed"] is False
     # Remaining encounter predictions should only reflect photos 1,2
     remaining_species = [sp["species"] for sp in data["encounters"][0]["species_predictions"]]
     assert "Robin" in remaining_species
@@ -3098,6 +3102,10 @@ def test_pipeline_detach_photo(app_and_db):
     # New burst predictions should reflect photo 3
     new_species = [sp["species"] for sp in enc["bursts"][1]["species_predictions"]]
     assert "Eagle" in new_species
+    assert enc["bursts"][1]["species_override"] == {
+        "species": "Eagle",
+        "confirmed": False,
+    }
 
 
 def test_pipeline_detach_burst_clears_stale_trace(app_and_db):

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -3108,6 +3108,64 @@ def test_pipeline_detach_photo(app_and_db):
     }
 
 
+def test_pipeline_detach_photo_confidence_weighted_override(app_and_db):
+    """The derived species_override on a detached single-photo burst uses the
+    same confidence-weighted vote as encounter_species_label — not the
+    prediction count. For a photo whose top-5 is [A .90, B .44, B .44] the
+    override must be A (weight 0.90 > 0.88), even though B appears twice.
+    This is the invariant the client-side detach mirror
+    (candidateSpeciesOverrideFromPhotos in pipeline_review.html) has to
+    match; a divergence would let the local save-cache path persist a
+    different unconfirmed override than the server detach-photo endpoint."""
+    import json as _json
+    app, db = app_and_db
+    client = app.test_client()
+
+    cache_dir = os.path.dirname(app.config["DB_PATH"])
+    ws_id = db._active_workspace_id
+    results = {
+        "encounters": [
+            {
+                "species": ["Robin", 0.9],
+                "confirmed_species": None,
+                "species_predictions": [],
+                "species_confirmed": False,
+                "photo_count": 2,
+                "burst_count": 1,
+                "time_range": [None, None],
+                "photo_ids": [1, 2],
+                "bursts": [
+                    {"photo_ids": [1, 2], "species_predictions": [], "species_override": None},
+                ],
+            }
+        ],
+        "photos": [
+            {"id": 1, "label": "KEEP", "filename": "a.jpg",
+             "species_top5": [["Robin", 0.9, "m1"]]},
+            {"id": 2, "label": "REVIEW", "filename": "b.jpg",
+             "species_top5": [
+                 ["Alpha", 0.90, "m1"],
+                 ["Beta", 0.44, "m1"],
+                 ["Beta", 0.44, "m2"],
+             ]},
+        ],
+        "summary": {"total_photos": 2, "encounter_count": 1, "burst_count": 1,
+                     "keep_count": 1, "review_count": 1, "reject_count": 0, "rarity_protected": 0},
+    }
+    path = os.path.join(cache_dir, f"pipeline_results_ws{ws_id}.json")
+    with open(path, "w") as f:
+        _json.dump(results, f)
+
+    resp = client.post("/api/pipeline/detach-photo",
+                       json={"encounter_index": 0, "burst_index": 0, "photo_id": 2})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    enc = data["encounters"][0]
+    detached = enc["bursts"][1]
+    assert detached["photo_ids"] == [2]
+    assert detached["species_override"] == {"species": "Alpha", "confirmed": False}
+
+
 def test_pipeline_detach_burst_clears_stale_trace(app_and_db):
     """detach-burst must drop the source encounter's per-pair trace because
     pairs involving the detached photos are no longer present in the


### PR DESCRIPTION
Fixes process-review detach behavior so detached bursts recompute their encounter species from the photos they contain, rather than copying the parent encounter label. Detached single-photo bursts now get an unconfirmed candidate from their own prediction unless they should keep inheriting an already-confirmed species. The group review modal mirrors the same cache update path so local detach saves do not reintroduce stale inherited labels. Validated with `pytest -q vireo/tests/test_app.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved species labeling when rebuilding encounters from selected photos.
  * Preserved confirmed species selections during burst updates and photo detachment.
  * Added more accurate unconfirmed species candidates for newly created bursts.
  * Corrected species-related fields when creating encounters from detached photos.

* **Tests**
  * Added coverage for species confidence, confirmation status, and detached-photo overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->