### PR TITLE
Keep Browse species badges in sync

### DIFF
--- a/tests/e2e/test_browse_single_select.py
+++ b/tests/e2e/test_browse_single_select.py
@@ -378,6 +378,59 @@ def test_add_keyword_input_suggests_existing_keyword(live_server, page):
     expect(page.locator("#detailKeywords")).to_contain_text("Alan's Hummingbird")
 
 
+def test_species_badge_tracks_detail_keyword_edits_without_reload(live_server, page):
+    """The grid's taxonomy badge must stay in sync with detail keyword edits."""
+    db = live_server["db"]
+    source_id = live_server["data"]["photos"][0]
+    target_id = live_server["data"]["photos"][1]
+    old_name = "Hawaii Creeper"
+    new_name = "Hawaii Amakihi"
+    old_id = db.add_keyword(old_name, kw_type="taxonomy")
+    new_id = db.add_keyword(new_name, kw_type="taxonomy")
+    db.tag_photo(target_id, old_id)
+    db.tag_photo(source_id, new_id)
+
+    page.goto(f"{live_server['url']}/browse")
+    card = page.locator(f'.grid-card[data-id="{target_id}"]')
+    expect(card.locator(".grid-card-img-wrap .species-badge")).to_have_text(
+        old_name
+    )
+    card.click()
+
+    old_tag = page.locator("#detailKeywords .keyword-tag", has_text=old_name)
+    expect(old_tag).to_be_visible()
+    with page.expect_response(
+        lambda r: f"/api/photos/{target_id}/keywords/{old_id}" in r.url
+        and r.request.method == "DELETE"
+        and r.status == 200
+    ):
+        old_tag.locator(".remove-kw").click()
+
+    expect(card.locator(".grid-card-img-wrap .species-badge")).to_have_count(0)
+    expect(old_tag).to_have_count(0)
+
+    keyword_input = page.locator("#addKeywordInput")
+    keyword_input.fill(new_name)
+    suggestion = page.locator(
+        "#addKeywordSuggestions .keyword-suggestion-option",
+        has_text=new_name,
+    )
+    expect(suggestion).to_be_visible()
+    with page.expect_response(
+        lambda r: f"/api/photos/{target_id}/keywords" in r.url
+        and r.request.method == "POST"
+        and r.status == 200
+    ):
+        suggestion.click()
+
+    expect(card.locator(".grid-card-img-wrap .species-badge")).to_have_text(
+        new_name
+    )
+    expect(card.locator(".grid-card-img-wrap .species-badge")).not_to_contain_text(
+        old_name
+    )
+
+
 def test_needs_identification_refreshes_after_identification_added(live_server, page):
     """A photo should leave the active Needs Identification grid after tagging."""
     db = live_server["db"]

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -2515,6 +2515,20 @@ function formatFileSize(bytes) {
   return (bytes / 1073741824).toFixed(1) + ' GB';
 }
 
