### PR TITLE
Split encounters on confident species changes

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -24183,6 +24183,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "hard_cut_time": ("seconds", 0.0, 86400.0),
             "hard_cut_score": ("score", 0.0, 1.0),
             "soft_cut_score": ("score", 0.0, 1.0),
+            "species_hard_cut_confidence": ("score", 0.0, 1.0),
+            "species_hard_cut_margin": ("score", 0.0, 1.0),
             "merge_score": ("score", 0.0, 1.0),
             "merge_max_gap": ("seconds", 0.0, 86400.0),
             "merge_tau": ("seconds", 1.0, 86400.0),

--- a/vireo/config.py
+++ b/vireo/config.py
@@ -146,6 +146,8 @@ DEFAULTS = {
         "hard_cut_time": 180.0,
         "hard_cut_score": 0.42,
         "soft_cut_score": 0.52,
+        "species_hard_cut_confidence": 0.80,
+        "species_hard_cut_margin": 0.60,
         "merge_score": 0.62,
         "merge_max_gap": 60.0,
         "merge_tau": 20.0,

--- a/vireo/config_schema.py
+++ b/vireo/config_schema.py
@@ -646,6 +646,18 @@ SCHEMA = {
         "label": "Encounter: soft-cut score",
         "desc": "Similarity below which encounters are likely to split.",
     },
+    "pipeline.species_hard_cut_confidence": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+        "category": "Pipeline", "scope": "both",
+        "label": "Encounter: species split confidence",
+        "desc": "Minimum mean classifier confidence required to split adjacent photos that strongly indicate different species.",
+    },
+    "pipeline.species_hard_cut_margin": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+        "category": "Pipeline", "scope": "both",
+        "label": "Encounter: species split margin",
+        "desc": "Minimum confidence lead over the runner-up species required for an automatic species boundary.",
+    },
     "pipeline.merge_score": {
         "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
         "category": "Pipeline", "scope": "both",

--- a/vireo/encounters.py
+++ b/vireo/encounters.py
@@ -31,6 +31,14 @@ DEFAULTS = {
     "hard_cut_time": 180.0,  # seconds
     "hard_cut_score": 0.42,
     "soft_cut_score": 0.52,
+    # A confident classifier change is stronger evidence than the blended
+    # similarity score: two clearly identified, different species should not
+    # remain in one encounter merely because they were photographed seconds
+    # apart against the same background. Confidence is averaged across the
+    # models present on each photo; the winning species must also clear the
+    # runner-up by the configured margin.
+    "species_hard_cut_confidence": 0.80,
+    "species_hard_cut_margin": 0.60,
     # Pass 2 merge thresholds
     "merge_score": 0.62,
     "merge_max_gap": 60.0,  # seconds
@@ -166,6 +174,105 @@ def sim_species(species_a, species_b):
     if not shared:
         return 0.0
     return sum(math.sqrt(dict_a[s] * dict_b[s]) for s in shared)
+
+
+def _normalized_species_name(name):
+    """Return a stable comparison key for classifier species labels."""
+    return " ".join(str(name or "").strip().casefold().split())
+
+
+def _confident_species_prediction(photo, config=None):
+    """Return a trustworthy winning species for one photo, or ``None``.
+
+    Classifier rows are grouped by model so repeated detections from one model
+    cannot manufacture consensus. Support for a species is its mean confidence
+    across all models represented on the photo, with zero support from a model
+    that chose another species. This makes two disagreeing classifiers
+    appropriately cautious while still allowing a single strongly decisive
+    classifier to provide evidence when it is the only model available.
+
+    An explicit detector ``subject_absent`` verdict vetoes the prediction. The
+    pipeline normally filters such predictions before grouping, but honoring
+    the verdict here protects regrouping from stale cached classifications.
+    """
+    if photo.get("subject_absent"):
+        return None
+
+    entries = photo.get("species_top5") or []
+    if not entries:
+        return None
+
+    cfg = {**DEFAULTS, **(config or {})}
+    min_confidence = cfg["species_hard_cut_confidence"]
+    min_margin = cfg["species_hard_cut_margin"]
+
+    by_model = defaultdict(dict)
+    display_names = {}
+    for entry in entries:
+        if not entry or len(entry) < 2:
+            continue
+        name = str(entry[0] or "").strip()
+        key = _normalized_species_name(name)
+        try:
+            confidence = float(entry[1])
+        except (TypeError, ValueError):
+            continue
+        if not key or not math.isfinite(confidence) or not 0.0 <= confidence <= 1.0:
+            continue
+        model = str(entry[2] or "unknown") if len(entry) >= 3 else "unknown"
+        prior = by_model[model].get(key)
+        if prior is None or confidence > prior:
+            by_model[model][key] = confidence
+            display_names[key] = name
+
+    if not by_model:
+        return None
+
+    model_count = len(by_model)
+    species_keys = {key for predictions in by_model.values() for key in predictions}
+    support = {
+        key: sum(predictions.get(key, 0.0) for predictions in by_model.values()) / model_count
+        for key in species_keys
+    }
+    ranked = sorted(support, key=lambda key: (-support[key], key))
+    winner = ranked[0]
+    winner_support = support[winner]
+    runner_up_support = support[ranked[1]] if len(ranked) > 1 else 0.0
+
+    # Require a strict majority of the represented classifiers to rank the
+    # same winner first. Two models must therefore agree; with a larger
+    # ensemble, one dissenting model cannot veto an otherwise clear result.
+    model_wins = 0
+    for predictions in by_model.values():
+        model_winner = min(
+            predictions,
+            key=lambda key: (-predictions[key], key),
+        )
+        if model_winner == winner:
+            model_wins += 1
+    if model_wins < math.floor(model_count / 2) + 1:
+        return None
+    if winner_support < min_confidence:
+        return None
+    if winner_support - runner_up_support < min_margin:
+        return None
+
+    return {
+        "species": display_names[winner],
+        "key": winner,
+        "confidence": winner_support,
+        "margin": winner_support - runner_up_support,
+        "model_count": model_count,
+    }
+
+
+def _confident_species_conflict(photo_a, photo_b, config=None):
+    """Return the two confident predictions when adjacent photos conflict."""
+    pred_a = _confident_species_prediction(photo_a, config=config)
+    pred_b = _confident_species_prediction(photo_b, config=config)
+    if pred_a is None or pred_b is None or pred_a["key"] == pred_b["key"]:
+        return None
+    return pred_a, pred_b
 
 
 def sim_meta(photo_a, photo_b):
@@ -355,7 +462,7 @@ def cut_microsegments(photos, config=None, emit_trace=False):
         emit_trace: when True, return (segments, trace) where each trace
             entry is {pair_index, score, dt_seconds, decision, components,
             thresholds}. Decisions: kept, cut_time, cut_score, cut_soft,
-            burst_id_kept.
+            cut_species, burst_id_kept.
 
     Returns:
         list of lists (each inner list is a microsegment of photo dicts), or
@@ -403,6 +510,9 @@ def cut_microsegments(photos, config=None, emit_trace=False):
         bid_a = sorted_photos[i].get("burst_id")
         bid_b = sorted_photos[i + 1].get("burst_id")
         decision = None
+        species_conflict = _confident_species_conflict(
+            sorted_photos[i], sorted_photos[i + 1], config=cfg
+        )
 
         both_null = ts_a is None and ts_b is None
         folder_a = sorted_photos[i].get("folder_id")
@@ -433,7 +543,15 @@ def cut_microsegments(photos, config=None, emit_trace=False):
             )
         )
 
