### PR TITLE
Highlights: show unscored photos and keep picks visible

### DIFF
--- a/docs/plans/2026-07-12-highlights-show-unscored-picks-design.md
+++ b/docs/plans/2026-07-12-highlights-show-unscored-picks-design.md
@@ -1,0 +1,165 @@
+# Highlights: show unscored photos (and picks) — design
+
+**Date:** 2026-07-12
+**Branch:** highlights-picks-not-showing
+
+## Problem
+
+On the Highlights page, photos the user explicitly flagged as **picks** can
+silently disappear. Diagnosed on the `'anianiau` species bucket: the user had
+3 picks, but only 1 appeared.
+
+Root cause: `get_highlights_candidates` (`db.py`) hard-excludes any photo whose
+`quality_score IS NULL`. Two of the three picks had never been quality-scored
+(the folder is only partially analyzed — 18 of 90 `'anianiau` photos have
+scores), so they were dropped from Highlights entirely — not mis-ranked,
+invisible. The one scored pick *did* surface first, because the bucket scorer
+already floats picks to the front (`_highlight_score_bucket(..., picked_first=True)`).
+
+This violates `CORE_PHILOSOPHY.md` ("no black boxes"): a user action (pick)
+produced a silently-vanishing result.
+
+## Goal
+
+Show all of a species' photos in Highlights — including unscored ones — while
+keeping the analyzed, quality-ranked photos as the curated default. Picks are
+always visible regardless of analysis state. Unscored photos are honestly
+labeled as not-yet-analyzed rather than masquerading as quality-ranked
+highlights.
+
+## Decisions (validated with user)
+
+1. **Picks always visible.** A flagged photo appears even with no quality
+   score. Within the picks group, scored picks rank above unscored picks.
+2. **Labeled boundary.** A divider — *"Not yet analyzed — N photos"* — marks
+   where the quality-ranked photos end and the chronological unscored tail
+   begins.
+3. **Unscored tail in capture order**, earliest-first.
+4. **Backfill the collapsed view to the limit** with unscored photos when there
+   aren't enough picks/scored to fill it (avoids near-empty cards for
+   mostly-unanalyzed species). The divider may therefore appear inside the
+   collapsed card, which is fine — it's labeled.
+
+## Design
+
+### 1. Data source — let unscored photos in
+
+`get_highlights_candidates` (`db.py`) currently gates:
+
+```sql
+AND p.quality_score IS NOT NULL
+AND p.quality_score >= :min_quality
+```
+
+Change to:
+
+```sql
+AND (p.quality_score >= :min_quality
+     OR (:min_quality <= 0 AND p.quality_score IS NULL))
+```
+
+- At the default `min_quality = 0`, unscored photos flow through.
+- If the user raises the quality floor, unscored photos (no measured quality)
+  drop out — a quality filter means "analyzed photos only."
+- The `flag != 'rejected'` guard stays; rejects remain excluded.
+
+This is the single source query feeding every Highlights path
+(`_build_highlights_payload`, `api_highlights_bucket`, per-photo eligibility),
+so they stay consistent. Life-list / best-photo use different candidate
+queries and are untouched.
+
+Each photo dict in `_collect_highlight_buckets` gains
+`is_analyzed = quality_score is not None`, driving the ordering tier and the
+frontend divider.
+
+Consequence: a species whose photos are *all* unscored now forms a bucket (it
+didn't before). It ranks at the bottom of the species list (best score ~0),
+which is correct.
+
+### 2. Ordering within a bucket
+
+Extend the sort in `_highlight_score_bucket` (`picked_first=True` path) so the
+ordered list is three contiguous regions:
+
+1. **Picks** (flagged): scored first (by score desc), then unscored (capture
+   time asc).
+2. **Scored non-picks**: by `highlight_score` desc.
+3. **Unscored non-picks**: capture time asc (earliest first).
+
+New key:
+
+```python
+key = (
+    0 if flagged else 1,                        # picks first
+    0 if quality_score is not None else 1,      # scored before unscored
+    -(highlight_score or 0),                    # ranks scored rows; inert for unscored (~0)
+    (timestamp is None, timestamp or 0, id),    # ranks unscored chronologically; stable tiebreak
+)
+```
+
+Because the scored-before-unscored tier separates the groups, the score term
+only moves scored rows and the timestamp term only moves unscored rows — they
+don't fight. `timestamp is None` pushes capture-time-less photos to the end of
+their group.
+
+Regression guards:
+- The new tiers only bite when a list contains unscored photos. The
+  `picked_first=False` caller draws from all-scored candidate sets, so its
+  output is unchanged in practice — pinned by a regression test.
+- The unidentified section uses the same scorer, so unscored unidentified
+  photos get the same picks-first / chronological treatment. Intended.
+
+### 3. Collapsed view and divider
+
+**Collapsed view:** no slicing change. `limited_bucket` already takes
+`photos[:limit_per_bucket]`; since picks → scored → unscored share one ordered
+list, the slice auto-backfills with unscored photos. `has_more` stays
+`len(photos) > limit`; "more" pages through the rest via existing offset
+pagination in `api_highlights_bucket`.
+
+**Divider:** two new bucket fields —
+- `unanalyzed_count` — number of unscored non-pick photos in the bucket
+- (per photo) `is_analyzed`
+
+Frontend (`highlights.html`) renders a thin divider —
+*"Not yet analyzed — {N} photos"* — immediately before the first rendered
+photo where `!is_analyzed && flag !== 'flagged'`. The ordering guarantees the
+unscored non-picks are one contiguous tail, so the condition fires exactly once.
+Unscored picks (flagged, at the front) are skipped by the `!== 'flagged'`
+clause. Works across pagination: wherever the boundary lands, the client sees
+`is_analyzed` flip and draws the divider. No divider if `unanalyzed_count == 0`.
+Reuse existing divider/subheading styling in `highlights.html`.
+
+## Testing
+
+`vireo/tests/test_app.py` (alongside existing highlights tests):
+
+- Unscored photos appear in their species bucket; fully-unscored species ranks
+  last.
+- Ordering: bucket with scored picks, unscored picks, scored non-picks,
+  unscored non-picks + shuffled timestamps → exact three-region order, unscored
+  tails chronological.
+- The `'anianiau` case: one scored pick + two unscored picks → all three
+  render, scored pick first, both unscored picks ahead of every non-pick.
+- `is_analyzed` and `unanalyzed_count` correct; divider-boundary photo is the
+  first unscored non-pick.
+- `min_quality > 0` excludes unscored photos.
+- Regression pin: `_highlight_score_bucket(picked_first=False)` unchanged for an
+  all-scored list.
+
+## Edge cases
+
+- Missing timestamp → end of its group.
+- Unscored unidentified photos handled by the shared scorer.
+- Bucket ranking driven by best analyzed score, so unanalyzed species sink.
+
+## Risks
+
+1. **Payload size / performance.** Relaxing the gate makes the candidate query
+   return all non-rejected photos, not just scored ones. Workspace-scope views
+   on large libraries build bigger in-memory buckets (`limit_per_bucket` caps
+   what's rendered, not what's processed). Spot-check timing; don't optimize
+   preemptively (YAGNI).
+2. **Curation eligibility.** An unscored photo can now be chosen as a
+   highlight/representative. Intended — you should be able to curate a pick
+   before analysis — but noted so it's a conscious choice.

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -323,17 +323,41 @@ def _highlight_score_bucket(photos, picked_first=False):
         }
         p["reasons"] = reasons[:3]
 
