### PR TITLE
Add taxonomy filters to the life list

### DIFF
--- a/tests/e2e/test_lifelist_add_verify.py
+++ b/tests/e2e/test_lifelist_add_verify.py
@@ -202,6 +202,83 @@ def test_sort_and_numbering_preferences_persist(live_server, page):
     expect(page.locator(".lifer-number").first).to_have_text("#1")
 
 
+def test_taxonomic_group_and_identification_level_filters(live_server, page):
+    db = live_server["db"]
+    folder_id = live_server["data"]["folders"][0]
+
+    aves = db.conn.execute(
+        "INSERT INTO taxa (name, common_name, rank) VALUES (?, ?, ?)",
+        ("Aves", "Birds", "class"),
+    ).lastrowid
+    mammalia = db.conn.execute(
+        "INSERT INTO taxa (name, common_name, rank) VALUES (?, ?, ?)",
+        ("Mammalia", "Mammals", "class"),
+    ).lastrowid
+    hawk_taxon = db.conn.execute(
+        "INSERT INTO taxa (name, common_name, rank, parent_id) "
+        "VALUES (?, ?, ?, ?)",
+        ("Buteo jamaicensis", "Red-tailed Hawk", "species", aves),
+    ).lastrowid
+    accipiter_taxon = db.conn.execute(
+        "INSERT INTO taxa (name, common_name, rank, parent_id) "
+        "VALUES (?, ?, ?, ?)",
+        ("Accipiter", None, "genus", aves),
+    ).lastrowid
+    fox_taxon = db.conn.execute(
+        "INSERT INTO taxa (name, common_name, rank, parent_id) "
+        "VALUES (?, ?, ?, ?)",
+        ("Vulpes vulpes", "Red Fox", "species", mammalia),
+    ).lastrowid
+    db.conn.execute(
+        "UPDATE keywords SET taxon_id = ?, type = 'taxonomy' WHERE name = ?",
+        (hawk_taxon, "Red-tailed Hawk"),
+    )
+
+    for name, taxon_id in (("Accipiter", accipiter_taxon),
+                           ("Red Fox", fox_taxon)):
+        keyword_id = db.add_keyword(name, kw_type="taxonomy")
+        db.conn.execute(
+            "UPDATE keywords SET taxon_id = ? WHERE id = ?",
+            (taxon_id, keyword_id),
+        )
+        photo_id = db.add_photo(
+            folder_id=folder_id,
+            filename=f"{name.lower().replace(' ', '-')}.jpg",
+            extension=".jpg",
+            file_size=1000,
+            file_mtime=500.0 + taxon_id,
+            timestamp="2024-06-01T12:00:00",
+        )
+        db.tag_photo(photo_id, keyword_id)
+    db.conn.commit()
+
+    page.goto(f"{live_server['url']}/life-list")
+    page.locator(".species-card").first.wait_for(state="visible")
+
+    group = page.locator("#taxonomicGroupSelect")
+    rank = page.locator("#identificationRankSelect")
+    expect(group.locator("option", has_text="Birds")).to_have_count(1)
+    expect(group.locator("option", has_text="Mammals")).to_have_count(1)
+
+    group.select_option(str(aves))
+    expect(page.locator(".species-name")).to_have_count(2)
+    expect(page.locator(".species-name")).to_contain_text([
+        "Accipiter", "Red-tailed Hawk",
+    ])
+
+    rank.select_option("species")
+    expect(page.locator(".species-name")).to_have_count(1)
+    expect(page.locator(".species-name")).to_have_text(["Red-tailed Hawk"])
+    expect(page.locator("#meta")).to_contain_text("1 shown")
+
+    group.select_option(str(mammalia))
+    expect(page.locator(".species-name")).to_have_text(["Red Fox"])
+
+    rank.select_option("all")
+    group.select_option("unknown")
+    expect(page.locator(".species-name")).to_have_text(["American Robin"])
+
+
 def test_life_list_loads_more_than_initial_100(live_server, page):
     _seed_large_hawk_life_list(live_server)
     page.goto(f"{live_server['url']}/life-list")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -9857,6 +9857,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
     ):
         rows = db.get_life_list_candidates(species=species_filter)
         locations_by_species = db.get_life_list_locations(species=species_filter)
