### PR TITLE
Keep browse photo labels synchronized during navigation

### DIFF
--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -362,6 +362,14 @@ def test_browse_lightbox_holds_off_center_transform_until_next_photo_is_ready(
             };
         }"""
     )
+    page.evaluate(
+        """() => {
+            window.__photoChangedDuringNavigation = [];
+            document.addEventListener('lightbox:photochanged', event => {
+                window.__photoChangedDuringNavigation.push(event.detail.photoId);
+            });
+        }"""
+    )
 
     page.keyboard.press("ArrowRight")
     page.wait_for_function("() => window._lbVisualTransitionPending === true")
@@ -380,6 +388,7 @@ def test_browse_lightbox_holds_off_center_transform_until_next_photo_is_ready(
     )
     expect(page.locator("#lightboxCounter")).to_contain_text("1 /")
     expect(page.locator("#lightboxActions")).to_have_attribute("inert", "")
+    assert page.evaluate("window.__photoChangedDuringNavigation") == []
 
     # Photo-targeted keyboard actions are suppressed along with the buttons;
     # they must not mutate the incoming photo while the outgoing one is shown.
@@ -444,6 +453,7 @@ def test_browse_lightbox_holds_off_center_transform_until_next_photo_is_ready(
         page.locator(".grid-card").nth(1).get_attribute("data-filename")
     )
     expect(page.locator("#lightboxCounter")).to_contain_text("2 /")
+    assert page.evaluate("window.__photoChangedDuringNavigation") == [next_id]
     assert page.evaluate(
         "!document.getElementById('lightboxActions').inert"
     )

--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -17,6 +17,12 @@ def test_browse_lightbox_arrows_navigate(live_server, page):
     argument, so _lightboxPhotoList stayed empty and lightboxNav() silently no-op'd.
     """
     url = live_server["url"]
+    page.route(
+        "**/photos/*/full",
+        lambda route: route.fulfill(
+            body=base64.b64decode(_PNG_1X1), content_type="image/png"
+        ),
+    )
     page.goto(f"{url}/browse")
 
     first_card = page.locator(".grid-card").first
@@ -148,7 +154,7 @@ def test_browse_lightbox_arrows_preserve_one_to_one_zoom(live_server, page):
     # 1:1 snap cannot resolve before we observe it.
     hold["active"] = True
     page.locator("[title='Next (→)']").click()
-    expect(page.locator("#lightboxCounter")).to_contain_text("2 /")
+    expect(page.locator("#lightboxCounter")).to_contain_text("1 /")
     # Guard that the hold worked: native zoom must still be unknown, so the
     # pending assertion below is genuinely exercising the deferred path.
     assert page.evaluate("window._lbNativeZoom") is None
@@ -287,11 +293,12 @@ def test_browse_lightbox_restores_and_carries_zoomed_viewport(live_server, page)
 def test_browse_lightbox_holds_off_center_transform_until_next_photo_is_ready(
     live_server, page
 ):
-    """100% navigation must not recenter the outgoing photo while loading.
+    """100% navigation must keep the outgoing photo intact while loading.
 
     The incoming photo's metadata often resolves before its image. Previously
     navigation reset pan immediately, visibly jerking the outgoing bitmap to
     center, then restored the carried viewport when the new bitmap decoded.
+    Its filename and counter also advanced while that old bitmap was visible.
     """
     first_svg = (
         '<svg xmlns="http://www.w3.org/2000/svg" width="4000" height="2000" '
@@ -356,8 +363,7 @@ def test_browse_lightbox_holds_off_center_transform_until_next_photo_is_ready(
         }"""
     )
 
-    page.locator("[title='Next (→)']").click()
-    expect(page.locator("#lightboxCounter")).to_contain_text("2 /")
+    page.keyboard.press("ArrowRight")
     page.wait_for_function("() => window._lbVisualTransitionPending === true")
     page.wait_for_function("() => window._lightboxCurrentId === window.photos[1].id")
     page.wait_for_timeout(100)
