### PR TITLE
Clarify photo GPS and map coordinate status

### DIFF
--- a/tests/e2e/test_location_section.py
+++ b/tests/e2e/test_location_section.py
@@ -99,6 +99,74 @@ def test_location_section_renders_empty(live_server, page):
     expect(section).to_be_visible()
     expect(page.locator("#locationInput")).to_be_visible()
     expect(page.locator("#locationFilled")).to_be_hidden()
+    expect(page.locator("#locationCoordinateStatus")).to_contain_text(
+        "No coordinates"
+    )
+
+
+def test_browse_cards_and_inspector_distinguish_coordinate_sources(
+    live_server, page
+):
+    """Cards and detail use three explicit, non-overlapping coordinate states."""
+    db = live_server["db"]
+    exif_id, assigned_id, none_id = live_server["data"]["photos"][:3]
+    with db.conn:
+        db.conn.execute(
+            "UPDATE photos SET latitude = 37.7749, longitude = -122.4194 "
+            "WHERE id = ?",
+            (exif_id,),
+        )
+        cursor = db.conn.execute(
+            "INSERT INTO keywords (name, type, latitude, longitude) "
+            "VALUES ('Assigned Park', 'location', 40.7829, -73.9654)"
+        )
+        db.conn.execute(
+            "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+            (assigned_id, cursor.lastrowid),
+        )
+
+    page.goto(f"{live_server['url']}/browse")
+    expected = {
+        exif_id: "EXIF GPS",
+        assigned_id: "Assigned map location",
+        none_id: "No coordinates",
+    }
+    for photo_id, label in expected.items():
+        card_status = page.locator(
+            f".grid-card[data-id='{photo_id}'] .grid-location-status"
+        )
+        expect(card_status).to_contain_text(label)
+
+    page.locator(f".grid-card[data-id='{exif_id}']").click()
+    expect(page.locator("#locationCoordinateStatus")).to_contain_text("EXIF GPS")
+
+    page.locator(f".grid-card[data-id='{assigned_id}']").click()
+    expect(page.locator("#locationCoordinateStatus")).to_contain_text(
+        "Assigned map location"
+    )
+
+    page.locator(f".grid-card[data-id='{none_id}']").click()
+    expect(page.locator("#locationCoordinateStatus")).to_contain_text(
+        "No coordinates"
+    )
+
+
+def test_browse_coordinate_filter_deep_link(live_server, page):
+    """Map links can open Browse already filtered to photos without coordinates."""
+    db = live_server["db"]
+    exif_id = live_server["data"]["photos"][0]
+    with db.conn:
+        db.conn.execute(
+            "UPDATE photos SET latitude = 37.7749, longitude = -122.4194 "
+            "WHERE id = ?",
+            (exif_id,),
+        )
+
+    page.goto(f"{live_server['url']}/browse?location_status=none")
+    expect(page.locator("#locationStatusFilter")).to_have_value("none")
+    page.locator(".grid-card").first.wait_for(state="visible")
+    assert page.locator(f".grid-card[data-id='{exif_id}']").count() == 0
+    assert page.locator(".grid-location-status.none").count() > 0
 
 
 def test_freetext_enter_creates_location(live_server, page):

--- a/tests/e2e/test_map_deep_link.py
+++ b/tests/e2e/test_map_deep_link.py
@@ -110,6 +110,10 @@ def test_map_photo_id_deep_link_focuses_marker(live_server, page):
     active_card = page.locator(f".sidebar-card.active[data-id='{pid}']")
     expect(active_card).to_be_visible()
     expect(page.locator("#mapStatus")).to_contain_text("Showing 1 of 1 geolocated photos")
+    expect(page.locator("#mapStatus")).to_contain_text("map coverage")
+    missing_link = page.locator("#mapStatus a")
+    expect(missing_link).to_have_attribute("href", "/browse?location_status=none")
+    expect(missing_link).to_contain_text("without coordinates")
 
 
 def test_map_photo_id_deep_link_reports_missing_location(live_server, page):
@@ -120,6 +124,17 @@ def test_map_photo_id_deep_link_reports_missing_location(live_server, page):
     page.goto(f"{live_server['url']}/map?photo_id={pid}")
 
     expect(page.locator("#mapStatus")).to_contain_text("No map location found for this photo.")
+
+
+def test_empty_map_links_to_photos_without_coordinates(live_server, page):
+    """An all-empty map gives users a working path to the affected photos."""
+    page.route("https://unpkg.com/**", _stub_leaflet)
+    page.goto(f"{live_server['url']}/map")
+
+    expect(page.locator("#mapStatus")).to_contain_text("No geolocated photos")
+    missing_link = page.locator("#mapStatus a")
+    expect(missing_link).to_have_attribute("href", "/browse?location_status=none")
+    expect(missing_link).to_contain_text("without coordinates")
 
 
 def test_map_photo_id_deep_link_is_one_shot_for_later_filters(live_server, page):

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2772,6 +2772,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     # user's existing action keeps working; they can re-bind toggle_ui from
     # the shortcuts editor.
     cfg.migrate_toggle_ui_h_conflict()
+    # Existing users commonly have the previous Browse card defaults persisted
+    # verbatim. Add the new coordinate-source field only for that exact legacy
+    # list; customized card layouts remain unchanged.
+    cfg.migrate_browse_location_status_field()
     # One-time rewrite of the global pipeline.default_strategy (legacy
     # hardcoded strategy name) to pipeline.default_process_id (saved_processes
     # id). The workspace-side rewrite happens inside Database(); this covers
@@ -3224,6 +3228,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             p["species"] = species_map.get(p["id"], [])
         return photo_dicts
 
