### PR TITLE
Fix flaky lightbox write fallback polling

### DIFF
--- a/tests/e2e/test_lightbox_flag_hotkeys.py
+++ b/tests/e2e/test_lightbox_flag_hotkeys.py
@@ -246,13 +246,14 @@ def test_lightbox_newer_failed_write_falls_back_to_older_success(live_server, pa
     page.route("**/api/batch/flag", handle_flag_write)
 
     page.keyboard.press("x")
-    # The flag write is dispatched asynchronously after the keypress; under CI
-    # CPU contention it can take well over 3s to reach the route handler, so use
-    # generous headroom before asserting it was held (the loop exits as soon as
-    # the request lands, so the ceiling only matters on the failure path).
+    # The flag write is dispatched asynchronously after the keypress. Keep
+    # pumping Playwright while waiting so its sync API can deliver the route
+    # callback; time.sleep() here can block that callback until after the
+    # assertion, depending on whether the request started before press()
+    # returned.
     deadline = time.time() + 10
     while "route" not in held and time.time() < deadline:
-        time.sleep(0.05)
+        page.wait_for_timeout(50)
     assert "route" in held, "expected first flag write to be held"
 
     page.keyboard.press("p")


### PR DESCRIPTION
The lightbox fallback end-to-end test now pumps Playwright events while waiting for its intercepted flag-write request. This prevents Python sleep polling from blocking the route callback and intermittently failing before the request can be captured.

Validated with the targeted regression test, the complete lightbox flag-hotkey test file, Ruff, and `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability for lightbox flagging under failure conditions.
  * Reduced timing-dependent failures in continuous integration by using non-blocking browser waits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->