### PR TITLE
Default detection overlays off

### DIFF
--- a/tests/e2e/test_lightbox_context_menu.py
+++ b/tests/e2e/test_lightbox_context_menu.py
@@ -152,9 +152,9 @@ def test_lightbox_menu_adds_species_highlight(live_server, page):
 def test_lightbox_overlay_toggles_persist_and_context_restores(live_server, page):
     """Lightbox overlay visibility toggles persist and stay recoverable.
 
-    Defaults with no stored preference: boxes/eye/info/chrome visible, masks
-    hidden (PR #1083). One click on each toggle therefore flips boxes, eye,
-    info and chrome OFF but flips masks ON.
+    Defaults with no stored preference: boxes/eye/masks hidden, info/chrome
+    visible. One click on each toggle therefore flips boxes, eye, and masks ON
+    but flips info and chrome OFF.
     """
     url = live_server["url"]
     page.goto(f"{url}/browse")
@@ -191,9 +191,9 @@ def test_lightbox_overlay_toggles_persist_and_context_restores(live_server, page
         "document.getElementById('lightboxOverlay').classList.contains('lb-hide-chrome')",
         timeout=2000,
     )
-    assert page.evaluate("localStorage.getItem('vireo.lb.boxesVisible')") == "0"
+    assert page.evaluate("localStorage.getItem('vireo.lb.boxesVisible')") == "1"
     assert page.evaluate("localStorage.getItem('vireo.lb.masksVisible')") == "1"
-    assert page.evaluate("localStorage.getItem('vireo.lb.eyeVisible')") == "0"
+    assert page.evaluate("localStorage.getItem('vireo.lb.eyeVisible')") == "1"
     assert page.evaluate("localStorage.getItem('vireo.lb.infoVisible')") == "0"
     assert page.evaluate("localStorage.getItem('vireo.lb.chromeVisible')") == "0"
 
@@ -234,9 +234,9 @@ def test_lightbox_overlay_toggles_persist_and_context_restores(live_server, page
         "document.getElementById('lightboxOverlay').classList.contains('lb-hide-info')",
         timeout=2000,
     )
-    assert page.locator("#lightboxToggleBoxes").inner_text() == "Show Boxes"
+    assert page.locator("#lightboxToggleBoxes").inner_text() == "Hide Boxes"
     assert page.locator("#lightboxToggleMasks").inner_text() == "Hide Masks"
-    assert page.locator("#lightboxToggleEye").inner_text() == "Show Eye"
+    assert page.locator("#lightboxToggleEye").inner_text() == "Hide Eye"
 
 
 def test_lightbox_right_click_does_not_toggle_zoom(live_server, page):

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2688,6 +2688,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     # workspace overrides. Gated by a marker so it runs once; re-saved
     # legacy values are preserved on subsequent boots.
     cfg.migrate_legacy_miss_thresholds(init_db)
+    # One-time rewrite of the previous eye-focus detection default from on to
+    # off in both global config and workspace overrides.
+    cfg.migrate_eye_detect_default_off(init_db)
     # One-time resolution of the browse.toggle_ui="h" default clashing with
     # any pre-existing browse binding on ``h``. Writes an explicit "" so the
     # user's existing action keeps working; they can re-bind toggle_ui from
@@ -3454,7 +3457,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "sam2_variant": sam2_variant,
                 "dinov2_variant": dinov2_variant,
                 "proxy_longest_edge": proxy_longest_edge,
-                "eye_detect_enabled": pipeline_cfg.get("eye_detect_enabled", True),
+                "eye_detect_enabled": pipeline_cfg.get("eye_detect_enabled", False),
                 "preview_max_size": effective_cfg.get("preview_max_size", 1920),
             },
             "mask_variant_coverage": db.mask_variant_coverage(),

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3635,6 +3635,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "review_mode must be a string or null, got "
                 f"{type(review_mode).__name__}", 400,
             )
