### PR TITLE
Canonicalize species casing at prediction and curation boundaries

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -10390,6 +10390,28 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # dst_existed=false; undo would then delete the user's
         # pre-existing highlight/preference/rep.
         species = db.resolve_species_display_name(species)
+        # Multi-homonym reconciliation. resolve_species_display_name
+        # preserves the caller's spelling when two intentionally-distinct
+        # root species keywords share a NOCASE key (legacy general
+        # ``Robin`` alongside taxonomy ``robin``) so bucket / parse /
+        # setter paths stay in agreement on one string. add_keyword's
+        # typed lookup below still prefers the taxonomy row, however, so
+        # a request submitted as ``Robin`` would snapshot dst_existed
+        # against ``Robin`` and then rename onto ``robin`` — leaving undo
+        # able to delete pre-existing ``robin`` curation rows it never
+        # created. Mirror add_keyword's ORDER BY here so snapshots and
+        # renames key on the exact spelling add_keyword will store. Rows
+        # with type NOT IN ('taxonomy', 'general') are excluded (matching
+        # add_keyword) so a deliberate individual/location/genre homonym
+        # doesn't misroute the target.
+        target_row = db.conn.execute(
+            "SELECT name FROM keywords WHERE name = ? COLLATE NOCASE "
+            "AND parent_id IS NULL AND type IN ('taxonomy', 'general') "
+            "ORDER BY (type = 'taxonomy') DESC, id ASC LIMIT 1",
+            (species,),
+        ).fetchone()
+        if target_row and target_row["name"]:
+            species = target_row["name"]
         error, status = _validate_highlight_photo_ids(db, photo_ids)
         if error:
             return json_error(error, status)

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -542,7 +542,8 @@ def _photo_highlight_entries(db, photo_id):
         None, min_quality=0.0, photo_id=photo_id
     )
     buckets, _unidentified = _collect_highlight_buckets(
-        candidates, confidence_threshold=0.0
+        candidates, confidence_threshold=0.0,
+        canonicalize_species=_species_canonicalizer(db),
     )
     entries = []
     for bucket in buckets:
@@ -588,10 +589,27 @@ def _normalize_highlight_presence_filter(value):
     return value
 
 
+def _species_canonicalizer(db):
+    """Memoized wrapper around db.resolve_species_display_name.
+
+    Bucket collection resolves the same handful of species strings for
+    thousands of candidate rows; caching avoids a keyword lookup per row.
+    """
+    cache = {}
+
+    def canonicalize(name):
+        if name not in cache:
+            cache[name] = db.resolve_species_display_name(name)
+        return cache[name]
+
+    return canonicalize
+
+
 def _collect_highlight_buckets(
     candidates,
     confidence_threshold,
     confirmation_filter="all",
+    canonicalize_species=None,
 ):
     confirmation_filter = _normalize_highlight_confirmation_filter(
         confirmation_filter
@@ -615,7 +633,15 @@ def _collect_highlight_buckets(
             and predicted_conf is not None
             and predicted_conf >= confidence_threshold
         ):
+            # Prediction labels are external vocabulary (classifier label
+            # files) with their own casing. Bucket by the spelling
+            # add_keyword would store so a predicted `Common Waxbill` and
+            # photos already accepted as `Common waxbill` land in ONE
+            # bucket, and so curation written from this bucket's label keys
+            # on the string the keyword row and eligibility queries use.
             species = r["predicted_species"]
+            if canonicalize_species is not None:
+                species = canonicalize_species(species) or species
             is_accepted = False
         else:
             species = None
@@ -9465,6 +9491,12 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             )
         if not species:
             return None, "species required"
+        # Canonicalize to the spelling add_keyword would store (see
+        # _parse_species_highlight_body) so the eligibility prechecks and
+        # the DB setters all key on one string.
+        species = _get_db().resolve_species_display_name(species)
+        if not species:
+            return None, "species required"
 
         photo_id = body.get("photo_id")
         # Ordered highlights are per-photo (multiple photos per species),
@@ -9510,7 +9542,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def _photo_can_be_highlights_preference(db, species, photo_id):
         candidates = db.get_highlights_candidates(None, min_quality=0.0)
         buckets, _unidentified = _collect_highlight_buckets(
-            candidates, confidence_threshold=0.0
+            candidates, confidence_threshold=0.0,
+            canonicalize_species=_species_canonicalizer(db),
         )
         for bucket in buckets:
             if bucket["species"] != species:
@@ -9600,6 +9633,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     def _parse_species_highlight_body(body, require_direction=False):
         species = body.get("species", "")
         species = species.strip() if isinstance(species, str) else ""
+        if not species:
+            return None, "species required"
+        # Canonicalize to the spelling add_keyword would store: the client
+        # sends bucket labels, which for unconfirmed buckets derive from
+        # prediction casing. The eligibility precheck compares against
+        # canonical bucket keys and the DB setters canonicalize on write,
+        # so parse-time canonicalization keeps all three in agreement.
+        species = _get_db().resolve_species_display_name(species)
         if not species:
             return None, "species required"
         photo_id = body.get("photo_id")
