### PR TITLE
Fix flaky lightbox resize e2e tests that blocked v0.24.0 release

### DIFF
--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -1521,7 +1521,15 @@ def test_browse_lightbox_resize_preserves_deferred_one_to_one(live_server, page)
         page.wait_for_timeout(25)
     assert "route" in held_original
 
-    native_zoom_before = page.evaluate("window._lbNativeZoom")
+    # Stash the pre-resize native zoom in a page variable rather than reading it
+    # into Python and interpolating it back. During the deferred /original swap
+    # _lbNativeZoom can be transiently unset; a Python None then formats into the
+    # wait expression as the literal `None`, which throws "None is not defined"
+    # in JS. Guard that it is a finite number first, then compare in-page.
+    page.wait_for_function(
+        "typeof window._lbNativeZoom === 'number' && isFinite(window._lbNativeZoom)"
+    )
+    page.evaluate("window._lbNativeZoomBaseline = window._lbNativeZoom")
 
     # Resize while the high-res source is still loading. The image is 4000px
     # wide so _lbFitScale (hence _lbNativeZoom) is width-constrained; shrinking
@@ -1531,7 +1539,7 @@ def test_browse_lightbox_resize_preserves_deferred_one_to_one(live_server, page)
     # signal that the debounced handler has actually executed — no fixed sleep.
     page.set_viewport_size({"width": 640, "height": 800})
     page.wait_for_function(
-        "Math.abs(window._lbNativeZoom - %r) > 0.1" % native_zoom_before
+        "Math.abs(window._lbNativeZoom - window._lbNativeZoomBaseline) > 0.1"
     )
 
     # The resize handler has now run while /original is still held. Pre-fix it
@@ -2117,7 +2125,15 @@ def test_browse_lightbox_resize_preserves_post_original_failure_fallback(
     assert waiting["currentSource"] == "full"
     assert waiting["desiredSource"] in ("2560", "3840")
 
-    native_zoom_before = page.evaluate("window._lbNativeZoom")
+    # Stash the pre-resize native zoom in a page variable rather than reading it
+    # into Python and interpolating it back. While the fallback tier is loading
+    # _lbNativeZoom can be transiently unset; a Python None then formats into the
+    # wait expression as the literal `None`, which throws "None is not defined"
+    # in JS. Guard that it is a finite number first, then compare in-page.
+    page.wait_for_function(
+        "typeof window._lbNativeZoom === 'number' && isFinite(window._lbNativeZoom)"
+    )
+    page.evaluate("window._lbNativeZoomBaseline = window._lbNativeZoom")
 
     # Resize while the fallback tier is still held. _lbRecomputeNativeZoom runs
     # unconditionally at the top of the resize handler (before any pending-state
@@ -2125,7 +2141,7 @@ def test_browse_lightbox_resize_preserves_post_original_failure_fallback(
     # signal that the debounced handler actually executed — no fixed sleep.
     page.set_viewport_size({"width": 640, "height": 800})
     page.wait_for_function(
-        "Math.abs(window._lbNativeZoom - %r) > 0.1" % native_zoom_before
+        "Math.abs(window._lbNativeZoom - window._lbNativeZoomBaseline) > 0.1"
     )
 
     # The resize handler has now run while the fallback tier is still loading.


### PR DESCRIPTION
## What & why

The **v0.24.0** release failed at the `full-e2e` gate (which runs on release tags but is skipped on PR CI), cascading to skip Build/release/update-website. The single failing test was:

```
FAILED tests/e2e/test_browse_lightbox.py::test_browse_lightbox_resize_preserves_deferred_one_to_one[chromium]
  playwright._impl._errors.Error: Page.wait_for_function: ReferenceError: None is not defined
```

### Root cause

Two resize tests read `window._lbNativeZoom` into Python and interpolated it back into a `wait_for_function` expression with `%r`:

```python
native_zoom_before = page.evaluate("window._lbNativeZoom")
...
page.wait_for_function("Math.abs(window._lbNativeZoom - %r) > 0.1" % native_zoom_before)
```

During the deferred high-res swap, `_lbNativeZoom` is transiently unset, so `page.evaluate` returns Python `None`. `%r` then formats it into the JS as the literal token `None`, producing `Math.abs(window._lbNativeZoom - None) > 0.1` → `ReferenceError: None is not defined`. Timing-dependent, hence flaky and only surfaced under full-e2e CPU contention.

### Fix

- Wait for `_lbNativeZoom` to be a finite number before capturing the baseline.
- Stash the baseline in a page variable (`window._lbNativeZoomBaseline`) and compare entirely in-page, so no Python value is ever interpolated into JS.
- Applied to both affected tests (`..._deferred_one_to_one` and `..._post_original_failure_fallback`).

This is a test-only change; product behavior is unchanged.

## Test results

Both tests pass, and are stable across repeated runs:

```
2 passed in 2.95s
# 5 consecutive loops:
2 passed / 2 passed / 2 passed / 2 passed / 2 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end resize tests to reliably handle deferred lightbox image swaps.
  * Added safeguards to wait for valid zoom values before comparing resize behavior, reducing intermittent test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->