### PR TITLE
release: v0.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vireo",
   "private": true,
-  "version": "0.21.0",
+  "version": "0.22.0",
   "scripts": {
     "tauri": "tauri"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vireo"
-version = "0.21.0"
+version = "0.22.0"
 description = "AI-powered wildlife photo organizer"
 requires-python = ">=3.11"
 dependencies = [

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4891,7 +4891,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vireo"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "dirs 5.0.1",
  "fs2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vireo"
-version = "0.21.0"
+version = "0.22.0"
 description = "AI-powered wildlife photo organizer"
 authors = []
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Vireo",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "identifier": "com.vireo.app",
   "build": {
     "frontendDist": "../build",


### PR DESCRIPTION
## What

Bump version `0.21.0` → `0.22.0` across all 5 manifests via `scripts/sync_version.py 0.22.0` + `cargo generate-lockfile`:
- `package.json`, `pyproject.toml`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.lock`

Diff is version-string-only (no dependency churn).

## Why

Cleans up a version tangle:
- The published **v0.21.0** is healthy (Latest release). Main had **2 unreleased commits** since it (#1213, #1217), still labeled 0.21.0.
- A **stray local-only `v0.22.0` tag** pointed *backwards* at an older commit (`9503880b`, code said 0.21.0), never pushed, no release. Deleted.

This gives a clean v0.22.0 to release from current main HEAD. After merge, I'll tag `v0.22.0` at the merge commit and push to trigger the release (which now builds cleanly thanks to the optional-signing fix #1210 and the palette e2e fix #1211).

## Verification

`sync_version.py` + `cargo generate-lockfile` are the repo's own release-bump steps (`scripts/release.sh`). CI on this PR validates the bumped tree builds/tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)