### PR TITLE
Stabilize import and highlights E2E tests

### DIFF
--- a/tests/e2e/test_highlights_initial_scope.py
+++ b/tests/e2e/test_highlights_initial_scope.py
@@ -334,6 +334,14 @@ def test_highlights_lightbox_pick_hidden_photo_promotes_to_visible(live_server, 
         arg=hidden_pid,
         timeout=3000,
     )
+    # openLightbox updates its internal navigation target before the incoming
+    # image has replaced the outgoing bitmap. Photo-targeted shortcuts are
+    # intentionally suppressed during that handoff, so wait until the visible
+    # identity commits (the missing fixture source settles via the error path).
+    page.wait_for_function(
+        "() => _lbVisualTransitionPending === false",
+        timeout=3000,
+    )
 
     page.keyboard.press("p")
 

--- a/tests/e2e/test_import_page.py
+++ b/tests/e2e/test_import_page.py
@@ -668,8 +668,17 @@ def test_import_duplicate_stream_result_ignored_after_controls_change(
     page.wait_for_function("window.__resolveDuplicates !== null")
     page.locator("#fileTypePreset").select_option("custom")
     page.locator("#chkVerifyByHash").check()
-    page.evaluate("() => window.__resolveDuplicates()")
-    page.wait_for_timeout(100)
+    # The control changes schedule a legitimate automatic refresh after the
+    # debounce interval. Cancel that future run so this assertion stays scoped
+    # to the stale duplicate stream we are releasing, then synchronize on the
+    # stale preview's own finally block instead of an arbitrary timeout.
+    page.evaluate(
+        """() => {
+          clearScheduledImportPreview();
+          window.__resolveDuplicates();
+        }"""
+    )
+    expect(page.locator("#btnPreview")).to_be_enabled()
 
     assert page.evaluate("window.__destinationPreviewCalled") is False
     expect(page.locator("#destStructure")).to_be_hidden()


### PR DESCRIPTION
## Summary

Stabilizes two Chromium E2E regressions by synchronizing with application lifecycle state instead of fixed timing. The import test cancels its queued automatic refresh and waits for the stale duplicate preview to settle, while the highlights test waits for the lightbox visual handoff before sending the pick shortcut. This preserves the scenarios under test while matching the current debounce and transition safety behavior.

## Testing

pytest -q tests/e2e/test_import_page.py tests/e2e/test_highlights_initial_scope.py --browser chromium --tb=short (50 passed)