### PR TITLE
Pause processing pipelines safely

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -3791,7 +3791,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if j.get("type") != "pipeline":
                 continue
             status = j.get("status")
-            if status == "running":
+            if status in {"running", "pausing", "paused"}:
                 active += 1
             elif status == "queued":
                 queued += 1

--- a/vireo/jobs.py
+++ b/vireo/jobs.py
@@ -205,7 +205,10 @@ class JobRunner:
         with self._lock:
             active = sum(
                 1 for j in self._jobs.values()
-                if j["type"] == "pipeline" and j["status"] == "running"
+                if (
+                    j["type"] == "pipeline"
+                    and j["status"] in ("running", "pausing", "paused")
+                )
             )
             if active >= SLOT_CAP:
                 return
@@ -281,7 +284,7 @@ class JobRunner:
                         "steps": [],
                         "ephemeral": False,
                         "counts_for_badge": True,
-                        "pausable": False,
+                        "pausable": True,
                         "runtime_warning": ctx["runtime_warning"],
                         # Pre-seeded for iteration safety — see start().
                         "_start_time": time.time(),
@@ -1126,6 +1129,62 @@ class JobRunner:
             self._publish_status_locked(job, "pausing")
         return True
 
+    def pause_requested(self, job_id):
+        """Return whether *job_id* currently has a pending pause request.
+
+        Pipeline jobs use this non-blocking probe to coordinate several worker
+        threads.  A single worker reaching a checkpoint is not enough to call
+        the whole pipeline paused; the pipeline publishes ``paused`` only once
+        every active participant has reached a safe boundary.
+        """
+        with self._lock:
+            return (
+                job_id in self._pause_requested
+                and job_id not in self._cancelled
+            )
+
+    def mark_paused(self, job_id):
+        """Publish ``paused`` if a live pause request still applies.
+
+        This is separate from :meth:`wait_if_paused` so multi-worker jobs can
+        wait for all of their workers before claiming that work has stopped.
+        """
+        with self._pause_condition:
+            job = self._jobs.get(job_id)
+            if (
+                job is None
+                or not job.get("pausable")
+                or job_id not in self._pause_requested
+                or job_id in self._cancelled
+                or job.get("status") not in ("pausing", "paused")
+            ):
+                return False
+            if job.get("status") != "paused":
+                self._publish_status_locked(job, "paused")
+            return True
+
+    def wait_if_paused(self, job_id, *, publish_paused=False):
+        """Wait for a pause request to clear, then report cancellation.
+
+        ``publish_paused`` is appropriate for ordinary single-worker jobs.
+        Coordinated jobs pass ``False`` and call :meth:`mark_paused` only after
+        all active workers are parked.
+        """
+        while True:
+            with self._pause_condition:
+                if job_id in self._cancelled:
+                    return True
+                job = self._jobs.get(job_id)
+                if (
+                    job is None
+                    or not job.get("pausable")
+                    or job_id not in self._pause_requested
+                ):
+                    return False
+                if publish_paused and job.get("status") != "paused":
+                    self._publish_status_locked(job, "paused")
+                self._pause_condition.wait()
+
     def resume_job(self, job_id):
         """Resume a pausing or paused job."""
         with self._pause_condition:
@@ -1150,24 +1209,7 @@ class JobRunner:
         those same boundaries are also safe places to sleep without losing
         the work function's in-memory state.
         """
-        while True:
-            with self._pause_condition:
-                if job_id in self._cancelled:
-                    return True
-                job = self._jobs.get(job_id)
-                if (
-                    job is None
-                    or not job.get("pausable")
-                    or job_id not in self._pause_requested
-                ):
-                    return False
-                if job.get("status") != "paused":
-                    self._publish_status_locked(job, "paused")
-                if job_id in self._cancelled:
-                    return True
-                if job_id not in self._pause_requested:
-                    return False
-                self._pause_condition.wait()
+        return self.wait_if_paused(job_id, publish_paused=True)
 
     def cancellation_requested(self, job_id):
         """Report cancellation without waiting on a pause request.

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -830,6 +830,12 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
         # replace the pipeline's abort policy still observe every checkpoint.
         return globals()["_should_abort"](abort_event)
 
+    def _should_abort_without_pause(abort_event):
+        """Check cancellation without parking while a shared lock is held."""
+        if _cancellation_requested():
+            abort_event.set()
+        return globals()["_should_abort"](abort_event)
+
     def _run_pause_participant(participant, work_fn, *, pre_registered=False):
         if not pre_registered:
             pause_gate.register(participant)
@@ -4952,7 +4958,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 skipped += 1
                                 processed = i + 1
                                 continue
