### PR TITLE
Preserve location keyword types during taxonomy marking

### DIFF
--- a/vireo/db.py
+++ b/vireo/db.py
@@ -16724,9 +16724,15 @@ class Database:
     def mark_species_keywords(self, taxonomy):
         """Mark keywords that are recognized species in the taxonomy.
 
-        Retypes any keyword whose name matches a taxon lookup: sets
-        is_species=1, type='taxonomy', and (if the local taxa table is
-        populated) links taxon_id to the matching taxa row by inat_id.
+        Retypes untyped and ``type='general'`` keywords whose names match a
+        taxon lookup, and repairs incomplete ``type='taxonomy'`` rows. Explicit
+        non-taxonomy types such as ``location``, ``genre``, and ``individual``
+        are user intent and must be preserved even when their names are taxon
+        homonyms (for example, the location "California" is also a plant
+        genus).
+
+        Matching rows get ``is_species=1``, ``type='taxonomy'``, and (if the
+        local taxa table is populated) a ``taxon_id`` link by iNaturalist id.
 
         Uses the local taxonomy only (no network requests).
 
@@ -16736,11 +16742,14 @@ class Database:
         # Also include already-typed taxonomy keywords whose taxon_id is
         # still NULL — those were created before the local taxa table was
         # populated (e.g. via add_keyword(..., is_species=True) from the
-        # classifier), and still need their hierarchy link filled in.
+        # classifier), and still need their hierarchy link filled in. Deliberate
+        # non-taxonomy types are excluded before lookup so a taxon homonym can
+        # never silently retype them.
         keywords = self.conn.execute(
             "SELECT id, name, type, taxon_id, is_species FROM keywords "
-            "WHERE is_species = 0 OR type IS NULL OR type != 'taxonomy' "
-            "   OR taxon_id IS NULL"
+            "WHERE (type IS NULL OR type IN ('general', 'taxonomy')) "
+            "  AND (is_species = 0 OR type IS NULL OR type != 'taxonomy' "
+            "       OR taxon_id IS NULL)"
         ).fetchall()
         updated = 0
         for kw in keywords:

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -12999,16 +12999,17 @@ class Database:
                 effective_type = updates.get('type', cur_type)
                 if 'type' not in updates and cur_type == 'general' and taxon_id:
                     effective_type = 'taxonomy'
-                # The type dropdown sends only {type: ...}. Keep the legacy
-                # is_species flag coherent on that path: otherwise demoting a
-                # taxonomy homonym to a deliberate type such as 'location'
-                # leaves is_species=1, and downstream queries that accept
-                # ``type='taxonomy' OR is_species=1`` still treat it as a
-                # species. Conversely, an explicit taxonomy type must make the
-                # row species-bearing even when no same-type peer exists.
-                if 'type' in updates:
-                    updates['is_species'] = int(effective_type == 'taxonomy')
                 type_changed = effective_type != cur_type
+                # The type dropdown sends only {type: ...}. Keep the legacy
+                # is_species flag coherent on an actual type transition:
+                # otherwise demoting a taxonomy homonym to a deliberate type
+                # such as 'location' leaves is_species=1, and downstream
+                # queries that accept ``type='taxonomy' OR is_species=1`` still
+                # treat it as a species. Do not touch no-op type submissions:
+                # legacy general rows can legitimately retain is_species=1
+                # until taxonomy marking normalizes them.
+                if 'type' in updates and type_changed:
+                    updates['is_species'] = int(effective_type == 'taxonomy')
                 if name_changed or type_changed:
                     # Merge into a same-slot same-type peer instead of
                     # writing a duplicate. Without this, top-level renames

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -12941,7 +12941,8 @@ class Database:
         already 'taxonomy' and the new name matches a different taxon,
         taxon_id is updated. Manually-set non-'general' types (e.g.
         'location', 'individual') are preserved. Explicit type/taxon_id
-        kwargs always win over auto-detection.
+        kwargs always win over auto-detection, and an explicit type change
+        reconciles the legacy ``is_species`` flag with the requested type.
         """
         if 'type' in kwargs:
             kt = kwargs['type']
@@ -12998,6 +12999,15 @@ class Database:
                 effective_type = updates.get('type', cur_type)
                 if 'type' not in updates and cur_type == 'general' and taxon_id:
                     effective_type = 'taxonomy'
+                # The type dropdown sends only {type: ...}. Keep the legacy
+                # is_species flag coherent on that path: otherwise demoting a
+                # taxonomy homonym to a deliberate type such as 'location'
+                # leaves is_species=1, and downstream queries that accept
+                # ``type='taxonomy' OR is_species=1`` still treat it as a
+                # species. Conversely, an explicit taxonomy type must make the
+                # row species-bearing even when no same-type peer exists.
+                if 'type' in updates:
+                    updates['is_species'] = int(effective_type == 'taxonomy')
                 type_changed = effective_type != cur_type
                 if name_changed or type_changed:
                     # Merge into a same-slot same-type peer instead of

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -14063,6 +14063,30 @@ def test_update_keyword_no_name_change_does_not_touch_type(tmp_path):
     assert row["taxon_id"] is None
 
 
