### PR TITLE
Make navbar tab reordering reliable

### DIFF
--- a/tests/e2e/test_navbar_reorder.py
+++ b/tests/e2e/test_navbar_reorder.py
@@ -43,41 +43,46 @@ def test_drag_reorder_persists_with_real_mouse(live_server, page):
 
 
 def test_reorder_uses_pointer_release_without_html_drop(live_server, page):
-    """Regression: reordering must not depend on WKWebView HTML drag events."""
+    """Regression: reordering must not depend on WKWebView HTML drag events.
+
+    Drives the drag with Playwright's real mouse API (so ``setPointerCapture``
+    works — synthetic ``PointerEvent`` dispatches throw ``NotFoundError``
+    because their ``pointerId`` isn't a real browser pointer) while asserting
+    that no ``dragstart``/``drop`` events fire on the strip. That combination
+    proves the reorder happens purely through the pointer-event path.
+    """
     url = live_server["url"]
     page.goto(f"{url}/browse")
     page.wait_for_selector(".nav-tab[data-nav-id='cull']")
 
     before = _nav_ids(page)
 
-    moved = page.evaluate("""() => {
+    page.evaluate("""() => {
         const strip = document.getElementById('navTabStrip');
-        const src = strip.querySelector(".nav-tab[data-nav-id='cull']");
-        const importTab = strip.querySelector(".nav-tab[data-nav-id='import']");
-        const srcRect = src.getBoundingClientRect();
-        const rect = importTab.getBoundingClientRect();
-        const startX = srcRect.left + srcRect.width / 2;
-        const clientX = rect.left + 1;
-        const clientY = rect.top + rect.height / 2;
-
-        const fire = (type, x) => {
-            const ev = new PointerEvent(type, {
-                bubbles: true, cancelable: true, isPrimary: true,
-                pointerId: 7, pointerType: 'mouse', button: 0,
-                buttons: type === 'pointerup' ? 0 : 1,
-                clientX: x, clientY,
-            });
-            el.dispatchEvent(ev);
-        };
-        const el = src;
-        fire('pointerdown', startX);
-        fire('pointermove', clientX);
-        fire('pointerup', clientX);
-        return true;
+        window.__htmlDragCount = 0;
+        ['dragstart', 'dragover', 'drop', 'dragend'].forEach(type => {
+            strip.addEventListener(type, () => { window.__htmlDragCount += 1; }, true);
+        });
     }""")
-    assert moved
+
+    src = page.query_selector(".nav-tab[data-nav-id='cull']")
+    dst = page.query_selector(".nav-tab[data-nav-id='import']")
+    sb, db = src.bounding_box(), dst.bounding_box()
+    page.mouse.move(sb["x"] + sb["width"] / 2, sb["y"] + sb["height"] / 2)
+    page.mouse.down()
+    for i in range(1, 11):
+        page.mouse.move(
+            sb["x"] + (db["x"] + 1 - sb["x"]) * i / 10,
+            db["y"] + db["height"] / 2,
+            steps=2,
+        )
+    page.mouse.up()
 
     page.wait_for_timeout(300)
+    html_drag_count = page.evaluate("window.__htmlDragCount")
+    assert html_drag_count == 0, (
+        f"reorder should not fire HTML5 drag events, saw {html_drag_count}"
+    )
     dom_after = _nav_ids(page)
     assert dom_after[0] == "cull", (
         f"tab did not move on pointer release: {dom_after}"

--- a/tests/e2e/test_navbar_reorder.py
+++ b/tests/e2e/test_navbar_reorder.py
@@ -1,10 +1,4 @@
-"""Drag-reorder of the navbar tab strip.
-
-Covers the "dropped tab snaps back" bug: the reorder must be committed on
-`dragend` (which fires reliably on the source element) and not depend on the
-`drop` event, because the macOS WKWebView the desktop app renders in
-frequently never fires `drop` for HTML5 drag-and-drop.
-"""
+"""Pointer drag-reorder of the navbar tab strip."""
 
 
 def _nav_ids(page):
@@ -38,6 +32,7 @@ def test_drag_reorder_persists_with_real_mouse(live_server, page):
     page.mouse.up()
 
     page.wait_for_timeout(300)
+    assert page.url.endswith("/browse"), "drag release unexpectedly followed the tab link"
     page.reload()
     page.wait_for_selector(".nav-tab[data-nav-id='cull']")
     after = _nav_ids(page)
@@ -47,13 +42,8 @@ def test_drag_reorder_persists_with_real_mouse(live_server, page):
     )
 
 
-def test_reorder_commits_without_drop_event(live_server, page):
-    """Regression: WKWebView fires dragstart/dragover/dragend but not drop.
-
-    Dispatch that exact event sequence (no `drop`) and assert the reorder is
-    still committed and persisted. On the old drop-only code the tab snapped
-    back; this must now succeed.
-    """
+def test_reorder_uses_pointer_release_without_html_drop(live_server, page):
+    """Regression: reordering must not depend on WKWebView HTML drag events."""
     url = live_server["url"]
     page.goto(f"{url}/browse")
     page.wait_for_selector(".nav-tab[data-nav-id='cull']")
@@ -64,20 +54,25 @@ def test_reorder_commits_without_drop_event(live_server, page):
         const strip = document.getElementById('navTabStrip');
         const src = strip.querySelector(".nav-tab[data-nav-id='cull']");
         const importTab = strip.querySelector(".nav-tab[data-nav-id='import']");
+        const srcRect = src.getBoundingClientRect();
         const rect = importTab.getBoundingClientRect();
-        // Aim just left of the first tab's midpoint so cull lands at the front.
+        const startX = srcRect.left + srcRect.width / 2;
         const clientX = rect.left + 1;
+        const clientY = rect.top + rect.height / 2;
 
-        const fire = (el, type, x) => {
-            const ev = new DragEvent(type, {
-                bubbles: true, cancelable: true,
-                dataTransfer: new DataTransfer(), clientX: x,
+        const fire = (type, x) => {
+            const ev = new PointerEvent(type, {
+                bubbles: true, cancelable: true, isPrimary: true,
+                pointerId: 7, pointerType: 'mouse', button: 0,
+                buttons: type === 'pointerup' ? 0 : 1,
+                clientX: x, clientY,
             });
             el.dispatchEvent(ev);
         };
-        fire(src, 'dragstart', 0);
-        fire(strip, 'dragover', clientX);
-        fire(src, 'dragend', clientX);   // NOTE: no 'drop' event
+        const el = src;
+        fire('pointerdown', startX);
+        fire('pointermove', clientX);
+        fire('pointerup', clientX);
         return true;
     }""")
     assert moved
