### PR TITLE
Link Settings to the Storage page

### DIFF
--- a/tests/e2e/test_settings.py
+++ b/tests/e2e/test_settings.py
@@ -1,6 +1,16 @@
 from playwright.sync_api import expect
 
 
+def test_settings_links_to_storage_page(live_server, page):
+    """Settings makes the dedicated storage page discoverable."""
+    url = live_server["url"]
+    page.goto(f"{url}/settings", timeout=5000)
+
+    storage_link = page.get_by_role("link", name="Open Storage")
+    expect(storage_link).to_be_visible()
+    expect(storage_link).to_have_attribute("href", "/storage")
+
+
 def test_settings_system_info_renders(live_server, page):
     """Settings page loads and displays system info section with real data."""
     url = live_server["url"]

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -118,6 +118,17 @@
 
 <div class="content">
 
+  <!-- Storage -->
+  <div class="section">
+    <div class="section-title">Storage</div>
+    <div style="display:flex;align-items:center;justify-content:space-between;gap:16px;">
+      <p style="font-size:13px;color:var(--text-dim);margin:0;">
+        View disk usage, configure preview caches, and clean up generated files on the dedicated Storage page.
+      </p>
+      <a href="/storage" class="btn btn-secondary" style="white-space:nowrap;">Open Storage</a>
+    </div>
+  </div>
+
   <!-- Models -->
   <div class="section">
     <div class="section-title">Models</div>


### PR DESCRIPTION
Adds a visible Storage section at the top of Settings so people looking for disk usage, cache configuration, or cleanup tools can discover the dedicated Storage page. The section includes a direct “Open Storage” link, and an end-to-end regression test verifies that the link is visible and targets `/storage`. Validated with `pytest -q tests/e2e/test_settings.py` (4 passed).