-        if bid_a is not None and bid_b is not None and bid_a == bid_b:
+        if species_conflict is not None:
+            # A camera burst id is not allowed to conceal a confidently
+            # identified species change. Burst mode can span a subject switch,
+            # and the classifier evidence is the more relevant encounter
+            # boundary signal in that case.
+            cuts.add(i)
+            recent_scores = []
+            decision = "cut_species"
+        elif bid_a is not None and bid_b is not None and bid_a == bid_b:
             decision = "burst_id_kept"
             recent_scores.append(score)
             if len(recent_scores) > 3:
@@ -490,11 +608,25 @@ def cut_microsegments(photos, config=None, emit_trace=False):
                 "score": float(score),
                 "dt_seconds": float(dt) if dt != float("inf") else None,
                 "decision": decision,
+                "species_conflict": (
+                    {
+                        "photo_a_species": species_conflict[0]["species"],
+                        "photo_a_confidence": species_conflict[0]["confidence"],
+                        "photo_a_margin": species_conflict[0]["margin"],
+                        "photo_b_species": species_conflict[1]["species"],
+                        "photo_b_confidence": species_conflict[1]["confidence"],
+                        "photo_b_margin": species_conflict[1]["margin"],
+                    }
+                    if species_conflict is not None
+                    else None
+                ),
                 "components": components,
                 "thresholds": {
                     "hard_cut_time": cfg["hard_cut_time"],
                     "hard_cut_score": cfg["hard_cut_score"],
                     "soft_cut_score": cfg["soft_cut_score"],
+                    "species_hard_cut_confidence": cfg["species_hard_cut_confidence"],
+                    "species_hard_cut_margin": cfg["species_hard_cut_margin"],
                 },
             })
 
