### PR TITLE
Improve Work Locally destination selection

### DIFF
--- a/tests/e2e/test_workspace.py
+++ b/tests/e2e/test_workspace.py
@@ -24,12 +24,20 @@ def test_work_locally_full_cycle(live_server, page, tmp_path):
     work_locally = page.get_by_role("button", name="Work Locally", exact=True)
     expect(work_locally).to_be_visible(timeout=5000)
     work_locally.click()
+    modal = page.locator("#stageLocalFoldersModal")
+    expect(modal).to_have_class("modal-overlay open")
+    chosen_parent = tmp_path / "chosen-local-storage"
+    modal.locator("[data-local-destination-base]").fill(str(chosen_parent))
+    expect(modal.locator("[data-local-destination-preview]")).to_contain_text(
+        str(chosen_parent / "nas-src")
+    )
+    modal.get_by_role("button", name="Copy Locally", exact=True).click()
 
     panel = page.locator("#localWorkspaceContent")
     expect(panel).to_contain_text("using local storage", timeout=15000)
 
     local_path = db.conn.execute("SELECT path FROM folders WHERE id=?", (folder_id,)).fetchone()["path"]
-    assert local_path != str(source)
+    assert local_path == str(chosen_parent / "nas-src")
     Path(local_path, "bird.jpg").write_bytes(b"edited-locally")
 
     page.get_by_role("button", name="Sync Back", exact=True).click()
