### PR TITLE
Flag conflicting bird classifications in process review

### DIFF
--- a/tests/e2e/test_pipeline_review_species.py
+++ b/tests/e2e/test_pipeline_review_species.py
@@ -568,6 +568,112 @@ def test_pipeline_review_marks_photo_and_burst_species_conflicts(live_server, pa
     )
 
 
+def _write_confirmed_burst_conflict_pipeline_cache(live_server, photo_ids):
+    """A single encounter with two bursts: the first (confirmed) burst holds
+    the only conflicting frame; the second is clean and unconfirmed so the
+    encounter stays visible when hide-confirmed is on."""
+    db = live_server["db"]
+    placeholders = ",".join("?" for _ in photo_ids)
+    rows = db.conn.execute(
+        f"SELECT id, filename, timestamp FROM photos WHERE id IN ({placeholders}) ORDER BY id",
+        photo_ids,
+    ).fetchall()
+    predictions = [
+        [("Little Grebe", 0.96, "Bird model"), ("Mute Swan", 0.04, "Bird model")],
+        [("Mute Swan", 0.92, "Bird model"), ("Little Grebe", 0.05, "Bird model")],
+        [("Mute Swan", 0.9, "Bird model"), ("Little Grebe", 0.06, "Bird model")],
+    ]
+    photos = []
+    for row, species_top5 in zip(rows, predictions, strict=True):
+        photos.append(
+            {
+                "id": row["id"],
+                "filename": row["filename"],
+                "timestamp": row["timestamp"],
+                "label": "REVIEW",
+                "quality_composite": 0.5,
+                "flag": "none",
+                "rating": 0,
+                "species_top5": species_top5,
+            }
+        )
+    ids = [photo["id"] for photo in photos]
+    cache = {
+        "photos": photos,
+        "encounters": [
+            {
+                "photo_ids": ids,
+                "photo_count": len(ids),
+                "burst_count": 2,
+                "time_range": [photos[0]["timestamp"], photos[-1]["timestamp"]],
+                "species": ["Mute Swan", 0.35],
+                "species_predictions": [],
+                "species_confirmed": False,
+                "confirmed_species": None,
+                "bursts": [
+                    {
+                        "photo_ids": ids[:1],
+                        "species_predictions": [],
+                        "species_override": {"species": "Mute Swan", "confirmed": True},
+                    },
+                    {
+                        "photo_ids": ids[1:],
+                        "species_predictions": [],
+                        "species_override": None,
+                    },
+                ],
+            }
+        ],
+        "summary": {
+            "total_photos": len(ids),
+            "encounter_count": 1,
+            "burst_count": 2,
+            "keep_count": 0,
+            "review_count": len(ids),
+            "reject_count": 0,
+            "rarity_protected": 0,
+        },
+    }
+    path = os.path.join(
+        os.path.dirname(db._db_path),
+        f"pipeline_results_ws{db._active_workspace_id}.json",
+    )
+    with open(path, "w") as f:
+        json.dump(cache, f)
+
+
+def test_pipeline_review_encounter_conflict_summary_respects_hide_confirmed(
+    live_server, page
+):
+    photo_ids = live_server["data"]["photos"][:3]
+    _write_confirmed_burst_conflict_pipeline_cache(live_server, photo_ids)
+
+    page.goto(f"{live_server['url']}/pipeline/review")
+
+    # Baseline: the conflict in the confirmed burst is counted at the
+    # encounter level and in the SPECIES_CONFLICT filter.
+    expect(page.locator(".encounter-species-conflict").first).to_contain_text(
+        "1 species conflict"
+    )
+    expect(page.locator("#countSpeciesConflict")).to_have_text(" (1)")
+
+    # Turn on Hide confirmed. The confirmed burst (which carries the only
+    # conflicting frame) is no longer rendered, so the encounter header/footer
+    # badges must disappear too — they used to keep counting hidden photos.
+    page.locator("#hideConfirmedBtn").click()
+    expect(page.locator(".encounter-card")).to_have_count(1)
+    expect(page.locator(".burst-strip")).to_have_count(1)
+    expect(page.locator(".encounter-species-conflict")).to_have_count(0)
+    expect(page.locator("#countSpeciesConflict")).to_have_text(" (0)")
+
+    # Toggling it back off should bring the badge back.
+    page.locator("#hideConfirmedBtn").click()
+    expect(page.locator(".encounter-species-conflict").first).to_contain_text(
+        "1 species conflict"
+    )
+    expect(page.locator("#countSpeciesConflict")).to_have_text(" (1)")
+
+
 def test_pipeline_review_conflicting_burst_can_split_and_undo(live_server, page):
     photo_ids = live_server["data"]["photos"][:3]
     _write_species_conflict_pipeline_cache(live_server, photo_ids)

