### PR TITLE
Keep lightbox controls clear of fitted images

### DIFF
--- a/tests/e2e/test_browse_lightbox.py
+++ b/tests/e2e/test_browse_lightbox.py
@@ -369,6 +369,70 @@ def test_browse_lightbox_filename_can_be_selected_without_resetting_zoom(
     ) is True
 
 
+def test_browse_lightbox_reserves_space_for_bottom_controls(live_server, page):
+    """The fitted image stays above the toolbar and expands when it is hidden."""
+    svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="1200" '
+        'viewBox="0 0 1600 1200"><rect width="1600" height="1200" fill="#274"/></svg>'
+    )
+    page.route(
+        "**/photos/*/full",
+        lambda route: route.fulfill(body=svg, content_type="image/svg+xml"),
+    )
+    page.set_viewport_size({"width": 1000, "height": 800})
+    page.goto(f"{live_server['url']}/browse")
+    page.locator(".grid-card").first.dblclick()
+
+    expect(page.locator("#lightboxOverlay")).to_have_class("lightbox-overlay active")
+    page.wait_for_function(
+        """() => {
+            const img = document.getElementById('lightboxImg');
+            return img && img.complete && img.naturalWidth === 1600;
+        }"""
+    )
+    page.wait_for_function(
+        """() => {
+            const wrapRect = document.getElementById('lightboxWrap').getBoundingClientRect();
+            const imageRect = document.getElementById('lightboxTransform').getBoundingClientRect();
+            return imageRect.top >= wrapRect.top - 1
+                && imageRect.bottom <= wrapRect.bottom + 1;
+        }"""
+    )
+
+    visible = page.evaluate(
+        """() => {
+            const wrap = document.getElementById('lightboxWrap');
+            const bar = document.querySelector('.lightbox-bottom-bar');
+            const image = document.getElementById('lightboxTransform');
+            const wrapRect = wrap.getBoundingClientRect();
+            const barRect = bar.getBoundingClientRect();
+            const imageRect = image.getBoundingClientRect();
+            return {
+                wrapHeight: wrapRect.height,
+                wrapBottom: wrapRect.bottom,
+                barTop: barRect.top,
+                imageBottom: imageRect.bottom,
+                fitScale: window._lbFitScale,
+            };
+        }"""
+    )
+    assert visible["wrapBottom"] < visible["barTop"]
+    assert visible["imageBottom"] <= visible["wrapBottom"] + 1
+
+    page.locator("#lightboxToggleChrome").click()
+    expect(page.locator("#lightboxOverlay")).to_have_class(
+        "lightbox-overlay active lb-hide-chrome"
+    )
+    page.wait_for_function(
+        """before => {
+            const wrap = document.getElementById('lightboxWrap');
+            return wrap.clientHeight > before.wrapHeight + 20
+                && window._lbFitScale > before.fitScale;
+        }""",
+        arg=visible,
+    )
+
+
 def test_browse_photo_id_deep_link_loads_target_folder_first_page(live_server, page):
     """Open in Browse must find a target that is not on global Browse page 1."""
     db = live_server["db"]

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -421,14 +421,18 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
   inset: 0;
   z-index: 9999;
   background: rgba(0,0,0,0.92);
-  align-items: center;
-  justify-content: center;
+  grid-template-rows: minmax(0, 1fr) auto;
+  align-items: stretch;
+  justify-items: center;
+  gap: 12px;
+  padding: 4vh 24px 16px;
+  box-sizing: border-box;
   cursor: zoom-out;
 }
-.lightbox-overlay.active { display: flex; }
+.lightbox-overlay.active { display: grid; }
 .lightbox-img-wrap {
-  width: 95vw;
-  height: 92vh;
+  width: min(95vw, 100%);
+  height: 100%;
   overflow: hidden;
   position: relative;
 }
@@ -528,10 +532,8 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
   display: none !important;
 }
 .lightbox-bottom-bar {
-  position: absolute;
-  left: 24px;
-  right: 24px;
-  bottom: 16px;
+  position: relative;
+  width: 100%;
   z-index: 10000;
   display: flex;
   align-items: flex-end;
@@ -7358,16 +7360,21 @@ function toggleLightboxZoom(e) {
   }, { passive: false });
 })();
 