@@ -85,7 +80,7 @@ def test_reorder_commits_without_drop_event(live_server, page):
     page.wait_for_timeout(300)
     dom_after = _nav_ids(page)
     assert dom_after[0] == "cull", (
-        f"tab did not move on dragend without drop: {dom_after}"
+        f"tab did not move on pointer release: {dom_after}"
     )
 
     page.reload()
@@ -97,46 +92,23 @@ def test_reorder_commits_without_drop_event(live_server, page):
 
 
 def test_aborted_drag_outside_strip_does_not_reorder(live_server, page):
-    """Regression: dragging a tab, leaving the strip, then releasing outside
-    the navbar must NOT commit a reorder from the stale in-strip pointer X.
-
-    Before the fix, `dragend` unconditionally called `commitReorder(lastClientX)`
-    and the strip `dragleave` handler only cleared the visual indicator, so an
-    aborted drag would silently reshuffle the tab order.
-    """
+    """Releasing outside the navbar must not persist the last inside position."""
     url = live_server["url"]
     page.goto(f"{url}/browse")
     page.wait_for_selector(".nav-tab[data-nav-id='cull']")
 
     before = _nav_ids(page)
-
-    result = page.evaluate("""() => {
-        const strip = document.getElementById('navTabStrip');
-        const src = strip.querySelector(".nav-tab[data-nav-id='cull']");
-        const importTab = strip.querySelector(".nav-tab[data-nav-id='import']");
-        const rect = importTab.getBoundingClientRect();
-        // A position that WOULD land cull at the front if it committed.
-        const inStripX = rect.left + 1;
-
-        const fire = (el, type, init) => {
-            const ev = new DragEvent(type, Object.assign({
-                bubbles: true, cancelable: true, dataTransfer: new DataTransfer(),
-            }, init || {}));
-            el.dispatchEvent(ev);
-        };
-        fire(src, 'dragstart', {clientX: 0});
-        fire(strip, 'dragover', {clientX: inStripX});
-        // Pointer leaves the strip: relatedTarget points at something
-        // outside the strip so the handler's !contains(relatedTarget)
-        // check fires.
-        fire(strip, 'dragleave', {clientX: inStripX, relatedTarget: document.body});
-        // User releases the mouse outside the navbar; dragend still fires
-        // on the source element, but there is no dragover to refresh
-        // lastClientX.
-        fire(src, 'dragend', {clientX: 0});
-        return true;
-    }""")
-    assert result
+    src = page.query_selector(".nav-tab[data-nav-id='cull']")
+    dst = page.query_selector(".nav-tab[data-nav-id='import']")
+    sb, db = src.bounding_box(), dst.bounding_box()
+    start_x = sb["x"] + sb["width"] / 2
+    strip_y = db["y"] + db["height"] / 2
+    destination_x = db["x"] + 1
+    page.mouse.move(start_x, strip_y)
+    page.mouse.down()
+    page.mouse.move(destination_x, strip_y, steps=10)
+    page.mouse.move(destination_x, db["y"] + db["height"] + 100, steps=5)
+    page.mouse.up()
 
     page.wait_for_timeout(300)
     dom_after = _nav_ids(page)

