### PR TITLE
Improve user-facing error messages

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2346,13 +2346,14 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         return jsonify({
             "error": "Internal server error",
             "code": "internal_error",
+            "message": "Something went wrong in Vireo. Try again.",
             "request_id": getattr(g, "request_id", None),
         }), 500
 
     _MAX_PER_PAGE = 500
 
-    def json_error(msg, status=400, *, code=None):
-        """Return a JSON error response. Standard shape: {"error": "msg"}."""
+    def json_error(msg, status=400, *, code=None, message=None):
+        """Return a JSON error response with an optional user-facing message."""
         if code is None:
             code = {
                 400: "invalid_request",
@@ -2366,7 +2367,87 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "code": code,
             "request_id": getattr(g, "request_id", None),
         }
+        if message:
+            payload["message"] = message
         return jsonify(payload), status
+
+    def _photo_not_found_error():
+        return json_error(
+            "photo_not_found",
+            404,
+            code="photo_not_found",
+            message=(
+                "This photo is no longer available in the active workspace. "
+                "Refresh the page and try again."
+            ),
+        )
+
+    def _keyword_not_found_error():
+        return json_error(
+            "keyword_not_found",
+            404,
+            code="keyword_not_found",
+            message=(
+                "That saved location no longer exists. Refresh the page and "
+                "select another location."
+            ),
+        )
+
+    def _google_maps_not_configured_error():
+        return json_error(
+            "no_api_key",
+            400,
+            code="no_api_key",
+            message=(
+                "Google Maps isn’t configured. Add an API key in Settings to "
+                "use Google place search."
+            ),
+        )
+
+    def _google_place_not_found_error():
+        return json_error(
+            "place_not_found",
+            404,
+            code="place_not_found",
+            message=(
+                "Google Maps couldn’t find that place. Search again and choose "
+                "another result."
+            ),
+        )
+
+    def _location_name_conflict_payload(err):
+        """Describe a location-keyword collision for both people and clients.
+
+        ``error`` remains the stable legacy code because existing clients use
+        it for branching. ``message`` is the text browser surfaces should show
+        to a person; ``error_detail`` retains the lower-level diagnostic for
+        logs and troubleshooting.
+        """
+        detail = str(err)
+        match = re.search(r"(?:child )?keyword '(.+?)' \((?:parent_id|id)=", detail)
+        if match:
+            message = (
+                f"Couldn’t assign this location because “{match.group(1)}” is "
+                "already used by another keyword. Rename that keyword in "
+                "Keywords, then try again."
+            )
+        else:
+            message = (
+                "Couldn’t assign this location because one of its place names "
+                "conflicts with an existing keyword. Rename the conflicting "
+                "keyword in Keywords, then try again."
+            )
+        return {
+            "error": "name_conflict",
+            "code": "name_conflict",
+            "message": message,
+            "error_detail": detail,
+        }
+
+    def _location_name_conflict_response(err):
+        payload = _location_name_conflict_payload(err)
+        payload["request_id"] = getattr(g, "request_id", None)
+        return jsonify(payload), 409
 
     def _resolve_remote_archive_target(remote_target_id, remote_subpath):
         """Shared remote-archive-target resolution for the import-photos
@@ -5289,7 +5370,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # mirrors serve_thumbnail / api_files_reveal.
         photo = db.get_photo(photo_id, verify_workspace=True)
         if not photo:
-            return json_error("not found", 404)
+            return _photo_not_found_error()
 
         result = dict(photo)
         _attach_location_statuses(db, [result])
@@ -5754,7 +5835,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         if db.conn.execute(
             "SELECT 1 FROM photos WHERE id = ?", (photo_id,)
         ).fetchone() is None:
-            return json_error("photo_not_found", 404)
+            return _photo_not_found_error()
         if not db._photo_in_workspace(photo_id):
             return json_error(
                 f"Photo {photo_id} does not belong to the active workspace", 403,
@@ -6548,7 +6629,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("excluded must be a boolean")
         old = db.get_photo(photo_id)
         if not old:
-            return json_error("not found", 404)
+            return _photo_not_found_error()
         old_value = "1" if old["wildlife_excluded"] else "0"
         new_value = "1" if excluded else "0"
         try:
@@ -6568,7 +6649,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         db = _get_db()
         photo = db.get_photo(photo_id, verify_workspace=True)
         if not photo:
-            return json_error("not found", 404)
+            return _photo_not_found_error()
         recipe = db.get_photo_edit_recipe(photo_id)
         payload = {"photo_id": photo_id, "recipe": recipe}
         if recipe and recipe.get("local"):
@@ -6599,7 +6680,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         db = _get_db()
         photo = db.get_photo(photo_id, verify_workspace=True)
         if not photo:
-            return json_error("not found", 404)
+            return _photo_not_found_error()
         import local_masks
         variant_row = db.conn.execute(
             "SELECT active_mask_variant FROM photos WHERE id=?",
@@ -6632,7 +6713,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("recipe must be a JSON object")
         photo = db.get_photo(photo_id, verify_workspace=True)
         if not photo:
-            return json_error("not found", 404)
+            return _photo_not_found_error()
         from image_edits import RecipeError, normalize_recipe, recipe_to_json
         try:
             normalized = normalize_recipe(recipe)
@@ -6675,7 +6756,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         db = _get_db()
         photo = db.get_photo(photo_id, verify_workspace=True)
         if not photo:
-            return json_error("not found", 404)
+            return _photo_not_found_error()
         from image_edits import recipe_to_json
         old_recipe = db.get_photo_edit_recipe(photo_id)
         old_value = recipe_to_json(old_recipe) or ""
@@ -6860,7 +6941,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         db = _get_db()
         photo = db.get_photo(photo_id, verify_workspace=True)
         if not photo:
-            return json_error("not found", 404)
+            return _photo_not_found_error()
         limit = min(max(1, request.args.get("limit", 50, type=int)), 200)
         rows = db.conn.execute(
             """SELECT eh.id, eh.description, eh.created_at, eh.undone,
