### PR TITLE
Add tags during photo import

### DIFF
--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -850,6 +850,72 @@ def test_import_copy_start_sends_restored_options(live_server, page):
     assert "after_import" not in body
 
 
+def test_import_start_sends_common_tags_and_gps_location_option(
+    live_server, page,
+):
+    url = live_server["url"]
+    captured = {}
+
+    def config_route(route):
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "google_maps_api_key": "configured-for-test",
+                "pipeline": {"default_strategy": None},
+            }),
+        )
+
+    def start_import(route):
+        captured["body"] = json.loads(route.request.post_data or "{}")
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"job_id": "import-tags-test"}),
+        )
+
+    page.route("**/api/config", config_route)
+    page.route("**/api/jobs/import-in-place", start_import)
+    page.goto(f"{url}/import")
+
+    page.locator("#sourceInput").fill("/tmp/card-a")
+    page.locator("#btnAddSource").click()
+    page.locator("#importTagInput").fill("Kenya trip")
+    page.locator("#importTagInput").press("Enter")
+    page.locator("#importTagInput").fill("Portfolio")
+    page.locator("#btnAddImportTag").click()
+    expect(page.locator("#importTagList .import-tag-chip")).to_have_count(2)
+    page.locator("#chkLocationFromGps").check()
+
+    page.locator("#btnStart").click()
+    expect(page.locator("#progressCard")).to_be_visible()
+
+    assert captured["body"]["tags"] == ["Kenya trip", "Portfolio"]
+    assert captured["body"]["location_from_gps"] is True
+
+
+def test_import_gps_location_option_explains_missing_api_key(live_server, page):
+    url = live_server["url"]
+
+    def config_route(route):
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({
+                "google_maps_api_key": "",
+                "pipeline": {"default_strategy": None},
+            }),
+        )
+
+    page.route("**/api/config", config_route)
+    page.goto(f"{url}/import")
+
+    expect(page.locator("#chkLocationFromGps")).to_be_disabled()
+    expect(page.locator("#locationGpsHint")).to_contain_text(
+        "Add a Google Maps API key in Settings"
+    )
+
+
 def test_import_new_workspace_forwards_explicit_after_import(live_server, page):
     """When the user actively picks a strategy for a new-workspace import,
     the client must forward that pick — only the untouched-dropdown case is

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5503,10 +5503,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         result["tagging"] = summary
 
         def cancel_requested():
-            return result.get("cancelled") or (
+            cancelled = result.get("cancelled") or (
                 job is not None and runner is not None
                 and runner.is_cancelled(job["id"])
             )
+            if cancelled:
+                # The cancellation may arrive after the importer itself has
+                # returned a successful result. Persist it on the shared
+                # result so downstream after-import chaining also stops.
+                result["cancelled"] = True
+            return cancelled
 
         if cancel_requested():
             summary["skipped"] = "import cancelled"

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5549,20 +5549,46 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     requested_name, kw_type="general", _commit=False,
                 )
                 stored = thread_db.conn.execute(
-                    "SELECT name FROM keywords WHERE id = ?", (keyword_id,),
+                    "SELECT name, parent_id, type FROM keywords WHERE id = ?",
+                    (keyword_id,),
                 ).fetchone()
                 keyword_name = (
                     stored["name"] if stored and stored["name"]
                     else requested_name
                 )
+                variant_ids = [keyword_id]
+                if stored is not None and keyword_match_key(stored["name"]):
+                    normalized_name = normalize_keyword_display(stored["name"])
+                    if stored["parent_id"] is None:
+                        peer_rows = thread_db.conn.execute(
+                            "SELECT id FROM keywords "
+                            "WHERE vireo_normalize_keyword(name) = ? "
+                            "COLLATE NOCASE AND parent_id IS NULL "
+                            "AND type = ? AND id != ?",
+                            (normalized_name, stored["type"], keyword_id),
+                        ).fetchall()
+                    else:
+                        peer_rows = thread_db.conn.execute(
+                            "SELECT id FROM keywords "
+                            "WHERE vireo_normalize_keyword(name) = ? "
+                            "COLLATE NOCASE AND parent_id = ? "
+                            "AND type = ? AND id != ?",
+                            (
+                                normalized_name, stored["parent_id"],
+                                stored["type"], keyword_id,
+                            ),
+                        ).fetchall()
+                    variant_ids.extend(row["id"] for row in peer_rows)
+                variant_placeholders = ",".join("?" for _ in variant_ids)
                 items = []
                 for photo_id in photo_ids:
                     if cancel_requested():
                         break
                     exists = thread_db.conn.execute(
                         "SELECT 1 FROM photo_keywords "
-                        "WHERE photo_id = ? AND keyword_id = ?",
-                        (photo_id, keyword_id),
+                        f"WHERE photo_id = ? AND keyword_id IN "
+                        f"({variant_placeholders})",
+                        [photo_id, *variant_ids],
                     ).fetchone()
                     if exists is not None:
                         continue

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5494,6 +5494,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "errors": [],
         }
         result["tagging"] = summary
+        if result.get("cancelled") or (
+            job is not None and runner is not None
+            and runner.is_cancelled(job["id"])
+        ):
+            summary["skipped"] = "import cancelled"
+            return
         if not photo_ids:
             summary["skipped"] = "no new photos"
             return

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5410,6 +5410,231 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "_details_by_place_id": {k: v["details"] for k, v in groups.items()},
         }, None
 
+    def _validate_import_tag_options(body):
+        """Normalize optional tags attached to a photo import request."""
+        raw_tags = body.get("tags", [])
+        if not isinstance(raw_tags, list):
+            return None, None, json_error("tags must be a list of names")
+        if len(raw_tags) > 50:
+            return None, None, json_error("at most 50 import tags are allowed")
+
+        tags = []
+        seen = set()
+        for raw in raw_tags:
+            if not isinstance(raw, str):
+                return None, None, json_error(
+                    "tags must contain only strings"
+                )
+            name = normalize_keyword_display(raw)
+            if not name:
+                return None, None, json_error("import tags must not be empty")
+            if len(name) > 200:
+                return None, None, json_error(
+                    "import tags must be 200 characters or fewer"
+                )
+            match_key = keyword_match_key(name) or name.casefold()
+            if match_key not in seen:
+                seen.add(match_key)
+                tags.append(name)
+
+        location_from_gps = body.get("location_from_gps", False)
+        if not isinstance(location_from_gps, bool):
+            return None, None, json_error(
+                "location_from_gps must be a boolean"
+            )
+        return tags, location_from_gps, None
+
+    def _queue_import_keyword_add(
+        db, photo_id, keyword_name, workspace_id, *, commit=False,
+    ):
+        """Thread-safe equivalent of _queue_keyword_add for import jobs."""
+        removed = db.remove_pending_changes(
+            photo_id, "keyword_remove", keyword_name,
+            workspace_id=workspace_id, _commit=commit,
+        )
+        if removed == 0:
+            db.queue_change(
+                photo_id, "keyword_add", keyword_name,
+                workspace_id=workspace_id, _commit=commit,
+            )
+
+    def _queue_import_location_sync(
+        db, photo_id, workspace_id, *, commit=False,
+    ):
+        """Thread-safe equivalent of _queue_location_sync_if_enabled."""
+        db.remove_pending_changes(
+            photo_id, "location", workspace_id=workspace_id, _commit=commit,
+        )
+        db.queue_change(
+            photo_id, "location", "effective",
+            workspace_id=workspace_id, _commit=commit,
+        )
+
+    def _apply_import_tags(
+        workspace_id, photo_ids, tags, location_from_gps, result,
+        *, job=None, runner=None,
+    ):
+        """Apply requested common tags and per-photo GPS locations.
+
+        Tagging is deliberately post-import: ``photo_ids`` is the importer's
+        authoritative set of successfully cataloged photos, so skipped
+        archive duplicates never gain tags. Failures here do not change the
+        copy/verification result; they are reported separately in the job.
+        """
+        if not tags and not location_from_gps:
+            return
+
+        summary = {
+            "requested_tags": list(tags),
+            "tagged_photos": 0,
+            "location_requested": bool(location_from_gps),
+            "locations_added": 0,
+            "locations_unresolved": 0,
+            "locations_skipped": 0,
+            "errors": [],
+        }
+        result["tagging"] = summary
+        if not photo_ids:
+            summary["skipped"] = "no new photos"
+            return
+
+        if job is not None and runner is not None:
+            phase = (
+                "Adding tags and GPS locations"
+                if tags and location_from_gps
+                else "Adding GPS locations"
+                if location_from_gps
+                else "Adding tags"
+            )
+            runner.push_event(job["id"], "progress", {
+                "current": job["progress"].get("current", 0),
+                "total": job["progress"].get("total", 0),
+                "current_file": "",
+                "phase": phase,
+            })
+
+        thread_db = Database(db_path)
+        thread_db.set_active_workspace(workspace_id)
+        tagged_photo_ids = set()
+
+        for requested_name in tags:
+            try:
+                keyword_id = thread_db.add_keyword(
+                    requested_name, kw_type="general", _commit=False,
+                )
+                stored = thread_db.conn.execute(
+                    "SELECT name FROM keywords WHERE id = ?", (keyword_id,),
+                ).fetchone()
+                keyword_name = (
+                    stored["name"] if stored and stored["name"]
+                    else requested_name
+                )
+                items = []
+                for photo_id in photo_ids:
+                    exists = thread_db.conn.execute(
+                        "SELECT 1 FROM photo_keywords "
+                        "WHERE photo_id = ? AND keyword_id = ?",
+                        (photo_id, keyword_id),
+                    ).fetchone()
+                    if exists is not None:
+                        continue
+                    thread_db.tag_photo(photo_id, keyword_id, _commit=False)
+                    _queue_import_keyword_add(
+                        thread_db, photo_id, keyword_name, workspace_id,
+                    )
+                    tagged_photo_ids.add(photo_id)
+                    items.append({
+                        "photo_id": photo_id,
+                        "old_value": "",
+                        "new_value": str(keyword_id),
+                    })
+                if items:
+                    thread_db.record_edit(
+                        "keyword_add",
+                        f'Added "{keyword_name}" during import to '
+                        f"{len(items)} photos",
+                        str(keyword_id), items, is_batch=True, _commit=False,
+                    )
+                thread_db.conn.commit()
+            except Exception as exc:
+                thread_db.conn.rollback()
+                log.exception("Failed to add import tag %r", requested_name)
+                summary["errors"].append(
+                    f'Could not add tag "{requested_name}": {exc}'
+                )
+        summary["tagged_photos"] = len(tagged_photo_ids)
+
+        if location_from_gps:
+            unresolved = 0
+            skipped = 0
+            added = 0
+            # The public bulk endpoint caps a request at 10,000 IDs. Imports
+            # can exceed that, so reuse its resolution logic in bounded
+            # chunks while sharing the persistent ~110 m geocode cache.
+            for photo_chunk in _gps_location_chunks(photo_ids, size=10000):
+                try:
+                    payload, error = _bulk_gps_location_payload(
+                        thread_db, {"photo_ids": photo_chunk},
+                    )
+                    if error is not None:
+                        raise RuntimeError("location resolution was rejected")
+                    details_by_place_id = payload.pop(
+                        "_details_by_place_id", {}
+                    )
+                    unresolved += len(payload["unresolved"])
+                    skipped += len(payload["skipped"])
+                    for group in payload["groups"]:
+                        details = details_by_place_id.get(group["place_id"])
+                        if not details:
+                            unresolved += len(group["photo_ids"])
+                            continue
+                        try:
+                            leaf_id = thread_db.upsert_place_chain(details)
+                        except Exception as exc:
+                            log.exception(
+                                "Failed to create GPS import location %s",
+                                group["place_id"],
+                            )
+                            summary["errors"].append(
+                                f"Could not create location "
+                                f"{group.get('summary') or group['place_id']}: "
+                                f"{exc}"
+                            )
+                            unresolved += len(group["photo_ids"])
+                            continue
+                        location_items = []
+                        for photo_id in group["photo_ids"]:
+                            thread_db.set_photo_location(photo_id, leaf_id)
+                            _queue_import_location_sync(
+                                thread_db, photo_id, workspace_id,
+                            )
+                            location_items.append({
+                                "photo_id": photo_id,
+                                "old_value": "",
+                                "new_value": str(leaf_id),
+                            })
+                        added += len(location_items)
+                        if location_items:
+                            thread_db.record_edit(
+                                "location_set",
+                                f"Added GPS location during import to "
+                                f"{len(location_items)} photos",
+                                "from_exif", location_items,
+                                is_batch=True, _commit=False,
+                            )
+                    thread_db.conn.commit()
+                except Exception as exc:
+                    thread_db.conn.rollback()
+                    log.exception("Failed to add GPS locations during import")
+                    summary["errors"].append(
+                        f"Could not add GPS locations: {exc}"
+                    )
+                    unresolved += len(photo_chunk)
+            summary["locations_added"] = added
+            summary["locations_unresolved"] = unresolved
+            summary["locations_skipped"] = skipped
+        thread_db.conn.close()
+
     # -- Edit API routes --
 
     @app.route("/api/photos/<int:photo_id>/wildlife_excluded", methods=["POST"])
@@ -17898,6 +18123,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 return json_error(f"source directory not found: {s}")
 
         recursive = bool(body.get("recursive", True))
+        import_tags, location_from_gps, tag_options_err = (
+            _validate_import_tag_options(body)
+        )
+        if tag_options_err is not None:
+            return tag_options_err
         db = _get_db()
         # Preflight an explicit after_import before creating a workspace so
         # a bad value doesn't leave an orphan Card Import behind. The
@@ -18118,7 +18348,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     job["id"], "scan", status="cancelled",
                     summary=f"{indexed} photos (cancelled)",
                 )
-                return {
+                result = {
                     "mode": "in_place",
                     "ok": False,
                     "cancelled": True,
@@ -18128,6 +18358,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     "errors": root_errors,
                     "photo_ids": photo_ids,
                 }
+                _apply_import_tags(
+                    active_ws, photo_ids, import_tags, location_from_gps,
+                    result, job=job, runner=runner,
+                )
+                return result
 
             metadata_warning = _scan_metadata_warning()
             summary = f"{indexed} photos"
@@ -18149,6 +18384,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "errors": root_errors,
                 "photo_ids": photo_ids,
             }
+            _apply_import_tags(
+                active_ws, photo_ids, import_tags, location_from_gps, result,
+                job=job, runner=runner,
+            )
             _chain_after_import(job, result)
             return result
 
@@ -18157,6 +18396,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "destination": None,
             "recursive": recursive,
             "after_import": after_import,
+            "tags": import_tags,
+            "location_from_gps": location_from_gps,
             "mode": "in_place",
             "workspace_id": active_ws,
             "created_workspace": created_workspace,
@@ -18378,6 +18619,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         skip_duplicates = bool(body.get("skip_duplicates", True))
         verify_by_hash = bool(body.get("verify_by_hash", False))
         recursive = bool(body.get("recursive", True))
+        import_tags, location_from_gps, tag_options_err = (
+            _validate_import_tag_options(body)
+        )
+        if tag_options_err is not None:
+            return tag_options_err
 
         active_ws, created_workspace, workspace_err = (
             _prepare_import_workspace(db, body)
@@ -18432,6 +18678,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "verify_by_hash": verify_by_hash,
             "recursive": recursive,
             "after_import": after_import,
+            "tags": import_tags,
+            "location_from_gps": location_from_gps,
             "remote_target_id": remote_target_id or None,
             "remote_subpath": remote_subpath or None,
             "workspace_id": active_ws,
@@ -18512,6 +18760,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             try:
                 result = run_import_job(
                     job, runner, db_path, active_ws, params,
+                )
+                _apply_import_tags(
+                    active_ws, result.get("photo_ids") or [], import_tags,
+                    location_from_gps, result, job=job, runner=runner,
                 )
                 _chain_after_import(job, result)
                 return result

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5318,7 +5318,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return None, json_error("collection not found", 404)
         return db.get_collection_photo_ids(collection_id), None
 
-    def _bulk_gps_location_payload(db, body):
+    def _bulk_gps_location_payload(db, body, cancel_check=None):
         """Build preview/apply data for resolving locations from EXIF GPS."""
         photo_ids, error = _bulk_gps_location_source_ids(db, body)
         if error is not None:
@@ -5352,7 +5352,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         unresolved = []
         skipped = []
         ordered_group_keys = []
+        cancelled = False
         for pid in photo_ids:
+            if cancel_check is not None and cancel_check():
+                cancelled = True
+                break
             photo = photos_map[pid]
             if pid in assigned_ids:
                 skipped.append({
@@ -5400,7 +5404,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "sample_filenames": group["sample_filenames"],
             })
 
-        return {
+        result = {
             "total": len(photo_ids),
             "resolvable": sum(group["count"] for group in group_list),
             "updated": 0,
@@ -5408,7 +5412,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "unresolved": unresolved,
             "skipped": skipped,
             "_details_by_place_id": {k: v["details"] for k, v in groups.items()},
-        }, None
+        }
+        if cancelled:
+            result["cancelled"] = True
+        return result, None
 
     def _validate_import_tag_options(body):
         """Normalize optional tags attached to a photo import request."""
@@ -5494,10 +5501,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "errors": [],
         }
         result["tagging"] = summary
-        if result.get("cancelled") or (
-            job is not None and runner is not None
-            and runner.is_cancelled(job["id"])
-        ):
+
+        def cancel_requested():
+            return result.get("cancelled") or (
+                job is not None and runner is not None
+                and runner.is_cancelled(job["id"])
+            )
+
+        if cancel_requested():
             summary["skipped"] = "import cancelled"
             return
         if not photo_ids:
@@ -5524,6 +5535,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         tagged_photo_ids = set()
 
         for requested_name in tags:
+            if cancel_requested():
+                summary["skipped"] = "import cancelled"
+                break
             try:
                 keyword_id = thread_db.add_keyword(
                     requested_name, kw_type="general", _commit=False,
@@ -5537,6 +5551,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 )
                 items = []
                 for photo_id in photo_ids:
+                    if cancel_requested():
+                        break
                     exists = thread_db.conn.execute(
                         "SELECT 1 FROM photo_keywords "
                         "WHERE photo_id = ? AND keyword_id = ?",
@@ -5548,12 +5564,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     _queue_import_keyword_add(
                         thread_db, photo_id, keyword_name, workspace_id,
                     )
-                    tagged_photo_ids.add(photo_id)
                     items.append({
                         "photo_id": photo_id,
                         "old_value": "",
                         "new_value": str(keyword_id),
                     })
+                if cancel_requested():
+                    thread_db.conn.rollback()
+                    summary["skipped"] = "import cancelled"
+                    break
                 if items:
                     thread_db.record_edit(
                         "keyword_add",
@@ -5562,6 +5581,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         str(keyword_id), items, is_batch=True, _commit=False,
                     )
                 thread_db.conn.commit()
+                tagged_photo_ids.update(item["photo_id"] for item in items)
             except Exception as exc:
                 thread_db.conn.rollback()
                 log.exception("Failed to add import tag %r", requested_name)
@@ -5570,26 +5590,37 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 )
         summary["tagged_photos"] = len(tagged_photo_ids)
 
-        if location_from_gps:
+        if location_from_gps and not cancel_requested():
             unresolved = 0
             skipped = 0
             added = 0
+            cancelled_during_gps = False
             # The public bulk endpoint caps a request at 10,000 IDs. Imports
             # can exceed that, so reuse its resolution logic in bounded
             # chunks while sharing the persistent ~110 m geocode cache.
             for photo_chunk in _gps_location_chunks(photo_ids, size=10000):
+                if cancel_requested():
+                    cancelled_during_gps = True
+                    break
                 try:
                     payload, error = _bulk_gps_location_payload(
                         thread_db, {"photo_ids": photo_chunk},
+                        cancel_check=cancel_requested,
                     )
                     if error is not None:
                         raise RuntimeError("location resolution was rejected")
+                    if payload.pop("cancelled", False) or cancel_requested():
+                        cancelled_during_gps = True
+                        break
                     details_by_place_id = payload.pop(
                         "_details_by_place_id", {}
                     )
                     unresolved += len(payload["unresolved"])
                     skipped += len(payload["skipped"])
                     for group in payload["groups"]:
+                        if cancel_requested():
+                            cancelled_during_gps = True
+                            break
                         details = details_by_place_id.get(group["place_id"])
                         if not details:
                             unresolved += len(group["photo_ids"])
@@ -5610,6 +5641,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                             continue
                         location_items = []
                         for photo_id in group["photo_ids"]:
+                            if cancel_requested():
+                                cancelled_during_gps = True
+                                break
                             thread_db.set_photo_location(photo_id, leaf_id)
                             _queue_import_location_sync(
                                 thread_db, photo_id, workspace_id,
@@ -5629,6 +5663,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                                 is_batch=True, _commit=False,
                             )
                     thread_db.conn.commit()
+                    if cancelled_during_gps:
+                        break
                 except Exception as exc:
                     thread_db.conn.rollback()
                     log.exception("Failed to add GPS locations during import")
@@ -5639,6 +5675,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             summary["locations_added"] = added
             summary["locations_unresolved"] = unresolved
             summary["locations_skipped"] = skipped
+            if cancelled_during_gps:
+                summary["skipped"] = "import cancelled"
+        elif location_from_gps:
+            summary["skipped"] = "import cancelled"
         thread_db.conn.close()
 
     # -- Edit API routes --

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -160,6 +160,16 @@ body { display: flex; flex-direction: column; height: 100vh; }
   display: flex; gap: 8px; justify-content: flex-end;
   padding: 12px 16px; border-top: 1px solid var(--border-primary);
 }
+.import-tag-list { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
+.import-tag-chip {
+  display: inline-flex; align-items: center; gap: 5px;
+  padding: 3px 7px; border: 1px solid var(--border-primary);
+  border-radius: 999px; background: var(--bg-tertiary); font-size: 12px;
+}
+.import-tag-chip button {
+  border: 0; background: transparent; color: var(--text-secondary);
+  cursor: pointer; padding: 0; line-height: 1;
+}
 </style>
 </head>
 <body>
@@ -241,6 +251,29 @@ body { display: flex; flex-direction: column; height: 100vh; }
         <label>Workspace name</label>
         <input type="text" id="newWorkspaceName" class="input-fixed" placeholder="New workspace">
       </div>
+    </div>
+
+    <div class="card" id="tagsCard">
+      <h3>Tags</h3>
+      <div class="row">
+        <input type="text" id="importTagInput" placeholder="Add a tag"
+               aria-label="Tag to add to imported photos"
+               onkeydown="handleImportTagKeydown(event)">
+        <button class="btn" type="button" id="btnAddImportTag"
+                onclick="addImportTagFromInput()">Add tag</button>
+      </div>
+      <div class="import-tag-list" id="importTagList"></div>
+      <div class="section-divider">
+        <label>
+          <input type="checkbox" id="chkLocationFromGps">
+          Add a location tag from each photo's GPS
+        </label>
+        <div class="hint" id="locationGpsHint">
+          Vireo resolves each GPS coordinate to a saved place. Photos without
+          GPS or a confident match remain untagged; existing locations are kept.
+        </div>
+      </div>
+      <div class="hint">Tags above are added to every photo included in this import.</div>
     </div>
 
     <div class="card" id="destCard">
@@ -330,6 +363,7 @@ body { display: flex; flex-direction: column; height: 100vh; }
       <div id="resultSummary" class="hint" style="margin-top:6px;"></div>
       <table class="folder-progress" id="resultFolders"></table>
       <div id="chainInfo" class="hint" style="margin-top:8px;"></div>
+      <div id="taggingInfo" class="hint" style="margin-top:8px;"></div>
       <div id="modelWarning" class="warn" style="display:none;"></div>
       <div class="result-links" style="margin-top:8px;">
         <a href="/browse">Open Browse</a> &nbsp;·&nbsp; <a href="/jobs">Open Jobs</a>
@@ -392,6 +426,53 @@ let destStructureSeq = 0;
 let importPreviewSeq = 0;
 let importPreviewTimer = null;
 let importThumbSchedulerCancel = null;
+let importTags = [];
+
+function normalizedImportTag(name) {
+  return String(name || '').trim().replace(/\s+/g, ' ');
+}
+
+function renderImportTags() {
+  const list = document.getElementById('importTagList');
+  list.innerHTML = '';
+  importTags.forEach((name, index) => {
+    const chip = document.createElement('span');
+    chip.className = 'import-tag-chip';
+    const label = document.createElement('span');
+    label.textContent = name;
+    const remove = document.createElement('button');
+    remove.type = 'button';
+    remove.setAttribute('aria-label', 'Remove tag ' + name);
+    remove.textContent = '×';
+    remove.onclick = () => {
+      importTags.splice(index, 1);
+      renderImportTags();
+    };
+    chip.append(label, remove);
+    list.appendChild(chip);
+  });
+}
+
+function addImportTag(name) {
+  const clean = normalizedImportTag(name);
+  if (!clean) return false;
+  if (!importTags.some(tag => tag.toLocaleLowerCase() === clean.toLocaleLowerCase())) {
+    importTags.push(clean);
+    renderImportTags();
+  }
+  return true;
+}
+
+function addImportTagFromInput() {
+  const input = document.getElementById('importTagInput');
+  if (addImportTag(input.value)) input.value = '';
+}
+
+function handleImportTagKeydown(event) {
+  if (event.key !== 'Enter' && event.key !== ',') return;
+  event.preventDefault();
+  addImportTagFromInput();
+}
 
 function selectedImportMode() {
   const checked = document.querySelector('input[name="importMode"]:checked');
@@ -1913,12 +1994,17 @@ function renderFolderTable(el, folders) {
 
 async function startImport() {
   showError('');
+  addImportTagFromInput();
   if (!sources.length) { showError('Add at least one source folder.'); return; }
   const copyMode = selectedImportMode() === 'copy';
   const body = {
     sources: sources,
     recursive: document.getElementById('chkRecursive').checked,
   };
+  if (importTags.length) body.tags = importTags.slice();
+  if (document.getElementById('chkLocationFromGps').checked) {
+    body.location_from_gps = true;
+  }
   if (document.getElementById('workspaceNew').checked) {
     const name = (document.getElementById('newWorkspaceName').value || '').trim();
     if (!name) { showError('Name the new workspace.'); return; }
@@ -2053,6 +2139,7 @@ function renderResult(res, status) {
       (status && status !== 'completed' ? ' · job ' + status : '');
     document.getElementById('resultFolders').innerHTML = '';
     renderChainInfo(res);
+    renderTaggingInfo(res);
     renderModelWarning(res);
     return;
   }
@@ -2084,7 +2171,39 @@ function renderResult(res, status) {
   renderFolderTable(document.getElementById('resultFolders'), res.folders || {});
 
   renderChainInfo(res);
+  renderTaggingInfo(res);
   renderModelWarning(res);
+}
+
+function renderTaggingInfo(res) {
+  const el = document.getElementById('taggingInfo');
+  const tagging = res.tagging;
+  if (!tagging) {
+    el.textContent = '';
+    return;
+  }
+  const parts = [];
+  if ((tagging.requested_tags || []).length) {
+    parts.push(
+      'Tags added to ' + (tagging.tagged_photos || 0) + ' photo' +
+      ((tagging.tagged_photos || 0) === 1 ? '' : 's')
+    );
+  }
+  if (tagging.location_requested) {
+    parts.push((tagging.locations_added || 0) + ' GPS location' +
+      ((tagging.locations_added || 0) === 1 ? '' : 's') + ' added');
+    if (tagging.locations_unresolved) {
+      parts.push(tagging.locations_unresolved + ' could not be resolved');
+    }
+    if (tagging.locations_skipped) {
+      parts.push(tagging.locations_skipped + ' already had a location');
+    }
+  }
+  if ((tagging.errors || []).length) {
+    parts.push(tagging.errors.join(' '));
+  }
+  if (tagging.skipped) parts.push('Tagging skipped: ' + tagging.skipped);
+  el.textContent = parts.join(' · ');
 }
 
 function renderChainInfo(res) {
@@ -2168,6 +2287,13 @@ async function initImportPage() {
   const pipelineCfg = Object.assign(
     {}, cfg.pipeline || {}, (overrides || {}).pipeline || {},
   );
+  const gpsCheckbox = document.getElementById('chkLocationFromGps');
+  const gpsHint = document.getElementById('locationGpsHint');
+  if (cfgOk && !String(cfg.google_maps_api_key || '').trim()) {
+    gpsCheckbox.disabled = true;
+    gpsHint.textContent =
+      'Add a Google Maps API key in Settings to resolve GPS coordinates into location tags.';
+  }
 
   const recents = ingestCfg.recent_destinations || [];
   const dl = document.getElementById('recentDestinations');

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -3266,6 +3266,137 @@ def test_import_photos_happy_path(app_and_db, tmp_path):
     assert result["safe_to_format"] is True
 
 
+def test_import_photos_adds_requested_tags(app_and_db, tmp_path):
+    app, db = app_and_db
+    client = app.test_client()
+    card = _import_card(tmp_path, ("DSC_0001.jpg", "DSC_0002.jpg"))
+    Image.new("RGB", (16, 16), "blue").save(
+        os.path.join(card, "DSC_0002.jpg")
+    )
+
+    resp = client.post("/api/jobs/import-photos", json={
+        "sources": [card],
+        "destination": str(tmp_path / "archive"),
+        "after_import": None,
+        "tags": ["Kenya trip", "Portfolio", "kenya trip"],
+    })
+    assert resp.status_code == 200, resp.get_json()
+    job_id = resp.get_json()["job_id"]
+    config = _job_config(client, job_id)
+    assert config["tags"] == ["Kenya trip", "Portfolio"]
+
+    job = wait_for_job_via_client(client, job_id)
+    assert job["status"] == "completed", job
+    result = job["result"]
+    assert result["tagging"]["tagged_photos"] == 2
+    assert result["tagging"]["errors"] == []
+    for photo_id in result["photo_ids"]:
+        names = {row["name"] for row in db.get_photo_keywords(photo_id)}
+        assert {"Kenya trip", "Portfolio"} <= names
+
+
+def test_duplicate_only_import_does_not_tag_existing_photos(
+    app_and_db, tmp_path,
+):
+    app, db = app_and_db
+    client = app.test_client()
+    card = _import_card(tmp_path)
+    destination = str(tmp_path / "archive")
+
+    first = client.post("/api/jobs/import-photos", json={
+        "sources": [card], "destination": destination, "after_import": None,
+    })
+    wait_for_job_via_client(client, first.get_json()["job_id"])
+
+    second = client.post("/api/jobs/import-photos", json={
+        "sources": [card],
+        "destination": destination,
+        "after_import": None,
+        "tags": ["Do not add to duplicates"],
+    })
+    job = wait_for_job_via_client(client, second.get_json()["job_id"])
+    result = job["result"]
+    assert result["photo_ids"] == []
+    assert result["tagging"]["skipped"] == "no new photos"
+    assert db.conn.execute(
+        "SELECT 1 FROM keywords WHERE name = ?",
+        ("Do not add to duplicates",),
+    ).fetchone() is None
+
+
+@pytest.mark.parametrize("field,value,error", [
+    ("tags", "Trip", "tags must be a list"),
+    ("tags", ["Trip", 4], "only strings"),
+    ("tags", ["   "], "must not be empty"),
+    ("location_from_gps", "yes", "must be a boolean"),
+])
+def test_import_tag_options_are_validated_before_starting_job(
+    app_and_db, tmp_path, field, value, error,
+):
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.post("/api/jobs/import-photos", json={
+        "sources": [_import_card(tmp_path)],
+        "destination": str(tmp_path / "archive"),
+        "after_import": None,
+        field: value,
+    })
+    assert resp.status_code == 400
+    assert error in resp.get_json()["error"]
+
+
+def test_import_can_add_structured_locations_from_each_photos_gps(
+    app_and_db, tmp_path, monkeypatch,
+):
+    from db import Database
+
+    app, db = app_and_db
+    client = app.test_client()
+    original_get = Database.get_photos_by_ids
+    details = {
+        "place_id": "import-gps-place",
+        "name": "Central Park",
+        "lat": 40.785091,
+        "lng": -73.968285,
+        "types": ["park"],
+        "address_components": [
+            {"name": "New York", "types": ["locality"]},
+            {"name": "New York", "types": ["administrative_area_level_1"]},
+            {"name": "United States", "types": ["country"]},
+        ],
+    }
+
+    def photos_with_gps(self, photo_ids):
+        rows = original_get(self, photo_ids)
+        enriched = {}
+        for photo_id, row in rows.items():
+            photo = dict(row)
+            photo["latitude"] = details["lat"]
+            photo["longitude"] = details["lng"]
+            enriched[photo_id] = photo
+        self.reverse_geocode_cache_put(
+            details["lat"], details["lng"], details["place_id"],
+            json.dumps(details),
+        )
+        return enriched
+
+    monkeypatch.setattr(Database, "get_photos_by_ids", photos_with_gps)
+    resp = client.post("/api/jobs/import-photos", json={
+        "sources": [_import_card(tmp_path)],
+        "destination": str(tmp_path / "archive"),
+        "after_import": None,
+        "location_from_gps": True,
+    })
+    assert resp.status_code == 200, resp.get_json()
+    job = wait_for_job_via_client(client, resp.get_json()["job_id"])
+    assert job["status"] == "completed", job
+    result = job["result"]
+    assert result["tagging"]["locations_added"] == 1
+    photo_id = result["photo_ids"][0]
+    location = db.get_assigned_photo_location(photo_id)
+    assert location["keyword_location_name"] == "Central Park"
+
+
 def test_import_in_place_no_destination_required(app_and_db, tmp_path):
     app, _ = app_and_db
     client = app.test_client()

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -3295,6 +3295,57 @@ def test_import_photos_adds_requested_tags(app_and_db, tmp_path):
         assert {"Kenya trip", "Portfolio"} <= names
 
 
+def test_import_tag_does_not_duplicate_normalized_legacy_peer(
+    app_and_db, tmp_path, monkeypatch,
+):
+    import import_job
+
+    app, db = app_and_db
+    client = app.test_client()
+    photo_id = db.conn.execute("SELECT id FROM photos LIMIT 1").fetchone()["id"]
+    clean_id = db.add_keyword("Import Legacy", kw_type="general")
+    legacy_id = db.conn.execute(
+        "INSERT INTO keywords (name, type) VALUES (?, 'general')",
+        ("‘Import Legacy",),
+    ).lastrowid
+    db.conn.commit()
+    db.tag_photo(photo_id, legacy_id)
+
+    def imported_result(job, runner, db_path, workspace_id, params):
+        return {
+            "ok": True,
+            "cancelled": False,
+            "photo_ids": [photo_id],
+            "discovered": 1,
+            "copied": 1,
+            "verified": 1,
+            "skipped_duplicate": 0,
+            "failed": 0,
+            "safe_to_format": True,
+            "unsafe_files": [],
+            "folders": {},
+            "errors": [],
+        }
+
+    monkeypatch.setattr(import_job, "run_import_job", imported_result)
+    resp = client.post("/api/jobs/import-photos", json={
+        "sources": [_import_card(tmp_path)],
+        "destination": str(tmp_path / "archive"),
+        "after_import": None,
+        "tags": ["Import Legacy"],
+    })
+    assert resp.status_code == 200, resp.get_json()
+    job = wait_for_job_via_client(client, resp.get_json()["job_id"])
+    assert job["status"] == "completed", job
+    assert job["result"]["tagging"]["tagged_photos"] == 0
+    linked = db.conn.execute(
+        "SELECT keyword_id FROM photo_keywords "
+        "WHERE photo_id = ? AND keyword_id IN (?, ?)",
+        (photo_id, clean_id, legacy_id),
+    ).fetchall()
+    assert [row["keyword_id"] for row in linked] == [legacy_id]
+
+
 def test_duplicate_only_import_does_not_tag_existing_photos(
     app_and_db, tmp_path,
 ):

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -3324,6 +3324,52 @@ def test_duplicate_only_import_does_not_tag_existing_photos(
     ).fetchone() is None
 
 
+def test_cancelled_import_does_not_apply_requested_tags(
+    app_and_db, tmp_path, monkeypatch,
+):
+    import import_job
+
+    app, db = app_and_db
+    client = app.test_client()
+    photo_id = db.conn.execute("SELECT id FROM photos LIMIT 1").fetchone()["id"]
+
+    def cancelled_result(job, runner, db_path, workspace_id, params):
+        return {
+            "ok": False,
+            "cancelled": True,
+            "photo_ids": [photo_id],
+            "discovered": 1,
+            "copied": 1,
+            "verified": 0,
+            "skipped_duplicate": 0,
+            "failed": 0,
+            "safe_to_format": False,
+            "unsafe_files": [],
+            "folders": {},
+            "errors": [],
+        }
+
+    monkeypatch.setattr(import_job, "run_import_job", cancelled_result)
+    resp = client.post("/api/jobs/import-photos", json={
+        "sources": [_import_card(tmp_path)],
+        "destination": str(tmp_path / "archive"),
+        "after_import": None,
+        "tags": ["Must not be added"],
+        "location_from_gps": True,
+    })
+    assert resp.status_code == 200, resp.get_json()
+    job = wait_for_job_via_client(client, resp.get_json()["job_id"])
+    # The synthetic worker returns a cancelled result without setting the
+    # runner's cancellation flag, so JobRunner records this fixture as failed;
+    # the production cancellation path sets both. The behavior under test is
+    # that the result marker alone suppresses all post-import mutations.
+    assert job["status"] == "failed", job
+    assert job["result"]["tagging"]["skipped"] == "import cancelled"
+    assert db.conn.execute(
+        "SELECT 1 FROM keywords WHERE name = ?", ("Must not be added",),
+    ).fetchone() is None
+
+
 @pytest.mark.parametrize("field,value,error", [
     ("tags", "Trip", "tags must be a list"),
     ("tags", ["Trip", 4], "only strings"),

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -3414,13 +3414,16 @@ def test_import_gps_tagging_stops_when_cancelled_during_resolution(
     resp = client.post("/api/jobs/import-photos", json={
         "sources": [_import_card(tmp_path)],
         "destination": str(tmp_path / "archive"),
-        "after_import": None,
+        "after_import": "quick_look",
         "location_from_gps": True,
     })
     assert resp.status_code == 200, resp.get_json()
     job = wait_for_job_via_client(client, resp.get_json()["job_id"])
     assert job["status"] == "cancelled", job
+    assert job["result"]["cancelled"] is True
     assert job["result"]["tagging"]["skipped"] == "import cancelled"
+    assert job["result"]["after_import_skipped"] == "import cancelled"
+    assert "process_job_id" not in job["result"]
     assert db.get_assigned_photo_location(photo_id) is None
 
 

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -3370,6 +3370,60 @@ def test_cancelled_import_does_not_apply_requested_tags(
     ).fetchone() is None
 
 
+def test_import_gps_tagging_stops_when_cancelled_during_resolution(
+    app_and_db, tmp_path, monkeypatch,
+):
+    import import_job
+    from db import Database
+
+    app, db = app_and_db
+    client = app.test_client()
+    runner = app._job_runner
+    photo_id = db.conn.execute("SELECT id FROM photos LIMIT 1").fetchone()["id"]
+    db.clear_photo_location(photo_id)
+
+    def imported_result(job, runner, db_path, workspace_id, params):
+        return {
+            "ok": True,
+            "cancelled": False,
+            "photo_ids": [photo_id],
+            "discovered": 1,
+            "copied": 1,
+            "verified": 1,
+            "skipped_duplicate": 0,
+            "failed": 0,
+            "safe_to_format": True,
+            "unsafe_files": [],
+            "folders": {},
+            "errors": [],
+        }
+
+    original_get = Database.get_photos_by_ids
+
+    def cancel_during_resolution(self, photo_ids):
+        running_ids = [
+            job_id for job_id, job in runner._jobs.items()
+            if job["type"] == "import" and job["status"] == "running"
+        ]
+        assert len(running_ids) == 1
+        assert runner.cancel_job(running_ids[0]) is True
+        return original_get(self, photo_ids)
+
+    monkeypatch.setattr(import_job, "run_import_job", imported_result)
+    monkeypatch.setattr(Database, "get_photos_by_ids", cancel_during_resolution)
+    resp = client.post("/api/jobs/import-photos", json={
+        "sources": [_import_card(tmp_path)],
+        "destination": str(tmp_path / "archive"),
+        "after_import": None,
+        "location_from_gps": True,
+    })
+    assert resp.status_code == 200, resp.get_json()
+    job = wait_for_job_via_client(client, resp.get_json()["job_id"])
+    assert job["status"] == "cancelled", job
+    assert job["result"]["tagging"]["skipped"] == "import cancelled"
+    assert db.get_assigned_photo_location(photo_id) is None
+
+
 @pytest.mark.parametrize("field,value,error", [
     ("tags", "Trip", "tags must be a list"),
     ("tags", ["Trip", 4], "only strings"),


### PR DESCRIPTION
Adds a Tags section to both in-place and archive photo imports so users can apply reusable free-form tags to successfully imported photos.

Optionally resolves each photo’s EXIF GPS coordinates through the existing structured location system, preserves existing locations, reports unresolved results, and guides users to configure a Google Maps API key when needed.

Duplicate-only archive imports remain untouched, and tagging failures stay separate from copy verification and card-safety results.

Validated with 38 import API tests (1 skipped), 28 import browser tests, Ruff, and `git diff --check`.