### PR TITLE
Show shared keywords for photo selections

### DIFF
--- a/tests/e2e/test_browse_single_select.py
+++ b/tests/e2e/test_browse_single_select.py
@@ -847,9 +847,11 @@ def test_multiselect_offers_partial_keyword_fill(live_server, page):
         );
       }
     """, timeout=3000)
-    expect(
-        page.locator(".selection-keyword-row", has_text="Red-tailed Hawk")
-    ).to_have_count(0)
+    row = page.locator(".selection-keyword-row", has_text="Red-tailed Hawk")
+    expect(row).to_be_visible()
+    expect(row).to_contain_text("On 5 of 5")
+    expect(row.locator("button", has_text="Add to")).to_have_count(0)
+    expect(row.locator("button", has_text="Remove from 5")).to_be_visible()
 
     page.evaluate("async () => (await fetch('/api/undo', {method: 'POST'})).ok")
     restored_with_keyword = page.evaluate("""
@@ -865,6 +867,47 @@ def test_multiselect_offers_partial_keyword_fill(live_server, page):
       }
     """)
     assert restored_with_keyword == original_with_keyword
+
+
+def test_multiselect_shows_and_removes_keyword_shared_by_all_photos(live_server, page):
+    """A keyword shared by the selection remains visible and removable."""
+    db = live_server["db"]
+    selected_ids = live_server["data"]["photos"]
+    keyword_name = "Shared selection keyword"
+    keyword_id = db.add_keyword(keyword_name)
+    for photo_id in selected_ids:
+        db.tag_photo(photo_id, keyword_id)
+
+    page.goto(f"{live_server['url']}/browse")
+    page.locator(".grid-card").first.wait_for(state="visible")
+    page.evaluate("""
+      photos.forEach(function(p) { selectedPhotos.add(p.id); });
+      renderGrid();
+      updateBatchBar();
+    """)
+
+    row = page.locator(".selection-keyword-row", has_text=keyword_name)
+    expect(row).to_be_visible()
+    expect(row).to_contain_text("On 5 of 5")
+    expect(row.locator("button", has_text="Add to")).to_have_count(0)
+    remove_button = row.locator("button", has_text="Remove from 5")
+    expect(remove_button).to_be_visible()
+
+    remove_button.click()
+    page.wait_for_function(
+        """
+        async ({photoIds, keywordId}) => {
+          const details = await Promise.all(
+            photoIds.map(id => fetch('/api/photos/' + id).then(r => r.json()))
+          );
+          return details.every(p =>
+            !(p.keywords || []).some(k => k.id === keywordId)
+          );
+        }
+        """,
+        arg={"photoIds": selected_ids, "keywordId": keyword_id},
+    )
+    expect(row).to_have_count(0)
 
 
 def test_multiselect_shrink_to_focused_photo_restores_detail(live_server, page):

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -1755,7 +1755,7 @@ body.sidebar-resizing {
         <div class="selection-action-hint" id="pasteEditHint"></div>
       </div>
       <div class="detail-section">
-        <div class="detail-section-title">Fill Missing Keywords</div>
+        <div class="detail-section-title">Keywords</div>
         <div class="selection-keyword-list" id="selectionKeywordSuggestions"></div>
       </div>
     </div>
@@ -5504,7 +5504,7 @@ async function loadSelectionKeywordSuggestions(ids) {
       body: JSON.stringify({photo_ids: ids}),
     }, { toast: false });
     if (seq !== selectionKeywordRequestSeq) return;
-    renderSelectionKeywordSuggestions(data.suggestions || [], data.selected_count || ids.length);
+    renderSelectionKeywordSuggestions(data.keywords || [], data.selected_count || ids.length);
   } catch(e) {
     if (seq === selectionKeywordRequestSeq && list) {
       list.innerHTML = '<div class="selection-empty">Could not load keyword suggestions.</div>';

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -5576,8 +5576,8 @@ def test_batch_keyword_route_queues_stored_name_after_normalization(app_and_db):
     assert remaining == []
 
 
-def test_selection_keyword_suggestions_return_partial_keywords(app_and_db):
-    """Multi-select suggestions should offer keywords present on only some photos."""
+def test_selection_keyword_suggestions_return_partial_and_shared_keywords(app_and_db):
+    """Multi-select keyword data includes both partial and shared keywords."""
     app, db = app_and_db
     ids = [
         row["id"]
@@ -5602,10 +5602,29 @@ def test_selection_keyword_suggestions_return_partial_keywords(app_and_db):
     assert by_name["Sparrow"]["count"] == 1
     assert by_name["Sparrow"]["missing_count"] == 2
 
+    shared_id = db.add_keyword("Shared selection keyword")
+    for photo_id in ids:
+        db.tag_photo(photo_id, shared_id)
+    resp = client.post(
+        "/api/selection/keyword-suggestions",
+        json={"photo_ids": ids},
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
     keywords_by_name = {item["name"]: item for item in data["keywords"]}
     assert keywords_by_name["Cardinal"]["present_photo_ids"] == [ids[0]]
     assert sorted(keywords_by_name["Cardinal"]["missing_photo_ids"]) == sorted(ids[1:])
     assert keywords_by_name["Sparrow"]["present_photo_ids"] == [ids[1]]
+    assert keywords_by_name["Shared selection keyword"] == {
+        "id": shared_id,
+        "name": "Shared selection keyword",
+        "type": "general",
+        "count": len(ids),
+        "missing_count": 0,
+        "present_photo_ids": ids,
+        "missing_photo_ids": [],
+    }
 
 
 def test_selection_keyword_suggestions_chunks_large_selection(app_and_db):


### PR DESCRIPTION
## Summary

Browse multi-select now renders the complete selected-keyword set, so keywords shared by every selected photo remain visible and removable.
The root cause was that the UI consumed only partial-keyword suggestions even though the API already returned complete keyword state.
The section is renamed to Keywords, while mixed keywords retain their add-to-missing behavior and regression coverage now verifies shared-keyword display and removal.

## Validation

- `pytest -q tests/e2e/test_browse_single_select.py`
- `pytest -q vireo/tests/test_app.py -k 'selection_keyword or batch_keyword'`
- `ruff check tests/e2e/test_browse_single_select.py vireo/tests/test_app.py`
- `git diff --check`
