### PR TITLE
Fix navbar tab drag-reorder snapping back in the desktop app

### DIFF
--- a/tests/e2e/test_navbar_reorder.py
+++ b/tests/e2e/test_navbar_reorder.py
@@ -1,0 +1,96 @@
+"""Drag-reorder of the navbar tab strip.
+
+Covers the "dropped tab snaps back" bug: the reorder must be committed on
+`dragend` (which fires reliably on the source element) and not depend on the
+`drop` event, because the macOS WKWebView the desktop app renders in
+frequently never fires `drop` for HTML5 drag-and-drop.
+"""
+
+
+def _nav_ids(page):
+    return page.eval_on_selector_all(
+        ".navbar .nav-tab:not(.is-ephemeral)",
+        "els => els.map(e => e.dataset.navId)",
+    )
+
+
+def test_drag_reorder_persists_with_real_mouse(live_server, page):
+    """A real native drag moves the tab and persists across reload."""
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+    page.wait_for_selector(".nav-tab[data-nav-id='cull']")
+
+    before = _nav_ids(page)
+    assert before[0] == "import"
+    assert "cull" in before
+
+    src = page.query_selector(".nav-tab[data-nav-id='cull']")
+    dst = page.query_selector(".nav-tab[data-nav-id='import']")
+    sb, db = src.bounding_box(), dst.bounding_box()
+    page.mouse.move(sb["x"] + sb["width"] / 2, sb["y"] + sb["height"] / 2)
+    page.mouse.down()
+    for i in range(1, 11):
+        page.mouse.move(
+            sb["x"] + (db["x"] - sb["x"]) * i / 10 + db["width"] / 2,
+            db["y"] + db["height"] / 2,
+            steps=2,
+        )
+    page.mouse.up()
+
+    page.wait_for_timeout(300)
+    page.reload()
+    page.wait_for_selector(".nav-tab[data-nav-id='cull']")
+    after = _nav_ids(page)
+
+    assert after.index("cull") < before.index("cull"), (
+        f"cull did not move earlier: before={before} after={after}"
+    )
+
+
+def test_reorder_commits_without_drop_event(live_server, page):
+    """Regression: WKWebView fires dragstart/dragover/dragend but not drop.
+
+    Dispatch that exact event sequence (no `drop`) and assert the reorder is
+    still committed and persisted. On the old drop-only code the tab snapped
+    back; this must now succeed.
+    """
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+    page.wait_for_selector(".nav-tab[data-nav-id='cull']")
+
+    before = _nav_ids(page)
+
+    moved = page.evaluate("""() => {
+        const strip = document.getElementById('navTabStrip');
+        const src = strip.querySelector(".nav-tab[data-nav-id='cull']");
+        const importTab = strip.querySelector(".nav-tab[data-nav-id='import']");
+        const rect = importTab.getBoundingClientRect();
+        // Aim just left of the first tab's midpoint so cull lands at the front.
+        const clientX = rect.left + 1;
+
+        const fire = (el, type, x) => {
+            const ev = new DragEvent(type, {
+                bubbles: true, cancelable: true,
+                dataTransfer: new DataTransfer(), clientX: x,
+            });
+            el.dispatchEvent(ev);
+        };
+        fire(src, 'dragstart', 0);
+        fire(strip, 'dragover', clientX);
+        fire(src, 'dragend', clientX);   // NOTE: no 'drop' event
+        return true;
+    }""")
+    assert moved
+
+    page.wait_for_timeout(300)
+    dom_after = _nav_ids(page)
+    assert dom_after[0] == "cull", (
+        f"tab did not move on dragend without drop: {dom_after}"
+    )
+
+    page.reload()
+    page.wait_for_selector(".nav-tab[data-nav-id='cull']")
+    after_reload = _nav_ids(page)
+    assert after_reload[0] == "cull", (
+        f"reorder did not persist: before={before} after={after_reload}"
+    )

--- a/tests/e2e/test_navbar_reorder.py
+++ b/tests/e2e/test_navbar_reorder.py
@@ -94,3 +94,59 @@ def test_reorder_commits_without_drop_event(live_server, page):
     assert after_reload[0] == "cull", (
         f"reorder did not persist: before={before} after={after_reload}"
     )