+    def _attach_location_statuses(db, photo_dicts):
+        """Attach the effective coordinate source used by Browse and Map UI."""
+        if not photo_dicts:
+            return photo_dicts
+        ids = [p["id"] for p in photo_dicts if isinstance(p.get("id"), int)]
+        statuses = db.get_photo_location_statuses(ids)
+        for photo in photo_dicts:
+            photo["location_status"] = statuses.get(photo.get("id"), "none")
+        return photo_dicts
+
     def _attach_species_representatives(db, photo_dicts):
         """Attach species representative state to photo dicts (in-place)."""
         if not photo_dicts:
@@ -3329,6 +3343,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         raw = request.args.get(name, "")
         return str(raw).strip().lower() in {"1", "true", "yes", "on"}
 
+    def _request_location_status_filter():
+        value = (request.args.get("location_status") or "").strip().lower()
+        if not value:
+            return None
+        if value not in {"exif", "assigned", "none"}:
+            raise ValueError(
+                "location_status must be 'exif', 'assigned', or 'none'"
+            )
+        return value
+
     @app.route("/api/browse/init")
     def api_browse_init():
         """Combined endpoint for browse page initial load — one request instead of five."""
@@ -3348,6 +3372,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         color_label = request.args.get("color_label", None)
         try:
             flag = _request_flag_filter()
+            location_status = _request_location_status_filter()
         except ValueError as e:
             return json_error(str(e), 400)
 
@@ -3364,8 +3389,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             keyword_whole_word=keyword_whole_word,
             color_label=color_label,
             flag=flag,
+            location_status=location_status,
         )
-        if not any([folder_id, rating_min, date_from, date_to, keyword, color_label, flag]):
+        if not any([folder_id, rating_min, date_from, date_to, keyword, color_label, flag, location_status]):
             total = db.count_photos()
         else:
             total = db.count_filtered_photos(
@@ -3378,12 +3404,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 keyword_whole_word=keyword_whole_word,
                 color_label=color_label,
                 flag=flag,
+                location_status=location_status,
             )
         folders = db.get_folder_tree()
         keywords = db.get_keyword_tree()
         collections = db.get_collections()
 
         photo_dicts = [dict(p) for p in photos]
+        _attach_location_statuses(db, photo_dicts)
         _attach_species(db, photo_dicts)
         _attach_species_representatives(db, photo_dicts)
         _attach_detections(db, photo_dicts)
@@ -4735,6 +4763,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         color_label = request.args.get("color_label", None)
         try:
             flag = _request_flag_filter()
+            location_status = _request_location_status_filter()
         except ValueError as e:
             return json_error(str(e), 400)
 
@@ -4751,10 +4780,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             keyword_whole_word=keyword_whole_word,
             color_label=color_label,
             flag=flag,
+            location_status=location_status,
         )
 
         # Total count — use count_photos for unfiltered, otherwise use efficient COUNT query
-        if not any([folder_id, rating_min, date_from, date_to, keyword, color_label, flag]):
+        if not any([folder_id, rating_min, date_from, date_to, keyword, color_label, flag, location_status]):
             total = db.count_photos()
         else:
             total = db.count_filtered_photos(
@@ -4767,9 +4797,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 keyword_whole_word=keyword_whole_word,
                 color_label=color_label,
                 flag=flag,
+                location_status=location_status,
             )
 
         photo_dicts = [dict(p) for p in photos]
+        _attach_location_statuses(db, photo_dicts)
         _attach_species(db, photo_dicts)
         _attach_species_representatives(db, photo_dicts)
         _attach_detections(db, photo_dicts)
@@ -4799,6 +4831,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         color_label = request.args.get("color_label", None)
         try:
             flag = _request_flag_filter()
+            location_status = _request_location_status_filter()
         except ValueError as e:
             return json_error(str(e), 400)
 
@@ -4813,6 +4846,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             keyword_whole_word=keyword_whole_word,
             color_label=color_label,
             flag=flag,
+            location_status=location_status,
         )
         return jsonify({"photo_ids": photo_ids, "total": len(photo_ids)})
 
@@ -4830,6 +4864,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         color_label = request.args.get("color_label", None)
         try:
             flag = _request_flag_filter()
+            location_status = _request_location_status_filter()
         except ValueError as e:
             return json_error(str(e), 400)
         data = db.get_calendar_data(
@@ -4837,6 +4872,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             keyword_match_case=keyword_match_case,
             keyword_whole_word=keyword_whole_word,
             color_label=color_label, flag=flag,
+            location_status=location_status,
         )
         return jsonify(data)
 
@@ -4854,6 +4890,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         color_label = request.args.get("color_label", None)
         try:
             flag = _request_flag_filter()
+            location_status = _request_location_status_filter()
         except ValueError as e:
             return json_error(str(e), 400)
         return jsonify(
@@ -4868,6 +4905,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 collection_id=collection_id,
                 color_label=color_label,
                 flag=flag,
+                location_status=location_status,
             )
         )
 
@@ -4882,6 +4920,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("not found", 404)
 
         result = dict(photo)
+        _attach_location_statuses(db, [result])
 
         # Parse exif_data JSON into metadata field
         raw_exif = result.pop("exif_data", None)
@@ -4985,6 +5024,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             photo = db.get_photo(pid, verify_workspace=True)
             if photo:
                 photos.append(dict(photo))
+        _attach_location_statuses(db, photos)
         _attach_species(db, photos)
         _attach_species_representatives(db, photos)
         _attach_detections(db, photos)
@@ -5178,8 +5218,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         )
 
         total_photos = db.count_photos()
-        total_without_gps = db.count_photos_without_gps()
-        total_with_gps = total_photos - total_without_gps
+        total_without_coordinates = db.count_photos_without_coordinates()
+        total_geolocated = total_photos - total_without_coordinates
 
         photo_dicts = [dict(p) for p in photos]
         _attach_edit_recipes(db, photo_dicts)
@@ -5188,8 +5228,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "photos": photo_dicts,
             "total_filtered": len(photos),
             "total_photos": total_photos,
