### PR TITLE
Create collections for every successful import

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -18161,6 +18161,40 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error(str(e))
         return None
 
+    def _create_import_collection(thread_db, photo_ids):
+        """Create the static collection that records one completed import.
+
+        Collection creation belongs to the import itself, not to optional
+        after-import processing.  Keeping it separate ensures "Import only"
+        runs remain discoverable in Browse while processed imports can reuse
+        the exact same scope for their chained pipeline job.
+        """
+        collection_name = "Import " + datetime.now().strftime("%Y-%m-%d %H:%M")
+        collection_id = thread_db.add_collection(
+            collection_name,
+            json.dumps([{"field": "photo_ids", "value": photo_ids}]),
+        )
+        return collection_id, collection_name
+
+    def _record_import_collection(result, workspace_id):
+        """Attach a collection to a complete, successful import result."""
+        photo_ids = result.get("photo_ids") or []
+        if not result.get("ok") or result.get("cancelled") or not photo_ids:
+            return None, None
+        try:
+            thread_db = Database(db_path)
+            thread_db.set_active_workspace(workspace_id)
+            collection_id, collection_name = _create_import_collection(
+                thread_db, photo_ids,
+            )
+            result["collection_id"] = collection_id
+            result["collection_name"] = collection_name
+            return thread_db, collection_id
+        except Exception as e:
+            log.exception("import collection creation failed")
+            result["collection_error"] = str(e)
+            return None, None
+
     @app.route("/api/jobs/import-in-place", methods=["POST"])
     def api_job_import_in_place():
         """Import existing folders without copying files.
@@ -18232,6 +18266,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         vireo_dir = os.path.dirname(thumb_cache_dir)
 
         def _chain_after_import(job, result):
+            photo_ids = result.get("photo_ids") or []
+            thread_db, col_id = _record_import_collection(result, active_ws)
+
             if after_import is None:
                 result["after_import_skipped"] = "import-only"
                 return
@@ -18241,21 +18278,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if result.get("cancelled"):
                 result["after_import_skipped"] = "import cancelled"
                 return
-            photo_ids = result.get("photo_ids") or []
             if not photo_ids:
                 result["after_import_skipped"] = "no photos"
                 return
-            try:
-                from datetime import datetime as _dt
-
-                thread_db = Database(db_path)
-                thread_db.set_active_workspace(active_ws)
-                col_id = thread_db.add_collection(
-                    "Import " + _dt.now().strftime("%Y-%m-%d %H:%M"),
-                    json.dumps(
-                        [{"field": "photo_ids", "value": photo_ids}]
-                    ),
+            if col_id is None:
+                result["after_import_skipped"] = (
+                    "failed to create import collection"
                 )
+                return
+            try:
                 process_job_id, model_warning = _enqueue_process_job(
                     thread_db, runner, active_ws,
                     collection_id=col_id,
@@ -18758,15 +18789,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         }
 
         def _chain_after_import(job, result):
-            """Enqueue the after-import process job, or record why not.
+            """Create the import collection and optionally enqueue processing.
 
             Every skip is written to the result as ``after_import_skipped``
-            so the jobs panel shows exactly what happened and why
-            (transparency rule). Guards, in order: import-only choice,
-            failed import (a green processing run must not hide a failed
-            import — rollup convention), cancelled import, and
-            duplicates-only imports with nothing new to process.
+            so the jobs panel shows exactly why processing did not run.  The
+            collection is independent: every successful import with new
+            photos gets one, including the import-only choice.
             """
+            photo_ids = result.get("photo_ids") or []
+            thread_db, col_id = _record_import_collection(result, active_ws)
+
             if after_import is None:
                 result["after_import_skipped"] = "import-only"
                 return
@@ -18776,23 +18808,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if result.get("cancelled"):
                 result["after_import_skipped"] = "import cancelled"
                 return
-            photo_ids = result.get("photo_ids") or []
             if not photo_ids:
                 result["after_import_skipped"] = "no new photos"
                 return
