### PR TITLE
Add filters to misses review

### DIFF
--- a/tests/e2e/test_misses_multi_select.py
+++ b/tests/e2e/test_misses_multi_select.py
@@ -169,6 +169,45 @@ def test_bulk_reject_uses_filters_that_rendered_visible_cards(live_server, page)
     page.evaluate("window.releaseHeldFilterLoad()")
 
 
+def test_recompute_uses_filters_that_rendered_visible_cards(live_server, page):
+    url = live_server["url"]
+    db = live_server["db"]
+    pids = live_server["data"]["photos"]
+    _seed_misses(db, pids, "no_subject")
+
+    page.goto(f"{url}/misses?rating_min=4")
+    expect(page.locator("[data-testid^='miss-card-no_subject-']")).to_have_count(1)
+    page.evaluate("""() => {
+      const realFetch = window.fetch.bind(window);
+      let held = false;
+      window.fetch = (url, options) => {
+        if (!held && String(url) === '/api/misses') {
+          held = true;
+          return new Promise(resolve => {
+            window.releaseHeldFilterLoad = () => realFetch(url, options).then(resolve);
+          });
+        }
+        return realFetch(url, options);
+      };
+    }""")
+    page.locator("#missRatingFilter").select_option("")
+    page.wait_for_function("window.releaseHeldFilterLoad != null")
+
+    page.locator("#missRecomputeBtn").click()
+    expect(page.locator("#missTuningStatus")).to_have_text(
+        "Recomputed visible photos; refreshing filters"
+    )
+    timestamps = {
+        row["id"]: row["miss_computed_at"]
+        for row in db.conn.execute(
+            "SELECT id, miss_computed_at FROM photos ORDER BY id"
+        )
+    }
+    assert timestamps[pids[0]] != "2026-04-22"
+    assert all(timestamps[pid] == "2026-04-22" for pid in pids[1:])
+    page.evaluate("window.releaseHeldFilterLoad()")
+
+
 def test_ctrl_click_toggles_selection(live_server, page):
     url = live_server["url"]
     db = live_server["db"]

--- a/tests/e2e/test_misses_multi_select.py
+++ b/tests/e2e/test_misses_multi_select.py
@@ -224,6 +224,37 @@ def test_recompute_uses_filters_that_rendered_visible_cards(live_server, page):
     page.evaluate("window.releaseHeldFilterLoad()")
 
 
+def test_initial_recompute_uses_url_filters_before_grid_loads(live_server, page):
+    url = live_server["url"]
+    db = live_server["db"]
+    pids = live_server["data"]["photos"]
+    _seed_misses(db, pids, "no_subject")
+    page.add_init_script("""(() => {
+      const realFetch = window.fetch.bind(window);
+      let held = false;
+      window.fetch = (url, options) => {
+        if (!held && String(url).includes('/api/misses?rating_min=4')) {
+          held = true;
+          return new Promise(resolve => {
+            window.releaseInitialMissesLoad = () => realFetch(url, options).then(resolve);
+          });
+        }
+        if (String(url).includes('/api/misses/recompute')) {
+          window.initialRecomputeBody = JSON.parse(options.body);
+        }
+        return realFetch(url, options);
+      };
+    })()""")
+
+    page.goto(f"{url}/misses?rating_min=4")
+    page.wait_for_function("window.releaseInitialMissesLoad != null")
+    expect(page.locator("#missRecomputeBtn")).to_be_enabled()
+    page.locator("#missRecomputeBtn").click()
+    page.wait_for_function("window.initialRecomputeBody != null")
+    assert page.evaluate("window.initialRecomputeBody.rating_min") == "4"
+    page.evaluate("window.releaseInitialMissesLoad()")
+
+
 def test_ctrl_click_toggles_selection(live_server, page):
     url = live_server["url"]
     db = live_server["db"]

--- a/tests/e2e/test_misses_multi_select.py
+++ b/tests/e2e/test_misses_multi_select.py
@@ -138,6 +138,37 @@ def test_filter_change_ignores_older_recompute_response(live_server, page):
     expect(page.locator("[data-testid^='miss-card-no_subject-']")).to_have_count(1)
 
 
+def test_bulk_reject_uses_filters_that_rendered_visible_cards(live_server, page):
+    url = live_server["url"]
+    db = live_server["db"]
+    pids = live_server["data"]["photos"]
+    _seed_misses(db, pids, "no_subject")
+
+    page.goto(f"{url}/misses?rating_min=4")
+    expect(page.locator("[data-testid^='miss-card-no_subject-']")).to_have_count(1)
+    page.evaluate("""() => {
+      const realFetch = window.fetch.bind(window);
+      let held = false;
+      window.fetch = (url, options) => {
+        if (!held && String(url) === '/api/misses') {
+          held = true;
+          return new Promise(resolve => {
+            window.releaseHeldFilterLoad = () => realFetch(url, options).then(resolve);
+          });
+        }
+        return realFetch(url, options);
+      };
+    }""")
+    page.locator("#missRatingFilter").select_option("")
+    page.wait_for_function("window.releaseHeldFilterLoad != null")
+
+    page.once("dialog", lambda dialog: dialog.accept())
+    page.locator("[data-testid='miss-reject-no_subject']").click()
+    assert _wait_for_flag(db, pids[0], "rejected") == "rejected"
+    assert all(db.get_photo(pid)["flag"] != "rejected" for pid in pids[1:])
+    page.evaluate("window.releaseHeldFilterLoad()")
+
+
 def test_ctrl_click_toggles_selection(live_server, page):
     url = live_server["url"]
     db = live_server["db"]

--- a/tests/e2e/test_misses_multi_select.py
+++ b/tests/e2e/test_misses_multi_select.py
@@ -106,6 +106,11 @@ def test_filter_change_ignores_older_threshold_preview(live_server, page):
 
 
 def test_filter_change_ignores_older_recompute_response(live_server, page):
+    """A recompute POST that returns after the user has changed filters must
+    not replace the newer filtered view with the previous filter's payload,
+    and — since the server-side recompute has still persisted miss flags for
+    the previous scope — must trigger a fresh loadMisses() for the current
+    filters so any overlapping photos reflect the new flags."""
     url = live_server["url"]
     db = live_server["db"]
     pids = live_server["data"]["photos"]
