### PR TITLE
Fix iNaturalist upload links and clipboard copy

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -85,6 +85,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -591,6 +612,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,6 +721,12 @@ name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -933,12 +969,18 @@ checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
 dependencies = [
  "bit-set",
  "cssparser",
- "foldhash",
+ "foldhash 0.2.0",
  "html5ever",
  "precomputed-hash",
  "selectors",
  "tendril",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpi"
@@ -1085,6 +1127,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1110,6 +1158,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -1156,6 +1210,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1170,6 +1230,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -1423,6 +1489,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1605,12 +1681,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1904,6 +2000,7 @@ dependencies = [
  "moxcms",
  "num-traits",
  "png 0.18.1",
+ "tiff",
 ]
 
 [[package]]
@@ -2319,6 +2416,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2384,6 +2490,7 @@ dependencies = [
  "block2",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
 ]
 
@@ -2696,6 +2803,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+]
+
+[[package]]
 name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2779,7 +2897,7 @@ checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml",
+ "quick-xml 0.41.0",
  "serde",
  "time",
 ]
@@ -2941,6 +3059,21 @@ name = "pxfm"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quick-xml"
@@ -4095,6 +4228,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-clipboard-manager"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206dc20af4ed210748ba945c2774e60fd0acd52b9a73a028402caf809e9b6ecf"
+dependencies = [
+ "arboard",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-dialog"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4404,6 +4552,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -4719,6 +4881,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom",
+ "petgraph",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4900,6 +5073,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-clipboard-manager",
  "tauri-plugin-dialog",
  "tauri-plugin-log",
  "tauri-plugin-opener",
@@ -5032,6 +5206,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.13.0",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.39.4",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5159,6 +5403,12 @@ dependencies = [
  "windows",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "winapi"
@@ -5701,6 +5951,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5779,6 +6047,23 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xattr"
@@ -5971,6 +6256,21 @@ name = "zmij"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd2f034a4bebf216c9e4b7083603e024cf930873fd67830cfb083c9fa33129d9"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]
 
 [[package]]
 name = "zvariant"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,6 +24,7 @@ tauri = { version = "2.10.3", features = ["tray-icon", "image-png"] }
 tauri-plugin-log = "2"
 tauri-plugin-shell = "2"
 tauri-plugin-dialog = "2"
+tauri-plugin-clipboard-manager = "2"
 tauri-plugin-process = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-updater = "2"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -26,6 +26,7 @@
     "shell:allow-spawn",
     "shell:allow-kill",
     "dialog:allow-open",
+    "clipboard-manager:allow-write-text",
     "process:allow-restart",
     "core:tray:default",
     "core:tray:allow-set-icon",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -133,6 +133,7 @@ pub fn run() {
         .plugin(build_log_plugin())
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_updater::Builder::new().build())

--- a/tests/e2e/test_external_navigation.py
+++ b/tests/e2e/test_external_navigation.py
@@ -25,16 +25,19 @@ def _item(photo_id=1, *, url=INAT_UPLOAD_URL, duplicate=False):
     }
 
 
-def _mock_tauri(page, *, fail_open=False):
+def _mock_tauri(page, *, fail_open=False, fail_copy=False):
     page.evaluate(
         """
-        failOpen => {
+        options => {
           window.__externalTest = { invokes: [], windowOpenCalls: [] };
           window.__TAURI_INTERNALS__ = {
             invoke: (command, args) => {
               window.__externalTest.invokes.push({ command, args });
-              if (failOpen && command === 'open_external_url') {
+              if (options.failOpen && command === 'open_external_url') {
                 return Promise.reject(new Error('browser launch failed'));
+              }
+              if (options.failCopy && command === 'plugin:clipboard-manager|write_text') {
+                return Promise.reject(new Error('clipboard write failed'));
               }
               return Promise.resolve(null);
             }
@@ -45,7 +48,7 @@ def _mock_tauri(page, *, fail_open=False):
           };
         }
         """,
-        fail_open,
+        {"failOpen": fail_open, "failCopy": fail_copy},
     )
 
 
@@ -69,7 +72,7 @@ def test_native_quick_open_reviews_checked_metadata_before_opening(live_server, 
     expect(page.locator("#inatIncludeDate0")).to_be_checked()
     expect(page.locator("#inatIncludeLocation0")).to_be_checked()
 
-    page.locator("#inatCards button", has_text="Open Upload Page").click()
+    page.locator("#inatCards a", has_text="Open Upload Page").click()
     page.wait_for_function(
         "window.__externalTest.invokes.some(call => "
         "call.command === 'open_external_url')"
@@ -93,7 +96,7 @@ def test_quick_open_can_omit_all_metadata_for_generic_upload(live_server, page):
     page.locator("#inatIncludeTaxon0").uncheck()
     page.locator("#inatIncludeDate0").uncheck()
     page.locator("#inatIncludeLocation0").uncheck()
-    page.locator("#inatCards button", has_text="Open Upload Page").click()
+    page.locator("#inatCards a", has_text="Open Upload Page").click()
     page.wait_for_function(
         "window.__externalTest.invokes.some(call => "
         "call.command === 'open_external_url')"
@@ -110,7 +113,7 @@ def test_native_open_failure_stays_put_and_offers_retry_and_copy(live_server, pa
     _mock_tauri(page, fail_open=True)
 
     page.evaluate("item => openInatQuickModal([item], [])", _item())
-    page.locator("#inatCards button", has_text="Open Upload Page").click()
+    page.locator("#inatCards a", has_text="Open Upload Page").click()
 
     assert len(_open_commands(page)) == 1
     assert page.evaluate("window.__externalTest.windowOpenCalls") == []
@@ -149,6 +152,28 @@ def test_browser_popup_block_never_replaces_vireo(live_server, page):
     expect(page.locator("#externalOpenModalUrl")).to_have_value(INAT_URL)
 
 
+def test_quick_upload_uses_real_link_when_tauri_bridge_is_missing(live_server, page):
+    page.goto(f"{live_server['url']}/browse")
+    page.evaluate("delete window.__TAURI_INTERNALS__")
+    fallback_base = f"{live_server['url']}/fake-inaturalist-upload"
+    page.evaluate(
+        "item => openInatQuickModal([item], [])",
+        _item(url=fallback_base),
+    )
+
+    link = page.locator("#inatCards a", has_text="Open Upload Page")
+    with page.expect_popup() as popup_info:
+        link.click()
+
+    popup = popup_info.value
+    popup.wait_for_url(fallback_base + "?**")
+    assert popup.url == (
+        fallback_base
+        + "?taxon_name=Corvus%20corax&observed_on=2026-07-12&lat=47.61&lng=-122.33"
+    )
+    expect(page.locator("#externalOpenModal")).to_have_count(0)
+
+
 def test_delegated_handler_covers_unannotated_external_links(live_server, page):
     page.goto(f"{live_server['url']}/settings")
     original_url = page.url
@@ -179,7 +204,7 @@ def test_internal_links_are_not_claimed_by_external_handler(live_server, page):
 
 def test_batch_quick_uploads_require_explicit_per_item_open(live_server, page):
     page.goto(f"{live_server['url']}/browse")
-    _mock_tauri(page)
+    _mock_tauri(page, fail_copy=True)
     items = [
         _item(1),
         _item(
@@ -191,7 +216,7 @@ def test_batch_quick_uploads_require_explicit_per_item_open(live_server, page):
 
     assert _open_commands(page) == []
     expect(page.locator("#inatModal")).to_have_class("modal-overlay open")
-    expect(page.locator("#inatCards button", has_text="Open Upload")).to_have_count(2)
+    expect(page.locator("#inatCards a", has_text="Open Upload")).to_have_count(2)
     expect(page.locator("#inatCards button", has_text="Copy URL")).to_have_count(2)
 
     # Copy still has a DOM fallback when clipboard permission is unavailable;
@@ -213,6 +238,46 @@ def test_batch_quick_uploads_require_explicit_per_item_open(live_server, page):
     )
     page.locator("#inatCards button", has_text="Copy URL").first.click()
     page.wait_for_function("window.__externalTest.execCopyCalls === 1")
+
+
+def test_native_copy_url_uses_system_clipboard_plugin(live_server, page):
+    page.goto(f"{live_server['url']}/browse")
+    _mock_tauri(page)
+    page.evaluate("item => openInatQuickModal([item], [])", _item())
+    page.evaluate(
+        """
+        () => {
+          Object.defineProperty(navigator, 'clipboard', {
+            configurable: true,
+            value: { writeText: () => Promise.reject(new Error('should not run')) }
+          });
+          window.__externalTest.execCopyCalls = 0;
+          document.execCommand = () => {
+            window.__externalTest.execCopyCalls += 1;
+            return true;
+          };
+        }
+        """
+    )
+
+    page.locator("#inatCards button", has_text="Copy URL").click()
+    page.wait_for_function(
+        "window.__externalTest.invokes.some(call => "
+        "call.command === 'plugin:clipboard-manager|write_text')"
+    )
+
+    copy_commands = page.evaluate(
+        "window.__externalTest.invokes.filter(call => "
+        "call.command === 'plugin:clipboard-manager|write_text')"
+    )
+    assert copy_commands == [
+        {
+            "command": "plugin:clipboard-manager|write_text",
+            "args": {"text": INAT_URL},
+        }
+    ]
+    assert page.evaluate("window.__externalTest.execCopyCalls") == 0
+    expect(page.locator("#toastContainer")).to_contain_text("URL copied.")
 
 
 def test_batch_quick_open_preserves_preparation_failures(live_server, page):

--- a/vireo/static/tauri-bridge.js
+++ b/vireo/static/tauri-bridge.js
@@ -178,10 +178,28 @@ function closeExternalOpenFailure() {
 
 async function copyExternalUrl(url) {
   var copied = false;
-  try {
-    await navigator.clipboard.writeText(url);
-    copied = true;
-  } catch (e) {
+  if (isTauri()) {
+    try {
+      // Use the native system pasteboard in the packaged app. WebKit's
+      // navigator.clipboard and execCommand paths can resolve/return true
+      // without putting anything on the macOS clipboard.
+      await window.__TAURI_INTERNALS__.invoke('plugin:clipboard-manager|write_text', {
+        text: url,
+      });
+      copied = true;
+    } catch (e) {
+      logError('Native clipboard write failed: ' + (e && e.message ? e.message : e));
+    }
+  }
+  if (!copied && navigator.clipboard && navigator.clipboard.writeText) {
+    try {
+      await navigator.clipboard.writeText(url);
+      copied = true;
+    } catch (e) {
+      logWarn('Web clipboard write failed: ' + (e && e.message ? e.message : e));
+    }
+  }
+  if (!copied) {
     // Always use a fresh throwaway textarea so non-modal callers (e.g. iNat
     // batch Copy URL buttons) never end up selecting a stale value left in
     // #externalOpenModalUrl from an earlier failure modal.
@@ -192,7 +210,9 @@ async function copyExternalUrl(url) {
     document.body.appendChild(temp);
     temp.focus();
     temp.select();
-    try { copied = document.execCommand('copy'); } catch (copyError) {}
+    try { copied = document.execCommand('copy'); } catch (copyError) {
+      logWarn('DOM clipboard fallback failed: ' + (copyError && copyError.message ? copyError.message : copyError));
+    }
     temp.remove();
   }
   if (typeof showToast === 'function') {

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -7523,8 +7523,7 @@ function _inatQuickUploadUrl(idx) {
   return base + (params.length ? '?' + params.join('&') : '');
 }
 
-async function openInatQuickUpload(idx) {
-  var url = _inatQuickUploadUrl(idx);
+async function _openInatQuickUploadNative(url) {
   if (await _inatOpenUrl(url)) {
     showToast('Opened iNaturalist in your browser.', 'success');
     return;
@@ -7535,6 +7534,26 @@ async function openInatQuickUpload(idx) {
       'Vireo could not open iNaturalist. Retry or copy the upload URL below.'
     );
   }
+}
+
+function openInatQuickUpload(event, idx) {
+  var url = _inatQuickUploadUrl(idx);
+  var link = event && event.currentTarget;
+  if (link) link.href = url;
+
+  if (typeof isTauri === 'function' && isTauri()) {
+    if (event) event.preventDefault();
+    _openInatQuickUploadNative(url);
+    return false;
+  }
+
+  // The loopback page can occasionally load without Tauri's IPC globals.
+  // Preserve a real link in that case: a normal browser opens a new tab, and
+  // the native shell's on_new_window hook sends the URL to the OS browser.
+  // Stop propagation so the delegated external-link handler does not replace
+  // this fallback with the unavailable IPC path.
+  if (event) event.stopPropagation();
+  return true;
 }
 
 function copyInatQuickUploadUrl(idx) {
@@ -7654,7 +7673,7 @@ async function openInatQuickModal(items, failures) {
       '</div>' +
       _inatQuickOptions(items[0], 0) +
       '<div style="margin-top:12px;">' +
-        '<button type="button" class="modal-btn modal-btn-primary" onclick="openInatQuickUpload(0)">Open Upload Page</button>' +
+        '<a class="modal-btn modal-btn-primary" href="' + escapeAttr(items[0].upload_url || 'https://www.inaturalist.org/observations/upload') + '" target="_blank" rel="noopener" onclick="return openInatQuickUpload(event, 0)" style="display:inline-block;text-decoration:none;">Open Upload Page</a>' +
         '<button type="button" class="modal-btn" onclick="copyInatQuickUploadUrl(0)" style="margin-left:8px;">Copy URL</button>' +
       '</div>' +
     '</div>';
@@ -7668,7 +7687,7 @@ async function openInatQuickModal(items, failures) {
         '<div style="display:flex;align-items:center;justify-content:space-between;gap:12px;">' +
           '<span style="font-size:13px;color:var(--text-primary);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">' + escapeHtml(item.filename) + '</span>' +
           '<span style="display:flex;align-items:center;gap:8px;white-space:nowrap;">' +
-            '<button type="button" onclick="openInatQuickUpload(' + idx + ')" style="border:0;background:none;color:var(--accent);font-size:12px;cursor:pointer;padding:0;">Open Upload</button>' +
+            '<a href="' + escapeAttr(item.upload_url || 'https://www.inaturalist.org/observations/upload') + '" target="_blank" rel="noopener" onclick="return openInatQuickUpload(event, ' + idx + ')" style="color:var(--accent);font-size:12px;">Open Upload</a>' +
             '<button type="button" onclick="copyInatQuickUploadUrl(' + idx + ')" style="border:0;background:none;color:var(--text-secondary);font-size:12px;cursor:pointer;padding:0;">Copy URL</button>' +
           '</span>' +
         '</div>' +


### PR DESCRIPTION
Fixes the iNaturalist Open Upload Page action when the packaged app page lacks native bridge globals by retaining a real external link while continuing to use the native command when available.

Adds native system clipboard support so Copy URL reliably writes on macOS, with browser and document fallbacks preserved.

Registers and scopes the clipboard plugin, and expands regression coverage for bridge-missing opens, native opens and failures, and clipboard behavior.

Validation: 12 external-navigation tests passed, 6 native navigation tests passed, the Rust app compiled successfully, and the diff check passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native clipboard support in the desktop app.
  * Quick-upload links now open reliably through the app or standard browser navigation.
  * Added fallback handling when native or browser clipboard access is unavailable.

* **Bug Fixes**
  * Improved clipboard copying reliability with clearer success and failure handling.
  * Updated quick-upload controls and external navigation behavior for consistency.
  * Added coverage for clipboard failures and missing app integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->