+        class_by_taxon = db.get_class_ancestors_for_taxa({
+            row["taxon_id"] for row in rows if row["taxon_id"] is not None
+        })
         photo_offset = max(0, int(photo_offset))
         if photos_per_species is None:
             photo_limit = None
@@ -9871,6 +9874,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             entry = buckets.setdefault(r["species"], {
                 "scientific_name": None,
                 "common_name": None,
+                "taxon_id": None,
+                "taxon_rank": None,
+                "taxonomic_class": None,
                 "photos": [],
                 "seen_ids": set(),
             })
@@ -9880,6 +9886,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 entry["scientific_name"] = r.get("scientific_name")
             if entry["common_name"] is None:
                 entry["common_name"] = r.get("common_name")
+            if entry["taxon_id"] is None and r.get("taxon_id") is not None:
+                entry["taxon_id"] = r["taxon_id"]
+                entry["taxon_rank"] = r.get("taxon_rank")
+                entry["taxonomic_class"] = class_by_taxon.get(r["taxon_id"])
             # A photo tagged with two same-name species keywords would
             # otherwise be appended once per row, inflating photo_count
             # and duplicating cards in the lightbox.
@@ -9975,6 +9985,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "species": species,
                 "scientific_name": entry["scientific_name"],
                 "common_name": entry["common_name"],
+                "taxon_id": entry["taxon_id"],
+                "taxon_rank": entry["taxon_rank"],
+                "taxonomic_class": entry["taxonomic_class"],
                 "photo_count": len(photos),
                 "first_seen": min(timestamps) if timestamps else None,
                 "last_seen": max(timestamps) if timestamps else None,

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -11949,6 +11949,8 @@ class Database:
                       p.subject_y_median, p.noise_estimate,
                       p.eye_tenengrad,
                       k.name AS species,
+                      t.id AS taxon_id,
+                      t.rank AS taxon_rank,
                       t.name AS scientific_name,
                       t.common_name
                FROM photo_keywords pk
@@ -12075,6 +12077,44 @@ class Database:
                     seen[r["id"]] = dict(r)
         return sorted(seen.values(),
                       key=lambda r: r["common_name"] or r["name"])