-            try:
-                from datetime import datetime as _dt
-
-                from db import Database
-
-                thread_db = Database(db_path)
-                thread_db.set_active_workspace(active_ws)
-                col_id = thread_db.add_collection(
-                    "Import " + _dt.now().strftime("%Y-%m-%d %H:%M"),
-                    json.dumps(
-                        [{"field": "photo_ids", "value": photo_ids}]
-                    ),
+            if col_id is None:
+                result["after_import_skipped"] = (
+                    "failed to create import collection"
                 )
+                return
+            try:
                 process_job_id, model_warning = _enqueue_process_job(
                     thread_db, runner, active_ws,
                     collection_id=col_id,

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -3554,7 +3554,7 @@ def test_import_can_add_structured_locations_from_each_photos_gps(
 
 
 def test_import_in_place_no_destination_required(app_and_db, tmp_path):
-    app, _ = app_and_db
+    app, db = app_and_db
     client = app.test_client()
     card = _import_card(tmp_path)
 
@@ -3578,6 +3578,11 @@ def test_import_in_place_no_destination_required(app_and_db, tmp_path):
     assert result["indexed"] == 1
     assert result["ok"] is True
     assert result["after_import_skipped"] == "import-only"
+    assert result["collection_name"].startswith("Import ")
+    photos = db.get_collection_photos(
+        result["collection_id"], per_page=999999,
+    )
+    assert [p["id"] for p in photos] == result["photo_ids"]
 
 
 def test_import_in_place_can_target_new_workspace(app_and_db, tmp_path):
@@ -4045,16 +4050,17 @@ def test_import_chains_process_job(app_and_db, tmp_path):
         assert pj["config"]["strategy"] == "quick_look"
         assert pj["config"].get("chained_from") == job_id
         col_id = pj["config"]["collection_id"]
+        assert res["collection_id"] == col_id
+        assert res["collection_name"].startswith("Import ")
         photos = db.get_collection_photos(col_id, per_page=999999)
         assert sorted(p["id"] for p in photos) == sorted(res["photo_ids"])
 
 
 def test_import_only_choice_skips_chaining(app_and_db, tmp_path):
-    """after_import null (and the omitted->workspace-default-null case)
-    never reaches /api/jobs/pipeline; the result says why."""
+    """Import-only still records the exact import as a Browse collection."""
     from wait import wait_for_job_via_client
 
-    app, _ = app_and_db
+    app, db = app_and_db
     card = _chain_card(tmp_path)
     with app.test_client() as client:
         job_id = _post_import(client, card, tmp_path / "arch", None)
@@ -4062,6 +4068,11 @@ def test_import_only_choice_skips_chaining(app_and_db, tmp_path):
         res = job["result"]
         assert res.get("after_import_skipped") == "import-only"
         assert "process_job_id" not in res
+        assert res["collection_name"].startswith("Import ")
+        photos = db.get_collection_photos(
+            res["collection_id"], per_page=999999,
+        )
+        assert sorted(p["id"] for p in photos) == sorted(res["photo_ids"])
 
 
 def test_failed_import_does_not_chain(app_and_db, tmp_path):
@@ -4084,8 +4095,43 @@ def test_failed_import_does_not_chain(app_and_db, tmp_path):
             assert res["failed"] >= 1
             assert res.get("after_import_skipped") == "import failed"
             assert "process_job_id" not in res
+            assert "collection_id" not in res
     finally:
         os.chmod(str(unreadable), 0o644)
+
+
+def test_cancelled_import_does_not_create_collection(
+        app_and_db, tmp_path, monkeypatch):
+    """Partial photo ids from a cancelled run must not look like a complete
+    import collection in Browse."""
+    import import_job
+    from wait import wait_for_job_via_client
+
+    app, db = app_and_db
+    existing_photo_id = db.conn.execute(
+        "SELECT id FROM photos ORDER BY id LIMIT 1"
+    ).fetchone()["id"]
+
+    def cancelled_result(*args, **kwargs):
+        return {
+            "ok": False,
+            "cancelled": True,
+            "photo_ids": [existing_photo_id],
+            "copied": 1,
+            "failed": 0,
+        }
+
+    monkeypatch.setattr(import_job, "run_import_job", cancelled_result)
+    card = _chain_card(tmp_path, n=1)
+    with app.test_client() as client:
+        job_id = _post_import(
+            client, card, tmp_path / "arch", "quick_look",
+        )
+        result = wait_for_job_via_client(client, job_id)["result"]
+
+    assert result["after_import_skipped"] == "import failed"
+    assert "collection_id" not in result
+    assert "process_job_id" not in result
 
 
 def test_duplicates_only_import_skips_chaining(app_and_db, tmp_path):
@@ -4104,6 +4150,7 @@ def test_duplicates_only_import_skips_chaining(app_and_db, tmp_path):
         assert res["skipped_duplicate"] == 2
         assert res.get("after_import_skipped") == "no new photos"
         assert "process_job_id" not in res
+        assert "collection_id" not in res
 
 
 def test_chained_run_surfaces_model_warning(app_and_db, tmp_path):


### PR DESCRIPTION
## Summary

- create a static collection for every successful import that adds photos
- make import-only and import-in-place runs discoverable from Browse
- reuse the import collection when optional post-import processing is enabled
- avoid creating misleading collections for failed, cancelled, or duplicates-only runs

## Root cause

Import collection creation was coupled to post-import processing. Choosing “Import only” returned before the collection was created, even though the import itself completed successfully.

## User impact

Every successful import now appears as an `Import YYYY-MM-DD HH:MM` collection, regardless of whether the user chooses additional processing.

## Validation

- `python -m pytest vireo/tests/test_jobs_api.py -q` — 174 passed, 13 skipped
- `python -m ruff check vireo/app.py vireo/tests/test_jobs_api.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Completed imports now automatically create Browse collections containing the imported photos.
  - Import results include the collection name and ID for easy access.
  - Import processing clearly reports when follow-up actions are skipped and why.

- **Bug Fixes**
  - Prevented collections from being created for cancelled, failed, duplicate-only, or photo-free imports.
  - Improved consistency between imported photo lists and the associated Browse collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->