### PR TITLE
Keep raw photo brightness consistent when opening images

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -25069,9 +25069,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # Unedited RAW primaries use their camera-rendered full-size preview
         # when available. Edited renders took the recipe branch above and keep
         # using the highlight-preserving RAW path.
-        source_for_extraction = image_path
-        if resolved_ext not in RAW_EXTENSIONS and companion_for_extraction:
-            source_for_extraction = companion_for_extraction
+        source_for_extraction = companion_for_extraction or image_path
 
         extraction_decode = (
             RAW_DECODE_CAMERA_RENDERED

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -25163,6 +25163,28 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                             "Companion re-extraction failed for photo %s; "
                             "keeping undersized RAW working copy", photo_id,
                         )
+            if primary_is_raw and trusted_wc_path:
+                expected_w, expected_h = _scaled_recipe_source_dimensions(photo)
+                display_is_near_full = (
+                    expected_w <= 0
+                    or expected_h <= 0
+                    or (
+                        uw >= expected_w * 0.99
+                        and uh >= expected_h * 0.99
+                    )
+                )
+                if not display_is_near_full:
+                    # RAW extraction can report success after falling back to
+                    # a preview-sized embedded JPEG. Do not persist that as
+                    # the 1:1 display cache when a trusted full-res copy is
+                    # already available, and mark the RAW retry so later
+                    # requests take the fast fallback path.
+                    with contextlib.suppress(OSError):
+                        os.unlink(wc_abs)
+                    _record_working_copy_failure(
+                        db, photo, source_for_extraction,
+                    )
+                    return send_file(trusted_wc_path, mimetype="image/jpeg")
             if not primary_is_raw:
                 updates = ["working_copy_path=?"]
                 params = [wc_rel]

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -25017,6 +25017,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 if source_is_older:
                     return send_file(display_cache_path, mimetype="image/jpeg")
 