+
+    def get_class_ancestors_for_taxa(self, taxon_ids):
+        """Map each taxon id to its class-rank ancestor.
+
+        Life List entries can be linked at any major rank, so preserve the
+        starting taxon id while walking toward the root.  The depth cap mirrors
+        :meth:`get_taxon_subtree` and also prevents malformed cyclic taxonomy
+        data from making the recursive query run forever.
+        """
+        ids = [taxon_id for taxon_id in taxon_ids if taxon_id is not None]
+        if not ids:
+            return {}
+        classes = {}
+        for chunk in _chunks(ids):
+            placeholders = ",".join("?" for _ in chunk)
+            rows = self.conn.execute(
+                f"""WITH RECURSIVE up(
+                           origin_id, id, parent_id, rank, name, common_name, depth
+                       ) AS (
+                           SELECT id, id, parent_id, rank, name, common_name, 0
+                           FROM taxa WHERE id IN ({placeholders})
+                           UNION ALL
+                           SELECT u.origin_id, t.id, t.parent_id, t.rank,
+                                  t.name, t.common_name, u.depth + 1
+                           FROM up u JOIN taxa t ON t.id = u.parent_id
+                           WHERE u.depth < 12
+                       )
+                       SELECT origin_id, id, name, common_name
+                       FROM up WHERE rank = 'class'""",
+                chunk,
+            ).fetchall()
+            for row in rows:
+                classes.setdefault(row["origin_id"], {
+                    "id": row["id"],
+                    "name": row["name"],
+                    "common_name": row["common_name"],
+                })
+        return classes
 
     def get_life_list_best_photo_by_taxon(self, taxon_ids):
         """Map taxon_id -> {id, filename} of a representative (highest quality_score,

--- a/vireo/templates/life_list.html
+++ b/vireo/templates/life_list.html
@@ -155,6 +155,18 @@
       <option value="most-photos">Most photos</option>
     </select>
   </div>
+  <div class="control-group">
+    <label for="taxonomicGroupSelect">Taxonomic group</label>
+    <select id="taxonomicGroupSelect">
+      <option value="all">All groups</option>
+    </select>
+  </div>
+  <div class="control-group">
+    <label for="identificationRankSelect">Identification level</label>
+    <select id="identificationRankSelect">
+      <option value="all">All levels</option>
+    </select>
+  </div>
   <div class="control-group" title="When enabled, number the visible cards in their current displayed order. Disable it to keep each species' original chronological lifer number.">
     <label for="renumberView">Life List numbering</label>
     <label class="numbering-toggle" for="renumberView">
@@ -304,7 +316,68 @@ async function loadLifeList() {
     meta.textContent = 'Failed to load life list.';
     return;
   }
+  populateLifeListTaxonomyFilters();
   render();
+}
+
+function replaceSelectOptions(select, options) {
+  var previous = select.value;
+  select.innerHTML = options.map(function(option) {
+    return '<option value="' + escapeAttr(option.value) + '">'
+      + escapeAttr(option.label) + '</option>';
+  }).join('');
+  if (options.some(function(option) { return option.value === previous; })) {
+    select.value = previous;
+  }
+}
+
+function populateLifeListTaxonomyFilters() {
+  var entries = (currentData && currentData.species) || [];
+  var classes = {};
+  var hasUnknownClass = false;
+  var hasUnknownRank = false;
+
+  entries.forEach(function(entry) {
+    var taxonomicClass = entry.taxonomic_class;
+    if (taxonomicClass && taxonomicClass.id != null) {
+      classes[String(taxonomicClass.id)] =
+        taxonomicClass.common_name || taxonomicClass.name;
+    } else {
+      hasUnknownClass = true;
+    }
+    if (!entry.taxon_rank) {
+      hasUnknownRank = true;
+    }
+  });
+
+  var groupOptions = [{ value: 'all', label: 'All groups' }];
+  Object.keys(classes).sort(function(a, b) {
+    return classes[a].localeCompare(classes[b]);
+  }).forEach(function(id) {
+    groupOptions.push({ value: id, label: classes[id] });
+  });
+  if (hasUnknownClass) {
+    groupOptions.push({ value: 'unknown', label: 'Unmatched / unknown' });
+  }
+  replaceSelectOptions(document.getElementById('taxonomicGroupSelect'), groupOptions);
+
+  var rankLabels = {
+    species: 'Species only',
+    genus: 'Genus',
+    family: 'Family',
+    order: 'Order',
+    class: 'Class',
+    phylum: 'Phylum',
+    kingdom: 'Kingdom'
+  };
+  var rankOptions = [{ value: 'all', label: 'All levels' }];
+  Object.keys(rankLabels).forEach(function(rank) {
+    rankOptions.push({ value: rank, label: rankLabels[rank] });
+  });
+  if (hasUnknownRank) {
+    rankOptions.push({ value: 'unknown', label: 'Unmatched / unknown' });
+  }
+  replaceSelectOptions(document.getElementById('identificationRankSelect'), rankOptions);
 }
 
 function sortedSpecies() {
@@ -435,6 +508,8 @@ function render() {
   controls.style.display = '';
 
   var search = document.getElementById('speciesSearch').value.trim();
+  var taxonomicGroup = document.getElementById('taxonomicGroupSelect').value;
+  var identificationRank = document.getElementById('identificationRankSelect').value;
   var searchOptions = VireoTextSearch.readOptions('lifeSpecies');
   var list = sortedSpecies();
   if (search) {
@@ -446,16 +521,32 @@ function render() {
       );
     });
   }
+  if (taxonomicGroup !== 'all') {
+    list = list.filter(function(entry) {
+      if (taxonomicGroup === 'unknown') return !entry.taxonomic_class;
+      return entry.taxonomic_class
+        && String(entry.taxonomic_class.id) === taxonomicGroup;
+    });
+  }
+  if (identificationRank !== 'all') {
+    list = list.filter(function(entry) {
+      if (identificationRank === 'unknown') return !entry.taxon_rank;
+      return entry.taxon_rank === identificationRank;
+    });
+  }
 
+  var filtersActive = Boolean(search)
+    || taxonomicGroup !== 'all'
+    || identificationRank !== 'all';
   meta.textContent = currentData.meta.species_count + ' species on your life list · '
     + currentData.meta.photo_count + ' tagged photos'
-    + (search ? ' · ' + list.length + ' matching' : '');
+    + (filtersActive ? ' · ' + list.length + ' shown' : '');
 
   var renumberView = document.getElementById('renumberView').checked;
   content.innerHTML = list.map(function(entry, index) {
     return renderCard(entry, renumberView ? index + 1 : entry.number);
   }).join('')
-    || '<div class="lifelist-empty" style="grid-column:1/-1;"><p>No species match this search.</p></div>';
+    || '<div class="lifelist-empty" style="grid-column:1/-1;"><p>No life-list entries match these filters.</p></div>';
 
   content.querySelectorAll('[data-load-more-species]').forEach(function(button) {
     button.addEventListener('click', function(event) {
@@ -515,6 +606,8 @@ function debounceRender() {
 }
 
 document.getElementById('speciesSearch').addEventListener('input', debounceRender);
+document.getElementById('taxonomicGroupSelect').addEventListener('change', render);
+document.getElementById('identificationRankSelect').addEventListener('change', render);
 document.getElementById('sortSelect').addEventListener('change', function() {
   saveLifeListViewPreference(LIFE_LIST_SORT_STORAGE_KEY, this.value);
   if (currentData) render();

--- a/vireo/tests/test_life_list.py
+++ b/vireo/tests/test_life_list.py
@@ -125,6 +125,8 @@ def test_page_renders(life_app):
     assert b"Export Life List" in resp.data
     assert b"Life List numbering" in resp.data
     assert b"Renumber for each view" in resp.data
+    assert b"Taxonomic group" in resp.data
+    assert b"Identification level" in resp.data
 
 
 def test_groups_by_species_and_counts(life_app):
@@ -638,6 +640,34 @@ def test_taxon_names_attached(life_app):
     assert sparrow["common_name"] == "House Sparrow"
     cardinal = _entry(data, "Northern Cardinal")
     assert cardinal["scientific_name"] is None
+
+
+def test_taxonomic_rank_and_class_attached(life_app):
+    app, db, _ = life_app
+    aves = db.conn.execute(
+        "INSERT INTO taxa (name, common_name, rank) VALUES (?, ?, ?)",
+        ("Aves", "Birds", "class"),
+    ).lastrowid
+    db.conn.execute(
+        "UPDATE taxa SET parent_id = ? WHERE name = ?",
+        (aves, "Passer domesticus"),
+    )
+    db.conn.commit()
+
+    data = _get_life_list(app)
+    sparrow = _entry(data, "House Sparrow")
+    assert sparrow["taxon_rank"] == "species"
+    assert sparrow["taxonomic_class"] == {
+        "id": aves,
+        "name": "Aves",
+        "common_name": "Birds",
+    }
+
+    # A legacy species flag without a linked reference taxon remains visible
+    # and is explicitly filterable as unmatched/unknown in the List UI.
+    cardinal = _entry(data, "Northern Cardinal")
+    assert cardinal["taxon_rank"] is None
+    assert cardinal["taxonomic_class"] is None
 
 
 def test_locations_from_location_keywords(life_app):


### PR DESCRIPTION
Adds taxonomic group and identification-level filters to the Life List, allowing users to focus on classes such as Birds or Mammals and restrict results to species-level identifications.

Enriches life-list API entries with linked taxon rank and class metadata through a bounded ancestry query, while preserving legacy unlinked tags under Unmatched / unknown.

The filters combine with existing search, sorting, numbering, and visible-result counts.

Validated with 55 unit, publishing, and browser tests plus Ruff and JavaScript syntax checks.