### PR TITLE
Improve NAS move reliability

### DIFF
--- a/vireo/app.py
+++ b/vireo/app.py
@@ -11996,6 +11996,24 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
             "new_count_so_far": progress.get("found", 0),
         }
 
+    def _new_images_walk_blocked_by_move():
+        """True while a storage move owns the source/archive filesystem.
+
+        The navbar probe is automatic and can otherwise start a whole-library
+        walk seconds after a move begins.  On SMB/NAS libraries that doubles
+        metadata/read pressure at exactly the point rsync is building its
+        file list.  Return a deferred pending response instead; the existing
+        client poll starts the walk after the move reaches a terminal state.
+        """
+        for job in app._job_runner.list_jobs():
+            if job.get("status") not in (
+                "queued", "running", "pausing", "paused",
+            ):
+                continue
+            if job.get("type") in ("move-folder", "move-photos"):
+                return True
+        return False
+
     @app.route("/api/workspaces/active/new-images")
     def api_workspace_new_images():
         db = _get_db()
@@ -12030,6 +12048,16 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                 "per_root": [],
                 "sample": [],
                 "error": recent_err,
+            })
+
+        if _new_images_walk_blocked_by_move():
+            return jsonify({
+                "workspace_id": ws_id,
+                "new_count": None,
+                "per_root": [],
+                "sample": [],
+                "pending": True,
+                "deferred_reason": "storage_move_active",
             })
 
         # Cache cold: run the filesystem walk in a background thread so the
@@ -12101,6 +12129,13 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         recent_err = cache.get_recent_error(db_path, ws_id)
         if recent_err is not None:
             return jsonify({"error": recent_err}), 500
+
+        if _new_images_walk_blocked_by_move():
+            return jsonify({
+                "pending": True,
+                "deferred_reason": "storage_move_active",
+                **_new_images_walk_progress_fields(db_path, ws_id),
+            }), 202
 
         # Cache cold (e.g. a scan just invalidated it): kick off — or
         # coalesce onto — a background walk. ``kickoff_compute`` reuses an

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -2092,14 +2092,18 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
     # from `.rsync-partial/` instead of treating it as already-moved (which
     # would then fail the --checksum verify forever, stranding the partial
     # until the user manually deletes it).
-    # Prefer a discovered GNU rsync even for local moves.  Finder-launched
+    # Prefer a discovered GNU rsync for local moves on POSIX. Finder-launched
     # macOS apps usually inherit a sparse PATH, so a bare ``rsync`` resolves
     # to Apple's legacy openrsync even when Homebrew GNU rsync is installed.
     # openrsync has been observed spinning after a transient SMB short read;
-    # GNU rsync exits with a useful error instead.  Keep the bare-name
-    # fallback for machines where GNU rsync is unavailable (and retain the
+    # GNU rsync exits with a useful error instead. Windows rsync distributions
+    # expect POSIX-style paths and can misread a native ``C:\...`` source as
+    # remote-shell syntax, so retain the prior bare-name behavior there. Keep
+    # the bare-name fallback on POSIX when GNU rsync is unavailable (and the
     # shutil fallback below when no rsync exists at all).
-    rsync_bin = resolve_rsync_bin() or "rsync"
+    rsync_bin = "rsync"
+    if sys.platform != "win32":
+        rsync_bin = resolve_rsync_bin() or rsync_bin
     extra_args = None
     if remote:
         rsync_bin = remote.get("rsync_bin")

--- a/vireo/move.py
+++ b/vireo/move.py
@@ -2092,7 +2092,14 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
     # from `.rsync-partial/` instead of treating it as already-moved (which
     # would then fail the --checksum verify forever, stranding the partial
     # until the user manually deletes it).
-    rsync_bin = "rsync"
+    # Prefer a discovered GNU rsync even for local moves.  Finder-launched
+    # macOS apps usually inherit a sparse PATH, so a bare ``rsync`` resolves
+    # to Apple's legacy openrsync even when Homebrew GNU rsync is installed.
+    # openrsync has been observed spinning after a transient SMB short read;
+    # GNU rsync exits with a useful error instead.  Keep the bare-name
+    # fallback for machines where GNU rsync is unavailable (and retain the
+    # shutil fallback below when no rsync exists at all).
+    rsync_bin = resolve_rsync_bin() or "rsync"
     extra_args = None
     if remote:
         rsync_bin = remote.get("rsync_bin")