-// Viewport resize: recompute nativeZoom while lightbox is open so fit ratio
-// stays accurate after window/devicePixelRatio changes.
+// Viewport and chrome resize: recompute nativeZoom while lightbox is open so
+// the fit ratio stays accurate after window/devicePixelRatio changes or the
+// bottom bar wraps, grows, or is hidden.
 (function() {
   var resizeTimer = null;
-  window.addEventListener('resize', function() {
+  var refreshSourceTier = false;
+  function scheduleLightboxLayoutRefresh(updateSourceTier) {
     var overlay = document.getElementById('lightboxOverlay');
     if (!overlay || !overlay.classList.contains('active')) return;
+    refreshSourceTier = refreshSourceTier || !!updateSourceTier;
     if (resizeTimer) clearTimeout(resizeTimer);
     resizeTimer = setTimeout(function() {
       resizeTimer = null;
+      var shouldUpdateSourceTier = refreshSourceTier;
+      refreshSourceTier = false;
       _lbRecomputeNativeZoom();
       // A deferred 1:1 keeps _lbZoom at fit while the high-res source loads.
       // _lbSetZoom clears _lbPending1To1 (and its trailing reschedule retargets
@@ -7383,20 +7390,44 @@ function toggleLightboxZoom(e) {
         _lbPending1To1Anchor = pendingAnchor;
         _lbClampPan();
         _lbApplyTransform();
-        if (!pendingDesiredSource || pendingDesiredSource === _lbCurrentSrcKey) {
-          _lbScheduleSourceSwap(_lbNativeZoom || 4);
-        } else {
-          _lbDesiredSrcKey = pendingDesiredSource;
-        }
-        if (_lbDesiredSrcKey === _lbCurrentSrcKey) {
-          _lbApplyPendingOneToOneZoom();
+        if (shouldUpdateSourceTier) {
+          if (!pendingDesiredSource || pendingDesiredSource === _lbCurrentSrcKey) {
+            _lbScheduleSourceSwap(_lbNativeZoom || 4);
+          } else {
+            _lbDesiredSrcKey = pendingDesiredSource;
+          }
+          if (_lbDesiredSrcKey === _lbCurrentSrcKey) {
+            _lbApplyPendingOneToOneZoom();
+          }
         }
         return;
       }
-      // Current zoom may now violate clamps; re-run through _lbSetZoom to re-clamp & re-apply.
-      _lbSetZoom(_lbZoom, null, null);
+      if (shouldUpdateSourceTier) {
+        // Current zoom may now violate clamps; re-run through _lbSetZoom to
+        // re-clamp, apply, and select the best source for a new viewport size.
+        _lbSetZoom(_lbZoom, null, null);
+      } else {
+        // A chrome-only resize changes the fit box but must not cancel a
+        // source swap or preload that is already in flight.
+        _lbClampPan();
+        _lbApplyTransform();
+        _lbSaveViewportState(_lightboxCurrentId);
+      }
     }, 100);
+  }
+
+  window.addEventListener('resize', function() {
+    scheduleLightboxLayoutRefresh(true);
   });
+  if (window.ResizeObserver) {
+    var wrap = document.getElementById('lightboxWrap');
+    if (wrap) {
+      var lightboxLayoutObserver = new ResizeObserver(function() {
+        scheduleLightboxLayoutRefresh(false);
+      });
+      lightboxLayoutObserver.observe(wrap);
+    }
+  }
 })();
 
 // Drag to pan when zoomed; single click (no drag) zooms out


### PR DESCRIPTION
The lightbox previously positioned its bottom toolbar over a fixed-height image area, allowing controls to cover the fitted image.
This changes the overlay to a two-row layout so the image always ends above the controls and hiding the UI returns that space to the image.
A resize observer recalculates the fit when controls wrap or change visibility without disrupting source swaps or high-resolution preloads.
Validated with the 36-test shared-lightbox suite, 13 context-menu and keyboard lightbox checks, two browse rendering tests, and Ruff.
