### PR TITLE
Add burst and encounter rejection controls

### DIFF
--- a/tests/e2e/test_pipeline_review_group_reject.py
+++ b/tests/e2e/test_pipeline_review_group_reject.py
@@ -518,6 +518,21 @@ def test_burst_modal_apply_blocked_while_bulk_reject_pending(live_server, page):
     assert apply_requests == []
     assert _flags(db, photo_ids) == ["none"] * 4
 
+    # The native Photo > Pick command must use the page's batchSetFlag helper
+    # rather than bypassing the modal through /api/batch/flag. The pending
+    # reject stays put and no database write lands while the bulk lock is held.
+    page.evaluate("() => nativeMenuSetFlag('flagged')")
+    expect(
+        page.get_by_text(
+            "A bulk reject for the selected photos is still finishing",
+            exact=False,
+        )
+    ).to_be_visible()
+    expect(page.locator("#grmCount")).to_have_text(
+        "0 picks, 1 rejects, 1 unsorted"
+    )
+    assert _flags(db, photo_ids) == ["none"] * 4
+
     held["route"].continue_()
 
     expect(page.locator("#undoMsg")).to_have_text("Rejected 2 photos in burst")

--- a/tests/e2e/test_pipeline_review_group_reject.py
+++ b/tests/e2e/test_pipeline_review_group_reject.py
@@ -464,6 +464,55 @@ def test_single_photo_flag_blocked_while_bulk_reject_pending(live_server, page):
     assert _flags(db, photo_ids) == ["rejected"] * 4
 
 
+def test_single_photo_flag_blocked_while_bulk_undo_pending(live_server, page):
+    """Undo restores are bulk writes too, so they must retain the photo-ID
+    lock until every prior flag has been restored."""
+    db = live_server["db"]
+    photo_ids = live_server["data"]["photos"][:4]
+    _write_grouped_pipeline_cache(live_server, photo_ids)
+
+    page.goto(f"{live_server['url']}/pipeline/review")
+    burst_button = page.get_by_test_id("reject-burst").first
+    burst_button.click()
+    expect(page.locator("#undoMsg")).to_have_text("Rejected 2 photos in burst")
+    assert _flags(db, photo_ids) == ["rejected", "rejected", "none", "none"]
+
+    held = {}
+
+    def handle_batch_flag(route):
+        if "route" not in held:
+            held["route"] = route
+            return
+        route.continue_()
+
+    page.route("**/api/batch/flag", handle_batch_flag)
+    page.locator("#undoToast .undo-toast-btn").click()
+
+    deadline = time.time() + 5
+    while "route" not in held and time.time() < deadline:
+        page.wait_for_timeout(50)
+    assert "route" in held, "expected the undo batch write to be held"
+
+    page.evaluate(
+        "([photoId]) => window.setFlagFor(photoId, 'flagged')",
+        [photo_ids[0]],
+    )
+
+    expect(
+        page.get_by_text(
+            "A bulk reject for this photo is still finishing", exact=False
+        )
+    ).to_be_visible()
+    assert _flags(db, photo_ids) == ["rejected", "rejected", "none", "none"]
+
+    held["route"].continue_()
+
+    expect(
+        page.get_by_text("Restored previous flags for burst", exact=True)
+    ).to_be_visible()
+    assert _flags(db, photo_ids) == ["none"] * 4
+
+
 def test_encounter_reject_respects_active_label_filter(live_server, page):
     """Same guarantee as the burst-level test, but for the encounter-level
     Reject/Clear button: hidden KEEP frames stay untouched when the Review

--- a/tests/e2e/test_pipeline_review_group_reject.py
+++ b/tests/e2e/test_pipeline_review_group_reject.py
@@ -312,6 +312,55 @@ def test_burst_reject_respects_active_label_filter(live_server, page):
     assert _flags(db, photo_ids) == ["none", "none", "rejected", "rejected"]
 
 
+def test_clear_rejects_reads_live_db_flags(live_server, page):
+    """`Clear rejects` must not overwrite a photo the user picked live in
+    Browse (another tab) just because the client cache still shows it as
+    rejected. Regression: the bulk action derived changedIds and
+    previousFlags from pipelineResults.photos[].flag — a client-side cache
+    that page-init refreshes on load but that goes stale the moment a
+    parallel session mutates flags — so a subsequent "Clear rejects" click
+    silently cleared the live pick and Undo restored the stale 'rejected'
+    rather than the pick."""
+    db = live_server["db"]
+    photo_ids = live_server["data"]["photos"][:4]
+    _write_grouped_pipeline_cache(live_server, photo_ids)
+
+    page.goto(f"{live_server['url']}/pipeline/review")
+    burst_buttons = page.get_by_test_id("reject-burst")
+    expect(burst_buttons).to_have_count(2)
+
+    # Reject the first burst: both photos become 'rejected' in the DB and in
+    # the in-page pipelineResults cache. The button flips to "Clear rejects".
+    burst_buttons.first.click()
+    expect(burst_buttons.first).to_have_attribute("aria-label", "Clear rejects")
+    assert _flags(db, photo_ids) == ["rejected", "rejected", "none", "none"]
+
+    # Simulate a live pick made in another Browse tab: the DB updates but the
+    # already-rendered pipelineResults cache does not. The bulk button still
+    # reads "Clear rejects" even though the first photo is now a pick.
+    db.update_photo_flag(photo_ids[0], "flagged")
+    expect(burst_buttons.first).to_have_attribute("aria-label", "Clear rejects")
+
+    burst_buttons.first.click()
+
+    # Only the truly-rejected photo in the burst is cleared. The live pick
+    # is preserved; the second burst is untouched.
+    expect(page.locator("#undoMsg")).to_have_text(
+        "Cleared rejects from 1 photo in burst"
+    )
+    assert _flags(db, photo_ids) == ["flagged", "none", "none", "none"]
+
+    page.locator("#undoToast .undo-toast-btn").click()
+
+    expect(
+        page.get_by_text("Restored previous flags for burst", exact=True)
+    ).to_be_visible()
+    # Undo restores what was actually in the DB when the bulk action ran —
+    # the second photo goes back to 'rejected', and the live pick stays a
+    # pick rather than being clobbered by a stale cached value.
+    assert _flags(db, photo_ids) == ["flagged", "rejected", "none", "none"]
+
+
 def test_encounter_reject_respects_active_label_filter(live_server, page):
     """Same guarantee as the burst-level test, but for the encounter-level
     Reject/Clear button: hidden KEEP frames stay untouched when the Review

