### PR TITLE
Align first-run guidance around Import and Process

### DIFF
--- a/vireo/static/help.json
+++ b/vireo/static/help.json
@@ -3,19 +3,19 @@
     "question": "How do I add photos to Vireo?",
     "category": "Getting Started",
     "keywords": ["scan", "import", "add", "folder", "photos", "directory"],
-    "answer": "Open Settings and add a folder under Scan Roots. Then go to the Jobs page and click Scan. Vireo will find all supported image files in that folder and its subfolders. First runs download AI models — anywhere from a few hundred megabytes to a few gigabytes depending on the classifier you choose — so give it a few minutes."
+    "answer": "Open Import, leave Add in place selected, and click Browse to choose one or more folders. Select an After import processing option, then click Start import. Vireo adds supported photos and their subfolders to the active workspace without moving or copying them. Choose Copy to archive instead when you want Vireo to copy photos into your archive."
   },
   {
     "question": "How do I classify my photos?",
     "category": "Getting Started",
     "keywords": ["classify", "identify", "species", "scan", "pipeline", "AI"],
-    "answer": "Run a scan from the Jobs page. The classification pipeline detects subjects, identifies species, and scores quality for every photo. Progress streams in real time in the log panel."
+    "answer": "When adding photos, choose a processing option under After import before clicking Start import. For photos already in the workspace, open Process, select the workspace folders, choose a strategy, and click Start Pipeline. Jobs shows progress; it is not where processing starts."
   },
   {
-    "question": "How do I review scan results?",
+    "question": "How do I review processing results?",
     "category": "Getting Started",
     "keywords": ["review", "results", "cull", "keep", "reject", "triage"],
-    "answer": "After a scan completes, every photo gets a label: keep, review, or reject. Open the Cull page to rapidly sort through them using keyboard shortcuts."
+    "answer": "Open Process Review to inspect classifications and any available quality recommendations. When culling analysis is available, open Cull to rapidly mark photos keep, review, or reject using keyboard shortcuts."
   },
   {
     "question": "How do I save my decisions to my photo files?",
@@ -48,10 +48,10 @@
     "answer": "Use the Move page to relocate photos to a different folder. Select photos and choose a destination. Vireo moves the actual files on disk and updates its database."
   },
   {
-    "question": "What is the Pipeline page?",
+    "question": "What is the Process page?",
     "category": "Classification",
     "keywords": ["pipeline", "steps", "detection", "classification", "quality", "scoring"],
-    "answer": "The Pipeline page shows you exactly how Vireo processes each photo: subject detection, species classification, and quality scoring. You can see bounding boxes, confidence scores, and quality metrics for any photo."
+    "answer": "The Process page runs indexing, species classification, feature extraction, and quality scoring for photos already in the active workspace. Use Import to add new photos; use Process when you want to run or rerun selected processing stages."
   },
   {
     "question": "What species can Vireo identify?",

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -2237,7 +2237,7 @@ function sendReport() {
       <select id="rescanFolderSelect" style="margin-left:26px;max-width:100%;padding:6px 8px;" disabled></select>
     </div>
     <div id="rescanEmptyNote" style="display:none;color:var(--text-secondary);font-size:13px;margin-bottom:10px;">
-      This workspace has no folders yet. Add one from the Workspace page first.
+      This workspace has no folders yet. Open Import to add photos first.
     </div>
     <div class="modal-actions">
       <button class="modal-btn" id="rescanRunBtn" onclick="runRescan()">Rescan</button>
@@ -10721,7 +10721,7 @@ async function openRescanModal() {
     const active = await safeFetch('/api/workspaces/active', {}, { toast: false });
     const folders = await safeFetch('/api/workspaces/' + active.id + '/folders', {}, { toast: false });
     if (!folders || folders.length === 0) {
-      emptyNote.textContent = 'This workspace has no folders yet. Add one from the Workspace page first.';
+      emptyNote.textContent = 'This workspace has no folders yet. Open Import to add photos first.';
       emptyNote.style.display = 'block';
       if (folderRadio) folderRadio.disabled = true;
       return;

--- a/vireo/templates/jobs.html
+++ b/vireo/templates/jobs.html
@@ -883,7 +883,7 @@
     });
 
     if (running.length === 0) {
-      pane.innerHTML = '<div class="jobs-overview-empty">No active jobs.<br><span style="font-size:12px;margin-top:8px;display:inline-block;">Start a pipeline from the Pipeline page, or run individual jobs from Browse.</span></div>';
+      pane.innerHTML = '<div class="jobs-overview-empty">No active jobs.<br><span style="font-size:12px;margin-top:8px;display:inline-block;">Import new photos from Import, process workspace photos from Process, or run individual jobs from Browse.</span></div>';
       return;
     }
 

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1329,6 +1329,11 @@ async function loadFolderScopeList() {
       });
     }
     list.innerHTML = '';
