### PR TITLE
Enable customizable Life List CSV downloads

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,7 +5,7 @@ mod sidecar;
 mod tray;
 mod updater;
 use sidecar::{SidecarStartError, SidecarState};
-use tauri::webview::NewWindowResponse;
+use tauri::webview::{DownloadEvent, NewWindowResponse};
 use tauri::window::{ProgressBarState, ProgressBarStatus};
 use tauri::{Manager, RunEvent};
 use tauri_plugin_dialog::{DialogExt, MessageDialogKind};
@@ -57,6 +57,32 @@ fn reload_main_window(app: &tauri::AppHandle) {
             log::error!("Failed to reload main window: {}", e);
         }
     }
+}
+
+fn handle_download<R: tauri::Runtime>(app: &tauri::AppHandle<R>, event: DownloadEvent<'_>) -> bool {
+    match event {
+        DownloadEvent::Requested { url, destination } => {
+            if !navigation::allow_download(app, &url) {
+                return false;
+            }
+            log::info!(
+                "Native download requested from {} to {}",
+                url,
+                destination.display()
+            );
+        }
+        DownloadEvent::Finished { url, path, success } => {
+            if success {
+                // WKWebView does not report the completed path on macOS, so
+                // retain the URL in the log even when `path` is unavailable.
+                log::info!("Native download finished from {} at {:?}", url, path);
+            } else {
+                log::error!("Native download failed from {}", url);
+            }
+        }
+        _ => {}
+    }
+    true
 }
 
 #[tauri::command]
@@ -152,6 +178,7 @@ pub fn run() {
                 .clone();
             let navigation_app = app.handle().clone();
             let popup_app = app.handle().clone();
+            let download_app = app.handle().clone();
             tauri::WebviewWindowBuilder::from_config(app.handle(), &main_config)?
                 .on_navigation(move |url| {
                     navigation::handle_navigation(&navigation_app, url)
@@ -160,6 +187,7 @@ pub fn run() {
                     navigation::handle_new_window(&popup_app, &url);
                     NewWindowResponse::Deny
                 })
+                .on_download(move |_webview, event| handle_download(&download_app, event))
                 .build()?;
 
             // Read the user's launch-time config (~/.vireo/config.json).

--- a/src-tauri/src/navigation.rs
+++ b/src-tauri/src/navigation.rs
@@ -286,7 +286,10 @@ mod tests {
             Some(43127)
         ));
         assert!(!blob_allowed("blob:null/opaque", Some(43127)));
-        assert!(!blob_allowed("http://localhost:43127/not-a-blob", Some(43127)));
+        assert!(!blob_allowed(
+            "http://localhost:43127/not-a-blob",
+            Some(43127)
+        ));
     }
 
     #[test]

--- a/src-tauri/src/navigation.rs
+++ b/src-tauri/src/navigation.rs
@@ -110,16 +110,35 @@ pub fn handle_navigation<R: Runtime>(app: &tauri::AppHandle<R>, url: &Url) -> bo
 /// Allow downloads only from Vireo's own packaged frontend or loopback
 /// backend. Download navigations can bypass the ordinary navigation callback
 /// on some webview engines, so they need the same origin check here.