--- a/vireo/templates/_navbar.html
+++ b/vireo/templates/_navbar.html
@@ -58,6 +58,10 @@ input[type=text], input[type=date], select, .path-input, .text-input, .model-sel
 .navbar a[data-nav-id].dragging {
   opacity: 0.4;
 }
+.navbar a[data-nav-id] {
+  -webkit-user-drag: none;
+  user-select: none;
+}
 .navbar .nav-drop-indicator {
   width: 2px;
   height: 24px;
@@ -2415,6 +2419,7 @@ window.NAV_ALL_PAGES = [
   function buildTabAnchor(page, opts) {
     const a = document.createElement('a');
     a.href = page.href;
+    a.draggable = false;
     a.className = 'nav-tab';
     if (opts && opts.ephemeral) a.classList.add('is-ephemeral');
     a.dataset.navId = page.id;
@@ -2683,7 +2688,7 @@ window.NAV_ALL_PAGES = [
 </script>
 
 <script>
-/* ---------- Drag-reorder over the unified strip ---------- */
+/* ---------- Pointer drag-reorder over the unified strip ---------- */
 (function() {
   function strip() { return document.getElementById('navTabStrip'); }
   function tabAnchors() {
@@ -2692,20 +2697,13 @@ window.NAV_ALL_PAGES = [
   }
 
   let draggedEl = null;
+  let pressedEl = null;
+  let pointerId = null;
+  let startX = 0;
+  let startY = 0;
   let indicator = null;
-  // Last pointer X seen while the drag was over the strip, and a guard so
-  // the reorder is committed exactly once per drag. We commit on `dragend`
-  // (which fires reliably on the source element across engines, including
-  // the macOS WKWebView the desktop app runs in) rather than relying solely
-  // on the `drop` event — WKWebView frequently never fires `drop` for HTML5
-  // drag-and-drop, which left the dragged tab snapping back to its original
-  // position. `drop`, when it does fire, is a fast-path.
-  //
-  // `lastClientX` is cleared when the pointer leaves the strip so an
-  // aborted drag (release outside the navbar) can't commit a reorder from
-  // the last in-strip position.
-  let lastClientX = null;
-  let committed = false;
+  let suppressClick = false;
+  const DRAG_THRESHOLD = 4;
 
   function createIndicator() {
     const el = document.createElement('span');
@@ -2739,96 +2737,79 @@ window.NAV_ALL_PAGES = [
     const newOrder = tabAnchors().map(a => a.dataset.navId);
     if (window._navTabs) window._navTabs.setTabs(newOrder);
   }
-  // Move the dragged tab to wherever `clientX` points and persist the new
-  // order. Guarded by `committed` so a drag that fires both `drop` and
-  // `dragend` only reorders/persists once.
-  function commitReorder(clientX) {
-    if (committed || !draggedEl || clientX == null) return;
+  function pointInsideStrip(clientX, clientY) {
     const s = strip();
-    if (!s) return;
-    committed = true;
+    if (!s) return false;
+    const rect = s.getBoundingClientRect();
+    return clientX >= rect.left && clientX <= rect.right &&
+      clientY >= rect.top && clientY <= rect.bottom;
+  }
+  function commitReorder(clientX) {
+    const s = strip();
+    if (!s || !draggedEl) return;
     removeIndicator();
     s.insertBefore(draggedEl, dropReference(clientX));
     persistCurrentOrder();
   }
-
-  function bindDragHandlers() {
-    tabAnchors().forEach(link => {
-      // Idempotent: ensure draggable=true (re-render replaces nodes).
-      link.draggable = true;
-      if (link.dataset.dragBound) return;
-      link.dataset.dragBound = '1';
-      link.addEventListener('dragstart', function(e) {
-        draggedEl = this;
-        lastClientX = null;
-        committed = false;
-        this.classList.add('dragging');
-        e.dataTransfer.effectAllowed = 'move';
-        e.dataTransfer.setData('text/plain', this.dataset.navId);
-      });
-      link.addEventListener('dragend', function() {
-        // Primary commit path: `dragend` always fires on the source, even
-        // in WKWebView where `drop` may not. No-op if `drop` already
-        // committed this drag.
-        commitReorder(lastClientX);
-        this.classList.remove('dragging');
-        removeIndicator();
-        draggedEl = null;
-        lastClientX = null;
-        committed = false;
-      });
-      link.addEventListener('dragover', function(e) {
-        if (!draggedEl || draggedEl === this) return;
-        e.preventDefault();
-        e.dataTransfer.dropEffect = 'move';
-        lastClientX = e.clientX;
-        showDropIndicator(e.clientX);
-      });
-      link.addEventListener('drop', function(e) {
-        // Fast-path when the engine delivers `drop`. `dragend` still fires
-        // afterward but `committed` makes it a no-op.
-        e.preventDefault();
-        e.stopPropagation();
-        commitReorder(e.clientX);
-      });
-    });
+  function finishDrag() {
+    if (draggedEl) draggedEl.classList.remove('dragging');
+    removeIndicator();
+    draggedEl = null;
+    pressedEl = null;
+    pointerId = null;
   }
 
-  // Re-bind every time the strip re-renders. We do that by hooking into
-  // _navTabs.fetchAndRender via a small wrapper — but simpler: a
-  // MutationObserver on the strip.
   function init() {
     const s = strip();
     if (!s) return;
-    // Strip-level dragleave is bound exactly once; re-running
-    // bindDragHandlers() on every MutationObserver tick would otherwise
-    // accumulate duplicate listeners.
-    s.addEventListener('dragleave', function(e) {
-      // When the drag exits the strip entirely, clear both the visual
-      // indicator and the pending drop position. Otherwise a subsequent
-      // `dragend` fired after the user releases outside the navbar would
-      // commit a reorder from the stale in-strip pointer X.
-      if (!s.contains(e.relatedTarget)) {
-        removeIndicator();
-        lastClientX = null;
+    // Native HTML drag-and-drop is unreliable in macOS WKWebView: depending
+    // on the release position it can omit `drop`, `dragover`, or report a
+    // spurious `dragleave`. Pointer capture gives us one dependable stream
+    // through release, including when the pointer leaves the navbar.
+    s.addEventListener('pointerdown', function(e) {
+      if (e.button !== 0 || !e.isPrimary) return;
+      if (e.target.closest('.nav-tab-close, .nav-tab-pin')) return;
+      const link = e.target.closest('.nav-tab:not(.is-ephemeral)');
+      if (!link || !s.contains(link)) return;
+      pressedEl = link;
+      pointerId = e.pointerId;
+      startX = e.clientX;
+      startY = e.clientY;
+      if (link.setPointerCapture) link.setPointerCapture(e.pointerId);
+    });
+
+    document.addEventListener('pointermove', function(e) {
+      if (!pressedEl || e.pointerId !== pointerId) return;
+      if (!draggedEl && Math.hypot(e.clientX - startX, e.clientY - startY) < DRAG_THRESHOLD) return;
+      if (!draggedEl) {
+        draggedEl = pressedEl;
+        draggedEl.classList.add('dragging');
       }
-    });
-    s.addEventListener('dragover', function(e) {
-      if (!draggedEl) return;
       e.preventDefault();
-      e.dataTransfer.dropEffect = 'move';
-      lastClientX = e.clientX;
-      showDropIndicator(e.clientX);
+      if (pointInsideStrip(e.clientX, e.clientY)) showDropIndicator(e.clientX);
+      else removeIndicator();
     });
-    s.addEventListener('drop', function(e) {
-      if (!draggedEl) return;
+
+    document.addEventListener('pointerup', function(e) {
+      if (!pressedEl || e.pointerId !== pointerId) return;
+      if (!draggedEl) {
+        finishDrag();
+        return;
+      }
       e.preventDefault();
       e.stopPropagation();
-      commitReorder(e.clientX);
+      suppressClick = true;
+      if (pointInsideStrip(e.clientX, e.clientY)) commitReorder(e.clientX);
+      finishDrag();
+      setTimeout(function() { suppressClick = false; }, 0);
     });
-    bindDragHandlers();
-    const mo = new MutationObserver(() => bindDragHandlers());
-    mo.observe(s, {childList: true});
+
+    document.addEventListener('pointercancel', finishDrag);
+    s.addEventListener('click', function(e) {
+      if (!suppressClick) return;
+      e.preventDefault();
+      e.stopPropagation();
+    }, true);
   }
 
   if (document.readyState === 'loading') {


### PR DESCRIPTION
Replaces the navbar's HTML5 drag-and-drop handling with pointer capture so reordered tabs persist reliably in the macOS WKWebView desktop app.

The previous fix committed on `dragend`, but still depended on inconsistent `dragover` and `dragleave` events for the saved release position, allowing tabs to snap back.

The new flow disables native link dragging, validates that release occurs inside the tab strip, suppresses accidental navigation after a drag, and leaves outside releases unchanged.

Validated with 47 navigation and tabs API tests plus Ruff checks, including real-pointer persistence and aborted-drag coverage.