@@ -7407,7 +7488,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "SELECT id, type FROM keywords WHERE id = ?", (keyword_id,),
         ).fetchone()
         if row is None:
-            return json_error("keyword_not_found", 404)
+            return _keyword_not_found_error()
         if row["type"] != "location":
             return json_error("keyword is not a location", 400)
         return None
@@ -7634,10 +7715,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             import config as cfg
             key = cfg.load().get("google_maps_api_key", "")
             if not key:
-                return json_error("no_api_key", 400)
+                return _google_maps_not_configured_error()
             details = places.place_details(place_id, key)
             if details is None:
-                return json_error("place_not_found", 404)
+                return _google_place_not_found_error()
 
         try:
             leaf_id = db.upsert_place_chain(details)
@@ -7645,10 +7726,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             # _upsert_one_keyword raises RuntimeError when the parent-chain
             # build hits an existing keyword of a different type at the same
             # (name, parent_id). Mirror /api/keywords/<id>/link-place's 409.
-            return jsonify({
-                "error": "name_conflict",
-                "error_detail": str(err),
-            }), 409
+            return _location_name_conflict_response(err)
         db.set_photo_location(photo_id, leaf_id)
         _queue_location_sync_if_enabled(photo_id)
         db.record_edit(
@@ -7879,18 +7957,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             import config as cfg
             key = cfg.load().get("google_maps_api_key", "")
             if not key:
-                return json_error("no_api_key", 400)
+                return _google_maps_not_configured_error()
             details = places.place_details(place_id, key)
             if details is None:
-                return json_error("place_not_found", 404)
+                return _google_place_not_found_error()
 
         try:
             leaf_id = db.upsert_place_chain(details)
         except RuntimeError as err:
-            return jsonify({
-                "error": "name_conflict",
-                "error_detail": str(err),
-            }), 409
+            return _location_name_conflict_response(err)
 
         items = []
         for pid in photo_ids:
@@ -7953,6 +8028,11 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                     "place_id": place_id,
                     "summary": group.get("summary") or place_id,
                     "error": "missing_details",
+                    "code": "missing_details",
+                    "message": (
+                        "Google Maps didn’t return enough information for this "
+                        "place. Search again and choose another result."
+                    ),
                 })
                 continue
             try:
@@ -7961,8 +8041,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 group_errors.append({
                     "place_id": place_id,
                     "summary": group.get("summary") or place_id,
-                    "error": "name_conflict",
-                    "error_detail": str(err),
+                    **_location_name_conflict_payload(err),
                 })
                 continue
             keyword_id_by_place_id[place_id] = leaf_id
@@ -8118,8 +8197,9 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         - 404 ``keyword_not_found`` — ``keyword_id`` doesn't exist.
         - 409 ``name_conflict`` — the parent chain would clash with an
           existing keyword of a different ``type`` at the same
-          ``(name, parent_id)``. Carries an ``error_detail`` string from the
-          underlying RuntimeError for debugging.
+          ``(name, parent_id)``. Carries a user-facing ``message`` plus an
+          ``error_detail`` string from the underlying RuntimeError for
+          debugging.
         """
         body = request.get_json(silent=True) or {}
         place_id = _extract_place_id(body)
@@ -8131,10 +8211,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             import config as cfg
             key = cfg.load().get("google_maps_api_key", "")
             if not key:
-                return json_error("no_api_key", 400)
+                return _google_maps_not_configured_error()
             details = places.place_details(place_id, key)
             if details is None:
-                return json_error("place_not_found", 404)
+                return _google_place_not_found_error()
 
         db = _get_db()
         try:
@@ -8146,17 +8226,20 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if "is type" in msg:
                 return jsonify({
                     "error": "wrong_keyword_type",
+                    "code": "wrong_keyword_type",
+                    "message": (
+                        "Only location keywords can be linked to Google Maps "
+                        "places."
+                    ),
                     "error_detail": msg,
+                    "request_id": getattr(g, "request_id", None),
                 }), 400
-            return json_error("keyword_not_found", 404)
+            return _keyword_not_found_error()
         except RuntimeError as err:
             # _upsert_one_keyword raises RuntimeError when the parent-chain
             # build hits an existing keyword of a different type at the same
             # (name, parent_id). Surface the message for debugging.
-            return jsonify({
-                "error": "name_conflict",
-                "error_detail": str(err),
-            }), 409
+            return _location_name_conflict_response(err)
 
         # Audit log: this action isn't tied to a single photo (it operates on
         # a keyword), so we omit the per-photo items list. ``photo_id`` in

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -2371,11 +2371,10 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             payload["message"] = message
         return jsonify(payload), status
 
-    def _photo_not_found_error():
+    def _photo_not_found_error(*, legacy_error="photo_not_found"):
         return json_error(
-            "photo_not_found",
+            legacy_error,
             404,
-            code="photo_not_found",
             message=(
                 "This photo is no longer available in the active workspace. "
                 "Refresh the page and try again."
@@ -2386,7 +2385,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         return json_error(
             "keyword_not_found",
             404,
-            code="keyword_not_found",
             message=(
                 "That saved location no longer exists. Refresh the page and "
                 "select another location."
@@ -2397,7 +2395,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         return json_error(
             "no_api_key",
             400,
-            code="no_api_key",
             message=(
                 "Google Maps isn’t configured. Add an API key in Settings to "
                 "use Google place search."
@@ -2408,7 +2405,6 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         return json_error(
             "place_not_found",
             404,
-            code="place_not_found",
             message=(
                 "Google Maps couldn’t find that place. Search again and choose "
                 "another result."
@@ -5370,7 +5366,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # mirrors serve_thumbnail / api_files_reveal.
         photo = db.get_photo(photo_id, verify_workspace=True)
         if not photo:
-            return _photo_not_found_error()
+            return _photo_not_found_error(legacy_error="not found")
 
         result = dict(photo)
         _attach_location_statuses(db, [result])
@@ -6629,7 +6625,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("excluded must be a boolean")
         old = db.get_photo(photo_id)
         if not old:
-            return _photo_not_found_error()
+            return _photo_not_found_error(legacy_error="not found")
         old_value = "1" if old["wildlife_excluded"] else "0"
         new_value = "1" if excluded else "0"
         try:
@@ -6649,7 +6645,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         db = _get_db()
         photo = db.get_photo(photo_id, verify_workspace=True)
         if not photo:
-            return _photo_not_found_error()
+            return _photo_not_found_error(legacy_error="not found")
         recipe = db.get_photo_edit_recipe(photo_id)
         payload = {"photo_id": photo_id, "recipe": recipe}
         if recipe and recipe.get("local"):
@@ -6680,7 +6676,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         db = _get_db()
         photo = db.get_photo(photo_id, verify_workspace=True)
         if not photo:
-            return _photo_not_found_error()
+            return _photo_not_found_error(legacy_error="not found")
         import local_masks
         variant_row = db.conn.execute(
             "SELECT active_mask_variant FROM photos WHERE id=?",
@@ -6713,7 +6709,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             return json_error("recipe must be a JSON object")
         photo = db.get_photo(photo_id, verify_workspace=True)
         if not photo:
-            return _photo_not_found_error()
+            return _photo_not_found_error(legacy_error="not found")
         from image_edits import RecipeError, normalize_recipe, recipe_to_json
         try:
             normalized = normalize_recipe(recipe)
@@ -6756,7 +6752,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         db = _get_db()
         photo = db.get_photo(photo_id, verify_workspace=True)
         if not photo:
-            return _photo_not_found_error()
+            return _photo_not_found_error(legacy_error="not found")
         from image_edits import recipe_to_json
         old_recipe = db.get_photo_edit_recipe(photo_id)
         old_value = recipe_to_json(old_recipe) or ""
@@ -6941,7 +6937,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         db = _get_db()
         photo = db.get_photo(photo_id, verify_workspace=True)
         if not photo:
-            return _photo_not_found_error()
+            return _photo_not_found_error(legacy_error="not found")
         limit = min(max(1, request.args.get("limit", 50, type=int)), 200)
         rows = db.conn.execute(
             """SELECT eh.id, eh.description, eh.created_at, eh.undone,