@@ -114,9 +119,11 @@ def test_filter_change_ignores_older_recompute_response(live_server, page):
     page.goto(f"{url}/misses")
     expect(page.locator("[data-testid^='miss-card-no_subject-']")).to_have_count(5)
     page.evaluate("""() => {
+      window.missesFetchCalls = [];
       const realFetch = window.fetch.bind(window);
       let held = false;
       window.fetch = (url, options) => {
+        window.missesFetchCalls.push(String(url));
         if (!held && String(url).includes('/api/misses/recompute')) {
           held = true;
           return new Promise(resolve => {
@@ -131,11 +138,21 @@ def test_filter_change_ignores_older_recompute_response(live_server, page):
 
     page.locator("#missRatingFilter").select_option("4")
     expect(page.locator("[data-testid^='miss-card-no_subject-']")).to_have_count(1)
+    calls_before_release = page.evaluate(
+        "window.missesFetchCalls.filter(u => u.startsWith('/api/misses') && !u.includes('/recompute') && !u.includes('/preview')).length"
+    )
     page.evaluate("window.releaseHeldRecompute()")
     expect(page.locator("#missTuningStatus")).to_have_text(
-        "Recompute finished for previous filters"
+        "Recomputed previous filters; refreshing current view"
     )
     expect(page.locator("[data-testid^='miss-card-no_subject-']")).to_have_count(1)
+    # The stale recompute must have scheduled a fresh /api/misses for the
+    # current filters so any overlapping photos pick up the newly persisted
+    # miss flags rather than continuing to render the pre-recompute payload.
+    page.wait_for_function(
+        f"window.missesFetchCalls.filter(u => u.startsWith('/api/misses') && !u.includes('/recompute') && !u.includes('/preview')).length > {calls_before_release}",
+        timeout=3000,
+    )
 
 
 def test_bulk_reject_uses_filters_that_rendered_visible_cards(live_server, page):

--- a/tests/e2e/test_misses_multi_select.py
+++ b/tests/e2e/test_misses_multi_select.py
@@ -260,6 +260,21 @@ def test_initial_recompute_uses_url_filters_before_grid_loads(live_server, page)
     page.evaluate("window.releaseInitialMissesLoad()")
 
 
+def test_pick_refreshes_unflagged_miss_filter(live_server, page):
+    url = live_server["url"]
+    db = live_server["db"]
+    pids = live_server["data"]["photos"]
+    _seed_misses(db, pids, "no_subject")
+
+    page.goto(f"{url}/misses?flag=none")
+    expect(page.locator("[data-testid^='miss-card-no_subject-']")).to_have_count(5)
+    page.locator(f"[data-testid='miss-card-no_subject-{pids[0]}']").click()
+    page.keyboard.press("p")
+
+    assert _wait_for_flag(db, pids[0], "flagged") == "flagged"
+    expect(page.locator("[data-testid^='miss-card-no_subject-']")).to_have_count(4)
+
+
 def test_ctrl_click_toggles_selection(live_server, page):
     url = live_server["url"]
     db = live_server["db"]

--- a/tests/e2e/test_misses_multi_select.py
+++ b/tests/e2e/test_misses_multi_select.py
@@ -145,7 +145,6 @@ def test_filter_change_ignores_older_recompute_response(live_server, page):
     expect(page.locator("#missTuningStatus")).to_have_text(
         "Recomputed previous filters; refreshing current view"
     )
-    expect(page.locator("[data-testid^='miss-card-no_subject-']")).to_have_count(1)
     # The stale recompute must have scheduled a fresh /api/misses for the
     # current filters so any overlapping photos pick up the newly persisted
     # miss flags rather than continuing to render the pre-recompute payload.

--- a/tests/e2e/test_misses_multi_select.py
+++ b/tests/e2e/test_misses_multi_select.py
@@ -71,6 +71,73 @@ def test_collection_and_rating_filters_limit_visible_misses(live_server, page):
     ).to_be_visible()
 
 
+def test_filter_change_ignores_older_threshold_preview(live_server, page):
+    url = live_server["url"]
+    db = live_server["db"]
+    pids = live_server["data"]["photos"]
+    _seed_misses(db, pids, "no_subject")
+
+    page.goto(f"{url}/misses")
+    expect(page.locator("[data-testid^='miss-card-no_subject-']")).to_have_count(5)
+    page.evaluate("""() => {
+      const realFetch = window.fetch.bind(window);
+      let held = false;
+      window.fetch = (url, options) => {
+        if (!held && String(url).includes('/api/misses/preview')) {
+          held = true;
+          return new Promise(resolve => {
+            window.releaseHeldPreview = () => realFetch(url, options).then(resolve);
+          });
+        }
+        return realFetch(url, options);
+      };
+    }""")
+    page.locator("#missCfgNoSubject").evaluate("""el => {
+      el.value = String(Number(el.value) + 1);
+      el.dispatchEvent(new Event('input', {bubbles: true}));
+    }""")
+    page.wait_for_function("window.releaseHeldPreview != null")
+
+    page.locator("#missRatingFilter").select_option("4")
+    expect(page.locator("[data-testid^='miss-card-no_subject-']")).to_have_count(1)
+    page.evaluate("window.releaseHeldPreview()")
+    page.wait_for_timeout(400)
+    expect(page.locator("[data-testid^='miss-card-no_subject-']")).to_have_count(1)
+
+
+def test_filter_change_ignores_older_recompute_response(live_server, page):
+    url = live_server["url"]
+    db = live_server["db"]
+    pids = live_server["data"]["photos"]
+    _seed_misses(db, pids, "no_subject")
+
+    page.goto(f"{url}/misses")
+    expect(page.locator("[data-testid^='miss-card-no_subject-']")).to_have_count(5)
+    page.evaluate("""() => {
+      const realFetch = window.fetch.bind(window);
+      let held = false;
+      window.fetch = (url, options) => {
+        if (!held && String(url).includes('/api/misses/recompute')) {
+          held = true;
+          return new Promise(resolve => {
+            window.releaseHeldRecompute = () => realFetch(url, options).then(resolve);
+          });
+        }
+        return realFetch(url, options);
+      };
+    }""")
+    page.locator("#missRecomputeBtn").click()
+    page.wait_for_function("window.releaseHeldRecompute != null")
+
+    page.locator("#missRatingFilter").select_option("4")
+    expect(page.locator("[data-testid^='miss-card-no_subject-']")).to_have_count(1)
+    page.evaluate("window.releaseHeldRecompute()")
+    expect(page.locator("#missTuningStatus")).to_have_text(
+        "Recompute finished for previous filters"
+    )
+    expect(page.locator("[data-testid^='miss-card-no_subject-']")).to_have_count(1)
+
+
 def test_ctrl_click_toggles_selection(live_server, page):
     url = live_server["url"]
     db = live_server["db"]

--- a/tests/e2e/test_misses_multi_select.py
+++ b/tests/e2e/test_misses_multi_select.py
@@ -4,6 +4,7 @@ Covers plain-click selection, ctrl-click toggle, shift-click range, shift+J/K
 keyboard extension, Esc-to-clear, toolbar actions, and bulk P/X/U acting on the
 selection. Double-click opens the shared lightbox.
 """
+import json
 import time
 
 from playwright.sync_api import expect
@@ -41,6 +42,33 @@ def _ctrl_click(page, locator):
     # Cmd on macOS, Ctrl elsewhere — both map to e.metaKey/e.ctrlKey in our
     # handler. Use Playwright's "Meta" because the test host is macOS.
     locator.click(modifiers=["Meta"])
+
+
+def test_collection_and_rating_filters_limit_visible_misses(live_server, page):
+    url = live_server["url"]
+    db = live_server["db"]
+    pids = live_server["data"]["photos"]
+    _seed_misses(db, pids, "no_subject")
+    collection_id = db.add_collection(
+        "Hawk review",
+        json.dumps([{"field": "photo_ids", "value": pids[:3]}]),
+    )
+
+    page.goto(f"{url}/misses")
+    page.locator("[data-testid^='miss-card-no_subject-']").first.wait_for(
+        state="visible", timeout=3000,
+    )
+    page.locator("#missCollectionFilter").select_option(str(collection_id))
+    expect(page.locator("[data-testid^='miss-card-no_subject-']")).to_have_count(3)
+    assert f"collection_id={collection_id}" in page.url
+
+    # The shared E2E fixture gives the first hawk four stars; the other two
+    # have no rating, so composing filters should leave exactly that miss.
+    page.locator("#missRatingFilter").select_option("4")
+    expect(page.locator("[data-testid^='miss-card-no_subject-']")).to_have_count(1)
+    expect(
+        page.locator(f"[data-testid='miss-card-no_subject-{pids[0]}']")
+    ).to_be_visible()
 
 
 def test_ctrl_click_toggles_selection(live_server, page):

--- a/tests/e2e/test_misses_multi_select.py
+++ b/tests/e2e/test_misses_multi_select.py
@@ -133,6 +133,10 @@ def test_filter_change_ignores_older_recompute_response(live_server, page):
         return realFetch(url, options);
       };
     }""")
+    saved_threshold = page.locator("#missCfgNoSubject").evaluate("""el => {
+      el.value = String(Number(el.value) + 1);
+      return Number(el.value) / 100;
+    }""")
     page.locator("#missRecomputeBtn").click()
     page.wait_for_function("window.releaseHeldRecompute != null")
 
@@ -152,6 +156,7 @@ def test_filter_change_ignores_older_recompute_response(live_server, page):
         f"window.missesFetchCalls.filter(u => u.startsWith('/api/misses') && !u.includes('/recompute') && !u.includes('/preview')).length > {calls_before_release}",
         timeout=3000,
     )
+    assert page.evaluate("originalMissConfig.miss_det_confidence") == saved_threshold
 
 
 def test_bulk_reject_uses_filters_that_rendered_visible_cards(live_server, page):

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -11467,6 +11467,75 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             grouped[category] = photos
         return grouped
 
+    def _miss_filter_photo_ids(db, values):
+        """Resolve Misses-page filters to an intersected workspace photo set."""
+        def value(name):
+            raw = values.get(name)
+            return None if raw in (None, "") else raw
+
+        def integer(name, minimum=None, maximum=None):
+            raw = value(name)
+            if raw is None:
+                return None
+            try:
+                parsed = int(raw)
+            except (TypeError, ValueError):
+                raise ValueError(f"{name} must be an integer") from None
+            if minimum is not None and parsed < minimum:
+                raise ValueError(f"{name} must be at least {minimum}")
+            if maximum is not None and parsed > maximum:
+                raise ValueError(f"{name} must be at most {maximum}")
+            return parsed
+
+        collection_id = integer("collection_id", minimum=1)
+        folder_id = integer("folder_id", minimum=1)
+        rating_min = integer("rating_min", minimum=1, maximum=5)
+        keyword = value("keyword")
+        date_from = value("date_from")
+        date_to = value("date_to")
+        color_label = value("color_label")
+        if color_label not in (None, "red", "yellow", "green", "blue", "purple"):
+            raise ValueError("invalid color_label")
+        flag = value("flag")
+        if flag not in (None, "none", "flagged", "rejected"):
+            raise ValueError("invalid flag")
+
+        def boolean(name):
+            raw = value(name)
+            if raw is None:
+                return False
+            if isinstance(raw, bool):
+                return raw
+            return str(raw).strip().lower() in {"1", "true", "yes", "on"}
+
+        has_browse_filters = any((
+            folder_id, rating_min, keyword, date_from, date_to, color_label, flag,
+        ))
+        photo_ids = None
+        if has_browse_filters:
+            photo_ids = set(db.get_photo_ids(
+                folder_id=folder_id,
+                rating_min=rating_min,
+                date_from=date_from,
+                date_to=date_to,
+                keyword=keyword,
+                keyword_match_case=boolean("keyword_match_case"),
+                keyword_whole_word=boolean("keyword_whole_word"),
+                color_label=color_label,
+                flag=flag,
+            ))
+        if collection_id is not None:
+            valid_ids = {c["id"] for c in db.get_collections()}
+            if collection_id not in valid_ids:
+                raise ValueError("collection not found")
+            collection_ids = db.collection_photo_ids(collection_id)
+            photo_ids = (
+                collection_ids
+                if photo_ids is None
+                else photo_ids & collection_ids
+            )
+        return photo_ids
+
     @app.route("/api/misses")
     def api_misses():
         """Return photos flagged as misses.