-    photos.sort(
-        key=lambda p: (
-            (1 if p.get("flag") == "flagged" else 0) if picked_first else 0,
-            p.get("highlight_score") or 0,
-            p.get("predicted_confidence") or 0,
-            p.get("quality_score") or 0,
-            p.get("rating") or 0,
-            -p.get("id", 0),
-        ),
-        reverse=True,
-    )
+    if picked_first:
+        # Highlights page ordering: three contiguous regions —
+        #   1. picks (flagged): analyzed first (by score desc), then
+        #      unanalyzed picks in capture order;
+        #   2. analyzed non-picks: by highlight_score desc;
+        #   3. unanalyzed non-picks: capture order (earliest first).
+        # The analyzed-before-unanalyzed tier separates the groups so the
+        # score term only reorders analyzed rows and the timestamp term only
+        # reorders unanalyzed rows — they never compete. Timestamps are ISO
+        # text, so lexicographic order is chronological; missing timestamps
+        # sort to the end of their group. This is an ascending sort (no
+        # reverse), negating the score to rank analyzed rows high-first.
+        def _bucket_sort_key(p):
+            analyzed = p.get("quality_score") is not None
+            ts = p.get("timestamp")
+            return (
+                0 if p.get("flag") == "flagged" else 1,
+                0 if analyzed else 1,
+                -(p.get("highlight_score") or 0) if analyzed else 0.0,
+                (ts is None, ts),
+                p.get("id", 0),
+            )
+
+        photos.sort(key=_bucket_sort_key)
+    else:
+        photos.sort(
+            key=lambda p: (
+                p.get("highlight_score") or 0,
+                p.get("predicted_confidence") or 0,
+                p.get("quality_score") or 0,
+                p.get("rating") or 0,
+                -p.get("id", 0),
+            ),
+            reverse=True,
+        )
 
 
 def _apply_preferred_photo(photos, preferred_photo_id, marker_key):
@@ -370,6 +394,20 @@ def _bucket_best_score(photos):
     """
     scores = [p.get("highlight_score") for p in photos if p.get("highlight_score") is not None]
     return max(scores) if scores else None
+
+
+def _bucket_unanalyzed_count(photos):
+    """Count photos that form the "Not yet analyzed" tail of a bucket.
+
+    Only unscored *non-pick* photos count: they are the contiguous
+    chronological tail the divider labels. Unscored picks stay at the front
+    with the other picks, so they are excluded here.
+    """
+    return sum(
+        1
+        for p in (photos or [])
+        if p.get("quality_score") is None and p.get("flag") != "flagged"
+    )
 
 
 def _apply_highlight_preferences(db, buckets):
@@ -450,6 +488,7 @@ def _apply_ordered_highlights(db, buckets):
         bucket["highlight_count"] = sum(
             1 for p in bucket.get("photos") or [] if p.get("is_highlighted")
         )
+        bucket["unanalyzed_count"] = _bucket_unanalyzed_count(bucket.get("photos"))
         bucket["best_quality"] = best.get("quality_score")
         bucket["best_score"] = best.get("highlight_score")
         bucket["best_timestamp"] = best.get("timestamp")
@@ -555,6 +594,7 @@ def _collect_highlight_buckets(
             "rating": r.get("rating") or 0,
             "flag": r.get("flag") or "none",
             "quality_score": r.get("quality_score"),
+            "is_analyzed": r.get("quality_score") is not None,
             "subject_sharpness": r.get("subject_sharpness"),
             "subject_size": r.get("subject_size"),
             "sharpness": r.get("sharpness"),
@@ -8699,6 +8739,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "photos": unidentified_limited,
                 "loaded_count": len(unidentified_limited),
                 "has_more": len(unidentified_photos) > len(unidentified_limited),
+                "unanalyzed_count": _bucket_unanalyzed_count(unidentified_photos),
             },
             "folders": [
                 {"id": f["id"], "name": f["name"], "photo_count": f["photo_count"]}

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -397,17 +397,29 @@ def _bucket_best_score(photos):
 
 
 def _bucket_unanalyzed_count(photos):
-    """Count photos that form the "Not yet analyzed" tail of a bucket.
+    """Length of the trailing "Not yet analyzed" tail of a bucket.
 
-    Only unscored *non-pick* photos count: they are the contiguous
-    chronological tail the divider labels. Unscored picks stay at the front
-    with the other picks, so they are excluded here.
+    Counts only the contiguous run of unscored non-pick photos at the END of
+    ``photos``. This is what the divider labels, so callers can trust that a
+    non-zero value marks a real tail below the divider.
+
+    Only the trailing run is counted (not every unscored non-pick in the
+    bucket) so that curated ordering — where
+    :func:`_apply_ordered_highlights` or :func:`_apply_highlight_preferences`
+    can promote an unscored, non-flagged photo to the front as a species
+    highlight or representative — doesn't inflate the count with photos that
+    now live above the divider. Unscored picks are excluded because they
+    stay grouped with the other picks at the front regardless.
     """