+///
+/// Same-origin `blob:` URLs are also allowed so the frontend's internal
+/// fallbacks (e.g. the issue-report modal saves diagnostics via
+/// `URL.createObjectURL` when the API can't email them) still work in the
+/// desktop shell. Blob URLs can only be created by a same-origin page, so
+/// gating on the inner origin keeps the trust boundary intact.
 pub fn allow_download<R: Runtime>(app: &tauri::AppHandle<R>, url: &Url) -> bool {
-    if matches!(
-        classify(url, backend_port(app)),
-        NavigationAction::AllowInternal
-    ) {
+    let port = backend_port(app);
+    if matches!(classify(url, port), NavigationAction::AllowInternal)
+        || is_same_origin_blob(url, port)
+    {
         true
     } else {
         log::warn!("Blocked download from non-Vireo URL: {}", url);
         false
     }
+}
+
+fn is_same_origin_blob(url: &Url, backend_port: Option<u16>) -> bool {
+    if url.scheme() != "blob" {
+        return false;
+    }
+    let Ok(inner) = Url::parse(url.path()) else {
+        return false;
+    };
+    matches!(
+        classify(&inner, backend_port),
+        NavigationAction::AllowInternal
+    )
 }
 
 /// Handle a `window.open` request. Vireo is intentionally single-webview:
@@ -157,11 +176,15 @@ pub fn open_external_url<R: Runtime>(
 
 #[cfg(test)]
 mod tests {
-    use super::{classify, NavigationAction};
+    use super::{classify, is_same_origin_blob, NavigationAction};
     use tauri::Url;
 
     fn action(raw: &str, port: Option<u16>) -> NavigationAction {
         classify(&Url::parse(raw).unwrap(), port)
+    }
+
+    fn blob_allowed(raw: &str, port: Option<u16>) -> bool {
+        is_same_origin_blob(&Url::parse(raw).unwrap(), port)
     }
 
     #[test]
@@ -233,6 +256,37 @@ mod tests {
             action("http://someone:secret@127.0.0.1:43127/browse", Some(43127)),
             NavigationAction::OpenExternal
         );
+    }
+
+    #[test]
+    fn allows_same_origin_blob_downloads() {
+        assert!(blob_allowed(
+            "blob:http://localhost:43127/1e2b-c",
+            Some(43127)
+        ));
+        assert!(blob_allowed(
+            "blob:http://127.0.0.1:43127/9f-08",
+            Some(43127)
+        ));
+        assert!(blob_allowed("blob:tauri://localhost/abc-1", None));
+    }
+
+    #[test]
+    fn blocks_cross_origin_and_malformed_blob_downloads() {
+        assert!(!blob_allowed(
+            "blob:https://evil.example.com/1e2b-c",
+            Some(43127)
+        ));
+        assert!(!blob_allowed(
+            "blob:http://localhost:43128/wrong-port",
+            Some(43127)
+        ));
+        assert!(!blob_allowed(
+            "blob:http://someone@localhost:43127/user-info",
+            Some(43127)
+        ));
+        assert!(!blob_allowed("blob:null/opaque", Some(43127)));
+        assert!(!blob_allowed("http://localhost:43127/not-a-blob", Some(43127)));
     }
 
     #[test]

--- a/src-tauri/src/navigation.rs
+++ b/src-tauri/src/navigation.rs
@@ -107,6 +107,21 @@ pub fn handle_navigation<R: Runtime>(app: &tauri::AppHandle<R>, url: &Url) -> bo
     }
 }
 
+/// Allow downloads only from Vireo's own packaged frontend or loopback
+/// backend. Download navigations can bypass the ordinary navigation callback
+/// on some webview engines, so they need the same origin check here.
+pub fn allow_download<R: Runtime>(app: &tauri::AppHandle<R>, url: &Url) -> bool {
+    if matches!(
+        classify(url, backend_port(app)),
+        NavigationAction::AllowInternal
+    ) {
+        true
+    } else {
+        log::warn!("Blocked download from non-Vireo URL: {}", url);
+        false
+    }
+}
+
 /// Handle a `window.open` request. Vireo is intentionally single-webview:
 /// external pages go to the OS browser and no child webview is ever created.
 pub fn handle_new_window<R: Runtime>(app: &tauri::AppHandle<R>, url: &Url) {

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -10126,6 +10126,31 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         best = entry.get("best")
         return [best] if best else []
 
+    _LIFE_LIST_SPECIES_CSV_COLUMNS = (
+        "number",
+        "species",
+        "scientific_name",
+        "common_name",
+        "photo_count",
+        "first_seen",
+        "last_seen",
+        "locations",
+        "best_photo_id",
+        "best_filename",
+    )
+    _LIFE_LIST_PHOTO_CSV_COLUMNS = (
+        "number",
+        "species",
+        "scientific_name",
+        "common_name",
+        "photo_id",
+        "filename",
+        "timestamp",
+        "is_life_list_photo",
+        "quality_score",
+        "locations",
+    )
+
     def _life_list_export_response(body, mimetype, extension):
         today = datetime.now(UTC).date().isoformat()
         resp = make_response(body)
@@ -10144,21 +10169,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return "'" + text
         return text
 
-    def _life_list_species_csv(payload):
+    def _life_list_species_csv(payload, fieldnames=None):
         out = io.StringIO()
-        fieldnames = [
-            "number",
-            "species",
-            "scientific_name",
-            "common_name",
-            "photo_count",
-            "first_seen",
-            "last_seen",
-            "locations",
-            "best_photo_id",
-            "best_filename",
-        ]
-        writer = csv.DictWriter(out, fieldnames=fieldnames)
+        fieldnames = fieldnames or _LIFE_LIST_SPECIES_CSV_COLUMNS
+        writer = csv.DictWriter(out, fieldnames=fieldnames, extrasaction="ignore")
         writer.writeheader()
         for entry in payload.get("species", []):
             best = entry.get("best") or {}
@@ -10178,21 +10192,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             })
         return out.getvalue()
 
