### PR TITLE
Scope replace-species to the corrected subject on multi-detection photos

### DIFF
--- a/vireo/db.py
+++ b/vireo/db.py
@@ -14104,9 +14104,15 @@ class Database:
                     # and the review/summary paths so stale rows from a prior
                     # label set on a re-classified neighbouring detection do
                     # not spuriously protect an obsolete species keyword.
+                    # Fold both sides through keyword_match_key so a raw
+                    # prediction species like `‘apapane` matches the stored
+                    # keyword `apapane` (add_keyword normalizes on write, so
+                    # a lower(trim(species)) SQL fold would otherwise miss
+                    # the still-live neighbour and queue its removal).
                     protected = {
-                        row["sp"] for row in self.conn.execute(
-                            """SELECT DISTINCT lower(trim(pr.species)) AS sp
+                        keyword_match_key(row["species"])
+                        for row in self.conn.execute(
+                            """SELECT DISTINCT pr.species AS species
                                FROM predictions pr
                                JOIN detections d ON d.id = pr.detection_id
                                LEFT JOIN prediction_review pr_rev
@@ -14127,6 +14133,7 @@ class Database:
                                  )""",
                             (ws, photo_id, this_det_id),
                         ).fetchall()
+                        if row["species"]
                     }
                     existing = self.conn.execute(
                         """SELECT k.id, k.name
@@ -14138,7 +14145,7 @@ class Database:
                     ).fetchall()
                     to_remove = [
                         row for row in existing
-                        if row["name"].strip().lower() not in protected
+                        if keyword_match_key(row["name"]) not in protected
                     ]
                     old_species = [row["name"] for row in to_remove]
                     for row in to_remove:

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -14099,6 +14099,11 @@ class Database:
                         (this_pred_id,),
                     ).fetchone()
                     this_det_id = this_det["detection_id"] if this_det else None