@@ -11479,17 +11548,23 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         db = _get_db()
         category = request.args.get("category")
         since = request.args.get("since") or None
+        try:
+            photo_ids = _miss_filter_photo_ids(db, request.args)
+        except ValueError as e:
+            return json_error(str(e), 400)
         if category is not None:
             if category not in ("no_subject", "clipped", "oof"):
                 return jsonify({"error": "invalid category"}), 400
-            photos = [dict(p) for p in db.list_misses(category=category, since=since)]
+            photos = [dict(p) for p in db.list_misses(
+                category=category, since=since, photo_ids=photo_ids
+            )]
             _attach_species_representatives(db, photos)
             _attach_edit_recipes(db, photos)
             return jsonify({"photos": photos, "category": category})
         grouped = {
-            "no_subject": db.list_misses(category="no_subject", since=since),
-            "clipped":    db.list_misses(category="clipped", since=since),
-            "oof":        db.list_misses(category="oof", since=since),
+            "no_subject": db.list_misses(category="no_subject", since=since, photo_ids=photo_ids),
+            "clipped":    db.list_misses(category="clipped", since=since, photo_ids=photo_ids),
+            "oof":        db.list_misses(category="oof", since=since, photo_ids=photo_ids),
         }
         return jsonify(_attach_miss_edit_recipes(db, grouped))
 
