### PR TITLE
Preload full-resolution images for faster lightbox zoom

### DIFF
--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -343,6 +343,64 @@ def test_browse_lightbox_skips_original_when_full_covers_one_to_one(
     assert page.evaluate("window._lbOriginalPreload") is None
 
 
+def test_browse_lightbox_cancels_original_warmup_when_zoom_leaves_fit(
+    live_server, page
+):
+    """A visible intermediate-tier upgrade takes priority over background warming."""
+    current_id = live_server["data"]["photos"][0]
+    db = live_server["db"]
+    db.conn.execute(
+        "UPDATE photos SET width=4000, height=2000 WHERE id=?",
+        (current_id,),
+    )
+    db.conn.commit()
+    full_svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="1920" height="960" '
+        'viewBox="0 0 1920 960"><rect width="1920" height="960" fill="#274"/></svg>'
+    )
+    preview_svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="2560" height="1280" '
+        'viewBox="0 0 2560 1280"><rect width="2560" height="1280" fill="#274"/></svg>'
+    )
+    original_requests = []
+
+    page.route(
+        "**/photos/*/full",
+        lambda route: route.fulfill(body=full_svg, content_type="image/svg+xml"),
+    )
+    page.route(
+        "**/photos/*/preview?size=2560*",
+        lambda route: route.fulfill(body=preview_svg, content_type="image/svg+xml"),
+    )
+
+    def serve_original(route):
+        original_requests.append(route.request.url)
+        route.fulfill(body=preview_svg, content_type="image/svg+xml")
+
+    page.route("**/photos/*/original", serve_original)
+    page.goto(f"{live_server['url']}/browse")
+    page.locator(".grid-card").first.dblclick()
+    page.wait_for_function("window._lbOriginalPreloadTimer !== null")
+
+    selected_key = page.evaluate(
+        """() => {
+            let zoom = 1.01;
+            while (zoom < window._lbNativeZoom && window._lbPickSourceKey(zoom) === 'full') {
+                zoom += 0.05;
+            }
+            const key = window._lbPickSourceKey(zoom);
+            window._lbSetZoom(zoom);
+            return key;
+        }"""
+    )
+    assert selected_key == "2560"
+    page.wait_for_timeout(800)
+
+    assert original_requests == []
+    assert page.evaluate("window._lbOriginalPreloadTimer") is None
+    assert page.evaluate("window._lbOriginalPreload") is None
+
+
 def test_browse_lightbox_does_not_preload_when_full_already_uses_original(
     live_server, page
 ):

--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -215,7 +215,17 @@ def test_browse_lightbox_preloads_current_original_after_preview_settles(
     live_server, page
 ):
     """The current photo's 100% source is decoded after a short dwell at Fit."""
-    svg = (
+    current_id = live_server["data"]["photos"][0]
+    live_server["db"].conn.execute(
+        "UPDATE photos SET width=4000, height=2000 WHERE id=?",
+        (current_id,),
+    )
+    live_server["db"].conn.commit()
+    full_svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="1920" height="960" '
+        'viewBox="0 0 1920 960"><rect width="1920" height="960" fill="#274"/></svg>'
+    )
+    original_svg = (
         '<svg xmlns="http://www.w3.org/2000/svg" width="4000" height="2000" '
         'viewBox="0 0 4000 2000"><rect width="4000" height="2000" fill="#274"/></svg>'
     )