+
+
+def test_aborted_drag_outside_strip_does_not_reorder(live_server, page):
+    """Regression: dragging a tab, leaving the strip, then releasing outside
+    the navbar must NOT commit a reorder from the stale in-strip pointer X.
+
+    Before the fix, `dragend` unconditionally called `commitReorder(lastClientX)`
+    and the strip `dragleave` handler only cleared the visual indicator, so an
+    aborted drag would silently reshuffle the tab order.
+    """
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+    page.wait_for_selector(".nav-tab[data-nav-id='cull']")
+
+    before = _nav_ids(page)
+
+    result = page.evaluate("""() => {
+        const strip = document.getElementById('navTabStrip');
+        const src = strip.querySelector(".nav-tab[data-nav-id='cull']");
+        const importTab = strip.querySelector(".nav-tab[data-nav-id='import']");
+        const rect = importTab.getBoundingClientRect();
+        // A position that WOULD land cull at the front if it committed.
+        const inStripX = rect.left + 1;
+
+        const fire = (el, type, init) => {
+            const ev = new DragEvent(type, Object.assign({
+                bubbles: true, cancelable: true, dataTransfer: new DataTransfer(),
+            }, init || {}));
+            el.dispatchEvent(ev);
+        };
+        fire(src, 'dragstart', {clientX: 0});
+        fire(strip, 'dragover', {clientX: inStripX});
+        // Pointer leaves the strip: relatedTarget points at something
+        // outside the strip so the handler's !contains(relatedTarget)
+        // check fires.
+        fire(strip, 'dragleave', {clientX: inStripX, relatedTarget: document.body});
+        // User releases the mouse outside the navbar; dragend still fires
+        // on the source element, but there is no dragover to refresh
+        // lastClientX.
+        fire(src, 'dragend', {clientX: 0});
+        return true;
+    }""")
+    assert result
+
+    page.wait_for_timeout(300)
+    dom_after = _nav_ids(page)
+    assert dom_after == before, (
+        f"aborted drag unexpectedly reordered tabs: before={before} after={dom_after}"
+    )
+
+    page.reload()
+    page.wait_for_selector(".nav-tab[data-nav-id='cull']")
+    after_reload = _nav_ids(page)
+    assert after_reload == before, (
+        f"aborted drag persisted a stale reorder: before={before} after_reload={after_reload}"
+    )

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -2655,6 +2655,15 @@ window.NAV_ALL_PAGES = [
 
   let draggedEl = null;
   let indicator = null;
+  // Last pointer X seen during the drag, and a guard so the reorder is
+  // committed exactly once per drag. We commit on `dragend` (which fires
+  // reliably on the source element across engines, including the macOS
+  // WKWebView the desktop app runs in) rather than relying solely on the
+  // `drop` event — WKWebView frequently never fires `drop` for HTML5
+  // drag-and-drop, which left the dragged tab snapping back to its
+  // original position. `drop`, when it does fire, is a fast-path.
+  let lastClientX = null;
+  let committed = false;
 
   function createIndicator() {
     const el = document.createElement('span');
@@ -2688,14 +2697,16 @@ window.NAV_ALL_PAGES = [
     const newOrder = tabAnchors().map(a => a.dataset.navId);
     if (window._navTabs) window._navTabs.setTabs(newOrder);
   }
-  function commitDrop(e) {
-    if (!draggedEl) return;
-    e.preventDefault();
-    e.stopPropagation();
+  // Move the dragged tab to wherever `clientX` points and persist the new
+  // order. Guarded by `committed` so a drag that fires both `drop` and
+  // `dragend` only reorders/persists once.
+  function commitReorder(clientX) {
+    if (committed || !draggedEl || clientX == null) return;
     const s = strip();
     if (!s) return;
+    committed = true;
     removeIndicator();
-    s.insertBefore(draggedEl, dropReference(e.clientX));
+    s.insertBefore(draggedEl, dropReference(clientX));
     persistCurrentOrder();
   }
 
@@ -2707,23 +2718,36 @@ window.NAV_ALL_PAGES = [
       link.dataset.dragBound = '1';
       link.addEventListener('dragstart', function(e) {
         draggedEl = this;
+        lastClientX = null;
+        committed = false;
         this.classList.add('dragging');
         e.dataTransfer.effectAllowed = 'move';
         e.dataTransfer.setData('text/plain', this.dataset.navId);
       });
       link.addEventListener('dragend', function() {
+        // Primary commit path: `dragend` always fires on the source, even
+        // in WKWebView where `drop` may not. No-op if `drop` already
+        // committed this drag.
+        commitReorder(lastClientX);
         this.classList.remove('dragging');
         removeIndicator();
         draggedEl = null;
+        lastClientX = null;
+        committed = false;
       });
       link.addEventListener('dragover', function(e) {
         if (!draggedEl || draggedEl === this) return;
         e.preventDefault();
         e.dataTransfer.dropEffect = 'move';
+        lastClientX = e.clientX;
         showDropIndicator(e.clientX);
       });
       link.addEventListener('drop', function(e) {
-        commitDrop(e);
+        // Fast-path when the engine delivers `drop`. `dragend` still fires
+        // afterward but `committed` makes it a no-op.
+        e.preventDefault();
+        e.stopPropagation();
+        commitReorder(e.clientX);
       });
     });
   }
@@ -2744,9 +2768,15 @@ window.NAV_ALL_PAGES = [
       if (!draggedEl) return;
       e.preventDefault();
       e.dataTransfer.dropEffect = 'move';
+      lastClientX = e.clientX;
       showDropIndicator(e.clientX);
     });