@@ -11506,9 +11581,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             )
         except ValueError as e:
             return json_error(str(e))
+        try:
+            photo_ids = _miss_filter_photo_ids(db, body)
+        except ValueError as e:
+            return json_error(str(e), 400)
         grouped = preview_misses_for_workspace(
             db, pipeline, detector_confidence=detector_confidence,
-            since=body.get("since") or None,
+            since=body.get("since") or None, photo_ids=photo_ids,
         )
         _attach_miss_edit_recipes(db, grouped)
         grouped["config"] = values
@@ -11528,6 +11607,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             )
         except ValueError as e:
             return json_error(str(e))
+        try:
+            photo_ids = _miss_filter_photo_ids(db, body)
+        except ValueError as e:
+            return json_error(str(e), 400)
 
         if body.get("save_defaults") is True:
             _save_miss_threshold_overrides(db, values, pipeline)
@@ -11535,9 +11618,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         since = body.get("since") or None
         updated = compute_misses_for_workspace(
             db, pipeline, detector_confidence=detector_confidence, since=since,
+            photo_ids=photo_ids,
         )
         grouped = preview_misses_for_workspace(
             db, pipeline, detector_confidence=detector_confidence, since=since,
+            photo_ids=photo_ids,
         )
         _attach_miss_edit_recipes(db, grouped)
         grouped["config"] = values
@@ -11566,7 +11651,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         since = body.get("since") or None
         if category not in ("no_subject", "clipped", "oof"):
             return jsonify({"error": "invalid category"}), 400