-    return sum(
-        1
-        for p in (photos or [])
-        if p.get("quality_score") is None and p.get("flag") != "flagged"
-    )
+    if not photos:
+        return 0
+    tail = 0
+    for p in reversed(photos):
+        if p.get("quality_score") is None and p.get("flag") != "flagged":
+            tail += 1
+        else:
+            break
+    return tail
 
 
 def _apply_highlight_preferences(db, buckets):
@@ -450,6 +462,10 @@ def _apply_highlight_preferences(db, buckets):
         # photos.
         bucket["best_score"] = _bucket_best_score(bucket["photos"])
         bucket["best_timestamp"] = top.get("timestamp")
+        # Run last so curated promotion (an unscored rep pushed to the front)
+        # doesn't leave a stale tail count that anchors the divider above
+        # analyzed content.
+        bucket["unanalyzed_count"] = _bucket_unanalyzed_count(bucket.get("photos"))
 
 
 def _apply_ordered_highlights(db, buckets):
@@ -488,7 +504,9 @@ def _apply_ordered_highlights(db, buckets):
         bucket["highlight_count"] = sum(
             1 for p in bucket.get("photos") or [] if p.get("is_highlighted")
         )
-        bucket["unanalyzed_count"] = _bucket_unanalyzed_count(bucket.get("photos"))
+        # unanalyzed_count is assigned in _apply_highlight_preferences instead:
+        # that runs after this pass and can still reorder photos, so anchoring
+        # the tail count here would be stale under curated ordering.
         bucket["best_quality"] = best.get("quality_score")
         bucket["best_score"] = best.get("highlight_score")
         bucket["best_timestamp"] = best.get("timestamp")

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -9960,8 +9960,12 @@ class Database:
             across the photo's detections (NULL if no usable prediction
             exists)
 
-        Only photos with ``quality_score >= min_quality`` that are not
-        user-rejected are returned. The API layer applies the final
+        Photos with ``quality_score >= min_quality`` that are not
+        user-rejected are returned. When ``min_quality <= 0`` (the default),
+        photos with no ``quality_score`` yet (not analyzed) are also included
+        so picks and other unscored photos still surface on the Highlights
+        page; raising the quality floor above 0 excludes them, since they have
+        no measured quality to compare. The API layer applies the final
         highlights ranking because it combines these persisted quality fields
         with prediction confidence and user ratings.
         """
@@ -10067,8 +10071,8 @@ class Database:
                WHERE wf.workspace_id = ?
                  {folder_filter}
                  {photo_filter}
-                 AND p.quality_score IS NOT NULL
-                 AND p.quality_score >= ?
+                 AND (p.quality_score >= ?
+                      OR (? <= 0 AND p.quality_score IS NULL))
                  AND (p.flag IS NULL OR p.flag != 'rejected')
                ORDER BY p.quality_score DESC""",
             (
@@ -10079,6 +10083,7 @@ class Database:
                 ws,
                 *folder_params,
                 *photo_params,
+                min_quality,
                 min_quality,
             ),
         ).fetchall()

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -10507,6 +10507,12 @@ class Database:
         are no longer eligible for the Highlights page. Stored rows are kept
         intact so un-rejecting a photo restores its selection.
 