+        # ``eye_detect_override`` is tri-state (None/True/False); accept
+        # only bool or missing so the plan matches what /api/jobs/pipeline
+        # would do.
+        eye_detect_override_body = body.get("eye_detect_override")
+        if (
+            eye_detect_override_body is not None
+            and not isinstance(eye_detect_override_body, bool)
+        ):
+            return json_error(
+                f"eye_detect_override must be boolean, got "
+                f"{type(eye_detect_override_body).__name__}", 400,
+            )
         params = PipelinePlanParams(
             collection_id=body.get("collection_id"),
             photo_ids=scope_photo_ids,
@@ -3642,6 +3654,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             skip_classify=bool(body.get("skip_classify")),
             skip_extract_masks=bool(body.get("skip_extract_masks")),
             skip_eye_keypoints=bool(body.get("skip_eye_keypoints")),
+            eye_detect_override=eye_detect_override_body,
             skip_regroup=bool(body.get("skip_regroup")),
             model_ids=body.get("model_ids") or (
                 [body["model_id"]] if body.get("model_id") else []
@@ -20804,6 +20817,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 f"{type(miss_enabled_body).__name__}"
             )
 
+        # ``eye_detect_override`` mirrors ``miss_enabled`` as a tri-state
+        # per-run switch (None = defer to workspace config). Same validation
+        # rationale: a string "false" would flow through as truthy and force
+        # eye detection on for a caller expecting the workspace default.
+        eye_detect_override_body = body.get("eye_detect_override")
+        if (
+            eye_detect_override_body is not None
+            and not isinstance(eye_detect_override_body, bool)
+        ):
+            return json_error(
+                f"eye_detect_override must be boolean, got "
+                f"{type(eye_detect_override_body).__name__}"
+            )
+
         # Validate ``model_id`` / ``model_ids`` shape BEFORE the folder-scope
         # collection is materialized. The auto-skip-classify block further
         # down calls ``list(params.model_ids or [])`` and ``by_id.get(mid, ...)``
@@ -20866,6 +20893,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             download_taxonomy=body.get("download_taxonomy", True),
             skip_extract_masks=body.get("skip_extract_masks", False),
             skip_eye_keypoints=body.get("skip_eye_keypoints", False),
+            eye_detect_override=eye_detect_override_body,
             skip_regroup=body.get("skip_regroup", False),
             # ``review_mode`` reaches ``body`` only through the strategy
             # expansion at the top of this handler (identify sets it to

--- a/vireo/config.py
+++ b/vireo/config.py
@@ -123,7 +123,7 @@ DEFAULTS = {
         # disable the override.
         "miss_classifier_override_conf": 0.8,
         # Eye-focus detection
-        "eye_detect_enabled": True,
+        "eye_detect_enabled": False,
         "eye_classifier_conf_gate": 0.50,
         "eye_detection_conf_gate": 0.50,
         "eye_window_k": 0.08,
@@ -297,6 +297,7 @@ def set(key, value):
 
 MIGRATION_MISS_THRESHOLDS = "miss_thresholds_2026_05"
 MIGRATION_TOGGLE_UI_H_CONFLICT = "toggle_ui_h_conflict_2026_07"
+MIGRATION_EYE_DETECT_DEFAULT_OFF = "eye_detect_default_off_2026_07"
 
 _LEGACY_MISS_DET_CONFIDENCE = 0.25
 _LEGACY_MISS_DET_CONFIDENCE_BURST = 0.15
@@ -403,6 +404,35 @@ def migrate_toggle_ui_h_conflict():
                         rewrote = True
                         break
         applied.append(MIGRATION_TOGGLE_UI_H_CONFLICT)
+        raw["_migrations_applied"] = applied
+        save(raw)
+        return rewrote
+
+
+def migrate_eye_detect_default_off(db=None):
+    """One-time rewrite of the previous eye-detection default.
+
+    Older versions defaulted ``pipeline.eye_detect_enabled`` to ``True``.
+    Because legacy save paths may have persisted the full merged config,
+    upgraded users would otherwise keep the old default even after DEFAULTS
+    changes. Rewrite only the exact legacy default value; an already-false
+    user setting remains false, and future explicit true settings are kept.
+    """
+    with _lock:
+        raw = _read_raw()
+        applied = _migrations_applied(raw)
+        if MIGRATION_EYE_DETECT_DEFAULT_OFF in applied:
+            return False
+        rewrote = False
+        pipeline = raw.get("pipeline")
+        if isinstance(pipeline, dict) and pipeline.get("eye_detect_enabled") is True:
+            pipeline["eye_detect_enabled"] = False
+            rewrote = True
+        if db is not None:
+            ws_rewrites = db.rewrite_legacy_eye_detect_default_in_workspaces()
+            if ws_rewrites:
+                rewrote = True
+        applied.append(MIGRATION_EYE_DETECT_DEFAULT_OFF)
         raw["_migrations_applied"] = applied
         save(raw)
         return rewrote

--- a/vireo/config.py
+++ b/vireo/config.py
@@ -441,9 +441,17 @@ def migrate_eye_detect_default_off(db=None):
             pipeline["eye_detect_enabled"] = False
             rewrote = True
         if db is not None:
-            ws_rewrites = db.rewrite_legacy_eye_detect_default_in_workspaces()
-            if ws_rewrites:
-                rewrote = True
+            # Only rewrite workspace ``eye_detect_enabled=True`` overrides
+            # when the global default they were mirroring was also True (or
+            # absent — the old DEFAULTS value). If the global was already
+            # explicit False, a workspace ``True`` override is an
+            # intentional per-workspace opt-in that intentionally differs
+            # from Settings; flipping it here would silently disable eye
+            # detection for that workspace after the upgrade.
+            if not global_was_explicit_false:
+                ws_rewrites = db.rewrite_legacy_eye_detect_default_in_workspaces()
+                if ws_rewrites:
+                    rewrote = True
             # A workspace's cached ``pipeline_results_ws*.json`` and stamped
             # ``last_group_fingerprint`` were produced with whatever
             # ``eye_detect_enabled`` was effective at the time. Flipping the

--- a/vireo/config.py
+++ b/vireo/config.py
@@ -428,6 +428,15 @@ def migrate_eye_detect_default_off(db=None):
         global_was_true = (
             isinstance(pipeline, dict) and pipeline.get("eye_detect_enabled") is True
         )
+        # An absent ``pipeline.eye_detect_enabled`` key means the config was
+        # relying on the previous DEFAULTS value, which was ``True`` — i.e.
+        # the same effective pre-migration state as an explicit ``True``.
+        # Only an explicit ``False`` in the raw config means the user (or
+        # DEFAULTS-persisting save code) had already committed to eye-off
+        # before this migration ran.
+        global_was_explicit_false = (
+            isinstance(pipeline, dict) and pipeline.get("eye_detect_enabled") is False
+        )
         if global_was_true:
             pipeline["eye_detect_enabled"] = False
             rewrote = True
@@ -441,11 +450,13 @@ def migrate_eye_detect_default_off(db=None):
             # default changes scoring/KEEP/REJECT decisions, but
             # ``compute_group_fingerprint`` only reads encounter/burst
             # settings — so without invalidation the Process page keeps
-            # reporting the prior cache as fresh. When the global default is
-            # flipping, every workspace without an explicit False override
-            # was relying on the True default; clear their fingerprints so
-            # the plan reports Group & Score as needing to re-run.
-            if global_was_true:
+            # reporting the prior cache as fresh. Any global state other than
+            # explicit ``False`` means workspaces without their own explicit
+            # ``False`` override were scoring with eye detection on (either
+            # via an explicit ``True`` global or the old ``True`` DEFAULTS
+            # value); clear their fingerprints so the plan reports Group &
+            # Score as needing to re-run.
+            if not global_was_explicit_false:
                 db.invalidate_group_fingerprints_without_explicit_eye_false()
         applied.append(MIGRATION_EYE_DETECT_DEFAULT_OFF)
         raw["_migrations_applied"] = applied

--- a/vireo/config.py
+++ b/vireo/config.py
@@ -425,13 +425,28 @@ def migrate_eye_detect_default_off(db=None):
             return False
         rewrote = False
         pipeline = raw.get("pipeline")
-        if isinstance(pipeline, dict) and pipeline.get("eye_detect_enabled") is True:
+        global_was_true = (
+            isinstance(pipeline, dict) and pipeline.get("eye_detect_enabled") is True
+        )
+        if global_was_true:
             pipeline["eye_detect_enabled"] = False
             rewrote = True
         if db is not None:
             ws_rewrites = db.rewrite_legacy_eye_detect_default_in_workspaces()
             if ws_rewrites:
                 rewrote = True
+            # A workspace's cached ``pipeline_results_ws*.json`` and stamped
+            # ``last_group_fingerprint`` were produced with whatever
+            # ``eye_detect_enabled`` was effective at the time. Flipping the
+            # default changes scoring/KEEP/REJECT decisions, but
+            # ``compute_group_fingerprint`` only reads encounter/burst
+            # settings — so without invalidation the Process page keeps
+            # reporting the prior cache as fresh. When the global default is
+            # flipping, every workspace without an explicit False override
+            # was relying on the True default; clear their fingerprints so
+            # the plan reports Group & Score as needing to re-run.
+            if global_was_true:
+                db.invalidate_group_fingerprints_without_explicit_eye_false()
         applied.append(MIGRATION_EYE_DETECT_DEFAULT_OFF)
         raw["_migrations_applied"] = applied
         save(raw)

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -14982,12 +14982,13 @@ class Database:
             if not has_explicit_false:
                 to_invalidate.append(row["id"])
         if to_invalidate:
-            placeholders = ",".join("?" * len(to_invalidate))
-            self.conn.execute(
-                f"UPDATE workspaces SET last_group_fingerprint = NULL "
-                f"WHERE id IN ({placeholders})",
-                to_invalidate,
-            )
+            for chunk in _chunks(to_invalidate):
+                placeholders = ",".join("?" * len(chunk))
+                self.conn.execute(
+                    f"UPDATE workspaces SET last_group_fingerprint = NULL "
+                    f"WHERE id IN ({placeholders})",
+                    list(chunk),
+                )
             self.conn.commit()
         return len(to_invalidate)
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -14913,7 +14913,13 @@ class Database:
         return updated
 
     def rewrite_legacy_eye_detect_default_in_workspaces(self):
-        """Rewrite the exact legacy eye-detection default in workspace overrides."""
+        """Rewrite the exact legacy eye-detection default in workspace overrides.
+
+        Also nulls ``last_group_fingerprint`` on any rewritten workspace so the
+        Process page treats its cached KEEP/REJECT decisions as outdated —
+        those results were scored with eye detection on, and the workspace's
+        effective ``eye_detect_enabled`` just changed to False.
+        """
         rows = self.conn.execute(
             "SELECT id, config_overrides FROM workspaces "
             "WHERE config_overrides IS NOT NULL"
@@ -14934,13 +14940,56 @@ class Database:
                 continue
             pipeline["eye_detect_enabled"] = False
             self.conn.execute(
-                "UPDATE workspaces SET config_overrides = ? WHERE id = ?",
+                "UPDATE workspaces "
+                "SET config_overrides = ?, last_group_fingerprint = NULL "
+                "WHERE id = ?",
                 (json.dumps(overrides), row["id"]),
             )
             updated += 1
         if updated:
             self.conn.commit()
         return updated
+
+    def invalidate_group_fingerprints_without_explicit_eye_false(self):
+        """Clear last_group_fingerprint on workspaces without an explicit
+        ``pipeline.eye_detect_enabled=False`` override.
+
+        Called from ``migrate_eye_detect_default_off`` when the global
+        default is about to flip from True to False. Workspaces that were
+        relying on the global default were producing eye-enabled scoring;
+        their cached triage must be treated as outdated so the Process page
+        re-runs Group & Score with the new default. Workspaces with an
+        explicit False override were already producing eye-disabled scoring
+        and don't need invalidation.
+        """
+        rows = self.conn.execute(
+            "SELECT id, config_overrides FROM workspaces "
+            "WHERE last_group_fingerprint IS NOT NULL"
+        ).fetchall()
+        to_invalidate = []
+        for row in rows:
+            raw = row["config_overrides"]
+            has_explicit_false = False
+            if raw is not None:
+                try:
+                    overrides = json.loads(raw) if isinstance(raw, str) else raw
+                except (json.JSONDecodeError, TypeError):
+                    overrides = None
+                if isinstance(overrides, dict):
+                    pipeline = overrides.get("pipeline")
+                    if isinstance(pipeline, dict) and pipeline.get("eye_detect_enabled") is False:
+                        has_explicit_false = True
+            if not has_explicit_false:
+                to_invalidate.append(row["id"])
+        if to_invalidate:
+            placeholders = ",".join("?" * len(to_invalidate))
+            self.conn.execute(
+                f"UPDATE workspaces SET last_group_fingerprint = NULL "
+                f"WHERE id IN ({placeholders})",
+                to_invalidate,
+            )
+            self.conn.commit()
+        return len(to_invalidate)
 
     # ------ iNaturalist submissions ------
 

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -14912,6 +14912,36 @@ class Database:
             self.conn.commit()
         return updated
 
+    def rewrite_legacy_eye_detect_default_in_workspaces(self):
+        """Rewrite the exact legacy eye-detection default in workspace overrides."""
+        rows = self.conn.execute(
+            "SELECT id, config_overrides FROM workspaces "
+            "WHERE config_overrides IS NOT NULL"
+        ).fetchall()
+        updated = 0
+        for row in rows:
+            raw = row["config_overrides"]
+            try:
+                overrides = json.loads(raw) if isinstance(raw, str) else raw
+            except (json.JSONDecodeError, TypeError):
+                continue
+            if not isinstance(overrides, dict):
+                continue
+            pipeline = overrides.get("pipeline")
+            if not isinstance(pipeline, dict):
+                continue
+            if pipeline.get("eye_detect_enabled") is not True:
+                continue
+            pipeline["eye_detect_enabled"] = False
+            self.conn.execute(
+                "UPDATE workspaces SET config_overrides = ? WHERE id = ?",
+                (json.dumps(overrides), row["id"]),
+            )
+            updated += 1
+        if updated:
+            self.conn.commit()
+        return updated
+
     # ------ iNaturalist submissions ------
 
     def record_inat_submission(self, photo_id, observation_id, observation_url):

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -1321,9 +1321,9 @@ def compute_review_readiness(db, mask_threshold=0.25, dinov2_variant=None):
     # lying this PR set out to fix. Mirrors how pipeline_job.py:3064-3066
     # reads the same key off the pipeline sub-dict before invoking the
     # eye stage.
-    eye_conf_gate = db.get_effective_config(cfg.load()).get(
-        "pipeline", {}
-    ).get("eye_classifier_conf_gate", 0.5)
+    pipeline_cfg = db.get_effective_config(cfg.load()).get("pipeline", {})
+    eye_conf_gate = pipeline_cfg.get("eye_classifier_conf_gate", 0.5)
+    eye_detect_enabled = bool(pipeline_cfg.get("eye_detect_enabled", False))
     eye_target = (
         db.count_eye_keypoint_attemptable(eye_conf_gate) if total else 0
     )
@@ -1364,7 +1364,15 @@ def compute_review_readiness(db, mask_threshold=0.25, dinov2_variant=None):
         out["enhancing_missing"].append("masks_partial")
     if usable_embeddings < feature_target:
         out["enhancing_missing"].append("embeddings")
-    if eye_attempts < eye_target:
+    # Only surface an eye-keypoint gap when the workspace has eye detection
+    # turned on. With the new default off, an eye-disabled workspace's
+    # Process flow deliberately skips the stage, so warning that results
+    # were "computed without eye keypoints and should re-run" would tell
+    # the user their run is degraded because of a feature they chose not
+    # to use — the exact kind of misleading readiness signal
+    # CORE_PHILOSOPHY.md's "no black boxes" rule forbids. Regression for
+    # Codex thread PRRT_kwDORn8c-s6QOH4L.
+    if eye_detect_enabled and eye_attempts < eye_target:
         out["enhancing_missing"].append("eye_keypoints")
     if cov["classified"] < feature_target:
         out["enhancing_missing"].append("species_predictions")

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -1476,7 +1476,7 @@ def eye_keypoint_stage_preflight(config):
     start (mirroring SAM2/DINOv2), so a missing-weights state is no longer
     a preflight skip — only the explicit config flag is.
     """
-    if not config.get("eye_detect_enabled", True):
+    if not config.get("eye_detect_enabled", False):
         return "Disabled in config"
     return None
 
@@ -1658,7 +1658,7 @@ def detect_eye_keypoints_stage(
     Args:
         db: Database with an active workspace.
         config: dict of tunables. Reads:
-            - eye_detect_enabled (bool, default True)
+            - eye_detect_enabled (bool, default False)
             - eye_classifier_conf_gate (float, default 0.5)
             - eye_detection_conf_gate (float, default 0.5)
             - eye_window_k (float, default 0.08)

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -5120,7 +5120,19 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 thread_db.set_active_workspace(workspace_id)
 
                 effective_cfg = thread_db.get_effective_config(cfg.load())
-                pipeline_cfg = effective_cfg.get("pipeline", {})
+                pipeline_cfg = dict(effective_cfg.get("pipeline", {}))
+
+                # Mirror the eye_keypoints_stage per-run override: when the
+                # caller opted in via skip_eye_keypoints=False (Process-page
+                # checkbox or API), carry that intent into scoring too.
+                # Without this, run_full_pipeline reloads the workspace
+                # config with eye_detect_enabled=False (the new default) and
+                # score_encounter ignores the eye_tenengrad values the eye
+                # stage just wrote, so the visible checkbox affects only the
+                # expensive keypoint pass — not the culling result the user
+                # actually sees.
+                if not params.skip_eye_keypoints:
+                    pipeline_cfg["eye_detect_enabled"] = True
 
                 photos = load_photo_features(thread_db, collection_id=collection_id, config=effective_cfg)
                 if params.exclude_photo_ids:

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -127,6 +127,17 @@ class PipelineParams:
     review_mode: str | None = None
     skip_classify: bool = False
     skip_eye_keypoints: bool = False
+    # Per-run override for the config-gated eye-detect setting. Semantics
+    # match miss_enabled: None defers to the workspace-effective
+    # ``pipeline.eye_detect_enabled``, a bool wins over workspace config in
+    # both directions. Set to True by the Process page when the user
+    # explicitly checks the Eye Keypoints stage box — that box is a
+    # per-run opt-in that must override the (default-off) Settings value
+    # so preflight and scoring see the enabled state. Left None by
+    # strategy expansion (``process_strategies.resolve_strategy``) so a
+    # ``full`` strategy chain from after-import respects the user's
+    # Settings default instead of silently forcing eye detection on.
+    eye_detect_override: bool | None = None
     # Per-run override for the config-gated misses stage. None defers to the
     # workspace-effective ``pipeline.miss_enabled`` (today's behavior); a
     # bool wins over workspace config in BOTH directions, mirroring how the
@@ -4780,13 +4791,19 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 effective_cfg = thread_db.get_effective_config(cfg.load())
                 pipeline_cfg = dict(effective_cfg.get("pipeline", {}))
 
-                # Reaching this branch means the caller did not set
-                # skip_eye_keypoints=True (checked above) — i.e. the Process
-                # page checkbox is on or an API caller explicitly opted in.
-                # Treat that per-run intent as an override of the Settings
-                # default so the preflight and stage function honor it even
-                # when the workspace/global config has eye_detect_enabled off.
-                pipeline_cfg["eye_detect_enabled"] = True
+                # Apply the per-run eye-detect override only when the caller
+                # sent an explicit signal. ``skip_eye_keypoints=False`` alone
+                # is not proof of opt-in: ``resolve_strategy('full')`` sets it
+                # to False as a base default, so an after-import ``full``
+                # chain would otherwise force ``eye_detect_enabled=True``
+                # against a workspace whose Settings default is False (the
+                # new default) — triggering SuperAnimal downloads and eye-
+                # based scoring by default. ``eye_detect_override`` is the
+                # explicit signal the Process page sends alongside its
+                # checkbox state; strategy expansion leaves it None, so a
+                # chained ``full`` run respects the user's Settings value.
+                if params.eye_detect_override is not None:
+                    pipeline_cfg["eye_detect_enabled"] = params.eye_detect_override
 
                 # Mirror the stage-level preflight so a no-op run doesn't pay the
                 # O(N) eligibility join cost or report a misleading
@@ -5122,17 +5139,21 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 effective_cfg = thread_db.get_effective_config(cfg.load())
                 pipeline_cfg = dict(effective_cfg.get("pipeline", {}))
 
-                # Mirror the eye_keypoints_stage per-run override: when the
-                # caller opted in via skip_eye_keypoints=False (Process-page
-                # checkbox or API), carry that intent into scoring too.
-                # Without this, run_full_pipeline reloads the workspace
-                # config with eye_detect_enabled=False (the new default) and
-                # score_encounter ignores the eye_tenengrad values the eye
-                # stage just wrote, so the visible checkbox affects only the
-                # expensive keypoint pass — not the culling result the user
-                # actually sees.
-                if not params.skip_eye_keypoints:
-                    pipeline_cfg["eye_detect_enabled"] = True
+                # Mirror the eye_keypoints_stage per-run override so scoring
+                # honors the same explicit intent. Without carrying the
+                # override into pipeline_cfg here, ``run_full_pipeline``
+                # reloads workspace config with ``eye_detect_enabled=False``
+                # (the new default) and ``score_encounter`` ignores the
+                # ``eye_tenengrad`` values the eye stage just wrote — so the
+                # visible checkbox would affect only the expensive keypoint
+                # pass, not the culling result the user actually sees.
+                # Gated on ``eye_detect_override`` (an explicit per-run
+                # signal), NOT on ``not skip_eye_keypoints``, because the
+                # latter is False by default in ``resolve_strategy('full')``
+                # too — using it would force eye scoring on for any chained
+                # ``full`` run regardless of workspace Settings.
+                if params.eye_detect_override is not None:
+                    pipeline_cfg["eye_detect_enabled"] = params.eye_detect_override
 
                 photos = load_photo_features(thread_db, collection_id=collection_id, config=effective_cfg)
                 if params.exclude_photo_ids:

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -5198,9 +5198,30 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             (workspace_id,),
                         ).fetchall()
                     }
+                    # A per-run eye override that differs from the
+                    # workspace's own effective ``eye_detect_enabled`` means
+                    # this run's KEEP/REJECT decisions came from scoring
+                    # settings the workspace's normal state wouldn't produce.
+                    # ``compute_group_fingerprint`` reads only encounter/burst
+                    # keys — not ``eye_detect_enabled`` — so stamping it here
+                    # would mark eye-scored (or eye-disabled) results as
+                    # settings-fresh for a later plan run against the
+                    # workspace's real settings. Treat that as a partial run
+                    # so ``pipeline_plan`` reports the cache as needing to
+                    # re-run instead of hiding the mismatch.
+                    workspace_eye_setting = bool(
+                        effective_cfg.get("pipeline", {}).get(
+                            "eye_detect_enabled", False,
+                        )
+                    )
+                    per_run_eye_override_differs = (
+                        params.eye_detect_override is not None
+                        and bool(params.eye_detect_override) != workspace_eye_setting
+                    )
                     covered_full_workspace = (
                         not params.exclude_photo_ids
                         and ws_photo_ids.issubset(collection_photo_ids)
+                        and not per_run_eye_override_differs
                     )
                     if covered_full_workspace:
                         thread_db.set_workspace_group_state(

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -4778,7 +4778,15 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 thread_db = Database(db_path)
                 thread_db.set_active_workspace(workspace_id)
                 effective_cfg = thread_db.get_effective_config(cfg.load())
-                pipeline_cfg = effective_cfg.get("pipeline", {})
+                pipeline_cfg = dict(effective_cfg.get("pipeline", {}))
+
+                # Reaching this branch means the caller did not set
+                # skip_eye_keypoints=True (checked above) — i.e. the Process
+                # page checkbox is on or an API caller explicitly opted in.
+                # Treat that per-run intent as an override of the Settings
+                # default so the preflight and stage function honor it even
+                # when the workspace/global config has eye_detect_enabled off.
+                pipeline_cfg["eye_detect_enabled"] = True
 
                 # Mirror the stage-level preflight so a no-op run doesn't pay the
                 # O(N) eligibility join cost or report a misleading

--- a/vireo/pipeline_plan.py
+++ b/vireo/pipeline_plan.py
@@ -32,6 +32,14 @@ class PipelinePlanParams:
     skip_extract_masks: bool = False
     skip_eye_keypoints: bool = False
     skip_regroup: bool = False
+    # Per-run override for the config-gated eye-detect setting. Mirrors
+    # ``PipelineParams.eye_detect_override``: None defers to the workspace-
+    # effective ``pipeline.eye_detect_enabled``; a bool wins in both
+    # directions. The Process page sends this alongside the Eye Keypoints
+    # checkbox state so the plan pill is honest — without it, an opt-in
+    # against a default-off workspace would still show
+    # "Will skip — Disabled in config" even though the actual job would run.
+    eye_detect_override: bool | None = None
     model_ids: list = field(default_factory=list)
     labels_files: list = field(default_factory=list)
     reclassify: bool = False
@@ -648,6 +656,16 @@ def _eye_keypoints_plan(db, params, photo_ids, pipeline_cfg, new_count=0):
         }
     from pipeline import eye_keypoint_stage_preflight
 
+    # Mirror ``pipeline_job``'s per-run override so the plan pill matches
+    # what the job would do: without this, a Process-page opt-in against
+    # a default-off workspace would still render "Will skip — Disabled in
+    # config" here even though the actual run would toggle the config on
+    # and execute the stage.
+    if params.eye_detect_override is not None:
+        pipeline_cfg = {
+            **pipeline_cfg,
+            "eye_detect_enabled": params.eye_detect_override,
+        }
     skip_reason = eye_keypoint_stage_preflight(pipeline_cfg)
     if skip_reason is not None:
         return {

--- a/vireo/pipeline_plan.py
+++ b/vireo/pipeline_plan.py
@@ -1044,6 +1044,39 @@ def _regroup_plan(db, params, db_path, ws_id, upstream_will_run, effective_cfg,
                     "fingerprint_outdated": True,
                 },
             }
+        # A per-run ``eye_detect_override`` that differs from the
+        # workspace's own effective ``eye_detect_enabled`` will cause
+        # regroup_stage to rescore with different eye behavior than the
+        # cached results. ``compute_group_fingerprint`` reads only
+        # encounter/burst keys — not ``eye_detect_enabled`` — so the
+        # fingerprint check above cannot see the mismatch. Without this
+        # signal, a default-off workspace with an existing default-off
+        # grouping cache would still show Group as ``done-prior`` after
+        # the Process-page Eye Keypoints checkbox toggles the override,
+        # even though the job would actually rescore with eye focus on.
+        # Mirror the freshness-stamp check in ``regroup_stage`` and
+        # surface will-run when the per-run intent disagrees with
+        # Settings.
+        workspace_eye_setting = bool(
+            (effective_cfg or {}).get("pipeline", {}).get(
+                "eye_detect_enabled", False,
+            )
+        )
+        if (
+            params.eye_detect_override is not None
+            and bool(params.eye_detect_override) != workspace_eye_setting
+        ):
+            return {
+                "state": "will-run",
+                "summary": (
+                    "Will re-group — eye focus setting differs for this run"
+                ),
+                "detail": {
+                    "cache_exists": True,
+                    "upstream_will_run": False,
+                    "eye_override_differs": True,
+                },
+            }
         return {
             "state": "done-prior",
             "summary": "Grouping cached from prior run",

--- a/vireo/scoring.py
+++ b/vireo/scoring.py
@@ -341,7 +341,7 @@ def score_encounter(encounter, config=None):
     # peers' eye_tenengrad. Skipped entirely when eye detection is
     # disabled so stale eye_tenengrad values from prior runs don't
     # influence scoring after the user turns the feature off.
-    eye_enabled = cfg.get("eye_detect_enabled", True)
+    eye_enabled = cfg.get("eye_detect_enabled", False)
     enc_eye_tenegrads = [
         p["eye_tenengrad"] for p in photos
         if p.get("eye_tenengrad") is not None

--- a/vireo/scoring.py
+++ b/vireo/scoring.py
@@ -310,6 +310,31 @@ def hard_reject_reasons(photo, q_score, config=None):
     return reasons
 
 
+def _normalize_scoring_config(config):
+    """Merge nested pipeline settings up so callers can pass either shape.
+
+    Two shapes reach scoring today:
+
+    * A flat pipeline config, e.g. ``effective_cfg["pipeline"]`` — the
+      shape ``pipeline_job``'s regroup stage and the test suite pass.
+    * A full effective config with pipeline keys nested under
+      ``config["pipeline"]`` — the shape ``_build_best_batch_response`` and
+      the browse-selection batch review path pass.
+
+    Without this normalization, the second shape silently reads pipeline
+    keys as absent and falls back to DEFAULTS/False. The most visible
+    breakage after defaulting ``eye_detect_enabled`` to False is that
+    scoring ignores ``eye_tenengrad`` on those paths even in workspaces
+    where the user has enabled eye detection in Settings.
+    """
+    if not config:
+        return {}
+    nested = config.get("pipeline")
+    if isinstance(nested, dict):
+        return {**config, **nested}
+    return config
+
+
 def score_encounter(encounter, config=None):
     """Score all photos in an encounter and apply hard reject rules.
 
@@ -326,7 +351,7 @@ def score_encounter(encounter, config=None):
     Returns:
         encounter dict (modified in place)
     """
-    cfg = {**DEFAULTS, **(config or {})}
+    cfg = {**DEFAULTS, **_normalize_scoring_config(config)}
     photos = encounter["photos"]
 
     # Compute per-encounter normalization data

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -5604,9 +5604,9 @@ function _lbPersistBool(key, value) {
   try { localStorage.setItem(key, value ? '1' : '0'); } catch (e) {}
 }
 
-var _lbBoxesVisible = _lbStoredBool('vireo.lb.boxesVisible', true);
+var _lbBoxesVisible = _lbStoredBool('vireo.lb.boxesVisible', false);
 var _lbMasksVisible = _lbStoredBool('vireo.lb.masksVisible', false);
-var _lbEyeVisible = _lbStoredBool('vireo.lb.eyeVisible', true);
+var _lbEyeVisible = _lbStoredBool('vireo.lb.eyeVisible', false);
 var _lbInfoVisible = _lbStoredBool('vireo.lb.infoVisible', true);
 var _lbChromeVisible = _lbStoredBool('vireo.lb.chromeVisible', true);
 

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -2178,6 +2178,14 @@ async function startPipeline() {
   body.skip_eye_keypoints = !eyeKeypointsEnabled;
   body.skip_regroup = !groupEnabled;
 
+  // Explicit per-run signal: the Eye Keypoints checkbox is the user's
+  // opt-in for this run. Send it as ``eye_detect_override`` so the backend
+  // can force ``pipeline_cfg["eye_detect_enabled"]`` accordingly — needed
+  // because the default Settings value is off, and reaching the stage with
+  // ``skip_eye_keypoints=false`` alone (which is also the ``full`` strategy
+  // default) is not proof of user intent.
+  body.eye_detect_override = !!eyeKeypointsEnabled;
+
   // Classification options (only if enabled)
   if (classifyEnabled) {
     var selectedModels = [];
@@ -4069,6 +4077,12 @@ function _buildPlanBody() {
   body.skip_extract_masks  = !document.getElementById('enableExtract').checked;
   body.skip_eye_keypoints  = !document.getElementById('enableEyeKeypoints').checked;
   body.skip_regroup        = !document.getElementById('enableGroup').checked;
+
+  // Mirror startPipeline: send the checkbox state as ``eye_detect_override``
+  // so the plan pill matches what the job would actually do — otherwise
+  // opting in on a default-off workspace still renders "Will skip —
+  // Disabled in config".
+  body.eye_detect_override = !!document.getElementById('enableEyeKeypoints').checked;
 
   // Mirror the strategy field startPipeline() sends so /api/pipeline/plan
   // expands the preset with the same rules /api/jobs/pipeline does. The

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -847,7 +847,7 @@ body { padding-bottom: 36px; }
   <div class="stage-card" id="card-eyekeypoints" data-testid="stage-card" data-advanced-stage>
     <div class="stage-header" onclick="toggleCard('eyekeypoints')">
       <span class="stage-num" id="numEyeKeypoints">6</span>
-      <input type="checkbox" class="stage-enable" id="enableEyeKeypoints" checked
+      <input type="checkbox" class="stage-enable" id="enableEyeKeypoints"
              onchange="onStageToggle('eyekeypoints')" onclick="event.stopPropagation()">
       <span class="stage-name">Eye Keypoints (optional)</span>
       <span class="stage-status-pill" id="pillEyeKeypoints"></span>
@@ -1027,15 +1027,16 @@ function initPipelinePage() {
       }
 
       // Eye keypoints stage default tracks the global eye_detect_enabled
-      // config so users who turned it off in Settings see it unchecked here
-      // by default. The checkbox is the per-run override.
+      // config. Missing config defaults off; the checkbox is the per-run
+      // override.
       var ekCb = document.getElementById('enableEyeKeypoints');
-      if (ekCb) ekCb.checked = cfg.eye_detect_enabled !== false;
+      if (ekCb) ekCb.checked = cfg.eye_detect_enabled === true;
 
       // Update saved config defaults from server
       _savedModelConfig.sam2_variant = cfg.sam2_variant;
       _savedModelConfig.dinov2_variant = cfg.dinov2_variant;
       _savedModelConfig.proxy_longest_edge = cfg.proxy_longest_edge;
+      _savedModelConfig.eye_detect_enabled = cfg.eye_detect_enabled === true;
 
       updateCardStates();
       if (typeof updateReadiness === 'function') updateReadiness();
@@ -1397,7 +1398,12 @@ function applyStrategyPreset() {
   if (!sel || sel.value === '__custom__') { refreshPipelineUI(); return; }
   var presets = {
     identify:   { classify: true,  extract: false, eyes: false, group: false },
-    full:       { classify: true,  extract: true,  eyes: true,  group: true  },
+    full:       {
+      classify: true,
+      extract: true,
+      eyes: _savedModelConfig.eye_detect_enabled === true,
+      group: true
+    },
     cull_ready: { classify: true,  extract: false, eyes: false, group: true  },
     quick_look: { classify: false, extract: false, eyes: false, group: false },
   };
@@ -3424,6 +3430,7 @@ function _currentModelConfigFromDom() {
     sam2_variant: samEl ? samEl.value : '',
     dinov2_variant: dinoEl ? dinoEl.value : '',
     proxy_longest_edge: proxyEl ? parseInt(proxyEl.value, 10) : 0,
+    eye_detect_enabled: false,
   };
 }
 
@@ -3455,6 +3462,7 @@ function onModelConfigChange() {
     sam2_variant: document.getElementById('cfgSam2').value,
     dinov2_variant: document.getElementById('cfgDinov2').value,
     proxy_longest_edge: parseInt(document.getElementById('cfgProxy').value),
+    eye_detect_enabled: _savedModelConfig.eye_detect_enabled === true,
   };
 
   // Save to server

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -2178,13 +2178,19 @@ async function startPipeline() {
   body.skip_eye_keypoints = !eyeKeypointsEnabled;
   body.skip_regroup = !groupEnabled;
 
-  // Explicit per-run signal: the Eye Keypoints checkbox is the user's
-  // opt-in for this run. Send it as ``eye_detect_override`` so the backend
-  // can force ``pipeline_cfg["eye_detect_enabled"]`` accordingly — needed
-  // because the default Settings value is off, and reaching the stage with
-  // ``skip_eye_keypoints=false`` alone (which is also the ``full`` strategy
-  // default) is not proof of user intent.
-  body.eye_detect_override = !!eyeKeypointsEnabled;
+  // Only send ``eye_detect_override`` when the checkbox is CHECKED — an
+  // explicit per-run opt-in that forces ``pipeline_cfg["eye_detect_enabled"]``
+  // on for the run. An unchecked box is not an explicit eye-scoring
+  // opt-out: on a workspace with Settings ``eye_detect_enabled=true``, the
+  // user may simply want to skip the (expensive) stage while still scoring
+  // against existing ``eye_tenengrad``. Sending ``false`` here would
+  // silently disable eye-based scoring on such workspaces and produce
+  // different KEEP/REJECT results than the same server-side strategy /
+  // API path would (which leaves the override ``None``). When unset, the
+  // backend falls back to workspace Settings.
+  if (eyeKeypointsEnabled) {
+    body.eye_detect_override = true;
+  }
 
   // Classification options (only if enabled)
   if (classifyEnabled) {
@@ -4078,11 +4084,17 @@ function _buildPlanBody() {
   body.skip_eye_keypoints  = !document.getElementById('enableEyeKeypoints').checked;
   body.skip_regroup        = !document.getElementById('enableGroup').checked;
 
-  // Mirror startPipeline: send the checkbox state as ``eye_detect_override``
-  // so the plan pill matches what the job would actually do — otherwise
-  // opting in on a default-off workspace still renders "Will skip —
-  // Disabled in config".
-  body.eye_detect_override = !!document.getElementById('enableEyeKeypoints').checked;
+  // Mirror startPipeline: only send ``eye_detect_override`` when the
+  // checkbox is CHECKED. An unchecked box means "skip the eye stage"
+  // and does NOT imply "disable eye scoring" — on a workspace with
+  // Settings ``eye_detect_enabled=true`` the plan must still reflect
+  // Settings for regroup, otherwise the plan would show a different
+  // outcome (e.g. no ``eye_override_differs``) than the workspace would
+  // produce via any non-Process-page path. Sending ``false`` here
+  // caused the plan to silently disable eye scoring on such workspaces.
+  if (document.getElementById('enableEyeKeypoints').checked) {
+    body.eye_detect_override = true;
+  }
 
   // Mirror the strategy field startPipeline() sends so /api/pipeline/plan
   // expands the preset with the same rules /api/jobs/pipeline does. The

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -816,6 +816,7 @@ var availableModels = [];
 var collectionPhotoIds = null;  // null = no filter
 var thumbSize = 400;
 var mode = 'review';
+var reviewDetectionBoxesVisible = false;
 
 /* Species color palette for bounding boxes */
 var _speciesColors = {};
@@ -1125,7 +1126,7 @@ document.addEventListener('lightbox:renderchanged', function(e) {
       window.vireoPhotoHasOrientationEdit(id)
     );
     document.querySelectorAll('.detection-box[data-photo-id="' + id + '"]').forEach(function(box) {
-      box.style.display = hideDetectionOverlay ? 'none' : '';
+      box.style.display = (reviewDetectionBoxesVisible && !hideDetectionOverlay) ? '' : 'none';
     });
   });
 });
@@ -1307,7 +1308,7 @@ function renderPredictionCard(pred) {
     var bHeight = (pred.box_h * 100).toFixed(2) + '%';
     imgHtml = '<div class="card-img-wrap">' + imgTag +
       representativeBadge +
-      '<div class="detection-box" data-photo-id="' + pred.photo_id + '" style="' + (hideDetectionOverlay ? 'display:none;' : '') + 'left:' + bLeft + ';top:' + bTop +
+      '<div class="detection-box" data-photo-id="' + pred.photo_id + '" style="' + ((reviewDetectionBoxesVisible && !hideDetectionOverlay) ? '' : 'display:none;') + 'left:' + bLeft + ';top:' + bTop +
       ';width:' + bWidth + ';height:' + bHeight + ';border-color:' + color + ';">' +
       '<span class="detection-label" style="background:' + color +
       ';color:#0A1F2E;">' + escapeHtml(displaySpecies) + ' ' + confPct + '%</span>' +

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -776,6 +776,10 @@
       <option value="date_desc">Date (newest)</option>
     </select>
     <button class="btn-batch-accept" id="acceptAllBtn" onclick="acceptAllPending()" style="display:none;">Accept All</button>
+    <button type="button" class="model-selector" id="toggleDetectionBoxesBtn"
+            onclick="toggleReviewDetectionBoxes()"
+            title="Toggle bounding-box overlays on review cards"
+            style="margin-left:12px;cursor:pointer;">Show Boxes</button>
     <label style="display:flex;align-items:center;gap:6px;font-size:12px;color:var(--text-muted,#888);margin-left:12px;">
       Min confidence:
       <input type="range" id="confFilter" min="0" max="90" step="5" value="0"
@@ -816,7 +820,46 @@ var availableModels = [];
 var collectionPhotoIds = null;  // null = no filter
 var thumbSize = 400;
 var mode = 'review';
-var reviewDetectionBoxesVisible = false;
+
+function _reviewStoredBool(key, fallback) {
+  try {
+    var value = localStorage.getItem(key);
+    if (value === '0') return false;
+    if (value === '1') return true;
+  } catch (e) {}
+  return fallback;
+}
+function _reviewPersistBool(key, value) {
+  try { localStorage.setItem(key, value ? '1' : '0'); } catch (e) {}
+}
+var REVIEW_BOXES_STORAGE_KEY = 'vireo.review.detectionBoxesVisible';
+var reviewDetectionBoxesVisible = _reviewStoredBool(REVIEW_BOXES_STORAGE_KEY, false);
+
+function _syncReviewDetectionBoxesBtn() {
+  var btn = document.getElementById('toggleDetectionBoxesBtn');
+  if (btn) btn.textContent = reviewDetectionBoxesVisible ? 'Hide Boxes' : 'Show Boxes';
+}
+
+function _syncReviewDetectionBoxes() {
+  document.querySelectorAll('.detection-box').forEach(function(box) {
+    var pid = parseInt(box.getAttribute('data-photo-id'), 10);
+    var hideDetectionOverlay = (
+      typeof window.vireoPhotoHasOrientationEdit === 'function' &&
+      !isNaN(pid) &&
+      window.vireoPhotoHasOrientationEdit(pid)
+    );
+    box.style.display = (reviewDetectionBoxesVisible && !hideDetectionOverlay) ? '' : 'none';
+  });
+}
+
+function toggleReviewDetectionBoxes() {
+  reviewDetectionBoxesVisible = !reviewDetectionBoxesVisible;
+  _reviewPersistBool(REVIEW_BOXES_STORAGE_KEY, reviewDetectionBoxesVisible);
+  _syncReviewDetectionBoxesBtn();
+  _syncReviewDetectionBoxes();
+}
+
+document.addEventListener('DOMContentLoaded', _syncReviewDetectionBoxesBtn);
 
 /* Species color palette for bounding boxes */
 var _speciesColors = {};

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -598,7 +598,7 @@
           <small>Runs the SuperAnimal keypoint stage to localize the animal's eye and use a windowed sharpness around it for the focus score. Weights are opt-in on the Process page.</small>
         </div>
         <div style="display:flex;align-items:center;gap:8px;">
-          <input type="checkbox" id="cfgEyeDetectEnabled" checked
+          <input type="checkbox" id="cfgEyeDetectEnabled"
                  onchange="saveConfig()" style="accent-color:var(--accent);">
         </div>
       </div>
@@ -1830,7 +1830,7 @@ async function loadConfig() {
 
     // Eye-focus detection tunables
     document.getElementById('cfgEyeDetectEnabled').checked =
-      p.eye_detect_enabled !== false;  // default true
+      p.eye_detect_enabled === true;  // default false
     var ecg = VireoPipelineConfig.percent(p.eye_classifier_conf_gate, 'eye_classifier_conf_gate');
     document.getElementById('cfgEyeClassifierConfGate').value = ecg;
     document.getElementById('cfgEyeClassifierConfGateVal').textContent = ecg + '%';
@@ -2082,7 +2082,7 @@ function resetPipelineDefaults() {
   document.getElementById('cfgEyeWindowK').value = eyeWindow;
   document.getElementById('cfgEyeWindowKVal').textContent =
     (eyeWindow / 100).toFixed(2);
-  document.getElementById('cfgEyeDetectEnabled').checked = p.eye_detect_enabled !== false;
+  document.getElementById('cfgEyeDetectEnabled').checked = p.eye_detect_enabled === true;
   document.getElementById('cfgMissEnabled').checked = p.miss_enabled !== false;
   setPercent('cfgMissDetConf', 'miss_det_confidence');
   var bboxMin = Math.round(

--- a/vireo/tests/test_config.py
+++ b/vireo/tests/test_config.py
@@ -990,6 +990,50 @@ def test_migrate_eye_detect_default_off_preserves_explicit_workspace_opt_ins(
     )
 
 
+def test_migrate_eye_detect_default_off_chunks_workspace_invalidation(
+    tmp_path, monkeypatch,
+):
+    """When more workspaces need their fingerprint cleared than SQLite's
+    bound-parameter limit, the invalidation UPDATE must be chunked. A
+    single ``UPDATE ... WHERE id IN (?, ?, ...)`` with a placeholder per
+    workspace raises ``OperationalError: too many SQL variables`` on
+    legacy 999-variable SQLite builds and would prevent the app from
+    starting (the migration runs during ``create_app``). Regression for
+    Codex thread PRRT_kwDORn8c-s6QODfD.
+    """
+    import config as cfg
+    from db import _SQLITE_PARAM_CHUNK_SIZE, Database
+
+    config_path = tmp_path / "config.json"
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(config_path))
+    config_path.write_text(
+        json.dumps({"pipeline": {"eye_detect_enabled": True}})
+    )
+    db = Database(str(tmp_path / "test.db"), initialize_schema=True)
+    # Create more workspaces than the chunk size so a naive single-IN
+    # UPDATE would need >_SQLITE_PARAM_CHUNK_SIZE placeholders. Each must
+    # be marked as having a stamped fingerprint so they enter the
+    # invalidation set.
+    count = _SQLITE_PARAM_CHUNK_SIZE + 25
+    ws_ids = []
+    for i in range(count):
+        ws_id = db.create_workspace(f"ws-{i}")
+        db.set_workspace_group_state(ws_id, f"fp-{i}", "2025-01-01T00:00:00Z")
+        ws_ids.append(ws_id)
+
+    assert cfg.migrate_eye_detect_default_off(db) is True
+
+    rows = db.conn.execute(
+        "SELECT id, last_group_fingerprint FROM workspaces"
+    ).fetchall()
+    fingerprints = {r["id"]: r["last_group_fingerprint"] for r in rows}
+    for ws_id in ws_ids:
+        assert fingerprints[ws_id] is None, (
+            f"workspace {ws_id} was relying on the global True default "
+            f"and must have its fingerprint cleared even at scale"
+        )
+
+
 def test_default_subject_types_includes_taxonomy_individual_genre(tmp_path, monkeypatch):
     """Default subject_types is the set of keyword types that count as
     'identifying' a photo — taxonomy + individual + genre by default."""

--- a/vireo/tests/test_config.py
+++ b/vireo/tests/test_config.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sys
 
@@ -300,7 +301,7 @@ def test_eye_focus_defaults_exist():
     from config import DEFAULTS
 
     p = DEFAULTS["pipeline"]
-    assert p["eye_detect_enabled"] is True
+    assert p["eye_detect_enabled"] is False
     assert p["eye_classifier_conf_gate"] == 0.50
     assert p["eye_detection_conf_gate"] == 0.50
     assert p["eye_window_k"] == 0.08
@@ -393,7 +394,10 @@ def test_reject_eye_focus_flows_from_config_to_scoring(tmp_path, monkeypatch):
     import config as cfg
     monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
     with open(cfg.CONFIG_PATH, "w") as f:
-        _json.dump({"pipeline": {"reject_eye_focus": 0.99}}, f)
+        _json.dump(
+            {"pipeline": {"eye_detect_enabled": True, "reject_eye_focus": 0.99}},
+            f,
+        )
 
     from db import Database
     from scoring import score_encounter
@@ -712,6 +716,80 @@ def test_migrate_toggle_ui_h_conflict_no_config_file(tmp_path, monkeypatch):
     assert cfg.migrate_toggle_ui_h_conflict() is False
     raw = _read_raw(cfg.CONFIG_PATH)
     assert cfg.MIGRATION_TOGGLE_UI_H_CONFLICT in raw["_migrations_applied"]
+
+
+def test_migrate_eye_detect_default_off_rewrites_legacy_true(
+    tmp_path, monkeypatch
+):
+    import config as cfg
+
+    config_path = tmp_path / "config.json"
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(config_path))
+    config_path.write_text(
+        json.dumps({"pipeline": {"eye_detect_enabled": True}})
+    )
+
+    assert cfg.migrate_eye_detect_default_off() is True
+    raw = json.loads(config_path.read_text())
+    assert raw["pipeline"]["eye_detect_enabled"] is False
+    assert cfg.MIGRATION_EYE_DETECT_DEFAULT_OFF in raw["_migrations_applied"]
+
+
+def test_migrate_eye_detect_default_off_preserves_false(tmp_path, monkeypatch):
+    import config as cfg
+
+    config_path = tmp_path / "config.json"
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(config_path))
+    config_path.write_text(
+        json.dumps({"pipeline": {"eye_detect_enabled": False}})
+    )
+
+    assert cfg.migrate_eye_detect_default_off() is False
+    raw = json.loads(config_path.read_text())
+    assert raw["pipeline"]["eye_detect_enabled"] is False
+    assert cfg.MIGRATION_EYE_DETECT_DEFAULT_OFF in raw["_migrations_applied"]
+
+
+def test_migrate_eye_detect_default_off_is_one_time(tmp_path, monkeypatch):
+    import config as cfg
+
+    config_path = tmp_path / "config.json"
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(config_path))
+    config_path.write_text(
+        json.dumps({"pipeline": {"eye_detect_enabled": True}})
+    )
+
+    assert cfg.migrate_eye_detect_default_off() is True
+    raw = json.loads(config_path.read_text())
+    raw["pipeline"]["eye_detect_enabled"] = True
+    config_path.write_text(json.dumps(raw))
+
+    assert cfg.migrate_eye_detect_default_off() is False
+    raw = json.loads(config_path.read_text())
+    assert raw["pipeline"]["eye_detect_enabled"] is True
+
+
+def test_migrate_eye_detect_default_off_rewrites_workspace_overrides(
+    tmp_path, monkeypatch
+):
+    import config as cfg
+    from db import Database
+
+    config_path = tmp_path / "config.json"
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(config_path))
+    config_path.write_text("{}")
+    db = Database(str(tmp_path / "test.db"), initialize_schema=True)
+    db.create_workspace(
+        "legacy",
+        config_overrides={"pipeline": {"eye_detect_enabled": True}},
+    )
+
+    assert cfg.migrate_eye_detect_default_off(db) is True
+    rows = db.conn.execute(
+        "SELECT config_overrides FROM workspaces WHERE name = 'legacy'"
+    ).fetchall()
+    overrides = json.loads(rows[0]["config_overrides"])
+    assert overrides["pipeline"]["eye_detect_enabled"] is False
 
 
 def test_default_subject_types_includes_taxonomy_individual_genre(tmp_path, monkeypatch):

--- a/vireo/tests/test_config.py
+++ b/vireo/tests/test_config.py
@@ -792,6 +792,124 @@ def test_migrate_eye_detect_default_off_rewrites_workspace_overrides(
     assert overrides["pipeline"]["eye_detect_enabled"] is False
 
 
+def test_migrate_eye_detect_default_off_invalidates_workspace_group_fingerprint(
+    tmp_path, monkeypatch,
+):
+    """A workspace override rewritten from True to False was previously
+    scoring with eye detection on. Its cached
+    ``pipeline_results_ws*.json`` reflects those KEEP/REJECT decisions,
+    but ``compute_group_fingerprint`` only reads encounter/burst settings.
+    The migration must null ``last_group_fingerprint`` on the rewritten
+    workspace so the Process page reports the cache as outdated rather
+    than serving stale eye-enabled scoring after the default flips.
+    """
+    import config as cfg
+    from db import Database
+
+    config_path = tmp_path / "config.json"
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(config_path))
+    config_path.write_text("{}")
+    db = Database(str(tmp_path / "test.db"), initialize_schema=True)
+    ws_id = db.create_workspace(
+        "legacy",
+        config_overrides={"pipeline": {"eye_detect_enabled": True}},
+    )
+    db.set_workspace_group_state(ws_id, "stale-fp", "2025-01-01T00:00:00Z")
+
+    assert cfg.migrate_eye_detect_default_off(db) is True
+
+    row = db.conn.execute(
+        "SELECT last_group_fingerprint FROM workspaces WHERE id = ?", (ws_id,),
+    ).fetchone()
+    assert row["last_group_fingerprint"] is None, (
+        "workspace whose eye_detect_enabled override was rewritten from True "
+        "to False must have its group fingerprint cleared so the plan page "
+        "treats prior eye-enabled scoring as outdated"
+    )
+
+
+def test_migrate_eye_detect_default_off_invalidates_default_relying_workspaces(
+    tmp_path, monkeypatch,
+):
+    """When the global default flips from True to False, workspaces that
+    were relying on the global default (no explicit False override) also
+    had their effective ``eye_detect_enabled`` change. Their cached
+    triage was scored with eye detection on and must be invalidated.
+    Workspaces with an explicit False override were already scoring
+    without eye detection and must keep their fingerprint.
+    """
+    import config as cfg
+    from db import Database
+
+    config_path = tmp_path / "config.json"
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(config_path))
+    config_path.write_text(
+        json.dumps({"pipeline": {"eye_detect_enabled": True}})
+    )
+    db = Database(str(tmp_path / "test.db"), initialize_schema=True)
+    ws_relying_id = db.create_workspace("relying")
+    ws_explicit_false_id = db.create_workspace(
+        "explicit-false",
+        config_overrides={"pipeline": {"eye_detect_enabled": False}},
+    )
+    db.set_workspace_group_state(ws_relying_id, "relying-fp", "2025-01-01T00:00:00Z")
+    db.set_workspace_group_state(
+        ws_explicit_false_id, "explicit-false-fp", "2025-01-01T00:00:00Z",
+    )
+
+    assert cfg.migrate_eye_detect_default_off(db) is True
+
+    rows = {
+        r["id"]: r["last_group_fingerprint"]
+        for r in db.conn.execute(
+            "SELECT id, last_group_fingerprint FROM workspaces",
+        ).fetchall()
+    }
+    assert rows[ws_relying_id] is None, (
+        "workspace relying on the global True default must have its "
+        "fingerprint cleared when the global flips to False"
+    )
+    assert rows[ws_explicit_false_id] == "explicit-false-fp", (
+        "workspace with an explicit False override was already scoring "
+        "eye-disabled; its fingerprint must not be cleared"
+    )
+
+
+def test_migrate_eye_detect_default_off_keeps_fingerprint_when_global_already_false(
+    tmp_path, monkeypatch,
+):
+    """When the global default is already False, workspaces without any
+    eye override were already scoring eye-disabled and their cached
+    triage remains accurate. Only workspaces whose override rewrites
+    from True to False should have their fingerprints cleared.
+    """
+    import config as cfg
+    from db import Database
+
+    config_path = tmp_path / "config.json"
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(config_path))
+    config_path.write_text(
+        json.dumps({"pipeline": {"eye_detect_enabled": False}})
+    )
+    db = Database(str(tmp_path / "test.db"), initialize_schema=True)
+    ws_no_override_id = db.create_workspace("no-override")
+    db.set_workspace_group_state(
+        ws_no_override_id, "keep-me", "2025-01-01T00:00:00Z",
+    )
+
+    assert cfg.migrate_eye_detect_default_off(db) is False
+
+    row = db.conn.execute(
+        "SELECT last_group_fingerprint FROM workspaces WHERE id = ?",
+        (ws_no_override_id,),
+    ).fetchone()
+    assert row["last_group_fingerprint"] == "keep-me", (
+        "when the global default was already False, workspaces without an "
+        "eye override were already scoring eye-disabled and must keep their "
+        "cached fingerprint"
+    )
+
+
 def test_default_subject_types_includes_taxonomy_individual_genre(tmp_path, monkeypatch):
     """Default subject_types is the set of keyword types that count as
     'identifying' a photo — taxonomy + individual + genre by default."""

--- a/vireo/tests/test_config.py
+++ b/vireo/tests/test_config.py
@@ -875,6 +875,47 @@ def test_migrate_eye_detect_default_off_invalidates_default_relying_workspaces(
     )
 
 
+def test_migrate_eye_detect_default_off_invalidates_when_global_key_absent(
+    tmp_path, monkeypatch,
+):
+    """When the raw config lacks ``pipeline.eye_detect_enabled`` entirely,
+    it was relying on the previous DEFAULTS value (``True``) — the same
+    effective pre-migration state as an explicit True. Default-relying
+    workspaces were therefore scoring eye-enabled and their fingerprints
+    must be invalidated even though ``pipeline`` is absent from disk.
+    Regression for Codex thread PRRT_kwDORn8c-s6QN0m2 (invalidation
+    gated only on a raw global True).
+    """
+    import config as cfg
+    from db import Database
+
+    config_path = tmp_path / "config.json"
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(config_path))
+    # Two shapes of the same "no explicit key" case: (a) pipeline block
+    # entirely absent, (b) pipeline present but eye_detect_enabled absent.
+    # Both mean the workspace was relying on the old True DEFAULTS.
+    config_path.write_text(json.dumps({"some_other_setting": 1}))
+
+    db = Database(str(tmp_path / "test.db"), initialize_schema=True)
+    ws_relying_id = db.create_workspace("relying")
+    db.set_workspace_group_state(
+        ws_relying_id, "relying-fp", "2025-01-01T00:00:00Z",
+    )
+
+    cfg.migrate_eye_detect_default_off(db)
+
+    row = db.conn.execute(
+        "SELECT last_group_fingerprint FROM workspaces WHERE id = ?",
+        (ws_relying_id,),
+    ).fetchone()
+    assert row["last_group_fingerprint"] is None, (
+        "workspace relying on the previous True DEFAULTS (raw config has "
+        "no pipeline.eye_detect_enabled key) must have its fingerprint "
+        "cleared when the default flips to False; otherwise the Process "
+        "page keeps reporting eye-scored triage as fresh"
+    )
+
+
 def test_migrate_eye_detect_default_off_keeps_fingerprint_when_global_already_false(
     tmp_path, monkeypatch,
 ):

--- a/vireo/tests/test_config.py
+++ b/vireo/tests/test_config.py
@@ -951,6 +951,45 @@ def test_migrate_eye_detect_default_off_keeps_fingerprint_when_global_already_fa
     )
 
 
+def test_migrate_eye_detect_default_off_preserves_explicit_workspace_opt_ins(
+    tmp_path, monkeypatch,
+):
+    """When the global config already had ``eye_detect_enabled=False`` (an
+    installation that intentionally scored eye-disabled globally before
+    this migration ran), a workspace override of ``True`` is an explicit
+    per-workspace opt-in — the user chose to run eye detection in that
+    workspace despite the global default. The migration must leave those
+    intentional overrides alone; otherwise upgrading silently disables
+    eye detection/scoring for workspaces whose settings intentionally
+    differed from the global default.
+    """
+    import config as cfg
+    from db import Database
+
+    config_path = tmp_path / "config.json"
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(config_path))
+    config_path.write_text(
+        json.dumps({"pipeline": {"eye_detect_enabled": False}})
+    )
+    db = Database(str(tmp_path / "test.db"), initialize_schema=True)
+    db.create_workspace(
+        "opt-in",
+        config_overrides={"pipeline": {"eye_detect_enabled": True}},
+    )
+
+    cfg.migrate_eye_detect_default_off(db)
+
+    row = db.conn.execute(
+        "SELECT config_overrides FROM workspaces WHERE name = 'opt-in'"
+    ).fetchone()
+    overrides = json.loads(row["config_overrides"])
+    assert overrides["pipeline"]["eye_detect_enabled"] is True, (
+        "when the global default was already False, a workspace "
+        "eye_detect_enabled=True override is an explicit per-workspace "
+        "opt-in and must not be flipped by the legacy-default migration"
+    )
+
+
 def test_default_subject_types_includes_taxonomy_individual_genre(tmp_path, monkeypatch):
     """Default subject_types is the set of keyword types that count as
     'identifying' a photo — taxonomy + individual + genre by default."""

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -878,7 +878,15 @@ def test_compute_review_readiness_no_masks(tmp_path):
 def test_compute_review_readiness_masks_present_no_eye(tmp_path):
     """Masks present for all photos, no eye keypoints →
     state='computable', 'eye_keypoints' in enhancing_missing."""
+    import config as cfg
     from pipeline import compute_review_readiness
+
+    # Eye readiness gaps are only surfaced when the workspace opts into
+    # eye detection (the default flipped off). Enable it explicitly so
+    # this pins the "computable but enhancing inputs missing" contract
+    # rather than the default-off suppression path.
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    cfg.save({"pipeline": {"eye_detect_enabled": True}})
 
     # _setup_db_with_photos populates masks, embeddings, and predictions
     # for every photo but does NOT set eye_x — exactly the "computable
@@ -1214,7 +1222,15 @@ def test_compute_review_readiness_eye_target_includes_routable_above_gate(tmp_pa
     from pipeline import compute_review_readiness
 
     cfg.CONFIG_PATH = str(tmp_path / "config.json")
-    cfg.save({"pipeline": {"eye_classifier_conf_gate": 0.5}})
+    # ``eye_detect_enabled`` gates whether the eye-keypoint gap surfaces
+    # in ``enhancing_missing``; the target count is orthogonal but the
+    # banner check below requires the feature to be turned on.
+    cfg.save({
+        "pipeline": {
+            "eye_classifier_conf_gate": 0.5,
+            "eye_detect_enabled": True,
+        }
+    })
 
     db = Database(str(tmp_path / "test.db"))
     fid = db.add_folder(str(tmp_path), name="photos")
@@ -1238,7 +1254,14 @@ def test_compute_review_readiness_eye_target_follows_gate_changes(tmp_path):
     from pipeline import compute_review_readiness
 
     cfg.CONFIG_PATH = str(tmp_path / "config.json")
-    cfg.save({"pipeline": {"eye_classifier_conf_gate": 0.5}})
+    # Feature must be on for the ``enhancing_missing`` banner to appear
+    # at all; the gate/target checks are the point of this test.
+    cfg.save({
+        "pipeline": {
+            "eye_classifier_conf_gate": 0.5,
+            "eye_detect_enabled": True,
+        }
+    })
 
     db = Database(str(tmp_path / "test.db"))
     fid = db.add_folder(str(tmp_path), name="photos")
@@ -1247,7 +1270,12 @@ def test_compute_review_readiness_eye_target_follows_gate_changes(tmp_path):
     out_strict = compute_review_readiness(db)
     assert out_strict["eye_keypoint_target_photos"] == 0
 
-    cfg.save({"pipeline": {"eye_classifier_conf_gate": 0.2}})
+    cfg.save({
+        "pipeline": {
+            "eye_classifier_conf_gate": 0.2,
+            "eye_detect_enabled": True,
+        }
+    })
     out_loose = compute_review_readiness(db)
     assert out_loose["eye_keypoint_target_photos"] == 1
     assert "eye_keypoints" in out_loose["enhancing_missing"]
@@ -1270,8 +1298,15 @@ def test_compute_review_readiness_eye_target_honors_workspace_pipeline_override(
 
     cfg.CONFIG_PATH = str(tmp_path / "config.json")
     # Global default gate stays at 0.5; only the active workspace lowers
-    # it, mirroring a user with a per-workspace looser threshold.
-    cfg.save({"pipeline": {"eye_classifier_conf_gate": 0.5}})
+    # it, mirroring a user with a per-workspace looser threshold. Enable
+    # eye detection at the global level so the ``enhancing_missing`` gap
+    # can surface (the default is off).
+    cfg.save({
+        "pipeline": {
+            "eye_classifier_conf_gate": 0.5,
+            "eye_detect_enabled": True,
+        }
+    })
 
     db = Database(str(tmp_path / "test.db"))
     ws_id = db.create_workspace(
@@ -1288,6 +1323,45 @@ def test_compute_review_readiness_eye_target_honors_workspace_pipeline_override(
     out = compute_review_readiness(db)
     assert out["eye_keypoint_target_photos"] == 1
     assert "eye_keypoints" in out["enhancing_missing"]
+
+
+def test_compute_review_readiness_suppresses_eye_gap_when_detection_disabled(tmp_path):
+    """When ``pipeline.eye_detect_enabled`` is False (the new default), the
+    readiness diagnostic must not flag ``eye_keypoints`` in
+    ``enhancing_missing`` even if eligible photos have no eye attempts.
+
+    Otherwise a default-off workspace's pipeline_review page reports the
+    result as "computed without eye keypoints — should re-run that stage"
+    for a stage the workspace has intentionally disabled, contradicting
+    the visible Settings state and the default Process flow (which
+    skips the stage). Regression for Codex thread PRRT_kwDORn8c-s6QOH4L.
+    """
+    import config as cfg
+    from db import Database
+    from pipeline import compute_review_readiness
+
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    cfg.save({
+        "pipeline": {
+            "eye_classifier_conf_gate": 0.5,
+            "eye_detect_enabled": False,
+        }
+    })
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder(str(tmp_path), name="photos")
+    # An Aves photo above the confidence gate would count toward the eye
+    # target if the feature were on — it's the same shape that
+    # ``test_..._eye_target_includes_routable_above_gate`` uses to
+    # deliberately surface the banner.
+    _add_eligible_photo(db, fid, "bird.jpg", 0.9, taxonomy_class="Aves")
+
+    out = compute_review_readiness(db)
+    assert "eye_keypoints" not in out["enhancing_missing"], (
+        "eye_keypoints must not appear in enhancing_missing when the "
+        "workspace has eye detection disabled — otherwise the review "
+        "page warns about a stage the user chose not to run"
+    )
 
 
 def test_save_results_preserves_miss_computed_at_across_reflow(tmp_path):

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -1963,7 +1963,15 @@ def test_eye_keypoint_stage_preflight_enabled(tmp_path, monkeypatch):
     from pipeline import eye_keypoint_stage_preflight
 
     assert eye_keypoint_stage_preflight({"eye_detect_enabled": True}) is None
-    assert eye_keypoint_stage_preflight({}) is None
+
+
+def test_eye_keypoint_stage_preflight_missing_config_defaults_disabled(
+    tmp_path, monkeypatch
+):
+    """Missing eye_detect_enabled follows the global default: disabled."""
+    from pipeline import eye_keypoint_stage_preflight
+
+    assert eye_keypoint_stage_preflight({}) == "Disabled in config"
 
 
 def test_eye_keypoint_stage_writes_nothing_when_weights_absent(

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -9619,6 +9619,161 @@ def test_pipeline_eye_keypoints_per_run_optin_overrides_config_disabled(
     )
 
 
+def test_pipeline_regroup_per_run_eye_optin_reaches_scoring_config(
+    tmp_path, monkeypatch,
+):
+    """The Process-page eye opt-in must also reach regroup/scoring, not
+    just the eye stage. When the user checks Eye Keypoints for a run and
+    Settings has ``eye_detect_enabled=False`` (the new default), the eye
+    stage runs and writes ``eye_tenengrad`` — but scoring reloads the
+    workspace config, sees eye disabled, and ignores those values so the
+    checkbox never affects culling results. The regroup stage must mirror
+    the eye stage's per-run override before calling ``run_full_pipeline``.
+    """
+    import config as cfg
+    import pipeline as pipeline_mod
+    import pipeline_job as pj
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    with open(cfg.CONFIG_PATH, "w") as f:
+        json.dump({"pipeline": {"eye_detect_enabled": False}}, f)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    pid = db.add_photo(folder_id, "p.jpg", ".jpg", 100, 1_000_000.0)
+    _drop_jpeg(folder_path, "p.jpg")
+    col_id = db.add_collection(
+        "Test", json.dumps([{"field": "photo_ids", "value": [pid]}]),
+    )
+
+    # Give load_photo_features a photo to return so regroup does not
+    # short-circuit on "No photos with pipeline features found."
+    monkeypatch.setattr(
+        pipeline_mod, "load_photo_features",
+        lambda *a, **kw: [
+            {"id": pid, "filename": "p.jpg", "timestamp": 1_000_000.0},
+        ],
+    )
+    monkeypatch.setattr(pipeline_mod, "save_results", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        pipeline_mod, "_resolve_collection_photo_ids",
+        lambda db_, cid: {pid},
+    )
+    monkeypatch.setattr(
+        pipeline_mod, "compute_group_fingerprint", lambda *a, **kw: "fp",
+    )
+
+    calls = {"configs": []}
+
+    def fake_run_full_pipeline(photos, config=None, emit_trace=False):
+        calls["configs"].append(dict(config or {}))
+        return {"encounters": [], "photos": [], "summary": {"groups": 0}}
+
+    monkeypatch.setattr(
+        pipeline_mod, "run_full_pipeline", fake_run_full_pipeline,
+    )
+
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_classify=True,
+        skip_extract_masks=True,
+        skip_eye_keypoints=False,
+        skip_regroup=False,
+    )
+    run_pipeline_job(_make_job(), FakeRunner(), db_path, ws_id, params)
+
+    assert calls["configs"], (
+        f"run_full_pipeline must be invoked by regroup_stage; got "
+        f"calls={calls['configs']!r}"
+    )
+    assert calls["configs"][0].get("eye_detect_enabled") is True, (
+        f"the per-run eye opt-in must surface as eye_detect_enabled=True "
+        f"in the pipeline_cfg passed to run_full_pipeline so scoring "
+        f"honors eye_tenengrad values the eye stage just wrote; got "
+        f"config={calls['configs'][0]!r}"
+    )
+
+
+def test_pipeline_regroup_no_optin_leaves_scoring_config_untouched(
+    tmp_path, monkeypatch,
+):
+    """When the user does NOT opt in to eye keypoints for a run
+    (``skip_eye_keypoints=True``), regroup must fall back to the
+    Settings-level ``eye_detect_enabled`` value instead of forcing it on.
+    Without this, unchecking the Process-page checkbox would silently
+    ignore workspaces where Settings still has eye detection enabled.
+    """
+    import config as cfg
+    import pipeline as pipeline_mod
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    with open(cfg.CONFIG_PATH, "w") as f:
+        json.dump({"pipeline": {"eye_detect_enabled": False}}, f)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    pid = db.add_photo(folder_id, "p.jpg", ".jpg", 100, 1_000_000.0)
+    _drop_jpeg(folder_path, "p.jpg")
+    col_id = db.add_collection(
+        "Test", json.dumps([{"field": "photo_ids", "value": [pid]}]),
+    )
+
+    monkeypatch.setattr(
+        pipeline_mod, "load_photo_features",
+        lambda *a, **kw: [
+            {"id": pid, "filename": "p.jpg", "timestamp": 1_000_000.0},
+        ],
+    )
+    monkeypatch.setattr(pipeline_mod, "save_results", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        pipeline_mod, "_resolve_collection_photo_ids",
+        lambda db_, cid: {pid},
+    )
+    monkeypatch.setattr(
+        pipeline_mod, "compute_group_fingerprint", lambda *a, **kw: "fp",
+    )
+
+    calls = {"configs": []}
+
+    def fake_run_full_pipeline(photos, config=None, emit_trace=False):
+        calls["configs"].append(dict(config or {}))
+        return {"encounters": [], "photos": [], "summary": {"groups": 0}}
+
+    monkeypatch.setattr(
+        pipeline_mod, "run_full_pipeline", fake_run_full_pipeline,
+    )
+
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_classify=True,
+        skip_extract_masks=True,
+        skip_eye_keypoints=True,
+        skip_regroup=False,
+    )
+    run_pipeline_job(_make_job(), FakeRunner(), db_path, ws_id, params)
+
+    assert calls["configs"], "run_full_pipeline must be invoked"
+    # Settings said False and user did not opt in — value stays False.
+    assert calls["configs"][0].get("eye_detect_enabled") is False, (
+        f"without a per-run opt-in, regroup must not force eye detection "
+        f"on: got config={calls['configs'][0]!r}"
+    )
+
+
 def test_detect_eye_keypoints_stage_honors_abort_check(tmp_path, monkeypatch):
     """detect_eye_keypoints_stage must accept an `abort_check` callable and
     break the per-photo loop the first time it returns True. Without this

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -9632,7 +9632,6 @@ def test_pipeline_regroup_per_run_eye_optin_reaches_scoring_config(
     """
     import config as cfg
     import pipeline as pipeline_mod
-    import pipeline_job as pj
     from db import Database
 
     monkeypatch.setenv("HOME", str(tmp_path))

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -7538,6 +7538,157 @@ def test_pipeline_regroup_invalidates_stamp_on_partial_run(tmp_path, monkeypatch
     assert row["last_grouped_at"] is None
 
 
+def test_pipeline_regroup_does_not_stamp_when_eye_override_differs(
+    tmp_path, monkeypatch,
+):
+    """A per-run ``eye_detect_override`` that flips the effective
+    ``eye_detect_enabled`` away from the workspace's own setting means the
+    resulting KEEP/REJECT decisions came from settings the workspace's
+    normal state would not reproduce. ``compute_group_fingerprint`` reads
+    only encounter/burst keys, so stamping it would let a later default-off
+    plan run against the workspace's real settings falsely report Group as
+    'done-prior' against eye-scored results. Regression for Codex thread
+    PRRT_kwDORn8c-s6QN0m3."""
+    import config as cfg
+    from db import Database
+    from PIL import Image
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    # Workspace default: eye detection off. The Process-page checkbox on
+    # this run flips it via ``eye_detect_override=True``.
+    with open(cfg.CONFIG_PATH, "w") as f:
+        json.dump({"pipeline": {"eye_detect_enabled": False}}, f)
+
+    photo_dir = tmp_path / "photos"
+    photo_dir.mkdir()
+    for name in ("a.jpg", "b.jpg"):
+        Image.new("RGB", (16, 16), "black").save(str(photo_dir / name))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    # Pre-stamp a fingerprint as if a prior FULL default-off regroup had
+    # completed cleanly. The one-off eye-on run must NOT overwrite this
+    # with a fresh stamp — that would lie about workspace freshness.
+    db.set_workspace_group_state(
+        ws_id, fingerprint="pre-existing-default-off", when_ts=1714579200,
+    )
+
+    import pipeline as pipeline_mod
+    monkeypatch.setattr(
+        pipeline_mod, "run_full_pipeline",
+        lambda photos, config=None, emit_trace=False: {
+            "summary": {"groups": 1}, "photos": photos,
+        },
+    )
+    monkeypatch.setattr(
+        pipeline_mod, "save_results",
+        lambda results, cache_dir, workspace_id: None,
+    )
+    monkeypatch.setattr(
+        pipeline_mod, "load_photo_features",
+        lambda thread_db, collection_id=None, config=None: [{"id": 1}],
+    )
+
+    params = PipelineParams(
+        source=str(photo_dir),
+        skip_classify=True,
+        skip_extract_masks=True,
+        # Explicit per-run opt-in against workspace's eye-off default.
+        eye_detect_override=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    with contextlib.suppress(Exception):
+        run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    db2 = Database(db_path)
+    row = db2.conn.execute(
+        "SELECT last_grouped_at, last_group_fingerprint FROM workspaces WHERE id=?",
+        (ws_id,),
+    ).fetchone()
+    assert row["last_group_fingerprint"] is None, (
+        "one-off eye-on regroup against a default-off workspace stamped "
+        "workspace freshness — a later default-off plan will falsely report "
+        "'done-prior' against eye-scored KEEP/REJECT results"
+    )
+    assert row["last_grouped_at"] is None
+
+
+def test_pipeline_regroup_stamps_when_eye_override_matches_workspace(
+    tmp_path, monkeypatch,
+):
+    """The eye-override guard must only trigger when the override *differs*
+    from the workspace's own eye setting — otherwise a Process-page run
+    that ticks the checkbox in a workspace that already has eye detection
+    on would be treated as partial and the plan would loop forever on
+    'settings changed'."""
+    import config as cfg
+    from db import Database
+    from PIL import Image
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    with open(cfg.CONFIG_PATH, "w") as f:
+        json.dump({"pipeline": {"eye_detect_enabled": True}}, f)
+
+    photo_dir = tmp_path / "photos"
+    photo_dir.mkdir()
+    for name in ("a.jpg", "b.jpg"):
+        Image.new("RGB", (16, 16), "black").save(str(photo_dir / name))
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    import pipeline as pipeline_mod
+    monkeypatch.setattr(
+        pipeline_mod, "run_full_pipeline",
+        lambda photos, config=None, emit_trace=False: {
+            "summary": {"groups": 1}, "photos": photos,
+        },
+    )
+    monkeypatch.setattr(
+        pipeline_mod, "save_results",
+        lambda results, cache_dir, workspace_id: None,
+    )
+    monkeypatch.setattr(
+        pipeline_mod, "load_photo_features",
+        lambda thread_db, collection_id=None, config=None: [{"id": 1}],
+    )
+
+    params = PipelineParams(
+        source=str(photo_dir),
+        skip_classify=True,
+        skip_extract_masks=True,
+        eye_detect_override=True,
+    )
+
+    runner = FakeRunner()
+    job = _make_job()
+
+    with contextlib.suppress(Exception):
+        run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    db2 = Database(db_path)
+    db2.set_active_workspace(ws_id)
+    row = db2.conn.execute(
+        "SELECT last_grouped_at, last_group_fingerprint FROM workspaces WHERE id=?",
+        (ws_id,),
+    ).fetchone()
+    assert row["last_grouped_at"] is not None, (
+        "an eye_detect_override matching the workspace's own setting must "
+        "still stamp workspace freshness — otherwise the plan would loop "
+        "on 'settings changed'"
+    )
+    from pipeline import compute_group_fingerprint
+    effective = db2.get_effective_config(cfg.load())
+    assert row["last_group_fingerprint"] == compute_group_fingerprint(effective)
+
+
 
 # --- Weighted overall progress ---------------------------------------------
 

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -9530,14 +9530,15 @@ def test_pipeline_eye_keypoints_stage_excluded_photos_do_not_influence_downloads
 def test_pipeline_eye_keypoints_per_run_optin_overrides_config_disabled(
     tmp_path, monkeypatch,
 ):
-    """Reaching eye_keypoints_stage means the caller passed
-    skip_eye_keypoints=False — the Process page checkbox or an API opt-in.
-    That per-run intent must override the Settings-level
-    ``eye_detect_enabled`` so the stage actually runs even when Settings
-    has eye detection off (the new default). Without this, the visible
-    checkbox on the Process page is a no-op until the user first flips
-    Settings, which is the very "black box" the CLAUDE.md philosophy
-    forbids.
+    """An explicit per-run eye opt-in — ``eye_detect_override=True`` set
+    from the Process-page checkbox or an API caller — must override the
+    Settings-level ``eye_detect_enabled`` so the stage actually runs even
+    when Settings has eye detection off (the new default). Without this,
+    the visible checkbox on the Process page is a no-op until the user
+    first flips Settings, which is the very "black box" the CLAUDE.md
+    philosophy forbids. ``skip_eye_keypoints=False`` alone is NOT the
+    signal — ``resolve_strategy('full')`` also sets it to False as a
+    base default (see ``test_pipeline_eye_keypoints_full_strategy_does_not_force_optin``).
     """
     import config as cfg
     import pipeline as pipeline_mod
@@ -9603,6 +9604,7 @@ def test_pipeline_eye_keypoints_per_run_optin_overrides_config_disabled(
         skip_classify=True,
         skip_extract_masks=False,
         skip_eye_keypoints=False,
+        eye_detect_override=True,
         skip_regroup=True,
     )
     run_pipeline_job(_make_job(), FakeRunner(), db_path, ws_id, params)
@@ -9619,16 +9621,98 @@ def test_pipeline_eye_keypoints_per_run_optin_overrides_config_disabled(
     )
 
 
+def test_pipeline_eye_keypoints_full_strategy_does_not_force_optin(
+    tmp_path, monkeypatch,
+):
+    """Codex thread 5 regression guard: a ``full``-strategy chain (e.g.
+    after-import) reaches ``run_pipeline_job`` with
+    ``skip_eye_keypoints=False`` from ``resolve_strategy('full')`` — that
+    is a strategy default, NOT an explicit user opt-in. When Settings has
+    ``eye_detect_enabled=False`` (the new default) and no
+    ``eye_detect_override`` is set, the stage-level preflight must skip
+    with "Disabled in config" instead of forcing eye detection on and
+    triggering SuperAnimal downloads and eye-based scoring by default.
+    """
+    import config as cfg
+    import pipeline as pipeline_mod
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    with open(cfg.CONFIG_PATH, "w") as f:
+        json.dump({"pipeline": {"eye_detect_enabled": False}}, f)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    pid = db.add_photo(folder_id, "p.jpg", ".jpg", 100, 1_000_000.0)
+    _drop_jpeg(folder_path, "p.jpg")
+    db.save_detections(
+        pid,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+          "confidence": 0.9, "category": "animal"}],
+        detector_model="MegaDetector",
+    )
+    col_id = db.add_collection(
+        "Test", json.dumps([{"field": "photo_ids", "value": [pid]}]),
+    )
+
+    _stub_extract_masks_heavy_ops(monkeypatch)
+
+    calls = {"count": 0}
+
+    def fake_detect_eye_keypoints_stage(
+        db_, config, progress_callback=None,
+        collection_id=None, exclude_photo_ids=None,
+        abort_check=None,
+    ):
+        calls["count"] += 1
+
+    monkeypatch.setattr(
+        pipeline_mod, "detect_eye_keypoints_stage",
+        fake_detect_eye_keypoints_stage,
+    )
+
+    # Mirror what resolve_strategy("full") produces: skip_eye_keypoints=False
+    # (base default), but no eye_detect_override (leave None so config wins).
+    from process_strategies import resolve_strategy
+    expanded = resolve_strategy("full")
+    assert expanded["skip_eye_keypoints"] is False
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_classify=True,
+        skip_extract_masks=False,
+        skip_eye_keypoints=expanded["skip_eye_keypoints"],
+        skip_regroup=True,
+    )
+    assert params.eye_detect_override is None, (
+        "strategy expansion must not set eye_detect_override — it is the "
+        "explicit opt-in signal, not a strategy default"
+    )
+    run_pipeline_job(_make_job(), FakeRunner(), db_path, ws_id, params)
+
+    assert calls["count"] == 0, (
+        f"detect_eye_keypoints_stage must not run when Settings has "
+        f"eye_detect_enabled=False and the caller did not explicitly "
+        f"opt in via eye_detect_override; got calls={calls['count']}"
+    )
+
+
 def test_pipeline_regroup_per_run_eye_optin_reaches_scoring_config(
     tmp_path, monkeypatch,
 ):
-    """The Process-page eye opt-in must also reach regroup/scoring, not
-    just the eye stage. When the user checks Eye Keypoints for a run and
-    Settings has ``eye_detect_enabled=False`` (the new default), the eye
-    stage runs and writes ``eye_tenengrad`` — but scoring reloads the
-    workspace config, sees eye disabled, and ignores those values so the
-    checkbox never affects culling results. The regroup stage must mirror
-    the eye stage's per-run override before calling ``run_full_pipeline``.
+    """The Process-page eye opt-in (``eye_detect_override=True``) must also
+    reach regroup/scoring, not just the eye stage. When the user checks
+    Eye Keypoints for a run and Settings has ``eye_detect_enabled=False``
+    (the new default), the eye stage runs and writes ``eye_tenengrad`` —
+    but scoring reloads the workspace config, sees eye disabled, and
+    ignores those values so the checkbox never affects culling results.
+    The regroup stage must mirror the eye stage's per-run override before
+    calling ``run_full_pipeline``.
     """
     import config as cfg
     import pipeline as pipeline_mod
@@ -9684,6 +9768,7 @@ def test_pipeline_regroup_per_run_eye_optin_reaches_scoring_config(
         skip_classify=True,
         skip_extract_masks=True,
         skip_eye_keypoints=False,
+        eye_detect_override=True,
         skip_regroup=False,
     )
     run_pipeline_job(_make_job(), FakeRunner(), db_path, ws_id, params)
@@ -9700,14 +9785,90 @@ def test_pipeline_regroup_per_run_eye_optin_reaches_scoring_config(
     )
 
 
+def test_pipeline_regroup_full_strategy_default_does_not_force_scoring_config(
+    tmp_path, monkeypatch,
+):
+    """Codex thread 5 regression guard for the regroup stage: an
+    after-import ``full``-strategy chain reaches regroup with
+    ``skip_eye_keypoints=False`` from the strategy default, but no
+    ``eye_detect_override`` — so scoring must respect Settings'
+    ``eye_detect_enabled=False`` rather than forcing eye scoring on.
+    """
+    import config as cfg
+    import pipeline as pipeline_mod
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    with open(cfg.CONFIG_PATH, "w") as f:
+        json.dump({"pipeline": {"eye_detect_enabled": False}}, f)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    pid = db.add_photo(folder_id, "p.jpg", ".jpg", 100, 1_000_000.0)
+    _drop_jpeg(folder_path, "p.jpg")
+    col_id = db.add_collection(
+        "Test", json.dumps([{"field": "photo_ids", "value": [pid]}]),
+    )
+
+    monkeypatch.setattr(
+        pipeline_mod, "load_photo_features",
+        lambda *a, **kw: [
+            {"id": pid, "filename": "p.jpg", "timestamp": 1_000_000.0},
+        ],
+    )
+    monkeypatch.setattr(pipeline_mod, "save_results", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        pipeline_mod, "_resolve_collection_photo_ids",
+        lambda db_, cid: {pid},
+    )
+    monkeypatch.setattr(
+        pipeline_mod, "compute_group_fingerprint", lambda *a, **kw: "fp",
+    )
+
+    calls = {"configs": []}
+
+    def fake_run_full_pipeline(photos, config=None, emit_trace=False):
+        calls["configs"].append(dict(config or {}))
+        return {"encounters": [], "photos": [], "summary": {"groups": 0}}
+
+    monkeypatch.setattr(
+        pipeline_mod, "run_full_pipeline", fake_run_full_pipeline,
+    )
+
+    from process_strategies import resolve_strategy
+    expanded = resolve_strategy("full")
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_classify=True,
+        skip_extract_masks=True,
+        skip_eye_keypoints=expanded["skip_eye_keypoints"],
+        skip_regroup=False,
+    )
+    assert params.eye_detect_override is None
+    run_pipeline_job(_make_job(), FakeRunner(), db_path, ws_id, params)
+
+    assert calls["configs"], "run_full_pipeline must be invoked"
+    assert calls["configs"][0].get("eye_detect_enabled") is False, (
+        f"strategy default skip_eye_keypoints=False without an explicit "
+        f"eye_detect_override must not force eye_detect_enabled=True in "
+        f"scoring config: got config={calls['configs'][0]!r}"
+    )
+
+
 def test_pipeline_regroup_no_optin_leaves_scoring_config_untouched(
     tmp_path, monkeypatch,
 ):
-    """When the user does NOT opt in to eye keypoints for a run
-    (``skip_eye_keypoints=True``), regroup must fall back to the
-    Settings-level ``eye_detect_enabled`` value instead of forcing it on.
-    Without this, unchecking the Process-page checkbox would silently
-    ignore workspaces where Settings still has eye detection enabled.
+    """When the caller sets ``skip_eye_keypoints=True`` (Process-page
+    checkbox off), regroup must fall back to the Settings-level
+    ``eye_detect_enabled`` value instead of forcing it on. Without this,
+    unchecking the Process-page checkbox would silently ignore workspaces
+    where Settings still has eye detection enabled.
     """
     import config as cfg
     import pipeline as pipeline_mod

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -10085,6 +10085,84 @@ def test_pipeline_regroup_no_optin_leaves_scoring_config_untouched(
     )
 
 
+def test_pipeline_regroup_no_optin_preserves_settings_eye_on(
+    tmp_path, monkeypatch,
+):
+    """Reverse-direction guard for the Process-page checkbox flow: when
+    Settings has ``eye_detect_enabled=True`` and the user unchecks the
+    Eye Keypoints checkbox on the Process page, the client must NOT send
+    ``eye_detect_override=false`` — an unchecked box means "skip the
+    stage", not "disable eye scoring". Regroup must fall back to
+    Settings ``True`` so the run scores against existing
+    ``eye_tenengrad`` values instead of silently ignoring them.
+    """
+    import config as cfg
+    import pipeline as pipeline_mod
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    with open(cfg.CONFIG_PATH, "w") as f:
+        json.dump({"pipeline": {"eye_detect_enabled": True}}, f)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    pid = db.add_photo(folder_id, "p.jpg", ".jpg", 100, 1_000_000.0)
+    _drop_jpeg(folder_path, "p.jpg")
+    col_id = db.add_collection(
+        "Test", json.dumps([{"field": "photo_ids", "value": [pid]}]),
+    )
+
+    monkeypatch.setattr(
+        pipeline_mod, "load_photo_features",
+        lambda *a, **kw: [
+            {"id": pid, "filename": "p.jpg", "timestamp": 1_000_000.0},
+        ],
+    )
+    monkeypatch.setattr(pipeline_mod, "save_results", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        pipeline_mod, "_resolve_collection_photo_ids",
+        lambda db_, cid: {pid},
+    )
+    monkeypatch.setattr(
+        pipeline_mod, "compute_group_fingerprint", lambda *a, **kw: "fp",
+    )
+
+    calls = {"configs": []}
+
+    def fake_run_full_pipeline(photos, config=None, emit_trace=False):
+        calls["configs"].append(dict(config or {}))
+        return {"encounters": [], "photos": [], "summary": {"groups": 0}}
+
+    monkeypatch.setattr(
+        pipeline_mod, "run_full_pipeline", fake_run_full_pipeline,
+    )
+
+    # Skip the stage but leave the override unset — the shape the Process
+    # page now sends when the Eye Keypoints checkbox is off.
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_classify=True,
+        skip_extract_masks=True,
+        skip_eye_keypoints=True,
+        skip_regroup=False,
+    )
+    assert params.eye_detect_override is None
+    run_pipeline_job(_make_job(), FakeRunner(), db_path, ws_id, params)
+
+    assert calls["configs"], "run_full_pipeline must be invoked"
+    assert calls["configs"][0].get("eye_detect_enabled") is True, (
+        f"a Process-page run that only skips the eye stage (no explicit "
+        f"eye_detect_override) must let scoring keep Settings' "
+        f"eye_detect_enabled=True: got config={calls['configs'][0]!r}"
+    )
+
+
 def test_detect_eye_keypoints_stage_honors_abort_check(tmp_path, monkeypatch):
     """detect_eye_keypoints_stage must accept an `abort_check` callable and
     break the per-photo loop the first time it returns True. Without this

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -9527,6 +9527,98 @@ def test_pipeline_eye_keypoints_stage_excluded_photos_do_not_influence_downloads
     )
 
 
+def test_pipeline_eye_keypoints_per_run_optin_overrides_config_disabled(
+    tmp_path, monkeypatch,
+):
+    """Reaching eye_keypoints_stage means the caller passed
+    skip_eye_keypoints=False — the Process page checkbox or an API opt-in.
+    That per-run intent must override the Settings-level
+    ``eye_detect_enabled`` so the stage actually runs even when Settings
+    has eye detection off (the new default). Without this, the visible
+    checkbox on the Process page is a no-op until the user first flips
+    Settings, which is the very "black box" the CLAUDE.md philosophy
+    forbids.
+    """
+    import config as cfg
+    import pipeline as pipeline_mod
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    with open(cfg.CONFIG_PATH, "w") as f:
+        json.dump({"pipeline": {"eye_detect_enabled": False}}, f)
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+    pid = db.add_photo(folder_id, "p.jpg", ".jpg", 100, 1_000_000.0)
+    _drop_jpeg(folder_path, "p.jpg")
+    db.save_detections(
+        pid,
+        [{"box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+          "confidence": 0.9, "category": "animal"}],
+        detector_model="MegaDetector",
+    )
+    col_id = db.add_collection(
+        "Test", json.dumps([{"field": "photo_ids", "value": [pid]}]),
+    )
+
+    _stub_extract_masks_heavy_ops(monkeypatch)
+
+    # Use the REAL preflight — the fix must feed it a config where
+    # eye_detect_enabled=True regardless of the on-disk setting.
+    monkeypatch.setattr(
+        Database, "list_photos_for_eye_keypoint_stage",
+        lambda self, **k: [
+            {"id": pid, "taxonomy_class": "Aves", "species_conf": 0.9},
+        ],
+    )
+    import keypoints as _kp_mod
+    monkeypatch.setattr(
+        _kp_mod, "ensure_keypoint_weights",
+        lambda name, progress_callback=None: "/fake/model.onnx",
+    )
+
+    calls = {"count": 0, "configs": []}
+
+    def fake_detect_eye_keypoints_stage(
+        db_, config, progress_callback=None,
+        collection_id=None, exclude_photo_ids=None,
+        abort_check=None,
+    ):
+        calls["count"] += 1
+        calls["configs"].append(dict(config))
+
+    monkeypatch.setattr(
+        pipeline_mod, "detect_eye_keypoints_stage",
+        fake_detect_eye_keypoints_stage,
+    )
+
+    params = PipelineParams(
+        collection_id=col_id,
+        skip_classify=True,
+        skip_extract_masks=False,
+        skip_eye_keypoints=False,
+        skip_regroup=True,
+    )
+    run_pipeline_job(_make_job(), FakeRunner(), db_path, ws_id, params)
+
+    assert calls["count"] == 1, (
+        f"detect_eye_keypoints_stage must run when the user opts in per-run "
+        f"even though eye_detect_enabled=False in config; got "
+        f"calls={calls['count']}"
+    )
+    assert calls["configs"][0].get("eye_detect_enabled") is True, (
+        f"the per-run opt-in must surface as eye_detect_enabled=True in the "
+        f"config passed to detect_eye_keypoints_stage so its internal "
+        f"preflight doesn't re-skip; got config={calls['configs'][0]!r}"
+    )
+
+
 def test_detect_eye_keypoints_stage_honors_abort_check(tmp_path, monkeypatch):
     """detect_eye_keypoints_stage must accept an `abort_check` callable and
     break the per-photo loop the first time it returns True. Without this