@@ -8226,7 +8222,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             if "is type" in msg:
                 return jsonify({
                     "error": "wrong_keyword_type",
-                    "code": "wrong_keyword_type",
+                    "code": "invalid_request",
                     "message": (
                         "Only location keywords can be linked to Google Maps "
                         "places."

--- a/vireo/static/vireo-api.js
+++ b/vireo/static/vireo-api.js
@@ -40,18 +40,39 @@
   }
 
   async function json(input, init, options) {
-    var response = await browserFetch(input, init);
+    var response;
+    try {
+      response = await browserFetch(input, init);
+    } catch (cause) {
+      var networkMessage = (
+        'Couldn’t reach Vireo. Check that the app is still running, then try again.'
+      );
+      if ((!options || options.toast !== false) && typeof global.showToast === 'function') {
+        global.showToast(networkMessage, 'error');
+      }
+      var networkError = new Error(networkMessage);
+      networkError.code = 'network_error';
+      networkError.cause = cause;
+      throw networkError;
+    }
     if (!response.ok) {
       var body = {};
       try { body = await response.json(); } catch (e) {}
-      var message = body.error || 'Request failed (' + response.status + ')';
+      // APIs may provide a stable machine-readable error code alongside a
+      // sentence intended for people. Never put the code in the toast when a
+      // friendly message is available.
+      var requestId = body.request_id || response.headers.get('X-Request-ID');
+      var message = body.message || body.error || 'Request failed (' + response.status + ')';
+      if (body.code === 'internal_error' && requestId) {
+        message += ' If it keeps happening, report request ID ' + requestId + '.';
+      }
       if ((!options || options.toast !== false) && typeof global.showToast === 'function') {
         global.showToast(message, 'error');
       }
       var error = new Error(message);
       error.status = response.status;
       error.code = body.code;
-      error.requestId = body.request_id || response.headers.get('X-Request-ID');
+      error.requestId = requestId;
       error.body = body;
       throw error;
     }

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -7302,7 +7302,7 @@ async function _submitLocationPlace(placeId, placeDetails) {
     }
     await _afterLocationMutation(ids, detailPhotoId);
   } catch(e) {
-    _showLocationError('Could not save location.');
+    _showLocationError(e && e.message ? e.message : 'Could not save location.');
   }
 }
 
@@ -7329,7 +7329,7 @@ async function _submitLocationKeyword(keyword) {
     }
     await _afterLocationMutation(ids, detailPhotoId);
   } catch(e) {
-    _showLocationError('Could not save location.');
+    _showLocationError(e && e.message ? e.message : 'Could not save location.');
   }
 }
 
