### PR TITLE
Universal photo filters: design + implementation plan

### DIFF
--- a/docs/plans/2026-07-19-universal-filters-design.md
+++ b/docs/plans/2026-07-19-universal-filters-design.md
@@ -82,7 +82,7 @@ expression, rendered as a locked chip:
 | Browse | workspace folders (status ok/partial) — the implicit baseline |
 | Map | has GPS or a location keyword (today's `get_geolocated_photos` predicate) |
 | Review | photos with predictions whose effective review status is `pending` — i.e. `COALESCE(prediction_review.status, 'pending') = 'pending'`, so the many predictions that have no `prediction_review` row (the default-pending storage model — see the `COALESCE(pr_rev.status, 'pending')` predicates already used across `db.py`) are included, not dropped |
-| Duplicates | photos whose `file_hash` groups ≥2; a matching member reveals its whole group |
+| Duplicates | photos whose `file_hash` groups ≥2; a matching member reveals its whole group. Groups come from the library-wide `find_duplicate_groups` (which intentionally spans workspaces — `db.py:4933` groups the whole `photos` table with no `workspace_folders` join, and `/api/duplicates/apply` resolves by `file_hash` across the catalog). The user expression runs through `/api/photos/query` in the current workspace's scope only to pick which *members* match; the Duplicates page then re-hydrates each matching member's full group from the library-wide grouper so cross-workspace duplicate sets stay complete and resolvable. Never derive groups from workspace-scoped query results — that would silently hide half of a duplicate pair when its other copy lives in a different workspace. |
 
 "Open results in…" hands the user expression to another page; the destination
 adds its own scope chip.

--- a/docs/plans/2026-07-19-universal-filters-design.md
+++ b/docs/plans/2026-07-19-universal-filters-design.md
@@ -1,0 +1,155 @@
+# Universal Photo Filters — Design
+
+Status: validated by interactive prototype (`docs/plans/2026-07-19-photo-filter-prototype/`, PR #1319, merged 2026-07-19).
+
+## Goal
+
+One holistic filter pattern applied identically to every photo-listing surface
+(Browse, Map, Review, Duplicates, and future pages): a quick-search box, a row
+of readable filter chips with a locked page-scope chip, and a popover holding
+quick filters (rating/flag/color), a rule builder over all metadata, and
+optional nested AND/OR/NONE logic. CLIP visual search is a first-class,
+visually distinct clause with honest error states.
+
+## Core decision: build on the smart-collection rule engine
+
+Vireo already has a universal filter DSL: `_build_query_from_rules`
+(vireo/db.py:17617), used by collections. It supports a nested
+`{"mode": "all|any|none", "rules": [...]}` tree, ~35 fields, workspace
+scoping, and a live-count preview endpoint (`POST /api/collections/preview`).
+
+The universal filter **is** this rule tree. Consequences:
+
+- "Save as Collection" is free — a saved filter is just a collection row
+  (`collections.rules` already stores this JSON).
+- Browse/Map/Review/Duplicates and collections converge on one SQL path.
+- The copy-pasted Browse-param filter block (duplicated across `get_photos`,
+  `get_photo_ids`, `count_filtered_photos`, `get_browse_summary`, plus a fifth
+  variant in `get_geolocated_photos`) gets replaced, fixing today's
+  inconsistency where Map accepts fewer filters than Browse.
+
+## Filter expression model
+
+```json
+{
+  "mode": "all",
+  "rules": [
+    {"field": "rating", "op": ">=", "value": 4},
+    {"mode": "any", "rules": [
+      {"field": "flag", "op": "is", "value": "pick"},
+      {"field": "color_label", "op": "in", "value": ["red", "yellow"]}
+    ]}
+  ]
+}
+```
+
+Extends the existing engine with (all validated server-side):
+
+- `in` / `not_in` ops (multi-select) for enum-like fields.
+- `between` for numbers and dates (engine already has `between` for
+  timestamp; generalize).
+- `recent_days` already exists; add `recent` with `{n, unit}` for
+  days/weeks/months/years ("is in the last").
+- New fields (columns exist, engine support doesn't): `filename`,
+  `file_size`, `width`, `height`, `focal_length`, `gps_lat`/`gps_lng` range,
+  `has_edits` (EXISTS on `photo_edit_recipes`), `has_visual_index` (EXISTS on
+  `photo_embeddings` for the active model), `burst_id`, `duplicate_group`
+  (equality on `file_hash`).
+- EXIF camera fields (`camera_make`, `camera_model`, `lens`, `aperture`,
+  `shutter_speed`, `iso`): promoted from `photos.exif_data` JSON to real
+  columns via a backfill migration (db_meta marker, not user_version — see
+  drift note in memory). Until promoted these have no efficient backing.
+
+The **visual clause** is not part of the rule tree. It rides alongside:
+
+```json
+{"visual": {"prompt": "bird flying at dusk", "strength": "balanced"}}
+```
+
+and reuses the `/api/photos/search` flow (candidate ids from the rule tree →
+embedding similarity → threshold by strength). Error states map to existing
+detections: `no_model`, `model_no_text_search` (timm), `no_embeddings` — the
+UI shows the clause in an error state and applies metadata rules only,
+exactly as prototyped. Never silently return zero.
+
+## Page scope
+
+Each page contributes a fixed, non-removable scope ANDed onto the user
+expression, rendered as a locked chip:
+
+| Page | Scope |
+|---|---|
+| Browse | workspace folders (status ok/partial) — the implicit baseline |
+| Map | has GPS or a location keyword (today's `get_geolocated_photos` predicate) |
+| Review | photos with predictions whose `prediction_review.status = 'pending'` |
+| Duplicates | photos whose `file_hash` groups ≥2; a matching member reveals its whole group |
+
+"Open results in…" hands the user expression to another page; the destination
+adds its own scope chip.
+
+## API surface
+
+- `GET/POST /api/photos/query` — rule tree + visual clause + sort + paging →
+  photo list + total. Replaces the per-page param soup; legacy params compile
+  to rule trees internally during migration.
+- `GET /api/filters/fields` — the field registry (label, category, type, ops,
+  enum values, suggest flag), server-defined so the UI picker and validation
+  share one source of truth.
+- `GET /api/filters/values?field=&q=&rules=` — typeahead facet values with
+  counts. Counts are computed against the expression **minus the rule being
+  edited** (drop the clause from its group — not "treat as true", which breaks
+  any/none groups; prototype review finding) and **including** an active,
+  healthy visual clause.
+
+## UI
+
+New shared assets following the established pattern (`vireo/static/` IIFE
+modules + a Jinja include):
+
+- `vireo/templates/_filterbar.html` — markup include.
+- `vireo/static/vireo-filter.js` — state, chips, popover, rule rows,
+  typeahead, keyboard (`⌘F` focus, `\` pause).
+- Pages adopt it and delete their inline filter widgets.
+
+Behavioral requirements carried from the prototype and its review cycle
+(these are hard requirements per CORE_PHILOSOPHY "no black boxes"):
+
+1. Chip text must state exact semantics ("Rating is at least 4 stars",
+   "Flag is one of Picked, Unflagged", "NOT (A OR B)" for none-groups —
+   never "NOT (A AND B)").
+2. Quick search is one replaceable clause; multiple text rules are a
+   deliberate Add-filter action.
+3. Quick rating shows its comparator (≥/=/≤); flags and colors multi-select
+   into `is one of` rules.
+4. Pause (`\`) disables filters without losing them: dimmed dashed chips,
+   "N would match" badge, persists, and any save/preview shows the count the
+   action will actually produce — not the paused view's count.
+5. Toggling Advanced logic off never rewrites the rule tree.
+6. Relative dates (`is in the last N days/weeks/months/years`) and `between`
+   are single rules.
+7. Facet counts must answer "how many results would I get" under the current
+   selections — never a global COUNT(*).
+
+## Persistence
+
+Active filter per page per workspace in `workspaces.ui_state` JSON
+(written via existing `PUT /api/workspaces/<id>`), including the `muted`
+flag. Saved filters are collections.
+
+## Species and multi-species
+
+The `species` filter field uses the keyword path (`photo_keywords` →
+`keywords` where `is_species=1 OR type='taxonomy'`, deduped by `taxon_id`
+per the multi-species model) with EXISTS predicates — a photo with several
+species matches if **any** species matches. Predictions
+(`predictions` + `prediction_review`) are a separate field axis
+(`prediction`, `prediction_confidence`, `prediction_status`), as in the
+prototype.
+
+## Out of scope (for now)
+
+- Lightroom-style multi-column metadata browser (facet columns). The
+  typeahead-with-counts covers the need; a column browser can layer on the
+  same `/api/filters/values` endpoint later.
+- ANN indexing for embeddings (brute-force matmul is fine at current scale).
+- Filter presets distinct from collections.

--- a/docs/plans/2026-07-19-universal-filters-design.md
+++ b/docs/plans/2026-07-19-universal-filters-design.md
@@ -81,7 +81,7 @@ expression, rendered as a locked chip:
 |---|---|
 | Browse | workspace folders (status ok/partial) — the implicit baseline |
 | Map | has GPS or a location keyword (today's `get_geolocated_photos` predicate) |
-| Review | photos with predictions whose `prediction_review.status = 'pending'` |
+| Review | photos with predictions whose effective review status is `pending` — i.e. `COALESCE(prediction_review.status, 'pending') = 'pending'`, so the many predictions that have no `prediction_review` row (the default-pending storage model — see the `COALESCE(pr_rev.status, 'pending')` predicates already used across `db.py`) are included, not dropped |
 | Duplicates | photos whose `file_hash` groups ≥2; a matching member reveals its whole group |
 
 "Open results in…" hands the user expression to another page; the destination
@@ -134,7 +134,21 @@ Behavioral requirements carried from the prototype and its review cycle
 
 Active filter per page per workspace in `workspaces.ui_state` JSON
 (written via existing `PUT /api/workspaces/<id>`), including the `muted`
-flag. Saved filters are collections.
+flag.
+
+Saved filters are collections, but because the visual clause is
+intentionally not part of the rule tree, `collections.rules` alone can't
+represent an expression with a visual component — a collection saved from
+such an expression would silently reopen as metadata-only. To avoid that,
+the collections schema gains a sibling `visual_json` column (nullable
+JSON: the same `{prompt, strength}` payload as the query envelope), and
+both the save-as-collection endpoint and the collection-open flow round-
+trip the pair `{rules, visual}` together. `_build_query_from_rules` keeps
+reading `rules`; the visual clause is applied by the same query pipeline
+that handles the live filter bar, so an opened collection with a visual
+clause behaves identically to the expression that produced it. Collection
+listings surface a visible marker (e.g. a small "visual" chip) so users
+know the clause is active before running it.
 
 ## Species and multi-species
 

--- a/docs/plans/2026-07-19-universal-filters-plan.md
+++ b/docs/plans/2026-07-19-universal-filters-plan.md
@@ -1,0 +1,114 @@
+# Universal Photo Filters — Implementation Plan
+
+Companion to `2026-07-19-universal-filters-design.md`. Five phases, one PR
+each. Every phase lands green: `python -m pytest tests/test_workspaces.py
+vireo/tests/test_db.py vireo/tests/test_app.py vireo/tests/test_photos_api.py
+vireo/tests/test_edits_api.py vireo/tests/test_jobs_api.py
+vireo/tests/test_darktable_api.py vireo/tests/test_config.py -v` plus new
+tests, plus a Playwright drive of the affected page.
+
+## Phase 1 — Backend: rule-engine extension + field registry (PR 1)
+
+All in `vireo/db.py` (`_build_query_from_rules`, 17617) and `vireo/app.py`
+unless noted.
+
+1. **EXIF column promotion.** Add columns `camera_make, camera_model, lens,
+   aperture, shutter_speed, iso` to `photos`; backfill from `exif_data` JSON
+   in a `db_meta`-marker migration (pattern: `repair_duplicate_photo_species`
+   guard, db.py 10821 — not user_version, which has drifted). Extract on
+   ingest going forward.
+2. **New rule fields** in `_build_query_from_rules`: `filename` (contains/
+   is/starts/ends, case toggle), `file_size`, `width`, `height`,
+   `focal_length`, the six EXIF fields, `gps_lat`/`gps_lng`, `has_edits`
+   (EXISTS `photo_edit_recipes`), `has_visual_index` (EXISTS
+   `photo_embeddings` for active model), `burst_id`, `duplicate_group`
+   (= `file_hash`), `species` (EXISTS via keyword/taxa path,
+   `get_species_keywords_for_photos` semantics, db.py 12379).
+3. **New ops**: `in`/`not_in` (enum multi-select); generalize `between`
+   beyond timestamp; `recent {n, unit}` for date fields. Validation rejects
+   unknown fields/ops/value shapes with 400s.
+4. **Field registry**: a module-level `FILTER_FIELDS` dict (label, category,
+   type, ops, enum values, suggest flag, SQL binding) consumed by both the
+   query builder and `GET /api/filters/fields`.
+5. **Endpoints**: `POST /api/photos/query` (rules + sort + paging → list +
+   total, workspace-scoped exactly like `get_photos`); `GET
+   /api/filters/fields`; `GET /api/filters/values` (distinct values + counts
+   for suggest fields; expression-minus-edited-rule semantics — drop the
+   clause from its group, never substitute true).
+6. **Tests** (`vireo/tests/test_db.py`, `test_photos_api.py`): each new
+   field/op; any/none group nesting; values endpoint counts under sibling
+   filters; migration backfill idempotence; validation failures.
+
+Nothing user-visible changes in this phase.
+
+## Phase 2 — Shared filter bar on Browse (PR 2)
+
+1. `vireo/templates/_filterbar.html` + `vireo/static/vireo-filter.js`
+   (IIFE on `window`, pattern: `VireoTextSearch`, vireo-utils.js:86).
+   Port the prototype's interaction model: quick search (single replaceable
+   clause + suggestion menu), chips row with locked scope chip and `+N`
+   overflow, popover with quick filters (rating comparator, multi-select
+   flags/colors), rule builder (field picker, per-type ops, typeahead
+   values with counts via `/api/filters/values`, enum count pills,
+   between/relative-date inputs), Advanced toggle (never rewrites the tree),
+   pause on `\`, undo toasts. Reuse prototype JS logic where it transfers;
+   all evaluation moves server-side.
+2. Wire Browse: replace `buildCurrentBrowseParams()`/inline widgets
+   (browse.html:3989) with the shared module calling `/api/photos/query`.
+   Legacy URL params (deep links) compile to an initial rule tree.
+3. Persistence: active expression + muted per page in `workspaces.ui_state`.
+4. Playwright: port the prototype's `verify_features.py` checks against the
+   real Browse page (typeahead counts, multi-select, relative date, between,
+   pause, chip labels).
+
+## Phase 3 — Visual (CLIP) clause (PR 3)
+
+1. `POST /api/photos/query` accepts `visual {prompt, strength}`; pipeline:
+   rule-tree candidate ids → `/api/photos/search` internals
+   (app.py 25807: active model, `get_photos_with_embedding`, text encode,
+   cosine, threshold by strength broad/balanced/strict) → ordered ids +
+   similarity.
+2. Error states surfaced in the response (`no_model`,
+   `model_no_text_search`, `no_embeddings`) → error chip + "metadata filters
+   shown only" badge; metadata rules still apply.
+3. Relevance sort only while the visual clause is active and healthy and
+   filters are not paused. Facet counts include the visual result set when
+   healthy.
+4. "Visual index: N of M photos" badge from embedding coverage.
+
+## Phase 4 — Map, Review, Duplicates adoption (PR 4)
+
+1. Map: replace `/api/photos/geo` param variant with `/api/photos/query` +
+   Map scope (GPS-or-location-keyword predicate from
+   `get_geolocated_photos`, db.py 7583). Scope chip; full field set now
+   works on Map (closing today's gap: no color/flag/collection filters).
+2. Review: scope = pending `prediction_review`; page-specific fields
+   (`prediction`, `prediction_confidence`, `prediction_status`) appear in
+   the picker only here (registry `pages` attribute).
+3. Duplicates: filter selects matching members; groups render complete with
+   "Matches filter" badges (prototype behavior), via `file_hash` grouping.
+4. "Open results in…" handoff: serialize expression, navigate, destination
+   adds its scope chip.
+
+## Phase 5 — Save-as-collection + legacy cleanup (PR 5)
+
+1. Save the current expression as a collection (rules JSON is already the
+   collection format). Save preview shows the post-save count (paused state
+   never inflates it). Opening a collection loads its rules into the filter
+   bar as editable chips.
+2. Delete the duplicated Browse-param filter blocks (`get_photos`,
+   `get_photo_ids`, `count_filtered_photos`, `get_browse_summary`,
+   `get_geolocated_photos` variant) once all callers use the rule path;
+   keep thin param→rules shims only where external deep links need them.
+3. Docs: update README/help for the filter bar and `\` shortcut.
+
+## Review-cycle regressions to guard (from prototype PR #1319)
+
+- Facet-count helper must drop the edited clause from its group
+  (any/none semantics), not treat it as true.
+- Group Match select routes through the same handler as rule edits — guard
+  clauses must not swallow it (regression af0a0d2b).
+- Debounced edits must be cancelled on tree mutation.
+- `none` group summaries join with OR inside NOT.
+- Saved state must strip `muted`; previews show post-action counts.
+- `escapeHtml` must escape quotes (attribute injection).

--- a/docs/plans/2026-07-19-universal-filters-plan.md
+++ b/docs/plans/2026-07-19-universal-filters-plan.md
@@ -27,17 +27,32 @@ unless noted.
 3. **New ops**: `in`/`not_in` (enum multi-select); generalize `between`
    beyond timestamp; `recent {n, unit}` for date fields. Validation rejects
    unknown fields/ops/value shapes with 400s.
-4. **Field registry**: a module-level `FILTER_FIELDS` dict (label, category,
+4. **Widen the `flag` rule leaf to preserve NULL-as-unflagged.** Today the
+   collection engine's `flag` leaf emits `p.flag = ?` (`db.py:17809-17811`),
+   while Browse's inline filter uses `COALESCE(p.flag, 'none') = ?`
+   (`db.py:7086-7088`). Once Browse switches to the rule engine (Phase 2),
+   the naive equality would silently drop every row with a legacy `NULL`
+   flag from the Unflagged chip — catalogs from older ingests and any code
+   path that leaves `flag` as `NULL` (undo, imports before the flag column
+   was populated) all fall into this bucket. Change the leaf to emit
+   `COALESCE(p.flag, 'none') = ?` for `equals`/`is` and the corresponding
+   `COALESCE(p.flag, 'none') != ?` for `is not`, and extend `in`/`not_in` on
+   `flag` the same way so a multi-select including "Unflagged" (`'none'`)
+   still catches `NULL`. Add a regression test that inserts a row with
+   `flag IS NULL` and asserts the Unflagged chip / `flag in ['none', …]`
+   rule both return it.
+5. **Field registry**: a module-level `FILTER_FIELDS` dict (label, category,
    type, ops, enum values, suggest flag, SQL binding) consumed by both the
    query builder and `GET /api/filters/fields`.
-5. **Endpoints**: `POST /api/photos/query` (rules + sort + paging → list +
+6. **Endpoints**: `POST /api/photos/query` (rules + sort + paging → list +
    total, workspace-scoped exactly like `get_photos`); `GET
    /api/filters/fields`; `GET /api/filters/values` (distinct values + counts
    for suggest fields; expression-minus-edited-rule semantics — drop the
    clause from its group, never substitute true).
-6. **Tests** (`vireo/tests/test_db.py`, `test_photos_api.py`): each new
+7. **Tests** (`vireo/tests/test_db.py`, `test_photos_api.py`): each new
    field/op; any/none group nesting; values endpoint counts under sibling
-   filters; migration backfill idempotence; validation failures.
+   filters; migration backfill idempotence; validation failures; NULL-flag
+   Unflagged regression (see step 4).
 
 Nothing user-visible changes in this phase.
 
@@ -67,7 +82,18 @@ Nothing user-visible changes in this phase.
    rule-tree candidate ids → `/api/photos/search` internals
    (app.py 25807: active model, `get_photos_with_embedding`, text encode,
    cosine, threshold by strength broad/balanced/strict) → ordered ids +
-   similarity.
+   similarity. **Candidate ids must not be handed to
+   `get_photos_with_embedding` inline.** Today that helper builds an
+   unchunked `IN (?, ?, …)` clause (`db.py:15019-15024`), which blows past
+   `SQLITE_MAX_VARIABLE_NUMBER` (999 on legacy builds) for any broad rule
+   tree over a large catalog and errors before cosine scoring runs. Route
+   the candidate scope through the same temp-table staging path
+   `_scope_clause` already uses (`db.py:5724-5735`) — either by teaching
+   `get_photos_with_embedding` to accept a scope handle instead of a raw
+   list, or by chunking the list into ≤900-id batches and unioning the
+   results — so a broad visual search over the full library never fails on
+   the variable cap. Tests must exercise this with a candidate set larger
+   than 999 ids.
 2. Error states surfaced in the response (`no_model`,
    `model_no_text_search`, `no_embeddings`) → error chip + "metadata filters
    shown only" badge; metadata rules still apply.
@@ -87,6 +113,14 @@ Nothing user-visible changes in this phase.
    the picker only here (registry `pages` attribute).
 3. Duplicates: filter selects matching members; groups render complete with
    "Matches filter" badges (prototype behavior), via `file_hash` grouping.
+   Duplicate groups are sourced from the library-wide `find_duplicate_groups`
+   (`db.py:4933` — intentionally spans workspaces, no `workspace_folders`
+   join), never re-derived from the workspace-scoped `/api/photos/query`
+   result set. The query result set is used only to decide which members
+   match the filter; the full cross-workspace group is then re-hydrated so
+   scan-visible duplicates that live in another workspace remain resolvable
+   through `/api/duplicates/apply` (`db.py:4922`, resolves by `file_hash`
+   library-wide).
 4. "Open results in…" handoff: serialize expression, navigate, destination
    adds its scope chip.
 

--- a/docs/plans/2026-07-19-universal-filters-plan.md
+++ b/docs/plans/2026-07-19-universal-filters-plan.md
@@ -92,10 +92,21 @@ Nothing user-visible changes in this phase.
 
 ## Phase 5 — Save-as-collection + legacy cleanup (PR 5)
 
-1. Save the current expression as a collection (rules JSON is already the
-   collection format). Save preview shows the post-save count (paused state
-   never inflates it). Opening a collection loads its rules into the filter
-   bar as editable chips.
+1. Save the current expression as a collection. The rule tree still goes
+   into `collections.rules`; the visual clause (which by design lives
+   outside the rule tree) goes into a new nullable `collections.visual_json`
+   column added in a `db_meta`-marker migration (same migration pattern as
+   the EXIF promotion in Phase 1). Both the save endpoint and the
+   collection-open flow must round-trip `{rules, visual}` together — saving
+   an expression with a visual clause and reopening it must reproduce the
+   same result set, not silently drop to metadata-only. Save preview shows
+   the post-save count (paused state never inflates it) and reflects the
+   visual clause when one is present. Opening a collection loads its rules
+   into the filter bar as editable chips and rehydrates the visual clause
+   into the visual input; a small "visual" marker on the collection row
+   makes the presence of the clause visible before running it. Tests cover
+   the round-trip explicitly (save → reload → identical result set) and
+   the metadata-only case (`visual_json IS NULL` → unchanged behavior).
 2. Delete the duplicated Browse-param filter blocks (`get_photos`,
    `get_photo_ids`, `count_filtered_photos`, `get_browse_summary`,
    `get_geolocated_photos` variant) once all callers use the rule path;


### PR DESCRIPTION
## What this is

Design doc + five-phase implementation plan for the universal photo filter system, following the interactive prototype validated and merged in #1319. Docs only — no code changes.

## Key architectural decisions

- **Build on the existing smart-collection rule engine** (`_build_query_from_rules`, vireo/db.py) instead of a parallel DSL. The universal filter *is* the collection rules JSON: save-as-collection is free, and Browse/Map/Review/Duplicates converge on one SQL path, replacing the Browse-param filter block that's currently copy-pasted across five db.py methods (with Map accepting fewer filters than Browse).
- **EXIF camera fields** (make/model/lens/aperture/shutter/ISO) get promoted from `exif_data` JSON to real columns via a db_meta-marker backfill migration.
- **CLIP visual search** is a clause alongside the rule tree, reusing the `/api/photos/search` pipeline, with the existing no_model / model_no_text_search / no_embeddings detections surfaced as honest error states.
- **Species filtering** uses the multi-species keyword→taxa path (any-species-matches semantics).
- **Facet counts / typeahead** via a new `/api/filters/values` endpoint with expression-minus-edited-rule semantics.
- Per-workspace persistence in `workspaces.ui_state`; page scopes rendered as locked chips.

## Phases (one PR each)

1. Backend: rule-engine fields/ops, EXIF migration, field registry, `/api/photos/query` + `/api/filters/*` endpoints
2. Shared filter bar UI on Browse
3. CLIP visual clause
4. Map / Review / Duplicates adoption
5. Save-as-collection + legacy filter-path cleanup

The plan also encodes the ten regression lessons from #1319's review cycle as hard requirements.

## Testing

Docs-only change. Standard suite still green on this branch's base (1615 passed, 14 skipped in #1319's final run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added design documentation for a universal photo-filter experience across Browse, Map, Review, and Duplicates.
  * Documented shared filtering rules, visual search behavior, filter controls, keyboard interactions, persistence, and saved collections.
  * Added a phased implementation plan covering backend filtering, interface updates, visual search, cross-surface support, and collection integration.
  * Recorded error handling, compatibility requirements, testing coverage, and out-of-scope items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->