-            "total_with_gps": total_with_gps,
-            "total_without_gps": total_without_gps,
+            "total_geolocated": total_geolocated,
+            "total_without_coordinates": total_without_coordinates,
+            # Compatibility for older clients; new UI uses coordinate-neutral
+            # names because assigned locations are included in these totals.
+            "total_with_gps": total_geolocated,
+            "total_without_gps": total_without_coordinates,
         })
 
     @app.route("/api/species")
@@ -8612,6 +8656,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             )
             return json_error(f"collection rules cannot be resolved: {e}", 400)
         photo_dicts = [dict(p) for p in photos]
+        _attach_location_statuses(db, photo_dicts)
         _attach_species(db, photo_dicts)
         _attach_species_representatives(db, photo_dicts)
         _attach_detections(db, photo_dicts)
@@ -23562,6 +23607,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         collection_id = request.args.get("collection_id", None, type=int)
         try:
             flag = _request_flag_filter()
+            location_status = _request_location_status_filter()
         except ValueError as e:
             return json_error(str(e), 400)
         ids_only = request.args.get("ids_only", "").lower() in ("1", "true", "yes")
@@ -23586,7 +23632,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         candidate_photo_ids = None
         if collection_id is not None:
             candidate_photo_ids = db.get_collection_photo_ids(collection_id)
-        elif any([folder_id, rating_min, date_from, date_to, keyword, color_label, flag]):
+        elif any([folder_id, rating_min, date_from, date_to, keyword, color_label, flag, location_status]):
             candidate_photo_ids = db.get_photo_ids(
                 folder_id=folder_id,
                 rating_min=rating_min,
@@ -23597,6 +23643,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 keyword_whole_word=keyword_whole_word,
                 color_label=color_label,
                 flag=flag,
+                location_status=location_status,
             )
 
         if candidate_photo_ids == []:
@@ -23663,6 +23710,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     photo_dicts.append(dict(photos_map[pid]))
                     sims_by_pid[pid] = round(sim, 4)
             _attach_species(db, photo_dicts)
+            _attach_location_statuses(db, photo_dicts)
             _attach_species_representatives(db, photo_dicts)
             _attach_detections(db, photo_dicts)
             _attach_edit_recipes(db, photo_dicts)

