### PR TITLE
Make folder moves clear and support renaming

### DIFF
--- a/tests/e2e/test_move_page.py
+++ b/tests/e2e/test_move_page.py
@@ -29,7 +29,7 @@ def test_move_folder_button_shows_preflight_progress(live_server, page):
     assert held_routes
 
     expect(btn).to_be_disabled()
-    expect(btn).to_have_text("Checking...")
+    expect(btn).to_have_text("Checking destination…")
 
     held_routes[0].fulfill(
         status=200,
@@ -46,7 +46,7 @@ def test_move_folder_button_shows_preflight_progress(live_server, page):
         "Confirm moving 3 photos from /photos/park to "
         "/tmp/vireo-archive/park?"
     )
-    expect(btn).to_have_text("Move Folder")
+    expect(btn).to_contain_text("Review move")
     expect(btn).to_be_enabled()
 
 
@@ -73,7 +73,29 @@ def test_move_folder_prints_full_move_before_submission(live_server, page):
 
     summary = page.locator("#quickMoveSummary")
     expect(summary).to_be_visible()
-    expect(summary).to_have_text(
-        "Confirm moving 3 photos from /photos/park to "
-        "/archive/2024-03-10/park?"
+    route_paths = summary.locator(".move-route-path")
+    expect(route_paths.nth(0)).to_have_text("/photos/park")
+    expect(route_paths.nth(1)).to_have_text("/archive/2024-03-10/park")
+    expect(summary.locator(".move-preview-meta")).to_contain_text("3 photos")
+
+
+def test_move_folder_can_be_renamed_in_final_location_preview(live_server, page):
+    live_server["db"].update_folder_counts()
+    url = live_server["url"]
+    page.goto(f"{url}/move")
+
+    page.locator("#quickFolderSelect").select_option(index=1)
+    expect(page.locator("#quickFolderName")).to_have_value("park")
+
+    page.locator("#quickDestInput").fill("/archive/2026")
+    page.locator("#quickFolderName").fill("2026-07-12")
+
+    summary = page.locator("#quickMoveSummary")
+    expect(summary).to_be_visible()
+    expect(summary.locator(".move-route-path").nth(1)).to_have_text(
+        "/archive/2026/2026-07-12"
     )
+    expect(summary.locator(".move-preview-meta")).to_contain_text(
+        "Folder will be renamed"
+    )
+    expect(page.locator("#quickMoveBtn")).to_be_enabled()

--- a/tests/e2e/test_move_page.py
+++ b/tests/e2e/test_move_page.py
@@ -99,3 +99,40 @@ def test_move_folder_can_be_renamed_in_final_location_preview(live_server, page)
         "Folder will be renamed"
     )
     expect(page.locator("#quickMoveBtn")).to_be_enabled()
+
+
+def test_move_folder_preserves_untouched_name_with_surrounding_spaces(
+    live_server, page
+):
+    """An unchanged folder name keeps its original whitespace.
+
+    A .trim() on submit would silently rename e.g. ' Shoot ' to 'Shoot' on
+    a no-op move — merging with a different existing folder. Leaving the
+    pre-populated name untouched must round-trip verbatim.
+    """
+    db = live_server["db"]
+    fid = db.add_folder("/photos/ shoot ", name=" shoot ")
+    db.add_photo(
+        folder_id=fid, filename="a.jpg", extension=".jpg",
+        file_size=1000, file_mtime=1.0, timestamp="2024-04-01T10:00:00",
+    )
+    db.update_folder_counts()
+    url = live_server["url"]
+    page.goto(f"{url}/move")
+
+    page.locator("#quickFolderSelect").select_option(value=str(fid))
+    expect(page.locator("#quickFolderName")).to_have_value(" shoot ")
+
+    page.locator("#quickDestInput").fill("/archive/2026")
+
+    summary = page.locator("#quickMoveSummary")
+    expect(summary).to_be_visible()
+    # The trailing whitespace is preserved on the destination leaf.
+    expect(summary.locator(".move-route-path").nth(1)).to_have_text(
+        "/archive/2026/ shoot "
+    )
+    # No rename notice — the user hasn't actually renamed anything.
+    expect(summary.locator(".move-preview-meta")).not_to_contain_text(
+        "Folder will be renamed"
+    )
+    expect(page.locator("#quickMoveBtn")).to_be_enabled()

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -19079,6 +19079,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("JSON body must be an object")
         folder_id = body.get("folder_id")
         destination = body.get("destination", "")
+        destination_name_raw = body.get("destination_name", "")
         remote_target_id = (body.get("remote_target_id") or "").strip()
         subpath = body.get("subpath", "")
         merge_raw = body.get("merge", False)
@@ -19156,6 +19157,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         import config as cfg
         import move as move_mod
+        try:
+            destination_name = move_mod.normalize_destination_name(
+                destination_name_raw)
+        except ValueError as exc:
+            return json_error(str(exc))
         effective_cfg = _get_db().get_effective_config(cfg.load())
         developed_dir = effective_cfg.get("darktable_output_dir", "") or ""
 
@@ -19268,6 +19274,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 developed_dir=developed_dir,
                 merge=merge,
                 remote=remote,
+                destination_name=destination_name,
             )
 
             # Tell the JobRunner whether the move actually succeeded. Without
@@ -19307,6 +19314,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         job_config = {
             "folder_id": folder_id, "destination": display_dest, "merge": merge,
         }
+        if destination_name:
+            job_config["destination_name"] = destination_name
         if remote:
             # Surface that this is an SSH transfer (and to where) so the job
             # panel can show it, per the UI-transparency rule.
@@ -19363,6 +19372,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("JSON body must be an object")
         folder_id = body.get("folder_id")
         destination = body.get("destination", "")
+        destination_name_raw = body.get("destination_name", "")
         mode = body.get("mode", "quick")
         if mode not in ("quick", "exact", "preview"):
             mode = "quick"
@@ -19371,6 +19381,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
         if not folder_id:
             return json_error("folder_id required")