@@ -9699,7 +9740,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         total_in_scope = db.count_filtered_photos(folder_id=folder_id)
 
         buckets, unidentified_photos = _collect_highlight_buckets(
-            candidates, confidence_threshold, confirmation_filter
+            candidates, confidence_threshold, confirmation_filter,
+            canonicalize_species=_species_canonicalizer(db),
         )
         eligible_count = sum(b["photo_count"] for b in buckets) + len(
             unidentified_photos
@@ -10761,7 +10803,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         candidates = db.get_highlights_candidates(folder_id, min_quality=min_quality)
         buckets, unidentified_photos = _collect_highlight_buckets(
-            candidates, confidence_threshold, confirmation_filter
+            candidates, confidence_threshold, confirmation_filter,
+            canonicalize_species=_species_canonicalizer(db),
         )
         buckets, unidentified_photos = _filter_highlight_sections(
             buckets,

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -12380,17 +12380,23 @@ class Database:
                     AND wf.workspace_id = sh.workspace_id
                    JOIN folders f ON f.id = p.folder_id
                     AND f.status IN ('ok', 'partial')"""
-            # NOCASE on the species comparison: the prediction fallback
-            # below yields the raw classifier label (external vocabulary,
-            # e.g. `Common Waxbill`), while sh.species is stored in the
-            # canonical keyword spelling (`Common waxbill`). An exact
-            # compare would mark every highlight starred from an
-            # unconfirmed bucket ineligible. Case-insensitive matches the
-            # dedupe rule used everywhere else (add_keyword COLLATE NOCASE).
+            # Two-branch species eligibility. Accepted keyword compares
+            # exact: same-NOCASE homonyms preserved by the migration
+            # (legacy general ``Robin`` alongside taxonomy ``robin``) are
+            # genuinely different species — a stored highlight for
+            # ``Robin`` must not become eligible for a photo whose
+            # accepted keyword resolves to ``robin``. Prediction fallback
+            # compares NOCASE: the classifier emits an external
+            # vocabulary spelling (e.g. ``Common Waxbill``) while
+            # sh.species stores the canonical keyword spelling
+            # (``Common waxbill``), so an exact compare would drop every
+            # highlight starred from an unconfirmed bucket. Applying
+            # NOCASE only to the fallback keeps the ambiguous-homonym
+            # boundary intact.
             eligibility_filter = """
                  AND COALESCE(p.flag, 'none') != 'rejected'
-                 AND sh.species = COALESCE(
-                     (
+                 AND (
+                     sh.species = (
                          SELECT k.name
                          FROM photo_keywords pk
                          JOIN keywords k ON k.id = pk.keyword_id
@@ -12398,29 +12404,38 @@ class Database:
                          WHERE pk.photo_id = sh.photo_id
                          ORDER BY pk.rowid DESC
                          LIMIT 1
-                     ),
-                     (
-                         SELECT pr.species
-                         FROM detections d
-                         JOIN predictions pr ON pr.detection_id = d.id
-                         LEFT JOIN prediction_review pr_rev
-                          ON pr_rev.prediction_id = pr.id
-                         AND pr_rev.workspace_id = sh.workspace_id
-                         WHERE d.photo_id = sh.photo_id
-                           AND pr.species IS NOT NULL
-                           AND COALESCE(pr_rev.status, 'pending') != 'rejected'
-                           AND pr.labels_fingerprint = (
-                               SELECT pr2.labels_fingerprint
-                               FROM predictions pr2
-                               WHERE pr2.detection_id = pr.detection_id
-                                 AND pr2.classifier_model = pr.classifier_model
-                               ORDER BY pr2.created_at DESC, pr2.id DESC
-                               LIMIT 1
-                           )
-                         ORDER BY pr.confidence DESC, pr.id DESC
-                         LIMIT 1
                      )
-                 ) COLLATE NOCASE"""
+                     OR (
+                         NOT EXISTS (
+                             SELECT 1
+                             FROM photo_keywords pk
+                             JOIN keywords k ON k.id = pk.keyword_id
+                              AND (k.is_species = 1 OR k.type = 'taxonomy')
+                             WHERE pk.photo_id = sh.photo_id
+                         )
+                         AND sh.species = (
+                             SELECT pr.species
+                             FROM detections d
+                             JOIN predictions pr ON pr.detection_id = d.id
+                             LEFT JOIN prediction_review pr_rev
+                              ON pr_rev.prediction_id = pr.id
+                             AND pr_rev.workspace_id = sh.workspace_id
+                             WHERE d.photo_id = sh.photo_id
+                               AND pr.species IS NOT NULL
+                               AND COALESCE(pr_rev.status, 'pending') != 'rejected'
+                               AND pr.labels_fingerprint = (
+                                   SELECT pr2.labels_fingerprint
+                                   FROM predictions pr2
+                                   WHERE pr2.detection_id = pr.detection_id
+                                     AND pr2.classifier_model = pr.classifier_model
+                                   ORDER BY pr2.created_at DESC, pr2.id DESC
+                                   LIMIT 1
+                               )
+                             ORDER BY pr.confidence DESC, pr.id DESC
+                             LIMIT 1
+                         ) COLLATE NOCASE
+                     )
+                 )"""
         if species:
             rows = self.conn.execute(
                 f"""SELECT sh.species, sh.photo_id, sh.rank

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -9265,28 +9265,45 @@ class Database:
 
         Species relabel endpoints snapshot curation dst_existed before
         add_keyword actually runs, so they need to know the final stored
-        spelling in advance. Two sources contribute:
+        spelling in advance. Three cases:
 
-        1. If a root taxonomy/general keyword row already matches
-           (SQLite ASCII NOCASE), preserve that stored spelling — the
-           existing curation rows key on it.
-        2. Otherwise apply the same species-casing convention that
-           add_keyword applies for new species keywords, so pre-existing
-           curation from predictions (which inserted `Black Phoebe`) is
-           matched even when the request submits `black phoebe`.
+        1. A single root taxonomy/general keyword row matches (SQLite
+           ASCII NOCASE) → preserve that stored spelling; existing
+           curation rows key on it.
+        2. Multiple distinct stored spellings match the same NOCASE key
+           (intentional homonyms — e.g. legacy general ``Robin`` alongside
+           taxonomy ``robin``) → preserve the caller's spelling. Silently
+           picking one would route bucket/curation writes across
+           genuinely different keyword rows, so the eligibility check
+           (which compares ``bucket["species"]`` to this result exactly)
+           would then reject requests coming from the other homonym's
+           bucket. Bucket collection, API parse, and DB setters all
+           funnel through this call, so preserving keeps them agreeing
+           on the same string.
+        3. No matching root keyword row → apply the same species-casing
+           convention that add_keyword applies for new species keywords,
+           so pre-existing curation from predictions (which inserted
+           `Black Phoebe`) is matched even when the request submits
+           `black phoebe`.
         """
         name = normalize_keyword_display(name)
         if not name:
             return name
-        existing = self.conn.execute(
-            "SELECT name FROM keywords "
+        rows = self.conn.execute(
+            "SELECT DISTINCT name FROM keywords "
             "WHERE name = ? COLLATE NOCASE AND parent_id IS NULL "
             "AND type IN ('taxonomy', 'general') "
-            "ORDER BY (type = 'taxonomy') DESC, id ASC LIMIT 1",
+            "ORDER BY (type = 'taxonomy') DESC, id ASC",
             (name,),
-        ).fetchone()
-        if existing and existing["name"]:
-            return existing["name"]
+        ).fetchall()
+        stored_names = [r["name"] for r in rows if r["name"]]
+        if len(stored_names) == 1:
+            return stored_names[0]
+        if len(stored_names) > 1:
+            for stored in stored_names:
+                if stored == name:
+                    return stored
+            return name
         import config as cfg
         override = cfg.get("keyword_case")
         if override and override != "auto":

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -10331,9 +10331,17 @@ class Database:
         if self.get_meta("curation_species_case_aligned_v2") != "1":
             try:
                 aligned = self._align_curation_species_case()
-                if aligned:
+                # Edit-history snapshots created after v1 but before the
+                # setter canonicalization fix still carry prediction-cased
+                # species in hl_prev/pref_prev/rep_prev; without this a
+                # later undo would recreate the orphaned curation rows v2
+                # is meant to repair.
+                history_aligned = self._align_curation_history_species()
+                if aligned or history_aligned:
                     log.info(
-                        "curation case alignment v2: moved %d row(s)", aligned
+                        "curation case alignment v2: moved %d row(s), "
+                        "rewrote %d history item(s)",
+                        aligned, history_aligned,
                     )
                 self.set_meta(
                     "curation_species_case_aligned_v2", "1", _commit=False
@@ -10384,6 +10392,82 @@ class Database:
                     f"DELETE FROM {table} WHERE species = ?", (old,)
                 )
         return moved
+
+    def _align_curation_history_species(self):
+        """Rewrite curation species snapshots in edit_history_items.old_value.
+
+        Relabel undo/redo payloads carry snapshots of curation rows keyed
+        by species name. Normalizing only the live tables leaves those
+        JSON snapshots pointing at the legacy spelling, so a later undo
+        would recreate orphaned curation rows that no longer compare
+        equal to ``keywords.name``. Apply the same punctuation
+        normalization + unambiguous stored-species casing to every
+        species value captured by hl_prev/pref_prev/rep_prev. Idempotent
+        on already-normalized rows, so it's safe to re-run in the v2
+        gate after v1 has already normalized the punctuation. Returns
+        the number of history rows rewritten; caller commits.
+        """
+        rewritten = 0
+        unique_species_by_key = self._unique_root_species_by_key()
+
+        def _normalized_curation_species(value):
+            clean = normalize_keyword_display(value or "")
+            if not clean:
+                return clean
+            return unique_species_by_key.get(keyword_match_key(clean), clean)
+
+        history_rows = self.conn.execute(
+            "SELECT id, old_value FROM edit_history_items "
+            "WHERE old_value IS NOT NULL AND old_value LIKE ?",
+            ('{%curation%',),
+        ).fetchall()
+        for row in history_rows:
+            try:
+                payload = json.loads(row["old_value"])
+            except (TypeError, ValueError):
+                continue
+            if not isinstance(payload, dict):
+                continue
+            curation = payload.get("curation")
+            if not isinstance(curation, dict):
+                continue
+            dirty = False
+            highlights = curation.get("hl_prev")
+            if isinstance(highlights, list):
+                for index, entry in enumerate(highlights):
+                    if isinstance(entry, str):
+                        normalized = _normalized_curation_species(entry)
+                        if normalized != entry:
+                            highlights[index] = normalized
+                            dirty = True
+                    elif isinstance(entry, dict):
+                        old = entry.get("species")
+                        if isinstance(old, str):
+                            normalized = _normalized_curation_species(old)
+                            if normalized != old:
+                                entry["species"] = normalized
+                                dirty = True
+            for key in ("pref_prev", "rep_prev"):
+                entries = curation.get(key)
+                if not isinstance(entries, list):
+                    continue
+                for entry in entries:
+                    if not isinstance(entry, dict):
+                        continue
+                    old = entry.get("species")
+                    if not isinstance(old, str):
+                        continue
+                    normalized = _normalized_curation_species(old)
+                    if normalized != old:
+                        entry["species"] = normalized
+                        dirty = True
+            if dirty:
+                self.conn.execute(
+                    "UPDATE edit_history_items SET old_value = ? WHERE id = ?",
+                    (json.dumps(payload, sort_keys=True), row["id"]),
+                )
+                rewritten += 1
+        return rewritten
 
     def _unique_root_species_by_key(self):
         """Map match_key → stored root species spelling, unambiguous only.
@@ -10824,73 +10908,7 @@ class Database:
         # homonym-ambiguity rules).
         curation_fixed += self._align_curation_species_case()
 
-        # Relabel undo/redo payloads carry snapshots of the same curation
-        # rows in edit_history_items.old_value. Normalizing only the live
-        # tables above leaves those JSON snapshots pointing at the legacy
-        # spelling; a later undo would then recreate orphaned curation rows
-        # that no longer compare equal to keywords.name. Apply the same
-        # punctuation normalization and unambiguous stored-species casing to
-        # every species value captured by hl_prev/pref_prev/rep_prev.
-        history_curation_fixed = 0
-        unique_species_by_key = self._unique_root_species_by_key()
-
-        def _normalized_curation_species(value):
-            clean = normalize_keyword_display(value or "")
-            if not clean:
-                return clean
-            return unique_species_by_key.get(keyword_match_key(clean), clean)
-
-        history_rows = self.conn.execute(
-            "SELECT id, old_value FROM edit_history_items "
-            "WHERE old_value IS NOT NULL AND old_value LIKE ?",
-            ('{%curation%',),
-        ).fetchall()
-        for row in history_rows:
-            try:
-                payload = json.loads(row["old_value"])
-            except (TypeError, ValueError):
-                continue
-            if not isinstance(payload, dict):
-                continue
-            curation = payload.get("curation")
-            if not isinstance(curation, dict):
-                continue
-            dirty = False
-            highlights = curation.get("hl_prev")
-            if isinstance(highlights, list):
-                for index, entry in enumerate(highlights):
-                    if isinstance(entry, str):
-                        normalized = _normalized_curation_species(entry)
-                        if normalized != entry:
-                            highlights[index] = normalized
-                            dirty = True
-                    elif isinstance(entry, dict):
-                        old = entry.get("species")
-                        if isinstance(old, str):
-                            normalized = _normalized_curation_species(old)
-                            if normalized != old:
-                                entry["species"] = normalized
-                                dirty = True
-            for key in ("pref_prev", "rep_prev"):
-                entries = curation.get(key)
-                if not isinstance(entries, list):
-                    continue
-                for entry in entries:
-                    if not isinstance(entry, dict):
-                        continue
-                    old = entry.get("species")
-                    if not isinstance(old, str):
-                        continue
-                    normalized = _normalized_curation_species(old)
-                    if normalized != old:
-                        entry["species"] = normalized
-                        dirty = True
-            if dirty:
-                self.conn.execute(
-                    "UPDATE edit_history_items SET old_value = ? WHERE id = ?",
-                    (json.dumps(payload, sort_keys=True), row["id"]),
-                )
-                history_curation_fixed += 1
+        history_curation_fixed = self._align_curation_history_species()
 
         if (
             dropped_empty or merged or renamed or pending_fixed

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -9231,12 +9231,34 @@ class Database:
             # First word capitalized, rest lowercase: "Black phoebe"
             words = name.split()
             if len(words) > 1:
-                return words[0].capitalize() + " " + " ".join(w.lower() for w in words[1:])
-            return name.capitalize()
+                first = self._sentence_case_first_word(words[0])
+                return first + " " + " ".join(w.lower() for w in words[1:])
+            return self._sentence_case_first_word(name)
         elif convention == "title":
             # Title Case: "Black Phoebe"
             return name.title()
         return name
+
+    @staticmethod
+    def _sentence_case_first_word(word):
+        """Capitalize a first word without mangling mixed-case eponyms.
+
+        ``str.capitalize()`` lowercases everything after the first letter,
+        so a classifier label like ``McKay's bunting`` would come out
+        ``Mckay's bunting``. Preserve existing internal casing unless the
+        word is ALL CAPS (shouty label files), which sentence-cases.
+        """
+        if not word:
+            return word
+        has_case = any(ch.lower() != ch.upper() for ch in word)
+        if has_case and word == word.upper():
+            chars = list(word.lower())
+            for idx, ch in enumerate(chars):
+                if ch.lower() != ch.upper():
+                    chars[idx] = ch.upper()
+                    break
+            return "".join(chars)
+        return word[0].upper() + word[1:]
 
     def resolve_species_display_name(self, name):
         """Predict the stored species name that add_keyword(is_species=True) would use.
@@ -10290,15 +10312,98 @@ class Database:
         the marker — so a failed run retries on the next open instead of
         leaving a half-normalized keyword table.
         """
-        if self.get_meta("keyword_names_normalized") == "1":
-            return
-        try:
-            self._normalize_keyword_data_once()
-            self.set_meta("keyword_names_normalized", "1", _commit=False)
-            self.conn.commit()
-        except Exception:
-            self.conn.rollback()
-            raise
+        if self.get_meta("keyword_names_normalized") != "1":
+            try:
+                self._normalize_keyword_data_once()
+                self.set_meta("keyword_names_normalized", "1", _commit=False)
+                self.conn.commit()
+            except Exception:
+                self.conn.rollback()
+                raise
+        # Second-generation curation case alignment. The v1 sweep above ran
+        # on databases before curation writes canonicalized their species
+        # input, so highlight/preference rows starred from prediction-cased
+        # bucket labels between the v1 run and that fix are still keyed with
+        # classifier casing (e.g. `Common Waxbill` vs the `Common waxbill`
+        # keyword). Re-run just the case-alignment pass once under its own
+        # marker; with the setters now canonicalizing on write, new
+        # mismatches cannot form afterwards.
+        if self.get_meta("curation_species_case_aligned_v2") != "1":
+            try:
+                aligned = self._align_curation_species_case()
+                if aligned:
+                    log.info(
+                        "curation case alignment v2: moved %d row(s)", aligned
+                    )
+                self.set_meta(
+                    "curation_species_case_aligned_v2", "1", _commit=False
+                )
+                self.conn.commit()
+            except Exception:
+                self.conn.rollback()
+                raise
+
+    def _align_curation_species_case(self):
+        """Re-key curation rows whose species differs from the keyword row
+        only by case.
+
+        ``normalize_keyword_display()`` preserves case, so the punctuation
+        sweep leaves a curation row keyed ``Saffron Finch`` untouched while
+        the species keyword row is ``Saffron finch`` — and the eligible
+        highlight/life-list queries compare those strings EXACT against
+        ``keywords.name``, so the curated selection silently drops out.
+
+        Restricted to match_keys with a single surviving root species
+        keyword: intentionally-distinct same-key homonyms (e.g. a legacy
+        ``type='general', is_species=1`` ``Robin`` alongside a taxonomy
+        ``robin``) must not have every curation row for the other spelling
+        rewritten onto the picked one — the joined queries would then match
+        a species keyword the photo doesn't carry. Ambiguous case-variant
+        homonyms are left as-is. Returns the number of rows moved; caller
+        commits.
+        """
+        moved = 0
+        unique_species_by_key = self._unique_root_species_by_key()
+        for table, rename in (
+            ("photo_preferences", self.rename_photo_preferences_species),
+            ("species_representatives",
+             self.rename_species_representatives_species),
+            ("species_highlights", self.rename_species_highlights_species),
+        ):
+            names = [
+                r["species"] for r in self.conn.execute(
+                    f"SELECT DISTINCT species FROM {table}"
+                ).fetchall()
+            ]
+            for old in names:
+                stored = unique_species_by_key.get(keyword_match_key(old or ""))
+                if not stored or stored == old:
+                    continue
+                moved += rename(old, stored, _commit=False) or 0
+                self.conn.execute(
+                    f"DELETE FROM {table} WHERE species = ?", (old,)
+                )
+        return moved
+
+    def _unique_root_species_by_key(self):
+        """Map match_key → stored root species spelling, unambiguous only.
+
+        Keys whose match_key resolves to more than one distinct stored
+        spelling (intentional same-key homonyms) are omitted so callers
+        can't rewrite curation across genuinely different keyword rows.
+        """
+        species_by_key = {}
+        for row in self.conn.execute(
+            "SELECT name FROM keywords "
+            "WHERE parent_id IS NULL AND (is_species = 1 OR type = 'taxonomy')"
+        ).fetchall():
+            species_by_key.setdefault(keyword_match_key(row["name"]), []).append(
+                row["name"]
+            )
+        return {
+            key: names[0] for key, names in species_by_key.items()
+            if len(set(names)) == 1
+        }
 
     def _normalize_keyword_data_once(self):
         """One-shot backfill: normalize every stored keyword/species name.
@@ -10715,58 +10820,9 @@ class Database:
                 )
 
         # Second curation pass: align case-only mismatches with the stored
-        # keyword spelling. normalize_keyword_display() preserves case, so
-        # the punctuation sweep above leaves a curation row keyed
-        # `Saffron Finch` untouched while the species keyword row is
-        # `Saffron finch` — and the eligible-highlight/life-list queries
-        # compare those strings EXACT against keywords.name, so the curated
-        # selection silently drops out.
-        #
-        # The match-key grouping earlier only merged within
-        # (match_key, parent_id, type), so intentionally-distinct
-        # same-key homonyms across types survive — for example a legacy
-        # `type='general', is_species=1` `Robin` alongside a taxonomy
-        # `robin`. A blind key→first-name map would then rewrite every
-        # curation row for the other spelling to the picked one,
-        # including for photos that carry the other keyword; the joined
-        # highlight/life-list queries then match a species keyword the
-        # photo doesn't have, so that photo's curation silently
-        # disappears. Restrict this pass to match_keys with a single
-        # surviving species keyword. Ambiguous case-variant homonyms are
-        # left as-is; the curation stays exactly where the pre-migration
-        # code had it, which is the same state that survived before the
-        # normalization work.
-        species_by_key = {}
-        for row in self.conn.execute(
-            "SELECT name FROM keywords "
-            "WHERE parent_id IS NULL AND (is_species = 1 OR type = 'taxonomy')"
-        ).fetchall():
-            species_by_key.setdefault(keyword_match_key(row["name"]), []).append(
-                row["name"]
-            )
-        unique_species_by_key = {
-            key: names[0] for key, names in species_by_key.items()
-            if len(set(names)) == 1
-        }
-        for table, rename in (
-            ("photo_preferences", self.rename_photo_preferences_species),
-            ("species_representatives",
-             self.rename_species_representatives_species),
-            ("species_highlights", self.rename_species_highlights_species),
-        ):
-            names = [
-                r["species"] for r in self.conn.execute(
-                    f"SELECT DISTINCT species FROM {table}"
-                ).fetchall()
-            ]
-            for old in names:
-                stored = unique_species_by_key.get(keyword_match_key(old or ""))
-                if not stored or stored == old:
-                    continue
-                curation_fixed += rename(old, stored, _commit=False) or 0
-                self.conn.execute(
-                    f"DELETE FROM {table} WHERE species = ?", (old,)
-                )
+        # keyword spelling (see _align_curation_species_case for the
+        # homonym-ambiguity rules).
+        curation_fixed += self._align_curation_species_case()
 
         # Relabel undo/redo payloads carry snapshots of the same curation
         # rows in edit_history_items.old_value. Normalizing only the live
@@ -10776,6 +10832,7 @@ class Database:
         # punctuation normalization and unambiguous stored-species casing to
         # every species value captured by hl_prev/pref_prev/rep_prev.
         history_curation_fixed = 0
+        unique_species_by_key = self._unique_root_species_by_key()
 
         def _normalized_curation_species(value):
             clean = normalize_keyword_display(value or "")
@@ -12044,6 +12101,8 @@ class Database:
         by the single-species Life List paging endpoint so incremental
         loads don't scan every species' representatives.
         """
+        if species is not None:
+            species = self.resolve_species_display_name(species)
         ws = self._ws_id()
         eligibility_filter = ""
         if eligible_only:
@@ -12135,7 +12194,17 @@ class Database:
         )
 
     def set_photo_preference(self, purpose, species, photo_id, _commit=True):
-        """Set the preferred photo for a species/purpose in this workspace."""
+        """Set the preferred photo for a species/purpose in this workspace.
+
+        ``species`` is canonicalized to the spelling ``add_keyword`` would
+        store (existing keyword row first, casing convention otherwise), so
+        curation keys written from prediction-cased bucket labels — e.g.
+        starring a photo in an unconfirmed ``Common Waxbill`` bucket — land
+        on the same key the keyword row will use once the species is
+        accepted. The eligible highlight/life-list queries compare these
+        strings exact against ``keywords.name``.
+        """
+        species = self.resolve_species_display_name(species)
         ws = self._ws_id()
         self.conn.execute(
             """INSERT INTO photo_preferences
@@ -12165,6 +12234,7 @@ class Database:
 
     def clear_photo_preference(self, purpose, species, _commit=True):
         """Clear the preferred photo for a species/purpose in this workspace."""
+        species = self.resolve_species_display_name(species)
         ws = self._ws_id()
         self.conn.execute(
             """DELETE FROM photo_preferences
@@ -12176,6 +12246,7 @@ class Database:
 
     def clear_species_representative(self, species, _commit=True):
         """Clear all representative photos for a species globally."""
+        species = self.resolve_species_display_name(species)
         ws = self._ws_id()
         self.conn.execute(
             "DELETE FROM species_representatives WHERE species = ?",
@@ -12206,6 +12277,8 @@ class Database:
 
         Result shape is ``{species: {photo_id: rank}}``.
         """
+        if species is not None:
+            species = self.resolve_species_display_name(species)
         ws = self._ws_id()
         eligibility_joins = ""
         eligibility_filter = ""
@@ -12216,6 +12289,13 @@ class Database:
                     AND wf.workspace_id = sh.workspace_id
                    JOIN folders f ON f.id = p.folder_id
                     AND f.status IN ('ok', 'partial')"""
+            # NOCASE on the species comparison: the prediction fallback
+            # below yields the raw classifier label (external vocabulary,
+            # e.g. `Common Waxbill`), while sh.species is stored in the
+            # canonical keyword spelling (`Common waxbill`). An exact
+            # compare would mark every highlight starred from an
+            # unconfirmed bucket ineligible. Case-insensitive matches the
+            # dedupe rule used everywhere else (add_keyword COLLATE NOCASE).
             eligibility_filter = """
                  AND COALESCE(p.flag, 'none') != 'rejected'
                  AND sh.species = COALESCE(
@@ -12249,7 +12329,7 @@ class Database:
                          ORDER BY pr.confidence DESC, pr.id DESC
                          LIMIT 1
                      )
-                 )"""
+                 ) COLLATE NOCASE"""
         if species:
             rows = self.conn.execute(
                 f"""SELECT sh.species, sh.photo_id, sh.rank
@@ -12276,7 +12356,14 @@ class Database:
         return result
 
     def add_species_highlight(self, species, photo_id, _commit=True):
-        """Add a photo to a species' ordered highlights, appending if new."""
+        """Add a photo to a species' ordered highlights, appending if new.
+
+        ``species`` is canonicalized to the spelling ``add_keyword`` would
+        store (see :meth:`set_photo_preference`) so highlight rows written
+        from prediction-cased bucket labels key on the same string the
+        keyword row and eligibility queries use.
+        """
+        species = self.resolve_species_display_name(species)
         ws = self._ws_id()
         row = self.conn.execute(
             """SELECT rank FROM species_highlights
@@ -12312,6 +12399,7 @@ class Database:
 
     def promote_species_highlight(self, species, photo_id, _commit=True):
         """Add a photo to a species' ordered highlights at rank 1."""
+        species = self.resolve_species_display_name(species)
         ws = self._ws_id()
         rows = self.conn.execute(
             """SELECT photo_id
@@ -12345,6 +12433,7 @@ class Database:
 
     def remove_species_highlight(self, species, photo_id, _commit=True):
         """Remove a photo from a species' ordered highlights."""
+        species = self.resolve_species_display_name(species)
         ws = self._ws_id()
         cur = self.conn.execute(
             """DELETE FROM species_highlights
@@ -12357,6 +12446,7 @@ class Database:
 
     def move_species_highlight(self, species, photo_id, direction, _commit=True):
         """Move a highlighted photo one step up/down within its species."""
+        species = self.resolve_species_display_name(species)
         ws = self._ws_id()
         rows = self.conn.execute(
             """SELECT photo_id

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -10352,8 +10352,8 @@ class Database:
                 raise
 
     def _align_curation_species_case(self):
-        """Re-key curation rows whose species differs from the keyword row
-        only by case.
+        """Re-key curation rows whose species differs from the canonical
+        spelling only by case.
 
         ``normalize_keyword_display()`` preserves case, so the punctuation
         sweep leaves a curation row keyed ``Saffron Finch`` untouched while
@@ -10361,17 +10361,30 @@ class Database:
         highlight/life-list queries compare those strings EXACT against
         ``keywords.name``, so the curated selection silently drops out.
 
-        Restricted to match_keys with a single surviving root species
-        keyword: intentionally-distinct same-key homonyms (e.g. a legacy
-        ``type='general', is_species=1`` ``Robin`` alongside a taxonomy
-        ``robin``) must not have every curation row for the other spelling
-        rewritten onto the picked one — the joined queries would then match
-        a species keyword the photo doesn't carry. Ambiguous case-variant
-        homonyms are left as-is. Returns the number of rows moved; caller
-        commits.
+        Two sources of the canonical spelling, mirroring
+        ``resolve_species_display_name`` (the function
+        ``_collect_highlight_buckets`` uses to canonicalize prediction
+        labels):
+
+        1. A single surviving root species keyword for the match_key.
+           Intentionally-distinct same-key homonyms (e.g. a legacy
+           ``type='general', is_species=1`` ``Robin`` alongside a taxonomy
+           ``robin``) must not have every curation row for the other
+           spelling rewritten onto the picked one — the joined queries
+           would then match a species keyword the photo doesn't carry.
+           Ambiguous case-variant homonyms are left as-is.
+        2. If no keyword row exists at all — e.g. a highlight starred from
+           an unconfirmed prediction bucket before the photo was accepted
+           — apply the detected case convention so the row lands on the
+           string the bucket will produce after this migration. Without
+           this, the bucket-side canonicalization drifts to (say)
+           ``Common waxbill`` while the highlight stays at
+           ``Common Waxbill``, silently un-starring the photo.
+
+        Returns the number of rows moved; caller commits.
         """
         moved = 0
-        unique_species_by_key = self._unique_root_species_by_key()
+        unique_species_by_key, all_species_keys = self._species_keyword_maps()
         for table, rename in (
             ("photo_preferences", self.rename_photo_preferences_species),
             ("species_representatives",
@@ -10384,7 +10397,9 @@ class Database:
                 ).fetchall()
             ]
             for old in names:
-                stored = unique_species_by_key.get(keyword_match_key(old or ""))
+                stored = self._canonical_curation_species(
+                    old, unique_species_by_key, all_species_keys
+                )
                 if not stored or stored == old:
                     continue
                 moved += rename(old, stored, _commit=False) or 0
@@ -10400,21 +10415,22 @@ class Database:
         by species name. Normalizing only the live tables leaves those
         JSON snapshots pointing at the legacy spelling, so a later undo
         would recreate orphaned curation rows that no longer compare
-        equal to ``keywords.name``. Apply the same punctuation
-        normalization + unambiguous stored-species casing to every
-        species value captured by hl_prev/pref_prev/rep_prev. Idempotent
-        on already-normalized rows, so it's safe to re-run in the v2
-        gate after v1 has already normalized the punctuation. Returns
-        the number of history rows rewritten; caller commits.
+        equal to the string the bucket / eligibility queries expect.
+        Route every species value captured by hl_prev/pref_prev/rep_prev
+        through the same canonicalization ``_align_curation_species_case``
+        applies to the live tables (unambiguous stored spelling, ambiguous
+        homonyms left alone, no-keyword predictions case-converted).
+        Idempotent on already-normalized rows, so it's safe to re-run in
+        the v2 gate after v1 has already normalized the punctuation.
+        Returns the number of history rows rewritten; caller commits.
         """
         rewritten = 0
-        unique_species_by_key = self._unique_root_species_by_key()
+        unique_species_by_key, all_species_keys = self._species_keyword_maps()
 
         def _normalized_curation_species(value):
-            clean = normalize_keyword_display(value or "")
-            if not clean:
-                return clean
-            return unique_species_by_key.get(keyword_match_key(clean), clean)
+            return self._canonical_curation_species(
+                value, unique_species_by_key, all_species_keys
+            )
 
         history_rows = self.conn.execute(
             "SELECT id, old_value FROM edit_history_items "
@@ -10469,12 +10485,21 @@ class Database:
                 rewritten += 1
         return rewritten
 
-    def _unique_root_species_by_key(self):
-        """Map match_key → stored root species spelling, unambiguous only.
+    def _species_keyword_maps(self):
+        """Return ``(unique_species_by_key, all_species_keys)`` for
+        curation alignment.
 
-        Keys whose match_key resolves to more than one distinct stored
-        spelling (intentional same-key homonyms) are omitted so callers
-        can't rewrite curation across genuinely different keyword rows.
+        ``unique_species_by_key``: match_key → stored root species
+        spelling, ONLY for keys resolving to a single distinct spelling.
+        Homonyms (multiple distinct spellings for the same key) are
+        omitted so callers can't rewrite curation across genuinely
+        different keyword rows.
+
+        ``all_species_keys``: set of match_keys with any root species
+        keyword row (ambiguous or not). Used to distinguish "no keyword
+        row at all" — safe to canonicalize a curation species via the
+        detected case convention — from "ambiguous homonym", which
+        must be left alone.
         """
         species_by_key = {}
         for row in self.conn.execute(
@@ -10484,10 +10509,41 @@ class Database:
             species_by_key.setdefault(keyword_match_key(row["name"]), []).append(
                 row["name"]
             )
-        return {
+        unique = {
             key: names[0] for key, names in species_by_key.items()
             if len(set(names)) == 1
         }
+        return unique, set(species_by_key.keys())
+
+    def _canonical_curation_species(
+        self, name, unique_species_by_key, all_species_keys,
+    ):
+        """Canonical spelling for a curation species value.
+
+        Agrees with ``_collect_highlight_buckets`` / ``resolve_species_display_name``:
+
+        - Unambiguous keyword match → use the stored spelling.
+        - Ambiguous homonym → leave alone (returns the punctuation-
+          normalized input unchanged).
+        - No keyword row for the match_key → apply the same case
+          convention ``_collect_highlight_buckets`` uses when it
+          canonicalizes predicted species labels, so a highlight starred
+          from a prediction-only bucket (no keyword exists yet because
+          the photo hasn't been accepted) keys on the string the bucket
+          will emit after this migration.
+
+        Empty input returns unchanged.
+        """
+        clean = normalize_keyword_display(name or "")
+        if not clean:
+            return clean
+        key = keyword_match_key(clean)
+        stored = unique_species_by_key.get(key)
+        if stored:
+            return stored
+        if key in all_species_keys:
+            return clean
+        return self.resolve_species_display_name(clean)
 
     def _normalize_keyword_data_once(self):
         """One-shot backfill: normalize every stored keyword/species name.

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -9265,22 +9265,35 @@ class Database:
 
         Species relabel endpoints snapshot curation dst_existed before
         add_keyword actually runs, so they need to know the final stored
-        spelling in advance. Three cases:
+        spelling in advance. Cases:
 
-        1. A single root taxonomy/general keyword row matches (SQLite
+        1. A single species-bearing root keyword row matches (SQLite
            ASCII NOCASE) → preserve that stored spelling; existing
-           curation rows key on it.
-        2. Multiple distinct stored spellings match the same NOCASE key
-           (intentional homonyms — e.g. legacy general ``Robin`` alongside
-           taxonomy ``robin``) → preserve the caller's spelling. Silently
-           picking one would route bucket/curation writes across
-           genuinely different keyword rows, so the eligibility check
-           (which compares ``bucket["species"]`` to this result exactly)
-           would then reject requests coming from the other homonym's
-           bucket. Bucket collection, API parse, and DB setters all
-           funnel through this call, so preserving keeps them agreeing
-           on the same string.
-        3. No matching root keyword row → apply the same species-casing
+           curation rows key on it. A non-species general homonym with
+           the same NOCASE key (e.g. a hand-tagged ``Common Waxbill``
+           general alongside a taxonomy ``Common waxbill``) is ignored
+           here — add_keyword's typed lookup prefers the taxonomy row,
+           so returning the general's spelling would key curation onto a
+           string add_keyword never stores.
+        2. Multiple species-bearing stored spellings match the same
+           NOCASE key (intentional homonyms — e.g. legacy general
+           ``Robin`` (is_species=1) alongside taxonomy ``robin``) →
+           preserve the caller's spelling. Silently picking one would
+           route bucket/curation writes across genuinely different
+           species rows, so the eligibility check (which compares
+           ``bucket["species"]`` to this result exactly) would then
+           reject requests coming from the other homonym's bucket.
+           Bucket collection, API parse, and DB setters all funnel
+           through this call, so preserving keeps them agreeing on the
+           same string. (Callers that need the exact spelling
+           add_keyword will land on after promotion — e.g. relabel
+           snapshots — apply add_keyword's ORDER BY themselves.)
+        3. No species-bearing row but a non-species general row shares
+           the NOCASE key → return that general's spelling.
+           add_keyword(is_species=True) would find and promote that row
+           in place, keeping its name, so curation must key on the same
+           string.
+        4. No matching root keyword row → apply the same species-casing
            convention that add_keyword applies for new species keywords,
            so pre-existing curation from predictions (which inserted
            `Black Phoebe`) is matched even when the request submits
@@ -9290,20 +9303,25 @@ class Database:
         if not name:
             return name
         rows = self.conn.execute(
-            "SELECT DISTINCT name FROM keywords "
+            "SELECT name, type, is_species FROM keywords "
             "WHERE name = ? COLLATE NOCASE AND parent_id IS NULL "
             "AND type IN ('taxonomy', 'general') "
             "ORDER BY (type = 'taxonomy') DESC, id ASC",
             (name,),
         ).fetchall()
-        stored_names = [r["name"] for r in rows if r["name"]]
-        if len(stored_names) == 1:
-            return stored_names[0]
-        if len(stored_names) > 1:
-            for stored in stored_names:
-                if stored == name:
-                    return stored
-            return name
+        if rows:
+            species_rows = [
+                r for r in rows
+                if r["is_species"] or r["type"] == "taxonomy"
+            ]
+            if len(species_rows) == 1:
+                return species_rows[0]["name"]
+            if len(species_rows) > 1:
+                for r in species_rows:
+                    if r["name"] == name:
+                        return r["name"]
+                return name
+            return rows[0]["name"]
         import config as cfg
         override = cfg.get("keyword_case")
         if override and override != "auto":

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -10269,6 +10269,162 @@ def test_species_highlights_add_preserves_ambiguous_homonym_species(app_and_db):
     assert [r["species"] for r in rows] == ["Robin"]
 
 
+def test_highlights_relabel_snapshots_match_add_keyword_pick_for_homonyms(
+    app_and_db,
+):
+    """When two intentionally-distinct species keywords share a NOCASE key
+    (legacy general ``Robin`` alongside taxonomy ``robin``), the relabel
+    snapshots must key on the SAME spelling ``add_keyword`` will store.
+    ``resolve_species_display_name`` preserves the caller spelling
+    (``Robin``) for bucket/parse/setter symmetry, but ``add_keyword``'s
+    typed lookup picks the taxonomy row (``robin``); before the fix the
+    snapshot compared destination curation against ``Robin`` while the
+    rename actually landed on ``robin``, so undo would delete a pre-existing
+    ``robin`` highlight it never created."""
+    app, db = app_and_db
+    client = app.test_client()
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES ('/hrhom', 'hrhom', 'ok')"
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO workspace_folders (workspace_id, folder_id) VALUES (?, ?)",
+        (db._ws_id(), fid),
+    )
+    old_kid = db.add_keyword("Legacy Species", is_species=True)
+    # Legacy general row with is_species=1 (a pre-migration state that
+    # the v2 sweep intentionally preserves for ambiguous homonyms), plus
+    # the taxonomy row add_keyword's typed lookup will pick.
+    legacy_robin = db.conn.execute(
+        "INSERT INTO keywords (name, type, is_species) "
+        "VALUES ('Robin', 'general', 1)"
+    ).lastrowid
+    taxonomy_robin = db.conn.execute(
+        "INSERT INTO keywords (name, type, is_species) "
+        "VALUES ('robin', 'taxonomy', 1)"
+    ).lastrowid
+    # The photo being relabelled currently carries the "Legacy Species"
+    # tag; the relabel will move it to whichever Robin row add_keyword
+    # picks (the taxonomy row).
+    pid = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+        "VALUES (?, 'moving.jpg', 0.9, 'none')",
+        (fid,),
+    ).lastrowid
+    db.tag_photo(pid, old_kid)
+    db.add_species_highlight("Legacy Species", pid)
+    # Pre-existing destination highlight, keyed on the taxonomy spelling
+    # (which is what add_keyword would store for a "Robin" request).
+    db.conn.execute(
+        "INSERT INTO species_highlights (workspace_id, species, photo_id, rank) "
+        "VALUES (?, 'robin', ?, 0)",
+        (db._ws_id(), pid),
+    )
+    db.conn.commit()
+
+    resp = client.post(
+        "/api/highlights/relabel",
+        json={"photo_ids": [pid], "species": "Robin"},
+    )
+    assert resp.status_code == 200
+    # add_keyword's typed lookup returns the taxonomy row, so the tag
+    # lands on `robin`. The pre-existing `robin` highlight survives.
+    tagged = db.conn.execute(
+        "SELECT k.name FROM photo_keywords pk "
+        "JOIN keywords k ON k.id = pk.keyword_id "
+        "WHERE pk.photo_id = ? AND (k.is_species = 1 OR k.type = 'taxonomy')",
+        (pid,),
+    ).fetchall()
+    assert [r["name"] for r in tagged] == ["robin"]
+    hl = db.get_species_highlights()
+    assert pid in (hl.get("robin") or {})
+
+    undone = db.undo_last_edit()
+    assert undone is not None
+    hl_after_undo = db.get_species_highlights()
+    # The pre-existing `robin` highlight must survive the undo — before
+    # the fix the snapshot recorded dst_existed=False (compared against
+    # "Robin") and undo deleted the user's pre-existing row.
+    assert pid in (hl_after_undo.get("robin") or {}), (
+        "Undo deleted pre-existing robin highlight because snapshots keyed "
+        "on the wrong spelling"
+    )
+    # And the original bucket is restored.
+    assert pid in (hl_after_undo.get("Legacy Species") or {})
+    # Silence the unused-variable warnings on the setup rows: keeping
+    # them named documents the two homonym roles.
+    assert legacy_robin != taxonomy_robin
+
+
+def test_species_highlight_eligibility_accepted_species_exact_match(app_and_db):
+    """When a photo's accepted keyword resolves to one specific spelling of
+    an ambiguous homonym, a stored highlight for the OTHER homonym must
+    stay ineligible. Applying COLLATE NOCASE across the whole eligibility
+    COALESCE relaxed the accepted-keyword branch too: a stored highlight
+    keyed ``Robin`` would then match a photo whose accepted keyword
+    subquery returned ``robin``, silently making the wrong species bucket
+    appear to have a highlight."""
+    app, db = app_and_db
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES ('/elig', 'elig', 'ok')"
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO workspace_folders (workspace_id, folder_id) VALUES (?, ?)",
+        (db._ws_id(), fid),
+    )
+    # Two intentionally-distinct root species keywords sharing a NOCASE
+    # key — the migration explicitly preserves this shape.
+    legacy_kid = db.conn.execute(
+        "INSERT INTO keywords (name, type, is_species) "
+        "VALUES ('Robin', 'general', 1)"
+    ).lastrowid
+    taxonomy_kid = db.conn.execute(
+        "INSERT INTO keywords (name, type, is_species) "
+        "VALUES ('robin', 'taxonomy', 1)"
+    ).lastrowid
+    pid = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+        "VALUES (?, 'elig.jpg', 0.9, 'none')",
+        (fid,),
+    ).lastrowid
+    # The photo's accepted keyword is the TAXONOMY row (lowercase
+    # ``robin``); the accepted-branch of the eligibility COALESCE
+    # returns exactly ``robin``.
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (pid, taxonomy_kid),
+    )
+    # Stored highlight keyed on the OTHER homonym's spelling
+    # (uppercase ``Robin``, the general row) — a plausible remnant when
+    # ambiguous-homonym curation is left alone by the v2 sweep.
+    db.conn.execute(
+        "INSERT INTO species_highlights (workspace_id, species, photo_id, rank) "
+        "VALUES (?, 'Robin', ?, 0)",
+        (db._ws_id(), pid),
+    )
+    db.conn.commit()
+
+    eligible = db.get_species_highlights("Robin", eligible_only=True)
+    # Before the fix the whole-COALESCE NOCASE would match ``Robin`` to
+    # the accepted ``robin`` and mark the highlight eligible. With the
+    # branch-specific NOCASE, the accepted keyword compares EXACT.
+    assert eligible == {}, (
+        "Cross-homonym match: stored 'Robin' highlight should NOT be "
+        "eligible for a photo whose accepted keyword is 'robin'"
+    )
+    # The same-spelling case still passes (sanity check the accepted
+    # branch still resolves an exact match).
+    db.conn.execute(
+        "DELETE FROM photo_keywords WHERE photo_id = ?", (pid,)
+    )
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (pid, legacy_kid),
+    )
+    db.conn.commit()
+    same_spelling = db.get_species_highlights("Robin", eligible_only=True)
+    assert pid in (same_spelling.get("Robin") or {})
+
+
 def test_highlights_save(app_and_db):
     """POST /api/highlights/save creates a static collection."""
     app, db = app_and_db

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -10425,6 +10425,82 @@ def test_species_highlight_eligibility_accepted_species_exact_match(app_and_db):
     assert pid in (same_spelling.get("Robin") or {})
 
 
+def test_resolve_species_display_name_prefers_taxonomy_over_general_homonym(
+    app_and_db,
+):
+    """When a taxonomy species row and a non-species general row share a
+    NOCASE key (e.g. taxonomy ``Common waxbill`` alongside a hand-tagged
+    ``Common Waxbill`` general), ``add_keyword(is_species=True)`` picks
+    the taxonomy row. ``resolve_species_display_name`` must mirror that
+    pick — otherwise the bucket collection keys prediction-only photos
+    under ``Common Waxbill``, curation setters store rows under the
+    non-taxonomy spelling, and once the prediction is accepted the
+    stored highlight no longer matches the accepted keyword spelling
+    (``Common waxbill``) and silently disappears from the bucket."""
+    _, db = app_and_db
+    # Taxonomy species row (the one add_keyword prefers).
+    db.conn.execute(
+        "INSERT INTO keywords (name, type, is_species) "
+        "VALUES ('Common waxbill', 'taxonomy', 1)"
+    )
+    # Separate non-species general row with classifier casing —
+    # someone hand-tagged the same spelling as a plain keyword.
+    db.conn.execute(
+        "INSERT INTO keywords (name, type, is_species) "
+        "VALUES ('Common Waxbill', 'general', 0)"
+    )
+    db.conn.commit()
+
+    # Every caller spelling must land on the taxonomy row's stored
+    # spelling: that's what add_keyword(is_species=True) will pick, and
+    # bucket / parse / setter paths all agree on the same string.
+    assert db.resolve_species_display_name("Common Waxbill") == "Common waxbill"
+    assert db.resolve_species_display_name("common waxbill") == "Common waxbill"
+    assert db.resolve_species_display_name("COMMON WAXBILL") == "Common waxbill"
+
+    # Cross-check the invariant: add_keyword(is_species=True) actually
+    # returns the taxonomy row — otherwise the resolve fix would be
+    # tracking a different behavior than reality.
+    picked_id = db.add_keyword("Common Waxbill", is_species=True)
+    picked_name = db.conn.execute(
+        "SELECT name FROM keywords WHERE id = ?", (picked_id,)
+    ).fetchone()["name"]
+    assert picked_name == "Common waxbill"
+
+
+def test_resolve_species_display_name_promotes_non_species_general_alone(
+    app_and_db,
+):
+    """When only a non-species general row shares the NOCASE key,
+    ``add_keyword(is_species=True)`` finds and promotes it in place —
+    is_species/type flip but the stored name is untouched. Resolve must
+    return that stored name so curation keys on the string the promoted
+    row will carry, not on a case-convention-derived spelling that
+    doesn't exist."""
+    _, db = app_and_db
+    db.conn.execute(
+        "INSERT INTO keywords (name, type, is_species) "
+        "VALUES ('Common Waxbill', 'general', 0)"
+    )
+    db.conn.commit()
+
+    # No taxonomy candidate for this NOCASE key, so add_keyword will
+    # promote the general row rather than insert a fresh taxonomy row.
+    # Resolve returns the general's stored spelling — the string
+    # curation setters must key on.
+    assert db.resolve_species_display_name("common waxbill") == "Common Waxbill"
+
+    # add_keyword promotes in place; the row's name doesn't change.
+    picked_id = db.add_keyword("common waxbill", is_species=True)
+    row = db.conn.execute(
+        "SELECT name, type, is_species FROM keywords WHERE id = ?",
+        (picked_id,),
+    ).fetchone()
+    assert row["name"] == "Common Waxbill"
+    assert row["type"] == "taxonomy"
+    assert row["is_species"] == 1
+
+
 def test_highlights_save(app_and_db):
     """POST /api/highlights/save creates a static collection."""
     app, db = app_and_db

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -10215,6 +10215,60 @@ def test_species_highlights_add_canonicalizes_prediction_cased_label(app_and_db)
     assert resp.get_json()["removed"] == 1
 
 
+def test_species_highlights_add_preserves_ambiguous_homonym_species(app_and_db):
+    """When two intentionally-distinct root species keywords share a
+    NOCASE key (legacy general ``Robin`` alongside taxonomy ``robin``),
+    curation requests from a specific bucket must land on that bucket's
+    exact spelling. Silently collapsing to one canonical spelling would
+    make the eligibility precheck (which compares ``bucket["species"]``
+    exact) reject the request coming from the other homonym's bucket."""
+    app, db = app_and_db
+    client = app.test_client()
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES ('/robin', 'robin', 'ok')"
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO workspace_folders (workspace_id, folder_id) VALUES (?, ?)",
+        (db._ws_id(), fid),
+    )
+    legacy_kw = db.conn.execute(
+        "INSERT INTO keywords (name, type, is_species) "
+        "VALUES ('Robin', 'general', 1)"
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO keywords (name, type, is_species) "
+        "VALUES ('robin', 'taxonomy', 1)"
+    )
+    legacy_pid = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+        "VALUES (?, 'legacy.jpg', 0.9, 'none')",
+        (fid,),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (legacy_pid, legacy_kw),
+    )
+    db.conn.commit()
+
+    resp = client.get(f"/api/highlights?folder_id={fid}&confidence_threshold=0.5")
+    assert resp.status_code == 200
+    buckets = resp.get_json()["buckets"]
+    legacy_bucket = next(b for b in buckets if b["species"] == "Robin")
+    assert legacy_pid in {p["id"] for p in legacy_bucket["photos"]}
+
+    resp = client.post(
+        "/api/species-highlights",
+        json={"species": "Robin", "photo_id": legacy_pid},
+    )
+    assert resp.status_code == 200
+
+    rows = db.conn.execute(
+        "SELECT species FROM species_highlights WHERE photo_id = ?",
+        (legacy_pid,),
+    ).fetchall()
+    assert [r["species"] for r in rows] == ["Robin"]
+
+
 def test_highlights_save(app_and_db):
     """POST /api/highlights/save creates a static collection."""
     app, db = app_and_db

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -10107,6 +10107,114 @@ def test_highlights_accepted_species_wins_over_higher_confidence_prediction(app_
     assert data["buckets"][0]["is_accepted"] is True
 
 
+def _seed_waxbill_casing_scenario(db):
+    """One accepted `Common waxbill` photo plus one photo whose only signal
+    is a raw title-cased prediction `Common Waxbill` (label-file casing —
+    prediction rows are external vocabulary and stay verbatim)."""
+    fid = db.conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES ('/wax', 'wax', 'ok')"
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO workspace_folders (workspace_id, folder_id) VALUES (?, ?)",
+        (db._ws_id(), fid),
+    )
+    waxbill_kw = db.conn.execute(
+        "INSERT INTO keywords (name, type, is_species) "
+        "VALUES ('Common waxbill', 'taxonomy', 1)"
+    ).lastrowid
+    accepted_pid = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+        "VALUES (?, 'accepted.jpg', 0.9, 'none')",
+        (fid,),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO photo_keywords (photo_id, keyword_id) VALUES (?, ?)",
+        (accepted_pid, waxbill_kw),
+    )
+    predicted_pid = db.conn.execute(
+        "INSERT INTO photos (folder_id, filename, quality_score, flag) "
+        "VALUES (?, 'predicted.jpg', 0.8, 'none')",
+        (fid,),
+    ).lastrowid
+    did = db.conn.execute(
+        "INSERT INTO detections (photo_id, detector_confidence) VALUES (?, 0.9)",
+        (predicted_pid,),
+    ).lastrowid
+    db.conn.execute(
+        "INSERT INTO predictions "
+        "(detection_id, classifier_model, species, confidence) "
+        "VALUES (?, 'm', 'Common Waxbill', 0.95)",
+        (did,),
+    )
+    db.conn.commit()
+    return fid, accepted_pid, predicted_pid
+
+
+def test_highlights_merges_prediction_casing_with_accepted_keyword(app_and_db):
+    """A title-cased classifier label and a sentence-cased accepted keyword
+    are the same species: one Highlights bucket, keyed by the keyword
+    spelling. Prediction rows keep label-file casing (external vocabulary),
+    so the merge must happen at bucket-collection time."""
+    app, db = app_and_db
+    client = app.test_client()
+    fid, accepted_pid, predicted_pid = _seed_waxbill_casing_scenario(db)
+
+    resp = client.get(f"/api/highlights?folder_id={fid}&confidence_threshold=0.7")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    waxbill_buckets = [
+        b for b in data["buckets"] if b["species"].lower() == "common waxbill"
+    ]
+    assert len(waxbill_buckets) == 1
+    bucket = waxbill_buckets[0]
+    assert bucket["species"] == "Common waxbill"
+    assert {p["id"] for p in bucket["photos"]} == {accepted_pid, predicted_pid}
+
+
+def test_species_highlights_add_canonicalizes_prediction_cased_label(app_and_db):
+    """Starring a photo in a prediction-cased bucket must store and surface
+    the highlight under the keyword spelling.
+
+    Regression for the silently-dropped star: the client sends the bucket
+    label (`Common Waxbill` from the classifier), but the eligibility
+    queries compare species strings exact against `keywords.name`
+    (`Common waxbill`). Without canonicalization at the route/setter, the
+    star writes a `Common Waxbill` row that no query ever matches again."""
+    app, db = app_and_db
+    client = app.test_client()
+    fid, _accepted_pid, predicted_pid = _seed_waxbill_casing_scenario(db)
+
+    resp = client.post(
+        "/api/species-highlights",
+        json={"species": "Common Waxbill", "photo_id": predicted_pid},
+    )
+    assert resp.status_code == 200
+
+    rows = db.conn.execute(
+        "SELECT species FROM species_highlights WHERE photo_id = ?",
+        (predicted_pid,),
+    ).fetchall()
+    assert [r["species"] for r in rows] == ["Common waxbill"]
+
+    resp = client.get(f"/api/highlights?folder_id={fid}&confidence_threshold=0.7")
+    bucket = next(
+        b for b in resp.get_json()["buckets"]
+        if b["species"] == "Common waxbill"
+    )
+    assert bucket["has_highlight_selection"] is True
+    starred = next(p for p in bucket["photos"] if p["id"] == predicted_pid)
+    assert starred["is_highlighted"] is True
+
+    # Un-starring with yet another casing of the same label must find and
+    # remove the canonical row rather than silently deleting nothing.
+    resp = client.delete(
+        "/api/species-highlights",
+        json={"species": "COMMON WAXBILL", "photo_id": predicted_pid},
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["removed"] == 1
+
+
 def test_highlights_save(app_and_db):
     """POST /api/highlights/save creates a static collection."""
     app, db = app_and_db

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -16311,3 +16311,61 @@ def test_best_photo_by_taxon(db):
     db.conn.commit()
     best = db.get_life_list_best_photo_by_taxon([ids['Melospiza melodia']])
     assert best[ids['Melospiza melodia']]['filename'] == 'high.jpg'
+
+
+def test_apply_case_convention_preserves_mixed_case_eponym(tmp_path):
+    """The 'lower' convention must not mangle mixed-case first words:
+    `McKay's bunting` keeps its internal capital, ALL-CAPS label-file
+    spellings sentence-case, plain words capitalize as before."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    try:
+        conv = db._apply_case_convention
+        assert conv("McKay's bunting", "lower") == "McKay's bunting"
+        assert conv("MALLARD DUCK", "lower") == "Mallard duck"
+        assert conv("black phoebe", "lower") == "Black phoebe"
+        assert conv("mallard", "lower") == "Mallard"
+    finally:
+        db.close()
+
+
+def test_curation_setters_canonicalize_species_casing(tmp_path):
+    """Curation writes with a prediction-cased label key on the stored
+    keyword spelling, and removal finds the row under any casing."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    try:
+        ws_id = db.ensure_default_workspace()
+        db.set_active_workspace(ws_id)
+        fid = db.add_folder('/photos', name='photos')
+        pid = db.add_photo(
+            folder_id=fid, filename='a.jpg', extension='.jpg',
+            file_size=100, file_mtime=1.0,
+        )
+        db.conn.execute(
+            "INSERT INTO keywords (name, type, is_species) "
+            "VALUES ('Common waxbill', 'taxonomy', 1)"
+        )
+        db.conn.commit()
+
+        db.set_photo_preference("life_list", "Common Waxbill", pid)
+        prefs = db.conn.execute(
+            "SELECT DISTINCT species FROM photo_preferences"
+        ).fetchall()
+        assert {r["species"] for r in prefs} == {"Common waxbill"}
+
+        rank = db.add_species_highlight("Common Waxbill", pid)
+        assert rank == 1
+        rows = db.conn.execute(
+            "SELECT species FROM species_highlights"
+        ).fetchall()
+        assert [r["species"] for r in rows] == ["Common waxbill"]
+
+        # Re-adding under yet another casing reuses the canonical row
+        # instead of appending a second rank.
+        assert db.add_species_highlight("COMMON WAXBILL", pid) == 1
+
+        removed = db.remove_species_highlight("Common Waxbill", pid)
+        assert removed == 1
+    finally:
+        db.close()

--- a/vireo/tests/test_keyword_migration.py
+++ b/vireo/tests/test_keyword_migration.py
@@ -1521,3 +1521,180 @@ def test_curation_case_alignment_v2_rewrites_history_snapshots(tmp_path):
         assert db.get_meta("curation_species_case_aligned_v2") == "1"
     finally:
         db.close()
+
+
+def test_curation_case_alignment_v2_rekeys_prediction_only_rows(tmp_path, monkeypatch):
+    """A ``species_highlights`` row starred from an unconfirmed prediction
+    before the corresponding keyword row exists must still land on the
+    canonical spelling the bucket-collection path emits — otherwise the
+    star silently disappears from the UI (bucket keyed
+    ``Common waxbill`` vs stored row ``Common Waxbill``) and a DELETE
+    keyed on the bucket label deletes zero rows.
+
+    The v2 sweep therefore falls back to the detected case convention
+    when no keyword row exists for the row's match_key, mirroring
+    ``resolve_species_display_name`` (which is what the bucket path uses
+    to canonicalize prediction labels).
+    """
+    # Isolate config so a real ~/.vireo/config.json `keyword_case`
+    # override can't preempt the auto-detected "lower" convention below.
+    import config as cfg
+    monkeypatch.setattr(cfg, "CONFIG_PATH", str(tmp_path / "config.json"))
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    db.close()
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    ws_id = conn.execute("SELECT id FROM workspaces LIMIT 1").fetchone()["id"]
+    conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES ('/p', 'p', 'ok')"
+    )
+    fid = conn.execute("SELECT id FROM folders WHERE path = '/p'").fetchone()["id"]
+    conn.execute(
+        "INSERT INTO photos (folder_id, filename) VALUES (?, 'a.jpg')", (fid,)
+    )
+    pid = conn.execute("SELECT id FROM photos LIMIT 1").fetchone()["id"]
+    # Three lower-convention species keywords establish the convention
+    # detector so the fallback picks "lower" for unseen predictions.
+    # None of them match "Common Waxbill" — the prediction has no keyword
+    # row at all, exercising the no-keyword branch.
+    for name in ("Black phoebe", "Saffron finch", "Anna's hummingbird"):
+        conn.execute(
+            "INSERT INTO keywords (name, type, is_species) "
+            "VALUES (?, 'taxonomy', 1)",
+            (name,),
+        )
+    # Pre-fix state: highlight starred from an unconfirmed prediction
+    # bucket labeled `Common Waxbill`; no `Common waxbill` keyword row
+    # yet because the photo was never accepted.
+    conn.execute(
+        "INSERT INTO species_highlights "
+        "(workspace_id, species, photo_id, rank) VALUES (?, ?, ?, 1)",
+        (ws_id, "Common Waxbill", pid),
+    )
+    # Same state on the two neighbour curation tables.
+    conn.execute(
+        "INSERT INTO photo_preferences "
+        "(workspace_id, purpose, species, photo_id) VALUES (?, 'picked', ?, ?)",
+        (ws_id, "Common Waxbill", pid),
+    )
+    conn.execute(
+        "INSERT INTO species_representatives "
+        "(species, photo_id, selected_order) VALUES (?, ?, 1)",
+        ("Common Waxbill", pid),
+    )
+    # Seed a matching relabel undo snapshot too — the same no-keyword
+    # branch has to run in `_align_curation_history_species` or a later
+    # undo would recreate the orphaned rows.
+    conn.execute(
+        "INSERT INTO edit_history (action_type, description) "
+        "VALUES ('relabel', 't')"
+    )
+    edit_id = conn.execute(
+        "SELECT id FROM edit_history LIMIT 1"
+    ).fetchone()["id"]
+    history_payload = {
+        "curation": {
+            "hl_prev": [{"species": "Common Waxbill", "rank": 1, "photo_id": pid}],
+            "pref_prev": [{"species": "Common Waxbill", "photo_id": pid}],
+            "rep_prev": [{"species": "Common Waxbill", "photo_id": pid}],
+        }
+    }
+    conn.execute(
+        "INSERT INTO edit_history_items "
+        "(edit_id, photo_id, old_value, new_value) VALUES (?, ?, ?, '')",
+        (edit_id, pid, json.dumps(history_payload)),
+    )
+    conn.execute(
+        "DELETE FROM db_meta WHERE key = 'curation_species_case_aligned_v2'"
+    )
+    conn.commit()
+    conn.close()
+
+    db = Database(db_path)
+    try:
+        highlight_species = [
+            r["species"] for r in db.conn.execute(
+                "SELECT species FROM species_highlights"
+            ).fetchall()
+        ]
+        preference_species = [
+            r["species"] for r in db.conn.execute(
+                "SELECT species FROM photo_preferences"
+            ).fetchall()
+        ]
+        representative_species = [
+            r["species"] for r in db.conn.execute(
+                "SELECT species FROM species_representatives"
+            ).fetchall()
+        ]
+        assert highlight_species == ["Common waxbill"]
+        assert preference_species == ["Common waxbill"]
+        assert representative_species == ["Common waxbill"]
+        # The bucket path uses `resolve_species_display_name` to
+        # canonicalize the raw prediction; storage and bucket agree now.
+        assert db.resolve_species_display_name("Common Waxbill") == "Common waxbill"
+        row = db.conn.execute(
+            "SELECT old_value FROM edit_history_items LIMIT 1"
+        ).fetchone()
+        rewritten = json.loads(row["old_value"])["curation"]
+        assert rewritten["hl_prev"][0]["species"] == "Common waxbill"
+        assert rewritten["pref_prev"][0]["species"] == "Common waxbill"
+        assert rewritten["rep_prev"][0]["species"] == "Common waxbill"
+        assert db.get_meta("curation_species_case_aligned_v2") == "1"
+    finally:
+        db.close()
+
+
+def test_curation_case_alignment_leaves_ambiguous_homonyms_alone(tmp_path):
+    """When the match_key has multiple distinct keyword spellings —
+    intentionally distinct homonyms — the sweep must not silently pick
+    one and rewrite curation across the other. The "no keyword row →
+    case-convert" fallback added for prediction-only rows must not
+    regress this safety.
+    """
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    db.close()
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    ws_id = conn.execute("SELECT id FROM workspaces LIMIT 1").fetchone()["id"]
+    conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES ('/p', 'p', 'ok')"
+    )
+    fid = conn.execute("SELECT id FROM folders WHERE path = '/p'").fetchone()["id"]
+    conn.execute(
+        "INSERT INTO photos (folder_id, filename) VALUES (?, 'a.jpg')", (fid,)
+    )
+    pid = conn.execute("SELECT id FROM photos LIMIT 1").fetchone()["id"]
+    # Two distinct root species keyword spellings for the same match_key.
+    conn.execute(
+        "INSERT INTO keywords (name, type, is_species) VALUES ('Robin', 'general', 1)"
+    )
+    conn.execute(
+        "INSERT INTO keywords (name, type, is_species) VALUES ('robin', 'taxonomy', 1)"
+    )
+    conn.execute(
+        "INSERT INTO species_highlights "
+        "(workspace_id, species, photo_id, rank) VALUES (?, 'ROBIN', ?, 1)",
+        (ws_id, pid),
+    )
+    conn.execute(
+        "DELETE FROM db_meta WHERE key = 'curation_species_case_aligned_v2'"
+    )
+    conn.commit()
+    conn.close()
+
+    db = Database(db_path)
+    try:
+        species = [
+            r["species"] for r in db.conn.execute(
+                "SELECT species FROM species_highlights"
+            ).fetchall()
+        ]
+        assert species == ["ROBIN"]
+        assert db.get_meta("curation_species_case_aligned_v2") == "1"
+    finally:
+        db.close()

--- a/vireo/tests/test_keyword_migration.py
+++ b/vireo/tests/test_keyword_migration.py
@@ -1383,3 +1383,71 @@ def test_migration_keeps_source_add_when_survivor_was_added_later(tmp_path):
         ).fetchone() is None
     finally:
         db.close()
+
+
+def test_curation_case_alignment_v2_runs_once_by_marker(tmp_path):
+    """The v2 case-alignment sweep runs once per database under its own
+    marker, catching curation rows starred with prediction casing between
+    the v1 repair and the setter canonicalization fix."""
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    db.close()
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    ws_id = conn.execute("SELECT id FROM workspaces LIMIT 1").fetchone()["id"]
+    conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES ('/p', 'p', 'ok')"
+    )
+    fid = conn.execute("SELECT id FROM folders WHERE path = '/p'").fetchone()["id"]
+    conn.execute(
+        "INSERT INTO photos (folder_id, filename) VALUES (?, 'a.jpg')", (fid,)
+    )
+    pid = conn.execute("SELECT id FROM photos LIMIT 1").fetchone()["id"]
+    conn.execute(
+        "INSERT INTO keywords (name, type, is_species) "
+        "VALUES ('Saffron finch', 'taxonomy', 1)"
+    )
+    # Simulate the pre-fix state: a highlight starred from a
+    # prediction-cased bucket label after the v1 repair already ran.
+    conn.execute(
+        "INSERT INTO species_highlights "
+        "(workspace_id, species, photo_id, rank) VALUES (?, ?, ?, 1)",
+        (ws_id, "Saffron Finch", pid),
+    )
+    conn.execute(
+        "DELETE FROM db_meta WHERE key = 'curation_species_case_aligned_v2'"
+    )
+    conn.commit()
+    conn.close()
+
+    db = Database(db_path)
+    try:
+        rows = db.conn.execute(
+            "SELECT species FROM species_highlights"
+        ).fetchall()
+        assert [r["species"] for r in rows] == ["Saffron finch"]
+        assert db.get_meta("curation_species_case_aligned_v2") == "1"
+    finally:
+        db.close()
+
+    # Marker present: a raw mismatch seeded now survives reopen untouched
+    # (one-shot semantics — the setters prevent new mismatches instead).
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO species_highlights "
+        "(workspace_id, species, photo_id, rank) "
+        "SELECT workspace_id, 'SAFFRON FINCH', photo_id, 2 "
+        "FROM species_highlights LIMIT 1"
+    )
+    conn.commit()
+    conn.close()
+
+    db = Database(db_path)
+    try:
+        rows = db.conn.execute(
+            "SELECT species FROM species_highlights ORDER BY rank"
+        ).fetchall()
+        assert [r["species"] for r in rows] == ["Saffron finch", "SAFFRON FINCH"]
+    finally:
+        db.close()

