### PR TITLE
Fix Photo Move 500-photo selection limit

### DIFF
--- a/vireo/templates/move.html
+++ b/vireo/templates/move.html
@@ -536,6 +536,7 @@ var allFolders = [];
 var photoList = [];
 var selectedPhotos = new Set();
 var lastSelectedIdx = -1;
+var photoLoadSeq = 0;
 var browserTargetInput = null;
 var browserPath = '';
 var browserHomePath = '';
@@ -1125,6 +1126,8 @@ async function loadPhotosForFolder() {
   var sel = document.getElementById('photoFolderSelect');
   var fid = parseInt(sel.value);
   var container = document.getElementById('photoGridContainer');
+  var seq = ++photoLoadSeq;
+  photoList = [];
   selectedPhotos.clear();
   lastSelectedIdx = -1;
   updatePhotoSelectionUI();
@@ -1137,14 +1140,35 @@ async function loadPhotosForFolder() {
   container.innerHTML = '<div class="loading">Loading photos...</div>';
 
   try {
-    var data = await safeFetch('/api/photos?folder_id=' + fid + '&per_page=500');
-    photoList = data.photos || [];
+    var page = 1;
+    var total = null;
+    var loadedPhotos = [];
+    while (total === null || loadedPhotos.length < total) {
+      var data = await safeFetch(
+        '/api/photos?folder_id=' + encodeURIComponent(fid) +
+        '&per_page=500&page=' + page
+      );
+      if (seq !== photoLoadSeq) return;
+
+      var pagePhotos = data.photos || [];
+      loadedPhotos = loadedPhotos.concat(pagePhotos);
+      if (typeof data.total === 'number') total = data.total;
+
+      if (pagePhotos.length < 500 || (total !== null && loadedPhotos.length >= total)) break;
+      page += 1;
+      var totalText = total !== null ? ' of ' + total.toLocaleString() : '';
+      container.innerHTML = '<div class="loading">Loading photos... ' +
+        loadedPhotos.length.toLocaleString() + totalText + '</div>';
+    }
+
+    photoList = loadedPhotos;
     if (photoList.length === 0) {
       container.innerHTML = '<div class="empty-state">No photos in this folder</div>';
       return;
     }
     renderPhotoGrid();
   } catch (e) {
+    if (seq !== photoLoadSeq) return;
     container.innerHTML = '<div class="empty-state">Failed to load photos</div>';
   }
 }

--- a/vireo/tests/test_move_api.py
+++ b/vireo/tests/test_move_api.py
@@ -57,6 +57,20 @@ def test_move_page_browser_stamps_requests(app_and_db):
     assert "if (seq !== browseSeq) return;" in html
 
 
+def test_move_page_loads_every_photo_page_for_selection(app_and_db):
+    """Photo Move must not stop at the API's 500-photo per-request cap."""
+    app, _ = app_and_db
+    client = app.test_client()
+    resp = client.get("/move")
+    html = resp.data.decode()
+
+    assert "var photoLoadSeq = 0;" in html
+    assert "while (total === null || loadedPhotos.length < total)" in html
+    assert "&per_page=500&page=' + page" in html
+    assert "loadedPhotos = loadedPhotos.concat(pagePhotos);" in html
+    assert "if (seq !== photoLoadSeq) return;" in html
+
+
 def test_move_page_pictures_shortcut_resolves_home_on_demand(app_and_db):
     """The Pictures shortcut must resolve the user's home directory before
     composing the path. Otherwise, opening the modal with a prefilled


### PR DESCRIPTION
## Summary
Photo Move now follows API pagination so folders larger than 500 expose every photo for selection while preserving the per-request safety cap. It also ignores stale responses when users switch folders during loading and shows pagination progress.

## Validation
- `python -m pytest vireo/tests/test_move_api.py -q` — 33 passed
- `ruff check vireo/tests/test_move_api.py` — passed