-                            if _should_abort(abort):
+                            if _should_abort_without_pause(abort):
                                 break
 
                             # GPU serialisation lives inside masking.generate_mask
@@ -4966,7 +4972,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                 skipped += 1
                                 processed = i + 1
                                 continue
-                            if _should_abort(abort):
+                            if _should_abort_without_pause(abort):
                                 break
 
                             mask_path = save_mask(
@@ -4974,7 +4980,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             )
                             completeness = crop_completeness(mask)
                             features = compute_all_quality_features(proxy, mask)
-                            if _should_abort(abort):
+                            if _should_abort_without_pause(abort):
                                 break
 
                             # Per-mask features (move from photos row into
@@ -5843,18 +5849,28 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
         # miss_stage's own gate covers the regroup-failed and abort cases, so
         # both stages can be invoked unconditionally and still reach a
         # terminal step status.
-        if abort.is_set():
-            # Both stages early-return as "Skipped" without touching grouping
-            # state, so the lock isn't needed — and skipping the calls would
-            # leave their step rows pending forever. Staying outside the lock
-            # also keeps an aborted/cancelled run from blocking behind a
-            # concurrent pipeline's regroup.
-            _run_pause_participant("regroup", regroup_stage)
-            _run_pause_participant("misses", miss_stage)
-        else:
-            with acquire_workspace_regroup(workspace_id):
-                _run_pause_participant("regroup", regroup_stage)
-                _run_pause_participant("misses", miss_stage)
+        def _run_regroup_and_misses():
+            if abort.is_set():
+                # Both stages early-return as "Skipped" without touching
+                # grouping state, so the lock isn't needed — and skipping the
+                # calls would leave their step rows pending forever. Staying
+                # outside the lock also keeps an aborted/cancelled run from
+                # blocking behind a concurrent pipeline's regroup.
+                regroup_stage()
+                miss_stage()
+            else:
+                # Pause checkpoints deliberately surround this critical
+                # section rather than living inside either stage: their shared
+                # lock must span regroup + misses atomically, but a paused job
+                # must not retain it and block another pipeline indefinitely.
+                with acquire_workspace_regroup(workspace_id):
+                    regroup_stage()
+                    miss_stage()
+            _pause_checkpoint()
+
+        _run_pause_participant(
+            "regroup_and_misses", _run_regroup_and_misses,
+        )
 
         _run_pause_participant("archive", archive_stage)
 

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -225,6 +225,72 @@ def _should_abort(abort_event):
     return abort_event.is_set()
 
 
+class _PipelinePauseGate:
+    """Park every active pipeline worker before publishing ``paused``.
+
+    Phase one has four concurrent workers.  Letting the first worker that
+    reaches a checkpoint publish ``paused`` would be misleading because the
+    other three could still be scanning, rendering, or loading a model.  This
+    gate tracks the active participants and only confirms the pause once all
+    of them are at safe checkpoints.  Later pipeline stages use the same gate
+    with one active participant.
+    """
+
+    def __init__(self, runner, job_id):
+        self._runner = runner
+        self._job_id = job_id
+        self._lock = threading.Lock()
+        self._active = set()
+        self._parked = set()
+
+    def _pause_requested(self):
+        probe = getattr(self._runner, "pause_requested", None)
+        return bool(probe and probe(self._job_id))
+
+    def _cancellation_requested(self):
+        probe = getattr(self._runner, "cancellation_requested", None)
+        if probe is not None:
+            return probe(self._job_id)
+        return self._runner.is_cancelled(self._job_id)
+
+    def register_many(self, participant_names):
+        with self._lock:
+            self._active.update(participant_names)
+
+    def register(self, participant_name):
+        self.register_many((participant_name,))
+
+    def unregister(self, participant_name):
+        with self._lock:
+            self._active.discard(participant_name)
+            self._parked.discard(participant_name)
+            all_parked = not self._active or self._active <= self._parked
+        if all_parked and self._pause_requested():
+            self._runner.mark_paused(self._job_id)
+
+    def checkpoint(self, participant_name):
+        """Wait through a requested pause and return cancellation state."""
+        if not self._pause_requested():
+            return self._cancellation_requested()
+
+        with self._lock:
+            if participant_name not in self._active:
+                return self._cancellation_requested()
+            self._parked.add(participant_name)
+            all_parked = self._active <= self._parked
+
+        if all_parked:
+            self._runner.mark_paused(self._job_id)
+
+        try:
+            return self._runner.wait_if_paused(
+                self._job_id, publish_paused=False,
+            )
+        finally:
+            with self._lock:
+                self._parked.discard(participant_name)
+
+
 def _recipe_render_source(photo, recipe, max_size, vireo_dir, folders):
     """Thin wrapper around the shared resolver, returning just the path.
 
@@ -734,6 +800,47 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
     """
     job["_start_time"] = time.time()
     abort = threading.Event()
