### PR TITLE
test(e2e): fix command-palette shortcut modifier for Linux CI (unblocks release gate)

### DIFF
--- a/tests/e2e/test_navigation.py
+++ b/tests/e2e/test_navigation.py
@@ -162,8 +162,11 @@ def test_cmdk_opens_palette(live_server, page):
     palette = page.query_selector("#commandPalette")
     assert palette is not None
     assert palette.is_hidden()
-    # Cmd+K (mac) or Ctrl+K elsewhere
-    page.keyboard.press("Meta+K")
+    # Cmd+K (mac) or Ctrl+K elsewhere. ControlOrMeta resolves to Meta on
+    # macOS and Control on Linux/Windows, matching the app's own
+    # `isMac ? e.metaKey : e.ctrlKey` handler — so this passes on the Linux
+    # CI runner where a hardcoded "Meta+K" silently does nothing.
+    page.keyboard.press("ControlOrMeta+K")
     page.wait_for_selector("#commandPalette:not([hidden])", timeout=2000)
     # Esc closes
     page.keyboard.press("Escape")
@@ -176,7 +179,7 @@ def test_cmdk_opens_palette(live_server, page):
 def test_palette_filters_by_query(live_server, page):
     url = live_server["url"]
     page.goto(f"{url}/browse")
-    page.keyboard.press("Meta+K")
+    page.keyboard.press("ControlOrMeta+K")
     page.wait_for_selector("#commandPalette:not([hidden])")
     page.fill("#cmdPaletteInput", "dup")
     # Wait for Duplicates row to be the (only/top) result
@@ -186,7 +189,7 @@ def test_palette_filters_by_query(live_server, page):
 def test_palette_enter_navigates(live_server, page):
     url = live_server["url"]
     page.goto(f"{url}/browse")
-    page.keyboard.press("Meta+K")
+    page.keyboard.press("ControlOrMeta+K")
     page.fill("#cmdPaletteInput", "dup")
     page.wait_for_selector(".cmd-palette-result[data-nav-id='duplicates'].selected")
     page.keyboard.press("Enter")
@@ -196,7 +199,7 @@ def test_palette_enter_navigates(live_server, page):
 def test_palette_arrow_keys_change_selection(live_server, page):
     url = live_server["url"]
     page.goto(f"{url}/browse")
-    page.keyboard.press("Meta+K")
+    page.keyboard.press("ControlOrMeta+K")
     # openCommandPalette refreshes tab state asynchronously before rendering,
     # so wait for the first selected row instead of querying immediately.
     page.wait_for_selector(".cmd-palette-result.selected", timeout=3000)
@@ -219,7 +222,7 @@ def test_cmd1_jumps_to_first_pinned_tab(live_server, page):
     page.goto(f"{url}/jobs")  # start somewhere not first
     # Wait for the dynamic tab strip to render so window._navTabs is populated.
     page.wait_for_selector(".nav-tab[data-nav-id='import']", timeout=3000)
-    page.keyboard.press("Meta+1")
+    page.keyboard.press("ControlOrMeta+1")
     page.wait_for_url(f"{url}/import", timeout=3000)
 
 
@@ -229,7 +232,7 @@ def test_cmdw_closes_ephemeral_tab(live_server, page):
     # /keywords is not in default pinned tabs — visiting makes it ephemeral.
     page.goto(f"{url}/keywords")
     page.wait_for_selector(".nav-tab[data-nav-id='keywords'].is-ephemeral", timeout=3000)
-    page.keyboard.press("Meta+W")
+    page.keyboard.press("ControlOrMeta+W")
     # After cmd+W, the page should navigate away from /keywords.
     page.wait_for_function("() => !location.pathname.startsWith('/keywords')", timeout=3000)
 
@@ -343,7 +346,7 @@ def test_palette_seeded_from_fallback_when_tabs_api_fails(live_server, page):
     # fetch is rejected.
     page.route("**/api/workspace/tabs", lambda route: route.abort())
     page.goto(f"{url}/browse")
-    page.keyboard.press("Meta+K")
+    page.keyboard.press("ControlOrMeta+K")
     page.wait_for_selector("#commandPalette:not([hidden])", timeout=2000)
     # Empty query should render the fallback page list, not an empty palette.
     rows = page.eval_on_selector_all(


### PR DESCRIPTION
## Why

The v0.21.0 release ([run 29181422268](https://github.com/jss367/vireo/actions/runs/29181422268)) is blocked by the new `full-e2e` gate (added in #1209). 7 command-palette tests in `tests/e2e/test_navigation.py` fail on the Linux CI runner — the palette never opens.

**It's a test bug, not an app bug.** The tests hardcode `page.keyboard.press("Meta+K")`, but the app's handler is platform-conditional:

```js
const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
const mod = isMac ? e.metaKey : e.ctrlKey;
```

- **macOS (local dev):** `isMac` true → app wants `metaKey` → `Meta+K` matches → tests pass.
- **Linux CI:** `isMac` false → app wants `ctrlKey` → `Meta+K` sets `metaKey` only → palette never opens → 7 timeouts.

These only surfaced now because `tests/e2e/` first became a release gate in #1209; the PR-level `e2e-smoke` subset doesn't cover them, and the last release (v0.18.0) ran no e2e at all.

## Fix

Use Playwright's **`ControlOrMeta`** modifier (Meta on macOS, Control on Linux/Windows) for the 7 palette shortcuts — mirroring the app's own `isMac ? metaKey : ctrlKey` logic, so the tests pass on every runner.

## Verification

- Reproduced locally: all 7 failing tests **pass** on macOS (the command palette was never broken).
- Platform-emulation harness reproduced the **exact Linux failure** (`navigator.platform=Linux` + `Meta+K` → palette stays closed).
- Full `test_navigation.py` suite (25 tests) passes locally with the fix.
- **Dispatched the Full browser suite on this branch (Linux)** to validate the fix directly — see checks.

Scope note: `test_cull_keyboard.py`'s `Meta+ArrowRight` was left alone — it hits a different handler that ignores modified arrows and passed in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)