--- a/vireo/tests/test_keyword_migration.py
+++ b/vireo/tests/test_keyword_migration.py
@@ -1451,3 +1451,73 @@ def test_curation_case_alignment_v2_runs_once_by_marker(tmp_path):
         assert [r["species"] for r in rows] == ["Saffron finch", "SAFFRON FINCH"]
     finally:
         db.close()
+
+
+def test_curation_case_alignment_v2_rewrites_history_snapshots(tmp_path):
+    """Undo/redo snapshots keyed on prediction casing (created between the
+    v1 sweep and the setter canonicalization fix) get rewritten by the v2
+    gate too, so a later undo can't recreate the orphaned curation rows
+    the v2 sweep is meant to repair."""
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    db.close()
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        "INSERT INTO folders (path, name, status) VALUES ('/p', 'p', 'ok')"
+    )
+    fid = conn.execute("SELECT id FROM folders WHERE path = '/p'").fetchone()["id"]
+    conn.execute(
+        "INSERT INTO photos (folder_id, filename) VALUES (?, 'a.jpg')", (fid,)
+    )
+    pid = conn.execute("SELECT id FROM photos LIMIT 1").fetchone()["id"]
+    conn.execute(
+        "INSERT INTO keywords (name, type, is_species) "
+        "VALUES ('Saffron finch', 'taxonomy', 1)"
+    )
+    # Seed a relabel edit_history_item captured with prediction casing.
+    # Both hl_prev entry shapes (bare string and dict) plus pref_prev
+    # and rep_prev cover the branches in _align_curation_history_species.
+    conn.execute(
+        "INSERT INTO edit_history (action_type, description) "
+        "VALUES ('relabel', 't')"
+    )
+    edit_id = conn.execute(
+        "SELECT id FROM edit_history LIMIT 1"
+    ).fetchone()["id"]
+    payload = {
+        "curation": {
+            "hl_prev": [
+                "Saffron Finch",
+                {"species": "Saffron Finch", "rank": 1, "photo_id": pid},
+            ],
+            "pref_prev": [{"species": "Saffron Finch", "photo_id": pid}],
+            "rep_prev": [{"species": "Saffron Finch", "photo_id": pid}],
+        }
+    }
+    conn.execute(
+        "INSERT INTO edit_history_items "
+        "(edit_id, photo_id, old_value, new_value) VALUES (?, ?, ?, '')",
+        (edit_id, pid, json.dumps(payload)),
+    )
+    conn.execute(
+        "DELETE FROM db_meta WHERE key = 'curation_species_case_aligned_v2'"
+    )
+    conn.commit()
+    conn.close()
+
+    db = Database(db_path)
+    try:
+        row = db.conn.execute(
+            "SELECT old_value FROM edit_history_items LIMIT 1"
+        ).fetchone()
+        rewritten = json.loads(row["old_value"])
+        curation = rewritten["curation"]
+        assert curation["hl_prev"][0] == "Saffron finch"
+        assert curation["hl_prev"][1]["species"] == "Saffron finch"
+        assert curation["pref_prev"][0]["species"] == "Saffron finch"
+        assert curation["rep_prev"][0]["species"] == "Saffron finch"
+        assert db.get_meta("curation_species_case_aligned_v2") == "1"
+    finally:
+        db.close()