--- a/tests/e2e/test_pipeline_review_species.py
+++ b/tests/e2e/test_pipeline_review_species.py
@@ -141,6 +141,78 @@ def _write_confirmation_pipeline_cache(live_server, photo_ids):
         json.dump(cache, f)
 
 
+def _write_species_conflict_pipeline_cache(live_server, photo_ids):
+    db = live_server["db"]
+    placeholders = ",".join("?" for _ in photo_ids)
+    rows = db.conn.execute(
+        f"SELECT id, filename, timestamp FROM photos WHERE id IN ({placeholders}) ORDER BY id",
+        photo_ids,
+    ).fetchall()
+    photos = []
+    predictions = [
+        [("Mute Swan", 0.93, "Bird model"), ("Little Grebe", 0.04, "Bird model")],
+        [("Little Grebe", 0.96, "Bird model"), ("Mute Swan", 0.04, "Bird model")],
+        [("Little Grebe", 0.88, "Bird model"), ("Mute Swan", 0.09, "Bird model")],
+    ]
+    for row, species_top5 in zip(rows, predictions, strict=True):
+        photos.append(
+            {
+                "id": row["id"],
+                "filename": row["filename"],
+                "timestamp": row["timestamp"],
+                "label": "REVIEW",
+                "quality_composite": 0.5,
+                "flag": "none",
+                "rating": 0,
+                "species_top5": species_top5,
+            }
+        )
+
+    ids = [photo["id"] for photo in photos]
+    cache = {
+        "photos": photos,
+        "encounters": [
+            {
+                "photo_ids": ids,
+                "photo_count": len(ids),
+                "burst_count": 2,
+                "time_range": [photos[0]["timestamp"], photos[-1]["timestamp"]],
+                "species": ["Mute Swan", 0.35],
+                "species_predictions": [],
+                "species_confirmed": False,
+                "confirmed_species": None,
+                "bursts": [
+                    {
+                        "photo_ids": ids[:1],
+                        "species_predictions": [],
+                        "species_override": None,
+                    },
+                    {
+                        "photo_ids": ids[1:],
+                        "species_predictions": [],
+                        "species_override": None,
+                    },
+                ],
+            }
+        ],
+        "summary": {
+            "total_photos": len(ids),
+            "encounter_count": 1,
+            "burst_count": 2,
+            "keep_count": 0,
+            "review_count": len(ids),
+            "reject_count": 0,
+            "rarity_protected": 0,
+        },
+    }
+    path = os.path.join(
+        os.path.dirname(db._db_path),
+        f"pipeline_results_ws{db._active_workspace_id}.json",
+    )
+    with open(path, "w") as f:
+        json.dump(cache, f)
+
+
 def _review_result_for_ids(live_server, photo_ids):
     db = live_server["db"]
     placeholders = ",".join("?" for _ in photo_ids)
@@ -442,3 +514,75 @@ def test_pipeline_review_view_settings_persist(live_server, page):
     page.locator("#speciesFilterClear").click()
     expect(page.locator("#speciesFilterInput")).to_have_value("")
     expect(page.locator(".encounter-card")).to_have_count(1)