@@ -7356,7 +7356,7 @@ async function _submitLocationText(name) {
       await _afterLocationMutation(ids, detailPhotoId);
     }
   } catch(e) {
-    _showLocationError('Could not save location.');
+    _showLocationError(e && e.message ? e.message : 'Could not save location.');
   }
 }
 
@@ -7369,7 +7369,7 @@ async function clearPhotoLocation() {
     renderLocationEmpty();
     await _afterLocationMutation([photoId], photoId);
   } catch(e) {
-    _showLocationError('Could not clear location.');
+    _showLocationError(e && e.message ? e.message : 'Could not clear location.');
   }
 }
 
@@ -7588,7 +7588,7 @@ async function acceptExifSuggestion(placeId) {
     clearExifSuggestion();
     await _afterLocationMutation(useBatch ? ids : [photoId], photoId);
   } catch(e) {
-    _showLocationError('Could not save location.');
+    _showLocationError(e && e.message ? e.message : 'Could not save location.');
   }
 }
 

--- a/vireo/templates/keywords.html
+++ b/vireo/templates/keywords.html
@@ -862,7 +862,7 @@
     if (!resp.ok) {
       let body = {};
       try { body = await resp.json(); } catch(e) {}
-      _showLinkError(body.error || ('Failed (HTTP ' + resp.status + ')'));
+      _showLinkError(body.message || body.error || ('Failed (HTTP ' + resp.status + ')'));
       return;
     }
     let data = {};

--- a/vireo/templates/pipeline.html
+++ b/vireo/templates/pipeline.html
@@ -3936,7 +3936,7 @@ async function setActiveMaskVariant(variant) {
     });
     var body = await resp.json();
     if (!resp.ok) {
-      _showSam2CoverageError(body.error || ('HTTP ' + resp.status));
+      _showSam2CoverageError(body.message || body.error || ('HTTP ' + resp.status));
       return;
     }
   } catch(e) {

--- a/vireo/templates/storage.html
+++ b/vireo/templates/storage.html
@@ -576,7 +576,7 @@ async function deleteMaskVariant(variant) {
     });
     var body = await resp.json();
     if (!resp.ok) {
-      _showMasksModalError(body.error || ('HTTP ' + resp.status));
+      _showMasksModalError(body.message || body.error || ('HTTP ' + resp.status));
       return;
     }
     document.getElementById('masksModalError').style.display = 'none';