@@ -2140,10 +2147,18 @@ def move_folder(db, folder_id, destination, progress_cb=None, developed_dir="",
 
     if timed_out:
         mins = RSYNC_STALL_TIMEOUT // 60
+        # rsync can emit the real cause (for example, the exact NAS file that
+        # returned a short read) and then wedge instead of exiting.  Do not
+        # throw that diagnostic away in favor of the generic watchdog text.
+        # Bound it because stderr can contain one warning per source file.
+        detail = stderr.strip()
+        if len(detail) > 1000:
+            detail = "…" + detail[-999:]
+        reported = f" rsync reported: {detail}" if detail else ""
         return {"moved": 0, "errors": [
             f"rsync stalled — no progress for over {mins} minutes, so the "
             f"copy was stopped. Originals are untouched; re-run with "
-            f"merge/resume to continue from where it left off."
+            f"merge/resume to continue from where it left off.{reported}"
         ]}
     if returncode != 0:
         return {"moved": 0, "errors": [f"rsync failed: {stderr.strip()}"]}

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -2407,6 +2407,58 @@ def test_move_folder_progress_shutil_fallback(move_env, monkeypatch):
     assert copy_calls[-1][1] == 3  # same 3-file denominator
 
 
+def test_move_folder_prefers_discovered_gnu_rsync(move_env, monkeypatch):
+    """Local NAS moves use discovered GNU rsync instead of a Finder app's
+    bare ``rsync`` resolving to macOS openrsync."""
+    import move as move_mod
+
+    env = move_env
+    captured = {}
+    monkeypatch.setattr(
+        move_mod, "resolve_rsync_bin", lambda configured="": "/gnu/rsync",
+    )
+
+    def fake_run(*args, **kwargs):
+        captured["rsync_bin"] = kwargs.get("rsync_bin")
+        return 1, "simulated failure", False
+
+    monkeypatch.setattr(move_mod, "_run_rsync_streamed", fake_run)
+    result = move_mod.move_folder(
+        db=env["db"], folder_id=env["fid_src"],
+        destination=str(env["dst"]),
+    )
+
+    assert captured["rsync_bin"] == "/gnu/rsync"
+    assert result["moved"] == 0
+
+
+def test_move_folder_stall_preserves_rsync_diagnostic(move_env, monkeypatch):
+    """A watchdog timeout includes stderr's filename/root cause instead of
+    replacing it with a generic 30-minute stall message."""
+    import move as move_mod
+
+    env = move_env
+    monkeypatch.setattr(
+        move_mod,
+        "_run_rsync_streamed",
+        lambda *args, **kwargs: (
+            -9,
+            "rsync: DSC_2042.NEF: file truncated while hashing\n",
+            True,
+        ),
+    )
+
+    result = move_mod.move_folder(
+        db=env["db"], folder_id=env["fid_src"],
+        destination=str(env["dst"]),
+    )
+
+    assert result["moved"] == 0
+    assert "stalled" in result["errors"][0]
+    assert "DSC_2042.NEF" in result["errors"][0]
+    assert "file truncated while hashing" in result["errors"][0]
+
+
 def test_move_folder_shutil_fallback_preserves_dir_symlink(move_env, monkeypatch):
     """The shutil fallback (rsync unavailable) must not silently drop a
     symlinked subdirectory. os.walk doesn't recurse into one, so without

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -2432,6 +2432,33 @@ def test_move_folder_prefers_discovered_gnu_rsync(move_env, monkeypatch):
     assert result["moved"] == 0
 
 
+def test_move_folder_windows_skips_discovered_rsync(move_env, monkeypatch):
+    """Native Windows paths must not be passed to auto-discovered POSIX rsync."""
+    import move as move_mod
+
+    env = move_env
+    captured = {}
+    monkeypatch.setattr(move_mod.sys, "platform", "win32")
+
+    def unexpected_resolve(configured=""):
+        raise AssertionError("Windows local moves must not discover rsync")
+
+    monkeypatch.setattr(move_mod, "resolve_rsync_bin", unexpected_resolve)
+
+    def fake_run(*args, **kwargs):
+        captured["rsync_bin"] = kwargs.get("rsync_bin")
+        return 1, "simulated failure", False
+
+    monkeypatch.setattr(move_mod, "_run_rsync_streamed", fake_run)
+    result = move_mod.move_folder(
+        db=env["db"], folder_id=env["fid_src"],
+        destination=str(env["dst"]),
+    )
+
+    assert captured["rsync_bin"] == "rsync"
+    assert result["moved"] == 0
+
+
 def test_move_folder_stall_preserves_rsync_diagnostic(move_env, monkeypatch):
     """A watchdog timeout includes stderr's filename/root cause instead of
     replacing it with a generic 30-minute stall message."""

--- a/vireo/tests/test_move.py
+++ b/vireo/tests/test_move.py
@@ -2414,6 +2414,7 @@ def test_move_folder_prefers_discovered_gnu_rsync(move_env, monkeypatch):
 
     env = move_env
     captured = {}
+    monkeypatch.setattr(move_mod.sys, "platform", "darwin")
     monkeypatch.setattr(
         move_mod, "resolve_rsync_bin", lambda configured="": "/gnu/rsync",
     )

--- a/vireo/tests/test_new_images_api.py
+++ b/vireo/tests/test_new_images_api.py
@@ -130,6 +130,50 @@ def test_api_new_images_returns_pending_when_walk_is_slow(app_and_db, monkeypatc
         release.set()
 
 
+def test_api_new_images_defers_walk_during_folder_move(app_and_db):
+    """The automatic navbar probe must not walk the NAS while rsync is moving
+    a folder on the same library."""
+    import threading
+    import time
+
+    app, db, ws_id, tmp_path = app_and_db
+    root = tmp_path / "shoot"
+    _touch_image(str(root / "IMG.JPG"))
+    db.add_folder(str(root), name="shoot")
+
+    release = threading.Event()
+    move_id = app._job_runner.start(
+        "move-folder",
+        lambda _job: release.wait(timeout=5),
+        workspace_id=ws_id,
+    )
+    client = app.test_client()
+    try:
+        resp = client.get("/api/workspaces/active/new-images")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["pending"] is True
+        assert data["deferred_reason"] == "storage_move_active"
+        assert not any(
+            job["type"] == "new_images_walk" and job["status"] == "running"
+            for job in app._job_runner.list_jobs()
+        )
+
+        snapshot = client.post(
+            "/api/workspaces/active/new-images/snapshot",
+        )
+        assert snapshot.status_code == 202
+        assert snapshot.get_json()["deferred_reason"] == "storage_move_active"
+    finally:
+        release.set()
+
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline:
+        if app._job_runner.get(move_id)["status"] != "running":
+            break
+        time.sleep(0.01)
+
+
 def test_api_new_images_returns_cached_after_background_compute_finishes(app_and_db):
     """Once the background walk finishes, the cache is populated and the next
     request returns the real count instantly — no second walk."""


### PR DESCRIPTION
## Summary

- defer automatic new-image directory walks while a folder or photo move is active
- use the discovered GNU `rsync` binary for local moves when available, avoiding the older system implementation under a sparse Finder launch environment
- retain bounded `rsync` stderr details when the move watchdog reports a stall

## Why

The observed move ran alongside automatic whole-library new-image scans and used the system `rsync` even though the configured GNU binary was installed. When the watchdog fired, its message omitted the most useful subprocess error context. These changes reduce competing NAS I/O and make genuine stalls diagnosable.

The scan guard is cooperative: it prevents new cold scans from starting while a move is active, but does not forcibly cancel a scan that was already underway.

## Verification

- `ruff check vireo/app.py vireo/move.py vireo/tests/test_move.py vireo/tests/test_new_images_api.py`
- `pytest -q vireo/tests/test_move.py vireo/tests/test_new_images_api.py` — 112 passed, 4 skipped