### PR TITLE
Rescue weak detections using encounter context

### DIFF
--- a/vireo/config.py
+++ b/vireo/config.py
@@ -125,6 +125,11 @@ DEFAULTS = {
         # below the workspace `detector_confidence` cutoff. Set to 1.01 to
         # disable the override.
         "miss_classifier_override_conf": 0.8,
+        # Contextual weak-detection rescue. The normal detector threshold
+        # remains authoritative everywhere else; boxes in this lower band are
+        # considered only when a short run is bracketed by strong detections.
+        "weak_detection_rescue_enabled": True,
+        "weak_detection_confidence": 0.12,
         # Eye-focus detection
         "eye_detect_enabled": False,
         "eye_classifier_conf_gate": 0.50,

--- a/vireo/config_schema.py
+++ b/vireo/config_schema.py
@@ -524,6 +524,24 @@ SCHEMA = {
             "no_subject. Set to 1.01 to disable."
         ),
     },
+    "pipeline.weak_detection_rescue_enabled": {
+        "type": "bool",
+        "category": "Pipeline", "scope": "both",
+        "label": "Rescue weak detections in sequences",
+        "desc": (
+            "Classify and group weak animal detections only when strong "
+            "detections bracket the same short photo sequence."
+        ),
+    },
+    "pipeline.weak_detection_confidence": {
+        "type": "float", "min": 0.0, "max": 1.0, "step": 0.01,
+        "category": "Pipeline", "scope": "both",
+        "label": "Weak-detection confidence",
+        "desc": (
+            "Lower confidence floor used only for contextually rescued "
+            "frames; the normal detector threshold is unchanged."
+        ),
+    },
     "pipeline.eye_detect_enabled": {
         "type": "bool",
         "category": "Pipeline", "scope": "both",

--- a/vireo/encounters.py
+++ b/vireo/encounters.py
@@ -50,6 +50,12 @@ DEFAULTS = {
     # Informational threshold included in grouping traces. Eligibility is
     # resolved before segmentation by pipeline.load_photo_features.
     "weak_detection_confidence": 0.12,
+    # Included in the grouping fingerprint so toggling weak-detection rescue
+    # in workspace settings invalidates cached results. load_photo_features
+    # gates rescue on this flag — flipping it re-labels the bracketed frames
+    # subject_uncertain vs subject_absent, which changes encounter membership
+    # and burst scoring. Not consumed by encounter segmentation directly.
+    "weak_detection_rescue_enabled": True,
 }
 
 

--- a/vireo/encounters.py
+++ b/vireo/encounters.py
@@ -47,6 +47,9 @@ DEFAULTS = {
     "merge_score": 0.62,
     "merge_max_gap": 60.0,  # seconds
     "merge_tau": 20.0,  # time constant for merge gap decay
+    # Informational threshold included in grouping traces. Eligibility is
+    # resolved before segmentation by pipeline.load_photo_features.
+    "weak_detection_confidence": 0.12,
 }
 
 
@@ -155,6 +158,7 @@ def _has_similarity_signal(photo):
         or bool(photo.get("species_top5"))
         or bool(photo.get("subject_absent"))
         or bool(photo.get("subject_present"))
+        or bool(photo.get("subject_uncertain"))
         or has_focal
         or has_gps
     )
@@ -340,8 +344,10 @@ def compute_s_enc(photo_a, photo_b, config=None, return_components=False):
     # Detector-state encoding from load_photo_features (mutually exclusive,
     # so at most one is True per photo):
     #   subject_absent  = detector ran, no qualifying detection (real signal)
-    #   subject_present = detector ran, has a qualifying detection
-    #   both False      = detector hasn't run yet — STATE IS UNKNOWN
+    #   subject_present   = detector ran, has a qualifying detection
+    #   subject_uncertain = weaker detection in a short sequence bracketed by
+    #                       matching-species strong detections
+    #   all False         = detector hasn't run yet — STATE IS UNKNOWN
     #
     # Three cases drive the subj/species treatment:
     #   - asymmetric (one absent, one *present*): contribute active 0 with
@@ -361,6 +367,8 @@ def compute_s_enc(photo_a, photo_b, config=None, return_components=False):
     absent_b = bool(photo_b.get("subject_absent"))
     present_a = bool(photo_a.get("subject_present"))
     present_b = bool(photo_b.get("subject_present"))
+    uncertain_a = bool(photo_a.get("subject_uncertain"))
+    uncertain_b = bool(photo_b.get("subject_uncertain"))
     asymmetric_subject = (absent_a and present_b) or (absent_b and present_a)
     both_absent = absent_a and absent_b
 
@@ -392,9 +400,15 @@ def compute_s_enc(photo_a, photo_b, config=None, return_components=False):
     # the encounter cut.
     missing = {
         "time": (not has_time_a, not has_time_b),
-        "subj": (not has_subj_a and not absent_a, not has_subj_b and not absent_b),
+        "subj": (
+            not has_subj_a and not absent_a and not uncertain_a,
+            not has_subj_b and not absent_b and not uncertain_b,
+        ),
         "global": (not has_global_a, not has_global_b),
-        "species": (not has_species_a and not absent_a, not has_species_b and not absent_b),
+        "species": (
+            not has_species_a and not absent_a and not uncertain_a,
+            not has_species_b and not absent_b and not uncertain_b,
+        ),
         "meta": (False, False),
     }
     absent = {
@@ -448,6 +462,8 @@ def compute_s_enc(photo_a, photo_b, config=None, return_components=False):
             "missing_b": bool(missing[k][1]),
             "absent_a": bool(absent[k][0]),
             "absent_b": bool(absent[k][1]),
+            "uncertain_a": bool(uncertain_a) if k in ("subj", "species") else False,
+            "uncertain_b": bool(uncertain_b) if k in ("subj", "species") else False,
         }
         for k in values
     }
@@ -600,7 +616,13 @@ def cut_microsegments(photos, config=None, emit_trace=False):
                     recent_scores = []
                     decision = "cut_soft"
             if decision is None:
-                decision = "kept"
+                if (
+                    sorted_photos[i].get("subject_uncertain")
+                    or sorted_photos[i + 1].get("subject_uncertain")
+                ):
+                    decision = "kept_weak_detection"
+                else:
+                    decision = "kept"
 
         if emit_trace:
             trace.append({
@@ -631,6 +653,7 @@ def cut_microsegments(photos, config=None, emit_trace=False):
                     "soft_cut_score": cfg["soft_cut_score"],
                     "species_hard_cut_confidence": cfg["species_hard_cut_confidence"],
                     "species_hard_cut_margin": cfg["species_hard_cut_margin"],
+                    "weak_detection_confidence": cfg["weak_detection_confidence"],
                 },
             })
 