+    pause_gate = _PipelinePauseGate(runner, job["id"])
+    pause_context = threading.local()
+
+    def _cancellation_requested():
+        probe = getattr(runner, "cancellation_requested", None)
+        if probe is not None:
+            return probe(job["id"])
+        return runner.is_cancelled(job["id"])
+
+    def _pause_checkpoint():
+        participant = getattr(pause_context, "participant", None)
+        if participant is None:
+            return _cancellation_requested()
+        cancelled = pause_gate.checkpoint(participant)
+        if cancelled:
+            abort.set()
+        return cancelled
+
+    # Shadow the module-level helper inside this run so the existing safe
+    # cancellation boundaries double as pause checkpoints.  Calls made from a
+    # library-owned helper thread have no registered participant and remain a
+    # non-blocking cancellation probe; the owning pipeline worker parks at its
+    # next outer boundary instead.
+    def _should_abort(abort_event):
+        if _pause_checkpoint():
+            abort_event.set()
+        # Resolve through the module namespace so tests and diagnostics that
+        # replace the pipeline's abort policy still observe every checkpoint.
+        return globals()["_should_abort"](abort_event)
+
+    def _run_pause_participant(participant, work_fn, *, pre_registered=False):
+        if not pre_registered:
+            pause_gate.register(participant)
+        pause_context.participant = participant
+        try:
+            _pause_checkpoint()
+            return work_fn()
+        finally:
+            pause_context.participant = None
+            pause_gate.unregister(participant)
+
     errors = job["errors"]  # shared list, append is thread-safe
     if params.destination or params.local_processing or params.remote_target_id:
         raise RuntimeError(
@@ -853,7 +960,10 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
 
         def _cancel_watcher():
             while not cancel_watcher_stop.is_set():
-                if runner.is_cancelled(job["id"]):
+                # This watcher must never park for Pause: it is not pipeline
+                # work and would otherwise publish ``paused`` before the real
+                # stage workers have reached safe checkpoints.
+                if _cancellation_requested():
                     abort.set()
                     return
                 if cancel_watcher_stop.wait(0.25):
@@ -988,6 +1098,20 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
         collection_ready = threading.Event()
         models_ready = threading.Event()
         loaded_models = {}  # populated by model_loader thread
+
+        def _put_scan_item(item):
+            """Put into the scan/thumbnail queue without defeating Pause.
+
+            Both ordinary photo items and the end sentinel can otherwise block
+            forever on a full queue after the thumbnail worker has parked.
+            """
+            while not _should_abort(abort):
+                try:
+                    scan_to_thumb.put(item, timeout=0.5)
+                    return True
+                except queue.Full:
+                    continue
+            return False
         # Resolved in collection_stage once the scanner has committed photo rows.
         # When set (i.e. snapshot-scoped runs), the collection is trimmed to this
         # set so every downstream stage (classify, extract_masks, eye_keypoints,
@@ -1040,17 +1164,9 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
 
                 def photo_cb(photo_id, path):
                     collected_photo_ids.append(photo_id)
-                    # Abort-aware put: a blocking no-timeout put would wedge the
-                    # scanner forever if the thumbnail consumer died with a full
-                    # queue (its setup can fail before its drain loop starts).
-                    # On abort the item is dropped — the consumer is gone and the
-                    # pipeline is tearing down anyway.
-                    while not _should_abort(abort):
-                        try:
-                            scan_to_thumb.put((photo_id, path), timeout=0.5)
-                            break
-                        except queue.Full:
-                            continue
+                    # Abort/pause-aware: a blocking put would wedge the scanner
+                    # if the thumbnail consumer parked or failed on a full queue.
+                    _put_scan_item((photo_id, path))
                     stages["scan"]["count"] = len(collected_photo_ids)
                     runner.update_step(job["id"], "scan",
                                        current_file=os.path.basename(path))
@@ -1070,7 +1186,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     )
 
                 def cancel_check():
-                    return _should_abort(abort) or runner.is_cancelled(job["id"])
+                    return _should_abort(abort) or _cancellation_requested()
 
                 # Accumulator so multi-folder scans (repair loop, scan-in-place
                 # with sources=[...]) don't rewind the overall progress at each
@@ -1126,7 +1242,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             summary="Skipped (using collection)",
                         )
                         _update_stages(runner, job["id"], stages)
-                        scan_to_thumb.put(_SENTINEL)
+                        _put_scan_item(_SENTINEL)
                         return
 
                     total_broken = sum(len(paths) for _, paths in broken)