+        if (
+            primary_is_raw
+            and trusted_wc_path
+            and not os.path.isfile(image_path)
+            and not companion_for_extraction
+        ):
+            # Preserve offline behavior without repeatedly retrying a missing
+            # RAW. A camera-rendered display cache or companion still wins
+            # above when available; otherwise the edit-quality working copy
+            # is the best usable full-resolution fallback.
+            return send_file(trusted_wc_path, mimetype="image/jpeg")
+
         has_current_raw_failure = (
             (not using_offline_cache or resolved_ext in RAW_EXTENSIONS)
             and _has_current_working_copy_failure(

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -24676,6 +24676,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
         recipe = db.get_photo_edit_recipe(photo_id)
+        from image_loader import RAW_EXTENSIONS
+
+        primary_is_raw = (
+            os.path.splitext(photo["filename"])[1].lower() in RAW_EXTENSIONS
+        )
 
         # Decide whether to trust the working copy as the full-res asset
         # by reading its actual on-disk dimensions, NOT the current
@@ -24788,9 +24793,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # purges previews and thumbnails but not working copies). Force
             # the RAW path so the recipe runs over preserve-highlights bytes,
             # not the older clipped-JPEG working copy.
-            primary_is_raw = (
-                os.path.splitext(photo["filename"])[1].lower() in RAW_EXTENSIONS
-            )
             image_path = None if primary_is_raw else trusted_wc_path
             using_offline_cache = False
             if image_path is None:
@@ -24960,7 +24962,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             img.close()
             return send_file(cache_path, mimetype="image/jpeg")
 
-        if trusted_wc_path:
+        # A RAW working copy is an edit-quality, highlight-preserving source.
+        # It deliberately looks flatter/darker than the camera-rendered JPEG
+        # used by thumbnails and previews, so it must not be used as the
+        # unedited lightbox rendition while the source is available.
+        if trusted_wc_path and not primary_is_raw:
             return send_file(trusted_wc_path, mimetype="image/jpeg")
 
         # Resolve original file path
@@ -24977,14 +24983,37 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             {photo["folder_id"]: folder["path"]},
         )
 
-        from image_loader import (
-            RAW_DECODE_PRESERVE_HIGHLIGHTS,
-            RAW_EXTENSIONS,
-        )
         resolved_ext = os.path.splitext(image_path)[1].lower()
         companion_for_extraction = _full_res_companion_path(
             folder["path"], using_offline_cache
         )
+
+        # Keep unedited RAW display bytes separate from the edit-quality
+        # working copy. The suffix is intentionally distinct from the legacy
+        # originals/<id>.jpg render cache so an upgrade cannot reuse a dark
+        # highlight-preserving render produced by an older version.
+        display_cache_path = None
+        if primary_is_raw:
+            display_cache_path = os.path.join(
+                vireo_dir, "originals", f"{photo_id}.display.jpg",
+            )
+            if os.path.exists(display_cache_path):
+                try:
+                    source_mtimes = [
+                        os.path.getmtime(path)
+                        for path in (image_path, companion_for_extraction)
+                        if path and os.path.exists(path)
+                    ]
+                    source_is_older = (
+                        not source_mtimes
+                        or os.path.getmtime(display_cache_path)
+                        >= max(source_mtimes)
+                    )
+                except OSError:
+                    source_is_older = False
+                if source_is_older:
+                    return send_file(display_cache_path, mimetype="image/jpeg")
+
         has_current_raw_failure = (
             (not using_offline_cache or resolved_ext in RAW_EXTENSIONS)
             and _has_current_working_copy_failure(
@@ -25006,6 +25035,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 image_path = companion_for_extraction
                 resolved_ext = os.path.splitext(image_path)[1].lower()
             else:
+                if primary_is_raw and trusted_wc_path:
+                    return send_file(trusted_wc_path, mimetype="image/jpeg")
                 log.info(
                     "Skipping original-image extraction for photo %s; RAW working-copy "
                     "extraction already failed for current source mtime",
@@ -25020,23 +25051,40 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         # Extract full-res working copy (on-demand upgrade)
         from image_loader import (
+            RAW_DECODE_CAMERA_RENDERED,
             RAW_DECODE_PRESERVE_HIGHLIGHTS,
             RAW_EXTENSIONS,
             extract_working_copy,
             load_image,
         )
-        wc_rel = f"working/{photo_id}.jpg"
-        wc_abs = os.path.join(vireo_dir, wc_rel)
+        if primary_is_raw:
+            wc_rel = None
+            wc_abs = display_cache_path
+            os.makedirs(os.path.dirname(wc_abs), exist_ok=True)
+        else:
+            wc_rel = f"working/{photo_id}.jpg"
+            wc_abs = os.path.join(vireo_dir, wc_rel)
         quality = cfg.load().get("working_copy_quality", 92)
 
-        # Prefer companion JPEG only for non-RAW sources. RAW primaries should
-        # be decoded through extract_working_copy's highlight-preserving RAW
-        # path rather than replaced with a camera-rendered JPEG.
+        # Unedited RAW primaries use their camera-rendered full-size preview
+        # when available. Edited renders took the recipe branch above and keep
+        # using the highlight-preserving RAW path.
         source_for_extraction = image_path
         if resolved_ext not in RAW_EXTENSIONS and companion_for_extraction:
             source_for_extraction = companion_for_extraction
 
-        if extract_working_copy(source_for_extraction, wc_abs, max_size=0, quality=quality):
+        extraction_decode = (
+            RAW_DECODE_CAMERA_RENDERED
+            if primary_is_raw
+            else RAW_DECODE_PRESERVE_HIGHLIGHTS
+        )
+        if extract_working_copy(
+            source_for_extraction,
+            wc_abs,
+            max_size=0,
+            quality=quality,
+            raw_decode=extraction_decode,
+        ):
             # Update DB so future requests are fast; also backfill
             # dimensions if missing so the full-res shortcut works next time
             from PIL import Image as _PILImage
@@ -25074,6 +25122,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     if extract_working_copy(
                         companion_for_extraction, wc_abs,
                         max_size=0, quality=quality,
+                        raw_decode=extraction_decode,
                     ):
                         with _PILImage.open(wc_abs) as upgraded:
                             uw, uh = upgraded.size
@@ -25082,17 +25131,18 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                             "Companion re-extraction failed for photo %s; "
                             "keeping undersized RAW working copy", photo_id,
                         )
-            updates = ["working_copy_path=?"]
-            params = [wc_rel]
-            if not photo["width"] or not photo["height"]:
-                updates.extend(["width=?", "height=?"])
-                params.extend([uw, uh])
-            params.append(photo_id)
-            db.conn.execute(
-                f"UPDATE photos SET {', '.join(updates)} WHERE id=?",
-                params,
-            )
-            db.conn.commit()
+            if not primary_is_raw:
+                updates = ["working_copy_path=?"]
+                params = [wc_rel]
+                if not photo["width"] or not photo["height"]:
+                    updates.extend(["width=?", "height=?"])
+                    params.extend([uw, uh])
+                params.append(photo_id)
+                db.conn.execute(
+                    f"UPDATE photos SET {', '.join(updates)} WHERE id=?",
+                    params,
+                )
+                db.conn.commit()
             return send_file(wc_abs, mimetype="image/jpeg")
 
         # extract_working_copy failed on a RAW source: try the full-res
@@ -25105,23 +25155,28 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             and companion_for_extraction
             and companion_for_extraction != source_for_extraction
             and extract_working_copy(
-                companion_for_extraction, wc_abs, max_size=0, quality=quality,
+                companion_for_extraction,
+                wc_abs,
+                max_size=0,
+                quality=quality,
+                raw_decode=extraction_decode,
             )
         ):
             from PIL import Image as _PILImage
             with _PILImage.open(wc_abs) as upgraded:
                 uw, uh = upgraded.size
-            updates = ["working_copy_path=?"]
-            params = [wc_rel]
-            if not photo["width"] or not photo["height"]:
-                updates.extend(["width=?", "height=?"])
-                params.extend([uw, uh])
-            params.append(photo_id)
-            db.conn.execute(
-                f"UPDATE photos SET {', '.join(updates)} WHERE id=?",
-                params,
-            )
-            db.conn.commit()
+            if not primary_is_raw:
+                updates = ["working_copy_path=?"]
+                params = [wc_rel]
+                if not photo["width"] or not photo["height"]:
+                    updates.extend(["width=?", "height=?"])
+                    params.extend([uw, uh])
+                params.append(photo_id)
+                db.conn.execute(
+                    f"UPDATE photos SET {', '.join(updates)} WHERE id=?",
+                    params,
+                )
+                db.conn.commit()
             log.info(
                 "RAW extraction failed for photo %s original; served "
                 "companion JPEG instead", photo_id,
@@ -25130,7 +25185,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         # Fallback: serve via load_image
         raw_decode = (
-            RAW_DECODE_PRESERVE_HIGHLIGHTS
+            RAW_DECODE_CAMERA_RENDERED
             if resolved_ext in RAW_EXTENSIONS
             else None
         )
@@ -25181,12 +25236,22 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if img is not None:
                 image_path = companion_for_extraction
         if img is None:
+            if primary_is_raw and trusted_wc_path:
+                # Source/offline bytes are unavailable. A working copy is less
+                # faithful to the camera rendition, but remains the best usable
+                # full-resolution fallback and preserves offline behavior.
+                return send_file(trusted_wc_path, mimetype="image/jpeg")
             _record_working_copy_failure(db, photo, image_path)
             return "Could not load image", 500
-        originals_dir = os.path.join(vireo_dir, "originals")
-        cache_path = os.path.join(originals_dir, f"{photo_id}.jpg")
-        os.makedirs(originals_dir, exist_ok=True)
+        if primary_is_raw:
+            cache_path = display_cache_path
+            os.makedirs(os.path.dirname(cache_path), exist_ok=True)
+        else:
+            originals_dir = os.path.join(vireo_dir, "originals")
+            cache_path = os.path.join(originals_dir, f"{photo_id}.jpg")
+            os.makedirs(originals_dir, exist_ok=True)
         img.save(cache_path, format="JPEG", quality=quality)
+        img.close()
         return send_file(cache_path, mimetype="image/jpeg")
 
     app.register_blueprint(create_photo_labels_blueprint(_get_db, json_error))

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -25076,13 +25076,36 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if primary_is_raw
             else RAW_DECODE_PRESERVE_HIGHLIGHTS
         )
-        if extract_working_copy(
-            source_for_extraction,
-            wc_abs,
-            max_size=0,
-            quality=quality,
-            raw_decode=extraction_decode,
-        ):
+
+        def _extract_original_copy(source_path):
+            output_path = wc_abs
+            tmp_path = None
+            if primary_is_raw:
+                fd, tmp_path = tempfile.mkstemp(
+                    prefix=f".{photo_id}.display.",
+                    suffix=".jpg.tmp",
+                    dir=os.path.dirname(wc_abs),
+                )
+                os.close(fd)
+                output_path = tmp_path
+            try:
+                extracted = extract_working_copy(
+                    source_path,
+                    output_path,
+                    max_size=0,
+                    quality=quality,
+                    raw_decode=extraction_decode,
+                )
+                if extracted and tmp_path:
+                    os.replace(tmp_path, wc_abs)
+                    tmp_path = None
+                return extracted
+            finally:
+                if tmp_path:
+                    with contextlib.suppress(OSError):
+                        os.unlink(tmp_path)
+
+        if _extract_original_copy(source_for_extraction):
             # Update DB so future requests are fast; also backfill
             # dimensions if missing so the full-res shortcut works next time
             from PIL import Image as _PILImage
@@ -25117,11 +25140,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         "from companion JPEG",
                         photo_id, uw, uh, expected_w, expected_h,
                     )
-                    if extract_working_copy(
-                        companion_for_extraction, wc_abs,
-                        max_size=0, quality=quality,
-                        raw_decode=extraction_decode,
-                    ):
+                    if _extract_original_copy(companion_for_extraction):
                         with _PILImage.open(wc_abs) as upgraded:
                             uw, uh = upgraded.size
                     else:
@@ -25152,13 +25171,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             resolved_ext in RAW_EXTENSIONS
             and companion_for_extraction
             and companion_for_extraction != source_for_extraction
-            and extract_working_copy(
-                companion_for_extraction,
-                wc_abs,
-                max_size=0,
-                quality=quality,
-                raw_decode=extraction_decode,
-            )
+            and _extract_original_copy(companion_for_extraction)
         ):
             from PIL import Image as _PILImage
             with _PILImage.open(wc_abs) as upgraded:
@@ -25234,21 +25247,34 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if img is not None:
                 image_path = companion_for_extraction
         if img is None:
+            _record_working_copy_failure(db, photo, image_path)
             if primary_is_raw and trusted_wc_path:
                 # Source/offline bytes are unavailable. A working copy is less
                 # faithful to the camera rendition, but remains the best usable
                 # full-resolution fallback and preserves offline behavior.
                 return send_file(trusted_wc_path, mimetype="image/jpeg")
-            _record_working_copy_failure(db, photo, image_path)
             return "Could not load image", 500
         if primary_is_raw:
             cache_path = display_cache_path
             os.makedirs(os.path.dirname(cache_path), exist_ok=True)
+            fd, tmp_path = tempfile.mkstemp(
+                prefix=f".{photo_id}.display.",
+                suffix=".jpg.tmp",
+                dir=os.path.dirname(cache_path),
+            )
+            os.close(fd)
+            try:
+                img.save(tmp_path, format="JPEG", quality=quality)
+                os.replace(tmp_path, cache_path)
+            except Exception:
+                with contextlib.suppress(OSError):
+                    os.unlink(tmp_path)
+                raise
         else:
             originals_dir = os.path.join(vireo_dir, "originals")
             cache_path = os.path.join(originals_dir, f"{photo_id}.jpg")
             os.makedirs(originals_dir, exist_ok=True)
-        img.save(cache_path, format="JPEG", quality=quality)
+            img.save(cache_path, format="JPEG", quality=quality)
         img.close()
         return send_file(cache_path, mimetype="image/jpeg")
 

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -24772,7 +24772,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     c_w, c_h = _cimg.size
             except Exception:
                 return None
-            if c_w >= orig_w and c_h >= orig_h:
+            # Camera JPEGs commonly omit a narrow sensor border. Match the
+            # tolerance used by camera-rendered RAW loading so a near-full
+            # sidecar remains the preferred tone-consistent display source.
+            if c_w >= orig_w * 0.99 and c_h >= orig_h * 0.99:
                 return companion_abs
             return None
 

--- a/vireo/image_loader.py
+++ b/vireo/image_loader.py
@@ -34,8 +34,13 @@ RAW_EXTENSIONS = {".nef", ".cr2", ".cr3", ".arw", ".raf", ".dng", ".rw2", ".orf"
 IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".tiff", ".tif", ".bmp", ".webp"}
 SUPPORTED_EXTENSIONS = IMAGE_EXTENSIONS | RAW_EXTENSIONS
 RAW_DECODE_JPEG_FIRST = "jpeg_first"
+RAW_DECODE_CAMERA_RENDERED = "camera_rendered"
 RAW_DECODE_PRESERVE_HIGHLIGHTS = "preserve_highlights"
-_RAW_DECODE_MODES = {RAW_DECODE_JPEG_FIRST, RAW_DECODE_PRESERVE_HIGHLIGHTS}
+_RAW_DECODE_MODES = {
+    RAW_DECODE_JPEG_FIRST,
+    RAW_DECODE_CAMERA_RENDERED,
+    RAW_DECODE_PRESERVE_HIGHLIGHTS,
+}
 
 # macOS "package" directories that hold OTHER apps' managed data. Walking
 # into them triggers Sequoia's "<app> would like to access data from other
@@ -371,8 +376,8 @@ def load_image(file_path, max_size=1024, raw_decode=RAW_DECODE_JPEG_FIRST):
     Args:
         file_path: Path to the image file
         max_size: Maximum dimension (longest side). None or 0 for full resolution.
-        raw_decode: RAW_DECODE_JPEG_FIRST (default) or
-            RAW_DECODE_PRESERVE_HIGHLIGHTS.
+        raw_decode: RAW_DECODE_JPEG_FIRST (default),
+            RAW_DECODE_CAMERA_RENDERED, or RAW_DECODE_PRESERVE_HIGHLIGHTS.
 
     Returns:
         PIL.Image.Image or None
@@ -516,7 +521,13 @@ def load_working_image(photo, vireo_dir, max_size=1024, folders=None):
     return load_image(source_path, max_size)
 
 
