### PR TITLE
Review details before opening iNaturalist uploads

### DIFF
--- a/tests/e2e/test_external_navigation.py
+++ b/tests/e2e/test_external_navigation.py
@@ -2,14 +2,22 @@
 
 from playwright.sync_api import expect
 
-INAT_URL = "https://www.inaturalist.org/observations/upload?taxon_name=Corvus"
+INAT_UPLOAD_URL = "https://www.inaturalist.org/observations/upload"
+INAT_URL = (
+    INAT_UPLOAD_URL
+    + "?taxon_name=Corvus%20corax&observed_on=2026-07-12&lat=47.61&lng=-122.33"
+)
 
 
-def _item(photo_id=1, *, url=INAT_URL, duplicate=False):
+def _item(photo_id=1, *, url=INAT_UPLOAD_URL, duplicate=False):
     return {
         "photo_id": photo_id,
         "filename": f"photo-{photo_id}.jpg",
         "upload_url": url,
+        "taxon_name": "Corvus corax",
+        "observed_on": "2026-07-12",
+        "latitude": 47.61,
+        "longitude": -122.33,
         "already_submitted": duplicate,
         "existing_url": (
             "https://www.inaturalist.org/observations/123" if duplicate else None
@@ -48,12 +56,24 @@ def _open_commands(page):
     )
 
 
-def test_native_quick_open_uses_one_command_and_only_a_toast(live_server, page):
+def test_native_quick_open_reviews_checked_metadata_before_opening(live_server, page):
     page.goto(f"{live_server['url']}/browse")
     original_url = page.url
     _mock_tauri(page)
 
     page.evaluate("item => openInatQuickModal([item], [])", _item())
+
+    assert _open_commands(page) == []
+    expect(page.locator("#inatModal")).to_have_class("modal-overlay open")
+    expect(page.locator("#inatIncludeTaxon0")).to_be_checked()
+    expect(page.locator("#inatIncludeDate0")).to_be_checked()
+    expect(page.locator("#inatIncludeLocation0")).to_be_checked()
+
+    page.locator("#inatCards button", has_text="Open Upload Page").click()
+    page.wait_for_function(
+        "window.__externalTest.invokes.some(call => "
+        "call.command === 'open_external_url')"
+    )
 
     commands = _open_commands(page)
     assert commands == [{"command": "open_external_url", "args": {"url": INAT_URL}}]
@@ -62,7 +82,26 @@ def test_native_quick_open_uses_one_command_and_only_a_toast(live_server, page):
     expect(page.locator("#toastContainer")).to_contain_text(
         "Opened iNaturalist in your browser."
     )
-    expect(page.locator("#inatModal")).not_to_have_class("open")
+    expect(page.locator("#inatModal")).to_have_class("modal-overlay open")
+
+
+def test_quick_open_can_omit_all_metadata_for_generic_upload(live_server, page):
+    page.goto(f"{live_server['url']}/browse")
+    _mock_tauri(page)
+    page.evaluate("item => openInatQuickModal([item], [])", _item())
+
+    page.locator("#inatIncludeTaxon0").uncheck()
+    page.locator("#inatIncludeDate0").uncheck()
+    page.locator("#inatIncludeLocation0").uncheck()
+    page.locator("#inatCards button", has_text="Open Upload Page").click()
+    page.wait_for_function(
+        "window.__externalTest.invokes.some(call => "
+        "call.command === 'open_external_url')"
+    )
+
+    assert _open_commands(page) == [
+        {"command": "open_external_url", "args": {"url": INAT_UPLOAD_URL}}
+    ]
 
 
 def test_native_open_failure_stays_put_and_offers_retry_and_copy(live_server, page):
@@ -71,6 +110,7 @@ def test_native_open_failure_stays_put_and_offers_retry_and_copy(live_server, pa
     _mock_tauri(page, fail_open=True)
 
     page.evaluate("item => openInatQuickModal([item], [])", _item())
+    page.locator("#inatCards button", has_text="Open Upload Page").click()
 
     assert len(_open_commands(page)) == 1
     assert page.evaluate("window.__externalTest.windowOpenCalls") == []
@@ -144,7 +184,6 @@ def test_batch_quick_uploads_require_explicit_per_item_open(live_server, page):
         _item(1),
         _item(
             2,
-            url="https://www.inaturalist.org/observations/upload?taxon_name=Pica",
         ),
     ]
 
@@ -152,7 +191,7 @@ def test_batch_quick_uploads_require_explicit_per_item_open(live_server, page):
 
     assert _open_commands(page) == []
     expect(page.locator("#inatModal")).to_have_class("modal-overlay open")
-    expect(page.locator("#inatCards a", has_text="Open Upload")).to_have_count(2)
+    expect(page.locator("#inatCards button", has_text="Open Upload")).to_have_count(2)
     expect(page.locator("#inatCards button", has_text="Copy URL")).to_have_count(2)
 
     # Copy still has a DOM fallback when clipboard permission is unavailable;
@@ -189,9 +228,8 @@ def test_batch_quick_open_preserves_preparation_failures(live_server, page):
         {"item": _item(1), "failures": failures},
     )
 