@@ -1193,7 +1309,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             )
                         except (OSError, RuntimeError) as e:
                             if isinstance(e, ScanCancelled) and (
-                                _should_abort(abort) or runner.is_cancelled(job["id"])
+                                _should_abort(abort) or _cancellation_requested()
                             ):
                                 abort.set()
                                 stages["scan"]["status"] = "skipped"
@@ -1210,14 +1326,14 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         finally:
                             advance_scan_acc()
 
-                    if _should_abort(abort) or runner.is_cancelled(job["id"]):
+                    if _should_abort(abort) or _cancellation_requested():
                         stages["scan"]["status"] = "skipped"
                         runner.update_step(
                             job["id"], "scan",
                             status="completed",
                             summary="Cancelled",
                         )
-                        scan_to_thumb.put(_SENTINEL)
+                        _put_scan_item(_SENTINEL)
                         return
 
                     from metadata import scan_metadata_warning
@@ -1236,7 +1352,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     runner.update_step(
                         job["id"], "scan", status="completed", summary=summary,
                     )
-                    scan_to_thumb.put(_SENTINEL)
+                    _put_scan_item(_SENTINEL)
                     return
 
                 # Determine source folder(s)
@@ -1302,7 +1418,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                     status="completed", summary="Skipped",
                                 )
                             abort.set()
-                            scan_to_thumb.put(_SENTINEL)
+                            _put_scan_item(_SENTINEL)
 
                         try:
                             if remote_archive is not None:
@@ -2135,7 +2251,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             )
                         finally:
                             advance_scan_acc()
-                if _should_abort(abort) or runner.is_cancelled(job["id"]):
+                if _should_abort(abort) or _cancellation_requested():
                     stages["scan"]["status"] = "skipped"
                     runner.update_step(
                         job["id"], "scan", status="completed", summary="Cancelled",
@@ -2156,7 +2272,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                        summary=scan_summary)
             except Exception as e:
                 if isinstance(e, ScanCancelled) and (
-                    _should_abort(abort) or runner.is_cancelled(job["id"])
+                    _should_abort(abort) or _cancellation_requested()
                 ):
                     abort.set()
                     stages["scan"]["status"] = "skipped"
@@ -2202,7 +2318,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                     "cache for %s",
                                     scanned_root,
                                 )
-                scan_to_thumb.put(_SENTINEL)
+                _put_scan_item(_SENTINEL)
                 _update_stages(runner, job["id"], stages)
 
         def collection_stage():
@@ -2216,6 +2332,9 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
             # Wait for scanner to complete (don't check abort -- we want the
             # collection regardless so the user can see scanned photos)
             while True:
+                # Pause is different from abort: this worker can park while it
+                # waits without giving up the collection the scanner produced.
+                _pause_checkpoint()
                 if stages["scan"]["status"] in ("completed", "failed", "skipped"):
                     break
                 time.sleep(0.1)
@@ -2348,6 +2467,9 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         pending_thumb_paths.clear()
 
                 while True:
+                    # Continue draining after cancellation, but park before
+                    # taking another item when the whole pipeline is paused.
+                    _pause_checkpoint()
                     try:
                         item = scan_to_thumb.get(timeout=1.0)
                     except queue.Empty:
@@ -3108,7 +3230,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         pass
 
                 def cancel_check():
-                    return _should_abort(abort) or runner.is_cancelled(job["id"])
+                    return _should_abort(abort) or _cancellation_requested()
 
                 if model_type == "timm":
                     if cancel_check():
@@ -3345,7 +3467,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         preload_err.__class__.__name__ == "ClassificationCancelled"
                     )
                     if (
-                        runner.is_cancelled(job["id"])
+                        _cancellation_requested()
                         or is_classification_cancelled
                         or str(preload_err) == "classification cancelled"
                     ):
@@ -3375,7 +3497,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     e.__class__.__name__ == "ClassificationCancelled"
                 )
                 if (
-                    runner.is_cancelled(job["id"])
+                    _cancellation_requested()
                     or is_classification_cancelled
                     or str(e) == "classification cancelled"
                 ):
@@ -3765,7 +3887,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             )
                             if (
                                 _should_abort(abort)
-                                or runner.is_cancelled(job["id"])
+                                or _cancellation_requested()
                                 or is_classification_cancelled
                                 or str(model_err) == "classification cancelled"
                             ):
@@ -5649,10 +5771,23 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
         threads = {}
 
         # Phase 1: scan + thumbnails + model loading (concurrent)
