### PR TITLE
Allow grouping from cached features

### DIFF
--- a/tests/e2e/test_pipeline.py
+++ b/tests/e2e/test_pipeline.py
@@ -204,14 +204,18 @@ def test_pipeline_labels_get_more_opens_download_modal(live_server, page):
     expect(page.locator("#pipelineTaxonCheckboxes")).to_contain_text("Birds")
 
 
-def test_pipeline_toggling_classify_off_marks_downstream_will_skip(live_server, page):
+def test_pipeline_toggling_classify_off_keeps_group_available(live_server, page):
     url = live_server["url"]
     page.goto(f"{url}/pipeline")
     page.click("#card-classify .stage-header")
     page.uncheck("#enableClassify")
-    for suffix in ["Classify", "Extract", "Group"]:
+    for suffix in ["Classify", "Extract"]:
         pill = page.locator(f"#pill{suffix}")
         expect(pill).to_contain_text("Will skip")
+    group = page.locator("#enableGroup")
+    expect(group).to_be_checked()
+    expect(group).to_be_enabled()
+    expect(page.locator("#pillGroup")).not_to_contain_text("Will skip")
     # Indexing stages are unaffected.
     expect(page.locator("#pillScan")).to_contain_text("Will run")
 
@@ -239,10 +243,13 @@ def test_pipeline_plan_summary_updates_on_toggle(live_server, page):
     page.click("#card-classify .stage-header")
     page.uncheck("#enableClassify")
     summary = page.locator("[data-testid='pipeline-plan-summary']")
-    for label in ("Classify", "Extract Features", "Group & Score"):
+    for label in ("Classify", "Extract Features"):
         expect(
             summary.locator(".plan-stage-row.will-skip", has_text=label)
         ).to_be_visible()
+    expect(
+        summary.locator(".plan-stage-row.will-run", has_text="Group & Score")
+    ).to_be_visible()
 
 
 def test_pipeline_concurrent_running_stages_keep_running_pill(live_server, page):
@@ -390,9 +397,9 @@ def test_pipeline_eye_keypoints_toggle_off_marks_will_skip(live_server, page):
     expect(page.locator("#pillGroup")).not_to_contain_text("Will skip")
 
 
-def test_pipeline_disabling_extract_cascades_to_eye_keypoints(live_server, page):
+def test_pipeline_disabling_extract_keeps_group_available(live_server, page):
     """Eye Keypoints needs masks from Extract, so toggling Extract off must
-    uncheck and disable the Eye Keypoints checkbox alongside Group."""
+    disable Eye Keypoints while leaving cached-feature grouping available."""
     url = live_server["url"]
     page.goto(f"{url}/pipeline")
     page.click("#card-extract .stage-header")
@@ -401,6 +408,10 @@ def test_pipeline_disabling_extract_cascades_to_eye_keypoints(live_server, page)
     expect(ek).not_to_be_checked()
     expect(ek).to_be_disabled()
     expect(page.locator("#pillEyeKeypoints")).to_contain_text("Will skip")
+    group = page.locator("#enableGroup")
+    expect(group).to_be_checked()
+    expect(group).to_be_enabled()
+    expect(page.locator("#pillGroup")).not_to_contain_text("Will skip")
 
 
 def test_pipeline_previews_pill_shows_pending_count(live_server, page):

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -1536,15 +1536,10 @@ function applyProcessToToggles(proc) {
     document.getElementById('enableMisses').checked = !!proc.miss_enabled;
     document.getElementById('enableSpeciesReview').checked =
       (proc.review_mode === 'species');
-    // Re-run the cascade so downstream enable/disable state is consistent,
-    // then force back on any stage the process says should run (the cascade
-    // would otherwise disable e.g. Group when Extract is off).
+    // Re-run the dependency handling so enabled/disabled state is consistent.
     ['classify', 'extract', 'eyekeypoints', 'group'].forEach(function(st) {
       try { onStageToggle(st); } catch (e) {}
     });
-    if (!proc.skip_regroup) {
-      var g = document.getElementById('enableGroup'); g.checked = true; g.disabled = false;
-    }
     if (!proc.skip_eye_keypoints) {
       var ek = document.getElementById('enableEyeKeypoints'); ek.checked = true; ek.disabled = false;
     }
@@ -2225,11 +2220,11 @@ function updateStartButton() {
   }
 }
 
-// -- Stage enable/disable dependency chain --
-// Eye keypoints sits off the linear chain: it depends on extract (needs masks)
-// but is not a prerequisite for group, so toggling it alone affects only itself.
+// -- Stage enable/disable dependencies --
+// Extract depends on Classify, and Eye Keypoints depends on Extract (needs
+// masks). Group is independent because it can regroup from cached features.
 function onStageToggle(stage) {
-  var chain = ['classify', 'extract', 'group'];
+  var chain = ['classify', 'extract'];
   var idx = chain.indexOf(stage);
 
   if (idx >= 0) {
@@ -2252,7 +2247,7 @@ function onStageToggle(stage) {
 
   // Sync eye keypoints to extract: if extract is off, eye keypoints can't
   // run (no masks); when extract comes back on, leave eye keypoints
-  // unchecked so user must opt in again, matching how group behaves.
+  // unchecked so the user must opt in again.
   var extCb = document.getElementById('enableExtract');
   var ekCb = document.getElementById('enableEyeKeypoints');
   if (extCb && ekCb && stage !== 'eyekeypoints') {


### PR DESCRIPTION
## Summary

Decouples Group & Score from the Classify → Extract Features dependency chain so users can regroup from cached features without rerunning extraction.
Keeps Eye Keypoints dependent on Extract Features.
Adds browser regression coverage for checkbox states and execution-plan reporting.

## Validation

- `python -m pytest -o addopts='' -q tests/e2e/test_pipeline.py` — 27 passed
- `python -m pytest -q vireo/tests/test_pipeline_plan.py` — 132 passed, 2 skipped
- `git diff --check origin/main...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated pipeline stage behavior so disabling Classify or Extract no longer incorrectly disables Group.
  * Group remains available when cached features allow regrouping.
  * Eye Keypoints still becomes unavailable when Extract is disabled.
  * Updated pipeline summaries to accurately reflect which stages will run or be skipped.

* **Tests**
  * Added and updated end-to-end coverage for the revised stage dependency behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->