### PR TITLE
Close pending changes overlay with Escape

### DIFF
--- a/tests/e2e/test_sync_panel.py
+++ b/tests/e2e/test_sync_panel.py
@@ -1,0 +1,55 @@
+"""End-to-end tests for the pending-changes sync overlay."""
+
+from playwright.sync_api import expect
+
+
+def test_escape_closes_pending_changes_overlay(live_server, page):
+    """Escape dismisses the Review Pending Changes overlay without leaking."""
+    page.goto(f"{live_server['url']}/browse")
+    page.evaluate(
+        """() => {
+            window.__syncEscapeLeaked = 0;
+            document.body.addEventListener('keydown', (event) => {
+                if (event.key === 'Escape') window.__syncEscapeLeaked += 1;
+            });
+            openSyncPreview();
+        }"""
+    )
+
+    overlay = page.locator("#syncPreviewOverlay")
+    expect(overlay).to_be_visible()
+
+    page.keyboard.press("Escape")
+
+    expect(overlay).to_be_hidden()
+    assert page.evaluate("window._syncModalOpen") is False
+    assert page.evaluate("window.__syncEscapeLeaked") == 0
+
+
+def test_escape_closes_lightbox_before_pending_changes_overlay(live_server, page):
+    """Stacked popups unwind one at a time, with the newest closing first."""
+    photo_id = live_server["data"]["photos"][0]
+    page.goto(f"{live_server['url']}/browse")
+    page.evaluate(
+        """(photoId) => {
+            openSyncPreview();
+            openLightbox(photoId, 'hawk1.jpg', [
+                {id: photoId, filename: 'hawk1.jpg'},
+            ]);
+        }""",
+        photo_id,
+    )
+
+    sync_overlay = page.locator("#syncPreviewOverlay")
+    lightbox = page.locator("#lightboxOverlay")
+    expect(sync_overlay).to_be_visible()
+    expect(lightbox).to_have_class("lightbox-overlay active")
+
+    page.keyboard.press("Escape")
+
+    expect(lightbox).not_to_have_class("lightbox-overlay active")
+    expect(sync_overlay).to_be_visible()
+
+    page.keyboard.press("Escape")
+
+    expect(sync_overlay).to_be_hidden()

--- a/vireo/templates/_sync_panel.html
+++ b/vireo/templates/_sync_panel.html
@@ -34,6 +34,7 @@ var _syncPreviewData = null;
 var _syncThumbSize = 120;
 var _syncActiveFilters = null;
 var _syncModalOpen = false;
+var _syncEscToken = null;
 var _syncLightboxPanelEl = null;
 
 async function checkPendingSync() {
@@ -106,6 +107,10 @@ function updateSyncThumbSize(val) {
 }
 
 async function openSyncPreview() {
+  var alreadyOpen = _syncModalOpen;
+  if (_syncEscToken !== null) Keymap.popEsc(_syncEscToken);
+  _syncEscToken = Keymap.pushEsc(function() { closeSyncPreview(); });
+  if (!alreadyOpen) Keymap.lockBodyScroll();
   _syncActiveFilters = null;
   _syncModalOpen = true;
   var overlay = document.getElementById('syncPreviewOverlay');
@@ -225,9 +230,15 @@ document.getElementById('syncPreviewContent').addEventListener('click', function
 });
 
 function closeSyncPreview() {
+  var wasOpen = _syncModalOpen;
+  if (_syncEscToken !== null) {
+    Keymap.popEsc(_syncEscToken);
+    _syncEscToken = null;
+  }
   document.getElementById('syncPreviewOverlay').style.display = 'none';
   _syncModalOpen = false;
   _syncDestroyLightboxPanel();
+  if (wasOpen) Keymap.unlockBodyScroll();
   checkPendingSync();
 }
 


### PR DESCRIPTION
## Summary
- Connect the Review Pending Changes overlay to the shared Escape stack so Escape dismisses it without leaking to page handlers.
- Preserve stacked-overlay ordering so a photo lightbox closes before the underlying sync preview and restore body scrolling on close.
- Add Playwright coverage for direct dismissal and nested popup behavior.

## Tests
- `pytest -q tests/e2e/test_sync_panel.py`
- `pytest -q tests/e2e/test_context_menu.py tests/e2e/test_keymap.py`