-def extract_working_copy(source_path, output_path, max_size=4096, quality=92):
+def extract_working_copy(
+    source_path,
+    output_path,
+    max_size=4096,
+    quality=92,
+    raw_decode=RAW_DECODE_PRESERVE_HIGHLIGHTS,
+):
     """Extract a JPEG working copy from an image file.
 
     Args:
@@ -524,6 +535,9 @@ def extract_working_copy(source_path, output_path, max_size=4096, quality=92):
         output_path: where to save the working copy JPEG
         max_size: max dimension (longest side). 0 or None for full resolution.
         quality: JPEG quality (1-95)
+        raw_decode: RAW decode strategy. Working copies default to the
+            highlight-preserving edit source; display renditions can request
+            RAW_DECODE_CAMERA_RENDERED without changing that edit source.
 
     Returns:
         True on success, False on failure
@@ -532,7 +546,7 @@ def extract_working_copy(source_path, output_path, max_size=4096, quality=92):
         img = load_image(
             source_path,
             max_size=max_size or None,
-            raw_decode=RAW_DECODE_PRESERVE_HIGHLIGHTS,
+            raw_decode=raw_decode,
         )
         if img is None:
             return False
@@ -554,6 +568,10 @@ def _load_raw(path, max_size, raw_decode=RAW_DECODE_JPEG_FIRST):
       3. If postprocess raises (e.g. libraw 0.22 can't decode Nikon HE*/TicoRAW),
          fall back to the embedded JPEG even if smaller than max_size.
 
+    Camera-rendered:
+      1. Use a near-full embedded JPEG for full-resolution display requests.
+      2. Otherwise follow the JPEG-first demosaic/fallback behavior.
+
     Preserve-highlights:
       1. Demosaic the RAW with auto-bright disabled and highlight blending on.
       2. Fall back to the embedded JPEG only if libraw cannot decode the RAW.
@@ -563,14 +581,38 @@ def _load_raw(path, max_size, raw_decode=RAW_DECODE_JPEG_FIRST):
     with rawpy.imread(str(path)) as raw:
         embedded = _extract_embedded_jpeg(raw)
 
-        # JPEG-first: if the embedded preview is large enough for the request,
-        # use it and skip the slower RAW decode entirely.
-        if (
-            raw_decode == RAW_DECODE_JPEG_FIRST
-            and embedded is not None
+        # JPEG-first browsing uses the embedded preview when it covers the
+        # requested size. Full-resolution camera-rendered browsing also accepts
+        # a preview whose two axes are within 1% of the active sensor area; many
+        # cameras omit a narrow border (for example 8256x5504 vs 8288x5520).
+        # That JPEG is the rendition used by thumbnails and fit-to-window views,
+        # so retaining it at 1:1 prevents a visible tone jump.
+        sensor_dims = sorted((raw.sizes.width, raw.sizes.height), reverse=True)
+        embedded_dims = sorted(embedded.size, reverse=True) if embedded else None
+        embedded_is_near_full = bool(
+            embedded_dims
+            and sensor_dims[0]
+            and sensor_dims[1]
+            and embedded_dims[0] >= sensor_dims[0] * 0.99
+            and embedded_dims[1] >= sensor_dims[1] * 0.99
+        )
+        embedded_covers_request = bool(
+            embedded is not None
             and max_size
             and max_size > 0
             and max(embedded.size) >= max_size
+        )
+        if (
+            raw_decode in (RAW_DECODE_JPEG_FIRST, RAW_DECODE_CAMERA_RENDERED)
+            and embedded is not None
+            and (
+                embedded_covers_request
+                or (
+                    raw_decode == RAW_DECODE_CAMERA_RENDERED
+                    and not max_size
+                    and embedded_is_near_full
+                )
+            )
         ):
             return embedded
 

--- a/vireo/preview_cache.py
+++ b/vireo/preview_cache.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 def cleanup_cached_files_for_deleted_photos(
     thumb_cache_dir, files, progress_callback=None,
 ):
-    """Remove thumbnail, preview, and working-copy files for deleted photos.
+    """Remove thumbnail, preview, working-copy, and display files for deleted photos.
 
     ``files`` is the list returned by ``db.delete_photos`` /
     ``db.delete_folder``. The FK cascade drops preview_cache rows when
@@ -35,6 +35,7 @@ def cleanup_cached_files_for_deleted_photos(
     vireo_dir = os.path.dirname(thumb_cache_dir)
     preview_dir = os.path.join(vireo_dir, "previews")
     working_dir = os.path.join(vireo_dir, "working")
+    originals_dir = os.path.join(vireo_dir, "originals")
     # Offline-cache layout: offline/{originals,xmp,companions}/{pid}{ext}.
     # The FK cascade drops the offline_originals row when the photo is
     # deleted, so we lose the exact stored paths — glob by photo id to
@@ -59,6 +60,17 @@ def cleanup_cached_files_for_deleted_photos(
                     log.warning(
                         "Failed to remove cached file %s after photo "
                         "delete — will be reclaimed by Clear Cache: %s",
+                        cached, e,
+                    )
+        for name in (f"{pid}.jpg", f"{pid}.display.jpg"):
+            cached = os.path.join(originals_dir, name)
+            if os.path.isfile(cached):
+                try:
+                    os.remove(cached)
+                except OSError as e:
+                    log.warning(
+                        "Failed to remove cached original rendition %s after "
+                        "photo delete — will be reclaimed by Clear Cache: %s",
                         cached, e,
                     )
         for variant in _glob.glob(os.path.join(preview_dir, f"{pid}_*.jpg")):

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -551,12 +551,13 @@ def _pair_raw_jpeg_companions(db, vireo_dir=None, thumb_cache_dir=None):
 
 
 def _invalidate_derived_caches(db, vireo_dir, photo_id, thumb_cache_dir=None):
-    """Delete cached thumbnail / working copy / tracked preview for a photo.
+    """Delete cached thumbnail / working copy / display / preview for a photo.
 
     Called when the scanner detects that an existing photo's source content
-    has changed (different file_hash). Thumbnails, working copies, and
-    preview-pyramid sizes are all derived from the source bytes, so they're
-    stale as soon as the source changes.
+    has changed (different file_hash). Thumbnails, working copies, unedited
+    full-resolution display renditions, and preview-pyramid sizes are all
+    derived from the source bytes, so they're stale as soon as the source
+    changes.
 
     Scope is intentionally O(1) per photo — untracked preview files
     (no preview_cache row) are handled by
@@ -624,6 +625,19 @@ def _invalidate_derived_caches(db, vireo_dir, photo_id, thumb_cache_dir=None):
         " WHERE id = ?",
         (photo_id,),
     )
+
+    display_file = os.path.join(
+        vireo_dir, "originals", f"{photo_id}.display.jpg",
+    )
+    if os.path.exists(display_file):
+        try:
+            os.remove(display_file)
+        except OSError:
+            log.debug(
+                "Could not delete stale RAW display rendition %s",
+                display_file,
+                exc_info=True,
+            )
 
     # Preview pyramid + its LRU accounting. Only drop a preview_cache row
     # for sizes whose file was successfully removed (or was already

--- a/vireo/scanner.py
+++ b/vireo/scanner.py
@@ -365,6 +365,11 @@ def _pair_raw_jpeg_companions(db, vireo_dir=None, thumb_cache_dir=None):
             "UPDATE photos SET companion_path = ? WHERE id = ?",
             (companion["filename"], primary["id"]),
         )
+        if vireo_dir:
+            # An unedited RAW display cache may have been rendered before the
+            # camera JPEG was paired. File mtimes cannot tell which source
+            # produced that cache, so discard it when the companion changes.
+            _invalidate_raw_display_cache(vireo_dir, primary["id"])
 
         # Transfer detections (and their cascaded predictions) from companion to primary.
         # Detection IDs are content-addressed on (photo_id, detector_model, box,
@@ -550,6 +555,21 @@ def _pair_raw_jpeg_companions(db, vireo_dir=None, thumb_cache_dir=None):
     commit_with_retry(db.conn)
 
 
+def _invalidate_raw_display_cache(vireo_dir, photo_id):
+    display_file = os.path.join(
+        vireo_dir, "originals", f"{photo_id}.display.jpg",
+    )
+    if os.path.exists(display_file):
+        try:
+            os.remove(display_file)
+        except OSError:
+            log.debug(
+                "Could not delete stale RAW display rendition %s",
+                display_file,
+                exc_info=True,
+            )
+
+
 def _invalidate_derived_caches(db, vireo_dir, photo_id, thumb_cache_dir=None):
     """Delete cached thumbnail / working copy / display / preview for a photo.
 
