### PR TITLE
Keep unedited RAW previews camera-rendered

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -24899,11 +24899,23 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # flatter/darker; treating it as canonical makes the photo appear
             # to gain a dark overlay when the lightbox swaps from /full to a
             # sharper preview tier.  Keep the working copy as the offline
-            # fallback when the source itself is unavailable.
+            # fallback when the source itself is unavailable, and defer to it
+            # when the current RAW mtime is already marked as a source-side
+            # extraction failure: the RAW failure gate below returns 500
+            # before the companion/working-copy fallbacks further down can
+            # run, so forcing the RAW here would drop the preview for
+            # RAW+JPEG pairs whose companion or working copy could still
+            # satisfy the request.
             source_path = os.path.join(
                 folder_row["path"], photo["filename"],
             )
-            if os.path.exists(source_path):
+            if os.path.exists(source_path) and not _has_current_working_copy_failure(
+                photo,
+                vireo_dir,
+                trust_existing_working_copy=False,
+                live_source_path=source_path,
+                folder_path=folder_row["path"],
+            ):
                 canonical = source_path
                 using_working_copy = False
             else:

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -17661,10 +17661,41 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                         continue
 
                 if not os.path.exists(cache_path):
-                    canonical, using_working_copy = _recipe_render_source(
-                        detail_photo, recipe, max_size, vireo_dir, folders,
-                    )
                     from image_loader import RAW_EXTENSIONS