@@ -637,7 +769,13 @@ def _merge_microsegments_with_map(segments, config=None):
         gap = _time_delta_seconds(last_a, first_b)
 
         did_merge = False
-        if gap <= cfg["merge_max_gap"]:
+        # Never stitch back across the same trustworthy classifier conflict
+        # that forced a pass-1 boundary. Without this guard, identical scene
+        # embeddings and a short time gap can immediately undo cut_species.
+        species_conflict = _confident_species_conflict(
+            merged[-1][-1], seg[0], config=cfg
+        )
+        if species_conflict is None and gap <= cfg["merge_max_gap"]:
             s_seg = compute_s_seg(merged[-1], seg, config=cfg)
             if s_seg > cfg["merge_score"]:
                 # Merge: extend the last segment

--- a/vireo/static/vireo-utils.js
+++ b/vireo/static/vireo-utils.js
@@ -260,6 +260,14 @@ var VireoPipelineConfig = (function() {
         soft_cut_score: percent(
           pipelineValue(p, 'soft_cut_score'), 'soft_cut_score'
         ),
+        species_hard_cut_confidence: percent(
+          pipelineValue(p, 'species_hard_cut_confidence'),
+          'species_hard_cut_confidence'
+        ),
+        species_hard_cut_margin: percent(
+          pipelineValue(p, 'species_hard_cut_margin'),
+          'species_hard_cut_margin'
+        ),
         merge_score: percent(pipelineValue(p, 'merge_score'), 'merge_score'),
         merge_max_gap: asNumber(
           pipelineValue(p, 'merge_max_gap'), 'merge_max_gap'

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -2405,6 +2405,12 @@ function renderAlgorithmTrace() {
     var thrParts = [];
     if (typeof thr.hard_cut_score === 'number') thrParts.push('hard_cut_score=' + thr.hard_cut_score.toFixed(2));
     if (typeof thr.soft_cut_score === 'number') thrParts.push('soft_cut_score=' + thr.soft_cut_score.toFixed(2));
+    if (typeof thr.species_hard_cut_confidence === 'number') {
+      thrParts.push('species_confidence=' + thr.species_hard_cut_confidence.toFixed(2));
+    }
+    if (typeof thr.species_hard_cut_margin === 'number') {
+      thrParts.push('species_margin=' + thr.species_hard_cut_margin.toFixed(2));
+    }
     if (typeof thr.hard_cut_time === 'number') thrParts.push('hard_cut_time=' + thr.hard_cut_time + 's');
     if (thrParts.length) {
       html += '<div class="trace-thresholds">cut if: ' + thrParts.join(' · ') + '</div>';

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -11504,7 +11504,13 @@ def test_save_grouping_defaults_persists_to_config(tmp_path, monkeypatch):
     app = create_app(db_path=db_path, thumb_cache_dir=thumb_dir, api_token="t")
     client = app.test_client()
 
-    payload = {"pipeline": {"w_species": 0.40, "hard_cut_score": 0.55, "tau_enc": 30.0}}
+    payload = {"pipeline": {
+        "w_species": 0.40,
+        "hard_cut_score": 0.55,
+        "species_hard_cut_confidence": 0.85,
+        "species_hard_cut_margin": 0.65,
+        "tau_enc": 30.0,
+    }}
     resp = client.post("/api/pipeline/save-grouping-defaults", json=payload)
     assert resp.status_code == 200, resp.get_json()
     body = resp.get_json()
@@ -11513,6 +11519,8 @@ def test_save_grouping_defaults_persists_to_config(tmp_path, monkeypatch):
     saved = cfg.load()
     assert saved["pipeline"]["w_species"] == 0.40
     assert saved["pipeline"]["hard_cut_score"] == 0.55
+    assert saved["pipeline"]["species_hard_cut_confidence"] == 0.85
+    assert saved["pipeline"]["species_hard_cut_margin"] == 0.65
     assert saved["pipeline"]["tau_enc"] == 30.0
 
 

--- a/vireo/tests/test_encounters.py
+++ b/vireo/tests/test_encounters.py
@@ -194,6 +194,138 @@ def test_sim_species_empty():
     assert sim_species(None, None) == 0.0
 
 
+def _strong_species(name):
+    return [
+        (name, 0.94, "classifier-a"),
+        (name, 0.90, "classifier-b"),
+    ]
+
+
+def test_confident_species_prediction_requires_model_consensus():
+    from encounters import _confident_species_prediction
+
+    photo = _make_photo(species=[
+        ("Verdin", 0.96, "classifier-a"),
+        ("Costa's Hummingbird", 0.95, "classifier-b"),
+    ])
+
+    assert _confident_species_prediction(photo) is None
+
+
+def test_confident_species_prediction_requires_decisive_margin():
+    from encounters import _confident_species_prediction
+
+    photo = _make_photo(species=[
+        ("Verdin", 0.90, "classifier-a"),
+        ("Costa's Hummingbird", 0.40, "classifier-a"),
+    ])
+
+    assert _confident_species_prediction(photo) is None
+
+
+def test_confident_species_prediction_ignores_stale_absent_subject():
+    from encounters import _confident_species_prediction
+
+    photo = _make_photo(species=_strong_species("Verdin"))
+    photo["subject_absent"] = True
+
+    assert _confident_species_prediction(photo) is None
+
+
+def test_confident_species_change_is_hard_encounter_boundary():
+    """Strong classifier disagreement wins over time, embeddings, and a
+    shared camera burst id, and pass 2 must not stitch the cut back together.
+    """
+    from encounters import cut_microsegments, segment_encounters
+
+    emb = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+    photos = [
+        _make_photo(
+            ts_offset_s=0,
+            subj_emb=emb,
+            global_emb=emb,
+            species=_strong_species("Verdin"),
+            focal_length=600,
+            burst_id="camera-burst-1",
+            photo_id=1,
+        ),
+        _make_photo(
+            ts_offset_s=0.05,
+            subj_emb=emb,
+            global_emb=emb,
+            species=_strong_species("Costa's Hummingbird"),
+            focal_length=600,
+            burst_id="camera-burst-1",
+            photo_id=2,
+        ),
+    ]
+
+    microsegments, trace = cut_microsegments(photos, emit_trace=True)
+    assert [len(segment) for segment in microsegments] == [1, 1]
+    assert trace[0]["decision"] == "cut_species"
+    conflict = trace[0]["species_conflict"]
+    assert conflict["photo_a_species"] == "Verdin"
+    assert conflict["photo_b_species"] == "Costa's Hummingbird"
+    for field in (
+        "photo_a_confidence",
+        "photo_a_margin",
+        "photo_b_confidence",
+        "photo_b_margin",
+    ):
+        assert math.isclose(conflict[field], 0.92)
+
+    encounters = segment_encounters(photos)
+    assert [encounter["photo_count"] for encounter in encounters] == [1, 1]
+
+
+def test_weak_species_change_does_not_force_encounter_boundary():
+    from encounters import segment_encounters
+
+    emb = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+    photos = [
+        _make_photo(
+            ts_offset_s=0,
+            subj_emb=emb,
+            global_emb=emb,
+            species=[("Verdin", 0.79, "classifier-a")],
+            focal_length=600,
+        ),
+        _make_photo(
+            ts_offset_s=0.05,
+            subj_emb=emb,
+            global_emb=emb,
+            species=[("Costa's Hummingbird", 0.79, "classifier-a")],
+            focal_length=600,
+        ),
+    ]
+
+    encounters = segment_encounters(photos)
+    assert [encounter["photo_count"] for encounter in encounters] == [2]
+
+
+def test_same_confident_species_with_different_case_stays_together():
+    from encounters import segment_encounters
+
+    emb = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+    photos = [
+        _make_photo(
+            ts_offset_s=0,
+            subj_emb=emb,
+            global_emb=emb,
+            species=_strong_species("Costa's Hummingbird"),
+        ),
+        _make_photo(
+            ts_offset_s=0.05,
+            subj_emb=emb,
+            global_emb=emb,
+            species=_strong_species("  costa's   hummingbird "),
+        ),
+    ]
+
+    encounters = segment_encounters(photos)
+    assert [encounter["photo_count"] for encounter in encounters] == [2]
+
+
 # -- sim_meta --
 
 
@@ -338,17 +470,20 @@ def test_cut_empty():
 
 
 def test_burst_id_prevents_cut():
-    """Photos sharing a camera burst ID should not be cut apart."""
+    """A camera burst still overrides ordinary score dissimilarity when the
+    classifier evidence is too weak to assert a species change.
+    """
     from encounters import cut_microsegments
 
     emb_a = np.array([1, 0, 0] * 256, dtype=np.float32)
     emb_b = np.array([0, 1, 0] * 256, dtype=np.float32)
     photos = [
-        _make_photo(0, subj_emb=emb_a, species=[("robin", 0.9)], burst_id="B001"),
-        _make_photo(10, subj_emb=emb_b, species=[("eagle", 0.9)], burst_id="B001"),
+        _make_photo(0, subj_emb=emb_a, species=[("robin", 0.7)], burst_id="B001"),
+        _make_photo(10, subj_emb=emb_b, species=[("eagle", 0.7)], burst_id="B001"),
     ]
     segments = cut_microsegments(photos)
-    # Despite different embeddings/species, shared burst_id keeps them together
+    # Despite different embeddings and weak species predictions, the shared
+    # burst id keeps them together. Strong species evidence is tested above.
     assert len(segments) == 1
 
 


### PR DESCRIPTION
## Summary

- add an automatic encounter boundary when adjacent photos have decisive, conflicting classifier consensus
- require majority model agreement, at least 80% mean confidence, and a 60-point lead over the runner-up
- prevent the encounter merge pass and camera burst IDs from undoing a confident species boundary
- expose the decision and configurable thresholds in grouping traces and settings

## Behavior

Weak, ambiguous, or stale classifications do not force a split. Photos explicitly marked as having no detected subject cannot contribute classifier evidence. This separates confidently identified different species while preserving continuous bursts when the evidence is uncertain.

## Validation

- `python -m pytest vireo/tests/test_encounters.py vireo/tests/test_pipeline.py vireo/tests/test_config.py vireo/tests/test_config_schema.py vireo/tests/test_app.py::test_save_grouping_defaults_persists_to_config vireo/tests/test_app.py::test_save_grouping_defaults_rejects_bad_values -q` — 268 passed
- `python -m pytest tests/e2e/test_pipeline_review_species.py -q` — 10 passed
- `python -m ruff check vireo/encounters.py vireo/tests/test_encounters.py vireo/config.py vireo/config_schema.py vireo/app.py vireo/tests/test_app.py`
- `git diff --check`