+                    # Restrict to the latest labels_fingerprint per
+                    # (detection, classifier_model) — mirrors get_predictions
+                    # and the review/summary paths so stale rows from a prior
+                    # label set on a re-classified neighbouring detection do
+                    # not spuriously protect an obsolete species keyword.
                     protected = {
                         row["sp"] for row in self.conn.execute(
                             """SELECT DISTINCT lower(trim(pr.species)) AS sp
@@ -14110,7 +14115,16 @@ class Database:
                                WHERE d.photo_id = ?
                                  AND pr.detection_id IS NOT ?
                                  AND COALESCE(pr_rev.status, 'pending')
-                                     != 'rejected'""",
+                                     != 'rejected'
+                                 AND pr.labels_fingerprint = (
+                                     SELECT pr2.labels_fingerprint
+                                     FROM predictions pr2
+                                     WHERE pr2.detection_id = pr.detection_id
+                                       AND pr2.classifier_model
+                                           = pr.classifier_model
+                                     ORDER BY pr2.created_at DESC, pr2.id DESC
+                                     LIMIT 1
+                                 )""",
                             (ws, photo_id, this_det_id),
                         ).fetchall()
                     }

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -14086,25 +14086,53 @@ class Database:
                 self.update_prediction_status(this_pred_id, "accepted", _commit=False)
                 old_species = []
                 if replace_species:
-                    old_species = [
-                        row["name"] for row in self.conn.execute(
-                            """SELECT k.name
-                               FROM photo_keywords pk
-                               JOIN keywords k ON k.id = pk.keyword_id
-                               WHERE pk.photo_id = ?
-                                 AND (k.is_species = 1 OR k.type = 'taxonomy')""",
-                            (photo_id,),
+                    # Replace corrects *this subject's* identity, so it must
+                    # not strip a species that belongs to a different detection
+                    # (another subject) on the same photo. Any species named by
+                    # a live prediction on another box is protected; without
+                    # this, correcting the teal's ID wiped the American Wigeon
+                    # confirmed on the neighbouring box. On a single-detection
+                    # photo no box is protected, so every species keyword is
+                    # replaced exactly as before.
+                    this_det = self.conn.execute(
+                        "SELECT detection_id FROM predictions WHERE id = ?",
+                        (this_pred_id,),
+                    ).fetchone()
+                    this_det_id = this_det["detection_id"] if this_det else None
+                    protected = {
+                        row["sp"] for row in self.conn.execute(
+                            """SELECT DISTINCT lower(trim(pr.species)) AS sp
+                               FROM predictions pr
+                               JOIN detections d ON d.id = pr.detection_id
+                               LEFT JOIN prediction_review pr_rev
+                                 ON pr_rev.prediction_id = pr.id
+                                AND pr_rev.workspace_id = ?
+                               WHERE d.photo_id = ?
+                                 AND pr.detection_id IS NOT ?
+                                 AND COALESCE(pr_rev.status, 'pending')
+                                     != 'rejected'""",
+                            (ws, photo_id, this_det_id),
                         ).fetchall()
-                    ]
-                    self.conn.execute(
-                        """DELETE FROM photo_keywords
-                           WHERE photo_id = ?
-                             AND keyword_id IN (
-                               SELECT id FROM keywords
-                               WHERE is_species = 1 OR type = 'taxonomy'
-                             )""",
+                    }
+                    existing = self.conn.execute(
+                        """SELECT k.id, k.name
+                           FROM photo_keywords pk
+                           JOIN keywords k ON k.id = pk.keyword_id
+                           WHERE pk.photo_id = ?
+                             AND (k.is_species = 1 OR k.type = 'taxonomy')""",
                         (photo_id,),
-                    )
+                    ).fetchall()
+                    to_remove = [
+                        row for row in existing
+                        if row["name"].strip().lower() not in protected
+                    ]
+                    old_species = [row["name"] for row in to_remove]
+                    for row in to_remove:
+                        self.conn.execute(
+                            """DELETE FROM photo_keywords
+                               WHERE photo_id = ? AND keyword_id = ?""",
+                            (photo_id, row["id"]),
+                        )
                     # The DB rows are gone, but sync_to_xmp only strips a
                     # keyword from the sidecar when a matching keyword_remove
                     # pending change exists. Queue one per removed species so a

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -14099,6 +14099,24 @@ class Database:
                         (this_pred_id,),
                     ).fetchone()
                     this_det_id = this_det["detection_id"] if this_det else None
+                    # Mirror Compare's visibility filter when picking which
+                    # neighbouring predictions may protect a species keyword:
+                    #   * skip 'alternative' rows (Compare drops them at
+                    #     app.py's api_predictions_compare, alongside
+                    #     'rejected');
+                    #   * skip detections below the workspace's effective
+                    #     detector_confidence — Compare marks those "dormant"
+                    #     and excludes their subjects entirely.
+                    # Without this, a below-threshold neighbour or an
+                    # alternative row on a real neighbour would keep an
+                    # already-stale species keyword on the photo — replace
+                    # would leave it in place and never queue a
+                    # keyword_remove, so the sidecar would still list the
+                    # dead species.
+                    import config as _cfg
+                    _det_threshold = self.get_effective_config(
+                        _cfg.load()
+                    ).get("detector_confidence", 0.2)
                     # Restrict to the latest labels_fingerprint per
                     # (detection, classifier_model) — mirrors get_predictions
                     # and the review/summary paths so stale rows from a prior
@@ -14121,7 +14139,8 @@ class Database:
                                WHERE d.photo_id = ?
                                  AND pr.detection_id IS NOT ?
                                  AND COALESCE(pr_rev.status, 'pending')
-                                     != 'rejected'
+                                     NOT IN ('rejected', 'alternative')
+                                 AND d.detector_confidence >= ?
                                  AND pr.labels_fingerprint = (
                                      SELECT pr2.labels_fingerprint
                                      FROM predictions pr2
@@ -14131,7 +14150,7 @@ class Database:
                                      ORDER BY pr2.created_at DESC, pr2.id DESC
                                      LIMIT 1
                                  )""",
-                            (ws, photo_id, this_det_id),
+                            (ws, photo_id, this_det_id, _det_threshold),
                         ).fetchall()
                         if row["species"]
                     }

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -14005,6 +14005,23 @@ class Database:
         limited_photo_ids = None
         if photo_ids is not None:
             limited_photo_ids = {int(pid) for pid in photo_ids}
+        # Load taxonomy once for the whole call so replace_species can protect
+        # keywords whose relationship to a neighbouring subject's prediction is
+        # broader/same/narrower — not just exact-text matches. Loaded here
+        # rather than inside _accept_for_photo so grouped accepts don't repeat
+        # the JSON parse per photo. None (missing/corrupt file, or unrelated
+        # import failure) cleanly degrades to exact-text protection.
+        _replace_taxonomy = None
+        _compare_pred_to_kws = None
+        if replace_species:
+            try:
+                from compare import compare_prediction_to_keywords as _cpk
+                from taxonomy import load_local_taxonomy as _llt
+                _replace_taxonomy = _llt()
+                _compare_pred_to_kws = _cpk
+            except Exception:
+                _replace_taxonomy = None
+                _compare_pred_to_kws = None
         pred = self.conn.execute(
             """SELECT pr.*,
                       pr.classifier_model AS model,
@@ -14127,9 +14144,8 @@ class Database:
                     # keyword `apapane` (add_keyword normalizes on write, so
                     # a lower(trim(species)) SQL fold would otherwise miss
                     # the still-live neighbour and queue its removal).
-                    protected = {
-                        keyword_match_key(row["species"])
-                        for row in self.conn.execute(
+                    neighbour_species = [
+                        row["species"] for row in self.conn.execute(
                             """SELECT DISTINCT pr.species AS species
                                FROM predictions pr
                                JOIN detections d ON d.id = pr.detection_id
@@ -14153,6 +14169,9 @@ class Database:
                             (ws, photo_id, this_det_id, _det_threshold),
                         ).fetchall()
                         if row["species"]
