### PR TITLE
Smooth 100% photo navigation in Browse

### DIFF
--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -572,6 +572,170 @@ def test_browse_lightbox_clears_transition_state_when_incoming_image_errors(
     assert saved["returned"] is not None
 
 
+def test_browse_lightbox_defers_overlays_while_visual_transition_pending(
+    live_server, page
+):
+    """Detection boxes must not paint against the frozen outgoing bitmap.
+
+    Regression: while `_lbVisualTransitionPending` is true the transform is
+    intentionally held on the outgoing image so the swap looks atomic. The
+    metadata fetch usually resolves before the incoming bitmap decodes, and
+    the metadata callback triggers `_lbLoadDetections` for the incoming
+    photo. Without deferral the box overlays render into
+    `#lightboxDetections` — a child of `#lightboxTransform` — using the
+    incoming photo's coordinates but drawn over the still-frozen outgoing
+    bitmap, briefly flashing next-photo boxes over the previous image.
+    """
+    first_svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="4000" height="2000" '
+        'viewBox="0 0 4000 2000"><rect width="4000" height="2000" fill="#274"/>'
+        '<circle cx="1000" cy="1400" r="180" fill="#fff"/></svg>'
+    )
+    next_svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="3000" height="3000" '
+        'viewBox="0 0 3000 3000"><rect width="3000" height="3000" fill="#426"/></svg>'
+    )
+    page.route(
+        "**/photos/*/full",
+        lambda route: route.fulfill(body=first_svg, content_type="image/svg+xml"),
+    )
+
+    url = live_server["url"]
+    page.set_viewport_size({"width": 1000, "height": 800})
+    page.goto(f"{url}/browse")
+    page.locator(".grid-card").nth(1).wait_for(state="visible")
+    next_id = page.evaluate("window.photos[1].id")
+
+    held_original = {}
+
+    def hold_next_original(route):
+        if f"/photos/{next_id}/original" in route.request.url:
+            held_original["route"] = route
+            return
+        route.fulfill(body=first_svg, content_type="image/svg+xml")
+
+    page.route("**/photos/*/original", hold_next_original)
+
+    detection_requests = []
+
+    def serve_detections(route):
+        detection_requests.append(route.request.url)
+        # Two boxes for the incoming photo, one for the outgoing photo so
+        # differentiating between "no detections yet" and "outgoing detections
+        # still showing" would be trivial had the regression re-surfaced.
+        if f"/api/detections/{next_id}" in route.request.url:
+            body = (
+                '[{"box_x":0.1,"box_y":0.2,"box_w":0.15,"box_h":0.20,'
+                '"category":"bird","detector_confidence":0.9},'
+                '{"box_x":0.5,"box_y":0.6,"box_w":0.12,"box_h":0.10,'
+                '"category":"bird","detector_confidence":0.8}]'
+            )
+        else:
+            body = (
+                '[{"box_x":0.3,"box_y":0.3,"box_w":0.1,"box_h":0.1,'
+                '"category":"bird","detector_confidence":0.7}]'
+            )
+        route.fulfill(body=body, content_type="application/json")
+
+    page.route("**/api/detections/*", serve_detections)
+
+    first_card = page.locator(".grid-card").first
+    first_card.wait_for(state="visible")
+    first_card.dblclick()
+    expect(page.locator("#lightboxOverlay")).to_have_class("lightbox-overlay active")
+    page.wait_for_function(
+        """() => {
+            const img = document.getElementById('lightboxImg');
+            return img && img.complete && img.naturalWidth === 4000;
+        }"""
+    )
+    # Trigger 1:1 so the arrow navigation opens the incoming photo at /original
+    # (which we hold below to keep the transition pending).
+    page.evaluate(
+        """() => {
+            window._lbPhotoW = 4000;
+            window._lbPhotoH = 2000;
+            window._lbRecomputeNativeZoom();
+            window._lbCurrentSrcKey = 'original';
+            window._lbApplyViewportState({
+                zoom: window._lbNativeZoom,
+                centerX: 0.5,
+                centerY: 0.5,
+                oneToOne: true,
+            });
+            window._lbSaveViewportState(window._lightboxCurrentId);
+        }"""
+    )
+
+    page.locator("[title='Next (→)']").click()
+    expect(page.locator("#lightboxCounter")).to_contain_text("2 /")
+    page.wait_for_function("() => window._lbVisualTransitionPending === true")
+    page.wait_for_function("() => window._lightboxCurrentId === window.photos[1].id")
+
+    # Wait for the incoming photo's metadata /api/photos/{id} to have resolved
+    # (which normally fires the detection load) while the image is still held.
+    page.wait_for_function(
+        """nextId => window._lbPhotoDataByPhoto
+            && Object.prototype.hasOwnProperty.call(
+                window._lbPhotoDataByPhoto, String(nextId)
+            )""",
+        arg=next_id,
+    )
+
+    deadline = time.time() + 2
+    while "route" not in held_original and time.time() < deadline:
+        page.wait_for_timeout(10)
+    assert "route" in held_original
+
+    # Give the deferred detection fetch a chance to have (incorrectly) fired.
+    page.wait_for_timeout(80)
+
+    during_pending = page.evaluate(
+        """() => {
+            const container = document.getElementById('lightboxDetections');
+            return {
+                pending: window._lbVisualTransitionPending,
+                childCount: container ? container.childElementCount : -1,
+                deferred: typeof window._lbDeferredOverlayApply === 'function',
+            };
+        }"""
+    )
+    assert during_pending["pending"] is True, (
+        "test setup: transition should still be pending while image is held"
+    )
+    assert during_pending["childCount"] == 0, (
+        "detection boxes rendered against the frozen outgoing transform"
+    )
+    assert during_pending["deferred"] is True, (
+        "overlay render was not deferred while the transition was pending"
+    )
+    # And the network fetch itself should not have gone out yet for the
+    # incoming photo — the deferral holds both the request and the render.
+    assert not any(
+        f"/api/detections/{next_id}" in url for url in detection_requests
+    ), "detection request for the incoming photo fired while transition pending"
+
+    held_original.pop("route").fulfill(
+        body=next_svg, content_type="image/svg+xml"
+    )
+
+    page.wait_for_function(
+        "() => window._lbVisualTransitionPending === false"
+    )
+    # Once the transition clears, the deferred overlay work runs and the
+    # incoming photo's detection boxes render normally.
+    page.wait_for_function(
+        """() => {
+            const container = document.getElementById('lightboxDetections');
+            return container && container.childElementCount === 2;
+        }""",
+        timeout=3000,
+    )
+    assert any(
+        f"/api/detections/{next_id}" in url for url in detection_requests
+    ), "detection fetch never fired after transition cleared"
+
+
 def test_browse_lightbox_pending_high_zoom_survives_native_zoom_race(live_server, page):
     """A saved zoom > 4 is not lost when native zoom is unknown at first apply.
 

--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -494,6 +494,84 @@ def test_browse_lightbox_mid_transition_save_does_not_leak_outgoing_transform(
     )
 
 
+def test_browse_lightbox_clears_transition_state_when_incoming_image_errors(
+    live_server, page
+):
+    """A non-'original' image error must clear _lbVisualTransitionPending.
+
+    Regression: handleInitialImageError's early-return path (taken when the
+    failing tier isn't the /original fallback candidate) previously left
+    _lbVisualTransitionPending true indefinitely. That kept the metadata
+    callback skipping layout updates and made _lbSaveViewportState treat the
+    incoming photo as still mid-transition even though the UI/counter had
+    already advanced to it, freezing the outgoing transform on screen until
+    the lightbox was closed or another navigation succeeded.
+    """
+    first_svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="4000" height="2000" '
+        'viewBox="0 0 4000 2000"><rect width="4000" height="2000" fill="#274"/>'
+        '<circle cx="1000" cy="1400" r="180" fill="#fff"/></svg>'
+    )
+
+    url = live_server["url"]
+    page.set_viewport_size({"width": 1000, "height": 800})
+    page.goto(f"{url}/browse")
+    page.locator(".grid-card").nth(1).wait_for(state="visible")
+    next_id = page.evaluate("window.photos[1].id")
+
+    def route_full(route):
+        # Fail the incoming photo's /full tier; the outgoing photo's /full
+        # still resolves normally so we can enter the mid-navigation window.
+        if f"/photos/{next_id}/full" in route.request.url:
+            route.fulfill(status=404, body=b"", content_type="text/plain")
+            return
+        route.fulfill(body=first_svg, content_type="image/svg+xml")
+
+    page.route("**/photos/*/full", route_full)
+
+    first_card = page.locator(".grid-card").first
+    first_card.wait_for(state="visible")
+    first_card.dblclick()
+    expect(page.locator("#lightboxOverlay")).to_have_class("lightbox-overlay active")
+    page.wait_for_function(
+        """() => {
+            const img = document.getElementById('lightboxImg');
+            return img && img.complete && img.naturalWidth === 4000;
+        }"""
+    )
+
+    # A fit-view navigation opens the incoming photo at _lbCurrentSrcKey='full'
+    # with _lbVisualTransitionPending=true. The /full request then 404s, so
+    # handleInitialImageError takes the non-'original' early-return path.
+    page.locator("[title='Next (→)']").click()
+    expect(page.locator("#lightboxCounter")).to_contain_text("2 /")
+    page.wait_for_function(
+        "() => window._lightboxCurrentId === window.photos[1].id"
+    )
+
+    page.wait_for_function(
+        "() => window._lbVisualTransitionPending === false",
+        timeout=3000,
+    )
+
+    # With the pending flag cleared, saving the current photo's viewport must
+    # go through the normal (non-guard) path — the guard block only activates
+    # while a transition is pending — so the incoming photo id is a legal
+    # save target rather than a frozen-outgoing snapshot sink.
+    saved = page.evaluate(
+        """() => {
+            const id = window._lightboxCurrentId;
+            const returned = window._lbSaveViewportState(id);
+            return {
+                returned: returned,
+                pendingFlag: window._lbVisualTransitionPending,
+            };
+        }"""
+    )
+    assert saved["pendingFlag"] is False
+    assert saved["returned"] is not None
+
+
 def test_browse_lightbox_pending_high_zoom_survives_native_zoom_race(live_server, page):
     """A saved zoom > 4 is not lost when native zoom is unknown at first apply.
 