+        try:
+            destination_name = move_mod.normalize_destination_name(
+                destination_name_raw)
+        except ValueError as exc:
+            return json_error(str(exc))
 
         folder = _get_db().conn.execute(
             "SELECT path, name FROM folders WHERE id = ?", (folder_id,)
@@ -19406,9 +19421,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # different remote path than the actual transfer (move_folder
             # uses posixpath.join), so an existing destination would be
             # reported as new and the first non-merge move would fail.
-            folder_name = (folder["name"]
-                           or os.path.basename(folder["path"].rstrip("/\\")))
-            resolved = posixpath.join(spec["ssh_dest_base"], folder_name)
+            landing_name = destination_name or folder["name"] \
+                or os.path.basename(folder["path"].rstrip("/\\"))
+            resolved = posixpath.join(spec["ssh_dest_base"], landing_name)
             exists, fcount, truncated, reachable, err = \
                 move_mod.remote_preflight(target, resolved)
             return jsonify({
@@ -19429,7 +19444,8 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if not os.path.isabs(destination):
             return json_error("destination must be an absolute path")
 
-        resolved = resolve_folder_dest(folder["path"], folder["name"], destination)
+        resolved = resolve_folder_dest(
+            folder["path"], folder["name"], destination, destination_name)
         exists = os.path.isdir(resolved)
         file_count = 0
         file_count_truncated = False

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -3799,11 +3799,13 @@ class Database:
         )
         self.conn.commit()
 
-    def move_folder_path(self, folder_id, new_path):
+    def move_folder_path(self, folder_id, new_path, new_name=None):
         """Update a folder's path and cascade to all children.
 
         Unlike relocate_folder (which only updates missing children),
-        this updates ALL child folders regardless of status.
+        this updates ALL child folders regardless of status. ``new_name`` is
+        used when the root folder is renamed as part of the move; descendants
+        keep their existing names.
         """
         old_row = self.conn.execute(
             "SELECT path FROM folders WHERE id = ?", (folder_id,)
@@ -3811,9 +3813,15 @@ class Database:
         if not old_row:
             return
         old_path = old_row["path"]
-        self.conn.execute(
-            "UPDATE folders SET path = ? WHERE id = ?", (new_path, folder_id)
-        )
+        if new_name is None:
+            self.conn.execute(
+                "UPDATE folders SET path = ? WHERE id = ?", (new_path, folder_id)
+            )
+        else:
+            self.conn.execute(
+                "UPDATE folders SET path = ?, name = ? WHERE id = ?",
+                (new_path, new_name, folder_id),
+            )
         children = self.conn.execute(
             """SELECT id, path FROM folders
                WHERE substr(REPLACE(path, '\\', '/'), 1, ?) = ?""",

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -1821,12 +1821,19 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
         # when this code runs on Windows; os.path.join would produce a
         # backslash and rsync would treat it as a single path segment.
         transfer_dest = posixpath.join(remote["ssh_dest_base"], landing_name)
-        catalog_path = resolve_folder_dest(
-            src_path, folder["name"], mount_base, landing_name)
+        # Join landing_name directly rather than routing it back through
+        # resolve_folder_dest: that helper calls normalize_destination_name,
+        # which would re-trim/reject a value we've already resolved. When the
+        # user didn't request a rename, landing_name is the raw folder_name
+        # (potentially with surrounding whitespace, or POSIX-legal ``:``/``\``
+        # on Linux/macOS filesystems that allow them). Preflight preserves
+        # those characters — the move job must too, or the copy lands at a
+        # different path than preflight showed and the catalog repoints to
+        # yet another (trimmed) path.
+        catalog_path = os.path.join(mount_base, landing_name)
         rsync_target = rsync_dest_spec(remote, transfer_dest)
     else:
-        transfer_dest = resolve_folder_dest(
-            src_path, folder["name"], destination, landing_name)
+        transfer_dest = os.path.join(destination, landing_name)
         catalog_path = transfer_dest
         rsync_target = transfer_dest
 

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -137,7 +137,11 @@ def normalize_destination_name(destination_name):
     folder that lands inside it.  Keeping the leaf name separate makes rename-
     while-moving explicit and prevents an entered name from escaping the
     selected parent.  Both slash styles are rejected because moves can target
-    a POSIX NAS from a Windows client (and vice versa).
+    a POSIX NAS from a Windows client (and vice versa).  Colons are rejected
+    too: on Windows ``os.path.join(r"D:\\archive", "C:shoot")`` returns the
+    drive-relative ``"C:shoot"``, so accepting a drive-qualified leaf would
+    let the entered name escape the selected parent and land the copy — and
+    the repointed ``catalog_path`` — outside the chosen destination.
 
     An empty value means "keep the source folder name" and is returned as an
     empty string for backwards-compatible callers.
@@ -149,8 +153,16 @@ def normalize_destination_name(destination_name):
     name = destination_name.strip()
     if not name:
         return ""
-    if name in (".", "..") or "/" in name or "\\" in name or "\0" in name:
-        raise ValueError("Folder name must be a single name without slashes")
+    if (
+        name in (".", "..")
+        or "/" in name
+        or "\\" in name
+        or ":" in name
+        or "\0" in name
+    ):
+        raise ValueError(
+            "Folder name must be a single name without slashes or colons"
+        )
     return name
 
 

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -1767,7 +1767,13 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
         return {"moved": 0, "errors": ["Folder not found"]}
 
     src_path = folder["path"]
-    folder_name = folder["name"] or os.path.basename(src_path)
+    # rstrip separators before basename() so a legacy row stored with a
+    # trailing '/' or '\\' still yields the folder leaf; without it a
+    # nameless folder row falls back to an empty landing_name here, and the
+    # copy lands directly in the selected parent (or merges into it) even
+    # though preflight — which uses the same rstrip in resolve_folder_dest
+    # and the remote branch — approves ``<parent>/<source-leaf>``.
+    folder_name = folder["name"] or os.path.basename(src_path.rstrip("/\\"))
     try:
         landing_name = normalize_destination_name(destination_name) or folder_name
     except ValueError as exc:

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -130,15 +130,42 @@ def build_remote_move_spec(target, subpath, rsync_bin, ssh_bin=""):
     }
 
 
-def resolve_folder_dest(folder_path, folder_name, destination):
+def normalize_destination_name(destination_name):
+    """Return a safe, single-component folder name for a move destination.
+
+    Folder moves accept a destination *parent* separately from the name of the
+    folder that lands inside it.  Keeping the leaf name separate makes rename-
+    while-moving explicit and prevents an entered name from escaping the
+    selected parent.  Both slash styles are rejected because moves can target
+    a POSIX NAS from a Windows client (and vice versa).
+
+    An empty value means "keep the source folder name" and is returned as an
+    empty string for backwards-compatible callers.
+    """
+    if destination_name is None:
+        return ""
+    if not isinstance(destination_name, str):
+        raise ValueError("Folder name must be a string")
+    name = destination_name.strip()
+    if not name:
+        return ""
+    if name in (".", "..") or "/" in name or "\\" in name or "\0" in name:
+        raise ValueError("Folder name must be a single name without slashes")
+    return name
+
+
+def resolve_folder_dest(folder_path, folder_name, destination,
+                        destination_name=""):
     """Compute the final landing path for a folder move.
 
-    The source folder is placed *inside* destination, keeping its name —
-    e.g. moving /local/birds to /nas/photos yields /nas/photos/birds.
+    The source folder is placed *inside* destination. By default it keeps its
+    name (moving /local/birds to /nas/photos yields /nas/photos/birds), while
+    ``destination_name`` allows an explicit rename during the move.
     Shared by move_folder() and the preflight route so the resolved path
     is computed in exactly one place.
     """
-    name = folder_name or os.path.basename(folder_path.rstrip("/\\"))
+    name = normalize_destination_name(destination_name) or folder_name \
+        or os.path.basename(folder_path.rstrip("/\\"))
     return os.path.join(destination, name)
 
 
@@ -1656,17 +1683,20 @@ def move_photos(db, photo_ids, destination, progress_cb=None):
 
 def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
                 merge=False, remote=None, reject_tracked_ancestor=False,
-                allow_tracked_merge=False):
+                allow_tracked_merge=False, destination_name=""):
     """Move an entire folder (and subfolders) to a destination.
 
-    The folder is placed inside the destination, preserving its name.
-    E.g., moving /local/birds to /nas/photos creates /nas/photos/birds.
+    The folder is placed inside the destination, preserving its name unless
+    ``destination_name`` explicitly renames it. E.g., moving /local/birds to
+    /nas/photos creates /nas/photos/birds by default.
 
     Args:
         db: Database instance
         folder_id: ID of the source folder
         destination: absolute path to parent destination directory. Ignored
             for a remote move (the destination comes from ``remote``).
+        destination_name: optional new name for the folder at the destination.
+            Must be one path component. Empty preserves the source name.
         progress_cb: optional callback(current, total, filename)
         merge: when False (default), refuse to write into a destination
             that already exists — the safe all-or-nothing behavior. When
@@ -1726,6 +1756,10 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
 
     src_path = folder["path"]
     folder_name = folder["name"] or os.path.basename(src_path)
+    try:
+        landing_name = normalize_destination_name(destination_name) or folder_name
+    except ValueError as exc:
+        return {"moved": 0, "errors": [str(exc)]}
 
     # Three destination views:
     #   transfer_dest — where rsync writes (NAS-side path for remote, local
@@ -1774,13 +1808,13 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
         # The NAS side is POSIX, so the SSH dest must be joined with '/' even
         # when this code runs on Windows; os.path.join would produce a
         # backslash and rsync would treat it as a single path segment.
-        name = folder["name"] or os.path.basename(src_path.rstrip("/\\"))
-        transfer_dest = posixpath.join(remote["ssh_dest_base"], name)
+        transfer_dest = posixpath.join(remote["ssh_dest_base"], landing_name)
         catalog_path = resolve_folder_dest(
-            src_path, folder["name"], mount_base)
+            src_path, folder["name"], mount_base, landing_name)
         rsync_target = rsync_dest_spec(remote, transfer_dest)
     else:
-        transfer_dest = resolve_folder_dest(src_path, folder["name"], destination)
+        transfer_dest = resolve_folder_dest(
+            src_path, folder["name"], destination, landing_name)
         catalog_path = transfer_dest
         rsync_target = transfer_dest
 
@@ -2169,7 +2203,7 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
         merge_counts = db.merge_staged_tree_into_archive(
             folder_id, merge_reconcile_base)
     else:
-        db.move_folder_path(folder_id, catalog_path)
+        db.move_folder_path(folder_id, catalog_path, new_name=landing_name)
     db.update_folder_counts()
 
     # Rebase any developed-output subdirs nested under the configured

--- a/vireo/templates/move.html
+++ b/vireo/templates/move.html
@@ -889,8 +889,21 @@ function resetQuickFolderName() {
 }
 
 function quickFolderNameResult() {
-  var name = document.getElementById('quickFolderName').value.trim();
-  if (!name) return {value: '', error: 'Enter a name for the folder.'};
+  var raw = document.getElementById('quickFolderName').value;
+  // "Unchanged from the pre-populated default" is a distinct state from
+  // "the user typed something that happens to trim to the source name":
+  // if we .trim() a source folder whose real name has leading or trailing
+  // whitespace on a no-op submit, we'd rename it to the trimmed variant
+  // (landing at /archive/Shoot instead of preserving /archive/ Shoot ).
+  // Signal "keep original" with an empty value + rename:false so callers
+  // send no destination_name and the backend uses folder.name verbatim.
+  var fid = parseInt(document.getElementById('quickFolderSelect').value);
+  var folder = fid ? allFolders.find(function(f) { return f.id === fid; }) : null;
+  if (folder && raw === sourceFolderName(folder)) {
+    return {value: '', error: '', rename: false};
+  }
+  var name = raw.trim();
+  if (!name) return {value: '', error: 'Enter a name for the folder.', rename: false};
   // Colon rejection matches the backend: on Windows, joining a parent with
   // e.g. "C:shoot" collapses to the drive-relative "C:shoot" and escapes
   // the selected parent, so the leaf name has to stay free of : as well.
@@ -898,9 +911,10 @@ function quickFolderNameResult() {
     return {
       value: '',
       error: 'Use a single folder name without slashes or colons.',
+      rename: false,
     };
   }
-  return {value: name, error: ''};
+  return {value: name, error: '', rename: true};
 }
 
 function setQuickMoveSummary(folder, finalPath) {
@@ -943,7 +957,7 @@ function setQuickMoveSummary(folder, finalPath) {
 
   var meta = document.createElement('div');
   meta.className = 'move-preview-meta';
-  var renamed = sourceFolderName(folder) !== quickFolderNameResult().value;
+  var renamed = quickFolderNameResult().rename;
   meta.textContent = count.toLocaleString() + ' photo' + (count !== 1 ? 's' : '') +
     ' · Includes subfolders' + (renamed ? ' · Folder will be renamed' : '');
 
@@ -1038,7 +1052,10 @@ function updateQuickMovePreview() {
     }
     var sub = subResult.value;
     var base = t.remote_path.replace(/\/+$/, '') + (sub ? '/' + sub : '');
-    var finalPath = base + '/' + destinationName;
+    // Fall back to the source folder's actual name when the user hasn't
+    // renamed: destinationName is intentionally empty in that case so the
+    // backend uses the untrimmed folder.name, so the preview must match.
+    var finalPath = base + '/' + (destinationName || sourceFolderName(folder));
     var finalDestSpec = rsyncDestSpec(t.user, t.host, finalPath);
 
     preview.textContent = '';

--- a/vireo/templates/move.html
+++ b/vireo/templates/move.html
@@ -891,8 +891,14 @@ function resetQuickFolderName() {
 function quickFolderNameResult() {
   var name = document.getElementById('quickFolderName').value.trim();
   if (!name) return {value: '', error: 'Enter a name for the folder.'};
-  if (name === '.' || name === '..' || /[\\\/]/.test(name)) {
-    return {value: '', error: 'Use a single folder name without slashes.'};
+  // Colon rejection matches the backend: on Windows, joining a parent with
+  // e.g. "C:shoot" collapses to the drive-relative "C:shoot" and escapes
+  // the selected parent, so the leaf name has to stay free of : as well.
+  if (name === '.' || name === '..' || /[\\\/:]/.test(name)) {
+    return {
+      value: '',
+      error: 'Use a single folder name without slashes or colons.',
+    };
   }
   return {value: name, error: ''};
 }

--- a/vireo/templates/move.html
+++ b/vireo/templates/move.html
@@ -8,31 +8,50 @@
 <link rel="stylesheet" href="/static/vireo-base.css">
 <title>Vireo - Move</title>
 <style>
-body { padding-bottom: 36px; }
-.content { max-width: 1100px; margin: 0 auto; padding: 20px; }
-.page-title { font-size: 20px; font-weight: 700; color: var(--text-primary); margin-bottom: 20px; }
+body { padding-bottom: 48px; }
+.content { max-width: 1120px; margin: 0 auto; padding: 32px 24px; }
+.page-header { margin-bottom: 24px; }
+.page-title {
+  font-size: 26px;
+  line-height: 1.2;
+  font-weight: 720;
+  letter-spacing: -0.025em;
+  color: var(--text-primary);
+  margin: 0 0 6px;
+}
+.page-subtitle {
+  color: var(--text-muted);
+  font-size: 14px;
+  line-height: 1.5;
+}
 
 /* Tabs */
 .move-tabs {
-  display: flex;
-  gap: 0;
-  border-bottom: 1px solid var(--border-primary);
-  margin-bottom: 20px;
+  display: inline-flex;
+  gap: 3px;
+  padding: 4px;
+  border: 1px solid var(--border-primary);
+  border-radius: 10px;
+  background: var(--bg-tertiary);
+  margin-bottom: 22px;
 }
 .move-tab {
-  padding: 10px 20px;
+  padding: 8px 15px;
   font-size: 13px;
+  font-weight: 600;
   color: var(--text-muted);
   cursor: pointer;
-  border-bottom: 2px solid transparent;
-  transition: color 0.15s, border-color 0.15s;
-  background: none;
-  border-top: none;
-  border-left: none;
-  border-right: none;
+  border: 0;
+  border-radius: 7px;
+  transition: color 0.15s, background 0.15s, box-shadow 0.15s;
+  background: transparent;
 }
-.move-tab:hover { color: var(--text-primary); }
-.move-tab.active { color: var(--text-primary); border-bottom-color: var(--accent); }
+.move-tab:hover { color: var(--text-primary); background: var(--bg-secondary); }
+.move-tab.active {
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  box-shadow: 0 1px 3px color-mix(in srgb, var(--text-primary) 10%, transparent);
+}
 
 .tab-panel { display: none; }
 .tab-panel.active { display: block; }
@@ -41,8 +60,8 @@ body { padding-bottom: 36px; }
 .move-section {
   background: var(--bg-secondary);
   border: 1px solid var(--border-primary);
-  border-radius: 6px;
-  padding: 20px;
+  border-radius: 12px;
+  padding: 24px;
   margin-bottom: 16px;
 }
 .move-section h3 {
@@ -56,6 +75,141 @@ body { padding-bottom: 36px; }
   color: var(--text-muted);
   margin: 0 0 16px 0;
 }
+
+/* Guided whole-folder move */
+.quick-move-section { max-width: 980px; padding: 0; overflow: hidden; }
+.quick-move-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 13px;
+  padding: 19px 22px 17px;
+  border-bottom: 1px solid var(--border-primary);
+}
+.quick-move-icon {
+  display: grid;
+  place-items: center;
+  width: 38px;
+  height: 38px;
+  flex: 0 0 38px;
+  border-radius: 10px;
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, var(--bg-tertiary));
+  border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border-primary));
+}
+.quick-move-icon svg { width: 20px; height: 20px; }
+.quick-move-header h3 { margin: 0 0 4px; font-size: 16px; }
+.quick-move-header p { margin: 0; color: var(--text-muted); font-size: 13px; line-height: 1.5; }
+.move-flow { padding: 20px 22px; }
+.move-step { display: grid; grid-template-columns: 34px minmax(0, 1fr); gap: 14px; }
+.step-number {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--accent-dim);
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 750;
+}
+.step-body { min-width: 0; }
+.step-title { display: block; margin: 3px 0 12px; font-size: 14px; font-weight: 650; color: var(--text-primary); }
+.step-connector { width: 1px; height: 22px; margin: 4px 0 4px 13px; background: var(--border-primary); }
+.field-group { margin-bottom: 14px; }
+.field-group:last-child { margin-bottom: 0; }
+.destination-fields {
+  display: grid;
+  grid-template-columns: minmax(0, 1.45fr) minmax(300px, 1fr);
+  align-items: start;
+  gap: 14px;
+}
+.destination-fields .field-group { margin-bottom: 0; }
+.field-label {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 6px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 650;
+}
+.field-hint { margin-top: 6px; color: var(--text-dim); font-size: 11.5px; line-height: 1.45; }
+.move-control,
+.move-control-row input,
+.move-control-row select {
+  width: 100%;
+  min-height: 40px;
+  padding: 9px 11px;
+  border: 1px solid var(--border-secondary);
+  border-radius: 7px;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 13px;
+}
+.move-control:focus,
+.move-control-row input:focus,
+.move-control-row select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 12%, transparent);
+}
+.move-control-row { display: flex; align-items: stretch; gap: 8px; }
+.move-control-row input, .move-control-row select { flex: 1; min-width: 0; }
+.move-control-row .btn { flex: 0 0 auto; }
+.field-error { min-height: 16px; margin-top: 5px; color: var(--danger); font-size: 11.5px; }
+.folder-info {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 20px;
+  margin-top: 7px;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+.folder-info:not(:empty)::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  flex: 0 0 6px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+.reset-name-btn { white-space: nowrap; }
+.move-preview-card {
+  margin-top: 18px;
+  padding: 14px 16px;
+  border: 1px solid color-mix(in srgb, var(--accent) 25%, var(--border-primary));
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--accent) 5%, var(--bg-tertiary));
+}
+.move-preview-eyebrow {
+  margin-bottom: 11px;
+  color: var(--text-dim);
+  font-size: 10.5px;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.move-route { display: grid; grid-template-columns: minmax(0, 1fr) 28px minmax(0, 1fr); align-items: center; gap: 10px; }
+.move-route-label { margin-bottom: 4px; color: var(--text-dim); font-size: 10.5px; font-weight: 650; }
+.move-route-path { color: var(--text-primary); font-family: var(--font-mono, monospace); font-size: 12px; line-height: 1.45; word-break: break-word; }
+.move-route-arrow { color: var(--accent); font-size: 20px; text-align: center; }
+.move-preview-meta { margin-top: 9px; color: var(--text-muted); font-size: 11.5px; }
+.move-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 15px 22px;
+  border-top: 1px solid var(--border-primary);
+  background: color-mix(in srgb, var(--bg-tertiary) 55%, var(--bg-secondary));
+}
+.move-safety { display: flex; align-items: flex-start; gap: 8px; color: var(--text-dim); font-size: 11.5px; line-height: 1.45; }
+.move-safety svg { width: 15px; height: 15px; flex: 0 0 15px; margin-top: 1px; color: var(--accent); }
+.quick-submit { min-height: 40px; padding: 9px 18px; border-radius: 7px; white-space: nowrap; }
+.quick-submit .button-arrow { margin-left: 7px; font-size: 15px; }
 
 /* Form row */
 .form-row {
@@ -275,17 +429,11 @@ body { padding-bottom: 36px; }
 }
 
 /* Folder info row */
-.folder-info {
-  font-size: 12px;
-  color: var(--text-dim);
-  margin-top: 4px;
-}
-
 /* Resolved-destination preview under the Move-folder destination input */
 .dest-preview {
-  font-size: 12px;
+  font-size: 11.5px;
   color: var(--text-dim);
-  margin-top: 6px;
+  margin-top: 10px;
   word-break: break-all;
 }
 .dest-preview .dest-preview-path {
@@ -350,15 +498,7 @@ body { padding-bottom: 36px; }
   word-break: break-all;
 }
 .move-summary {
-  margin-top: 14px;
-  padding: 10px 12px;
-  border: 1px solid var(--border-primary);
-  border-radius: 4px;
-  background: var(--bg-tertiary);
-  color: var(--text-secondary);
-  font-size: 13px;
-  line-height: 1.5;
-  word-break: break-word;
+  display: none;
 }
 .browser-folder-item {
   padding: 6px 10px;
@@ -386,6 +526,22 @@ body { padding-bottom: 36px; }
   color: var(--text-primary);
 }
 .new-folder-row input:focus { outline: none; border-color: var(--accent); }
+
+@media (max-width: 850px) {
+  .destination-fields { grid-template-columns: 1fr; }
+  .destination-fields .field-group { margin-bottom: 14px; }
+}
+
+@media (max-width: 700px) {
+  .content { padding: 22px 14px; }
+  .move-tabs { display: flex; }
+  .move-tab { flex: 1; padding-inline: 9px; }
+  .quick-move-header, .move-flow, .move-actions { padding-left: 17px; padding-right: 17px; }
+  .move-route { grid-template-columns: 1fr; }
+  .move-route-arrow { transform: rotate(90deg); text-align: left; padding-left: 4px; }
+  .move-actions { align-items: stretch; flex-direction: column; }
+  .quick-submit { width: 100%; }
+}
 </style>
 </head>
 <body>
@@ -393,7 +549,10 @@ body { padding-bottom: 36px; }
 {% include '_navbar.html' %}
 
 <div class="content">
-  <h2 class="page-title">Move Photos</h2>
+  <div class="page-header">
+    <h2 class="page-title">Move Photos</h2>
+    <p class="page-subtitle">Reorganize folders and photos without losing edits, metadata, or library links.</p>
+  </div>
 
   <div class="move-tabs">
     <button class="move-tab active" onclick="switchTab('quick')">Quick Move</button>
@@ -403,38 +562,91 @@ body { padding-bottom: 36px; }
 
   <!-- Quick Move Tab -->
   <div class="tab-panel active" id="tab-quick">
-    <div class="move-section">
-      <h3>Move Entire Folder</h3>
-      <p class="desc">Move all files in a folder (including subfolders) to a new location. Files are copied first, verified, then originals are removed.</p>
-
-      <div class="form-row">
-        <label>Source Folder</label>
-        <select id="quickFolderSelect" onchange="onQuickFolderChange()">
-          <option value="">-- Select a folder --</option>
-        </select>
-      </div>
-      <div class="folder-info" id="quickFolderInfo"></div>
-
-      <div class="form-row">
-        <label>Destination</label>
-        <div class="dest-row">
-          <select id="quickDestMode" onchange="onQuickDestModeChange()">
-            <option value="local">Local path</option>
-          </select>
+    <div class="move-section quick-move-section">
+      <div class="quick-move-header">
+        <div class="quick-move-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M3 7.5h6l2 2h10v8.75A1.75 1.75 0 0 1 19.25 20H4.75A1.75 1.75 0 0 1 3 18.25z"/>
+            <path d="M7.5 14h9M13.5 11l3 3-3 3"/>
+          </svg>
+        </div>
+        <div>
+          <h3>Move an entire folder</h3>
+          <p>Choose where it should live and rename it if you’d like. Subfolders and companion files move with it.</p>
         </div>
       </div>
-      <div class="dest-row" id="quickLocalRow" style="margin-bottom:8px;">
-        <input type="text" id="quickDestInput" placeholder="/path/to/destination" oninput="updateQuickMoveBtn()">
-        <button class="btn btn-secondary btn-small" onclick="openBrowser('quickDestInput')">Browse</button>
-      </div>
-      <div class="dest-row" id="quickRemoteRow" style="display:none; margin-bottom:8px;">
-        <input type="text" id="quickSubpathInput" placeholder="Optional subfolder under the target (e.g. USA/2026)" oninput="updateQuickMoveBtn()">
-      </div>
-      <div class="dest-preview" id="quickDestPreview"></div>
-      <div class="move-summary" id="quickMoveSummary" style="display:none;"></div>
 
-      <div style="margin-top:16px;">
-        <button class="btn btn-primary" id="quickMoveBtn" onclick="startQuickMove()" disabled>Move Folder</button>
+      <div class="move-flow">
+        <div class="move-step">
+          <div class="step-number">1</div>
+          <div class="step-body">
+            <label class="step-title" for="quickFolderSelect">Choose the folder to move</label>
+            <select class="move-control" id="quickFolderSelect" onchange="onQuickFolderChange()">
+              <option value="">Select a folder…</option>
+            </select>
+            <div class="folder-info" id="quickFolderInfo"></div>
+          </div>
+        </div>
+
+        <div class="step-connector" aria-hidden="true"></div>
+
+        <div class="move-step">
+          <div class="step-number">2</div>
+          <div class="step-body">
+            <span class="step-title">Choose its new location</span>
+
+            <div class="field-group">
+              <label class="field-label" for="quickDestMode">Destination type</label>
+              <select class="move-control" id="quickDestMode" onchange="onQuickDestModeChange()">
+                <option value="local">A folder on this Mac or a mounted drive</option>
+              </select>
+            </div>
+
+            <div class="destination-fields">
+              <div class="field-group" id="quickLocalRow">
+                <label class="field-label" for="quickDestInput">Destination parent folder</label>
+                <div class="move-control-row">
+                  <input type="text" id="quickDestInput" placeholder="Choose where it will live" oninput="updateQuickMoveBtn()">
+                  <button class="btn btn-secondary" type="button" onclick="openBrowser('quickDestInput')">
+                    Browse
+                  </button>
+                </div>
+                <div class="field-hint">The moved folder will be created inside this location.</div>
+              </div>
+
+              <div class="field-group" id="quickRemoteRow" style="display:none;">
+                <label class="field-label" for="quickSubpathInput">Folder inside remote target <span style="font-weight:400;color:var(--text-dim);">Optional</span></label>
+                <input class="move-control" type="text" id="quickSubpathInput" placeholder="For example: USA/2026" oninput="updateQuickMoveBtn()">
+                <div class="field-hint">Leave blank to use the remote target’s main folder.</div>
+              </div>
+
+              <div class="field-group">
+                <label class="field-label" for="quickFolderName">Folder name</label>
+                <div class="move-control-row">
+                  <input type="text" id="quickFolderName" placeholder="Select a source folder first" oninput="updateQuickMoveBtn()" disabled>
+                  <button class="btn btn-secondary reset-name-btn" id="quickResetNameBtn" type="button" onclick="resetQuickFolderName()" disabled>Use original</button>
+                </div>
+                <div class="field-hint">Edit this name to rename the folder as part of the move.</div>
+                <div class="field-error" id="quickFolderNameError" role="status"></div>
+              </div>
+            </div>
+
+            <div class="move-preview-card" id="quickMoveSummary" style="display:none;"></div>
+            <div class="dest-preview" id="quickDestPreview"></div>
+          </div>
+        </div>
+      </div>
+
+      <div class="move-actions">
+        <div class="move-safety">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M12 3 4.5 6v5.5c0 4.6 3.2 7.7 7.5 9.5 4.3-1.8 7.5-4.9 7.5-9.5V6z"/><path d="m9 12 2 2 4-4"/>
+          </svg>
+          <span>Vireo copies and verifies every file before removing the originals.</span>
+        </div>
+        <button class="btn btn-primary quick-submit" id="quickMoveBtn" onclick="startQuickMove()" disabled>
+          Review move <span class="button-arrow" aria-hidden="true">→</span>
+        </button>
       </div>
     </div>
   </div>
@@ -640,32 +852,98 @@ function populateFolderSelects() {
 function onQuickFolderChange() {
   var sel = document.getElementById('quickFolderSelect');
   var info = document.getElementById('quickFolderInfo');
+  var nameInput = document.getElementById('quickFolderName');
+  var resetBtn = document.getElementById('quickResetNameBtn');
   var fid = parseInt(sel.value);
   if (!fid) {
     info.textContent = '';
+    nameInput.value = '';
+    nameInput.disabled = true;
+    resetBtn.disabled = true;
     updateQuickMoveBtn();
     return;
   }
   var folder = allFolders.find(function(f) { return f.id === fid; });
   if (folder) {
     var count = folder.photo_count || 0;
-    info.textContent = 'Source: ' + folder.path + ' · ' +
+    info.textContent = folder.path + ' · ' +
       count.toLocaleString() + ' photo' + (count !== 1 ? 's' : '');
+    nameInput.value = sourceFolderName(folder);
+    nameInput.disabled = false;
+    resetBtn.disabled = false;
   }
   updateQuickMoveBtn();
+}
+
+function sourceFolderName(folder) {
+  var srcPath = (folder && folder.path) || '';
+  return (folder && folder.name) ||
+    srcPath.replace(/[\\\/]+$/, '').split(/[\\\/]/).pop() || '';
+}
+
+function resetQuickFolderName() {
+  var fid = parseInt(document.getElementById('quickFolderSelect').value);
+  var folder = allFolders.find(function(f) { return f.id === fid; });
+  document.getElementById('quickFolderName').value = sourceFolderName(folder);
+  updateQuickMoveBtn();
+}
+
+function quickFolderNameResult() {
+  var name = document.getElementById('quickFolderName').value.trim();
+  if (!name) return {value: '', error: 'Enter a name for the folder.'};
+  if (name === '.' || name === '..' || /[\\\/]/.test(name)) {
+    return {value: '', error: 'Use a single folder name without slashes.'};
+  }
+  return {value: name, error: ''};
 }
 
 function setQuickMoveSummary(folder, finalPath) {
   var summary = document.getElementById('quickMoveSummary');
   if (!folder || !finalPath) {
-    summary.textContent = '';
+    summary.replaceChildren();
     summary.style.display = 'none';
     return '';
   }
   var count = folder.photo_count || 0;
   var text = 'Confirm moving ' + count.toLocaleString() + ' photo' +
     (count !== 1 ? 's' : '') + ' from ' + folder.path + ' to ' + finalPath + '?';
-  summary.textContent = text;
+
+  summary.replaceChildren();
+  var eyebrow = document.createElement('div');
+  eyebrow.className = 'move-preview-eyebrow';
+  eyebrow.textContent = 'Final location';
+
+  var route = document.createElement('div');
+  route.className = 'move-route';
+  function routePoint(label, path) {
+    var point = document.createElement('div');
+    var routeLabel = document.createElement('div');
+    routeLabel.className = 'move-route-label';
+    routeLabel.textContent = label;
+    var routePath = document.createElement('div');
+    routePath.className = 'move-route-path';
+    routePath.textContent = path;
+    point.appendChild(routeLabel);
+    point.appendChild(routePath);
+    return point;
+  }
+  route.appendChild(routePoint('FROM', folder.path));
+  var arrow = document.createElement('div');
+  arrow.className = 'move-route-arrow';
+  arrow.setAttribute('aria-hidden', 'true');
+  arrow.textContent = '→';
+  route.appendChild(arrow);
+  route.appendChild(routePoint('TO', finalPath));
+
+  var meta = document.createElement('div');
+  meta.className = 'move-preview-meta';
+  var renamed = sourceFolderName(folder) !== quickFolderNameResult().value;
+  meta.textContent = count.toLocaleString() + ' photo' + (count !== 1 ? 's' : '') +
+    ' · Includes subfolders' + (renamed ? ' · Folder will be renamed' : '');
+
+  summary.appendChild(eyebrow);
+  summary.appendChild(route);
+  summary.appendChild(meta);
   summary.style.display = 'block';
   return text;
 }
@@ -674,16 +952,22 @@ function updateQuickMoveBtn() {
   var fid = document.getElementById('quickFolderSelect').value;
   var remoteId = quickRemoteTargetId();
   var btn = document.getElementById('quickMoveBtn');
+  var nameResult = quickFolderNameResult();
+  var nameError = document.getElementById('quickFolderNameError');
+  nameError.textContent = fid ? nameResult.error : '';
   var ready;
   if (remoteId) {
     // Remote needs a usable GNU rsync; no destination text is required (the
     // target carries it). An optional subpath refines where under it.
-    ready = !!fid && quickRsyncAvailable;
+    ready = !!fid && quickRsyncAvailable && !nameResult.error;
   } else {
-    ready = !!(fid && document.getElementById('quickDestInput').value.trim());
+    ready = !!(fid && document.getElementById('quickDestInput').value.trim()
+      && !nameResult.error);
   }
   btn.disabled = quickMoveBusy || !ready;
-  btn.textContent = quickMoveBusy ? 'Checking...' : 'Move Folder';
+  btn.innerHTML = quickMoveBusy
+    ? 'Checking destination…'
+    : 'Review move <span class="button-arrow" aria-hidden="true">→</span>';
   updateQuickMovePreview();
 }
 
@@ -693,20 +977,18 @@ function setQuickMoveBusy(isBusy) {
 }
 
 // Compute the final landing path, mirroring move.py move_folder():
-// the source folder is placed *inside* the destination, keeping its name.
+// the named folder is placed *inside* the destination. The editable name
+// allows a rename during the same safe move.
 // Detect Windows-style paths (containing '\') so the preview matches
 // os.path.join on a Windows backend, where 'C:\Archive\' + 'Birds' is
 // 'C:\Archive\Birds', not 'C:\Archive\/Birds'. Also lets the folder.name
 // fallback split a backslash-delimited source path.
-function resolvedMoveDest(folder, destination) {
+function resolvedMoveDest(folder, destination, destinationName) {
   var srcPath = (folder && folder.path) || '';
   var winStyle = destination.indexOf('\\') !== -1 || srcPath.indexOf('\\') !== -1;
   var sep = winStyle ? '\\' : '/';
   var trimRe = winStyle ? /[\\\/]+$/ : /\/+$/;
-  var splitRe = winStyle ? /[\\\/]/ : /\//;
-
-  var folderName = (folder && folder.name) ||
-    srcPath.replace(trimRe, '').split(splitRe).pop();
+  var folderName = destinationName || sourceFolderName(folder);
   return destination.replace(trimRe, '') + sep + folderName;
 }
 
@@ -720,6 +1002,13 @@ function updateQuickMovePreview() {
     return;
   }
   var folder = allFolders.find(function(f) { return f.id === fid; });
+  var nameResult = quickFolderNameResult();
+  if (nameResult.error) {
+    preview.textContent = '';
+    setQuickMoveSummary(null, '');
+    return;
+  }
+  var destinationName = nameResult.value;
 
   if (remoteId) {
     var t = quickRemoteTargets.find(function(x) { return x.id === remoteId; });
@@ -742,10 +1031,8 @@ function updateQuickMovePreview() {
       return;
     }
     var sub = subResult.value;
-    var folderName = (folder && folder.name) ||
-      ((folder && folder.path) || '').replace(/\/+$/, '').split('/').pop();
     var base = t.remote_path.replace(/\/+$/, '') + (sub ? '/' + sub : '');
-    var finalPath = base + '/' + folderName;
+    var finalPath = base + '/' + destinationName;
     var finalDestSpec = rsyncDestSpec(t.user, t.host, finalPath);
 
     preview.textContent = '';
@@ -777,7 +1064,7 @@ function updateQuickMovePreview() {
     rstatus.className = 'dest-status';
     preview.appendChild(rstatus);
     setQuickMoveSummary(folder, finalDestSpec);
-    scheduleQuickPreflight(fid, null, remoteId, sub);
+    scheduleQuickPreflight(fid, null, remoteId, sub, destinationName);
     return;
   }
 
@@ -787,18 +1074,9 @@ function updateQuickMovePreview() {
     setQuickMoveSummary(null, '');
     return;
   }
-  var finalPath = resolvedMoveDest(folder, dest);
+  var finalPath = resolvedMoveDest(folder, dest, destinationName);
 
-  // The resolved path is computable client-side, so show it instantly.
   preview.textContent = '';
-  var pathLine = document.createElement('div');
-  pathLine.textContent = 'Folder will be moved to: ';
-  var pathSpan = document.createElement('span');
-  pathSpan.className = 'dest-preview-path';
-  pathSpan.textContent = finalPath;
-  pathLine.appendChild(pathSpan);
-  preview.appendChild(pathLine);
-
   // Whether the destination already exists (and how much is in it) requires
   // hitting the filesystem, so fetch it from the preflight endpoint and fill
   // in this line asynchronously. Debounced so typing a path doesn't spam it.
@@ -807,7 +1085,7 @@ function updateQuickMovePreview() {
   status.className = 'dest-status';
   preview.appendChild(status);
   setQuickMoveSummary(folder, finalPath);
-  scheduleQuickPreflight(fid, dest, '', '');
+  scheduleQuickPreflight(fid, dest, '', '', destinationName);
 }
 
 function _destWarn(text) {
@@ -869,7 +1147,7 @@ function normalizeRemoteSubpath(raw) {
 var quickPreflightSeq = 0;
 var quickPreflightTimer = null;
 
-function scheduleQuickPreflight(fid, dest, remoteId, subpath) {
+function scheduleQuickPreflight(fid, dest, remoteId, subpath, destinationName) {
   if (quickPreflightTimer) clearTimeout(quickPreflightTimer);
   // Bump the sequence on *every* call, not just when a request starts. Any
   // change to the destination must immediately invalidate an in-flight
@@ -879,7 +1157,12 @@ function scheduleQuickPreflight(fid, dest, remoteId, subpath) {
   // exists/new-folder text for the wrong destination.
   var seq = ++quickPreflightSeq;
   if (remoteId) {
-    var body = {folder_id: fid, remote_target_id: remoteId, subpath: subpath || ''};
+    var body = {
+      folder_id: fid,
+      remote_target_id: remoteId,
+      subpath: subpath || '',
+      destination_name: destinationName,
+    };
     quickPreflightTimer = setTimeout(function() { runQuickPreflight(seq, body); }, 350);
     return;
   }
@@ -890,7 +1173,11 @@ function scheduleQuickPreflight(fid, dest, remoteId, subpath) {
   var isAbs = dest.charAt(0) === '/' || /^[A-Za-z]:[\\\/]/.test(dest) || /^\\\\/.test(dest);
   if (!isAbs) return;
   quickPreflightTimer = setTimeout(function() {
-    runQuickPreflight(seq, {folder_id: fid, destination: dest});
+    runQuickPreflight(seq, {
+      folder_id: fid,
+      destination: dest,
+      destination_name: destinationName,
+    });
   }, 350);
 }
 
@@ -929,7 +1216,8 @@ async function runQuickPreflight(seq, body) {
     // the user or holding up typing. Local-path only: the exact walk re-scans
     // a local dir, so for a remote target the capped "at least N" line stands.
     if (!data.remote && data.file_count_truncated) {
-      requestExactDestCount(body.folder_id, body.destination, seq);
+      requestExactDestCount(
+        body.folder_id, body.destination, body.destination_name, seq);
     }
   } else {
     status.textContent = '✓ New folder — nothing exists at this location yet.';
@@ -951,11 +1239,16 @@ function setDestExistsStatus(status, n, truncated) {
 // result landing after the user has changed the destination is discarded
 // instead of overwriting the line for the wrong path. Stays silent on failure:
 // the capped "at least N" line is already a valid answer.
-function requestExactDestCount(fid, dest, seq) {
+function requestExactDestCount(fid, dest, destinationName, seq) {
   fetch('/api/move-folder/preflight', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({folder_id: fid, destination: dest, mode: 'exact'}),
+    body: JSON.stringify({
+      folder_id: fid,
+      destination: dest,
+      destination_name: destinationName,
+      mode: 'exact',
+    }),
   }).then(function(resp) {
     return resp.ok ? resp.json() : null;
   }).then(function(data) {
@@ -976,6 +1269,11 @@ async function startQuickMove() {
   var fid = parseInt(document.getElementById('quickFolderSelect').value);
   if (!fid) return;
   var remoteId = quickRemoteTargetId();
+  var nameResult = quickFolderNameResult();
+  if (nameResult.error) {
+    showToast(nameResult.error, 'error');
+    return;
+  }
 
   // Build the destination half of the request body — a local path or a
   // remote target + optional subpath. The same shape is reused for both the
@@ -1001,11 +1299,12 @@ async function startQuickMove() {
     destBody = {
       remote_target_id: remoteId,
       subpath: subResult.value,
+      destination_name: nameResult.value,
     };
   } else {
     var dest = document.getElementById('quickDestInput').value.trim();
     if (!dest) return;
-    destBody = {destination: dest};
+    destBody = {destination: dest, destination_name: nameResult.value};
   }
 
   var folder = allFolders.find(function(f) { return f.id === fid; });

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -205,6 +205,11 @@ def test_move_folder_can_rename_during_move(move_env):
     assert folder["name"] == "2026-07-12"
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows strips trailing spaces from path components, so a ' shoot ' "
+    "directory can't exist on disk — the untrimmed-name invariant is a POSIX concern.",
+)
 def test_move_folder_no_op_rename_preserves_untrimmed_source_name(tmp_path):
     """A no-op rename lands at the source's raw name — spaces and all.
 

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -182,6 +182,46 @@ def test_move_folder_copies_tree(move_env):
     assert folder["path"] == str(env["dst"] / "src")
 
 
+def test_move_folder_can_rename_during_move(move_env):
+    """An explicit destination name moves and renames in one safe operation."""
+    from move import move_folder
+
+    env = move_env
+    result = move_folder(
+        db=env["db"],
+        folder_id=env["fid_src"],
+        destination=str(env["dst"]),
+        destination_name="2026-07-12",
+    )
+
+    landing = env["dst"] / "2026-07-12"
+    assert result["errors"] == []
+    assert (landing / "bird1.jpg").exists()
+    assert not env["src"].exists()
+    folder = env["db"].conn.execute(
+        "SELECT path, name FROM folders WHERE id = ?", (env["fid_src"],)
+    ).fetchone()
+    assert folder["path"] == str(landing)
+    assert folder["name"] == "2026-07-12"
+
+
+def test_move_folder_rejects_destination_name_with_path_segments(move_env):
+    """The rename field cannot escape the separately selected parent."""
+    from move import move_folder
+
+    env = move_env
+    result = move_folder(
+        db=env["db"],
+        folder_id=env["fid_src"],
+        destination=str(env["dst"]),
+        destination_name="../somewhere-else",
+    )
+
+    assert result["moved"] == 0
+    assert "without slashes" in result["errors"][0]
+    assert env["src"].exists()
+
+
 def test_move_folder_reports_cleanup_error_after_commit(move_env, monkeypatch):
     """Catalog repoints first, so a post-commit rmtree failure is committed.
 
@@ -2132,6 +2172,10 @@ def test_resolve_folder_dest():
     # Falls back to basename when name is empty
     assert resolve_folder_dest("/a/birds/", "", "/nas/photos") == \
         os.path.join("/nas/photos", "birds")
+    # An explicit final name supports rename-while-moving.
+    assert resolve_folder_dest(
+        "/a/12", "12", "/nas/photos/2026", "2026-07-12"
+    ) == os.path.join("/nas/photos/2026", "2026-07-12")
 
 
 def test_move_folder_updates_counts(move_env):

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -248,6 +248,57 @@ def test_move_folder_no_op_rename_preserves_untrimmed_source_name(tmp_path):
     assert folder["path"] == str(landing)
 
 
+def test_move_folder_no_op_rename_uses_source_leaf_when_name_missing(tmp_path):
+    """A nameless folder row whose path ends in '/' must still land at its leaf.
+
+    Legacy/relocated rows can carry an empty ``name`` alongside a ``path``
+    stored with a trailing separator. ``os.path.basename("/photos/shoot/")``
+    is ``""``, so without stripping the separator the no-op rename fallback
+    collapses to ``""`` and the copy lands directly in the selected parent
+    (potentially merging with a different folder). Preflight and
+    ``resolve_folder_dest`` already ``rstrip("/\\")`` before basename();
+    ``move_folder`` must too.
+    """
+    from move import move_folder
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+
+    src = tmp_path / "shoot"
+    src.mkdir()
+    (src / "bird.jpg").write_bytes(b"\xff\xd8" + b"\x00" * 100)
+    dst = tmp_path / "archive"
+    dst.mkdir()
+
+    fid = db.add_folder(str(src), name="shoot")
+    # Simulate a legacy row: blank name, trailing separator on path.
+    db.conn.execute(
+        "UPDATE folders SET name = '', path = ? WHERE id = ?",
+        (str(src) + "/", fid),
+    )
+    db.conn.commit()
+
+    db.add_photo(folder_id=fid, filename="bird.jpg", extension=".jpg",
+                 file_size=102, file_mtime=1.0)
+
+    result = move_folder(
+        db=db,
+        folder_id=fid,
+        destination=str(dst),
+        destination_name="",
+    )
+
+    landing = dst / "shoot"
+    assert result["errors"] == []
+    assert landing.is_dir()
+    assert (landing / "bird.jpg").exists()
+    folder = db.conn.execute(
+        "SELECT path FROM folders WHERE id = ?", (fid,)
+    ).fetchone()
+    assert folder["path"] == str(landing)
+
+
 def test_move_folder_rejects_destination_name_with_path_segments(move_env):
     """The rename field cannot escape the separately selected parent."""
     from move import move_folder

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -205,6 +205,49 @@ def test_move_folder_can_rename_during_move(move_env):
     assert folder["name"] == "2026-07-12"
 
 
+def test_move_folder_no_op_rename_preserves_untrimmed_source_name(tmp_path):
+    """A no-op rename lands at the source's raw name — spaces and all.
+
+    When the user leaves the Folder name field unchanged, the UI sends
+    ``destination_name=""`` so the backend keeps the source folder name
+    verbatim. If move_folder trims that fallback, the copy lands at
+    ``/archive/shoot`` while preflight showed ``/archive/ shoot `` — the
+    catalog then points at a folder that doesn't match what the user
+    approved and could silently merge with a different existing folder.
+    """
+    from move import move_folder
+
+    db = Database(str(tmp_path / "test.db"))
+    ws_id = db.ensure_default_workspace()
+    db.set_active_workspace(ws_id)
+
+    src = tmp_path / " shoot "
+    src.mkdir()
+    (src / "bird.jpg").write_bytes(b"\xff\xd8" + b"\x00" * 100)
+    dst = tmp_path / "archive"
+    dst.mkdir()
+
+    fid = db.add_folder(str(src), name=" shoot ")
+    db.add_photo(folder_id=fid, filename="bird.jpg", extension=".jpg",
+                 file_size=102, file_mtime=1.0)
+
+    result = move_folder(
+        db=db,
+        folder_id=fid,
+        destination=str(dst),
+        destination_name="",
+    )
+
+    landing = dst / " shoot "
+    assert result["errors"] == []
+    assert landing.is_dir()
+    assert (landing / "bird.jpg").exists()
+    folder = db.conn.execute(
+        "SELECT path FROM folders WHERE id = ?", (fid,)
+    ).fetchone()
+    assert folder["path"] == str(landing)
+
+
 def test_move_folder_rejects_destination_name_with_path_segments(move_env):
     """The rename field cannot escape the separately selected parent."""
     from move import move_folder

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -222,6 +222,43 @@ def test_move_folder_rejects_destination_name_with_path_segments(move_env):
     assert env["src"].exists()
 
 
+def test_move_folder_rejects_drive_qualified_destination_name(move_env):
+    """A Windows drive-qualified leaf like C:shoot must not escape the parent.
+
+    os.path.join(r"D:\\archive", "C:shoot") returns the drive-relative path
+    "C:shoot" on Windows, so accepting a colon-bearing leaf would drop the
+    copy — and repoint catalog_path — outside the selected destination.
+    """
+    from move import move_folder
+
+    env = move_env
+    result = move_folder(
+        db=env["db"],
+        folder_id=env["fid_src"],
+        destination=str(env["dst"]),
+        destination_name="C:shoot",
+    )
+
+    assert result["moved"] == 0
+    assert "colons" in result["errors"][0]
+    assert env["src"].exists()
+
+
+def test_normalize_destination_name_rejects_colon():
+    """Drive-qualified and colon-containing leaves are rejected everywhere."""
+    import pytest
+    from move import normalize_destination_name
+
+    for bad in ("C:shoot", "D:\\archive", "foo:bar", ":", "bird:cage/nest"):
+        with pytest.raises(ValueError):
+            normalize_destination_name(bad)
+
+    # Valid single-component names still pass through.
+    assert normalize_destination_name("2026-07-12") == "2026-07-12"
+    assert normalize_destination_name("") == ""
+    assert normalize_destination_name(None) == ""
+
+
 def test_move_folder_reports_cleanup_error_after_commit(move_env, monkeypatch):
     """Catalog repoints first, so a post-commit rmtree failure is committed.
 

--- a/vireo/tests/test_move_api.py
+++ b/vireo/tests/test_move_api.py
@@ -448,6 +448,29 @@ def test_move_folder_preflight_rejects_invalid_destination_name(
     assert "without slashes" in resp.get_json()["error"]
 
 
+def test_move_folder_preflight_rejects_drive_qualified_destination_name(
+    app_and_db, tmp_path,
+):
+    """A Windows drive-qualified leaf (colon) is rejected at the API boundary.
+
+    Left through, os.path.join(destination, "C:shoot") on a Windows client
+    would collapse to "C:shoot" and land the copy — plus the repointed
+    catalog_path — outside the selected destination.
+    """
+    app, db = app_and_db
+    folder = db.get_folder_tree()[0]
+    client = app.test_client()
+
+    resp = client.post("/api/move-folder/preflight", json={
+        "folder_id": folder["id"],
+        "destination": str(tmp_path),
+        "destination_name": "C:shoot",
+    })
+
+    assert resp.status_code == 400
+    assert "colons" in resp.get_json()["error"]
+
+
 def test_move_folder_preflight_caps_existing_destination_count(app_and_db, tmp_path):
     """Preflight should not recursively count an unbounded destination tree."""
     app, db = app_and_db

--- a/vireo/tests/test_move_api.py
+++ b/vireo/tests/test_move_api.py
@@ -171,6 +171,46 @@ def test_move_folder_job_starts(app_and_db, tmp_path):
     assert data["job_id"].startswith("move-folder-")
 
 
+def test_move_folder_job_passes_explicit_destination_name(
+    app_and_db, tmp_path, monkeypatch,
+):
+    """The rename shown by preflight is also used by the asynchronous move."""
+    import move as move_module
+    from wait import wait_for_job_via_client
+
+    app, db = app_and_db
+    parent = tmp_path / "move_folder_dst"
+    parent.mkdir()
+    fid = db.get_folder_tree()[0]["id"]
+    captured = {}
+
+    def fake_move_folder(
+        db,
+        folder_id,
+        destination,
+        progress_cb=None,
+        developed_dir=None,
+        merge=False,
+        remote=None,
+        destination_name="",
+    ):
+        captured["destination_name"] = destination_name
+        return {"moved": 1, "errors": []}
+
+    monkeypatch.setattr(move_module, "move_folder", fake_move_folder)
+    client = app.test_client()
+    resp = client.post("/api/jobs/move-folder", json={
+        "folder_id": fid,
+        "destination": str(parent),
+        "destination_name": "2026-07-12",
+    })
+
+    assert resp.status_code == 200
+    job = wait_for_job_via_client(client, resp.get_json()["job_id"])
+    assert job["status"] == "completed"
+    assert captured["destination_name"] == "2026-07-12"
+
+
 def test_move_folder_job_invalidates_missing_originals_cache(
     app_and_db, tmp_path, monkeypatch,
 ):
@@ -192,9 +232,11 @@ def test_move_folder_job_invalidates_missing_originals_cache(
         developed_dir=None,
         merge=False,
         remote=None,
+        destination_name="",
     ):
         assert folder_id == fid
         assert destination == str(dst)
+        assert destination_name == ""
         return {"moved": 1, "errors": []}
 
     monkeypatch.setattr(move_module, "move_folder", fake_move_folder)
@@ -364,6 +406,46 @@ def test_move_folder_preflight_dest_exists(app_and_db, tmp_path):
     assert data["file_count"] == 1
     assert data["file_count_truncated"] is False
     assert data["resolved_dest"] == str(landing)
+
+
+def test_move_folder_preflight_uses_explicit_destination_name(
+    app_and_db, tmp_path,
+):
+    """Preflight resolves the editable folder name as the final path leaf."""
+    app, db = app_and_db
+    parent = tmp_path / "dest"
+    parent.mkdir()
+    folder = db.get_folder_tree()[0]
+
+    client = app.test_client()
+    resp = client.post("/api/move-folder/preflight", json={
+        "folder_id": folder["id"],
+        "destination": str(parent),
+        "destination_name": "2026-07-12",
+    })
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["resolved_dest"] == str(parent / "2026-07-12")
+    assert data["exists"] is False
+
+
+def test_move_folder_preflight_rejects_invalid_destination_name(
+    app_and_db, tmp_path,
+):
+    """The final folder name is one component, never a hidden path override."""
+    app, db = app_and_db
+    folder = db.get_folder_tree()[0]
+    client = app.test_client()
+
+    resp = client.post("/api/move-folder/preflight", json={
+        "folder_id": folder["id"],
+        "destination": str(tmp_path),
+        "destination_name": "2026/07/12",
+    })
+
+    assert resp.status_code == 400
+    assert "without slashes" in resp.get_json()["error"]
 
 
 def test_move_folder_preflight_caps_existing_destination_count(app_and_db, tmp_path):


### PR DESCRIPTION
## Summary

- Replaces the ambiguous destination field with a guided source, parent-folder, editable folder-name, and exact final-path flow.
- Adds rename-while-moving support across local and remote preflight/execution, validates the leaf name, and updates the cataloged name after success.
- Fixes the extra nested source basename caused by treating a user-entered final path as a parent directory.

## Validation

- Passed 70 focused backend/API/database tests, 4 browser tests, Ruff, and `git diff --check`.