+                    ]
+                    protected = {
+                        keyword_match_key(s) for s in neighbour_species
                     }
                     existing = self.conn.execute(
                         """SELECT k.id, k.name
@@ -14162,9 +14181,40 @@ class Database:
                              AND (k.is_species = 1 OR k.type = 'taxonomy')""",
                         (photo_id,),
                     ).fetchall()
+                    # Compare treats a neighbouring subject's prediction as
+                    # supporting an existing keyword under the taxonomy —
+                    # match (same taxon), refinement (existing is broader
+                    # than the prediction), broader (existing is more
+                    # specific than the prediction). See compare.py's
+                    # compare_prediction_to_keywords and the "keyword
+                    # support" counters in templates/compare.html. Without
+                    # this, a photo tagged with a broader ancestor keyword
+                    # (e.g. Anatidae) that is only "held down" by a
+                    # neighbour's American Wigeon prediction is stripped
+                    # when a different box is replaced, and its curation
+                    # (highlights, representatives) gets migrated onto the
+                    # new species — the wrong subject. With no taxonomy
+                    # available the check quietly no-ops and we fall back
+                    # to exact-text protection, matching prior behaviour.
+                    def _supported_by_neighbour_taxonomy(kw_name):
+                        if not _replace_taxonomy or not neighbour_species:
+                            return False
+                        if _compare_pred_to_kws is None:
+                            return False
+                        for pred_species in neighbour_species:
+                            cmp_result = _compare_pred_to_kws(
+                                pred_species, [kw_name], _replace_taxonomy,
+                            )
+                            if cmp_result["category"] in (
+                                "match", "refinement", "broader",
+                            ):
+                                return True
+                        return False
+
                     to_remove = [
                         row for row in existing
                         if keyword_match_key(row["name"]) not in protected
+                        and not _supported_by_neighbour_taxonomy(row["name"])
                     ]
                     old_species = [row["name"] for row in to_remove]
                     for row in to_remove:

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -5513,6 +5513,71 @@ def test_replace_species_ignores_stale_fingerprint_predictions_on_neighbour(tmp_
     assert (pid, "Green-winged Teal") in removed
 
 
+def test_replace_species_normalizes_protected_species_before_matching(tmp_path):
+    """The neighbour's *live* prediction species must be folded through the
+    same keyword-normalization as the photo's stored keyword before deciding
+    what to protect.
+
+    Regression: predictions.species stores the raw model output (e.g.
+    `‘apapane` with a leading edge quote), while add_keyword normalizes on
+    write so the photo actually carries the clean keyword `apapane`. A
+    naive `lower(trim(species))` fold on the SQL side would leave the raw
+    edge quote in place, `keyword.name.strip().lower() not in protected`
+    would be True, and replace_species would queue a keyword_remove for
+    the still-live neighbouring subject.
+    """
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder("/photos")
+    pid = db.add_photo(
+        folder_id=fid, filename="ducks.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    # Photo carries the neighbour's species under the normalized (clean)
+    # spelling — the shape add_keyword actually writes.
+    apapane = db.add_keyword("apapane", is_species=True)
+    stale = db.add_keyword("Green-winged Teal", is_species=True)
+    db.tag_photo(pid, apapane)
+    db.tag_photo(pid, stale)
+
+    d_target, d_neighbour = db.save_detections(pid, [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
+         "confidence": 0.9, "category": "animal"},
+        {"box": {"x": 0.6, "y": 0.5, "w": 0.2, "h": 0.2},
+         "confidence": 0.8, "category": "animal"},
+    ], detector_model="MDV6")
+    # Neighbour's live prediction still carries the raw edge-quote form
+    # that predictions.species records verbatim.
+    db.add_prediction(
+        d_neighbour, "‘apapane", 0.95, "bioclip",
+        labels_fingerprint="fp",
+    )
+    db.add_prediction(
+        d_target, "Blue-winged Teal", 0.92, "bioclip",
+        labels_fingerprint="fp",
+    )
+    target_pred = next(
+        r for r in db.get_predictions(photo_ids=[pid])
+        if r["detection_id"] == d_target
+    )
+
+    result = db.accept_prediction(target_pred["id"], replace_species=True)
+
+    names = {k["name"] for k in db.get_photo_keywords(pid)}
+    assert "Blue-winged Teal" in names
+    assert "apapane" in names                  # protected across normalization
+    assert "Green-winged Teal" not in names    # this subject's stale ID gone
+    assert result["affected"][0]["old_species"] == ["Green-winged Teal"]
+    removed = {
+        (c["photo_id"], c["value"])
+        for c in db.get_pending_changes()
+        if c["change_type"] == "keyword_remove"
+    }
+    assert (pid, "Green-winged Teal") in removed
+    assert (pid, "apapane") not in removed
+
+
 def test_accept_prediction_queues_normalized_species(tmp_path):
     """When the prediction's species carries stray edge quotes (e.g.
     `‘apapane`), accept_prediction must tag the photo with the normalized

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -5748,6 +5748,191 @@ def test_replace_species_preserves_neighbour_above_threshold(tmp_path):
     assert "Green-winged Teal" not in names
 
 
+def test_replace_species_protects_taxonomy_ancestor_of_neighbour_prediction(
+    tmp_path, monkeypatch,
+):
+    """A broader taxonomy keyword (e.g. Anatidae) supported by a neighbouring
+    subject's prediction under the taxonomy — not just by exact text — must
+    survive replace_species and its curation must not be migrated onto the
+    new species.
+
+    Regression: the protected set only contained ``keyword_match_key(pr.species)``
+    so a multi-detection photo carrying a family-level keyword like Anatidae
+    alongside the neighbour's American Wigeon still had Anatidae deleted when
+    a different box was replaced, and the ``rename_*_species`` migration then
+    rebound Anatidae's curation onto the corrected species — the wrong
+    subject.
+    """
+    import json as _json
+
+    import taxonomy as taxonomy_mod
+    from db import Database
+    from taxonomy import Taxonomy
+
+    # Minimal taxonomy: Anatidae family + three species inside it. Enough for
+    # Compare's relationship rules to fire:
+    #   * Anatidae vs American Wigeon -> ancestor / refinement (must protect)
+    #   * Green-winged Teal vs American Wigeon -> sibling / conflict (must not)
+    tax_path = tmp_path / "taxonomy.json"
+    with open(tax_path, "w") as f:
+        _json.dump({
+            "last_updated": "2026-07-18",
+            "source": "test",
+            "taxa_by_common": {
+                "american wigeon": {
+                    "taxon_id": 1,
+                    "scientific_name": "Mareca americana",
+                    "common_name": "American Wigeon",
+                    "rank": "species",
+                    "lineage_names": [
+                        "Animalia", "Chordata", "Aves", "Anseriformes",
+                        "Anatidae", "Mareca", "Mareca americana",
+                    ],
+                    "lineage_ranks": [
+                        "kingdom", "phylum", "class", "order",
+                        "family", "genus", "species",
+                    ],
+                },
+                "green-winged teal": {
+                    "taxon_id": 2,
+                    "scientific_name": "Anas crecca",
+                    "common_name": "Green-winged Teal",
+                    "rank": "species",
+                    "lineage_names": [
+                        "Animalia", "Chordata", "Aves", "Anseriformes",
+                        "Anatidae", "Anas", "Anas crecca",
+                    ],
+                    "lineage_ranks": [
+                        "kingdom", "phylum", "class", "order",
+                        "family", "genus", "species",
+                    ],
+                },
+                "wood duck": {
+                    "taxon_id": 3,
+                    "scientific_name": "Aix sponsa",
+                    "common_name": "Wood Duck",
+                    "rank": "species",
+                    "lineage_names": [
+                        "Animalia", "Chordata", "Aves", "Anseriformes",
+                        "Anatidae", "Aix", "Aix sponsa",
+                    ],
+                    "lineage_ranks": [
+                        "kingdom", "phylum", "class", "order",
+                        "family", "genus", "species",
+                    ],
+                },
+                "anatidae": {
+                    "taxon_id": 4,
+                    "scientific_name": "Anatidae",
+                    "common_name": "Anatidae",
+                    "rank": "family",
+                    "lineage_names": [
+                        "Animalia", "Chordata", "Aves", "Anseriformes",
+                        "Anatidae",
+                    ],
+                    "lineage_ranks": [
+                        "kingdom", "phylum", "class", "order", "family",
+                    ],
+                },
+            },
+            "taxa_by_scientific": {
+                "anatidae": {
+                    "taxon_id": 4,
+                    "scientific_name": "Anatidae",
+                    "common_name": "Anatidae",
+                    "rank": "family",
+                    "lineage_names": [
+                        "Animalia", "Chordata", "Aves", "Anseriformes",
+                        "Anatidae",
+                    ],
+                    "lineage_ranks": [
+                        "kingdom", "phylum", "class", "order", "family",
+                    ],
+                },
+            },
+        }, f)
+    fake_tax = Taxonomy(str(tax_path))
+    monkeypatch.setattr(
+        taxonomy_mod, "load_local_taxonomy", lambda: fake_tax,
+    )
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder("/photos")
+    pid = db.add_photo(
+        folder_id=fid, filename="ducks.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    # Photo carries the neighbour's species AND a broader family taxonomy
+    # keyword — the shape a photo picks up from a prior curation pass. It
+    # also carries an unrelated stale species that only the target box's
+    # (soon-to-be-replaced) old identity supported.
+    wigeon = db.add_keyword("American Wigeon", is_species=True)
+    anatidae = db.add_keyword("Anatidae", kw_type="taxonomy")
+    stale_teal = db.add_keyword("Green-winged Teal", is_species=True)
+    db.tag_photo(pid, wigeon)
+    db.tag_photo(pid, anatidae)
+    db.tag_photo(pid, stale_teal)
+
+    # Seed curation state on the family keyword so we can verify it is NOT
+    # migrated onto the new species when Anatidae survives replace.
+    ws_id = db._ws_id()
+    db.conn.execute(
+        """INSERT INTO photo_preferences
+             (workspace_id, purpose, species, photo_id)
+           VALUES (?, ?, ?, ?)""",
+        (ws_id, "highlights", "Anatidae", pid),
+    )
+    db.conn.commit()
+
+    d_target, d_neighbour = db.save_detections(pid, [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
+         "confidence": 0.9, "category": "animal"},
+        {"box": {"x": 0.6, "y": 0.5, "w": 0.2, "h": 0.2},
+         "confidence": 0.85, "category": "animal"},
+    ], detector_model="MDV6")
+    db.add_prediction(
+        d_neighbour, "American Wigeon", 0.99, "bioclip",
+        labels_fingerprint="fp",
+    )
+    db.add_prediction(
+        d_target, "Wood Duck", 0.92, "bioclip",
+        labels_fingerprint="fp",
+    )
+    target_pred = next(
+        r for r in db.get_predictions(photo_ids=[pid])
+        if r["detection_id"] == d_target
+    )
+
+    result = db.accept_prediction(target_pred["id"], replace_species=True)
+
+    names = {k["name"] for k in db.get_photo_keywords(pid)}
+    assert "Wood Duck" in names                # target's corrected identity
+    assert "American Wigeon" in names           # exact-text neighbour survives
+    assert "Anatidae" in names                  # taxonomy ancestor survives
+    assert "Green-winged Teal" not in names     # target's stale ID gone
+    # Anatidae must not appear in old_species: it wasn't stripped, so no
+    # keyword_remove was queued and the curation migration was skipped.
+    assert "Anatidae" not in result["affected"][0]["old_species"]
+    assert "Green-winged Teal" in result["affected"][0]["old_species"]
+    removed = {
+        (c["photo_id"], c["value"])
+        for c in db.get_pending_changes()
+        if c["change_type"] == "keyword_remove"
+    }
+    assert (pid, "Green-winged Teal") in removed
+    assert (pid, "Anatidae") not in removed
+    assert (pid, "American Wigeon") not in removed
+    # Anatidae's curation stayed on Anatidae — not silently rebound to the
+    # newly-added Wood Duck.
+    prefs = db.conn.execute(
+        "SELECT species FROM photo_preferences WHERE photo_id = ?",
+        (pid,),
+    ).fetchall()
+    pref_species = {row["species"] for row in prefs}
+    assert "Anatidae" in pref_species
+    assert "Wood Duck" not in pref_species
+
+
 def test_accept_prediction_queues_normalized_species(tmp_path):
     """When the prediction's species carries stray edge quotes (e.g.
     `‘apapane`), accept_prediction must tag the photo with the normalized

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -5578,6 +5578,176 @@ def test_replace_species_normalizes_protected_species_before_matching(tmp_path):
     assert (pid, "apapane") not in removed
 
 