+        Eligibility mirrors :meth:`get_highlights_candidates` at the default
+        quality floor: not-yet-analyzed (``quality_score IS NULL``) photos
+        stay eligible, because they now appear on the Highlights page and can
+        be saved as highlights. Filtering them out here would silently drop a
+        highlight the user just chose until analysis ran.
+
         Result shape is ``{species: {photo_id: rank}}``.
         """
         ws = self._ws_id()
@@ -10520,7 +10526,6 @@ class Database:
                    JOIN folders f ON f.id = p.folder_id
                     AND f.status IN ('ok', 'partial')"""
             eligibility_filter = """
-                 AND p.quality_score IS NOT NULL
                  AND COALESCE(p.flag, 'none') != 'rejected'
                  AND sh.species = COALESCE(
                      (

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -675,20 +675,32 @@ async function moveSpeciesHighlight(species, photoId, direction, button) {
 }
 
 // Render a strip's cards, inserting the "Not yet analyzed" divider before the
-// first unscored non-pick photo. The ordering guarantees those photos form one
-// contiguous tail, so the divider fires exactly once. Unscored picks (flagged,
-// at the front) are skipped so no stray divider appears up top.
-function renderStripCards(photos, unanalyzedCount) {
-  var html = '';
-  var dividerShown = false;
-  for (var i = 0; i < photos.length; i++) {
-    var p = photos[i];
-    if (!dividerShown && unanalyzedCount && !p.is_analyzed && p.flag !== 'flagged') {
-      html += '<div class="analyzed-divider">Not yet analyzed — ' + unanalyzedCount
-        + ' photo' + (unanalyzedCount === 1 ? '' : 's') + '</div>';
-      dividerShown = true;
+// trailing contiguous run of unscored non-pick photos. Walking backward from
+// the end anchors the divider to the actual tail boundary even after curated
+// ordering (species highlights, representatives) has promoted an unscored,
+// non-flagged photo to the front — a first-encountered check would have
+// misfired on that promoted card and left analyzed photos below the label.
+// If the visible slice ends on an analyzed photo (or on a flagged photo),
+// there is no tail and no divider fires. Unscored picks (flagged, at the
+// front) are always excluded from the tail.
+function renderStripCards(photos, _unanalyzedCount) {
+  var tailStart = photos.length;
+  for (var j = photos.length - 1; j >= 0; j--) {
+    var q = photos[j];
+    if (!q.is_analyzed && q.flag !== 'flagged') {
+      tailStart = j;
+    } else {
+      break;
     }
-    html += renderCard(p);
+  }
+  var tailCount = photos.length - tailStart;
+  var html = '';
+  for (var i = 0; i < photos.length; i++) {
+    if (i === tailStart && tailCount) {
+      html += '<div class="analyzed-divider">Not yet analyzed — ' + tailCount
+        + ' photo' + (tailCount === 1 ? '' : 's') + '</div>';
+    }
+    html += renderCard(photos[i]);
   }
   return html;
 }
@@ -784,7 +796,17 @@ function render() {
   var meta = document.getElementById('meta');
   var controls = document.getElementById('controlsBar');
 
-  if (!currentData.folders.length) {
+  // Only bail to the empty state when NOTHING is renderable. Gating on
+  // folders alone would hide unscored-only workspaces (or subtrees): the
+  // folder dropdown is sourced from get_folders_with_quality_data, which is
+  // scored-only, but the highlights payload can still return eligible
+  // buckets and unidentified photos from unscored candidates. The workspace
+  // scope option is prepended unconditionally, so an empty folder list
+  // remains navigable via that entry.
+  var hasBuckets = (currentData.buckets || []).length > 0;
+  var hasUnidentified = !!(currentData.unidentified
+    && currentData.unidentified.photo_count);
+  if (!currentData.folders.length && !hasBuckets && !hasUnidentified) {
     content.innerHTML = '';
     empty.style.display = 'block';
     meta.textContent = '';

--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -60,6 +60,7 @@
   .bucket-expand:hover { text-decoration:underline; }
 
   .unid-divider { padding:20px 24px 8px; font-size:11px; color:var(--text-secondary); text-transform:uppercase; letter-spacing:1px; border-top:2px solid var(--border-primary); margin-top:8px; }
+  .analyzed-divider { grid-column:1 / -1; padding:8px 2px 2px; font-size:11px; color:var(--text-secondary); text-transform:uppercase; letter-spacing:1px; border-top:1px solid var(--border-primary); margin-top:4px; }
 
   .highlights-empty { text-align:center; padding:80px 24px; color:var(--text-secondary); }
   .highlights-empty a { color:var(--accent); }
@@ -673,6 +674,25 @@ async function moveSpeciesHighlight(species, photoId, direction, button) {
   }
 }
 
+// Render a strip's cards, inserting the "Not yet analyzed" divider before the
+// first unscored non-pick photo. The ordering guarantees those photos form one
+// contiguous tail, so the divider fires exactly once. Unscored picks (flagged,
+// at the front) are skipped so no stray divider appears up top.
+function renderStripCards(photos, unanalyzedCount) {
+  var html = '';
+  var dividerShown = false;
+  for (var i = 0; i < photos.length; i++) {
+    var p = photos[i];
+    if (!dividerShown && unanalyzedCount && !p.is_analyzed && p.flag !== 'flagged') {
+      html += '<div class="analyzed-divider">Not yet analyzed — ' + unanalyzedCount
+        + ' photo' + (unanalyzedCount === 1 ? '' : 's') + '</div>';
+      dividerShown = true;
+    }
+    html += renderCard(p);
+  }
+  return html;
+}
+
 function renderBucket(bucket) {
   var perRow = parseInt(document.getElementById('perRowSlider').value);
   var expanded = expandedBuckets.has(bucket.species);
@@ -711,7 +731,7 @@ function renderBucket(bucket) {
     + '<div class="bucket-meta">' + meta + '</div></div>'
     + actions
     + '</div>'
-    + '<div class="bucket-strip">' + visible.map(renderCard).join('') + '</div>'
+    + '<div class="bucket-strip">' + renderStripCards(visible, bucket.unanalyzed_count) + '</div>'
     + expandBtn
     + '</section>';
 }
@@ -738,7 +758,7 @@ function renderUnidentified() {
     + '<div class="bucket-meta">' + unid.photo_count + ' photos</div></div>'
     + '<div class="bucket-actions"><button class="bucket-action" data-action="change-unidentified">Set species</button></div>'
     + '</div>'
-    + '<div class="bucket-strip">' + visible.map(renderCard).join('') + '</div>'
+    + '<div class="bucket-strip">' + renderStripCards(visible, unid.unanalyzed_count) + '</div>'
     + expandBtn
     + '</section>';
 }

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -4830,7 +4830,11 @@ def test_highlights_candidates_include_unscored_picks_and_order(app_and_db):
     """Unscored photos now flow into Highlights: all three picks appear (the
     real bug was two vanishing), ordered picks -> scored -> unscored, with
     is_analyzed flags and unanalyzed_count set for the divider."""
-    from app import _apply_ordered_highlights, _collect_highlight_buckets
+    from app import (
+        _apply_highlight_preferences,
+        _apply_ordered_highlights,
+        _collect_highlight_buckets,
+    )
 
     app, db = app_and_db
     fid, ids = _seed_anianiau_bucket(db)
@@ -4838,6 +4842,10 @@ def test_highlights_candidates_include_unscored_picks_and_order(app_and_db):
     candidates = db.get_highlights_candidates(fid, min_quality=0.0)
     buckets, _unid = _collect_highlight_buckets(candidates, 0.70)
     _apply_ordered_highlights(db, buckets)
+    # unanalyzed_count is assigned in _apply_highlight_preferences (which
+    # always runs after ordering in the real flow) so its tail count
+    # reflects any curated promotion. Mirror the full pipeline here.
+    _apply_highlight_preferences(db, buckets)
     bucket = next(b for b in buckets if b["species"] == "Anianiau")
 
     order = [p["filename"] for p in bucket["photos"]]
@@ -4876,6 +4884,137 @@ def test_highlights_candidates_exclude_unscored_when_quality_floor_raised(app_an
 
     # Only np_high (0.90) clears the 0.5 floor; the rejected 0.99 stays excluded.
     assert names == {"np_high.jpg"}
+
+
+def test_highlights_unscored_only_workspace_returns_content_with_empty_folders(app_and_db):
+    """Unscored-only workspaces must not silently blank the Highlights page.
+
+    ``get_folders_with_quality_data`` is scored-only, so the payload's
+    ``folders`` list is empty when nothing has been analyzed. But the
+    highlights payload can still return eligible content (buckets and
+    unidentified photos) via the min_quality<=0 admission of unscored
+    candidates. The frontend gate must key off actual content, not folder
+    presence — this test pins the API contract so a future regression that
+    drops content when ``folders == []`` is caught here.
+    """
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.get("/api/highlights")
+    assert resp.status_code == 200
+    data = resp.get_json()
+
+    # The scored-only folder dropdown is legitimately empty in this fixture.
+    assert data["folders"] == []
+    # ...but the payload still carries eligible content — the workspace has
+    # three unscored, unrejected photos in the unidentified section.
+    assert data["unidentified"]["photo_count"] == 3
+    assert data["meta"]["eligible"] == 3
+
+
+def test_highlights_unanalyzed_count_reflects_tail_after_representative_promotion(app_and_db):
+    """Curated promotion of an unscored photo must not misplace the divider.
+
+    ``_apply_highlight_preferences`` runs after the initial bucket sort and
+    can promote an unscored, non-flagged photo to the front when it's saved
+    as the species representative. The tail count anchors the "Not yet
+    analyzed" divider, so under the old (total-unscored-non-picks) semantic
+    a promoted unscored rep would inflate the count and the frontend divider
+    would misfire above analyzed photos. The tail semantic (trailing
+    contiguous run of unscored non-picks) fixes that: after promotion, the
+    count is the number of unscored non-picks that remain at the actual
+    tail, not the total in the bucket.
+    """
+    from app import (
+        _apply_highlight_preferences,
+        _apply_ordered_highlights,
+        _collect_highlight_buckets,
+    )
+
+    _app, db = app_and_db
+    fid = db.add_folder('/photos/curate', name='curate')
+    kid = db.add_keyword('Iiwi', is_species=True)
+    scored_a = db.add_photo(
+        folder_id=fid, filename='scored_a.jpg', extension='.jpg',
+        file_size=1000, file_mtime=1.0, timestamp='2024-01-01T10:00:00',
+    )
+    scored_b = db.add_photo(
+        folder_id=fid, filename='scored_b.jpg', extension='.jpg',
+        file_size=1001, file_mtime=2.0, timestamp='2024-01-02T10:00:00',
+    )
+    unscored_rep = db.add_photo(
+        folder_id=fid, filename='unscored_rep.jpg', extension='.jpg',
+        file_size=1002, file_mtime=3.0, timestamp='2024-01-03T10:00:00',
+    )
+    unscored_tail = db.add_photo(
+        folder_id=fid, filename='unscored_tail.jpg', extension='.jpg',
+        file_size=1003, file_mtime=4.0, timestamp='2024-01-04T10:00:00',
+    )
+    for pid in (scored_a, scored_b, unscored_rep, unscored_tail):
+        db.tag_photo(pid, kid)
+    _set_photo_quality_flag(db, scored_a, quality=0.9)
+    _set_photo_quality_flag(db, scored_b, quality=0.4)
+    # unscored_rep and unscored_tail deliberately left with quality_score=NULL.
+
+    # Sanity-check the pre-curation ordering: unscored non-picks form a
+    # contiguous tail, so the tail count equals the total unscored non-pick
+    # count (2). This is the state the divider was designed for.
+    candidates = db.get_highlights_candidates(fid, min_quality=0.0)
+    buckets, _unid = _collect_highlight_buckets(candidates, 0.70)
+    _apply_ordered_highlights(db, buckets)
+    _apply_highlight_preferences(db, buckets)
+    bucket = next(b for b in buckets if b["species"] == "Iiwi")
+    assert [p["filename"] for p in bucket["photos"]] == [
+        "scored_a.jpg", "scored_b.jpg",
+        "unscored_rep.jpg", "unscored_tail.jpg",
+    ]
+    assert bucket["unanalyzed_count"] == 2
+
+    # Now promote unscored_rep to species representative. Preferences run
+    # after the initial sort and push it to the front, so the tail shrinks
+    # to just unscored_tail — anything else would place the divider above
+    # analyzed content.
+    db.set_species_representative("Iiwi", unscored_rep)
+
+    candidates = db.get_highlights_candidates(fid, min_quality=0.0)
+    buckets, _unid = _collect_highlight_buckets(candidates, 0.70)
+    _apply_ordered_highlights(db, buckets)
+    _apply_highlight_preferences(db, buckets)
+    bucket = next(b for b in buckets if b["species"] == "Iiwi")
+
+    order = [p["filename"] for p in bucket["photos"]]
+    assert order[0] == "unscored_rep.jpg"  # rep promoted to the front
+    assert order[-1] == "unscored_tail.jpg"  # tail intact
+    assert bucket["unanalyzed_count"] == 1  # tail-only, not 2
+
+
+def test_bucket_unanalyzed_count_ignores_non_trailing_unscored():
+    """Only the trailing contiguous run of unscored non-picks counts.
+
+    Curated ordering can leave an unscored, non-flagged photo above analyzed
+    content; those interior unscored photos must NOT be counted, or the
+    frontend divider would misfire on the first one and leave analyzed
+    photos below the label.
+    """
+    from app import _bucket_unanalyzed_count
+
+    # Interior unscored rep, then a contiguous analyzed run, then two tail
+    # photos: only the trailing pair counts.
+    photos = [
+        {"id": 1, "quality_score": None, "flag": "none"},   # promoted, interior
+        {"id": 2, "quality_score": 0.9, "flag": "none"},
+        {"id": 3, "quality_score": 0.5, "flag": "none"},
+        {"id": 4, "quality_score": None, "flag": "none"},   # tail
+        {"id": 5, "quality_score": None, "flag": "none"},   # tail
+    ]
+    assert _bucket_unanalyzed_count(photos) == 2
+
+    # No trailing tail at all — an analyzed photo at the end means the
+    # divider must not fire.
+    photos = [
+        {"id": 1, "quality_score": None, "flag": "none"},
+        {"id": 2, "quality_score": 0.9, "flag": "none"},
+    ]
+    assert _bucket_unanalyzed_count(photos) == 0
 
 
 def test_rename_homonym_non_species_keyword_leaves_species_preferences(app_and_db):

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -4734,6 +4734,150 @@ def test_apply_ordered_highlights_resorts_when_visible_match():
     assert marks == {1: False, 2: True}
 
 
+def test_highlight_score_bucket_orders_picks_then_scored_then_unscored():
+    """Highlights ordering (picked_first) forms three contiguous regions:
+    picks (scored first, then unscored in capture order), scored non-picks by
+    score, then unscored non-picks in capture order. No rich metrics are set,
+    so highlight_score collapses to quality_score (+0.08 pick bonus)."""
+    from app import _highlight_score_bucket
+
+    photos = [
+        # scored non-picks (out of order to prove score sorts them)
+        {"id": 4, "quality_score": 0.3, "flag": "none", "timestamp": "2024-01-07"},
+        {"id": 5, "quality_score": 0.9, "flag": "none", "timestamp": "2024-01-06"},
+        # unscored non-picks (later capture times, shuffled)
+        {"id": 6, "quality_score": None, "flag": "none", "timestamp": "2024-03-02"},
+        {"id": 7, "quality_score": None, "flag": "none", "timestamp": "2024-03-01"},
+        # picks: one scored, two unscored (shuffled capture times)
+        {"id": 1, "quality_score": 0.5, "flag": "flagged", "timestamp": "2024-01-05"},
+        {"id": 2, "quality_score": None, "flag": "flagged", "timestamp": "2024-01-09"},
+        {"id": 3, "quality_score": None, "flag": "flagged", "timestamp": "2024-01-02"},
+    ]
+    _highlight_score_bucket(photos, picked_first=True)
+    # picks first (scored pick 1, then unscored picks 3<2 by capture time),
+    # then scored non-picks by score (5 before 4),
+    # then unscored non-picks by capture time (7 before 6).
+    assert [p["id"] for p in photos] == [1, 3, 2, 5, 4, 7, 6]
+
+
+def test_highlight_score_bucket_picked_first_false_unchanged():
+    """Regression: the non-picks-first path (life list / best-photo) still
+    ranks purely by score descending, ignoring flag and capture time."""
+    from app import _highlight_score_bucket
+
+    photos = [
+        {"id": 1, "quality_score": 0.4, "flag": "flagged", "timestamp": "2024-01-01"},
+        {"id": 2, "quality_score": 0.9, "flag": "none", "timestamp": "2024-01-09"},
+        {"id": 3, "quality_score": 0.6, "flag": "none", "timestamp": "2024-01-02"},
+    ]
+    _highlight_score_bucket(photos, picked_first=False)
+    assert [p["id"] for p in photos] == [2, 3, 1]
+
+
+def test_bucket_unanalyzed_count_counts_unscored_non_picks_only():
+    from app import _bucket_unanalyzed_count
+
+    photos = [
+        {"id": 1, "quality_score": 0.5, "flag": "flagged"},   # scored pick
+        {"id": 2, "quality_score": None, "flag": "flagged"},  # unscored pick (excluded)
+        {"id": 3, "quality_score": 0.4, "flag": "none"},      # scored non-pick
+        {"id": 4, "quality_score": None, "flag": "none"},     # unscored non-pick
+        {"id": 5, "quality_score": None, "flag": "none"},     # unscored non-pick
+    ]
+    assert _bucket_unanalyzed_count(photos) == 2
+    assert _bucket_unanalyzed_count([]) == 0
+    assert _bucket_unanalyzed_count(None) == 0
+
+
+def _set_photo_quality_flag(db, photo_id, quality=None, flag=None):
+    db.conn.execute(
+        "UPDATE photos SET quality_score = ?, flag = ? WHERE id = ?",
+        (quality, flag, photo_id),
+    )
+    db.conn.commit()
+
+
+def _seed_anianiau_bucket(db):
+    """Seed one species folder mirroring the real bug: a scored pick, two
+    unscored picks, scored/unscored non-picks, and a rejected photo. Returns
+    (folder_id, {label: photo_id})."""
+    fid = db.add_folder('/photos/hawaii', name='hawaii')
+    kid = db.add_keyword('Anianiau', is_species=True)
+    spec = [
+        # label, quality, flag, timestamp
+        ("scored_pick",   0.45, "flagged", "2024-01-05T10:00:00"),
+        ("unscored_pickB", None, "flagged", "2024-01-02T10:00:00"),
+        ("unscored_pickA", None, "flagged", "2024-01-09T10:00:00"),
+        ("np_high",       0.90, None,       "2024-01-06T10:00:00"),
+        ("np_low",        0.40, None,       "2024-01-07T10:00:00"),
+        ("unp_early",     None, None,       "2024-03-01T10:00:00"),
+        ("unp_late",      None, None,       "2024-03-02T10:00:00"),
+        ("rejected",      0.99, "rejected", "2024-01-01T10:00:00"),
+    ]
+    ids = {}
+    for i, (label, quality, flag, ts) in enumerate(spec):
+        pid = db.add_photo(
+            folder_id=fid, filename=f"{label}.jpg", extension='.jpg',
+            file_size=1000 + i, file_mtime=float(i), timestamp=ts,
+        )
+        db.tag_photo(pid, kid)
+        _set_photo_quality_flag(db, pid, quality=quality, flag=flag)
+        ids[label] = pid
+    return fid, ids
+
+
+def test_highlights_candidates_include_unscored_picks_and_order(app_and_db):
+    """Unscored photos now flow into Highlights: all three picks appear (the
+    real bug was two vanishing), ordered picks -> scored -> unscored, with
+    is_analyzed flags and unanalyzed_count set for the divider."""
+    from app import _apply_ordered_highlights, _collect_highlight_buckets
+
+    app, db = app_and_db
+    fid, ids = _seed_anianiau_bucket(db)
+
+    candidates = db.get_highlights_candidates(fid, min_quality=0.0)
+    buckets, _unid = _collect_highlight_buckets(candidates, 0.70)
+    _apply_ordered_highlights(db, buckets)
+    bucket = next(b for b in buckets if b["species"] == "Anianiau")
+
+    order = [p["filename"] for p in bucket["photos"]]
+    assert order == [
+        "scored_pick.jpg",       # scored pick leads
+        "unscored_pickB.jpg",    # unscored picks next, capture order
+        "unscored_pickA.jpg",
+        "np_high.jpg",           # scored non-picks by score
+        "np_low.jpg",
+        "unp_early.jpg",         # unscored non-picks last, capture order
+        "unp_late.jpg",
+    ]
+    # rejected photo is still excluded entirely
+    assert "rejected.jpg" not in order
+
+    by_name = {p["filename"]: p for p in bucket["photos"]}
+    assert by_name["scored_pick.jpg"]["is_analyzed"] is True
+    assert by_name["unscored_pickA.jpg"]["is_analyzed"] is False
+    assert by_name["unp_early.jpg"]["is_analyzed"] is False
+    # Only unscored non-picks form the labeled "not yet analyzed" tail.
+    assert bucket["unanalyzed_count"] == 2
+
+
+def test_highlights_candidates_exclude_unscored_when_quality_floor_raised(app_and_db):
+    """Raising the quality floor above 0 drops unscored photos (no measured
+    quality) and low-scored ones, leaving only photos above the floor."""
+    from app import _collect_highlight_buckets
+
+    app, db = app_and_db
+    fid, ids = _seed_anianiau_bucket(db)
+
+    candidates = db.get_highlights_candidates(fid, min_quality=0.5)
+    buckets, _unid = _collect_highlight_buckets(candidates, 0.70)
+    bucket = next(b for b in buckets if b["species"] == "Anianiau")
+    names = {p["filename"] for p in bucket["photos"]}
+
+    # Only np_high (0.90) clears the 0.5 floor; the rejected 0.99 stays excluded.
+    assert names == {"np_high.jpg"}
+
+
 def test_rename_homonym_non_species_keyword_leaves_species_preferences(app_and_db):
     """Renaming an unrelated same-name keyword must not rewrite species prefs."""
     app, db = app_and_db
@@ -8275,17 +8419,22 @@ def test_highlights_page_renders_after_redesign(app_and_db):
     assert b"Per row" in resp.data
 
 
-def test_highlights_get_empty(app_and_db):
-    """GET /api/highlights returns empty buckets when no quality data exists."""
+def test_highlights_get_includes_unscored_photos(app_and_db):
+    """Unscored photos now surface on Highlights (the page used to be empty
+    until analysis ran). The fixture's three unanalyzed photos — none carrying
+    an accepted species keyword — appear in the unidentified section, marked
+    not-yet-analyzed so the divider can label them."""
     app, _ = app_and_db
     client = app.test_client()
     resp = client.get("/api/highlights")
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["buckets"] == []
-    assert data["unidentified"]["photo_count"] == 0
-    assert data["folders"] == []
-    assert data["meta"]["eligible"] == 0
+    unid = data["unidentified"]
+    assert unid["photo_count"] == 3
+    assert unid["unanalyzed_count"] == 3
+    assert all(p["is_analyzed"] is False for p in unid["photos"])
+    assert data["meta"]["eligible"] == 3
 
 
 def test_highlights_buckets_by_accepted_species(app_and_db):

--- a/vireo/tests/test_life_list.py
+++ b/vireo/tests/test_life_list.py
@@ -193,11 +193,11 @@ def test_representative_preference_promotes_existing_highlight_to_top(life_app):
     }
 
 
-def test_representative_preference_skips_highlight_when_ineligible(life_app):
-    # p3 (sparrow) is life-list eligible but has no quality_score, so it
-    # can't appear in Highlights. Setting it as representative must not
-    # create an invisible species_highlights row the user can't see or
-    # remove from the Highlights page.
+def test_representative_preference_promotes_unscored_pick_to_highlight(life_app):
+    # p3 (sparrow) has no quality_score, but Highlights now admits
+    # unscored photos at min_quality=0 so users can curate a pick before
+    # analysis. Setting an unscored photo as representative must create
+    # the species_highlights row so it shows up on the Highlights page.
     app, db, ids = life_app
 
     resp = app.test_client().post("/api/photo-preferences", json={
@@ -207,9 +207,11 @@ def test_representative_preference_skips_highlight_when_ineligible(life_app):
     })
     assert resp.status_code == 200
     body = resp.get_json()
-    assert body["highlight_rank"] is None
+    assert body["highlight_rank"] == 1
 
-    assert db.get_species_highlights("House Sparrow") == {}
+    assert db.get_species_highlights("House Sparrow") == {
+        "House Sparrow": {ids["p3"]: 1},
+    }
 
 
 def test_representatives_are_global_but_filtered_to_workspace(life_app):

--- a/vireo/tests/test_life_list.py
+++ b/vireo/tests/test_life_list.py
@@ -214,6 +214,38 @@ def test_representative_preference_promotes_unscored_pick_to_highlight(life_app)
     }
 
 
+def test_unscored_species_highlight_renders_as_highlighted(life_app):
+    # An unscored photo saved as a species highlight must render as a chosen
+    # highlight. get_species_highlights(eligible_only=True) — used by the
+    # render/order path — has to admit unscored rows the widened write path
+    # now accepts, otherwise the just-saved highlight is silently dropped and
+    # the highlight-selection filters misclassify it until analysis runs.
+    app, db, ids = life_app
+    client = app.test_client()
+
+    resp = client.post("/api/species-highlights", json={
+        "species": "House Sparrow",
+        "photo_id": ids["p3"],
+    })
+    assert resp.status_code == 200
+
+    # The eligibility-filtered read (what _apply_ordered_highlights uses) must
+    # include the unscored row.
+    assert db.get_species_highlights("House Sparrow", eligible_only=True) == {
+        "House Sparrow": {ids["p3"]: 1},
+    }
+
+    # And the rendered bucket marks it as a highlight.
+    data = client.get("/api/highlights?scope=workspace").get_json()
+    sparrow = next(
+        b for b in data["buckets"] if b["species"] == "House Sparrow"
+    )
+    assert sparrow["has_highlight_selection"] is True
+    p3_card = next(p for p in sparrow["photos"] if p["id"] == ids["p3"])
+    assert p3_card["is_highlighted"] is True
+    assert p3_card["highlight_rank"] == 1
+
+
 def test_representatives_are_global_but_filtered_to_workspace(life_app):
     app, db, _ = life_app
     client = app.test_client()


### PR DESCRIPTION
## Problem

Photos flagged as **picks** could silently disappear from the Highlights page. `get_highlights_candidates` hard-excluded any photo with a `NULL` `quality_score`, so a pick on a not-yet-analyzed photo never appeared at all. Diagnosed on the `'Anianiau` bucket: 3 picks, only 1 showing — the other two had never been quality-scored (that folder is ~80% unanalyzed). This is exactly the "no black boxes" case `CORE_PHILOSOPHY.md` warns against: a user action producing a silently-vanishing result.

## Change

- **`db.py`** — `get_highlights_candidates` now admits unscored photos at the default quality floor, and excludes them only when the user raises `min_quality` above 0 (a quality filter should mean "analyzed photos only"). Rejected photos stay excluded.
- **`app.py`** — each bucket is ordered as three contiguous regions:
  1. picks (analyzed first by score, then unscored picks in capture order)
  2. analyzed non-picks by `highlight_score`
  3. unscored non-picks in capture order (earliest first)

  Adds `is_analyzed` per photo and `unanalyzed_count` per bucket + unidentified. The `picked_first=False` scorer path (life list / best-photo) is unchanged.
- **`highlights.html`** — `renderStripCards` inserts a *"Not yet analyzed — N photos"* grid-spanning divider before the unscored tail, so unranked photos don't masquerade as quality-ranked highlights. Collapsed cards backfill to the limit with unscored photos, avoiding near-empty cards for mostly-unanalyzed species.

Design doc: `docs/plans/2026-07-12-highlights-show-unscored-picks-design.md`.

## Tests

5 new tests (three-region ordering, `unanalyzed_count`, candidate inclusion, quality-floor exclusion, and a regression pin on the non-picks-first scorer) plus an updated empty-state test.

```
1568 passed, 14 skipped
```

## Verification

Ran against a `sqlite3 .backup` snapshot of the live DB (throwaway instance, real app untouched). The real `'Anianiau` bucket now returns **all three picks**, correctly ordered:

```
pos     id  flag      analyzed  score    timestamp
  0   51896  flagged   True      0.5311   ...10:51:02   ← scored pick, leads
  1   51958  flagged   False     0.08     ...10:51:12   ← previously invisible
  2   51994  flagged   False     0.08     ...10:51:32   ← previously invisible
  3   56172  none      True      0.6828   ...           ← scored non-picks by score
```

`unanalyzed_count: 80`, divider boundary lands at the first unscored non-pick. Frontend pixels not driven (no Playwright in the env); the divider renders over the confirmed fields and is unit-covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)