### PR TITLE
Fix lightbox navigation on visual variants page

### DIFF
--- a/tests/e2e/test_variants_lightbox.py
+++ b/tests/e2e/test_variants_lightbox.py
@@ -51,3 +51,50 @@ def test_variants_lightbox_arrows_navigate_displayed_photos(live_server, page):
     page.locator("#lightboxPrev").click()
     expect(page.locator("#lightboxFilename")).to_have_text("first.jpg")
     expect(page.locator("#lightboxCounter")).to_contain_text("1 / 2")
+
+
+def test_variants_lightbox_deduplicates_photos_across_clusters(live_server, page):
+    """A photo that appears in more than one cluster still lets next/prev advance."""
+    page.route(
+        "**/photos/*/full*",
+        lambda route: route.fulfill(
+            body=base64.b64decode(_PNG_1X1), content_type="image/png"
+        ),
+    )
+    page.goto(f"{live_server['url']}/variants")
+
+    page.evaluate(
+        """() => renderClusters({
+            species: 'Test bird',
+            total_photos: 3,
+            num_clusters: 2,
+            distance_threshold: 0.4,
+            clusters: [
+                {
+                    count: 2,
+                    photos: [
+                        {photo: {id: 900010, filename: 'first.jpg'}},
+                        {photo: {id: 900011, filename: 'second.jpg'}}
+                    ]
+                },
+                {
+                    count: 2,
+                    photos: [
+                        {photo: {id: 900011, filename: 'second.jpg'}},
+                        {photo: {id: 900012, filename: 'third.jpg'}}
+                    ]
+                }
+            ]
+        })"""
+    )
+
+    # Opening the duplicated photo must land on its first (deduped) position
+    # and allow forward navigation to reach the third photo.
+    page.locator('.cluster-thumb[data-photo-id="900011"]').first.click()
+    expect(page.locator("#lightboxOverlay")).to_have_class("lightbox-overlay active")
+    expect(page.locator("#lightboxFilename")).to_have_text("second.jpg")
+    expect(page.locator("#lightboxCounter")).to_contain_text("2 / 3")
+
+    page.locator("#lightboxNext").click()
+    expect(page.locator("#lightboxFilename")).to_have_text("third.jpg")
+    expect(page.locator("#lightboxCounter")).to_contain_text("3 / 3")

--- a/tests/e2e/test_variants_lightbox.py
+++ b/tests/e2e/test_variants_lightbox.py
@@ -1,0 +1,53 @@
+"""E2E coverage for lightbox navigation on the visual variants page."""
+
+import base64
+
+from playwright.sync_api import expect
+
+_PNG_1X1 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8"
+    "/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+)
+
+
+def test_variants_lightbox_arrows_navigate_displayed_photos(live_server, page):
+    """Variant thumbnails provide the shared lightbox its navigation list."""
+    page.route(
+        "**/photos/*/full*",
+        lambda route: route.fulfill(
+            body=base64.b64decode(_PNG_1X1), content_type="image/png"
+        ),
+    )
+    page.goto(f"{live_server['url']}/variants")
+
+    page.evaluate(
+        """() => renderClusters({
+            species: 'Test bird',
+            total_photos: 2,
+            num_clusters: 2,
+            distance_threshold: 0.4,
+            clusters: [
+                {
+                    count: 1,
+                    photos: [{photo: {id: 900001, filename: 'first.jpg'}}]
+                },
+                {
+                    count: 1,
+                    photos: [{photo: {id: 900002, filename: 'second.jpg'}}]
+                }
+            ]
+        })"""
+    )
+
+    page.locator('.cluster-thumb[data-photo-id="900001"]').click()
+    expect(page.locator("#lightboxOverlay")).to_have_class("lightbox-overlay active")
+    expect(page.locator("#lightboxFilename")).to_have_text("first.jpg")
+    expect(page.locator("#lightboxCounter")).to_contain_text("1 / 2")
+
+    page.locator("#lightboxNext").click()
+    expect(page.locator("#lightboxFilename")).to_have_text("second.jpg")
+    expect(page.locator("#lightboxCounter")).to_contain_text("2 / 2")
+
+    page.locator("#lightboxPrev").click()
+    expect(page.locator("#lightboxFilename")).to_have_text("first.jpg")
+    expect(page.locator("#lightboxCounter")).to_contain_text("1 / 2")

--- a/vireo/templates/variants.html
+++ b/vireo/templates/variants.html
@@ -312,9 +312,19 @@ function renderClusters(data) {
 
   // Keep the displayed cluster order as the lightbox navigation order.  The
   // shared lightbox can only enable its arrows when the opening page supplies
-  // the surrounding photos.
+  // the surrounding photos.  A photo with multiple detections can appear in
+  // more than one cluster; dedupe by id so lightbox findIndex lookups don't
+  // bounce back to an earlier copy and skip later photos.
+  var seenPhotoIds = {};
   variantPhotos = data.clusters.reduce(function(photos, cluster) {
-    return photos.concat(cluster.photos.map(function(item) { return item.photo; }));
+    cluster.photos.forEach(function(item) {
+      var photo = item.photo;
+      if (photo && !seenPhotoIds[photo.id]) {
+        seenPhotoIds[photo.id] = true;
+        photos.push(photo);
+      }
+    });
+    return photos;
   }, []);
 
   // Header

--- a/vireo/templates/variants.html
+++ b/vireo/templates/variants.html
@@ -233,6 +233,7 @@
 <script>
 var allSpecies = [];
 var activeSpecies = null;
+var variantPhotos = [];
 
 async function loadSpecies() {
   try {
@@ -309,6 +310,13 @@ function renderClusters(data) {
   var area = document.getElementById('clusterArea');
   var html = '';
 
+  // Keep the displayed cluster order as the lightbox navigation order.  The
+  // shared lightbox can only enable its arrows when the opening page supplies
+  // the surrounding photos.
+  variantPhotos = data.clusters.reduce(function(photos, cluster) {
+    return photos.concat(cluster.photos.map(function(item) { return item.photo; }));
+  }, []);
+
   // Header
   html += '<div class="cluster-header">' +
     '<h2>' + escapeHtml(data.species) + '</h2>' +
@@ -367,7 +375,11 @@ function renderClusters(data) {
 document.getElementById('clusterArea').addEventListener('click', function(e) {
   var thumb = e.target.closest('.cluster-thumb[data-photo-id]');
   if (thumb) {
-    openLightbox(parseInt(thumb.dataset.photoId, 10), thumb.dataset.filename || '');
+    openLightbox(
+      parseInt(thumb.dataset.photoId, 10),
+      thumb.dataset.filename || '',
+      variantPhotos
+    );
     return;
   }
   var labelBtn = e.target.closest('.cluster-label-btn[data-cluster-idx]');


### PR DESCRIPTION
Fixes previous and next navigation on the visual variants page by passing the displayed, cluster-ordered photo list into the shared lightbox. This restores both arrow-button and keyboard navigation across visual groups. Adds Playwright regression coverage for forward and backward navigation.

Validation: pytest -q tests/e2e/test_browse_lightbox.py::test_browse_lightbox_arrows_navigate tests/e2e/test_variants_lightbox.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lightbox navigation on the visual variants page.
  * Next and previous controls now move through all displayed photos in the correct order.

* **Tests**
  * Added end-to-end coverage verifying lightbox photo navigation, filenames, and counters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->