### PR TITLE
Handle near-full RAW thumbnail fallbacks

### DIFF
--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -50,6 +50,9 @@ from render_source import (
 from render_source import (
     scaled_recipe_source_dimensions as _scaled_recipe_source_dimensions,
 )
+from render_source import (
+    working_copy_path_if_satisfies as _working_copy_path_if_satisfies,
+)
 
 log = logging.getLogger(__name__)
 
@@ -315,6 +318,47 @@ def _retry_thumbnail_with_companion(
         cache_dir,
         size=thumb_size,
         **recipe_kwargs,
+    )
+
+
+def _retry_thumbnail_with_working_copy(
+    thread_db, generate_thumbnail, photo, photo_id, raw_source_path,
+    cache_dir, thumb_size, recipe, vireo_dir,
+):
+    """Retry an edited RAW thumbnail from a near-full local JPEG copy."""
+    if not photo or not recipe or not vireo_dir:
+        return None
+    if os.path.splitext(raw_source_path or "")[1].lower() not in _RAW_EXTENSIONS:
+        return None
+    wc_path = _working_copy_path_if_satisfies(
+        photo, recipe, thumb_size, vireo_dir, thumbnail_tolerance=True,
+    )
+    if not wc_path or os.path.abspath(wc_path) == os.path.abspath(raw_source_path):
+        return None
+    log.info(
+        "Pipeline thumbnail RAW decode failed for photo %s; "
+        "falling back to near-full JPEG working copy",
+        photo_id,
+    )
+    file_mtime = _photo_value(photo, "file_mtime")
+    if file_mtime is not None:
+        with contextlib.suppress(Exception):
+            thread_db.conn.execute(
+                "UPDATE photos SET"
+                " working_copy_failed_at=datetime('now'),"
+                " working_copy_failed_mtime=?,"
+                " working_copy_failed_source='source'"
+                " WHERE id=?",
+                (file_mtime, photo_id),
+            )
+            commit_with_retry(thread_db.conn)
+    return generate_thumbnail(
+        photo_id,
+        wc_path,
+        cache_dir,
+        size=thumb_size,
+        recipe=recipe,
+        native_size=_recipe_source_dimensions(photo),
     )
 
 
@@ -2264,6 +2308,17 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 generated = 0
                 skipped = 0
                 failed = 0
+                failed_photos = []
+                failure_detail_limit = 100
+
+                def _record_failure(photo_id, photo_path, reason):
+                    if len(failed_photos) >= failure_detail_limit:
+                        return
+                    failed_photos.append({
+                        "id": photo_id,
+                        "filename": os.path.basename(photo_path or ""),
+                        "reason": reason,
+                    })
 
                 # Mark photos.thumb_path so the dashboard's coverage query
                 # (`thumb_path IS NOT NULL`) reflects each freshly-generated or
@@ -2323,7 +2378,15 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                         folder_path=folders.get(detail_photo["folder_id"]),
                                     )
                                 ):
-                                    skipped += 1
+                                    failed += 1
+                                    _record_failure(
+                                        photo_id, photo_path,
+                                        "RAW decode previously failed and no "
+                                        "acceptable fallback is available",
+                                    )
+                                    stages["thumbnails"]["count"] = (
+                                        generated + skipped + failed
+                                    )
                                     continue
                         recipe_kwargs = {"recipe": recipe} if recipe else {}
                         if recipe:
@@ -2355,8 +2418,22 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 photo_id, photo_path, cache_dir, thumb_size,
                                 recipe, folders.get(detail_photo["folder_id"]),
                             )
+                        if (
+                            result_path is None
+                            and detail_photo is not None
+                            and os.path.splitext(photo_path)[1].lower() in _RAW_EXTENSIONS
+                        ):
+                            result_path = _retry_thumbnail_with_working_copy(
+                                thread_db, generate_thumbnail, detail_photo,
+                                photo_id, photo_path, cache_dir, thumb_size,
+                                recipe, effective_vireo_dir,
+                            )
                         if result_path is None:
                             failed += 1
+                            _record_failure(
+                                photo_id, photo_path,
+                                "No acceptable thumbnail render source",
+                            )
                         elif already_exists:
                             skipped += 1
                             pending_thumb_paths.append((f"{photo_id}.jpg", photo_id))
@@ -2365,9 +2442,13 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             pending_thumb_paths.append((f"{photo_id}.jpg", photo_id))
                         if len(pending_thumb_paths) >= THUMB_PATH_BATCH:
                             _flush_thumb_paths()