--- a/vireo/templates/welcome.html
+++ b/vireo/templates/welcome.html
@@ -260,7 +260,7 @@ if (typeof safeFetch === 'undefined') {
     if (!resp.ok) {
       var body = {};
       try { body = await resp.json(); } catch(e) {}
-      throw new Error(body.error || 'Request failed (' + resp.status + ')');
+      throw new Error(body.message || body.error || 'Request failed (' + resp.status + ')');
     }
     var text = await resp.text();
     if (!text) return null;

--- a/vireo/tests/test_app.py
+++ b/vireo/tests/test_app.py
@@ -55,6 +55,9 @@ def test_browse_page(app_and_db):
     html = resp.get_data(as_text=True)
     assert 'id="syncBanner"' in html
     assert 'function refreshPendingSyncBanner()' in html
+    assert html.count(
+        "_showLocationError(e && e.message ? e.message : 'Could not"
+    ) == 5
 
 
 def test_browse_discloses_raw_jpeg_pairs_and_offers_source_switch(app_and_db):

--- a/vireo/tests/test_error_helpers.py
+++ b/vireo/tests/test_error_helpers.py
@@ -19,4 +19,24 @@ def test_json_error_custom_status(app_and_db):
     resp = client.get('/api/photos/999999')
     assert resp.status_code == 404
     data = resp.get_json()
-    assert 'error' in data
+    assert data['error'] == 'photo_not_found'
+    assert data['code'] == 'photo_not_found'
+    assert 'no longer available in the active workspace' in data['message']
+
+
+def test_unhandled_api_error_has_recovery_message_and_request_id(app_and_db):
+    """Unexpected failures give the browser a safe recovery message and trace id."""
+    app, _ = app_and_db
+
+    @app.get('/api/test-unhandled-error')
+    def _test_unhandled_error():
+        raise RuntimeError('sensitive internal detail')
+
+    resp = app.test_client().get('/api/test-unhandled-error')
+    assert resp.status_code == 500
+    data = resp.get_json()
+    assert data['error'] == 'Internal server error'
+    assert data['code'] == 'internal_error'
+    assert data['message'] == 'Something went wrong in Vireo. Try again.'
+    assert data['request_id'] == resp.headers['X-Request-ID']
+    assert 'sensitive internal detail' not in data['message']

--- a/vireo/tests/test_error_helpers.py
+++ b/vireo/tests/test_error_helpers.py
@@ -19,8 +19,8 @@ def test_json_error_custom_status(app_and_db):
     resp = client.get('/api/photos/999999')
     assert resp.status_code == 404
     data = resp.get_json()
-    assert data['error'] == 'photo_not_found'
-    assert data['code'] == 'photo_not_found'
+    assert data['error'] == 'not found'
+    assert data['code'] == 'not_found'
     assert 'no longer available in the active workspace' in data['message']
 
 

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -7081,7 +7081,13 @@ def test_post_photo_location_returns_400_on_empty_api_key(app_and_db):
         json={"place_id": "ChIJ_x"},
     )
     assert resp.status_code == 400
-    assert resp.get_json()["error"] == "no_api_key"
+    body = resp.get_json()
+    assert body["error"] == "no_api_key"
+    assert body["code"] == "no_api_key"
+    assert body["message"] == (
+        "Google Maps isn’t configured. Add an API key in Settings to use "
+        "Google place search."
+    )
 
 
 def test_post_photo_location_returns_404_when_google_returns_none(app_and_db, monkeypatch):
@@ -7102,7 +7108,13 @@ def test_post_photo_location_returns_404_when_google_returns_none(app_and_db, mo
         json={"place_id": "ChIJ_unknown"},
     )
     assert resp.status_code == 404
-    assert resp.get_json()["error"] == "place_not_found"
+    body = resp.get_json()
+    assert body["error"] == "place_not_found"
+    assert body["code"] == "place_not_found"
+    assert body["message"] == (
+        "Google Maps couldn’t find that place. Search again and choose another "
+        "result."
+    )
 
 
 def test_post_photo_location_returns_409_on_name_conflict(app_and_db, monkeypatch):
