### PR TITLE
Repair legacy MegaDetector cache duplication

### DIFF
--- a/vireo/schema.py
+++ b/vireo/schema.py
@@ -549,27 +549,38 @@ def _merge_legacy_detector_alias(conn):
     # coincidentally share the loser's prompt coordinates, and rewriting it
     # would break equality against its own detection row.
     #
-    # Skip the remap when another retained megadetector-v6 detection on the
-    # same photo still sits at the loser's exact coordinates (for example the
-    # same box under a different category, outside this alias group). Because
-    # find_stale_masks compares only (detector_model, prompt_xywh) and ignores
-    # category, that mask remains fresh against the other detection — moving
-    # it to this group's survivor would point it at a different subject and
-    # make the cache stale.
+    # find_stale_masks picks a single "primary" detection per photo — the
+    # highest-confidence non-full-image row, tie-broken by smallest id — and
+    # only that row's coordinates keep the mask fresh. Skip the remap only
+    # when that primary IS a retained megadetector-v6 row still sitting at
+    # the loser's exact coordinates (for example the same box under a
+    # different category, outside this alias group and higher-confidence than
+    # the merged survivor). In every other case — including a retained row at
+    # the loser coords that is lower-confidence than the survivor — the
+    # primary sits elsewhere; leaving the mask at the loser coords would
+    # immediately flag it stale, so remap to the survivor coords instead.
     for photo_id, loser_coords, survivor_coords in mask_prompt_remaps:
-        other_match = conn.execute(
+        primary = conn.execute(
             """
-            SELECT 1 FROM detections d
-            WHERE d.photo_id = ?
-              AND d.detector_model = ?
-              AND d.box_x = ? AND d.box_y = ?
-              AND d.box_w = ? AND d.box_h = ?
-              AND d.id NOT IN (SELECT old_id FROM legacy_detection_merge)
+            SELECT detector_model, box_x, box_y, box_w, box_h
+            FROM detections
+            WHERE photo_id = ?
+              AND detector_model != 'full-image'
+              AND id NOT IN (SELECT old_id FROM legacy_detection_merge)
+            ORDER BY detector_confidence DESC, id ASC
             LIMIT 1
             """,
-            (photo_id, _CANONICAL_DETECTOR_MODEL, *loser_coords),
+            (photo_id,),
         ).fetchone()
-        if other_match is not None:
+        primary_matches_loser = (
+            primary is not None
+            and primary["detector_model"] == _CANONICAL_DETECTOR_MODEL
+            and (
+                primary["box_x"], primary["box_y"],
+                primary["box_w"], primary["box_h"],
+            ) == loser_coords
+        )
+        if primary_matches_loser:
             continue
         conn.execute(
             """

--- a/vireo/schema.py
+++ b/vireo/schema.py
@@ -181,11 +181,52 @@ def _merge_legacy_detector_alias(conn):
         (_CANONICAL_DETECTOR_MODEL, _LEGACY_DETECTOR_MODEL),
     )
 
-    legacy_count = conn.execute(
-        "SELECT COUNT(*) FROM detections WHERE detector_model = ?",
-        (_LEGACY_DETECTOR_MODEL,),
-    ).fetchone()[0]
-    if not legacy_count:
+    # Load every detection row that carries either alias in one pass so we can
+    # detect not just literal legacy rows but also canonical rows kept from the
+    # short-lived unversioned rename: those already carry the current model name
+    # yet keep their old rowid instead of the content-addressed one. Skipping
+    # them here would let the next detector rerun UPSERT under the correct id
+    # and delete the pre-existing canonical row, cascading its predictions and
+    # reviews.
+    from detection_id import detection_id as _detection_id
+
+    rows = conn.execute(
+        """
+        SELECT id, photo_id, detector_model, box_x, box_y, box_w, box_h,
+               detector_confidence, category, created_at
+        FROM detections
+        WHERE detector_model IN (?, ?)
+        """,
+        (_LEGACY_DETECTOR_MODEL, _CANONICAL_DETECTOR_MODEL),
+    ).fetchall()
+
+    def _expected_content_id(row):
+        """Return the content-addressed id ``row`` should have, or ``None``.
+
+        Historical fixtures with a NULL category or coordinate cannot be
+        content-addressed, so the caller falls back to preserving the raw
+        rowid for those rows.
+        """
+        coords = (row["box_x"], row["box_y"], row["box_w"], row["box_h"])
+        if row["category"] is None or any(value is None for value in coords):
+            return None
+        return _detection_id(
+            row["photo_id"], _CANONICAL_DETECTOR_MODEL, coords, row["category"],
+        )
+
+    def _is_stale_canonical(row):
+        """True if ``row`` is a canonical alias whose id needs to be re-keyed."""
+        if row["detector_model"] != _CANONICAL_DETECTOR_MODEL:
+            return False
+        expected = _expected_content_id(row)
+        return expected is not None and expected != row["id"]
+
+    has_legacy = any(
+        row["detector_model"] == _LEGACY_DETECTOR_MODEL for row in rows
+    )
+    has_stale_canonical = any(_is_stale_canonical(row) for row in rows)
+
+    if not has_legacy and not has_stale_canonical:
         # Zero-box detector runs can carry the old key even when no detection row
         # exists, so normalize them on the warm/empty path too.
         conn.execute(
@@ -212,6 +253,10 @@ def _merge_legacy_detector_alias(conn):
         )
         return
 
+    legacy_count = sum(
+        1 for row in rows if row["detector_model"] == _LEGACY_DETECTOR_MODEL
+    )
+
     conn.execute("DROP TABLE IF EXISTS temp.legacy_detector_groups")
     conn.execute("DROP TABLE IF EXISTS temp.legacy_detection_merge")
     conn.execute("DROP TABLE IF EXISTS temp.legacy_prediction_merge")
@@ -220,17 +265,7 @@ def _merge_legacy_detector_alias(conn):
     # writes. The canonical content-addressed id is the survivor even when a box
     # exists only under the legacy key, so a later detector rerun will UPSERT that
     # row instead of deleting it (and cascading its predictions/reviews).
-    from detection_id import detection_id as _detection_id
 
-    rows = conn.execute(
-        """
-        SELECT id, photo_id, detector_model, box_x, box_y, box_w, box_h,
-               detector_confidence, category, created_at
-        FROM detections
-        WHERE detector_model IN (?, ?)
-        """,
-        (_LEGACY_DETECTOR_MODEL, _CANONICAL_DETECTOR_MODEL),
-    ).fetchall()
     groups = {}
     for row in rows:
         coords = (row["box_x"], row["box_y"], row["box_w"], row["box_h"])
@@ -273,10 +308,19 @@ def _merge_legacy_detector_alias(conn):
     mask_prompt_remaps: list[tuple[int, tuple, tuple]] = []
 
     for group_rows in groups.values():
-        if not any(
+        group_has_legacy = any(
             row["detector_model"] == _LEGACY_DETECTOR_MODEL
             for row in group_rows
-        ):
+        )
+        group_has_stale_canonical = any(
+            _is_stale_canonical(row) for row in group_rows
+        )
+        # Legacy-touched groups always run through the merge to canonicalize the
+        # model name. Canonical-only groups only need attention when at least one
+        # row keeps a non-content-addressed id from a pre-versioned rename —
+        # otherwise the group is already in its final shape and processing it
+        # would be a no-op (survivor_id == source.id, no losers to merge).
+        if not group_has_legacy and not group_has_stale_canonical:
             continue
         canonical_rows = [
             row for row in group_rows

--- a/vireo/schema.py
+++ b/vireo/schema.py
@@ -130,20 +130,32 @@ _LEGACY_DETECTOR_MODEL = "MegaDetector"
 _CANONICAL_DETECTOR_MODEL = "megadetector-v6"
 
 
-def _merge_review_status_sql():
-    """Return the status expression used when two prediction reviews collide."""
-    return """
+def _merge_review_winning_column_sql(column):
+    """Return the CASE expression picking ``column`` from the winning review row.
+
+    Two prediction_review rows collide when both the legacy and canonical
+    prediction rows carry a review in the same workspace. The winner is:
+      1. The non-pending row when the other is pending; otherwise
+      2. The row with the later ``reviewed_at`` (NULLs treated as oldest);
+      3. Ties keep the pre-existing row.
+    Applying the same expression to every merged column keeps status,
+    reviewed_at, individual, group_id, and the vote counts sourced from the
+    same row — otherwise a rejected status from one row could be stored
+    alongside the accepted-group metadata from the other, and grouped
+    accepts later use group_id/individual to retag other photos.
+    """
+    return f"""
         CASE
           WHEN prediction_review.status = 'pending'
                AND excluded.status <> 'pending'
-            THEN excluded.status
+            THEN excluded.{column}
           WHEN prediction_review.status <> 'pending'
                AND excluded.status = 'pending'
-            THEN prediction_review.status
+            THEN prediction_review.{column}
           WHEN COALESCE(excluded.reviewed_at, '')
                > COALESCE(prediction_review.reviewed_at, '')
-            THEN excluded.status
-          ELSE prediction_review.status
+            THEN excluded.{column}
+          ELSE prediction_review.{column}
         END
     """
 
@@ -472,18 +484,12 @@ def _merge_legacy_detector_alias(conn):
         JOIN legacy_prediction_merge pm ON pm.old_id = r.prediction_id
         WHERE 1
         ON CONFLICT(prediction_id, workspace_id) DO UPDATE SET
-          status = {_merge_review_status_sql()},
-          reviewed_at = CASE
-            WHEN prediction_review.reviewed_at IS NULL THEN excluded.reviewed_at
-            WHEN excluded.reviewed_at IS NULL THEN prediction_review.reviewed_at
-            WHEN excluded.reviewed_at > prediction_review.reviewed_at
-              THEN excluded.reviewed_at
-            ELSE prediction_review.reviewed_at
-          END,
-          individual = COALESCE(prediction_review.individual, excluded.individual),
-          group_id = COALESCE(prediction_review.group_id, excluded.group_id),
-          vote_count = COALESCE(prediction_review.vote_count, excluded.vote_count),
-          total_votes = COALESCE(prediction_review.total_votes, excluded.total_votes)
+          status = {_merge_review_winning_column_sql('status')},
+          reviewed_at = {_merge_review_winning_column_sql('reviewed_at')},
+          individual = {_merge_review_winning_column_sql('individual')},
+          group_id = {_merge_review_winning_column_sql('group_id')},
+          vote_count = {_merge_review_winning_column_sql('vote_count')},
+          total_votes = {_merge_review_winning_column_sql('total_votes')}
         """
     )
 

--- a/vireo/schema.py
+++ b/vireo/schema.py
@@ -380,19 +380,21 @@ def _merge_legacy_detector_alias(conn):
 
     # Realign mask prompts stored under a loser box to the survivor's exact
     # coordinates so find_stale_masks and count_extract_stale keep matching
-    # after the alias merge. Runs before predictions are moved because
-    # photo_masks and detections are not FK-linked; ordering is only for
-    # locality with the group-building code above.
+    # after the alias merge. Constrain to MegaDetector-family masks (already
+    # canonicalized by the rename above): another detector's mask can
+    # coincidentally share the loser's prompt coordinates, and rewriting it
+    # would break equality against its own detection row.
     for photo_id, loser_coords, survivor_coords in mask_prompt_remaps:
         conn.execute(
             """
             UPDATE photo_masks
                SET prompt_x = ?, prompt_y = ?, prompt_w = ?, prompt_h = ?
              WHERE photo_id = ?
+               AND detector_model = ?
                AND prompt_x = ? AND prompt_y = ?
                AND prompt_w = ? AND prompt_h = ?
             """,
-            (*survivor_coords, photo_id, *loser_coords),
+            (*survivor_coords, photo_id, _CANONICAL_DETECTOR_MODEL, *loser_coords),
         )
 
     # Copy loser predictions onto their survivor detection. The identity UNIQUE

--- a/vireo/schema.py
+++ b/vireo/schema.py
@@ -7,6 +7,7 @@ web requests open an initialized database and never perform schema work.
 
 from __future__ import annotations
 
+import json
 import sqlite3
 import threading
 from collections.abc import Callable
@@ -125,6 +126,384 @@ def _restore_direct_default_navigation(conn):
     )
 
 
+_LEGACY_DETECTOR_MODEL = "MegaDetector"
+_CANONICAL_DETECTOR_MODEL = "megadetector-v6"
+
+
+def _merge_review_status_sql():
+    """Return the status expression used when two prediction reviews collide."""
+    return """
+        CASE
+          WHEN prediction_review.status = 'pending'
+               AND excluded.status <> 'pending'
+            THEN excluded.status
+          WHEN prediction_review.status <> 'pending'
+               AND excluded.status = 'pending'
+            THEN prediction_review.status
+          WHEN COALESCE(excluded.reviewed_at, '')
+               > COALESCE(prediction_review.reviewed_at, '')
+            THEN excluded.status
+          ELSE prediction_review.status
+        END
+    """
+
+
+def _merge_legacy_detector_alias(conn):
+    """Consolidate pre-versioned MegaDetector cache rows without losing review data.
+
+    Older builds stored MegaDetector V6 rows under ``MegaDetector``. A short-lived
+    startup migration renamed that key to ``megadetector-v6``, but catalogs that
+    skipped that build could later accumulate a second, canonical copy of every
+    box. Multi-subject Compare then rendered the two cache rows as two subjects.
+
+    Prefer an existing canonical detection for each identical box. If a box exists
+    only under the legacy key, keep its lowest-id row. Predictions, classifier-run
+    markers, review state, and edit-history prediction references are moved to the
+    survivor before duplicate detections are deleted.
+    """
+    legacy_count = conn.execute(
+        "SELECT COUNT(*) FROM detections WHERE detector_model = ?",
+        (_LEGACY_DETECTOR_MODEL,),
+    ).fetchone()[0]
+    if not legacy_count:
+        # Zero-box detector runs can carry the old key even when no detection row
+        # exists, so normalize them on the warm/empty path too.
+        conn.execute(
+            """
+            INSERT INTO detector_runs
+                (photo_id, detector_model, run_at, box_count)
+            SELECT photo_id, ?, run_at, box_count
+            FROM detector_runs
+            WHERE detector_model = ?
+            ON CONFLICT(photo_id, detector_model) DO UPDATE SET
+              run_at = CASE
+                WHEN detector_runs.run_at IS NULL THEN excluded.run_at
+                WHEN excluded.run_at IS NULL THEN detector_runs.run_at
+                WHEN excluded.run_at > detector_runs.run_at THEN excluded.run_at
+                ELSE detector_runs.run_at
+              END,
+              box_count = MAX(detector_runs.box_count, excluded.box_count)
+            """,
+            (_CANONICAL_DETECTOR_MODEL, _LEGACY_DETECTOR_MODEL),
+        )
+        conn.execute(
+            "DELETE FROM detector_runs WHERE detector_model = ?",
+            (_LEGACY_DETECTOR_MODEL,),
+        )
+        return
+
+    conn.execute("DROP TABLE IF EXISTS temp.legacy_detector_groups")
+    conn.execute("DROP TABLE IF EXISTS temp.legacy_detection_merge")
+    conn.execute("DROP TABLE IF EXISTS temp.legacy_prediction_merge")
+
+    # Build one group for every geometry touched by the legacy alias. An existing
+    # canonical row wins; otherwise retain the lowest legacy id. ``IS`` joins below
+    # intentionally make NULL coordinates/category compare equal for old fixtures.
+    conn.execute(
+        """
+        CREATE TEMP TABLE legacy_detector_groups AS
+        SELECT
+          COALESCE(
+            MIN(CASE WHEN detector_model = 'megadetector-v6' THEN id END),
+            MIN(id)
+          ) AS survivor_id,
+          photo_id, box_x, box_y, box_w, box_h, category,
+          MAX(detector_confidence) AS max_confidence,
+          MIN(created_at) AS first_created
+        FROM detections
+        WHERE detector_model IN ('MegaDetector', 'megadetector-v6')
+        GROUP BY photo_id, box_x, box_y, box_w, box_h, category
+        HAVING SUM(CASE WHEN detector_model = 'MegaDetector' THEN 1 ELSE 0 END) > 0
+        """
+    )
+    conn.execute("CREATE UNIQUE INDEX temp.idx_legacy_detector_groups_survivor ON legacy_detector_groups(survivor_id)")
+    conn.execute(
+        """
+        CREATE TEMP TABLE legacy_detection_merge AS
+        SELECT d.id AS old_id, g.survivor_id
+        FROM detections d
+        JOIN legacy_detector_groups g
+          ON g.photo_id = d.photo_id
+         AND g.box_x IS d.box_x
+         AND g.box_y IS d.box_y
+         AND g.box_w IS d.box_w
+         AND g.box_h IS d.box_h
+         AND g.category IS d.category
+        WHERE d.detector_model IN ('MegaDetector', 'megadetector-v6')
+          AND d.id <> g.survivor_id
+        """
+    )
+    conn.execute("CREATE UNIQUE INDEX temp.idx_legacy_detection_merge_old ON legacy_detection_merge(old_id)")
+
+    # Keep the strongest cached confidence and oldest creation timestamp on the
+    # survivor. In the normal duplicate case these values are already identical.
+    conn.execute(
+        """
+        UPDATE detections
+        SET detector_confidence = (
+              SELECT max_confidence FROM legacy_detector_groups
+              WHERE survivor_id = detections.id
+            ),
+            created_at = COALESCE(created_at, (
+              SELECT first_created FROM legacy_detector_groups
+              WHERE survivor_id = detections.id
+            ))
+        WHERE id IN (SELECT survivor_id FROM legacy_detector_groups)
+        """
+    )
+
+    # Copy loser predictions onto their survivor detection. The identity UNIQUE
+    # makes this both an insert for legacy-only information and a merge for output
+    # already regenerated under the canonical detection id.
+    conn.execute(
+        """
+        INSERT INTO predictions (
+          detection_id, classifier_model, labels_fingerprint, species,
+          confidence, category, scientific_name, taxonomy_kingdom,
+          taxonomy_phylum, taxonomy_class, taxonomy_order, taxonomy_family,
+          taxonomy_genus, created_at
+        )
+        SELECT m.survivor_id, p.classifier_model, p.labels_fingerprint,
+               p.species, p.confidence, p.category, p.scientific_name,
+               p.taxonomy_kingdom, p.taxonomy_phylum, p.taxonomy_class,
+               p.taxonomy_order, p.taxonomy_family, p.taxonomy_genus,
+               p.created_at
+        FROM predictions p
+        JOIN legacy_detection_merge m ON m.old_id = p.detection_id
+        WHERE 1
+        ON CONFLICT(detection_id, classifier_model, labels_fingerprint, species)
+        DO UPDATE SET
+          confidence = CASE
+            WHEN predictions.confidence IS NULL THEN excluded.confidence
+            WHEN excluded.confidence IS NULL THEN predictions.confidence
+            WHEN excluded.confidence > predictions.confidence THEN excluded.confidence
+            ELSE predictions.confidence
+          END,
+          category = COALESCE(predictions.category, excluded.category),
+          scientific_name = COALESCE(predictions.scientific_name, excluded.scientific_name),
+          taxonomy_kingdom = COALESCE(predictions.taxonomy_kingdom, excluded.taxonomy_kingdom),
+          taxonomy_phylum = COALESCE(predictions.taxonomy_phylum, excluded.taxonomy_phylum),
+          taxonomy_class = COALESCE(predictions.taxonomy_class, excluded.taxonomy_class),
+          taxonomy_order = COALESCE(predictions.taxonomy_order, excluded.taxonomy_order),
+          taxonomy_family = COALESCE(predictions.taxonomy_family, excluded.taxonomy_family),
+          taxonomy_genus = COALESCE(predictions.taxonomy_genus, excluded.taxonomy_genus),
+          created_at = CASE
+            WHEN predictions.created_at IS NULL THEN excluded.created_at
+            WHEN excluded.created_at IS NULL THEN predictions.created_at
+            WHEN excluded.created_at < predictions.created_at THEN excluded.created_at
+            ELSE predictions.created_at
+          END
+        """
+    )
+
+    # Map every soon-to-be-deleted prediction id to the prediction that now owns
+    # its identity on the survivor. This drives both review-state and undo-history
+    # repair before the loser rows cascade away.
+    conn.execute(
+        """
+        CREATE TEMP TABLE legacy_prediction_merge AS
+        SELECT old_p.id AS old_id, MIN(new_p.id) AS survivor_id
+        FROM predictions old_p
+        JOIN legacy_detection_merge dm ON dm.old_id = old_p.detection_id
+        JOIN predictions new_p
+          ON new_p.detection_id = dm.survivor_id
+         AND new_p.classifier_model = old_p.classifier_model
+         AND new_p.labels_fingerprint = old_p.labels_fingerprint
+         AND new_p.species IS old_p.species
+        GROUP BY old_p.id
+        """
+    )
+    conn.execute("CREATE UNIQUE INDEX temp.idx_legacy_prediction_merge_old ON legacy_prediction_merge(old_id)")
+
+    conn.execute(
+        f"""
+        INSERT INTO prediction_review (
+          prediction_id, workspace_id, status, reviewed_at,
+          individual, group_id, vote_count, total_votes
+        )
+        SELECT pm.survivor_id, r.workspace_id, r.status, r.reviewed_at,
+               r.individual, r.group_id, r.vote_count, r.total_votes
+        FROM prediction_review r
+        JOIN legacy_prediction_merge pm ON pm.old_id = r.prediction_id
+        WHERE 1
+        ON CONFLICT(prediction_id, workspace_id) DO UPDATE SET
+          status = {_merge_review_status_sql()},
+          reviewed_at = CASE
+            WHEN prediction_review.reviewed_at IS NULL THEN excluded.reviewed_at
+            WHEN excluded.reviewed_at IS NULL THEN prediction_review.reviewed_at
+            WHEN excluded.reviewed_at > prediction_review.reviewed_at
+              THEN excluded.reviewed_at
+            ELSE prediction_review.reviewed_at
+          END,
+          individual = COALESCE(prediction_review.individual, excluded.individual),
+          group_id = COALESCE(prediction_review.group_id, excluded.group_id),
+          vote_count = COALESCE(prediction_review.vote_count, excluded.vote_count),
+          total_votes = COALESCE(prediction_review.total_votes, excluded.total_votes)
+        """
+    )
+
+    # prediction_accept history stores a bare prediction id in old_value. Newer
+    # history payloads can store it in JSON; update both forms so undo/redo keeps
+    # addressing the surviving prediction after duplicate rows are removed.
+    conn.execute(
+        """
+        UPDATE edit_history_items
+        SET old_value = (
+          SELECT CAST(pm.survivor_id AS TEXT)
+          FROM legacy_prediction_merge pm
+          WHERE CAST(pm.old_id AS TEXT) = edit_history_items.old_value
+        )
+        WHERE edit_id IN (
+          SELECT id FROM edit_history WHERE action_type = 'prediction_accept'
+        )
+          AND old_value IN (
+            SELECT CAST(old_id AS TEXT) FROM legacy_prediction_merge
+          )
+        """
+    )
+    prediction_id_map = dict(conn.execute("SELECT old_id, survivor_id FROM legacy_prediction_merge").fetchall())
+    json_history = conn.execute(
+        "SELECT id, old_value FROM edit_history_items WHERE ltrim(old_value) LIKE '{%'"
+    ).fetchall()
+    for item_id, raw_value in json_history:
+        try:
+            payload = json.loads(raw_value)
+            old_prediction_id = int(payload.get("prediction_id"))
+        except (AttributeError, TypeError, ValueError, json.JSONDecodeError):
+            continue
+        survivor_id = prediction_id_map.get(old_prediction_id)
+        if survivor_id is None:
+            continue
+        payload["prediction_id"] = survivor_id
+        conn.execute(
+            "UPDATE edit_history_items SET old_value = ? WHERE id = ?",
+            (json.dumps(payload, separators=(",", ":")), item_id),
+        )
+
+    # Preserve classifier completion markers and prefer the later run time / larger
+    # recorded output count when both aliases already have the same run identity.
+    conn.execute(
+        """
+        INSERT INTO classifier_runs (
+          detection_id, classifier_model, labels_fingerprint,
+          run_at, prediction_count
+        )
+        SELECT dm.survivor_id, cr.classifier_model, cr.labels_fingerprint,
+               cr.run_at, cr.prediction_count
+        FROM classifier_runs cr
+        JOIN legacy_detection_merge dm ON dm.old_id = cr.detection_id
+        WHERE 1
+        ON CONFLICT(detection_id, classifier_model, labels_fingerprint)
+        DO UPDATE SET
+          run_at = CASE
+            WHEN classifier_runs.run_at IS NULL THEN excluded.run_at
+            WHEN excluded.run_at IS NULL THEN classifier_runs.run_at
+            WHEN excluded.run_at > classifier_runs.run_at THEN excluded.run_at
+            ELSE classifier_runs.run_at
+          END,
+          prediction_count = MAX(
+            classifier_runs.prediction_count, excluded.prediction_count
+          )
+        """
+    )
+
+    merged_detection_count = conn.execute("SELECT COUNT(*) FROM legacy_detection_merge").fetchone()[0]
+    merged_prediction_count = conn.execute("SELECT COUNT(*) FROM legacy_prediction_merge").fetchone()[0]
+
+    # Deleting loser detections now safely cascades only records already copied to
+    # their survivor. Normalize every retained legacy-only survivor afterward.
+    conn.execute("DELETE FROM detections WHERE id IN (SELECT old_id FROM legacy_detection_merge)")
+    conn.execute(
+        "UPDATE detections SET detector_model = ? WHERE detector_model = ?",
+        (_CANONICAL_DETECTOR_MODEL, _LEGACY_DETECTOR_MODEL),
+    )
+
+    # Merge zero-box and populated detector-run aliases, then make box_count agree
+    # with the repaired cache for every photo touched by legacy detections.
+    conn.execute(
+        """
+        INSERT INTO detector_runs (photo_id, detector_model, run_at, box_count)
+        SELECT photo_id, ?, run_at, box_count
+        FROM detector_runs
+        WHERE detector_model = ?
+        ON CONFLICT(photo_id, detector_model) DO UPDATE SET
+          run_at = CASE
+            WHEN detector_runs.run_at IS NULL THEN excluded.run_at
+            WHEN excluded.run_at IS NULL THEN detector_runs.run_at
+            WHEN excluded.run_at > detector_runs.run_at THEN excluded.run_at
+            ELSE detector_runs.run_at
+          END,
+          box_count = MAX(detector_runs.box_count, excluded.box_count)
+        """,
+        (_CANONICAL_DETECTOR_MODEL, _LEGACY_DETECTOR_MODEL),
+    )
+    conn.execute(
+        "DELETE FROM detector_runs WHERE detector_model = ?",
+        (_LEGACY_DETECTOR_MODEL,),
+    )
+    conn.execute(
+        """
+        INSERT INTO detector_runs (photo_id, detector_model, run_at, box_count)
+        SELECT g.photo_id, 'megadetector-v6', MIN(d.created_at), COUNT(d.id)
+        FROM (SELECT DISTINCT photo_id FROM legacy_detector_groups) g
+        JOIN detections d
+          ON d.photo_id = g.photo_id
+         AND d.detector_model = 'megadetector-v6'
+        GROUP BY g.photo_id
+        ON CONFLICT(photo_id, detector_model) DO UPDATE SET
+          box_count = excluded.box_count,
+          run_at = COALESCE(detector_runs.run_at, excluded.run_at)
+        """
+    )
+
+    # Recompute counts after prediction identities have been folded together.
+    conn.execute(
+        """
+        UPDATE classifier_runs
+        SET prediction_count = (
+          SELECT COUNT(*) FROM predictions p
+          WHERE p.detection_id = classifier_runs.detection_id
+            AND p.classifier_model = classifier_runs.classifier_model
+            AND p.labels_fingerprint = classifier_runs.labels_fingerprint
+        )
+        WHERE detection_id IN (
+          SELECT survivor_id FROM legacy_detector_groups
+        )
+        """
+    )
+
+    conn.execute(
+        "INSERT OR REPLACE INTO db_meta(key, value) VALUES (?, ?)",
+        (
+            "legacy_megadetector_alias_repair",
+            json.dumps(
+                {
+                    "legacy_detections": legacy_count,
+                    "merged_detections": merged_detection_count,
+                    "remapped_predictions": merged_prediction_count,
+                },
+                sort_keys=True,
+            ),
+        ),
+    )
+
+
+def _validate_legacy_detector_alias_merge(conn):
+    legacy_detections = conn.execute(
+        "SELECT COUNT(*) FROM detections WHERE detector_model = ?",
+        (_LEGACY_DETECTOR_MODEL,),
+    ).fetchone()[0]
+    legacy_runs = conn.execute(
+        "SELECT COUNT(*) FROM detector_runs WHERE detector_model = ?",
+        (_LEGACY_DETECTOR_MODEL,),
+    ).fetchone()[0]
+    if legacy_detections or legacy_runs:
+        raise RuntimeError("schema migration validation failed: legacy MegaDetector aliases remain")
+    fk_errors = conn.execute("PRAGMA foreign_key_check").fetchall()
+    if fk_errors:
+        raise RuntimeError("schema migration validation failed: detector repair broke foreign keys")
+
+
 MIGRATIONS = (
     Migration(
         version=5,
@@ -142,6 +521,12 @@ MIGRATIONS = (
         name="restore-direct-default-navigation",
         apply=_restore_direct_default_navigation,
     ),
+    Migration(
+        version=8,
+        name="merge-legacy-megadetector-alias",
+        apply=_merge_legacy_detector_alias,
+        validate=_validate_legacy_detector_alias_merge,
+    ),
 )
 
 
@@ -149,9 +534,7 @@ def _apply_pending(conn):
     current = conn.execute("PRAGMA user_version").fetchone()[0]
     latest = MIGRATIONS[-1].version if MIGRATIONS else current
     if current > latest:
-        raise RuntimeError(
-            f"database schema version {current} is newer than supported {latest}"
-        )
+        raise RuntimeError(f"database schema version {current} is newer than supported {latest}")
 
     for migration in MIGRATIONS:
         if migration.version <= current:

--- a/vireo/schema.py
+++ b/vireo/schema.py
@@ -161,6 +161,14 @@ def _merge_legacy_detector_alias(conn):
     markers, review state, and edit-history prediction references are moved to the
     survivor before duplicate detections are deleted.
     """
+    # Masks persist the detector key alongside the prompt geometry. Keep that
+    # denormalized key aligned with the detection rows so a valid mask does not
+    # become stale merely because this migration canonicalized its model name.
+    conn.execute(
+        "UPDATE photo_masks SET detector_model = ? WHERE detector_model = ?",
+        (_CANONICAL_DETECTOR_MODEL, _LEGACY_DETECTOR_MODEL),
+    )
+
     legacy_count = conn.execute(
         "SELECT COUNT(*) FROM detections WHERE detector_model = ?",
         (_LEGACY_DETECTOR_MODEL,),

--- a/vireo/schema.py
+++ b/vireo/schema.py
@@ -156,8 +156,8 @@ def _merge_legacy_detector_alias(conn):
     skipped that build could later accumulate a second, canonical copy of every
     box. Multi-subject Compare then rendered the two cache rows as two subjects.
 
-    Prefer an existing canonical detection for each identical box. If a box exists
-    only under the legacy key, keep its lowest-id row. Predictions, classifier-run
+    Collapse boxes on the detector cache's rounded natural key and make the normal
+    canonical content-addressed id their survivor. Predictions, classifier-run
     markers, review state, and edit-history prediction references are moved to the
     survivor before duplicate detections are deleted.
     """
@@ -204,44 +204,119 @@ def _merge_legacy_detector_alias(conn):
     conn.execute("DROP TABLE IF EXISTS temp.legacy_detection_merge")
     conn.execute("DROP TABLE IF EXISTS temp.legacy_prediction_merge")
 
-    # Build one group for every geometry touched by the legacy alias. An existing
-    # canonical row wins; otherwise retain the lowest legacy id. ``IS`` joins below
-    # intentionally make NULL coordinates/category compare equal for old fixtures.
-    conn.execute(
+    # Build groups with the same four-decimal box identity used by normal detector
+    # writes. The canonical content-addressed id is the survivor even when a box
+    # exists only under the legacy key, so a later detector rerun will UPSERT that
+    # row instead of deleting it (and cascading its predictions/reviews).
+    from detection_id import detection_id as _detection_id
+
+    rows = conn.execute(
         """
-        CREATE TEMP TABLE legacy_detector_groups AS
-        SELECT
-          COALESCE(
-            MIN(CASE WHEN detector_model = 'megadetector-v6' THEN id END),
-            MIN(id)
-          ) AS survivor_id,
-          photo_id, box_x, box_y, box_w, box_h, category,
-          MAX(detector_confidence) AS max_confidence,
-          MIN(created_at) AS first_created
+        SELECT id, photo_id, detector_model, box_x, box_y, box_w, box_h,
+               detector_confidence, category, created_at
         FROM detections
-        WHERE detector_model IN ('MegaDetector', 'megadetector-v6')
-        GROUP BY photo_id, box_x, box_y, box_w, box_h, category
-        HAVING SUM(CASE WHEN detector_model = 'MegaDetector' THEN 1 ELSE 0 END) > 0
-        """
-    )
-    conn.execute("CREATE UNIQUE INDEX temp.idx_legacy_detector_groups_survivor ON legacy_detector_groups(survivor_id)")
+        WHERE detector_model IN (?, ?)
+        """,
+        (_LEGACY_DETECTOR_MODEL, _CANONICAL_DETECTOR_MODEL),
+    ).fetchall()
+    groups = {}
+    for row in rows:
+        coords = (row["box_x"], row["box_y"], row["box_w"], row["box_h"])
+        if row["category"] is None or any(value is None for value in coords):
+            # Defensive support for malformed historical fixtures. Real detector
+            # boxes always have a category and four coordinates; keep NULL-bearing
+            # rows distinct because they cannot have a content-addressed id.
+            key = ("raw", row["photo_id"], *coords, row["category"])
+        else:
+            qbox = tuple(f"{round(value, 4):.4f}" for value in coords)
+            key = ("quantized", row["photo_id"], *qbox, row["category"])
+        groups.setdefault(key, []).append(row)
+
     conn.execute(
         """
-        CREATE TEMP TABLE legacy_detection_merge AS
-        SELECT d.id AS old_id, g.survivor_id
-        FROM detections d
-        JOIN legacy_detector_groups g
-          ON g.photo_id = d.photo_id
-         AND g.box_x IS d.box_x
-         AND g.box_y IS d.box_y
-         AND g.box_w IS d.box_w
-         AND g.box_h IS d.box_h
-         AND g.category IS d.category
-        WHERE d.detector_model IN ('MegaDetector', 'megadetector-v6')
-          AND d.id <> g.survivor_id
+        CREATE TEMP TABLE legacy_detector_groups (
+          survivor_id INTEGER PRIMARY KEY,
+          photo_id INTEGER NOT NULL,
+          max_confidence REAL,
+          first_created TEXT
+        )
         """
     )
-    conn.execute("CREATE UNIQUE INDEX temp.idx_legacy_detection_merge_old ON legacy_detection_merge(old_id)")
+    conn.execute(
+        """
+        CREATE TEMP TABLE legacy_detection_merge (
+          old_id INTEGER PRIMARY KEY,
+          survivor_id INTEGER NOT NULL
+        )
+        """
+    )
+
+    for group_rows in groups.values():
+        if not any(
+            row["detector_model"] == _LEGACY_DETECTOR_MODEL
+            for row in group_rows
+        ):
+            continue
+        canonical_rows = [
+            row for row in group_rows
+            if row["detector_model"] == _CANONICAL_DETECTOR_MODEL
+        ]
+        source = min(canonical_rows or group_rows, key=lambda row: row["id"])
+        coords = (
+            source["box_x"], source["box_y"],
+            source["box_w"], source["box_h"],
+        )
+        if source["category"] is None or any(value is None for value in coords):
+            survivor_id = source["id"]
+        else:
+            survivor_id = _detection_id(
+                source["photo_id"], _CANONICAL_DETECTOR_MODEL,
+                coords, source["category"],
+            )
+
+        group_ids = {row["id"] for row in group_rows}
+        occupant = conn.execute(
+            "SELECT id FROM detections WHERE id = ?", (survivor_id,),
+        ).fetchone()
+        if occupant is not None and occupant["id"] not in group_ids:
+            raise RuntimeError(
+                f"canonical detection id collision while migrating {survivor_id}"
+            )
+
+        confidences = [
+            row["detector_confidence"] for row in group_rows
+            if row["detector_confidence"] is not None
+        ]
+        created_values = [
+            row["created_at"] for row in group_rows
+            if row["created_at"] is not None
+        ]
+        max_confidence = max(confidences) if confidences else None
+        first_created = min(created_values) if created_values else None
+        if occupant is None:
+            conn.execute(
+                """
+                INSERT INTO detections (
+                  id, photo_id, detector_model, box_x, box_y, box_w, box_h,
+                  detector_confidence, category, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    survivor_id, source["photo_id"], _CANONICAL_DETECTOR_MODEL,
+                    *coords, max_confidence, source["category"], first_created,
+                ),
+            )
+        conn.execute(
+            "INSERT INTO legacy_detector_groups VALUES (?, ?, ?, ?)",
+            (survivor_id, source["photo_id"], max_confidence, first_created),
+        )
+        conn.executemany(
+            "INSERT INTO legacy_detection_merge VALUES (?, ?)",
+            [
+                (row["id"], survivor_id) for row in group_rows
+                if row["id"] != survivor_id
+            ],
+        )
 
     # Keep the strongest cached confidence and oldest creation timestamp on the
     # survivor. In the normal duplicate case these values are already identical.

--- a/vireo/schema.py
+++ b/vireo/schema.py
@@ -292,6 +292,22 @@ def _merge_legacy_detector_alias(conn):
                 f"canonical detection id collision while migrating {survivor_id}"
             )
 
+        # When an existing content-addressed row already occupies survivor_id, it
+        # is the row that will remain in the table after the merge — the INSERT
+        # below is skipped, so its raw box coordinates are what masks must be
+        # realigned to. Otherwise the retained row is the freshly inserted one
+        # using `source`'s coordinates.
+        if occupant is not None:
+            survivor_row = next(
+                row for row in group_rows if row["id"] == occupant["id"]
+            )
+        else:
+            survivor_row = source
+        survivor_coords = (
+            survivor_row["box_x"], survivor_row["box_y"],
+            survivor_row["box_w"], survivor_row["box_h"],
+        )
+
         confidences = [
             row["detector_confidence"] for row in group_rows
             if row["detector_confidence"] is not None
@@ -331,7 +347,7 @@ def _merge_legacy_detector_alias(conn):
         # differ from the survivor's. Skip rows with any NULL coordinate — a
         # mask cannot exactly-match a NULL prompt column, so there is nothing
         # to realign.
-        if any(value is None for value in coords):
+        if any(value is None for value in survivor_coords):
             continue
         for row in group_rows:
             loser_coords = (
@@ -339,10 +355,10 @@ def _merge_legacy_detector_alias(conn):
             )
             if any(value is None for value in loser_coords):
                 continue
-            if loser_coords == coords:
+            if loser_coords == survivor_coords:
                 continue
             mask_prompt_remaps.append(
-                (source["photo_id"], loser_coords, coords),
+                (source["photo_id"], loser_coords, survivor_coords),
             )
 
     # Keep the strongest cached confidence and oldest creation timestamp on the

--- a/vireo/schema.py
+++ b/vireo/schema.py
@@ -368,13 +368,38 @@ def _merge_legacy_detector_alias(conn):
     for item_id, raw_value in json_history:
         try:
             payload = json.loads(raw_value)
+        except (TypeError, json.JSONDecodeError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+
+        changed = False
+        try:
             old_prediction_id = int(payload.get("prediction_id"))
-        except (AttributeError, TypeError, ValueError, json.JSONDecodeError):
+        except (TypeError, ValueError):
+            pass
+        else:
+            survivor_id = prediction_id_map.get(old_prediction_id)
+            if survivor_id is not None:
+                payload["prediction_id"] = survivor_id
+                changed = True
+
+        prediction_ids = payload.get("prediction_ids")
+        if isinstance(prediction_ids, list):
+            remapped_ids = []
+            for value in prediction_ids:
+                try:
+                    prediction_id = int(value)
+                except (TypeError, ValueError):
+                    remapped_ids.append(value)
+                    continue
+                survivor_id = prediction_id_map.get(prediction_id)
+                remapped_ids.append(survivor_id if survivor_id is not None else value)
+                changed = changed or survivor_id is not None
+            payload["prediction_ids"] = remapped_ids
+
+        if not changed:
             continue
-        survivor_id = prediction_id_map.get(old_prediction_id)
-        if survivor_id is None:
-            continue
-        payload["prediction_id"] = survivor_id
         conn.execute(
             "UPDATE edit_history_items SET old_value = ? WHERE id = ?",
             (json.dumps(payload, separators=(",", ":")), item_id),

--- a/vireo/schema.py
+++ b/vireo/schema.py
@@ -160,6 +160,114 @@ def _merge_review_winning_column_sql(column):
     """
 
 
+def _merge_null_species_predictions(conn):
+    """Explicit merge path for classifier predictions with ``species IS NULL``.
+
+    The main INSERT relies on the ``UNIQUE(detection_id, classifier_model,
+    labels_fingerprint, species)`` constraint to drive its ON CONFLICT UPSERT,
+    but SQLite treats NULLs as distinct in UNIQUE constraints — so two rows
+    with matching non-null columns and ``species = NULL`` do not collide.
+    Without this pass every legacy NULL-species prediction would be inserted
+    as a fresh row on the survivor detection, leaving a duplicate that
+    ``legacy_prediction_merge`` never maps to; that duplicate would then
+    surface as an extra cached prediction (with a stale higher confidence
+    than the merged winner).
+
+    For each legacy NULL-species prediction: if the survivor already has a
+    matching (classifier_model, labels_fingerprint, species=NULL) row, merge
+    into it using the same rules as the main UPSERT (winning confidence,
+    COALESCEd taxonomy, earliest created_at). Otherwise insert onto the
+    survivor. Subsequent losers targeting the same survivor row fall back
+    into the merge branch on the freshly inserted row.
+    """
+    null_losers = conn.execute(
+        """
+        SELECT m.survivor_id, p.classifier_model, p.labels_fingerprint,
+               p.confidence, p.category, p.scientific_name,
+               p.taxonomy_kingdom, p.taxonomy_phylum, p.taxonomy_class,
+               p.taxonomy_order, p.taxonomy_family, p.taxonomy_genus,
+               p.created_at
+        FROM predictions p
+        JOIN legacy_detection_merge m ON m.old_id = p.detection_id
+        WHERE p.species IS NULL
+        """
+    ).fetchall()
+
+    def _pick_higher_confidence(cur, new):
+        if cur is None:
+            return new
+        if new is None:
+            return cur
+        return max(cur, new)
+
+    def _pick_earlier(cur, new):
+        if cur is None:
+            return new
+        if new is None:
+            return cur
+        return min(cur, new)
+
+    for row in null_losers:
+        (survivor_id, classifier_model, labels_fingerprint, loser_confidence,
+         loser_category, loser_sci, loser_king, loser_phyl, loser_cls,
+         loser_ord, loser_fam, loser_gen, loser_created) = row
+
+        existing = conn.execute(
+            """
+            SELECT id, confidence, created_at
+            FROM predictions
+            WHERE detection_id = ?
+              AND classifier_model = ?
+              AND labels_fingerprint = ?
+              AND species IS NULL
+            """,
+            (survivor_id, classifier_model, labels_fingerprint),
+        ).fetchone()
+
+        if existing is None:
+            conn.execute(
+                """
+                INSERT INTO predictions (
+                  detection_id, classifier_model, labels_fingerprint, species,
+                  confidence, category, scientific_name, taxonomy_kingdom,
+                  taxonomy_phylum, taxonomy_class, taxonomy_order,
+                  taxonomy_family, taxonomy_genus, created_at
+                ) VALUES (?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (survivor_id, classifier_model, labels_fingerprint,
+                 loser_confidence, loser_category, loser_sci,
+                 loser_king, loser_phyl, loser_cls, loser_ord, loser_fam,
+                 loser_gen, loser_created),
+            )
+            continue
+
+        existing_id, existing_confidence, existing_created = existing
+        conn.execute(
+            """
+            UPDATE predictions
+            SET confidence = ?,
+                category = COALESCE(category, ?),
+                scientific_name = COALESCE(scientific_name, ?),
+                taxonomy_kingdom = COALESCE(taxonomy_kingdom, ?),
+                taxonomy_phylum = COALESCE(taxonomy_phylum, ?),
+                taxonomy_class = COALESCE(taxonomy_class, ?),
+                taxonomy_order = COALESCE(taxonomy_order, ?),
+                taxonomy_family = COALESCE(taxonomy_family, ?),
+                taxonomy_genus = COALESCE(taxonomy_genus, ?),
+                created_at = ?
+            WHERE id = ?
+            """,
+            (
+                _pick_higher_confidence(existing_confidence, loser_confidence),
+                loser_category, loser_sci,
+                loser_king, loser_phyl, loser_cls,
+                loser_ord, loser_fam, loser_gen,
+                _pick_earlier(existing_created, loser_created),
+                existing_id,
+            ),
+        )
+
+
 def _merge_legacy_detector_alias(conn):
     """Consolidate pre-versioned MegaDetector cache rows without losing review data.
 
@@ -440,7 +548,29 @@ def _merge_legacy_detector_alias(conn):
     # canonicalized by the rename above): another detector's mask can
     # coincidentally share the loser's prompt coordinates, and rewriting it
     # would break equality against its own detection row.
+    #
+    # Skip the remap when another retained megadetector-v6 detection on the
+    # same photo still sits at the loser's exact coordinates (for example the
+    # same box under a different category, outside this alias group). Because
+    # find_stale_masks compares only (detector_model, prompt_xywh) and ignores
+    # category, that mask remains fresh against the other detection — moving
+    # it to this group's survivor would point it at a different subject and
+    # make the cache stale.
     for photo_id, loser_coords, survivor_coords in mask_prompt_remaps:
+        other_match = conn.execute(
+            """
+            SELECT 1 FROM detections d
+            WHERE d.photo_id = ?
+              AND d.detector_model = ?
+              AND d.box_x = ? AND d.box_y = ?
+              AND d.box_w = ? AND d.box_h = ?
+              AND d.id NOT IN (SELECT old_id FROM legacy_detection_merge)
+            LIMIT 1
+            """,
+            (photo_id, _CANONICAL_DETECTOR_MODEL, *loser_coords),
+        ).fetchone()
+        if other_match is not None:
+            continue
         conn.execute(
             """
             UPDATE photo_masks
@@ -456,6 +586,13 @@ def _merge_legacy_detector_alias(conn):
     # Copy loser predictions onto their survivor detection. The identity UNIQUE
     # makes this both an insert for legacy-only information and a merge for output
     # already regenerated under the canonical detection id.
+    #
+    # NULL species is handled separately below: SQLite's UNIQUE constraint treats
+    # NULLs as distinct, so ON CONFLICT would never fire for species=NULL rows and
+    # a stray duplicate would be inserted on the survivor. That duplicate would
+    # not receive a `legacy_prediction_merge` entry pointing at it, so it would
+    # linger as an unmapped extra row and could surface as the top cached
+    # prediction (with a stale/higher confidence than the merged winner).
     conn.execute(
         """
         INSERT INTO predictions (
@@ -471,7 +608,7 @@ def _merge_legacy_detector_alias(conn):
                p.created_at
         FROM predictions p
         JOIN legacy_detection_merge m ON m.old_id = p.detection_id
-        WHERE 1
+        WHERE p.species IS NOT NULL
         ON CONFLICT(detection_id, classifier_model, labels_fingerprint, species)
         DO UPDATE SET
           confidence = CASE
@@ -496,6 +633,8 @@ def _merge_legacy_detector_alias(conn):
           END
         """
     )
+
+    _merge_null_species_predictions(conn)
 
     # Map every soon-to-be-deleted prediction id to the prediction that now owns
     # its identity on the survivor. This drives both review-state and undo-history

--- a/vireo/schema.py
+++ b/vireo/schema.py
@@ -251,6 +251,15 @@ def _merge_legacy_detector_alias(conn):
         """
     )
 
+    # find_stale_masks and count_extract_stale require exact equality between
+    # photo_masks.prompt_xywh and a detection row's box_xywh. When two aliased
+    # detections differ by sub-quantization drift (e.g. 0.10001 vs 0.10002),
+    # a mask created from the loser box would suddenly fail that equality
+    # against the surviving canonical row and be flagged stale. Track the
+    # (photo, loser_coords) -> survivor_coords remaps so we can realign the
+    # mask prompt in the same transaction.
+    mask_prompt_remaps: list[tuple[int, tuple, tuple]] = []
+
     for group_rows in groups.values():
         if not any(
             row["detector_model"] == _LEGACY_DETECTOR_MODEL
@@ -318,6 +327,24 @@ def _merge_legacy_detector_alias(conn):
             ],
         )
 
+        # Plan mask prompt remaps for every loser box whose exact coordinates
+        # differ from the survivor's. Skip rows with any NULL coordinate — a
+        # mask cannot exactly-match a NULL prompt column, so there is nothing
+        # to realign.
+        if any(value is None for value in coords):
+            continue
+        for row in group_rows:
+            loser_coords = (
+                row["box_x"], row["box_y"], row["box_w"], row["box_h"],
+            )
+            if any(value is None for value in loser_coords):
+                continue
+            if loser_coords == coords:
+                continue
+            mask_prompt_remaps.append(
+                (source["photo_id"], loser_coords, coords),
+            )
+
     # Keep the strongest cached confidence and oldest creation timestamp on the
     # survivor. In the normal duplicate case these values are already identical.
     conn.execute(
@@ -334,6 +361,23 @@ def _merge_legacy_detector_alias(conn):
         WHERE id IN (SELECT survivor_id FROM legacy_detector_groups)
         """
     )
+
+    # Realign mask prompts stored under a loser box to the survivor's exact
+    # coordinates so find_stale_masks and count_extract_stale keep matching
+    # after the alias merge. Runs before predictions are moved because
+    # photo_masks and detections are not FK-linked; ordering is only for
+    # locality with the group-building code above.
+    for photo_id, loser_coords, survivor_coords in mask_prompt_remaps:
+        conn.execute(
+            """
+            UPDATE photo_masks
+               SET prompt_x = ?, prompt_y = ?, prompt_w = ?, prompt_h = ?
+             WHERE photo_id = ?
+               AND prompt_x = ? AND prompt_y = ?
+               AND prompt_w = ? AND prompt_h = ?
+            """,
+            (*survivor_coords, photo_id, *loser_coords),
+        )
 
     # Copy loser predictions onto their survivor detection. The identity UNIQUE
     # makes this both an insert for legacy-only information and a merge for output

--- a/vireo/tests/test_schema.py
+++ b/vireo/tests/test_schema.py
@@ -312,6 +312,7 @@ def test_legacy_megadetector_alias_merge_preserves_predictions_and_reviews(tmp_p
             [
                 (300, workspace_id, "prediction_accept", "accepted Robin", "1"),
                 (301, workspace_id, "keyword_add", "added Sparrow", "1"),
+                (302, workspace_id, "prediction_accept", "accepted subject Sparrow", "1"),
             ],
         )
         db.conn.executemany(
@@ -330,6 +331,18 @@ def test_legacy_megadetector_alias_merge_preserves_predictions_and_reviews(tmp_p
                         {
                             "prediction_id": 202,
                             "prediction_status": "pending",
+                        }
+                    ),
+                    "1",
+                ),
+                (
+                    402,
+                    302,
+                    photo_id,
+                    json.dumps(
+                        {
+                            "prediction_ids": [201, 202, 203, 999],
+                            "no_tag": True,
                         }
                     ),
                     "1",
@@ -383,8 +396,18 @@ def test_legacy_megadetector_alias_merge_preserves_predictions_and_reviews(tmp_p
 
         bare_history = conn.execute("SELECT old_value FROM edit_history_items WHERE id = 400").fetchone()[0]
         json_history = json.loads(conn.execute("SELECT old_value FROM edit_history_items WHERE id = 401").fetchone()[0])
+        subject_history = json.loads(conn.execute("SELECT old_value FROM edit_history_items WHERE id = 402").fetchone()[0])
         assert bare_history == "200"
         assert json_history["prediction_id"] == by_species["Sparrow"]["id"]
+        assert subject_history == {
+            "prediction_ids": [
+                by_species["Robin"]["id"],
+                by_species["Sparrow"]["id"],
+                by_species["Hawk"]["id"],
+                999,
+            ],
+            "no_tag": True,
+        }
 
         detector_runs = conn.execute(
             """

--- a/vireo/tests/test_schema.py
+++ b/vireo/tests/test_schema.py
@@ -304,6 +304,9 @@ def test_legacy_megadetector_alias_merge_preserves_predictions_and_reviews(tmp_p
                 (empty_photo_id, "MegaDetector", "2026-04-23T04:01:00", 0),
             ],
         )
+        # Mask prompt matches the exact coordinates of a *legacy* row (id=101),
+        # not the canonical survivor (id=100). Without a prompt remap the mask
+        # would be flagged stale after the merge because 0.10001 != 0.10002.
         db.conn.execute(
             """
             INSERT INTO photo_masks (
@@ -313,7 +316,7 @@ def test_legacy_megadetector_alias_merge_preserves_predictions_and_reviews(tmp_p
             """,
             (
                 photo_id, "sam2-small", "/masks/bird.png", 1,
-                "MegaDetector", 0.10002, 0.2, 0.3, 0.4,
+                "MegaDetector", 0.10001, 0.2, 0.3, 0.4,
             ),
         )
         db.conn.executemany(
@@ -429,11 +432,20 @@ def test_legacy_megadetector_alias_merge_preserves_predictions_and_reviews(tmp_p
             "no_tag": True,
         }
 
-        mask_model = conn.execute(
-            "SELECT detector_model FROM photo_masks WHERE photo_id = ?",
+        mask_row = conn.execute(
+            """
+            SELECT detector_model, prompt_x, prompt_y, prompt_w, prompt_h
+            FROM photo_masks WHERE photo_id = ?
+            """,
             (photo_id,),
-        ).fetchone()[0]
-        assert mask_model == "megadetector-v6"
+        ).fetchone()
+        assert mask_row["detector_model"] == "megadetector-v6"
+        # Prompt coords must be realigned to the survivor detection's exact
+        # coordinates so find_stale_masks / count_extract_stale keep matching.
+        assert mask_row["prompt_x"] == pytest.approx(0.10002)
+        assert mask_row["prompt_y"] == pytest.approx(0.2)
+        assert mask_row["prompt_w"] == pytest.approx(0.3)
+        assert mask_row["prompt_h"] == pytest.approx(0.4)
 
         detector_runs = conn.execute(
             """

--- a/vireo/tests/test_schema.py
+++ b/vireo/tests/test_schema.py
@@ -4,6 +4,7 @@ import threading
 import pytest
 import schema
 from db import Database
+from detection_id import detection_id
 
 
 def test_ensure_schema_applies_registry_and_validation(tmp_path):
@@ -243,10 +244,10 @@ def test_legacy_megadetector_alias_merge_preserves_predictions_and_reviews(tmp_p
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             [
-                (100, photo_id, "megadetector-v6", 0.1, 0.2, 0.3, 0.4, 0.8, "animal", "2026-04-26T00:00:00"),
-                (101, photo_id, "MegaDetector", 0.1, 0.2, 0.3, 0.4, 0.9, "animal", "2026-04-23T00:00:00"),
+                (100, photo_id, "megadetector-v6", 0.10002, 0.2, 0.3, 0.4, 0.8, "animal", "2026-04-26T00:00:00"),
+                (101, photo_id, "MegaDetector", 0.10001, 0.2, 0.3, 0.4, 0.9, "animal", "2026-04-23T00:00:00"),
                 # A second pre-global-cache row for the same legacy box.
-                (102, photo_id, "MegaDetector", 0.1, 0.2, 0.3, 0.4, 0.85, "animal", "2026-04-23T00:01:00"),
+                (102, photo_id, "MegaDetector", 0.10003, 0.2, 0.3, 0.4, 0.85, "animal", "2026-04-23T00:01:00"),
                 # Legacy-only geometry must survive under the canonical name.
                 (103, photo_id, "MegaDetector", 0.6, 0.2, 0.2, 0.2, 0.7, "animal", "2026-04-23T00:02:00"),
             ],
@@ -312,7 +313,7 @@ def test_legacy_megadetector_alias_merge_preserves_predictions_and_reviews(tmp_p
             """,
             (
                 photo_id, "sam2-small", "/masks/bird.png", 1,
-                "MegaDetector", 0.1, 0.2, 0.3, 0.4,
+                "MegaDetector", 0.10002, 0.2, 0.3, 0.4,
             ),
         )
         db.conn.executemany(
@@ -370,20 +371,28 @@ def test_legacy_megadetector_alias_merge_preserves_predictions_and_reviews(tmp_p
 
     schema.ensure_schema(db_path)
 
+    primary_detection_id = detection_id(
+        photo_id, "megadetector-v6", (0.10002, 0.2, 0.3, 0.4), "animal",
+    )
+    hawk_detection_id = detection_id(
+        photo_id, "megadetector-v6", (0.6, 0.2, 0.2, 0.2), "animal",
+    )
     with sqlite3.connect(db_path) as conn:
         conn.row_factory = sqlite3.Row
         detections = conn.execute(
             """
-            SELECT id, detector_model, detector_confidence
+            SELECT id, detector_model, detector_confidence, box_x
             FROM detections WHERE photo_id = ? ORDER BY id
             """,
             (photo_id,),
         ).fetchall()
-        assert [(r["id"], r["detector_model"]) for r in detections] == [
-            (100, "megadetector-v6"),
-            (103, "megadetector-v6"),
-        ]
-        assert detections[0]["detector_confidence"] == pytest.approx(0.9)
+        assert {r["id"] for r in detections} == {
+            primary_detection_id, hawk_detection_id,
+        }
+        assert {r["detector_model"] for r in detections} == {"megadetector-v6"}
+        primary = next(r for r in detections if r["id"] == primary_detection_id)
+        assert primary["box_x"] == pytest.approx(0.10002)
+        assert primary["detector_confidence"] == pytest.approx(0.9)
 
         predictions = conn.execute(
             """
@@ -391,25 +400,24 @@ def test_legacy_megadetector_alias_merge_preserves_predictions_and_reviews(tmp_p
             FROM predictions p
             LEFT JOIN prediction_review r
               ON r.prediction_id = p.id AND r.workspace_id = ?
-            WHERE p.detection_id IN (100, 103)
+            WHERE p.detection_id IN (?, ?)
             ORDER BY p.species
             """,
-            (workspace_id,),
+            (workspace_id, primary_detection_id, hawk_detection_id),
         ).fetchall()
         by_species = {r["species"]: r for r in predictions}
         assert set(by_species) == {"Hawk", "Robin", "Sparrow"}
-        assert by_species["Robin"]["id"] == 200
         assert by_species["Robin"]["confidence"] == pytest.approx(0.9)
         assert by_species["Robin"]["status"] == "accepted"
-        assert by_species["Sparrow"]["detection_id"] == 100
+        assert by_species["Sparrow"]["detection_id"] == primary_detection_id
         assert by_species["Sparrow"]["status"] == "accepted"
-        assert by_species["Hawk"]["id"] == 203
+        assert by_species["Hawk"]["detection_id"] == hawk_detection_id
         assert by_species["Hawk"]["status"] == "accepted"
 
         bare_history = conn.execute("SELECT old_value FROM edit_history_items WHERE id = 400").fetchone()[0]
         json_history = json.loads(conn.execute("SELECT old_value FROM edit_history_items WHERE id = 401").fetchone()[0])
         subject_history = json.loads(conn.execute("SELECT old_value FROM edit_history_items WHERE id = 402").fetchone()[0])
-        assert bare_history == "200"
+        assert bare_history == str(by_species["Robin"]["id"])
         assert json_history["prediction_id"] == by_species["Sparrow"]["id"]
         assert subject_history == {
             "prediction_ids": [
@@ -445,6 +453,33 @@ def test_legacy_megadetector_alias_merge_preserves_predictions_and_reviews(tmp_p
 
     with Database(db_path, initialize_schema=False) as migrated_db:
         assert migrated_db.find_stale_masks() == []
+        rerun_ids = migrated_db.write_detection_batch(
+            photo_id,
+            "megadetector-v6",
+            [
+                {
+                    "box": {"x": 0.10002, "y": 0.2, "w": 0.3, "h": 0.4},
+                    "confidence": 0.9,
+                    "category": "animal",
+                },
+                {
+                    "box": {"x": 0.6, "y": 0.2, "w": 0.2, "h": 0.2},
+                    "confidence": 0.7,
+                    "category": "animal",
+                },
+            ],
+        )
+        assert set(rerun_ids) == {primary_detection_id, hawk_detection_id}
+        remaining = migrated_db.conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM predictions p
+            JOIN prediction_review r ON r.prediction_id = p.id
+            WHERE p.detection_id IN (?, ?) AND r.status = 'accepted'
+            """,
+            (primary_detection_id, hawk_detection_id),
+        ).fetchone()[0]
+        assert remaining == 3
 
 
 def test_legacy_megadetector_zero_box_run_is_normalized_without_detections(tmp_path):

--- a/vireo/tests/test_schema.py
+++ b/vireo/tests/test_schema.py
@@ -494,6 +494,102 @@ def test_legacy_megadetector_alias_merge_preserves_predictions_and_reviews(tmp_p
         assert remaining == 3
 
 
+def test_legacy_merge_realigns_masks_to_existing_survivor_row_coords(tmp_path):
+    """When a content-addressed canonical row already occupies ``survivor_id`` and a
+    lower-id canonical duplicate exists with different raw box coordinates, mask
+    prompts must be realigned to the retained row's coordinates. Using the lower-id
+    duplicate's coordinates (the previous behaviour) would leave every mask stale
+    against ``find_stale_masks``/``count_extract_stale``.
+    """
+    db_path = str(tmp_path / "vireo.db")
+    schema.ensure_schema(db_path)
+
+    occupant_coords = (0.10002, 0.2, 0.3, 0.4)
+    source_coords = (0.10001, 0.2, 0.3, 0.4)
+
+    with Database(db_path, initialize_schema=False) as db:
+        folder_id = db.add_folder(str(tmp_path / "photos"), name="photos")
+        photo_id = db.add_photo(
+            folder_id,
+            "bird.jpg",
+            ".jpg",
+            1,
+            1.0,
+            timestamp="2026-01-01T00:00:00",
+            width=100,
+            height=100,
+        )
+        occupant_id = detection_id(
+            photo_id, "megadetector-v6", occupant_coords, "animal",
+        )
+        # Guard: the retained row must have a non-trivial content-addressed id so
+        # the lower-id duplicate wins `min(..., key=row.id)`.
+        assert occupant_id != 100
+
+        db.conn.executemany(
+            """
+            INSERT INTO detections (
+              id, photo_id, detector_model, box_x, box_y, box_w, box_h,
+              detector_confidence, category, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                # Lower-id canonical duplicate — becomes ``source``.
+                (100, photo_id, "megadetector-v6",
+                 *source_coords, 0.8, "animal", "2026-04-24T00:00:00"),
+                # Existing content-addressed canonical row — becomes ``occupant``.
+                (occupant_id, photo_id, "megadetector-v6",
+                 *occupant_coords, 0.9, "animal", "2026-04-26T00:00:00"),
+                # A legacy row so this group is included in the merge.
+                (101, photo_id, "MegaDetector",
+                 *source_coords, 0.85, "animal", "2026-04-23T00:00:00"),
+            ],
+        )
+        # Mask stored at the retained row's exact coordinates. A remap targeting
+        # ``source``'s coordinates would break equality against every remaining
+        # detection.
+        db.conn.execute(
+            """
+            INSERT INTO photo_masks (
+              photo_id, variant, path, created_at, detector_model,
+              prompt_x, prompt_y, prompt_w, prompt_h
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (photo_id, "sam2-small", "/masks/bird.png", 1,
+             "megadetector-v6", *occupant_coords),
+        )
+        db.conn.commit()
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("PRAGMA user_version = 7")
+
+    schema.ensure_schema(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        detections = conn.execute(
+            "SELECT id, box_x, box_y, box_w, box_h FROM detections WHERE photo_id = ?",
+            (photo_id,),
+        ).fetchall()
+        # Only the pre-existing content-addressed row remains.
+        assert [r["id"] for r in detections] == [occupant_id]
+        assert detections[0]["box_x"] == pytest.approx(occupant_coords[0])
+
+        mask = conn.execute(
+            "SELECT prompt_x, prompt_y, prompt_w, prompt_h FROM photo_masks WHERE photo_id = ?",
+            (photo_id,),
+        ).fetchone()
+        assert (
+            mask["prompt_x"],
+            mask["prompt_y"],
+            mask["prompt_w"],
+            mask["prompt_h"],
+        ) == pytest.approx(occupant_coords)
+
+    with Database(db_path, initialize_schema=False) as migrated_db:
+        assert migrated_db.find_stale_masks() == []
+
+
 def test_legacy_megadetector_zero_box_run_is_normalized_without_detections(tmp_path):
     """A legacy empty-scene run has no detection row to drive the main merge."""
     db_path = str(tmp_path / "vireo.db")

--- a/vireo/tests/test_schema.py
+++ b/vireo/tests/test_schema.py
@@ -590,6 +590,121 @@ def test_legacy_merge_realigns_masks_to_existing_survivor_row_coords(tmp_path):
         assert migrated_db.find_stale_masks() == []
 
 
+def test_legacy_merge_prompt_remap_leaves_other_detector_masks_alone(tmp_path):
+    """The prompt remap must only touch MegaDetector-family masks.
+
+    ``find_stale_masks`` requires both ``detector_model`` and ``prompt_xywh``
+    equality with the photo's primary detection. If another model's mask
+    happens to share the loser MegaDetector box's exact coordinates, blindly
+    rewriting its prompt would leave the mask no longer matching any row for
+    its own detector, so a valid cache entry would be flagged stale and
+    deleted/re-extracted.
+    """
+    db_path = str(tmp_path / "vireo.db")
+    schema.ensure_schema(db_path)
+
+    canonical_coords = (0.10002, 0.2, 0.3, 0.4)
+    legacy_coords = (0.10001, 0.2, 0.3, 0.4)
+
+    with Database(db_path, initialize_schema=False) as db:
+        folder_id = db.add_folder(str(tmp_path / "photos"), name="photos")
+        photo_id = db.add_photo(
+            folder_id,
+            "bird.jpg",
+            ".jpg",
+            1,
+            1.0,
+            timestamp="2026-01-01T00:00:00",
+            width=100,
+            height=100,
+        )
+        db.conn.executemany(
+            """
+            INSERT INTO detections (
+              id, photo_id, detector_model, box_x, box_y, box_w, box_h,
+              detector_confidence, category, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                # MegaDetector alias pair to drive the merge — the canonical
+                # row at ``canonical_coords`` survives and the legacy row at
+                # ``legacy_coords`` becomes the loser.
+                (100, photo_id, "megadetector-v6",
+                 *canonical_coords, 0.8, "animal", "2026-04-26T00:00:00"),
+                (101, photo_id, "MegaDetector",
+                 *legacy_coords, 0.85, "animal", "2026-04-23T00:00:00"),
+                # An unrelated detector's box that coincidentally sits at
+                # the same coordinates as the loser MegaDetector row.
+                # Its higher confidence makes it the photo's primary
+                # detection, so find_stale_masks compares against it.
+                (200, photo_id, "grounding-dino",
+                 *legacy_coords, 0.95, "animal", "2026-04-24T00:00:00"),
+            ],
+        )
+        db.conn.executemany(
+            """
+            INSERT INTO photo_masks (
+              photo_id, variant, path, created_at, detector_model,
+              prompt_x, prompt_y, prompt_w, prompt_h
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                # Legacy MegaDetector mask — must be realigned to the
+                # canonical survivor's coordinates.
+                (photo_id, "sam2-small", "/masks/bird-mega.png", 1,
+                 "MegaDetector", *legacy_coords),
+                # Non-MegaDetector mask that already matches its own
+                # primary detection at ``legacy_coords``. The migration
+                # must not touch this row.
+                (photo_id, "sam2-large", "/masks/bird-dino.png", 1,
+                 "grounding-dino", *legacy_coords),
+            ],
+        )
+        db.conn.commit()
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("PRAGMA user_version = 7")
+
+    schema.ensure_schema(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        masks = {
+            row["variant"]: row
+            for row in conn.execute(
+                """
+                SELECT variant, detector_model,
+                       prompt_x, prompt_y, prompt_w, prompt_h
+                FROM photo_masks WHERE photo_id = ?
+                """,
+                (photo_id,),
+            )
+        }
+        mega = masks["sam2-small"]
+        assert mega["detector_model"] == "megadetector-v6"
+        assert (
+            mega["prompt_x"], mega["prompt_y"],
+            mega["prompt_w"], mega["prompt_h"],
+        ) == pytest.approx(canonical_coords)
+
+        dino = masks["sam2-large"]
+        assert dino["detector_model"] == "grounding-dino"
+        assert (
+            dino["prompt_x"], dino["prompt_y"],
+            dino["prompt_w"], dino["prompt_h"],
+        ) == pytest.approx(legacy_coords)
+        assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+
+    with Database(db_path, initialize_schema=False) as migrated_db:
+        # The grounding-dino mask matches its own primary detection and
+        # must not be flagged stale by the alias merge. The MegaDetector
+        # mask remains stale because the primary detection is dino, which
+        # is a normal (unrelated) staleness — not caused by the merge.
+        stale = migrated_db.find_stale_masks()
+        stale_variants = {row["variant"] for row in stale}
+        assert "sam2-large" not in stale_variants
+
+
 def test_legacy_megadetector_zero_box_run_is_normalized_without_detections(tmp_path):
     """A legacy empty-scene run has no detection row to drive the main merge."""
     db_path = str(tmp_path / "vireo.db")

--- a/vireo/tests/test_schema.py
+++ b/vireo/tests/test_schema.py
@@ -12,7 +12,7 @@ def test_ensure_schema_applies_registry_and_validation(tmp_path):
     schema.ensure_schema(db_path)
 
     with sqlite3.connect(db_path) as conn:
-        assert conn.execute("PRAGMA user_version").fetchone()[0] == 7
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 8
         assert conn.execute(
             "SELECT value FROM db_meta WHERE key='schema_manager'"
         ).fetchone()[0] == "registry-v1"
@@ -40,14 +40,14 @@ def test_failed_registry_migration_rolls_back_version_and_data(tmp_path, monkeyp
         )
         raise RuntimeError("simulated interruption")
 
-    migration = schema.Migration(8, "interrupted", fail_after_write)
+    migration = schema.Migration(9, "interrupted", fail_after_write)
     monkeypatch.setattr(schema, "MIGRATIONS", (*schema.MIGRATIONS, migration))
 
     with pytest.raises(RuntimeError, match="simulated interruption"):
         schema.ensure_schema(db_path)
 
     with sqlite3.connect(db_path) as conn:
-        assert conn.execute("PRAGMA user_version").fetchone()[0] == 7
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 8
         assert conn.execute(
             "SELECT 1 FROM db_meta WHERE key='partial_migration'"
         ).fetchone() is None
@@ -72,7 +72,7 @@ def test_concurrent_schema_startup_is_serialized(tmp_path):
     assert not errors
     assert all(not thread.is_alive() for thread in threads)
     with sqlite3.connect(db_path) as conn:
-        assert conn.execute("PRAGMA user_version").fetchone()[0] == 7
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 8
 
 
 def test_navigation_restore_changes_only_consolidated_default(tmp_path):
@@ -203,3 +203,244 @@ def test_navigation_consolidation_records_changed_ids(tmp_path, monkeypatch):
     assert marker is not None and marker[0] == "1"
     assert recorded is not None
     assert json.loads(recorded[0]) == [default_id]
+
+
+def test_legacy_megadetector_alias_merge_preserves_predictions_and_reviews(tmp_path):
+    """Skipped detector-key upgrades must not duplicate subjects or lose decisions."""
+    import json
+
+    db_path = str(tmp_path / "vireo.db")
+    schema.ensure_schema(db_path)
+
+    with Database(db_path, initialize_schema=False) as db:
+        workspace_id = db._active_workspace_id
+        folder_id = db.add_folder(str(tmp_path / "photos"), name="photos")
+        photo_id = db.add_photo(
+            folder_id,
+            "bird.jpg",
+            ".jpg",
+            1,
+            1.0,
+            timestamp="2026-01-01T00:00:00",
+            width=100,
+            height=100,
+        )
+        empty_photo_id = db.add_photo(
+            folder_id,
+            "empty.jpg",
+            ".jpg",
+            1,
+            1.0,
+            timestamp="2026-01-02T00:00:00",
+            width=100,
+            height=100,
+        )
+        db.conn.executemany(
+            """
+            INSERT INTO detections (
+              id, photo_id, detector_model, box_x, box_y, box_w, box_h,
+              detector_confidence, category, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (100, photo_id, "megadetector-v6", 0.1, 0.2, 0.3, 0.4, 0.8, "animal", "2026-04-26T00:00:00"),
+                (101, photo_id, "MegaDetector", 0.1, 0.2, 0.3, 0.4, 0.9, "animal", "2026-04-23T00:00:00"),
+                # A second pre-global-cache row for the same legacy box.
+                (102, photo_id, "MegaDetector", 0.1, 0.2, 0.3, 0.4, 0.85, "animal", "2026-04-23T00:01:00"),
+                # Legacy-only geometry must survive under the canonical name.
+                (103, photo_id, "MegaDetector", 0.6, 0.2, 0.2, 0.2, 0.7, "animal", "2026-04-23T00:02:00"),
+            ],
+        )
+        db.conn.executemany(
+            """
+            INSERT INTO predictions (
+              id, detection_id, classifier_model, labels_fingerprint,
+              species, confidence, category, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (200, 100, "BioCLIP-2.5", "birds", "Robin", 0.8, "match", "2026-04-26T01:00:00"),
+                (201, 101, "BioCLIP-2.5", "birds", "Robin", 0.9, "match", "2026-04-23T01:00:00"),
+                (202, 102, "iNat21", "tol", "Sparrow", 0.7, "conflict", "2026-04-23T01:01:00"),
+                (203, 103, "BioCLIP-2.5", "birds", "Hawk", 0.6, "new", "2026-04-23T01:02:00"),
+            ],
+        )
+        db.conn.executemany(
+            """
+            INSERT INTO prediction_review (
+              prediction_id, workspace_id, status, reviewed_at
+            ) VALUES (?, ?, ?, ?)
+            """,
+            [
+                (200, workspace_id, "pending", "2026-04-26T02:00:00"),
+                (201, workspace_id, "accepted", "2026-04-27T02:00:00"),
+                (202, workspace_id, "accepted", "2026-04-27T02:01:00"),
+                (203, workspace_id, "accepted", "2026-04-27T02:02:00"),
+            ],
+        )
+        db.conn.executemany(
+            """
+            INSERT INTO classifier_runs (
+              detection_id, classifier_model, labels_fingerprint,
+              run_at, prediction_count
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            [
+                (100, "BioCLIP-2.5", "birds", "2026-04-26T03:00:00", 1),
+                (101, "BioCLIP-2.5", "birds", "2026-04-27T03:00:00", 1),
+                (102, "iNat21", "tol", "2026-04-27T03:01:00", 1),
+            ],
+        )
+        db.conn.executemany(
+            """
+            INSERT INTO detector_runs (
+              photo_id, detector_model, run_at, box_count
+            ) VALUES (?, ?, ?, ?)
+            """,
+            [
+                (photo_id, "MegaDetector", "2026-04-23T04:00:00", 3),
+                (photo_id, "megadetector-v6", "2026-04-26T04:00:00", 1),
+                (empty_photo_id, "MegaDetector", "2026-04-23T04:01:00", 0),
+            ],
+        )
+        db.conn.executemany(
+            """
+            INSERT INTO edit_history (
+              id, workspace_id, action_type, description, new_value
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            [
+                (300, workspace_id, "prediction_accept", "accepted Robin", "1"),
+                (301, workspace_id, "keyword_add", "added Sparrow", "1"),
+            ],
+        )
+        db.conn.executemany(
+            """
+            INSERT INTO edit_history_items (
+              id, edit_id, photo_id, old_value, new_value
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            [
+                (400, 300, photo_id, "201", "1"),
+                (
+                    401,
+                    301,
+                    photo_id,
+                    json.dumps(
+                        {
+                            "prediction_id": 202,
+                            "prediction_status": "pending",
+                        }
+                    ),
+                    "1",
+                ),
+            ],
+        )
+        db.conn.commit()
+
+    # Reproduce a catalog that has completed v7 but skipped the old, unversioned
+    # detector-key normalization.
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("PRAGMA user_version = 7")
+
+    schema.ensure_schema(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        detections = conn.execute(
+            """
+            SELECT id, detector_model, detector_confidence
+            FROM detections WHERE photo_id = ? ORDER BY id
+            """,
+            (photo_id,),
+        ).fetchall()
+        assert [(r["id"], r["detector_model"]) for r in detections] == [
+            (100, "megadetector-v6"),
+            (103, "megadetector-v6"),
+        ]
+        assert detections[0]["detector_confidence"] == pytest.approx(0.9)
+
+        predictions = conn.execute(
+            """
+            SELECT p.id, p.detection_id, p.species, p.confidence, r.status
+            FROM predictions p
+            LEFT JOIN prediction_review r
+              ON r.prediction_id = p.id AND r.workspace_id = ?
+            WHERE p.detection_id IN (100, 103)
+            ORDER BY p.species
+            """,
+            (workspace_id,),
+        ).fetchall()
+        by_species = {r["species"]: r for r in predictions}
+        assert set(by_species) == {"Hawk", "Robin", "Sparrow"}
+        assert by_species["Robin"]["id"] == 200
+        assert by_species["Robin"]["confidence"] == pytest.approx(0.9)
+        assert by_species["Robin"]["status"] == "accepted"
+        assert by_species["Sparrow"]["detection_id"] == 100
+        assert by_species["Sparrow"]["status"] == "accepted"
+        assert by_species["Hawk"]["id"] == 203
+        assert by_species["Hawk"]["status"] == "accepted"
+
+        bare_history = conn.execute("SELECT old_value FROM edit_history_items WHERE id = 400").fetchone()[0]
+        json_history = json.loads(conn.execute("SELECT old_value FROM edit_history_items WHERE id = 401").fetchone()[0])
+        assert bare_history == "200"
+        assert json_history["prediction_id"] == by_species["Sparrow"]["id"]
+
+        detector_runs = conn.execute(
+            """
+            SELECT photo_id, detector_model, box_count
+            FROM detector_runs
+            WHERE photo_id IN (?, ?)
+            ORDER BY photo_id
+            """,
+            (photo_id, empty_photo_id),
+        ).fetchall()
+        assert [(r["photo_id"], r["detector_model"], r["box_count"]) for r in detector_runs] == [
+            (photo_id, "megadetector-v6", 2),
+            (empty_photo_id, "megadetector-v6", 0),
+        ]
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 8
+        assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+
+
+def test_legacy_megadetector_zero_box_run_is_normalized_without_detections(tmp_path):
+    """A legacy empty-scene run has no detection row to drive the main merge."""
+    db_path = str(tmp_path / "vireo.db")
+    schema.ensure_schema(db_path)
+
+    with Database(db_path, initialize_schema=False) as db:
+        folder_id = db.add_folder(str(tmp_path / "photos"), name="photos")
+        photo_id = db.add_photo(
+            folder_id,
+            "empty.jpg",
+            ".jpg",
+            1,
+            1.0,
+            timestamp="2026-01-02T00:00:00",
+            width=100,
+            height=100,
+        )
+        db.conn.execute(
+            """
+            INSERT INTO detector_runs (
+              photo_id, detector_model, run_at, box_count
+            ) VALUES (?, 'MegaDetector', '2026-04-23T04:01:00', 0)
+            """,
+            (photo_id,),
+        )
+        db.conn.commit()
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("PRAGMA user_version = 7")
+
+    schema.ensure_schema(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute(
+            """
+            SELECT detector_model, box_count FROM detector_runs
+            WHERE photo_id = ?
+            """,
+            (photo_id,),
+        ).fetchone() == ("megadetector-v6", 0)
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 8

--- a/vireo/tests/test_schema.py
+++ b/vireo/tests/test_schema.py
@@ -303,6 +303,18 @@ def test_legacy_megadetector_alias_merge_preserves_predictions_and_reviews(tmp_p
                 (empty_photo_id, "MegaDetector", "2026-04-23T04:01:00", 0),
             ],
         )
+        db.conn.execute(
+            """
+            INSERT INTO photo_masks (
+              photo_id, variant, path, created_at, detector_model,
+              prompt_x, prompt_y, prompt_w, prompt_h
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                photo_id, "sam2-small", "/masks/bird.png", 1,
+                "MegaDetector", 0.1, 0.2, 0.3, 0.4,
+            ),
+        )
         db.conn.executemany(
             """
             INSERT INTO edit_history (
@@ -409,6 +421,12 @@ def test_legacy_megadetector_alias_merge_preserves_predictions_and_reviews(tmp_p
             "no_tag": True,
         }
 
+        mask_model = conn.execute(
+            "SELECT detector_model FROM photo_masks WHERE photo_id = ?",
+            (photo_id,),
+        ).fetchone()[0]
+        assert mask_model == "megadetector-v6"
+
         detector_runs = conn.execute(
             """
             SELECT photo_id, detector_model, box_count
@@ -424,6 +442,9 @@ def test_legacy_megadetector_alias_merge_preserves_predictions_and_reviews(tmp_p
         ]
         assert conn.execute("PRAGMA user_version").fetchone()[0] == 8
         assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+
+    with Database(db_path, initialize_schema=False) as migrated_db:
+        assert migrated_db.find_stale_masks() == []
 
 
 def test_legacy_megadetector_zero_box_run_is_normalized_without_detections(tmp_path):

--- a/vireo/tests/test_schema.py
+++ b/vireo/tests/test_schema.py
@@ -1108,3 +1108,209 @@ def test_legacy_megadetector_zero_box_run_is_normalized_without_detections(tmp_p
             (photo_id,),
         ).fetchone() == ("megadetector-v6", 0)
         assert conn.execute("PRAGMA user_version").fetchone()[0] == 8
+
+
+def test_legacy_merge_prompt_remap_skips_when_other_detection_matches(tmp_path):
+    """Skip the mask prompt realignment when another retained megadetector-v6
+    detection on the same photo still sits at the loser's exact coordinates.
+
+    ``find_stale_masks`` compares only ``(detector_model, prompt_xywh)`` and
+    ignores category, so a mask that already matches that other detection
+    would remain fresh against it. Rewriting the mask to this alias group's
+    survivor coordinates would silently point it at a different subject and
+    turn a valid cache entry stale.
+    """
+    canonical_coords = (0.10002, 0.2, 0.3, 0.4)
+    legacy_coords = (0.10001, 0.2, 0.3, 0.4)
+
+    db_path = str(tmp_path / "vireo.db")
+    schema.ensure_schema(db_path)
+
+    with Database(db_path, initialize_schema=False) as db:
+        folder_id = db.add_folder(str(tmp_path / "photos"), name="photos")
+        photo_id = db.add_photo(
+            folder_id,
+            "bird.jpg",
+            ".jpg",
+            1,
+            1.0,
+            timestamp="2026-01-01T00:00:00",
+            width=100,
+            height=100,
+        )
+        # Unrelated megadetector-v6 detection whose coords equal the loser's
+        # (e.g. same box under a different category). Its id must fall outside
+        # ``legacy_detection_merge`` so it counts as retained.
+        other_detection_id = detection_id(
+            photo_id, "megadetector-v6", legacy_coords, "person",
+        )
+        db.conn.executemany(
+            """
+            INSERT INTO detections (
+              id, photo_id, detector_model, box_x, box_y, box_w, box_h,
+              detector_confidence, category, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                # MegaDetector alias pair — canonical survives, legacy loses.
+                (100, photo_id, "megadetector-v6",
+                 *canonical_coords, 0.8, "animal", "2026-04-26T00:00:00"),
+                (101, photo_id, "MegaDetector",
+                 *legacy_coords, 0.85, "animal", "2026-04-23T00:00:00"),
+                # Retained megadetector-v6 row co-located with the loser.
+                (other_detection_id, photo_id, "megadetector-v6",
+                 *legacy_coords, 0.95, "person", "2026-04-24T00:00:00"),
+            ],
+        )
+        # Mask stored under the loser's exact coordinates, model
+        # ``megadetector-v6`` (so both the ``other`` retained detection and
+        # the loser row share its ``(detector_model, prompt_xywh)`` identity).
+        db.conn.execute(
+            """
+            INSERT INTO photo_masks (
+              photo_id, variant, path, created_at, detector_model,
+              prompt_x, prompt_y, prompt_w, prompt_h
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (photo_id, "sam2-small", "/masks/bird.png", 1,
+             "megadetector-v6", *legacy_coords),
+        )
+        db.conn.commit()
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("PRAGMA user_version = 7")
+
+    schema.ensure_schema(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        mask = conn.execute(
+            """
+            SELECT detector_model, prompt_x, prompt_y, prompt_w, prompt_h
+            FROM photo_masks WHERE photo_id = ?
+            """,
+            (photo_id,),
+        ).fetchone()
+        # The mask must stay pinned to the loser coordinates because the
+        # retained ``other`` detection still matches it. Remapping to the
+        # alias survivor would make it stale against every remaining row.
+        assert mask["detector_model"] == "megadetector-v6"
+        assert (
+            mask["prompt_x"], mask["prompt_y"],
+            mask["prompt_w"], mask["prompt_h"],
+        ) == pytest.approx(legacy_coords)
+        assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+
+
+def test_legacy_merge_null_species_predictions_collapse_to_one_row(tmp_path):
+    """A migrated legacy/canonical pair whose classifier rows carry
+    ``species IS NULL`` must produce exactly one NULL-species prediction on
+    the survivor, not two.
+
+    SQLite treats NULLs as distinct in UNIQUE constraints, so the main
+    prediction INSERT's ON CONFLICT branch never fires for NULL species and
+    a naive UPSERT would insert a duplicate row. ``legacy_prediction_merge``
+    then maps review/history to ``MIN(new_p.id)`` and the extra row is left
+    unmapped — surfacing as an additional cached prediction with the loser's
+    (potentially higher) confidence.
+    """
+    canonical_coords = (0.10002, 0.2, 0.3, 0.4)
+    legacy_coords = (0.10001, 0.2, 0.3, 0.4)
+
+    db_path = str(tmp_path / "vireo.db")
+    schema.ensure_schema(db_path)
+
+    with Database(db_path, initialize_schema=False) as db:
+        workspace_id = db._active_workspace_id
+        folder_id = db.add_folder(str(tmp_path / "photos"), name="photos")
+        photo_id = db.add_photo(
+            folder_id,
+            "bird.jpg",
+            ".jpg",
+            1,
+            1.0,
+            timestamp="2026-01-01T00:00:00",
+            width=100,
+            height=100,
+        )
+        db.conn.executemany(
+            """
+            INSERT INTO detections (
+              id, photo_id, detector_model, box_x, box_y, box_w, box_h,
+              detector_confidence, category, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (100, photo_id, "megadetector-v6",
+                 *canonical_coords, 0.9, "animal", "2026-04-26T00:00:00"),
+                (101, photo_id, "MegaDetector",
+                 *legacy_coords, 0.9, "animal", "2026-04-23T00:00:00"),
+            ],
+        )
+        # Both classifier rows have species=NULL — the ambiguous "no
+        # confident label" output that classifiers cache alongside a
+        # confidence score. Same classifier_model/labels_fingerprint means
+        # they represent the same run identity on their respective detections.
+        db.conn.executemany(
+            """
+            INSERT INTO predictions (
+              id, detection_id, classifier_model, labels_fingerprint,
+              species, confidence, category, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (200, 100, "BioCLIP-2.5", "birds", None,
+                 0.4, "match", "2026-04-26T01:00:00"),
+                (201, 101, "BioCLIP-2.5", "birds", None,
+                 0.9, "match", "2026-04-23T01:00:00"),
+            ],
+        )
+        db.conn.execute(
+            """
+            INSERT INTO prediction_review (
+              prediction_id, workspace_id, status, reviewed_at
+            ) VALUES (?, ?, ?, ?)
+            """,
+            (201, workspace_id, "accepted", "2026-04-27T02:00:00"),
+        )
+        db.conn.commit()
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("PRAGMA user_version = 7")
+
+    schema.ensure_schema(db_path)
+
+    survivor_detection_id = detection_id(
+        photo_id, "megadetector-v6", canonical_coords, "animal",
+    )
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            """
+            SELECT id, species, confidence, created_at
+            FROM predictions
+            WHERE detection_id = ?
+              AND classifier_model = 'BioCLIP-2.5'
+              AND labels_fingerprint = 'birds'
+            """,
+            (survivor_detection_id,),
+        ).fetchall()
+        # Exactly one NULL-species row survives on the merged detection.
+        assert len(rows) == 1
+        survivor_prediction = rows[0]
+        assert survivor_prediction["species"] is None
+        # Winning confidence and earliest created_at are merged in.
+        assert survivor_prediction["confidence"] == pytest.approx(0.9)
+        assert survivor_prediction["created_at"] == "2026-04-23T01:00:00"
+
+        # The legacy prediction's review must carry over to the surviving row.
+        review = conn.execute(
+            """
+            SELECT status FROM prediction_review
+            WHERE prediction_id = ? AND workspace_id = ?
+            """,
+            (survivor_prediction["id"], workspace_id),
+        ).fetchone()
+        assert review is not None
+        assert review["status"] == "accepted"
+        assert conn.execute("PRAGMA foreign_key_check").fetchall() == []

--- a/vireo/tests/test_schema.py
+++ b/vireo/tests/test_schema.py
@@ -1202,6 +1202,118 @@ def test_legacy_merge_prompt_remap_skips_when_other_detection_matches(tmp_path):
         assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
 
 
+def test_legacy_merge_prompt_remap_moves_when_other_detection_is_not_primary(tmp_path):
+    """Remap the mask to the survivor coords when a retained megadetector-v6
+    row at the loser coordinates is lower-confidence than the merged survivor.
+
+    ``find_stale_masks`` picks a single primary detection per photo — the
+    highest-confidence non-full-image row, tie-broken by smallest id — and
+    only that row's coordinates keep the mask fresh. If a lower-confidence
+    retained detection happens to sit at the loser coords, the alias survivor
+    is still the primary; leaving the mask pinned to the loser coords would
+    immediately flag it stale, so the migration must move it to the survivor.
+    """
+    canonical_coords = (0.20002, 0.3, 0.4, 0.5)
+    legacy_coords = (0.20001, 0.3, 0.4, 0.5)
+
+    db_path = str(tmp_path / "vireo.db")
+    schema.ensure_schema(db_path)
+
+    with Database(db_path, initialize_schema=False) as db:
+        folder_id = db.add_folder(str(tmp_path / "photos"), name="photos")
+        photo_id = db.add_photo(
+            folder_id,
+            "bird.jpg",
+            ".jpg",
+            1,
+            1.0,
+            timestamp="2026-01-01T00:00:00",
+            width=100,
+            height=100,
+        )
+        # A retained megadetector-v6 row co-located with the loser but at a
+        # confidence lower than the merged alias survivor. It is NOT the
+        # post-merge primary, so leaving the mask at its coords would make it
+        # stale against the true primary (the alias survivor).
+        other_detection_id = detection_id(
+            photo_id, "megadetector-v6", legacy_coords, "person",
+        )
+        db.conn.executemany(
+            """
+            INSERT INTO detections (
+              id, photo_id, detector_model, box_x, box_y, box_w, box_h,
+              detector_confidence, category, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                # MegaDetector alias pair — survivor's max confidence is 0.9.
+                (200, photo_id, "megadetector-v6",
+                 *canonical_coords, 0.85, "animal", "2026-04-26T00:00:00"),
+                (201, photo_id, "MegaDetector",
+                 *legacy_coords, 0.9, "animal", "2026-04-23T00:00:00"),
+                # Retained non-primary detection at the loser coords.
+                (other_detection_id, photo_id, "megadetector-v6",
+                 *legacy_coords, 0.3, "person", "2026-04-24T00:00:00"),
+            ],
+        )
+        db.conn.execute(
+            """
+            INSERT INTO photo_masks (
+              photo_id, variant, path, created_at, detector_model,
+              prompt_x, prompt_y, prompt_w, prompt_h
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (photo_id, "sam2-small", "/masks/bird.png", 1,
+             "megadetector-v6", *legacy_coords),
+        )
+        db.conn.commit()
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("PRAGMA user_version = 7")
+
+    schema.ensure_schema(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        mask = conn.execute(
+            """
+            SELECT detector_model, prompt_x, prompt_y, prompt_w, prompt_h
+            FROM photo_masks WHERE photo_id = ?
+            """,
+            (photo_id,),
+        ).fetchone()
+        # Migrated: the mask must move to the survivor coordinates because
+        # the retained detection at the loser coords is not the primary.
+        assert mask["detector_model"] == "megadetector-v6"
+        assert (
+            mask["prompt_x"], mask["prompt_y"],
+            mask["prompt_w"], mask["prompt_h"],
+        ) == pytest.approx(canonical_coords)
+
+        # And find_stale_masks agrees: the mask is fresh against the
+        # post-merge primary (the alias survivor) at its new prompt coords.
+        stale_ids = conn.execute(
+            """
+            SELECT pm.rowid FROM photo_masks pm
+            WHERE NOT EXISTS (
+              SELECT 1 FROM detections d
+              WHERE d.id = (
+                SELECT d2.id FROM detections d2
+                WHERE d2.photo_id = pm.photo_id
+                  AND d2.detector_model != 'full-image'
+                ORDER BY d2.detector_confidence DESC, d2.id ASC
+                LIMIT 1
+              )
+                AND d.detector_model = pm.detector_model
+                AND d.box_x = pm.prompt_x AND d.box_y = pm.prompt_y
+                AND d.box_w = pm.prompt_w AND d.box_h = pm.prompt_h
+            )
+            """,
+        ).fetchall()
+        assert stale_ids == []
+        assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+
+
 def test_legacy_merge_null_species_predictions_collapse_to_one_row(tmp_path):
     """A migrated legacy/canonical pair whose classifier rows carry
     ``species IS NULL`` must produce exactly one NULL-species prediction on

--- a/vireo/tests/test_schema.py
+++ b/vireo/tests/test_schema.py
@@ -705,6 +705,222 @@ def test_legacy_merge_prompt_remap_leaves_other_detector_masks_alone(tmp_path):
         assert "sam2-large" not in stale_variants
 
 
+def test_legacy_merge_review_metadata_follows_winning_row(tmp_path):
+    """A conflicting prediction_review row must copy every merged column from
+    the same source row that wins the status/timestamp comparison. Otherwise a
+    newer rejected review from one row can end up alongside the older accepted
+    row's ``individual``/``group_id``/vote counts, and grouped-accept logic
+    then retags other photos with the loser row's metadata.
+    """
+    canonical_coords = (0.10002, 0.2, 0.3, 0.4)
+    legacy_coords = (0.10001, 0.2, 0.3, 0.4)
+
+    db_path = str(tmp_path / "vireo.db")
+    schema.ensure_schema(db_path)
+
+    with Database(db_path, initialize_schema=False) as db:
+        workspace_id = db._active_workspace_id
+        folder_id = db.add_folder(str(tmp_path / "photos"), name="photos")
+        photo_id = db.add_photo(
+            folder_id,
+            "bird.jpg",
+            ".jpg",
+            1,
+            1.0,
+            timestamp="2026-01-01T00:00:00",
+            width=100,
+            height=100,
+        )
+        db.conn.executemany(
+            """
+            INSERT INTO detections (
+              id, photo_id, detector_model, box_x, box_y, box_w, box_h,
+              detector_confidence, category, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (100, photo_id, "megadetector-v6",
+                 *canonical_coords, 0.9, "animal", "2026-04-26T00:00:00"),
+                (101, photo_id, "MegaDetector",
+                 *legacy_coords, 0.9, "animal", "2026-04-23T00:00:00"),
+            ],
+        )
+        # Two predictions with matching (classifier_model, labels_fingerprint,
+        # species) — one on the canonical detection, one on the legacy alias —
+        # collapse to a single survivor prediction during the merge.
+        db.conn.executemany(
+            """
+            INSERT INTO predictions (
+              id, detection_id, classifier_model, labels_fingerprint,
+              species, confidence, category, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (200, 100, "BioCLIP-2.5", "birds", "Robin", 0.8, "match", "2026-04-26T01:00:00"),
+                (201, 101, "BioCLIP-2.5", "birds", "Robin", 0.9, "match", "2026-04-23T01:00:00"),
+            ],
+        )
+        # Both predictions carry a prediction_review row for the SAME workspace,
+        # so the merge UPSERT hits the ON CONFLICT branch. The legacy row (201)
+        # has the more recent reviewed_at, so it wins the merge.
+        db.conn.executemany(
+            """
+            INSERT INTO prediction_review (
+              prediction_id, workspace_id, status, reviewed_at,
+              individual, group_id, vote_count, total_votes
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (200, workspace_id, "accepted", "2026-04-27T02:00:00",
+                 "bob", "groupB", 3, 5),
+                (201, workspace_id, "rejected", "2026-06-01T02:00:00",
+                 "alice", "groupA", 1, 2),
+            ],
+        )
+        db.conn.commit()
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("PRAGMA user_version = 7")
+
+    schema.ensure_schema(db_path)
+
+    survivor_detection_id = detection_id(
+        photo_id, "megadetector-v6", canonical_coords, "animal",
+    )
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        survivor_prediction = conn.execute(
+            """
+            SELECT id FROM predictions
+            WHERE detection_id = ? AND species = 'Robin'
+            """,
+            (survivor_detection_id,),
+        ).fetchone()
+        assert survivor_prediction is not None
+        review = conn.execute(
+            """
+            SELECT status, reviewed_at, individual, group_id,
+                   vote_count, total_votes
+            FROM prediction_review
+            WHERE prediction_id = ? AND workspace_id = ?
+            """,
+            (survivor_prediction["id"], workspace_id),
+        ).fetchone()
+        # The legacy row wins on reviewed_at, so every merged field must come
+        # from it — the auxiliary metadata cannot latch onto the accepted row.
+        assert review["status"] == "rejected"
+        assert review["reviewed_at"] == "2026-06-01T02:00:00"
+        assert review["individual"] == "alice"
+        assert review["group_id"] == "groupA"
+        assert review["vote_count"] == 1
+        assert review["total_votes"] == 2
+
+
+def test_legacy_merge_review_pending_loses_to_decided_metadata(tmp_path):
+    """When one review is 'pending' and the other is decided, the decided row
+    wins the status merge; every other merged column must follow it, so a
+    pending row's NULL metadata cannot outrank a decided row's group tag.
+    """
+    canonical_coords = (0.10002, 0.2, 0.3, 0.4)
+    legacy_coords = (0.10001, 0.2, 0.3, 0.4)
+
+    db_path = str(tmp_path / "vireo.db")
+    schema.ensure_schema(db_path)
+
+    with Database(db_path, initialize_schema=False) as db:
+        workspace_id = db._active_workspace_id
+        folder_id = db.add_folder(str(tmp_path / "photos"), name="photos")
+        photo_id = db.add_photo(
+            folder_id,
+            "bird.jpg",
+            ".jpg",
+            1,
+            1.0,
+            timestamp="2026-01-01T00:00:00",
+            width=100,
+            height=100,
+        )
+        db.conn.executemany(
+            """
+            INSERT INTO detections (
+              id, photo_id, detector_model, box_x, box_y, box_w, box_h,
+              detector_confidence, category, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (100, photo_id, "megadetector-v6",
+                 *canonical_coords, 0.9, "animal", "2026-04-26T00:00:00"),
+                (101, photo_id, "MegaDetector",
+                 *legacy_coords, 0.9, "animal", "2026-04-23T00:00:00"),
+            ],
+        )
+        db.conn.executemany(
+            """
+            INSERT INTO predictions (
+              id, detection_id, classifier_model, labels_fingerprint,
+              species, confidence, category, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (200, 100, "BioCLIP-2.5", "birds", "Robin", 0.8, "match", "2026-04-26T01:00:00"),
+                (201, 101, "BioCLIP-2.5", "birds", "Robin", 0.9, "match", "2026-04-23T01:00:00"),
+            ],
+        )
+        # Canonical (existing) is decided; legacy (excluded) is pending with a
+        # newer timestamp. The decided row must still win — and carry its own
+        # metadata even though the pending row's is NULL.
+        db.conn.executemany(
+            """
+            INSERT INTO prediction_review (
+              prediction_id, workspace_id, status, reviewed_at,
+              individual, group_id, vote_count, total_votes
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (200, workspace_id, "accepted", "2026-04-27T02:00:00",
+                 "bob", "groupB", 3, 5),
+                (201, workspace_id, "pending", "2026-06-01T02:00:00",
+                 None, None, None, None),
+            ],
+        )
+        db.conn.commit()
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("PRAGMA user_version = 7")
+
+    schema.ensure_schema(db_path)
+
+    survivor_detection_id = detection_id(
+        photo_id, "megadetector-v6", canonical_coords, "animal",
+    )
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        survivor_prediction = conn.execute(
+            """
+            SELECT id FROM predictions
+            WHERE detection_id = ? AND species = 'Robin'
+            """,
+            (survivor_detection_id,),
+        ).fetchone()
+        review = conn.execute(
+            """
+            SELECT status, reviewed_at, individual, group_id,
+                   vote_count, total_votes
+            FROM prediction_review
+            WHERE prediction_id = ? AND workspace_id = ?
+            """,
+            (survivor_prediction["id"], workspace_id),
+        ).fetchone()
+        # Decided beats pending regardless of timestamp; and every merged
+        # column keeps the decided row's values (not COALESCE'd from pending).
+        assert review["status"] == "accepted"
+        assert review["reviewed_at"] == "2026-04-27T02:00:00"
+        assert review["individual"] == "bob"
+        assert review["group_id"] == "groupB"
+        assert review["vote_count"] == 3
+        assert review["total_votes"] == 5
+
+
 def test_legacy_megadetector_zero_box_run_is_normalized_without_detections(tmp_path):
     """A legacy empty-scene run has no detection row to drive the main merge."""
     db_path = str(tmp_path / "vireo.db")

--- a/vireo/tests/test_schema.py
+++ b/vireo/tests/test_schema.py
@@ -921,6 +921,152 @@ def test_legacy_merge_review_pending_loses_to_decided_metadata(tmp_path):
         assert review["total_votes"] == 5
 
 
+def test_legacy_merge_rekeys_canonical_rows_without_content_ids(tmp_path):
+    """Catalogs that ran the short-lived unversioned rename may already carry
+    ``detector_model = 'megadetector-v6'`` yet keep the pre-rename rowid instead
+    of the content-addressed id. The migration must re-key those rows even when
+    no literal ``MegaDetector`` alias remains — otherwise the next detector
+    rerun UPSERTs under the true content-addressed id and deletes the old
+    canonical row, cascading its predictions/reviews.
+    """
+    box = (0.10002, 0.2, 0.3, 0.4)
+    other_box = (0.6, 0.2, 0.2, 0.2)
+
+    db_path = str(tmp_path / "vireo.db")
+    schema.ensure_schema(db_path)
+
+    with Database(db_path, initialize_schema=False) as db:
+        workspace_id = db._active_workspace_id
+        folder_id = db.add_folder(str(tmp_path / "photos"), name="photos")
+        photo_id = db.add_photo(
+            folder_id,
+            "bird.jpg",
+            ".jpg",
+            1,
+            1.0,
+            timestamp="2026-01-01T00:00:00",
+            width=100,
+            height=100,
+        )
+        expected_primary_id = detection_id(
+            photo_id, "megadetector-v6", box, "animal",
+        )
+        expected_other_id = detection_id(
+            photo_id, "megadetector-v6", other_box, "animal",
+        )
+        # Guard: force ids that cannot collide with the true content-addressed
+        # values, so the migration is genuinely re-keying.
+        assert 500 not in (expected_primary_id, expected_other_id)
+        assert 501 not in (expected_primary_id, expected_other_id)
+
+        db.conn.executemany(
+            """
+            INSERT INTO detections (
+              id, photo_id, detector_model, box_x, box_y, box_w, box_h,
+              detector_confidence, category, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (500, photo_id, "megadetector-v6",
+                 *box, 0.9, "animal", "2026-04-26T00:00:00"),
+                (501, photo_id, "megadetector-v6",
+                 *other_box, 0.7, "animal", "2026-04-26T00:00:00"),
+            ],
+        )
+        db.conn.executemany(
+            """
+            INSERT INTO predictions (
+              id, detection_id, classifier_model, labels_fingerprint,
+              species, confidence, category, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (600, 500, "BioCLIP-2.5", "birds", "Robin",
+                 0.9, "match", "2026-04-26T01:00:00"),
+                (601, 501, "BioCLIP-2.5", "birds", "Hawk",
+                 0.6, "new", "2026-04-26T01:00:00"),
+            ],
+        )
+        db.conn.executemany(
+            """
+            INSERT INTO prediction_review (
+              prediction_id, workspace_id, status, reviewed_at
+            ) VALUES (?, ?, ?, ?)
+            """,
+            [
+                (600, workspace_id, "accepted", "2026-04-27T02:00:00"),
+                (601, workspace_id, "accepted", "2026-04-27T02:01:00"),
+            ],
+        )
+        db.conn.commit()
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("PRAGMA user_version = 7")
+
+    schema.ensure_schema(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        detections = conn.execute(
+            "SELECT id, detector_model FROM detections WHERE photo_id = ? ORDER BY id",
+            (photo_id,),
+        ).fetchall()
+        assert {r["id"] for r in detections} == {
+            expected_primary_id, expected_other_id,
+        }
+        assert {r["detector_model"] for r in detections} == {"megadetector-v6"}
+
+        # Reviews and predictions must remain attached to the re-keyed detections.
+        surviving_predictions = conn.execute(
+            """
+            SELECT p.species, r.status
+            FROM predictions p
+            JOIN prediction_review r
+              ON r.prediction_id = p.id AND r.workspace_id = ?
+            WHERE p.detection_id IN (?, ?)
+            ORDER BY p.species
+            """,
+            (workspace_id, expected_primary_id, expected_other_id),
+        ).fetchall()
+        assert [(r["species"], r["status"]) for r in surviving_predictions] == [
+            ("Hawk", "accepted"),
+            ("Robin", "accepted"),
+        ]
+
+    # After the migration, rerunning the detector must be a no-op that keeps
+    # every prediction/review — this is the regression the reviewer flagged:
+    # without re-keying, `write_detection_batch` would delete the old row.
+    with Database(db_path, initialize_schema=False) as migrated_db:
+        rerun_ids = migrated_db.write_detection_batch(
+            photo_id,
+            "megadetector-v6",
+            [
+                {
+                    "box": {"x": box[0], "y": box[1], "w": box[2], "h": box[3]},
+                    "confidence": 0.9,
+                    "category": "animal",
+                },
+                {
+                    "box": {"x": other_box[0], "y": other_box[1],
+                            "w": other_box[2], "h": other_box[3]},
+                    "confidence": 0.7,
+                    "category": "animal",
+                },
+            ],
+        )
+        assert set(rerun_ids) == {expected_primary_id, expected_other_id}
+        remaining = migrated_db.conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM predictions p
+            JOIN prediction_review r ON r.prediction_id = p.id
+            WHERE p.detection_id IN (?, ?) AND r.status = 'accepted'
+            """,
+            (expected_primary_id, expected_other_id),
+        ).fetchone()[0]
+        assert remaining == 2
+
+
 def test_legacy_megadetector_zero_box_run_is_normalized_without_detections(tmp_path):
     """A legacy empty-scene run has no detection row to drive the main merge."""
     db_path = str(tmp_path / "vireo.db")


### PR DESCRIPTION
## Summary

- add an ordered schema migration that consolidates legacy `MegaDetector` detections with their canonical `megadetector-v6` counterparts
- preserve predictions, classifier runs, review decisions, and edit-history references while removing duplicate detection rows
- normalize legacy-only and zero-box detector runs so the migration is safe across catalog states

## Why

A temporary, unversioned normalization was removed before every installation had necessarily run it. Catalogs that skipped that release could later accumulate canonical rows alongside legacy rows for the same boxes. Compare then displayed the duplicate cache records as separate subjects.

## Verification

- `ruff check vireo/schema.py vireo/tests/test_schema.py`
- `pytest -q vireo/tests/test_schema.py` — 9 passed
- `pytest -q vireo/tests/test_app.py::test_compare_predictions_api_canonicalizes_alias_prediction` — 1 passed
- broader schema/compare/app selection — 27 passed, 1 unrelated order-dependent failure caused by fixture tag leakage (the failing test passes in isolation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration of legacy MegaDetector data to the current detector model.
  * Preserved detection details, classifier results, review status, and edit history during migration.
  * Normalized detector runs with no detections without creating duplicate records.
  * Added validation to ensure migrated data remains consistent and complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->