### PR DESCRIPTION
Rebuilds closed #1214 on the #1215 choke-point foundation — 437 lines instead of ~930, no parallel read-tolerant API, no re-registered SQL function.

## Problem

Classifier labels are an external vocabulary with their own casing: label files say `Common Waxbill`, the keyword row says `Common waxbill`. Two user-visible bugs on main:

1. **Split buckets** — Highlights keyed unconfirmed photos by the raw prediction label and accepted photos by the keyword spelling, so one species showed as two buckets.
2. **Silently dropped stars** — starring a photo in a prediction-cased bucket wrote `species_highlights` keyed with classifier casing; the exact-match eligibility queries then never matched it again.

## Design

Same principle as #1215's XMP layers: canonicalize at the external-vocabulary boundary, keep stored state canonical, don't tolerate mixed state at read time.

- **Bucket collection** (`_collect_highlight_buckets`) keys predicted species through `db.resolve_species_display_name` (memoized per request) — the spelling `add_keyword` would store. Prediction rows stay verbatim (they're regenerated model output, like sidecar files).
- **Curation setters** (`set_photo_preference`, `add/promote/remove/move_species_highlight`, `clear_*`, species-filtered getters) and the two route body parsers canonicalize species input the same way, so bucket labels, eligibility prechecks, and stored rows agree on one string.
- **Eligibility fix**: `get_species_highlights`' fallback compares the photo's raw prediction label — now case-insensitively (`COLLATE NOCASE`), matching the dedupe rule used everywhere else. The exact compare marked every highlight starred from an unconfirmed bucket ineligible.
- **Eponym-safe casing** (carried from #1214): the `lower` convention no longer mangles `McKay's bunting` → `Mckay's bunting`, and ALL-CAPS label spellings sentence-case.
- **One-shot v2 repair** under its own `db_meta` marker re-runs just the curation case alignment, catching rows starred with prediction casing between #1215's repair and this fix. The pass is factored into `_align_curation_species_case`, shared with the v1 sweep.

## What was NOT carried from #1214

The six shadow `*_canonical` curation methods, the `vireo_normalize_keyword` UDF re-registration, and `add_prediction` write-canonicalization (which forced a reuse-rows restructure to avoid reclassify duplicates; unnecessary once display and accept both canonicalize).

## Tests

Two end-to-end regressions (bucket merging across casings; star → stored canonical → surfaces as highlighted → un-star under a third casing), curation setter canonicalization, eponym casing, and v2 marker gating (runs once, later mismatches untouched). Adapted from #1214's suite where applicable.

## Validation

- Focused suites: `test_app`, `test_db`, `test_keyword_migration`, `test_edits_api`, `test_photos_api`, `test_workspaces` — 1428 passed, ruff clean.
- Dry run against a copy of the production DB: v2 marker set, zero remaining curation/keyword casing mismatches.

Supersedes #1214.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Species spelling is now canonicalized end-to-end across highlights, photo preferences, and species curation, improving correct bucket merging when capitalization differs (including non-ASCII cases).
  - Species parsing/validation now fails fast when species is missing, and curation writes/read paths use the canonical stored spelling.
  - Added a one-time curation maintenance alignment that rekeys live curation and undo/redo snapshots to prevent case-mismatch recreation, while preserving intentionally distinct homonyms.
  - Improved sentence-case formatting for new casing conventions.

- **Tests**
  - Expanded regression coverage for casing mismatches, relabel/undo snapshot correctness, prediction-only scenarios, homonym ambiguity, and one-shot v2 alignment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->