-                    except Exception:
+                    except Exception as exc:
                         failed += 1
-                        log.debug("Thumbnail failed for photo %s", photo_id)
+                        _record_failure(photo_id, photo_path, str(exc))
+                        log.debug(
+                            "Thumbnail failed for photo %s", photo_id,
+                            exc_info=True,
+                        )
                     # Include failed in the progress counter so the dashboard
                     # reflects all work attempted, not just successes. Mixed
                     # success/failure must not hide behind a 0/N progress bar.
@@ -2430,7 +2511,15 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                         folder_path=folders.get(detail_photo["folder_id"]),
                                     )
                                 ):
-                                    skipped += 1
+                                    failed += 1
+                                    _record_failure(
+                                        photo_id, photo_path,
+                                        "RAW decode previously failed and no "
+                                        "acceptable fallback is available",
+                                    )
+                                    stages["thumbnails"]["count"] = (
+                                        generated + skipped + failed
+                                    )
                                     continue
                             recipe_kwargs = {"recipe": recipe} if recipe else {}
                             if recipe:
@@ -2462,8 +2551,22 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                     photo_id, photo_path, cache_dir, thumb_size,
                                     recipe, folder_path,
                                 )
+                            if (
+                                result_path is None
+                                and detail_photo is not None
+                                and os.path.splitext(photo_path)[1].lower() in _RAW_EXTENSIONS
+                            ):
+                                result_path = _retry_thumbnail_with_working_copy(
+                                    thread_db, generate_thumbnail, detail_photo,
+                                    photo_id, photo_path, cache_dir, thumb_size,
+                                    recipe, effective_vireo_dir,
+                                )
                             if result_path is None:
                                 failed += 1
+                                _record_failure(
+                                    photo_id, photo_path,
+                                    "No acceptable thumbnail render source",
+                                )
                             elif already_exists:
                                 skipped += 1
                                 pending_thumb_paths.append((f"{photo_id}.jpg", photo_id))
@@ -2472,9 +2575,13 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 pending_thumb_paths.append((f"{photo_id}.jpg", photo_id))
                             if len(pending_thumb_paths) >= THUMB_PATH_BATCH:
                                 _flush_thumb_paths()
-                        except Exception:
+                        except Exception as exc:
                             failed += 1
-                            log.debug("Thumbnail failed for photo %s", photo_id)
+                            _record_failure(photo_id, photo_path, str(exc))
+                            log.debug(
+                                "Thumbnail failed for photo %s", photo_id,
+                                exc_info=True,
+                            )
                         stages["thumbnails"]["count"] = generated + skipped + failed
                         stages["thumbnails"]["total"] = total
                         processed = generated + skipped + failed
@@ -2495,20 +2602,33 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 _flush_thumb_paths()
 
                 from thumbnails import format_summary as thumb_summary
-                thumb_result = {"generated": generated, "skipped": skipped, "failed": failed}
+                thumb_result = {
+                    "generated": generated,
+                    "skipped": skipped,
+                    "failed": failed,
+                }
+                if failed_photos:
+                    thumb_result["failed_photos"] = failed_photos
+                if failed > len(failed_photos):
+                    thumb_result["failed_photos_truncated"] = (
+                        failed - len(failed_photos)
+                    )
                 processed = generated + skipped + failed
-                # Mixed-outcome rollup: any failure flips status to 'failed'.
-                # The summary still shows both counts so partial success is visible,
-                # but status surfaces the problem on the job history list.
-                final_status = "failed" if failed > 0 else "completed"
-                stages["thumbnails"]["status"] = final_status
+                # Per-photo failures leave coverage gaps but do not invalidate
+                # thumbnails that were generated successfully. Keep the stage
+                # terminal and expose the affected photos as repair details;
+                # fatal setup/runtime exceptions still take the except path.
+                stages["thumbnails"]["status"] = "completed"
+                stages["thumbnails"]["error_count"] = failed
                 thumb_rollup = (
-                    f"[thumbnails] {failed} of {processed} thumbnails failed to generate"
+                    f"{failed} of {processed} thumbnails need attention"
                     if failed > 0 else None
                 )
                 if thumb_rollup:
-                    errors.append(thumb_rollup)
-                runner.update_step(job["id"], "thumbnails", status=final_status,
+                    result.setdefault("warnings", []).append(
+                        f"[thumbnails] {thumb_rollup}"
+                    )
+                runner.update_step(job["id"], "thumbnails", status="completed",
                                    summary=thumb_summary(thumb_result),
                                    error_count=failed,
                                    error=thumb_rollup,

--- a/vireo/render_source.py
+++ b/vireo/render_source.py
@@ -206,9 +206,16 @@ def thumbnail_source_dimensions_are_acceptable(
     a small relative shortfall, a small absolute shortfall, and a stable
     aspect ratio. Full-resolution preview/export paths intentionally keep
     using :func:`is_undersized` instead of this thumbnail-only policy.
+
+    When the expected dimensions are unknown (<= 0), returns True so callers
+    match :func:`is_undersized`'s pass-through semantic — a photo row missing
+    ``width``/``height`` should not cause an otherwise-decoded thumbnail to
+    be rejected. A broken image (width/height <= 0) is still unacceptable.
     """
-    if expected_w <= 0 or expected_h <= 0 or width <= 0 or height <= 0:
+    if width <= 0 or height <= 0:
         return False
+    if expected_w <= 0 or expected_h <= 0:
+        return True
     if width >= expected_w and height >= expected_h:
         return True
 

--- a/vireo/render_source.py
+++ b/vireo/render_source.py
@@ -192,6 +192,36 @@ def image_is_smaller_than_expected(img, expected_w, expected_h, *, abs_slack=1, 
     )
 
 
+def thumbnail_source_dimensions_are_acceptable(
+    width, height, expected_w, expected_h, *,
+    max_shortfall_px=32, max_shortfall_ratio=0.01,
+    max_aspect_ratio_delta=0.005,
+):
+    """Return whether a near-full image is safe for a thumbnail render.
+
+    Some RAW formats report the nominal sensor bounds while their embedded
+    JPEG contains the slightly smaller active image area. That difference is
+    harmless at thumbnail scale, but a relative tolerance alone would also
+    accept large missing borders on high-resolution files. Require all three:
+    a small relative shortfall, a small absolute shortfall, and a stable
+    aspect ratio. Full-resolution preview/export paths intentionally keep
+    using :func:`is_undersized` instead of this thumbnail-only policy.
+    """
+    if expected_w <= 0 or expected_h <= 0 or width <= 0 or height <= 0:
+        return False
+    if width >= expected_w and height >= expected_h:
+        return True
+
+    allowed_w = min(max_shortfall_px, expected_w * max_shortfall_ratio)
+    allowed_h = min(max_shortfall_px, expected_h * max_shortfall_ratio)
+    if width < expected_w - allowed_w or height < expected_h - allowed_h:
+        return False
+
+    expected_aspect = expected_w / expected_h
+    actual_aspect = width / height
+    return abs(actual_aspect / expected_aspect - 1.0) <= max_aspect_ratio_delta
+
+
 def companion_image_can_replace_raw_result(
     companion_img, current_img, expected_w, expected_h,
 ):
@@ -216,6 +246,7 @@ def companion_image_can_replace_raw_result(
 
 def working_copy_satisfies_recipe_render(
     photo, recipe, max_size, vireo_dir, *, rel_slack=0.0,
+    thumbnail_tolerance=False,
 ):
     """Return True when the working copy is large enough for this recipe render.
 
@@ -270,6 +301,10 @@ def working_copy_satisfies_recipe_render(
             wc_scale = max_size / wc_render_long
             wc_render_w = wc_render_w * wc_scale
             wc_render_h = wc_render_h * wc_scale
+    if thumbnail_tolerance:
+        return thumbnail_source_dimensions_are_acceptable(
+            wc_render_w, wc_render_h, required_w, required_h,
+        )
     return not is_undersized(
         wc_render_w, wc_render_h, required_w, required_h,
         abs_slack=0, rel_slack=rel_slack,
@@ -278,6 +313,7 @@ def working_copy_satisfies_recipe_render(
 
 def working_copy_path_if_satisfies(
     photo, recipe, max_size, vireo_dir, *, rel_slack=0.0,
+    thumbnail_tolerance=False,
 ):
     """Return the working-copy path when it can satisfy this recipe render."""
     wc_rel = photo_value(photo, "working_copy_path")
@@ -288,6 +324,7 @@ def working_copy_path_if_satisfies(
         return None
     if not working_copy_satisfies_recipe_render(
         photo, recipe, max_size, vireo_dir, rel_slack=rel_slack,
+        thumbnail_tolerance=thumbnail_tolerance,
     ):
         return None
     return wc_path

--- a/vireo/templates/jobs.html
+++ b/vireo/templates/jobs.html
@@ -151,6 +151,7 @@
 .tree-status-icon.pending { color: var(--text-ghost); }
 .tree-status-icon.running { color: var(--accent); animation: pulse-step 1.5s ease-in-out infinite; }
 .tree-status-icon.completed { color: var(--success, #4caf50); }
+.tree-status-icon.warning { color: var(--warning, #f0a030); }
 .tree-status-icon.failed { color: var(--danger); }
 .tree-status-icon.cancelled { color: var(--text-muted); }
 @keyframes pulse-step {
@@ -159,6 +160,12 @@
 }
 .tree-step-label { flex: 1; color: var(--text-primary); }
 .tree-step-label.pending { color: var(--text-ghost); }
+.tree-repair-list {
+  margin: 6px 8px 8px 40px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+.tree-repair-item { padding: 2px 0; }
 .tree-step-summary { font-size: 12px; color: var(--text-muted); }
 .tree-step-progress-text {
   font-size: 12px; color: var(--text-muted); font-variant-numeric: tabular-nums;
@@ -184,6 +191,10 @@
   margin: 4px 0 4px 26px; padding: 6px 10px; font-size: 12px;
   color: var(--danger); background: color-mix(in srgb, var(--danger) 10%, transparent);
   border-radius: 4px; font-family: var(--font-mono, monospace);
+}
+.tree-step-error.warning {
+  color: var(--warning, #f0a030);
+  background: color-mix(in srgb, var(--warning, #f0a030) 10%, transparent);
 }
 .tree-leaves {
   margin-left: 26px; padding: 4px 0; max-height: 300px; overflow: hidden;
@@ -212,6 +223,7 @@
 .tree-step-errors {
   font-size: 11px; color: var(--danger); font-weight: 500;
 }
+.tree-step-errors.warning { color: var(--warning, #f0a030); }
 .tree-step-throughput {
   margin-left: 26px; padding: 2px 8px; font-size: 12px;
   color: var(--text-muted); font-style: italic;
@@ -304,11 +316,13 @@
     return '<span class="tree-toggle">' + (isExpanded ? '\u25BC' : '\u25B6') + '</span>';
   }
 
-  function statusIcon(status) {
+  function statusIcon(status, warningCount) {
     switch (status) {
       case 'pending': return '<span class="tree-status-icon pending">\u25CB</span>';
       case 'running': return '<span class="tree-status-icon running">\u25CB</span>';
-      case 'completed': return '<span class="tree-status-icon completed">\u2713</span>';
+      case 'completed':
+        if (warningCount > 0) return '<span class="tree-status-icon warning" title="Completed with warnings">!</span>';
+        return '<span class="tree-status-icon completed">\u2713</span>';
       case 'failed': return '<span class="tree-status-icon failed">\u2717</span>';
       case 'cancelled': return '<span class="tree-status-icon cancelled">\u2298</span>';
       default: return '<span class="tree-status-icon pending">\u25CB</span>';
@@ -444,14 +458,15 @@
 
   function renderRichStep(step, job, isLive) {
     var isRunning = step.status === 'running';
-    var isExpanded = isRunning || step.status === 'failed';
+    var warningCount = step.error_count || (step.error ? 1 : 0);
+    var isExpanded = isRunning || step.status === 'failed' || (step.status === 'completed' && warningCount > 0);
     if (collapsedSteps[step.id] === true) isExpanded = false;
     if (collapsedSteps[step.id] === false) isExpanded = true;
 
     var html = '<div class="tree-step" data-step-id="' + esc(step.id) + '">';
     html += '<div class="tree-step-header" data-toggle-step="' + esc(step.id) + '">';
     html += toggleIcon(isExpanded);
-    html += statusIcon(step.status);
+    html += statusIcon(step.status, warningCount);
     html += '<span class="tree-step-label' + (step.status === 'pending' ? ' pending' : '') + '">' + esc(step.label) + '</span>';
 
     // 1-3: Progress counts, bar, percentage (for steps with progress)
@@ -487,7 +502,9 @@
     var ec = step.error_count || 0;
     if (step.error) ec = Math.max(ec, 1);
     if (ec > 0) {
-      html += '<span class="tree-step-errors">' + ec + ' error' + (ec > 1 ? 's' : '') + '</span>';
+      var issueLabel = step.status === 'completed' ? 'warning' : 'error';
+      var issueClass = step.status === 'completed' ? ' warning' : '';
+      html += '<span class="tree-step-errors' + issueClass + '">' + ec + ' ' + issueLabel + (ec > 1 ? 's' : '') + '</span>';
     }
 
     // Retry button for failed steps on live jobs
@@ -531,7 +548,26 @@
 
       // Error detail
       if (step.error) {
-        html += '<div class="tree-step-error">' + esc(step.error) + '</div>';
+        var detailClass = step.status === 'completed' ? ' warning' : '';
+        html += '<div class="tree-step-error' + detailClass + '">' + esc(step.error) + '</div>';
+      }
+
+      var stageResult = job.result && job.result.stages
+        ? job.result.stages[step.id] : null;
+      var repairPhotos = stageResult && stageResult.failed_photos;
+      if (repairPhotos && repairPhotos.length > 0) {
+        html += '<div class="tree-repair-list">';
+        repairPhotos.forEach(function(photo) {
+          var label = photo.filename || ('Photo ' + photo.id);
+          html += '<div class="tree-repair-item"><b>' + esc(label) + '</b>' +
+            (photo.reason ? ': ' + esc(photo.reason) : '') + '</div>';
+        });
+        if (stageResult.failed_photos_truncated) {
+          html += '<div class="tree-repair-item">And ' +
+            stageResult.failed_photos_truncated.toLocaleString() +
+            ' more. Missing thumbnails remain available for later repair.</div>';
+        }
+        html += '</div>';
       }
 
       // Leaf buffer (files processed)

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -97,6 +97,10 @@ body { padding-bottom: 36px; }
   background: var(--danger, #E74C3C);
   color: #fff;
 }
+.stage-status-pill.warning {
+  background: color-mix(in srgb, var(--warning, #F0A030) 20%, transparent);
+  color: var(--warning, #F0A030);
+}
 .stage-status-pill.blocked {
   background: color-mix(in srgb, var(--danger, #E74C3C) 18%, transparent);
   color: var(--danger, #E74C3C);
@@ -2354,18 +2358,22 @@ function _updatePipelineStageUI(p) {
   // substages reach a terminal state. Resolving each substage event in
   // isolation made the pill flash 'Done' as soon as the first substage
   // finished, even though more work was pending.
-  var cardAgg = {};  // cardSuffix -> {running, failed, completed, skipped, present}
+  var cardAgg = {};  // cardSuffix -> aggregate substage outcomes
   for (var stageName in stages) {
     var cardSuffix = _stageToCard[stageName];
     if (!cardSuffix) continue;
     var agg = cardAgg[cardSuffix] || (cardAgg[cardSuffix] = {
-      running: false, failed: false, completed: 0, skipped: 0, present: 0,
+      running: false, failed: false, warning: false,
+      completed: 0, skipped: 0, present: 0,
     });
     agg.present += 1;
     var st = stages[stageName].status;
     if (st === 'running') agg.running = true;
     else if (st === 'failed') agg.failed = true;
-    else if (st === 'completed') agg.completed += 1;
+    else if (st === 'completed') {
+      agg.completed += 1;
+      if ((stages[stageName].error_count || 0) > 0) agg.warning = true;
+    }
     else if (st === 'skipped') agg.skipped += 1;
   }
 
@@ -2417,8 +2425,8 @@ function _updatePipelineStageUI(p) {
       numEl.className = 'stage-num complete';
       delete _runningStages[cardSuffix2];
       if (a.completed > 0) {
-        _stageOutcomes[cardSuffix2] = 'done';
-        _setPill(cardSuffix2, 'done');
+        _stageOutcomes[cardSuffix2] = a.warning ? 'warning' : 'done';
+        _setPill(cardSuffix2, a.warning ? 'warning' : 'done');
         if (cardSuffix2 === 'Source') _showSourceEjectSafe(stages['ingest']);
       } else {
         // Every substage was skipped. Backend 'skipped' covers both
@@ -3818,6 +3826,7 @@ function _formatPillLabel(stage, planEntry, state) {
   // labels — counts during a run come from a separate channel.
   if (state === 'running')   return 'Running…';
   if (state === 'done')      return 'Done';
+  if (state === 'warning')   return 'Completed with warnings';
   if (state === 'failed')    return 'Failed';
   if (state === 'cancelled') return 'Cancelled';
   if (state === 'will-skip') return 'Will skip';

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -6818,7 +6818,7 @@ def test_pipeline_thumbnail_retry_uses_near_full_working_copy(tmp_path):
     )
 
     assert result.endswith("7.jpg")
-    assert calls[0][1] == str(wc_path)
+    assert os.path.normpath(calls[0][1]) == os.path.normpath(str(wc_path))
 
 
 def test_thumbnail_progress_counter_includes_failed(tmp_path, monkeypatch):

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -6687,9 +6687,8 @@ def _make_photo_dir(tmp_path, n):
     return photo_dir
 
 
-def test_thumbnail_failures_flip_stage_status_to_failed(tmp_path, monkeypatch):
-    """If any thumbnail fails, the stage status must be 'failed' (not 'completed'),
-    even when some thumbnails succeeded. Mixed-outcome rollups are 'failed'."""
+def test_thumbnail_failures_complete_stage_with_repair_warnings(tmp_path, monkeypatch):
+    """Per-photo gaps warn without invalidating successful thumbnails."""
     import config as cfg
     from db import Database
 
@@ -6723,12 +6722,7 @@ def test_thumbnail_failures_flip_stage_status_to_failed(tmp_path, monkeypatch):
     job = _make_job()
     runner = FakeRunner()
 
-    pipeline_result = None
-    try:
-        pipeline_result = run_pipeline_job(job, runner, db_path, ws_id, params)
-    except RuntimeError:
-        # Expected: pipeline raises when a stage ends up in 'failed'.
-        pipeline_result = job.get("result")
+    pipeline_result = run_pipeline_job(job, runner, db_path, ws_id, params)
 
     thumb_result = pipeline_result["stages"]["thumbnails"]
     assert thumb_result["failed"] > 0, (
@@ -6744,15 +6738,20 @@ def test_thumbnail_failures_flip_stage_status_to_failed(tmp_path, monkeypatch):
         if step == "thumbnails" and kwargs.get("status")
     ]
     final_status = final_thumb_updates[-1]["status"]
-    assert final_status == "failed", (
-        f"Mixed-outcome rollup must report 'failed', got {final_status!r}. "
+    assert final_status == "completed", (
+        f"Mixed-outcome rollup must report 'completed', got {final_status!r}. "
         f"Result: {thumb_result}"
     )
+    assert final_thumb_updates[-1]["error_count"] == thumb_result["failed"]
+    assert len(thumb_result["failed_photos"]) == thumb_result["failed"]
+    assert all(item["filename"] for item in thumb_result["failed_photos"])
+    assert pipeline_result["warnings"] == [
+        f"[thumbnails] {thumb_result['failed']} of 4 thumbnails need attention"
+    ]
 
 
-def test_thumbnail_failures_append_rollup_error(tmp_path, monkeypatch):
-    """Per-file thumbnail failures must surface as exactly one rollup entry
-    in the pipeline errors list — not N per-file entries."""
+def test_thumbnail_failures_append_rollup_warning_not_job_error(tmp_path, monkeypatch):
+    """Coverage gaps surface once as warnings without failing the job."""
     import config as cfg
     from db import Database
 
@@ -6779,18 +6778,47 @@ def test_thumbnail_failures_append_rollup_error(tmp_path, monkeypatch):
     )
     job = _make_job()
 
-    with contextlib.suppress(RuntimeError):
-        run_pipeline_job(job, FakeRunner(), db_path, ws_id, params)
+    result = run_pipeline_job(job, FakeRunner(), db_path, ws_id, params)
 
-    errors = job["errors"]
-    thumb_errors = [e for e in errors if "thumbnail" in e.lower()]
-    assert len(thumb_errors) == 1, (
-        f"Expected exactly one rollup entry for thumbnail failures, got "
-        f"{len(thumb_errors)}: {thumb_errors}"
+    assert job["errors"] == []
+    assert result["warnings"] == [
+        "[thumbnails] 3 of 3 thumbnails need attention"
+    ]
+    assert len(result["stages"]["thumbnails"]["failed_photos"]) == 3
+
+
+def test_pipeline_thumbnail_retry_uses_near_full_working_copy(tmp_path):
+    from PIL import Image
+    from pipeline_job import _retry_thumbnail_with_working_copy
+
+    vireo_dir = tmp_path / "vireo"
+    working_dir = vireo_dir / "working"
+    working_dir.mkdir(parents=True)
+    wc_path = working_dir / "7.jpg"
+    Image.new("RGB", (5392, 3592), "red").save(wc_path)
+    photo = {
+        "id": 7,
+        "filename": "photo.NEF",
+        "width": 5408,
+        "height": 3608,
+        "working_copy_path": "working/7.jpg",
+        "file_mtime": None,
+    }
+    calls = []
+
+    def generate(photo_id, source_path, cache_dir, **kwargs):
+        calls.append((photo_id, source_path, kwargs))
+        return str(tmp_path / "thumbs" / "7.jpg")
+
+    result = _retry_thumbnail_with_working_copy(
+        object(), generate, photo, 7, str(tmp_path / "photo.NEF"),
+        str(tmp_path / "thumbs"), 300,
+        {"crop": {"x": 0, "y": 0, "w": 0.5, "h": 1}},
+        str(vireo_dir),
     )
-    assert "3" in thumb_errors[0], (
-        f"Rollup should mention the failure count (3), got: {thumb_errors[0]!r}"
-    )
+
+    assert result.endswith("7.jpg")
+    assert calls[0][1] == str(wc_path)
 
 
 def test_thumbnail_progress_counter_includes_failed(tmp_path, monkeypatch):
@@ -10390,8 +10418,12 @@ def test_pipeline_scan_thumbnails_honor_raw_marker_after_source_selection(
     )
 
     thumbnails_stage = result["stages"]["thumbnails"]
-    assert thumbnails_stage["failed"] == 0
-    assert thumbnails_stage["skipped"] == 1
+    assert thumbnails_stage["failed"] == 1
+    assert thumbnails_stage["skipped"] == 0
+    assert thumbnails_stage["failed_photos"][0]["filename"] == "source.NEF"
+    assert result["warnings"] == [
+        "[thumbnails] 1 of 1 thumbnails need attention"
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/vireo/tests/test_render_source.py
+++ b/vireo/tests/test_render_source.py
@@ -60,6 +60,22 @@ def test_thumbnail_tolerance_accepts_near_full_nikon_active_area():
     assert rs.is_undersized(5392, 3592, 5408, 3608) is True
 
 
+def test_thumbnail_tolerance_unknown_expected_is_acceptable():
+    # Photo rows with missing width/height feed (0, 0) into the thumbnail gate
+    # via _scaled_recipe_source_dimensions. Match is_undersized's pass-through
+    # so an otherwise-decoded thumbnail is not rejected as undersized.
+    assert rs.thumbnail_source_dimensions_are_acceptable(
+        800, 600, 0, 0,
+    ) is True
+    assert rs.thumbnail_source_dimensions_are_acceptable(
+        800, 600, 6000, 0,
+    ) is True
+    # A broken image (0-sized) is still unacceptable regardless of expected.
+    assert rs.thumbnail_source_dimensions_are_acceptable(
+        0, 0, 0, 0,
+    ) is False
+
+
 def test_thumbnail_tolerance_rejects_large_or_misshapen_shortfalls():
     # More than the 32px absolute ceiling, despite remaining within 1%.
     assert rs.thumbnail_source_dimensions_are_acceptable(

--- a/vireo/tests/test_render_source.py
+++ b/vireo/tests/test_render_source.py
@@ -52,6 +52,25 @@ def test_is_undersized_relative_tolerance_for_scanner():
     ) is True
 
 
+def test_thumbnail_tolerance_accepts_near_full_nikon_active_area():
+    assert rs.thumbnail_source_dimensions_are_acceptable(
+        5392, 3592, 5408, 3608,
+    ) is True
+    # Full-resolution callers remain strict for the same dimensions.
+    assert rs.is_undersized(5392, 3592, 5408, 3608) is True
+
+
+def test_thumbnail_tolerance_rejects_large_or_misshapen_shortfalls():
+    # More than the 32px absolute ceiling, despite remaining within 1%.
+    assert rs.thumbnail_source_dimensions_are_acceptable(
+        5960, 3970, 6000, 4000,
+    ) is False
+    # A matching long edge must not hide a substantially truncated short edge.
+    assert rs.thumbnail_source_dimensions_are_acceptable(
+        6000, 3376, 6000, 4000,
+    ) is False
+
+
 def test_companion_replaces_undersized_decode_on_tie():
     # img tied the source on the long edge but is short on the other axis; a
     # full-size companion should replace it.

--- a/vireo/tests/test_thumbnails.py
+++ b/vireo/tests/test_thumbnails.py
@@ -457,6 +457,38 @@ def test_generate_all_does_not_record_thumb_path_on_failure(tmp_path, monkeypatc
     assert row["thumb_path"] is None
 
 
+def test_generate_thumbnail_accepts_near_full_raw_active_area(tmp_path, monkeypatch):
+    import thumbnails as thumbnails_mod
+
+    monkeypatch.setattr(
+        thumbnails_mod, "load_image",
+        lambda *args, **kwargs: Image.new("RGB", (5392, 3592), "red"),
+    )
+
+    result = thumbnails_mod.generate_thumbnail(
+        1, str(tmp_path / "photo.NEF"), str(tmp_path / "thumbs"),
+        min_source_size=(5408, 3608),
+    )
+
+    assert result == str(tmp_path / "thumbs" / "1.jpg")
+
+
+def test_generate_thumbnail_rejects_truncated_raw_preview(tmp_path, monkeypatch):
+    import thumbnails as thumbnails_mod
+
+    monkeypatch.setattr(
+        thumbnails_mod, "load_image",
+        lambda *args, **kwargs: Image.new("RGB", (6000, 3376), "red"),
+    )
+
+    result = thumbnails_mod.generate_thumbnail(
+        1, str(tmp_path / "photo.NEF"), str(tmp_path / "thumbs"),
+        min_source_size=(6000, 4000),
+    )
+
+    assert result is None
+
+
 def test_generate_all_uses_near_full_working_copy_after_current_raw_failure(
     tmp_path, monkeypatch,
 ):

--- a/vireo/tests/test_thumbnails.py
+++ b/vireo/tests/test_thumbnails.py
@@ -473,6 +473,28 @@ def test_generate_thumbnail_accepts_near_full_raw_active_area(tmp_path, monkeypa
     assert result == str(tmp_path / "thumbs" / "1.jpg")
 
 
+def test_generate_thumbnail_accepts_unknown_min_source_size(tmp_path, monkeypatch):
+    """A photo row missing width/height feeds (0, 0) into min_source_size via
+    _scaled_recipe_source_dimensions. The gate must not reject an otherwise-
+    successfully-decoded thumbnail just because the expected dims are unknown
+    — that regresses legacy/unsupported-RAW libraries with no usable JPEG
+    fallback back to permanently thumbnail-less.
+    """
+    import thumbnails as thumbnails_mod
+
+    monkeypatch.setattr(
+        thumbnails_mod, "load_image",
+        lambda *args, **kwargs: Image.new("RGB", (800, 600), "red"),
+    )
+
+    result = thumbnails_mod.generate_thumbnail(
+        1, str(tmp_path / "photo.NEF"), str(tmp_path / "thumbs"),
+        min_source_size=(0, 0),
+    )
+
+    assert result == str(tmp_path / "thumbs" / "1.jpg")
+
+
 def test_generate_thumbnail_rejects_truncated_raw_preview(tmp_path, monkeypatch):
     import thumbnails as thumbnails_mod
 

--- a/vireo/thumbnails.py
+++ b/vireo/thumbnails.py
@@ -12,11 +12,11 @@ from image_loader import (
     load_image,
 )
 from render_source import (
-    image_is_smaller_than_expected,
-    recipe_render_source,
+    photo_value as _photo_value,
 )
 from render_source import (
-    photo_value as _photo_value,
+    recipe_render_source,
+    thumbnail_source_dimensions_are_acceptable,
 )
 from render_source import (
     recipe_source_dimensions as _recipe_source_dimensions,
@@ -132,7 +132,7 @@ def _retry_thumbnail_with_working_copy(
     if os.path.splitext(source_path or "")[1].lower() not in RAW_EXTENSIONS:
         return None
     wc_path = _working_copy_path_if_satisfies(
-        photo, recipe, size, vireo_dir, rel_slack=0.01,
+        photo, recipe, size, vireo_dir, thumbnail_tolerance=True,
     )
     if not wc_path or os.path.abspath(wc_path) == os.path.abspath(source_path):
         return None
@@ -209,7 +209,9 @@ def generate_thumbnail(
         return None
     if min_source_size:
         expected_w, expected_h = min_source_size
-        if image_is_smaller_than_expected(img, expected_w, expected_h):
+        if not thumbnail_source_dimensions_are_acceptable(
+            img.size[0], img.size[1], expected_w, expected_h,
+        ):
             log.info(
                 "Thumbnail source for photo %s is undersized (%dx%d, "
                 "expected %dx%d): %s",


### PR DESCRIPTION
Near-full embedded RAW previews were rejected when their active image area differed slightly from nominal sensor dimensions, leaving edited photos without thumbnails and marking otherwise successful pipeline runs as failed.
This adds a thumbnail-only tolerance bounded by relative size, absolute pixels, and aspect ratio, while preserving strict full-resolution preview and export validation and adding a working-copy retry to streaming pipelines.
Residual per-photo failures now complete with warnings and expose a bounded repair list with filenames and reasons in pipeline and job views.
Validated with 231 relevant tests passing, 19 skipped, Ruff checks, and `git diff --check`.