@@ -7149,6 +7161,11 @@ def test_post_photo_location_returns_409_on_name_conflict(app_and_db, monkeypatc
     assert resp.status_code == 409
     body = resp.get_json()
     assert body["error"] == "name_conflict"
+    assert body["code"] == "name_conflict"
+    assert body["message"] == (
+        "Couldn’t assign this location because “New York County” is already "
+        "used by another keyword. Rename that keyword in Keywords, then try again."
+    )
     assert "New York County" in body["error_detail"]
 
 
@@ -7169,7 +7186,13 @@ def test_post_photo_location_returns_404_on_missing_photo(app_and_db, monkeypatc
         json={"place_id": "ChIJ_x"},
     )
     assert resp.status_code == 404
-    assert resp.get_json()["error"] == "photo_not_found"
+    body = resp.get_json()
+    assert body["error"] == "photo_not_found"
+    assert body["code"] == "photo_not_found"
+    assert body["message"] == (
+        "This photo is no longer available in the active workspace. Refresh "
+        "the page and try again."
+    )
 
 
 def _add_out_of_workspace_photo(db):
@@ -8478,7 +8501,13 @@ def test_post_keyword_link_place_returns_404_on_missing_keyword(
         json={"place_id": "ChIJ_x"},
     )
     assert resp.status_code == 404
-    assert resp.get_json()["error"] == "keyword_not_found"
+    body = resp.get_json()
+    assert body["error"] == "keyword_not_found"
+    assert body["code"] == "keyword_not_found"
+    assert body["message"] == (
+        "That saved location no longer exists. Refresh the page and select "
+        "another location."
+    )
 
 
 def test_post_keyword_link_place_returns_400_on_wrong_keyword_type(
@@ -8509,6 +8538,10 @@ def test_post_keyword_link_place_returns_400_on_wrong_keyword_type(
     assert resp.status_code == 400
     body = resp.get_json()
     assert body["error"] == "wrong_keyword_type"
+    assert body["code"] == "wrong_keyword_type"
+    assert body["message"] == (
+        "Only location keywords can be linked to Google Maps places."
+    )
     assert "general" in body["error_detail"]
 
 
@@ -8605,6 +8638,9 @@ def test_post_keyword_link_place_returns_409_on_cross_type_collision(
     assert resp.status_code == 409, resp.get_json()
     body = resp.get_json()
     assert body["error"] == "name_conflict"
+    assert body["code"] == "name_conflict"
+    assert "“New York County”" in body["message"]
+    assert "Rename that keyword in Keywords" in body["message"]
     # The exception detail should mention the offending name for debugging.
     assert "New York County" in body.get("error_detail", "")
 

--- a/vireo/tests/test_photos_api.py
+++ b/vireo/tests/test_photos_api.py
@@ -7083,7 +7083,7 @@ def test_post_photo_location_returns_400_on_empty_api_key(app_and_db):
     assert resp.status_code == 400
     body = resp.get_json()
     assert body["error"] == "no_api_key"
-    assert body["code"] == "no_api_key"
+    assert body["code"] == "invalid_request"
     assert body["message"] == (
         "Google Maps isn’t configured. Add an API key in Settings to use "
         "Google place search."
@@ -7110,7 +7110,7 @@ def test_post_photo_location_returns_404_when_google_returns_none(app_and_db, mo
     assert resp.status_code == 404
     body = resp.get_json()
     assert body["error"] == "place_not_found"
-    assert body["code"] == "place_not_found"
+    assert body["code"] == "not_found"
     assert body["message"] == (
         "Google Maps couldn’t find that place. Search again and choose another "
         "result."
@@ -7188,7 +7188,7 @@ def test_post_photo_location_returns_404_on_missing_photo(app_and_db, monkeypatc
     assert resp.status_code == 404
     body = resp.get_json()
     assert body["error"] == "photo_not_found"
-    assert body["code"] == "photo_not_found"
+    assert body["code"] == "not_found"
     assert body["message"] == (
         "This photo is no longer available in the active workspace. Refresh "
         "the page and try again."
@@ -8503,7 +8503,7 @@ def test_post_keyword_link_place_returns_404_on_missing_keyword(
     assert resp.status_code == 404
     body = resp.get_json()
     assert body["error"] == "keyword_not_found"
-    assert body["code"] == "keyword_not_found"
+    assert body["code"] == "not_found"
     assert body["message"] == (
         "That saved location no longer exists. Refresh the page and select "
         "another location."
@@ -8538,7 +8538,7 @@ def test_post_keyword_link_place_returns_400_on_wrong_keyword_type(
     assert resp.status_code == 400
     body = resp.get_json()
     assert body["error"] == "wrong_keyword_type"
-    assert body["code"] == "wrong_keyword_type"
+    assert body["code"] == "invalid_request"
     assert body["message"] == (
         "Only location keywords can be linked to Google Maps places."
     )


### PR DESCRIPTION
Machine-readable API errors were being shown directly to users, while some Browse handlers replaced useful failures with generic text. This adds separate actionable messages for location, stale-resource, network, and internal failures while preserving stable error codes and diagnostic details. Browse and other direct API consumers now retain the human-readable message, and unexpected server errors include a request ID for support. Validated with 303 relevant tests, Ruff, JavaScript syntax checking, and `git diff --check`.
