### PR TITLE
Show Reveal in Finder in every lightbox

### DIFF
--- a/tests/e2e/test_review_context_menu.py
+++ b/tests/e2e/test_review_context_menu.py
@@ -120,6 +120,38 @@ def test_review_card_open_lightbox_opens_overlay(live_server, page):
     expect(page.locator("#lightboxOverlay")).to_be_visible()
 
 
+def test_review_lightbox_reveal_fires_endpoint(live_server, page):
+    """The shared lightbox keeps its reveal action outside Browse."""
+    url = live_server["url"]
+    page.goto(f"{url}/review")
+
+    card = page.locator(".card[data-pred-id]").first
+    card.wait_for(state="visible")
+    card.click(button="right")
+    menu = page.locator(".vireo-ctx-menu")
+    menu.locator(".vireo-ctx-item", has_text="Open in Lightbox").click()
+    expect(page.locator("#lightboxOverlay")).to_be_visible()
+
+    page.evaluate(
+        """
+        const img = document.getElementById('lightboxImg');
+        img.dispatchEvent(new MouseEvent('contextmenu', {
+            bubbles: true, cancelable: true, clientX: 300, clientY: 300,
+            button: 2,
+        }));
+        """
+    )
+    lightbox_menu = page.locator(".vireo-ctx-menu")
+    reveal = lightbox_menu.locator(".vireo-ctx-item", has_text="Reveal in")
+    expect(reveal).to_be_visible()
+
+    with page.expect_response(
+        lambda r: "/api/files/reveal" in r.url and r.status == 200
+    ):
+        reveal.click()
+    expect(lightbox_menu).to_be_hidden()
+
+
 def test_review_lightbox_rating_chip_posts_batch(live_server, page):
     """Regression guard: rating chips in the lightbox context menu on /review
     must POST to /api/batch/rating via setReviewRating. Previously the menu

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -7570,10 +7570,8 @@ function buildLightboxContextMenu(pid) {
   if (has('openInEditor')) {
     items = items.concat(window.buildOpenInEditorMenuItems([pid]));
   }
-  if (has('revealPhoto')) {
-    items.push({ label: window.VIREO_REVEAL_LABEL,
-      onClick: function() { window.revealPhoto(pid); } });
-  }
+  items.push({ label: window.VIREO_REVEAL_LABEL,
+    onClick: function() { revealLightboxPhoto(pid); } });
   if (has('copyPhotoPaths')) {
     items.push({ label: 'Copy Path',
       onClick: function() { window.copyPhotoPaths([pid]); } });
@@ -7584,6 +7582,33 @@ function buildLightboxContextMenu(pid) {
     onClick: function() { closeLightbox(); } });
 
   return items;
+}
+
+function revealLightboxPhoto(pid) {
+  // Browse and Review each expose their own reveal helpers. Other pages can
+  // also open the shared lightbox, so keep a direct API fallback here rather
+  // than hiding the action based on which page happened to launch it.
+  if (typeof window.revealPhoto === 'function') {
+    window.revealPhoto(pid);
+    return;
+  }
+  if (typeof window.revealReviewPhoto === 'function') {
+    window.revealReviewPhoto(pid);
+    return;
+  }
+  safeFetch('/api/files/reveal', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({photo_id: pid}),
+  }, { toast: false }).then(function(data) {
+    if (typeof showRevealFeedback === 'function') showRevealFeedback(data);
+  }).catch(function(err) {
+    if (typeof showToast === 'function') {
+      showToast('Reveal failed: ' + (err.message || 'request failed'), 'error');
+    } else {
+      console.error('revealLightboxPhoto failed', err);
+    }
+  });
 }
 
 (function() {


### PR DESCRIPTION
Makes the shared lightbox always show the platform-specific reveal action, reusing Browse and Review helpers when available and falling back to the reveal API elsewhere.

Adds an end-to-end regression test that opens the lightbox from Review and verifies the action reaches the reveal endpoint.

Tests: `pytest -q tests/e2e/test_lightbox_context_menu.py tests/e2e/test_review_context_menu.py` (19 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the lightbox’s “Reveal in” action so it works consistently across review and other pages.
  * Added success and error feedback when revealing a file.
  * Ensured the context menu closes after the action is selected.

* **Tests**
  * Added end-to-end coverage confirming the reveal request succeeds and the context menu is hidden afterward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->