### PR TITLE
Fix Highlights best ribbon rendering

### DIFF
--- a/vireo/templates/highlights.html
+++ b/vireo/templates/highlights.html
@@ -700,7 +700,7 @@ function renderStripCards(photos, _unanalyzedCount) {
       html += '<div class="analyzed-divider">Not yet analyzed — ' + tailCount
         + ' photo' + (tailCount === 1 ? '' : 's') + '</div>';
     }
-    html += renderCard(photos[i]);
+    html += renderCard(photos[i], i);
   }
   return html;
 }


### PR DESCRIPTION
Pass each Highlights card its strip index when rendering.

This restores the advanced-mode “Best” ribbon, which disappeared because the renderer never received index zero.

Validated with `pytest -q tests/e2e/test_highlights_initial_scope.py::test_highlights_best_ui_is_advanced_only --browser chromium`.