@@ -626,18 +646,7 @@ def _invalidate_derived_caches(db, vireo_dir, photo_id, thumb_cache_dir=None):
         (photo_id,),
     )
 
-    display_file = os.path.join(
-        vireo_dir, "originals", f"{photo_id}.display.jpg",
-    )
-    if os.path.exists(display_file):
-        try:
-            os.remove(display_file)
-        except OSError:
-            log.debug(
-                "Could not delete stale RAW display rendition %s",
-                display_file,
-                exc_info=True,
-            )
+    _invalidate_raw_display_cache(vireo_dir, photo_id)
 
     # Preview pyramid + its LRU accounting. Only drop a preview_cache row
     # for sizes whose file was successfully removed (or was already

--- a/vireo/tests/test_image_loader.py
+++ b/vireo/tests/test_image_loader.py
@@ -143,6 +143,54 @@ def test_raw_uses_embedded_jpeg_when_large_enough(tmp_path, monkeypatch):
     assert fake.postprocess_calls == 0, "postprocess should be skipped"
 
 
+def test_raw_camera_rendered_mode_uses_near_full_embedded_jpeg(
+    tmp_path, monkeypatch,
+):
+    """Full-size lightbox display keeps the camera rendition used by previews."""
+    from image_loader import RAW_DECODE_CAMERA_RENDERED, load_image
+
+    nef = tmp_path / "test.nef"
+    nef.write_bytes(b"fake NEF content")
+
+    fake = _install_fake_raw(monkeypatch, _FakeRaw(
+        embedded_jpeg=_jpeg_bytes((8256, 5504), color="green"),
+        sensor_size=(8288, 5520),
+        postprocess_size=(8288, 5520),
+    ))
+
+    result = load_image(
+        str(nef), max_size=None, raw_decode=RAW_DECODE_CAMERA_RENDERED,
+    )
+
+    assert result is not None
+    assert result.size == (8256, 5504)
+    assert fake.postprocess_calls == 0
+
+
+def test_raw_camera_rendered_mode_rejects_cropped_embedded_jpeg(
+    tmp_path, monkeypatch,
+):
+    """A matching long edge cannot hide a substantially cropped short edge."""
+    from image_loader import RAW_DECODE_CAMERA_RENDERED, load_image
+
+    nef = tmp_path / "test.nef"
+    nef.write_bytes(b"fake NEF content")
+
+    fake = _install_fake_raw(monkeypatch, _FakeRaw(
+        embedded_jpeg=_jpeg_bytes((6000, 3376)),
+        sensor_size=(6000, 4000),
+        postprocess_size=(6000, 4000),
+    ))
+
+    result = load_image(
+        str(nef), max_size=None, raw_decode=RAW_DECODE_CAMERA_RENDERED,
+    )
+
+    assert result is not None
+    assert result.size == (6000, 4000)
+    assert fake.postprocess_calls == 1
+
+
 def test_raw_preserve_highlights_mode_bypasses_embedded_jpeg(tmp_path, monkeypatch):
     """Edit-quality RAW loads demosaic instead of using camera-rendered JPEGs."""
     import rawpy

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1306,6 +1306,70 @@ def test_original_serves_full_res_working_copy(app_and_db):
     assert resp.status_code == 200
 
 
