### PR TITLE
Add thumbnail sizing to Missing Originals

### DIFF
--- a/tests/e2e/test_missing_originals_thumbnail_size.py
+++ b/tests/e2e/test_missing_originals_thumbnail_size.py
@@ -1,0 +1,31 @@
+from playwright.sync_api import expect
+
+
+def test_missing_originals_thumbnail_slider_resizes_previews(live_server, page):
+    page.goto(f"{live_server['url']}/browse")
+
+    slider = page.locator("#missingPhotosThumbSizeSlider")
+    expect(slider).to_have_value("56")
+
+    page.evaluate(
+        """() => {
+            const list = document.getElementById('missingPhotosList');
+            list.innerHTML = `
+                <div class="missing-photo-row">
+                    <div class="missing-photo-thumb"><span>preview</span></div>
+                </div>`;
+        }"""
+    )
+    thumb = page.locator(".missing-photo-thumb")
+    expect(thumb).to_have_css("width", "56px")
+    expect(thumb).to_have_css("height", "56px")
+
+    slider.evaluate(
+        """el => {
+            el.value = '120';
+            el.dispatchEvent(new Event('input', { bubbles: true }));
+        }"""
+    )
+
+    expect(thumb).to_have_css("width", "120px")
+    expect(thumb).to_have_css("height", "120px")

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -1461,7 +1461,9 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
 }
 .missing-photo-row:last-child { border-bottom: none; }
 .missing-photo-thumb {
-  width: 56px; height: 56px; flex-shrink: 0;
+  width: var(--missing-thumb-size, 56px);
+  height: var(--missing-thumb-size, 56px);
+  flex-shrink: 0;
   background: var(--bg-tertiary);
   border-radius: 4px;
   display: flex; align-items: center; justify-content: center;
@@ -2230,6 +2232,13 @@ function sendReport() {
       <label><input type="checkbox" id="missingPhotosSelectAll" onchange="toggleAllMissingPhotos(this.checked)"> Select all</label>
       <span id="missingPhotosSelectedCount">0 selected</span>
       <span class="spacer"></span>
+      <label style="display:flex;align-items:center;gap:4px;" title="Thumbnail size">
+        <input type="range" id="missingPhotosThumbSizeSlider" min="40" max="160" step="8" value="56"
+               aria-label="Thumbnail size"
+               style="width:80px;accent-color:var(--accent);"
+               oninput="updateMissingPhotosThumbSize(this.value)">
+        <span style="font-size:10px;color:var(--text-faint);">&#9638;</span>
+      </label>
       <label title="Also delete the .xmp sidecar files left behind on disk."><input type="checkbox" id="missingPhotosDeleteSidecars" checked> Also delete leftover XMP sidecars</label>
     </div>
     <div id="missingPhotosList" style="flex:1;overflow-y:auto;"></div>
@@ -11727,6 +11736,11 @@ function _escapeAttr(s) {
   return String(s == null ? '' : s).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 function _escapeHtml(s) { return _escapeAttr(s); }
+
+function updateMissingPhotosThumbSize(value) {
+  const list = document.getElementById('missingPhotosList');
+  if (list) list.style.setProperty('--missing-thumb-size', value + 'px');
+}
 
 async function loadMissingPhotos() {
   const container = document.getElementById('missingPhotosList');


### PR DESCRIPTION
Adds a compact size slider to the Missing Originals toolbar so cached previews can be adjusted from 40px to 160px while preserving the existing 56px default. The preview rows now read their dimensions from a scoped CSS variable updated by the control. Adds a Playwright regression test covering the default size and live resizing behavior. Validation: focused Playwright test passed, 49 Missing Originals tests passed, and `git diff --check` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a thumbnail-size slider to the “Missing Originals” view.
  * Thumbnail previews now resize immediately as the slider value changes.

* **Tests**
  * Added end-to-end coverage verifying thumbnail sizing at the default and adjusted dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->