+def test_replace_species_ignores_alternative_prediction_on_neighbour(tmp_path):
+    """The protected set must exclude neighbour predictions whose review
+    status is ``'alternative'`` — Compare drops those rows explicitly, so a
+    stale species keyword that only survives via an alternative row is not
+    "still tagged by another subject", it's just an out-of-band species
+    tag that replace should strip.
+    """
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder("/photos")
+    pid = db.add_photo(
+        folder_id=fid, filename="ducks.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    # Photo carries a stale species tag whose only backing on the neighbour
+    # is an 'alternative' prediction row.
+    stale = db.add_keyword("Green-winged Teal", is_species=True)
+    db.tag_photo(pid, stale)
+
+    d_target, d_neighbour = db.save_detections(pid, [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
+         "confidence": 0.9, "category": "animal"},
+        {"box": {"x": 0.6, "y": 0.5, "w": 0.2, "h": 0.2},
+         "confidence": 0.8, "category": "animal"},
+    ], detector_model="MDV6")
+    # Neighbour: primary picks a wigeon, alternative names the stale teal.
+    db.add_prediction(
+        d_neighbour, "American Wigeon", 0.95, "bioclip",
+        labels_fingerprint="fp",
+    )
+    db.add_prediction(
+        d_neighbour, "Green-winged Teal", 0.40, "bioclip",
+        status="alternative", labels_fingerprint="fp",
+    )
+    # Target box: wrong teal, needs correction to Blue-winged Teal.
+    db.add_prediction(
+        d_target, "Blue-winged Teal", 0.92, "bioclip",
+        labels_fingerprint="fp",
+    )
+    target_pred = next(
+        r for r in db.get_predictions(photo_ids=[pid])
+        if r["detection_id"] == d_target and r["status"] != "alternative"
+    )
+
+    result = db.accept_prediction(target_pred["id"], replace_species=True)
+
+    names = {k["name"] for k in db.get_photo_keywords(pid)}
+    assert "Blue-winged Teal" in names
+    assert "Green-winged Teal" not in names    # alternative must not protect it
+    assert "Green-winged Teal" in result["affected"][0]["old_species"]
+    removed = {
+        (c["photo_id"], c["value"])
+        for c in db.get_pending_changes()
+        if c["change_type"] == "keyword_remove"
+    }
+    assert (pid, "Green-winged Teal") in removed
+
+
+def test_replace_species_ignores_below_threshold_neighbour(tmp_path):
+    """The protected set must exclude neighbour predictions whose detection
+    sits below the workspace's ``detector_confidence`` threshold — Compare
+    treats those as dormant and hides them, so a stale species keyword that
+    only survives via a below-threshold neighbour is not "another visible
+    subject" and replace must strip it.
+    """
+    import config as cfg
+    from db import Database
+
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    cfg.save({"detector_confidence": 0.5})
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder("/photos")
+    pid = db.add_photo(
+        folder_id=fid, filename="ducks.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    # Photo carries a stale species tag whose only backing on the neighbour
+    # is a below-threshold detection.
+    stale = db.add_keyword("Green-winged Teal", is_species=True)
+    db.tag_photo(pid, stale)
+
+    d_target, d_dormant = db.save_detections(pid, [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
+         "confidence": 0.9, "category": "animal"},
+        # Below the 0.5 workspace threshold — Compare treats as dormant.
+        {"box": {"x": 0.6, "y": 0.5, "w": 0.2, "h": 0.2},
+         "confidence": 0.2, "category": "animal"},
+    ], detector_model="MDV6")
+    db.add_prediction(
+        d_dormant, "Green-winged Teal", 0.95, "bioclip",
+        labels_fingerprint="fp",
+    )
+    db.add_prediction(
+        d_target, "Blue-winged Teal", 0.92, "bioclip",
+        labels_fingerprint="fp",
+    )
+    target_pred = next(
+        r for r in db.get_predictions(photo_ids=[pid])
+        if r["detection_id"] == d_target
+    )
+
+    result = db.accept_prediction(target_pred["id"], replace_species=True)
+
+    names = {k["name"] for k in db.get_photo_keywords(pid)}
+    assert "Blue-winged Teal" in names
+    # Dormant (below-threshold) neighbour must not protect the stale tag.
+    assert "Green-winged Teal" not in names
+    assert "Green-winged Teal" in result["affected"][0]["old_species"]
+    removed = {
+        (c["photo_id"], c["value"])
+        for c in db.get_pending_changes()
+        if c["change_type"] == "keyword_remove"
+    }
+    assert (pid, "Green-winged Teal") in removed
+
+
+def test_replace_species_preserves_neighbour_above_threshold(tmp_path):
+    """Companion to the below-threshold test: an above-threshold neighbour
+    with a non-alternative prediction MUST still protect its species even
+    when the workspace's detector_confidence is set high enough that the
+    default 0.2 would have hidden neighbours in the earlier test. This
+    guards against the visibility filter accidentally protecting nothing.
+    """
+    import config as cfg
+    from db import Database
+
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+    cfg.save({"detector_confidence": 0.5})
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder("/photos")
+    pid = db.add_photo(
+        folder_id=fid, filename="ducks.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    wigeon = db.add_keyword("American Wigeon", is_species=True)
+    stale = db.add_keyword("Green-winged Teal", is_species=True)
+    db.tag_photo(pid, wigeon)
+    db.tag_photo(pid, stale)
+
+    d_target, d_wigeon = db.save_detections(pid, [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
+         "confidence": 0.9, "category": "animal"},
+        # Comfortably above the 0.5 workspace threshold.
+        {"box": {"x": 0.6, "y": 0.5, "w": 0.2, "h": 0.2},
+         "confidence": 0.85, "category": "animal"},
+    ], detector_model="MDV6")
+    db.add_prediction(
+        d_wigeon, "American Wigeon", 0.99, "bioclip",
+        labels_fingerprint="fp",
+    )
+    db.add_prediction(
+        d_target, "Blue-winged Teal", 0.92, "bioclip",
+        labels_fingerprint="fp",
+    )
+    target_pred = next(
+        r for r in db.get_predictions(photo_ids=[pid])
+        if r["detection_id"] == d_target
+    )
+
+    db.accept_prediction(target_pred["id"], replace_species=True)
+
+    names = {k["name"] for k in db.get_photo_keywords(pid)}
+    assert "Blue-winged Teal" in names
+    assert "American Wigeon" in names          # visible neighbour still protects
+    assert "Green-winged Teal" not in names
+
+
 def test_accept_prediction_queues_normalized_species(tmp_path):
     """When the prediction's species carries stray edge quotes (e.g.
     `‘apapane`), accept_prediction must tag the photo with the normalized

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -5391,6 +5391,64 @@ def test_accept_subject_species_preserves_existing_tag_and_accepts_models(tmp_pa
     assert statuses == {"bioclip": "accepted", "inat": "accepted"}
 
 
+def test_replace_species_preserves_other_subject_on_multi_detection_photo(tmp_path):
+    """Replacing one subject's species must not strip a species that belongs
+    to a different detection (subject) on the same photo.
+
+    Regression: accept_prediction(replace_species=True) deleted every species
+    keyword on the photo, so correcting the teal box's ID wiped the American
+    Wigeon confirmed on the other box.
+    """
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder("/photos")
+    pid = db.add_photo(
+        folder_id=fid, filename="ducks.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    wigeon = db.add_keyword("American Wigeon", is_species=True)
+    stale_teal = db.add_keyword("Green-winged Teal", is_species=True)
+    db.tag_photo(pid, wigeon)
+    db.tag_photo(pid, stale_teal)
+
+    d_wigeon, d_teal = db.save_detections(pid, [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
+         "confidence": 0.9, "category": "animal"},
+        {"box": {"x": 0.6, "y": 0.5, "w": 0.2, "h": 0.2},
+         "confidence": 0.8, "category": "animal"},
+    ], detector_model="MDV6")
+    # The wigeon box keeps a live prediction naming the wigeon; the teal box's
+    # real identity is Blue-winged Teal.
+    db.add_prediction(
+        d_wigeon, "American Wigeon", 0.99, "bioclip", labels_fingerprint="fp",
+    )
+    db.add_prediction(
+        d_teal, "Blue-winged Teal", 0.95, "bioclip", labels_fingerprint="fp",
+    )
+    teal_pred = next(
+        r for r in db.get_predictions(photo_ids=[pid])
+        if r["detection_id"] == d_teal
+    )
+
+    result = db.accept_prediction(teal_pred["id"], replace_species=True)
+
+    names = {k["name"] for k in db.get_photo_keywords(pid)}
+    assert "Blue-winged Teal" in names        # this subject's corrected ID
+    assert "American Wigeon" in names          # other subject preserved
+    assert "Green-winged Teal" not in names    # this subject's stale ID gone
+    # The stripped species is reported (and only it), so the sidecar remove is
+    # queued for the stale teal but not the still-tagged wigeon.
+    assert result["affected"][0]["old_species"] == ["Green-winged Teal"]
+    removed = {
+        (c["photo_id"], c["value"])
+        for c in db.get_pending_changes()
+        if c["change_type"] == "keyword_remove"
+    }
+    assert (pid, "Green-winged Teal") in removed
+    assert (pid, "American Wigeon") not in removed
+
+
 def test_accept_prediction_queues_normalized_species(tmp_path):
     """When the prediction's species carries stray edge quotes (e.g.
     `‘apapane`), accept_prediction must tag the photo with the normalized

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -5449,6 +5449,70 @@ def test_replace_species_preserves_other_subject_on_multi_detection_photo(tmp_pa
     assert (pid, "American Wigeon") not in removed
 
 
+def test_replace_species_ignores_stale_fingerprint_predictions_on_neighbour(tmp_path):
+    """The protected-species query must only consider the neighbouring
+    detection's *current* labels_fingerprint. A re-classified detection can
+    still carry pending predictions from an older label set naming a species
+    that the current run no longer produces; those stale rows must not
+    shield an obsolete species keyword from replace_species.
+    """
+    from db import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    fid = db.add_folder("/photos")
+    pid = db.add_photo(
+        folder_id=fid, filename="ducks.jpg", extension=".jpg",
+        file_size=100, file_mtime=1.0,
+    )
+    # The photo carries a stale species tag left over from when the neighbour
+    # was previously classified as Green-winged Teal.
+    fresh_wigeon = db.add_keyword("American Wigeon", is_species=True)
+    stale_teal = db.add_keyword("Green-winged Teal", is_species=True)
+    db.tag_photo(pid, fresh_wigeon)
+    db.tag_photo(pid, stale_teal)
+
+    d_target, d_neighbour = db.save_detections(pid, [
+        {"box": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
+         "confidence": 0.9, "category": "animal"},
+        {"box": {"x": 0.6, "y": 0.5, "w": 0.2, "h": 0.2},
+         "confidence": 0.8, "category": "animal"},
+    ], detector_model="MDV6")
+    # Neighbour's *old* fingerprint still has a pending row naming the stale
+    # species — the kind of row get_predictions() filters out.
+    db.add_prediction(
+        d_neighbour, "Green-winged Teal", 0.90, "bioclip",
+        labels_fingerprint="fp_old",
+    )
+    # Neighbour's *current* fingerprint names the wigeon; the target box was
+    # classified as the wrong teal and needs correction to Blue-winged Teal.
+    db.add_prediction(
+        d_neighbour, "American Wigeon", 0.95, "bioclip",
+        labels_fingerprint="fp_new",
+    )
+    db.add_prediction(
+        d_target, "Blue-winged Teal", 0.92, "bioclip",
+        labels_fingerprint="fp_new",
+    )
+    target_pred = next(
+        r for r in db.get_predictions(photo_ids=[pid])
+        if r["detection_id"] == d_target
+    )
+
+    result = db.accept_prediction(target_pred["id"], replace_species=True)
+
+    names = {k["name"] for k in db.get_photo_keywords(pid)}
+    assert "Blue-winged Teal" in names
+    assert "American Wigeon" in names          # protected by current fp
+    assert "Green-winged Teal" not in names    # stale fp must not protect it
+    assert "Green-winged Teal" in result["affected"][0]["old_species"]
+    removed = {
+        (c["photo_id"], c["value"])
+        for c in db.get_pending_changes()
+        if c["change_type"] == "keyword_remove"
+    }
+    assert (pid, "Green-winged Teal") in removed
+
+
 def test_accept_prediction_queues_normalized_species(tmp_path):
     """When the prediction's species carries stray edge quotes (e.g.
     `‘apapane`), accept_prediction must tag the photo with the normalized


### PR DESCRIPTION
## What & why

`accept_prediction(replace_species=True)` deleted **every** species/taxonomy keyword on a photo before adding the new one. On a multi-detection photo that means correcting one subject's ID wipes a species confirmed on a *different* box — e.g. replacing the Blue-winged Teal box's ID strips the American Wigeon standing next to it.

Reachable today via Compare's batch **"Replace species keyword"** and via any photo that already carries a second species keyword.

## Fix

Replace now preserves any species named by a **live (non-rejected) prediction on another detection** of the same photo. Concretely, before deleting species keywords it computes a `protected` set from predictions on other boxes and skips those.

- Single-detection photos have no other box, so `protected` is empty and replace behaves exactly as before.
- The stripped species are still reported in `affected[].old_species` and their sidecar `keyword_remove`s queued — just no longer including the other subject's still-tagged species.

This complements the Compare work (which already hides "Replace" for multi-subject photos and offers "Add additional species" via `accept_subject_species`); this fixes the DB layer so the batch path and any residual caller are also safe.

## Tests

- New: `test_replace_species_preserves_other_subject_on_multi_detection_photo` (wigeon+teal photo, replace teal box → wigeon survives, stale teal removed, correct removes queued).
- Full `test_db.py` + `test_app.py`: **951 passed, 1 skipped**. Ruff clean.

## Scope note

This is the first of the multi-species backend confirm-path fixes tracked in #1298. The other top-priority item — making `/api/encounters/species` additive instead of single-slot (confirming a second species untags the first) — is intentionally **not** in this PR: it only becomes meaningful and safe alongside the rapid-review UI change, since the endpoint needs the UI to signal "additional species" vs "correction" intent. It'll come as its own PR with that UI work.

Based on `multi-species-photo-review` (#1294) since it builds on the multi-subject infra; will retarget to `main` when that merges.
