### PR TITLE
Keep location review actions visible above Jobs panel

### DIFF
--- a/tests/e2e/test_location_review.py
+++ b/tests/e2e/test_location_review.py
@@ -127,3 +127,39 @@ def test_browse_review_on_map_opens_the_selected_photos(live_server, page):
     expect(page.locator("#locationReviewEmptyMessage")).to_contain_text(
         "skipped without changes"
     )
+
+
+def test_location_review_actions_stay_above_open_bottom_panel(live_server, page):
+    """Opening the shared jobs panel must not cover the review controls."""
+    photo_id = live_server["data"]["photos"][0]
+    with live_server["db"].conn:
+        live_server["db"].conn.execute(
+            "UPDATE photos SET latitude = ?, longitude = ? WHERE id = ?",
+            (33.2550, -116.4050, photo_id),
+        )
+
+    page.set_viewport_size({"width": 890, "height": 600})
+    page.route("https://unpkg.com/**", _stub_leaflet)
+    page.goto(f"{live_server['url']}/browse")
+    page.evaluate(
+        "photoId => sessionStorage.setItem('vireoLocationReviewSource', "
+        "JSON.stringify({photo_ids: [photoId]}))",
+        photo_id,
+    )
+    page.goto(f"{live_server['url']}/locations/review?source=selection")
+    expect(page.locator("#locationReviewGroupTitle")).to_have_text("1 photo")
+
+    page.locator("#bpArrow").click()
+    page.wait_for_function(
+        "() => document.body.style.getPropertyValue('--bottom-offset') === '268px'"
+    )
+
+    positions = page.evaluate(
+        """() => ({
+          actionsBottom: document.querySelector('.location-review-actions')
+            .getBoundingClientRect().bottom,
+          panelTop: document.getElementById('bottomPanel').getBoundingClientRect().top
+        })"""
+    )
+    assert positions["actionsBottom"] <= positions["panelTop"]
+    expect(page.locator("#locationReviewAssign")).to_be_in_viewport()

--- a/vireo/templates/location_review.html
+++ b/vireo/templates/location_review.html
@@ -11,7 +11,7 @@
 html, body { height: 100%; overflow: hidden; }
 body { margin: 0; }
 .location-review-page {
-  height: calc(100vh - 76px);
+  height: calc(100vh - 48px - var(--bottom-offset, 28px));
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -266,7 +266,7 @@ body { margin: 0; }
 }
 @media (max-width: 860px) {
   html, body { overflow: auto; }
-  .location-review-page { height: auto; min-height: calc(100vh - 76px); }
+  .location-review-page { height: auto; min-height: calc(100vh - 48px - var(--bottom-offset, 28px)); }
   .location-review-main { grid-template-columns: 1fr; grid-template-rows: 58vh auto; }
   .location-review-map-column { border-right: 0; border-bottom: 1px solid var(--border-primary); }
   .location-review-panel { min-height: 560px; }


### PR DESCRIPTION
Fixes the location-review action footer being covered when the shared Jobs panel is open.
The page previously subtracted a fixed collapsed-panel height; it now uses the live `--bottom-offset` value in desktop and responsive layouts so the buttons remain usable.
Adds an end-to-end regression test at a narrow desktop viewport that opens the panel and verifies the controls remain above it and inside the viewport.
Validation: `pytest -q tests/e2e/test_location_review.py --browser chromium` (3 passed).