+
+
+def test_pipeline_review_marks_photo_and_burst_species_conflicts(live_server, page):
+    photo_ids = live_server["data"]["photos"][:3]
+    _write_species_conflict_pipeline_cache(live_server, photo_ids)
+
+    page.goto(f"{live_server['url']}/pipeline/review")
+
+    conflicts = page.locator("[data-species-conflict]")
+    expect(conflicts).to_have_count(2)
+    expect(conflicts.first).to_contain_text("Little Grebe 96%")
+    expect(conflicts.first).to_have_attribute(
+        "title",
+        re.compile(r"Strong classification conflict: 1 classifier averages Little Grebe at 96%.*Mute Swan averages 4%"),
+    )
+    expect(page.locator(".burst-species-conflict")).to_contain_text(
+        "2 suggest Little Grebe"
+    )
+    expect(page.locator(".encounter-species-conflict").first).to_contain_text(
+        "2 species conflicts"
+    )
+    expect(page.locator("#countSpeciesConflict")).to_have_text(" (2)")
+
+    threshold_examples = page.evaluate(
+        """
+        () => ({
+          possible: analyzePhotoSpeciesConflict({
+            species_top5: [
+              ['Little Grebe', 0.62, 'Bird model'],
+              ['Mute Swan', 0.31, 'Bird model'],
+            ],
+          }, 'Mute Swan').severity,
+          matching: analyzePhotoSpeciesConflict({
+            species_top5: [
+              ['Mute Swan', 0.94, 'Bird model'],
+              ['Little Grebe', 0.03, 'Bird model'],
+            ],
+          }, 'Mute Swan').severity,
+        })
+        """
+    )
+    assert threshold_examples == {"possible": "possible", "matching": None}
+
+    page.locator('[data-filter="SPECIES_CONFLICT"]').click()
+    expect(page.locator(".photo-card")).to_have_count(2)
+    expect(page.locator(".photo-card").filter(has_text="Little Grebe")).to_have_count(2)
+
+    conflicts.first.click()
+    expect(page.locator(".inspect-species-conflict")).to_be_visible()
+    expect(page.locator(".inspect-species-conflict")).to_contain_text(
+        "This photo averages Little Grebe at 96%"
+    )
+
+
+def test_pipeline_review_conflicting_burst_can_split_and_undo(live_server, page):
+    photo_ids = live_server["data"]["photos"][:3]
+    _write_species_conflict_pipeline_cache(live_server, photo_ids)
+
+    page.goto(f"{live_server['url']}/pipeline/review")
+
+    split = page.locator(".burst-conflict-split")
+    expect(split).to_have_count(1)
+    split.click()
+
+    expect(page.locator(".encounter-card")).to_have_count(2)
+    expect(page.locator("[data-species-conflict]")).to_have_count(0)
+    expect(page.locator("#undoToast")).to_be_visible()
+    expect(page.locator("#undoMsg")).to_have_text("Burst detached from encounter")
+
+    page.locator("#undoToast button").click()
+    expect(page.locator(".encounter-card")).to_have_count(1)
+    expect(page.locator("[data-species-conflict]")).to_have_count(2)

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -192,6 +192,7 @@
 /* Filter bar */
 .filter-bar {
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
   margin-bottom: 16px;
   align-items: center;
@@ -209,6 +210,11 @@
 .filter-btn:hover { border-color: var(--text-muted); }
 .filter-btn.active { background: var(--accent); color: var(--accent-text); border-color: var(--accent); }
 .filter-btn .count { margin-left: 4px; opacity: 0.7; }
+.filter-btn.species-conflicts.active {
+  background: var(--warning);
+  border-color: var(--warning);
+  color: var(--accent-text);
+}
 .species-filter-wrap {
   display: flex;
   align-items: center;
@@ -475,6 +481,82 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+.species-conflict-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  max-width: 100%;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+.species-conflict-badge.strong {
+  background: color-mix(in srgb, var(--danger) 18%, var(--bg-secondary));
+  border-color: var(--danger);
+  color: var(--danger);
+}
+.species-conflict-badge.possible {
+  background: color-mix(in srgb, var(--warning) 16%, var(--bg-secondary));
+  border-color: var(--warning);
+  color: var(--warning);
+}
+.photo-species-conflict {
+  width: calc(100% - 12px);
+  margin: 0 6px 6px;
+  padding: 4px 7px;
+  justify-content: flex-start;
+  background-clip: padding-box;
+  cursor: pointer;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+.photo-species-conflict .species-conflict-label {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+.encounter-species-conflict,
+.burst-species-conflict {
+  padding: 3px 8px;
+  cursor: help;
+  flex-shrink: 0;
+}
+.burst-conflict-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex-shrink: 0;
+}
+.burst-conflict-split {
+  border: 1px solid var(--warning);
+  border-radius: 999px;
+  padding: 3px 8px;
+  background: transparent;
+  color: var(--warning);
+  font-size: 10px;
+  font-weight: 700;
+  cursor: pointer;
+}
+.burst-conflict-split:hover {
+  background: color-mix(in srgb, var(--warning) 14%, transparent);
+}
+.inspect-species-conflict {
+  margin: 10px 0 14px;
+  padding: 10px 12px;
+  border-radius: 6px;
+  font-size: 12px;
+  line-height: 1.45;
+}
+.inspect-species-conflict strong { color: var(--text-primary); }
+.inspect-species-conflict .species-conflict-explanation {
+  display: block;
+  margin-top: 3px;
+  color: var(--text-secondary);
+  font-weight: 400;
 }
 
 /* Slider controls */
@@ -1631,6 +1713,7 @@ input[type="range"]::-moz-range-thumb {
       <button class="filter-btn" data-filter="KEEP" onclick="setFilter('KEEP')">Keep<span class="count" id="countKeep"></span></button>
       <button class="filter-btn" data-filter="REVIEW" onclick="setFilter('REVIEW')">Review<span class="count" id="countReview"></span></button>
       <button class="filter-btn" data-filter="REJECT" onclick="setFilter('REJECT')">Reject<span class="count" id="countReject"></span></button>
+      <button class="filter-btn species-conflicts" data-filter="SPECIES_CONFLICT" onclick="setFilter('SPECIES_CONFLICT')" title="Show photos whose classification conflicts with the species suggested for their encounter or burst">Species conflicts<span class="count" id="countSpeciesConflict"></span></button>
       <button class="filter-btn" id="hideConfirmedBtn" onclick="toggleHideConfirmed()" title="Hide encounters/bursts whose species has been confirmed">Hide confirmed</button>
       <div class="species-filter-wrap">
         <div class="search-control">
@@ -1823,7 +1906,7 @@ var showPhotoLabels = false;
 var collapsedEncounters = new Set();
 var PIPELINE_SIDEBAR_STORAGE_KEY = 'vireo.pipelineReview.sidebarCollapsed';
 var PIPELINE_VIEW_STATE_STORAGE_KEY = 'vireo.pipelineReview.viewState';
-var PIPELINE_REVIEW_FILTERS = ['all', 'KEEP', 'REVIEW', 'REJECT'];
+var PIPELINE_REVIEW_FILTERS = ['all', 'KEEP', 'REVIEW', 'REJECT', 'SPECIES_CONFLICT'];
 var PIPELINE_ENCOUNTER_SORTS = ['default', 'photos_desc', 'photos_asc', 'bursts_desc', 'time_desc', 'time_asc'];
 // Display order for the encounter list. Does NOT reorder pipelineResults.encounters;
 // renderResults() iterates a sorted list of original indices so every encounter's
@@ -2429,6 +2512,252 @@ function missingTimestampBadge(enc) {
     n + ' missing timestamp' + (n === 1 ? '' : 's') + '</span>';
 }
 
+// Species-conflict review aid. These thresholds are deliberately conservative:
+// a warning needs both a credible alternative and a meaningful margin over the
+// current encounter/burst suggestion. The values are classifier confidence,
+// not measured identification accuracy.
+var SPECIES_CONFLICT_THRESHOLDS = {
+  strongAlternative: 0.80,
+  strongExpectedMax: 0.20,
+  strongMargin: 0.60,
+  possibleAlternative: 0.55,
+  possibleExpectedMax: 0.35,
+  possibleMargin: 0.25,
+};
+
+function normalizedSpeciesName(name) {
+  return String(name || '').trim().toLocaleLowerCase().replace(/\s+/g, ' ');
+}
+
+function speciesCandidateForReviewUnit(enc, burst) {
+  var override = burst && burst.species_override;
+  if (override && override.species) return override.species;
+  if (enc && enc.confirmed_species) return enc.confirmed_species;
+  if (enc && enc.species && enc.species[0]) return enc.species[0];
+  return null;
+}
+
+function analyzePhotoSpeciesConflict(photo, expectedSpecies) {
+  var expectedKey = normalizedSpeciesName(expectedSpecies);
+  var top5 = (photo && photo.species_top5) || [];
+  if (!expectedKey || top5.length === 0) return null;
+
+  // A model may contribute several detections/crops. Retain its strongest
+  // confidence for each species so repeated detections do not inflate support.
+  var byModel = {};
+  top5.forEach(function(entry) {
+    if (!entry || entry.length < 2) return;
+    var species = String(entry[0] || '').trim();
+    var confidence = Number(entry[1]);
+    var model = String(entry[2] || 'unknown');
+    if (!species || !isFinite(confidence) || confidence < 0 || confidence > 1) return;
+    if (!byModel[model]) byModel[model] = {};
+    var prior = byModel[model][species];
+    if (prior == null || confidence > prior) byModel[model][species] = confidence;
+  });
+  var models = Object.keys(byModel);
+  if (models.length === 0) return null;
+
+  var speciesNames = {};
+  models.forEach(function(model) {
+    Object.keys(byModel[model]).forEach(function(species) {
+      if (normalizedSpeciesName(species) !== expectedKey) speciesNames[species] = true;
+    });
+  });
+
+  function averageSupport(speciesKey) {
+    var total = 0;
+    models.forEach(function(model) {
+      var best = 0;
+      Object.keys(byModel[model]).forEach(function(species) {
+        if (normalizedSpeciesName(species) === speciesKey) {
+          best = Math.max(best, byModel[model][species]);
+        }
+      });
+      total += best;
+    });
+    return total / models.length;
+  }
+
+  var expectedSupport = averageSupport(expectedKey);
+  var alternative = null;
+  var alternativeSupport = 0;
+  Object.keys(speciesNames).forEach(function(species) {
+    var support = averageSupport(normalizedSpeciesName(species));
+    if (support > alternativeSupport) {
+      alternative = species;
+      alternativeSupport = support;
+    }
+  });
+  if (!alternative) return {
+    expectedSpecies: expectedSpecies,
+    expectedSupport: expectedSupport,
+    modelCount: models.length,
+    severity: null,
+  };
+
+  var alternativeKey = normalizedSpeciesName(alternative);
+  var alternativeModelWins = 0;
+  models.forEach(function(model) {
+    var topSpecies = null;
+    var topConfidence = -1;
+    Object.keys(byModel[model]).forEach(function(species) {
+      var confidence = byModel[model][species];
+      if (confidence > topConfidence) {
+        topSpecies = species;
+        topConfidence = confidence;
+      }
+    });
+    if (normalizedSpeciesName(topSpecies) === alternativeKey) alternativeModelWins++;
+  });
+
+  var margin = alternativeSupport - expectedSupport;
+  var enoughModelAgreement = alternativeModelWins >= Math.ceil(models.length / 2);
+  var t = SPECIES_CONFLICT_THRESHOLDS;
+  var severity = null;
+  if (enoughModelAgreement &&
+      alternativeSupport >= t.strongAlternative &&
+      expectedSupport <= t.strongExpectedMax &&
+      margin >= t.strongMargin) {
+    severity = 'strong';
+  } else if (enoughModelAgreement &&
+             alternativeSupport >= t.possibleAlternative &&
+             expectedSupport <= t.possibleExpectedMax &&
+             margin >= t.possibleMargin) {
+    severity = 'possible';
+  }
+
+  return {
+    expectedSpecies: expectedSpecies,
+    expectedSupport: expectedSupport,
+    alternativeSpecies: alternative,
+    alternativeSupport: alternativeSupport,
+    alternativeModelWins: alternativeModelWins,
+    modelCount: models.length,
+    margin: margin,
+    severity: severity,
+  };
+}
+
+function buildSpeciesConflictEvidence(photoMap) {
+  var evidence = {};
+  (pipelineResults.encounters || []).forEach(function(enc) {
+    if (enc.bursts && enc.bursts.length > 0) {
+      enc.bursts.forEach(function(burst) {
+        var expected = speciesCandidateForReviewUnit(enc, burst);
+        (burst.photo_ids || burst || []).forEach(function(pid) {
+          var photo = photoMap[pid];
+          if (photo) evidence[pid] = analyzePhotoSpeciesConflict(photo, expected);
+        });
+      });
+    } else {
+      var expected = speciesCandidateForReviewUnit(enc, null);
+      (enc.photo_ids || []).forEach(function(pid) {
+        var photo = photoMap[pid];
+        if (photo) evidence[pid] = analyzePhotoSpeciesConflict(photo, expected);
+      });
+    }
+  });
+  return evidence;
+}
+
+function formatSpeciesConfidence(value) {
+  return Math.round((Number(value) || 0) * 100) + '%';
+}
+
+function speciesConflictTitle(issue) {
+  if (!issue || !issue.severity) return '';
+  var strength = issue.severity === 'strong' ? 'Strong' : 'Possible';
+  var classifiers = issue.modelCount + ' classifier' + (issue.modelCount === 1 ? '' : 's');
+  return strength + ' classification conflict: ' + classifiers +
+    (issue.modelCount === 1 ? ' averages ' : ' average ') +
+    issue.alternativeSpecies + ' at ' + formatSpeciesConfidence(issue.alternativeSupport) +
+    ', while ' + issue.expectedSpecies + ' averages ' +
+    formatSpeciesConfidence(issue.expectedSupport) + '. Click to inspect this photo and its review group.';
+}
+
+function summarizeSpeciesConflicts(photoIds, evidence) {
+  var classifiedCount = 0;
+  var issues = [];
+  (photoIds || []).forEach(function(pid) {
+    var item = evidence[pid];
+    if (item) classifiedCount++;
+    if (item && item.severity) issues.push(item);
+  });
+  if (issues.length === 0) return null;
+
+  var groups = {};
+  issues.forEach(function(issue) {
+    var key = normalizedSpeciesName(issue.alternativeSpecies);
+    if (!groups[key]) groups[key] = {species: issue.alternativeSpecies, count: 0, strong: 0};
+    groups[key].count++;
+    if (issue.severity === 'strong') groups[key].strong++;
+  });
+  var dominant = null;
+  Object.keys(groups).forEach(function(key) {
+    var group = groups[key];
+    if (!dominant || group.count > dominant.count ||
+        (group.count === dominant.count && group.strong > dominant.strong)) {
+      dominant = group;
+    }
+  });
+  return {
+    issueCount: issues.length,
+    classifiedCount: classifiedCount,
+    dominantSpecies: dominant.species,
+    dominantCount: dominant.count,
+    severity: dominant.strong > 0 ? 'strong' : 'possible',
+  };
+}
+
+function renderEncounterSpeciesConflict(enc, evidence) {
+  var summary = summarizeSpeciesConflicts(enc.photo_ids || [], evidence);
+  if (!summary) return '';
+  var mostPhotosConflict = summary.classifiedCount > 0 &&
+    summary.issueCount >= Math.ceil(summary.classifiedCount * 0.6) &&
+    summary.dominantCount >= Math.ceil(summary.issueCount * 0.7);
+  var title;
+  if (mostPhotosConflict) {
+    title = summary.issueCount + ' of ' + summary.classifiedCount +
+      ' classified photos conflict with this encounter suggestion; most suggest ' +
+      summary.dominantSpecies + '. The encounter species suggestion may be wrong.';
+  } else {
+    title = summary.issueCount + ' of ' + summary.classifiedCount +
+      ' classified photos conflict with this encounter suggestion. They may belong in a different group.';
+  }
+  return '<span class="species-conflict-badge encounter-species-conflict ' + summary.severity +
+    '" title="' + escapeAttr(title) + '">&#9888; ' + summary.issueCount +
+    ' species conflict' + (summary.issueCount === 1 ? '' : 's') + '</span>';
+}
+
+function renderBurstSpeciesConflict(enc, encIdx, burst, burstIdx, evidence) {
+  var ids = burst.photo_ids || burst || [];
+  var summary = summarizeSpeciesConflicts(ids, evidence);
+  // A burst marker should mean the burst itself has a consistent conflict,
+  // not merely that one unusual frame inside a long burst needs photo review.
+  if (!summary || ids.length < 2 || summary.dominantCount < 2 ||
+      summary.dominantCount < Math.ceil(summary.classifiedCount / 2)) return '';
+  var title = summary.dominantCount + ' of ' + summary.classifiedCount +
+    ' classified photos in this burst suggest ' + summary.dominantSpecies +
+    ' instead of the current species suggestion.';
+  var html = '<span class="burst-conflict-actions">';
+  html += '<span class="species-conflict-badge burst-species-conflict ' + summary.severity +
+    '" title="' + escapeAttr(title) + '">&#9888; ' + summary.dominantCount +
+    ' suggest ' + escapeHtml(summary.dominantSpecies) + '</span>';
+  if (enc.bursts && enc.bursts.length > 1) {
+    html += '<button class="burst-conflict-split" onclick="event.stopPropagation();detachBurst(' +
+      encIdx + ',' + burstIdx + ')" title="Move this burst into its own encounter">Split burst</button>';
+  }
+  html += '</span>';
+  return html;
+}
+
+function photoMatchesPipelineFilter(photo, issue) {
+  if (activeFilter === 'all') return true;
+  if (activeFilter === 'SPECIES_CONFLICT') return !!(issue && issue.severity);
+  return photo.label === activeFilter;
+}
+
 function renderResults() {
   if (!pipelineResults) return;
   var container = document.getElementById('encountersContainer');
@@ -2436,6 +2765,7 @@ function renderResults() {
   // Build photo lookup
   var photoMap = {};
   pipelineResults.photos.forEach(function(p) { photoMap[p.id] = p; });
+  var speciesConflictEvidence = buildSpeciesConflictEvidence(photoMap);
 
   // Build encounter photo set for species-filtered encounters
   var speciesVisibleIds = null;
@@ -2467,17 +2797,21 @@ function renderResults() {
   }
 
   // Update filter counts (respecting species filter and hide-confirmed)
-  var counts = {all: 0, KEEP: 0, REVIEW: 0, REJECT: 0};
+  var counts = {all: 0, KEEP: 0, REVIEW: 0, REJECT: 0, SPECIES_CONFLICT: 0};
   pipelineResults.photos.forEach(function(p) {
     if (speciesVisibleIds && !speciesVisibleIds.has(p.id)) return;
     if (confirmedHiddenIds && confirmedHiddenIds.has(p.id)) return;
     counts.all++;
     if (p.label) counts[p.label] = (counts[p.label] || 0) + 1;
+    if (speciesConflictEvidence[p.id] && speciesConflictEvidence[p.id].severity) {
+      counts.SPECIES_CONFLICT++;
+    }
   });
   var ce = document.getElementById('countAll'); if (ce) ce.textContent = ' (' + counts.all + ')';
   ce = document.getElementById('countKeep'); if (ce) ce.textContent = ' (' + (counts.KEEP||0) + ')';
   ce = document.getElementById('countReview'); if (ce) ce.textContent = ' (' + (counts.REVIEW||0) + ')';
   ce = document.getElementById('countReject'); if (ce) ce.textContent = ' (' + (counts.REJECT||0) + ')';
+  ce = document.getElementById('countSpeciesConflict'); if (ce) ce.textContent = ' (' + counts.SPECIES_CONFLICT + ')';
 
   var html = '';
   // Track which encounter indices actually produced a card so focus
@@ -2510,7 +2844,7 @@ function renderResults() {
       var p = photoMap[pid];
       if (!p) return false;
       if (confirmedHiddenIds && confirmedHiddenIds.has(pid)) return false;
-      return activeFilter === 'all' || p.label === activeFilter;
+      return photoMatchesPipelineFilter(p, speciesConflictEvidence[pid]);
     });
     if (!hasVisible) return;
 
@@ -2528,6 +2862,7 @@ function renderResults() {
     if (enc.burst_count) html += '<span>' + enc.burst_count + ' bursts</span>';
     if (timeRange) html += '<span>' + timeRange + '</span>';
     html += missingTimestampBadge(enc);
+    html += renderEncounterSpeciesConflict(enc, speciesConflictEvidence);
     html += '</span></div>';
     html += '<div class="encounter-body" id="encBody' + ei + '"' + (isCollapsed ? ' style="display:none;"' : '') + '>';
 
@@ -2547,13 +2882,14 @@ function renderResults() {
         if (!burst.species_override && enc.bursts.length > 1) {
           html += '<span class="burst-species-edit" onclick="toggleSpeciesDropdown(event,' + ei + ',' + bi + ',\'top\')">&#9998;</span>';
         }
+        html += renderBurstSpeciesConflict(enc, ei, burst, bi, speciesConflictEvidence);
         html += '<button class="detach-btn" onclick="detachBurst(' + ei + ',' + bi + ')" title="Detach burst">&times;</button>';
         html += '</div>';
         burstIds.forEach(function(pid) {
           var p = photoMap[pid];
           if (!p) return;
-          if (activeFilter !== 'all' && p.label !== activeFilter) return;
-          html += renderPhotoCard(p, ei, bi);
+          if (!photoMatchesPipelineFilter(p, speciesConflictEvidence[pid])) return;
+          html += renderPhotoCard(p, ei, bi, speciesConflictEvidence[pid]);
         });
         html += '</div>';
       });
@@ -2562,8 +2898,8 @@ function renderResults() {
       encPhotoIds.forEach(function(pid) {
         var p = photoMap[pid];
         if (!p) return;
-        if (activeFilter !== 'all' && p.label !== activeFilter) return;
-        html += renderPhotoCard(p, null, null);
+        if (!photoMatchesPipelineFilter(p, speciesConflictEvidence[pid])) return;
+        html += renderPhotoCard(p, null, null, speciesConflictEvidence[pid]);
       });
     }
 
@@ -2576,6 +2912,7 @@ function renderResults() {
     if (enc.burst_count) html += '<span>' + enc.burst_count + ' bursts</span>';
     if (timeRange) html += '<span>' + timeRange + '</span>';
     html += missingTimestampBadge(enc);
+    html += renderEncounterSpeciesConflict(enc, speciesConflictEvidence);
     html += '</span></div>';
 
     html += '</div></div>';
@@ -2600,7 +2937,7 @@ function renderResults() {
   }
 }
 
-function renderPhotoCard(p, encIdx, burstIdx) {
+function renderPhotoCard(p, encIdx, burstIdx, speciesConflict) {
   var label = (p.label || '').toLowerCase();
   var manualLabel = '';
   var visibleLabel = '';
@@ -2633,6 +2970,15 @@ function renderPhotoCard(p, encIdx, burstIdx) {
     html += '<div class="photo-info">' + escapeHtml(p.filename || '') + ' &middot; Q=' + q.toFixed(2) + '</div>';
   } else {
     html += '<div class="photo-info">' + escapeHtml(p.filename || '') + '</div>';
+  }
+  if (speciesConflict && speciesConflict.severity) {
+    var conflictTitle = escapeAttr(speciesConflictTitle(speciesConflict));
+    html += '<button class="species-conflict-badge photo-species-conflict ' + speciesConflict.severity +
+      '" data-species-conflict="' + speciesConflict.severity + '" onclick="event.stopPropagation();openInspect(' +
+      p.id + ')" title="' + conflictTitle + '" aria-label="' + conflictTitle + '">';
+    html += '<span aria-hidden="true">&#9888;</span><span class="species-conflict-label">' +
+      escapeHtml(speciesConflict.alternativeSpecies) + ' ' +
+      formatSpeciesConfidence(speciesConflict.alternativeSupport) + '</span></button>';
   }
   html += '</div>';
   return html;
@@ -5394,6 +5740,26 @@ function buildPipelineMetadataHtml(photo) {
       html += '<div class="reject-reason">&#9888; ' + r + '</div>';
     });
     html += '</div>';
+  }
+
+  var conflictEnc = pipelineResults && pipelineResults.encounters &&
+    pipelineResults.encounters[grmState.encIdx];
+  var conflictBurst = conflictEnc && conflictEnc.bursts &&
+    conflictEnc.bursts[grmState.burstIdx];
+  var conflictExpected = speciesCandidateForReviewUnit(conflictEnc, conflictBurst);
+  var speciesConflict = analyzePhotoSpeciesConflict(photo, conflictExpected);
+  if (speciesConflict && speciesConflict.severity) {
+    var conflictHeading = speciesConflict.severity === 'strong'
+      ? 'Strong classification conflict'
+      : 'Possible classification conflict';
+    html += '<div class="species-conflict-badge inspect-species-conflict ' +
+      speciesConflict.severity + '"><span aria-hidden="true">&#9888;</span><span><strong>' +
+      conflictHeading + '</strong><span class="species-conflict-explanation">This photo averages ' +
+      escapeHtml(speciesConflict.alternativeSpecies) + ' at ' +
+      formatSpeciesConfidence(speciesConflict.alternativeSupport) + ', while the current suggestion ' +
+      escapeHtml(speciesConflict.expectedSpecies) + ' averages ' +
+      formatSpeciesConfidence(speciesConflict.expectedSupport) +
+      '. Review the burst before changing its grouping or species.</span></span></div>';
   }
 
   // Species predictions: this photo, then the consensus for the burst being

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -2710,8 +2710,16 @@ function summarizeSpeciesConflicts(photoIds, evidence) {
   };
 }
 
-function renderEncounterSpeciesConflict(enc, evidence) {
-  var summary = summarizeSpeciesConflicts(enc.photo_ids || [], evidence);
+function renderEncounterSpeciesConflict(enc, evidence, hiddenIds) {
+  // Match the set of photos that renderResults() will actually draw for this
+  // encounter: when hide-confirmed is on, confirmed bursts are skipped, so a
+  // conflict living only in a confirmed burst shouldn't be tallied here (the
+  // SPECIES_CONFLICT count already filters the same way).
+  var ids = enc.photo_ids || [];
+  if (hiddenIds && hiddenIds.size) {
+    ids = ids.filter(function(pid) { return !hiddenIds.has(pid); });
+  }
+  var summary = summarizeSpeciesConflicts(ids, evidence);
   if (!summary) return '';
   var mostPhotosConflict = summary.classifiedCount > 0 &&
     summary.issueCount >= Math.ceil(summary.classifiedCount * 0.6) &&
@@ -2862,7 +2870,7 @@ function renderResults() {
     if (enc.burst_count) html += '<span>' + enc.burst_count + ' bursts</span>';
     if (timeRange) html += '<span>' + timeRange + '</span>';
     html += missingTimestampBadge(enc);
-    html += renderEncounterSpeciesConflict(enc, speciesConflictEvidence);
+    html += renderEncounterSpeciesConflict(enc, speciesConflictEvidence, confirmedHiddenIds);
     html += '</span></div>';
     html += '<div class="encounter-body" id="encBody' + ei + '"' + (isCollapsed ? ' style="display:none;"' : '') + '>';
 
@@ -2912,7 +2920,7 @@ function renderResults() {
     if (enc.burst_count) html += '<span>' + enc.burst_count + ' bursts</span>';
     if (timeRange) html += '<span>' + timeRange + '</span>';
     html += missingTimestampBadge(enc);
-    html += renderEncounterSpeciesConflict(enc, speciesConflictEvidence);
+    html += renderEncounterSpeciesConflict(enc, speciesConflictEvidence, confirmedHiddenIds);
     html += '</span></div>';
 
     html += '</div></div>';


### PR DESCRIPTION
## What changed

- compare each photo’s cached species predictions with the active encounter or burst suggestion
- show strong and possible classification-conflict badges at photo, burst, and encounter level
- explain the competing confidence values in burst review
- add a Species conflicts filter for focused review
- allow consistently conflicting bursts to be split into their own encounter with the existing Undo flow

## Why

An encounter-level species vote can hide a confidently classified outlier when a photo or burst has been grouped into the wrong encounter. These warnings surface the per-photo evidence without changing grouping automatically, so the photographer remains in control.

## Validation

- `python -m pytest tests/e2e/test_pipeline_review_species.py tests/e2e/test_pipeline_rapid_review.py -q` — 35 passed
- `python -m pytest tests/e2e/test_pipeline.py vireo/tests/test_pipeline.py vireo/tests/test_pipeline_api.py -q` — 168 passed, 34 skipped
- `python -m ruff check tests/e2e/test_pipeline_review_species.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added species classification conflict indicators at photo, burst, and encounter levels in Pipeline Review.
  - Added conflict severity details, tooltips, and inspection-panel explanations.
  - Added a `SPECIES_CONFLICT` filter with conflict counts.
  - Added support for splitting conflicting bursts and undoing the change.

- **Tests**
  - Added end-to-end coverage for conflict detection, filtering, inspection details, burst splitting, and undo behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->