### PR TITLE
Make the Browse sidebar resizable

### DIFF
--- a/tests/e2e/test_browse_sidebar_resize.py
+++ b/tests/e2e/test_browse_sidebar_resize.py
@@ -45,6 +45,28 @@ def test_browse_sidebar_resizer_supports_keyboard_controls(live_server, page):
     expect(resizer).to_have_attribute("aria-valuenow", str(round(initial_width + 10)))
 
 
+def test_browse_sidebar_resizer_keys_do_not_move_grid_selection(live_server, page):
+    # ArrowLeft/ArrowRight on the resize handle also drive the page-level
+    # Browse shortcut handler (moveBrowseSelection), so without
+    # stopPropagation the advertised keyboard resize control would
+    # simultaneously select or move to a photo and pop the detail panel.
+    page.goto(live_server["url"] + "/browse")
+
+    page.locator(".grid-card").first.wait_for(state="visible")
+    assert page.evaluate("selectedIndex") == -1
+
+    resizer = page.locator("#browseSidebarResizer")
+    resizer.focus()
+    resizer.press("ArrowRight")
+    resizer.press("ArrowLeft")
+
+    assert page.evaluate("selectedIndex") == -1
+    assert page.evaluate("selectedPhotoId") is None
+    assert not page.evaluate(
+        "document.getElementById('detailContent').classList.contains('visible')"
+    )
+
+
 def test_browse_sidebar_max_width_reserves_room_for_detail_panel(live_server, page):
     # On a viewport this narrow, the naive `innerWidth - 360` cap would allow
     # the sidebar to grow to 600px, which — combined with the always-visible

--- a/tests/e2e/test_browse_sidebar_resize.py
+++ b/tests/e2e/test_browse_sidebar_resize.py
@@ -43,3 +43,29 @@ def test_browse_sidebar_resizer_supports_keyboard_controls(live_server, page):
 
     assert abs(sidebar.bounding_box()["width"] - (initial_width + 10)) <= 1
     expect(resizer).to_have_attribute("aria-valuenow", str(round(initial_width + 10)))
+
+
+def test_browse_sidebar_max_width_reserves_room_for_detail_panel(live_server, page):
+    # On a viewport this narrow, the naive `innerWidth - 360` cap would allow
+    # the sidebar to grow to 600px, which — combined with the always-visible
+    # 340px detail panel — would leave under 100px for the photo grid. Assert
+    # the cap actually reserves enough space for the grid.
+    page.set_viewport_size({"width": 1024, "height": 768})
+    page.goto(live_server["url"] + "/browse")
+
+    sidebar = page.locator("#browseSidebar")
+    resizer = page.locator("#browseSidebarResizer")
+    detail_panel = page.locator("#detailPanel")
+    expect(detail_panel).to_be_visible()
+
+    resizer.focus()
+    resizer.press("End")
+
+    sidebar_width = sidebar.bounding_box()["width"]
+    detail_width = detail_panel.bounding_box()["width"]
+    resizer_width = resizer.bounding_box()["width"]
+    remaining = 1024 - sidebar_width - detail_width - resizer_width
+    assert remaining >= 300, (
+        f"Sidebar cap left only {remaining}px for the photo grid "
+        f"(sidebar={sidebar_width}, detail={detail_width}, handle={resizer_width})"
+    )