--- a/vireo/config.py
+++ b/vireo/config.py
@@ -74,7 +74,9 @@ DEFAULTS = {
     # out of "Needs Identification" and are skipped by the classifier.
     "subject_types": ["taxonomy", "individual", "genre"],
     # --- Display ---
-    "browse_card_fields": ["filename", "rating", "flag", "sharpness"],
+    "browse_card_fields": [
+        "filename", "location_status", "rating", "flag", "sharpness"
+    ],
     "photos_per_page": 50,
     "thumbnail_size": 400,
     "thumbnail_quality": 85,
@@ -300,6 +302,7 @@ MIGRATION_MISS_THRESHOLDS = "miss_thresholds_2026_05"
 MIGRATION_TOGGLE_UI_H_CONFLICT = "toggle_ui_h_conflict_2026_07"
 MIGRATION_EYE_DETECT_DEFAULT_OFF = "eye_detect_default_off_2026_07"
 MIGRATION_DEFAULT_STRATEGY_TO_PROCESS_ID = "default_strategy_to_process_id_2026_07"
+MIGRATION_BROWSE_LOCATION_STATUS = "browse_location_status_2026_07"
 
 _LEGACY_MISS_DET_CONFIDENCE = 0.25
 _LEGACY_MISS_DET_CONFIDENCE_BURST = 0.15
@@ -406,6 +409,31 @@ def migrate_toggle_ui_h_conflict():
                         rewrote = True
                         break
         applied.append(MIGRATION_TOGGLE_UI_H_CONFLICT)
+        raw["_migrations_applied"] = applied
+        save(raw)
+        return rewrote
+
+
+def migrate_browse_location_status_field():
+    """Add coordinate source to the exact legacy default Browse card fields.
+
+    Customized card-field lists stay untouched. This makes the newly explicit
+    GPS/assigned/none state visible after upgrade for users who were still on
+    the previous default rather than only for fresh installs.
+    """
+    legacy_default = ["filename", "rating", "flag", "sharpness"]
+    new_default = [
+        "filename", "location_status", "rating", "flag", "sharpness"
+    ]
+    with _lock:
+        raw = _read_raw()
+        applied = _migrations_applied(raw)
+        if MIGRATION_BROWSE_LOCATION_STATUS in applied:
+            return False
+        rewrote = raw.get("browse_card_fields") == legacy_default
+        if rewrote:
+            raw["browse_card_fields"] = new_default
+        applied.append(MIGRATION_BROWSE_LOCATION_STATUS)
         raw["_migrations_applied"] = applied
         save(raw)
         return rewrote

--- a/vireo/config_schema.py
+++ b/vireo/config_schema.py
@@ -186,7 +186,7 @@ SCHEMA = {
     "browse_card_fields": {
         "type": "list_string",
         "items_enum": [
-            "filename", "rating", "flag", "sharpness", "species",
+            "filename", "location_status", "rating", "flag", "sharpness", "species",
             "dimensions", "file_size", "capture_date", "extension",
             "quality_score",
         ],

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -6665,6 +6665,71 @@ class Database:
             "detected_count": detected_count,
         }
 
+    @staticmethod
+    def _append_location_status_filter(conditions, location_status):
+        """Add a Browse coordinate-source predicate using the photo alias ``p``.
+
+        ``exif`` means the original photo has a complete EXIF coordinate pair.
+        ``assigned`` means EXIF GPS is absent or incomplete but a linked,
+        structured location supplies a complete pair. ``none`` means neither
+        source can place the photo on the map.
+        """
+        if location_status is None:
+            return
+        assigned_exists = """EXISTS (
+            SELECT 1 FROM photo_keywords pk_location_status
+            JOIN keywords k_location_status
+              ON k_location_status.id = pk_location_status.keyword_id
+            WHERE pk_location_status.photo_id = p.id
+              AND k_location_status.type = 'location'
+              AND k_location_status.latitude IS NOT NULL
+              AND k_location_status.longitude IS NOT NULL
+        )"""
+        no_exif = "(p.latitude IS NULL OR p.longitude IS NULL)"
+        if location_status == "exif":
+            conditions.append(
+                "p.latitude IS NOT NULL AND p.longitude IS NOT NULL"
+            )
+        elif location_status == "assigned":
+            conditions.append(f"{no_exif} AND {assigned_exists}")
+        elif location_status == "none":
+            conditions.append(f"{no_exif} AND NOT {assigned_exists}")
+        else:
+            raise ValueError(
+                "location_status must be 'exif', 'assigned', or 'none'"
+            )
+
+    def get_photo_location_statuses(self, photo_ids):
+        """Return ``{photo_id: exif|assigned|none}`` for the requested photos."""
+        if not photo_ids:
+            return {}
+        result = {}
+        for chunk in _chunks(list(dict.fromkeys(photo_ids))):
+            placeholders = ",".join("?" for _ in chunk)
+            rows = self.conn.execute(
+                f"""
+                SELECT p.id,
+                       CASE
+                         WHEN p.latitude IS NOT NULL AND p.longitude IS NOT NULL
+                           THEN 'exif'
+                         WHEN EXISTS (
+                           SELECT 1 FROM photo_keywords pk
+                           JOIN keywords k ON k.id = pk.keyword_id
+                           WHERE pk.photo_id = p.id
+                             AND k.type = 'location'
+                             AND k.latitude IS NOT NULL
+                             AND k.longitude IS NOT NULL
+                         ) THEN 'assigned'
+                         ELSE 'none'
+                       END AS location_status
+                FROM photos p
+                WHERE p.id IN ({placeholders})
+                """,
+                list(chunk),
+            ).fetchall()
+            result.update({row["id"]: row["location_status"] for row in rows})
+        return result
+
     def get_calendar_data(
         self,
         year,
@@ -6675,6 +6740,7 @@ class Database:
         keyword_whole_word=False,
         color_label=None,
         flag=None,
+        location_status=None,
     ):
         """Return daily photo counts for a given year, scoped to active workspace."""
         ws = self._ws_id()
@@ -6697,6 +6763,7 @@ class Database:
         if flag is not None:
             conditions.append("COALESCE(p.flag, 'none') = ?")
             where_params.append(flag)
+        self._append_location_status_filter(conditions, location_status)
         if keyword is not None:
             kw_clause, kw_params = _keyword_token_clause(
                 keyword,
@@ -6757,6 +6824,7 @@ class Database:
         keyword_whole_word=False,
         color_label=None,
         flag=None,
+        location_status=None,
     ):
         """Return paginated, filtered photo list scoped to active workspace."""
         conditions = ["wf.workspace_id = ?"]
@@ -6780,6 +6848,7 @@ class Database:
         if flag is not None:
             conditions.append("COALESCE(p.flag, 'none') = ?")
             where_params.append(flag)
+        self._append_location_status_filter(conditions, location_status)
 
         join_clause = ("JOIN workspace_folders wf ON wf.folder_id = p.folder_id"
                        "\nJOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')")
@@ -6844,6 +6913,7 @@ class Database:
         keyword_whole_word=False,
         color_label=None,
         flag=None,
+        location_status=None,
     ):
         """Return all filtered photo IDs scoped to active workspace."""
         conditions = ["wf.workspace_id = ?"]
@@ -6867,6 +6937,7 @@ class Database:
         if flag is not None:
             conditions.append("COALESCE(p.flag, 'none') = ?")
             where_params.append(flag)
+        self._append_location_status_filter(conditions, location_status)
 
         join_clause = ("JOIN workspace_folders wf ON wf.folder_id = p.folder_id"
                        "\nJOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')")
@@ -6920,6 +6991,7 @@ class Database:
         keyword_whole_word=False,
         color_label=None,
         flag=None,
+        location_status=None,
     ):
         """Return count of photos matching the given filters, scoped to active workspace."""
         conditions = ["wf.workspace_id = ?"]
@@ -6943,6 +7015,7 @@ class Database:
         if flag is not None:
             conditions.append("COALESCE(p.flag, 'none') = ?")
             where_params.append(flag)
+        self._append_location_status_filter(conditions, location_status)
 
         join_clause = ("JOIN workspace_folders wf ON wf.folder_id = p.folder_id"
                        "\nJOIN folders f ON f.id = p.folder_id AND f.status IN ('ok', 'partial')")
@@ -6987,6 +7060,7 @@ class Database:
         collection_id=None,
         color_label=None,
         flag=None,
+        location_status=None,
     ):
         """Return summary stats for the browse panel, scoped to active workspace and filters."""
         ws = self._ws_id()
@@ -7012,6 +7086,7 @@ class Database:
         if flag is not None:
             conditions.append("COALESCE(p.flag, 'none') = ?")
             where_params.append(flag)
+        self._append_location_status_filter(conditions, location_status)
 
         # When browsing a collection, restrict photos to those matching the
         # collection's rules by using a subquery from _build_collection_query.
@@ -7426,6 +7501,10 @@ class Database:
         ]
 
     def count_photos_without_gps(self):