-        threads["scanner"] = threading.Thread(target=scanner_stage, daemon=True)
-        threads["collection"] = threading.Thread(target=collection_stage, daemon=True)
-        threads["thumbnail"] = threading.Thread(target=thumbnail_stage, daemon=True)
-        threads["model_loader"] = threading.Thread(target=model_loader_stage, daemon=True)
+        phase_one = {
+            "scanner": scanner_stage,
+            "collection": collection_stage,
+            "thumbnail": thumbnail_stage,
+            "model_loader": model_loader_stage,
+        }
+        # Register the complete phase before starting its first thread.  If the
+        # first worker reaches Pause immediately, it must wait for the other
+        # three rather than declaring the whole pipeline paused on its own.
+        pause_gate.register_many(phase_one)
+        for name, stage_fn in phase_one.items():
+            threads[name] = threading.Thread(
+                target=_run_pause_participant,
+                args=(name, stage_fn),
+                kwargs={"pre_registered": True},
+                daemon=True,
+            )
 
         for t in threads.values():
             t.start()
@@ -5670,7 +5805,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
         # call on abort would leave the runner.set_steps-created rows
         # persisted as "pending" with no finished_at, forever. Each stage
         # checks abort internally and marks itself "Skipped".
-        previews_stage()
+        _run_pause_participant("previews", previews_stage)
 
         # Phase 2: detect (needs collection; runs MegaDetector once across all
         # photos so each per-model classify step reuses cached detections
@@ -5680,21 +5815,21 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
         # the `detect` step row reaches a terminal status. Skipping the call
         # would leave the row pending forever on a model-loader failure.
         # detect_stage handles abort internally and marks itself skipped.
-        detect_stage()
+        _run_pause_participant("detect", detect_stage)
 
         # Phase 3: classify per model (reads cached detections from detect_stage).
         # Always invoked for the same reason: every `classify:<model_id>` row
         # must land in a terminal state so the jobs tree finalizes cleanly on
         # a loader-triggered abort.
-        classify_stage()
+        _run_pause_participant("classify", classify_stage)
 
         # Phase 3: extract-masks (needs classify output)
-        extract_masks_stage()
+        _run_pause_participant("extract_masks", extract_masks_stage)
 
         # Phase 3.5: eye keypoints (needs masks + classifier output). No-op when
         # SuperAnimal weights are absent — users opt in on the pipeline models
         # card. Per-photo failures log and continue rather than abort the stage.
-        eye_keypoints_stage()
+        _run_pause_participant("eye_keypoints", eye_keypoints_stage)
 
         # Phases 4 + 5: regroup and miss detection. Held under the
         # per-workspace regroup lock TOGETHER so a concurrent same-workspace
@@ -5714,14 +5849,14 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
             # leave their step rows pending forever. Staying outside the lock
             # also keeps an aborted/cancelled run from blocking behind a
             # concurrent pipeline's regroup.
-            regroup_stage()
-            miss_stage()
+            _run_pause_participant("regroup", regroup_stage)
+            _run_pause_participant("misses", miss_stage)
         else:
             with acquire_workspace_regroup(workspace_id):
-                regroup_stage()
-                miss_stage()
+                _run_pause_participant("regroup", regroup_stage)
+                _run_pause_participant("misses", miss_stage)
 
-        archive_stage()
+        _run_pause_participant("archive", archive_stage)
 
         cancel_watcher_stop.set()
 
@@ -5736,7 +5871,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
         failed_stages = [
             name for name, s in stages.items() if s.get("status") == "failed"
         ]
-        if failed_stages and not runner.is_cancelled(job["id"]):
+        if failed_stages and not _cancellation_requested():
             # Stash the structured result on the job BEFORE raising so the
             # completion event and job_history still carry per-stage details
             # (stages dict, errors list). Without this, the pipeline UI loses