--- a/tests/e2e/test_browse_sidebar_resize.py
+++ b/tests/e2e/test_browse_sidebar_resize.py
@@ -1,0 +1,45 @@
+"""Browse sidebar resizing behavior."""
+
+from playwright.sync_api import expect
+
+
+def test_browse_sidebar_can_be_dragged_wider_and_remembers_width(live_server, page):
+    page.goto(live_server["url"] + "/browse")
+
+    sidebar = page.locator("#browseSidebar")
+    resizer = page.locator("#browseSidebarResizer")
+    expect(resizer).to_be_visible()
+
+    initial_width = sidebar.bounding_box()["width"]
+    handle_box = resizer.bounding_box()
+    page.mouse.move(
+        handle_box["x"] + handle_box["width"] / 2,
+        handle_box["y"] + min(100, handle_box["height"] / 2),
+    )
+    page.mouse.down()
+    page.mouse.move(
+        handle_box["x"] + handle_box["width"] / 2 + 140,
+        handle_box["y"] + min(100, handle_box["height"] / 2),
+    )
+    page.mouse.up()
+
+    expanded_width = sidebar.bounding_box()["width"]
+    assert expanded_width >= initial_width + 130
+    expect(resizer).to_have_attribute("aria-valuenow", str(round(expanded_width)))
+
+    page.reload()
+    assert abs(sidebar.bounding_box()["width"] - expanded_width) <= 1
+
+
+def test_browse_sidebar_resizer_supports_keyboard_controls(live_server, page):
+    page.goto(live_server["url"] + "/browse")
+
+    sidebar = page.locator("#browseSidebar")
+    resizer = page.locator("#browseSidebarResizer")
+    initial_width = sidebar.bounding_box()["width"]
+
+    resizer.focus()
+    resizer.press("ArrowRight")
+
+    assert abs(sidebar.bounding_box()["width"] - (initial_width + 10)) <= 1
+    expect(resizer).to_have_attribute("aria-valuenow", str(round(initial_width + 10)))

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2053,14 +2053,17 @@ function initBrowseSidebarResize() {
   resizer.addEventListener('keydown', function(e) {
     if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
       e.preventDefault();
+      e.stopPropagation();
       var direction = e.key === 'ArrowRight' ? 1 : -1;
       var step = e.shiftKey ? 50 : 10;
       setBrowseSidebarWidth(sidebar.getBoundingClientRect().width + direction * step, true);
     } else if (e.key === 'Home') {
       e.preventDefault();
+      e.stopPropagation();
       setBrowseSidebarWidth(BROWSE_SIDEBAR_MIN_WIDTH, true);
     } else if (e.key === 'End') {
       e.preventDefault();
+      e.stopPropagation();
       setBrowseSidebarWidth(browseSidebarMaxWidth(), true);
     }
   });

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -26,12 +26,43 @@ body {
 /* ---------- Sidebar ---------- */
 .sidebar {
   width: 260px;
-  min-width: 260px;
+  min-width: 200px;
+  max-width: 600px;
   background: var(--bg-secondary);
   border-right: 1px solid var(--border-primary);
   overflow-y: auto;
   padding: 12px 0;
   flex-shrink: 0;
+}
+.sidebar-resizer {
+  width: 7px;
+  margin-left: -4px;
+  flex: 0 0 7px;
+  position: relative;
+  z-index: 3;
+  cursor: col-resize;
+  touch-action: none;
+  outline: none;
+}
+.sidebar-resizer::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 3px;
+  width: 1px;
+  background: transparent;
+  transition: background 0.12s, box-shadow 0.12s;
+}
+.sidebar-resizer:hover::after,
+.sidebar-resizer:focus-visible::after,
+.sidebar-resizer.dragging::after {
+  background: var(--accent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 25%, transparent);
+}
+body.sidebar-resizing {
+  cursor: col-resize;
+  user-select: none;
 }
 .sidebar-section { padding: 0 14px; margin-bottom: 16px; }
 .sidebar-title {
@@ -1394,7 +1425,7 @@ body {
 <div class="main-layout">
 
   <!-- Sidebar -->
-  <aside class="sidebar">
+  <aside class="sidebar" id="browseSidebar">
     <div class="sidebar-section">
       <div class="sidebar-title">Folders</div>
       <div id="folderTree"></div>
@@ -1407,6 +1438,12 @@ body {
       </div>
     </div>
   </aside>
+
+  <div class="sidebar-resizer" id="browseSidebarResizer" role="separator"
+       aria-label="Resize Browse sidebar" aria-orientation="vertical"
+       aria-controls="browseSidebar" aria-valuemin="200" aria-valuemax="600"
+       aria-valuenow="260" tabindex="0"
+       title="Drag to resize the sidebar"></div>
 
   <!-- Content -->
   <div class="content-area">
@@ -1932,6 +1969,97 @@ var browseCompareIds = [];
 var browseCompareOffset = 0;
 var browseCompareSeq = 0;
 var browseCompareEscToken = null;
+
+/* ---------- Resizable sidebar ---------- */
+var BROWSE_SIDEBAR_DEFAULT_WIDTH = 260;
+var BROWSE_SIDEBAR_MIN_WIDTH = 200;
+var BROWSE_SIDEBAR_MAX_WIDTH = 600;
+var BROWSE_SIDEBAR_STORAGE_KEY = 'vireo.browse.sidebarWidth';
+
+function browseSidebarMaxWidth() {
+  // Keep enough room for the photo area and its controls on narrower windows.
+  return Math.max(
+    BROWSE_SIDEBAR_MIN_WIDTH,
+    Math.min(BROWSE_SIDEBAR_MAX_WIDTH, window.innerWidth - 360)
+  );
+}
+
+function setBrowseSidebarWidth(width, persist) {
+  var sidebar = document.getElementById('browseSidebar');
+  var resizer = document.getElementById('browseSidebarResizer');
+  if (!sidebar || !resizer) return;
+  var nextWidth = Math.round(Math.max(
+    BROWSE_SIDEBAR_MIN_WIDTH,
+    Math.min(browseSidebarMaxWidth(), Number(width) || BROWSE_SIDEBAR_DEFAULT_WIDTH)
+  ));
+  sidebar.style.width = nextWidth + 'px';
+  sidebar.style.flexBasis = nextWidth + 'px';
+  resizer.setAttribute('aria-valuenow', String(nextWidth));
+  resizer.setAttribute('aria-valuemax', String(browseSidebarMaxWidth()));
+  if (persist) {
+    try { localStorage.setItem(BROWSE_SIDEBAR_STORAGE_KEY, String(nextWidth)); } catch (e) {}
+  }
+  requestAnimationFrame(updateGridTail);
+}
+
+function initBrowseSidebarResize() {
+  var sidebar = document.getElementById('browseSidebar');
+  var resizer = document.getElementById('browseSidebarResizer');
+  if (!sidebar || !resizer) return;
+
+  var storedWidth = BROWSE_SIDEBAR_DEFAULT_WIDTH;
+  try { storedWidth = Number(localStorage.getItem(BROWSE_SIDEBAR_STORAGE_KEY)) || storedWidth; } catch (e) {}
+  setBrowseSidebarWidth(storedWidth, false);
+
+  resizer.addEventListener('pointerdown', function(e) {
+    if (e.button !== 0) return;
+    e.preventDefault();
+    var startX = e.clientX;
+    var startWidth = sidebar.getBoundingClientRect().width;
+    resizer.setPointerCapture(e.pointerId);
+    resizer.classList.add('dragging');
+    document.body.classList.add('sidebar-resizing');
+
+    function onPointerMove(moveEvent) {
+      setBrowseSidebarWidth(startWidth + moveEvent.clientX - startX, false);
+    }
+    function stopDragging(upEvent) {
+      setBrowseSidebarWidth(sidebar.getBoundingClientRect().width, true);
+      resizer.classList.remove('dragging');
+      document.body.classList.remove('sidebar-resizing');
+      resizer.removeEventListener('pointermove', onPointerMove);
+      resizer.removeEventListener('pointerup', stopDragging);
+      resizer.removeEventListener('pointercancel', stopDragging);
+      if (resizer.hasPointerCapture(upEvent.pointerId)) {
+        resizer.releasePointerCapture(upEvent.pointerId);
+      }
+    }
+    resizer.addEventListener('pointermove', onPointerMove);
+    resizer.addEventListener('pointerup', stopDragging);
+    resizer.addEventListener('pointercancel', stopDragging);
+  });
+
+  resizer.addEventListener('keydown', function(e) {
+    if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+      e.preventDefault();
+      var direction = e.key === 'ArrowRight' ? 1 : -1;
+      var step = e.shiftKey ? 50 : 10;
+      setBrowseSidebarWidth(sidebar.getBoundingClientRect().width + direction * step, true);
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      setBrowseSidebarWidth(BROWSE_SIDEBAR_MIN_WIDTH, true);
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      setBrowseSidebarWidth(browseSidebarMaxWidth(), true);
+    }
+  });
+
+  resizer.addEventListener('dblclick', function() {
+    setBrowseSidebarWidth(BROWSE_SIDEBAR_DEFAULT_WIDTH, true);
+  });
+}
+
+initBrowseSidebarResize();
 
 function refreshPendingSyncBanner() {
   if (typeof checkPendingSync === 'function') {
@@ -4165,6 +4293,8 @@ function ensureViewportHydrated() {
 }
 
 window.addEventListener('resize', function() {
+  var sidebar = document.getElementById('browseSidebar');
+  if (sidebar) setBrowseSidebarWidth(sidebar.getBoundingClientRect().width, false);
   // Column count and card heights change with width — re-estimate the tail
   requestAnimationFrame(updateGridTail);
 });

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1975,12 +1975,23 @@ var BROWSE_SIDEBAR_DEFAULT_WIDTH = 260;
 var BROWSE_SIDEBAR_MIN_WIDTH = 200;
 var BROWSE_SIDEBAR_MAX_WIDTH = 600;
 var BROWSE_SIDEBAR_STORAGE_KEY = 'vireo.browse.sidebarWidth';
+// Room the resize cap must leave for the rest of the Browse layout: the
+// always-visible detail panel sibling (340px, fixed), the resize handle
+// itself (7px), and a minimum photo/content column so the grid stays usable.
+var BROWSE_DETAIL_PANEL_WIDTH = 340;
+var BROWSE_SIDEBAR_HANDLE_WIDTH = 7;
+var BROWSE_MIN_CONTENT_WIDTH = 360;
 
 function browseSidebarMaxWidth() {
-  // Keep enough room for the photo area and its controls on narrower windows.
   return Math.max(
     BROWSE_SIDEBAR_MIN_WIDTH,
-    Math.min(BROWSE_SIDEBAR_MAX_WIDTH, window.innerWidth - 360)
+    Math.min(
+      BROWSE_SIDEBAR_MAX_WIDTH,
+      window.innerWidth
+        - BROWSE_DETAIL_PANEL_WIDTH
+        - BROWSE_SIDEBAR_HANDLE_WIDTH
+        - BROWSE_MIN_CONTENT_WIDTH
+    )
   );
 }
 


### PR DESCRIPTION
Adds a draggable resize handle to the Browse sidebar so long folder and collection names can be revealed when needed. The width is constrained to preserve the photo area, persists across reloads, and can also be adjusted with the keyboard or reset by double-clicking. Adds end-to-end coverage for drag resizing, persistence, and keyboard controls.

Validation: `pytest -q tests/e2e/test_browse_sidebar_resize.py tests/e2e/test_collection_context_menu.py tests/e2e/test_browse_context_menu.py tests/e2e/test_browse_single_select.py` (49 passed).