### PR TITLE
Keep location review actions visible below notification banners

### DIFF
--- a/tests/e2e/test_location_review.py
+++ b/tests/e2e/test_location_review.py
@@ -200,3 +200,47 @@ def test_location_review_actions_stay_above_open_bottom_panel(live_server, page)
     )
     assert positions["actionsBottom"] <= positions["panelTop"]
     expect(page.locator("#locationReviewAssign")).to_be_in_viewport()
+
+
+def test_location_review_actions_stay_visible_below_top_banner(live_server, page):
+    """Shared notification banners must resize rather than clip the review page."""
+    photo_id = live_server["data"]["photos"][0]
+    with live_server["db"].conn:
+        live_server["db"].conn.execute(
+            "UPDATE photos SET latitude = ?, longitude = ? WHERE id = ?",
+            (33.2550, -116.4050, photo_id),
+        )
+
+    page.set_viewport_size({"width": 890, "height": 600})
+    page.route("https://unpkg.com/**", _stub_leaflet)
+    page.goto(f"{live_server['url']}/browse")
+    page.evaluate(
+        "photoId => sessionStorage.setItem('vireoLocationReviewSource', "
+        "JSON.stringify({photo_ids: [photoId]}))",
+        photo_id,
+    )
+    page.goto(f"{live_server['url']}/locations/review?source=selection")
+    expect(page.locator("#locationReviewGroupTitle")).to_have_text("1 photo")
+
+    page.evaluate(
+        """() => {
+          document.getElementById('newImagesMsg').textContent = '7 new images';
+          document.getElementById('newImagesBanner').style.display = 'flex';
+        }"""
+    )
+
+    positions = page.evaluate(
+        """() => ({
+          bannerBottom: document.getElementById('newImagesBanner')
+            .getBoundingClientRect().bottom,
+          reviewTop: document.querySelector('.location-review-page')
+            .getBoundingClientRect().top,
+          actionsBottom: document.querySelector('.location-review-actions')
+            .getBoundingClientRect().bottom,
+          bottomBarTop: document.getElementById('bottomToggle')
+            .getBoundingClientRect().top
+        })"""
+    )
+    assert positions["reviewTop"] >= positions["bannerBottom"]
+    assert positions["actionsBottom"] <= positions["bottomBarTop"]
+    expect(page.locator("#locationReviewAssign")).to_be_in_viewport()

--- a/vireo/templates/location_review.html
+++ b/vireo/templates/location_review.html
@@ -9,9 +9,19 @@
 <title>Vireo - Review Photo Locations</title>
 <style>
 html, body { height: 100%; overflow: hidden; }
-body { margin: 0; }
+body {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  padding-bottom: var(--bottom-offset, 28px);
+}
+.navbar,
+.runtime-warning-banner,
+.missing-folders-banner,
+.new-images-banner,
+.dup-cleanup-banner { flex-shrink: 0; }
 .location-review-page {
-  height: calc(100vh - 48px - var(--bottom-offset, 28px));
+  flex: 1;
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -292,7 +302,8 @@ body { margin: 0; }
   border-color: var(--border-secondary) !important;
 }
 @media (max-width: 860px) {
-  html, body { overflow: auto; }
+  html, body { height: auto; overflow: auto; }
+  body { display: block; padding-bottom: var(--bottom-offset, 28px); }
   .location-review-page { height: auto; min-height: calc(100vh - 48px - var(--bottom-offset, 28px)); }
   .location-review-header { flex-wrap: wrap; }
   .location-review-source { order: 3; width: 100%; max-width: none; margin-left: 0; }


### PR DESCRIPTION
## Summary

- Size the desktop location-review page from the vertical space remaining after visible notification banners.
- Preserve the existing bottom Jobs panel offset and mobile scrolling behavior.
- Add an end-to-end regression test for the 890×600 layout with the new-images banner visible.

## Root cause

The review page used a fixed viewport-height calculation that accounted for the navigation bar and bottom panel, but not shared notification banners rendered in normal document flow. A visible banner therefore pushed the fixed-height review surface below the viewport and made its bottom actions inaccessible.

## Validation

- `pytest -q tests/e2e/test_location_review.py` — 5 passed