@@ -223,18 +233,18 @@ def test_browse_lightbox_preloads_current_original_after_preview_settles(
 
     def serve_original(route):
         original_requests.append(route.request.url)
-        route.fulfill(body=svg, content_type="image/svg+xml")
+        route.fulfill(body=original_svg, content_type="image/svg+xml")
 
     page.route(
         "**/photos/*/full",
-        lambda route: route.fulfill(body=svg, content_type="image/svg+xml"),
+        lambda route: route.fulfill(body=full_svg, content_type="image/svg+xml"),
     )
     page.route("**/photos/*/original", serve_original)
     page.goto(f"{live_server['url']}/browse")
     page.locator(".grid-card").first.dblclick()
     expect(page.locator("#lightboxOverlay")).to_have_class("lightbox-overlay active")
 
-    current_id = page.evaluate("window._lightboxCurrentId")
+    assert page.evaluate("window._lightboxCurrentId") == current_id
     page.wait_for_function(
         """photoId => window._lbOriginalPreload && (
             window._lbOriginalPreload.photoId === photoId &&
@@ -245,6 +255,92 @@ def test_browse_lightbox_preloads_current_original_after_preview_settles(
 
     assert any(f"/photos/{current_id}/original" in url for url in original_requests)
     assert page.evaluate("window._lbCurrentSrcKey") == "full"
+
+
+def test_browse_lightbox_waits_for_fit_image_before_preloading_original(
+    live_server, page
+):
+    """A slow Fit render is not made slower by a competing original request."""
+    current_id = live_server["data"]["photos"][0]
+    db = live_server["db"]
+    db.conn.execute(
+        "UPDATE photos SET width=4000, height=2000 WHERE id=?",
+        (current_id,),
+    )
+    db.conn.commit()
+    full_svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="1920" height="960" '
+        'viewBox="0 0 1920 960"><rect width="1920" height="960" fill="#274"/></svg>'
+    )
+    original_svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="4000" height="2000" '
+        'viewBox="0 0 4000 2000"><rect width="4000" height="2000" fill="#274"/></svg>'
+    )
+    held_full = {}
+    original_requests = []
+
+    def hold_full(route):
+        held_full["route"] = route
+
+    def serve_original(route):
+        original_requests.append(route.request.url)
+        route.fulfill(body=original_svg, content_type="image/svg+xml")
+
+    page.route("**/photos/*/full", hold_full)
+    page.route("**/photos/*/original", serve_original)
+    page.goto(f"{live_server['url']}/browse")
+    page.locator(".grid-card").first.dblclick()
+    page.wait_for_function("window._lbFullUsesOriginal === false")
+    page.wait_for_timeout(800)
+
+    assert "route" in held_full
+    assert original_requests == []
+
+    held_full.pop("route").fulfill(body=full_svg, content_type="image/svg+xml")
+    page.wait_for_function(
+        """photoId => window._lbOriginalPreload && (
+            window._lbOriginalPreload.photoId === photoId &&
+            window._lbOriginalPreload.status === 'decoded'
+        )""",
+        arg=current_id,
+    )
+
+
+def test_browse_lightbox_skips_original_when_full_covers_one_to_one(
+    live_server, page
+):
+    """Small photos stay on /full at 100%, so warming /original is wasteful."""
+    current_id = live_server["data"]["photos"][0]
+    db = live_server["db"]
+    db.conn.execute(
+        "UPDATE photos SET width=1600, height=800 WHERE id=?",
+        (current_id,),
+    )
+    db.conn.commit()
+    svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" '
+        'viewBox="0 0 1600 800"><rect width="1600" height="800" fill="#274"/></svg>'
+    )
+    original_requests = []
+
+    page.route(
+        "**/photos/*/full",
+        lambda route: route.fulfill(body=svg, content_type="image/svg+xml"),
+    )
+
+    def serve_original(route):
+        original_requests.append(route.request.url)
+        route.fulfill(body=svg, content_type="image/svg+xml")
+
+    page.route("**/photos/*/original", serve_original)
+    page.goto(f"{live_server['url']}/browse")
+    page.locator(".grid-card").first.dblclick()
+    page.wait_for_function("window._lbNativeZoom !== null")
+    page.wait_for_timeout(800)
+
+    assert page.evaluate("window._lbPickSourceKey(window._lbNativeZoom)") == "full"
+    assert original_requests == []
+    assert page.evaluate("window._lbOriginalPreload") is None
 
 
 def test_browse_lightbox_does_not_preload_when_full_already_uses_original(

--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -211,6 +211,42 @@ def test_browse_lightbox_predecodes_adjacent_photo_for_current_source_tier(
     assert page.evaluate("window._lightboxCurrentId") != next_id
 
 
+def test_browse_lightbox_preloads_current_original_after_preview_settles(
+    live_server, page
+):
+    """The current photo's 100% source is decoded after a short dwell at Fit."""
+    svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="4000" height="2000" '
+        'viewBox="0 0 4000 2000"><rect width="4000" height="2000" fill="#274"/></svg>'
+    )
+    original_requests = []
+
+    def serve_original(route):
+        original_requests.append(route.request.url)
+        route.fulfill(body=svg, content_type="image/svg+xml")
+
+    page.route(
+        "**/photos/*/full",
+        lambda route: route.fulfill(body=svg, content_type="image/svg+xml"),
+    )
+    page.route("**/photos/*/original", serve_original)
+    page.goto(f"{live_server['url']}/browse")
+    page.locator(".grid-card").first.dblclick()
+    expect(page.locator("#lightboxOverlay")).to_have_class("lightbox-overlay active")
+
+    current_id = page.evaluate("window._lightboxCurrentId")
+    page.wait_for_function(
+        """photoId => window._lbOriginalPreload && (
+            window._lbOriginalPreload.photoId === photoId &&
+            window._lbOriginalPreload.status === 'decoded'
+        )""",
+        arg=current_id,
+    )
+
+    assert any(f"/photos/{current_id}/original" in url for url in original_requests)
+    assert page.evaluate("window._lbCurrentSrcKey") == "full"
+
+
 def test_browse_lightbox_restores_and_carries_zoomed_viewport(live_server, page):
     """Arrow navigation preserves pan/zoom per photo and carries it to unseen photos."""
     svg = (

--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -247,6 +247,41 @@ def test_browse_lightbox_preloads_current_original_after_preview_settles(
     assert page.evaluate("window._lbCurrentSrcKey") == "full"
 
 
+def test_browse_lightbox_does_not_preload_when_full_already_uses_original(
+    live_server, page
+):
+    """Full-resolution preview mode must not request the original twice."""
+    db = live_server["db"]
+    db.update_workspace(
+        db._active_workspace_id,
+        config_overrides={"preview_max_size": 0},
+    )
+    svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="4000" height="2000" '
+        'viewBox="0 0 4000 2000"><rect width="4000" height="2000" fill="#274"/></svg>'
+    )
+    original_requests = []
+
+    page.route(
+        "**/photos/*/full",
+        lambda route: route.fulfill(body=svg, content_type="image/svg+xml"),
+    )
+
+    def serve_original(route):
+        original_requests.append(route.request.url)
+        route.fulfill(body=svg, content_type="image/svg+xml")
+
+    page.route("**/photos/*/original", serve_original)
+    page.goto(f"{live_server['url']}/browse")
+    page.locator(".grid-card").first.dblclick()
+    expect(page.locator("#lightboxOverlay")).to_have_class("lightbox-overlay active")
+    page.wait_for_function("window._lbFullUsesOriginal === true")
+    page.wait_for_timeout(800)
+
+    assert original_requests == []
+    assert page.evaluate("window._lbOriginalPreload") is None
+
+
 def test_browse_lightbox_restores_and_carries_zoomed_viewport(live_server, page):
     """Arrow navigation preserves pan/zoom per photo and carries it to unseen photos."""
     svg = (

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -4925,6 +4925,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # detail panel can render the filled state without a second roundtrip.
         result["location"] = _serialize_photo_location(db, photo_id)
         result["edit_recipe"] = db.get_photo_edit_recipe(photo_id)
+        # The shared lightbox normally warms /original after /full settles.
+        # In full-resolution preview mode /full already redirects to /original,
+        # so tell the client not to repeat that potentially expensive RAW work.
+        import config as cfg
+        result["full_uses_original"] = (
+            db.get_effective_config(cfg.load()).get("preview_max_size") == 0
+        )
 
         # Read XMP sidecar keywords
         folder = db.conn.execute(

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -8343,6 +8343,8 @@ function _lbShouldPreloadOriginal(photoId) {
     _lbCurrentSrcKey !== 'full' ||
     _lbFullUsesOriginal !== false ||
     _lbOriginalUnavailable ||
+    _lbZoom > 1.001 ||
+    (_lbDesiredSrcKey && _lbDesiredSrcKey !== 'full') ||
     !_lbNativeZoom ||
     _lbPickSourceKey(_lbNativeZoom) !== 'original'
   ) return false;
@@ -8446,6 +8448,9 @@ function _lbScheduleSourceSwap(targetZoom) {
   if (!_lightboxCurrentId) return;
   var desired = _lbPickSourceKey(targetZoom);
   _lbDesiredSrcKey = desired;
+  if (_lbZoom > 1.001 && desired !== 'original') {
+    _lbCancelOriginalPreload();
+  }
   if (desired === _lbCurrentSrcKey) {
     _lbPrimeAdjacentPhotos(desired);
     return;

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -8336,27 +8336,30 @@ function _lbCancelOriginalPreload() {
   _lbOriginalPreload = null;
 }
 
-function _lbScheduleOriginalPreload(photoId) {
-  _lbCancelOriginalPreload();
+function _lbShouldPreloadOriginal(photoId) {
   if (
     photoId == null ||
     _lightboxCurrentId !== photoId ||
-    _lbCurrentSrcKey === 'original' ||
+    _lbCurrentSrcKey !== 'full' ||
     _lbFullUsesOriginal !== false ||
-    _lbOriginalUnavailable
-  ) return;
+    _lbOriginalUnavailable ||
+    !_lbNativeZoom ||
+    _lbPickSourceKey(_lbNativeZoom) !== 'original'
+  ) return false;
+  var img = document.getElementById('lightboxImg');
+  return !!(img && img.complete && img.naturalWidth && img.naturalHeight);
+}
+
+function _lbScheduleOriginalPreload(photoId) {
+  _lbCancelOriginalPreload();
+  if (!_lbShouldPreloadOriginal(photoId)) return;
 
   // Give navigation and the neighboring fit-tier preloads first use of the
   // decoder. The dwell also prevents fast arrowing from starting expensive
   // full-resolution RAW extraction for every photo passed along the way.
   _lbOriginalPreloadTimer = setTimeout(function() {
     _lbOriginalPreloadTimer = null;
-    if (
-      _lightboxCurrentId !== photoId ||
-      _lbCurrentSrcKey === 'original' ||
-      _lbFullUsesOriginal !== false ||
-      _lbOriginalUnavailable
-    ) return;
+    if (!_lbShouldPreloadOriginal(photoId)) return;
 
     var url = _lbSrcUrl(photoId, 'original');
     var preload = new Image();

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3629,6 +3629,8 @@ var _lbPendingViewportState = null;
 var _lbVisualTransitionPending = false; // keep the outgoing bitmap/transform frozen until the incoming image is decoded
 var _lbDeferredOverlayApply = null; // detections/eye render withheld while _lbVisualTransitionPending; drained when the transition clears
 var _lbAdjacentPreloads = {}; // decoded immediate neighbors, keyed by photo id + source URL
+var _lbOriginalPreloadTimer = null; // short dwell before warming the current photo's 100% source
+var _lbOriginalPreload = null; // retained decoded original for an instant first 100% click
 var _lbEditRecipeByPhoto = {};
 var _lbEditRecipeKnownByPhoto = {};
 var _lbEditRecipeWriteSeq = 0;
@@ -4405,6 +4407,7 @@ function _lbSetEditBusy(busy) {
 
 function _lbReloadCurrentRenderAfterEdit(photoId) {
   if (_lightboxCurrentId !== photoId) return;
+  _lbCancelOriginalPreload();
   var img = document.getElementById('lightboxImg');
   var wrap = document.getElementById('lightboxWrap');
   if (!img) return;
@@ -4435,6 +4438,7 @@ function _lbReloadCurrentRenderAfterEdit(photoId) {
     }
     _lbRecomputeNativeZoom();
     _lbApplyTransform();
+    _lbScheduleOriginalPreload(photoId);
   };
   img.onerror = function() {
     img.onload = null;
@@ -5118,6 +5122,7 @@ function _lbRefreshVisiblePhotoImages(photoId) {
 
 function _lbReloadEditedSource(photoId, seq) {
   if (_lightboxCurrentId !== photoId) return;
+  _lbCancelOriginalPreload();
   var img = document.getElementById('lightboxImg');
   if (!img) return;
   var key = _lbCurrentSrcKey || 'full';
@@ -5131,6 +5136,7 @@ function _lbReloadEditedSource(photoId, seq) {
     _lbClearAdjustmentPreview();
     _lbRecomputeNativeZoom();
     _lbApplyTransform();
+    if (key === 'full') _lbScheduleOriginalPreload(photoId);
   });
   img.src = _lbSrcUrl(photoId, key);
 }
@@ -6524,6 +6530,7 @@ window.vireoRefreshEditRecipeCache = _lbRefreshEditRecipeCache;
 function openLightbox(photoId, filename, photoList, options) {
   var alreadyOpen = !!window._lbEscToken;
   options = options || {};
+  _lbCancelOriginalPreload();
   var fallbackViewportState = options.fallbackViewportState || null;
   _lbFlushPendingAdjustmentSave();
   if (alreadyOpen && _lightboxCurrentId != null) {
@@ -6786,6 +6793,7 @@ function openLightbox(photoId, filename, photoList, options) {
     _lbApplyTransform();
     _lbFlushDeferredOverlayApply();
     _lbPrimeAdjacentPhotos(_lbCurrentSrcKey);
+    if (_lbCurrentSrcKey === 'full') _lbScheduleOriginalPreload(photoId);
   }
   function handleInitialImageError() {
     if (_lightboxCurrentId !== photoId || _lbOpenSeq !== openSeq) return;
@@ -7088,6 +7096,7 @@ function closeLightbox(e) {
   _lbClearPendingViewportRestore();
   if (_lbSwapTimer) { clearTimeout(_lbSwapTimer); _lbSwapTimer = null; }
   _lbDesiredSrcKey = null;
+  _lbCancelOriginalPreload();
   _lbClearAdjacentPreloads();
   _lbClearAdjustmentPreview();
   var adjustPanel = document.getElementById('lightboxAdjustPanel');
@@ -8310,6 +8319,66 @@ function _lbClearAdjacentPreloads() {
   _lbAdjacentPreloads = {};
 }
 
+function _lbCancelOriginalPreload() {
+  if (_lbOriginalPreloadTimer) {
+    clearTimeout(_lbOriginalPreloadTimer);
+    _lbOriginalPreloadTimer = null;
+  }
+  if (_lbOriginalPreload && _lbOriginalPreload.img) {
+    _lbOriginalPreload.img.onload = null;
+    _lbOriginalPreload.img.onerror = null;
+    _lbOriginalPreload.img.removeAttribute('src');
+  }
+  _lbOriginalPreload = null;
+}
+
+function _lbScheduleOriginalPreload(photoId) {
+  _lbCancelOriginalPreload();
+  if (
+    photoId == null ||
+    _lightboxCurrentId !== photoId ||
+    _lbCurrentSrcKey === 'original' ||
+    _lbOriginalUnavailable
+  ) return;
+
+  // Give navigation and the neighboring fit-tier preloads first use of the
+  // decoder. The dwell also prevents fast arrowing from starting expensive
+  // full-resolution RAW extraction for every photo passed along the way.
+  _lbOriginalPreloadTimer = setTimeout(function() {
+    _lbOriginalPreloadTimer = null;
+    if (
+      _lightboxCurrentId !== photoId ||
+      _lbCurrentSrcKey === 'original' ||
+      _lbOriginalUnavailable
+    ) return;
+
+    var url = _lbSrcUrl(photoId, 'original');
+    var preload = new Image();
+    var entry = {
+      img: preload,
+      photoId: photoId,
+      sourceKey: 'original',
+      url: url,
+      status: 'loading'
+    };
+    _lbOriginalPreload = entry;
+    preload.fetchPriority = 'low';
+    var supportsDecode = typeof preload.decode === 'function';
+    preload.onload = function() {
+      if (!supportsDecode) entry.status = 'decoded';
+    };
+    preload.onerror = function() { entry.status = 'failed'; };
+    preload.src = url;
+    if (supportsDecode) {
+      preload.decode().then(function() {
+        entry.status = 'decoded';
+      }).catch(function() {
+        // onload/onerror remains the fallback for WebViews with incomplete decode support.
+      });
+    }
+  }, 400);
+}
+
 function _lbPrimeAdjacentPhotos(sourceKey) {
   if (_lightboxPhotoList.length < 2 || _lightboxCurrentId == null) {
     _lbClearAdjacentPreloads();
@@ -8403,6 +8472,10 @@ function _lbScheduleSourceSwap(targetZoom) {
         // case img.naturalWidth belongs to a DIFFERENT source than our closure's
         // `key`, so bail rather than record wrong dims or recalibrate stale state.
         if (_lbCurrentSrcKey !== key) return;
+        // Keep the decoded background original alive until the visible image
+        // has adopted it; releasing it earlier can make some WebViews decode
+        // the same full-resolution bytes a second time on the first 100% click.
+        if (key === 'original') _lbCancelOriginalPreload();
         if (!_lbPhotoW && key === 'original' && img.naturalWidth) {
           _lbPhotoW = img.naturalWidth;
           _lbPhotoH = img.naturalHeight;

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3618,6 +3618,7 @@ var _lbSessionFullLongEdge = null;  // last learned /full size across photos; be
 var _lbPending1To1 = false;  // true when z/click was pressed with unknown nativeZoom; upgrade to true 1:1 once learned
 var _lbPending1To1Anchor = null; // optional client-space anchor for a deferred 1:1 snap
 var _lbOriginalUnavailable = false;  // true after /original fails; fall back to current decoded source dimensions
+var _lbFullUsesOriginal = null; // metadata-backed: preview_max_size=0 makes /full redirect to /original
 var _lbCurrentWildlifeExcluded = false;
 var _lbFlagEditSeq = 0;      // increments for local flag writes so stale metadata fetches cannot overwrite the chip
 var _lbOpenSeq = 0;          // increments for every lightbox open so old metadata fetches cannot reapply after reopen
@@ -6653,6 +6654,7 @@ function openLightbox(photoId, filename, photoList, options) {
   _lbPending1To1Anchor = null;
   _lbPendingViewportState = restoreViewportState;
   _lbOriginalUnavailable = false;
+  _lbFullUsesOriginal = null;
   _lbEditRecipe = null;
   _lbEditRecipeLoaded = false;
   _lbRenderedAdjustmentValues = _lbAdjustmentValues(null);
@@ -6700,6 +6702,7 @@ function openLightbox(photoId, filename, photoList, options) {
       _lbApplyMaskVisibility();
       _lbPhotoW = data.width || null;
       _lbPhotoH = data.height || null;
+      _lbFullUsesOriginal = !!data.full_uses_original;
       _lbPhotoOrientation = _lbMetadataOrientation(data.metadata);
       var currentLayoutRecipe = _lbEditRecipeByPhoto[String(photoId)];
       _lbCurrentEditRecipe = _lbRecipeHasEdits(currentLayoutRecipe)
@@ -6730,6 +6733,7 @@ function openLightbox(photoId, filename, photoList, options) {
       if (!_lbVisualTransitionPending) {
         _lbRecomputeNativeZoom();
         if (!_lbTryApplyPendingViewportState()) _lbApplyPendingOneToOneZoom();
+        if (_lbCurrentSrcKey === 'full') _lbScheduleOriginalPreload(photoId);
       }
       // Detection boxes, the eye marker, and the mask overlay are children of
       // lightboxTransform. While _lbVisualTransitionPending is true the
@@ -8338,6 +8342,7 @@ function _lbScheduleOriginalPreload(photoId) {
     photoId == null ||
     _lightboxCurrentId !== photoId ||
     _lbCurrentSrcKey === 'original' ||
+    _lbFullUsesOriginal !== false ||
     _lbOriginalUnavailable
   ) return;
 
@@ -8349,6 +8354,7 @@ function _lbScheduleOriginalPreload(photoId) {
     if (
       _lightboxCurrentId !== photoId ||
       _lbCurrentSrcKey === 'original' ||
+      _lbFullUsesOriginal !== false ||
       _lbOriginalUnavailable
     ) return;
 

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -517,6 +517,22 @@ def test_api_photo_detail(app_and_db):
     data = resp.get_json()
     assert data['filename'] == 'bird1.jpg'
     assert 'keywords' in data
+    assert data['full_uses_original'] is False
+
+
+def test_api_photo_detail_reports_full_resolution_preview_mode(app_and_db):
+    """Photo detail tells the lightbox when /full already serves /original."""
+    app, db = app_and_db
+    db.update_workspace(
+        db._active_workspace_id,
+        config_overrides={"preview_max_size": 0},
+    )
+    pid = db.get_photos()[0]['id']
+
+    resp = app.test_client().get(f'/api/photos/{pid}')
+
+    assert resp.status_code == 200
+    assert resp.get_json()['full_uses_original'] is True
 
 
 def test_api_photo_detail_includes_on_disk_path(app_and_db):


### PR DESCRIPTION
Preloads and decodes the current lightbox photo’s original after a short dwell, making the first 100% interaction more responsive.

Cancels pending work during rapid navigation or close, and refreshes warmed images after edits to avoid unnecessary RAW processing and stale renders. Adds Playwright coverage for background original decoding while the visible image remains at the fit tier.

Validation: `python -m pytest -o addopts= tests/e2e/test_browse_lightbox.py -q` (27 passed) and Ruff checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved lightbox image loading by preloading the current photo’s original-quality image after a brief viewing period.
  * Automatically upgrades the displayed image to the original quality once it is ready.

* **Bug Fixes**
  * Reduced redundant image decoding and prevented stale preload activity when navigating, editing, opening, or closing the lightbox.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->