--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -354,6 +354,146 @@ def test_browse_lightbox_holds_off_center_transform_until_next_photo_is_ready(
     assert abs(carried["centerY"] - before["viewport"]["centerY"]) < 0.03
 
 
+def test_browse_lightbox_mid_transition_save_does_not_leak_outgoing_transform(
+    live_server, page
+):
+    """A save while the outgoing bitmap is still frozen must not stomp the
+    incoming photo's intended inspection point.
+
+    Regression: while _lbVisualTransitionPending is true, _lightboxCurrentId
+    already points at the incoming photo but the DOM transform still belongs
+    to the outgoing bitmap. A save triggered by another arrow press or
+    closeLightbox in that window used to read the DOM and record the outgoing
+    transform under the incoming photo's id, replacing the state the next
+    open of that photo would otherwise restore.
+    """
+    first_svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="4000" height="2000" '
+        'viewBox="0 0 4000 2000"><rect width="4000" height="2000" fill="#274"/>'
+        '<circle cx="1000" cy="1400" r="180" fill="#fff"/></svg>'
+    )
+    next_svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="3000" height="3000" '
+        'viewBox="0 0 3000 3000"><rect width="3000" height="3000" fill="#426"/></svg>'
+    )
+    page.route(
+        "**/photos/*/full",
+        lambda route: route.fulfill(body=first_svg, content_type="image/svg+xml"),
+    )
+
+    url = live_server["url"]
+    page.set_viewport_size({"width": 1000, "height": 800})
+    page.goto(f"{url}/browse")
+    page.locator(".grid-card").nth(1).wait_for(state="visible")
+    next_id = page.evaluate("window.photos[1].id")
+    held_original = {}
+
+    def hold_next_original(route):
+        if f"/photos/{next_id}/original" in route.request.url:
+            held_original["route"] = route
+            return
+        route.fulfill(body=first_svg, content_type="image/svg+xml")
+
+    page.route("**/photos/*/original", hold_next_original)
+
+    first_card = page.locator(".grid-card").first
+    first_card.wait_for(state="visible")
+    first_card.dblclick()
+    expect(page.locator("#lightboxOverlay")).to_have_class("lightbox-overlay active")
+    page.wait_for_function(
+        """() => {
+            const img = document.getElementById('lightboxImg');
+            return img && img.complete && img.naturalWidth === 4000;
+        }"""
+    )
+
+    outgoing = page.evaluate(
+        """() => {
+            window._lbPhotoW = 4000;
+            window._lbPhotoH = 2000;
+            window._lbRecomputeNativeZoom();
+            window._lbCurrentSrcKey = 'original';
+            window._lbApplyViewportState({
+                zoom: window._lbNativeZoom,
+                centerX: 0.20,
+                centerY: 0.75,
+                oneToOne: true,
+            });
+            window._lbSaveViewportState(window._lightboxCurrentId);
+            return window._lbViewportStateFromCurrent();
+        }"""
+    )
+
+    # Prime a distinctive saved viewport for the incoming photo so we can
+    # tell "our intended state survives" from "outgoing DOM state leaked in".
+    incoming_id = page.evaluate("window.photos[1].id")
+    intended = {"zoom": 2.5, "centerX": 0.80, "centerY": 0.15}
+    page.evaluate(
+        """([id, state]) => {
+            window._lbViewportByPhotoId[String(id)] = {
+                zoom: state.zoom,
+                centerX: state.centerX,
+                centerY: state.centerY,
+                oneToOne: false,
+                pending1To1: false,
+            };
+        }""",
+        [incoming_id, intended],
+    )
+
+    page.locator("[title='Next (→)']").click()
+    expect(page.locator("#lightboxCounter")).to_contain_text("2 /")
+    page.wait_for_function("() => window._lbVisualTransitionPending === true")
+    page.wait_for_function("() => window._lightboxCurrentId === window.photos[1].id")
+    page.wait_for_timeout(50)
+    deadline = time.time() + 2
+    while "route" not in held_original and time.time() < deadline:
+        page.wait_for_timeout(10)
+    assert "route" in held_original
+
+    # Simulate the user pressing another arrow / closing the lightbox before
+    # the incoming image finishes decoding: openLightbox / lightboxNav /
+    # closeLightbox all call _lbSaveViewportState(_lightboxCurrentId) in this
+    # state. The DOM transform is still the outgoing bitmap's.
+    saved_during_transition = page.evaluate(
+        """(id) => {
+            const returned = window._lbSaveViewportState(id);
+            return {
+                returned: returned,
+                stored: window._lbViewportByPhotoId[String(id)],
+            };
+        }""",
+        incoming_id,
+    )
+
+    # The stored state for the incoming photo must not be the outgoing
+    # bitmap's transform. It should be either the pending restore state that
+    # openLightbox armed for the incoming photo, or the pre-existing saved
+    # state we primed above — never the outgoing photo's centerX/centerY.
+    stored = saved_during_transition["stored"]
+    assert stored is not None
+    # Guard against the specific regression: the outgoing photo's off-center
+    # inspection point (0.20, 0.75) must not be recorded under the incoming
+    # photo's id.
+    assert not (
+        abs(stored["centerX"] - outgoing["centerX"]) < 0.05
+        and abs(stored["centerY"] - outgoing["centerY"]) < 0.05
+    ), (
+        "outgoing DOM transform leaked into incoming photo's saved viewport"
+    )
+
+    held_original.pop("route").fulfill(
+        body=next_svg, content_type="image/svg+xml"
+    )
+    page.wait_for_function(
+        """() => {
+            const img = document.getElementById('lightboxImg');
+            return window._lbVisualTransitionPending === false
+                && img && img.complete && img.naturalWidth === 3000;
+        }"""
+    )
+
+
 def test_browse_lightbox_pending_high_zoom_survives_native_zoom_race(live_server, page):
     """A saved zoom > 4 is not lost when native zoom is unknown at first apply.
 

--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -132,6 +132,40 @@ def test_browse_lightbox_arrows_preserve_one_to_one_zoom(live_server, page):
     assert page.evaluate("window._lbZoom") > 1.001
 
 
+def test_browse_lightbox_predecodes_adjacent_photo_for_current_source_tier(
+    live_server, page
+):
+    """The next photo is decoded while the user is still viewing the current one."""
+    svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="4000" height="2000" '
+        'viewBox="0 0 4000 2000"><rect width="4000" height="2000" fill="#274"/></svg>'
+    )
+    original_requests = []
+
+    def serve_original(route):
+        original_requests.append(route.request.url)
+        route.fulfill(body=svg, content_type="image/svg+xml")
+
+    page.route("**/photos/*/original", serve_original)
+    page.goto(f"{live_server['url']}/browse")
+    first_card = page.locator(".grid-card").first
+    first_card.wait_for(state="visible")
+    first_card.dblclick()
+    expect(page.locator("#lightboxOverlay")).to_have_class("lightbox-overlay active")
+
+    next_id = page.evaluate("window._lightboxPhotoList[1].id")
+    page.evaluate("window._lbScheduleSourceSwap(100)")
+    page.wait_for_function(
+        """nextId => Object.values(window._lbAdjacentPreloads).some(entry => (
+            entry.photoId === nextId && entry.sourceKey === 'original' && entry.status === 'decoded'
+        ))""",
+        arg=next_id,
+    )
+
+    assert any(f"/photos/{next_id}/original" in url for url in original_requests)
+    assert page.evaluate("window._lightboxCurrentId") != next_id
+
+
 def test_browse_lightbox_restores_and_carries_zoomed_viewport(live_server, page):
     """Arrow navigation preserves pan/zoom per photo and carries it to unseen photos."""
     svg = (
@@ -203,6 +237,121 @@ def test_browse_lightbox_restores_and_carries_zoomed_viewport(live_server, page)
     assert abs(restored_view["zoom"] - first_view["zoom"]) < 0.05
     assert abs(restored_view["centerX"] - first_view["centerX"]) < 0.03
     assert abs(restored_view["centerY"] - first_view["centerY"]) < 0.03
+
+
+def test_browse_lightbox_holds_off_center_transform_until_next_photo_is_ready(
+    live_server, page
+):
+    """100% navigation must not recenter the outgoing photo while loading.
+
+    The incoming photo's metadata often resolves before its image. Previously
+    navigation reset pan immediately, visibly jerking the outgoing bitmap to
+    center, then restored the carried viewport when the new bitmap decoded.
+    """
+    first_svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="4000" height="2000" '
+        'viewBox="0 0 4000 2000"><rect width="4000" height="2000" fill="#274"/>'
+        '<circle cx="1000" cy="1400" r="180" fill="#fff"/></svg>'
+    )
+    next_svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="3000" height="3000" '
+        'viewBox="0 0 3000 3000"><rect width="3000" height="3000" fill="#426"/></svg>'
+    )
+    page.route(
+        "**/photos/*/full",
+        lambda route: route.fulfill(body=first_svg, content_type="image/svg+xml"),
+    )
+
+    url = live_server["url"]
+    page.set_viewport_size({"width": 1000, "height": 800})
+    page.goto(f"{url}/browse")
+    page.locator(".grid-card").nth(1).wait_for(state="visible")
+    next_id = page.evaluate("window.photos[1].id")
+    held_original = {}
+
+    def hold_next_original(route):
+        if f"/photos/{next_id}/original" in route.request.url:
+            held_original["route"] = route
+            return
+        route.fulfill(body=first_svg, content_type="image/svg+xml")
+
+    page.route("**/photos/*/original", hold_next_original)
+
+    first_card = page.locator(".grid-card").first
+    first_card.wait_for(state="visible")
+    first_card.dblclick()
+    expect(page.locator("#lightboxOverlay")).to_have_class("lightbox-overlay active")
+    page.wait_for_function(
+        """() => {
+            const img = document.getElementById('lightboxImg');
+            return img && img.complete && img.naturalWidth === 4000;
+        }"""
+    )
+
+    before = page.evaluate(
+        """() => {
+            window._lbPhotoW = 4000;
+            window._lbPhotoH = 2000;
+            window._lbRecomputeNativeZoom();
+            window._lbCurrentSrcKey = 'original';
+            window._lbApplyViewportState({
+                zoom: window._lbNativeZoom,
+                centerX: 0.24,
+                centerY: 0.70,
+                oneToOne: true,
+            });
+            window._lbSaveViewportState(window._lightboxCurrentId);
+            const transform = document.getElementById('lightboxTransform');
+            return {
+                cssTransform: transform.style.transform,
+                width: transform.style.width,
+                height: transform.style.height,
+                viewport: window._lbViewportStateFromCurrent(),
+            };
+        }"""
+    )
+
+    page.locator("[title='Next (→)']").click()
+    expect(page.locator("#lightboxCounter")).to_contain_text("2 /")
+    page.wait_for_function("() => window._lbVisualTransitionPending === true")
+    page.wait_for_function("() => window._lightboxCurrentId === window.photos[1].id")
+    page.wait_for_timeout(100)
+
+    deadline = time.time() + 2
+    while "route" not in held_original and time.time() < deadline:
+        page.wait_for_timeout(10)
+    assert "route" in held_original
+
+    while_loading = page.evaluate(
+        """() => {
+            const transform = document.getElementById('lightboxTransform');
+            return {
+                cssTransform: transform.style.transform,
+                width: transform.style.width,
+                height: transform.style.height,
+            };
+        }"""
+    )
+    assert while_loading == {
+        "cssTransform": before["cssTransform"],
+        "width": before["width"],
+        "height": before["height"],
+    }
+
+    held_original.pop("route").fulfill(
+        body=next_svg, content_type="image/svg+xml"
+    )
+    page.wait_for_function(
+        """() => {
+            const img = document.getElementById('lightboxImg');
+            return window._lbVisualTransitionPending === false
+                && window._lbPendingViewportState === null
+                && img && img.complete && img.naturalWidth === 3000;
+        }"""
+    )
+    carried = page.evaluate("window._lbViewportStateFromCurrent()")
+    assert abs(carried["centerX"] - before["viewport"]["centerX"]) < 0.03
+    assert abs(carried["centerY"] - before["viewport"]["centerY"]) < 0.03
 
 
 def test_browse_lightbox_pending_high_zoom_survives_native_zoom_race(live_server, page):

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -5304,6 +5304,22 @@ function _lbViewportStateFromCurrent() {
 
 function _lbSaveViewportState(photoId) {
   if (photoId == null) return null;
+  // Mid-navigation the DOM transform still belongs to the outgoing photo but
+  // _lightboxCurrentId has already advanced to the incoming id. Reading from
+  // the DOM here would misattribute the frozen bitmap to the incoming photo
+  // and stomp its intended inspection point. Prefer the pending restore
+  // state (what handleInitialImageLoad is about to apply), and otherwise
+  // leave any previously saved state alone.
+  if (_lbVisualTransitionPending && String(photoId) === String(_lightboxCurrentId)) {
+    var pending = _lbPendingViewportState;
+    if (pending) {
+      var pendingClone = _lbCloneViewportState(pending);
+      _lbViewportByPhotoId[String(photoId)] = pendingClone;
+      return _lbCloneViewportState(pendingClone);
+    }
+    var existing = _lbViewportByPhotoId[String(photoId)];
+    return existing ? _lbCloneViewportState(existing) : null;
+  }
   var state = _lbViewportStateFromCurrent();
   _lbViewportByPhotoId[String(photoId)] = state;
   return _lbCloneViewportState(state);

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3586,6 +3586,7 @@ var _lbConfirmedFlags = {};   // last server-confirmed flag per photo, isolated 
 var _lbViewportByPhotoId = {};  // per-session lightbox viewport cache keyed by photo id
 var _lbPendingViewportState = null;
 var _lbVisualTransitionPending = false; // keep the outgoing bitmap/transform frozen until the incoming image is decoded
+var _lbDeferredOverlayApply = null; // detections/eye render withheld while _lbVisualTransitionPending; drained when the transition clears
 var _lbAdjacentPreloads = {}; // decoded immediate neighbors, keyed by photo id + source URL
 var _lbEditRecipeByPhoto = {};
 var _lbEditRecipeKnownByPhoto = {};
@@ -5379,6 +5380,21 @@ function _lbApplyViewportState(state) {
   return true;
 }
 
+function _lbFlushDeferredOverlayApply() {
+  // Called from handleInitialImageLoad and the terminal handleInitialImageError
+  // branch, i.e. wherever _lbVisualTransitionPending flips back to false. The
+  // metadata callback stashes the detection/eye render here so overlays don't
+  // paint against the still-frozen outgoing transform. Re-apply the mask
+  // overlay too because _lbApplyMaskVisibility only adds the `show` class when
+  // the transition is clear, so an in-flight mask load could have been gated.
+  var pending = _lbDeferredOverlayApply;
+  _lbDeferredOverlayApply = null;
+  if (typeof pending === 'function') {
+    try { pending(); } catch (_) {}
+  }
+  _lbApplyMaskVisibility();
+}
+
 function _lbClearPendingViewportRestore() {
   // Called from user-driven viewport mutations (wheel/keyboard/click zoom,
   // drag pan) so a still-armed restore carried over by arrow navigation
@@ -5907,17 +5923,26 @@ function _lbApplyMaskVisibility() {
   };
   img.onload = function() {
     // Re-check the toggle: the user may have hidden masks between
-    // src assignment and the load resolving.
-    if (seq === _lbMaskLoadSeq && _lbMasksVisible && _lbMaskCurrentUrl === expectedUrl) {
+    // src assignment and the load resolving. Also re-check the visual
+    // transition: while the outgoing bitmap is still frozen on screen,
+    // painting the incoming photo's mask would show it over the previous
+    // image. handleInitialImageLoad re-runs _lbApplyMaskVisibility once
+    // the transition clears, so the mask surfaces as soon as it is safe.
+    if (
+      seq === _lbMaskLoadSeq
+      && _lbMasksVisible
+      && _lbMaskCurrentUrl === expectedUrl
+      && !_lbVisualTransitionPending
+    ) {
       img.classList.add('show');
     }
   };
   if (img.getAttribute('src') !== expectedUrl) {
     img.classList.remove('show');
     img.src = expectedUrl;
-  } else if (img.naturalWidth > 0) {
+  } else if (img.naturalWidth > 0 && !_lbVisualTransitionPending) {
     // Same URL and we know it loaded successfully — safe to re-show
-    // without re-fetching.
+    // without re-fetching, once the visual transition has cleared.
     img.classList.add('show');
   }
   // If src matches but naturalWidth is 0, the previous load either failed
@@ -6504,6 +6529,11 @@ function openLightbox(photoId, filename, photoList, options) {
   // applied together from handleInitialImageLoad, before the browser's next
   // paint, so an off-center view never flashes through a centered state.
   _lbVisualTransitionPending = alreadyOpen;
+  // A previous open's deferred overlay closure captured the previous photo id
+  // and metadata. If this open's image resolves before its own metadata does,
+  // draining that stale closure would render the previous photo's detections
+  // and eye marker over the incoming bitmap.
+  _lbDeferredOverlayApply = null;
 
   _lightboxCurrentId = photoId;
   if (photoList) _lightboxPhotoList = photoList;
@@ -6653,12 +6683,28 @@ function openLightbox(photoId, filename, photoList, options) {
         _lbRecomputeNativeZoom();
         if (!_lbTryApplyPendingViewportState()) _lbApplyPendingOneToOneZoom();
       }
-      _lbLoadDetections(photoId);
-      _lbRenderEyeCrosshair(data);
+      // Detection boxes, the eye marker, and the mask overlay are children of
+      // lightboxTransform. While _lbVisualTransitionPending is true the
+      // transform is intentionally frozen on the outgoing bitmap, so painting
+      // the incoming photo's overlays now would layer them over the previous
+      // image until handleInitialImageLoad swaps in the new bitmap. Defer the
+      // render calls that actually inject DOM content until the transition
+      // clears; the visibility/toggle helpers are safe to run either way
+      // because they only touch empty containers or button labels.
+      var applyOverlays = function() {
+        _lbLoadDetections(photoId);
+        _lbRenderEyeCrosshair(data);
+      };
       _lbApplyBoxesVisibility();
       _lbApplyEyeVisibility();
       _lbApplyMaskToggleButton();
       _lbApplyMaskVisibility();
+      if (_lbVisualTransitionPending) {
+        _lbDeferredOverlayApply = applyOverlays;
+      } else {
+        _lbDeferredOverlayApply = null;
+        applyOverlays();
+      }
     })
     .catch(function() {
       if (_lightboxCurrentId !== photoId || _lbOpenSeq !== openSeq) return;
@@ -6697,6 +6743,7 @@ function openLightbox(photoId, filename, photoList, options) {
       _lbApplyPendingOneToOneZoom();
     }
     _lbApplyTransform();
+    _lbFlushDeferredOverlayApply();
     _lbPrimeAdjacentPhotos(_lbCurrentSrcKey);
   }
   function handleInitialImageError() {
@@ -6714,6 +6761,7 @@ function openLightbox(photoId, filename, photoList, options) {
       _lbRecomputeNativeZoom();
       if (!_lbTryApplyPendingViewportState()) _lbApplyPendingOneToOneZoom();
       _lbApplyTransform();
+      _lbFlushDeferredOverlayApply();
       return;
     }
     _lbOriginalUnavailable = true;
@@ -6991,6 +7039,7 @@ function closeLightbox(e) {
   _lbPanX = 0;
   _lbPanY = 0;
   _lbVisualTransitionPending = false;
+  _lbDeferredOverlayApply = null;
   _lbClearPendingViewportRestore();
   if (_lbSwapTimer) { clearTimeout(_lbSwapTimer); _lbSwapTimer = null; }
   _lbDesiredSrcKey = null;

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -6704,6 +6704,16 @@ function openLightbox(photoId, filename, photoList, options) {
     if (_lbCurrentSrcKey !== 'original') {
       img.onload = null;
       img.onerror = null;
+      // No further fallback tier is available. Clear the pending visual
+      // transition — otherwise the metadata callback would keep skipping
+      // layout updates and _lbSaveViewportState would keep treating the
+      // incoming photo as mid-transition even though the UI already points
+      // at it. Apply any deferred viewport state so the layout reflects
+      // the incoming photo instead of the frozen outgoing bitmap.
+      _lbVisualTransitionPending = false;
+      _lbRecomputeNativeZoom();
+      if (!_lbTryApplyPendingViewportState()) _lbApplyPendingOneToOneZoom();
+      _lbApplyTransform();
       return;
     }
     _lbOriginalUnavailable = true;

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3585,6 +3585,8 @@ var _lbFlagPendingByPhoto = {};  // count of in-flight flag writes PER photo; li
 var _lbConfirmedFlags = {};   // last server-confirmed flag per photo, isolated from optimistic page helpers
 var _lbViewportByPhotoId = {};  // per-session lightbox viewport cache keyed by photo id
 var _lbPendingViewportState = null;
+var _lbVisualTransitionPending = false; // keep the outgoing bitmap/transform frozen until the incoming image is decoded
+var _lbAdjacentPreloads = {}; // decoded immediate neighbors, keyed by photo id + source URL
 var _lbEditRecipeByPhoto = {};
 var _lbEditRecipeKnownByPhoto = {};
 var _lbEditRecipeWriteSeq = 0;
@@ -6480,6 +6482,12 @@ function openLightbox(photoId, filename, photoList, options) {
   var transitionZoom = restoreViewportState
     ? Math.max(1.0, restoreViewportState.zoom || 1.0)
     : 1.0;
+  // During arrow navigation the <img> still paints the outgoing bitmap until
+  // the replacement has decoded. Keep its transform frozen too. The incoming
+  // photo's dimensions, true 1:1 scale, and normalized viewport center are
+  // applied together from handleInitialImageLoad, before the browser's next
+  // paint, so an off-center view never flashes through a centered state.
+  _lbVisualTransitionPending = alreadyOpen;
 
   _lightboxCurrentId = photoId;
   if (photoList) _lightboxPhotoList = photoList;
@@ -6565,7 +6573,9 @@ function openLightbox(photoId, filename, photoList, options) {
   _lbSetAdjustmentStatus('');
   if (_lbSwapTimer) { clearTimeout(_lbSwapTimer); _lbSwapTimer = null; }
   _lbDesiredSrcKey = null;
-  _lbApplyTransform();  // Clear stale pan while preserving 1:1 scale when requested.
+  if (!_lbVisualTransitionPending) {
+    _lbApplyTransform();
+  }
 
   // Fetch original dimensions (async, non-blocking for image display)
   var flagFetchSeq = _lbFlagEditSeq;
@@ -6619,8 +6629,14 @@ function openLightbox(photoId, filename, photoList, options) {
       }
       _lbApplyWildlifeExcludedButton();
       _lbRecordFetchedFlag(photoId, data.flag, flagFetchSeq);
-      _lbRecomputeNativeZoom();
-      if (!_lbTryApplyPendingViewportState()) _lbApplyPendingOneToOneZoom();
+      // Metadata commonly wins the race with image decoding. Updating the
+      // transform here would lay out the still-visible outgoing bitmap using
+      // the incoming photo's dimensions, producing the navigation jerk. Let
+      // the image-load handler commit image + viewport atomically instead.
+      if (!_lbVisualTransitionPending) {
+        _lbRecomputeNativeZoom();
+        if (!_lbTryApplyPendingViewportState()) _lbApplyPendingOneToOneZoom();
+      }
       _lbLoadDetections(photoId);
       _lbRenderEyeCrosshair(data);
       _lbApplyBoxesVisibility();
@@ -6636,6 +6652,7 @@ function openLightbox(photoId, filename, photoList, options) {
   function handleInitialImageLoad() {
     img.onload = null;
     img.onerror = null;
+    if (_lightboxCurrentId !== photoId || _lbOpenSeq !== openSeq) return;
     // Only record the /full tier size if the currently loaded source is still /full.
     // A quick user zoom can trigger a debounced swap to a higher tier before /full
     // finishes loading, which would otherwise make us record the swapped source's
@@ -6648,6 +6665,7 @@ function openLightbox(photoId, filename, photoList, options) {
       _lbPhotoW = img.naturalWidth;
       _lbPhotoH = img.naturalHeight;
     }
+    _lbVisualTransitionPending = false;
     _lbRecomputeNativeZoom();
     if (
       _lbCurrentSrcKey === 'full' &&
@@ -6663,6 +6681,7 @@ function openLightbox(photoId, filename, photoList, options) {
       _lbApplyPendingOneToOneZoom();
     }
     _lbApplyTransform();
+    _lbPrimeAdjacentPhotos(_lbCurrentSrcKey);
   }
   function handleInitialImageError() {
     if (_lightboxCurrentId !== photoId || _lbOpenSeq !== openSeq) return;
@@ -6945,9 +6964,11 @@ function closeLightbox(e) {
   _lbZoom = 1.0;
   _lbPanX = 0;
   _lbPanY = 0;
+  _lbVisualTransitionPending = false;
   _lbClearPendingViewportRestore();
   if (_lbSwapTimer) { clearTimeout(_lbSwapTimer); _lbSwapTimer = null; }
   _lbDesiredSrcKey = null;
+  _lbClearAdjacentPreloads();
   _lbClearAdjustmentPreview();
   var adjustPanel = document.getElementById('lightboxAdjustPanel');
   if (adjustPanel) adjustPanel.classList.remove('open');
@@ -8098,11 +8119,80 @@ function _lbSrcUrl(photoId, key) {
   return url;
 }
 
+function _lbClearAdjacentPreloads() {
+  Object.keys(_lbAdjacentPreloads).forEach(function(cacheKey) {
+    var entry = _lbAdjacentPreloads[cacheKey];
+    if (entry && entry.img) {
+      entry.img.onload = null;
+      entry.img.onerror = null;
+      entry.img.removeAttribute('src');
+    }
+  });
+  _lbAdjacentPreloads = {};
+}
+
+function _lbPrimeAdjacentPhotos(sourceKey) {
+  if (_lightboxPhotoList.length < 2 || _lightboxCurrentId == null) {
+    _lbClearAdjacentPreloads();
+    return;
+  }
+  var currentIdx = _lightboxPhotoList.findIndex(function(photo) {
+    return photo.id === _lightboxCurrentId;
+  });
+  if (currentIdx === -1) return;
+
+  var keep = {};
+  [currentIdx - 1, currentIdx + 1].forEach(function(idx) {
+    if (idx < 0 || idx >= _lightboxPhotoList.length) return;
+    var photo = _lightboxPhotoList[idx];
+    if (Object.prototype.hasOwnProperty.call(photo, 'edit_recipe')) {
+      _lbRememberEditRecipe(photo.id, photo.edit_recipe);
+    }
+    var key = sourceKey || 'full';
+    var url = _lbSrcUrl(photo.id, key);
+    var cacheKey = String(photo.id) + '|' + url;
+    keep[cacheKey] = true;
+    if (_lbAdjacentPreloads[cacheKey]) return;
+
+    var preload = new Image();
+    var entry = { img: preload, photoId: photo.id, sourceKey: key, status: 'loading' };
+    _lbAdjacentPreloads[cacheKey] = entry;
+    preload.fetchPriority = 'low';
+    var supportsDecode = typeof preload.decode === 'function';
+    preload.onload = function() {
+      if (!supportsDecode) entry.status = 'decoded';
+    };
+    preload.onerror = function() { entry.status = 'failed'; };
+    preload.src = url;
+    if (supportsDecode) {
+      preload.decode().then(function() {
+        entry.status = 'decoded';
+      }).catch(function() {
+        // onload/onerror remains the fallback for WebViews with incomplete decode support.
+      });
+    }
+  });
+
+  Object.keys(_lbAdjacentPreloads).forEach(function(cacheKey) {
+    if (keep[cacheKey]) return;
+    var stale = _lbAdjacentPreloads[cacheKey];
+    if (stale && stale.img) {
+      stale.img.onload = null;
+      stale.img.onerror = null;
+      stale.img.removeAttribute('src');
+    }
+    delete _lbAdjacentPreloads[cacheKey];
+  });
+}
+
 function _lbScheduleSourceSwap(targetZoom) {
   if (!_lightboxCurrentId) return;
   var desired = _lbPickSourceKey(targetZoom);
   _lbDesiredSrcKey = desired;
-  if (desired === _lbCurrentSrcKey) return;
+  if (desired === _lbCurrentSrcKey) {
+    _lbPrimeAdjacentPhotos(desired);
+    return;
+  }
 
   if (_lbSwapTimer) clearTimeout(_lbSwapTimer);
   _lbSwapTimer = setTimeout(function() {
@@ -8148,6 +8238,7 @@ function _lbScheduleSourceSwap(targetZoom) {
       });
       img.src = url;
       _lbCurrentSrcKey = key;
+      _lbPrimeAdjacentPhotos(key);
     };
     preloader.onerror = function() {
       if (_lightboxCurrentId !== photoId) return;


### PR DESCRIPTION
## Summary

- keep the outgoing lightbox image and transform frozen until the incoming photo has decoded
- apply the incoming photo's true 100% scale and remembered viewport position atomically
- predecode adjacent photos at the active source tier to make sequential navigation respond immediately
- clean up adjacent preloads when the lightbox closes or the navigation window changes
- add deterministic coverage for delayed image decoding and adjacent-photo preloading

## Root cause

At 100% zoom, Browse saved the current normalized viewport but reset pan before the next photo finished loading. The still-visible outgoing bitmap therefore jumped to center, then moved again when the incoming photo restored the saved viewport. Metadata could also arrive before image decoding and apply the incoming dimensions to the outgoing bitmap.

## User impact

When navigating between photos at 100%, the current photo now stays still until the replacement is ready. The next photo appears already at the corresponding inspection point and correct scale, without the intermediate recentering jerk. Adjacent photos are decoded at low priority to reduce the wait between frames.

## Validation

- `python -m pytest tests/e2e/test_browse_lightbox.py -q` — 23 passed
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lightbox navigation to prevent outgoing images from snapping or leaking their viewport position during transitions.
  * Preserved off-center zoom and pan states until the next image is ready.
  * Improved handling when incoming image variants fail to load, allowing navigation and viewport saving to continue correctly.

* **Performance**
  * Added preloading and decoding of adjacent photos for smoother lightbox navigation.

* **Tests**
  * Added end-to-end coverage for lightbox preloading, transitions, viewport preservation, and image-load failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->