### PR TITLE
Stabilize full-e2e release gate: rerun net + deflake resize/flag tests

### DIFF
--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -29,6 +29,12 @@ jobs:
           pip install -e ".[dev]"
           python -m playwright install --with-deps chromium
       - name: Run complete Playwright suite
+        # These browser tests are timing-sensitive and occasionally flake under
+        # CI CPU contention (see the "harden flaky lightbox test" history). This
+        # is the release gate, so a single transient flake must not block a
+        # release: rerun failures up to twice. A genuinely broken test still
+        # fails all three attempts; only tests that pass on retry are tolerated.
         run: >-
           python -m pytest -o addopts='' -q tests/e2e/
           --tb=short --timeout=120 --timeout-method=thread
+          --reruns 2 --reruns-delay 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dev = [
     "pytest>=9.0",
     "pytest-cov>=6.0",
     "pytest-playwright>=0.7",
+    "pytest-rerunfailures>=15.0",
     "pytest-timeout>=2.3",
     "pytest-xdist>=3.6",
     "ruff>=0.11",

--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -1,4 +1,5 @@
 import base64
+import re
 import time
 
 from playwright.sync_api import expect
@@ -96,6 +97,26 @@ def test_browse_photo_id_deep_link_loads_target_after_first_folder_page(live_ser
 def test_browse_lightbox_arrows_preserve_one_to_one_zoom(live_server, page):
     """Navigating from a 1:1 lightbox view keeps the next photo at 1:1."""
     url = live_server["url"]
+
+    # The pending-1:1 state set on navigation is cleared the instant the next
+    # photo's native zoom is learned — which happens via TWO async paths: the
+    # /api/photos/<id> metadata fetch and the /original image's onload. If
+    # either resolves before the synchronous assertion below, _lbPending1To1
+    # has already flipped to False and the test flakes (it did on the v0.23.0
+    # release build). Hold both for the target photo so the pending state is
+    # deterministic during the assertion window; the second phase then learns
+    # native zoom explicitly and verifies the deferred snap applies.
+    hold = {"active": False, "held": []}
+
+    def _hold_when_active(route):
+        if hold["active"]:
+            hold["held"].append(route)  # park it; never resolves during asserts
+        else:
+            route.continue_()
+
+    page.route(re.compile(r"/api/photos/\d+$"), _hold_when_active)
+    page.route("**/photos/*/original", _hold_when_active)
+
     page.goto(f"{url}/browse")
 
     first_card = page.locator(".grid-card").first
@@ -113,8 +134,14 @@ def test_browse_lightbox_arrows_preserve_one_to_one_zoom(live_server, page):
         }"""
     )
 
+    # From here on, stall the next photo's native-zoom sources so the deferred
+    # 1:1 snap cannot resolve before we observe it.
+    hold["active"] = True
     page.locator("[title='Next (→)']").click()
     expect(page.locator("#lightboxCounter")).to_contain_text("2 /")
+    # Guard that the hold worked: native zoom must still be unknown, so the
+    # pending assertion below is genuinely exercising the deferred path.
+    assert page.evaluate("window._lbNativeZoom") is None
     assert page.evaluate("window._lbZoom > 1.001") is True
     assert page.evaluate("window._lbPending1To1") is True
     assert page.evaluate(
@@ -133,6 +160,11 @@ def test_browse_lightbox_arrows_preserve_one_to_one_zoom(live_server, page):
     )
     assert restored
     assert page.evaluate("window._lbZoom") > 1.001
+
+    # Release the parked requests so context teardown doesn't wait on them.
+    hold["active"] = False
+    for route in hold["held"]:
+        route.abort()
 
 
 def test_browse_lightbox_predecodes_adjacent_photo_for_current_source_tier(

--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -1431,6 +1431,23 @@ def test_browse_lightbox_waits_for_original_before_one_to_one_snap(live_server, 
 
     page.route("**/photos/*/original", hold_first_original)
 
+    # The fixture photos are seeded without width/height, so /api/photos/<id>
+    # returns width=null. When that async metadata fetch resolves it overwrites
+    # the _lbPhotoW=4000 injected below with null (app: `_lbPhotoW = data.width
+    # || null`), which nulls _lbNativeZoom. Depending on whether that lands
+    # before or after the native-zoom reads below, the test either crashed
+    # ("None is not defined") or hung waiting for native zoom to settle. Force
+    # real dimensions into the metadata response so _lbPhotoW stays 4000 and
+    # native zoom is stable for the duration of the test.
+    def force_photo_dims(route):
+        resp = route.fetch()
+        data = resp.json()
+        data["width"] = 4000
+        data["height"] = 2000
+        route.fulfill(response=resp, json=data)
+
+    page.route(re.compile(r"/api/photos/\d+$"), force_photo_dims)
+
     url = live_server["url"]
     page.set_viewport_size({"width": 1000, "height": 800})
     page.goto(f"{url}/browse")
@@ -1461,7 +1478,10 @@ def test_browse_lightbox_waits_for_original_before_one_to_one_snap(live_server, 
     )
     assert abs(page.evaluate("window._lbZoom") - 1) < 0.001
     assert page.evaluate("window._lbCurrentSrcKey") == "full"
-    deadline = time.time() + 2
+    # The deferred swap is scheduled on a debounced timer; under CI CPU
+    # contention that timer plus the preloader round-trip can take well over 2s,
+    # so allow generous headroom before asserting the /original request was held.
+    deadline = time.time() + 8
     while "route" not in held_original and time.time() < deadline:
         page.wait_for_timeout(25)
     assert "route" in held_original
@@ -1510,6 +1530,23 @@ def test_browse_lightbox_resize_preserves_deferred_one_to_one(live_server, page)
             route.fulfill(body=original_svg, content_type="image/svg+xml")
 
     page.route("**/photos/*/original", hold_first_original)
+
+    # The fixture photos are seeded without width/height, so /api/photos/<id>
+    # returns width=null. When that async metadata fetch resolves it overwrites
+    # the _lbPhotoW=4000 injected below with null (app: `_lbPhotoW = data.width
+    # || null`), which nulls _lbNativeZoom. Depending on whether that lands
+    # before or after the native-zoom reads below, the test either crashed
+    # ("None is not defined") or hung waiting for native zoom to settle. Force
+    # real dimensions into the metadata response so _lbPhotoW stays 4000 and
+    # native zoom is stable for the duration of the test.
+    def force_photo_dims(route):
+        resp = route.fetch()
+        data = resp.json()
+        data["width"] = 4000
+        data["height"] = 2000
+        route.fulfill(response=resp, json=data)
+
+    page.route(re.compile(r"/api/photos/\d+$"), force_photo_dims)
 
     url = live_server["url"]
     page.set_viewport_size({"width": 1000, "height": 800})

--- a/tests/e2e/test_lightbox_flag_hotkeys.py
+++ b/tests/e2e/test_lightbox_flag_hotkeys.py
@@ -246,7 +246,11 @@ def test_lightbox_newer_failed_write_falls_back_to_older_success(live_server, pa
     page.route("**/api/batch/flag", handle_flag_write)
 
     page.keyboard.press("x")
-    deadline = time.time() + 3
+    # The flag write is dispatched asynchronously after the keypress; under CI
+    # CPU contention it can take well over 3s to reach the route handler, so use
+    # generous headroom before asserting it was held (the loop exits as soon as
+    # the request lands, so the ceiling only matters on the failure path).
+    deadline = time.time() + 10
     while "route" not in held and time.time() < deadline:
         time.sleep(0.05)
     assert "route" in held, "expected first flag write to be held"


### PR DESCRIPTION
## Why

The `full-e2e` job is the release gate (PR CI skips it), and it's chronically flaky under CI CPU contention — it blocked **v0.23.0** and **v0.24.0**, and the file history has ~25 "harden/stabilize flaky lightbox test" commits. Fixing them one at a time hasn't converged. This PR adds a safety net **and** deterministically fixes the specific tests that failed the recent release builds.

## Changes

### Rerun safety net (systemic)
- Add `pytest-rerunfailures` to the `[dev]` extra and run the e2e gate with `--reruns 2 --reruns-delay 1` (`e2e-full.yml`). A transient flake that passes on retry no longer blocks a release; a genuinely broken test still fails all three attempts.

### Deterministic per-test fixes (reduce how often reruns are needed)

**`resize_preserves_deferred_one_to_one` + `waits_for_original_before_one_to_one_snap`** — Root cause: the e2e fixture seeds photos without width/height (`conftest.py:61`), so `/api/photos/<id>` returns `width: null`. When that async metadata fetch resolves it overwrites the test-injected `_lbPhotoW = 4000` with `null` (app code: `_lbPhotoW = data.width || null`), nulling `_lbNativeZoom`. Depending on the race, the test either crashed (`None is not defined` — the original v0.24.0 failure) or hung on the native-zoom wait (30s timeout — the re-run failure). Fix: force real dims into the metadata response so native zoom stays stable. Also widened a too-tight 2s held-request deadline to 8s.

**`arrows_preserve_one_to_one_zoom`** — On 1:1-preserving arrow nav the lightbox sets `_lbPending1To1 = true` and defers the snap until the next photo's native zoom is learned (via metadata fetch or `/original` onload). The test asserted the pending flag synchronously right after Next, so whenever a source won the race the flag had already cleared. Fix: hold the target photo's metadata + `/original` for the assertion window so the pending state is deterministic, with an `_lbNativeZoom is None` guard proving the hold is in effect.

**`test_lightbox_newer_failed_write_falls_back_to_older_success`** — widened the 3s held-request deadline to 10s (the async flag write can take longer than 3s under contention → `assert 'route' in {}`).

All changes are test/CI-only; product behavior is unchanged.

## Test results

```
# four previously-failing tests, 5 consecutive runs:
4 passed (x5)
# with the gate invocation (--reruns 2):
4 passed
# full affected files:
test_browse_lightbox.py + test_lightbox_flag_hotkeys.py -> 34 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)