+def test_update_keyword_explicit_location_type_clears_species_flag(tmp_path):
+    """Demoting a taxonomy homonym without a merge peer clears is_species.
+
+    The Keywords UI sends only ``type`` for this edit. Leaving the legacy flag
+    set would make species queries continue to treat the location as taxonomy
+    even though taxonomy marking now preserves explicit non-taxonomy types.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    kid = db.add_keyword("California", kw_type="taxonomy")
+    before = db.conn.execute(
+        "SELECT type, is_species FROM keywords WHERE id = ?", (kid,),
+    ).fetchone()
+    assert dict(before) == {"type": "taxonomy", "is_species": 1}
+
+    effective_id = db.update_keyword(kid, type="location")
+
+    assert effective_id == kid
+    after = db.conn.execute(
+        "SELECT type, is_species FROM keywords WHERE id = ?", (kid,),
+    ).fetchone()
+    assert dict(after) == {"type": "location", "is_species": 0}
+
+
 def test_update_keyword_explicit_type_and_taxon_id_kwargs_win(tmp_path):
     """Caller-supplied type and taxon_id win over auto-detection. Used by
     the bulk-type-apply UI path."""

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -1447,6 +1447,59 @@ def test_mark_species_keywords_sets_type_taxonomy(tmp_path):
     assert row['type'] == 'taxonomy'
 
 
+def test_mark_species_keywords_preserves_explicit_location_homonym(tmp_path):
+    """A location name that is also a taxon must remain a location.
+
+    ``California`` is both a geographic name and a plant genus. Retyping a
+    location hierarchy node as taxonomy makes subsequent Google Place chain
+    upserts fail with ``name_conflict``.
+    """
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    country_id = db.add_keyword("United States", kw_type="location")
+    location_id = db.add_keyword(
+        "California", parent_id=country_id, kw_type="location",
+    )
+
+    class FakeTaxonomy:
+        def lookup(self, name):
+            if name == "California":
+                return {"taxon_id": 123, "scientific_name": "California"}
+            return None
+
+    updated = db.mark_species_keywords(FakeTaxonomy())
+
+    assert updated == 0
+    row = db.conn.execute(
+        "SELECT type, is_species, taxon_id FROM keywords WHERE id = ?",
+        (location_id,),
+    ).fetchone()
+    assert dict(row) == {
+        "type": "location",
+        "is_species": 0,
+        "taxon_id": None,
+    }
+
+    leaf_id = db.upsert_place_chain({
+        "place_id": "test-california-park",
+        "name": "Test California Park",
+        "types": ["park"],
+        "lat": 32.9,
+        "lng": -117.2,
+        "address_components": [
+            {"name": "United States", "types": ["country"]},
+            {
+                "name": "California",
+                "types": ["administrative_area_level_1"],
+            },
+        ],
+    })
+    leaf = db.conn.execute(
+        "SELECT type, parent_id FROM keywords WHERE id = ?", (leaf_id,),
+    ).fetchone()
+    assert dict(leaf) == {"type": "location", "parent_id": location_id}
+
+
 def test_mark_species_keywords_links_local_taxon_id(tmp_path):
     """mark_species_keywords links keywords.taxon_id when taxa table has a match."""
     from db import Database

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -14087,6 +14087,26 @@ def test_update_keyword_explicit_location_type_clears_species_flag(tmp_path):
     assert dict(after) == {"type": "location", "is_species": 0}
 
 
+def test_update_keyword_noop_general_type_preserves_legacy_species_flag(tmp_path):
+    """Re-selecting General must not erase a legacy species marker."""
+    from db import Database
+    db = Database(str(tmp_path / "test.db"))
+    cur = db.conn.execute(
+        "INSERT INTO keywords (name, type, is_species) "
+        "VALUES ('Robin', 'general', 1)"
+    )
+    kid = cur.lastrowid
+    db.conn.commit()
+
+    effective_id = db.update_keyword(kid, type="general")
+
+    assert effective_id == kid
+    row = db.conn.execute(
+        "SELECT type, is_species FROM keywords WHERE id = ?", (kid,),
+    ).fetchone()
+    assert dict(row) == {"type": "general", "is_species": 1}
+
+
 def test_update_keyword_explicit_type_and_taxon_id_kwargs_win(tmp_path):
     """Caller-supplied type and taxon_id win over auto-detection. Used by
     the bulk-type-apply UI path."""


### PR DESCRIPTION
## Summary

- Preserve explicit location, genre, and individual keyword types when taxonomy names are backfilled.
- Fix the root cause of `name_conflict` errors where a location such as California was retyped because its name also matched a biological taxon.
- Add regression coverage that marks taxonomy names and then successfully inserts a Google place chain through `United States → California`.

## Validation

- `PYTHONPATH=vireo /opt/anaconda3/envs/py311/bin/python -m pytest vireo/tests/test_db.py -q -k 'mark_species_keywords or upsert_place_chain'` — 15 passed.