### PR TITLE
Allow GPS resolution for large photo libraries

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -5487,9 +5487,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "unresolved": [],
                 "skipped": [],
             }, None
-        if len(photo_ids) > 10000:
-            return None, json_error("too many photo_ids", 400)
-
         photos_map = db.get_photos_by_ids(photo_ids)
         if len(photos_map) != len(photo_ids):
             return None, json_error("One or more photos were not found", 404)
@@ -5757,9 +5754,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             skipped = 0
             added = 0
             cancelled_during_gps = False
-            # The public bulk endpoint caps a request at 10,000 IDs. Imports
-            # can exceed that, so reuse its resolution logic in bounded
-            # chunks while sharing the persistent ~110 m geocode cache.
+            # Resolve imports in bounded chunks to limit each payload's memory
+            # use and give cancellation a chance between large batches while
+            # sharing the persistent ~110 m geocode cache.
             for photo_chunk in _gps_location_chunks(photo_ids, size=10000):
                 if cancel_requested():
                     cancelled_during_gps = True

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -7290,6 +7290,44 @@ def test_batch_location_from_exif_preview_groups_without_linking(
     ).fetchone()[0] == 0
 
 
+def test_batch_location_from_exif_accepts_more_than_ten_thousand_photos(
+    app_and_db,
+):
+    """Large libraries are not rejected by the old arbitrary request cap."""
+    app, db = app_and_db
+    folder_id = db.conn.execute(
+        "SELECT id FROM folders WHERE path = ?", ("/photos/2024",),
+    ).fetchone()["id"]
+    db.conn.executemany(
+        "INSERT INTO photos "
+        "(folder_id, filename, extension, file_size, file_mtime) "
+        "VALUES (?, ?, '.jpg', 1, 1)",
+        [
+            (folder_id, f"large-library-{index}.jpg")
+            for index in range(10_001)
+        ],
+    )
+    db.conn.commit()
+    photo_ids = [
+        row["id"] for row in db.conn.execute(
+            "SELECT id FROM photos WHERE filename LIKE 'large-library-%' "
+            "ORDER BY id"
+        ).fetchall()
+    ]
+
+    resp = app.test_client().post(
+        "/api/batch/location/from-exif",
+        json={"photo_ids": photo_ids, "apply": False},
+    )
+
+    assert resp.status_code == 200, resp.get_json()
+    body = resp.get_json()
+    assert body["total"] == 10_001
+    assert body["resolvable"] == 0
+    assert len(body["unresolved"]) == 10_001
+    assert {item["reason"] for item in body["unresolved"]} == {"missing_gps"}
+
+
 def test_batch_location_from_exif_apply_assigns_per_photo_places(
     app_and_db, monkeypatch,
 ):


### PR DESCRIPTION
Resolve GPS rejected selections larger than 10,000 photos even though its database queries already process IDs in safe chunks.
This removes the arbitrary endpoint cap so photographers can resolve location data across large libraries.
It also updates the import-path comment and adds a regression test covering 10,001 photos.
Validation: `pytest -q vireo/tests/test_photos_api.py`, `ruff check vireo/app.py vireo/tests/test_photos_api.py`, and `git diff --check`.