--- a/vireo/templates/jobs.html
+++ b/vireo/templates/jobs.html
@@ -133,10 +133,11 @@
 }
 .btn-pause {
   font-size: 12px; padding: 4px 12px; border-radius: 4px; cursor: pointer;
-  background: var(--bg-tertiary); color: var(--text-primary);
-  border: 1px solid var(--border-secondary);
+  background: var(--warning, #d99a24); color: #1f1b12;
+  border: 1px solid color-mix(in srgb, var(--warning, #d99a24) 75%, #000);
+  font-weight: 600;
 }
-.btn-pause:hover { border-color: var(--accent); }
+.btn-pause:hover { filter: brightness(1.06); }
 .btn-pause:disabled { cursor: progress; opacity: 0.65; }
 .btn-retry {
   font-size: 11px; padding: 2px 8px; border-radius: 3px; cursor: pointer;
@@ -226,6 +227,8 @@
 .job-card-header {
   padding: 16px 24px; border-bottom: 1px solid var(--border-primary);
   display: flex; align-items: center; gap: 12px; background: var(--bg-secondary);
+  position: sticky; top: 0; z-index: 5;
+  box-shadow: 0 2px 6px color-mix(in srgb, #000 12%, transparent);
 }
 .job-card-workspace {
   font-size: 12px; padding: 2px 8px; border-radius: 4px;

--- a/vireo/tests/test_jobs.py
+++ b/vireo/tests/test_jobs.py
@@ -85,6 +85,78 @@ def test_pausable_job_stops_at_checkpoint_and_resumes():
     assert status_events == ["pausing", "paused", "running"]
 
 
+def test_pipeline_pause_gate_waits_for_every_active_worker():
+    """A pipeline is not reported paused while one worker is still in-flight."""
+    from jobs import JobRunner
+    from pipeline_job import _PipelinePauseGate
+
+    runner = JobRunner()
+    release_slow_worker = threading.Event()
+    slow_worker_started = threading.Event()
+    stop = threading.Event()
+    counts = {"fast": 0, "slow": 0}
+
+    def work(job):
+        gate = _PipelinePauseGate(runner, job["id"])
+        gate.register_many(("fast", "slow"))
+
+        def fast_worker():
+            try:
+                while True:
+                    if gate.checkpoint("fast") or stop.is_set():
+                        return
+                    counts["fast"] += 1
+                    time.sleep(0.005)
+            finally:
+                gate.unregister("fast")
+
+        def slow_worker():
+            try:
+                # Simulate a model/GPU batch that cannot be interrupted until
+                # it reaches its next safe boundary.
+                slow_worker_started.set()
+                assert release_slow_worker.wait(timeout=3)
+                while True:
+                    if gate.checkpoint("slow") or stop.is_set():
+                        return
+                    counts["slow"] += 1
+                    time.sleep(0.005)
+            finally:
+                gate.unregister("slow")
+
+        threads = [
+            threading.Thread(target=fast_worker),
+            threading.Thread(target=slow_worker),
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=5)
+            assert not thread.is_alive()
+        return dict(counts)
+
+    job_id = runner.start("pipeline", work, pausable=True)
+    assert slow_worker_started.wait(timeout=2)
+    deadline = time.monotonic() + 2
+    while counts["fast"] < 3 and time.monotonic() < deadline:
+        time.sleep(0.01)
+
+    assert runner.pause_job(job_id) is True
+    time.sleep(0.05)
+    assert runner.get(job_id)["status"] == "pausing"
+
+    release_slow_worker.set()
+    _wait_for_status(runner, job_id, "paused")
+    paused_counts = dict(counts)
+    time.sleep(0.05)
+    assert counts == paused_counts
+
+    assert runner.resume_job(job_id) is True
+    stop.set()
+    job = wait_for_job_via_runner(runner, job_id)
+    assert job["status"] == "completed"
+
+
 def test_pause_status_events_stay_ordered_through_completion():
     """Competing pause and worker transitions cannot publish stale states."""
     from jobs import JobRunner

--- a/vireo/tests/test_jobs_api.py
+++ b/vireo/tests/test_jobs_api.py
@@ -232,6 +232,17 @@ def test_pipeline_slots_counts_only_pipeline_jobs(app_and_db):
         "config": {},
         "result": {"ok": True},
     }
+    paused_pipeline = {
+        "id": "pipe-paused-1",
+        "type": "pipeline",
+        "status": "paused",
+        "started_at": "2026-05-27T09:45:00",
+        "finished_at": None,
+        "progress": {"current": 5, "total": 10},
+        "errors": [],
+        "config": {},
+        "result": None,
+    }
     running_scan = {
         "id": "scan-running-1",
         "type": "scan",
@@ -246,14 +257,15 @@ def test_pipeline_slots_counts_only_pipeline_jobs(app_and_db):
     with runner._lock:
         runner._jobs["pipe-running-1"] = running_pipeline
         runner._jobs["pipe-done-1"] = finished_pipeline
+        runner._jobs["pipe-paused-1"] = paused_pipeline
         runner._jobs["scan-running-1"] = running_scan
 
     from jobs import SLOT_CAP
     resp = client.get('/api/pipeline/slots')
     assert resp.status_code == 200
     data = resp.get_json()
-    assert data["active"] == 1, \
-        "only running pipelines count toward active slots"
+    assert data["active"] == 2, \
+        "running and paused pipelines both occupy active slots"
     assert data["queued"] == 0
     assert data["slot_cap"] == SLOT_CAP
 

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -7287,6 +7287,11 @@ def test_workspace_regroup_lock_spans_regroup_and_miss(tmp_path, monkeypatch):
     ws_id = db._active_workspace_id
 
     events = []
+    pause_state = {
+        "requested": False,
+        "lock_held": False,
+        "wait_lock_states": [],
+    }
 
     real_acquire = pipeline_locks.acquire_workspace_regroup
 
@@ -7298,11 +7303,15 @@ def test_workspace_regroup_lock_spans_regroup_and_miss(tmp_path, monkeypatch):
         def __enter__(self):
             events.append(("acquire", self._ws))
             self._inner.__enter__()
+            pause_state["lock_held"] = True
             return self
 
         def __exit__(self, *args):
             events.append(("release", self._ws))
-            return self._inner.__exit__(*args)
+            try:
+                return self._inner.__exit__(*args)
+            finally:
+                pause_state["lock_held"] = False
 
     monkeypatch.setattr(
         pj, "acquire_workspace_regroup",
@@ -7311,6 +7320,9 @@ def test_workspace_regroup_lock_spans_regroup_and_miss(tmp_path, monkeypatch):
 
     def _ok_run(photos, config=None, emit_trace=False):
         events.append(("regroup_work", ws_id))
+        # Simulate Pause arriving during regroup work. The pipeline must defer
+        # its blocking wait until after the shared regroup/misses lock releases.
+        pause_state["requested"] = True
         return {"summary": {"groups": 1}, "photos": photos}
 
     monkeypatch.setattr(pipeline_mod, "run_full_pipeline", _ok_run)
@@ -7321,6 +7333,22 @@ def test_workspace_regroup_lock_spans_regroup_and_miss(tmp_path, monkeypatch):
     )
 
     class TrackingRunner(FakeRunner):
+        def pause_requested(self, job_id):
+            return pause_state["requested"]
+
+        def cancellation_requested(self, job_id):
+            return False
+
+        def mark_paused(self, job_id):
+            return True
+
+        def wait_if_paused(self, job_id, *, publish_paused=False):
+            pause_state["wait_lock_states"].append(
+                pause_state["lock_held"],
+            )
+            pause_state["requested"] = False
+            return False
+
         def update_step(self, job_id, step_id, **kwargs):
             if step_id == "misses":
                 events.append(("miss_step", kwargs.get("status")))
@@ -7376,6 +7404,10 @@ def test_workspace_regroup_lock_spans_regroup_and_miss(tmp_path, monkeypatch):
         "miss step must run inside the same lock as regroup — otherwise "
         "a second same-workspace pipeline could sneak in and rewrite "
         f"grouping state between them. events: {interesting}"
+    )
+    assert pause_state["wait_lock_states"] == [False], (
+        "Pause must block only after the regroup/misses lock is released; "
+        f"wait states: {pause_state['wait_lock_states']}"
     )
 
 
@@ -8238,6 +8270,7 @@ def test_pipeline_extract_masks_cancel_marks_stage_cancelled(
 
 def _run_extract_masks_for_test(
     tmp_path, monkeypatch, sam2_variant, photo_specs,
+    *, runner=None, on_generate_mask=None,
 ):
     """Drive a single pipeline run with extract_masks enabled and the heavy
     SAM2/DINOv2 calls stubbed.  Returns (db, runner, generate_mask_calls)
@@ -8298,6 +8331,8 @@ def _run_extract_masks_for_test(
         # Track every (variant, det_box) we get asked about — the cache
         # short-circuit must skip past this entirely on a hit.
         generate_mask_calls.append((variant, tuple(sorted(det_box.items()))))
+        if on_generate_mask is not None:
+            on_generate_mask()
         return np.ones((4, 4), dtype=bool)
 
     monkeypatch.setattr(masking, "render_proxy", fake_render_proxy)
@@ -8335,11 +8370,83 @@ def _run_extract_masks_for_test(
         skip_extract_masks=False,
         skip_regroup=True,
     )
-    runner = FakeRunner()
+    runner = runner or FakeRunner()
     job = _make_job()
     run_pipeline_job(job, runner, db_path, ws_id, params)
 
     return db, runner, generate_mask_calls, photo_ids
+
+
+def test_extract_masks_pause_waits_outside_photo_lock(tmp_path, monkeypatch):
+    """Pause may be requested under a photo lock but must wait after release."""
+    import pipeline_job as pj
+    import pipeline_locks
+
+    pause_state = {
+        "requested": False,
+        "lock_held": False,
+        "wait_lock_states": [],
+    }
+    real_acquire = pipeline_locks.acquire_photo_mask
+
+    class TrackingLock:
+        def __init__(self, inner):
+            self._inner = inner
+
+        def __enter__(self):
+            self._inner.__enter__()
+            pause_state["lock_held"] = True
+            return self
+
+        def __exit__(self, *args):
+            try:
+                return self._inner.__exit__(*args)
+            finally:
+                pause_state["lock_held"] = False
+
+    monkeypatch.setattr(
+        pj, "acquire_photo_mask",
+        lambda photo_id: TrackingLock(real_acquire(photo_id)),
+    )
+
+    class PauseTrackingRunner(FakeRunner):
+        def pause_requested(self, job_id):
+            return pause_state["requested"]
+
+        def cancellation_requested(self, job_id):
+            return False
+
+        def mark_paused(self, job_id):
+            return True
+
+        def wait_if_paused(self, job_id, *, publish_paused=False):
+            pause_state["wait_lock_states"].append(
+                pause_state["lock_held"],
+            )
+            pause_state["requested"] = False
+            return False
+
+    def request_pause():
+        assert pause_state["lock_held"] is True
+        pause_state["requested"] = True
+
+    _run_extract_masks_for_test(
+        tmp_path,
+        monkeypatch,
+        "sam2-small",
+        [{
+            "filename": "a.jpg",
+            "box": (10, 20, 100, 200),
+            "model": "MegaDetector",
+        }],
+        runner=PauseTrackingRunner(),
+        on_generate_mask=request_pause,
+    )
+
+    assert pause_state["wait_lock_states"] == [False], (
+        "Pause must block only after the per-photo mask lock is released; "
+        f"wait states: {pause_state['wait_lock_states']}"
+    )
 
 
 def _apply_extract_masks_stubs(monkeypatch, generate_mask_calls):

--- a/vireo/tests/test_pipeline_queue.py
+++ b/vireo/tests/test_pipeline_queue.py
@@ -9,6 +9,7 @@ so they stay meaningful regardless of the current ``SLOT_CAP`` value.
 """
 
 import threading
+import time
 
 from db import Database
 from wait import wait_for_job_via_runner
@@ -202,6 +203,59 @@ def test_enqueue_beyond_slot_cap_stays_queued(tmp_path):
     assert extra_started.wait(timeout=2.0), (
         "extra pipeline did not promote after slots cleared"
     )
+    wait_for_job_via_runner(runner, extra_id)
+
+
+def test_paused_pipeline_keeps_its_scheduler_slot(tmp_path):
+    """Pausing must not let the queue exceed the pipeline concurrency cap."""
+    from jobs import SLOT_CAP
+
+    runner, _ = _make_runner_with_db(tmp_path)
+    release = threading.Event()
+    started_events = [threading.Event() for _ in range(SLOT_CAP)]
+    occupant_ids = []
+
+    for started in started_events:
+        def work(job, _started=started):
+            _started.set()
+            while not release.is_set():
+                if runner.is_cancelled(job["id"]):
+                    break
+                time.sleep(0.005)
+            return {}
+
+        occupant_ids.append(runner.enqueue_pipeline(
+            work_fn=work, config={}, workspace_id=1,
+        ))
+
+    for index, started in enumerate(started_events):
+        assert started.wait(timeout=2), f"occupant {index} never started"
+
+    paused_id = occupant_ids[0]
+    assert runner.get(paused_id)["pausable"] is True
+    assert runner.pause_job(paused_id) is True
+    deadline = time.monotonic() + 2
+    while runner.get(paused_id)["status"] != "paused" and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert runner.get(paused_id)["status"] == "paused"
+
+    extra_started = threading.Event()
+
+    def extra_work(job):
+        extra_started.set()
+        return {}
+
+    extra_id = runner.enqueue_pipeline(
+        work_fn=extra_work, config={}, workspace_id=1,
+    )
+    assert runner.get(extra_id)["status"] == "queued"
+    assert not extra_started.wait(timeout=0.1)
+
+    assert runner.resume_job(paused_id) is True
+    release.set()
+    for occupant_id in occupant_ids:
+        wait_for_job_via_runner(runner, occupant_id)
+    assert extra_started.wait(timeout=2)
     wait_for_job_via_runner(runner, extra_id)
 
 


### PR DESCRIPTION
## Summary

- Adds a prominent, sticky Pause/Resume control to running processing pipelines.
- Coordinates concurrent stage workers so the job reports Paused only after every active worker reaches a safe checkpoint, while Cancel remains available.
- Keeps paused pipelines in their scheduler slots and reports slot occupancy accurately, fixing the previous pipeline configuration that explicitly disabled pausing.
- Validated with job, queue, orchestration, and API test suites (461 passed, 66 skipped) plus Ruff checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pipeline jobs now pause safely across concurrent processing stages and resume reliably.
  * Paused and pausing pipeline jobs continue to occupy scheduler capacity, preventing excess queued work from starting.
* **Bug Fixes**
  * Improved pause and cancellation coordination to avoid misleading status updates and pipeline stalls.
  * Prevented queue deadlocks when pipeline stages pause or stop unexpectedly.
* **Style**
  * Pause controls now use a clearer warning appearance.
  * Job detail headers remain visible while scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->