-        affected = db.bulk_reject_miss_category(category, since=since)
+        try:
+            photo_ids = _miss_filter_photo_ids(db, body)
+        except ValueError as e:
+            return json_error(str(e), 400)
+        affected = db.bulk_reject_miss_category(
+            category, since=since, photo_ids=photo_ids
+        )
         if affected:
             items = [
                 {"photo_id": a["photo_id"],

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -13910,13 +13910,15 @@ class Database:
         """Back-compat shim — prefer get_detector_run_photo_ids."""
         return self.get_detector_run_photo_ids(detector_model)
 
-    def list_misses(self, category=None, since=None):
+    def list_misses(self, category=None, since=None, photo_ids=None):
         """Return photos flagged as misses in the active workspace.
 
         category: None | "no_subject" | "clipped" | "oof"
         since: optional ISO timestamp; if set, restricts to photos whose
             miss_computed_at >= since. Used by the pipeline-review step to
             scope results to the current run.
+        photo_ids: optional iterable restricting results to an already-resolved
+            collection or filter scope. An empty iterable matches no photos.
 
         Excludes photos already flagged as rejected. Scoped to folders
         linked to the active workspace. ``detection_box`` and
@@ -13941,6 +13943,8 @@ class Database:
         if since:
             where = f"({where}) AND p.miss_computed_at >= ?"
             params.append(since)
+        scope_clause, scope_params = self._scope_clause(photo_ids)
+        params.extend(scope_params)
 
         rows = self.conn.execute(
             f"SELECT p.id, p.folder_id, p.filename, p.companion_path, "
@@ -13954,6 +13958,7 @@ class Database:
             f"WHERE wf.workspace_id = ? "
             f"  AND ({where}) "
             f"  AND (p.flag IS NULL OR p.flag != 'rejected') "
+            f"  {scope_clause} "
             f"ORDER BY p.timestamp DESC",
             params,
         ).fetchall()
@@ -14016,7 +14021,7 @@ class Database:
         )
         self.conn.commit()
 
-    def bulk_reject_miss_category(self, category, since=None):
+    def bulk_reject_miss_category(self, category, since=None, photo_ids=None):
         """Set flag='rejected' on every photo flagged with that miss category
         in the active workspace and not already rejected.
 
@@ -14025,6 +14030,9 @@ class Database:
         keeps bulk reject scoped to the /misses view the user is looking
         at (e.g. the current pipeline run), so older misses not shown on
         screen aren't silently rejected.
+
+        ``photo_ids`` further restricts the mutation to the collection and
+        Browse-style filters currently visible on the Misses page.
 
         Returns a list of ``{"photo_id": int, "old_value": str}`` for each
         photo whose flag was changed. The caller (``/api/misses/reject``)
@@ -14043,13 +14051,16 @@ class Database:
         if since:
             since_clause = "    AND p.miss_computed_at >= ? "
             params.append(since)
+        scope_clause, scope_params = self._scope_clause(photo_ids)
+        params.extend(scope_params)
         rows = self.conn.execute(
             f"SELECT p.id, p.flag FROM photos p "
             f"JOIN workspace_folders wf ON wf.folder_id = p.folder_id "
             f"WHERE wf.workspace_id = ? "
             f"  AND p.{col}=1 "
             f"  AND (p.flag IS NULL OR p.flag != 'rejected') "
-            f"{since_clause}",
+            f"{since_clause}"
+            f"{scope_clause}",
             params,
         ).fetchall()
         # Preserve NULL flag values in old_value so undo is lossless.

--- a/vireo/misses.py
+++ b/vireo/misses.py
@@ -178,10 +178,14 @@ def _fetch_workspace_miss_rows(db, detector_confidence=None):
     return [dict(r) for r in rows]
 
 
-def _target_ids_from_scope(rows, collection_id=None, db=None, since=None):
-    target_ids = None
+def _target_ids_from_scope(rows, collection_id=None, db=None, since=None,
+                           photo_ids=None):
+    target_ids = set(photo_ids) if photo_ids is not None else None
     if collection_id is not None:
-        target_ids = db.collection_photo_ids(collection_id)
+        collection_ids = db.collection_photo_ids(collection_id)
+        target_ids = (
+            collection_ids if target_ids is None else target_ids & collection_ids
+        )
     if since is not None:
         since_ids = {
             r["id"] for r in rows
@@ -294,7 +298,7 @@ def _attach_primary_detections(db, photos):
 
 
 def preview_misses_for_workspace(db, pipeline_config, detector_confidence=None,
-                                 since=None):
+                                 since=None, photo_ids=None):
     """Return dynamically derived misses without writing DB flags."""
     if not pipeline_config.get("miss_enabled", True):
         return {"no_subject": [], "clipped": [], "oof": []}
@@ -303,7 +307,9 @@ def preview_misses_for_workspace(db, pipeline_config, detector_confidence=None,
     rows = _fetch_workspace_miss_rows(
         db, detector_confidence=detector_confidence
     )
-    target_ids = _target_ids_from_scope(rows, since=since)
+    target_ids = _target_ids_from_scope(
+        rows, since=since, photo_ids=photo_ids
+    )
     _, flags_by_id = _derive_miss_updates(
         rows, pipeline_config, target_ids=target_ids
     )
@@ -348,7 +354,7 @@ def preview_misses_for_workspace(db, pipeline_config, detector_confidence=None,
 
 def compute_misses_for_workspace(
     db, pipeline_config, collection_id=None, exclude_photo_ids=None, now=None,
-    detector_confidence=None, since=None,
+    detector_confidence=None, since=None, photo_ids=None,
 ):
     """Compute and persist miss flags for photos in the active workspace.
 
@@ -366,6 +372,9 @@ def compute_misses_for_workspace(
     not touched — so a partial pipeline run does not stamp
     `miss_computed_at` on photos outside its scope, which would
     otherwise defeat the `/misses?since=` review-window filter.
+
+    `photo_ids` accepts an already-resolved intersection of Misses-page
+    filters. It composes with `collection_id` and `since` when supplied.
 
     `exclude_photo_ids` mirrors the preview-deselection filter applied by
     earlier pipeline stages (`params.exclude_photo_ids`). Those photos
@@ -400,7 +409,8 @@ def compute_misses_for_workspace(
         db, detector_confidence=detector_confidence
     )
     target_ids = _target_ids_from_scope(
-        rows, collection_id=collection_id, db=db, since=since
+        rows, collection_id=collection_id, db=db, since=since,
+        photo_ids=photo_ids,
     )
 
     # Microsecond precision: the /misses?since=... review window uses

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -661,6 +661,7 @@ function syncMissFilterUrl() {
 function applyMissFilters() {
   if (missFilterTimer) clearTimeout(missFilterTimer);
   missFilterTimer = null;
+  invalidateMissPreview();
   syncMissFilterUrl();
   selection.clear();
   focusedCategory = null;
@@ -855,7 +856,7 @@ async function previewMisses() {
 async function recomputeMisses() {
   if (!missConfigLoaded) return;
   invalidateMissPreview();
-  missLoadRequestId++;
+  var requestId = ++missLoadRequestId;
   var btn = document.getElementById('missRecomputeBtn');
   var body = collectMissThresholds();
   addMissFiltersToBody(body);
@@ -872,8 +873,16 @@ async function recomputeMisses() {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     });
+    if (requestId !== missLoadRequestId) {
+      setMissTuningStatus('Recompute finished for previous filters');
+      return;
+    }
     if (!r.ok) throw new Error('http ' + r.status);
     var data = await r.json();
+    if (requestId !== missLoadRequestId) {
+      setMissTuningStatus('Recompute finished for previous filters');
+      return;
+    }
     previewActive = false;
     previewPayload = null;
     applyMissesPayload(data);

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -906,6 +906,10 @@ async function recomputeMisses() {
       return;
     }
     if (missFilterParams().toString() !== requestedFilters.toString()) {
+      if (data.config && data.saved_defaults) {
+        missConfig = data.config;
+        originalMissConfig = Object.assign({}, data.config);
+      }
       setMissTuningStatus('Recomputed visible photos; refreshing filters');
       loadMisses();
       return;

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -561,6 +561,7 @@ var missLightboxCurrent = null;
 var selection = new Set();
 var missFilterTimer = null;
 var missLoadRequestId = 0;
+var appliedMissFilters = new URLSearchParams();
 var MISS_FILTER_FIELDS = {
   collection_id: 'missCollectionFilter',
   folder_id: 'missFolderFilter',
@@ -646,9 +647,17 @@ function missFilterParams() {
   return params;
 }
 
-function addMissFiltersToBody(body) {
-  missFilterParams().forEach(function(value, key) { body[key] = value; });
+function addFilterParamsToBody(body, params) {
+  params.forEach(function(value, key) { body[key] = value; });
   return body;
+}
+
+function addMissFiltersToBody(body) {
+  return addFilterParamsToBody(body, missFilterParams());
+}
+
+function addAppliedMissFiltersToBody(body) {
+  return addFilterParamsToBody(body, appliedMissFilters);
 }
 
 function syncMissFilterUrl() {
@@ -829,8 +838,9 @@ async function previewMisses() {
   }
   var requestId = ++previewRequestId;
   missLoadRequestId++;
+  var requestedFilters = missFilterParams();
   var body = collectMissThresholds();
-  addMissFiltersToBody(body);
+  addFilterParamsToBody(body, requestedFilters);
   var since = getSinceParam();
   if (since) body.since = since;
   setMissTuningStatus('Previewing...');
@@ -843,6 +853,7 @@ async function previewMisses() {
     if (!r.ok) throw new Error('http ' + r.status);
     var data = await r.json();
     if (requestId !== previewRequestId) return;
+    appliedMissFilters = new URLSearchParams(requestedFilters.toString());
     previewActive = true;
     previewPayload = data;
     applyMissesPayload(data);
@@ -858,8 +869,9 @@ async function recomputeMisses() {
   invalidateMissPreview();
   var requestId = ++missLoadRequestId;
   var btn = document.getElementById('missRecomputeBtn');
+  var requestedFilters = missFilterParams();
   var body = collectMissThresholds();
-  addMissFiltersToBody(body);
+  addFilterParamsToBody(body, requestedFilters);
   var since = getSinceParam();
   if (since) body.since = since;
   body.save_defaults = !!document.getElementById('missSaveDefaults').checked;
@@ -883,6 +895,7 @@ async function recomputeMisses() {
       setMissTuningStatus('Recompute finished for previous filters');
       return;
     }
+    appliedMissFilters = new URLSearchParams(requestedFilters.toString());
     previewActive = false;
     previewPayload = null;
     applyMissesPayload(data);
@@ -941,7 +954,8 @@ async function loadMisses() {
     await previewMisses();
     return;
   }
-  var params = missFilterParams();
+  var requestedFilters = missFilterParams();
+  var params = new URLSearchParams(requestedFilters.toString());
   if (since) params.set('since', since);
   var url = '/api/misses' + (params.toString() ? '?' + params.toString() : '');
   var r = await fetch(url);
@@ -953,6 +967,7 @@ async function loadMisses() {
   }
   var data = await r.json();
   if (requestId !== missLoadRequestId) return;
+  appliedMissFilters = new URLSearchParams(requestedFilters.toString());
   applyMissesPayload(data);
 }
 
@@ -1192,7 +1207,9 @@ async function bulkReject(cat, e) {
   // Match the /misses?since=... review-window scope so bulk reject only
   // touches photos visible in this view, not older misses from prior runs.
   var since = getSinceParam();
-  var body = addMissFiltersToBody(since ? { category: cat, since: since } : { category: cat });
+  var body = addAppliedMissFiltersToBody(
+    since ? { category: cat, since: since } : { category: cat }
+  );
   var r = await fetch('/api/misses/reject', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -300,6 +300,33 @@
     border: 1px solid var(--border-primary);
     border-radius: 6px;
   }
+  .misses-filters {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin: 0 0 12px;
+    padding: 10px 12px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-primary);
+    border-radius: 6px;
+  }
+  .misses-filters input,
+  .misses-filters select,
+  .misses-filters button {
+    min-height: 30px;
+    border: 1px solid var(--border-secondary);
+    border-radius: 4px;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    padding: 5px 8px;
+    font-size: 12px;
+  }
+  .misses-filters input[type="search"] { flex: 1 1 220px; min-width: 160px; }
+  .misses-filters input[type="date"] { width: 130px; }
+  .misses-filters button { cursor: pointer; color: var(--text-secondary); }
+  .misses-filters button:hover { border-color: var(--accent); color: var(--text-primary); }
+  .misses-filter-label { font-size: 11px; color: var(--text-secondary); }
   .misses-tuning-head {
     display: flex;
     align-items: center;
@@ -412,6 +439,40 @@
     <a href="/misses" style="color:var(--accent);margin-left:8px;">Show all</a>
   </div>
 
+  <div class="misses-filters" aria-label="Miss filters">
+    <select id="missCollectionFilter" onchange="applyMissFilters()" title="Filter by collection">
+      <option value="">All collections</option>
+    </select>
+    <select id="missFolderFilter" onchange="applyMissFilters()" title="Filter by folder and its subfolders">
+      <option value="">All folders</option>
+    </select>
+    <input id="missSearchFilter" type="search" placeholder="Search keywords or filenames..."
+           autocomplete="off" oninput="scheduleMissFilter()"
+           onkeydown="if(event.key==='Enter'){event.preventDefault();applyMissFilters();}">
+    <select id="missRatingFilter" onchange="applyMissFilters()" title="Minimum star rating">
+      <option value="">Any rating</option>
+      <option value="1">1+ stars</option><option value="2">2+ stars</option>
+      <option value="3">3+ stars</option><option value="4">4+ stars</option>
+      <option value="5">5 stars</option>
+    </select>
+    <select id="missFlagFilter" onchange="applyMissFilters()" title="Filter by pick status">
+      <option value="">Any pick status</option>
+      <option value="none">Unflagged</option>
+      <option value="flagged">Picks</option>
+    </select>
+    <select id="missColorFilter" onchange="applyMissFilters()" title="Filter by color label">
+      <option value="">Any color</option>
+      <option value="red">Red</option><option value="yellow">Yellow</option>
+      <option value="green">Green</option><option value="blue">Blue</option>
+      <option value="purple">Purple</option>
+    </select>
+    <span class="misses-filter-label">Captured</span>
+    <input id="missDateFrom" type="date" onchange="applyMissFilters()" title="Captured from">
+    <span class="misses-filter-label">to</span>
+    <input id="missDateTo" type="date" onchange="applyMissFilters()" title="Captured through">
+    <button type="button" onclick="clearMissFilters()">Clear filters</button>
+  </div>
+
   <div class="misses-tuning" id="missesTuning">
     <div class="misses-tuning-head">
       <span class="misses-tuning-title">Miss thresholds</span>
@@ -498,6 +559,18 @@ var missLightboxCurrent = null;
 // sections accumulates them all. The focused card doubles as the anchor for
 // shift-click range selection (range stays within the clicked category).
 var selection = new Set();
+var missFilterTimer = null;
+var missLoadRequestId = 0;
+var MISS_FILTER_FIELDS = {
+  collection_id: 'missCollectionFilter',
+  folder_id: 'missFolderFilter',
+  keyword: 'missSearchFilter',
+  rating_min: 'missRatingFilter',
+  flag: 'missFlagFilter',
+  color_label: 'missColorFilter',
+  date_from: 'missDateFrom',
+  date_to: 'missDateTo',
+};
 var MISS_TUNING_CONTROL_IDS = [
   'missCfgDetectorFloor',
   'missCfgNoSubject',
@@ -561,6 +634,80 @@ function getSinceParam() {
     var s = u.searchParams.get('since');
     return s || null;
   } catch (e) { return null; }
+}
+
+function missFilterParams() {
+  var params = new URLSearchParams();
+  Object.keys(MISS_FILTER_FIELDS).forEach(function(key) {
+    var el = document.getElementById(MISS_FILTER_FIELDS[key]);
+    var value = el ? String(el.value || '').trim() : '';
+    if (value) params.set(key, value);
+  });
+  return params;
+}
+
+function addMissFiltersToBody(body) {
+  missFilterParams().forEach(function(value, key) { body[key] = value; });
+  return body;
+}
+
+function syncMissFilterUrl() {
+  var url = new URL(window.location.href);
+  Object.keys(MISS_FILTER_FIELDS).forEach(function(key) { url.searchParams.delete(key); });
+  missFilterParams().forEach(function(value, key) { url.searchParams.set(key, value); });
+  window.history.replaceState({}, '', url.pathname + (url.searchParams.toString() ? '?' + url.searchParams.toString() : ''));
+}
+
+function applyMissFilters() {
+  if (missFilterTimer) clearTimeout(missFilterTimer);
+  missFilterTimer = null;
+  syncMissFilterUrl();
+  selection.clear();
+  focusedCategory = null;
+  focusedIndex = -1;
+  loadMisses();
+}
+
+function scheduleMissFilter() {
+  if (missFilterTimer) clearTimeout(missFilterTimer);
+  missFilterTimer = setTimeout(applyMissFilters, 250);
+}
+
+function clearMissFilters() {
+  Object.keys(MISS_FILTER_FIELDS).forEach(function(key) {
+    var el = document.getElementById(MISS_FILTER_FIELDS[key]);
+    if (el) el.value = '';
+  });
+  applyMissFilters();
+}
+
+async function initMissFilters() {
+  var current = new URL(window.location.href).searchParams;
+  var results = await Promise.all([
+    fetch('/api/collections').then(function(r) { return r.ok ? r.json() : []; }).catch(function() { return []; }),
+    fetch('/api/folders').then(function(r) { return r.ok ? r.json() : []; }).catch(function() { return []; }),
+  ]);
+  var collectionSelect = document.getElementById('missCollectionFilter');
+  (results[0] || []).forEach(function(c) {
+    var option = document.createElement('option');
+    option.value = c.id;
+    option.textContent = c.name + (c.photo_count == null ? '' : ' (' + c.photo_count + ')');
+    option.disabled = !!c.count_error;
+    collectionSelect.appendChild(option);
+  });
+  var folderSelect = document.getElementById('missFolderFilter');
+  (results[1] || []).slice().sort(function(a, b) {
+    return String(a.path || a.name || '').localeCompare(String(b.path || b.name || ''));
+  }).forEach(function(f) {
+    var option = document.createElement('option');
+    option.value = f.id;
+    option.textContent = f.path || f.name || ('Folder ' + f.id);
+    folderSelect.appendChild(option);
+  });
+  Object.keys(MISS_FILTER_FIELDS).forEach(function(key) {
+    var el = document.getElementById(MISS_FILTER_FIELDS[key]);
+    if (el && current.has(key)) el.value = current.get(key);
+  });
 }
 
 function setMissTuningStatus(text) {
@@ -680,7 +827,9 @@ async function previewMisses() {
     previewTimer = null;
   }
   var requestId = ++previewRequestId;
+  missLoadRequestId++;
   var body = collectMissThresholds();
+  addMissFiltersToBody(body);
   var since = getSinceParam();
   if (since) body.since = since;
   setMissTuningStatus('Previewing...');
@@ -706,8 +855,10 @@ async function previewMisses() {
 async function recomputeMisses() {
   if (!missConfigLoaded) return;
   invalidateMissPreview();
+  missLoadRequestId++;
   var btn = document.getElementById('missRecomputeBtn');
   var body = collectMissThresholds();
+  addMissFiltersToBody(body);
   var since = getSinceParam();
   if (since) body.since = since;
   body.save_defaults = !!document.getElementById('missSaveDefaults').checked;
@@ -768,6 +919,7 @@ function applyMissesPayload(data) {
 
 /* ---------- Fetch + render ---------- */
 async function loadMisses() {
+  var requestId = ++missLoadRequestId;
   var since = getSinceParam();
   if (since) {
     var b = document.getElementById('scopeBanner');
@@ -780,14 +932,18 @@ async function loadMisses() {
     await previewMisses();
     return;
   }
-  var url = '/api/misses' + (since ? '?since=' + encodeURIComponent(since) : '');
+  var params = missFilterParams();
+  if (since) params.set('since', since);
+  var url = '/api/misses' + (params.toString() ? '?' + params.toString() : '');
   var r = await fetch(url);
+  if (requestId !== missLoadRequestId) return;
   if (!r.ok) {
     document.getElementById('missesRoot').innerHTML =
       '<div class="misses-empty-page">Failed to load misses.</div>';
     return;
   }
   var data = await r.json();
+  if (requestId !== missLoadRequestId) return;
   applyMissesPayload(data);
 }
 
@@ -1027,7 +1183,7 @@ async function bulkReject(cat, e) {
   // Match the /misses?since=... review-window scope so bulk reject only
   // touches photos visible in this view, not older misses from prior runs.
   var since = getSinceParam();
-  var body = since ? { category: cat, since: since } : { category: cat };
+  var body = addMissFiltersToBody(since ? { category: cat, since: since } : { category: cat });
   var r = await fetch('/api/misses/reject', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -1606,7 +1762,9 @@ document.addEventListener('lightbox:flagchanged', function(e) {
 
 /* ---------- Boot ---------- */
 installMissSliderHandlers();
-loadMissConfig().then(loadMisses);
+initMissFilters().then(function() {
+  return loadMissConfig();
+}).then(loadMisses);
 </script>
 
 </body>

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -718,6 +718,13 @@ async function initMissFilters() {
     var el = document.getElementById(MISS_FILTER_FIELDS[key]);
     if (el && current.has(key)) el.value = current.get(key);
   });
+  // Seed the applied-filters snapshot from the URL so recompute/bulk reject
+  // scope to the URL-requested review set if the user clicks before the first
+  // /api/misses response applies (e.g. /misses?rating_min=4). Without this,
+  // loadMissConfig() enables the Recompute button while appliedMissFilters is
+  // still empty, and an early click POSTs an unfiltered recompute that flags
+  // photos outside the URL scope.
+  appliedMissFilters = missFilterParams();
 }
 
 function setMissTuningStatus(text) {

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -1282,6 +1282,10 @@ function _clearMissRepresentativeStateIfIneligible(photoIds, flag) {
  * the card from the list, so j/k navigation stays continuous. The card will
  * disappear on the next loadMisses() (list_misses excludes flag='rejected').
  */
+function refreshAppliedFlagFilter() {
+  if (appliedMissFilters.has('flag')) loadMisses();
+}
+
 async function flagFocusedMiss(photoId, flag) {
   try {
     var r = await fetch('/api/photos/' + photoId + '/flag', {
@@ -1301,6 +1305,7 @@ async function flagFocusedMiss(photoId, flag) {
     var label = flag === 'flagged' ? 'Flagged' : flag === 'rejected' ? 'Rejected' : 'Cleared';
     showToast(label + ' photo', 'success');
   }
+  refreshAppliedFlagFilter();
 }
 
 /* ---------- Bulk flag/reject for the multi-selection ----------
@@ -1330,6 +1335,7 @@ async function bulkFlagSelection(flag) {
   }
   clearSelection();
   if (repChanged) render();
+  refreshAppliedFlagFilter();
 }
 
 /* Bulk unflag-as-miss across the selection. Each photo can be flagged in
@@ -1795,10 +1801,11 @@ document.addEventListener('lightbox:flagchanged', function(e) {
   var detail = e && e.detail ? e.detail : {};
   var photoId = detail.photoId;
   var flag = detail.flag;
-  if (photoId == null || flag !== 'rejected') return;
+  if (photoId == null) return;
   if (_clearMissRepresentativeStateIfIneligible([photoId], flag)) {
     render();
   }
+  refreshAppliedFlagFilter();
 });
 
 /* ---------- Boot ---------- */

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -894,18 +894,13 @@ async function recomputeMisses() {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     });
-    if (requestId !== missLoadRequestId) {
-      if (r.ok) {
-        setMissTuningStatus('Recomputed previous filters; refreshing current view');
-        loadMisses();
-      } else {
-        setMissTuningStatus('Recompute finished for previous filters');
-      }
-      return;
-    }
     if (!r.ok) throw new Error('http ' + r.status);
     var data = await r.json();
     if (requestId !== missLoadRequestId) {
+      if (data.config && data.saved_defaults) {
+        missConfig = data.config;
+        originalMissConfig = Object.assign({}, data.config);
+      }
       setMissTuningStatus('Recomputed previous filters; refreshing current view');
       loadMisses();
       return;

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -888,13 +888,19 @@ async function recomputeMisses() {
       body: JSON.stringify(body),
     });
     if (requestId !== missLoadRequestId) {
-      setMissTuningStatus('Recompute finished for previous filters');
+      if (r.ok) {
+        setMissTuningStatus('Recomputed previous filters; refreshing current view');
+        loadMisses();
+      } else {
+        setMissTuningStatus('Recompute finished for previous filters');
+      }
       return;
     }
     if (!r.ok) throw new Error('http ' + r.status);
     var data = await r.json();
     if (requestId !== missLoadRequestId) {
-      setMissTuningStatus('Recompute finished for previous filters');
+      setMissTuningStatus('Recomputed previous filters; refreshing current view');
+      loadMisses();
       return;
     }
     if (missFilterParams().toString() !== requestedFilters.toString()) {

--- a/vireo/templates/misses.html
+++ b/vireo/templates/misses.html
@@ -869,7 +869,9 @@ async function recomputeMisses() {
   invalidateMissPreview();
   var requestId = ++missLoadRequestId;
   var btn = document.getElementById('missRecomputeBtn');
-  var requestedFilters = missFilterParams();
+  // Recompute the photos that produced the cards the user is looking at.
+  // Live controls may already represent a newer filter whose load is pending.
+  var requestedFilters = new URLSearchParams(appliedMissFilters.toString());
   var body = collectMissThresholds();
   addFilterParamsToBody(body, requestedFilters);
   var since = getSinceParam();
@@ -893,6 +895,11 @@ async function recomputeMisses() {
     var data = await r.json();
     if (requestId !== missLoadRequestId) {
       setMissTuningStatus('Recompute finished for previous filters');
+      return;
+    }
+    if (missFilterParams().toString() !== requestedFilters.toString()) {
+      setMissTuningStatus('Recomputed visible photos; refreshing filters');
+      loadMisses();
       return;
     }
     appliedMissFilters = new URLSearchParams(requestedFilters.toString());

--- a/vireo/tests/test_misses_api.py
+++ b/vireo/tests/test_misses_api.py
@@ -99,6 +99,91 @@ def test_api_misses_filter_by_category(client, db_with_misses):
     assert len(data["photos"]) == 1
 
 
+def test_api_misses_filters_by_collection_and_browse_attributes(
+    client, db_with_misses,
+):
+    _, db, ids = db_with_misses
+    collection_id = db.add_collection(
+        "Review subset",
+        json.dumps([{
+            "field": "photo_ids",
+            "value": [ids["no_subject"], ids["clipped"]],
+        }]),
+    )
+    db.update_photo_rating(ids["no_subject"], 2)
+    db.update_photo_rating(ids["clipped"], 5)
+    db.set_color_label(ids["clipped"], "red")
+    keyword_id = db.add_keyword("keeper")
+    db.tag_photo(ids["clipped"], keyword_id)
+
+    r = client.get(
+        f"/api/misses?collection_id={collection_id}&rating_min=4"
+        "&color_label=red&keyword=keeper"
+    )
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["no_subject"] == []
+    assert [p["id"] for p in data["clipped"]] == [ids["clipped"]]
+    assert data["oof"] == []
+
+
+def test_api_misses_reject_and_recompute_honor_collection_filter(
+    client, db_with_misses,
+):
+    _, db, ids = db_with_misses
+    # Put two photos in the same category, but only one in the filter scope.
+    db.conn.execute(
+        "UPDATE photos SET miss_clipped=1 WHERE id=?", (ids["no_subject"],)
+    )
+    db.conn.commit()
+    collection_id = db.add_collection(
+        "Only clipped",
+        json.dumps([{"field": "photo_ids", "value": [ids["clipped"]]}]),
+    )
+
+    recompute = client.post(
+        "/api/misses/recompute",
+        data=json.dumps({"collection_id": collection_id}),
+        content_type="application/json",
+    )
+    assert recompute.status_code == 200
+    assert recompute.get_json()["updated"] == 1
+
+    # Re-seed the persisted category after recompute; this assertion exercises
+    # reject scoping independently of the classifier's fixture-derived result.
+    db.conn.execute(
+        "UPDATE photos SET miss_clipped=1 WHERE id IN (?, ?)",
+        (ids["no_subject"], ids["clipped"]),
+    )
+    db.conn.commit()
+
+    reject = client.post(
+        "/api/misses/reject",
+        data=json.dumps({
+            "category": "clipped",
+            "collection_id": collection_id,
+        }),
+        content_type="application/json",
+    )
+    assert reject.status_code == 200
+    assert reject.get_json()["rejected"] == 1
+    flags = {
+        row["id"]: row["flag"]
+        for row in db.conn.execute(
+            "SELECT id, flag FROM photos WHERE id IN (?, ?)",
+            (ids["no_subject"], ids["clipped"]),
+        )
+    }
+    assert flags[ids["clipped"]] == "rejected"
+    assert flags[ids["no_subject"]] != "rejected"
+
+
+def test_api_misses_rejects_unknown_collection(client):
+    r = client.get("/api/misses?collection_id=999999")
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "collection not found"
+
+
 def test_api_bulk_reject_sets_flag(client, db_with_misses):
     r = client.post(
         "/api/misses/reject",


### PR DESCRIPTION
Adds composable collection, folder, keyword or filename, rating, pick-status, color-label, and capture-date filters to the Misses page. Filter state is preserved in the URL, and request ordering prevents stale responses from replacing newer results. Preview, recompute, and bulk rejection now share the visible filter scope so hidden photos are not changed. Validated with 78 focused API, database, and browser tests, JavaScript syntax checking, Python compilation, Ruff, and diff checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive filters to the Misses page, including collection, folder, keyword, rating, flag, color label, and capture date.
  * Miss previews, recomputes, and bulk rejections now apply the active filter scope.
  * Filter selections sync with the URL and remain consistent during updates.

* **Bug Fixes**
  * Prevented outdated responses from replacing newer filtered results.
  * Ensured flag changes and “pick” actions refresh affected filtered views.
  * Added validation and clear errors for invalid filter values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->