@@ -73,6 +81,9 @@ def test_shared_folder_local_status_follows_workspace_switch(live_server, page, 
     assert page.request.post(f"{live_server['url']}/api/workspaces/{first}/activate").ok
     page.goto(f"{live_server['url']}/workspace", timeout=5000)
     page.get_by_role("button", name="Work Locally", exact=True).click()
+    page.locator("#stageLocalFoldersModal").get_by_role(
+        "button", name="Copy Locally", exact=True
+    ).click()
     expect(page.get_by_text("Local · 2 workspaces", exact=True)).to_be_visible(timeout=15000)
 
     assert page.request.post(f"{live_server['url']}/api/workspaces/{second}/activate").ok

--- a/vireo/services/local_folder.py
+++ b/vireo/services/local_folder.py
@@ -919,8 +919,8 @@ def sync_folder(
             if progress:
                 progress(done, total, rel)
         workspace_ids = affected_workspace_ids(db, root_folder_id)
-        _remove_folder_dir(vireo_dir, root_folder_id, root["local_path"])
         _restore_catalog(db, root_folder_id)
+        _remove_folder_dir(vireo_dir, root_folder_id, root["local_path"])
         for workspace_id in workspace_ids:
             db.invalidate_new_images_cache_for_workspace(workspace_id)
         return {
@@ -958,8 +958,8 @@ def discard_folder(db, root_folder_id: int, vireo_dir: str, *, acknowledge_publi
         if root is None:
             raise LocalWorkspaceError("Local folder mapping is missing its root")
         workspace_ids = affected_workspace_ids(db, root_folder_id)
-        _remove_folder_dir(vireo_dir, root_folder_id, root["local_path"])
         _restore_catalog(db, root_folder_id)
+        _remove_folder_dir(vireo_dir, root_folder_id, root["local_path"])
         for workspace_id in workspace_ids:
             db.invalidate_new_images_cache_for_workspace(workspace_id)
         return {"ok": True, "root_folder_id": root_folder_id, "discarded": True}

--- a/vireo/services/local_folder.py
+++ b/vireo/services/local_folder.py
@@ -376,7 +376,6 @@ def _catalog_records(
             raise LocalWorkspaceError(
                 f"Local destination overlaps a folder Vireo already manages: {catalog_source}"
             )
-    own_session_dir = folder_dir(vireo_dir, root_folder_id)
     protected_session_roots = [
         Path(vireo_dir) / "local-folders",
         Path(vireo_dir) / "local-workspaces",
@@ -385,10 +384,10 @@ def _catalog_records(
         overlaps = _physical_is_within(
             str(local_root), str(session_root)
         ) or _physical_is_within(str(session_root), str(local_root))
-        belongs_to_current_session = _physical_is_within(
-            str(local_root), str(own_session_dir)
+        belongs_to_current_files = _physical_is_within(
+            str(local_root), str(default_local_base(vireo_dir, root_folder_id))
         )
-        if overlaps and not belongs_to_current_session:
+        if overlaps and not belongs_to_current_files:
             raise LocalWorkspaceError(
                 f"Local destination overlaps Vireo session storage: {session_root}"
             )

--- a/vireo/services/local_folder.py
+++ b/vireo/services/local_folder.py
@@ -58,6 +58,26 @@ def folder_dir(vireo_dir: str, root_folder_id: int) -> Path:
     return Path(vireo_dir) / "local-folders" / str(int(root_folder_id))
 
 
+def default_local_base(vireo_dir: str, root_folder_id: int) -> Path:
+    """Return the parent directory used for a folder's managed local copy."""
+    return folder_dir(vireo_dir, root_folder_id) / "files"
+
+
+def _safe_folder_name(source_path: str, root_folder_id: int) -> str:
+    name = Path(source_path.rstrip("/\\")).name or f"folder-{root_folder_id}"
+    return "".join(ch if ch.isalnum() or ch in "._-" else "_" for ch in name)
+
+
+def default_local_path(vireo_dir: str, root_folder_id: int, source_path: str) -> Path:
+    return local_path_for_base(
+        default_local_base(vireo_dir, root_folder_id), root_folder_id, source_path
+    )
+
+
+def local_path_for_base(local_base: str | Path, root_folder_id: int, source_path: str) -> Path:
+    return Path(local_base) / _safe_folder_name(source_path, root_folder_id)
+
+
 def manifest_path(vireo_dir: str, root_folder_id: int) -> Path:
     return folder_dir(vireo_dir, root_folder_id) / "manifest.json"
 
@@ -66,21 +86,36 @@ def _sync_recovery_path(vireo_dir: str, root_folder_id: int) -> Path:
     return folder_dir(vireo_dir, root_folder_id) / "sync-recovery.json"
 
 
-def _remove_folder_dir(vireo_dir: str, root_folder_id: int) -> None:
+def _remove_tree(path: Path) -> None:
     """Remove a managed tree without ever following a replacement symlink."""
-    base = folder_dir(vireo_dir, root_folder_id)
     try:
-        st = os.lstat(base)
+        st = os.lstat(path)
     except FileNotFoundError:
         return
     if stat.S_ISLNK(st.st_mode):
         with suppress(FileNotFoundError):
-            os.unlink(base)
+            os.unlink(path)
     elif stat.S_ISDIR(st.st_mode):
-        shutil.rmtree(base, ignore_errors=True)
+        shutil.rmtree(path, ignore_errors=True)
     else:
         with suppress(FileNotFoundError):
-            os.unlink(base)
+            os.unlink(path)
+
+
+def _remove_folder_dir(
+    vireo_dir: str, root_folder_id: int, local_path: str | None = None
+) -> None:
+    """Remove session metadata and its copy, including a custom destination."""
+    base = folder_dir(vireo_dir, root_folder_id)
+    if local_path:
+        local_root = Path(local_path)
+        try:
+            inside_session = _physical_is_within(str(local_root), str(base))
+        except OSError:
+            inside_session = False
+        if not inside_session:
+            _remove_tree(local_root)
+    _remove_tree(base)
 
 
 def folder_state(db, root_folder_id: int) -> dict | None:
@@ -301,14 +336,25 @@ def _catalog_records(db, root_folder_id: int, local_base: Path) -> tuple[list[di
                 "Finish or discard that session before staging this folder."
             )
 
-    name = Path(source_path.rstrip("/\\")).name or f"folder-{root_folder_id}"
-    safe_name = "".join(ch if ch.isalnum() or ch in "._-" else "_" for ch in name)
-    local_root = local_base / safe_name
+    local_root = local_base / _safe_folder_name(source_path, root_folder_id)
     if _physical_is_within(str(local_root), source_path) or _physical_is_within(
         source_path, str(local_root)
     ):
         raise LocalWorkspaceError(
             "Managed local storage overlaps the source folder; move Vireo's data directory to local storage first"
+        )
+    for existing in db.conn.execute(
+        "SELECT root_folder_id, local_path FROM local_folder_mappings WHERE is_root=1"
+    ).fetchall():
+        if _physical_is_within(str(local_root), existing["local_path"]) or _physical_is_within(
+            existing["local_path"], str(local_root)
+        ):
+            raise LocalWorkspaceError(
+                f"Local destination overlaps an existing local copy: {existing['local_path']}"
+            )
+    if os.path.lexists(local_root):
+        raise LocalWorkspaceError(
+            f"Local destination already exists: {local_root}. Choose another location or rename the existing folder."
         )
 
     root = {
@@ -386,6 +432,7 @@ def stage_folder(
     root_folder_id: int,
     vireo_dir: str,
     *,
+    local_base: str | None = None,
     progress=None,
     cancel_check=None,
     begin_commit=None,
@@ -393,7 +440,6 @@ def stage_folder(
     """Copy one top-level folder locally and atomically rebase the catalog."""
     root_folder_id = int(root_folder_id)
     with _folder_lock(root_folder_id):
-        base = folder_dir(vireo_dir, root_folder_id)
         with stage_boundary_lock():
             covering = local_root_for_folder(db, root_folder_id)
             if covering is not None:
@@ -401,7 +447,24 @@ def stage_folder(
                     raise LocalWorkspaceError("This folder is already staged locally")
                 raise LocalWorkspaceError(f"This folder is already covered by local folder {covering}")
             _remove_folder_dir(vireo_dir, root_folder_id)
-            roots, folders = _catalog_records(db, root_folder_id, base / "files")
+            selected_base = Path(local_base).expanduser() if local_base else default_local_base(
+                vireo_dir, root_folder_id
+            )
+            if not selected_base.is_absolute():
+                raise LocalWorkspaceError("Local destination must be an absolute path")
+            roots, folders = _catalog_records(db, root_folder_id, selected_base)
+            local_root = roots[0]["local_path"]
+            try:
+                os.makedirs(local_root, exist_ok=False)
+            except FileExistsError:
+                raise LocalWorkspaceError(
+                    f"Local destination already exists: {local_root}. "
+                    "Choose another location or rename the existing folder."
+                ) from None
+            except OSError as exc:
+                raise LocalWorkspaceError(
+                    f"Could not create the local destination {local_root}: {exc}"
+                ) from exc
             db.conn.execute("BEGIN IMMEDIATE")
             try:
                 db.conn.execute(
@@ -426,12 +489,15 @@ def stage_folder(
                 db.conn.commit()
             except BaseException:
                 db.conn.rollback()
+                _remove_folder_dir(vireo_dir, root_folder_id, local_root)
                 raise
 
         copied = 0
         copied_bytes = 0
         try:
-            entries_per_root, total_files, total_bytes = _collect_source_entries(roots, base)
+            entries_per_root, total_files, total_bytes = _collect_source_entries(
+                roots, Path(roots[0]["local_path"])
+            )
             manifest = {
                 "version": MANIFEST_VERSION,
                 "root_folder_id": root_folder_id,
@@ -442,7 +508,6 @@ def stage_folder(
                 "files": [],
             }
             root = roots[0]
-            os.makedirs(root["local_path"], exist_ok=True)
             for rel, source, st in entries_per_root[0]:
                 if cancel_check and cancel_check():
                     raise LocalWorkspaceCancelled("Local folder transfer cancelled")
@@ -496,12 +561,15 @@ def stage_folder(
                 "root_folder_id": root_folder_id,
                 "files": total_files,
                 "bytes": total_bytes,
-                "local_path": str(base / "files"),
+                "local_path": roots[0]["local_path"],
             }
         except BaseException:
             current = folder_state(db, root_folder_id)
             if current and current.get("state") == "staging":
-                _remove_folder_dir(vireo_dir, root_folder_id)
+                root = _root_mapping(db, root_folder_id)
+                _remove_folder_dir(
+                    vireo_dir, root_folder_id, root["local_path"] if root else None
+                )
                 _delete_state_rows(db, root_folder_id)
                 db.conn.commit()
             raise
@@ -513,11 +581,21 @@ def folder_status(db, root_folder_id: int, vireo_dir: str) -> dict:
     covering = local_root_for_folder(db, root_folder_id)
     if covering is None:
         row = db.conn.execute("SELECT path FROM folders WHERE id=?", (root_folder_id,)).fetchone()
+        source_path = row["path"] if row else None
         return {
             "state": "remote",
             "folder_id": root_folder_id,
             "root_folder_id": root_folder_id,
-            "source_path": row["path"] if row else None,
+            "source_path": source_path,
+            "default_local_base": str(default_local_base(vireo_dir, root_folder_id)),
+            "local_folder_name": (
+                _safe_folder_name(source_path, root_folder_id) if source_path else None
+            ),
+            "default_local_path": (
+                str(default_local_path(vireo_dir, root_folder_id, source_path))
+                if source_path
+                else None
+            ),
             "workspace_ids": workspace_ids_for_folder_tree(db, root_folder_id),
         }
     root_folder_id = covering
@@ -792,7 +870,7 @@ def sync_folder(
                 progress(done, total, rel)
         workspace_ids = affected_workspace_ids(db, root_folder_id)
         _restore_catalog(db, root_folder_id)
-        _remove_folder_dir(vireo_dir, root_folder_id)
+        _remove_folder_dir(vireo_dir, root_folder_id, root["local_path"])
         for workspace_id in workspace_ids:
             db.invalidate_new_images_cache_for_workspace(workspace_id)
         return {
@@ -813,7 +891,10 @@ def discard_folder(db, root_folder_id: int, vireo_dir: str, *, acknowledge_publi
             raise LocalWorkspaceError("This folder is not working locally")
         state = state_row["state"]
         if state == "staging":
-            _remove_folder_dir(vireo_dir, root_folder_id)
+            root = _root_mapping(db, root_folder_id)
+            _remove_folder_dir(
+                vireo_dir, root_folder_id, root["local_path"] if root else None
+            )
             _delete_state_rows(db, root_folder_id)
             db.conn.commit()
             return {"ok": True, "root_folder_id": root_folder_id, "discarded": True}
@@ -823,9 +904,12 @@ def discard_folder(db, root_folder_id: int, vireo_dir: str, *, acknowledge_publi
             )
         if state not in {"active", "syncing"}:
             raise LocalWorkspaceError("Local folder is not in a recoverable state")
+        root = _root_mapping(db, root_folder_id)
+        if root is None:
+            raise LocalWorkspaceError("Local folder mapping is missing its root")
         workspace_ids = affected_workspace_ids(db, root_folder_id)
         _restore_catalog(db, root_folder_id)
-        _remove_folder_dir(vireo_dir, root_folder_id)
+        _remove_folder_dir(vireo_dir, root_folder_id, root["local_path"])
         for workspace_id in workspace_ids:
             db.invalidate_new_images_cache_for_workspace(workspace_id)
         return {"ok": True, "root_folder_id": root_folder_id, "discarded": True}

--- a/vireo/services/local_folder.py
+++ b/vireo/services/local_folder.py
@@ -92,14 +92,17 @@ def _remove_tree(path: Path) -> None:
         st = os.lstat(path)
     except FileNotFoundError:
         return
-    if stat.S_ISLNK(st.st_mode):
-        with suppress(FileNotFoundError):
+    try:
+        if stat.S_ISLNK(st.st_mode):
             os.unlink(path)
-    elif stat.S_ISDIR(st.st_mode):
-        shutil.rmtree(path, ignore_errors=True)
-    else:
-        with suppress(FileNotFoundError):
+        elif stat.S_ISDIR(st.st_mode):
+            shutil.rmtree(path)
+        else:
             os.unlink(path)
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        raise LocalWorkspaceError(f"Could not remove local data at {path}: {exc}") from exc
 
 
 def _remove_folder_dir(
@@ -343,6 +346,34 @@ def _catalog_records(db, root_folder_id: int, local_base: Path) -> tuple[list[di
         raise LocalWorkspaceError(
             "Managed local storage overlaps the source folder; move Vireo's data directory to local storage first"
         )
+    catalog_source_paths = {
+        row["path"]
+        for row in db.conn.execute("SELECT path FROM folders").fetchall()
+        if row["path"]
+    }
+    catalog_source_paths.update(
+        row["source_path"]
+        for row in db.conn.execute(
+            "SELECT source_path FROM local_folder_mappings"
+        ).fetchall()
+        if row["source_path"]
+    )
+    catalog_source_paths.update(
+        row["source_path"]
+        for row in db.conn.execute(
+            "SELECT source_path FROM local_workspace_folders"
+        ).fetchall()
+        if row["source_path"]
+    )
+    for catalog_source in catalog_source_paths:
+        if catalog_source == source_path:
+            continue
+        if _physical_is_within(str(local_root), catalog_source) or _physical_is_within(
+            catalog_source, str(local_root)
+        ):
+            raise LocalWorkspaceError(
+                f"Local destination overlaps a folder Vireo already manages: {catalog_source}"
+            )
     for existing in db.conn.execute(
         "SELECT root_folder_id, local_path FROM local_folder_mappings WHERE is_root=1"
     ).fetchall():
@@ -869,8 +900,8 @@ def sync_folder(
             if progress:
                 progress(done, total, rel)
         workspace_ids = affected_workspace_ids(db, root_folder_id)
-        _restore_catalog(db, root_folder_id)
         _remove_folder_dir(vireo_dir, root_folder_id, root["local_path"])
+        _restore_catalog(db, root_folder_id)
         for workspace_id in workspace_ids:
             db.invalidate_new_images_cache_for_workspace(workspace_id)
         return {
@@ -908,8 +939,8 @@ def discard_folder(db, root_folder_id: int, vireo_dir: str, *, acknowledge_publi
         if root is None:
             raise LocalWorkspaceError("Local folder mapping is missing its root")
         workspace_ids = affected_workspace_ids(db, root_folder_id)
-        _restore_catalog(db, root_folder_id)
         _remove_folder_dir(vireo_dir, root_folder_id, root["local_path"])
+        _restore_catalog(db, root_folder_id)
         for workspace_id in workspace_ids:
             db.invalidate_new_images_cache_for_workspace(workspace_id)
         return {"ok": True, "root_folder_id": root_folder_id, "discarded": True}

--- a/vireo/services/local_folder.py
+++ b/vireo/services/local_folder.py
@@ -303,7 +303,9 @@ def _load_sync_recovery(vireo_dir: str, root_folder_id: int) -> set | None:
     return result
 
 
-def _catalog_records(db, root_folder_id: int, local_base: Path) -> tuple[list[dict], list[dict]]:
+def _catalog_records(
+    db, root_folder_id: int, local_base: Path, vireo_dir: str
+) -> tuple[list[dict], list[dict]]:
     row = db.conn.execute(
         "SELECT id, path, status FROM folders WHERE id=?", (root_folder_id,)
     ).fetchone()
@@ -373,6 +375,22 @@ def _catalog_records(db, root_folder_id: int, local_base: Path) -> tuple[list[di
         ):
             raise LocalWorkspaceError(
                 f"Local destination overlaps a folder Vireo already manages: {catalog_source}"
+            )
+    own_session_dir = folder_dir(vireo_dir, root_folder_id)
+    protected_session_roots = [
+        Path(vireo_dir) / "local-folders",
+        Path(vireo_dir) / "local-workspaces",
+    ]
+    for session_root in protected_session_roots:
+        overlaps = _physical_is_within(
+            str(local_root), str(session_root)
+        ) or _physical_is_within(str(session_root), str(local_root))
+        belongs_to_current_session = _physical_is_within(
+            str(local_root), str(own_session_dir)
+        )
+        if overlaps and not belongs_to_current_session:
+            raise LocalWorkspaceError(
+                f"Local destination overlaps Vireo session storage: {session_root}"
             )
     for existing in db.conn.execute(
         "SELECT root_folder_id, local_path FROM local_folder_mappings WHERE is_root=1"
@@ -483,7 +501,9 @@ def stage_folder(
             )
             if not selected_base.is_absolute():
                 raise LocalWorkspaceError("Local destination must be an absolute path")
-            roots, folders = _catalog_records(db, root_folder_id, selected_base)
+            roots, folders = _catalog_records(
+                db, root_folder_id, selected_base, vireo_dir
+            )
             local_root = roots[0]["local_path"]
             try:
                 os.makedirs(local_root, exist_ok=False)

--- a/vireo/static/tauri-bridge.js
+++ b/vireo/static/tauri-bridge.js
@@ -57,6 +57,7 @@ window.addEventListener('unhandledrejection', function(event) {
  * @param {string} [title] - Dialog title
  * @param {object} [opts] - Options
  * @param {boolean} [opts.multiple] - Allow selecting multiple folders
+ * @param {string} [opts.defaultPath] - Directory shown when the dialog opens
  * @returns {Promise<string|string[]|null>} Selected directory path(s), or null if cancelled.
  *   Returns an array when `opts.multiple` is true, otherwise a string.
  */
@@ -67,6 +68,7 @@ async function pickDirectory(title, opts) {
     directory: true,
     multiple: !!opts.multiple,
     title: title || 'Select Folder',
+    defaultPath: opts.defaultPath || undefined,
   });
   return result || null;
 }

--- a/vireo/static/vireo-work-locally.js
+++ b/vireo/static/vireo-work-locally.js
@@ -281,7 +281,7 @@
           folder_ids: pendingStageItems.map(function(item) { return item.requested_folder_id; }),
           destination_bases: destinationBases
         })
-      });
+      }, {toast: false});
       var modal = document.getElementById('stageLocalFoldersModal');
       if (modal) modal.classList.remove('open');
       pendingStageItems = [];

--- a/vireo/static/vireo-work-locally.js
+++ b/vireo/static/vireo-work-locally.js
@@ -4,6 +4,7 @@
   var data = null;
   var activeJob = null;
   var actionInFlight = false;
+  var pendingStageItems = [];
 
   function selectedItems(folderIds, localOnly) {
     var wanted = folderIds && folderIds.length
@@ -19,6 +20,67 @@
     return ((data && data.folders) || []).find(function(item) {
       return Number(item.requested_folder_id) === Number(folderId);
     }) || null;
+  }
+
+  function folderName(path) {
+    var parts = String(path || '').replace(/[\\/]+$/, '').split(/[\\/]/);
+    return parts[parts.length - 1] || 'Folder';
+  }
+
+  function joinPath(parent, name) {
+    var base = String(parent || '').replace(/[\\/]+$/, '');
+    if (!base) return name;
+    return base + (base.indexOf('\\') >= 0 ? '\\' : '/') + name;
+  }
+
+  function updateStageDestinationPreview(input) {
+    var preview = document.querySelector(
+      '[data-local-destination-preview="' + input.dataset.localDestinationBase + '"]'
+    );
+    if (!preview) return;
+    preview.textContent = joinPath(input.value.trim(), input.dataset.localFolderName);
+  }
+
+  function closeStageDialog() {
+    if (actionInFlight) return;
+    var modal = document.getElementById('stageLocalFoldersModal');
+    if (modal) modal.classList.remove('open');
+    pendingStageItems = [];
+  }
+
+  function openStageDialog(folderIds) {
+    if (actionInFlight || activeJob) return;
+    var items = selectedItems(folderIds, false).filter(function(item) {
+      return item.state === 'remote';
+    });
+    if (!items.length) return;
+    pendingStageItems = items;
+    var container = document.getElementById('stageLocalFoldersModalItems');
+    var error = document.getElementById('stageLocalFoldersError');
+    var modal = document.getElementById('stageLocalFoldersModal');
+    if (!container || !modal) return;
+    if (error) error.textContent = '';
+    container.innerHTML = items.map(function(item) {
+      var id = Number(item.requested_folder_id);
+      var source = item.source_path || item.display_path || '';
+      var name = folderName(source);
+      var localName = item.local_folder_name || name;
+      var base = item.default_local_base || '';
+      var finalPath = item.default_local_path || joinPath(base, localName);
+      var shared = (item.workspace_ids || []).length;
+      return '<div class="setting-row" style="display:block;padding:12px 0;">' +
+        '<div style="font-size:13px;font-weight:600;color:var(--text-primary);margin-bottom:3px;">' + escapeHtml(name) + '</div>' +
+        '<div style="font-family:monospace;font-size:10px;color:var(--text-dim);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;margin-bottom:9px;" title="' + escapeAttr(source) + '">' + escapeHtml(source) + '</div>' +
+        '<label class="modal-label" for="localDestinationBase-' + id + '">Create the local copy in</label>' +
+        '<div style="display:flex;gap:7px;align-items:center;">' +
+          '<input class="modal-input" id="localDestinationBase-' + id + '" data-local-destination-base="' + id + '" data-folder-name="' + escapeAttr(name) + '" data-local-folder-name="' + escapeAttr(localName) + '" value="' + escapeAttr(base) + '" style="flex:1;font-family:monospace;font-size:12px;">' +
+          '<button class="modal-btn" data-browse-local-destination="' + id + '" style="white-space:nowrap;">Browse...</button>' +
+        '</div>' +
+        '<div style="font-size:10px;color:var(--text-dim);margin-top:5px;">Local folder: <span data-local-destination-preview="' + id + '" style="font-family:monospace;">' + escapeHtml(finalPath) + '</span></div>' +
+        (shared > 1 ? '<div style="font-size:10px;color:var(--accent);margin-top:4px;">This copy will be shared by ' + shared + ' linked workspaces.</div>' : '') +
+      '</div>';
+    }).join('');
+    modal.classList.add('open');
   }
 
   function progressMarkup() {
@@ -192,27 +254,43 @@
     }
   }
 
-  async function stage(folderIds) {
-    if (actionInFlight || activeJob) return;
-    var items = selectedItems(folderIds, false).filter(function(item) { return item.state === 'remote'; });
-    if (!items.length) return;
-    var shared = items.some(function(item) { return (item.workspace_ids || []).length > 1; });
-    var message = 'Copy ' + items.length + ' folder' + (items.length === 1 ? '' : 's') + ' to Vireo\'s managed local storage?\n\n' +
-      'The source files will not change until you sync back.';
-    if (shared) message += '\n\nShared folders will use the same local copy in every linked workspace.';
-    if (!confirm(message)) return;
+  async function submitStageDialog() {
+    if (actionInFlight || activeJob || !pendingStageItems.length) return;
+    var error = document.getElementById('stageLocalFoldersError');
+    var button = document.getElementById('confirmStageLocalFolders');
+    var destinationBases = {};
+    for (var i = 0; i < pendingStageItems.length; i += 1) {
+      var id = Number(pendingStageItems[i].requested_folder_id);
+      var input = document.querySelector('[data-local-destination-base="' + id + '"]');
+      var destination = input ? input.value.trim() : '';
+      if (!destination) {
+        if (error) error.textContent = 'Choose a destination for every local copy.';
+        if (input) input.focus();
+        return;
+      }
+      destinationBases[String(id)] = destination;
+    }
     actionInFlight = true;
+    if (button) button.disabled = true;
+    if (error) error.textContent = '';
     try {
       var result = await Vireo.api.json('/api/workspaces/active/local-folders/stage', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({folder_ids: items.map(function(item) { return item.requested_folder_id; })})
+        body: JSON.stringify({
+          folder_ids: pendingStageItems.map(function(item) { return item.requested_folder_id; }),
+          destination_bases: destinationBases
+        })
       });
+      var modal = document.getElementById('stageLocalFoldersModal');
+      if (modal) modal.classList.remove('open');
+      pendingStageItems = [];
       watchJob(result.job_id);
-    } catch (_error) {
-      await load();
+    } catch (requestError) {
+      if (error) error.textContent = requestError.message || 'Could not start the local copy.';
     } finally {
       actionInFlight = false;
+      if (button) button.disabled = false;
     }
   }
 
@@ -365,12 +443,32 @@
     var button = event.target.closest('[data-local-folders-action], [data-legacy-action]');
     if (!button || button.disabled) return;
     var action = button.dataset.localFoldersAction;
-    if (action === 'stage-all') stage(null);
+    if (action === 'stage-all') openStageDialog(null);
     else if (action === 'manage') openManager();
     else if (button.dataset.legacyAction) legacyAction(button.dataset.legacyAction);
   });
 
   document.getElementById('closeLocalFoldersModal').addEventListener('click', closeManager);
+  document.getElementById('cancelStageLocalFolders').addEventListener('click', closeStageDialog);
+  document.getElementById('confirmStageLocalFolders').addEventListener('click', submitStageDialog);
+  document.getElementById('stageLocalFoldersModalItems').addEventListener('input', function(event) {
+    if (event.target.matches('[data-local-destination-base]')) {
+      updateStageDestinationPreview(event.target);
+    }
+  });
+  document.getElementById('stageLocalFoldersModalItems').addEventListener('click', async function(event) {
+    var button = event.target.closest('[data-browse-local-destination]');
+    if (!button) return;
+    var id = button.dataset.browseLocalDestination;
+    var input = document.querySelector('[data-local-destination-base="' + id + '"]');
+    if (!input || typeof pickDirectory !== 'function') return;
+    var chosen = await pickDirectory('Choose a location for ' + input.dataset.folderName, {
+      defaultPath: input.value.trim()
+    });
+    if (!chosen || Array.isArray(chosen)) return;
+    input.value = chosen;
+    updateStageDestinationPreview(input);
+  });
   document.getElementById('syncSelectedLocalFolders').addEventListener('click', function() {
     var selected = managerSelection();
     if (!selected.length) return;
@@ -387,7 +485,7 @@
   window.vireoLocalFolders = {
     load: load,
     statusFor: statusFor,
-    stage: function(folderId) { return stage([Number(folderId)]); },
+    stage: function(folderId) { return openStageDialog([Number(folderId)]); },
     sync: function(folderId) { return sync([Number(folderId)]); },
     discard: function(folderId) { return discard([Number(folderId)]); }
   };

--- a/vireo/templates/workspace.html
+++ b/vireo/templates/workspace.html
@@ -99,6 +99,22 @@
   </div>
 </div>
 
+<!-- Choose local-copy destinations -->
+<div class="modal-overlay" id="stageLocalFoldersModal">
+  <div class="modal" style="max-width:680px;width:90%;">
+    <h3 style="margin:0 0 8px 0;font-size:16px;">Work Locally</h3>
+    <div style="font-size:12px;color:var(--text-secondary);line-height:1.5;margin-bottom:14px;">
+      Choose where Vireo should create each local copy. The source files stay unchanged until you sync back.
+    </div>
+    <div id="stageLocalFoldersModalItems"></div>
+    <div class="modal-error" id="stageLocalFoldersError"></div>
+    <div class="modal-actions" style="margin-top:16px;display:flex;gap:8px;justify-content:flex-end;">
+      <button class="modal-btn" id="cancelStageLocalFolders">Cancel</button>
+      <button class="modal-btn modal-btn-primary" id="confirmStageLocalFolders">Copy Locally</button>
+    </div>
+  </div>
+</div>
+
 <!-- Shared local-folder bulk actions -->
 <div class="modal-overlay" id="localFoldersModal">
   <div class="modal">

--- a/vireo/tests/test_local_folder.py
+++ b/vireo/tests/test_local_folder.py
@@ -141,6 +141,31 @@ def test_custom_local_destination_refuses_other_session_directory(tmp_path):
         db.close()
 
 
+def test_custom_local_destination_refuses_session_metadata_directory(tmp_path):
+    source = tmp_path / "nas" / "1"
+    source.mkdir(parents=True)
+    (source / "bird.jpg").write_bytes(b"original")
+    vireo_dir = tmp_path / "vireo"
+    vireo_dir.mkdir()
+    db = Database(str(vireo_dir / "vireo.db"))
+    workspace_id = db.create_workspace("Numeric folder")
+    folder_id = db.add_folder(str(source), name="1", link_to_workspace=False)
+    assert folder_id == 1
+    db.add_workspace_folder(workspace_id, folder_id)
+    try:
+        with pytest.raises(LocalWorkspaceError, match="session storage"):
+            stage_folder(
+                db,
+                folder_id,
+                str(vireo_dir),
+                local_base=str(vireo_dir / "local-folders"),
+            )
+        assert not (vireo_dir / "local-folders" / "1").exists()
+        assert db.get_folder(folder_id)["path"] == str(source)
+    finally:
+        db.close()
+
+
 def test_custom_local_cleanup_failure_preserves_session(tmp_path, monkeypatch):
     from services import local_folder as service
 

--- a/vireo/tests/test_local_folder.py
+++ b/vireo/tests/test_local_folder.py
@@ -100,7 +100,50 @@ def test_custom_local_destination_refuses_existing_folder(tmp_path):
                 db, folder_id, str(vireo_dir), local_base=str(local_parent)
             )
         assert (existing / "keep.txt").read_text() == "do not overwrite"
-        assert db.get_folder(folder_id)["path"].endswith("/nas/photos")
+        assert Path(db.get_folder(folder_id)["path"]) == _source
+    finally:
+        db.close()
+
+
+def test_custom_local_destination_refuses_other_catalog_source(tmp_path):
+    db, vireo_dir, _source, _first, _second, folder_id = _shared_environment(tmp_path)
+    other_source = tmp_path / "nas" / "other-source"
+    other_source.mkdir()
+    db.add_folder(str(other_source), name="other-source", link_to_workspace=False)
+    try:
+        with pytest.raises(LocalWorkspaceError, match="already manages"):
+            stage_folder(
+                db, folder_id, str(vireo_dir), local_base=str(other_source)
+            )
+        assert not (other_source / "photos").exists()
+    finally:
+        db.close()
+
+
+def test_custom_local_cleanup_failure_preserves_session(tmp_path, monkeypatch):
+    from services import local_folder as service
+
+    db, vireo_dir, source, first, _second, folder_id = _shared_environment(tmp_path)
+    local_parent = tmp_path / "fast-storage"
+    local_root = local_parent / "photos"
+    stage_folder(db, folder_id, str(vireo_dir), local_base=str(local_parent))
+    real_rmtree = service.shutil.rmtree
+
+    def refuse_custom_cleanup(path, *args, **kwargs):
+        if Path(path) == local_root:
+            raise PermissionError("destination is busy")
+        return real_rmtree(path, *args, **kwargs)
+
+    monkeypatch.setattr(service.shutil, "rmtree", refuse_custom_cleanup)
+    try:
+        with pytest.raises(LocalWorkspaceError, match="Could not remove local data"):
+            discard_folder(db, folder_id, str(vireo_dir))
+
+        assert local_root.is_dir()
+        assert Path(db.get_folder(folder_id)["path"]) == local_root
+        assert folder_status(db, folder_id, str(vireo_dir))["state"] == "active"
+        assert workspace_status(db, first, str(vireo_dir))["state"] == "active"
+        assert source.is_dir()
     finally:
         db.close()
 
@@ -301,7 +344,7 @@ def test_folder_stage_endpoint_accepts_destination_and_uses_folder_name_in_job(t
             vireo_dir / "local-folders" / str(folder_id) / "files"
         )
         assert item["local_folder_name"] == "104NCZ_8"
-        assert item["default_local_path"].endswith("/104NCZ_8")
+        assert Path(item["default_local_path"]).name == "104NCZ_8"
 
         response = client.post(
             "/api/workspaces/active/local-folders/stage",

--- a/vireo/tests/test_local_folder.py
+++ b/vireo/tests/test_local_folder.py
@@ -63,6 +63,48 @@ def test_shared_folder_uses_one_local_copy_in_every_workspace(tmp_path):
         db.close()
 
 
+def test_custom_local_destination_is_used_and_removed_after_sync(tmp_path):
+    db, vireo_dir, source, _first, _second, folder_id = _shared_environment(tmp_path)
+    local_parent = tmp_path / "fast-storage"
+    try:
+        result = stage_folder(
+            db, folder_id, str(vireo_dir), local_base=str(local_parent)
+        )
+
+        local_root = local_parent / "photos"
+        assert result["local_path"] == str(local_root)
+        assert db.get_folder(folder_id)["path"] == str(local_root)
+        assert (local_root / "bird.jpg").read_bytes() == b"original"
+        assert (vireo_dir / "local-folders" / str(folder_id) / "manifest.json").is_file()
+
+        (local_root / "bird.jpg").write_bytes(b"edited locally")
+        sync_folder(db, folder_id, str(vireo_dir))
+
+        assert (source / "bird.jpg").read_bytes() == b"edited locally"
+        assert not local_root.exists()
+        assert local_parent.is_dir()
+        assert not (vireo_dir / "local-folders" / str(folder_id)).exists()
+    finally:
+        db.close()
+
+
+def test_custom_local_destination_refuses_existing_folder(tmp_path):
+    db, vireo_dir, _source, _first, _second, folder_id = _shared_environment(tmp_path)
+    local_parent = tmp_path / "fast-storage"
+    existing = local_parent / "photos"
+    existing.mkdir(parents=True)
+    (existing / "keep.txt").write_text("do not overwrite")
+    try:
+        with pytest.raises(LocalWorkspaceError, match="already exists"):
+            stage_folder(
+                db, folder_id, str(vireo_dir), local_base=str(local_parent)
+            )
+        assert (existing / "keep.txt").read_text() == "do not overwrite"
+        assert db.get_folder(folder_id)["path"].endswith("/nas/photos")
+    finally:
+        db.close()
+
+
 def test_workspace_status_is_derived_from_independent_root_folders(tmp_path):
     db = Database(str(tmp_path / "vireo.db"))
     workspace_id = db.create_workspace("Mixed")
@@ -228,6 +270,57 @@ def test_folder_scoped_http_cycle_and_shared_status(tmp_path, monkeypatch):
         assert response.status_code == 202
         assert wait_for_job_via_client(client, response.get_json()["job_id"])["status"] == "completed"
         assert (source / "bird.jpg").read_bytes() == b"edited"
+
+
+def test_folder_stage_endpoint_accepts_destination_and_uses_folder_name_in_job(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from app import create_app
+
+    source = tmp_path / "nas" / "104NCZ_8"
+    source.mkdir(parents=True)
+    (source / "bird.jpg").write_bytes(b"original")
+    vireo_dir = tmp_path / "vireo"
+    thumbs = vireo_dir / "thumbnails"
+    thumbs.mkdir(parents=True)
+    db_path = str(vireo_dir / "vireo.db")
+    db = Database(db_path)
+    workspace_id = db.create_workspace("Trip")
+    folder_id = db.add_folder(str(source), name="104NCZ_8", link_to_workspace=False)
+    db.add_workspace_folder(workspace_id, folder_id)
+    db.set_active_workspace(workspace_id)
+    db.close()
+
+    app = create_app(db_path, thumb_cache_dir=str(thumbs))
+    app.config["TESTING"] = True
+    destination = tmp_path / "chosen-local-storage"
+    with app.test_client() as client:
+        assert client.post(f"/api/workspaces/{workspace_id}/activate", json={}).status_code == 200
+        before = client.get("/api/workspaces/active/local-folders").get_json()
+        item = before["folders"][0]
+        assert item["default_local_base"] == str(
+            vireo_dir / "local-folders" / str(folder_id) / "files"
+        )
+        assert item["local_folder_name"] == "104NCZ_8"
+        assert item["default_local_path"].endswith("/104NCZ_8")
+
+        response = client.post(
+            "/api/workspaces/active/local-folders/stage",
+            json={
+                "folder_ids": [folder_id],
+                "destination_bases": {str(folder_id): str(destination)},
+            },
+        )
+        assert response.status_code == 202, response.get_json()
+        job = wait_for_job_via_client(client, response.get_json()["job_id"])
+        assert job["status"] == "completed"
+        assert job["steps"][0]["label"] == "Copy 104NCZ_8 locally"
+        assert job["progress"]["phase"] == "Copying 104NCZ_8 locally"
+
+    check_db = Database(db_path)
+    try:
+        assert check_db.get_folder(folder_id)["path"] == str(destination / "104NCZ_8")
+    finally:
+        check_db.close()
 
 
 def test_local_root_under_folder_finds_descendant_session(tmp_path):

--- a/vireo/tests/test_local_folder.py
+++ b/vireo/tests/test_local_folder.py
@@ -120,6 +120,27 @@ def test_custom_local_destination_refuses_other_catalog_source(tmp_path):
         db.close()
 
 
+def test_custom_local_destination_refuses_other_session_directory(tmp_path):
+    db, vireo_dir, _source, _first, _second, folder_id = _shared_environment(tmp_path)
+    other_source = tmp_path / "nas" / "other-source"
+    other_source.mkdir()
+    other_id = db.add_folder(
+        str(other_source), name="other-source", link_to_workspace=False
+    )
+    other_session_base = vireo_dir / "local-folders" / str(other_id) / "files"
+    try:
+        with pytest.raises(LocalWorkspaceError, match="session storage"):
+            stage_folder(
+                db,
+                folder_id,
+                str(vireo_dir),
+                local_base=str(other_session_base),
+            )
+        assert not (other_session_base / "photos").exists()
+    finally:
+        db.close()
+
+
 def test_custom_local_cleanup_failure_preserves_session(tmp_path, monkeypatch):
     from services import local_folder as service
 

--- a/vireo/tests/test_local_folder.py
+++ b/vireo/tests/test_local_folder.py
@@ -166,7 +166,9 @@ def test_custom_local_destination_refuses_session_metadata_directory(tmp_path):
         db.close()
 
 
-def test_custom_local_cleanup_failure_preserves_session(tmp_path, monkeypatch):
+def test_custom_local_cleanup_failure_preserves_copy_after_catalog_restore(
+    tmp_path, monkeypatch
+):
     from services import local_folder as service
 
     db, vireo_dir, source, first, _second, folder_id = _shared_environment(tmp_path)
@@ -186,10 +188,50 @@ def test_custom_local_cleanup_failure_preserves_session(tmp_path, monkeypatch):
             discard_folder(db, folder_id, str(vireo_dir))
 
         assert local_root.is_dir()
-        assert Path(db.get_folder(folder_id)["path"]) == local_root
-        assert folder_status(db, folder_id, str(vireo_dir))["state"] == "active"
-        assert workspace_status(db, first, str(vireo_dir))["state"] == "active"
+        assert Path(db.get_folder(folder_id)["path"]) == source
+        assert folder_status(db, folder_id, str(vireo_dir))["state"] == "remote"
+        assert workspace_status(db, first, str(vireo_dir))["state"] == "remote"
         assert source.is_dir()
+    finally:
+        db.close()
+
+
+@pytest.mark.parametrize("operation", ["discard", "sync"])
+def test_catalog_restore_failure_keeps_local_copy_and_session(
+    tmp_path, monkeypatch, operation
+):
+    from services import local_folder as service
+
+    db, vireo_dir, source, first, _second, folder_id = _shared_environment(tmp_path)
+    local_parent = tmp_path / "fast-storage"
+    local_root = local_parent / "photos"
+    stage_folder(db, folder_id, str(vireo_dir), local_base=str(local_parent))
+    (local_root / "bird.jpg").write_bytes(b"edited locally")
+
+    def refuse_catalog_restore(_db, _root_folder_id):
+        raise OSError("catalog is busy")
+
+    monkeypatch.setattr(service, "_restore_catalog", refuse_catalog_restore)
+    try:
+        with pytest.raises(OSError, match="catalog is busy"):
+            if operation == "sync":
+                sync_folder(db, folder_id, str(vireo_dir))
+            else:
+                discard_folder(db, folder_id, str(vireo_dir))
+
+        assert local_root.is_dir()
+        assert (local_root / "bird.jpg").read_bytes() == b"edited locally"
+        assert Path(db.get_folder(folder_id)["path"]) == local_root
+        expected_state = "recovery" if operation == "sync" else "active"
+        assert folder_status(db, folder_id, str(vireo_dir))["state"] == expected_state
+        workspace = workspace_status(db, first, str(vireo_dir))
+        assert workspace["state"] == "active"
+        assert workspace["folders"][0]["state"] == expected_state
+        assert service.folder_state(db, folder_id)["state"] == (
+            "syncing" if operation == "sync" else "active"
+        )
+        expected_source = b"edited locally" if operation == "sync" else b"original"
+        assert (source / "bird.jpg").read_bytes() == expected_source
     finally:
         db.close()
 

--- a/vireo/web/local_folder.py
+++ b/vireo/web/local_folder.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import threading
 
 from db import Database
@@ -11,6 +12,7 @@ from services.local_folder import (
     affected_workspace_ids,
     discard_folder,
     folder_status,
+    local_path_for_base,
     local_root_for_folder,
     local_root_under_folder,
     stage_folder,
@@ -118,6 +120,23 @@ def create_local_folder_blueprint(
             )
         return None
 
+    def _folder_names(db, root_ids):
+        names = {}
+        paths = {}
+        for root_id in root_ids:
+            row = db.conn.execute(
+                """SELECT COALESCE(lfm.source_path, f.path) AS source_path
+                   FROM folders f
+                   LEFT JOIN local_folder_mappings lfm
+                     ON lfm.folder_id=f.id AND lfm.is_root=1
+                   WHERE f.id=?""",
+                (root_id,),
+            ).fetchone()
+            path = row["source_path"] if row else ""
+            paths[root_id] = path
+            names[root_id] = os.path.basename(path.rstrip("/\\")) or "Folder"
+        return names, paths
+
     @blueprint.get("/api/workspaces/active/local-folders")
     def local_folder_status():
         db, workspace_id, error = _active_context()
@@ -185,6 +204,39 @@ def create_local_folder_blueprint(
                 "The selected folders are already local or contain a folder working locally",
                 409,
             )
+        raw_destinations = body.get("destination_bases") or {}
+        if not isinstance(raw_destinations, dict):
+            return json_error("destination_bases must be an object", 400)
+        root_names, source_paths = _folder_names(db, root_ids)
+        destination_bases = {}
+        final_destinations = []
+        for root_id in root_ids:
+            raw = raw_destinations.get(str(root_id), raw_destinations.get(root_id))
+            if raw is None:
+                continue
+            if not isinstance(raw, str) or not raw.strip():
+                return json_error("Each local destination must be a non-empty path", 400)
+            destination = os.path.normpath(os.path.expanduser(raw.strip()))
+            if not os.path.isabs(destination):
+                return json_error("Each local destination must be an absolute path", 400)
+            destination_bases[root_id] = destination
+            final_destinations.append(
+                (root_id, os.path.normcase(os.path.abspath(local_path_for_base(
+                    destination, root_id, source_paths[root_id]
+                ))))
+            )
+        for index, (root_id, path) in enumerate(final_destinations):
+            for other_id, other_path in final_destinations[index + 1:]:
+                try:
+                    overlaps = os.path.commonpath([path, other_path]) in {path, other_path}
+                except ValueError:
+                    overlaps = False
+                if overlaps:
+                    return json_error(
+                        f"The selected destinations for {root_names[root_id]} and "
+                        f"{root_names[other_id]} overlap. Choose separate locations.",
+                        400,
+                    )
         runner = get_runner()
 
         def work(job):
@@ -195,7 +247,7 @@ def create_local_folder_blueprint(
                 runner.set_steps(
                     job["id"],
                     [
-                        {"id": f"folder-{root_id}", "label": f"Copy folder {root_id} locally"}
+                        {"id": f"folder-{root_id}", "label": f"Copy {root_names[root_id]} locally"}
                         for root_id in root_ids
                     ],
                 )
@@ -203,13 +255,16 @@ def create_local_folder_blueprint(
                     step_id = f"folder-{root_id}"
                     runner.update_step(job["id"], step_id, status="running")
 
-                    def report(current, total, current_bytes, total_bytes, path, _root=root_id):
+                    def report(
+                        current, total, current_bytes, total_bytes, path,
+                        _root=root_id, _name=root_names[root_id],
+                    ):
                         job["progress"].update(
                             {
                                 "current": current,
                                 "total": total,
                                 "current_file": path,
-                                "phase": f"Copying folder {_root} locally",
+                                "phase": f"Copying {_name} locally",
                                 "bytes_current": current_bytes,
                                 "bytes_total": total_bytes,
                                 "root_folder_id": _root,
@@ -227,6 +282,7 @@ def create_local_folder_blueprint(
                         thread_db,
                         root_id,
                         vireo_dir,
+                        local_base=destination_bases.get(root_id),
                         progress=report,
                         cancel_check=lambda: runner.is_cancelled(job["id"]),
                         begin_commit=lambda: runner.begin_uncancellable(job["id"]),
@@ -273,6 +329,7 @@ def create_local_folder_blueprint(
             return request_error
         if not root_ids:
             return json_error("No selected folders are working locally", 409)
+        root_names, _source_paths = _folder_names(db, root_ids)
         counts = body.get("confirmed_deletion_counts") or {}
         if not isinstance(counts, dict):
             return json_error("confirmed_deletion_counts must be an object", 400)
@@ -317,7 +374,7 @@ def create_local_folder_blueprint(
                 runner.set_steps(
                     job["id"],
                     [
-                        {"id": f"folder-{root_id}", "label": f"Sync folder {root_id} to source"}
+                        {"id": f"folder-{root_id}", "label": f"Sync {root_names[root_id]} to source"}
                         for root_id in root_ids
                     ],
                 )
@@ -325,13 +382,16 @@ def create_local_folder_blueprint(
                     step_id = f"folder-{root_id}"
                     runner.update_step(job["id"], step_id, status="running")
 
-                    def report(current, total, path, _root=root_id):
+                    def report(
+                        current, total, path,
+                        _root=root_id, _name=root_names[root_id],
+                    ):
                         job["progress"].update(
                             {
                                 "current": current,
                                 "total": total,
                                 "current_file": path,
-                                "phase": f"Syncing folder {_root} to source",
+                                "phase": f"Syncing {_name} to source",
                                 "root_folder_id": _root,
                             }
                         )
@@ -395,6 +455,7 @@ def create_local_folder_blueprint(
             return request_error
         if not root_ids:
             return json_error("No selected folders are working locally", 409)
+        root_names, _source_paths = _folder_names(db, root_ids)
         acknowledge = body.get("acknowledge_published") is True
         runner = get_runner()
 
@@ -406,7 +467,7 @@ def create_local_folder_blueprint(
                 runner.set_steps(
                     job["id"],
                     [
-                        {"id": f"folder-{root_id}", "label": f"Discard local folder {root_id}"}
+                        {"id": f"folder-{root_id}", "label": f"Discard local copy of {root_names[root_id]}"}
                         for root_id in root_ids
                     ],
                 )


### PR DESCRIPTION
## Summary
- Replace the Work Locally confirmation with a destination chooser that previews each local copy and supports the native folder picker.
- Safely stage, sync, and discard copies in custom locations without overwriting existing folders.
- Use folder names instead of internal database IDs in copy, sync, and discard progress.

## Testing
- `pytest -q vireo/tests/test_local_folder.py tests/e2e/test_workspace.py vireo/tests/test_local_workspace.py vireo/tests/test_workspaces_api.py vireo/tests/test_build_static.py` (129 passed, 3 skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Work Locally dialog for selecting a destination directory for each folder.
  * Added destination previews and directory browsing through the native folder picker.
  * Added clearer folder names and progress labels during local copying, syncing, and discarding.
  * Added validation to prevent invalid, overlapping, or already-existing destinations.

* **Bug Fixes**
  * Improved cleanup of managed local copies, including safer handling of symbolic links.
  * Ensured selected local destinations are preserved throughout staging and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->