+    if (folders.length === 0) {
+      list.innerHTML = 'No photos are in this workspace yet. '
+        + '<a href="/import" style="color:var(--accent);">Open Import to add photos</a>.';
+      return;
+    }
     folders.forEach(function(f) {
       // Only offer top-level entries: children are covered by the
       // server-side subtree expansion, and listing every dated folder

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -3572,7 +3572,7 @@ function renderEmptyState(readiness) {
                species_predictions: 'species predictions'})[k] || k;
     });
     body.textContent = 'You can compute results now. Quality will be lower without: '
-      + labels.join(', ') + '. Re-run those stages on the Pipeline page later to improve.';
+      + labels.join(', ') + '. Re-run those stages on the Process page later to improve.';
   }
   actions.innerHTML = '<button class="compute-btn" onclick="computeReviewNow()">'
     + 'Compute results now</button>';

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -595,7 +595,7 @@
       <div class="setting-row">
         <div class="setting-label">
           Enable eye-focus detection
-          <small>Runs the SuperAnimal keypoint stage to localize the animal's eye and use a windowed sharpness around it for the focus score. Weights are opt-in on the Pipeline page.</small>
+          <small>Runs the SuperAnimal keypoint stage to localize the animal's eye and use a windowed sharpness around it for the focus score. Weights are opt-in on the Process page.</small>
         </div>
         <div style="display:flex;align-items:center;gap:8px;">
           <input type="checkbox" id="cfgEyeDetectEnabled" checked

--- a/vireo/templates/workspace.html
+++ b/vireo/templates/workspace.html
@@ -30,8 +30,8 @@
     <div class="section-title">Folders</div>
     <div id="wsFoldersContent"><span style="color:var(--text-ghost);font-size:13px;">Loading...</span></div>
     <div style="margin-top:12px;border-top:1px solid var(--border-primary);padding-top:12px;">
