### PR TITLE
Show filename in lightbox position indicator

### DIFF
--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -33,15 +33,18 @@ def test_browse_lightbox_arrows_navigate(live_server, page):
     counter = page.locator("#lightboxCounter")
     expect(counter).to_be_visible()
     expect(counter).to_contain_text("1 /")
+    expect(counter).to_contain_text(first_filename)
 
     page.locator("[title='Next (→)']").click()
 
     expect(filename_display).not_to_have_text(first_filename)
     expect(counter).to_contain_text("2 /")
+    expect(counter).to_contain_text(filename_display.text_content())
 
     page.locator("[title='Previous (←)']").click()
     expect(filename_display).to_have_text(first_filename)
     expect(counter).to_contain_text("1 /")
+    expect(counter).to_contain_text(first_filename)
 
 
 def test_browse_photo_id_deep_link_loads_target_folder_first_page(live_server, page):

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3410,7 +3410,7 @@ async function createWorkspace() {
   </div>
   <div class="lightbox-filename" id="lightboxFilename"></div>
   <div class="lightbox-flag-status" id="lightboxFlagStatus" aria-live="polite"></div>
-  <div id="lightboxCounter" style="display:none;position:absolute;top:16px;left:50%;transform:translateX(-50%);color:rgba(255,255,255,0.6);font-size:13px;background:rgba(0,0,0,0.5);padding:3px 10px;border-radius:4px;"></div>
+  <div id="lightboxCounter" style="display:none;position:absolute;top:16px;left:50%;transform:translateX(-50%);max-width:calc(100vw - 160px);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:rgba(255,255,255,0.6);font-size:13px;background:rgba(0,0,0,0.5);padding:3px 10px;border-radius:4px;"></div>
   <div id="lightboxActions" class="lightbox-actions">
     <button class="lb-action-btn" id="lightboxToggleBoxes" onclick="event.stopPropagation(); toggleLightboxBoxes();" title="Toggle detection boxes (b)">
       Hide Boxes
@@ -6809,9 +6809,13 @@ function openLightbox(photoId, filename, photoList, options) {
   var counter = document.getElementById('lightboxCounter');
   if (_lightboxPhotoList.length > 1) {
     var idx = _lightboxPhotoList.findIndex(function(p) { return p.id === photoId; });
-    counter.textContent = (idx + 1) + ' / ' + _lightboxPhotoList.length;
+    var counterFilename = filename || (currentFromList && currentFromList.filename) || '';
+    counter.textContent = (idx + 1) + ' / ' + _lightboxPhotoList.length
+      + (counterFilename ? ' \u00b7 ' + counterFilename : '');
+    counter.title = counterFilename;
     counter.style.display = '';
   } else {
+    counter.title = '';
     counter.style.display = 'none';
   }
 }


### PR DESCRIPTION
## Summary

Add the current photo filename beside the position count in the shared lightbox header so users can identify an image while navigating.
Long filenames truncate within the available viewport width and expose the full value on hover.
Extend the Browse lightbox navigation test to verify the displayed filename stays synchronized across next and previous navigation.

## Testing

`pytest -q tests/e2e/test_browse_lightbox.py::test_browse_lightbox_arrows_navigate`