-    def _life_list_photos_csv(payload, photo_mode):
+    def _life_list_photos_csv(payload, photo_mode, fieldnames=None):
         out = io.StringIO()
-        fieldnames = [
-            "number",
-            "species",
-            "scientific_name",
-            "common_name",
-            "photo_id",
-            "filename",
-            "timestamp",
-            "is_life_list_photo",
-            "quality_score",
-            "locations",
-        ]
-        writer = csv.DictWriter(out, fieldnames=fieldnames)
+        fieldnames = fieldnames or _LIFE_LIST_PHOTO_CSV_COLUMNS
+        writer = csv.DictWriter(out, fieldnames=fieldnames, extrasaction="ignore")
         writer.writeheader()
         for entry in payload.get("species", []):
             for photo in _life_list_export_photos(entry, photo_mode):
@@ -10264,6 +10267,32 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if photo_mode not in {"best", "all"}:
             return json_error("photos must be best or all")
 
+        csv_columns = None
+        if "columns" in request.args:
+            if fmt != "csv":
+                return json_error("columns is only supported for csv exports")
+            available_columns = (
+                _LIFE_LIST_PHOTO_CSV_COLUMNS
+                if detail == "photos"
+                else _LIFE_LIST_SPECIES_CSV_COLUMNS
+            )
+            requested_columns = {
+                column.strip()
+                for column in request.args.get("columns", "").split(",")
+                if column.strip()
+            }
+            if not requested_columns:
+                return json_error("select at least one csv column")
+            unknown_columns = requested_columns.difference(available_columns)
+            if unknown_columns:
+                return json_error(
+                    "unknown csv columns: " + ", ".join(sorted(unknown_columns))
+                )
+            csv_columns = [
+                column for column in available_columns
+                if column in requested_columns
+            ]
+
         db = _get_db()
         uses_photo_scope = fmt == "files" or (fmt == "csv" and detail == "photos")
         payload_photos_per_species = (
@@ -10282,9 +10311,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return _life_list_export_response(body, "application/json", "json")
         if fmt == "csv":
             body = (
-                _life_list_photos_csv(payload, photo_mode)
+                _life_list_photos_csv(payload, photo_mode, csv_columns)
                 if detail == "photos"
-                else _life_list_species_csv(payload)
+                else _life_list_species_csv(payload, csv_columns)
             )
             return _life_list_export_response(body, "text/csv; charset=utf-8", "csv")
         if fmt == "files":

--- a/vireo/templates/life_list.html
+++ b/vireo/templates/life_list.html
@@ -25,9 +25,14 @@
   .publish-option { display:flex; gap:8px; align-items:flex-start; margin-top:12px; font-size:13px; color:var(--text-secondary); }
   .publish-status { min-height:16px; margin-top:10px; font-size:12px; color:var(--text-secondary); }
   .export-grid { display:grid; grid-template-columns:1fr 1fr; gap:12px; }
+  .export-columns-wrap { grid-column:1 / -1; }
+  .export-columns { display:grid; grid-template-columns:repeat(2, minmax(0, 1fr)); gap:7px 16px; padding:10px; border:1px solid var(--border-primary); border-radius:6px; background:var(--bg-tertiary); }
+  .export-column-option { display:flex; align-items:flex-start; gap:7px; font-size:12px; color:var(--text-secondary); cursor:pointer; }
+  .export-column-option input { margin:1px 0 0; }
   @media (max-width: 640px) {
     .lifelist-actions { margin-left:0; width:100%; justify-content:flex-end; }
     .export-grid { grid-template-columns:1fr; }
+    .export-columns { grid-template-columns:1fr; }
   }
 
   .lifelist-meta { padding:8px 24px; font-size:12px; color:var(--text-secondary); }
@@ -209,7 +214,11 @@
           <option value="all">All listed photos</option>
         </select>
       </div>
-      <label class="publish-option" style="margin-top:22px;">
+      <div id="exportColumnsWrap" class="export-columns-wrap" style="display:none;">
+        <span class="modal-label">Columns</span>
+        <div id="exportColumns" class="export-columns"></div>
+      </div>
+      <label id="exportLocationsWrap" class="publish-option" style="margin-top:22px;">
         <input id="exportLocations" type="checkbox">
         <span>Include location keywords.</span>
       </label>
@@ -273,6 +282,33 @@ var currentData = null;
 var debounceTimer = null;
 var LIFE_LIST_SORT_STORAGE_KEY = 'vireo.lifeList.sort';
 var LIFE_LIST_RENUMBER_STORAGE_KEY = 'vireo.lifeList.renumber';
+var LIFE_LIST_EXPORT_COLUMNS = {
+  species: [
+    ['number', 'Life-list number'],
+    ['species', 'Displayed species name'],
+    ['scientific_name', 'Scientific name'],
+    ['common_name', 'Common name'],
+    ['photo_count', 'Photo count'],
+    ['first_seen', 'First seen date'],
+    ['last_seen', 'Last seen date'],
+    ['locations', 'Locations'],
+    ['best_photo_id', 'Representative photo ID'],
+    ['best_filename', 'Representative filename'],
+  ],
+  photos: [
+    ['number', 'Life-list number'],
+    ['species', 'Displayed species name'],
+    ['scientific_name', 'Scientific name'],
+    ['common_name', 'Common name'],
+    ['photo_id', 'Photo ID'],
+    ['filename', 'Filename'],
+    ['timestamp', 'Date and time'],
+    ['is_life_list_photo', 'Life-list photo'],
+    ['quality_score', 'Quality score'],
+    ['locations', 'Locations'],
+  ],
+};
+var lifeListExportColumnSelections = {species: null, photos: null};
 var LIFE_LIST_SORTS = ['newest', 'life-order', 'alpha', 'most-photos'];
 var LIFE_LIST_PAGE_SIZE = 100;
 var lifeListLightboxSpecies = null;
@@ -633,15 +669,71 @@ function closeExportModal() {
   document.getElementById('exportModal').classList.remove('open');
 }
 
+function exportColumnSelection(detail) {
+  if (!lifeListExportColumnSelections[detail]) {
+    var selection = {};
+    LIFE_LIST_EXPORT_COLUMNS[detail].forEach(function(column) {
+      selection[column[0]] = true;
+    });
+    lifeListExportColumnSelections[detail] = selection;
+  }
+  return lifeListExportColumnSelections[detail];
+}
+
+function selectedExportColumns(detail) {
+  var selection = exportColumnSelection(detail);
+  return LIFE_LIST_EXPORT_COLUMNS[detail]
+    .map(function(column) { return column[0]; })
+    .filter(function(column) { return selection[column]; });
+}
+
+function updateExportLocationsVisibility() {
+  var format = document.getElementById('exportFormat').value;
+  var detail = document.getElementById('exportDetail').value;
+  var showLocations = format === 'json' || format === 'txt';
+  if (format === 'csv') {
+    showLocations = selectedExportColumns(detail).indexOf('locations') !== -1;
+  }
+  document.getElementById('exportLocationsWrap').style.display = showLocations ? '' : 'none';
+}
+
+function renderExportColumns(detail) {
+  var container = document.getElementById('exportColumns');
+  var selection = exportColumnSelection(detail);
+  container.textContent = '';
+  LIFE_LIST_EXPORT_COLUMNS[detail].forEach(function(column) {
+    var label = document.createElement('label');
+    label.className = 'export-column-option';
+    var checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.value = column[0];
+    checkbox.checked = selection[column[0]];
+    checkbox.addEventListener('change', function() {
+      selection[column[0]] = checkbox.checked;
+      document.getElementById('exportStatus').textContent = '';
+      updateExportLocationsVisibility();
+    });
+    var text = document.createElement('span');
+    text.textContent = column[1];
+    label.appendChild(checkbox);
+    label.appendChild(text);
+    container.appendChild(label);
+  });
+}
+
 function updateExportControls() {
   var format = document.getElementById('exportFormat').value;
   var detailWrap = document.getElementById('exportDetailWrap');
   var photosWrap = document.getElementById('exportPhotosWrap');
+  var columnsWrap = document.getElementById('exportColumnsWrap');
   var detail = document.getElementById('exportDetail').value;
   detailWrap.style.display = format === 'csv' ? '' : 'none';
   photosWrap.style.display = (
     format === 'files' || (format === 'csv' && detail === 'photos')
   ) ? '' : 'none';
+  columnsWrap.style.display = format === 'csv' ? '' : 'none';
+  if (format === 'csv') renderExportColumns(detail);
+  updateExportLocationsVisibility();
 }
 
 function downloadLifeListExport() {
@@ -649,15 +741,29 @@ function downloadLifeListExport() {
   var detail = document.getElementById('exportDetail').value;
   var photos = document.getElementById('exportPhotos').value;
   var includeLocations = document.getElementById('exportLocations').checked ? '1' : '0';
+  var columns = format === 'csv' ? selectedExportColumns(detail) : [];
+  if (format === 'csv' && !columns.length) {
+    document.getElementById('exportStatus').textContent = 'Select at least one column.';
+    return;
+  }
   var params = new URLSearchParams({
     format: format,
     detail: detail,
     include_locations: includeLocations,
   });
+  if (format === 'csv') params.set('columns', columns.join(','));
   if (format === 'files' || (format === 'csv' && detail === 'photos')) {
     params.set('photos', photos);
   }
-  window.location.href = '/api/life-list/export?' + params.toString();
+  var link = document.createElement('a');
+  link.href = '/api/life-list/export?' + params.toString();
+  // Explicitly mark this as a download. WKWebView otherwise treats showable
+  // formats such as CSV as a normal page navigation even when the response
+  // carries Content-Disposition: attachment.
+  link.download = '';
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
   closeExportModal();
 }
 

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -12493,6 +12493,8 @@ def test_native_shell_owns_external_navigation_policy():
     assert "navigation::handle_navigation(&navigation_app, url)" in lib
     assert ".on_new_window(" in lib
     assert "NewWindowResponse::Deny" in lib
+    assert ".on_download(" in lib
+    assert "handle_download(&download_app, event)" in lib
 
 
 def test_pipeline_plan_accepts_folder_scope(app_and_db):

--- a/vireo/tests/test_life_list.py
+++ b/vireo/tests/test_life_list.py
@@ -127,6 +127,10 @@ def test_page_renders(life_app):
     assert b"Renumber for each view" in resp.data
     assert b"Taxonomic group" in resp.data
     assert b"Identification level" in resp.data
+    assert b'id="exportColumns"' in resp.data
+    assert b"Representative filename" in resp.data
+    assert b"Quality score" in resp.data
+    assert b"link.download = ''" in resp.data
 
 
 def test_groups_by_species_and_counts(life_app):
@@ -771,6 +775,58 @@ def test_life_list_export_species_csv_with_locations(life_app):
     cardinal = next(r for r in rows if r["species"] == "Northern Cardinal")
     assert cardinal["locations"] == "Backyard"
     assert cardinal["best_filename"] == "card2.jpg"
+
+
+def test_life_list_export_species_csv_selected_columns(life_app):
+    app, _, _ = life_app
+    resp = app.test_client().get(
+        "/api/life-list/export?format=csv"
+        "&columns=species,photo_count,best_filename"
+    )
+    assert resp.status_code == 200
+
+    reader = csv.DictReader(io.StringIO(resp.get_data(as_text=True)))
+    assert reader.fieldnames == ["species", "photo_count", "best_filename"]
+    rows = list(reader)
+    cardinal = next(r for r in rows if r["species"] == "Northern Cardinal")
+    assert cardinal == {
+        "species": "Northern Cardinal",
+        "photo_count": "2",
+        "best_filename": "card2.jpg",
+    }
+
+
+def test_life_list_export_photo_csv_selected_columns(life_app):
+    app, _, ids = life_app
+    resp = app.test_client().get(
+        "/api/life-list/export?format=csv&detail=photos&photos=all"
+        "&columns=species,photo_id,filename"
+    )
+    assert resp.status_code == 200
+
+    reader = csv.DictReader(io.StringIO(resp.get_data(as_text=True)))
+    assert reader.fieldnames == ["species", "photo_id", "filename"]
+    rows = list(reader)
+    assert [int(row["photo_id"]) for row in rows] == [
+        ids["p3"], ids["p2"], ids["p1"]
+    ]
+
+
+@pytest.mark.parametrize(
+    "query, message",
+    [
+        ("format=csv&columns=", "select at least one csv column"),
+        ("format=csv&columns=species,not_a_column", "unknown csv columns"),
+        ("format=json&columns=species", "only supported for csv"),
+    ],
+)
+def test_life_list_export_rejects_invalid_column_selection(
+    life_app, query, message
+):
+    app, _, _ = life_app
+    resp = app.test_client().get("/api/life-list/export?" + query)
+    assert resp.status_code == 400
+    assert message in resp.get_json()["error"]
 
 
 def test_life_list_export_csv_escapes_formula_leading_cells(life_app):


### PR DESCRIPTION
This enables Life List exports in Vireo's native window by accepting downloads only from Vireo's trusted local backend and marking export links as downloads.

CSV exports now offer per-column checkboxes for species summaries and photo rows, while preserving location-keyword opt-in and backwards-compatible full-column API behavior.

The backend validates selected columns and rejects empty or unknown selections.

Validation: `pytest -q vireo/tests/test_life_list.py` (46 passed), `cargo test --manifest-path src-tauri/Cargo.toml` (20 passed), the native shell policy test, JavaScript syntax validation, and diff checks.
