### PR TITLE
Add full browser and API contract gates

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -27,7 +27,11 @@ env:
   CARGO_BUILD_JOBS: "3"
 
 jobs:
+  full-e2e:
+    uses: ./.github/workflows/e2e-full.yml
+
   build:
+    needs: full-e2e
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -1,0 +1,34 @@
+name: Full browser suite
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  schedule:
+    - cron: "23 9 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: full-browser-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  full-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+          cache: pip
+      - name: Install Vireo and Chromium
+        run: |
+          pip install -e ".[dev]"
+          python -m playwright install --with-deps chromium
+      - name: Run complete Playwright suite
+        run: >-
+          python -m pytest -o addopts='' -q tests/e2e/
+          --tb=short --timeout=120 --timeout-method=thread

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -34,8 +34,9 @@ that information for interactive use.
 ## Required checks
 
 Pull requests run Python tests and linting, critical Playwright journeys, route
-contract checks, and Rust formatting, linting, and unit tests when applicable.
-Releases continue to run the complete Playwright suite.
+and API-response contract checks, and Rust formatting, linting, and unit tests
+when applicable. Nightly and release workflows run the complete Playwright
+suite before release artifacts are built.
 
 The large-library benchmark enforces these 100,000-photo pull-request budgets:
 

--- a/vireo/tests/contracts/api_responses.json
+++ b/vireo/tests/contracts/api_responses.json
@@ -1,0 +1,104 @@
+[
+  {
+    "name": "internal health",
+    "method": "GET",
+    "path": "/api/health",
+    "status": 200,
+    "body": {"status": "ok"}
+  },
+  {
+    "name": "automation health",
+    "method": "GET",
+    "path": "/api/v1/health",
+    "headers": {"X-Vireo-Token": "$api_token"},
+    "status": 200,
+    "body": {"service": "vireo", "status": "ok"}
+  },
+  {
+    "name": "automation token required",
+    "method": "GET",
+    "path": "/api/v1/health",
+    "status": 401,
+    "error": {
+      "error": "Invalid or missing X-Vireo-Token",
+      "code": "unauthorized"
+    }
+  },
+  {
+    "name": "rating validation",
+    "method": "POST",
+    "path": "/api/photos/1/rating",
+    "json": {"rating": true},
+    "status": 400,
+    "error": {
+      "error": "rating must be an integer 0-5",
+      "code": "invalid_request"
+    }
+  },
+  {
+    "name": "flag validation",
+    "method": "POST",
+    "path": "/api/photos/1/flag",
+    "json": {"flag": "maybe"},
+    "status": 400,
+    "error": {
+      "error": "flag must be 'none', 'flagged', or 'rejected'",
+      "code": "invalid_request"
+    }
+  },
+  {
+    "name": "color label validation",
+    "method": "POST",
+    "path": "/api/photos/1/color_label",
+    "json": {"color": "orange"},
+    "status": 400,
+    "error": {
+      "error": "color must be one of ('red', 'yellow', 'green', 'blue', 'purple')",
+      "code": "invalid_request"
+    }
+  },
+  {
+    "name": "batch rating requires photos",
+    "method": "POST",
+    "path": "/api/batch/rating",
+    "json": {"rating": 3},
+    "status": 400,
+    "error": {
+      "error": "photo_ids required",
+      "code": "invalid_request"
+    }
+  },
+  {
+    "name": "workspace tab id type",
+    "method": "POST",
+    "path": "/api/workspace/tabs/pin",
+    "json": {},
+    "status": 400,
+    "error": {
+      "error": "nav_id must be a string",
+      "code": "invalid_request"
+    }
+  },
+  {
+    "name": "workspace tab id value",
+    "method": "POST",
+    "path": "/api/workspace/tabs/pin",
+    "json": {"nav_id": "retired-page"},
+    "status": 400,
+    "error": {
+      "error": "nav_id is not a known page",
+      "code": "invalid_request"
+    }
+  },
+  {
+    "name": "workspace tab order type",
+    "method": "POST",
+    "path": "/api/workspace/tabs/reorder",
+    "json": {},
+    "status": 400,
+    "error": {
+      "error": "tabs must be a list",
+      "code": "invalid_request"
+    }
+  }
+]

--- a/vireo/tests/test_api_response_contract.py
+++ b/vireo/tests/test_api_response_contract.py
@@ -1,0 +1,38 @@
+"""Behavior snapshots for stable statuses and JSON error envelopes."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+CONTRACT_PATH = Path(__file__).with_name("contracts") / "api_responses.json"
+CASES = json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize("case", CASES, ids=[case["name"] for case in CASES])
+def test_api_response_contract(app_and_db, case):
+    app, _ = app_and_db
+    headers = {
+        key: app.config["API_TOKEN"] if value == "$api_token" else value
+        for key, value in case.get("headers", {}).items()
+    }
+
+    response = app.test_client().open(
+        case["path"],
+        method=case["method"],
+        headers=headers,
+        json=case.get("json"),
+    )
+
+    assert response.status_code == case["status"]
+    request_id = response.headers.get("X-Request-ID")
+    assert request_id
+
+    body = response.get_json()
+    if "error" not in case:
+        assert body == case["body"]
+        return
+
+    assert set(body) == {"error", "code", "request_id"}
+    assert body["request_id"] == request_id
+    assert {"error": body["error"], "code": body["code"]} == case["error"]


### PR DESCRIPTION
## Summary

- run the complete Playwright suite nightly and on demand
- require that suite to pass before release artifacts are built
- snapshot representative API success responses, status codes, stable error codes, messages, and request IDs
- update the architecture documentation to describe the enforced gates

## Why

The foundation added fast pull-request smoke coverage and method/path route snapshots, but two planned safeguards were still missing: complete scheduled/release browser coverage and behavioral contracts for response statuses and error envelopes. This closes those gaps before more routes are extracted from the monolith.

## User impact

There are no intended interface or workflow changes. Releases now wait for the full browser suite, and accidental API behavior changes fail with focused contract output.

## Validation

- complete Playwright suite: 434 passed, 1 skipped
- focused route, security, authentication, and response-contract suite: 30 passed
- post-rebase API and route contracts: 11 passed
- workflow YAML parsing, Ruff, and diff checks passed