+                    folder_path = folders.get(detail_photo["folder_id"])
+                    raw_source_path = None
+                    if (
+                        not recipe
+                        and folder_path
+                        and os.path.splitext(detail_photo["filename"])[1].lower()
+                        in RAW_EXTENSIONS
+                    ):
+                        # Mirror /photos/<id>/preview: an unedited RAW must
+                        # warm from the camera-rendered source, not the
+                        # highlight-preserving working copy. Otherwise the
+                        # precompute job writes flatter/darker bytes into the
+                        # tracked preview cache and _serve_preview returns
+                        # those cache hits before its own RAW-source branch
+                        # ever runs, so the migration's one-time purge is
+                        # undone on the first warmup.
+                        candidate = os.path.join(
+                            folder_path, detail_photo["filename"],
+                        )
+                        if os.path.exists(candidate) and not _has_current_working_copy_failure(
+                            detail_photo,
+                            vireo_dir,
+                            trust_existing_working_copy=False,
+                            live_source_path=candidate,
+                            folder_path=folder_path,
+                        ):
+                            raw_source_path = candidate
+                    if raw_source_path:
+                        canonical = raw_source_path
+                        using_working_copy = False
+                    else:
+                        canonical, using_working_copy = _recipe_render_source(
+                            detail_photo, recipe, max_size, vireo_dir, folders,
+                        )
                     if (
                         not using_working_copy
                         and os.path.splitext(canonical)[1].lower() in RAW_EXTENSIONS

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -1790,6 +1790,126 @@ def _migrate_edit_math_render_caches(app):
             pass
 
 
+def _migrate_unedited_raw_preview_sources(app):
+    """Drop previews that may have used an edit-quality RAW working copy.
+
+    RAW working copies deliberately preserve highlight headroom and therefore
+    look flatter/darker than the camera-rendered rendition used for browsing.
+    Older preview routing treated that working copy as the canonical source
+    even when a RAW had no edit recipe.  Those bytes are keyed only by
+    ``(photo_id, size)``, so fixing source selection alone would keep serving
+    already-cached dark tiers indefinitely.
+
+    Purge only recipe-free RAWs that currently have a working copy, and gate
+    the migration in ``db_meta`` so large libraries pay the directory scan
+    once.  If any cache file cannot be inspected or removed, leave the marker
+    unset so the next launch retries instead of permanently adopting stale
+    pixels.
+    """
+    from image_loader import RAW_EXTENSIONS
+
+    marker = "unedited_raw_camera_preview_source_v1"
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    preview_dir = os.path.join(vireo_dir, "previews")
+    db = Database(app.config["DB_PATH"])
+    try:
+        if db.get_meta(marker) == "1":
+            return
+
+        rows = db.conn.execute(
+            """SELECT p.id, p.filename
+               FROM photos p
+               LEFT JOIN photo_edit_recipes r ON r.photo_id = p.id
+               WHERE p.working_copy_path IS NOT NULL
+                 AND r.photo_id IS NULL"""
+        ).fetchall()
+        affected = {
+            int(row["id"])
+            for row in rows
+            if os.path.splitext(row["filename"] or "")[1].lower()
+            in RAW_EXTENSIONS
+        }
+
+        purge_failed = False
+        names_by_pid = {}
+        try:
+            preview_names = os.listdir(preview_dir)
+        except FileNotFoundError:
+            preview_names = ()
+        except OSError:
+            log.warning(
+                "Failed to list preview cache dir %s while migrating "
+                "unedited RAW preview sources; retrying next launch",
+                preview_dir,
+                exc_info=True,
+            )
+            preview_names = ()
+            purge_failed = True
+
+        for name in preview_names:
+            if not name.endswith(".jpg"):
+                continue
+            underscore = name.find("_")
+            if underscore <= 0:
+                continue
+            try:
+                photo_id = int(name[:underscore])
+            except ValueError:
+                continue
+            if photo_id in affected:
+                names_by_pid.setdefault(photo_id, set()).add(name)
+
+        invalidated = 0
+        for photo_id in affected:
+            tracked = db.conn.execute(
+                "SELECT size FROM preview_cache WHERE photo_id=?",
+                (photo_id,),
+            ).fetchall()
+            names = names_by_pid.get(photo_id, set())
+            names.update(
+                f"{photo_id}_{row['size']}.jpg" for row in tracked
+            )
+            photo_failed = False
+            for name in names:
+                path = os.path.join(preview_dir, name)
+                try:
+                    if os.path.exists(path):
+                        os.remove(path)
+                except OSError:
+                    log.warning(
+                        "Failed to remove stale unedited RAW preview %s",
+                        path,
+                        exc_info=True,
+                    )
+                    photo_failed = True
+                    purge_failed = True
+            if photo_failed:
+                continue
+            cursor = db.conn.execute(
+                "DELETE FROM preview_cache WHERE photo_id=?", (photo_id,)
+            )
+            invalidated += max(cursor.rowcount, 0)
+
+        if purge_failed:
+            db.conn.commit()
+            return
+
+        db.set_meta(marker, "1", _commit=False)
+        db.conn.commit()
+        if affected:
+            log.info(
+                "Invalidated %d preview-cache entries across %d unedited "
+                "RAW photos so camera-rendered previews can regenerate",
+                invalidated,
+                len(affected),
+            )
+    finally:
+        try:
+            db.conn.close()
+        except Exception:
+            pass
+
+
 def _enforce_preview_cache_quota_at_startup(app):
     """Reconcile and evict at startup so prior runs / external deletes
     can't leave the table out of sync or over quota.
@@ -2010,6 +2130,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
     _migrate_legacy_preview_cache(app)
     _migrate_edit_math_render_caches(app)
+    _migrate_unedited_raw_preview_sources(app)
     _enforce_preview_cache_quota_at_startup(app)
 
     # Request timing middleware — logs slow requests and user actions
@@ -24767,6 +24888,28 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if pair_source_path:
             canonical = pair_source_path
             using_working_copy = False
+        elif (
+            not render_recipe
+            and os.path.splitext(photo["filename"])[1].lower()
+            in RAW_EXTENSIONS
+        ):
+            # An unedited RAW must use the camera-rendered decode for every
+            # lightbox tier.  Its working copy is an edit-quality,
+            # highlight-preserving render that intentionally looks
+            # flatter/darker; treating it as canonical makes the photo appear
+            # to gain a dark overlay when the lightbox swaps from /full to a
+            # sharper preview tier.  Keep the working copy as the offline
+            # fallback when the source itself is unavailable.
+            source_path = os.path.join(
+                folder_row["path"], photo["filename"],
+            )
+            if os.path.exists(source_path):
+                canonical = source_path
+                using_working_copy = False
+            else:
+                canonical, using_working_copy = _recipe_render_source(
+                    photo, render_recipe, size, vireo_dir, folders,
+                )
         else:
             canonical, using_working_copy = _recipe_render_source(
                 photo, render_recipe, size, vireo_dir, folders,

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -2773,9 +2773,40 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 pass  # photo may have been deleted mid-pipeline
                             continue
                     if not os.path.exists(cache_path):
-                        canonical = _recipe_render_source(
-                            detail_photo, recipe, max_size, base_dir, folders,
-                        )
+                        folder_path = folders.get(detail_photo["folder_id"])
+                        raw_source_path = None
+                        if (
+                            not recipe
+                            and folder_path
+                            and os.path.splitext(detail_photo["filename"])[1].lower()
+                            in _RAW_EXTENSIONS
+                        ):
+                            # Mirror /photos/<id>/preview: an unedited RAW
+                            # must warm from the camera-rendered source,
+                            # not the highlight-preserving working copy.
+                            # Otherwise the pipeline preview stage writes
+                            # flatter/darker bytes into the tracked preview
+                            # cache and _serve_preview returns those cache
+                            # hits before its own RAW-source branch ever
+                            # runs, so the migration's one-time purge is
+                            # undone the first time this stage runs.
+                            candidate = os.path.join(
+                                folder_path, detail_photo["filename"],
+                            )
+                            if os.path.exists(candidate) and not _has_current_working_copy_failure(
+                                detail_photo,
+                                base_dir,
+                                trust_existing_working_copy=False,
+                                live_source_path=candidate,
+                                folder_path=folder_path,
+                            ):
+                                raw_source_path = candidate
+                        if raw_source_path:
+                            canonical = raw_source_path
+                        else:
+                            canonical = _recipe_render_source(
+                                detail_photo, recipe, max_size, base_dir, folders,
+                            )
                         if (
                             os.path.splitext(canonical)[1].lower() in _RAW_EXTENSIONS
                             and _has_current_working_copy_failure(

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -5378,6 +5378,81 @@ def test_preview_job_honors_raw_failure_marker_after_source_selection(
     )
 
 
+def test_preview_job_warms_unedited_raw_from_camera_rendered_source(
+    client_with_photo, monkeypatch,
+):
+    """Precompute must warm from the RAW source, not the working copy — otherwise
+    the tracked preview cache locks in the highlight-preserving dark render and
+    /photos/<id>/preview returns those cache hits before its own RAW-source
+    branch ever runs."""
+    import os
+    import time
+
+    import image_loader
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    client = app.test_client()
+    folder = db.conn.execute(
+        "SELECT path FROM folders WHERE id = (SELECT folder_id FROM photos WHERE id=?)",
+        (photo_id,),
+    ).fetchone()
+    raw_path = os.path.join(folder["path"], "source.NEF")
+    with open(raw_path, "wb") as raw_file:
+        raw_file.write(b"raw bytes decoded by the test double")
+
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    working_dir = os.path.join(vireo_dir, "working")
+    os.makedirs(working_dir, exist_ok=True)
+    working_path = os.path.join(working_dir, f"{photo_id}.jpg")
+    Image.new("RGB", (800, 600), (25, 25, 25)).save(working_path, "JPEG")
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='source.NEF', extension='.nef',
+               companion_path=NULL,
+               working_copy_path=?, width=800, height=600
+           WHERE id=?""",
+        (f"working/{photo_id}.jpg", photo_id),
+    )
+    db.conn.commit()
+
+    loaded = []
+
+    def tracking_load(path, max_size=1024, **kwargs):
+        loaded.append(os.fspath(path))
+        color = (220, 220, 220) if os.fspath(path) == raw_path else (25, 25, 25)
+        return Image.new("RGB", (800, 600), color)
+
+    monkeypatch.setattr(image_loader, "load_image", tracking_load)
+
+    resp = client.post("/api/jobs/previews", json={})
+    assert resp.status_code == 200
+    job_id = resp.get_json()["job_id"]
+
+    deadline = time.time() + 10
+    while time.time() < deadline:
+        status_resp = client.get(f"/api/jobs/{job_id}")
+        if status_resp.status_code != 200:
+            time.sleep(0.05)
+            continue
+        data = status_resp.get_json()
+        if data.get("status") in ("completed", "failed"):
+            break
+        time.sleep(0.05)
+
+    assert data["status"] == "completed"
+    # The warmer decoded the RAW source, not the dark working copy.
+    assert raw_path in loaded
+    assert working_path not in loaded
+    preview_path = os.path.join(
+        vireo_dir, "previews", f"{photo_id}_1920.jpg",
+    )
+    assert os.path.exists(preview_path)
+    with Image.open(preview_path) as warmed:
+        # Camera-rendered brightness, not the flat/dark working-copy tone.
+        assert warmed.getpixel((400, 300))[0] > 200
+
+
 def test_preview_job_does_not_adopt_untracked_edited_preview_after_unlink_failure(
     client_with_photo, monkeypatch,
 ):

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1302,6 +1302,78 @@ def test_unedited_raw_preview_uses_camera_rendered_source_not_working_copy(
         assert rendered.getpixel((400, 300))[0] > 200
 
 
+def test_unedited_raw_preview_falls_back_when_source_extraction_marked_failed(
+    client_with_photo, monkeypatch,
+):
+    """RAW+JPEG pairs with a source-failure marker keep the working-copy
+    fallback instead of 500ing on the sharper preview tier."""
+    import io
+    import os
+
+    import image_loader
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    folder = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id "
+        "WHERE p.id=?",
+        (photo_id,),
+    ).fetchone()
+    raw_path = os.path.join(folder["path"], "source.NEF")
+    with open(raw_path, "wb") as raw_file:
+        raw_file.write(b"raw bytes that libraw cannot decode")
+    companion_path = os.path.join(folder["path"], "source.JPG")
+    Image.new("RGB", (800, 600), (220, 220, 220)).save(
+        companion_path, "JPEG",
+    )
+
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    working_dir = os.path.join(vireo_dir, "working")
+    os.makedirs(working_dir, exist_ok=True)
+    working_path = os.path.join(working_dir, f"{photo_id}.jpg")
+    Image.new("RGB", (800, 600), (25, 25, 25)).save(
+        working_path, "JPEG",
+    )
+    mtime = os.path.getmtime(raw_path)
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='source.NEF', extension='.nef',
+               companion_path='source.JPG',
+               working_copy_path=?, width=800, height=600,
+               file_mtime=?,
+               working_copy_failed_at=datetime('now'),
+               working_copy_failed_mtime=?,
+               working_copy_failed_source='source'
+           WHERE id=?""",
+        (f"working/{photo_id}.jpg", mtime, mtime, photo_id),
+    )
+    db.conn.commit()
+
+    loaded = []
+
+    def tracking_load(path, max_size=1024, **kwargs):
+        loaded.append(os.fspath(path))
+        if os.fspath(path) == raw_path:
+            raise AssertionError(
+                "unedited RAW preview retried a source-failed RAW decode"
+            )
+        # The working copy is the pre-PR fallback for source-failed RAWs.
+        # Return its (dark) pixels so the response is a valid JPEG rather
+        # than 500ing before the fallback path can run.
+        return Image.new("RGB", (800, 600), (25, 25, 25))
+
+    monkeypatch.setattr(image_loader, "load_image", tracking_load)
+
+    response = app.test_client().get(
+        f"/photos/{photo_id}/preview?size=2560"
+    )
+
+    assert response.status_code == 200, response.get_data(as_text=True)
+    assert raw_path not in loaded
+    with Image.open(io.BytesIO(response.data)):
+        pass
+
+
 def test_preview_falls_back_to_original(app_and_db, tmp_path):
     """Preview endpoint falls back to original when no working copy exists."""
     app, db = app_and_db

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -1247,6 +1247,61 @@ def test_preview_uses_working_copy(app_and_db):
     assert resp.status_code == 200
 
 
+def test_unedited_raw_preview_uses_camera_rendered_source_not_working_copy(
+    client_with_photo, monkeypatch,
+):
+    """Sharper lightbox tiers must not swap to the dark RAW edit source."""
+    import io
+    import os
+
+    import image_loader
+    from PIL import Image
+
+    app, db, photo_id = client_with_photo
+    folder = db.conn.execute(
+        "SELECT f.path FROM photos p JOIN folders f ON f.id=p.folder_id "
+        "WHERE p.id=?",
+        (photo_id,),
+    ).fetchone()
+    raw_path = os.path.join(folder["path"], "source.NEF")
+    with open(raw_path, "wb") as raw_file:
+        raw_file.write(b"raw bytes decoded by the test double")
+
+    vireo_dir = os.path.dirname(app.config["THUMB_CACHE_DIR"])
+    working_dir = os.path.join(vireo_dir, "working")
+    os.makedirs(working_dir, exist_ok=True)
+    working_path = os.path.join(working_dir, f"{photo_id}.jpg")
+    Image.new("RGB", (800, 600), (25, 25, 25)).save(
+        working_path, "JPEG",
+    )
+    db.conn.execute(
+        """UPDATE photos
+           SET filename='source.NEF', extension='.nef',
+               working_copy_path=?, width=800, height=600
+           WHERE id=?""",
+        (f"working/{photo_id}.jpg", photo_id),
+    )
+    db.conn.commit()
+
+    loaded = []
+
+    def camera_rendered_load(path, max_size=1024, **kwargs):
+        loaded.append((os.fspath(path), kwargs))
+        color = (220, 220, 220) if os.fspath(path) == raw_path else (25, 25, 25)
+        return Image.new("RGB", (800, 600), color)
+
+    monkeypatch.setattr(image_loader, "load_image", camera_rendered_load)
+
+    response = app.test_client().get(
+        f"/photos/{photo_id}/preview?size=2560"
+    )
+
+    assert response.status_code == 200
+    assert loaded == [(raw_path, {})]
+    with Image.open(io.BytesIO(response.data)) as rendered:
+        assert rendered.getpixel((400, 300))[0] > 200
+
+
 def test_preview_falls_back_to_original(app_and_db, tmp_path):
     """Preview endpoint falls back to original when no working copy exists."""
     app, db = app_and_db
@@ -5668,6 +5723,93 @@ def test_legacy_migration_preserves_preview_max_size_zero(tmp_path, monkeypatch)
     # File stays exactly where it was; no renamed version was produced.
     assert legacy.exists()
     assert not (preview_dir / "42_1920.jpg").exists()
+
+
+def test_startup_invalidates_unedited_raw_previews_built_from_working_copies(
+    tmp_path, monkeypatch,
+):
+    """Existing dark RAW tiers are purged once; ordinary JPEGs are retained."""
+    import config as cfg
+    from app import create_app
+    from db import Database
+    from PIL import Image
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    cfg.save({**cfg.DEFAULTS, "preview_max_size": 1920})
+
+    photos_dir = tmp_path / "photos"
+    photos_dir.mkdir()
+    raw_source = photos_dir / "source.NEF"
+    raw_source.write_bytes(b"raw bytes")
+    jpeg_source = photos_dir / "plain.jpg"
+    Image.new("RGB", (200, 150), (180, 90, 40)).save(
+        jpeg_source, "JPEG",
+    )
+
+    vireo_dir = tmp_path / "vireo"
+    thumb_dir = vireo_dir / "thumbnails"
+    preview_dir = vireo_dir / "previews"
+    working_dir = vireo_dir / "working"
+    thumb_dir.mkdir(parents=True)
+    preview_dir.mkdir()
+    working_dir.mkdir()
+    db_path = str(vireo_dir / "vireo.db")
+
+    db = Database(db_path)
+    workspace_id = db.ensure_default_workspace()
+    db.set_active_workspace(workspace_id)
+    folder_id = db.add_folder(str(photos_dir), name="photos")
+    raw_id = db.add_photo(
+        folder_id=folder_id,
+        filename=raw_source.name,
+        extension=".nef",
+        file_size=raw_source.stat().st_size,
+        file_mtime=raw_source.stat().st_mtime,
+        width=200,
+        height=150,
+    )
+    jpeg_id = db.add_photo(
+        folder_id=folder_id,
+        filename=jpeg_source.name,
+        extension=".jpg",
+        file_size=jpeg_source.stat().st_size,
+        file_mtime=jpeg_source.stat().st_mtime,
+        width=200,
+        height=150,
+    )
+    for photo_id in (raw_id, jpeg_id):
+        working = working_dir / f"{photo_id}.jpg"
+        Image.new("RGB", (200, 150), (25, 25, 25)).save(working, "JPEG")
+        db.conn.execute(
+            "UPDATE photos SET working_copy_path=? WHERE id=?",
+            (f"working/{photo_id}.jpg", photo_id),
+        )
+
+    raw_preview = preview_dir / f"{raw_id}_2560.jpg"
+    jpeg_preview = preview_dir / f"{jpeg_id}_2560.jpg"
+    raw_preview.write_bytes(b"dark raw preview")
+    jpeg_preview.write_bytes(b"ordinary jpeg preview")
+    db.preview_cache_insert(raw_id, 2560, raw_preview.stat().st_size)
+    db.preview_cache_insert(jpeg_id, 2560, jpeg_preview.stat().st_size)
+    db.conn.commit()
+
+    create_app(db_path=db_path, thumb_cache_dir=str(thumb_dir))
+
+    assert not raw_preview.exists()
+    assert db.preview_cache_get(raw_id, 2560) is None
+    assert jpeg_preview.exists()
+    assert db.preview_cache_get(jpeg_id, 2560) is not None
+    assert db.get_meta("unedited_raw_camera_preview_source_v1") == "1"
+
+    # The source-selection fix prevents new dark entries. The migration itself
+    # remains one-shot and does not repeatedly clear healthy future previews.
+    raw_preview.write_bytes(b"new camera-rendered preview")
+    db.preview_cache_insert(raw_id, 2560, raw_preview.stat().st_size)
+    create_app(db_path=db_path, thumb_cache_dir=str(thumb_dir))
+    assert raw_preview.exists()
+    assert db.preview_cache_get(raw_id, 2560) is not None
+    db.close()
 
 
 def test_edit_math_version_bump_invalidates_edited_photo_caches(tmp_path, monkeypatch):

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -10876,6 +10876,106 @@ def test_pipeline_previews_honor_raw_failure_marker_after_source_selection(
     assert db.preview_cache_get(photo_id, 1920) is None
 
 
+def test_pipeline_previews_warm_unedited_raw_from_camera_rendered_source(
+    tmp_path, monkeypatch,
+):
+    """Pipeline preview stage must warm from the RAW source, not the
+    highlight-preserving working copy. Otherwise the tracked preview cache
+    locks in the dark render and /photos/<id>/preview returns those cache
+    hits before its own RAW-source branch ever runs."""
+    import config as cfg
+    import image_loader
+    import scanner
+    import thumbnails
+    from db import Database
+    from PIL import Image
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    photo_dir = tmp_path / "photos"
+    photo_dir.mkdir()
+    raw_path = photo_dir / "source.NEF"
+    raw_path.write_bytes(b"raw bytes decoded by the test double")
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    folder_id = db.add_folder(str(photo_dir), name="photos")
+    photo_id = db.add_photo(
+        folder_id=folder_id,
+        filename="source.NEF",
+        extension=".nef",
+        file_size=raw_path.stat().st_size,
+        file_mtime=raw_path.stat().st_mtime,
+        width=800,
+        height=600,
+    )
+    working_dir = tmp_path / "working"
+    working_dir.mkdir()
+    working_path = working_dir / f"{photo_id}.jpg"
+    Image.new("RGB", (800, 600), (25, 25, 25)).save(str(working_path))
+    # Setting exif_data non-null keeps _find_broken_metadata_folders from
+    # flagging this row for a repair scan that would otherwise call
+    # extract_working_copy against the placeholder RAW bytes and mark the
+    # source as failed — masking the source-selection behavior we want to
+    # exercise here.
+    db.conn.execute(
+        "UPDATE photos SET working_copy_path=?, exif_data='{}' WHERE id=?",
+        (f"working/{photo_id}.jpg", photo_id),
+    )
+    db.conn.commit()
+    collection_id = db.add_collection("Test", json.dumps([]))
+
+    def fake_generate_thumbnail(photo_id, photo_path, cache_dir, size=300, **kwargs):
+        os.makedirs(cache_dir, exist_ok=True)
+        thumb_path = os.path.join(cache_dir, f"{photo_id}.jpg")
+        Image.new("RGB", (size, size), "green").save(thumb_path)
+        return thumb_path
+
+    monkeypatch.setattr(thumbnails, "generate_thumbnail", fake_generate_thumbnail)
+    monkeypatch.setattr(scanner, "extract_working_copy", lambda *args, **kwargs: False)
+
+    loaded = []
+
+    def tracking_load_image(file_path, max_size=1024, **kwargs):
+        loaded.append(os.fspath(file_path))
+        color = (
+            (220, 220, 220)
+            if os.path.abspath(str(file_path)) == os.path.abspath(str(raw_path))
+            else (25, 25, 25)
+        )
+        return Image.new("RGB", (800, 600), color)
+
+    monkeypatch.setattr(image_loader, "load_image", tracking_load_image)
+
+    result = run_pipeline_job(
+        _make_job(),
+        FakeRunner(),
+        db_path,
+        ws_id,
+        PipelineParams(
+            collection_id=collection_id,
+            skip_classify=True,
+            skip_extract_masks=True,
+            skip_regroup=True,
+            preview_max_size=1920,
+        ),
+    )
+
+    previews = result["stages"]["previews"]
+    assert previews["failed"] == 0
+    assert previews["generated"] == 1
+    # The warmer decoded the RAW source, not the dark working copy.
+    assert str(raw_path) in loaded
+    assert str(working_path) not in loaded
+    # base_dir = dirname(db_path) when no thumb_cache_dir override; matches
+    # the pipeline's effective_vireo_dir setup at pipeline_job.py:758.
+    preview_path = tmp_path / "previews" / f"{photo_id}_1920.jpg"
+    assert preview_path.exists()
+    with Image.open(preview_path) as warmed:
+        assert warmed.getpixel((400, 300))[0] > 200
+
+
 def test_pipeline_scan_thumbnails_use_recipe_source_before_live_raw(
     tmp_path, monkeypatch,
 ):


### PR DESCRIPTION
## Summary

Fix unedited RAW lightbox tiers to use the camera-rendered source instead of the darker highlight-preserving working copy.
Add a one-time startup migration that clears affected preview caches so existing libraries repair themselves while ordinary JPEG caches remain intact.
Add regression coverage for RAW preview source selection and migration idempotency.

## Validation

- `python -m ruff check vireo/app.py vireo/tests/test_photos_api.py`
- `python -m pytest tests/test_workspaces.py vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py vireo/tests/test_darktable_api.py vireo/tests/test_config.py -q` (1,626 passed, 14 skipped)