--- a/vireo/tests/test_pipeline_plan.py
+++ b/vireo/tests/test_pipeline_plan.py
@@ -1891,6 +1891,50 @@ def test_eye_keypoints_plan_will_skip_when_preflight_fails(tmp_path, monkeypatch
     assert "disabled in config" in eye["summary"]
 
 
+def test_eye_keypoints_plan_honors_per_run_override_against_config_disabled(
+    tmp_path, monkeypatch,
+):
+    """When Settings has ``eye_detect_enabled=False`` but the caller opted
+    in via ``eye_detect_override=True`` (Process-page checkbox on), the
+    plan must show the stage as ``will-run``, not ``will-skip — Disabled
+    in config``. The pill has to match what the job would actually do —
+    which is toggle the config on for the run and execute the stage.
+    """
+    from pipeline_plan import compute_plan
+    db, folder_id = _make_db(tmp_path)
+    # Give the stage some eligible work so it lands on will-run (not
+    # done-prior). eye_keypoint_stage_preflight is exercised with the
+    # REAL implementation — no monkeypatch — so the override must reach
+    # its config lookup.
+    pid, did = _add_photo_with_detection(db, folder_id, "a.jpg")
+    db.conn.execute(
+        "UPDATE photos SET mask_path='/m/a.png' WHERE id=?", (pid,),
+    )
+    db.conn.execute(
+        """INSERT INTO predictions
+            (detection_id, classifier_model, labels_fingerprint,
+             species, confidence)
+           VALUES (?, ?, ?, ?, ?)""",
+        (did, "BioCLIP-2", "fp1", "robin", 0.9),
+    )
+    db.conn.commit()
+
+    plan_no_override = compute_plan(
+        db, _params(), str(tmp_path / "test.db"),
+    )
+    assert plan_no_override["stages"]["EyeKeypoints"]["state"] == "will-skip"
+
+    plan_with_override = compute_plan(
+        db, _params(eye_detect_override=True), str(tmp_path / "test.db"),
+    )
+    eye = plan_with_override["stages"]["EyeKeypoints"]
+    assert eye["state"] != "will-skip", (
+        f"eye_detect_override=True must let the plan pill show what the "
+        f"job would actually do (run the stage), not the stale Settings "
+        f"disabled reason: got {eye!r}"
+    )
+
+
 def test_eye_keypoints_plan_done_prior_when_all_processed(tmp_path, monkeypatch):
     """The headline bug case: every eligible photo has eye_tenengrad set
     (with the current fingerprint, so it isn't stale), so the next run is

--- a/vireo/tests/test_pipeline_plan.py
+++ b/vireo/tests/test_pipeline_plan.py
@@ -2329,6 +2329,80 @@ def test_regroup_plan_will_run_when_workspace_fingerprint_outdated(tmp_path, mon
 
 
 
+def test_regroup_plan_will_run_when_eye_detect_override_differs_from_workspace(
+    tmp_path, monkeypatch,
+):
+    """Cache is fresh against workspace settings, but the run carries a
+    ``eye_detect_override`` that flips ``eye_detect_enabled`` for THIS
+    press. Because ``compute_group_fingerprint`` doesn't hash
+    ``eye_detect_enabled``, the fingerprint match alone would let the
+    plan report ``done-prior`` — hiding the fact that ``regroup_stage``
+    will actually rescore with different eye behavior. The plan must
+    call this out as will-run instead.
+    """
+    from pipeline_plan import compute_plan
+    db, folder_id = _make_db(tmp_path)
+    pid, did = _add_photo_with_detection(db, folder_id, "a.jpg")
+    _mark_sam_done(db, pid, "/m/a.png")
+    from labels_fingerprint import TOL_SENTINEL
+    db.record_classifier_run(did, "BioCLIP-2", TOL_SENTINEL, prediction_count=1)
+
+    cache_path = os.path.join(
+        str(tmp_path), f"pipeline_results_ws{db._active_workspace_id}.json",
+    )
+    with open(cache_path, "w") as f:
+        f.write('{"photos": []}')
+
+    # Workspace's own effective config: eye off (the new default). Stamp
+    # fingerprint so the fingerprint check would pass without the override.
+    import config as cfg
+    from pipeline import compute_group_fingerprint
+    effective = db.get_effective_config(cfg.load())
+    db.set_workspace_group_state(
+        db._active_workspace_id,
+        fingerprint=compute_group_fingerprint(effective),
+        when_ts=1714579200,
+    )
+
+    import labels as labels_mod
+    import models as models_mod
+    monkeypatch.setattr(models_mod, "get_models", lambda: [
+        {"id": "m1", "name": "BioCLIP-2",
+         "model_str": "hf-hub:imageomics/bioclip-2",
+         "model_type": "bioclip", "downloaded": True},
+    ])
+    monkeypatch.setattr(labels_mod, "get_active_labels", lambda: [])
+    monkeypatch.setattr(labels_mod, "get_saved_labels", lambda: [])
+
+    # Sanity check: no override → plan is done-prior.
+    plan_no_override = compute_plan(
+        db,
+        _params(model_ids=["m1"], skip_eye_keypoints=True),
+        str(tmp_path / "test.db"),
+    )
+    assert plan_no_override["stages"]["Group"]["state"] == "done-prior"
+
+    # Same state + eye_detect_override=True (Process-page checkbox) → the
+    # eye override differs from the workspace's eye-off setting, so
+    # regroup will rescore with different eye behavior; must be will-run.
+    plan_with_override = compute_plan(
+        db,
+        _params(
+            model_ids=["m1"], skip_eye_keypoints=True,
+            eye_detect_override=True,
+        ),
+        str(tmp_path / "test.db"),
+    )
+    group = plan_with_override["stages"]["Group"]
+    assert group["state"] == "will-run", (
+        "eye_detect_override differs from workspace eye_detect_enabled — "
+        "regroup will rescore with different eye behavior, so the plan "
+        "must report will-run instead of the cache-fresh done-prior: "
+        f"got {group!r}"
+    )
+    assert group.get("detail", {}).get("eye_override_differs") is True
+
+
 def test_regroup_plan_will_run_when_cache_exists_but_fingerprint_invalidated(
     tmp_path, monkeypatch,
 ):

--- a/vireo/tests/test_scoring.py
+++ b/vireo/tests/test_scoring.py
@@ -478,3 +478,79 @@ def test_eye_detect_disabled_suppresses_eye_soft_reject():
     assert not any(
         "eye_soft" in r for r in soft_eye.get("reject_reasons", [])
     )
+
+
+def test_score_encounter_honors_nested_pipeline_eye_detect_enabled():
+    """When callers pass a full effective config (with pipeline keys nested
+    under ``config['pipeline']``), score_encounter must honor the nested
+    ``eye_detect_enabled`` rather than silently reading it as absent.
+
+    ``_build_best_batch_response`` and the browse-selection batch review
+    path both hand ``run_selected_batch_review`` the top-level effective
+    config. Without this normalization, photos with a real ``eye_tenengrad``
+    would rank by body sharpness in those flows even in workspaces where
+    Settings has eye detection enabled.
+    """
+    from scoring import score_encounter
+
+    a = _make_base_photo(subject_tenengrad=50000, eye_tenengrad=5000)
+    b = _make_base_photo(subject_tenengrad=5000, eye_tenengrad=50000)
+    enc = {"photos": [a, b]}
+
+    # Nested shape, matching effective_cfg = db.get_effective_config(...)
+    score_encounter(enc, config={"pipeline": {"eye_detect_enabled": True}})
+
+    assert b["focus_score"] > a["focus_score"], (
+        f"nested pipeline eye_detect_enabled must reach scoring; got "
+        f"A={a['focus_score']} vs B={b['focus_score']}"
+    )
+
+
+def test_score_encounter_nested_pipeline_disables_eye_when_false():
+    """Symmetric to the nested-enabled test: a nested
+    ``pipeline.eye_detect_enabled=False`` must suppress eye-based ranking
+    even when top-level config keys are also present.
+    """
+    from scoring import score_encounter
+
+    a = _make_base_photo(subject_tenengrad=50000, eye_tenengrad=5000)
+    b = _make_base_photo(subject_tenengrad=5000, eye_tenengrad=50000)
+    enc = {"photos": [a, b]}
+
+    score_encounter(enc, config={"pipeline": {"eye_detect_enabled": False}})
+
+    assert a["focus_score"] > b["focus_score"]
+    assert "eye_focus_score" not in a
+    assert "eye_focus_score" not in b
+
+
+def test_score_encounter_nested_pipeline_reject_thresholds():
+    """A user-configured ``reject_eye_focus`` nested under ``pipeline``
+    must reach scoring the same way the flat shape does. Otherwise
+    the batch-review paths silently apply DEFAULTS on the reject rule
+    despite the workspace's tuning.
+    """
+    from scoring import score_encounter
+
+    soft_eye = _make_base_photo(
+        subject_tenengrad=50000, eye_tenengrad=1000,
+    )
+    enc = {"photos": [soft_eye]}
+
+    # Set threshold high so eye_focus_score (percentile rank in a single-
+    # photo cohort = 0.5) reliably falls below it — proves the value
+    # from the nested pipeline dict actually reached scoring.
+    score_encounter(
+        enc,
+        config={"pipeline": {
+            "eye_detect_enabled": True,
+            "reject_eye_focus": 0.75,
+        }},
+    )
+
+    assert any(
+        "eye_soft" in r for r in soft_eye.get("reject_reasons", [])
+    ), (
+        f"nested reject_eye_focus threshold must reach scoring; got "
+        f"reasons={soft_eye.get('reject_reasons')!r}"
+    )

--- a/vireo/tests/test_scoring.py
+++ b/vireo/tests/test_scoring.py
@@ -308,7 +308,7 @@ def test_focus_score_uses_eye_tenengrad_when_populated():
     b = _make_base_photo(subject_tenengrad=5000, eye_tenengrad=50000)
     enc = {"photos": [a, b]}
 
-    score_encounter(enc)
+    score_encounter(enc, config={"eye_detect_enabled": True})
 
     assert b["focus_score"] > a["focus_score"], (
         f"eye-based ranking should put sharp-eye photo ahead; "
@@ -324,7 +324,7 @@ def test_focus_score_falls_back_to_subject_tenengrad_when_eye_null():
     b = _make_base_photo(subject_tenengrad=5000, eye_tenengrad=None)
     enc = {"photos": [a, b]}
 
-    score_encounter(enc)
+    score_encounter(enc, config={"eye_detect_enabled": True})
 
     assert a["focus_score"] > b["focus_score"], (
         "without eye_tenengrad, score_encounter must rank on subject_tenengrad"
@@ -345,7 +345,7 @@ def test_focus_score_mixed_eye_and_body_ranks_within_their_group():
     d = _make_base_photo(subject_tenengrad=10000, eye_tenengrad=None)
     enc = {"photos": [a, b, c, d]}
 
-    score_encounter(enc)
+    score_encounter(enc, config={"eye_detect_enabled": True})
 
     assert b["focus_score"] > a["focus_score"]
     assert d["focus_score"] > c["focus_score"]
@@ -369,7 +369,7 @@ def test_body_only_focus_not_diluted_by_eye_capable_peers():
     body_lo = _make_base_photo(subject_tenengrad=5000, eye_tenengrad=None)
     body_hi = _make_base_photo(subject_tenengrad=20000, eye_tenengrad=None)
     mixed_enc = {"photos": [eye_a, eye_b, body_lo, body_hi]}
-    score_encounter(mixed_enc)
+    score_encounter(mixed_enc, config={"eye_detect_enabled": True})
     mixed_body_lo = body_lo["focus_score"]
     mixed_body_hi = body_hi["focus_score"]
 
@@ -379,7 +379,7 @@ def test_body_only_focus_not_diluted_by_eye_capable_peers():
     ref_lo = _make_base_photo(subject_tenengrad=5000, eye_tenengrad=None)
     ref_hi = _make_base_photo(subject_tenengrad=20000, eye_tenengrad=None)
     ref_enc = {"photos": [ref_lo, ref_hi]}
-    score_encounter(ref_enc)
+    score_encounter(ref_enc, config={"eye_detect_enabled": True})
 
     assert mixed_body_lo == ref_lo["focus_score"], (
         f"body-only low scorer should not be diluted by eye peers: "
@@ -403,7 +403,10 @@ def test_reject_eye_soft_fires_when_eye_present_and_below_threshold():
     )
     enc = {"photos": [soft_eye, sharp_eye]}
 
-    score_encounter(enc, config={"reject_eye_focus": 0.35})
+    score_encounter(
+        enc,
+        config={"eye_detect_enabled": True, "reject_eye_focus": 0.35},
+    )
 
     assert any("eye_soft" in r for r in soft_eye.get("reject_reasons", []))
     assert not any("eye_soft" in r for r in sharp_eye.get("reject_reasons", []))
@@ -435,6 +438,21 @@ def test_eye_detect_disabled_falls_back_to_body_focus():
     enc = {"photos": [a, b]}
 
     score_encounter(enc, config={"eye_detect_enabled": False})
+
+    assert a["focus_score"] > b["focus_score"]
+    assert "eye_focus_score" not in a
+    assert "eye_focus_score" not in b
+
+
+def test_eye_detect_missing_config_defaults_disabled():
+    """Missing eye_detect_enabled follows the global default: disabled."""
+    from scoring import score_encounter
+
+    a = _make_base_photo(subject_tenengrad=50000, eye_tenengrad=5000)
+    b = _make_base_photo(subject_tenengrad=5000, eye_tenengrad=50000)
+    enc = {"photos": [a, b]}
+
+    score_encounter(enc)
 
     assert a["focus_score"] > b["focus_score"]
     assert "eye_focus_score" not in a


### PR DESCRIPTION
## Summary
Default bounding-box overlays and eye-focus detection to off across lightbox, review, settings, process UI, scoring, and pipeline preflight. Add a one-time migration so legacy saved eye-detection defaults in global config and workspace overrides are rewritten from on to off. Update focused unit and e2e coverage for the new default behavior.

## Validation
- python -m pytest vireo/tests/test_config.py vireo/tests/test_pipeline.py::test_eye_keypoint_stage_preflight_disabled vireo/tests/test_pipeline.py::test_eye_keypoint_stage_preflight_enabled vireo/tests/test_pipeline.py::test_eye_keypoint_stage_preflight_missing_config_defaults_disabled vireo/tests/test_scoring.py
- python -m pytest vireo/tests/test_pipeline_plan.py vireo/tests/test_process_strategies.py tests/e2e/test_lightbox_context_menu.py::test_lightbox_overlay_toggles_persist_and_context_restores
- python -m pytest vireo/tests/test_app.py::test_pipeline_page_init_api

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Eye-Focus Detection is now off by default and can be enabled per pipeline run.
  * Pipeline planning and scoring now reflect the selected eye-detection setting.
  * Added a Review-page toggle to show or hide detection boxes, with the preference preserved across reloads.
  * Lightbox detection boxes and eye markers now start hidden by default.

* **Bug Fixes**
  * Prevented cached grouping results from appearing current when run settings differ.
  * Improved handling of nested scoring configuration and invalid eye-detection inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->