-    # The batch had preparation failures, so the auto-open shortcut must be
-    # skipped and the modal must render both the prepared upload and the
-    # failure summary — otherwise those dropped photos are silently lost.
+    # The review modal must render both the prepared upload and the failure
+    # summary — otherwise those dropped photos are silently lost.
     assert _open_commands(page) == []
     expect(page.locator("#inatModal")).to_have_class("modal-overlay open")
     expect(page.locator("#inatCards", has_text="Open Upload Page")).to_be_visible()

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -27,7 +27,7 @@ import uuid
 import webbrowser
 from datetime import UTC, datetime
 from pathlib import Path
-from urllib.parse import quote, urlencode, urlsplit
+from urllib.parse import quote, urlsplit
 
 import places
 from db import (
@@ -14447,26 +14447,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         species = pred["species"] if pred else ""
         scientific = pred["scientific_name"] if pred else ""
 
-        # Percent-encode every value: scientific names contain spaces, and an
-        # unencoded space makes the URL invalid, so the desktop opener plugin
-        # rejects it and nothing opens.
-        params = []
-        if scientific:
-            params.append(("taxon_name", scientific))
-        elif species:
-            params.append(("taxon_name", species))
-        if photo["timestamp"]:
-            params.append(("observed_on", photo["timestamp"][:10]))
         loc = db.get_effective_photo_location(photo_id)
         lat = loc["latitude"] if loc else None
         lng = loc["longitude"] if loc else None
-        if lat is not None and lng is not None:
-            params.append(("lat", str(lat)))
-            params.append(("lng", str(lng)))
-
+        # The browser uploader does not document query parameters for
+        # pre-filling an observation. In particular, taxon_name is an
+        # observation-search parameter, not an uploader parameter. Open the
+        # generic uploader and keep the prepared metadata in this response for
+        # Vireo's authenticated direct-upload flow.
         upload_url = "https://www.inaturalist.org/observations/upload"
-        if params:
-            upload_url += "?" + urlencode(params)
 
         # Check submission history
         subs = db.get_inat_submissions([photo_id])

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -7502,6 +7502,45 @@ async function _inatOpenUrl(url) {
   return false;
 }
 
+function _inatQuickUploadUrl(idx) {
+  var item = inatQueue[idx];
+  var base = (item && item.upload_url) || 'https://www.inaturalist.org/observations/upload';
+  base = base.split('?')[0];
+  var params = [];
+  var taxon = document.getElementById('inatIncludeTaxon' + idx);
+  var date = document.getElementById('inatIncludeDate' + idx);
+  var location = document.getElementById('inatIncludeLocation' + idx);
+  if (taxon && taxon.checked && item.taxon_name) {
+    params.push('taxon_name=' + encodeURIComponent(item.taxon_name));
+  }
+  if (date && date.checked && item.observed_on) {
+    params.push('observed_on=' + encodeURIComponent(item.observed_on));
+  }
+  if (location && location.checked && item.latitude !== '' && item.longitude !== '') {
+    params.push('lat=' + encodeURIComponent(String(item.latitude)));
+    params.push('lng=' + encodeURIComponent(String(item.longitude)));
+  }
+  return base + (params.length ? '?' + params.join('&') : '');
+}
+
+async function openInatQuickUpload(idx) {
+  var url = _inatQuickUploadUrl(idx);
+  if (await _inatOpenUrl(url)) {
+    showToast('Opened iNaturalist in your browser.', 'success');
+    return;
+  }
+  if (typeof showExternalOpenFailure === 'function') {
+    showExternalOpenFailure(
+      url,
+      'Vireo could not open iNaturalist. Retry or copy the upload URL below.'
+    );
+  }
+}
+
+function copyInatQuickUploadUrl(idx) {
+  return copyExternalUrl(_inatQuickUploadUrl(idx));
+}
+
 async function submitToInat(photoId) {
   try {
     var data = await safeFetch('/api/inat/prepare/' + photoId, {}, { toast: false });
@@ -7554,29 +7593,10 @@ async function submitToInatBatch(photoIds) {
 }
 
 async function openInatQuickModal(items, failures) {
-  var skipAutoOpenForDuplicate = items.length === 1 && !!items[0].already_submitted;
-  var hasFailures = !!(failures && failures.length);
-  // When batch preparation left other photos in a failure state, always render
-  // the modal so the failure summary is visible instead of silently dropping it.
-  if (items.length === 1 && items[0].upload_url && !skipAutoOpenForDuplicate && !hasFailures) {
-    var opened = await _inatOpenUrl(items[0].upload_url);
-    if (opened) {
-      showToast('Opened iNaturalist in your browser.', 'success');
-      return;
-    }
-    if (typeof showExternalOpenFailure === 'function') {
-      showExternalOpenFailure(
-        items[0].upload_url,
-        'Vireo could not open iNaturalist. Retry or copy the prepared upload URL below.'
-      );
-      return;
-    }
-  }
-
   if (window._inatEscToken) Keymap.popEsc(window._inatEscToken);
   window._inatEscToken = Keymap.pushEsc(function() { closeInatModal(); });
 
-  inatQueue = [];
+  inatQueue = items.slice();
   var title = items.length === 1 ? 'Open in iNaturalist' : 'Open ' + items.length + ' iNaturalist uploads';
   document.getElementById('inatModalTitle').textContent = title;
   document.getElementById('inatProgress').style.display = 'none';
@@ -7596,6 +7616,29 @@ async function openInatQuickModal(items, failures) {
     return '<div class="inat-card-status warning" style="margin-top:6px;">&#9888; Already submitted to iNaturalist: ' + linkOrText + '. Opening a new upload will create a duplicate observation.</div>';
   }
 
+  function _inatQuickOptions(item, idx) {
+    var hasTaxon = !!item.taxon_name;
+    var hasDate = !!item.observed_on;
+    var hasLocation = item.latitude !== '' && item.longitude !== '';
+    var taxonText = hasTaxon ? item.taxon_name : 'No detected taxon';
+    var dateText = hasDate ? item.observed_on : 'No observation date';
+    var locationText = hasLocation
+      ? String(item.latitude) + ', ' + String(item.longitude)
+      : 'No location';
+    return '<fieldset style="border:0;padding:0;margin:12px 0 0;display:flex;flex-direction:column;gap:8px;">' +
+      '<legend style="font-size:13px;color:var(--text-primary);margin-bottom:7px;">Include in the upload link</legend>' +
+      '<label style="font-size:13px;color:var(--text-secondary);display:flex;align-items:center;gap:8px;">' +
+        '<input id="inatIncludeTaxon' + idx + '" type="checkbox"' + (hasTaxon ? ' checked' : ' disabled') + '> Taxon: ' + escapeHtml(taxonText) +
+      '</label>' +
+      '<label style="font-size:13px;color:var(--text-secondary);display:flex;align-items:center;gap:8px;">' +
+        '<input id="inatIncludeDate' + idx + '" type="checkbox"' + (hasDate ? ' checked' : ' disabled') + '> Date: ' + escapeHtml(dateText) +
+      '</label>' +
+      '<label style="font-size:13px;color:var(--text-secondary);display:flex;align-items:center;gap:8px;">' +
+        '<input id="inatIncludeLocation' + idx + '" type="checkbox"' + (hasLocation ? ' checked' : ' disabled') + '> Location: ' + escapeHtml(locationText) +
+      '</label>' +
+    '</fieldset>';
+  }
+
   var html = '';
   if (items.length === 1) {
     html += '<div class="inat-card">' +
@@ -7603,36 +7646,33 @@ async function openInatQuickModal(items, failures) {
         '<img class="inat-card-thumb" src="/thumbnails/' + items[0].photo_id + '.jpg" alt="">' +
         '<div style="flex:1;min-width:0;">' +
           '<div style="font-size:13px;color:var(--text-primary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">' + escapeHtml(items[0].filename) + '</div>' +
-          '<div class="inat-card-status warning">' +
-            (skipAutoOpenForDuplicate
-              ? 'Did not auto-open — this photo appears already submitted. Review the warning below before opening a new upload.'
-              : 'Use the prepared link below.') +
-          '</div>' +
           _inatAlreadySubmittedWarning(items[0]) +
         '</div>' +
       '</div>' +
       '<div style="font-size:13px;line-height:1.5;color:var(--text-secondary);">' +
-        'Direct uploads need an iNaturalist token in Settings. This link opens iNaturalist with the prepared taxon, date, and location.' +
+        'Choose which details Vireo should add to the iNaturalist upload link.' +
       '</div>' +
+      _inatQuickOptions(items[0], 0) +
       '<div style="margin-top:12px;">' +
-        '<a class="modal-btn modal-btn-primary" href="' + escapeAttr(items[0].upload_url) + '" target="_blank" rel="noopener" onclick="return openExternalLink(event, this.href)" style="display:inline-block;text-decoration:none;">Open Upload Page</a>' +
-        '<button type="button" class="modal-btn" data-external-url="' + escapeAttr(items[0].upload_url) + '" onclick="copyExternalUrl(this.getAttribute(\'data-external-url\'))" style="margin-left:8px;">Copy URL</button>' +
+        '<button type="button" class="modal-btn modal-btn-primary" onclick="openInatQuickUpload(0)">Open Upload Page</button>' +
+        '<button type="button" class="modal-btn" onclick="copyInatQuickUploadUrl(0)" style="margin-left:8px;">Copy URL</button>' +
       '</div>' +
     '</div>';
   } else {
     html += '<div class="inat-card">' +
       '<div style="font-size:13px;line-height:1.5;color:var(--text-secondary);margin-bottom:10px;">' +
-        'Direct uploads need an iNaturalist token in Settings. Open each prepared upload page below.' +
+        'Direct uploads need an iNaturalist token in Settings. Open the iNaturalist upload page for each photo below.' +
       '</div>';
-    items.forEach(function(item) {
+    items.forEach(function(item, idx) {
       html += '<div style="display:flex;flex-direction:column;gap:4px;padding:8px 0;border-top:1px solid var(--border-primary);">' +
         '<div style="display:flex;align-items:center;justify-content:space-between;gap:12px;">' +
           '<span style="font-size:13px;color:var(--text-primary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">' + escapeHtml(item.filename) + '</span>' +
           '<span style="display:flex;align-items:center;gap:8px;white-space:nowrap;">' +
-            '<a href="' + escapeAttr(item.upload_url) + '" target="_blank" rel="noopener" onclick="return openExternalLink(event, this.href)" style="color:var(--accent);font-size:12px;">Open Upload</a>' +
-            '<button type="button" data-external-url="' + escapeAttr(item.upload_url) + '" onclick="copyExternalUrl(this.getAttribute(\'data-external-url\'))" style="border:0;background:none;color:var(--text-secondary);font-size:12px;cursor:pointer;padding:0;">Copy URL</button>' +
+            '<button type="button" onclick="openInatQuickUpload(' + idx + ')" style="border:0;background:none;color:var(--accent);font-size:12px;cursor:pointer;padding:0;">Open Upload</button>' +
+            '<button type="button" onclick="copyInatQuickUploadUrl(' + idx + ')" style="border:0;background:none;color:var(--text-secondary);font-size:12px;cursor:pointer;padding:0;">Copy URL</button>' +
           '</span>' +
         '</div>' +
+        _inatQuickOptions(item, idx) +
         _inatAlreadySubmittedWarning(item) +
       '</div>';
     });

--- a/vireo/tests/test_inat.py
+++ b/vireo/tests/test_inat.py
@@ -1,6 +1,5 @@
 import os
 import sys
-from urllib.parse import parse_qs, urlparse
 
 import pytest
 
@@ -302,27 +301,24 @@ def test_api_inat_prepare_uses_assigned_location_coords(app_and_db):
 
     assert data['latitude'] == 48.8566
     assert data['longitude'] == 2.3522
-    assert "lat=48.8566" in data["upload_url"]
-    assert "lng=2.3522" in data["upload_url"]
+    assert data["upload_url"] == "https://www.inaturalist.org/observations/upload"
 
 
-def test_api_inat_prepare_url_encodes_quick_upload_params(app_and_db):
-    """The prefilled upload URL must be valid: a scientific name with a space
-    (e.g. "Cardinalis cardinalis") has to be percent-encoded, otherwise the
-    desktop opener plugin rejects the malformed URL and nothing opens."""
+def test_api_inat_prepare_uses_generic_browser_upload_url(app_and_db):
+    """Token-free handoff opens iNaturalist's generic browser uploader.
+
+    Prepared metadata remains in the response for direct uploads, but it must
+    not be attached as unsupported uploader query parameters.
+    """
     app, _db, pid = app_and_db
     client = app.test_client()
     resp = client.get(f'/api/inat/prepare/{pid}')
     assert resp.status_code == 200
     data = resp.get_json()
 
-    url = data["upload_url"]
-    # No raw spaces anywhere in the URL.
-    assert " " not in url
-    # The taxon name still round-trips back to the real binomial.
-    qs = parse_qs(urlparse(url).query)
-    assert qs["taxon_name"] == ["Cardinalis cardinalis"]
-    assert qs["observed_on"] == ["2024-06-01"]
+    assert data["upload_url"] == "https://www.inaturalist.org/observations/upload"
+    assert data["scientific_name"] == "Cardinalis cardinalis"
+    assert data["timestamp"].startswith("2024-06-01")
 
 
 def test_api_inat_prepare_preserves_zero_coordinates(app_and_db):
@@ -340,10 +336,11 @@ def test_api_inat_prepare_preserves_zero_coordinates(app_and_db):
 
     client = app.test_client()
     resp = client.get(f'/api/inat/prepare/{pid}')
-    query = parse_qs(urlparse(resp.get_json()["upload_url"]).query)
+    data = resp.get_json()
 
-    assert query["lat"] == ["0.0"]
-    assert query["lng"] == ["0.0"]
+    assert data["latitude"] == 0.0
+    assert data["longitude"] == 0.0
+    assert data["upload_url"] == "https://www.inaturalist.org/observations/upload"
 
 
 def test_api_inat_prepare_marks_quick_mode_as_not_photo_upload(app_and_db):


### PR DESCRIPTION
Vireo previously opened token-free iNaturalist uploads immediately with a fixed metadata query string, giving users no way to review or omit the detected details.
This change opens a review screen for individual and batch uploads, with taxon, observation date, and location included through checked-by-default options when available.
The browser handoff now starts from iNaturalist's generic upload URL and builds the selected query parameters only when the user opens or copies the link.
Validated with the 10 external-navigation browser tests, three focused iNaturalist API tests, Ruff, and diff checks.
