### PR TITLE
Generalize process review search

### DIFF
--- a/tests/e2e/test_pipeline_review_species.py
+++ b/tests/e2e/test_pipeline_review_species.py
@@ -294,6 +294,27 @@ def test_predictionless_pipeline_encounter_can_add_species(live_server, page):
     assert {r["id"] for r in rows} == set(photo_ids)
 
 
+def test_pipeline_review_search_matches_filename_without_species_predictions(
+    live_server, page
+):
+    photo_ids = live_server["data"]["photos"][1:3]
+    _write_predictionless_pipeline_cache(live_server, photo_ids)
+
+    page.goto(f"{live_server['url']}/pipeline/review")
+
+    search = page.locator("#speciesFilterInput")
+    expect(search).to_have_attribute("placeholder", "Search species or filename...")
+    expect(page.locator(".encounter-card")).to_have_count(1)
+
+    search.fill("hawk2.jpg")
+    expect(page.locator(".encounter-card")).to_have_count(1)
+    expect(page.locator("#countAll")).to_have_text(" (2)")
+
+    search.fill("not-a-photo.jpg")
+    expect(page.locator(".encounter-card")).to_have_count(0)
+    expect(page.locator("#countAll")).to_have_text(" (0)")
+
+
 def test_pipeline_review_species_confirm_ignores_duplicate_inflight_clicks(live_server, page):
     photo_ids = live_server["data"]["photos"][:2]
     _write_confirmation_pipeline_cache(live_server, photo_ids)