+        """Backward-compatible alias for :meth:`count_photos_without_coordinates`."""
+        return self.count_photos_without_coordinates()
+
+    def count_photos_without_coordinates(self):
         """Count photos in the active workspace that the map can't plot.
 
         A photo IS plottable when either its EXIF lat/lng are both present

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -351,6 +351,22 @@ body.sidebar-resizing {
   margin-top: 4px;
 }
 .grid-card-rating { font-size: 12px; color: var(--warning); }
+.grid-location-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 5px;
+  border: 1px solid var(--border-secondary);
+  border-radius: 999px;
+  padding: 1px 6px;
+  font-size: 9px;
+  font-weight: 600;
+  line-height: 16px;
+  white-space: nowrap;
+}
+.grid-location-status.exif { color: var(--accent); }
+.grid-location-status.assigned { color: var(--info); }
+.grid-location-status.none { color: var(--text-ghost); }
 .grid-card-flag {
   font-size: 10px;
   padding: 1px 5px;
@@ -972,6 +988,21 @@ body.sidebar-resizing {
   font-size: 11px;
   color: var(--warning);
 }
+.coordinate-status {
+  display: flex;
+  align-items: flex-start;
+  gap: 7px;
+  margin: 0 0 8px;
+  border: 1px solid var(--border-secondary);
+  border-radius: 5px;
+  padding: 7px 8px;
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.35;
+}
+.coordinate-status.exif { border-color: color-mix(in srgb, var(--accent) 45%, var(--border-secondary)); }
+.coordinate-status.assigned { border-color: color-mix(in srgb, var(--info) 45%, var(--border-secondary)); }
+.coordinate-status.none { color: var(--text-ghost); }
 /* Google Places autocomplete dropdown z-index — must sit above the detail panel. */
 .pac-container { z-index: 10000 !important; }
 .detail-summary {
@@ -1548,6 +1579,12 @@ body.sidebar-resizing {
         <option value="blue">Blue</option>
         <option value="purple">Purple</option>
       </select>
+      <select id="locationStatusFilter" onchange="applyFilters()" title="Filter by coordinate source" style="font-size:12px;">
+        <option value="">Coordinates: Any</option>
+        <option value="exif">EXIF GPS</option>
+        <option value="assigned">Assigned map location</option>
+        <option value="none">No coordinates</option>
+      </select>
       <select id="sortSelect" onchange="applyFilters()" title="Sort order">
         <option value="date">Capture date (oldest)</option>
         <option value="date_desc">Capture date (newest)</option>
@@ -1774,6 +1811,7 @@ body.sidebar-resizing {
 
       <div class="detail-section location-section" id="locationSection">
         <div class="detail-section-title">Location</div>
+        <div id="locationCoordinateStatus" class="coordinate-status none"></div>
         <div id="locationFilled" class="single-only" hidden></div>
         <div id="locationEmpty">
           <div class="keyword-autocomplete">
@@ -2000,7 +2038,7 @@ var selectionKeywordMissingById = {};
 var selectionKeywordPresentById = {};
 var selectionKeywordNameById = {};
 var showDetectionBoxes = false;
-var cardFields = ["filename", "rating", "flag", "color_label", "sharpness"]; // default, overridden by config
+var cardFields = ["filename", "location_status", "rating", "flag", "color_label", "sharpness"]; // default, overridden by config
 var inatSubmitted = {};  // {photo_id: true}
 var colorLabels = {};    // {photo_id: color_string}
 // Which photo ids we've confirmed color-label state for. `colorLabels[id]`
@@ -2443,6 +2481,7 @@ function bindKeywordAutocomplete(inputId, dropdownId, submitFn) {
 function hasActiveBrowseFilter() {
   var searchInput = document.getElementById('searchInput');
   var colorFilter = document.getElementById('colorFilter');
+  var locationStatusFilter = document.getElementById('locationStatusFilter');
   var dateFrom = document.getElementById('dateFrom');
   var dateTo = document.getElementById('dateTo');
   return !!(
@@ -2454,6 +2493,7 @@ function hasActiveBrowseFilter() {
     flagFilter ||
     (searchInput && searchInput.value.trim()) ||
     (colorFilter && colorFilter.value) ||
+    (locationStatusFilter && locationStatusFilter.value) ||
     (dateFrom && dateFrom.value) ||
     (dateTo && dateTo.value)
   );
@@ -2502,6 +2542,16 @@ function renderCardField(field, p) {
   switch (field) {
     case 'filename':
       return '<div class="grid-card-name" title="' + escapeAttr(p.filename) + '">' + escapeHtml(p.filename) + '</div>';
+    case 'location_status':
+      var locationStatus = p.location_status || 'none';
+      var locationLabels = {
+        exif: ['📍', 'EXIF GPS', 'Embedded GPS coordinates from the photo'],
+        assigned: ['●', 'Assigned map location', 'Map coordinates from an assigned Vireo location'],
+        none: ['⊘', 'No coordinates', 'No EXIF GPS or assigned map coordinates']
+      };
+      var locationLabel = locationLabels[locationStatus] || locationLabels.none;
+      return '<span class="grid-location-status ' + locationStatus + '" title="' + escapeAttr(locationLabel[2]) + '">' +
+        locationLabel[0] + ' ' + locationLabel[1] + '</span>';
     case 'rating':
       if (p.rating > 0) {
         var stars = '';
@@ -2834,7 +2884,17 @@ async function bootstrapBrowse() {
   var bootstrapSucceeded = false;
   try {
     applyBrowseConfig(await _cfgPromise);
-    var data = await safeFetch('/api/browse/init?per_page=' + perPage + '&sort=' + document.getElementById('sortSelect').value);
+    var pageParams = new URLSearchParams(window.location.search);
+    var initialLocationStatus = pageParams.get('location_status') || '';
+    if (!initialLocationStatus && pageParams.get('missing_gps') === '1') {
+      initialLocationStatus = 'none';
+    }
+    if (['exif', 'assigned', 'none'].indexOf(initialLocationStatus) !== -1) {
+      document.getElementById('locationStatusFilter').value = initialLocationStatus;
+    }
+    var initParams = buildCurrentBrowseParams();
+    initParams.set('per_page', perPage);
+    var data = await safeFetch('/api/browse/init?' + initParams.toString());
 
     // Populate everything from a single response
     photos = data.photos || [];
@@ -3901,6 +3961,9 @@ function buildCurrentBrowseParams() {
   var colorFilter = document.getElementById('colorFilter').value;
   if (colorFilter) params.set('color_label', colorFilter);
 
+  var locationStatus = document.getElementById('locationStatusFilter').value;
+  if (locationStatus) params.set('location_status', locationStatus);
+
   var dateFrom = document.getElementById('dateFrom').value;
   var dateTo = document.getElementById('dateTo').value;
   if (dateFrom) params.set('date_from', dateFrom);
@@ -4061,6 +4124,8 @@ async function loadCalendarData() {
   if (flagFilter) params.set('flag', flagFilter);
   var colorFilter = document.getElementById('colorFilter').value;
   if (colorFilter) params.set('color_label', colorFilter);
+  var locationStatus = document.getElementById('locationStatusFilter').value;
+  if (locationStatus) params.set('location_status', locationStatus);
   appendKeywordSearchParams(params);
 
   calendarData = await safeFetch('/api/photos/calendar?' + params.toString());
@@ -4207,6 +4272,12 @@ function calendarChangeYear(delta) {
 }
 
 function applyFilters() {
+  var locationStatus = document.getElementById('locationStatusFilter').value;
+  var url = new URL(window.location.href);
+  if (locationStatus) url.searchParams.set('location_status', locationStatus);
+  else url.searchParams.delete('location_status');
+  url.searchParams.delete('missing_gps');
+  window.history.replaceState({}, '', url.pathname + url.search);
   if (timelineMode) loadCalendarData();
   activeCollectionId = null;
   reloadBrowseResults();
@@ -4303,6 +4374,8 @@ function appendClipSearchScopeParams(params) {
 
   var colorFilter = document.getElementById('colorFilter').value;
   if (colorFilter) params.set('color_label', colorFilter);
+  var locationStatus = document.getElementById('locationStatusFilter').value;
+  if (locationStatus) params.set('location_status', locationStatus);
 
   var dateFrom = document.getElementById('dateFrom').value;
   var dateTo = document.getElementById('dateTo').value;
@@ -6282,6 +6355,7 @@ function renderDetail(photo) {
   var detailThumb = window.vireoThumbnailUrl ? window.vireoThumbnailUrl(photo) : '/thumbnails/' + photo.id + '.jpg';
   document.getElementById('detailImg').src = detailThumb;
   document.getElementById('detailFilename').textContent = photo.filename;
+  renderCoordinateStatus(photo);
 
   // Rating stars
   var ratingHtml = '';
@@ -6566,6 +6640,8 @@ async function loadSummary() {
   if (flagFilter) params.set('flag', flagFilter);
   var colorFilter = document.getElementById('colorFilter').value;
   if (colorFilter) params.set('color_label', colorFilter);
+  var locationStatus = document.getElementById('locationStatusFilter').value;
+  if (locationStatus) params.set('location_status', locationStatus);
   var dateFrom = document.getElementById('dateFrom').value;
   var dateTo = document.getElementById('dateTo').value;
   if (dateFrom) params.set('date_from', dateFrom);
@@ -6808,6 +6884,27 @@ function _batchColorLoaded(ids) {
 function renderBatchInspector(ids, opts) {
   opts = opts || {};
   var known = _batchAllLoaded(ids);
+
+  var coordinateEl = document.getElementById('locationCoordinateStatus');
+  if (coordinateEl) {
+    if (!known) {
+      coordinateEl.className = 'coordinate-status none';
+      coordinateEl.textContent = 'Coordinate sources are mixed or still loading for this selection.';
+    } else {
+      var counts = {exif: 0, assigned: 0, none: 0};
+      ids.forEach(function(id) {
+        var p = photos.find(function(photo) { return photo.id === id; });
+        var status = p && counts[p.location_status] != null ? p.location_status : 'none';
+        counts[status]++;
+      });
+      coordinateEl.className = 'coordinate-status';
+      coordinateEl.textContent = [
+        counts.exif + ' EXIF GPS',
+        counts.assigned + ' assigned map location' + (counts.assigned === 1 ? '' : 's'),
+        counts.none + ' without coordinates'
+      ].join(' · ');
+    }
+  }
 
   var rs = known ? _batchRatingState(ids) : { unanimous: false, value: 0 };
   var r = rs.unanimous ? rs.value : 0;
@@ -7079,7 +7176,28 @@ async function _afterLocationMutation(photoIds, detailPhotoId) {
     await filterByCollection(activeCollectionId);
     return;
   }
-  if (photoIds && photoIds.length) refreshGridCards(photoIds);
+  if (document.getElementById('locationStatusFilter').value) {
+    resetAndLoad();
+    return;
+  }
+  if (photoIds && photoIds.length) {
+    var loadedIds = new Set(photos.map(function(photo) { return photo.id; }));
+    var idsToRefresh = photoIds.filter(function(id) { return loadedIds.has(id); });
+    try {
+      for (var offset = 0; offset < idsToRefresh.length; offset += 500) {
+        var statusData = await safeFetch('/api/photos/by-ids', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({photo_ids: idsToRefresh.slice(offset, offset + 500)})
+        }, {toast: false});
+        (statusData.photos || []).forEach(function(updated) {
+          var local = photos.find(function(photo) { return photo.id === updated.id; });
+          if (local) local.location_status = updated.location_status || 'none';
+        });
+      }
+    } catch (e) {}
+    refreshGridCards(idsToRefresh);
+  }
   // If a multi-selection is still active, keep the batch inspector rendered.
   // Falling through to loadDetail(anchor) would strip .batch-mode and rewire
   // the rating stars to setRating(anchorId, i) — collapsing the panel to the
@@ -7271,6 +7389,31 @@ function clearExifSuggestion() {
   sugg.hidden = true;
   sugg.innerHTML = '';
   if (sugg.dataset) delete sugg.dataset.photoId;
+}
+
+function formatCoordinatePair(latitude, longitude) {
+  if (latitude == null || longitude == null) return '';
+  return Number(latitude).toFixed(5) + ', ' + Number(longitude).toFixed(5);
+}
+
+function renderCoordinateStatus(photo) {
+  var el = document.getElementById('locationCoordinateStatus');
+  if (!el) return;
+  var status = photo && photo.location_status ? photo.location_status : 'none';
+  var text;
+  if (status === 'exif') {
+    text = '📍 EXIF GPS — ' + formatCoordinatePair(photo.latitude, photo.longitude) +
+      '. Embedded in the original photo and used on the map.';
+  } else if (status === 'assigned') {
+    var loc = photo.location || {};
+    var coords = formatCoordinatePair(loc.latitude, loc.longitude);
+    text = '● Assigned map location' + (coords ? ' — ' + coords : '') +
+      '. The original photo does not contain a complete EXIF GPS pair.';
+  } else {
+    text = '⊘ No coordinates — this photo has no complete EXIF GPS pair or assigned map location.';
+  }
+  el.className = 'coordinate-status ' + status;
+  el.textContent = text;
 }
 
 function renderLocationFilled(loc) {

--- a/vireo/templates/map.html
+++ b/vireo/templates/map.html
@@ -597,9 +597,17 @@ async function loadPhotos() {
 
     if (data.photos.length === 0) {
       renderSidebar([]);
-      document.getElementById('mapStatus').textContent = focusPhotoId !== null
-        ? 'No map location found for this photo.'
-        : 'No geolocated photos found. Photos with GPS data in their EXIF metadata will appear here.';
+      var emptyStatus = document.getElementById('mapStatus');
+      if (focusPhotoId !== null) {
+        emptyStatus.textContent = 'No map location found for this photo.';
+      } else {
+        var emptyMessage = 'No geolocated photos found. Photos with EXIF GPS or an assigned map location will appear here.';
+        if (data.total_without_coordinates > 0) {
+          emptyMessage += ' <a href="/browse?location_status=none">Browse ' +
+            data.total_without_coordinates + ' without coordinates</a>.';
+        }
+        emptyStatus.innerHTML = emptyMessage;
+      }
       legendControl.update({});
       return;
     }
@@ -618,7 +626,7 @@ async function loadPhotos() {
 
       var provenanceLine = '';
       if (p.coord_source === 'keyword' && p.keyword_location_name) {
-        provenanceLine = '<div class="popup-provenance">\u{1F4CD} from location: '
+        provenanceLine = '<div class="popup-provenance">\u{1F4CD} from assigned location: '
           + escapeHtml(p.keyword_location_name) + '</div>';
       } else if (p.coord_source === 'exif') {
         provenanceLine = '<div class="popup-provenance">\u{1F4CD} from EXIF GPS</div>';
@@ -655,18 +663,18 @@ async function loadPhotos() {
       }
     }
 
-    /* GPS coverage stats — global (unfiltered) for consistency */
+    /* Map-coordinate coverage stats — global (unfiltered) for consistency */
     var totalFiltered = data.total_filtered;
-    var totalWithGps = data.total_with_gps;
+    var totalGeolocated = data.total_geolocated;
     var totalPhotos = data.total_photos;
-    var missingGps = data.total_without_gps;
-    var pct = totalPhotos > 0 ? Math.round((totalWithGps / totalPhotos) * 100) : 0;
+    var missingCoordinates = data.total_without_coordinates;
+    var pct = totalPhotos > 0 ? Math.round((totalGeolocated / totalPhotos) * 100) : 0;
 
     var statusEl = document.getElementById('mapStatus');
-    var parts = ['Showing ' + totalFiltered + ' of ' + totalWithGps + ' geolocated photos'];
-    parts.push(pct + '% GPS coverage');
-    if (missingGps > 0) {
-      parts.push('<a href="/browse?missing_gps=1">' + missingGps + ' missing GPS</a>');
+    var parts = ['Showing ' + totalFiltered + ' of ' + totalGeolocated + ' geolocated photos'];
+    parts.push(pct + '% map coverage');
+    if (missingCoordinates > 0) {
+      parts.push('<a href="/browse?location_status=none">' + missingCoordinates + ' without coordinates</a>');
     }
     if (focusPhotoId === null || photoMarkers[focusPhotoId]) {
       statusEl.innerHTML = parts.join(' &mdash; ');

--- a/vireo/templates/settings.html
+++ b/vireo/templates/settings.html
@@ -1781,7 +1781,7 @@ async function loadConfig() {
     document.getElementById('cfgBrowseThumbVal').textContent = bt + 'px';
     document.getElementById('cfgOpenInBrowser').checked = cfg.open_in_browser === true;
     // Load browse card fields
-    loadCardFieldCheckboxes(cfg.browse_card_fields || ["filename", "rating", "flag", "sharpness"]);
+    loadCardFieldCheckboxes(cfg.browse_card_fields || ["filename", "location_status", "rating", "flag", "sharpness"]);
     // Load detection settings
     var dc = Math.round((cfg.detector_confidence != null ? cfg.detector_confidence : 0.20) * 100);
     document.getElementById('cfgDetectorConf').value = dc;
@@ -1897,6 +1897,7 @@ async function loadConfig() {
 
 var CARD_FIELD_OPTIONS = [
   { id: 'filename', label: 'Filename', desc: 'Photo filename' },
+  { id: 'location_status', label: 'Coordinate source', desc: 'EXIF GPS, assigned map location, or no coordinates' },
   { id: 'rating', label: 'Rating', desc: 'Star rating' },
   { id: 'flag', label: 'Flag', desc: 'Flagged / rejected indicator' },
   { id: 'sharpness', label: 'Sharpness', desc: 'Sharpness score' },

--- a/vireo/testing/userfirst/scenarios/map_geo.py
+++ b/vireo/testing/userfirst/scenarios/map_geo.py
@@ -145,22 +145,22 @@ def run(session):
             "(document.getElementById('mapStatus') || {}).textContent || ''"
         )
         # The status bar either shows the explicit "No geolocated photos
-        # found" message or "Showing 0 of 0 geolocated photos | 0% GPS
+        # found" message or "Showing 0 of 0 geolocated photos | 0% map
         # coverage".  Match those exact zero shapes — a substring check
-        # for "0%" would also match "100% GPS coverage", and "Showing 0"
+        # for "0%" would also match "100% map coverage", and "Showing 0"
         # would match "Showing 0 of 100" (visible-after-filtering, not a
         # zero-GPS state).
         zero_gps_status = (
             "No geolocated" in status_text
             or (
                 re.search(r"\bShowing 0 of 0\b", status_text) is not None
-                and re.search(r"(?<!\d)0% GPS coverage\b", status_text) is not None
+                and re.search(r"(?<!\d)0% map coverage\b", status_text) is not None
             )
         )
         session.assert_that(
             zero_gps_status,
-            "expected zero-GPS status ('No geolocated' message or "
-            f"'Showing 0 of 0' + '0% GPS coverage'), got {status_text!r}",
+            "expected zero-coordinate status ('No geolocated' message or "
+            f"'Showing 0 of 0' + '0% map coverage'), got {status_text!r}",
         )
 
         sidebar_text = session.eval(

--- a/vireo/tests/test_config.py
+++ b/vireo/tests/test_config.py
@@ -718,6 +718,35 @@ def test_migrate_toggle_ui_h_conflict_no_config_file(tmp_path, monkeypatch):
     assert cfg.MIGRATION_TOGGLE_UI_H_CONFLICT in raw["_migrations_applied"]
 
 
+def test_migrate_browse_location_status_rewrites_exact_legacy_default(
+    tmp_path, monkeypatch
+):
+    import config as cfg
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    _write_raw(cfg.CONFIG_PATH, {
+        "browse_card_fields": ["filename", "rating", "flag", "sharpness"],
+    })
+
+    assert cfg.migrate_browse_location_status_field() is True
+    raw = _read_raw(cfg.CONFIG_PATH)
+    assert raw["browse_card_fields"] == [
+        "filename", "location_status", "rating", "flag", "sharpness"
+    ]
+    assert cfg.MIGRATION_BROWSE_LOCATION_STATUS in raw["_migrations_applied"]
+
+
+def test_migrate_browse_location_status_preserves_custom_layout(
+    tmp_path, monkeypatch
+):
+    import config as cfg
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    custom = ["filename", "species"]
+    _write_raw(cfg.CONFIG_PATH, {"browse_card_fields": custom})
+
+    assert cfg.migrate_browse_location_status_field() is False
+    assert _read_raw(cfg.CONFIG_PATH)["browse_card_fields"] == custom
+
+
 def test_migrate_eye_detect_default_off_rewrites_legacy_true(
     tmp_path, monkeypatch
 ):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -65,6 +65,57 @@ def test_api_photos_pagination(app_and_db):
     assert len(data['photos']) == 1
 
 
+def test_api_photos_reports_and_filters_coordinate_sources(app_and_db):
+    """Browse separates embedded GPS, assigned map coordinates, and neither."""
+    app, db = app_and_db
+    photos = db.get_photos(sort="name")
+    exif_id, assigned_id, none_id = [photo["id"] for photo in photos]
+    with db.conn:
+        db.conn.execute(
+            "UPDATE photos SET latitude = 37.7749, longitude = -122.4194 "
+            "WHERE id = ?",
+            (exif_id,),
+        )
+        cursor = db.conn.execute(
+            "INSERT INTO keywords (name, type, latitude, longitude) "
+            "VALUES ('Assigned Park', 'location', 40.7829, -73.9654)"
+        )
+        db.conn.execute(
+            "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+            (assigned_id, cursor.lastrowid),
+        )
+
+    client = app.test_client()
+    response = client.get("/api/photos?sort=name")
+    assert response.status_code == 200
+    statuses = {
+        photo["id"]: photo["location_status"]
+        for photo in response.get_json()["photos"]
+    }
+    assert statuses == {
+        exif_id: "exif",
+        assigned_id: "assigned",
+        none_id: "none",
+    }
+
+    for status, expected_id in (
+        ("exif", exif_id),
+        ("assigned", assigned_id),
+        ("none", none_id),
+    ):
+        filtered = client.get(f"/api/photos?location_status={status}&sort=name")
+        assert filtered.status_code == 200
+        body = filtered.get_json()
+        assert body["total"] == 1
+        assert [photo["id"] for photo in body["photos"]] == [expected_id]
+
+        ids = client.get(f"/api/photos/ids?location_status={status}&sort=name")
+        assert ids.status_code == 200
+        assert ids.get_json()["photo_ids"] == [expected_id]
+
+    assert client.get("/api/photos?location_status=gpsish").status_code == 400
+
+
 def test_api_photos_filter_folder(app_and_db):
     """GET /api/photos?folder_id= filters by folder."""
     app, db = app_and_db
@@ -873,9 +924,13 @@ def test_api_photos_geo_returns_geolocated(app_and_db):
     assert 'photos' in data
     assert 'total_filtered' in data
     assert 'total_with_gps' in data
+    assert 'total_geolocated' in data
+    assert 'total_without_coordinates' in data
     assert 'total_photos' in data
     assert data['total_filtered'] == 1
     assert data['total_with_gps'] == 1
+    assert data['total_geolocated'] == 1
+    assert data['total_without_coordinates'] == 2
     assert data['total_photos'] == 3
     assert len(data['photos']) == 1
     assert data['photos'][0]['latitude'] == 37.77


### PR DESCRIPTION
## Summary

Makes coordinate provenance explicit across Browse and Map by distinguishing embedded EXIF GPS, assigned map locations, and photos without coordinates.
Adds coordinate-source API filtering, card and inspector states, batch summaries, deep-linkable Browse filters, and a safe migration that updates only the previous default card layout.
Corrects Map coverage terminology and replaces the broken missing-GPS link while retaining compatibility with older query parameters and API fields.

## Validation

- 420 relevant tests passed
- Ruff, Python compilation, static-template checks, and `git diff --check` passed
