### PR TITLE
Speed up routine duplicate handling during imports

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -18366,6 +18366,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         file_types = body.get("file_types", "both")
         skip_duplicates = bool(body.get("skip_duplicates", True))
         verify_by_hash = bool(body.get("verify_by_hash", False))
+        trust_likely_duplicates = bool(
+            body.get("trust_likely_duplicates", False)
+        ) and not verify_by_hash
         recursive = bool(body.get("recursive", True))
 
         active_ws, created_workspace, workspace_err = (
@@ -18419,6 +18422,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "file_types": file_types,
             "skip_duplicates": skip_duplicates,
             "verify_by_hash": verify_by_hash,
+            "trust_likely_duplicates": trust_likely_duplicates,
             "recursive": recursive,
             "after_import": after_import,
             "remote_target_id": remote_target_id or None,
@@ -18492,6 +18496,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 file_types=file_types,
                 skip_duplicates=skip_duplicates,
                 verify_by_hash=verify_by_hash,
+                trust_likely_duplicates=trust_likely_duplicates,
                 recursive=recursive,
                 after_import=after_import,
                 remote_target=remote_target,

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -1931,6 +1931,16 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         and unverified_duplicate == 0
         and (copied + skipped_duplicate) == discovered
     )
+    unverified_duplicates_only = (
+        unverified_duplicate > 0
+        and not cancelled
+        and failed == 0
+        and not discovery_errors
+        and not dup_link_failed
+        and not partial_scope
+        and not remote_unverified
+        and (copied + skipped_duplicate) == discovered
+    )
     result = {
         "discovered": discovered,
         "copied": copied,
@@ -1944,6 +1954,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         "photo_ids": sorted(imported_photo_ids),
         "skipped_duplicate": skipped_duplicate,
         "unverified_duplicate": unverified_duplicate,
+        "unverified_duplicates_only": unverified_duplicates_only,
         "failed": failed,
         "safe_to_format": safe_to_format,
         "unsafe_files": unsafe_files,
@@ -3307,6 +3318,15 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         and unverified_duplicate == 0
         and (copied + skipped_duplicate) == discovered
     )
