### PR TITLE
Fix GPS lookup certificate verification in packaged builds

### DIFF
--- a/vireo/places.py
+++ b/vireo/places.py
@@ -48,10 +48,17 @@ logger = logging.getLogger(__name__)
 _PLACE_DETAILS_URL = "https://maps.googleapis.com/maps/api/place/details/json"
 _GEOCODE_URL = "https://maps.googleapis.com/maps/api/geocode/json"
 
-# PyInstaller's embedded Python does not reliably discover a system CA bundle
-# on macOS.  Use the CA bundle shipped with Vireo instead of depending on the
-# interpreter's build-time OpenSSL paths.
-_SSL_CONTEXT = ssl.create_default_context(cafile=certifi.where())
+def _create_ssl_context():
+    """Return a trust context containing configured and bundled CA roots."""
+    context = ssl.create_default_context()
+    # PyInstaller's embedded Python does not reliably discover a system CA
+    # bundle on macOS. Add Vireo's bundled roots without discarding system,
+    # SSL_CERT_FILE, or SSL_CERT_DIR roots needed by managed environments.
+    context.load_verify_locations(cafile=certifi.where())
+    return context
+
+
+_SSL_CONTEXT = _create_ssl_context()
 
 # Google statuses that mean "no match" — we return ``None`` silently.
 _EMPTY_STATUSES = {"ZERO_RESULTS", "NOT_FOUND"}

--- a/vireo/places.py
+++ b/vireo/places.py
@@ -37,13 +37,21 @@ from __future__ import annotations
 
 import json
 import logging
+import ssl
 import urllib.parse
 import urllib.request
+
+import certifi
 
 logger = logging.getLogger(__name__)
 
 _PLACE_DETAILS_URL = "https://maps.googleapis.com/maps/api/place/details/json"
 _GEOCODE_URL = "https://maps.googleapis.com/maps/api/geocode/json"
+
+# PyInstaller's embedded Python does not reliably discover a system CA bundle
+# on macOS.  Use the CA bundle shipped with Vireo instead of depending on the
+# interpreter's build-time OpenSSL paths.
+_SSL_CONTEXT = ssl.create_default_context(cafile=certifi.where())
 
 # Google statuses that mean "no match" — we return ``None`` silently.
 _EMPTY_STATUSES = {"ZERO_RESULTS", "NOT_FOUND"}
@@ -63,7 +71,7 @@ def _get_json(url: str) -> dict:
 
     Kept tiny so tests can monkeypatch ``urllib.request.urlopen`` directly.
     """
-    with urllib.request.urlopen(url, timeout=10) as f:
+    with urllib.request.urlopen(url, timeout=10, context=_SSL_CONTEXT) as f:
         body = f.read()
     return json.loads(body)
 

--- a/vireo/tests/test_places.py
+++ b/vireo/tests/test_places.py
@@ -62,6 +62,24 @@ def test_http_requests_use_bundled_ca_bundle(monkeypatch):
     assert places._SSL_CONTEXT.cert_store_stats()["x509_ca"] > 0
 
 
+def test_ssl_context_preserves_configured_roots_and_adds_bundled_roots(monkeypatch):
+    """The bundled roots augment rather than replace environment defaults."""
+    from vireo import places
+
+    class FakeContext:
+        loaded_cafiles = []
+
+        def load_verify_locations(self, *, cafile):
+            self.loaded_cafiles.append(cafile)
+
+    context = FakeContext()
+    monkeypatch.setattr(places.ssl, "create_default_context", lambda: context)
+    monkeypatch.setattr(places.certifi, "where", lambda: "/bundled/cacert.pem")
+
+    assert places._create_ssl_context() is context
+    assert context.loaded_cafiles == ["/bundled/cacert.pem"]
+
+
 def test_place_details_parses_response(monkeypatch):
     """Place Details OK response is normalized into the wrapper's dict shape."""
     from vireo import places

--- a/vireo/tests/test_places.py
+++ b/vireo/tests/test_places.py
@@ -45,6 +45,23 @@ def _make_fake_urlopen(payload: dict, captured_urls: list | None = None):
     return fake_urlopen
 
 
+def test_http_requests_use_bundled_ca_bundle(monkeypatch):
+    """Packaged builds must not rely on Python's build-time CA paths."""
+    from vireo import places
+
+    captured = {}
+
+    def fake_urlopen(url, *args, **kwargs):
+        captured.update(kwargs)
+        return _FakeResponse({"status": "ZERO_RESULTS"})
+
+    monkeypatch.setattr("vireo.places.urllib.request.urlopen", fake_urlopen)
+
+    assert places.place_details("missing", "FAKE_KEY") is None
+    assert captured["context"] is places._SSL_CONTEXT
+    assert places._SSL_CONTEXT.cert_store_stats()["x509_ca"] > 0
+
+
 def test_place_details_parses_response(monkeypatch):
     """Place Details OK response is normalized into the wrapper's dict shape."""
     from vireo import places
@@ -233,7 +250,7 @@ def test_reverse_geocode_raises_transient_on_network_failure(monkeypatch):
     transient — wrapper raises PlacesTransientError chained from the cause."""
     from vireo import places
 
-    def boom(url, timeout=10):
+    def boom(url, timeout=10, context=None):
         raise urllib.error.URLError("simulated network failure")
 
     monkeypatch.setattr("vireo.places.urllib.request.urlopen", boom)


### PR DESCRIPTION
## Summary

- Use Vireo’s bundled certificate authority (CA) store for Google Places and Geocoding HTTPS requests.
- Add regression coverage confirming packaged requests receive a populated SSL context.

The packaged macOS sidecar previously relied on Python build-time certificate paths, causing every GPS lookup to fail before reaching Google.

## Validation

- `python -m pytest vireo/tests/test_places.py -q`
- `python -m pytest vireo/tests/test_photos_api.py -q -k "reverse_geocode or batch_location_from_exif"`
- `python -m ruff check vireo/places.py vireo/tests/test_places.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTPS certificate validation for Places and Geocoding requests by using a bundled, up-to-date certificate authority bundle.
  * Increased reliability across environments where system certificate discovery may be unavailable or incomplete.

* **Tests**
  * Added coverage to verify secure requests use the bundled certificate authorities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->