+function renderSpeciesBadges(species, inline) {
+  if (!Array.isArray(species) || species.length === 0) return '';
+  var maxShow = 3;
+  var style = inline ? ' style="position:static;padding:0;"' : '';
+  var html = '<div class="species-badges"' + style + '>';
+  species.slice(0, maxShow).forEach(function(name) {
+    html += '<span class="species-badge">' + escapeHtml(name) + '</span>';
+  });
+  if (species.length > maxShow) {
+    html += '<span class="species-badge-overflow">+' + (species.length - maxShow) + ' more</span>';
+  }
+  return html + '</div>';
+}
+
 function renderCardField(field, p) {
   switch (field) {
     case 'filename':
@@ -2544,19 +2558,7 @@ function renderCardField(field, p) {
       if (p.sharpness != null) return '<span style="font-size:10px;color:var(--text-ghost);" title="Sharpness score">' + Math.round(p.sharpness) + '</span>';
       return '';
     case 'species':
-      if (p.species && p.species.length > 0) {
-        var maxShow = 3;
-        var html = '<div class="species-badges" style="position:static;padding:0;">';
-        p.species.slice(0, maxShow).forEach(function(s) {
-          html += '<span class="species-badge">' + escapeHtml(s) + '</span>';
-        });
-        if (p.species.length > maxShow) {
-          html += '<span class="species-badge-overflow">+' + (p.species.length - maxShow) + ' more</span>';
-        }
-        html += '</div>';
-        return html;
-      }
-      return '';
+      return renderSpeciesBadges(p.species, true);
     case 'dimensions':
       if (p.width && p.height) return '<span style="font-size:10px;color:var(--text-ghost);">' + p.width + ' \u00d7 ' + p.height + '</span>';
       return '';
@@ -2645,17 +2647,8 @@ function renderPhotoCard(p, idx) {
 
   // Species badges on image overlay (only when NOT in cardFields — if in cardFields, rendered below)
   var speciesBadgeHtml = '';
-  if (cardFields.indexOf('species') === -1 && p.species && p.species.length > 0) {
-    var maxShow = 3;
-    var shown = p.species.slice(0, maxShow);
-    speciesBadgeHtml = '<div class="species-badges">';
-    shown.forEach(function(s) {
-      speciesBadgeHtml += '<span class="species-badge">' + escapeHtml(s) + '</span>';
-    });
-    if (p.species.length > maxShow) {
-      speciesBadgeHtml += '<span class="species-badge-overflow">+' + (p.species.length - maxShow) + ' more</span>';
-    }
-    speciesBadgeHtml += '</div>';
+  if (cardFields.indexOf('species') === -1) {
+    speciesBadgeHtml = renderSpeciesBadges(p.species, false);
   }
 
   var thumbUrl = window.vireoThumbnailUrl ? window.vireoThumbnailUrl(p) : '/thumbnails/' + p.id + '.jpg';
@@ -2761,6 +2754,17 @@ function refreshGridCards(photoIds) {
     // when async metadata arrives after the card was appended.
     var wrap = card.querySelector('.grid-card-img-wrap');
     if (wrap) {
+      var speciesBadges = wrap.querySelector('.species-badges');
+      var speciesBadgeHtml = cardFields.indexOf('species') === -1
+        ? renderSpeciesBadges(p.species, false)
+        : '';
+      if (speciesBadges && speciesBadgeHtml) {
+        speciesBadges.outerHTML = speciesBadgeHtml;
+      } else if (speciesBadges) {
+        speciesBadges.remove();
+      } else if (speciesBadgeHtml) {
+        wrap.insertAdjacentHTML('beforeend', speciesBadgeHtml);
+      }
       var existing = wrap.querySelector('.inat-badge');
       var shouldShow = !!inatSubmitted[String(id)];
       if (shouldShow && !existing) {
@@ -5561,6 +5565,7 @@ async function applySelectionKeyword(keywordId) {
       body: JSON.stringify({photo_ids: ids, keyword_id: keywordId}),
     });
   } catch(e) { return; }
+  await _refreshBrowseKeywordState(ids);
   selectionKeywordKey = '';
   loadSelectionKeywordSuggestions(getActiveSelection());
   loadKeywords();
@@ -5581,6 +5586,7 @@ async function removeSelectionKeyword(keywordId) {
       body: JSON.stringify({photo_ids: ids, keyword_id: keywordId}),
     });
   } catch(e) { return; }
+  await _refreshBrowseKeywordState(ids);
   _clearRepresentativeStateAfterKeywordRemoval(ids, removedName);
   selectionKeywordKey = '';
   loadSelectionKeywordSuggestions(getActiveSelection());
@@ -5673,6 +5679,45 @@ function _keywordNameFromCache(keywordId) {
     if (k && k.id === keywordId) return k.name;
   }
   return null;
+}
+
+// Keyword edits update the detail panel from /api/photos/:id, but Browse card
+// badges render from the separate `photos` cache populated by /api/photos.
+// Refresh the loaded rows from the authoritative batch endpoint after every
+// keyword mutation so taxonomy badges and representative state cannot drift.
+async function _refreshBrowseKeywordState(photoIds) {
+  if (!Array.isArray(photoIds) || !photoIds.length) return;
+  var loadedIds = new Set(photos.map(function(photo) { return photo.id; }));
+  var ids = Array.from(new Set(photoIds)).filter(function(id) {
+    return loadedIds.has(id);
+  });
+  if (!ids.length) return;
+
+  var refreshed = [];
+  try {
+    for (var offset = 0; offset < ids.length; offset += 500) {
+      var data = await safeFetch('/api/photos/by-ids', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({photo_ids: ids.slice(offset, offset + 500)}),
+      }, {toast: false});
+      (data.photos || []).forEach(function(updated) {
+        var local = photos.find(function(photo) { return photo.id === updated.id; });
+        if (!local) return;
+        local.species = Array.isArray(updated.species) ? updated.species : [];
+        local.life_list = Array.isArray(updated.life_list) ? updated.life_list : [];
+        local.species_representatives = Array.isArray(updated.species_representatives)
+          ? updated.species_representatives
+          : local.life_list;
+        local.is_species_representative = !!updated.is_species_representative;
+        refreshed.push(updated.id);
+      });
+    }
+  } catch (e) {
+    // The keyword save already succeeded; a later page reload remains a safe
+    // fallback if this non-critical card refresh is interrupted.
+  }
+  if (refreshed.length) refreshGridCards(refreshed);
 }
 
 // Server-side eligibility requires the photo to still carry the species
@@ -5785,6 +5830,7 @@ async function confirmBatchKeyword() {
       body: JSON.stringify(payload),
     });
   } catch(e) { return; }