@@ -366,6 +372,13 @@ def test_browse_lightbox_holds_off_center_transform_until_next_photo_is_ready(
     while "route" not in held_original and time.time() < deadline:
         page.wait_for_timeout(10)
     assert "route" in held_original
+
+    # The outgoing bitmap remains visible while the incoming original is
+    # loading, so its filename and position must remain visible too.
+    expect(page.locator("#lightboxFilename")).to_have_text(
+        first_card.get_attribute("data-filename")
+    )
+    expect(page.locator("#lightboxCounter")).to_contain_text("1 /")
 
     while_loading = page.evaluate(
         """() => {
@@ -394,6 +407,10 @@ def test_browse_lightbox_holds_off_center_transform_until_next_photo_is_ready(
                 && img && img.complete && img.naturalWidth === 3000;
         }"""
     )
+    expect(page.locator("#lightboxFilename")).to_have_text(
+        page.locator(".grid-card").nth(1).get_attribute("data-filename")
+    )
+    expect(page.locator("#lightboxCounter")).to_contain_text("2 /")
     carried = page.evaluate("window._lbViewportStateFromCurrent()")
     assert abs(carried["centerX"] - before["viewport"]["centerX"]) < 0.03
     assert abs(carried["centerY"] - before["viewport"]["centerY"]) < 0.03
@@ -487,7 +504,7 @@ def test_browse_lightbox_mid_transition_save_does_not_leak_outgoing_transform(
     )
 
     page.locator("[title='Next (→)']").click()
-    expect(page.locator("#lightboxCounter")).to_contain_text("2 /")
+    expect(page.locator("#lightboxCounter")).to_contain_text("1 /")
     page.wait_for_function("() => window._lbVisualTransitionPending === true")
     page.wait_for_function("() => window._lightboxCurrentId === window.photos[1].id")
     page.wait_for_timeout(50)
@@ -548,9 +565,8 @@ def test_browse_lightbox_clears_transition_state_when_incoming_image_errors(
     failing tier isn't the /original fallback candidate) previously left
     _lbVisualTransitionPending true indefinitely. That kept the metadata
     callback skipping layout updates and made _lbSaveViewportState treat the
-    incoming photo as still mid-transition even though the UI/counter had
-    already advanced to it, freezing the outgoing transform on screen until
-    the lightbox was closed or another navigation succeeded.
+    incoming photo as still mid-transition, freezing the outgoing transform on
+    screen until the lightbox was closed or another navigation succeeded.
     """
     first_svg = (
         '<svg xmlns="http://www.w3.org/2000/svg" width="4000" height="2000" '
@@ -589,7 +605,7 @@ def test_browse_lightbox_clears_transition_state_when_incoming_image_errors(
     # with _lbVisualTransitionPending=true. The /full request then 404s, so
     # handleInitialImageError takes the non-'original' early-return path.
     page.locator("[title='Next (→)']").click()
-    expect(page.locator("#lightboxCounter")).to_contain_text("2 /")
+    expect(page.locator("#lightboxCounter")).to_contain_text("1 /")
     page.wait_for_function(
         "() => window._lightboxCurrentId === window.photos[1].id"
     )
@@ -713,7 +729,7 @@ def test_browse_lightbox_defers_overlays_while_visual_transition_pending(
     )
 
     page.locator("[title='Next (→)']").click()
-    expect(page.locator("#lightboxCounter")).to_contain_text("2 /")
+    expect(page.locator("#lightboxCounter")).to_contain_text("1 /")
     page.wait_for_function("() => window._lbVisualTransitionPending === true")
     page.wait_for_function("() => window._lightboxCurrentId === window.photos[1].id")
 

--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -379,6 +379,12 @@ def test_browse_lightbox_holds_off_center_transform_until_next_photo_is_ready(
         first_card.get_attribute("data-filename")
     )
     expect(page.locator("#lightboxCounter")).to_contain_text("1 /")
+    expect(page.locator("#lightboxActions")).to_have_attribute("inert", "")
+
+    # Photo-targeted keyboard actions are suppressed along with the buttons;
+    # they must not mutate the incoming photo while the outgoing one is shown.
+    page.keyboard.press("p")
+    assert page.evaluate("window._lbFlagPendingWrites") == 0
 
     while_loading = page.evaluate(
         """() => {
@@ -411,6 +417,9 @@ def test_browse_lightbox_holds_off_center_transform_until_next_photo_is_ready(
         page.locator(".grid-card").nth(1).get_attribute("data-filename")
     )
     expect(page.locator("#lightboxCounter")).to_contain_text("2 /")
+    assert page.evaluate(
+        "!document.getElementById('lightboxActions').inert"
+    )
     carried = page.evaluate("window._lbViewportStateFromCurrent()")
     assert abs(carried["centerX"] - before["viewport"]["centerX"]) < 0.03
     assert abs(carried["centerY"] - before["viewport"]["centerY"]) < 0.03
@@ -613,6 +622,13 @@ def test_browse_lightbox_clears_transition_state_when_incoming_image_errors(
     page.wait_for_function(
         "() => window._lbVisualTransitionPending === false",
         timeout=3000,
+    )
+    expect(page.locator("#lightboxFilename")).to_have_text(
+        page.locator(".grid-card").nth(1).get_attribute("data-filename")
+    )
+    expect(page.locator("#lightboxCounter")).to_contain_text("2 /")
+    assert page.evaluate(
+        "!document.getElementById('lightboxActions').inert"
     )
 
     # With the pending flag cleared, saving the current photo's viewport must

--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -369,6 +369,9 @@ def test_browse_lightbox_holds_off_center_transform_until_next_photo_is_ready(
                 window.__photoChangedDuringNavigation.push(event.detail.photoId);
             });
             document.getElementById('lightboxAdjustPanel').classList.add('open');
+            const externalPanel = document.createElement('div');
+            externalPanel.id = 'syncLightboxPanel';
+            document.getElementById('lightboxOverlay').appendChild(externalPanel);
         }"""
     )
 
@@ -390,6 +393,7 @@ def test_browse_lightbox_holds_off_center_transform_until_next_photo_is_ready(
     expect(page.locator("#lightboxCounter")).to_contain_text("1 /")
     expect(page.locator("#lightboxActions")).to_have_attribute("inert", "")
     expect(page.locator("#lightboxAdjustPanel")).to_have_attribute("inert", "")
+    expect(page.locator("#syncLightboxPanel")).to_have_attribute("inert", "")
     assert page.evaluate("window.__photoChangedDuringNavigation") == []
 
     # Photo-targeted keyboard actions are suppressed along with the buttons;
@@ -461,6 +465,10 @@ def test_browse_lightbox_holds_off_center_transform_until_next_photo_is_ready(
     )
     assert page.evaluate(
         "!document.getElementById('lightboxAdjustPanel').inert"
+    )
+    assert page.evaluate(
+        "!document.getElementById('syncLightboxPanel') || "
+        "!document.getElementById('syncLightboxPanel').inert"
     )
     carried = page.evaluate("window._lbViewportStateFromCurrent()")
     assert abs(carried["centerX"] - before["viewport"]["centerX"]) < 0.03

--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -386,6 +386,33 @@ def test_browse_lightbox_holds_off_center_transform_until_next_photo_is_ready(
     page.keyboard.press("p")
     assert page.evaluate("window._lbFlagPendingWrites") == 0
 
+    interaction_state = page.evaluate(
+        """() => {
+            const img = document.getElementById('lightboxImg');
+            const beforeZoom = window._lbZoom;
+            img.dispatchEvent(new WheelEvent('wheel', {
+                bubbles: true, cancelable: true, deltaY: -120,
+                clientX: 400, clientY: 300,
+            }));
+            img.dispatchEvent(new MouseEvent('contextmenu', {
+                bubbles: true, cancelable: true, button: 2,
+                clientX: 400, clientY: 300,
+            }));
+            img.dispatchEvent(new MouseEvent('click', {
+                bubbles: true, cancelable: true, button: 0,
+                clientX: 400, clientY: 300,
+            }));
+            return {
+                beforeZoom: beforeZoom,
+                afterZoom: window._lbZoom,
+                nativePhotoIds: window.nativeMenuActivePhotoIds(),
+            };
+        }"""
+    )
+    assert interaction_state["afterZoom"] == interaction_state["beforeZoom"]
+    assert interaction_state["nativePhotoIds"] == []
+    expect(page.locator(".vireo-ctx-menu")).to_have_count(0)
+
     while_loading = page.evaluate(
         """() => {
             const transform = document.getElementById('lightboxTransform');

--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -368,6 +368,7 @@ def test_browse_lightbox_holds_off_center_transform_until_next_photo_is_ready(
             document.addEventListener('lightbox:photochanged', event => {
                 window.__photoChangedDuringNavigation.push(event.detail.photoId);
             });
+            document.getElementById('lightboxAdjustPanel').classList.add('open');
         }"""
     )
 
@@ -388,6 +389,7 @@ def test_browse_lightbox_holds_off_center_transform_until_next_photo_is_ready(
     )
     expect(page.locator("#lightboxCounter")).to_contain_text("1 /")
     expect(page.locator("#lightboxActions")).to_have_attribute("inert", "")
+    expect(page.locator("#lightboxAdjustPanel")).to_have_attribute("inert", "")
     assert page.evaluate("window.__photoChangedDuringNavigation") == []
 
     # Photo-targeted keyboard actions are suppressed along with the buttons;
@@ -456,6 +458,9 @@ def test_browse_lightbox_holds_off_center_transform_until_next_photo_is_ready(
     assert page.evaluate("window.__photoChangedDuringNavigation") == [next_id]
     assert page.evaluate(
         "!document.getElementById('lightboxActions').inert"
+    )
+    assert page.evaluate(
+        "!document.getElementById('lightboxAdjustPanel').inert"
     )
     carried = page.evaluate("window._lbViewportStateFromCurrent()")
     assert abs(carried["centerX"] - before["viewport"]["centerX"]) < 0.03
@@ -651,7 +656,6 @@ def test_browse_lightbox_clears_transition_state_when_incoming_image_errors(
     # with _lbVisualTransitionPending=true. The /full request then 404s, so
     # handleInitialImageError takes the non-'original' early-return path.
     page.locator("[title='Next (→)']").click()
-    expect(page.locator("#lightboxCounter")).to_contain_text("1 /")
     page.wait_for_function(
         "() => window._lightboxCurrentId === window.photos[1].id"
     )

--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -54,6 +54,50 @@ def test_browse_lightbox_arrows_navigate(live_server, page):
     expect(counter).to_contain_text(first_filename)
 
 
+def test_browse_lightbox_same_photo_reopen_does_not_lock_controls(live_server, page):
+    """Reopening the visible photo must not wait for a same-src load event."""
+    page.route(
+        "**/photos/*/full",
+        lambda route: route.fulfill(
+            body=base64.b64decode(_PNG_1X1), content_type="image/png"
+        ),
+    )
+    page.goto(f"{live_server['url']}/browse")
+
+    page.locator(".grid-card").first.dblclick()
+    expect(page.locator("#lightboxOverlay")).to_have_class("lightbox-overlay active")
+    page.wait_for_function(
+        """() => {
+            const img = document.getElementById('lightboxImg');
+            return img && img.complete && img.naturalWidth > 0;
+        }"""
+    )
+
+    state = page.evaluate(
+        """() => {
+            const current = window._lightboxPhotoList.find(
+                photo => photo.id === window._lightboxCurrentId
+            );
+            window.openLightbox(
+                current.id,
+                current.filename,
+                window._lightboxPhotoList
+            );
+            return {
+                pending: window._lbVisualTransitionPending,
+                actionsInert: document.getElementById('lightboxActions').inert,
+                adjustInert: document.getElementById('lightboxAdjustPanel').inert,
+            };
+        }"""
+    )
+
+    assert state == {
+        "pending": False,
+        "actionsInert": False,
+        "adjustInert": False,
+    }
+
+
 def test_browse_photo_id_deep_link_loads_target_folder_first_page(live_server, page):
     """Open in Browse must find a target that is not on global Browse page 1."""
     db = live_server["db"]

--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -427,6 +427,8 @@ def test_browse_lightbox_holds_off_center_transform_until_next_photo_is_ready(
     assert interaction_state["afterZoom"] == interaction_state["beforeZoom"]
     assert interaction_state["nativePhotoIds"] == []
     expect(page.locator(".vireo-ctx-menu")).to_have_count(0)
+    page.evaluate("window.lightboxDelete()")
+    expect(page.locator("#deleteModal")).not_to_have_class("modal-overlay open")
 
     while_loading = page.evaluate(
         """() => {

--- a/tests/e2e/test_highlights_initial_scope.py
+++ b/tests/e2e/test_highlights_initial_scope.py
@@ -1189,9 +1189,11 @@ def test_highlights_lightbox_next_preserves_pending_one_to_one_zoom(live_server,
                 oneToOne: false,
                 pending1To1: false,
             };
-            lightboxNav(1);
-            return {
-                counter: document.getElementById('lightboxCounter').textContent,
+                lightboxNav(1);
+                return {
+                    currentId: window._lightboxCurrentId,
+                    nextId: next.id,
+                    counter: document.getElementById('lightboxCounter').textContent,
                 pending1To1: window._lbPending1To1,
                 zoom: window._lbZoom,
                 srcKey: window._lbCurrentSrcKey,
@@ -1199,7 +1201,8 @@ def test_highlights_lightbox_next_preserves_pending_one_to_one_zoom(live_server,
         }"""
     )
 
-    assert "2 /" in handoff["counter"]
+    assert handoff["currentId"] == handoff["nextId"]
+    assert "1 /" in handoff["counter"]
     assert handoff["pending1To1"] is True
     assert handoff["zoom"] > 1.001
     assert handoff["srcKey"] == "original"

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -6596,9 +6596,6 @@ function openLightbox(photoId, filename, photoList, options) {
   // resolve "the photo I was just looking at".
   if (window.vireoEditNav) window.vireoEditNav.setLastPhoto(photoId);
   _lbApplyEditButtonState();
-  try {
-    document.dispatchEvent(new CustomEvent('lightbox:photochanged', { detail: { photoId: photoId } }));
-  } catch(_) {}
   var currentFromList = _lightboxPhotoList.find(function(x) { return x.id === photoId; });
   if (currentFromList && Object.prototype.hasOwnProperty.call(currentFromList, 'flag')) {
     _lbRememberConfirmedFlag(photoId, currentFromList.flag);
@@ -6624,6 +6621,7 @@ function openLightbox(photoId, filename, photoList, options) {
   // that bitmap, then advance all three in the image-load task before the next
   // paint. Internal navigation state still advances immediately, so rapid
   // arrow presses continue to target the right photo.
+  var visibleIdentityCommitted = false;
   function commitVisiblePhotoIdentity() {
     label.textContent = filename || '';
     _lbSetFlagStatus(_lbConfirmedFlagFor(photoId));
@@ -6639,6 +6637,14 @@ function openLightbox(photoId, filename, photoList, options) {
     } else {
       counter.title = '';
       counter.style.display = 'none';
+    }
+    if (!visibleIdentityCommitted) {
+      visibleIdentityCommitted = true;
+      try {
+        document.dispatchEvent(new CustomEvent('lightbox:photochanged', {
+          detail: { photoId: photoId }
+        }));
+      } catch(_) {}
     }
   }
 

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3442,7 +3442,7 @@ async function createWorkspace() {
   <span class="lightbox-close" onclick="closeLightbox(event)">&times;</span>
   <div id="lightboxPrev" class="lightbox-nav" onclick="event.stopPropagation(); lightboxNav(-1);" style="position:absolute;left:12px;top:50%;transform:translateY(-50%);font-size:36px;color:rgba(255,255,255,0.5);cursor:pointer;padding:16px;user-select:none;z-index:10001;" title="Previous (←)">&#9664;</div>
   <div id="lightboxNext" class="lightbox-nav" onclick="event.stopPropagation(); lightboxNav(1);" style="position:absolute;right:12px;top:50%;transform:translateY(-50%);font-size:36px;color:rgba(255,255,255,0.5);cursor:pointer;padding:16px;user-select:none;z-index:10001;" title="Next (→)">&#9654;</div>
-  <div class="lightbox-img-wrap" id="lightboxWrap" onclick="event.stopPropagation(); if (Math.abs(_lbZoom - 1.0) < 0.001 && !window._lightboxZoomHandled) toggleLightboxZoom(event); window._lightboxZoomHandled = false;">
+  <div class="lightbox-img-wrap" id="lightboxWrap" onclick="event.stopPropagation(); if (!_lbVisualTransitionPending && Math.abs(_lbZoom - 1.0) < 0.001 && !window._lightboxZoomHandled) toggleLightboxZoom(event); window._lightboxZoomHandled = false;">
     <span class="lightbox-zoom-badge" id="lightboxZoomBadge" style="display:none;">1:1</span>
     <div class="lightbox-transform" id="lightboxTransform">
       <img id="lightboxImg" src="" alt="">
@@ -7000,6 +7000,7 @@ function toggleLightboxZoom(e) {
     if (!wrap.contains(e.target) && e.target !== wrap) return;
 
     e.preventDefault();
+    if (_lbVisualTransitionPending) return;
     // Trackpad pinch: e.ctrlKey === true; zoom factor more sensitive.
     var scale = e.ctrlKey ? 0.02 : 0.0015;
     var zoomFactor = Math.exp(-e.deltaY * scale);
@@ -7058,6 +7059,7 @@ function toggleLightboxZoom(e) {
   document.addEventListener('mousedown', function(e) {
     // Right-click (button 2) opens the context menu — never start a pan.
     if (e.button !== 0) return;
+    if (_lbVisualTransitionPending) return;
     var wrap = document.getElementById('lightboxWrap');
     if (!wrap || _lbZoom <= 1.001) return;
     if (e.target.tagName === 'BUTTON' || e.target.closest('button')) return;
@@ -7259,6 +7261,7 @@ function buildLightboxContextMenu(pid) {
     // handler in full control.)
     e.preventDefault();
     e.stopPropagation();
+    if (_lbVisualTransitionPending) return;
     var pid = _lightboxCurrentId;
     if (!pid) return;
     openContextMenu(e, buildLightboxContextMenu(pid));
@@ -8897,11 +8900,15 @@ function nativeMenuLightboxOpen() {
 }
 
 function nativeMenuActivePhotoIds() {
-  if (
-    nativeMenuLightboxOpen() &&
-    typeof _lightboxCurrentId !== 'undefined' &&
-    _lightboxCurrentId != null
-  ) {
+  if (nativeMenuLightboxOpen()) {
+    // Navigation advances the internal id before the incoming bitmap is
+    // visible. Do not let native Photo menu commands target that hidden photo.
+    if (typeof _lbVisualTransitionPending !== 'undefined' && _lbVisualTransitionPending) {
+      return [];
+    }
+    if (typeof _lightboxCurrentId === 'undefined' || _lightboxCurrentId == null) {
+      return [];
+    }
     return [_lightboxCurrentId];
   }
   if (

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -543,6 +543,9 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
 }
+.lightbox-actions.lb-photo-transition-pending {
+  opacity: 0.55;
+}
 .lifelist-lb-panel { display:flex; flex-direction:column; gap:6px; align-items:stretch; padding:4px 8px; border-radius:4px; background:rgba(12,14,16,0.88); border:1px solid rgba(255,255,255,0.42); color:#f4f7f8; font-size:12px; font-weight:650; text-shadow:0 1px 1px rgba(0,0,0,0.75); }
 .lifelist-lb-row { display:flex; align-items:center; gap:8px; justify-content:space-between; }
 .lifelist-lb-row .lifelist-lb-species { white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:180px; }
@@ -3636,6 +3639,14 @@ var _lbEditRecipeWriteSeqByPhoto = {};
 var _lbPhotoDataByPhoto = {};
 var _lbRenderVersionByPhoto = {};
 
+function _lbSetPhotoTransitionPending(pending) {
+  var actions = document.getElementById('lightboxActions');
+  if (!actions) return;
+  actions.classList.toggle('lb-photo-transition-pending', !!pending);
+  actions.inert = !!pending;
+  actions.setAttribute('aria-busy', pending ? 'true' : 'false');
+}
+
 // --- Species Representative panel, shared across every page's lightbox.
 // Driven by the `life_list` block on GET /api/photos/<id> (cached in
 // _lbPhotoDataByPhoto), so the action works wherever a photo is opened — not
@@ -5580,7 +5591,9 @@ function _lbRecordFlag(photoId, flag) {
   var p = _lightboxPhotoList.find(function(x) { return x.id === photoId; });
   if (p) p.flag = normalized;
   _lbRememberConfirmedFlag(photoId, normalized);
-  if (_lightboxCurrentId === photoId) _lbSetFlagStatus(normalized);
+  if (_lightboxCurrentId === photoId && !_lbVisualTransitionPending) {
+    _lbSetFlagStatus(normalized);
+  }
 }
 
 function _lbCacheFlag(photoId, flag) {
@@ -6570,6 +6583,7 @@ function openLightbox(photoId, filename, photoList, options) {
   // applied together from handleInitialImageLoad, before the browser's next
   // paint, so an off-center view never flashes through a centered state.
   _lbVisualTransitionPending = alreadyOpen;
+  _lbSetPhotoTransitionPending(_lbVisualTransitionPending);
   // A previous open's deferred overlay closure captured the previous photo id
   // and metadata. If this open's image resolves before its own metadata does,
   // draining that stale closure would render the previous photo's detections
@@ -6595,7 +6609,7 @@ function openLightbox(photoId, filename, photoList, options) {
     _lbForgetConfirmedFlag(photoId);
   }
   _lbCurrentWildlifeExcluded = !!(currentFromList && currentFromList.wildlife_excluded);
-  _lbSetFlagStatus(_lbConfirmedFlagFor(photoId));
+  if (!alreadyOpen) _lbSetFlagStatus(_lbConfirmedFlagFor(photoId));
 
   var overlay = document.getElementById('lightboxOverlay');
   var img = document.getElementById('lightboxImg');
@@ -6612,6 +6626,8 @@ function openLightbox(photoId, filename, photoList, options) {
   // arrow presses continue to target the right photo.
   function commitVisiblePhotoIdentity() {
     label.textContent = filename || '';
+    _lbSetFlagStatus(_lbConfirmedFlagFor(photoId));
+    _lbApplyWildlifeExcludedButton();
     var counter = document.getElementById('lightboxCounter');
     if (_lightboxPhotoList.length > 1) {
       var idx = _lightboxPhotoList.findIndex(function(p) { return p.id === photoId; });
@@ -6792,6 +6808,7 @@ function openLightbox(photoId, filename, photoList, options) {
       _lbPhotoH = img.naturalHeight;
     }
     _lbVisualTransitionPending = false;
+    _lbSetPhotoTransitionPending(false);
     _lbRecomputeNativeZoom();
     if (
       _lbCurrentSrcKey === 'full' &&
@@ -6821,7 +6838,9 @@ function openLightbox(photoId, filename, photoList, options) {
       // incoming photo as mid-transition. Apply any deferred viewport state
       // so the layout reflects the incoming photo instead of the frozen
       // outgoing bitmap.
+      commitVisiblePhotoIdentity();
       _lbVisualTransitionPending = false;
+      _lbSetPhotoTransitionPending(false);
       _lbRecomputeNativeZoom();
       if (!_lbTryApplyPendingViewportState()) _lbApplyPendingOneToOneZoom();
       _lbApplyTransform();
@@ -7094,6 +7113,7 @@ function closeLightbox(e) {
   _lbPanX = 0;
   _lbPanY = 0;
   _lbVisualTransitionPending = false;
+  _lbSetPhotoTransitionPending(false);
   _lbDeferredOverlayApply = null;
   _lbClearPendingViewportRestore();
   if (_lbSwapTimer) { clearTimeout(_lbSwapTimer); _lbSwapTimer = null; }
@@ -7887,8 +7907,26 @@ document.addEventListener('keydown', function(e) {
     (e.target && e.target.isContentEditable);
   // Editable check must come before arrow handling so arrows inside form
   // fields (e.g. the mask-variant <select>) change the value, not the photo.
-  if (!editable0 && e.key === 'ArrowRight') { lightboxNav(1); e.preventDefault(); }
-  if (!editable0 && e.key === 'ArrowLeft') { lightboxNav(-1); e.preventDefault(); }
+  if (!editable0 && e.key === 'ArrowRight') {
+    lightboxNav(1);
+    e.preventDefault();
+    e.stopImmediatePropagation();
+    return;
+  }
+  if (!editable0 && e.key === 'ArrowLeft') {
+    lightboxNav(-1);
+    e.preventDefault();
+    e.stopImmediatePropagation();
+    return;
+  }
+  // The outgoing photo is still visible while the incoming source decodes.
+  // Suppress photo-targeted shortcuts until the visible identity commits so
+  // ratings, edits, and zoom operations cannot affect a hidden photo.
+  if (_lbVisualTransitionPending && e.key !== 'Escape') {
+    e.preventDefault();
+    e.stopImmediatePropagation();
+    return;
+  }
   if (!editable0 && !e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey && !lightboxKeyMatchesConfiguredBrowseShortcut(e)) {
     if (e.key.toLowerCase() === 'f') {
       requestLightboxFullscreen();

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -7483,7 +7483,12 @@ async function lightboxToggleWildlifeExcluded() {
 
 function lightboxDelete() {
   var overlay = document.getElementById('lightboxOverlay');
-  if (!_lightboxCurrentId || !overlay || !overlay.classList.contains('active')) return;
+  if (
+    _lbVisualTransitionPending ||
+    !_lightboxCurrentId ||
+    !overlay ||
+    !overlay.classList.contains('active')
+  ) return;
   var currentId = _lightboxCurrentId;
   var p = _lightboxPhotoList.find(function(x) { return x.id === currentId; });
   var companionCount = (p && p.companion_path) ? 1 : 0;

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -543,7 +543,8 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
 }
-.lightbox-actions.lb-photo-transition-pending {
+.lightbox-actions.lb-photo-transition-pending,
+.lightbox-adjust-panel.lb-photo-transition-pending {
   opacity: 0.55;
 }
 .lifelist-lb-panel { display:flex; flex-direction:column; gap:6px; align-items:stretch; padding:4px 8px; border-radius:4px; background:rgba(12,14,16,0.88); border:1px solid rgba(255,255,255,0.42); color:#f4f7f8; font-size:12px; font-weight:650; text-shadow:0 1px 1px rgba(0,0,0,0.75); }
@@ -3640,11 +3641,13 @@ var _lbPhotoDataByPhoto = {};
 var _lbRenderVersionByPhoto = {};
 
 function _lbSetPhotoTransitionPending(pending) {
-  var actions = document.getElementById('lightboxActions');
-  if (!actions) return;
-  actions.classList.toggle('lb-photo-transition-pending', !!pending);
-  actions.inert = !!pending;
-  actions.setAttribute('aria-busy', pending ? 'true' : 'false');
+  ['lightboxActions', 'lightboxAdjustPanel'].forEach(function(id) {
+    var controls = document.getElementById(id);
+    if (!controls) return;
+    controls.classList.toggle('lb-photo-transition-pending', !!pending);
+    controls.inert = !!pending;
+    controls.setAttribute('aria-busy', pending ? 'true' : 'false');
+  });
 }
 
 // --- Species Representative panel, shared across every page's lightbox.

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -3641,7 +3641,7 @@ var _lbPhotoDataByPhoto = {};
 var _lbRenderVersionByPhoto = {};
 
 function _lbSetPhotoTransitionPending(pending) {
-  ['lightboxActions', 'lightboxAdjustPanel'].forEach(function(id) {
+  ['lightboxActions', 'lightboxAdjustPanel', 'syncLightboxPanel'].forEach(function(id) {
     var controls = document.getElementById(id);
     if (!controls) return;
     controls.classList.toggle('lb-photo-transition-pending', !!pending);

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -6604,6 +6604,28 @@ function openLightbox(photoId, filename, photoList, options) {
   var similarBtn = document.getElementById('lightboxSimilar');
   var inatBtn = document.getElementById('lightboxInat');
   var wrap = document.getElementById('lightboxWrap');
+
+  // The browser keeps painting the outgoing bitmap while a newly assigned
+  // image source loads. Keep the visible filename and position paired with
+  // that bitmap, then advance all three in the image-load task before the next
+  // paint. Internal navigation state still advances immediately, so rapid
+  // arrow presses continue to target the right photo.
+  function commitVisiblePhotoIdentity() {
+    label.textContent = filename || '';
+    var counter = document.getElementById('lightboxCounter');
+    if (_lightboxPhotoList.length > 1) {
+      var idx = _lightboxPhotoList.findIndex(function(p) { return p.id === photoId; });
+      var counterFilename = filename || (currentFromList && currentFromList.filename) || '';
+      counter.textContent = (idx + 1) + ' / ' + _lightboxPhotoList.length
+        + (counterFilename ? ' \u00b7 ' + counterFilename : '');
+      counter.title = counterFilename;
+      counter.style.display = '';
+    } else {
+      counter.title = '';
+      counter.style.display = 'none';
+    }
+  }
+
   // Reset pan for the new photo, but keep a 1:1 transform during arrow
   // navigation so the outgoing image does not visibly snap back to fit before
   // the replacement finishes loading.
@@ -6756,6 +6778,7 @@ function openLightbox(photoId, filename, photoList, options) {
     img.onload = null;
     img.onerror = null;
     if (_lightboxCurrentId !== photoId || _lbOpenSeq !== openSeq) return;
+    commitVisiblePhotoIdentity();
     // Only record the /full tier size if the currently loaded source is still /full.
     // A quick user zoom can trigger a debounced swap to a higher tier before /full
     // finishes loading, which would otherwise make us record the swapped source's
@@ -6795,9 +6818,9 @@ function openLightbox(photoId, filename, photoList, options) {
       // No further fallback tier is available. Clear the pending visual
       // transition — otherwise the metadata callback would keep skipping
       // layout updates and _lbSaveViewportState would keep treating the
-      // incoming photo as mid-transition even though the UI already points
-      // at it. Apply any deferred viewport state so the layout reflects
-      // the incoming photo instead of the frozen outgoing bitmap.
+      // incoming photo as mid-transition. Apply any deferred viewport state
+      // so the layout reflects the incoming photo instead of the frozen
+      // outgoing bitmap.
       _lbVisualTransitionPending = false;
       _lbRecomputeNativeZoom();
       if (!_lbTryApplyPendingViewportState()) _lbApplyPendingOneToOneZoom();
@@ -6815,7 +6838,7 @@ function openLightbox(photoId, filename, photoList, options) {
   img.onload = handleInitialImageLoad;
   img.onerror = handleInitialImageError;
   img.src = _lbSrcUrl(photoId, _lbCurrentSrcKey);
-  label.textContent = filename || '';
+  if (!alreadyOpen) commitVisiblePhotoIdentity();
   inspectBtn.onclick = function() { closeLightbox(); openPipeline(photoId); };
   similarBtn.onclick = function() { closeLightbox(); findSimilar(photoId); };
   inatBtn.onclick = function() { submitToInat(photoId); };
@@ -6846,19 +6869,6 @@ function openLightbox(photoId, filename, photoList, options) {
   // pages that don't run the pipeline still get the lightbox unchanged.
   _lbLoadMaskVariants(photoId);
 
-  // Show position indicator if navigating a list
-  var counter = document.getElementById('lightboxCounter');
-  if (_lightboxPhotoList.length > 1) {
-    var idx = _lightboxPhotoList.findIndex(function(p) { return p.id === photoId; });
-    var counterFilename = filename || (currentFromList && currentFromList.filename) || '';
-    counter.textContent = (idx + 1) + ' / ' + _lightboxPhotoList.length
-      + (counterFilename ? ' \u00b7 ' + counterFilename : '');
-    counter.title = counterFilename;
-    counter.style.display = '';
-  } else {
-    counter.title = '';
-    counter.style.display = 'none';
-  }
 }
 
 function lightboxNav(delta) {

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -6539,6 +6539,13 @@ window.vireoRefreshEditRecipeCache = _lbRefreshEditRecipeCache;
 
 function openLightbox(photoId, filename, photoList, options) {
   var alreadyOpen = !!window._lbEscToken;
+  var transitionAlreadyPending = _lbVisualTransitionPending;
+  var reopeningVisiblePhoto = !!(
+    alreadyOpen &&
+    !transitionAlreadyPending &&
+    _lightboxCurrentId != null &&
+    String(_lightboxCurrentId) === String(photoId)
+  );
   options = options || {};
   var fallbackViewportState = options.fallbackViewportState || null;
   _lbFlushPendingAdjustmentSave();
@@ -6585,7 +6592,14 @@ function openLightbox(photoId, filename, photoList, options) {
   // photo's dimensions, true 1:1 scale, and normalized viewport center are
   // applied together from handleInitialImageLoad, before the browser's next
   // paint, so an off-center view never flashes through a centered state.
-  _lbVisualTransitionPending = alreadyOpen;
+  // Re-running an "Open in Lightbox" command for the photo that is already
+  // visible does not require an identity handoff. In particular, assigning
+  // the same img.src again is not guaranteed to emit load/error, so arming the
+  // transition lock here could leave every photo control inert indefinitely.
+  // Do retain the lock when this call supersedes a transition already in
+  // flight: _lightboxCurrentId then names the incoming photo, not necessarily
+  // the bitmap that is still visible.
+  _lbVisualTransitionPending = alreadyOpen && !reopeningVisiblePhoto;
   _lbSetPhotoTransitionPending(_lbVisualTransitionPending);
   // A previous open's deferred overlay closure captured the previous photo id
   // and metadata. If this open's image resolves before its own metadata does,
@@ -6866,7 +6880,7 @@ function openLightbox(photoId, filename, photoList, options) {
   img.onload = handleInitialImageLoad;
   img.onerror = handleInitialImageError;
   img.src = _lbSrcUrl(photoId, _lbCurrentSrcKey);
-  if (!alreadyOpen) commitVisiblePhotoIdentity();
+  if (!_lbVisualTransitionPending) commitVisiblePhotoIdentity();
   inspectBtn.onclick = function() { closeLightbox(); openPipeline(photoId); };
   similarBtn.onclick = function() { closeLightbox(); findSimilar(photoId); };
   inatBtn.onclick = function() { submitToInat(photoId); };


### PR DESCRIPTION
Browse navigation now keeps the visible filename and position counter paired with the outgoing bitmap until the incoming image finishes loading, then commits them together. This fixes the 100% zoom mismatch caused when the browser continued painting the old image after navigation state had already advanced. Regression coverage stalls the next image during keyboard navigation and updates neighboring transition expectations. Tested with `python -m pytest tests/e2e/test_browse_lightbox.py -q` (26 passed).