### PR TITLE
Fix empty collection dropdown from one bad folder rule

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -8172,9 +8172,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # whole list — that blanks every collection dropdown in the UI.
             # Degrade to an unknown count and flag it so the client can show
             # the collection instead of hiding all of them.
+            #
+            # Only rule-validation failures degrade to count_error: the pickers
+            # tell users to fix the rule, so labelling a locked/corrupt DB or a
+            # bad generated query as count_error would send them to edit rules
+            # that aren't the actual problem. ValueError covers both malformed
+            # rules (raised by _build_query_from_rules) and malformed JSON in
+            # the rules column (json.JSONDecodeError is a ValueError subclass).
+            # Anything else bubbles up as a 500 so real infra failures surface.
             try:
                 d["photo_count"] = db.count_collection_photos(c["id"])
-            except Exception:
+            except ValueError:
                 app.logger.exception(
                     "Failed to count photos for collection %s (%s)",
                     c["id"],

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3345,29 +3345,31 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         collection_dicts = []
         for c in collections:
             d = dict(c)
-            # Mirror /api/collections so the Browse sidebar's first paint already
-            # knows which collections are degraded — otherwise a degraded row
-            # renders as a normal clickable item until loadCollectionCounts()
-            # comes back, and a fast click drops it into the 400 /photos path.
-            # Only rule-validation failures (ValueError from _build_query_from_rules,
-            # including malformed JSON in rules) degrade; real infra errors bubble
-            # up as 500 like elsewhere.
+            # Flag degraded rules at first paint so a fast click on the
+            # sidebar row can't fall into the 400 /photos path before
+            # loadCollectionCounts() lands. Only validate the rules — do
+            # not run COUNT(DISTINCT p.id) per collection here; that
+            # N+1 is what the async loadCollectionCounts() call in
+            # bootstrapBrowse() was designed to avoid, and re-adding it
+            # to the critical first-paint path makes opening Browse wait
+            # on every smart-collection query. Malformed JSON is treated
+            # as degraded too — those rules would 400 downstream just
+            # like an unresolvable rule.
             try:
-                d["photo_count"] = db.count_collection_photos(c["id"])
-            except ValueError:
-                app.logger.exception(
-                    "Failed to count photos for collection %s (%s) during browse init",
+                parsed_rules = json.loads(c["rules"])
+            except (TypeError, ValueError):
+                d["can_add_photos"] = False
+                d["count_error"] = True
+                collection_dicts.append(d)
+                continue
+            d["can_add_photos"] = _collection_accepts_manual_photos(parsed_rules)
+            if not db.rules_resolvable(parsed_rules):
+                app.logger.warning(
+                    "Collection %s (%s) has unresolvable rules; marking degraded",
                     c["id"],
                     c["name"],
                 )
-                d["photo_count"] = None
                 d["count_error"] = True
-            try:
-                d["can_add_photos"] = _collection_accepts_manual_photos(
-                    json.loads(c["rules"])
-                )
-            except (TypeError, ValueError):
-                d["can_add_photos"] = False
             collection_dicts.append(d)
 
         return jsonify(

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3362,7 +3362,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 d["count_error"] = True
                 collection_dicts.append(d)
                 continue
-            d["can_add_photos"] = _collection_accepts_manual_photos(parsed_rules)
             if not db.rules_resolvable(parsed_rules):
                 app.logger.warning(
                     "Collection %s (%s) has unresolvable rules; marking degraded",
@@ -3370,6 +3369,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     c["name"],
                 )
                 d["count_error"] = True
+                # Same reasoning as /api/collections: an unresolvable rule
+                # cannot be safely merged into via add-photos, so keep it
+                # out of the add-to-collection modal.
+                d["can_add_photos"] = False
+            else:
+                d["can_add_photos"] = _collection_accepts_manual_photos(parsed_rules)
             collection_dicts.append(d)
 
         return jsonify(
@@ -8209,12 +8214,21 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 )
                 d["photo_count"] = None
                 d["count_error"] = True
-            try:
-                d["can_add_photos"] = _collection_accepts_manual_photos(
-                    json.loads(c["rules"])
-                )
-            except (TypeError, ValueError):
+            # Degraded rows must never advertise manual-add support: the
+            # add-to-collection modal filters only on can_add_photos, and
+            # /api/collections/<id>/add-photos calls set(ids_rule["value"])
+            # on the existing rule — which 500s on any malformed photo_ids
+            # payload (non-scalar entries, non-list value, etc.). If the
+            # rule is bad enough to fail count, it isn't safe to merge into.
+            if d.get("count_error"):
                 d["can_add_photos"] = False
+            else:
+                try:
+                    d["can_add_photos"] = _collection_accepts_manual_photos(
+                        json.loads(c["rules"])
+                    )
+                except (TypeError, ValueError):
+                    d["can_add_photos"] = False
             result.append(d)
         return jsonify(result)
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -8372,8 +8372,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         page = request.args.get("page", 1, type=int)
         default_per_page = cfg.load().get("photos_per_page", 50)
         per_page = max(1, min(request.args.get("per_page", default_per_page, type=int), _MAX_PER_PAGE))
-        photos = db.get_collection_photos(collection_id, page=page, per_page=per_page)
-        total = db.count_collection_photos(collection_id)
+        # If the saved rules can't be resolved (e.g. an unknown field/op left
+        # over from an older schema), surface a 400 instead of a 500 so
+        # callers can render a real error — this is the same collection state
+        # that /api/collections flags with count_error=True.
+        try:
+            photos = db.get_collection_photos(collection_id, page=page, per_page=per_page)
+            total = db.count_collection_photos(collection_id)
+        except ValueError as e:
+            app.logger.exception(
+                "Collection %s has unresolvable rules", collection_id
+            )
+            return json_error(f"collection rules cannot be resolved: {e}", 400)
         photo_dicts = [dict(p) for p in photos]
         _attach_species(db, photo_dicts)
         _attach_species_representatives(db, photo_dicts)
@@ -8392,7 +8402,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def api_collection_photo_ids(collection_id):
         """Return every photo ID matching a collection."""
         db = _get_db()
-        photo_ids = db.get_collection_photo_ids(collection_id)
+        try:
+            photo_ids = db.get_collection_photo_ids(collection_id)
+        except ValueError as e:
+            app.logger.exception(
+                "Collection %s has unresolvable rules", collection_id
+            )
+            return json_error(f"collection rules cannot be resolved: {e}", 400)
         return jsonify({"photo_ids": photo_ids, "total": len(photo_ids)})
 
     # -- Highlights --
@@ -13639,7 +13655,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("collection_id required", 400)
 
         db = _get_db()
-        photos = db.get_collection_photos(collection_id, page=1, per_page=100000)
+        try:
+            photos = db.get_collection_photos(collection_id, page=1, per_page=100000)
+        except ValueError as e:
+            app.logger.exception(
+                "Collection %s has unresolvable rules", collection_id
+            )
+            return json_error(f"collection rules cannot be resolved: {e}", 400)
 
         folder_rows = db.conn.execute("SELECT id, path, name FROM folders").fetchall()
         folder_map = {r["id"]: dict(r) for r in folder_rows}

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -8168,7 +8168,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         result = []
         for c in collections:
             d = dict(c)
-            d["photo_count"] = db.count_collection_photos(c["id"])
+            # A single collection with an unresolvable rule must not 500 the
+            # whole list — that blanks every collection dropdown in the UI.
+            # Degrade to an unknown count and flag it so the client can show
+            # the collection instead of hiding all of them.
+            try:
+                d["photo_count"] = db.count_collection_photos(c["id"])
+            except Exception:
+                app.logger.exception(
+                    "Failed to count photos for collection %s (%s)",
+                    c["id"],
+                    c["name"],
+                )
+                d["photo_count"] = None
+                d["count_error"] = True
             try:
                 d["can_add_photos"] = _collection_accepts_manual_photos(
                     json.loads(c["rules"])

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3345,6 +3345,23 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         collection_dicts = []
         for c in collections:
             d = dict(c)
+            # Mirror /api/collections so the Browse sidebar's first paint already
+            # knows which collections are degraded — otherwise a degraded row
+            # renders as a normal clickable item until loadCollectionCounts()
+            # comes back, and a fast click drops it into the 400 /photos path.
+            # Only rule-validation failures (ValueError from _build_query_from_rules,
+            # including malformed JSON in rules) degrade; real infra errors bubble
+            # up as 500 like elsewhere.
+            try:
+                d["photo_count"] = db.count_collection_photos(c["id"])
+            except ValueError:
+                app.logger.exception(
+                    "Failed to count photos for collection %s (%s) during browse init",
+                    c["id"],
+                    c["name"],
+                )
+                d["photo_count"] = None
+                d["count_error"] = True
             try:
                 d["can_add_photos"] = _collection_accepts_manual_photos(
                     json.loads(c["rules"])

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -14606,6 +14606,22 @@ class Database:
         """
         return self.conn.execute(query, params).fetchone()[0]
 
+    def rules_resolvable(self, rules):
+        """Return True if a rule tree can be resolved to SQL clauses without
+        executing them.
+
+        Callers (notably ``/api/browse/init``) use this to flag degraded
+        collections at first paint without running the full
+        ``COUNT(DISTINCT p.id)`` per collection — that N+1 is what the
+        Browse client's async ``loadCollectionCounts()`` was built to
+        avoid. Only the query-building step is exercised.
+        """
+        try:
+            self._build_query_from_rules(rules)
+        except ValueError:
+            return False
+        return True
+
     def count_photos_for_rules(self, rules):
         """Return the number of photos in the active workspace that match
         an unsaved rules list. Used by the smart-collection modal preview.

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -14354,9 +14354,15 @@ class Database:
                 base = _path_for_subtree_match(str(value or ""))
                 subtree_params = [base, _escape_like(base) + "/%"]
                 norm = "REPLACE(f.path, '\\', '/')"
-                if op == "under":
+                # Legacy folder collections were saved with op "is"/"is not"
+                # before the rule vocabulary switched to "under"/"not_under".
+                # Treat the old ops as aliases so those rows keep resolving
+                # (a single unrecognized rule used to raise ValueError and 500
+                # the whole /api/collections list). "is" always meant the
+                # folder and its descendants, which is exactly "under".
+                if op in ("under", "is", "equals"):
                     return f"({norm} = ? OR {norm} LIKE ? ESCAPE '\\')", subtree_params
-                if op == "not_under":
+                if op in ("not_under", "is not"):
                     return (
                         f"(f.path IS NULL OR ({norm} != ? AND {norm} NOT LIKE ? ESCAPE '\\'))",
                         subtree_params,

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -110,6 +110,23 @@ body {
   text-transform: uppercase;
   letter-spacing: 0.03em;
 }
+/* Collections whose rules can't be resolved (count_error). We keep the row
+   visible + right-clickable so the user can edit or delete it, but the
+   left-click filter path bails out with a toast — filtering to it would
+   400 /api/collections/<id>/photos. */
+.tree-item.unavailable { color: var(--text-faint); cursor: not-allowed; }
+.tree-item.unavailable .collection-name { text-decoration: line-through; }
+.tree-item .collection-unavailable-badge {
+  margin-left: auto;
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 8px;
+  background: var(--warning-bg, #fef3c7);
+  color: var(--warning-fg, #92400e);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
 .tree-indent { width: 16px; flex-shrink: 0; }
 .tree-toggle {
   width: 16px;
@@ -2559,18 +2576,29 @@ function renderCollectionList(collections) {
   var html = '';
   collections.forEach(function(c) {
     collectionsById[c.id] = c;
-    var count = c.photo_count != null ? c.photo_count : '';
     var canAddPhotos = collectionAcceptsManualPhotos(c);
     var kind = canAddPhotos ? 'manual' : 'smart';
     var kindLabel = canAddPhotos ? 'Manual' : 'Smart';
     var resolveBtn = (c.name === 'GPS Without Location Keyword')
       ? '<button class="collection-resolve-btn" type="button" title="Resolve locations from GPS" onclick="event.stopPropagation(); openGpsResolveForCollection(' + c.id + ')">Resolve GPS</button>'
       : '';
-    html += '<div class="tree-item" data-collection-id="' + c.id + '" data-collection-kind="' + kind + '" onclick="filterByCollection(' + c.id + ')">' +
+    // count_error: /api/collections couldn't resolve this collection's rules,
+    // so filtering to it would 400 the /photos endpoint. Show it as
+    // unavailable (with edit still reachable via right-click) instead of
+    // rendering a clickable filter that silently fails.
+    var unavailable = !!c.count_error;
+    var itemClass = 'tree-item' + (unavailable ? ' unavailable' : '');
+    var titleAttr = unavailable
+      ? ' title="This collection\'s rules could not be resolved. Right-click → Edit Rules to fix it."'
+      : '';
+    var trailing = unavailable
+      ? '<span class="collection-unavailable-badge">unavailable</span>'
+      : '<span class="count">' + (c.photo_count != null ? c.photo_count : '') + '</span>';
+    html += '<div class="' + itemClass + '" data-collection-id="' + c.id + '" data-collection-kind="' + kind + '"' + titleAttr + ' onclick="filterByCollection(' + c.id + ')">' +
       '<span class="collection-name">' + escapeHtml(c.name) + '</span>' +
       '<span class="collection-kind-badge ' + kind + '">' + kindLabel + '</span>' +
       resolveBtn +
-      '<span class="count">' + count + '</span></div>';
+      trailing + '</div>';
   });
   document.getElementById('collectionList').innerHTML = html || '<div style="font-size:12px;color:var(--text-ghost);padding:4px 8px;">No collections</div>';
 }
@@ -2740,8 +2768,8 @@ async function loadCollectionCounts() {
     if (gen !== collectionCountLoadGen) return;
     if (!data) return;
     var items = document.querySelectorAll('#collectionList .tree-item');
-    var countsById = {};
-    data.forEach(function(c) { countsById[c.id] = c.photo_count; });
+    var metaById = {};
+    data.forEach(function(c) { metaById[c.id] = c; });
     items.forEach(function(el) {
       var id = parseInt(el.dataset.collectionId, 10);
       if (isNaN(id)) {
@@ -2750,9 +2778,36 @@ async function loadCollectionCounts() {
         var m = onclick.match(/filterByCollection\((\d+)\)/);
         if (m) id = parseInt(m[1], 10);
       }
-      if (!isNaN(id)) {
+      var meta = !isNaN(id) ? metaById[id] : null;
+      if (!meta) return;
+      // Keep our in-memory copy in sync so filterByCollection's guard fires
+      // for collections that transitioned to (or out of) unavailable.
+      collectionsById[id] = meta;
+      var wasUnavailable = el.classList.contains('unavailable');
+      var isUnavailable = !!meta.count_error;
+      if (wasUnavailable !== isUnavailable) {
+        el.classList.toggle('unavailable', isUnavailable);
+        var trailing = el.querySelector('.count, .collection-unavailable-badge');
+        if (trailing) {
+          if (isUnavailable) {
+            trailing.className = 'collection-unavailable-badge';
+            trailing.textContent = 'unavailable';
+          } else {
+            trailing.className = 'count';
+            trailing.textContent = meta.photo_count != null ? meta.photo_count : '';
+          }
+        }
+        if (isUnavailable) {
+          el.setAttribute(
+            'title',
+            "This collection's rules could not be resolved. Right-click → Edit Rules to fix it."
+          );
+        } else {
+          el.removeAttribute('title');
+        }
+      } else if (!isUnavailable) {
         var span = el.querySelector('.count');
-        if (span && countsById[id] != null) span.textContent = countsById[id];
+        if (span && meta.photo_count != null) span.textContent = meta.photo_count;
       }
     });
   } catch(e) {}
@@ -2822,6 +2877,23 @@ function refreshBrowseSidebarCounts() {
 }
 
 async function filterByCollection(id, options) {
+  // Guard: degraded (count_error) collections would 400 /api/collections/<id>/photos.
+  // Surface the reason instead of silently reloading into an error state. The
+  // sidebar renders these rows as `.tree-item.unavailable` and the context menu
+  // suppresses "Filter by this Collection", so this branch also catches any
+  // programmatic caller (deep-link, membership-change refresh) that pre-dates
+  // the guard.
+  var collectionMeta = collectionsById[id];
+  if (collectionMeta && collectionMeta.count_error) {
+    if (typeof showToast === 'function') {
+      showToast(
+        (collectionMeta.name || 'This collection') +
+          " is unavailable — its rules could not be resolved. Right-click → Edit Rules to fix it.",
+        'error'
+      );
+    }
+    return;
+  }
   cancelScheduledSearchFilter();
   var preserveAnchor = !(options && options.preserveAnchor === false);
   var anchor = preserveAnchor ? captureSelectedPhotoAnchor() : null;
@@ -7532,18 +7604,24 @@ document.addEventListener('contextmenu', function(e) {
   if (isNaN(cid)) return;
   var nameEl = ti.querySelector('.collection-name');
   var name = nameEl ? nameEl.textContent : '';
-  var items = [
-    { label: 'Filter by this Collection',
-      onClick: function() { filterByCollection(cid); } },
-  ];
-  if (name === 'GPS Without Location Keyword') {
-    items.push({
-      label: 'Resolve GPS Locations',
-      onClick: function() { openGpsResolveForCollection(cid); },
-    });
+  var meta = collectionsById[cid];
+  var isUnavailable = !!(meta && meta.count_error);
+  // Degraded collections can't be filtered (the /photos endpoint would 400)
+  // and GPS resolve reads from the same collection rules — hide both while
+  // keeping the edit/rename/duplicate/delete actions reachable so the user
+  // can fix or discard the row.
+  var items = [];
+  if (!isUnavailable) {
+    items.push({ label: 'Filter by this Collection',
+      onClick: function() { filterByCollection(cid); } });
+    if (name === 'GPS Without Location Keyword') {
+      items.push({
+        label: 'Resolve GPS Locations',
+        onClick: function() { openGpsResolveForCollection(cid); },
+      });
+    }
   }
-  items = items.concat([
-    { separator: true },
+  var editActions = [
     { label: 'Edit Rules',
       onClick: function() { editCollection(cid); } },
     { label: 'Rename',
@@ -7553,7 +7631,11 @@ document.addEventListener('contextmenu', function(e) {
     { separator: true },
     { label: 'Delete Collection',
       onClick: function() { deleteCollectionById(cid, name); } },
-  ]);
+  ];
+  // Only emit a leading separator when there are filter/GPS actions above it
+  // to divide from — for degraded rows the menu starts at Edit Rules.
+  if (items.length) items.push({ separator: true });
+  items = items.concat(editActions);
   openContextMenu(e, items);
 });
 

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2579,14 +2579,17 @@ function renderCollectionList(collections) {
     var canAddPhotos = collectionAcceptsManualPhotos(c);
     var kind = canAddPhotos ? 'manual' : 'smart';
     var kindLabel = canAddPhotos ? 'Manual' : 'Smart';
-    var resolveBtn = (c.name === 'GPS Without Location Keyword')
-      ? '<button class="collection-resolve-btn" type="button" title="Resolve locations from GPS" onclick="event.stopPropagation(); openGpsResolveForCollection(' + c.id + ')">Resolve GPS</button>'
-      : '';
     // count_error: /api/collections couldn't resolve this collection's rules,
     // so filtering to it would 400 the /photos endpoint. Show it as
     // unavailable (with edit still reachable via right-click) instead of
     // rendering a clickable filter that silently fails.
     var unavailable = !!c.count_error;
+    // Suppress the Resolve GPS shortcut on unavailable collections — it
+    // posts collection_id to /api/batch/location/from-exif, which resolves
+    // the same rules and would repeat the failure inside the modal.
+    var resolveBtn = (c.name === 'GPS Without Location Keyword' && !unavailable)
+      ? '<button class="collection-resolve-btn" type="button" title="Resolve locations from GPS" onclick="event.stopPropagation(); openGpsResolveForCollection(' + c.id + ')">Resolve GPS</button>'
+      : '';
     var itemClass = 'tree-item' + (unavailable ? ' unavailable' : '');
     var titleAttr = unavailable
       ? ' title="This collection\'s rules could not be resolved. Right-click → Edit Rules to fix it."'
@@ -5392,6 +5395,19 @@ async function openGpsResolve(source) {
 }
 
 function openGpsResolveForCollection(collectionId) {
+  // Same guard as filterByCollection: degraded collections would just
+  // re-hit the unresolvable rules inside /api/batch/location/from-exif.
+  var collectionMeta = collectionsById[collectionId];
+  if (collectionMeta && collectionMeta.count_error) {
+    if (typeof showToast === 'function') {
+      showToast(
+        (collectionMeta.name || 'This collection') +
+          " is unavailable — its rules could not be resolved. Right-click → Edit Rules to fix it.",
+        'error'
+      );
+    }
+    return;
+  }
   openGpsResolve({collection_id: collectionId});
 }
 

--- a/vireo/templates/compare.html
+++ b/vireo/templates/compare.html
@@ -530,9 +530,18 @@ async function loadCollections() {
       var opt = document.createElement('option');
       opt.value = c.id;
       opt.textContent = c.name;
+      // count_error means /api/collections couldn't resolve this collection's
+      // rules — comparing against it would just 400 the downstream fetch.
+      // Show it disabled so the state is visible instead of offering a
+      // source that can't render.
+      if (c.count_error) {
+        opt.disabled = true;
+        opt.textContent = c.name + ' (unavailable — edit rules to fix)';
+        opt.title = "This collection's rules could not be resolved. Edit it in Browse to make it usable.";
+      }
       sel.appendChild(opt);
     });
-    var all = data.find(function(c) { return c.name === 'All Photos'; });
+    var all = data.find(function(c) { return c.name === 'All Photos' && !c.count_error; });
     if (all) {
       sel.value = all.id;
       loadComparison();

--- a/vireo/templates/cull.html
+++ b/vireo/templates/cull.html
@@ -425,6 +425,15 @@ async function loadCollections() {
       var opt = document.createElement('option');
       opt.value = c.id;
       opt.textContent = c.name;
+      // count_error means /api/collections couldn't resolve this collection's
+      // rules — scoping the cull to it would just 400 the downstream /photos
+      // fetch. Show it disabled so the state is visible instead of offering
+      // a source that can't run.
+      if (c.count_error) {
+        opt.disabled = true;
+        opt.textContent = c.name + ' (unavailable — edit rules to fix)';
+        opt.title = "This collection's rules could not be resolved. Edit it in Browse to make it usable.";
+      }
       sel.appendChild(opt);
     });
     sel.addEventListener('change', onCullCollectionChange);

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1288,7 +1288,18 @@ async function loadCollections() {
     var collections = await safeFetch('/api/collections', {}, { toast: false });
     if (!Array.isArray(collections)) return;
     collections.forEach(function(c) {
-      sel.innerHTML += '<option value="' + c.id + '">' + escapeHtml(c.name) + '</option>';
+      // count_error means /api/collections couldn't resolve this collection's
+      // rules — selecting it would 500 the downstream /photos endpoint and
+      // leave the pipeline advertising a source it can't actually run. Show
+      // it disabled with a hint so the user knows to edit the rules instead.
+      var disabled = c.count_error ? ' disabled' : '';
+      var label = c.count_error
+        ? escapeHtml(c.name) + ' (unavailable — edit rules to fix)'
+        : escapeHtml(c.name);
+      var title = c.count_error
+        ? ' title="This collection\'s rules could not be resolved. Edit it in Browse to make it usable."'
+        : '';
+      sel.innerHTML += '<option value="' + c.id + '"' + disabled + title + '>' + label + '</option>';
     });
   } catch(e) {
     // Don't fail silently: an empty picker used to look like "no collections"

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1283,13 +1283,21 @@ document.addEventListener('DOMContentLoaded', initNewImagesCard);
 
 // -- Collection picker --
 async function loadCollections() {
+  var sel = document.getElementById('collectionPicker');
   try {
     var collections = await safeFetch('/api/collections', {}, { toast: false });
-    var sel = document.getElementById('collectionPicker');
+    if (!Array.isArray(collections)) return;
     collections.forEach(function(c) {
       sel.innerHTML += '<option value="' + c.id + '">' + escapeHtml(c.name) + '</option>';
     });
-  } catch(e) {}
+  } catch(e) {
+    // Don't fail silently: an empty picker used to look like "no collections"
+    // even when the endpoint was 500ing. Surface it so the cause is visible.
+    console.error('Failed to load collections:', e);
+    if (typeof showToast === 'function') {
+      showToast('Could not load collections — see console for details', 'error');
+    }
+  }
 }
 
 // -- Card 1: Source --

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -3372,8 +3372,17 @@ function populateReviewScopeCollections(collections) {
   reviewScopeCollections.forEach(function(c) {
     var opt = document.createElement('option');
     opt.value = String(c.id);
-    var count = c.photo_count != null ? ' (' + c.photo_count + ')' : '';
-    opt.textContent = c.name + count;
+    // count_error collections have unresolvable rules; picking one would 400
+    // the pipeline reflow request. Show it disabled with a hint instead of
+    // offering a scope that can't run.
+    if (c.count_error) {
+      opt.disabled = true;
+      opt.textContent = c.name + ' (unavailable — edit rules to fix)';
+      opt.title = "This collection's rules could not be resolved. Edit it in Browse to make it usable.";
+    } else {
+      var count = c.photo_count != null ? ' (' + c.photo_count + ')' : '';
+      opt.textContent = c.name + count;
+    }
     sel.appendChild(opt);
   });
   updateReviewScopeControls();

--- a/vireo/templates/review.html
+++ b/vireo/templates/review.html
@@ -903,6 +903,15 @@ async function loadCollectionFilter() {
       var opt = document.createElement('option');
       opt.value = c.id;
       opt.textContent = c.name;
+      // count_error means /api/collections couldn't resolve this collection's
+      // rules — selecting it would 400 the downstream /photos endpoint and
+      // (previously) silently widen the review scope back to every prediction.
+      // Show it disabled with a hint so the state is visible.
+      if (c.count_error) {
+        opt.disabled = true;
+        opt.textContent = c.name + ' (unavailable — edit rules to fix)';
+        opt.title = "This collection's rules could not be resolved. Edit it in Browse to make it usable.";
+      }
       sel.appendChild(opt);
     });
   } catch(e) {}
@@ -920,7 +929,17 @@ async function switchCollection(val) {
       collectionPhotoIds = new Set(data.photos.map(function(p) { return p.id; }));
       predictions = allPredictions.filter(function(p) { return collectionPhotoIds.has(p.photo_id); });
     } catch(e) {
-      predictions = allPredictions.slice();
+      // The old catch fell back to allPredictions.slice(), which silently
+      // widened the review scope to every prediction — the opposite of what
+      // the user asked for. Keep the scope empty and surface the failure
+      // instead so a broken rule can't quietly turn "just this collection"
+      // into "everything".
+      console.error('Failed to load photos for collection ' + val + ':', e);
+      collectionPhotoIds = new Set();
+      predictions = [];
+      if (typeof showToast === 'function') {
+        showToast('Could not load photos for this collection — check its rules', 'error');
+      }
     }
   }
   renderAll();

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -11807,7 +11807,7 @@ def test_review_switch_collection_does_not_silently_widen_scope():
     """
     from pathlib import Path
     src = Path(__file__).parent.parent / "templates" / "review.html"
-    text = src.read_text()
+    text = src.read_text(encoding="utf-8")
     # Locate the switchCollection function and the catch branch inside it.
     fn_start = text.find("async function switchCollection")
     assert fn_start != -1, "switchCollection function not found"

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -11755,14 +11755,15 @@ def test_pipeline_picker_disables_degraded_collections(app_and_db):
 def test_collection_pickers_disable_degraded_collections(app_and_db):
     """Every page that renders a collection picker from /api/collections must
     honor count_error. Before this fix only the pipeline picker did — the
-    review, cull, compare, and pipeline-review pickers still appended every
-    collection as selectable, so picking a broken one 400'd the downstream
-    request. Regression guard: the same count_error / 'unavailable' branch
-    that exists on the pipeline page must exist on each of these pages too.
+    review, cull, compare, pipeline-review, and browse pickers still appended
+    every collection as selectable, so picking a broken one 400'd the
+    downstream request. Regression guard: the same count_error /
+    'unavailable' branch that exists on the pipeline page must exist on each
+    of these pages too.
     """
     app, _db = app_and_db
     client = app.test_client()
-    for route in ("/review", "/cull", "/compare", "/pipeline/review"):
+    for route in ("/review", "/cull", "/compare", "/pipeline/review", "/browse"):
         html = client.get(route).get_data(as_text=True)
         assert "count_error" in html, (
             f"{route} does not check count_error on its collection picker"
@@ -11770,6 +11771,32 @@ def test_collection_pickers_disable_degraded_collections(app_and_db):
         assert "unavailable" in html, (
             f"{route} does not label degraded collections as unavailable"
         )
+
+
+def test_browse_filter_by_collection_guards_degraded_rows():
+    """The Browse sidebar renders every collection from /api/collections as a
+    clickable filter target (filterByCollection). Before this fix,
+    left-clicking a degraded row hit /api/collections/<id>/photos, which now
+    400s, leaving Browse advertising a source that can't load. Regression
+    guard: filterByCollection must bail out at the top for count_error rows
+    (with a toast) rather than firing the request.
+    """
+    from pathlib import Path
+    src = Path(__file__).parent.parent / "templates" / "browse.html"
+    text = src.read_text()
+    fn_start = text.find("async function filterByCollection")
+    assert fn_start != -1, "filterByCollection function not found"
+    # Grab enough of the function body to include the guard block. The guard
+    # must reference count_error and return before the normal load path runs.
+    body = text[fn_start:fn_start + 2000]
+    assert "count_error" in body, (
+        "browse.html filterByCollection does not check count_error"
+    )
+    guard_end = body.find("return;")
+    fetch_start = body.find("loadPhotos")
+    assert guard_end != -1 and fetch_start != -1 and guard_end < fetch_start, (
+        "browse.html filterByCollection does not early-return before loading"
+    )
 
 
 def test_review_switch_collection_does_not_silently_widen_scope():

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -11705,6 +11705,53 @@ def test_collections_list_survives_one_unresolvable_rule(app_and_db):
     assert by_id[bad]["count_error"] is True
 
 
+def test_collection_photos_returns_400_for_unresolvable_rule(app_and_db):
+    """When a collection's rules can't be resolved, /photos, /photo-ids and
+    /api/import/collection-preview must return a 400, not 500. Otherwise the
+    pipeline picker (which just shows every collection from /api/collections)
+    would advertise a source whose downstream endpoints crash the moment a
+    user selects it — leaving the UI stuck.
+    """
+    import json
+    app, db = app_and_db
+    client = app.test_client()
+
+    bad = db.add_collection(
+        "Broken", json.dumps([{"field": "nonexistent_field", "op": "is", "value": 1}])
+    )
+
+    resp = client.get(f"/api/collections/{bad}/photos")
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+    resp = client.get(f"/api/collections/{bad}/photo-ids")
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+    resp = client.post(
+        "/api/import/collection-preview",
+        json={"collection_id": bad},
+    )
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+
+def test_pipeline_picker_disables_degraded_collections(app_and_db):
+    """The pipeline page's collection picker must not offer degraded
+    collections as selectable — count_error entries render with a `disabled`
+    attribute so users can't accidentally pick a source that would 500 the
+    downstream /photos endpoint.
+    """
+    app, _db = app_and_db
+    client = app.test_client()
+    html = client.get("/pipeline").get_data(as_text=True)
+    # The renderer keys off c.count_error and adds ' disabled' to the option
+    # (plus a tooltip explaining why it's unavailable). Assert the branch is
+    # actually in the template rather than probing it from the DOM.
+    assert "c.count_error" in html
+    assert "unavailable" in html
+
+
 def test_collection_preview_returns_match_count(app_and_db):
     """POST /api/collections/preview returns the count of photos that
     would match an unsaved rules list. Powers the smart-collection

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -11705,6 +11705,52 @@ def test_collections_list_survives_one_unresolvable_rule(app_and_db):
     assert by_id[bad]["count_error"] is True
 
 
+def test_browse_init_flags_degraded_without_counting(app_and_db, monkeypatch):
+    """/api/browse/init must mark collections with unresolvable rules as
+    degraded (count_error=True) so the sidebar first paint disables them —
+    but it must NOT run COUNT(DISTINCT p.id) per collection to figure that
+    out. That N+1 is what the async loadCollectionCounts() in
+    bootstrapBrowse() was designed to avoid, and re-adding it to the
+    critical first-paint path makes Browse wait on every smart-collection
+    query.
+    """
+    import json
+    import sqlite3
+
+    from db import Database
+
+    app, db = app_and_db
+    client = app.test_client()
+
+    good = db.add_collection(
+        "Rating 5", json.dumps([{"field": "rating", "op": ">=", "value": 5}])
+    )
+    bad = db.add_collection(
+        "Broken", json.dumps([{"field": "nonexistent_field", "op": "is", "value": 1}])
+    )
+
+    # If browse init still ran a full count per collection, this monkeypatch
+    # would blow up the request. The endpoint must derive the count_error
+    # flag from rule validation alone, with actual counts left to the
+    # client's async /api/collections call.
+    def boom(self, _cid):
+        raise sqlite3.OperationalError("count_collection_photos should not run on browse init")
+
+    monkeypatch.setattr(Database, "count_collection_photos", boom)
+
+    resp = client.get("/api/browse/init")
+    assert resp.status_code == 200
+    by_id = {c["id"]: c for c in resp.get_json()["collections"]}
+
+    # The healthy collection is neither degraded nor eagerly counted.
+    assert by_id[good].get("count_error") in (None, False)
+    assert "photo_count" not in by_id[good]
+
+    # The broken one is still flagged so the sidebar renders it disabled
+    # before loadCollectionCounts() has a chance to run.
+    assert by_id[bad]["count_error"] is True
+
+
 def test_collections_list_surfaces_non_rule_failures(app_and_db, monkeypatch):
     """The count_error path is for rule-validation failures only. If
     count_collection_photos raises a genuine infrastructure error (locked or

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -11705,6 +11705,39 @@ def test_collections_list_survives_one_unresolvable_rule(app_and_db):
     assert by_id[bad]["count_error"] is True
 
 
+def test_collections_list_surfaces_non_rule_failures(app_and_db, monkeypatch):
+    """The count_error path is for rule-validation failures only. If
+    count_collection_photos raises a genuine infrastructure error (locked or
+    corrupt DB, bad generated query), /api/collections must NOT silently
+    downgrade it to a count_error row — the pickers would then tell the user
+    to fix the rule when the real problem is DB-side. Non-ValueError errors
+    must bubble up so the 5xx surfaces where a human will see it.
+    """
+    import json
+    import sqlite3
+
+    from db import Database
+
+    app, db = app_and_db
+    client = app.test_client()
+
+    db.add_collection(
+        "Rating 5", json.dumps([{"field": "rating", "op": ">=", "value": 5}])
+    )
+
+    # Patch the class so the per-request Database instance built by
+    # _get_db() is affected too — the route does not share the fixture's
+    # instance.
+    def boom(self, _cid):
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(Database, "count_collection_photos", boom)
+
+    resp = client.get("/api/collections")
+    # Not a 200 with count_error — a real 5xx so the incident is visible.
+    assert resp.status_code >= 500
+
+
 def test_collection_photos_returns_400_for_unresolvable_rule(app_and_db):
     """When a collection's rules can't be resolved, /photos, /photo-ids and
     /api/import/collection-preview must return a 400, not 500. Otherwise the

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -11862,7 +11862,6 @@ def test_degraded_collections_never_advertise_manual_add(app_and_db, monkeypatch
     append target.
     """
     import json
-    import sqlite3
 
     from db import Database
 

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -11816,7 +11816,7 @@ def test_browse_filter_by_collection_guards_degraded_rows():
     """
     from pathlib import Path
     src = Path(__file__).parent.parent / "templates" / "browse.html"
-    text = src.read_text()
+    text = src.read_text(encoding="utf-8")
     fn_start = text.find("async function filterByCollection")
     assert fn_start != -1, "filterByCollection function not found"
     # Grab enough of the function body to include the guard block. The guard

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -11752,6 +11752,50 @@ def test_pipeline_picker_disables_degraded_collections(app_and_db):
     assert "unavailable" in html
 
 
+def test_collection_pickers_disable_degraded_collections(app_and_db):
+    """Every page that renders a collection picker from /api/collections must
+    honor count_error. Before this fix only the pipeline picker did — the
+    review, cull, compare, and pipeline-review pickers still appended every
+    collection as selectable, so picking a broken one 400'd the downstream
+    request. Regression guard: the same count_error / 'unavailable' branch
+    that exists on the pipeline page must exist on each of these pages too.
+    """
+    app, _db = app_and_db
+    client = app.test_client()
+    for route in ("/review", "/cull", "/compare", "/pipeline/review"):
+        html = client.get(route).get_data(as_text=True)
+        assert "count_error" in html, (
+            f"{route} does not check count_error on its collection picker"
+        )
+        assert "unavailable" in html, (
+            f"{route} does not label degraded collections as unavailable"
+        )
+
+
+def test_review_switch_collection_does_not_silently_widen_scope():
+    """When /api/collections/<id>/photos fails, the review page must not fall
+    back to `allPredictions.slice()` — that silently widened the scope back
+    to every prediction, the opposite of what the user asked for. Regression
+    guard on the template source itself.
+    """
+    from pathlib import Path
+    src = Path(__file__).parent.parent / "templates" / "review.html"
+    text = src.read_text()
+    # Locate the switchCollection function and the catch branch inside it.
+    fn_start = text.find("async function switchCollection")
+    assert fn_start != -1, "switchCollection function not found"
+    fn_end = text.find("\n}", fn_start)
+    assert fn_end != -1
+    body = text[fn_start:fn_end]
+    # The old silent fallback assigned allPredictions.slice() from the catch;
+    # the new behavior keeps the scope empty and surfaces a toast.
+    assert "predictions = allPredictions.slice()" not in body.split("catch")[1], (
+        "review.html still silently widens scope on collection load failure"
+    )
+    assert "predictions = []" in body
+    assert "showToast" in body
+
+
 def test_collection_preview_returns_match_count(app_and_db):
     """POST /api/collections/preview returns the count of photos that
     would match an unsaved rules list. Powers the smart-collection

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -11852,6 +11852,55 @@ def test_collection_pickers_disable_degraded_collections(app_and_db):
         )
 
 
+def test_degraded_collections_never_advertise_manual_add(app_and_db, monkeypatch):
+    """A count_error collection must not report can_add_photos=True from
+    either /api/collections or /api/browse/init. The add-to-collection
+    modal filters only on can_add_photos, and /api/collections/<id>/add-photos
+    reaches set(ids_rule["value"]) — which 500s on any malformed photo_ids
+    payload. Defense-in-depth alongside the picker guards: degraded rows
+    are surfaced (so the user can edit them) but never offered as an
+    append target.
+    """
+    import json
+    import sqlite3
+
+    from db import Database
+
+    app, db = app_and_db
+    client = app.test_client()
+
+    # A static photo_ids collection whose count query fails at rule-resolve
+    # time: the shape looks like a manual-add target, but the DB can't
+    # count it, so it lands in the count_error path.
+    bad = db.add_collection(
+        "Broken static",
+        json.dumps([
+            {"field": "photo_ids", "value": [1, 2, 3]},
+            {"field": "nonexistent_field", "op": "is", "value": 1},
+        ]),
+    )
+
+    resp = client.get("/api/collections")
+    assert resp.status_code == 200
+    by_id = {c["id"]: c for c in resp.get_json()}
+    assert by_id[bad]["count_error"] is True
+    assert by_id[bad]["can_add_photos"] is False, (
+        "degraded /api/collections row must not advertise manual-add support"
+    )
+
+    # /api/browse/init derives count_error from cheap rule validation, so
+    # patch that instead of count_collection_photos to trigger the branch.
+    monkeypatch.setattr(Database, "rules_resolvable", lambda self, rules: False)
+
+    resp = client.get("/api/browse/init")
+    assert resp.status_code == 200
+    by_id = {c["id"]: c for c in resp.get_json()["collections"]}
+    assert by_id[bad]["count_error"] is True
+    assert by_id[bad]["can_add_photos"] is False, (
+        "degraded /api/browse/init row must not advertise manual-add support"
+    )
+
+
 def test_browse_filter_by_collection_guards_degraded_rows():
     """The Browse sidebar renders every collection from /api/collections as a
     clickable filter target (filterByCollection). Before this fix,

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -11676,6 +11676,35 @@ def test_save_grouping_defaults_rejects_bad_values(tmp_path, monkeypatch):
         assert _math.isfinite(pipe["tau_enc"])
 
 
+def test_collections_list_survives_one_unresolvable_rule(app_and_db):
+    """A single collection whose rule can't be resolved must not 500 the
+    whole /api/collections list. Before this, one bad rule raised an
+    unhandled ValueError, the endpoint 500'd, and every collection
+    dropdown in the UI came back empty. The bad collection should degrade
+    to photo_count=None with count_error=True; the others still count.
+    """
+    import json
+    app, db = app_and_db
+    client = app.test_client()
+
+    good = db.add_collection(
+        "Rating 5", json.dumps([{"field": "rating", "op": ">=", "value": 5}])
+    )
+    bad = db.add_collection(
+        "Broken", json.dumps([{"field": "nonexistent_field", "op": "is", "value": 1}])
+    )
+
+    resp = client.get("/api/collections")
+    assert resp.status_code == 200
+    by_id = {c["id"]: c for c in resp.get_json()}
+
+    assert by_id[good]["photo_count"] == 1
+    assert "count_error" not in by_id[good]
+
+    assert by_id[bad]["photo_count"] is None
+    assert by_id[bad]["count_error"] is True
+
+
 def test_collection_preview_returns_match_count(app_and_db):
     """POST /api/collections/preview returns the count of photos that
     would match an unsaved rules list. Powers the smart-collection

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -8938,6 +8938,12 @@ def test_folder_legacy_is_op_resolves_like_under(tmp_path, monkeypatch):
     legacy_is_not = [{"field": "folder", "op": "is not", "value": "/photos/2023"}]
     assert db.count_photos_for_rules(legacy_is_not) == 1  # only the sibling
 
+    # 'equals' is the third legacy alias; it also resolves like 'under'
+    # (the folder plus its descendants), matching how the rule behaved
+    # when the older UI wrote it.
+    legacy_equals = [{"field": "folder", "op": "equals", "value": "/photos/2023"}]
+    assert db.count_photos_for_rules(legacy_equals) == 2
+
     # count_collection_photos (used by /api/collections) must not raise.
     import json
     cid = db.add_collection("Legacy Folder", json.dumps(legacy_is))

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -8912,6 +8912,38 @@ def test_folder_under_rule_matches_backslash_paths(tmp_path, monkeypatch):
     assert db.count_photos_for_rules(under_sib) == 1
 
 
+def test_folder_legacy_is_op_resolves_like_under(tmp_path, monkeypatch):
+    """Folder collections saved with the pre-'under' vocabulary use op 'is'
+    (and 'is not'). Those legacy ops must resolve as aliases for
+    'under'/'not_under' instead of raising 'unsupported field/op', which
+    previously 500'd the whole /api/collections list and blanked every
+    collection dropdown."""
+    import config as cfg
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+
+    f_2023 = db.add_folder("/photos/2023", name="2023")
+    f_sub = db.add_folder("/photos/2023/trip", name="trip", parent_id=f_2023)
+    f_sib = db.add_folder("/photos/2023-trip", name="2023-trip")
+    for fid, name in [(f_2023, "a"), (f_sub, "b"), (f_sib, "c")]:
+        db.add_photo(folder_id=fid, filename=f"{name}.jpg", extension=".jpg",
+                     file_size=100, file_mtime=1.0)
+
+    legacy_is = [{"field": "folder", "op": "is", "value": "/photos/2023"}]
+    assert db.count_photos_for_rules(legacy_is) == 2  # folder + descendant
+
+    legacy_is_not = [{"field": "folder", "op": "is not", "value": "/photos/2023"}]
+    assert db.count_photos_for_rules(legacy_is_not) == 1  # only the sibling
+
+    # count_collection_photos (used by /api/collections) must not raise.
+    import json
+    cid = db.add_collection("Legacy Folder", json.dumps(legacy_is))
+    assert db.count_collection_photos(cid) == 2
+
+
 def test_check_filename_collisions(db):
     """check_filename_collisions detects conflicts at destination folder."""
     fid1 = db.add_folder("/src", name="src")


### PR DESCRIPTION
## What was wrong

On the process (pipeline) page, the **collection dropdown was empty** in the "Ramona 2026" workspace. Root cause traced from `~/.vireo/vireo.log`:

```
ERROR __main__: Unhandled error: GET /api/collections
  ... db.py, in _build_leaf
ValueError: unsupported collection rule field/op: folder/is
API: GET /api/collections → 500
```

One collection ("ramona") was saved with a legacy folder rule op:
```json
[{"field": "folder", "op": "is", "value": "/Users/julius/Pictures/2026/2026-03-22"}]
```
The current folder-rule builder only handles `under`/`not_under`, so `is` fell through to `raise ValueError`. Because `/api/collections` counts photos for **every** collection to build the list, that one unresolvable rule 500'd the whole endpoint — and the frontend's empty `catch {}` made it look like "no collections" rather than an error.

## Changes (defense in depth)

- **`db.py`** — treat legacy folder ops `is`/`is not` (and `equals`) as aliases for `under`/`not_under`, so old rows self-heal at query time. (`is` always meant "this folder + descendants", which is exactly `under`.)
- **`app.py`** — `/api/collections` no longer lets one collection's rule error take down the whole list: it degrades that collection to `photo_count: null` + `count_error: true` and logs the exception.
- **`pipeline.html`** — `loadCollections()` guards the response shape and surfaces failures (console + toast) instead of failing silently.

## Data

The live "ramona" collection row (id 13) in `~/.vireo/vireo.db` was also repaired in place (`op: is` → `under`) to unblock immediately; the `db.py` alias makes that self-healing going forward, so no migration is needed.

## Tests

- `test_folder_legacy_is_op_resolves_like_under` — legacy `is`/`is not` folder rules resolve like `under`/`not_under`, and `count_collection_photos` doesn't raise.
- `test_collections_list_survives_one_unresolvable_rule` — `/api/collections` returns 200 with a degraded entry when one collection has an unresolvable rule; other collections still count.

Full required suite: `1589 passed, 14 skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Collection rule errors no longer cause server failures; affected API requests return clear error responses.
  * Legacy folder rule operators continue to work correctly.
  * Review scopes no longer silently expand when loading a collection fails.
  * Collection loading errors now provide visible notifications.

* **UI Improvements**
  * Collections with unresolved rules are clearly marked as unavailable and disabled across collection pickers.
  * Default selection avoids unavailable collections.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->