--- a/tests/e2e/test_pipeline_review_group_reject.py
+++ b/tests/e2e/test_pipeline_review_group_reject.py
@@ -1,0 +1,127 @@
+"""Process-review controls for rejecting a burst or full encounter."""
+
+import json
+import os
+
+from playwright.sync_api import expect
+
+
+def _write_grouped_pipeline_cache(live_server, photo_ids):
+    db = live_server["db"]
+    placeholders = ",".join("?" for _ in photo_ids)
+    rows = db.conn.execute(
+        f"SELECT id, filename, timestamp, flag FROM photos "
+        f"WHERE id IN ({placeholders}) ORDER BY id",
+        photo_ids,
+    ).fetchall()
+    photos = [
+        {
+            "id": row["id"],
+            "filename": row["filename"],
+            "timestamp": row["timestamp"],
+            "label": "REVIEW",
+            "quality_composite": 0.5,
+            "flag": row["flag"],
+            "rating": 0,
+        }
+        for row in rows
+    ]
+    ids = [photo["id"] for photo in photos]
+    bursts = [
+        {"photo_ids": ids[:2], "species_predictions": [], "species_override": None},
+        {"photo_ids": ids[2:], "species_predictions": [], "species_override": None},
+    ]
+    cache = {
+        "photos": photos,
+        "encounters": [
+            {
+                "photo_ids": ids,
+                "photo_count": len(ids),
+                "burst_count": len(bursts),
+                "time_range": [photos[0]["timestamp"], photos[-1]["timestamp"]],
+                "species": [],
+                "species_predictions": [],
+                "species_confirmed": False,
+                "confirmed_species": None,
+                "bursts": bursts,
+            }
+        ],
+        "summary": {
+            "total_photos": len(ids),
+            "encounter_count": 1,
+            "burst_count": len(bursts),
+            "keep_count": 0,
+            "review_count": len(ids),
+            "reject_count": 0,
+            "rarity_protected": 0,
+        },
+    }
+    path = os.path.join(
+        os.path.dirname(db._db_path),
+        f"pipeline_results_ws{db._active_workspace_id}.json",
+    )
+    with open(path, "w") as cache_file:
+        json.dump(cache, cache_file)
+
+
+def _flags(db, photo_ids):
+    placeholders = ",".join("?" for _ in photo_ids)
+    rows = db.conn.execute(
+        f"SELECT id, flag FROM photos WHERE id IN ({placeholders}) ORDER BY id",
+        photo_ids,
+    ).fetchall()
+    return [row["flag"] for row in rows]
+
+
+def test_reject_burst_and_undo_restores_prior_flags(live_server, page):
+    db = live_server["db"]
+    photo_ids = live_server["data"]["photos"][:4]
+    db.update_photo_flag(photo_ids[0], "flagged")
+    _write_grouped_pipeline_cache(live_server, photo_ids)
+
+    page.goto(f"{live_server['url']}/pipeline/review")
+    burst_buttons = page.get_by_test_id("reject-burst")
+    expect(burst_buttons).to_have_count(2)
+
+    burst_buttons.first.click()
+
+    expect(page.locator("#undoMsg")).to_have_text("Rejected 2 photos in burst")
+    expect(page.get_by_test_id("reject-burst").first).to_have_attribute(
+        "aria-label", "Clear rejects"
+    )
+    assert _flags(db, photo_ids) == ["rejected", "rejected", "none", "none"]
+    expect(
+        page.locator(f'.photo-card[data-photo-id="{photo_ids[0]}"] .flag-rejected')
+    ).to_have_text("X")
+
+    page.locator("#undoToast .undo-toast-btn").click()
+
+    expect(page.get_by_test_id("reject-burst").first).to_have_attribute(
+        "aria-label", "Reject burst"
+    )
+    expect(page.get_by_text("Restored previous flags for burst", exact=True)).to_be_visible()
+    assert _flags(db, photo_ids) == ["flagged", "none", "none", "none"]
+
+
+def test_reject_and_clear_full_encounter(live_server, page):
+    db = live_server["db"]
+    photo_ids = live_server["data"]["photos"][:4]
+    _write_grouped_pipeline_cache(live_server, photo_ids)
+
+    page.goto(f"{live_server['url']}/pipeline/review")
+    encounter_button = page.get_by_test_id("reject-encounter")
+    expect(encounter_button).to_have_attribute("aria-label", "Reject encounter")
+
+    encounter_button.click()
+
+    expect(encounter_button).to_have_attribute("aria-label", "Clear rejects")
+    expect(page.locator("#undoMsg")).to_have_text("Rejected 4 photos in encounter")
+    assert _flags(db, photo_ids) == ["rejected"] * 4
+
+    encounter_button.click()
+
+    expect(encounter_button).to_have_attribute("aria-label", "Reject encounter")
+    expect(page.locator("#undoMsg")).to_have_text(
+        "Cleared rejects from 4 photos in encounter"
+    )
+    assert _flags(db, photo_ids) == ["none"] * 4

--- a/tests/e2e/test_pipeline_review_group_reject.py
+++ b/tests/e2e/test_pipeline_review_group_reject.py
@@ -513,6 +513,30 @@ def test_single_photo_flag_blocked_while_bulk_undo_pending(live_server, page):
     assert _flags(db, photo_ids) == ["none"] * 4
 
 