+def test_unedited_raw_original_uses_camera_display_cache_not_working_copy(
+    app_and_db, monkeypatch, tmp_path,
+):
+    """Opening an unedited RAW must not swap to the dark edit working copy."""
+    import io
+
+    import image_loader
+    from image_loader import RAW_DECODE_CAMERA_RENDERED
+    from PIL import Image
+
+    app, db = app_and_db
+    client = app.test_client()
+    photo = db.get_photos()[0]
+    photo_id = photo["id"]
+
+    source_dir = tmp_path / "raw-source"
+    source_dir.mkdir()
+    source_path = source_dir / "source.NEF"
+    source_path.write_bytes(b"fake raw")
+    db.conn.execute(
+        "UPDATE folders SET path=? WHERE id=?",
+        (str(source_dir), photo["folder_id"]),
+    )
+
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    working_dir = os.path.join(vireo_dir, "working")
+    os.makedirs(working_dir, exist_ok=True)
+    working_path = os.path.join(working_dir, f"{photo_id}.jpg")
+    Image.new("RGB", (800, 600), (30, 30, 30)).save(working_path, "JPEG")
+    working_bytes = open(working_path, "rb").read()
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='source.NEF', extension='.nef', width=800, height=600,
+               working_copy_path=?
+           WHERE id=?""",
+        (f"working/{photo_id}.jpg", photo_id),
+    )
+    db.conn.commit()
+
+    calls = []
+
+    def camera_extract(source, output, **kwargs):
+        calls.append((os.fspath(source), os.fspath(output), kwargs))
+        Image.new("RGB", (800, 600), (220, 220, 220)).save(output, "JPEG")
+        return True
+
+    monkeypatch.setattr(image_loader, "extract_working_copy", camera_extract)
+
+    first = client.get(f"/photos/{photo_id}/original")
+    second = client.get(f"/photos/{photo_id}/original")
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert len(calls) == 1, "second request should reuse the display cache"
+    called_source, called_output, called_kwargs = calls[0]
+    assert called_source == str(source_path)
+    assert called_output.endswith(f"{photo_id}.display.jpg")
+    assert called_kwargs["raw_decode"] == RAW_DECODE_CAMERA_RENDERED
+    with Image.open(io.BytesIO(first.data)) as rendered:
+        assert rendered.getpixel((0, 0))[0] > 200
+    assert open(working_path, "rb").read() == working_bytes
+    assert db.get_photo(photo_id)["working_copy_path"] == f"working/{photo_id}.jpg"
+
+
 def test_original_trusts_raw_working_copy_even_when_smaller_than_stored_dims(app_and_db):
     """Original endpoint trusts RAW working copy when sensor dims slightly exceed wc.
 

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -4517,13 +4517,14 @@ def test_original_falls_back_to_companion_when_raw_extraction_fails(
     assert resp.mimetype == "image/jpeg"
 
 
-def test_unedited_raw_original_prefers_full_size_companion(
+def test_unedited_raw_original_prefers_near_full_companion(
     client_with_photo, monkeypatch,
 ):
-    """A full-size companion is already the camera-rendered display source.
+    """A near-full companion is already the camera-rendered display source.
 
     Prefer it before decoding the RAW so cameras whose embedded preview is
-    undersized do not fall through to a differently toned libraw demosaic.
+    just shy of sensor dimensions do not fall through to a differently toned
+    libraw demosaic.
     """
     import io
     import os
@@ -4542,7 +4543,7 @@ def test_unedited_raw_original_prefers_full_size_companion(
     with open(raw_path, "wb") as f:
         f.write(b"unsupported raw")
     companion_path = os.path.join(folder_path, "source.JPG")
-    Image.new("RGB", (6000, 4000), (90, 140, 180)).save(
+    Image.new("RGB", (5976, 3984), (90, 140, 180)).save(
         companion_path, "JPEG", quality=85,
     )
 
@@ -4577,7 +4578,7 @@ def test_unedited_raw_original_prefers_full_size_companion(
     assert resp.status_code == 200, resp.get_data(as_text=True)
     assert resp.mimetype == "image/jpeg"
     assert extract_calls == [companion_path]
-    # The persisted display cache must be the full-size companion render.
+    # The persisted display cache must be the near-full companion render.
     with Image.open(io.BytesIO(resp.data)) as img:
         assert max(img.size) >= 5400
 

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -4447,16 +4447,13 @@ def test_original_falls_back_to_companion_when_raw_extraction_fails(
     assert resp.mimetype == "image/jpeg"
 
 
-def test_original_uses_companion_when_raw_extract_returns_undersized(
+def test_unedited_raw_original_prefers_full_size_companion(
     client_with_photo, monkeypatch,
 ):
-    """``extract_working_copy`` returns True even when ``_load_raw`` falls
-    back to a small embedded JPEG, so a successful extract can still
-    produce a working copy that's a fraction of the sensor's full
-    resolution. /photos/<id>/original must detect that fallback and
-    re-extract from the companion JPEG before caching it as the
-    working copy — otherwise every later 1:1 request silently serves
-    the downscaled preview even though a full-size sidecar exists.
+    """A full-size companion is already the camera-rendered display source.
+
+    Prefer it before decoding the RAW so cameras whose embedded preview is
+    undersized do not fall through to a differently toned libraw demosaic.
     """
     import io
     import os
@@ -4496,32 +4493,21 @@ def test_original_uses_companion_when_raw_extract_returns_undersized(
     real_extract = image_loader.extract_working_copy
     extract_calls = []
 
-    def extract_with_size_fallback(source, output, *args, **kwargs):
+    def track_companion_extract(source, output, *args, **kwargs):
         extract_calls.append(str(source))
         if str(source).lower().endswith(".nef"):
-            # Stand in for `_load_raw` returning the embedded JPEG when
-            # libraw can't demosaic the RAW: write an undersized JPEG
-            # and return True (matches the current contract).
-            os.makedirs(os.path.dirname(output), exist_ok=True)
-            Image.new("RGB", (1600, 1067), (200, 50, 50)).save(
-                output, "JPEG", quality=85,
-            )
-            return True
+            raise AssertionError("unedited display should prefer companion JPEG")
         return real_extract(source, output, *args, **kwargs)
 
-    monkeypatch.setattr(image_loader, "extract_working_copy", extract_with_size_fallback)
+    monkeypatch.setattr(image_loader, "extract_working_copy", track_companion_extract)
 
     client = app.test_client()
     resp = client.get(f"/photos/{photo_id}/original")
 
     assert resp.status_code == 200, resp.get_data(as_text=True)
     assert resp.mimetype == "image/jpeg"
-    # Both sources must be tried — RAW first, then companion after the
-    # undersized output is detected.
-    assert len(extract_calls) == 2
-    assert extract_calls[0].lower().endswith(".nef")
-    assert extract_calls[1].lower().endswith(".jpg")
-    # The persisted working copy must be the full-size companion render.
+    assert extract_calls == [companion_path]
+    # The persisted display cache must be the full-size companion render.
     with Image.open(io.BytesIO(resp.data)) as img:
         assert max(img.size) >= 5400
 

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1346,13 +1346,21 @@ def test_unedited_raw_original_uses_camera_display_cache_not_working_copy(
     db.conn.commit()
 
     calls = []
+    replacements = []
+    import app as app_module
+    real_replace = app_module.os.replace
 
     def camera_extract(source, output, **kwargs):
         calls.append((os.fspath(source), os.fspath(output), kwargs))
         Image.new("RGB", (800, 600), (220, 220, 220)).save(output, "JPEG")
         return True
 
+    def tracking_replace(source, destination):
+        replacements.append((os.fspath(source), os.fspath(destination)))
+        return real_replace(source, destination)
+
     monkeypatch.setattr(image_loader, "extract_working_copy", camera_extract)
+    monkeypatch.setattr(app_module.os, "replace", tracking_replace)
 
     first = client.get(f"/photos/{photo_id}/original")
     second = client.get(f"/photos/{photo_id}/original")
@@ -1362,8 +1370,13 @@ def test_unedited_raw_original_uses_camera_display_cache_not_working_copy(
     assert len(calls) == 1, "second request should reuse the display cache"
     called_source, called_output, called_kwargs = calls[0]
     assert called_source == str(source_path)
-    assert called_output.endswith(f"{photo_id}.display.jpg")
+    assert called_output.endswith(".jpg.tmp")
     assert called_kwargs["raw_decode"] == RAW_DECODE_CAMERA_RENDERED
+    display_path = os.path.join(
+        vireo_dir, "originals", f"{photo_id}.display.jpg",
+    )
+    assert replacements == [(called_output, display_path)]
+    assert not os.path.exists(called_output)
     with Image.open(io.BytesIO(first.data)) as rendered:
         assert rendered.getpixel((0, 0))[0] > 200
     assert open(working_path, "rb").read() == working_bytes
@@ -4389,6 +4402,63 @@ def test_original_refreshes_failure_marker_when_stale_retry_fails(
     assert row["age_seconds"] is not None and row["age_seconds"] < 60
 
 
+def test_original_records_raw_failure_before_working_copy_fallback(
+    client_with_photo, monkeypatch,
+):
+    """A usable fallback must not leave repeated RAW retries unthrottled."""
+    import os
+
+    import image_loader
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    folder_path = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id "
+        "WHERE p.id=?",
+        (photo_id,),
+    ).fetchone()["path"]
+    raw_path = os.path.join(folder_path, "failed.NEF")
+    with open(raw_path, "wb") as raw_file:
+        raw_file.write(b"unsupported raw")
+
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    working_dir = os.path.join(vireo_dir, "working")
+    os.makedirs(working_dir, exist_ok=True)
+    working_path = os.path.join(working_dir, f"{photo_id}.jpg")
+    Image.new("RGB", (800, 600), (40, 80, 120)).save(working_path, "JPEG")
+    working_rel = f"working/{photo_id}.jpg"
+    file_mtime = os.path.getmtime(raw_path)
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='failed.NEF', extension='.nef',
+               width=800, height=600, file_mtime=?,
+               working_copy_path=?, working_copy_failed_at=NULL,
+               working_copy_failed_mtime=NULL,
+               working_copy_failed_source=NULL
+           WHERE id=?""",
+        (file_mtime, working_rel, photo_id),
+    )
+    db.conn.commit()
+
+    monkeypatch.setattr(image_loader, "extract_working_copy", lambda *a, **k: False)
+    monkeypatch.setattr(image_loader, "load_image", lambda *a, **k: None)
+
+    response = app.test_client().get(f"/photos/{photo_id}/original")
+
+    assert response.status_code == 200
+    with open(working_path, "rb") as working_file:
+        assert response.data == working_file.read()
+    row = db.conn.execute(
+        """SELECT working_copy_failed_at, working_copy_failed_mtime,
+                  working_copy_failed_source
+           FROM photos WHERE id=?""",
+        (photo_id,),
+    ).fetchone()
+    assert row["working_copy_failed_at"] is not None
+    assert row["working_copy_failed_mtime"] == file_mtime
+    assert row["working_copy_failed_source"] == "source"
+
+
 def test_original_falls_back_to_companion_when_raw_extraction_fails(
     client_with_photo, monkeypatch,
 ):
@@ -4558,7 +4628,7 @@ def test_edited_original_uses_companion_when_raw_returns_undersized(
     db.conn.commit()
     # An edit recipe routes the request through the highlight-preserving
     # decode path that the new size-validation guards.
-    db.set_photo_edit_recipe(photo_id, {"rotation": 0})
+    db.set_photo_edit_recipe(photo_id, {"rotation": 90})
 
     load_calls = []
 

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1383,7 +1383,9 @@ def test_unedited_raw_original_uses_camera_display_cache_not_working_copy(
     assert db.get_photo(photo_id)["working_copy_path"] == f"working/{photo_id}.jpg"
 
 
-def test_original_trusts_raw_working_copy_even_when_smaller_than_stored_dims(app_and_db):
+def test_original_trusts_raw_working_copy_even_when_smaller_than_stored_dims(
+    app_and_db, monkeypatch,
+):
     """Original endpoint trusts RAW working copy when sensor dims slightly exceed wc.
 
     Stored RAW sensor dimensions can legitimately exceed embedded-JPEG-derived
@@ -1394,6 +1396,7 @@ def test_original_trusts_raw_working_copy_even_when_smaller_than_stored_dims(app
     just slower — and burst-review zoom would loop on every request.
     """
     import config as cfg
+    import image_loader
 
     app, db = app_and_db
     client = app.test_client()
@@ -1426,6 +1429,12 @@ def test_original_trusts_raw_working_copy_even_when_smaller_than_stored_dims(app
         (f"working/{pid}.jpg", pid),
     )
     db.conn.commit()
+
+    def fail_missing_raw_retry(*args, **kwargs):
+        raise AssertionError("missing RAW source should use the trusted working copy")
+
+    monkeypatch.setattr(image_loader, "extract_working_copy", fail_missing_raw_retry)
+    monkeypatch.setattr(image_loader, "load_image", fail_missing_raw_retry)
 
     resp = client.get(f"/photos/{pid}/original")
     assert resp.status_code == 200

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -4468,6 +4468,79 @@ def test_original_records_raw_failure_before_working_copy_fallback(
     assert row["working_copy_failed_source"] == "source"
 
 
+def test_original_uses_trusted_copy_when_raw_display_is_undersized(
+    client_with_photo, monkeypatch,
+):
+    """A preview-sized embedded JPEG must not become the 1:1 display cache."""
+    import os
+
+    import image_loader
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    folder_path = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id "
+        "WHERE p.id=?",
+        (photo_id,),
+    ).fetchone()["path"]
+    raw_path = os.path.join(folder_path, "embedded.NEF")
+    with open(raw_path, "wb") as raw_file:
+        raw_file.write(b"unsupported raw")
+
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    working_dir = os.path.join(vireo_dir, "working")
+    os.makedirs(working_dir, exist_ok=True)
+    working_rel = f"working/{photo_id}.jpg"
+    working_path = os.path.join(vireo_dir, working_rel)
+    Image.new("RGB", (800, 600), (40, 80, 120)).save(working_path, "JPEG")
+    file_mtime = os.path.getmtime(raw_path)
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='embedded.NEF', extension='.nef',
+               width=800, height=600, file_mtime=?,
+               companion_path=NULL, working_copy_path=?,
+               working_copy_failed_at=NULL,
+               working_copy_failed_mtime=NULL,
+               working_copy_failed_source=NULL
+           WHERE id=?""",
+        (file_mtime, working_rel, photo_id),
+    )
+    db.conn.commit()
+
+    extract_calls = []
+
+    def extract_embedded_preview(source, output, *args, **kwargs):
+        extract_calls.append(str(source))
+        Image.new("RGB", (320, 240), (180, 90, 40)).save(output, "JPEG")
+        return True
+
+    monkeypatch.setattr(
+        image_loader, "extract_working_copy", extract_embedded_preview,
+    )
+
+    client = app.test_client()
+    first = client.get(f"/photos/{photo_id}/original")
+    second = client.get(f"/photos/{photo_id}/original")
+
+    with open(working_path, "rb") as working_file:
+        working_bytes = working_file.read()
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.data == working_bytes
+    assert second.data == working_bytes
+    assert extract_calls == [raw_path]
+    assert not os.path.exists(
+        os.path.join(vireo_dir, "originals", f"{photo_id}.display.jpg")
+    )
+    row = db.conn.execute(
+        """SELECT working_copy_failed_mtime, working_copy_failed_source
+           FROM photos WHERE id=?""",
+        (photo_id,),
+    ).fetchone()
+    assert row["working_copy_failed_mtime"] == file_mtime
+    assert row["working_copy_failed_source"] == "source"
+
+
 def test_original_falls_back_to_companion_when_raw_extraction_fails(
     client_with_photo, monkeypatch,
 ):

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -2853,6 +2853,10 @@ def test_rescan_invalidates_preview_cache_rows_when_file_content_changes(tmp_pat
     # Seed a preview file + accounting row, as /photos/<id>/preview would.
     preview_file = preview_dir / f"{photo_id}_1920.jpg"
     Image.new("RGB", (1920, 1440), color=(255, 0, 0)).save(str(preview_file), "JPEG")
+    originals_dir = vireo_dir / "originals"
+    originals_dir.mkdir()
+    display_file = originals_dir / f"{photo_id}.display.jpg"
+    Image.new("RGB", (800, 600), color=(255, 0, 0)).save(display_file, "JPEG")
     file_bytes = preview_file.stat().st_size
     db.preview_cache_insert(photo_id, 1920, file_bytes)
     assert db.preview_cache_total_bytes() == file_bytes
@@ -2863,6 +2867,7 @@ def test_rescan_invalidates_preview_cache_rows_when_file_content_changes(tmp_pat
     scan(root, db, incremental=True, vireo_dir=str(vireo_dir))
 
     assert not preview_file.exists(), "preview file should be deleted"
+    assert not display_file.exists(), "RAW display cache should be deleted"
     assert db.preview_cache_get(photo_id, 1920) is None, (
         "preview_cache row must be deleted alongside the file; "
         "leaving it inflates preview_cache_total_bytes and triggers "

--- a/vireo/tests/test_scanner.py
+++ b/vireo/tests/test_scanner.py
@@ -1130,6 +1130,36 @@ def test_pairing_transfers_edit_recipe_from_companion(tmp_path):
     assert db.get_photo_edit_recipe(photo["id"]) is None
 
 
+def test_pairing_invalidates_existing_raw_display_cache(tmp_path):
+    """A newly paired camera JPEG must replace a pre-pairing RAW rendition."""
+    from db import Database
+    from scanner import _pair_raw_jpeg_companions
+
+    img_dir = tmp_path / "photos"
+    img_dir.mkdir()
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder(str(img_dir), name="photos")
+    raw_id = db.add_photo(
+        folder_id=folder_id, filename="IMG_002.cr3", extension=".cr3",
+        file_size=2000, file_mtime=1.0,
+    )
+    db.add_photo(
+        folder_id=folder_id, filename="IMG_002.jpg", extension=".jpg",
+        file_size=1000, file_mtime=1.0,
+    )
+
+    originals_dir = tmp_path / "originals"
+    originals_dir.mkdir()
+    display_cache = originals_dir / f"{raw_id}.display.jpg"
+    display_cache.write_bytes(b"pre-pairing RAW display")
+
+    _pair_raw_jpeg_companions(db, vireo_dir=str(tmp_path))
+
+    photo = db.get_photo(raw_id)
+    assert photo["companion_path"] == "IMG_002.jpg"
+    assert not display_cache.exists()
+
+
 def test_pairing_transfers_local_mask_snapshot_files(tmp_path):
     """Pairing raw+JPEG must move edit-mask snapshot files to the primary id.
 


### PR DESCRIPTION
Fixes a tone jump that made unedited raw photos appear dark after opening or zooming because the full-resolution route reused a highlight-preserving edit working copy. Unedited viewing now uses a camera-rendered full-resolution decode and its own freshness-checked cache, while edited renders retain highlight-preserving processing. Source changes and photo deletion invalidate the new display cache, and regression tests cover full-size embedded previews, cropped-preview rejection, route behavior, cache reuse, and cleanup.

Validation:
- `python -m pytest -q vireo/tests/test_image_loader.py vireo/tests/test_photos_api.py`
- `python -m pytest -q vireo/tests/test_scanner.py vireo/tests/test_app.py` (477 passed)
- `ruff check` and `git diff --check`
- Confirmed against the reproducing Nikon file: displayed brightness `0.7645`, matching the preview instead of the previous `0.3047` render.