-    s.addEventListener('drop', commitDrop);
+    s.addEventListener('drop', function(e) {
+      if (!draggedEl) return;
+      e.preventDefault();
+      e.stopPropagation();
+      commitReorder(e.clientX);
+    });
     bindDragHandlers();
     const mo = new MutationObserver(() => bindDragHandlers());
     mo.observe(s, {childList: true});

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -2655,13 +2655,17 @@ window.NAV_ALL_PAGES = [
 
   let draggedEl = null;
   let indicator = null;
-  // Last pointer X seen during the drag, and a guard so the reorder is
-  // committed exactly once per drag. We commit on `dragend` (which fires
-  // reliably on the source element across engines, including the macOS
-  // WKWebView the desktop app runs in) rather than relying solely on the
-  // `drop` event — WKWebView frequently never fires `drop` for HTML5
-  // drag-and-drop, which left the dragged tab snapping back to its
-  // original position. `drop`, when it does fire, is a fast-path.
+  // Last pointer X seen while the drag was over the strip, and a guard so
+  // the reorder is committed exactly once per drag. We commit on `dragend`
+  // (which fires reliably on the source element across engines, including
+  // the macOS WKWebView the desktop app runs in) rather than relying solely
+  // on the `drop` event — WKWebView frequently never fires `drop` for HTML5
+  // drag-and-drop, which left the dragged tab snapping back to its original
+  // position. `drop`, when it does fire, is a fast-path.
+  //
+  // `lastClientX` is cleared when the pointer leaves the strip so an
+  // aborted drag (release outside the navbar) can't commit a reorder from
+  // the last in-strip position.
   let lastClientX = null;
   let committed = false;
 
@@ -2762,7 +2766,14 @@ window.NAV_ALL_PAGES = [
     // bindDragHandlers() on every MutationObserver tick would otherwise
     // accumulate duplicate listeners.
     s.addEventListener('dragleave', function(e) {
-      if (!s.contains(e.relatedTarget)) removeIndicator();
+      // When the drag exits the strip entirely, clear both the visual
+      // indicator and the pending drop position. Otherwise a subsequent
+      // `dragend` fired after the user releases outside the navbar would
+      // commit a reorder from the stale in-strip pointer X.
+      if (!s.contains(e.relatedTarget)) {
+        removeIndicator();
+        lastClientX = null;
+      }
     });
     s.addEventListener('dragover', function(e) {
       if (!draggedEl) return;


### PR DESCRIPTION
## What & why

The navbar section names (Import, Browse, Cull, Review, …) are a reorderable tab strip — you can drag them to change their order. But in the **desktop app**, dragging a tab showed the drag ghost moving and then **snapped it back to its original position** on release; the new order was never applied or saved.

**Root cause:** the reorder was only committed inside the `drop` event handler. The desktop app renders in macOS **WKWebView** (via Tauri), which has a long-standing gap where the HTML5 `drop` event frequently never fires. No `drop` → the tab is never moved and nothing is persisted.

This never showed up in tests because Playwright's WebKit build *does* fire `drop`, so the existing navigation suite stayed green while the shipped app failed.

## Fix

Commit the reorder on **`dragend`** instead — it fires reliably on the source element across engines, including WKWebView. `drop` is kept as a fast-path, and a `committed` guard makes sure a drag that fires both events only reorders/persists once. Pointer X is tracked from `dragover` so `dragend` knows where to drop.

No backend changes — `/api/workspace/tabs/reorder` was already correct.

## Tests

New `tests/e2e/test_navbar_reorder.py`:
- `test_drag_reorder_persists_with_real_mouse` — real native drag reorders and persists across reload.
- `test_reorder_commits_without_drop_event` — dispatches the exact WKWebView sequence (`dragstart`/`dragover`/`dragend`, **no** `drop`) and asserts the reorder still commits + persists. **Fails on the old drop-only code** (reproduces the snap-back), passes now.

Verified:
- Both new tests pass on `--browser webkit` and `--browser chromium`.
- The no-drop regression test fails on `main` (confirmed via stash), passes with the fix.
- Existing `tests/e2e/test_navigation.py` (25 tests) still green on WebKit.

## Note on verification

The bug is only reproducible in *real* WKWebView, which automation can't drive natively — so final confirmation is a real drag in the desktop app. The regression test simulates the precise failing event sequence, which is the closest automated proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navbar tab drag-and-drop reordering across browsers, including macOS WKWebView.
  * Reordered tabs now reliably save when the standard drop event is unavailable.
  * Prevented duplicate reorder operations when multiple drag events are triggered.
  * Added coverage to verify that tab order persists after reloading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->