+def test_bulk_reject_surfaces_live_flag_read_failure(live_server, page):
+    """A failed live-state read must use the standard request error toast
+    instead of silently abandoning the group action."""
+    db = live_server["db"]
+    photo_ids = live_server["data"]["photos"][:4]
+    _write_grouped_pipeline_cache(live_server, photo_ids)
+
+    page.goto(f"{live_server['url']}/pipeline/review")
+    page.route(
+        "**/api/pipeline/group/state",
+        lambda route: route.fulfill(
+            status=500,
+            json={"error": "Could not read current photo flags"},
+        ),
+    )
+
+    page.get_by_test_id("reject-burst").first.click()
+
+    expect(
+        page.get_by_text("Could not read current photo flags", exact=True)
+    ).to_be_visible()
+    assert _flags(db, photo_ids) == ["none"] * 4
+
+
 def test_encounter_reject_respects_active_label_filter(live_server, page):
     """Same guarantee as the burst-level test, but for the encounter-level
     Reject/Clear button: hidden KEEP frames stay untouched when the Review

--- a/tests/e2e/test_pipeline_review_group_reject.py
+++ b/tests/e2e/test_pipeline_review_group_reject.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import re
 import time
 
 from playwright.sync_api import expect
@@ -446,11 +447,12 @@ def test_single_photo_flag_blocked_while_bulk_reject_pending(live_server, page):
         page.wait_for_timeout(50)
     assert "route" in held, "expected the encounter group-state read to be held"
 
-    page.evaluate(
+    landed = page.evaluate(
         "([photoId]) => window.setFlagFor(photoId, 'flagged')",
         [photo_ids[0]],
     )
 
+    assert landed is False
     expect(
         page.get_by_text(
             "A bulk reject for this photo is still finishing", exact=False
@@ -462,6 +464,64 @@ def test_single_photo_flag_blocked_while_bulk_reject_pending(live_server, page):
 
     expect(page.locator("#undoMsg")).to_have_text("Rejected 4 photos in encounter")
     assert _flags(db, photo_ids) == ["rejected"] * 4
+
+
+def test_burst_modal_apply_blocked_while_bulk_reject_pending(live_server, page):
+    """The burst review modal writes flags through its own group/apply route,
+    so it must consult the shared photo-ID lock independently."""
+    db = live_server["db"]
+    photo_ids = live_server["data"]["photos"][:4]
+    _write_grouped_pipeline_cache(live_server, photo_ids)
+
+    page.goto(f"{live_server['url']}/pipeline/review")
+    held = {}
+
+    def handle_group_state(route):
+        if "route" not in held:
+            held["route"] = route
+            return
+        route.continue_()
+
+    page.route("**/api/pipeline/group/state", handle_group_state)
+    page.get_by_test_id("reject-burst").first.click()
+
+    deadline = time.time() + 5
+    while "route" not in held and time.time() < deadline:
+        page.wait_for_timeout(50)
+    assert "route" in held, "expected the bulk live-state read to be held"
+
+    # The grid remains interactive while the bulk read is pending. Open the
+    # same burst in the modal, make a reject decision, and try to apply it.
+    page.locator(f'.photo-card[data-photo-id="{photo_ids[0]}"] img').click()
+    expect(page.locator("#grmApplyBtn")).to_be_enabled()
+    page.keyboard.press("x")
+    expect(page.locator("#grmApplyFlagsChk")).to_be_checked()
+
+    apply_requests = []
+    page.on(
+        "request",
+        lambda request: (
+            apply_requests.append(request)
+            if "/api/pipeline/group/apply" in request.url
+            else None
+        ),
+    )
+    page.locator("#grmApplyBtn").click()
+
+    expect(
+        page.get_by_text(
+            "A bulk reject for this group is still finishing", exact=False
+        )
+    ).to_be_visible()
+    expect(page.locator("#grmOverlay")).to_have_class(re.compile(r"\bopen\b"))
+    expect(page.locator("#grmApplyBtn")).to_be_enabled()
+    assert apply_requests == []
+    assert _flags(db, photo_ids) == ["none"] * 4
+
+    held["route"].continue_()
+
+    expect(page.locator("#undoMsg")).to_have_text("Rejected 2 photos in burst")
+    assert _flags(db, photo_ids) == ["rejected", "rejected", "none", "none"]
 
 
 def test_single_photo_flag_blocked_while_bulk_undo_pending(live_server, page):

--- a/tests/e2e/test_pipeline_review_group_reject.py
+++ b/tests/e2e/test_pipeline_review_group_reject.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import time
 
 from playwright.sync_api import expect
 
@@ -359,6 +360,63 @@ def test_clear_rejects_reads_live_db_flags(live_server, page):
     # the second photo goes back to 'rejected', and the live pick stays a
     # pick rather than being clobbered by a stale cached value.
     assert _flags(db, photo_ids) == ["flagged", "rejected", "none", "none"]
+
+
+def test_burst_reject_blocked_while_encounter_reject_pending(live_server, page):
+    """When an encounter reject is still writing, clicking a burst reject
+    inside it must be blocked — otherwise both requests snapshot
+    previousFlags from the pre-first-action DB read, and the burst's later
+    Undo could restore the shared photos to 'none', silently rolling back
+    part of the encounter reject."""
+    db = live_server["db"]
+    photo_ids = live_server["data"]["photos"][:4]
+    _write_grouped_pipeline_cache(live_server, photo_ids)
+
+    page.goto(f"{live_server['url']}/pipeline/review")
+    burst_buttons = page.get_by_test_id("reject-burst")
+    expect(burst_buttons).to_have_count(2)
+    encounter_button = page.get_by_test_id("reject-encounter")
+
+    # Hold the encounter's /api/pipeline/group/state request in flight so
+    # its bulk action keeps the lock while we try to fire a burst-level
+    # bulk action. Only hold the first call — post-release runs and the
+    # test cleanup issue further live reads that must pass through.
+    held = {}
+
+    def handle_group_state(route):
+        if "route" not in held:
+            held["route"] = route
+            return
+        route.continue_()
+
+    page.route("**/api/pipeline/group/state", handle_group_state)
+
+    encounter_button.click()
+
+    deadline = time.time() + 5
+    while "route" not in held and time.time() < deadline:
+        page.wait_for_timeout(50)
+    assert "route" in held, "expected the encounter group-state read to be held"
+
+    # Clicking a burst reject inside the still-writing encounter must be
+    # blocked with a user-visible toast, not silently kick off a second
+    # bulk action.
+    burst_buttons.first.click()
+    expect(
+        page.get_by_text(
+            "Another bulk reject is still finishing", exact=False
+        )
+    ).to_be_visible()
+    # The blocked burst click must not have altered any DB flags: the
+    # encounter's write is still gated on the held read.
+    assert _flags(db, photo_ids) == ["none"] * 4
+
+    # Release the encounter read so its bulk write can proceed against the
+    # real endpoint (the batch-flag call is not intercepted).
+    held["route"].continue_()
+
+    expect(page.locator("#undoMsg")).to_have_text("Rejected 4 photos in encounter")
+    assert _flags(db, photo_ids) == ["rejected"] * 4
 
 
 def test_encounter_reject_respects_active_label_filter(live_server, page):

--- a/tests/e2e/test_pipeline_review_group_reject.py
+++ b/tests/e2e/test_pipeline_review_group_reject.py
@@ -224,3 +224,117 @@ def test_encounter_reject_skips_hidden_confirmed_bursts(live_server, page):
         "Cleared rejects from 2 photos in encounter"
     )
     assert _flags(db, photo_ids) == ["none"] * 4
+
+
+def _write_mixed_label_pipeline_cache(live_server, photo_ids):
+    """Encounter with a single burst whose photos carry mixed labels so
+    changing the label filter hides some frames inside the burst."""
+    db = live_server["db"]
+    placeholders = ",".join("?" for _ in photo_ids)
+    rows = db.conn.execute(
+        f"SELECT id, filename, timestamp, flag FROM photos "
+        f"WHERE id IN ({placeholders}) ORDER BY id",
+        photo_ids,
+    ).fetchall()
+    # First two photos are KEEP, last two are REVIEW. Selecting the REVIEW
+    # filter should hide the KEEP frames but still render the burst.
+    labels = ["KEEP", "KEEP", "REVIEW", "REVIEW"]
+    photos = [
+        {
+            "id": row["id"],
+            "filename": row["filename"],
+            "timestamp": row["timestamp"],
+            "label": labels[idx],
+            "quality_composite": 0.5,
+            "flag": row["flag"],
+            "rating": 0,
+        }
+        for idx, row in enumerate(rows)
+    ]
+    ids = [photo["id"] for photo in photos]
+    bursts = [
+        {"photo_ids": ids, "species_predictions": [], "species_override": None},
+    ]
+    cache = {
+        "photos": photos,
+        "encounters": [
+            {
+                "photo_ids": ids,
+                "photo_count": len(ids),
+                "burst_count": len(bursts),
+                "time_range": [photos[0]["timestamp"], photos[-1]["timestamp"]],
+                "species": [],
+                "species_predictions": [],
+                "species_confirmed": False,
+                "confirmed_species": None,
+                "bursts": bursts,
+            }
+        ],
+        "summary": {
+            "total_photos": len(ids),
+            "encounter_count": 1,
+            "burst_count": len(bursts),
+            "keep_count": 2,
+            "review_count": 2,
+            "reject_count": 0,
+            "rarity_protected": 0,
+        },
+    }
+    path = os.path.join(
+        os.path.dirname(db._db_path),
+        f"pipeline_results_ws{db._active_workspace_id}.json",
+    )
+    with open(path, "w") as cache_file:
+        json.dump(cache, cache_file)
+
+
+def test_burst_reject_respects_active_label_filter(live_server, page):
+    """When the Review label filter is active, clicking `Reject burst` must
+    only touch photos that pass the filter. Regression for the case where the
+    button targeted the raw burst photo list, so it could flip flags on
+    KEEP/non-conflict frames hidden by the filter."""
+    db = live_server["db"]
+    photo_ids = live_server["data"]["photos"][:4]
+    _write_mixed_label_pipeline_cache(live_server, photo_ids)
+
+    page.goto(f"{live_server['url']}/pipeline/review")
+    page.locator('.filter-btn[data-filter="REVIEW"]').click()
+    # Two KEEP frames hide; the two REVIEW frames remain rendered in the burst.
+    expect(page.locator(".photo-card")).to_have_count(2)
+
+    burst_button = page.get_by_test_id("reject-burst")
+    burst_button.click()
+
+    expect(page.locator("#undoMsg")).to_have_text("Rejected 2 photos in burst")
+    expect(burst_button).to_have_attribute("aria-label", "Clear rejects")
+    # The hidden KEEP frames must be untouched; only the visible REVIEW frames
+    # are rejected.
+    assert _flags(db, photo_ids) == ["none", "none", "rejected", "rejected"]
+
+
+def test_encounter_reject_respects_active_label_filter(live_server, page):
+    """Same guarantee as the burst-level test, but for the encounter-level
+    Reject/Clear button: hidden KEEP frames stay untouched when the Review
+    filter is active."""
+    db = live_server["db"]
+    photo_ids = live_server["data"]["photos"][:4]
+    _write_mixed_label_pipeline_cache(live_server, photo_ids)
+
+    page.goto(f"{live_server['url']}/pipeline/review")
+    page.locator('.filter-btn[data-filter="REVIEW"]').click()
+    expect(page.locator(".photo-card")).to_have_count(2)
+
+    encounter_button = page.get_by_test_id("reject-encounter")
+    encounter_button.click()
+
+    expect(page.locator("#undoMsg")).to_have_text("Rejected 2 photos in encounter")
+    expect(encounter_button).to_have_attribute("aria-label", "Clear rejects")
+    assert _flags(db, photo_ids) == ["none", "none", "rejected", "rejected"]
+
+    encounter_button.click()
+
+    expect(encounter_button).to_have_attribute("aria-label", "Reject encounter")
+    expect(page.locator("#undoMsg")).to_have_text(
+        "Cleared rejects from 2 photos in encounter"
+    )
+    assert _flags(db, photo_ids) == ["none"] * 4

--- a/tests/e2e/test_pipeline_review_group_reject.py
+++ b/tests/e2e/test_pipeline_review_group_reject.py
@@ -125,3 +125,102 @@ def test_reject_and_clear_full_encounter(live_server, page):
         "Cleared rejects from 4 photos in encounter"
     )
     assert _flags(db, photo_ids) == ["none"] * 4
+
+
+def _write_partially_confirmed_pipeline_cache(live_server, photo_ids):
+    """Encounter with a confirmed first burst and an unconfirmed second burst."""
+    db = live_server["db"]
+    placeholders = ",".join("?" for _ in photo_ids)
+    rows = db.conn.execute(
+        f"SELECT id, filename, timestamp, flag FROM photos "
+        f"WHERE id IN ({placeholders}) ORDER BY id",
+        photo_ids,
+    ).fetchall()
+    photos = [
+        {
+            "id": row["id"],
+            "filename": row["filename"],
+            "timestamp": row["timestamp"],
+            "label": "REVIEW",
+            "quality_composite": 0.5,
+            "flag": row["flag"],
+            "rating": 0,
+        }
+        for row in rows
+    ]
+    ids = [photo["id"] for photo in photos]
+    bursts = [
+        {
+            "photo_ids": ids[:2],
+            "species_predictions": [],
+            "species_override": {"species": "American Robin", "confirmed": True},
+        },
+        {"photo_ids": ids[2:], "species_predictions": [], "species_override": None},
+    ]
+    cache = {
+        "photos": photos,
+        "encounters": [
+            {
+                "photo_ids": ids,
+                "photo_count": len(ids),
+                "burst_count": len(bursts),
+                "time_range": [photos[0]["timestamp"], photos[-1]["timestamp"]],
+                "species": [],
+                "species_predictions": [],
+                "species_confirmed": False,
+                "confirmed_species": None,
+                "bursts": bursts,
+            }
+        ],
+        "summary": {
+            "total_photos": len(ids),
+            "encounter_count": 1,
+            "burst_count": len(bursts),
+            "keep_count": 0,
+            "review_count": len(ids),
+            "reject_count": 0,
+            "rarity_protected": 0,
+        },
+    }
+    path = os.path.join(
+        os.path.dirname(db._db_path),
+        f"pipeline_results_ws{db._active_workspace_id}.json",
+    )
+    with open(path, "w") as cache_file:
+        json.dump(cache, cache_file)
+
+
+def test_encounter_reject_skips_hidden_confirmed_bursts(live_server, page):
+    """With `Hide confirmed` active, the encounter-level Reject/Clear button
+    must only touch the bursts that are actually rendered — not the ones the
+    user hid by confirming their species. Regression for the case where the
+    header control read `Clear rejects`/`Reject encounter` off the whole
+    photo list, so clicking it could flip flags on invisible photos."""
+    db = live_server["db"]
+    photo_ids = live_server["data"]["photos"][:4]
+    _write_partially_confirmed_pipeline_cache(live_server, photo_ids)
+
+    page.goto(f"{live_server['url']}/pipeline/review")
+    expect(page.locator(".burst-strip")).to_have_count(2)
+
+    page.locator("#hideConfirmedBtn").click()
+    expect(page.locator(".burst-strip")).to_have_count(1)
+
+    encounter_button = page.get_by_test_id("reject-encounter")
+    expect(encounter_button).to_have_attribute("aria-label", "Reject encounter")
+
+    encounter_button.click()
+
+    expect(encounter_button).to_have_attribute("aria-label", "Clear rejects")
+    expect(page.locator("#undoMsg")).to_have_text("Rejected 2 photos in encounter")
+    # First (confirmed, hidden) burst must be untouched; only the visible
+    # unconfirmed burst's photos are rejected.
+    assert _flags(db, photo_ids) == ["none", "none", "rejected", "rejected"]
+
+    encounter_button.click()
+
+    expect(encounter_button).to_have_attribute("aria-label", "Reject encounter")
+    expect(page.locator("#undoMsg")).to_have_text(
+        "Cleared rejects from 2 photos in encounter"
+    )
+    assert _flags(db, photo_ids) == ["none"] * 4

--- a/tests/e2e/test_pipeline_review_group_reject.py
+++ b/tests/e2e/test_pipeline_review_group_reject.py
@@ -419,6 +419,51 @@ def test_burst_reject_blocked_while_encounter_reject_pending(live_server, page):
     assert _flags(db, photo_ids) == ["rejected"] * 4
 
 
+def test_single_photo_flag_blocked_while_bulk_reject_pending(live_server, page):
+    """The shared lightbox/per-photo flag path must honor the same photo-ID
+    lock as overlapping bulk actions. Otherwise a pick made while the bulk
+    request is paused can be overwritten by the eventual batch write and its
+    Undo restores the pre-pick snapshot."""
+    db = live_server["db"]
+    photo_ids = live_server["data"]["photos"][:4]
+    _write_grouped_pipeline_cache(live_server, photo_ids)
+
+    page.goto(f"{live_server['url']}/pipeline/review")
+    encounter_button = page.get_by_test_id("reject-encounter")
+    held = {}
+
+    def handle_group_state(route):
+        if "route" not in held:
+            held["route"] = route
+            return
+        route.continue_()
+
+    page.route("**/api/pipeline/group/state", handle_group_state)
+    encounter_button.click()
+
+    deadline = time.time() + 5
+    while "route" not in held and time.time() < deadline:
+        page.wait_for_timeout(50)
+    assert "route" in held, "expected the encounter group-state read to be held"
+
+    page.evaluate(
+        "([photoId]) => window.setFlagFor(photoId, 'flagged')",
+        [photo_ids[0]],
+    )
+
+    expect(
+        page.get_by_text(
+            "A bulk reject for this photo is still finishing", exact=False
+        )
+    ).to_be_visible()
+    assert _flags(db, photo_ids) == ["none"] * 4
+
+    held["route"].continue_()
+
+    expect(page.locator("#undoMsg")).to_have_text("Rejected 4 photos in encounter")
+    assert _flags(db, photo_ids) == ["rejected"] * 4
+
+
 def test_encounter_reject_respects_active_label_filter(live_server, page):
     """Same guarantee as the burst-level test, but for the encounter-level
     Reject/Clear button: hidden KEEP frames stay untouched when the Review

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -3799,6 +3799,18 @@ function restorePipelineReviewFlags(previousFlags, noun) {
     var flag = normalizedPipelineReviewFlag(previousFlags[pid]);
     byFlag[flag].push(parseInt(pid, 10));
   });