--- a/vireo/pipeline.py
+++ b/vireo/pipeline.py
@@ -232,6 +232,67 @@ def load_photo_features(db, collection_id=None, config=None,
     import config as cfg
     effective_cfg = db.get_effective_config(cfg.load())
     min_conf = effective_cfg.get("detector_confidence", 0.2)
+    pipeline_cfg = effective_cfg.get("pipeline", {})
+    weak_rescue_enabled = pipeline_cfg.get(
+        "weak_detection_rescue_enabled", True,
+    )
+    weak_confidence = pipeline_cfg.get("weak_detection_confidence", 0.12)
+    photo_ids_for_dets = [row["id"] for row in rows]
+
+    # Find only low-confidence runs bracketed by normal-confidence animal
+    # detections. The classifier uses this same pure selector, so reruns and
+    # regroup-only passes agree about which frames are eligible for rescue.
+    weak_runs = []
+    weak_candidate_ids = set()
+    raw_mdv6_dets = {}
+    if weak_rescue_enabled and weak_confidence < min_conf:
+        from weak_detections import contextual_weak_runs
+
+        raw_mdv6_dets = db.get_detections_for_photos(
+            photo_ids_for_dets,
+            min_conf=weak_confidence,
+            detector_model="megadetector-v6",
+        )
+        weak_runs = contextual_weak_runs(
+            [dict(row) for row in rows],
+            raw_mdv6_dets,
+            detector_confidence=min_conf,
+            weak_confidence=weak_confidence,
+            max_gap=pipeline_cfg.get("burst_time_gap", 3.0),
+        )
+        weak_candidate_ids = {
+            photo_id
+            for run in weak_runs
+            for photo_id in run["photo_ids"]
+        }
+
+    # Keep the normal confidence predicate index-friendly for the rest of a
+    # potentially large workspace. Only the small, preselected candidate set
+    # gets the lower floor in the subject and prediction queries below.
+    detection_floor_sql = "AND d.detector_confidence >= ?"
+    detection_floor_params = (min_conf,)
+    if weak_candidate_ids:
+        db.conn.execute(
+            "CREATE TEMP TABLE IF NOT EXISTS pipeline_weak_detection_ids "
+            "(id INTEGER PRIMARY KEY)"
+        )
+        db.conn.execute("DELETE FROM pipeline_weak_detection_ids")
+        db.conn.executemany(
+            "INSERT OR IGNORE INTO pipeline_weak_detection_ids (id) VALUES (?)",
+            [(photo_id,) for photo_id in weak_candidate_ids],
+        )
+        detection_floor_sql = """AND (
+              d.detector_confidence >= ?
+              OR (
+                  d.detector_confidence >= ?
+                  AND d.detector_model = 'megadetector-v6'
+                  AND d.category = 'animal'
+                  AND d.photo_id IN (
+                      SELECT id FROM pipeline_weak_detection_ids
+                  )
+              )
+          )"""
+        detection_floor_params = (min_conf, weak_confidence)
 
     # Preserve every qualifying animal detection as a first-class subject,
     # including detections that do not have a species prediction yet. The
@@ -240,21 +301,28 @@ def load_photo_features(db, collection_id=None, config=None,
     subject_det_rows = db.conn.execute(
         f"""SELECT d.id AS detection_id, d.photo_id,
                    d.box_x, d.box_y, d.box_w, d.box_h,
-                   d.detector_confidence, d.category
+                   d.detector_confidence, d.category, d.detector_model
             FROM detections d
             JOIN photos p ON p.id = d.photo_id
             JOIN workspace_folders wf ON wf.folder_id = p.folder_id
             WHERE wf.workspace_id = ?
-              AND d.detector_confidence >= ?
+              {detection_floor_sql}
               AND d.detector_model != 'full-image'
               AND d.category = 'animal'
               {scope_sql}
             ORDER BY d.photo_id, d.detector_confidence DESC, d.id ASC""",
-        (ws_id, min_conf, *scope_params),
+        (ws_id, *detection_floor_params, *scope_params),
     ).fetchall()
     subjects_by_photo = defaultdict(list)
     subjects_by_detection = {}
     for det in subject_det_rows:
+        is_contextual_weak = (
+            det["photo_id"] in weak_candidate_ids
+            and det["detector_model"] == "megadetector-v6"
+            and det["detector_confidence"] < min_conf
+        )
+        if det["detector_confidence"] < min_conf and not is_contextual_weak:
+            continue
         subject = {
             "detection_id": det["detection_id"],
             "box": {
@@ -289,29 +357,34 @@ def load_photo_features(db, collection_id=None, config=None,
         pred_rows = db.conn.execute(
             f"""SELECT d.photo_id, d.id AS detection_id,
                       pr.species, pr.confidence,
-                      pr.classifier_model AS model
+                      pr.classifier_model AS model,
+                      d.detector_confidence, d.detector_model
                FROM predictions pr
                JOIN detections d ON d.id = pr.detection_id
                JOIN photos p ON p.id = d.photo_id
                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
                WHERE wf.workspace_id = ?
-                 AND d.detector_confidence >= ?
+                 {detection_floor_sql}
                  AND pr.labels_fingerprint = ?
                  {scope_sql}
                ORDER BY d.photo_id, pr.confidence DESC""",
-            (ws_id, min_conf, labels_fingerprint, *scope_params),
+            (
+                ws_id, *detection_floor_params, labels_fingerprint,
+                *scope_params,
+            ),
         ).fetchall()
     else:
         pred_rows = db.conn.execute(
             f"""SELECT d.photo_id, d.id AS detection_id,
                       pr.species, pr.confidence,
-                      pr.classifier_model AS model
+                      pr.classifier_model AS model,
+                      d.detector_confidence, d.detector_model
                FROM predictions pr
                JOIN detections d ON d.id = pr.detection_id
                JOIN photos p ON p.id = d.photo_id
                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
                WHERE wf.workspace_id = ?
-                 AND d.detector_confidence >= ?
+                 {detection_floor_sql}
                  {scope_sql}
                  AND pr.labels_fingerprint = (
                      SELECT pr2.labels_fingerprint FROM predictions pr2
@@ -321,7 +394,7 @@ def load_photo_features(db, collection_id=None, config=None,
                      LIMIT 1
                  )
                ORDER BY d.photo_id, pr.confidence DESC""",
-            (ws_id, min_conf, *scope_params),
+            (ws_id, *detection_floor_params, *scope_params),
         ).fetchall()
 
     # Group predictions by photo_id, keep top K
@@ -329,6 +402,13 @@ def load_photo_features(db, collection_id=None, config=None,
     species_by_photo = defaultdict(list)
     for pr in pred_rows:
         pid = pr["photo_id"]
+        is_contextual_weak = (
+            pid in weak_candidate_ids
+            and pr["detector_model"] == "megadetector-v6"
+            and pr["detector_confidence"] < min_conf
+        )
+        if pr["detector_confidence"] < min_conf and not is_contextual_weak:
+            continue
         if len(species_by_photo[pid]) < top_k:
             species_by_photo[pid].append((pr["species"], pr["confidence"], pr["model"]))
         subject = subjects_by_detection.get(pr["detection_id"])
@@ -341,7 +421,6 @@ def load_photo_features(db, collection_id=None, config=None,
     # read-time helper. This replaces the old photos.detection_box /
     # photos.detection_conf columns; the helper applies the same threshold
     # resolved above.
-    photo_ids_for_dets = [row["id"] for row in rows]
     dets_by_photo = db.get_detections_for_photos(
         photo_ids_for_dets, min_conf=min_conf,
     )
@@ -405,6 +484,57 @@ def load_photo_features(db, collection_id=None, config=None,
         if names
     }
 
+    # Classification is intentionally more permissive than grouping: it may
+    # evaluate every bracketed weak run, but grouping promotes the run to an
+    # uncertain (rather than absent) subject state only when the two strong
+    # anchors independently identify the same species. This prevents a burst
+    # spanning a real subject change from being glued together by time alone.
+    rescued_weak_ids = set()
+    weak_context_by_photo = {}
+    if weak_runs:
+        from weak_detections import matching_anchor_species
+
+        species_floor = effective_cfg.get("classification_threshold", 0.4)
+        for run in weak_runs:
+            context = matching_anchor_species(
+                run,
+                species_by_photo,
+                confirmed_by_photo=confirmed_by_photo,
+                min_confidence=species_floor,
+            )
+            if context is None:
+                continue
+            for photo_id in run["photo_ids"]:
+                rescued_weak_ids.add(photo_id)
+                weak_context_by_photo[photo_id] = context
+
+    # Weak predictions/boxes are visible downstream only after the matching-
+    # species gate succeeds. Keep non-rescued candidates equivalent to the
+    # long-standing normal-threshold behavior.
+    for photo_id in weak_candidate_ids - rescued_weak_ids:
+        species_by_photo.pop(photo_id, None)
+        kept_subjects = [
+            subject for subject in subjects_by_photo.get(photo_id, [])
+            if subject["detection_confidence"] >= min_conf
+        ]
+        if kept_subjects:
+            subjects_by_photo[photo_id] = kept_subjects
+        else:
+            subjects_by_photo.pop(photo_id, None)
+
+    # Rescued photos use their best raw MDV6 box for display and downstream
+    # classification context. Ordinary photos continue to use the normal
+    # threshold map above.
+    for photo_id in rescued_weak_ids:
+        raw = raw_mdv6_dets.get(photo_id) or []
+        if raw:
+            top = raw[0]
+            primary_det_by_photo[photo_id] = {
+                "x": top["x"], "y": top["y"],
+                "w": top["w"], "h": top["h"],
+                "detection_conf": top["confidence"],
+            }
+
     # Only accept embeddings written with the currently configured DINOv2
     # variant. Without this check, switching variants leaves stale embeddings
     # of the old dim in place and the regroup stage crashes with
@@ -438,13 +568,14 @@ def load_photo_features(db, collection_id=None, config=None,
                        "w": det["w"], "h": det["h"]}
             det_conf = det["detection_conf"]
 
-        # Three states encoded as two booleans (mutually exclusive: at
+        # Four states encoded as three booleans (mutually exclusive: at
         # most one is True at a time):
         #
-        #   subject_absent=True   detector ran AND found no qualifying
-        #                         detection (box_count=0, or all boxes
-        #                         below the workspace threshold)
+        #   subject_absent=True   detector ran AND found no qualifying or
+        #                         contextually rescued detection
         #   subject_present=True  detector ran AND has a passing detection
+        #   subject_uncertain=True detector found a weaker box in a short run
+        #                         bracketed by matching-species anchors
         #   both False            detector hasn't run yet — state is
         #                         "unknown" (compute_s_enc treats the same
         #                         way as cached-feature absence: drop and
@@ -454,9 +585,11 @@ def load_photo_features(db, collection_id=None, config=None,
         # `full-image` fallback rows can't sway the signal. Read at
         # regroup time because regroup runs BEFORE the miss stage —
         # photos.miss_no_subject would lag by one run.
+        subject_uncertain = pid in rescued_weak_ids
         subject_absent = (
             pid in detected_photo_ids
             and pid not in mdv6_passing_photo_ids
+            and not subject_uncertain
         )
         subject_present = pid in mdv6_passing_photo_ids
 
@@ -488,6 +621,8 @@ def load_photo_features(db, collection_id=None, config=None,
             "confirmed_species": confirmed_by_photo.get(pid),
             "subject_absent": subject_absent,
             "subject_present": subject_present,
+            "subject_uncertain": subject_uncertain,
+            "weak_detection_context": weak_context_by_photo.get(pid),
             "focal_length": row["focal_length"],
             "burst_id": row["burst_id"],
             "noise_estimate": row["noise_estimate"],

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -4722,6 +4722,45 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 # detector_confidence" — the user's remediation differs
                 # (download weights vs lower the threshold).
                 detector_confidence = effective_cfg.get("detector_confidence", 0.2)
+                weak_rescue_enabled = pipeline_cfg.get(
+                    "weak_detection_rescue_enabled", True,
+                )
+                weak_detection_confidence = pipeline_cfg.get(
+                    "weak_detection_confidence", 0.12,
+                )
+
+                # Recompute the same contextual-weak set that classify_stage
+                # and load_photo_features use, so a bracketed weak frame that
+                # got classified above also gets SAM masks + quality features
+                # here. Without this, scoring.hard_reject_reasons drops the
+                # rescued frame with `no_subject_mask` on a first-time pipeline
+                # run (predictions land, but the mask worklist skipped it) —
+                # partially undoing the rescue.
+                contextual_weak_ids: set = set()
+                if (
+                    weak_rescue_enabled
+                    and weak_detection_confidence < detector_confidence
+                    and photos
+                ):
+                    from weak_detections import contextual_weak_runs
+                    raw_mdv6_dets = thread_db.get_detections_for_photos(
+                        [p["id"] for p in photos],
+                        min_conf=weak_detection_confidence,
+                        detector_model="megadetector-v6",
+                    )
+                    weak_runs = contextual_weak_runs(
+                        photos,
+                        raw_mdv6_dets,
+                        detector_confidence=detector_confidence,
+                        weak_confidence=weak_detection_confidence,
+                        max_gap=pipeline_cfg.get("burst_time_gap", 3.0),
+                    )
+                    contextual_weak_ids = {
+                        photo_id
+                        for run in weak_runs
+                        for photo_id in run["photo_ids"]
+                    }
+
                 photo_det_map = {}
                 photos_with_detections = 0
                 photos_subthreshold_only = 0
@@ -4733,12 +4772,28 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     # legacy `mask_path IS NULL` prefilter gone, sub-threshold-
                     # only photos would otherwise enter SAM extraction on
                     # variant cache misses.
-                    dets = [
-                        d for d in thread_db.get_detections(
-                            p["id"], min_conf=detector_confidence,
-                        )
-                        if d["detector_model"] != "full-image"
-                    ]
+                    #
+                    # Contextual weak-rescue photos get the lower floor plus
+                    # the same MDv6/animal constraints that classify_stage and
+                    # load_photo_features apply, so mask extraction picks up
+                    # the same bracketed frame those two stages already opted
+                    # in to.
+                    if p["id"] in contextual_weak_ids:
+                        dets = [
+                            d for d in thread_db.get_detections(
+                                p["id"],
+                                min_conf=weak_detection_confidence,
+                                detector_model="megadetector-v6",
+                            )
+                            if d["category"] == "animal"
+                        ]
+                    else:
+                        dets = [
+                            d for d in thread_db.get_detections(
+                                p["id"], min_conf=detector_confidence,
+                            )
+                            if d["detector_model"] != "full-image"
+                        ]
                     if dets:
                         photos_with_detections += 1
                         primary = dets[0]  # already ordered by confidence DESC

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -4755,11 +4755,31 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         weak_confidence=weak_detection_confidence,
                         max_gap=pipeline_cfg.get("burst_time_gap", 3.0),
                     )
-                    contextual_weak_ids = {
+                    weak_scope_ids = {
                         photo_id
                         for run in weak_runs
-                        for photo_id in run["photo_ids"]
+                        for photo_id in (
+                            run["left_photo_id"],
+                            *run["photo_ids"],
+                            run["right_photo_id"],
+                        )
                     }
+                    if weak_scope_ids:
+                        # Mask only frames that pass the same matching-species
+                        # anchor gate as encounter grouping. Candidate weak
+                        # runs with conflicting or unclassified anchors remain
+                        # ordinary sub-threshold detections throughout.
+                        from pipeline import load_photo_features
+                        weak_features = load_photo_features(
+                            thread_db,
+                            config=effective_cfg,
+                            photo_ids=weak_scope_ids,
+                        )
+                        contextual_weak_ids = {
+                            feature["id"]
+                            for feature in weak_features
+                            if feature.get("subject_uncertain")
+                        }
 
                 photo_det_map = {}
                 photos_with_detections = 0

--- a/vireo/pipeline_job.py
+++ b/vireo/pipeline_job.py
@@ -3802,6 +3802,13 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 grouping_window = user_cfg.get("grouping_window_seconds", 5)
                 similarity_threshold = user_cfg.get("similarity_threshold", 0.85)
                 detector_confidence = user_cfg.get("detector_confidence", 0.2)
+                pipeline_cfg = user_cfg.get("pipeline", {})
+                weak_rescue_enabled = pipeline_cfg.get(
+                    "weak_detection_rescue_enabled", True,
+                )
+                weak_detection_confidence = pipeline_cfg.get(
+                    "weak_detection_confidence", 0.12,
+                )
 
                 tax = loaded_models["tax"]
                 # Fingerprint for the FIRST model is preloaded by model_loader_stage.
@@ -3816,6 +3823,43 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                 folders = detect_state["folders"]
                 cached_detections = detect_state["detections"]
                 total = len(photos)
+
+                # A low-confidence box is not globally promoted. Only select
+                # weak runs bracketed by ordinary detections in one tightly
+                # timed sequence. This gives the classifier a chance to
+                # validate threshold-cliff frames without making every weak
+                # MegaDetector result eligible throughout the library.
+                contextual_weak_ids = set()
+                if (
+                    weak_rescue_enabled
+                    and weak_detection_confidence < detector_confidence
+                    and photos
+                ):
+                    from weak_detections import contextual_weak_runs
+
+                    raw_mdv6_detections = thread_db.get_detections_for_photos(
+                        [p["id"] for p in photos],
+                        min_conf=weak_detection_confidence,
+                        detector_model="megadetector-v6",
+                    )
+                    weak_runs = contextual_weak_runs(
+                        photos,
+                        raw_mdv6_detections,
+                        detector_confidence=detector_confidence,
+                        weak_confidence=weak_detection_confidence,
+                        max_gap=pipeline_cfg.get("burst_time_gap", 3.0),
+                    )
+                    contextual_weak_ids = {
+                        photo_id
+                        for run in weak_runs
+                        for photo_id in run["photo_ids"]
+                    }
+                    if contextual_weak_ids:
+                        log.info(
+                            "Classification: rescuing %d weak-detection "
+                            "photo(s) across %d bracketed sequence(s)",
+                            len(contextual_weak_ids), len(weak_runs),
+                        )
 
                 total_predictions_stored = 0
                 total_full_image_fallbacks = 0
@@ -4124,6 +4168,14 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                             # classifiers still get one attempt and future reruns
                             # can hit classifier_runs for that attempt.
                             full_image_fallback = False
+                            is_contextual_weak = (
+                                photo["id"] in contextual_weak_ids
+                            )
+                            detection_floor = (
+                                weak_detection_confidence
+                                if is_contextual_weak
+                                else detector_confidence
+                            )
                             if photo["id"] in cached_detections:
                                 # cached_detections from _detect_batch can include
                                 # full-image rows when an earlier pass synthesized
@@ -4139,7 +4191,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                     and d.get(
                                         "confidence",
                                         d.get("detector_confidence", 0),
-                                    ) >= detector_confidence
+                                    ) >= detection_floor
                                 ]
                             else:
                                 photo_dets = [
@@ -4153,11 +4205,38 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                                         "category": d["category"],
                                     }
                                     for d in thread_db.get_detections(
-                                        photo["id"], min_conf=detector_confidence,
+                                        photo["id"], min_conf=detection_floor,
                                     )
                                     if d["detector_model"] != "full-image"
                                     and d["category"] == "animal"
                                 ]
+                            if is_contextual_weak and not photo_dets:
+                                # detect_state intentionally caches only rows
+                                # passing the ordinary workspace threshold on
+                                # reuse runs. Recover the raw weak row from the
+                                # database for this explicitly selected bridge.
+                                photo_dets = [
+                                    {
+                                        "id": d["id"],
+                                        "box_x": d["box_x"],
+                                        "box_y": d["box_y"],
+                                        "box_w": d["box_w"],
+                                        "box_h": d["box_h"],
+                                        "confidence": d["detector_confidence"],
+                                        "category": d["category"],
+                                    }
+                                    for d in thread_db.get_detections(
+                                        photo["id"],
+                                        min_conf=weak_detection_confidence,
+                                        detector_model="megadetector-v6",
+                                    )
+                                    if d["category"] == "animal"
+                                ]
+                            if is_contextual_weak and photo_dets:
+                                # One best weak crop is enough to validate the
+                                # bridge. Classifying every low-confidence box
+                                # would multiply work and false-positive risk.
+                                photo_dets = photo_dets[:1]
                             detections_to_classify = photo_dets
                             if not detections_to_classify:
                                 # Distinguish "no eligible detection at the
@@ -4500,6 +4579,10 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                         parts.append(f"{skipped_existing} cached")
                     if full_image_fallbacks:
                         parts.append(f"{full_image_fallbacks} full-image fallback")
+                    if contextual_weak_ids:
+                        parts.append(
+                            f"{len(contextual_weak_ids)} weak detections rescued"
+                        )
                     if failed:
                         parts.append(f"{failed} failed")
                     runner.update_step(
@@ -4545,6 +4628,7 @@ def run_pipeline_job(job, runner, db_path, workspace_id, params,
                     "failed": total_failed,
                     "already_classified": total_skipped_existing,
                     "full_image_fallbacks": total_full_image_fallbacks,
+                    "weak_detection_rescues": len(contextual_weak_ids),
                     "model_count": len(resolved_specs_local),
                     "models_succeeded": models_succeeded,
                     "models_skipped": len(skipped_model_names),

--- a/vireo/templates/pipeline_review.html
+++ b/vireo/templates/pipeline_review.html
@@ -702,6 +702,10 @@ input[type="range"]::-moz-range-thumb {
   color: rgba(180, 180, 180, 0.85);
   font-style: italic;
 }
+.algo-trace .trace-component-uncertain {
+  color: rgba(90, 170, 220, 0.95);
+  font-style: italic;
+}
 .algo-trace .trace-empty {
   font-size: 11px; color: var(--text-dim); font-style: italic; padding: 4px;
 }
@@ -2612,6 +2616,9 @@ function renderAlgorithmTrace() {
     if (typeof thr.species_hard_cut_margin === 'number') {
       thrParts.push('species_margin=' + thr.species_hard_cut_margin.toFixed(2));
     }
+    if (typeof thr.weak_detection_confidence === 'number') {
+      thrParts.push('weak_detection=' + thr.weak_detection_confidence.toFixed(2));
+    }
     if (typeof thr.hard_cut_time === 'number') thrParts.push('hard_cut_time=' + thr.hard_cut_time + 's');
     if (thrParts.length) {
       html += '<div class="trace-thresholds">cut if: ' + thrParts.join(' · ') + '</div>';
@@ -2624,7 +2631,10 @@ function renderAlgorithmTrace() {
     else rowCls += ' kept';
     var dt = (t.dt_seconds === null || t.dt_seconds === undefined) ? '∞' : t.dt_seconds.toFixed(1) + 's';
     var score = (typeof t.score === 'number') ? t.score.toFixed(3) : '-';
-    var decision = t.decision || '?';
+    var decisionLabels = {
+      kept_weak_detection: 'kept · weak detection rescued'
+    };
+    var decision = decisionLabels[t.decision] || t.decision || '?';
     html += '<div class="' + rowCls + '">';
     html += '<span>pair ' + (i + 1) + ' · ' + dt + '</span>';
     html += '<span>S=' + score + '</span>';
@@ -2671,6 +2681,14 @@ function renderAlgorithmTrace() {
             // don't go re-embed photos that legitimately have no subject.
             parts.push('<span class="trace-component-absent">' + escapeHtml(k)
               + '=neutral (no subject on both, w=' + w + ')</span>');
+          } else if (c.uncertain_a || c.uncertain_b) {
+            var uncertainWho;
+            if (c.uncertain_a && c.uncertain_b) uncertainWho = 'both';
+            else if (c.uncertain_a) uncertainWho = nameA;
+            else uncertainWho = nameB;
+            parts.push('<span class="trace-component-uncertain">'
+              + escapeHtml(k) + '=context-rescued weak detection on '
+              + escapeHtml(uncertainWho) + ' (w=' + w + ')</span>');
           } else {
             var who;
             if (c.missing_a && c.missing_b) who = 'both';

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -204,6 +204,123 @@ def test_load_photo_features_subject_absent_from_current_detections(tmp_path):
     )
 
 
+def test_load_photo_features_rescues_bracketed_weak_grackle_run(
+    tmp_path, monkeypatch,
+):
+    """Strong matching-species anchors turn only the intervening weak boxes
+    into the explicit uncertain state, preserving one encounter without
+    lowering the workspace detector threshold.
+    """
+    import config as cfg
+    from db import Database
+    from pipeline import load_photo_features, run_grouping
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder(str(tmp_path / "photos"), name="photos")
+    base = datetime(2026, 7, 18, 8, 36, 35, 990000)
+    confidences = [0.229, 0.185, 0.156, 0.149, 0.172, 0.193, 0.186, 0.798]
+    photo_ids = []
+    detection_ids = []
+    for index, confidence in enumerate(confidences):
+        # The final anchor is 2.12 seconds after the preceding weak frame,
+        # matching DSC_4384 -> DSC_4385.
+        offset = index * 0.05 if index < 7 else 2.42
+        photo_id = db.add_photo(
+            folder_id, f"DSC_{4378 + index}.NEF", ".nef", 100, 1.0,
+            timestamp=(base + timedelta(seconds=offset)).isoformat(),
+            width=8280, height=5520,
+        )
+        detection_id = db.write_detection_batch(
+            photo_id,
+            "megadetector-v6",
+            [{
+                "box": {"x": 0.05, "y": 0.0, "w": 0.87, "h": 0.96},
+                "confidence": confidence,
+                "category": "animal",
+            }],
+        )[0]
+        photo_ids.append(photo_id)
+        detection_ids.append(detection_id)
+
+    db.add_prediction(
+        detection_ids[0], "Great-tailed Grackle", 0.7846, "inat21",
+        category="match",
+    )
+    db.add_prediction(
+        detection_ids[-1], "Great-tailed Grackle", 0.9026, "inat21",
+        category="match",
+    )
+
+    photos = load_photo_features(db)
+    by_id = {photo["id"]: photo for photo in photos}
+    for photo_id in photo_ids[1:-1]:
+        photo = by_id[photo_id]
+        assert photo["subject_uncertain"] is True
+        assert photo["subject_present"] is False
+        assert photo["subject_absent"] is False
+        assert 0.12 <= photo["detection_conf"] < 0.20
+        assert photo["weak_detection_context"]["species"] == (
+            "Great-tailed Grackle"
+        )
+
+    encounters = run_grouping(
+        photos,
+        config=cfg.DEFAULTS["pipeline"],
+        emit_trace=True,
+    )
+    assert len(encounters) == 1
+    assert encounters[0]["photo_count"] == 8
+    assert encounters[0]["species"] == ("Great-tailed Grackle", 0.8436)
+    assert any(
+        row["decision"] == "kept_weak_detection"
+        for row in encounters[0]["trace"]
+    )
+
+
+def test_load_photo_features_does_not_rescue_conflicting_species_anchors(
+    tmp_path, monkeypatch,
+):
+    """A weak run between different species keeps the ordinary absent state."""
+    import config as cfg
+    from db import Database
+    from pipeline import load_photo_features
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db = Database(str(tmp_path / "test.db"))
+    folder_id = db.add_folder(str(tmp_path / "photos"), name="photos")
+    ids = []
+    detection_ids = []
+    for index, confidence in enumerate((0.9, 0.18, 0.9)):
+        photo_id = db.add_photo(
+            folder_id, f"photo{index}.jpg", ".jpg", 100, 1.0,
+            timestamp=f"2026-07-18T08:36:3{index}",
+        )
+        detection_id = db.write_detection_batch(
+            photo_id,
+            "megadetector-v6",
+            [{
+                "box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+                "confidence": confidence,
+                "category": "animal",
+            }],
+        )[0]
+        ids.append(photo_id)
+        detection_ids.append(detection_id)
+    db.add_prediction(detection_ids[0], "Grackle", 0.9, "inat21")
+    db.add_prediction(detection_ids[2], "Cowbird", 0.9, "inat21")
+
+    middle = {p["id"]: p for p in load_photo_features(db)}[ids[1]]
+    assert middle["subject_uncertain"] is False
+    assert middle["subject_absent"] is True
+    assert middle["detection_conf"] is None
+    assert middle["species_top5"] == []
+
+
 def test_load_photo_features_subject_absent_false_when_detector_never_ran(tmp_path):
     """A photo with no detector_runs row hasn't had the detector run yet
     (e.g. first-time regroup with skip_classify=True, or newly imported

--- a/vireo/tests/test_pipeline.py
+++ b/vireo/tests/test_pipeline.py
@@ -3036,6 +3036,24 @@ def test_compute_group_fingerprint_ignores_unrelated_pipeline_keys():
     assert unrelated == base
 
 
+def test_compute_group_fingerprint_changes_with_weak_rescue_toggle():
+    """Toggling ``pipeline.weak_detection_rescue_enabled`` must bump the
+    fingerprint. The flag flips load_photo_features between treating
+    bracketed weak frames as ``subject_uncertain`` vs ``subject_absent``,
+    which changes encounter membership and burst scoring. If the fingerprint
+    ignored it, a workspace with cached results could toggle rescue on/off
+    without any upstream stage having new work and the Process page would
+    still report the grouping cache as fresh."""
+    from pipeline import compute_group_fingerprint
+    on = compute_group_fingerprint(
+        {"pipeline": {"weak_detection_rescue_enabled": True}},
+    )
+    off = compute_group_fingerprint(
+        {"pipeline": {"weak_detection_rescue_enabled": False}},
+    )
+    assert on != off
+
+
 def test_serialize_results_counts_missing_timestamps():
     """Each serialized encounter reports how many of its photos lack a timestamp."""
     from pipeline import serialize_results

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -3404,6 +3404,81 @@ def test_pipeline_classify_passes_each_qualifying_detection_to_prepare_image(
     )
 
 
+def test_pipeline_classifies_bracketed_weak_detection_without_lowering_threshold(
+    tmp_path, monkeypatch,
+):
+    """A weak box between two strong, tightly timed frames gets one targeted
+    classifier attempt even though the workspace threshold remains 0.20.
+    """
+    import classifier as classifier_mod
+    import classify_job
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+
+    photo_ids = []
+    for index, confidence in enumerate((0.9, 0.18, 0.9)):
+        filename = f"bird{index}.jpg"
+        photo_id = db.add_photo(
+            folder_id, filename, ".jpg", 12345, 1_000_000.0 + index,
+            timestamp=f"2026-07-18T08:36:3{index}",
+        )
+        _drop_jpeg(folder_path, filename)
+        db.write_detection_batch(
+            photo_id,
+            "megadetector-v6",
+            [{
+                "box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+                "confidence": confidence,
+                "category": "animal",
+            }],
+        )
+        photo_ids.append(photo_id)
+
+    collection_id = db.add_collection(
+        "Weak bridge",
+        json.dumps([{"field": "photo_ids", "value": photo_ids}]),
+    )
+    model_id = _setup_fake_downloaded_model(tmp_path, monkeypatch)
+
+    captured = []
+
+    def capturing_prepare_image(photo, folders, detection, vireo_dir=None):
+        captured.append((photo["filename"], detection["confidence"]))
+        return None, "", ""
+
+    monkeypatch.setattr(classify_job, "_prepare_image", capturing_prepare_image)
+
+    class FakeClassifier:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(classifier_mod, "Classifier", FakeClassifier)
+
+    params = PipelineParams(
+        collection_id=collection_id,
+        model_ids=[model_id],
+        skip_extract_masks=True,
+        skip_regroup=True,
+    )
+    runner = FakeRunner()
+    job = _make_job()
+    with contextlib.suppress(RuntimeError):
+        run_pipeline_job(job, runner, db_path, ws_id, params)
+
+    assert ("bird1.jpg", 0.18) in captured
+    assert [name for name, _ in captured].count("bird1.jpg") == 1
+
+
 def test_pipeline_reclassify_purges_stale_detection_rows(tmp_path, monkeypatch):
     """On reclassify, prior-run detection rows must be deleted after model 1
     re-runs MegaDetector so that subsequent non-reclassify runs don't reuse

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -8204,14 +8204,17 @@ def _stub_extract_masks_heavy_ops(monkeypatch):
     return state
 
 
-def test_extract_masks_stage_includes_bracketed_weak_detection(
-    tmp_path, monkeypatch,
+@pytest.mark.parametrize(
+    ("right_species", "expected_proxy_calls"),
+    (("Great-tailed Grackle", 3), ("Brown-headed Cowbird", 2)),
+)
+def test_extract_masks_stage_gates_weak_detection_on_matching_anchor_species(
+    tmp_path, monkeypatch, right_species, expected_proxy_calls,
 ):
-    """A context-rescued weak box must enter the SAM mask worklist.
+    """Only a species-validated weak box enters the SAM mask worklist.
 
     Classification already lowers its crop floor for a bracketed weak frame;
-    mask extraction must use the same contextual set or a first-time full
-    pipeline run later rejects that frame for having no subject mask.
+    mask extraction must also apply grouping's matching-anchor-species gate.
     """
     import config as cfg
     from db import Database
@@ -8227,6 +8230,7 @@ def test_extract_masks_stage_includes_bracketed_weak_detection(
     folder_id = db.add_folder(folder_path)
 
     photo_ids = []
+    detection_ids = []
     for index, confidence in enumerate((0.9, 0.18, 0.9)):
         filename = f"bird{index}.jpg"
         photo_id = db.add_photo(
@@ -8234,7 +8238,7 @@ def test_extract_masks_stage_includes_bracketed_weak_detection(
             timestamp=f"2026-07-18T08:36:3{index}",
         )
         _drop_jpeg(folder_path, filename)
-        db.write_detection_batch(
+        detection_id = db.write_detection_batch(
             photo_id,
             "megadetector-v6",
             [{
@@ -8242,8 +8246,16 @@ def test_extract_masks_stage_includes_bracketed_weak_detection(
                 "confidence": confidence,
                 "category": "animal",
             }],
-        )
+        )[0]
         photo_ids.append(photo_id)
+        detection_ids.append(detection_id)
+
+    db.add_prediction(
+        detection_ids[0], "Great-tailed Grackle", 0.9, "inat21",
+    )
+    db.add_prediction(
+        detection_ids[-1], right_species, 0.9, "inat21",
+    )
 
     collection_id = db.add_collection(
         "Weak mask bridge",
@@ -8260,7 +8272,7 @@ def test_extract_masks_stage_includes_bracketed_weak_detection(
     runner = FakeRunner()
     run_pipeline_job(_make_job(), runner, db_path, ws_id, params)
 
-    assert state["proxy_calls"] == 3
+    assert state["proxy_calls"] == expected_proxy_calls
 
 
 def test_pipeline_extract_masks_cancel_marks_stage_cancelled(

--- a/vireo/tests/test_pipeline_job.py
+++ b/vireo/tests/test_pipeline_job.py
@@ -8204,6 +8204,65 @@ def _stub_extract_masks_heavy_ops(monkeypatch):
     return state
 
 
+def test_extract_masks_stage_includes_bracketed_weak_detection(
+    tmp_path, monkeypatch,
+):
+    """A context-rescued weak box must enter the SAM mask worklist.
+
+    Classification already lowers its crop floor for a bracketed weak frame;
+    mask extraction must use the same contextual set or a first-time full
+    pipeline run later rejects that frame for having no subject mask.
+    """
+    import config as cfg
+    from db import Database
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg.CONFIG_PATH = str(tmp_path / "config.json")
+
+    db_path = str(tmp_path / "test.db")
+    db = Database(db_path)
+    ws_id = db._active_workspace_id
+    folder_path = str(tmp_path / "photos")
+    os.makedirs(folder_path, exist_ok=True)
+    folder_id = db.add_folder(folder_path)
+
+    photo_ids = []
+    for index, confidence in enumerate((0.9, 0.18, 0.9)):
+        filename = f"bird{index}.jpg"
+        photo_id = db.add_photo(
+            folder_id, filename, ".jpg", 1000, 1_000_000.0 + index,
+            timestamp=f"2026-07-18T08:36:3{index}",
+        )
+        _drop_jpeg(folder_path, filename)
+        db.write_detection_batch(
+            photo_id,
+            "megadetector-v6",
+            [{
+                "box": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+                "confidence": confidence,
+                "category": "animal",
+            }],
+        )
+        photo_ids.append(photo_id)
+
+    collection_id = db.add_collection(
+        "Weak mask bridge",
+        json.dumps([{"field": "photo_ids", "value": photo_ids}]),
+    )
+    state = _stub_extract_masks_heavy_ops(monkeypatch)
+
+    params = PipelineParams(
+        collection_id=collection_id,
+        skip_classify=True,
+        skip_extract_masks=False,
+        skip_regroup=True,
+    )
+    runner = FakeRunner()
+    run_pipeline_job(_make_job(), runner, db_path, ws_id, params)
+
+    assert state["proxy_calls"] == 3
+
+
 def test_pipeline_extract_masks_cancel_marks_stage_cancelled(
     tmp_path, monkeypatch,
 ):

--- a/vireo/tests/test_weak_detections.py
+++ b/vireo/tests/test_weak_detections.py
@@ -1,0 +1,85 @@
+"""Regression tests for context-aware weak animal detection rescue."""
+
+from datetime import datetime, timedelta
+
+
+def _photos(confidences, *, gap=0.05, folder_id=1):
+    base = datetime(2026, 7, 18, 8, 36, 35, 990000)
+    photos = []
+    detections = {}
+    for index, confidence in enumerate(confidences):
+        photo_id = index + 1
+        photos.append({
+            "id": photo_id,
+            "folder_id": folder_id,
+            "timestamp": (base + timedelta(seconds=index * gap)).isoformat(),
+        })
+        if confidence is not None:
+            detections[photo_id] = [{
+                "confidence": confidence,
+                "category": "animal",
+                "detector_model": "megadetector-v6",
+            }]
+    return photos, detections
+
+
+def test_contextual_weak_run_matches_grackle_threshold_cliff():
+    from weak_detections import contextual_weak_runs
+
+    photos, detections = _photos([
+        0.229, 0.185, 0.156, 0.149, 0.172, 0.193, 0.186, 0.798,
+    ])
+
+    assert contextual_weak_runs(photos, detections) == [{
+        "photo_ids": [2, 3, 4, 5, 6, 7],
+        "left_photo_id": 1,
+        "right_photo_id": 8,
+        "left_confidence": 0.229,
+        "right_confidence": 0.798,
+    }]
+
+
+def test_contextual_weak_run_requires_two_strong_anchors():
+    from weak_detections import contextual_weak_runs
+
+    photos, detections = _photos([0.9, 0.18, 0.17, None, 0.9])
+    assert contextual_weak_runs(photos, detections) == []
+
+
+def test_contextual_weak_run_does_not_cross_long_gap_or_folder():
+    from weak_detections import contextual_weak_runs
+
+    photos, detections = _photos([0.9, 0.18, 0.9], gap=4.0)
+    assert contextual_weak_runs(photos, detections, max_gap=3.0) == []
+
+    photos, detections = _photos([0.9, 0.18, 0.9])
+    photos[1]["folder_id"] = 2
+    assert contextual_weak_runs(photos, detections) == []
+
+
+def test_contextual_weak_run_ignores_interleaved_other_folder():
+    from weak_detections import contextual_weak_runs
+
+    photos, detections = _photos([0.9, 0.18, 0.9])
+    photos.insert(1, {
+        "id": 99,
+        "folder_id": 2,
+        "timestamp": "2026-07-18T08:36:36.015000",
+    })
+
+    assert contextual_weak_runs(photos, detections)[0]["photo_ids"] == [2]
+
+
+def test_matching_anchor_species_requires_agreement():
+    from weak_detections import matching_anchor_species
+
+    run = {"photo_ids": [2], "left_photo_id": 1, "right_photo_id": 3}
+    species = {
+        1: [("Great-tailed Grackle", 0.78, "inat21")],
+        3: [("Great-tailed Grackle", 0.90, "inat21")],
+    }
+    match = matching_anchor_species(run, species)
+    assert match["species"] == "Great-tailed Grackle"
+
+    species[3] = [("Brown-headed Cowbird", 0.90, "inat21")]
+    assert matching_anchor_species(run, species) is None

--- a/vireo/weak_detections.py
+++ b/vireo/weak_detections.py
@@ -1,0 +1,206 @@
+"""Context-aware rescue for low-confidence animal detections.
+
+MegaDetector confidence is intentionally conservative, but treating a box at
+0.199 as definitive evidence that no subject exists creates a sharp grouping
+cliff.  This module identifies only the safer case: a contiguous run of weak
+animal detections, in one folder, bracketed by normal-confidence detections in
+the same short camera sequence.
+
+The classifier may evaluate every candidate run.  Encounter grouping applies
+the stronger ``matching_anchor_species`` gate before treating the middle
+frames as uncertain rather than absent.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+
+def _get(row, key, default=None):
+    """Read from plain dicts and sqlite3.Row values."""
+    if hasattr(row, "get"):
+        return row.get(key, default)
+    try:
+        value = row[key]
+    except (KeyError, IndexError, TypeError):
+        return default
+    return value
+
+
+def _parse_timestamp(value):
+    if isinstance(value, datetime):
+        return value
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _confidence(detection):
+    value = _get(detection, "confidence")
+    if value is None:
+        value = _get(detection, "detector_confidence")
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _max_animal_confidence(detections):
+    values = [
+        _confidence(det)
+        for det in (detections or [])
+        if _get(det, "category", "animal") == "animal"
+        and _get(det, "detector_model") != "full-image"
+    ]
+    return max(values, default=0.0)
+
+
+def contextual_weak_runs(
+    photos,
+    detections_by_photo,
+    *,
+    detector_confidence=0.20,
+    weak_confidence=0.12,
+    max_gap=3.0,
+):
+    """Return weak runs bracketed by strong detections.
+
+    Each result is a dict containing ``photo_ids``, ``left_photo_id``, and
+    ``right_photo_id``.  A weak run is eligible only when every adjacent pair
+    is within ``max_gap`` seconds and every photo is in the same folder.  A
+    truly empty frame, a box below ``weak_confidence``, a folder boundary, or
+    a long pause breaks the bridge.
+    """
+    if weak_confidence >= detector_confidence:
+        return []
+
+    photos_by_folder = {}
+    for photo in photos or []:
+        timestamp = _parse_timestamp(_get(photo, "timestamp"))
+        folder_id = _get(photo, "folder_id")
+        if timestamp is None or folder_id is None:
+            continue
+        photo_id = _get(photo, "id")
+        confidence = _max_animal_confidence(
+            detections_by_photo.get(photo_id, [])
+        )
+        if confidence >= detector_confidence:
+            state = "strong"
+        elif confidence >= weak_confidence:
+            state = "weak"
+        else:
+            state = "none"
+        photos_by_folder.setdefault(folder_id, []).append({
+            "id": photo_id,
+            "folder_id": folder_id,
+            "timestamp": timestamp,
+            "confidence": confidence,
+            "state": state,
+        })
+
+    runs = []
+    for ordered in photos_by_folder.values():
+        # Analyze each folder independently. Different imports can contain
+        # overlapping capture times; an unrelated photo from another folder
+        # must not interrupt an otherwise valid camera sequence.
+        ordered.sort(key=lambda item: (item["timestamp"], item["id"] or 0))
+        index = 0
+        while index < len(ordered):
+            if ordered[index]["state"] != "weak":
+                index += 1
+                continue
+            start = index
+            while (
+                index + 1 < len(ordered)
+                and ordered[index + 1]["state"] == "weak"
+            ):
+                index += 1
+            end = index
+            left = ordered[start - 1] if start > 0 else None
+            right = ordered[end + 1] if end + 1 < len(ordered) else None
+            weak_items = ordered[start:end + 1]
+
+            if (
+                left is not None
+                and right is not None
+                and left["state"] == "strong"
+                and right["state"] == "strong"
+            ):
+                sequence = [left, *weak_items, right]
+                gaps_are_short = all(
+                    0.0
+                    <= (b["timestamp"] - a["timestamp"]).total_seconds()
+                    <= max_gap
+                    for a, b in zip(sequence, sequence[1:], strict=False)
+                )
+                if gaps_are_short:
+                    runs.append({
+                        "photo_ids": [item["id"] for item in weak_items],
+                        "left_photo_id": left["id"],
+                        "right_photo_id": right["id"],
+                        "left_confidence": left["confidence"],
+                        "right_confidence": right["confidence"],
+                    })
+            index += 1
+    return runs
+
+
+def _normalized_species(name):
+    return " ".join(str(name or "").strip().casefold().split())
+
+
+def _anchor_species(photo_id, species_by_photo, confirmed_by_photo, min_confidence):
+    confirmed = (confirmed_by_photo or {}).get(photo_id)
+    if confirmed:
+        return _normalized_species(confirmed), str(confirmed), 1.0
+
+    best = None
+    for entry in (species_by_photo or {}).get(photo_id, []):
+        if not entry or len(entry) < 2:
+            continue
+        try:
+            confidence = float(entry[1])
+        except (TypeError, ValueError):
+            continue
+        if confidence < min_confidence:
+            continue
+        name = str(entry[0] or "").strip()
+        key = _normalized_species(name)
+        if key and (best is None or confidence > best[2]):
+            best = (key, name, confidence)
+    return best
+
+
+def matching_anchor_species(
+    run,
+    species_by_photo,
+    *,
+    confirmed_by_photo=None,
+    min_confidence=0.40,
+):
+    """Return shared anchor species metadata, or ``None`` when unsafe.
+
+    Both strong anchor photos must independently identify the same species.
+    A user-confirmed keyword is accepted as confidence 1.0; otherwise the
+    best classifier result must meet ``min_confidence``.
+    """
+    left = _anchor_species(
+        run["left_photo_id"], species_by_photo, confirmed_by_photo,
+        min_confidence,
+    )
+    right = _anchor_species(
+        run["right_photo_id"], species_by_photo, confirmed_by_photo,
+        min_confidence,
+    )
+    if left is None or right is None or left[0] != right[0]:
+        return None
+    return {
+        "species": left[1],
+        "left_confidence": left[2],
+        "right_confidence": right[2],
+        "left_photo_id": run["left_photo_id"],
+        "right_photo_id": run["right_photo_id"],
+    }


### PR DESCRIPTION
Fixes a detector-threshold cliff that split obvious subjects into unlabeled encounters when their confidence fell just below the normal cutoff.

Adds a guarded weak-detection rescue path that requires a tightly timed, same-folder sequence bracketed by strong detections whose species agree, while leaving the global detector threshold unchanged.

The pipeline now classifies the best weak crop, represents rescued frames explicitly during encounter grouping, and explains the decision in Pipeline Review with configurable controls.

Validated with 354 passing tests, 19 expected skips, lint and diff checks, and the real DSC_4379–DSC_4384 sequence against a copied database, where it joined the surrounding Great-tailed Grackle encounter at 0.8287 confidence.