--- a/tests/e2e/test_pipeline_review_species.py
+++ b/tests/e2e/test_pipeline_review_species.py
@@ -1437,7 +1437,7 @@ def _write_mixed_shape_hidden_object_burst_pipeline_cache(
         json.dump(cache, f)
 
 
-def test_pipeline_review_search_blocks_hidden_only_aggregate_species_in_mixed_shape(
+def test_pipeline_review_search_preserves_aggregate_species_for_raw_bursts_alongside_hidden(
     live_server, page
 ):
     photos = live_server["data"]["photos"]
@@ -1464,15 +1464,21 @@ def test_pipeline_review_search_blocks_hidden_only_aggregate_species_in_mixed_sh
     page.locator("#hideConfirmedBtn").click()
     expect(page.locator(".burst-strip")).to_have_count(1)
 
-    # With Hide confirmed on, searching the hidden burst's confirmed species
-    # must NOT match: the aggregate species is only sourced from the hidden
-    # object burst (no visible object burst backs it), so surfacing the
-    # encounter would render only the unrelated raw burst.
+    # With Hide confirmed on, the raw visible burst is opaque — we can't tell
+    # which species it contributes to the aggregate. The GRM detach flow can
+    # leave the source raw burst carrying unconfirmed Red-tailed Hawk photos
+    # while its detached sibling is confirmed to Red-tailed Hawk, so the raw
+    # burst may well share the hidden burst's species. Keep the aggregate
+    # species searchable so those legitimate matches aren't dropped; the
+    # tradeoff is that the encounter also surfaces for the rare case where
+    # the raw burst genuinely has no such species, and only the raw burst's
+    # own photo renders.
     search.fill("Red-tailed Hawk")
-    expect(page.locator(".encounter-card")).to_have_count(0)
-    expect(page.locator("#countAll")).to_have_text(" (0)")
+    expect(page.locator(".encounter-card")).to_have_count(1)
+    expect(page.locator("#countAll")).to_have_text(" (1)")
 
-    # The hidden burst's filename must not match either.
+    # The hidden burst's filename must not match — filenames are scoped to
+    # photos in visible bursts, so nothing from the hidden burst leaks in.
     search.fill("hawk1.jpg")
     expect(page.locator(".encounter-card")).to_have_count(0)
     expect(page.locator("#countAll")).to_have_text(" (0)")
@@ -1483,7 +1489,7 @@ def test_pipeline_review_search_blocks_hidden_only_aggregate_species_in_mixed_sh
     expect(page.locator(".encounter-card")).to_have_count(1)
     expect(page.locator("#countAll")).to_have_text(" (1)")
 
-    # Toggling Hide confirmed back off restores the aggregate species match.
+    # Toggling Hide confirmed back off keeps the aggregate species match.
     page.locator("#hideConfirmedBtn").click()
     search.fill("Red-tailed Hawk")
     expect(page.locator(".encounter-card")).to_have_count(1)

--- a/tests/e2e/test_pipeline_review_species.py
+++ b/tests/e2e/test_pipeline_review_species.py
@@ -315,6 +315,106 @@ def test_pipeline_review_search_matches_filename_without_species_predictions(
     expect(page.locator("#countAll")).to_have_text(" (0)")
 
 
+def _write_low_confidence_consensus_pipeline_cache(live_server, photo_ids):
+    """Cache an encounter whose consensus label sits below the default slider.
+
+    The classifier picks 'Mute Swan' as the encounter-level winner with an
+    average confidence of 0.35 (below the default 40% slider). Every
+    prediction that shares that species also stays under the threshold, so
+    the encounter should NOT match a species search unless the user drops
+    the slider below 35%.
+    """
+    db = live_server["db"]
+    placeholders = ",".join("?" for _ in photo_ids)
+    rows = db.conn.execute(
+        f"SELECT id, filename, timestamp FROM photos WHERE id IN ({placeholders}) ORDER BY id",
+        photo_ids,
+    ).fetchall()
+    photos = [
+        {
+            "id": row["id"],
+            "filename": row["filename"],
+            "timestamp": row["timestamp"],
+            "label": "REVIEW",
+            "quality_composite": 0.5,
+            "flag": "none",
+            "rating": 0,
+        }
+        for row in rows
+    ]
+    ids = [p["id"] for p in photos]
+    cache = {
+        "photos": photos,
+        "encounters": [
+            {
+                "photo_ids": ids,
+                "photo_count": len(ids),
+                "burst_count": 1,
+                "time_range": [photos[0]["timestamp"], photos[-1]["timestamp"]],
+                "species": ["Mute Swan", 0.35],
+                "species_predictions": [
+                    {
+                        "species": "Mute Swan",
+                        "count": len(ids),
+                        "avg_confidence": 0.35,
+                        "models": [{"model": "Bird model", "confidence": 0.35}],
+                    }
+                ],
+                "species_confirmed": False,
+                "confirmed_species": None,
+                "bursts": [
+                    {
+                        "photo_ids": ids,
+                        "species_predictions": [],
+                        "species_override": None,
+                    }
+                ],
+            }
+        ],
+        "summary": {
+            "total_photos": len(ids),
+            "encounter_count": 1,
+            "burst_count": 1,
+            "keep_count": 0,
+            "review_count": len(ids),
+            "reject_count": 0,
+            "rarity_protected": 0,
+        },
+    }
+    path = os.path.join(
+        os.path.dirname(db._db_path),
+        f"pipeline_results_ws{db._active_workspace_id}.json",
+    )
+    with open(path, "w") as f:
+        json.dump(cache, f)
+
+
+def test_pipeline_review_search_respects_min_confidence_for_consensus_label(
+    live_server, page
+):
+    photo_ids = live_server["data"]["photos"][1:3]
+    _write_low_confidence_consensus_pipeline_cache(live_server, photo_ids)
+
+    page.goto(f"{live_server['url']}/pipeline/review")
+
+    expect(page.locator(".encounter-card")).to_have_count(1)
+
+    search = page.locator("#speciesFilterInput")
+    search.fill("Mute Swan")
+
+    # The consensus label is displayed on the card but its confidence (0.35)
+    # is below the default 40% slider, so the search must not match through
+    # the encounter's classifier-derived label.
+    expect(page.locator(".encounter-card")).to_have_count(0)
+    expect(page.locator("#countAll")).to_have_text(" (0)")
+
+    # Dropping the slider under the prediction's confidence brings the
+    # encounter back — the search still works, just gated by the threshold.
+    page.evaluate("setMinConfidence(30)")
+    expect(page.locator(".encounter-card")).to_have_count(1)
+    expect(page.locator("#countAll")).to_have_text(" (2)")
+
+
 def test_pipeline_review_species_confirm_ignores_duplicate_inflight_clicks(live_server, page):
     photo_ids = live_server["data"]["photos"][:2]
     _write_confirmation_pipeline_cache(live_server, photo_ids)

--- a/tests/e2e/test_pipeline_review_species.py
+++ b/tests/e2e/test_pipeline_review_species.py
@@ -1343,6 +1343,152 @@ def test_pipeline_review_search_falls_back_to_aggregate_for_mixed_legacy_bursts(
     expect(page.locator("#countAll")).to_have_text(f" ({len(photo_ids)})")
 
 
+def _write_mixed_shape_hidden_object_burst_pipeline_cache(
+    live_server, raw_id, hidden_id
+):
+    """Cache an encounter with a visible legacy raw burst alongside a hidden
+    object burst that carries a confirmed override. The aggregate carries the
+    hidden burst's confirmed species — the GRM detach flow can leave the raw
+    source burst opaque while the detached object burst is confirmed away —
+    so searching that species must not surface the encounter and render only
+    the unrelated raw visible burst.
+    """
+    db = live_server["db"]
+    rows = db.conn.execute(
+        "SELECT id, filename, timestamp FROM photos WHERE id IN (?, ?) ORDER BY id",
+        (raw_id, hidden_id),
+    ).fetchall()
+    photos = [
+        {
+            "id": row["id"],
+            "filename": row["filename"],
+            "timestamp": row["timestamp"],
+            "label": "REVIEW",
+            "quality_composite": 0.5,
+            "flag": "none",
+            "rating": 0,
+        }
+        for row in rows
+    ]
+    raw_photo = next(p for p in photos if p["id"] == raw_id)
+    hidden_photo = next(p for p in photos if p["id"] == hidden_id)
+    cache = {
+        "photos": photos,
+        "encounters": [
+            {
+                "photo_ids": [raw_photo["id"], hidden_photo["id"]],
+                "photo_count": 2,
+                "burst_count": 2,
+                "time_range": [raw_photo["timestamp"], hidden_photo["timestamp"]],
+                "species": [],
+                # Aggregate carries the hidden burst's species — it was rolled
+                # up from every photo in the encounter, including the ones in
+                # the object burst that ended up confirmed.
+                "species_predictions": [
+                    {
+                        "species": "Red-tailed Hawk",
+                        "count": 1,
+                        "avg_confidence": 0.9,
+                        "models": [{"model": "Bird model", "confidence": 0.9}],
+                    }
+                ],
+                "species_confirmed": False,
+                "confirmed_species": None,
+                "bursts": [
+                    # Legacy raw burst — no per-burst predictions to consult.
+                    [raw_photo["id"]],
+                    # Object burst confirmed to Red-tailed Hawk — Hide confirmed
+                    # will hide this burst and its filename.
+                    {
+                        "photo_ids": [hidden_photo["id"]],
+                        "species_predictions": [
+                            {
+                                "species": "Red-tailed Hawk",
+                                "count": 1,
+                                "avg_confidence": 0.9,
+                                "models": [
+                                    {"model": "Bird model", "confidence": 0.9}
+                                ],
+                            }
+                        ],
+                        "species_override": {
+                            "species": "Red-tailed Hawk",
+                            "confirmed": True,
+                        },
+                    },
+                ],
+            }
+        ],
+        "summary": {
+            "total_photos": 2,
+            "encounter_count": 1,
+            "burst_count": 2,
+            "keep_count": 0,
+            "review_count": 2,
+            "reject_count": 0,
+            "rarity_protected": 0,
+        },
+    }
+    path = os.path.join(
+        os.path.dirname(db._db_path),
+        f"pipeline_results_ws{db._active_workspace_id}.json",
+    )
+    with open(path, "w") as f:
+        json.dump(cache, f)
+
+
+def test_pipeline_review_search_blocks_hidden_only_aggregate_species_in_mixed_shape(
+    live_server, page
+):
+    photos = live_server["data"]["photos"]
+    # photos[3]=robin1 (raw visible burst); photos[0]=hawk1 (object hidden burst
+    # confirmed to Red-tailed Hawk).
+    _write_mixed_shape_hidden_object_burst_pipeline_cache(
+        live_server, photos[3], photos[0]
+    )
+
+    page.goto(f"{live_server['url']}/pipeline/review")
+    expect(page.locator(".encounter-card")).to_have_count(1)
+    expect(page.locator(".burst-strip")).to_have_count(2)
+
+    search = page.locator("#speciesFilterInput")
+
+    # Baseline (Hide confirmed off): the aggregate species matches; both
+    # bursts render, and the raw burst's filename still matches too.
+    search.fill("Red-tailed Hawk")
+    expect(page.locator(".encounter-card")).to_have_count(1)
+    search.fill("robin1.jpg")
+    expect(page.locator(".encounter-card")).to_have_count(1)
+
+    search.fill("")
+    page.locator("#hideConfirmedBtn").click()
+    expect(page.locator(".burst-strip")).to_have_count(1)
+
+    # With Hide confirmed on, searching the hidden burst's confirmed species
+    # must NOT match: the aggregate species is only sourced from the hidden
+    # object burst (no visible object burst backs it), so surfacing the
+    # encounter would render only the unrelated raw burst.
+    search.fill("Red-tailed Hawk")
+    expect(page.locator(".encounter-card")).to_have_count(0)
+    expect(page.locator("#countAll")).to_have_text(" (0)")
+
+    # The hidden burst's filename must not match either.
+    search.fill("hawk1.jpg")
+    expect(page.locator(".encounter-card")).to_have_count(0)
+    expect(page.locator("#countAll")).to_have_text(" (0)")
+
+    # The visible raw burst's filename still matches — its photo is what
+    # actually renders under Hide confirmed.
+    search.fill("robin1.jpg")
+    expect(page.locator(".encounter-card")).to_have_count(1)
+    expect(page.locator("#countAll")).to_have_text(" (1)")
+
+    # Toggling Hide confirmed back off restores the aggregate species match.
+    page.locator("#hideConfirmedBtn").click()
+    search.fill("Red-tailed Hawk")
+    expect(page.locator(".encounter-card")).to_have_count(1)
+
+
 def _write_cross_field_pipeline_cache(live_server, photo_ids):
     """Cache an encounter whose eligible predictions are 'Mute Grouse' and
     'Trumpeter Swan'. A multi-token search for 'Mute Swan' shouldn't match:

--- a/tests/e2e/test_pipeline_review_species.py
+++ b/tests/e2e/test_pipeline_review_species.py
@@ -1217,6 +1217,132 @@ def test_pipeline_review_search_falls_back_to_aggregate_for_legacy_bursts(
     expect(page.locator("#countAll")).to_have_text(f" ({len(photo_ids)})")
 
 
+def _write_mixed_legacy_and_object_burst_pipeline_cache(live_server, photo_ids):
+    """Cache an unconfirmed encounter whose ``bursts`` mix the legacy raw
+    photo-id array shape (no per-burst predictions) with an object burst
+    that carries its own ``species_predictions``. The GRM detach flow
+    can leave the source burst as a raw array while appending a new
+    object burst, so search under Hide confirmed must still match the
+    encounter aggregate species — the raw burst is opaque to the visible-
+    burst gate and might well be the source of the aggregate species.
+    """
+    assert len(photo_ids) >= 2, "need at least two photos to split into two bursts"
+    db = live_server["db"]
+    placeholders = ",".join("?" for _ in photo_ids)
+    rows = db.conn.execute(
+        f"SELECT id, filename, timestamp FROM photos WHERE id IN ({placeholders}) ORDER BY id",
+        photo_ids,
+    ).fetchall()
+    photos = [
+        {
+            "id": row["id"],
+            "filename": row["filename"],
+            "timestamp": row["timestamp"],
+            "label": "REVIEW",
+            "quality_composite": 0.5,
+            "flag": "none",
+            "rating": 0,
+        }
+        for row in rows
+    ]
+    ids = [p["id"] for p in photos]
+    raw_ids = ids[:1]
+    object_ids = ids[1:]
+    cache = {
+        "photos": photos,
+        "encounters": [
+            {
+                "photo_ids": ids,
+                "photo_count": len(ids),
+                "burst_count": 2,
+                "time_range": [photos[0]["timestamp"], photos[-1]["timestamp"]],
+                "species": [],
+                # Aggregate carries a species that only the opaque raw
+                # burst could source (the object burst below predicts a
+                # different species).
+                "species_predictions": [
+                    {
+                        "species": "Mute Swan",
+                        "count": len(ids),
+                        "avg_confidence": 0.9,
+                        "models": [{"model": "Bird model", "confidence": 0.9}],
+                    }
+                ],
+                "species_confirmed": False,
+                "confirmed_species": None,
+                "bursts": [
+                    # Legacy raw shape — no per-burst prediction data.
+                    raw_ids,
+                    # Object burst that predicts a different species than
+                    # the aggregate. It stays visible under Hide confirmed
+                    # (no override), so the visible-burst gate must not
+                    # exclude the aggregate species just because this
+                    # burst doesn't back it.
+                    {
+                        "photo_ids": object_ids,
+                        "species_predictions": [
+                            {
+                                "species": "Trumpeter Swan",
+                                "count": len(object_ids),
+                                "avg_confidence": 0.85,
+                                "models": [
+                                    {"model": "Bird model", "confidence": 0.85}
+                                ],
+                            }
+                        ],
+                        "species_override": None,
+                    },
+                ],
+            }
+        ],
+        "summary": {
+            "total_photos": len(ids),
+            "encounter_count": 1,
+            "burst_count": 2,
+            "keep_count": 0,
+            "review_count": len(ids),
+            "reject_count": 0,
+            "rarity_protected": 0,
+        },
+    }
+    path = os.path.join(
+        os.path.dirname(db._db_path),
+        f"pipeline_results_ws{db._active_workspace_id}.json",
+    )
+    with open(path, "w") as f:
+        json.dump(cache, f)
+
+
+def test_pipeline_review_search_falls_back_to_aggregate_for_mixed_legacy_bursts(
+    live_server, page
+):
+    photo_ids = live_server["data"]["photos"][1:4]
+    _write_mixed_legacy_and_object_burst_pipeline_cache(live_server, photo_ids)
+
+    page.goto(f"{live_server['url']}/pipeline/review")
+    expect(page.locator(".encounter-card")).to_have_count(1)
+
+    search = page.locator("#speciesFilterInput")
+
+    # Baseline: aggregate prediction matches without any filtering.
+    search.fill("Mute Swan")
+    expect(page.locator(".encounter-card")).to_have_count(1)
+
+    search.fill("")
+    page.locator("#hideConfirmedBtn").click()
+
+    # No burst is confirmed, so the whole encounter is still visible.
+    # The visible bursts are mixed (one raw legacy array, one object).
+    # Because the raw burst is opaque to the visible-burst gate — it
+    # cannot report which species it contributes to the aggregate — the
+    # gate must fall back to trusting the aggregate. Searching the
+    # aggregate species must therefore still match, even though the
+    # object visible burst predicts a different species.
+    search.fill("Mute Swan")
+    expect(page.locator(".encounter-card")).to_have_count(1)
+    expect(page.locator("#countAll")).to_have_text(f" ({len(photo_ids)})")
+
+
 def _write_cross_field_pipeline_cache(live_server, photo_ids):
     """Cache an encounter whose eligible predictions are 'Mute Grouse' and
     'Trumpeter Swan'. A multi-token search for 'Mute Swan' shouldn't match:

--- a/tests/e2e/test_pipeline_review_species.py
+++ b/tests/e2e/test_pipeline_review_species.py
@@ -415,6 +415,183 @@ def test_pipeline_review_search_respects_min_confidence_for_consensus_label(
     expect(page.locator("#countAll")).to_have_text(" (2)")
 
 
+def _write_unconfirmed_burst_override_pipeline_cache(live_server, photo_ids):
+    """Cache an encounter whose burst carries an unconfirmed classifier-derived
+    override (as `detach-photo` and group-review paths stamp them). The override
+    species also has a burst-level prediction with confidence 0.35 — below the
+    default 40% slider — so searching that species must NOT match through the
+    unconfirmed override; only the threshold-gated prediction path applies.
+    """
+    db = live_server["db"]
+    placeholders = ",".join("?" for _ in photo_ids)
+    rows = db.conn.execute(
+        f"SELECT id, filename, timestamp FROM photos WHERE id IN ({placeholders}) ORDER BY id",
+        photo_ids,
+    ).fetchall()
+    photos = [
+        {
+            "id": row["id"],
+            "filename": row["filename"],
+            "timestamp": row["timestamp"],
+            "label": "REVIEW",
+            "quality_composite": 0.5,
+            "flag": "none",
+            "rating": 0,
+        }
+        for row in rows
+    ]
+    ids = [p["id"] for p in photos]
+    cache = {
+        "photos": photos,
+        "encounters": [
+            {
+                "photo_ids": ids,
+                "photo_count": len(ids),
+                "burst_count": 1,
+                "time_range": [photos[0]["timestamp"], photos[-1]["timestamp"]],
+                "species": [],
+                "species_predictions": [],
+                "species_confirmed": False,
+                "confirmed_species": None,
+                "bursts": [
+                    {
+                        "photo_ids": ids,
+                        "species_predictions": [
+                            {
+                                "species": "Mute Swan",
+                                "count": len(ids),
+                                "avg_confidence": 0.35,
+                                "models": [{"model": "Bird model", "confidence": 0.35}],
+                            }
+                        ],
+                        "species_override": {"species": "Mute Swan", "confirmed": False},
+                    }
+                ],
+            }
+        ],
+        "summary": {
+            "total_photos": len(ids),
+            "encounter_count": 1,
+            "burst_count": 1,
+            "keep_count": 0,
+            "review_count": len(ids),
+            "reject_count": 0,
+            "rarity_protected": 0,
+        },
+    }
+    path = os.path.join(
+        os.path.dirname(db._db_path),
+        f"pipeline_results_ws{db._active_workspace_id}.json",
+    )
+    with open(path, "w") as f:
+        json.dump(cache, f)
+
+
+def test_pipeline_review_search_gates_unconfirmed_burst_override(live_server, page):
+    photo_ids = live_server["data"]["photos"][1:3]
+    _write_unconfirmed_burst_override_pipeline_cache(live_server, photo_ids)
+
+    page.goto(f"{live_server['url']}/pipeline/review")
+
+    expect(page.locator(".encounter-card")).to_have_count(1)
+
+    search = page.locator("#speciesFilterInput")
+    search.fill("Mute Swan")
+
+    # The burst override is unconfirmed (classifier-derived) and its backing
+    # prediction sits at 0.35 — below the default 40% slider — so the search
+    # must not surface it via the override bypass.
+    expect(page.locator(".encounter-card")).to_have_count(0)
+    expect(page.locator("#countAll")).to_have_text(" (0)")
+
+    # Dropping the slider below the prediction's confidence brings the
+    # encounter back through the gated burst prediction path.
+    page.evaluate("setMinConfidence(30)")
+    expect(page.locator(".encounter-card")).to_have_count(1)
+    expect(page.locator("#countAll")).to_have_text(" (2)")
+
+
+def _write_confirmed_burst_override_pipeline_cache(live_server, photo_ids):
+    """Cache an encounter whose burst carries a *confirmed* override for a
+    species with no supporting predictions. Confirmed overrides are manual
+    labels, so they must bypass the confidence slider regardless of any
+    classifier prediction (or lack thereof).
+    """
+    db = live_server["db"]
+    placeholders = ",".join("?" for _ in photo_ids)
+    rows = db.conn.execute(
+        f"SELECT id, filename, timestamp FROM photos WHERE id IN ({placeholders}) ORDER BY id",
+        photo_ids,
+    ).fetchall()
+    photos = [
+        {
+            "id": row["id"],
+            "filename": row["filename"],
+            "timestamp": row["timestamp"],
+            "label": "REVIEW",
+            "quality_composite": 0.5,
+            "flag": "none",
+            "rating": 0,
+        }
+        for row in rows
+    ]
+    ids = [p["id"] for p in photos]
+    cache = {
+        "photos": photos,
+        "encounters": [
+            {
+                "photo_ids": ids,
+                "photo_count": len(ids),
+                "burst_count": 1,
+                "time_range": [photos[0]["timestamp"], photos[-1]["timestamp"]],
+                "species": [],
+                "species_predictions": [],
+                "species_confirmed": False,
+                "confirmed_species": None,
+                "bursts": [
+                    {
+                        "photo_ids": ids,
+                        "species_predictions": [],
+                        "species_override": {"species": "Mute Swan", "confirmed": True},
+                    }
+                ],
+            }
+        ],
+        "summary": {
+            "total_photos": len(ids),
+            "encounter_count": 1,
+            "burst_count": 1,
+            "keep_count": 0,
+            "review_count": len(ids),
+            "reject_count": 0,
+            "rarity_protected": 0,
+        },
+    }
+    path = os.path.join(
+        os.path.dirname(db._db_path),
+        f"pipeline_results_ws{db._active_workspace_id}.json",
+    )
+    with open(path, "w") as f:
+        json.dump(cache, f)
+
+
+def test_pipeline_review_search_matches_confirmed_burst_override(live_server, page):
+    photo_ids = live_server["data"]["photos"][1:3]
+    _write_confirmed_burst_override_pipeline_cache(live_server, photo_ids)
+
+    page.goto(f"{live_server['url']}/pipeline/review")
+
+    expect(page.locator(".encounter-card")).to_have_count(1)
+
+    search = page.locator("#speciesFilterInput")
+    search.fill("Mute Swan")
+
+    # Confirmed manual overrides bypass the slider — the encounter must match
+    # even at the default threshold with no classifier predictions.
+    expect(page.locator(".encounter-card")).to_have_count(1)
+    expect(page.locator("#countAll")).to_have_text(" (2)")
+
+
 def test_pipeline_review_species_confirm_ignores_duplicate_inflight_clicks(live_server, page):
     photo_ids = live_server["data"]["photos"][:2]
     _write_confirmation_pipeline_cache(live_server, photo_ids)

--- a/tests/e2e/test_pipeline_review_species.py
+++ b/tests/e2e/test_pipeline_review_species.py
@@ -953,12 +953,15 @@ def test_pipeline_review_search_scopes_mixed_encounter_prior_label(
     expect(page.locator(".burst-strip")).to_have_count(1)
 
     # With Hide confirmed on, only the robin burst renders. The encounter is
-    # unconfirmed at the encounter level, so the surviving prior label is
-    # backed exclusively by the now-hidden confirmed hawk override. Searching
-    # 'Red-tailed Hawk' must not surface the encounter.
+    # unconfirmed, but renderSpeciesWidget still inherits and displays
+    # `enc.confirmed_species` on the no-override robin burst, so the visible
+    # burst-level widget reads 'Red-tailed Hawk'. Searching that label must
+    # therefore surface the encounter — the visible burst is displaying it.
+    # Only the robin photo is counted because the confirmed hawk burst
+    # remains hidden.
     search.fill("Red-tailed Hawk")
-    expect(page.locator(".encounter-card")).to_have_count(0)
-    expect(page.locator("#countAll")).to_have_text(" (0)")
+    expect(page.locator(".encounter-card")).to_have_count(1)
+    expect(page.locator("#countAll")).to_have_text(" (1)")
 
     # The visible burst's species still matches.
     search.fill("American Robin")
@@ -1116,6 +1119,102 @@ def test_pipeline_review_search_matches_confirmed_burst_override(live_server, pa
     # even at the default threshold with no classifier predictions.
     expect(page.locator(".encounter-card")).to_have_count(1)
     expect(page.locator("#countAll")).to_have_text(" (2)")
+
+
+def _write_legacy_raw_burst_pipeline_cache(live_server, photo_ids):
+    """Cache an unconfirmed encounter whose ``bursts`` entries are the
+    legacy raw photo-id array shape this page still supports — no
+    per-burst ``species_predictions`` or ``species_override``. The
+    encounter-level aggregate carries the classifier prediction. Under
+    Hide confirmed, the search must still match the aggregate species
+    even though no burst carries per-burst prediction evidence.
+    """
+    db = live_server["db"]
+    placeholders = ",".join("?" for _ in photo_ids)
+    rows = db.conn.execute(
+        f"SELECT id, filename, timestamp FROM photos WHERE id IN ({placeholders}) ORDER BY id",
+        photo_ids,
+    ).fetchall()
+    photos = [
+        {
+            "id": row["id"],
+            "filename": row["filename"],
+            "timestamp": row["timestamp"],
+            "label": "REVIEW",
+            "quality_composite": 0.5,
+            "flag": "none",
+            "rating": 0,
+        }
+        for row in rows
+    ]
+    ids = [p["id"] for p in photos]
+    cache = {
+        "photos": photos,
+        "encounters": [
+            {
+                "photo_ids": ids,
+                "photo_count": len(ids),
+                "burst_count": 1,
+                "time_range": [photos[0]["timestamp"], photos[-1]["timestamp"]],
+                "species": [],
+                "species_predictions": [
+                    {
+                        "species": "Mute Swan",
+                        "count": len(ids),
+                        "avg_confidence": 0.9,
+                        "models": [{"model": "Bird model", "confidence": 0.9}],
+                    }
+                ],
+                "species_confirmed": False,
+                "confirmed_species": None,
+                # Legacy raw shape: burst is the photo-id array itself,
+                # not an object with species_predictions/species_override.
+                "bursts": [ids],
+            }
+        ],
+        "summary": {
+            "total_photos": len(ids),
+            "encounter_count": 1,
+            "burst_count": 1,
+            "keep_count": 0,
+            "review_count": len(ids),
+            "reject_count": 0,
+            "rarity_protected": 0,
+        },
+    }
+    path = os.path.join(
+        os.path.dirname(db._db_path),
+        f"pipeline_results_ws{db._active_workspace_id}.json",
+    )
+    with open(path, "w") as f:
+        json.dump(cache, f)
+
+
+def test_pipeline_review_search_falls_back_to_aggregate_for_legacy_bursts(
+    live_server, page
+):
+    photo_ids = live_server["data"]["photos"][1:3]
+    _write_legacy_raw_burst_pipeline_cache(live_server, photo_ids)
+
+    page.goto(f"{live_server['url']}/pipeline/review")
+    expect(page.locator(".encounter-card")).to_have_count(1)
+
+    search = page.locator("#speciesFilterInput")
+
+    # Baseline: aggregate prediction matches.
+    search.fill("Mute Swan")
+    expect(page.locator(".encounter-card")).to_have_count(1)
+
+    search.fill("")
+    page.locator("#hideConfirmedBtn").click()
+
+    # None of the legacy bursts are confirmed, so the encounter is still
+    # entirely visible. Because the bursts don't carry per-burst
+    # prediction data, the visible-burst gate must fall back to the
+    # aggregate — searching the aggregate species must still match.
+    search.fill("Mute Swan")
+    expect(page.locator(".encounter-card")).to_have_count(1)
+    expect(page.locator("#countAll")).to_have_text(f" ({len(photo_ids)})")
 
 
 def _write_cross_field_pipeline_cache(live_server, photo_ids):

--- a/tests/e2e/test_pipeline_review_species.py
+++ b/tests/e2e/test_pipeline_review_species.py
@@ -575,6 +575,141 @@ def _write_confirmed_burst_override_pipeline_cache(live_server, photo_ids):
         json.dump(cache, f)
 
 
+def _write_mixed_confirmed_burst_pipeline_cache(live_server, hawk_id, robin_id):
+    """Cache an encounter with two bursts: the first (confirmed) burst carries
+    a confirmed override for 'Red-tailed Hawk' with filename hawk1.jpg; the
+    second (unconfirmed) burst has no override and holds robin1.jpg. When Hide
+    confirmed is on, the confirmed burst should not contribute its species or
+    filename to the search — otherwise queries for the hidden burst's content
+    would surface the unrelated visible burst.
+    """
+    db = live_server["db"]
+    rows = db.conn.execute(
+        "SELECT id, filename, timestamp FROM photos WHERE id IN (?, ?) ORDER BY id",
+        (hawk_id, robin_id),
+    ).fetchall()
+    photos = [
+        {
+            "id": row["id"],
+            "filename": row["filename"],
+            "timestamp": row["timestamp"],
+            "label": "REVIEW",
+            "quality_composite": 0.5,
+            "flag": "none",
+            "rating": 0,
+        }
+        for row in rows
+    ]
+    hawk_photo = next(p for p in photos if p["id"] == hawk_id)
+    robin_photo = next(p for p in photos if p["id"] == robin_id)
+    cache = {
+        "photos": photos,
+        "encounters": [
+            {
+                "photo_ids": [hawk_photo["id"], robin_photo["id"]],
+                "photo_count": 2,
+                "burst_count": 2,
+                "time_range": [hawk_photo["timestamp"], robin_photo["timestamp"]],
+                "species": [],
+                "species_predictions": [],
+                "species_confirmed": False,
+                "confirmed_species": None,
+                "bursts": [
+                    {
+                        "photo_ids": [hawk_photo["id"]],
+                        "species_predictions": [],
+                        "species_override": {
+                            "species": "Red-tailed Hawk",
+                            "confirmed": True,
+                        },
+                    },
+                    {
+                        "photo_ids": [robin_photo["id"]],
+                        "species_predictions": [
+                            {
+                                "species": "American Robin",
+                                "count": 1,
+                                "avg_confidence": 0.92,
+                                "models": [
+                                    {"model": "Bird model", "confidence": 0.92}
+                                ],
+                            }
+                        ],
+                        "species_override": None,
+                    },
+                ],
+            }
+        ],
+        "summary": {
+            "total_photos": 2,
+            "encounter_count": 1,
+            "burst_count": 2,
+            "keep_count": 0,
+            "review_count": 2,
+            "reject_count": 0,
+            "rarity_protected": 0,
+        },
+    }
+    path = os.path.join(
+        os.path.dirname(db._db_path),
+        f"pipeline_results_ws{db._active_workspace_id}.json",
+    )
+    with open(path, "w") as f:
+        json.dump(cache, f)
+
+
+def test_pipeline_review_search_scopes_to_visible_bursts_with_hide_confirmed(
+    live_server, page
+):
+    photos = live_server["data"]["photos"]
+    # hawk1.jpg (index 0) goes in the confirmed burst; robin1.jpg (index 3) is
+    # the visible unconfirmed burst.
+    _write_mixed_confirmed_burst_pipeline_cache(live_server, photos[0], photos[3])
+
+    page.goto(f"{live_server['url']}/pipeline/review")
+    expect(page.locator(".encounter-card")).to_have_count(1)
+    expect(page.locator(".burst-strip")).to_have_count(2)
+
+    # Baseline (Hide confirmed off): both burst species and filenames match.
+    search = page.locator("#speciesFilterInput")
+    search.fill("Red-tailed Hawk")
+    expect(page.locator(".encounter-card")).to_have_count(1)
+    search.fill("hawk1.jpg")
+    expect(page.locator(".encounter-card")).to_have_count(1)
+
+    search.fill("")
+    page.locator("#hideConfirmedBtn").click()
+    expect(page.locator(".burst-strip")).to_have_count(1)
+
+    # With Hide confirmed on, searching the hidden burst's confirmed override
+    # species must NOT match — otherwise the encounter would surface with only
+    # its unrelated visible burst rendered.
+    search.fill("Red-tailed Hawk")
+    expect(page.locator(".encounter-card")).to_have_count(0)
+    expect(page.locator("#countAll")).to_have_text(" (0)")
+
+    # Same for the hidden burst's filename.
+    search.fill("hawk1.jpg")
+    expect(page.locator(".encounter-card")).to_have_count(0)
+    expect(page.locator("#countAll")).to_have_text(" (0)")
+
+    # The visible burst's species and filename still match.
+    search.fill("American Robin")
+    expect(page.locator(".encounter-card")).to_have_count(1)
+    expect(page.locator("#countAll")).to_have_text(" (1)")
+
+    search.fill("robin1.jpg")
+    expect(page.locator(".encounter-card")).to_have_count(1)
+    expect(page.locator("#countAll")).to_have_text(" (1)")
+
+    # Toggling Hide confirmed back off restores matches on the confirmed
+    # burst's species/filename.
+    page.locator("#hideConfirmedBtn").click()
+    search.fill("Red-tailed Hawk")
+    expect(page.locator(".encounter-card")).to_have_count(1)
+    expect(page.locator("#countAll")).to_have_text(" (2)")
+
+
 def test_pipeline_review_search_matches_confirmed_burst_override(live_server, page):
     photo_ids = live_server["data"]["photos"][1:3]
     _write_confirmed_burst_override_pipeline_cache(live_server, photo_ids)

--- a/tests/e2e/test_pipeline_review_species.py
+++ b/tests/e2e/test_pipeline_review_species.py
@@ -592,6 +592,107 @@ def test_pipeline_review_search_matches_confirmed_burst_override(live_server, pa
     expect(page.locator("#countAll")).to_have_text(" (2)")
 
 
+def _write_cross_field_pipeline_cache(live_server, photo_ids):
+    """Cache an encounter whose eligible predictions are 'Mute Grouse' and
+    'Trumpeter Swan'. A multi-token search for 'Mute Swan' shouldn't match:
+    no single field contains both tokens, even though 'Mute' appears in one
+    prediction and 'Swan' in another.
+    """
+    db = live_server["db"]
+    placeholders = ",".join("?" for _ in photo_ids)
+    rows = db.conn.execute(
+        f"SELECT id, filename, timestamp FROM photos WHERE id IN ({placeholders}) ORDER BY id",
+        photo_ids,
+    ).fetchall()
+    photos = [
+        {
+            "id": row["id"],
+            "filename": row["filename"],
+            "timestamp": row["timestamp"],
+            "label": "REVIEW",
+            "quality_composite": 0.5,
+            "flag": "none",
+            "rating": 0,
+        }
+        for row in rows
+    ]
+    ids = [p["id"] for p in photos]
+    cache = {
+        "photos": photos,
+        "encounters": [
+            {
+                "photo_ids": ids,
+                "photo_count": len(ids),
+                "burst_count": 1,
+                "time_range": [photos[0]["timestamp"], photos[-1]["timestamp"]],
+                "species": [],
+                "species_predictions": [
+                    {
+                        "species": "Mute Grouse",
+                        "count": len(ids),
+                        "avg_confidence": 0.9,
+                        "models": [{"model": "Bird model", "confidence": 0.9}],
+                    },
+                    {
+                        "species": "Trumpeter Swan",
+                        "count": len(ids),
+                        "avg_confidence": 0.85,
+                        "models": [{"model": "Bird model", "confidence": 0.85}],
+                    },
+                ],
+                "species_confirmed": False,
+                "confirmed_species": None,
+                "bursts": [
+                    {
+                        "photo_ids": ids,
+                        "species_predictions": [],
+                        "species_override": None,
+                    }
+                ],
+            }
+        ],
+        "summary": {
+            "total_photos": len(ids),
+            "encounter_count": 1,
+            "burst_count": 1,
+            "keep_count": 0,
+            "review_count": len(ids),
+            "reject_count": 0,
+            "rarity_protected": 0,
+        },
+    }
+    path = os.path.join(
+        os.path.dirname(db._db_path),
+        f"pipeline_results_ws{db._active_workspace_id}.json",
+    )
+    with open(path, "w") as f:
+        json.dump(cache, f)
+
+
+def test_pipeline_review_search_rejects_cross_field_token_split(live_server, page):
+    photo_ids = live_server["data"]["photos"][1:3]
+    _write_cross_field_pipeline_cache(live_server, photo_ids)
+
+    page.goto(f"{live_server['url']}/pipeline/review")
+
+    expect(page.locator(".encounter-card")).to_have_count(1)
+
+    search = page.locator("#speciesFilterInput")
+    search.fill("Mute Swan")
+
+    # Neither 'Mute Grouse' nor 'Trumpeter Swan' contains the full query, so
+    # the encounter must not match — even though each token appears once
+    # across the two prediction fields.
+    expect(page.locator(".encounter-card")).to_have_count(0)
+    expect(page.locator("#countAll")).to_have_text(" (0)")
+
+    # Searching a single prediction verbatim still matches, proving the
+    # threshold-gated prediction path is unaffected.
+    search.fill("Trumpeter Swan")
+    expect(page.locator(".encounter-card")).to_have_count(1)
+    expect(page.locator("#countAll")).to_have_text(" (2)")
+
+
 def test_pipeline_review_species_confirm_ignores_duplicate_inflight_clicks(live_server, page):
     photo_ids = live_server["data"]["photos"][:2]
     _write_confirmation_pipeline_cache(live_server, photo_ids)

--- a/tests/e2e/test_pipeline_review_species.py
+++ b/tests/e2e/test_pipeline_review_species.py
@@ -841,6 +841,266 @@ def test_pipeline_review_search_scopes_aggregate_predictions_to_visible_bursts(
     expect(page.locator("#countAll")).to_have_text(" (1)")
 
 
+def _write_mixed_encounter_prior_label_pipeline_cache(
+    live_server, hawk_id, robin_id
+):
+    """Cache a mixed encounter where the encounter-level confirmation was
+    withdrawn (species_confirmed=False) but the serializer keeps the prior
+    'Red-tailed Hawk' label in enc.confirmed_species for replacement flows.
+    The only burst still carrying that label is a confirmed override on the
+    hawk burst (which Hide confirmed will hide); the visible robin burst has
+    no override. Searching the prior label under Hide confirmed must not
+    surface the encounter.
+    """
+    db = live_server["db"]
+    rows = db.conn.execute(
+        "SELECT id, filename, timestamp FROM photos WHERE id IN (?, ?) ORDER BY id",
+        (hawk_id, robin_id),
+    ).fetchall()
+    photos = [
+        {
+            "id": row["id"],
+            "filename": row["filename"],
+            "timestamp": row["timestamp"],
+            "label": "REVIEW",
+            "quality_composite": 0.5,
+            "flag": "none",
+            "rating": 0,
+        }
+        for row in rows
+    ]
+    hawk_photo = next(p for p in photos if p["id"] == hawk_id)
+    robin_photo = next(p for p in photos if p["id"] == robin_id)
+    cache = {
+        "photos": photos,
+        "encounters": [
+            {
+                "photo_ids": [hawk_photo["id"], robin_photo["id"]],
+                "photo_count": 2,
+                "burst_count": 2,
+                "time_range": [hawk_photo["timestamp"], robin_photo["timestamp"]],
+                "species": [],
+                "species_predictions": [],
+                # Mixed encounter: the encounter itself is unconfirmed, but a
+                # prior label survives (serializer keeps it for replacement).
+                "species_confirmed": False,
+                "confirmed_species": "Red-tailed Hawk",
+                "bursts": [
+                    {
+                        "photo_ids": [hawk_photo["id"]],
+                        "species_predictions": [],
+                        "species_override": {
+                            "species": "Red-tailed Hawk",
+                            "confirmed": True,
+                        },
+                    },
+                    {
+                        "photo_ids": [robin_photo["id"]],
+                        "species_predictions": [
+                            {
+                                "species": "American Robin",
+                                "count": 1,
+                                "avg_confidence": 0.92,
+                                "models": [
+                                    {"model": "Bird model", "confidence": 0.92}
+                                ],
+                            }
+                        ],
+                        "species_override": None,
+                    },
+                ],
+            }
+        ],
+        "summary": {
+            "total_photos": 2,
+            "encounter_count": 1,
+            "burst_count": 2,
+            "keep_count": 0,
+            "review_count": 2,
+            "reject_count": 0,
+            "rarity_protected": 0,
+        },
+    }
+    path = os.path.join(
+        os.path.dirname(db._db_path),
+        f"pipeline_results_ws{db._active_workspace_id}.json",
+    )
+    with open(path, "w") as f:
+        json.dump(cache, f)
+
+
+def test_pipeline_review_search_scopes_mixed_encounter_prior_label(
+    live_server, page
+):
+    photos = live_server["data"]["photos"]
+    _write_mixed_encounter_prior_label_pipeline_cache(
+        live_server, photos[0], photos[3]
+    )
+
+    page.goto(f"{live_server['url']}/pipeline/review")
+    expect(page.locator(".encounter-card")).to_have_count(1)
+    expect(page.locator(".burst-strip")).to_have_count(2)
+
+    search = page.locator("#speciesFilterInput")
+
+    # Baseline (Hide confirmed off): the prior encounter label is still
+    # searchable because the confirmed burst carrying it is visible.
+    search.fill("Red-tailed Hawk")
+    expect(page.locator(".encounter-card")).to_have_count(1)
+
+    search.fill("")
+    page.locator("#hideConfirmedBtn").click()
+    expect(page.locator(".burst-strip")).to_have_count(1)
+
+    # With Hide confirmed on, only the robin burst renders. The encounter is
+    # unconfirmed at the encounter level, so the surviving prior label is
+    # backed exclusively by the now-hidden confirmed hawk override. Searching
+    # 'Red-tailed Hawk' must not surface the encounter.
+    search.fill("Red-tailed Hawk")
+    expect(page.locator(".encounter-card")).to_have_count(0)
+    expect(page.locator("#countAll")).to_have_text(" (0)")
+
+    # The visible burst's species still matches.
+    search.fill("American Robin")
+    expect(page.locator(".encounter-card")).to_have_count(1)
+    expect(page.locator("#countAll")).to_have_text(" (1)")
+
+
+def _write_visible_burst_below_threshold_pipeline_cache(
+    live_server, hawk_id, robin_id
+):
+    """Cache an encounter whose encounter-level aggregate carries 'Peregrine
+    Falcon' at high confidence (rolled up from the hidden confirmed hawk
+    burst), while the visible robin burst only has a below-threshold Falcon
+    prediction. Under Hide confirmed at the default 40% slider, the aggregate
+    passes the threshold gate but the visible burst's own Falcon evidence is
+    below it — searching 'Peregrine Falcon' must not surface the encounter.
+    """
+    db = live_server["db"]
+    rows = db.conn.execute(
+        "SELECT id, filename, timestamp FROM photos WHERE id IN (?, ?) ORDER BY id",
+        (hawk_id, robin_id),
+    ).fetchall()
+    photos = [
+        {
+            "id": row["id"],
+            "filename": row["filename"],
+            "timestamp": row["timestamp"],
+            "label": "REVIEW",
+            "quality_composite": 0.5,
+            "flag": "none",
+            "rating": 0,
+        }
+        for row in rows
+    ]
+    hawk_photo = next(p for p in photos if p["id"] == hawk_id)
+    robin_photo = next(p for p in photos if p["id"] == robin_id)
+    hidden_pred = {
+        "species": "Peregrine Falcon",
+        "count": 1,
+        "avg_confidence": 0.9,
+        "models": [{"model": "Bird model", "confidence": 0.9}],
+    }
+    visible_pred = {
+        "species": "Peregrine Falcon",
+        "count": 1,
+        "avg_confidence": 0.1,
+        "models": [{"model": "Bird model", "confidence": 0.1}],
+    }
+    # Aggregate carries a Falcon entry whose top model confidence passes
+    # the default slider — but that evidence comes from the hidden burst.
+    aggregate_pred = {
+        "species": "Peregrine Falcon",
+        "count": 2,
+        "avg_confidence": 0.5,
+        "models": [{"model": "Bird model", "confidence": 0.9}],
+    }
+    cache = {
+        "photos": photos,
+        "encounters": [
+            {
+                "photo_ids": [hawk_photo["id"], robin_photo["id"]],
+                "photo_count": 2,
+                "burst_count": 2,
+                "time_range": [hawk_photo["timestamp"], robin_photo["timestamp"]],
+                "species": [],
+                "species_predictions": [aggregate_pred],
+                "species_confirmed": False,
+                "confirmed_species": None,
+                "bursts": [
+                    {
+                        "photo_ids": [hawk_photo["id"]],
+                        "species_predictions": [hidden_pred],
+                        "species_override": {
+                            "species": "Red-tailed Hawk",
+                            "confirmed": True,
+                        },
+                    },
+                    {
+                        "photo_ids": [robin_photo["id"]],
+                        "species_predictions": [visible_pred],
+                        "species_override": None,
+                    },
+                ],
+            }
+        ],
+        "summary": {
+            "total_photos": 2,
+            "encounter_count": 1,
+            "burst_count": 2,
+            "keep_count": 0,
+            "review_count": 2,
+            "reject_count": 0,
+            "rarity_protected": 0,
+        },
+    }
+    path = os.path.join(
+        os.path.dirname(db._db_path),
+        f"pipeline_results_ws{db._active_workspace_id}.json",
+    )
+    with open(path, "w") as f:
+        json.dump(cache, f)
+
+
+def test_pipeline_review_search_gates_visible_burst_support_by_confidence(
+    live_server, page
+):
+    photos = live_server["data"]["photos"]
+    _write_visible_burst_below_threshold_pipeline_cache(
+        live_server, photos[0], photos[3]
+    )
+
+    page.goto(f"{live_server['url']}/pipeline/review")
+    expect(page.locator(".encounter-card")).to_have_count(1)
+    expect(page.locator(".burst-strip")).to_have_count(2)
+
+    search = page.locator("#speciesFilterInput")
+
+    # Baseline (Hide confirmed off): the aggregate Falcon prediction passes
+    # the slider and matches.
+    search.fill("Peregrine Falcon")
+    expect(page.locator(".encounter-card")).to_have_count(1)
+
+    search.fill("")
+    page.locator("#hideConfirmedBtn").click()
+    expect(page.locator(".burst-strip")).to_have_count(1)
+
+    # With Hide confirmed on, the aggregate still passes threshold, but the
+    # only visible burst has Falcon at 0.1 — below the 40% default. Aggregate
+    # search must require threshold-passing visible-burst support, so it
+    # does not surface the encounter.
+    search.fill("Peregrine Falcon")
+    expect(page.locator(".encounter-card")).to_have_count(0)
+    expect(page.locator("#countAll")).to_have_text(" (0)")
+
+    # Dropping the slider so the visible burst's Falcon prediction meets the
+    # threshold brings the encounter back — visible-burst support is now real.
+    page.evaluate("setMinConfidence(5)")
+    search.fill("Peregrine Falcon")
+    expect(page.locator(".encounter-card")).to_have_count(1)
+    expect(page.locator("#countAll")).to_have_text(" (1)")
+
+
 def test_pipeline_review_search_matches_confirmed_burst_override(live_server, page):
     photo_ids = live_server["data"]["photos"][1:3]
     _write_confirmed_burst_override_pipeline_cache(live_server, photo_ids)

--- a/tests/e2e/test_pipeline_review_species.py
+++ b/tests/e2e/test_pipeline_review_species.py
@@ -710,6 +710,137 @@ def test_pipeline_review_search_scopes_to_visible_bursts_with_hide_confirmed(
     expect(page.locator("#countAll")).to_have_text(" (2)")
 
 
+def _write_aggregate_from_confirmed_burst_pipeline_cache(
+    live_server, hawk_id, robin_id
+):
+    """Cache an encounter whose two bursts both contribute classifier
+    predictions to the encounter-level aggregate. The confirmed burst
+    predicts 'Red-tailed Hawk' at 0.92; the unconfirmed burst predicts
+    'American Robin' at 0.92. The encounter aggregate carries both species,
+    which is the shape the pipeline actually serializes (species_predictions
+    is rolled up from every photo in the encounter). Under Hide confirmed,
+    searching 'Red-tailed Hawk' must not surface the encounter — the only
+    evidence for that species is in the hidden burst.
+    """
+    db = live_server["db"]
+    rows = db.conn.execute(
+        "SELECT id, filename, timestamp FROM photos WHERE id IN (?, ?) ORDER BY id",
+        (hawk_id, robin_id),
+    ).fetchall()
+    photos = [
+        {
+            "id": row["id"],
+            "filename": row["filename"],
+            "timestamp": row["timestamp"],
+            "label": "REVIEW",
+            "quality_composite": 0.5,
+            "flag": "none",
+            "rating": 0,
+        }
+        for row in rows
+    ]
+    hawk_photo = next(p for p in photos if p["id"] == hawk_id)
+    robin_photo = next(p for p in photos if p["id"] == robin_id)
+    hawk_pred = {
+        "species": "Red-tailed Hawk",
+        "count": 1,
+        "avg_confidence": 0.92,
+        "models": [{"model": "Bird model", "confidence": 0.92}],
+    }
+    robin_pred = {
+        "species": "American Robin",
+        "count": 1,
+        "avg_confidence": 0.92,
+        "models": [{"model": "Bird model", "confidence": 0.92}],
+    }
+    cache = {
+        "photos": photos,
+        "encounters": [
+            {
+                "photo_ids": [hawk_photo["id"], robin_photo["id"]],
+                "photo_count": 2,
+                "burst_count": 2,
+                "time_range": [hawk_photo["timestamp"], robin_photo["timestamp"]],
+                "species": [],
+                # Aggregate rolled up from every photo — includes the hawk
+                # prediction contributed by the confirmed burst.
+                "species_predictions": [hawk_pred, robin_pred],
+                "species_confirmed": False,
+                "confirmed_species": None,
+                "bursts": [
+                    {
+                        "photo_ids": [hawk_photo["id"]],
+                        "species_predictions": [hawk_pred],
+                        "species_override": {
+                            "species": "Red-tailed Hawk",
+                            "confirmed": True,
+                        },
+                    },
+                    {
+                        "photo_ids": [robin_photo["id"]],
+                        "species_predictions": [robin_pred],
+                        "species_override": None,
+                    },
+                ],
+            }
+        ],
+        "summary": {
+            "total_photos": 2,
+            "encounter_count": 1,
+            "burst_count": 2,
+            "keep_count": 0,
+            "review_count": 2,
+            "reject_count": 0,
+            "rarity_protected": 0,
+        },
+    }
+    path = os.path.join(
+        os.path.dirname(db._db_path),
+        f"pipeline_results_ws{db._active_workspace_id}.json",
+    )
+    with open(path, "w") as f:
+        json.dump(cache, f)
+
+
+def test_pipeline_review_search_scopes_aggregate_predictions_to_visible_bursts(
+    live_server, page
+):
+    photos = live_server["data"]["photos"]
+    # hawk1.jpg goes in the confirmed burst; robin1.jpg is the visible burst.
+    _write_aggregate_from_confirmed_burst_pipeline_cache(
+        live_server, photos[0], photos[3]
+    )
+
+    page.goto(f"{live_server['url']}/pipeline/review")
+    expect(page.locator(".encounter-card")).to_have_count(1)
+    expect(page.locator(".burst-strip")).to_have_count(2)
+
+    search = page.locator("#speciesFilterInput")
+
+    # Baseline (Hide confirmed off): the aggregate carries both species, so
+    # 'Red-tailed Hawk' matches via either the confirmed burst's override or
+    # the encounter aggregate.
+    search.fill("Red-tailed Hawk")
+    expect(page.locator(".encounter-card")).to_have_count(1)
+
+    search.fill("")
+    page.locator("#hideConfirmedBtn").click()
+    expect(page.locator(".burst-strip")).to_have_count(1)
+
+    # With Hide confirmed on, the encounter aggregate still contains
+    # 'Red-tailed Hawk' (rolled up from the hidden burst), but no visible
+    # burst supports it — searching must not surface the encounter with only
+    # the unrelated Robin burst rendered.
+    search.fill("Red-tailed Hawk")
+    expect(page.locator(".encounter-card")).to_have_count(0)
+    expect(page.locator("#countAll")).to_have_text(" (0)")
+
+    # The visible burst's species still matches.
+    search.fill("American Robin")
+    expect(page.locator(".encounter-card")).to_have_count(1)
+    expect(page.locator("#countAll")).to_have_text(" (1)")
+
+
 def test_pipeline_review_search_matches_confirmed_burst_override(live_server, page):
     photo_ids = live_server["data"]["photos"][1:3]
     _write_confirmed_burst_override_pipeline_cache(live_server, photo_ids)

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -2356,9 +2356,12 @@ function encounterMatchesSearch(enc, photoMap) {
       if (b && b.species_override && b.species_override.confirmed === true) {
         return b.species_override.species === enc.confirmed_species;
       }
-      // Bursts without an override inherit the encounter-level label only
-      // when the encounter itself is confirmed.
-      return !(b && b.species_override) && enc.species_confirmed;
+      // Bursts without an override inherit and display `enc.confirmed_species`
+      // whenever it is set (see renderSpeciesWidget's burst branch), including
+      // mixed encounters where the encounter itself is unconfirmed. Requiring
+      // `species_confirmed` here would hide the label from search even though
+      // the visible burst is still showing it as its own label.
+      return !(b && b.species_override);
     });
   }
   if (confirmedLabelHasVisibleBurst) fields.push(enc.confirmed_species);
@@ -2392,16 +2395,26 @@ function encounterMatchesSearch(enc, photoMap) {
   // species regardless of confidence would let a hidden burst's high-confidence
   // prediction push the aggregate over the threshold while a below-threshold
   // sighting on the visible burst quietly keeps the encounter searchable.
+  // Legacy raw bursts store `bursts` as arrays of photo IDs with no
+  // per-burst prediction data. Gating the encounter aggregate against a
+  // visible-burst set built from that shape would drop every
+  // encounter-level prediction whenever Hide confirmed is on — even
+  // though nothing is actually hidden. Only apply the visible-support
+  // gate when at least one burst on the encounter carries per-burst
+  // prediction data; otherwise trust the aggregate.
+  var burstsCarryPredictions = bursts.some(function(burst) {
+    return burst && Array.isArray(burst.species_predictions);
+  });
   var visibleBurstSpecies = null;
-  if (hideConfirmed && bursts.length > 0) {
+  if (hideConfirmed && bursts.length > 0 && burstsCarryPredictions) {
     visibleBurstSpecies = new Set();
     bursts.forEach(function(burst) {
       if (!burstVisible(burst)) return;
-      if (burst.species_override && burst.species_override.confirmed === true
+      if (burst && burst.species_override && burst.species_override.confirmed === true
           && burst.species_override.species) {
         visibleBurstSpecies.add(burst.species_override.species);
       }
-      (burst.species_predictions || []).forEach(function(sp) {
+      (burst && burst.species_predictions || []).forEach(function(sp) {
         if (!sp || !sp.species) return;
         if ((sp.models || []).some(function(m) { return m.confidence >= threshold; })) {
           visibleBurstSpecies.add(sp.species);

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -2331,14 +2331,33 @@ function encounterMatchesSearch(enc, photoMap) {
   var threshold = minConfidence / 100;
   var fields = [];
 
-  // Manually assigned species (confirmed encounter label and confirmed
-  // per-burst overrides) are not classifier output, so they always match
-  // regardless of the confidence slider. Unconfirmed burst overrides are
-  // classifier-derived candidates (e.g. from detach-photo or group-review)
-  // and must go through the threshold-gated prediction paths below —
-  // otherwise raising the slider would fail to hide low-confidence matches.
-  fields.push(enc.confirmed_species);
-  (enc.bursts || []).forEach(function(burst) {
+  // When Hide confirmed is on, the render loop below skips confirmed bursts
+  // (and their photos). Search must scope its burst-level fields — per-burst
+  // confirmed overrides, per-burst predictions, and per-photo filenames — to
+  // only the bursts that will actually render. Otherwise a query matching a
+  // hidden confirmed burst's species or filename surfaces the encounter and
+  // shows only the unrelated unconfirmed burst's content.
+  var bursts = enc.bursts || [];
+  function burstVisible(burst) {
+    return !hideConfirmed || !isBurstConfirmed(enc, burst);
+  }
+
+  // Manually assigned encounter label. The encounter widget still renders
+  // (even when some bursts hide), so it stays searchable — unless every burst
+  // that inherits the encounter-level confirmation is hidden, which would tie
+  // the label exclusively to hidden content.
+  var confirmedLabelHasVisibleBurst = true;
+  if (hideConfirmed && enc.species_confirmed && bursts.length > 0) {
+    confirmedLabelHasVisibleBurst = bursts.some(function(b) {
+      return !(b && b.species_override) && burstVisible(b);
+    });
+  }
+  if (confirmedLabelHasVisibleBurst) fields.push(enc.confirmed_species);
+
+  // Confirmed per-burst overrides — manual labels that always bypass the
+  // slider, but only from bursts that will render.
+  bursts.forEach(function(burst) {
+    if (!burstVisible(burst)) return;
     if (burst.species_override && burst.species_override.confirmed === true) {
       fields.push(burst.species_override.species);
     }
@@ -2355,7 +2374,8 @@ function encounterMatchesSearch(enc, photoMap) {
       fields.push(sp.species);
     }
   });
-  (enc.bursts || []).forEach(function(burst) {
+  bursts.forEach(function(burst) {
+    if (!burstVisible(burst)) return;
     (burst.species_predictions || []).forEach(function(sp) {
       if ((sp.models || []).some(function(m) { return m.confidence >= threshold; })) {
         fields.push(sp.species);
@@ -2365,7 +2385,22 @@ function encounterMatchesSearch(enc, photoMap) {
 
   // Filename search remains encounter-level: finding one photo keeps its
   // whole encounter visible so the surrounding burst context is not lost.
-  (enc.photo_ids || []).forEach(function(pid) {
+  // Under Hide confirmed, restrict to photos in bursts that will render.
+  var filenamePids;
+  if (bursts.length > 0) {
+    filenamePids = [];
+    bursts.forEach(function(burst) {
+      if (!burstVisible(burst)) return;
+      (burst.photo_ids || burst || []).forEach(function(pid) {
+        filenamePids.push(pid);
+      });
+    });
+  } else if (hideConfirmed && enc.species_confirmed) {
+    filenamePids = [];
+  } else {
+    filenamePids = enc.photo_ids || [];
+  }
+  filenamePids.forEach(function(pid) {
     var photo = photoMap && photoMap[pid];
     if (photo) fields.push(photo.filename);
   });

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -2331,15 +2331,19 @@ function encounterMatchesSearch(enc, photoMap) {
   var threshold = minConfidence / 100;
   var fields = [];
 
-  // Include species names that are shown as the encounter/burst label even
-  // when they were manually assigned and do not occur in classifier output.
+  // Manually assigned species (confirmed encounter label and per-burst
+  // overrides) are not classifier output, so they always match regardless
+  // of the confidence slider.
   fields.push(enc.confirmed_species);
-  if (enc.species) fields.push(enc.species[0]);
   (enc.bursts || []).forEach(function(burst) {
     if (burst.species_override) fields.push(burst.species_override.species);
   });
 
-  // Preserve the confidence-slider behavior for classifier suggestions.
+  // Classifier-derived species — including the encounter consensus label in
+  // enc.species — flow through species_predictions with per-model confidence,
+  // so gate them behind the min-confidence slider. Adding enc.species[0]
+  // separately would bypass that gate and let low-confidence matches survive
+  // even after the user raised the threshold.
   (enc.species_predictions || []).forEach(function(sp) {
     if ((sp.models || []).some(function(m) { return m.confidence >= threshold; })) {
       fields.push(sp.species);

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -2370,7 +2370,13 @@ function encounterMatchesSearch(enc, photoMap) {
     if (photo) fields.push(photo.filename);
   });
 
-  return VireoTextSearch.matchesFields(fields, speciesFilter, speciesFilterSearchOptions);
+  // Match the full query against each candidate field independently so a
+  // multi-token query like "Mute Swan" can't be satisfied by pairing "Mute"
+  // from one field (e.g. "Mute Grouse") with "Swan" from another (e.g.
+  // "Trumpeter Swan"). A single field must contain every token to match.
+  return fields.some(function(field) {
+    return VireoTextSearch.matchesFields(field, speciesFilter, speciesFilterSearchOptions);
+  });
 }
 
 // -- Rendering --

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -2399,17 +2399,24 @@ function encounterMatchesSearch(enc, photoMap) {
   // per-burst prediction data. Gating the encounter aggregate against a
   // visible-burst set built from that shape would drop every
   // encounter-level prediction whenever Hide confirmed is on — even
-  // though nothing is actually hidden. Only apply the visible-support
-  // gate when at least one burst on the encounter carries per-burst
-  // prediction data; otherwise trust the aggregate.
-  var burstsCarryPredictions = bursts.some(function(burst) {
-    return burst && Array.isArray(burst.species_predictions);
-  });
+  // though nothing is actually hidden. The gate is only sound when we
+  // can fully account for what every visible burst contributes to the
+  // aggregate, so require every VISIBLE burst to carry per-burst
+  // predictions before enabling it. Otherwise (all-raw, or a mix where
+  // a visible raw burst sits alongside an object burst — the GRM detach
+  // flow leaves the source burst as a raw array while appending a new
+  // object burst) at least one visible burst is opaque to us and could
+  // be the source of an aggregate species we would otherwise drop, so
+  // trust the aggregate.
+  var visibleBursts = bursts.filter(burstVisible);
+  var visibleBurstsAllCarryPredictions = visibleBursts.length > 0
+    && visibleBursts.every(function(burst) {
+      return burst && Array.isArray(burst.species_predictions);
+    });
   var visibleBurstSpecies = null;
-  if (hideConfirmed && bursts.length > 0 && burstsCarryPredictions) {
+  if (hideConfirmed && visibleBurstsAllCarryPredictions) {
     visibleBurstSpecies = new Set();
-    bursts.forEach(function(burst) {
-      if (!burstVisible(burst)) return;
+    visibleBursts.forEach(function(burst) {
       if (burst && burst.species_override && burst.species_override.confirmed === true
           && burst.species_override.species) {
         visibleBurstSpecies.add(burst.species_override.species);

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -2428,46 +2428,18 @@ function encounterMatchesSearch(enc, photoMap) {
       });
     });
   }
-  // Even in the fallback path — mixed shapes where the visible-burst gate is
-  // disabled — hidden object bursts can leak their classifier evidence into
-  // the encounter aggregate. Collect species that only hidden object bursts
-  // source (confirmed override or threshold-passing prediction) and no
-  // visible object burst backs, and drop those from the aggregate. The
-  // visible raw burst stays opaque, so we accept a small false-negative
-  // risk on legitimate raw-burst matches to avoid the more confusing false
-  // positive of surfacing an unrelated visible raw burst when the user
-  // searches for a species that only a hidden confirmed burst carries.
-  var hiddenBurstOnlySpecies = null;
-  if (hideConfirmed && !visibleBurstsAllCarryPredictions) {
-    var hiddenObjectSpecies = new Set();
-    var visibleObjectSpecies = new Set();
-    bursts.forEach(function(burst) {
-      if (!burst) return;
-      var target = burstVisible(burst) ? visibleObjectSpecies : hiddenObjectSpecies;
-      if (burst.species_override && burst.species_override.confirmed === true
-          && burst.species_override.species) {
-        target.add(burst.species_override.species);
-      }
-      if (Array.isArray(burst.species_predictions)) {
-        burst.species_predictions.forEach(function(sp) {
-          if (!sp || !sp.species) return;
-          if ((sp.models || []).some(function(m) { return m.confidence >= threshold; })) {
-            target.add(sp.species);
-          }
-        });
-      }
-    });
-    if (hiddenObjectSpecies.size > 0) {
-      hiddenBurstOnlySpecies = new Set();
-      hiddenObjectSpecies.forEach(function(species) {
-        if (!visibleObjectSpecies.has(species)) hiddenBurstOnlySpecies.add(species);
-      });
-      if (hiddenBurstOnlySpecies.size === 0) hiddenBurstOnlySpecies = null;
-    }
-  }
+  // In the fallback path — mixed shapes where at least one visible burst is a
+  // legacy raw photo-id array — we can't enumerate that burst's species. Do
+  // not drop aggregate species that only hidden object bursts back either:
+  // the GRM detach flow can leave the source burst raw while the detached
+  // object burst is confirmed to a species that the raw burst still carries
+  // (unconfirmed) in its own photos, so filtering that species out would
+  // silence a legitimate raw-burst match. The tradeoff is a small false-
+  // positive risk when the raw burst genuinely does not share the hidden
+  // burst's species — the encounter still renders only the visible raw
+  // burst, which the user can inspect.
   (enc.species_predictions || []).forEach(function(sp) {
     if (visibleBurstSpecies && !visibleBurstSpecies.has(sp.species)) return;
-    if (hiddenBurstOnlySpecies && hiddenBurstOnlySpecies.has(sp.species)) return;
     if ((sp.models || []).some(function(m) { return m.confidence >= threshold; })) {
       fields.push(sp.species);
     }

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -1717,7 +1717,7 @@ input[type="range"]::-moz-range-thumb {
       <button class="filter-btn" id="hideConfirmedBtn" onclick="toggleHideConfirmed()" title="Hide encounters/bursts whose species has been confirmed">Hide confirmed</button>
       <div class="species-filter-wrap">
         <div class="search-control">
-          <input type="text" id="speciesFilterInput" placeholder="Filter by species..." oninput="setSpeciesFilter(this.value)">
+          <input type="text" id="speciesFilterInput" placeholder="Search species or filename..." aria-label="Search process review by species or filename" oninput="setSpeciesFilter(this.value)">
           <button id="speciesFilterMatchCaseBtn" class="search-option-btn" type="button" aria-pressed="false" onclick="toggleSpeciesFilterSearchOption('match_case')" title="Match case">Aa</button>
           <button id="speciesFilterWholeWordBtn" class="search-option-btn" type="button" aria-pressed="false" onclick="toggleSpeciesFilterSearchOption('whole_word')" title="Match whole word">ab</button>
         </div>
@@ -2326,14 +2326,34 @@ function clearSpeciesFilter() {
   renderResults();
 }
 
-function encounterMatchesSpecies(enc) {
+function encounterMatchesSearch(enc, photoMap) {
   if (!speciesFilter) return true;
-  if (!enc.species_predictions || enc.species_predictions.length === 0) return false;
   var threshold = minConfidence / 100;
-  return enc.species_predictions.some(function(sp) {
-    if (!VireoTextSearch.matchesFields(sp.species, speciesFilter, speciesFilterSearchOptions)) return false;
-    return (sp.models || []).some(function(m) { return m.confidence >= threshold; });
+  var fields = [];
+
+  // Include species names that are shown as the encounter/burst label even
+  // when they were manually assigned and do not occur in classifier output.
+  fields.push(enc.confirmed_species);
+  if (enc.species) fields.push(enc.species[0]);
+  (enc.bursts || []).forEach(function(burst) {
+    if (burst.species_override) fields.push(burst.species_override.species);
   });
+
+  // Preserve the confidence-slider behavior for classifier suggestions.
+  (enc.species_predictions || []).forEach(function(sp) {
+    if ((sp.models || []).some(function(m) { return m.confidence >= threshold; })) {
+      fields.push(sp.species);
+    }
+  });
+
+  // Filename search remains encounter-level: finding one photo keeps its
+  // whole encounter visible so the surrounding burst context is not lost.
+  (enc.photo_ids || []).forEach(function(pid) {
+    var photo = photoMap && photoMap[pid];
+    if (photo) fields.push(photo.filename);
+  });
+
+  return VireoTextSearch.matchesFields(fields, speciesFilter, speciesFilterSearchOptions);
 }
 
 // -- Rendering --
@@ -2781,12 +2801,12 @@ function renderResults() {
   pipelineResults.photos.forEach(function(p) { photoMap[p.id] = p; });
   var speciesConflictEvidence = buildSpeciesConflictEvidence(photoMap);
 
-  // Build encounter photo set for species-filtered encounters
+  // Build the photo set for encounters matching the species/filename search.
   var speciesVisibleIds = null;
   if (speciesFilter) {
     speciesVisibleIds = new Set();
     pipelineResults.encounters.forEach(function(enc) {
-      if (encounterMatchesSpecies(enc)) {
+      if (encounterMatchesSearch(enc, photoMap)) {
         (enc.photo_ids || []).forEach(function(pid) { speciesVisibleIds.add(pid); });
       }
     });
@@ -2841,8 +2861,8 @@ function renderResults() {
       timeRange = t0.substring(0,8) + (t1 ? ' - ' + t1.substring(0,8) : '');
     }
 
-    // Check if encounter passes species filter
-    if (!encounterMatchesSpecies(enc)) return;
+    // Check if the encounter passes the species/filename search.
+    if (!encounterMatchesSearch(enc, photoMap)) return;
 
     // Hide confirmed: skip the whole encounter if every one of its photos is hidden
     var encPhotoIds = enc.photo_ids || [];

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -2344,12 +2344,21 @@ function encounterMatchesSearch(enc, photoMap) {
 
   // Manually assigned encounter label. The encounter widget still renders
   // (even when some bursts hide), so it stays searchable — unless every burst
-  // that inherits the encounter-level confirmation is hidden, which would tie
-  // the label exclusively to hidden content.
+  // that carries the label is hidden. For mixed/partial encounters the
+  // serializer keeps `confirmed_species` even when `species_confirmed` is
+  // false (for replacement flows), so the label may only be backed by a
+  // per-burst confirmed override; if that override is on a hidden burst the
+  // label must not surface the encounter.
   var confirmedLabelHasVisibleBurst = true;
-  if (hideConfirmed && enc.species_confirmed && bursts.length > 0) {
+  if (hideConfirmed && enc.confirmed_species && bursts.length > 0) {
     confirmedLabelHasVisibleBurst = bursts.some(function(b) {
-      return !(b && b.species_override) && burstVisible(b);
+      if (!burstVisible(b)) return false;
+      if (b && b.species_override && b.species_override.confirmed === true) {
+        return b.species_override.species === enc.confirmed_species;
+      }
+      // Bursts without an override inherit the encounter-level label only
+      // when the encounter itself is confirmed.
+      return !(b && b.species_override) && enc.species_confirmed;
     });
   }
   if (confirmedLabelHasVisibleBurst) fields.push(enc.confirmed_species);
@@ -2376,13 +2385,27 @@ function encounterMatchesSearch(enc, photoMap) {
   // that at least one visible burst also predicts, so searching a species
   // whose only evidence is inside a hidden burst can't surface an unrelated
   // visible burst.
+  // Support means: a visible burst has evidence the search should follow. A
+  // confirmed burst override qualifies (manual label always counts), and so
+  // does a burst-level prediction whose confidence meets the slider — matching
+  // the gate applied to the aggregate below. Recording every visible burst
+  // species regardless of confidence would let a hidden burst's high-confidence
+  // prediction push the aggregate over the threshold while a below-threshold
+  // sighting on the visible burst quietly keeps the encounter searchable.
   var visibleBurstSpecies = null;
   if (hideConfirmed && bursts.length > 0) {
     visibleBurstSpecies = new Set();
     bursts.forEach(function(burst) {
       if (!burstVisible(burst)) return;
+      if (burst.species_override && burst.species_override.confirmed === true
+          && burst.species_override.species) {
+        visibleBurstSpecies.add(burst.species_override.species);
+      }
       (burst.species_predictions || []).forEach(function(sp) {
-        if (sp && sp.species) visibleBurstSpecies.add(sp.species);
+        if (!sp || !sp.species) return;
+        if ((sp.models || []).some(function(m) { return m.confidence >= threshold; })) {
+          visibleBurstSpecies.add(sp.species);
+        }
       });
     });
   }

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -2369,7 +2369,25 @@ function encounterMatchesSearch(enc, photoMap) {
   // behind the min-confidence slider. Adding enc.species[0] separately would
   // bypass that gate and let low-confidence matches survive even after the
   // user raised the threshold.
+  //
+  // The encounter-level aggregate is rolled up from every photo in the
+  // encounter, so under Hide confirmed it can carry a species contributed
+  // only by a hidden confirmed burst. Restrict aggregate species to those
+  // that at least one visible burst also predicts, so searching a species
+  // whose only evidence is inside a hidden burst can't surface an unrelated
+  // visible burst.
+  var visibleBurstSpecies = null;
+  if (hideConfirmed && bursts.length > 0) {
+    visibleBurstSpecies = new Set();
+    bursts.forEach(function(burst) {
+      if (!burstVisible(burst)) return;
+      (burst.species_predictions || []).forEach(function(sp) {
+        if (sp && sp.species) visibleBurstSpecies.add(sp.species);
+      });
+    });
+  }
   (enc.species_predictions || []).forEach(function(sp) {
+    if (visibleBurstSpecies && !visibleBurstSpecies.has(sp.species)) return;
     if ((sp.models || []).some(function(m) { return m.confidence >= threshold; })) {
       fields.push(sp.species);
     }

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -2399,15 +2399,14 @@ function encounterMatchesSearch(enc, photoMap) {
   // per-burst prediction data. Gating the encounter aggregate against a
   // visible-burst set built from that shape would drop every
   // encounter-level prediction whenever Hide confirmed is on — even
-  // though nothing is actually hidden. The gate is only sound when we
-  // can fully account for what every visible burst contributes to the
-  // aggregate, so require every VISIBLE burst to carry per-burst
+  // though nothing is actually hidden. The strict gate is only sound
+  // when we can fully account for what every visible burst contributes
+  // to the aggregate, so require every VISIBLE burst to carry per-burst
   // predictions before enabling it. Otherwise (all-raw, or a mix where
   // a visible raw burst sits alongside an object burst — the GRM detach
   // flow leaves the source burst as a raw array while appending a new
-  // object burst) at least one visible burst is opaque to us and could
-  // be the source of an aggregate species we would otherwise drop, so
-  // trust the aggregate.
+  // object burst) at least one visible burst is opaque and could be the
+  // source of an aggregate species we would otherwise drop.
   var visibleBursts = bursts.filter(burstVisible);
   var visibleBurstsAllCarryPredictions = visibleBursts.length > 0
     && visibleBursts.every(function(burst) {
@@ -2429,8 +2428,46 @@ function encounterMatchesSearch(enc, photoMap) {
       });
     });
   }
+  // Even in the fallback path — mixed shapes where the visible-burst gate is
+  // disabled — hidden object bursts can leak their classifier evidence into
+  // the encounter aggregate. Collect species that only hidden object bursts
+  // source (confirmed override or threshold-passing prediction) and no
+  // visible object burst backs, and drop those from the aggregate. The
+  // visible raw burst stays opaque, so we accept a small false-negative
+  // risk on legitimate raw-burst matches to avoid the more confusing false
+  // positive of surfacing an unrelated visible raw burst when the user
+  // searches for a species that only a hidden confirmed burst carries.
+  var hiddenBurstOnlySpecies = null;
+  if (hideConfirmed && !visibleBurstsAllCarryPredictions) {
+    var hiddenObjectSpecies = new Set();
+    var visibleObjectSpecies = new Set();
+    bursts.forEach(function(burst) {
+      if (!burst) return;
+      var target = burstVisible(burst) ? visibleObjectSpecies : hiddenObjectSpecies;
+      if (burst.species_override && burst.species_override.confirmed === true
+          && burst.species_override.species) {
+        target.add(burst.species_override.species);
+      }
+      if (Array.isArray(burst.species_predictions)) {
+        burst.species_predictions.forEach(function(sp) {
+          if (!sp || !sp.species) return;
+          if ((sp.models || []).some(function(m) { return m.confidence >= threshold; })) {
+            target.add(sp.species);
+          }
+        });
+      }
+    });
+    if (hiddenObjectSpecies.size > 0) {
+      hiddenBurstOnlySpecies = new Set();
+      hiddenObjectSpecies.forEach(function(species) {
+        if (!visibleObjectSpecies.has(species)) hiddenBurstOnlySpecies.add(species);
+      });
+      if (hiddenBurstOnlySpecies.size === 0) hiddenBurstOnlySpecies = null;
+    }
+  }
   (enc.species_predictions || []).forEach(function(sp) {
     if (visibleBurstSpecies && !visibleBurstSpecies.has(sp.species)) return;
+    if (hiddenBurstOnlySpecies && hiddenBurstOnlySpecies.has(sp.species)) return;
     if ((sp.models || []).some(function(m) { return m.confidence >= threshold; })) {
       fields.push(sp.species);
     }

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -2331,23 +2331,36 @@ function encounterMatchesSearch(enc, photoMap) {
   var threshold = minConfidence / 100;
   var fields = [];
 
-  // Manually assigned species (confirmed encounter label and per-burst
-  // overrides) are not classifier output, so they always match regardless
-  // of the confidence slider.
+  // Manually assigned species (confirmed encounter label and confirmed
+  // per-burst overrides) are not classifier output, so they always match
+  // regardless of the confidence slider. Unconfirmed burst overrides are
+  // classifier-derived candidates (e.g. from detach-photo or group-review)
+  // and must go through the threshold-gated prediction paths below —
+  // otherwise raising the slider would fail to hide low-confidence matches.
   fields.push(enc.confirmed_species);
   (enc.bursts || []).forEach(function(burst) {
-    if (burst.species_override) fields.push(burst.species_override.species);
+    if (burst.species_override && burst.species_override.confirmed === true) {
+      fields.push(burst.species_override.species);
+    }
   });
 
   // Classifier-derived species — including the encounter consensus label in
-  // enc.species — flow through species_predictions with per-model confidence,
-  // so gate them behind the min-confidence slider. Adding enc.species[0]
-  // separately would bypass that gate and let low-confidence matches survive
-  // even after the user raised the threshold.
+  // enc.species and burst-level predictions that back unconfirmed overrides —
+  // flow through species_predictions with per-model confidence, so gate them
+  // behind the min-confidence slider. Adding enc.species[0] separately would
+  // bypass that gate and let low-confidence matches survive even after the
+  // user raised the threshold.
   (enc.species_predictions || []).forEach(function(sp) {
     if ((sp.models || []).some(function(m) { return m.confidence >= threshold; })) {
       fields.push(sp.species);
     }
+  });
+  (enc.bursts || []).forEach(function(burst) {
+    (burst.species_predictions || []).forEach(function(sp) {
+      if ((sp.models || []).some(function(m) { return m.confidence >= threshold; })) {
+        fields.push(sp.species);
+      }
+    });
   });
 
   // Filename search remains encounter-level: finding one photo keeps its


### PR DESCRIPTION
Process Review search now matches photo filenames as well as predicted and manually assigned species names. Filename matches retain the full encounter so reviewers keep burst context, while existing confidence, case-sensitive, whole-word, and persisted search behavior remains intact. The search prompt and accessibility label now describe both supported fields. Validated with 13 focused browser and application tests, including a regression test for filename search when species predictions are absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the pipeline review “species filter” to search **species or photo filename** (updated placeholder + accessibility label).
  * Improved matching to respect **min confidence** across encounter consensus, burst predictions, and confirmed overrides.
  * With **Hide confirmed** enabled, results are scoped to **visible bursts**, including correct handling of aggregate evidence and legacy cache shapes.
* **Tests**
  * Added end-to-end coverage for filename matching, confidence gating, confirmed/unconfirmed override behavior, hide-confirmed scoping (aggregate/mixed cases), legacy fallback scenarios, and blocking cross-field token-split matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->