-      <a href="/pipeline" class="btn btn-secondary" style="text-decoration:none;display:inline-block;">+ Add Folder</a>
-      <div style="font-size:11px;color:var(--text-dim);margin-top:4px;">Opens the Process page to add and scan a folder</div>
+      <a href="/import" class="btn btn-secondary" style="text-decoration:none;display:inline-block;">+ Import Photos</a>
+      <div style="font-size:11px;color:var(--text-dim);margin-top:4px;">Add folders in place or copy photos into an archive</div>
     </div>
   </div>
 

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -6255,7 +6255,7 @@ def test_get_active_subject_types_workspace_override_wins(app_and_db, tmp_path, 
 
 
 def test_workspace_page_no_scan_button(app_and_db):
-    """Workspace page should not have a Scan & Add button — folders are added via Pipeline."""
+    """Workspace page should not expose the retired Scan & Add action."""
     app, _ = app_and_db
     with app.test_client() as c:
         resp = c.get('/workspace')
@@ -6265,15 +6265,15 @@ def test_workspace_page_no_scan_button(app_and_db):
         assert 'scanAndAddFolder' not in html
 
 
-def test_workspace_page_has_add_folder_link(app_and_db):
-    """Workspace page should have an Add Folder button linking to Pipeline."""
+def test_workspace_page_has_import_photos_link(app_and_db):
+    """Workspace page should send users to Import when they need photos."""
     app, _ = app_and_db
     with app.test_client() as c:
         resp = c.get('/workspace')
         assert resp.status_code == 200
         html = resp.data.decode()
-        assert 'href="/pipeline"' in html
-        assert 'Add Folder' in html
+        assert 'href="/import"' in html
+        assert 'Import Photos' in html
 
 
 # -- Missing folder API tests --
@@ -11707,6 +11707,7 @@ def test_process_page_has_no_import_source(app_and_db):
     assert 'id="radioNewImages"' in html
     assert 'id="strategySelect"' in html
     assert "folder_ids" in html
+    assert "Open Import to add photos" in html
     assert "<title>Vireo - Process</title>" in html
 
 

--- a/website/src/pages/docs.astro
+++ b/website/src/pages/docs.astro
@@ -33,18 +33,18 @@ for (const entry of helpData) {
       </div>
 
       <div class="docs-step">
-        <h3>2. Add your photo folders</h3>
-        <p>Open Vireo and click <strong>Add Folder</strong> in the sidebar. Navigate to any directory containing your wildlife photos. Vireo reads your files in place — nothing is moved or copied. You can add multiple folders.</p>
+        <h3>2. Import your photos</h3>
+        <p>Open <strong>Import</strong>, leave <strong>Add in place</strong> selected, and click <strong>Browse</strong> to choose one or more folders. Vireo indexes the photos where they already live — nothing is moved or copied. Choose <strong>Copy to archive</strong> instead only when you want Vireo to copy photos from a card or source folder into your archive.</p>
       </div>
 
       <div class="docs-step">
-        <h3>3. Run your first scan</h3>
-        <p>Click <strong>Scan</strong> to start the classification pipeline. Vireo will detect subjects, classify species, and score quality for every photo. Progress streams in real time — you can watch the log panel for details. First runs download the AI models — anywhere from a few hundred megabytes to a few gigabytes depending on the classifier you choose — so give it a few minutes.</p>
+        <h3>3. Choose what happens after import</h3>
+        <p>Under <strong>After import</strong>, choose a processing option such as <strong>Identify birds</strong>, then click <strong>Start import</strong>. Vireo adds the photos to the active workspace and starts processing as a background job. First runs may download AI models — anywhere from a few hundred megabytes to a few gigabytes — so give them a few minutes. Use <strong>Jobs</strong> only to monitor progress.</p>
       </div>
 
       <div class="docs-step">
         <h3>4. Review results</h3>
-        <p>Once the scan completes, every photo has a label: <strong>keep</strong>, <strong>review</strong>, or <strong>reject</strong>. Open the <strong>Cull</strong> page to rapidly sort through them. Use keyboard shortcuts to move through photos and make decisions.</p>
+        <p>Open <strong>Process Review</strong> to inspect classifications and any available quality recommendations. When culling analysis is available, open <strong>Cull</strong> to rapidly mark photos keep, review, or reject with keyboard shortcuts. Use <strong>Process</strong> later when you want to rerun processing for photos already in the workspace.</p>
       </div>
 
       <div class="docs-step">

--- a/website/src/pages/download.astro
+++ b/website/src/pages/download.astro
@@ -128,15 +128,15 @@ const windowsBetaAvailable = windowsVersion !== '0.18.0';
         <div class="quickstart__step">
           <span class="quickstart__number">2</span>
           <div>
-            <h3>Add folders</h3>
-            <p>Point Vireo at one or more folders of wildlife photos. It reads your files in place — nothing is moved or copied.</p>
+            <h3>Import photos</h3>
+            <p>Open Import, choose Add in place, and select one or more folders. Your photos stay where they are.</p>
           </div>
         </div>
         <div class="quickstart__step">
           <span class="quickstart__number">3</span>
           <div>
-            <h3>Scan &amp; classify</h3>
-            <p>Vireo downloads the AI models on first use, then scans and classifies your photos locally.</p>
+            <h3>Choose processing</h3>
+            <p>Select an After import option and start the import. Vireo downloads any required AI models, then processes your photos locally.</p>
           </div>
         </div>
         <div class="quickstart__step">

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -18,18 +18,18 @@ const base = import.meta.env.BASE_URL;
       <div class="hiw__grid">
         <div class="hiw__step">
           <div class="hiw__number">1</div>
-          <h3 class="hiw__title">Add Your Folders</h3>
+          <h3 class="hiw__title">Import Your Photos</h3>
           <p class="hiw__desc">
-            Point Vireo at your photo directories. It scans and indexes images
-            automatically — no importing or copying files.
+            Open Import and add your photo folders in place, or copy a card
+            into your archive. You choose where every file lives.
           </p>
         </div>
         <div class="hiw__step">
           <div class="hiw__number">2</div>
           <h3 class="hiw__title">AI Classifies</h3>
           <p class="hiw__desc">
-            Walk away from your computer while on-device models identify
-            species, detect duplicates, and score image quality.
+            Choose what runs after import, then walk away while on-device models
+            identify species, detect duplicates, and score image quality.
           </p>
         </div>
         <div class="hiw__step">


### PR DESCRIPTION
This aligns Vireo's first-run guidance around one canonical flow: Import new photos, Process workspace photos, then review results in Process Review or Cull.
It fixes the Workspace entry point, adds an actionable empty state to Process, and clarifies that Jobs monitors work rather than starting it.
The website homepage, download quick start, documentation, in-app help, and remaining visible Pipeline terminology now match the actual interface.
Validated with targeted application tests, JSON parsing, the complete Astro website build, and `git diff --check`.