+  var ids = Object.keys(previousFlags).map(function(pid) { return parseInt(pid, 10); });
+  // Undo is another bulk flag write and must hold the same photo-ID lock as
+  // the forward action. Otherwise a pick/reject started while these restore
+  // requests are running can be overwritten by the older snapshot.
+  var overlaps = ids.some(function(pid) {
+    return pipelineReviewGroupFlagInFlightPhotoIds.has(pid);
+  });
+  if (overlaps) {
+    showToast('Another flag change is still finishing — try Undo again in a moment', 'error');
+    return Promise.resolve();
+  }
+  ids.forEach(function(pid) { pipelineReviewGroupFlagInFlightPhotoIds.add(pid); });
   var sequence = Promise.resolve();
   ['none', 'flagged', 'rejected'].forEach(function(flag) {
     if (!byFlag[flag].length) return;
@@ -3818,6 +3830,8 @@ function restorePipelineReviewFlags(previousFlags, noun) {
     renderResults();
     showToast('Restored previous flags for ' + noun, 'success');
     refreshLatestScopeSnapshotIfCurrent();
+  }).finally(function() {
+    ids.forEach(function(pid) { pipelineReviewGroupFlagInFlightPhotoIds.delete(pid); });
   });
 }
 

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -3873,7 +3873,7 @@ function setPipelineReviewGroupFlag(target, flag) {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({photo_ids: ids, species: ''}),
-  }, {toast: false}).then(function(data) {
+  }).then(function(data) {
     var live = (data && data.photos) || {};
     var liveFlagFor = function(pid) {
       return normalizedPipelineReviewFlag(live[pid] && live[pid].flag);

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -3944,6 +3944,15 @@ function setPipelineReviewFlag(photoId, flag) {
     notifyReadOnlyScopedView();
     return Promise.resolve();
   }
+  // A group action snapshots live flags before writing its batch. Allowing a
+  // per-photo pick/reject for one of those same IDs before the batch finishes
+  // would let the batch overwrite the newer choice, while its Undo would
+  // restore the older snapshot. Honor the group lock here as well as in the
+  // bulk path so every overlapping flag write is serialized.
+  if (pipelineReviewGroupFlagInFlightPhotoIds.has(photoId)) {
+    showToast('A bulk reject for this photo is still finishing — try again in a moment', 'error');
+    return Promise.resolve();
+  }
 
   return safeFetch('/api/photos/' + photoId + '/flag', {
     method: 'POST',

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -378,6 +378,32 @@
   cursor: default;
 }
 .encounter-footer:hover { background: var(--bg-tertiary); }
+.group-reject-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex-shrink: 0;
+  border: 1px solid color-mix(in srgb, var(--danger) 65%, var(--border-primary));
+  border-radius: 5px;
+  padding: 4px 8px;
+  background: transparent;
+  color: var(--danger);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+}
+.group-reject-btn:hover {
+  background: color-mix(in srgb, var(--danger) 12%, transparent);
+  border-color: var(--danger);
+}
+.group-reject-btn.all-rejected {
+  background: color-mix(in srgb, var(--danger) 16%, transparent);
+}
+.group-reject-btn:disabled {
+  opacity: 0.55;
+  cursor: wait;
+}
 
 /* Burst strip */
 .burst-strip {
@@ -396,6 +422,13 @@
   writing-mode: vertical-lr;
   text-orientation: mixed;
   padding: 4px 0;
+  flex-shrink: 0;
+}
+.burst-controls {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 4px;
   flex-shrink: 0;
 }
 
@@ -3078,7 +3111,9 @@ function renderResults() {
     if (timeRange) html += '<span>' + timeRange + '</span>';
     html += missingTimestampBadge(enc);
     html += renderEncounterSpeciesConflict(enc, speciesConflictEvidence, confirmedHiddenIds);
-    html += '</span></div>';
+    html += '</span>';
+    html += renderGroupRejectButton('encounter', ei, null, encPhotoIds, photoMap);
+    html += '</div>';
     html += '<div class="encounter-body" id="encBody' + ei + '"' + (isCollapsed ? ' style="display:none;"' : '') + '>';
 
     if (enc.bursts && enc.bursts.length > 0) {
@@ -3086,7 +3121,7 @@ function renderResults() {
         if (hideConfirmed && isBurstConfirmed(enc, burst)) return;
         var burstIds = burst.photo_ids || burst;
         html += '<div class="burst-strip">';
-        html += '<div style="display:flex;align-items:center;gap:6px;margin-bottom:4px;">';
+        html += '<div class="burst-controls">';
         if (enc.bursts.length > 1) {
           html += '<span class="burst-label">B' + (bi+1) + '</span>';
         }
@@ -3098,6 +3133,7 @@ function renderResults() {
           html += '<span class="burst-species-edit" onclick="toggleSpeciesDropdown(event,' + ei + ',' + bi + ',\'top\')">&#9998;</span>';
         }
         html += renderBurstSpeciesConflict(enc, ei, burst, bi, speciesConflictEvidence);
+        html += renderGroupRejectButton('burst', ei, bi, burstIds, photoMap);
         html += '<button class="detach-btn" onclick="detachBurst(' + ei + ',' + bi + ')" title="Detach burst">&times;</button>';
         html += '</div>';
         burstIds.forEach(function(pid) {
@@ -3636,9 +3672,159 @@ function findEncounterForPhoto(photoId) {
 }
 
 var inspectPhotoId = null;
+var pipelineReviewGroupFlagInFlight = {};
 
 function pipelineReviewBareKey(e, key) {
   return !e.ctrlKey && !e.metaKey && !e.altKey && e.key && e.key.toLowerCase() === key;
+}
+
+function normalizedPipelineReviewFlag(flag) {
+  return flag === 'flagged' || flag === 'rejected' ? flag : 'none';
+}
+
+function updatePipelineReviewPhotoFlag(photo, flag) {
+  if (!photo) return;
+  photo.flag = flag;
+  // Rejected photos lose representative eligibility server-side
+  // (get_species_representatives(eligible_only=True) filters them out), so
+  // mirror that in the review cache immediately.
+  if (flag === 'rejected') {
+    if (photo.is_species_representative) photo.is_species_representative = false;
+    if (Array.isArray(photo.life_list)) {
+      photo.life_list.forEach(function(entry) {
+        if (!entry) return;
+        if (entry.is_current_photo) entry.is_current_photo = false;
+        if (entry.is_species_representative) entry.is_species_representative = false;
+      });
+    }
+  }
+}
+
+function renderGroupRejectButton(kind, encIdx, burstIdx, photoIds, photoMap) {
+  photoIds = Array.isArray(photoIds) ? photoIds : [];
+  var allRejected = photoIds.length > 0 && photoIds.every(function(pid) {
+    return photoMap[pid] && photoMap[pid].flag === 'rejected';
+  });
+  var noun = kind === 'burst' ? 'burst' : 'encounter';
+  var label = allRejected ? 'Clear rejects' : 'Reject ' + noun;
+  var title = allRejected
+    ? 'Clear the rejected flag from every photo in this ' + noun
+    : 'Mark every photo in this ' + noun + ' as rejected';
+  var handler = kind === 'burst'
+    ? 'toggleBurstRejected(event,' + encIdx + ',' + burstIdx + ')'
+    : 'toggleEncounterRejected(event,' + encIdx + ')';
+  var testId = kind === 'burst' ? 'reject-burst' : 'reject-encounter';
+  return '<button type="button" class="group-reject-btn' + (allRejected ? ' all-rejected' : '') +
+    '" data-testid="' + testId + '" onclick="' + handler + '" title="' + escapeAttr(title) +
+    '" aria-label="' + escapeAttr(label) + '"><span aria-hidden="true">&times;</span>' +
+    escapeHtml(label) + '</button>';
+}
+
+function groupFlagTarget(encIdx, burstIdx) {
+  if (!pipelineResults || !pipelineResults.encounters) return null;
+  var enc = pipelineResults.encounters[encIdx];
+  if (!enc) return null;
+  if (burstIdx == null) {
+    return {key: 'encounter:' + encIdx, noun: 'encounter', photoIds: enc.photo_ids || []};
+  }
+  var burst = enc.bursts && enc.bursts[burstIdx];
+  if (!burst) return null;
+  return {
+    key: 'burst:' + encIdx + ':' + burstIdx,
+    noun: 'burst',
+    photoIds: burst.photo_ids || burst || [],
+  };
+}
+
+function restorePipelineReviewFlags(previousFlags, noun) {
+  var byFlag = {none: [], flagged: [], rejected: []};
+  Object.keys(previousFlags).forEach(function(pid) {
+    var flag = normalizedPipelineReviewFlag(previousFlags[pid]);
+    byFlag[flag].push(parseInt(pid, 10));
+  });
+  var sequence = Promise.resolve();
+  ['none', 'flagged', 'rejected'].forEach(function(flag) {
+    if (!byFlag[flag].length) return;
+    sequence = sequence.then(function() {
+      return safeFetch('/api/batch/flag', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({photo_ids: byFlag[flag], flag: flag}),
+      }).then(function() {
+        byFlag[flag].forEach(function(pid) {
+          updatePipelineReviewPhotoFlag(findPhotoInResults(pid), flag);
+        });
+      });
+    });
+  });
+  return sequence.then(function() {
+    renderResults();
+    showToast('Restored previous flags for ' + noun, 'success');
+    refreshLatestScopeSnapshotIfCurrent();
+  });
+}
+
+function setPipelineReviewGroupFlag(target, flag) {
+  if (!target || pipelineReviewGroupFlagInFlight[target.key]) return Promise.resolve();
+  if (isScopedReviewView()) {
+    notifyReadOnlyScopedView();
+    return Promise.resolve();
+  }
+  var ids = Array.from(new Set((target.photoIds || []).map(function(pid) {
+    return parseInt(pid, 10);
+  }).filter(function(pid) { return !!pid && !!findPhotoInResults(pid); })));
+  var changedIds = ids.filter(function(pid) {
+    return normalizedPipelineReviewFlag(findPhotoInResults(pid).flag) !== flag;
+  });
+  if (!changedIds.length) return Promise.resolve();
+
+  var previousFlags = {};
+  changedIds.forEach(function(pid) {
+    previousFlags[pid] = normalizedPipelineReviewFlag(findPhotoInResults(pid).flag);
+  });
+  pipelineReviewGroupFlagInFlight[target.key] = true;
+  return safeFetch('/api/batch/flag', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({photo_ids: changedIds, flag: flag}),
+  }).then(function() {
+    changedIds.forEach(function(pid) {
+      updatePipelineReviewPhotoFlag(findPhotoInResults(pid), flag);
+    });
+    renderResults();
+    refreshLatestScopeSnapshotIfCurrent();
+    var count = changedIds.length;
+    var message = flag === 'rejected'
+      ? 'Rejected ' + count + ' photo' + (count === 1 ? '' : 's') + ' in ' + target.noun
+      : 'Cleared rejects from ' + count + ' photo' + (count === 1 ? '' : 's') + ' in ' + target.noun;
+    showUndo(message, function() {
+      restorePipelineReviewFlags(previousFlags, target.noun);
+    });
+  }).finally(function() {
+    delete pipelineReviewGroupFlagInFlight[target.key];
+  });
+}
+
+function toggleEncounterRejected(event, encIdx) {
+  if (event && event.stopPropagation) event.stopPropagation();
+  var target = groupFlagTarget(encIdx, null);
+  if (!target) return;
+  var allRejected = target.photoIds.length > 0 && target.photoIds.every(function(pid) {
+    var photo = findPhotoInResults(pid);
+    return photo && photo.flag === 'rejected';
+  });
+  setPipelineReviewGroupFlag(target, allRejected ? 'none' : 'rejected');
+}
+
+function toggleBurstRejected(event, encIdx, burstIdx) {
+  if (event && event.stopPropagation) event.stopPropagation();
+  var target = groupFlagTarget(encIdx, burstIdx);
+  if (!target) return;
+  var allRejected = target.photoIds.length > 0 && target.photoIds.every(function(pid) {
+    var photo = findPhotoInResults(pid);
+    return photo && photo.flag === 'rejected';
+  });
+  setPipelineReviewGroupFlag(target, allRejected ? 'none' : 'rejected');
 }
 
 function setPipelineReviewFlag(photoId, flag) {
@@ -3657,23 +3843,7 @@ function setPipelineReviewFlag(photoId, flag) {
   }).then(function() {
     var photo = findPhotoInResults(photoId);
     if (photo) {
-      photo.flag = flag;
-      // Rejected photos lose representative eligibility server-side
-      // (get_species_representatives(eligible_only=True) filters them out),
-      // so drop the cached representative fields — the pipeline grid renders
-      // the Representative badge from photo.is_species_representative and
-      // would otherwise keep displaying it on a photo that's just been
-      // rejected via the inspect shortcut or the shared lightbox reject.
-      if (flag === 'rejected') {
-        if (photo.is_species_representative) photo.is_species_representative = false;
-        if (Array.isArray(photo.life_list)) {
-          photo.life_list.forEach(function(entry) {
-            if (!entry) return;
-            if (entry.is_current_photo) entry.is_current_photo = false;
-            if (entry.is_species_representative) entry.is_species_representative = false;
-          });
-        }
-      }
+      updatePipelineReviewPhotoFlag(photo, flag);
     }
     renderResults();
     if (inspectPhotoId === photoId && document.getElementById('inspectOverlay').classList.contains('open')) {

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -3066,6 +3066,9 @@ function renderResults() {
   // management below can pick a *visible* encounter (not one that was
   // filtered out by species filter, hide-confirmed, or label filter).
   var renderedIndices = [];
+  // Reset the click-time target cache; it's rebuilt below to mirror the exact
+  // set of photos each Reject/Clear button represents on screen.
+  pipelineReviewVisibleTargets = {};
   encounterSortOrder().forEach(function(ei) {
     var enc = pipelineResults.encounters[ei];
     var timeRange = '';
@@ -3078,23 +3081,21 @@ function renderResults() {
     // Check if the encounter passes the species/filename search.
     if (!encounterMatchesSearch(enc, photoMap)) return;
 
-    // Hide confirmed: skip the whole encounter if every one of its photos is hidden
+    // Build the set of photos this encounter will actually draw: skip
+    // hide-confirmed photos and photos filtered out by the active label /
+    // species-conflict filter. The encounter card is rendered only if this
+    // set is non-empty, and the encounter-level Reject/Clear button targets
+    // exactly this set so it can never flip flags on photos the user can't
+    // see.
     var encPhotoIds = enc.photo_ids || [];
-    if (hideConfirmed) {
-      var anyVisible = encPhotoIds.some(function(pid) {
-        return !confirmedHiddenIds.has(pid);
-      });
-      if (!anyVisible) return;
-    }
-
-    // Check if any photo in this encounter passes the label filter
-    var hasVisible = encPhotoIds.some(function(pid) {
+    var visibleEncIds = encPhotoIds.filter(function(pid) {
       var p = photoMap[pid];
       if (!p) return false;
       if (confirmedHiddenIds && confirmedHiddenIds.has(pid)) return false;
       return photoMatchesPipelineFilter(p, speciesConflictEvidence[pid]);
     });
-    if (!hasVisible) return;
+    if (!visibleEncIds.length) return;
+    pipelineReviewVisibleTargets['encounter:' + ei] = visibleEncIds;
 
     renderedIndices.push(ei);
 
@@ -3112,7 +3113,7 @@ function renderResults() {
     html += missingTimestampBadge(enc);
     html += renderEncounterSpeciesConflict(enc, speciesConflictEvidence, confirmedHiddenIds);
     html += '</span>';
-    html += renderGroupRejectButton('encounter', ei, null, visibleEncounterPhotoIds(enc), photoMap);
+    html += renderGroupRejectButton('encounter', ei, null, visibleEncIds, photoMap);
     html += '</div>';
     html += '<div class="encounter-body" id="encBody' + ei + '"' + (isCollapsed ? ' style="display:none;"' : '') + '>';
 
@@ -3120,6 +3121,15 @@ function renderResults() {
       enc.bursts.forEach(function(burst, bi) {
         if (hideConfirmed && isBurstConfirmed(enc, burst)) return;
         var burstIds = burst.photo_ids || burst;
+        // Narrow the burst's Reject/Clear target to photos that actually
+        // render — the active label / species-conflict filter can hide
+        // frames inside a burst even though the burst strip itself is drawn.
+        var visibleBurstIds = burstIds.filter(function(pid) {
+          var p = photoMap[pid];
+          if (!p) return false;
+          return photoMatchesPipelineFilter(p, speciesConflictEvidence[pid]);
+        });
+        pipelineReviewVisibleTargets['burst:' + ei + ':' + bi] = visibleBurstIds;
         html += '<div class="burst-strip">';
         html += '<div class="burst-controls">';
         if (enc.bursts.length > 1) {
@@ -3133,7 +3143,7 @@ function renderResults() {
           html += '<span class="burst-species-edit" onclick="toggleSpeciesDropdown(event,' + ei + ',' + bi + ',\'top\')">&#9998;</span>';
         }
         html += renderBurstSpeciesConflict(enc, ei, burst, bi, speciesConflictEvidence);
-        html += renderGroupRejectButton('burst', ei, bi, burstIds, photoMap);
+        html += renderGroupRejectButton('burst', ei, bi, visibleBurstIds, photoMap);
         html += '<button class="detach-btn" onclick="detachBurst(' + ei + ',' + bi + ')" title="Detach burst">&times;</button>';
         html += '</div>';
         burstIds.forEach(function(pid) {
@@ -3692,6 +3702,13 @@ function findEncounterForPhoto(photoId) {
 
 var inspectPhotoId = null;
 var pipelineReviewGroupFlagInFlight = {};
+// Photo IDs each rendered bulk-reject button actually represents, keyed by the
+// same 'encounter:ei' / 'burst:ei:bi' strings that group flag targets use.
+// renderResults() rebuilds this every render so hide-confirmed AND the label /
+// species-conflict filter both narrow the target to what the user can see.
+// groupFlagTarget() reads from here so the click applies to the visible set,
+// not the raw underlying photo list.
+var pipelineReviewVisibleTargets = {};
 
 function pipelineReviewBareKey(e, key) {
   return !e.ctrlKey && !e.metaKey && !e.altKey && e.key && e.key.toLowerCase() === key;
@@ -3744,17 +3761,26 @@ function groupFlagTarget(encIdx, burstIdx) {
   var enc = pipelineResults.encounters[encIdx];
   if (!enc) return null;
   if (burstIdx == null) {
-    // Match the button's rendered scope: when "Hide confirmed" is on we
-    // exclude confirmed bursts so users can't accidentally flag photos
-    // they can't see.
-    return {key: 'encounter:' + encIdx, noun: 'encounter', photoIds: visibleEncounterPhotoIds(enc)};
+    // Read the exact set of photos the encounter button represents on
+    // screen: renderResults() cached it under this key, and it already
+    // excludes photos hidden by Hide confirmed or by the active label /
+    // species-conflict filter so a click can't flip flags on photos the
+    // user can't see. Fall back to the hide-confirmed-only set only when
+    // the cache is missing (e.g. no render has happened yet).
+    var encKey = 'encounter:' + encIdx;
+    var encIds = pipelineReviewVisibleTargets[encKey];
+    if (!encIds) encIds = visibleEncounterPhotoIds(enc);
+    return {key: encKey, noun: 'encounter', photoIds: encIds};
   }
   var burst = enc.bursts && enc.bursts[burstIdx];
   if (!burst) return null;
+  var burstKey = 'burst:' + encIdx + ':' + burstIdx;
+  var burstIds = pipelineReviewVisibleTargets[burstKey];
+  if (!burstIds) burstIds = burst.photo_ids || burst || [];
   return {
-    key: 'burst:' + encIdx + ':' + burstIdx,
+    key: burstKey,
     noun: 'burst',
-    photoIds: burst.photo_ids || burst || [],
+    photoIds: burstIds,
   };
 }
 

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -3950,6 +3950,41 @@ function toggleBurstRejected(event, encIdx, burstIdx) {
   setPipelineReviewGroupFlag(target, allRejected ? 'none' : 'rejected');
 }
 
+// Native Photo menu commands prefer a page-level batchSetFlag helper. In the
+// burst modal, route those commands through the modal's pending zones (the
+// same behavior as its P/X/Space shortcuts) rather than writing directly to
+// /api/batch/flag behind the modal's Apply workflow.
+function batchSetFlag(flag) {
+  if (flag !== 'flagged' && flag !== 'rejected' && flag !== 'none') {
+    return Promise.resolve(false);
+  }
+  var overlay = document.getElementById('grmOverlay');
+  if (overlay && overlay.classList.contains('open') && grmState) {
+    var ids = _grmActionTargetIds();
+    var overlapsBulkFlagWrite = ids.some(function(pid) {
+      return pipelineReviewGroupFlagInFlightPhotoIds.has(pid);
+    });
+    if (overlapsBulkFlagWrite) {
+      showToast('A bulk reject for the selected photos is still finishing — try again in a moment', 'error');
+      return Promise.resolve(false);
+    }
+    if (flag === 'flagged') grmMovePick();
+    else if (flag === 'rejected') grmMoveReject();
+    else grmMoveCandidate();
+    return Promise.resolve(true);
+  }
+
+  var activeIds = typeof nativeMenuActivePhotoIds === 'function'
+    ? nativeMenuActivePhotoIds()
+    : [];
+  if (!activeIds.length) return Promise.resolve(false);
+  return Promise.all(activeIds.map(function(pid) {
+    return setPipelineReviewFlag(pid, flag);
+  })).then(function(results) {
+    return results.every(function(result) { return result !== false; });
+  });
+}
+
 function setPipelineReviewFlag(photoId, flag) {
   if (flag !== 'flagged' && flag !== 'rejected' && flag !== 'none') return Promise.resolve();
   photoId = parseInt(photoId, 10);

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -3821,32 +3821,69 @@ function setPipelineReviewGroupFlag(target, flag) {
   var ids = Array.from(new Set((target.photoIds || []).map(function(pid) {
     return parseInt(pid, 10);
   }).filter(function(pid) { return !!pid && !!findPhotoInResults(pid); })));
-  var changedIds = ids.filter(function(pid) {
-    return normalizedPipelineReviewFlag(findPhotoInResults(pid).flag) !== flag;
-  });
-  if (!changedIds.length) return Promise.resolve();
+  if (!ids.length) return Promise.resolve();
 
-  var previousFlags = {};
-  changedIds.forEach(function(pid) {
-    previousFlags[pid] = normalizedPipelineReviewFlag(findPhotoInResults(pid).flag);
-  });
   pipelineReviewGroupFlagInFlight[target.key] = true;
-  return safeFetch('/api/batch/flag', {
+  // pipelineResults.photos[].flag is a cache written when the pipeline ran;
+  // GET /api/pipeline/results serves it as-is without refreshing from the DB
+  // (unlike the GRM, which fetches /api/pipeline/group/state on open). If the
+  // user picked a photo in Browse after the cache was written, the cache can
+  // still read 'rejected' for it. Deriving changedIds and previousFlags from
+  // the stale cache would post flag: 'none' for that live pick on "Clear
+  // rejects", and Undo would restore the cached 'rejected' rather than the
+  // pick. Read live DB flags first and drive the decision off those.
+  return safeFetch('/api/pipeline/group/state', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({photo_ids: changedIds, flag: flag}),
-  }).then(function() {
-    changedIds.forEach(function(pid) {
-      updatePipelineReviewPhotoFlag(findPhotoInResults(pid), flag);
+    body: JSON.stringify({photo_ids: ids, species: ''}),
+  }, {toast: false}).then(function(data) {
+    var live = (data && data.photos) || {};
+    var liveFlagFor = function(pid) {
+      return normalizedPipelineReviewFlag(live[pid] && live[pid].flag);
+    };
+    // Sync the review cache to the live snapshot so subsequent button
+    // labels and card badges reflect truth, not the cache's opening value.
+    ids.forEach(function(pid) {
+      var liveFlag = liveFlagFor(pid);
+      var photo = findPhotoInResults(pid);
+      if (photo && normalizedPipelineReviewFlag(photo.flag) !== liveFlag) {
+        updatePipelineReviewPhotoFlag(photo, liveFlag);
+      }
     });
-    renderResults();
-    refreshLatestScopeSnapshotIfCurrent();
-    var count = changedIds.length;
-    var message = flag === 'rejected'
-      ? 'Rejected ' + count + ' photo' + (count === 1 ? '' : 's') + ' in ' + target.noun
-      : 'Cleared rejects from ' + count + ' photo' + (count === 1 ? '' : 's') + ' in ' + target.noun;
-    showUndo(message, function() {
-      restorePipelineReviewFlags(previousFlags, target.noun);
+    // "Reject" applies the reject flag to anything not already rejected —
+    // including live picks — because the user explicitly asked to reject the
+    // group. "Clear rejects" only touches photos that are actually rejected;
+    // it must never overwrite a live pick or an unflagged photo to 'none'.
+    var changedIds = ids.filter(function(pid) {
+      var liveFlag = liveFlagFor(pid);
+      if (flag === 'none') return liveFlag === 'rejected';
+      return liveFlag !== flag;
+    });
+    if (!changedIds.length) {
+      renderResults();
+      return;
+    }
+    var previousFlags = {};
+    changedIds.forEach(function(pid) {
+      previousFlags[pid] = liveFlagFor(pid);
+    });
+    return safeFetch('/api/batch/flag', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({photo_ids: changedIds, flag: flag}),
+    }).then(function() {
+      changedIds.forEach(function(pid) {
+        updatePipelineReviewPhotoFlag(findPhotoInResults(pid), flag);
+      });
+      renderResults();
+      refreshLatestScopeSnapshotIfCurrent();
+      var count = changedIds.length;
+      var message = flag === 'rejected'
+        ? 'Rejected ' + count + ' photo' + (count === 1 ? '' : 's') + ' in ' + target.noun
+        : 'Cleared rejects from ' + count + ' photo' + (count === 1 ? '' : 's') + ' in ' + target.noun;
+      showUndo(message, function() {
+        restorePipelineReviewFlags(previousFlags, target.noun);
+      });
     });
   }).finally(function() {
     delete pipelineReviewGroupFlagInFlight[target.key];

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -3702,6 +3702,15 @@ function findEncounterForPhoto(photoId) {
 
 var inspectPhotoId = null;
 var pipelineReviewGroupFlagInFlight = {};
+// Photo IDs that any in-flight bulk reject/clear is currently mutating. We
+// check for overlap in setPipelineReviewGroupFlag so an encounter-level
+// action and one of its burst-level actions can't run concurrently: each
+// snapshots previousFlags from its own /api/pipeline/group/state read, so
+// two overlapping writes would let the later Undo restore shared photos to
+// the pre-first-action state, silently rolling back part of the earlier
+// action. Non-overlapping bulk actions (different bursts, different
+// encounters) still proceed in parallel.
+var pipelineReviewGroupFlagInFlightPhotoIds = new Set();
 // Photo IDs each rendered bulk-reject button actually represents, keyed by the
 // same 'encounter:ei' / 'burst:ei:bi' strings that group flag targets use.
 // renderResults() rebuilds this every render so hide-confirmed AND the label /
@@ -3823,7 +3832,21 @@ function setPipelineReviewGroupFlag(target, flag) {
   }).filter(function(pid) { return !!pid && !!findPhotoInResults(pid); })));
   if (!ids.length) return Promise.resolve();
 
+  // Block bulk actions whose photos overlap an in-flight bulk action — e.g.,
+  // clicking Reject burst while the parent encounter's Reject is still
+  // running. Both requests would snapshot previousFlags from the pre-first
+  // DB read, and the later Undo could restore the shared photos to 'none',
+  // silently reverting part of the earlier action.
+  var overlaps = ids.some(function(pid) {
+    return pipelineReviewGroupFlagInFlightPhotoIds.has(pid);
+  });
+  if (overlaps) {
+    showToast('Another bulk reject is still finishing — try again in a moment', 'error');
+    return Promise.resolve();
+  }
+
   pipelineReviewGroupFlagInFlight[target.key] = true;
+  ids.forEach(function(pid) { pipelineReviewGroupFlagInFlightPhotoIds.add(pid); });
   // pipelineResults.photos[].flag is a cache written when the pipeline ran;
   // GET /api/pipeline/results serves it as-is without refreshing from the DB
   // (unlike the GRM, which fetches /api/pipeline/group/state on open). If the
@@ -3887,6 +3910,7 @@ function setPipelineReviewGroupFlag(target, flag) {
     });
   }).finally(function() {
     delete pipelineReviewGroupFlagInFlight[target.key];
+    ids.forEach(function(pid) { pipelineReviewGroupFlagInFlightPhotoIds.delete(pid); });
   });
 }
 

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -3112,7 +3112,7 @@ function renderResults() {
     html += missingTimestampBadge(enc);
     html += renderEncounterSpeciesConflict(enc, speciesConflictEvidence, confirmedHiddenIds);
     html += '</span>';
-    html += renderGroupRejectButton('encounter', ei, null, encPhotoIds, photoMap);
+    html += renderGroupRejectButton('encounter', ei, null, visibleEncounterPhotoIds(enc), photoMap);
     html += '</div>';
     html += '<div class="encounter-body" id="encBody' + ei + '"' + (isCollapsed ? ' style="display:none;"' : '') + '>';
 
@@ -3283,6 +3283,25 @@ function isBurstConfirmed(enc, burst) {
   var ovr = burst && burst.species_override;
   if (ovr) return !!ovr.confirmed;
   return !!(enc && enc.species_confirmed);
+}
+
+// Photo IDs the user currently sees inside this encounter's body. When
+// "Hide confirmed" is off, this is every photo in the encounter. When on,
+// photos belonging to confirmed bursts (or a confirmed no-burst encounter)
+// are excluded so encounter-level actions only touch what's on screen.
+function visibleEncounterPhotoIds(enc) {
+  var ids = (enc && enc.photo_ids) || [];
+  if (!hideConfirmed) return ids.slice();
+  if (enc.bursts && enc.bursts.length > 0) {
+    var hidden = new Set();
+    enc.bursts.forEach(function(burst) {
+      if (isBurstConfirmed(enc, burst)) {
+        (burst.photo_ids || burst || []).forEach(function(pid) { hidden.add(pid); });
+      }
+    });
+    return ids.filter(function(pid) { return !hidden.has(pid); });
+  }
+  return enc.species_confirmed ? [] : ids.slice();
 }
 
 function toggleHideConfirmed() {
@@ -3725,7 +3744,10 @@ function groupFlagTarget(encIdx, burstIdx) {
   var enc = pipelineResults.encounters[encIdx];
   if (!enc) return null;
   if (burstIdx == null) {
-    return {key: 'encounter:' + encIdx, noun: 'encounter', photoIds: enc.photo_ids || []};
+    // Match the button's rendered scope: when "Hide confirmed" is on we
+    // exclude confirmed bursts so users can't accidentally flag photos
+    // they can't see.
+    return {key: 'encounter:' + encIdx, noun: 'encounter', photoIds: visibleEncounterPhotoIds(enc)};
   }
   var burst = enc.bursts && enc.bursts[burstIdx];
   if (!burst) return null;

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -3965,7 +3965,10 @@ function setPipelineReviewFlag(photoId, flag) {
   // bulk path so every overlapping flag write is serialized.
   if (pipelineReviewGroupFlagInFlightPhotoIds.has(photoId)) {
     showToast('A bulk reject for this photo is still finishing — try again in a moment', 'error');
-    return Promise.resolve();
+    // The shared lightbox treats every resolved value except false as a
+    // successful write and updates its own cache/event listeners. Return an
+    // explicit failure so its UI stays on the last confirmed database flag.
+    return Promise.resolve(false);
   }
 
   return safeFetch('/api/photos/' + photoId + '/flag', {
@@ -7282,11 +7285,33 @@ async function grmApply() {
   }
   if (grmState.applying) return;
   grmSetApplying(true);
+  var grmFlagLockIds = [];
 
   try {
     var diff = grmComputeDiff();
     var checks = grmResolveChecks(diff);
     var species = document.getElementById('grmSpecies').value.trim();
+
+    // GRM pick/reject writes use /api/pipeline/group/apply rather than the
+    // per-photo helper, so serialize them explicitly with bulk Reject/Clear
+    // and Undo. Holding the lock through the full apply also blocks a bulk
+    // action from starting after the modal write has begun.
+    if (checks.flags) {
+      var candidateFlagLockIds = grmState.items
+        .filter(function(p) { return !grmState.removed.has(p.id); })
+        .map(function(p) { return p.id; });
+      var overlapsBulkFlagWrite = candidateFlagLockIds.some(function(pid) {
+        return pipelineReviewGroupFlagInFlightPhotoIds.has(pid);
+      });
+      if (overlapsBulkFlagWrite) {
+        showToast('A bulk reject for this group is still finishing — try Apply again in a moment', 'error');
+        return;
+      }
+      grmFlagLockIds = candidateFlagLockIds;
+      grmFlagLockIds.forEach(function(pid) {
+        pipelineReviewGroupFlagInFlightPhotoIds.add(pid);
+      });
+    }
 
     // --- Flags side (picks/rejects/candidates + removed→detach) ---
     // Only committed when the "Apply picks/rejects" box is checked. Removals are
@@ -7522,6 +7547,9 @@ async function grmApply() {
       }, 0);
     });
   } finally {
+    grmFlagLockIds.forEach(function(pid) {
+      pipelineReviewGroupFlagInFlightPhotoIds.delete(pid);
+    });
     var overlay = document.getElementById('grmOverlay');
     if (overlay && overlay.classList.contains('open')) {
       grmSetApplying(false);


### PR DESCRIPTION
## Summary
Adds one-click reject and clear controls for bursts and full encounters on Process Review. The bulk action uses the existing photo flag API and offers an Undo action that restores each photo’s prior flag, including mixed picks and rejects. Adds browser coverage for burst rejection, full-encounter rejection, clearing, and undo restoration.

## Validation
- `pytest -q tests/e2e/test_pipeline_review_group_reject.py` (2 passed)
- `pytest -q tests/e2e/test_pipeline_review_species.py tests/e2e/test_pipeline_rapid_review.py tests/e2e/test_page_loads.py` (71 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reject and clear controls for entire encounters and bursts in Pipeline Review.
  * Bulk actions now apply only to photos currently visible under active filters, including hidden-confirmed and label filters.
  * Added user feedback when conflicting photo or bulk actions are temporarily unavailable.
  * Undo now restores the correct previous photo flags, including changes made concurrently.

* **Tests**
  * Added end-to-end coverage for bulk reject, clear, filtering, visibility, concurrency, and undo behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->