### PR TITLE
Improve move confirmation spacing

### DIFF
--- a/tests/e2e/test_move_page.py
+++ b/tests/e2e/test_move_page.py
@@ -46,6 +46,12 @@ def test_move_folder_button_shows_preflight_progress(live_server, page):
         "Confirm moving 3 photos from /photos/park to "
         "/tmp/vireo-archive/park?"
     )
+    assert page.locator("#confirmMessage").text_content() == (
+        "Confirm moving 3 photos from /photos/park to "
+        "/tmp/vireo-archive/park?\n\n"
+        "Files will be copied and verified before originals are removed."
+    )
+    expect(page.locator("#confirmMessage")).to_have_css("white-space", "pre-line")
     expect(btn).to_contain_text("Review move")
     expect(btn).to_be_enabled()
 

--- a/vireo/templates/move.html
+++ b/vireo/templates/move.html
@@ -508,7 +508,12 @@ body { padding-bottom: 48px; }
   line-height: 1.3;
   letter-spacing: -0.015em;
 }
-.confirm-message { color: var(--text-secondary); font-size: 13px; line-height: 1.5; }
+.confirm-message {
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.5;
+  white-space: pre-line;
+}
 .confirm-route {
   overflow: hidden;
   margin-bottom: 14px;
@@ -1514,8 +1519,8 @@ async function startQuickMove() {
     ? setQuickMoveSummary(folder, finalPath)
     : 'Confirm moving photos from ' + sourcePath + ' to ' + finalPath + '?';
   var verifyText = remoteId
-    ? ' Transferred over SSH and verified by checksum before originals are removed.'
-    : ' Files will be copied and verified before originals are removed.';
+    ? '\n\nTransferred over SSH and verified by checksum before originals are removed.'
+    : '\n\nFiles will be copied and verified before originals are removed.';
   if (pf.exists) {
     var p = pf.preview || {};
     var copyN = p.will_copy;


### PR DESCRIPTION
## Summary

Add a clear paragraph break between the move summary and the verification/removal safety note for local and SSH folder moves.
Preserve intentional line breaks in confirmation messages and add browser coverage for the rendered spacing and exact copy.

## Validation

`pytest -q tests/e2e/test_move_page.py` (7 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved move confirmation dialogs with clearer spacing between the move summary and safety instructions.
  * Preserved intended line breaks in confirmation messages for local and remote moves.
  * Added stricter validation to ensure confirmation text displays completely and accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->