+  await _refreshBrowseKeywordState(ids);
   if (!selectedKeyword) invalidateKeywordAutocompleteCache();
   selectionKeywordKey = '';
   loadSelectionKeywordSuggestions(ids);
@@ -6926,6 +6972,7 @@ async function addKeyword(keyword) {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
+    await _refreshBrowseKeywordState(ids);
     input.value = '';
     state.selectedKeyword = null;
     hideKeywordSuggestions('addKeywordInput');
@@ -6957,6 +7004,7 @@ async function removeKeyword(photoId, keywordId) {
     await safeFetch('/api/photos/' + photoId + '/keywords/' + keywordId, {
       method: 'DELETE',
     });
+    await _refreshBrowseKeywordState([photoId]);
     _clearRepresentativeStateAfterKeywordRemoval(
       [photoId],
       _keywordNameFromCache(keywordId),
@@ -7653,6 +7701,7 @@ async function setKeywordType(kwId, newType, el) {
     var dropdown = el.closest('.keyword-type-dropdown');
     if (dropdown) dropdown.classList.remove('open');
     // Refresh detail panel and keyword tree
+    await _refreshBrowseKeywordState(photos.map(function(photo) { return photo.id; }));
     if (selectedPhotoId) loadDetail(selectedPhotoId);
     loadKeywords();
   } catch(e) {}


### PR DESCRIPTION
## Summary

Fix Browse species badges so keyword edits update cached photo metadata and both overlay and card render paths without a reload.

The root cause was that detail keyword mutations refetched the sidebar while leaving the grid photo cache and overlay markup stale; this now refreshes authoritative state after single, batch, removal, and type edits.

Add end-to-end coverage for replacing Hawaii Creeper with Hawaii Amakihi.

## Validation

- `pytest -q -o addopts= tests/e2e/test_browse_single_select.py` (33 passed)
- `pytest -q vireo/tests/test_build_static.py vireo/tests/test_app.py::test_templates_jinja_free_except_includes` (2 passed)
- `ruff check tests/e2e/test_browse_single_select.py`