+    unverified_duplicates_only = (
+        unverified_duplicate > 0
+        and not cancelled
+        and failed == 0
+        and not discovery_errors
+        and not dup_link_failed
+        and not partial_scope
+        and (copied + skipped_duplicate) == discovered
+    )
     result = {
         "discovered": discovered,
         "copied": copied,
@@ -3314,6 +3334,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         "photo_ids": sorted(imported_photo_ids),
         "skipped_duplicate": skipped_duplicate,
         "unverified_duplicate": unverified_duplicate,
+        "unverified_duplicates_only": unverified_duplicates_only,
         "failed": failed,
         "safe_to_format": safe_to_format,
         "unsafe_files": unsafe_files,

--- a/vireo/import_job.py
+++ b/vireo/import_job.py
@@ -208,6 +208,11 @@ class ImportParams:
     file_types: str = "both"
     skip_duplicates: bool = True
     verify_by_hash: bool = False
+    # Fast interactive-import mode: accept a cataloged duplicate candidate
+    # from the metadata-first checker without re-reading both complete files.
+    # The result reports these separately and never claims the card is safe
+    # to format until they have been byte-verified.
+    trust_likely_duplicates: bool = False
     recursive: bool = True
     # After-import process strategy name. Stored in the job config for the
     # PR 3 chaining hook; unused by the import job itself.
@@ -438,12 +443,44 @@ def _key_twin_rows(db, key):
 
 def _hash_twin_rows(db, file_hash):
     return db.conn.execute(
-        """SELECT p.id, p.filename, f.path AS folder_path,
+        """SELECT p.id, p.filename, p.file_size, f.path AS folder_path,
                   f.status AS folder_status
            FROM photos p JOIN folders f ON f.id = p.folder_id
            WHERE p.file_hash = ?""",
         (file_hash,),
     ).fetchall()
+
+
+def _likely_twin_rows(db, token, source_file, path_under_source):
+    """Return live off-source catalog twins that plausibly back ``token``.
+
+    This is the intentionally fast duplicate mode: the checker has already
+    matched filename + byte size + capture time (or, for metadata-poor files,
+    a stored hash). We only stat the proposed archive twin to make sure it
+    still exists off the card at the expected size; we do not read either
+    complete file. Callers must report the resulting skip as unverified.
+    """
+    rows = (
+        _hash_twin_rows(db, token[1])
+        if token[0] == "hash"
+        else _key_twin_rows(db, token[1])
+    )
+    try:
+        source_size = os.path.getsize(str(source_file))
+    except OSError:
+        return []
+    likely = []
+    for row in rows:
+        twin_path = os.path.join(row["folder_path"], row["filename"])
+        if path_under_source(twin_path):
+            continue
+        try:
+            if os.path.getsize(twin_path) != source_size:
+                continue
+        except OSError:
+            continue
+        likely.append(row)
+    return likely
 
 
 def _linkable_twin_dirs(rows, under_destination):
@@ -640,6 +677,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
     copied = 0
     verified = 0            # count of files independently checksum-verified
     skipped_duplicate = 0
+    unverified_duplicate = 0
     failed = 0
     unsafe_files = []
     folder_counts = {}
@@ -871,6 +909,22 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
                     _fail(rel, source_file, f"duplicate check failed: {e}")
                     continue
                 if token is not None:
+                    if (
+                        params.trust_likely_duplicates
+                        and not params.verify_by_hash
+                    ):
+                        likely_rows = _likely_twin_rows(
+                            db, token, source_file, _path_under_any_source,
+                        )
+                        if likely_rows:
+                            skipped_duplicate += 1
+                            unverified_duplicate += 1
+                            dup_skipped += 1
+                            _counts(rel)["skipped_duplicate"] += 1
+                            dup_dirs.update(_linkable_twin_dirs(
+                                likely_rows, _path_under_destination,
+                            ))
+                            continue
                     # Confirm against a cataloged twin's on-disk bytes (mount
                     # side is locally readable). Only a byte-verified twin
                     # backs a skip; otherwise import the file normally.
@@ -1859,6 +1913,14 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
             "path": "<remote>",
             "reason": "enable verify_by_hash for remote verification",
         })
+    if unverified_duplicate:
+        unsafe_files.append({
+            "path": "Likely duplicates",
+            "reason": (
+                f"{unverified_duplicate} matched by filename, byte size, "
+                "and capture time but were not compared byte-for-byte"
+            ),
+        })
     safe_to_format = (
         not cancelled
         and failed == 0
@@ -1866,6 +1928,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         and not dup_link_failed
         and not partial_scope
         and not remote_unverified
+        and unverified_duplicate == 0
         and (copied + skipped_duplicate) == discovered
     )
     result = {
@@ -1880,6 +1943,7 @@ def _run_remote_import_job(job, runner, db, workspace_id, params):
         # after-import processing. See PR #1113 review.
         "photo_ids": sorted(imported_photo_ids),
         "skipped_duplicate": skipped_duplicate,
+        "unverified_duplicate": unverified_duplicate,
         "failed": failed,
         "safe_to_format": safe_to_format,
         "unsafe_files": unsafe_files,
@@ -2077,6 +2141,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
     copied = 0
     verified = 0
     skipped_duplicate = 0
+    unverified_duplicate = 0
     failed = 0
     unsafe_files = []          # [{path, reason}] — failed copies etc.
     # (folder_counts is initialized above _emit — see there.)
@@ -2280,6 +2345,21 @@ def run_import_job(job, runner, db_path, workspace_id, params):
                     _fail(rel, source_file, f"duplicate check failed: {e}")
                     continue
                 if token is not None:
+                    if (
+                        params.trust_likely_duplicates
+                        and not params.verify_by_hash
+                    ):
+                        likely_rows = _likely_twin_rows(
+                            db, token, source_file, _path_under_any_source,
+                        )
+                        if likely_rows:
+                            skipped_duplicate += 1
+                            unverified_duplicate += 1
+                            _counts(rel)["skipped_duplicate"] += 1
+                            dup_dirs.update(_linkable_twin_dirs(
+                                likely_rows, _path_under_destination,
+                            ))
+                            continue
                     accept = False
                     # verified_twin_rows records only the twin(s) whose
                     # bytes we actually hashed on disk this run and
@@ -3210,12 +3290,21 @@ def run_import_job(job, runner, db_path, workspace_id, params):
             )
         else:
             partial_scope = True
+    if unverified_duplicate:
+        unsafe_files.append({
+            "path": "Likely duplicates",
+            "reason": (
+                f"{unverified_duplicate} matched by filename, byte size, "
+                "and capture time but were not compared byte-for-byte"
+            ),
+        })
     safe_to_format = (
         not cancelled
         and failed == 0
         and not discovery_errors
         and not dup_link_failed
         and not partial_scope
+        and unverified_duplicate == 0
         and (copied + skipped_duplicate) == discovered
     )
     result = {
@@ -3224,6 +3313,7 @@ def run_import_job(job, runner, db_path, workspace_id, params):
         "verified": verified,
         "photo_ids": sorted(imported_photo_ids),
         "skipped_duplicate": skipped_duplicate,
+        "unverified_duplicate": unverified_duplicate,
         "failed": failed,
         "safe_to_format": safe_to_format,
         "unsafe_files": unsafe_files,

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -107,6 +107,7 @@ body { display: flex; flex-direction: column; height: 100vh; }
 .pill { display: inline-flex; align-items: center; gap: 6px; border-radius: 12px; padding: 3px 10px; font-size: 12px; font-weight: 600; }
 .pill-ok { background: color-mix(in srgb, var(--success, #2da44e) 18%, transparent); color: var(--success, #2da44e); }
 .pill-bad { background: color-mix(in srgb, var(--danger, #cf222e) 18%, transparent); color: var(--danger, #cf222e); }
+.pill-warn { background: color-mix(in srgb, var(--warning, #bf8700) 18%, transparent); color: var(--warning, #9a6700); }
 .unsafe-list { margin: 6px 0 0 0; padding-left: 18px; font-size: 12px; color: var(--text-secondary); }
 .result-links a { color: var(--accent); font-size: 12px; }
 #importError { color: var(--danger); font-size: 12px; margin-top: 6px; display: none; }
@@ -284,7 +285,10 @@ body { display: flex; flex-direction: column; height: 100vh; }
       <div class="section-divider">
         <div class="option-stack">
           <label><input type="checkbox" id="chkSkipDuplicates" checked> Skip duplicates</label>
-          <label><input type="checkbox" id="chkVerifyByHash"> Verify copied files with full content hashes</label>
+          <label><input type="radio" name="duplicateVerification" id="chkTrustLikelyDuplicates" checked> Trust likely duplicates</label>
+          <div class="hint">Fast — matches filename, byte size, and EXIF capture time to the second. Existing files are not read again.</div>
+          <label><input type="radio" name="duplicateVerification" id="chkVerifyByHash"> Verify duplicates byte-for-byte</label>
+          <div class="hint">Slower — reads the complete source and existing archive copy to confirm their contents are identical.</div>
         </div>
       </div>
     </div>
@@ -457,7 +461,7 @@ function setFolderTemplate(template) {
 function wireDestStructureInvalidation() {
   [
     'chkRecursive', 'fileTypePreset', 'destMode', 'remoteSubpath',
-    'chkSkipDuplicates', 'chkVerifyByHash', 'destInput',
+    'chkSkipDuplicates', 'chkTrustLikelyDuplicates', 'chkVerifyByHash', 'destInput',
     'folderTemplatePreset', 'folderTemplate',
   ].forEach((id) => {
     const el = document.getElementById(id);
@@ -1632,6 +1636,7 @@ function destStructureSignature(destination, fileTypes, recursive, excludePaths)
     recursive: recursive,
     skip_duplicates: document.getElementById('chkSkipDuplicates').checked,
     verify_by_hash: document.getElementById('chkVerifyByHash').checked,
+    trust_likely_duplicates: document.getElementById('chkTrustLikelyDuplicates').checked,
     exclude_paths: (excludePaths || []).slice().sort(),
   });
 }
@@ -1645,6 +1650,7 @@ function importPreviewSignature() {
     recursive: document.getElementById('chkRecursive').checked,
     skip_duplicates: document.getElementById('chkSkipDuplicates').checked,
     verify_by_hash: document.getElementById('chkVerifyByHash').checked,
+    trust_likely_duplicates: document.getElementById('chkTrustLikelyDuplicates').checked,
   });
 }
 
@@ -1948,6 +1954,8 @@ async function startImport() {
     body.file_types = fileTypes;
     body.skip_duplicates = document.getElementById('chkSkipDuplicates').checked;
     body.verify_by_hash = document.getElementById('chkVerifyByHash').checked;
+    body.trust_likely_duplicates =
+      document.getElementById('chkTrustLikelyDuplicates').checked;
   }
   // For new-workspace imports where the user hasn't touched the After
   // Import dropdown, the visible selection was prefilled from the
@@ -2060,6 +2068,22 @@ function renderResult(res, status) {
     pill.className = 'pill pill-ok';
     pill.textContent = 'Safe to format the card — every file is verified in the archive';
     unsafe.style.display = 'none';
+  } else if (res.unverified_duplicate) {
+    pill.className = 'pill pill-warn';
+    pill.textContent = 'Import complete — keep the card until likely duplicates are verified';
+    const files = res.unsafe_files || [];
+    unsafe.style.display = '';
+    if (!files.length) {
+      const li = document.createElement('li');
+      li.textContent = res.unverified_duplicate +
+        ' likely duplicates matched by filename, byte size, and capture time, but were not compared byte-for-byte.';
+      unsafe.appendChild(li);
+    }
+    files.forEach((u) => {
+      const item = document.createElement('li');
+      item.textContent = u.path + ' — ' + u.reason;
+      unsafe.appendChild(item);
+    });
   } else {
     pill.className = 'pill pill-bad';
     pill.textContent = 'Do NOT format the card yet';

--- a/vireo/templates/import.html
+++ b/vireo/templates/import.html
@@ -2068,7 +2068,10 @@ function renderResult(res, status) {
     pill.className = 'pill pill-ok';
     pill.textContent = 'Safe to format the card — every file is verified in the archive';
     unsafe.style.display = 'none';
-  } else if (res.unverified_duplicate) {
+  } else if (
+    res.unverified_duplicates_only
+    && (!status || status === 'completed')
+  ) {
     pill.className = 'pill pill-warn';
     pill.textContent = 'Import complete — keep the card until likely duplicates are verified';
     const files = res.unsafe_files || [];

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -12090,6 +12090,7 @@ def test_import_page_returns_200(app_and_db):
     assert "Trust likely duplicates" in html
     assert "Verify duplicates byte-for-byte" in html
     assert "capture time to the second" in html
+    assert "res.unverified_duplicates_only" in html
     assert 'id="safeToFormatPill"' in html
     assert "/api/jobs/import-in-place" in html
     assert "/api/jobs/import-photos" in html

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -12087,6 +12087,9 @@ def test_import_page_returns_200(app_and_db):
     assert 'id="afterImportSelect"' in html
     assert 'value="__none__"' in html  # "None — import only" option
     assert "/api/import/check-duplicates" in html
+    assert "Trust likely duplicates" in html
+    assert "Verify duplicates byte-for-byte" in html
+    assert "capture time to the second" in html
     assert 'id="safeToFormatPill"' in html
     assert "/api/jobs/import-in-place" in html
     assert "/api/jobs/import-photos" in html

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -616,6 +616,66 @@ def test_key_match_with_different_bytes_imports_as_distinct(tmp_path):
     assert result["safe_to_format"] is True
 
 
+def test_trust_likely_duplicates_skips_metadata_match_without_byte_check(
+    tmp_path,
+):
+    """Fast mode deliberately trusts filename + size + capture second.
+
+    A same-metadata, different-bytes twin is skipped, reported separately
+    as unverified, and must keep the safe-to-format result false.
+    """
+    from import_job import ImportParams, run_import_job
+    from PIL.ExifTags import Base as ExifBase
+
+    dt = datetime(2026, 5, 1, 10, 15, 30)
+    card = tmp_path / "card"
+    card.mkdir()
+    card_file = card / "IMG_0400.jpg"
+    img = Image.new("RGB", (16, 16), "red")
+    exif = img.getexif()
+    exif[ExifBase.DateTimeOriginal] = dt.strftime("%Y:%m:%d %H:%M:%S")
+    img.save(str(card_file), exif=exif)
+    card_bytes = card_file.read_bytes()
+
+    library = tmp_path / "library"
+    library.mkdir()
+    twin_file = library / "IMG_0400.jpg"
+    twin_file.write_bytes(
+        card_bytes[:-1] + bytes([card_bytes[-1] ^ 0xFF])
+    )
+    assert twin_file.stat().st_size == card_file.stat().st_size
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES (?, ?, 'ok')",
+        (str(library), "library"),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, extension, file_size,"
+        " timestamp) VALUES (?, ?, '.jpg', ?, ?)",
+        (fid, "IMG_0400.jpg", len(card_bytes), "2026-05-01T10:15:30"),
+    )
+    db.conn.commit()
+
+    archive = tmp_path / "archive"
+    result = run_import_job(
+        _make_job(), FakeRunner(), db_path, ws_id,
+        ImportParams(
+            sources=[str(card)],
+            destination=str(archive),
+            trust_likely_duplicates=True,
+        ),
+    )
+
+    assert result["copied"] == 0
+    assert result["skipped_duplicate"] == 1
+    assert result["unverified_duplicate"] == 1
+    assert result["safe_to_format"] is False
+    assert not list(archive.rglob("IMG_0400.jpg"))
+
+
 def test_intra_run_key_collision_across_cards_imports_second_as_fresh(tmp_path):
     """Two cards can hold different bytes at the same filename+size+
     capture-second (say, an IMG_XXXX rollover after a firmware reset).

--- a/vireo/tests/test_import_job.py
+++ b/vireo/tests/test_import_job.py
@@ -672,6 +672,7 @@ def test_trust_likely_duplicates_skips_metadata_match_without_byte_check(
     assert result["copied"] == 0
     assert result["skipped_duplicate"] == 1
     assert result["unverified_duplicate"] == 1
+    assert result["unverified_duplicates_only"] is True
     assert result["safe_to_format"] is False
     assert not list(archive.rglob("IMG_0400.jpg"))
 

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -3247,6 +3247,7 @@ def test_import_photos_happy_path(app_and_db, tmp_path):
         "sources": [card],
         "destination": dest,
         "after_import": "cull_ready",
+        "trust_likely_duplicates": True,
     })
     assert resp.status_code == 200, resp.get_json()
     job_id = resp.get_json()["job_id"]
@@ -3257,6 +3258,7 @@ def test_import_photos_happy_path(app_and_db, tmp_path):
     assert config["destination"] == dest
     assert config["folder_template"] == "%Y/%Y-%m-%d"
     assert config["after_import"] == "cull_ready"
+    assert config["trust_likely_duplicates"] is True
 
     job = wait_for_job_via_client(client, job_id)
     assert job["status"] == "completed", job


### PR DESCRIPTION
Adds two clearly explained import choices: “Trust likely duplicates” and “Verify duplicates byte-for-byte.”

Fast mode trusts filename, byte size, and EXIF capture time to the second, while detailed mode retains full source-and-archive content verification. Likely matches are reported separately and never produce a safe-to-format confirmation until byte verification; existing API callers retain the prior detailed behavior.

Tests: `125 passed, 1 skipped` across the import job, duplicate checker, API, and Import page coverage.