### PR TITLE
Fix higher-rank Life List taxonomy filters

### DIFF
--- a/tests/e2e/test_pipeline_review_species.py
+++ b/tests/e2e/test_pipeline_review_species.py
@@ -1682,6 +1682,10 @@ def test_pipeline_review_species_confirm_ignores_duplicate_inflight_clicks(live_
     _write_confirmation_pipeline_cache(live_server, photo_ids)
 
     page.goto(f"{live_server['url']}/pipeline/review")
+    confirm_button = page.locator(
+        '[data-species-widget="1"][data-enc="1"] .species-confirm-btn'
+    ).first
+    confirm_button.wait_for(state="visible")
 
     page.evaluate(
         """
@@ -1722,9 +1726,7 @@ def test_pipeline_review_species_confirm_ignores_duplicate_inflight_clicks(live_
     )
 
     assert post_count == 1
-    expect(
-        page.locator('[data-species-widget="1"][data-enc="1"] .species-confirm-btn').first
-    ).to_be_disabled()
+    expect(confirm_button).to_be_disabled()
 
     page.evaluate("() => window.__resolveSpeciesPost()")
     page.evaluate("() => Promise.all(window.__confirmPromises)")

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -32,6 +32,7 @@ from urllib.parse import quote, urlsplit
 
 import places
 from db import (
+    _LIFE_LIST_ANCESTOR_SUPPRESSION_CLAUSE,
     KEYWORD_TYPES,
     Database,
     IncompatibleDatabaseError,
@@ -9950,9 +9951,15 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
         # `get_photo_life_list_species` — both admit linked higher-rank
         # taxonomy identifications so a photo tagged only with a genus /
         # family / class entry can save the life-list representative for
-        # the entry it actually renders under.
+        # the entry it actually renders under. Ancestor suppression is
+        # applied via the shared clause so the write is denied for an
+        # ancestor keyword (``Aves``) when the same photo carries a
+        # descendant identification (``American Robin``); saving
+        # ``Aves`` there would render as ``is_current_photo`` false on
+        # the next read (see :meth:`get_species_representative_lists`)
+        # and leave a curation row nothing else considers eligible.
         row = db.conn.execute(
-            """SELECT 1
+            f"""SELECT 1
                FROM photo_keywords pk
                JOIN keywords k ON k.id = pk.keyword_id
                 AND (k.is_species = 1 OR k.type = 'taxonomy')
@@ -9977,6 +9984,7 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                          )
                      )
                  )
+                 {_LIFE_LIST_ANCESTOR_SUPPRESSION_CLAUSE}
                LIMIT 1""",
             (ws, photo_id, species, species),
         ).fetchone()

--- a/vireo/app.py
+++ b/vireo/app.py
@@ -9939,25 +9939,23 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
 
     def _photo_can_be_life_list_preference(db, species, photo_id):
         ws = db._ws_id()
-        # Accept a hierarchy leaf whose taxon links back to a root species
-        # with the same curation name. See the matching comment on
-        # Database.get_species_representative_lists: after root-repair the
-        # photo may only carry the hierarchical leaf ("verdin"), whose
-        # spelling differs from the root ("Verdin") even though the same
-        # taxon is still attached. Without this fallback, updating a
-        # preserved root-key preference would fail eligibility.
-        # Match the (t.rank = 'species' OR t.rank IS NULL) guard used by
-        # the life-list / species-bucket queries. Without it, a photo
-        # tagged only with a linked genus/family whose name happens to
-        # match the requested species would pass eligibility here but
-        # not appear in any bucket, so a saved representative would be
-        # invisible.
+        # Accept a hierarchy leaf whose taxon links back to a root
+        # identification with the same curation name. See the matching
+        # comment on Database.get_species_representative_lists: after
+        # root-repair the photo may only carry the hierarchical leaf
+        # ("verdin"), whose spelling differs from the root ("Verdin") even
+        # though the same taxon is still attached. Without this fallback,
+        # updating a preserved root-key preference would fail eligibility.
+        # Eligibility mirrors :meth:`Database.get_life_list_candidates` and
+        # `get_photo_life_list_species` — both admit linked higher-rank
+        # taxonomy identifications so a photo tagged only with a genus /
+        # family / class entry can save the life-list representative for
+        # the entry it actually renders under.
         row = db.conn.execute(
             """SELECT 1
                FROM photo_keywords pk
                JOIN keywords k ON k.id = pk.keyword_id
                 AND (k.is_species = 1 OR k.type = 'taxonomy')
-               LEFT JOIN taxa t ON t.id = k.taxon_id
                JOIN photos p ON p.id = pk.photo_id
                 AND COALESCE(p.flag, 'none') != 'rejected'
                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
@@ -9965,21 +9963,17 @@ def create_app(db_path, thumb_cache_dir=None, api_token=None):
                JOIN folders f ON f.id = p.folder_id
                 AND f.status IN ('ok', 'partial')
                WHERE pk.photo_id = ?
-                 AND (t.rank = 'species' OR t.rank IS NULL)
                  AND (
                      k.name = ?
                      OR (
                          k.taxon_id IS NOT NULL
                          AND EXISTS (
                              SELECT 1 FROM keywords root
-                             LEFT JOIN taxa rt ON rt.id = root.taxon_id
                              WHERE root.parent_id IS NULL
                                AND (root.is_species = 1
                                     OR root.type = 'taxonomy')
                                AND root.taxon_id = k.taxon_id
                                AND root.name = ?
-                               AND (rt.rank = 'species'
-                                    OR rt.rank IS NULL)
                          )
                      )
                  )

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -9747,28 +9747,18 @@ class Database:
                         ")",
                         (taxon_id, existing["id"], taxon_id),
                     )
-                else:
-                    # No species-rank taxon available. Clear a stale
-                    # non-species taxon_id (e.g. a legacy row bound to
-                    # the genus/family from the old species-agnostic
-                    # lookup) so the row falls under the readers'
-                    # ``t.rank IS NULL`` branch until a genuine
-                    # species-rank match becomes available. Without
-                    # this the is_species/taxonomy promotion below
-                    # still succeeds, but every downstream
-                    # ``t.rank = 'species' OR t.rank IS NULL`` filter
-                    # (Life List, Compare, Explorer, highlight /
-                    # preference eligibility) silently hides the
-                    # just-accepted keyword.
-                    self.conn.execute(
-                        "UPDATE keywords SET taxon_id = NULL "
-                        "WHERE id = ? AND type IN ('general', 'taxonomy') "
-                        "AND taxon_id IS NOT NULL "
-                        "AND COALESCE("
-                        "  (SELECT rank FROM taxa WHERE id = keywords.taxon_id), ''"
-                        ") != 'species'",
-                        (existing["id"],),
-                    )
+                # Preserve an existing higher-rank ``taxon_id`` when no
+                # species-rank replacement is available. Earlier revisions
+                # cleared the link so the row would fall under the old
+                # ``t.rank = 'species' OR t.rank IS NULL`` filters used by
+                # Life List, Compare, and highlight/preference eligibility.
+                # Those readers now accept linked higher-rank identifications
+                # (see :meth:`get_life_list_candidates` and
+                # :meth:`get_life_list_locations`), so clearing here would
+                # strip the row's ``taxon_rank`` / ``scientific_name`` /
+                # ``taxonomic_class`` metadata and silently break the new
+                # genus / family / class Life List filters — mirroring the
+                # startup preservation in :meth:`mark_species_keywords`.
             if kw_type is None and not is_species and existing["type"] == "general":
                 taxon_id = self._lookup_taxon_id_for_keyword(
                     name, prefer_species=True,

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -262,6 +262,57 @@ def _chunks(values, size=_SQLITE_PARAM_CHUNK_SIZE):
         yield values[idx:idx + size]
 
 
+# Life-list ancestor suppression. Broadening the identification-keyword
+# rank guard admits linked genus/family/class rows, but Lightroom catalog
+# imports copy every ``includeParents`` ancestor onto the photo as a flat
+# keyword (see ``vireo/catalog.py``) and the classifier already treats
+# ancestor tags as "broader labels for the same taxon" rather than
+# separate identifications (see ``_can_auto_accept_detection_prediction``
+# in ``vireo/classify_job.py``). Without a hierarchy filter, a normal
+# species-tagged robin would also inflate ``Turdus`` / ``Turdidae`` /
+# ``Aves`` Life List buckets on those catalogs.
+#
+# Suppress a linked higher-rank taxonomy keyword on a photo whenever the
+# same photo carries another linked taxonomy keyword whose taxon is a
+# strict descendant of it. Species-rank keywords are never suppressed;
+# unlinked keywords (``taxon_id IS NULL``) can't be checked for ancestry
+# and pass through unchanged. The clause references outer aliases
+# ``pk`` (photo_keywords) and ``k`` (keywords); callers don't need to
+# join ``taxa`` themselves because the rank/ancestry checks resolve
+# ``k.taxon_id`` via inner subqueries.
+_LIFE_LIST_ANCESTOR_SUPPRESSION_CLAUSE = """
+    AND NOT (
+        k.taxon_id IS NOT NULL
+        AND EXISTS (
+            SELECT 1 FROM taxa t_sup_rank
+            WHERE t_sup_rank.id = k.taxon_id
+              AND t_sup_rank.rank IS NOT NULL
+              AND t_sup_rank.rank != 'species'
+        )
+        AND EXISTS (
+            SELECT 1 FROM photo_keywords pk_sup
+            JOIN keywords k_sup ON k_sup.id = pk_sup.keyword_id
+             AND (k_sup.is_species = 1 OR k_sup.type = 'taxonomy')
+             AND k_sup.taxon_id IS NOT NULL
+            WHERE pk_sup.photo_id = pk.photo_id
+              AND k_sup.id != k.id
+              AND k.taxon_id IN (
+                  WITH RECURSIVE anc(id) AS (
+                      SELECT parent_id FROM taxa
+                       WHERE id = k_sup.taxon_id
+                         AND parent_id IS NOT NULL
+                      UNION ALL
+                      SELECT t_anc.parent_id
+                      FROM taxa t_anc JOIN anc a ON t_anc.id = a.id
+                       WHERE t_anc.parent_id IS NOT NULL
+                  )
+                  SELECT id FROM anc
+              )
+        )
+    )
+"""
+
+
 # Canonical set of keyword type values stored in keywords.type.
 # - taxonomy: a species/genus/etc. (linked to taxa via taxon_id)
 # - individual: a named person, pet, or otherwise tracked individual
@@ -12857,6 +12908,15 @@ class Database:
         Explorer continues to count only species-rank taxa through
         :meth:`get_life_list_taxon_ids`.
 
+        A linked higher-rank taxonomy keyword is suppressed when the same
+        photo carries another linked taxonomy keyword whose taxon is a
+        strict descendant of it, so a species-tagged robin also carrying
+        Lightroom-imported ``includeParents`` ancestors (``Turdus`` /
+        ``Turdidae`` / ``Aves``) or classifier-added broader labels does
+        not inflate every ancestor rank's Life List bucket. See
+        :data:`_LIFE_LIST_ANCESTOR_SUPPRESSION_CLAUSE` for the shared
+        SQL fragment.
+
         Unlike :meth:`get_highlights_candidates`, photos without a
         ``quality_score`` are included — a species the user confirmed but
         never ran through the pipeline still belongs on the life list. The
@@ -12918,6 +12978,7 @@ class Database:
                LEFT JOIN taxa t ON t.id = k.taxon_id
                WHERE COALESCE(p.flag, 'none') != 'rejected'
                  {species_filter}
+                 {_LIFE_LIST_ANCESTOR_SUPPRESSION_CLAUSE}
                ORDER BY k.name, p.timestamp""",
             params,
         ).fetchall()
@@ -13122,6 +13183,13 @@ class Database:
         can complete ``POST /api/photo-preferences`` for the entry it
         actually appears under on the Life List.
 
+        Ancestor suppression mirrors :meth:`get_life_list_candidates`: a
+        linked higher-rank taxonomy keyword on the photo is hidden when
+        the photo also carries another linked taxonomy keyword whose
+        taxon is a strict descendant of it, so the shared Set
+        Representative row surfaces only under the specific
+        identification the photo actually resolves to.
+
         Linked-taxon hierarchy leaves are canonicalized to the same-taxon
         root keyword's stored spelling — mirroring
         :meth:`get_species_keywords_for_photos` — so ``api_photo_detail`` can
@@ -13150,7 +13218,7 @@ class Database:
         """
         ws = self._ws_id()
         rows = self.conn.execute(
-            """SELECT k.name, k.parent_id, k.taxon_id
+            f"""SELECT k.name, k.parent_id, k.taxon_id
                FROM photo_keywords pk
                JOIN keywords k ON k.id = pk.keyword_id
                 AND (k.is_species = 1 OR k.type = 'taxonomy')
@@ -13161,6 +13229,7 @@ class Database:
                JOIN folders f ON f.id = p.folder_id
                 AND f.status IN ('ok', 'partial')
                WHERE pk.photo_id = ?
+                 {_LIFE_LIST_ANCESTOR_SUPPRESSION_CLAUSE}
                ORDER BY CASE WHEN k.parent_id IS NULL THEN 1 ELSE 0 END,
                         k.id""",
             (ws, photo_id),
@@ -13216,6 +13285,12 @@ class Database:
         taxon-linked root fallback so a hierarchy leaf surviving repair
         (``verdin`` vs canonical root ``Verdin``) still contributes its
         location keywords to the requested bucket.
+
+        Ancestor suppression also mirrors :meth:`get_life_list_candidates`:
+        a linked higher-rank taxonomy keyword's locations are dropped
+        when the same photo carries another linked taxonomy keyword whose
+        taxon is a strict descendant of it, so ``Aves`` doesn't inherit
+        every location where a robin was tagged.
         """
         ws = self._ws_id()
         species_filter = ""
@@ -13252,6 +13327,8 @@ class Database:
                JOIN photo_keywords plk ON plk.photo_id = p.id
                JOIN keywords lk ON lk.id = plk.keyword_id
                 AND lk.type = 'location'
+               WHERE 1=1
+                 {_LIFE_LIST_ANCESTOR_SUPPRESSION_CLAUSE}
                ORDER BY k.name, lk.name""",
             tuple(params),
         ).fetchall()
@@ -13312,8 +13389,13 @@ class Database:
             # eligible-only reader that ``GET /api/photos/<id>`` uses to
             # decide ``is_current_photo``, so the shared Set Representative
             # affordance would keep offering the write even after it had
-            # already succeeded.
-            eligibility_filter = """
+            # already succeeded. The shared ancestor-suppression clause is
+            # appended so an ancestor keyword (``Aves``) does not survive
+            # eligibility when the same photo also carries a descendant
+            # identification (``American Robin``) — otherwise the class
+            # bucket the Life List query already hides would still show a
+            # current representative here.
+            eligibility_filter = f"""
                  AND COALESCE(p.flag, 'none') != 'rejected'
                  AND f.status IN ('ok', 'partial')
                  AND EXISTS (
@@ -13336,6 +13418,7 @@ class Database:
                                )
                            )
                        )
+                       {_LIFE_LIST_ANCESTOR_SUPPRESSION_CLAUSE}
                  )"""
         species_filter = ""
         params = [ws]

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -12856,12 +12856,16 @@ class Database:
         return rows
 
     def get_life_list_candidates(self, species=None):
-        """Return (photo x accepted-species-keyword) rows for the life list.
+        """Return (photo x accepted-identification-keyword) life-list rows.
 
         Every non-rejected photo in a workspace-visible folder carrying an
-        accepted species keyword (``is_species = 1`` or ``type = 'taxonomy'``)
-        produces one row per species keyword. Taxonomy names ride along from
-        ``taxa`` when the keyword is linked.
+        accepted identification keyword (``is_species = 1`` or
+        ``type = 'taxonomy'``) produces one row per keyword. Taxonomy names
+        and ranks ride along from ``taxa`` when the keyword is linked. Linked
+        higher-rank identifications are included so the Life List can show and
+        filter genus-, family-, and other non-species-level observations; the
+        Explorer continues to count only species-rank taxa through
+        :meth:`get_life_list_taxon_ids`.
 
         Unlike :meth:`get_highlights_candidates`, photos without a
         ``quality_score`` are included — a species the user confirmed but
@@ -12923,7 +12927,6 @@ class Database:
                 AND f.status IN ('ok', 'partial')
                LEFT JOIN taxa t ON t.id = k.taxon_id
                WHERE COALESCE(p.flag, 'none') != 'rejected'
-                 AND (t.rank = 'species' OR t.rank IS NULL)
                  {species_filter}
                ORDER BY k.name, p.timestamp""",
             params,

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -13117,15 +13117,20 @@ class Database:
         return dict(row) if row else None
 
     def get_photo_life_list_species(self, photo_id):
-        """Return this photo's lifelist-eligible species names in the active
-        workspace, ordered by name.
+        """Return this photo's lifelist-eligible identification names in the
+        active workspace, ordered by name.
 
         Same eligibility rule as :meth:`get_life_list_candidates`: an accepted
-        species keyword (``is_species = 1`` or ``type = 'taxonomy'``) on a
-        non-rejected photo in a workspace-visible folder. Returns ``[]`` when
-        the photo carries no such species (or is rejected / outside the
-        workspace), which is exactly when no "Add to Life List" affordance
-        should appear.
+        identification keyword (``is_species = 1`` or ``type = 'taxonomy'``)
+        on a non-rejected photo in a workspace-visible folder. Returns ``[]``
+        when the photo carries no such identification (or is rejected /
+        outside the workspace), which is exactly when no "Set Representative"
+        affordance should appear. Linked higher-rank taxonomy identifications
+        (genus, family, class, …) are included for the same reason they are
+        in :meth:`get_life_list_candidates` — so a photo tagged only with a
+        higher-rank identification exposes the shared representative row and
+        can complete ``POST /api/photo-preferences`` for the entry it
+        actually appears under on the Life List.
 
         Linked-taxon hierarchy leaves are canonicalized to the same-taxon
         root keyword's stored spelling — mirroring
@@ -13159,7 +13164,6 @@ class Database:
                FROM photo_keywords pk
                JOIN keywords k ON k.id = pk.keyword_id
                 AND (k.is_species = 1 OR k.type = 'taxonomy')
-               LEFT JOIN taxa t ON t.id = k.taxon_id
                JOIN photos p ON p.id = pk.photo_id
                 AND COALESCE(p.flag, 'none') != 'rejected'
                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
@@ -13167,7 +13171,6 @@ class Database:
                JOIN folders f ON f.id = p.folder_id
                 AND f.status IN ('ok', 'partial')
                WHERE pk.photo_id = ?
-                 AND (t.rank = 'species' OR t.rank IS NULL)
                ORDER BY CASE WHEN k.parent_id IS NULL THEN 1 ELSE 0 END,
                         k.id""",
             (ws, photo_id),

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -13304,24 +13304,25 @@ class Database:
         eligibility_filter = ""
         if eligible_only:
             # Accept a hierarchy leaf whose taxon links back to a root
-            # species with the curation-keyed name. After
+            # identification with the curation-keyed name. After
             # repair_duplicate_photo_species detaches a redundant root but
             # leaves the hierarchical leaf attached, the leaf's stored
             # spelling may differ from the root ("verdin" vs "Verdin"), yet
-            # the photo still represents the same species via a shared
-            # taxon_id. An exact k.name = sr.species compare would then
-            # silently drop that photo from Life List / Representative
+            # the photo still represents the same identification via a
+            # shared taxon_id. An exact k.name = sr.species compare would
+            # then silently drop that photo from Life List / Representative
             # eligibility even though curation was intentionally preserved
             # on the root key.
-            # Restrict the eligibility EXISTS to species-rank taxonomy rows.
-            # `mark_species_keywords` stamps `is_species=1`/`type='taxonomy'`
-            # regardless of the linked taxon's rank, so a genus/family
-            # keyword whose display name happens to match a species curation
-            # key (e.g. a genus row named `Puma`) would otherwise satisfy
-            # eligibility for the `Puma` species representative even though
-            # sibling queries (get_life_list_candidates, get_species_keywords_for_photos,
-            # etc.) exclude the photo from the species bucket via the same
-            # `(t.rank = 'species' OR t.rank IS NULL)` guard.
+            # Eligibility mirrors :meth:`get_life_list_candidates`,
+            # :meth:`get_photo_life_list_species`, and
+            # ``_photo_can_be_life_list_preference`` — all admit linked
+            # higher-rank taxonomy identifications (genus, family, class,
+            # …). Without this, a just-saved representative for a
+            # higher-rank Life List entry would be dropped by the
+            # eligible-only reader that ``GET /api/photos/<id>`` uses to
+            # decide ``is_current_photo``, so the shared Set Representative
+            # affordance would keep offering the write even after it had
+            # already succeeded.
             eligibility_filter = """
                  AND COALESCE(p.flag, 'none') != 'rejected'
                  AND f.status IN ('ok', 'partial')
@@ -13330,9 +13331,7 @@ class Database:
                      FROM photo_keywords pk
                      JOIN keywords k ON k.id = pk.keyword_id
                       AND (k.is_species = 1 OR k.type = 'taxonomy')
-                     LEFT JOIN taxa t ON t.id = k.taxon_id
                      WHERE pk.photo_id = sr.photo_id
-                       AND (t.rank = 'species' OR t.rank IS NULL)
                        AND (
                            k.name = sr.species
                            OR (

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -13205,15 +13205,20 @@ class Database:
         return sorted(chosen.values(), key=lambda n: keyword_match_key(n))
 
     def get_life_list_locations(self, species=None):
-        """Return {species name: [location keyword names]} for the life list.
+        """Return {identification name: [location keyword names]} for the life list.
 
-        A location is attributed to a species when at least one
-        workspace-visible, non-rejected photo carries both the species
-        keyword and a ``type = 'location'`` keyword.
+        A location is attributed to an identification when at least one
+        workspace-visible, non-rejected photo carries both the
+        identification keyword and a ``type = 'location'`` keyword.
+        Higher-rank taxonomy identifications (genus, family, class, …) are
+        eligible here for the same reason they are in
+        :meth:`get_life_list_candidates` — so a genus-level entry rendered
+        on the Life List keeps its location chips and CSV values instead of
+        appearing with an empty ``locations`` list.
 
-        When ``species`` is given, only that species is scanned — used by
-        the single-species paging endpoint so incremental loads don't do
-        catalog-wide work. Matching mirrors
+        When ``species`` is given, only that identification is scanned —
+        used by the single-identification paging endpoint so incremental
+        loads don't do catalog-wide work. Matching mirrors
         :meth:`get_life_list_candidates`: raw ``k.name`` first, then a
         taxon-linked root fallback so a hierarchy leaf surviving repair
         (``verdin`` vs canonical root ``Verdin``) still contributes its
@@ -13245,7 +13250,6 @@ class Database:
                JOIN keywords k ON k.id = pk.keyword_id
                 AND (k.is_species = 1 OR k.type = 'taxonomy')
                 {species_filter}
-               LEFT JOIN taxa t ON t.id = k.taxon_id
                JOIN photos p ON p.id = pk.photo_id
                 AND COALESCE(p.flag, 'none') != 'rejected'
                JOIN workspace_folders wf ON wf.folder_id = p.folder_id
@@ -13255,7 +13259,6 @@ class Database:
                JOIN photo_keywords plk ON plk.photo_id = p.id
                JOIN keywords lk ON lk.id = plk.keyword_id
                 AND lk.type = 'location'
-               WHERE t.rank = 'species' OR t.rank IS NULL
                ORDER BY k.name, lk.name""",
             tuple(params),
         ).fetchall()

--- a/vireo/db.py
+++ b/vireo/db.py
@@ -18910,15 +18910,17 @@ class Database:
         Matching rows get ``is_species=1``, ``type='taxonomy'``, and (if the
         local taxa table is populated and the lookup resolves to a
         species-rank taxon) a ``taxon_id`` link by iNaturalist id.
-        ``taxon_id`` is left NULL when only a higher-rank (genus/family)
-        match exists — binding to a non-species-rank taxon would satisfy the
-        marking pass but make the row invisible to every rank-filtered
-        reader that restricts to ``t.rank = 'species' OR t.rank IS NULL``.
-        A ``type='taxonomy'`` row whose ``taxon_id`` was bound by the old
-        species-agnostic lookup to a non-species-rank taxon (genus/family)
-        is rebound to the species-rank taxon whenever ``taxonomy.lookup``
-        resolves to one; otherwise the new ``rank = 'species'`` filters
-        would silently drop every photo carrying the accepted keyword.
+        ``taxon_id`` is left NULL when the row had no prior link and only
+        a higher-rank (genus/family) match exists — binding an unlinked
+        row to a non-species-rank taxon would auto-promote it in a way the
+        classifier callers never asked for. A ``type='taxonomy'`` row
+        whose ``taxon_id`` was bound by the old species-agnostic lookup
+        to a non-species-rank taxon (genus/family) is rebound to the
+        species-rank taxon whenever ``taxonomy.lookup`` resolves to one;
+        when no species-rank replacement exists, the higher-rank link is
+        preserved so ``get_life_list_candidates`` can keep surfacing the
+        row's ``taxon_rank`` / ``scientific_name`` / ``taxonomic_class``
+        metadata for genus/family/class Life List filters.
 
         Uses the local taxonomy only (no network requests).
 
@@ -18991,23 +18993,18 @@ class Database:
                 and lookup_local_id != kw["taxon_id"]
             ):
                 rebind_taxon_id = lookup_local_id
-            # When the existing binding is non-species-rank and no
-            # species-rank replacement is available, clear ``taxon_id`` to
-            # NULL. Leaving the higher-rank link in place would satisfy
-            # ``mark_species_keywords`` but make the row invisible to
-            # every rank-filtered reader (Life List, Compare,
-            # highlight/preference eligibility) that restricts to
-            # ``t.rank = 'species' OR t.rank IS NULL``; NULLing it lets
-            # the accepted keyword stay visible via the ``rank IS NULL``
-            # fallback until a species-rank taxon becomes available,
-            # mirroring ``add_keyword``'s reuse-path clearing (see
-            # ``test_add_species_clears_higher_rank_taxon_when_no_species_match``).
-            should_clear_taxon = (
-                kw["taxon_id"] is not None
-                and kw["taxon_rank"] is not None
-                and kw["taxon_rank"] != "species"
-                and rebind_taxon_id is None
-            )
+            # Preserve an existing higher-rank ``taxon_id`` when no
+            # species-rank replacement is available. Earlier revisions
+            # cleared the link to keep the row visible under the old
+            # ``t.rank = 'species' OR t.rank IS NULL`` filters used by
+            # Life List, Compare, and highlight/preference eligibility.
+            # Those readers now accept linked higher-rank identifications
+            # (see :meth:`get_life_list_candidates` and
+            # :meth:`get_life_list_locations`), so clearing on startup
+            # would strip the row's ``taxon_rank`` / ``scientific_name`` /
+            # ``taxonomic_class`` metadata and silently break the new
+            # genus / family / class Life List filters after the first
+            # restart.
             # Skip no-op updates so the "updated" count reflects real
             # changes. A matched row is fully consistent when type is
             # 'taxonomy', is_species is 1, and (taxon_id is already set to
@@ -19021,7 +19018,6 @@ class Database:
                 or is_species_fix
                 or is_taxon_link
                 or is_rebind
-                or should_clear_taxon
             ):
                 continue
             if is_rebind:
@@ -19029,12 +19025,6 @@ class Database:
                     "UPDATE keywords SET is_species = 1, type = 'taxonomy', "
                     "taxon_id = ? WHERE id = ?",
                     (rebind_taxon_id, kw["id"]),
-                )
-            elif should_clear_taxon:
-                self.conn.execute(
-                    "UPDATE keywords SET is_species = 1, type = 'taxonomy', "
-                    "taxon_id = NULL WHERE id = ?",
-                    (kw["id"],),
                 )
             else:
                 self.conn.execute(

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -19460,19 +19460,16 @@ def test_mark_species_keywords_keeps_species_taxon_when_only_higher_rank_availab
     assert row["taxon_id"] == species_taxon
 
 
-def test_mark_species_keywords_clears_higher_rank_taxon_when_no_species_match(tmp_path):
-    """A fully typed taxonomy row already bound by the old species-agnostic
-    lookup to a higher-rank taxon (genus/family) must have its stale
-    non-species ``taxon_id`` cleared to NULL on the next
+def test_mark_species_keywords_preserves_higher_rank_taxon_when_no_species_match(tmp_path):
+    """A fully typed taxonomy row already linked to a higher-rank taxon
+    (genus/family/class) must retain that link on the next
     ``mark_species_keywords`` pass when no species-rank replacement is
-    available. Leaving the higher-rank link in place would satisfy the
-    marking pass but make the row invisible to every rank-filtered reader
-    (Life List, Compare, Explorer, highlight/preference eligibility) that
-    restricts to ``t.rank = 'species' OR t.rank IS NULL`` — clearing the
-    binding keeps the accepted keyword visible via the ``rank IS NULL``
-    fallback until a species-rank taxon becomes available. Mirrors
-    ``add_keyword``'s reuse-path clearing (see
-    ``test_add_species_clears_higher_rank_taxon_when_no_species_match``).
+    available. ``get_life_list_candidates`` and ``get_life_list_locations``
+    now surface linked higher-rank identifications so their
+    ``taxon_rank`` / ``scientific_name`` / ``taxonomic_class`` metadata
+    powers the new genus / family / class Life List filters; clearing
+    the ``taxon_id`` on startup would strip that metadata and silently
+    break those filters after the first restart.
     """
     from db import Database
 
@@ -19489,10 +19486,10 @@ def test_mark_species_keywords_clears_higher_rank_taxon_when_no_species_match(tm
         "SELECT id FROM taxa WHERE rank = 'family'"
     ).fetchone()["id"]
 
-    # Legacy row: fully typed taxonomy species but bound to the
-    # non-species-rank family taxon by the old species-agnostic lookup.
-    # add_keyword auto-promotes/clears on insert, so bypass it with
-    # direct SQL to simulate the upgraded catalog.
+    # Fully typed taxonomy row linked to a valid higher-rank taxon (a
+    # ``Corvidae`` family observation the user has accepted). add_keyword
+    # is species-preferring on insert, so bypass it with direct SQL to
+    # simulate the upgraded catalog.
     cur = db.conn.execute(
         "INSERT INTO keywords (name, type, is_species, taxon_id) "
         "VALUES ('Corvidae', 'taxonomy', 1, ?)",
@@ -19512,14 +19509,14 @@ def test_mark_species_keywords_clears_higher_rank_taxon_when_no_species_match(tm
             return self.lookup(name) is not None
 
     updated = db.mark_species_keywords(FakeTaxonomy())
-    assert updated == 1
+    assert updated == 0
     row = db.conn.execute(
         "SELECT is_species, type, taxon_id FROM keywords WHERE id = ?",
         (kid,),
     ).fetchone()
     assert row["type"] == "taxonomy"
     assert row["is_species"] == 1
-    assert row["taxon_id"] is None
+    assert row["taxon_id"] == family_taxon
 
 
 def test_repair_duplicate_photo_species_preserves_highlight_eligibility(tmp_path):

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -19245,18 +19245,18 @@ def test_add_species_leaves_taxon_null_when_only_higher_rank_matches(tmp_path):
     assert row["taxon_id"] is None
 
 
-def test_add_species_clears_higher_rank_taxon_when_no_species_match(tmp_path):
-    """A pre-existing keyword row bound to a higher-rank taxon
-    (e.g. a legacy row stamped with the genus/family taxon before
-    ``prefer_species`` existed) must have that stale non-species
-    ``taxon_id`` cleared to NULL when the next species accept cannot
-    find a species-rank match. Without the clear the reuse branch
-    leaves the higher-rank binding in place while the taxonomy
-    promotion below still stamps ``is_species = 1``/``type =
-    'taxonomy'``, so every rank-filtered reader (Life List,
-    Compare, Explorer, highlight/preference eligibility) that
-    restricts to ``t.rank = 'species' OR t.rank IS NULL`` silently
-    hides the just-accepted keyword.
+def test_add_species_preserves_higher_rank_taxon_when_no_species_match(tmp_path):
+    """A pre-existing keyword row bound to a valid higher-rank taxon
+    (e.g. a ``Corvidae`` family observation) must keep that
+    ``taxon_id`` when the next species-typed accept cannot find a
+    species-rank match. ``get_life_list_candidates`` and
+    ``get_life_list_locations`` now surface linked higher-rank
+    identifications so their ``taxon_rank`` / ``scientific_name`` /
+    ``taxonomic_class`` metadata powers the new genus / family /
+    class Life List filters; clearing the ``taxon_id`` here would
+    strip that metadata on the next normal keyword edit and silently
+    break those filters — mirroring the preservation guarantee that
+    :meth:`mark_species_keywords` gives on startup.
     """
     from db import Database
 
@@ -19273,21 +19273,18 @@ def test_add_species_clears_higher_rank_taxon_when_no_species_match(tmp_path):
         "SELECT id FROM taxa WHERE rank = 'family'"
     ).fetchone()["id"]
 
-    # Legacy row: correctly typed taxonomy species but bound to the
-    # non-species-rank family taxon by the old species-agnostic lookup.
-    kid = db.add_keyword("Corvidae", is_species=True)
-    db.conn.execute(
-        "UPDATE keywords SET taxon_id = ? WHERE id = ?",
-        (family_taxon, kid),
+    # Fully typed taxonomy row linked to a valid higher-rank taxon.
+    # ``add_keyword`` is species-preferring on insert, so bypass it
+    # with direct SQL to simulate the upgraded catalog.
+    cur = db.conn.execute(
+        "INSERT INTO keywords (name, type, is_species, taxon_id) "
+        "VALUES ('Corvidae', 'taxonomy', 1, ?)",
+        (family_taxon,),
     )
+    kid = cur.lastrowid
     db.conn.commit()
-    pre = db.conn.execute(
-        "SELECT taxon_id FROM keywords WHERE id = ?", (kid,)
-    ).fetchone()
-    assert pre["taxon_id"] == family_taxon
 
-    # Accepting again with is_species=True should clear the stale
-    # higher-rank binding rather than leaving it in place.
+    # Re-adding as a taxonomy keyword must NOT clear the family link.
     same = db.add_keyword("Corvidae", is_species=True)
     assert same == kid
     row = db.conn.execute(
@@ -19296,7 +19293,19 @@ def test_add_species_clears_higher_rank_taxon_when_no_species_match(tmp_path):
     ).fetchone()
     assert row["is_species"] == 1
     assert row["type"] == "taxonomy"
-    assert row["taxon_id"] is None
+    assert row["taxon_id"] == family_taxon
+
+    # The same guarantee must hold for the kw_type='taxonomy' variant
+    # taken by other callers.
+    same_typed = db.add_keyword("Corvidae", kw_type="taxonomy")
+    assert same_typed == kid
+    row = db.conn.execute(
+        "SELECT is_species, type, taxon_id FROM keywords WHERE id = ?",
+        (kid,),
+    ).fetchone()
+    assert row["is_species"] == 1
+    assert row["type"] == "taxonomy"
+    assert row["taxon_id"] == family_taxon
 
 
 def test_mark_species_keywords_rebinds_higher_rank_taxonomy_link(tmp_path):

--- a/vireo/tests/test_db.py
+++ b/vireo/tests/test_db.py
@@ -19944,18 +19944,21 @@ def test_get_species_highlights_prediction_fallback_prefers_same_name_root(tmp_p
     )
 
 
-def test_curation_eligibility_rejects_higher_rank_taxonomy_homonym(tmp_path):
+def test_curation_eligibility_higher_rank_taxonomy_homonym(tmp_path):
     """A linked higher-rank taxonomy keyword (e.g. a genus row named
-    ``Puma``) must not satisfy species-curation eligibility for the
-    matching species highlight or representative.
+    ``Puma``) is eligible for the identification-name-keyed
+    representative curation row that shares its stored spelling, but
+    not for the species-only ordered-highlights row keyed on the same
+    name.
 
-    ``mark_species_keywords`` stamps ``is_species=1``/``type='taxonomy'``
-    regardless of the linked taxon's rank, so without the same
-    ``(t.rank = 'species' OR t.rank IS NULL)`` guard used by sibling
-    species queries (``get_life_list_candidates``,
-    ``get_species_keywords_for_photos`` etc.), a genus-linked keyword
-    named ``Puma`` would keep a species ``Puma`` curation row eligible
-    for a photo that is no longer in the species bucket.
+    Representative eligibility mirrors the widened
+    :meth:`get_life_list_candidates`, :meth:`get_photo_life_list_species`,
+    and ``_photo_can_be_life_list_preference`` write path — the Life
+    List renders higher-rank identifications so their photos must
+    survive the ``eligible_only=True`` read that ``GET /api/photos/<id>``
+    uses to decide whether the shared Set-Representative button is
+    current. ``get_species_highlights`` remains species-only, because
+    the Highlights page still only surfaces species buckets.
     """
     from db import Database
 
@@ -19991,23 +19994,24 @@ def test_curation_eligibility_rejects_higher_rank_taxonomy_homonym(tmp_path):
     )
     db.tag_photo(pid, kid)
 
-    # Curation rows stored under the canonical "Puma" species key.
+    # Curation rows stored under the "Puma" identification key.
     db.set_species_representative("Puma", pid)
     db.add_species_highlight("Puma", pid)
     db.conn.commit()
 
-    # Sibling species queries already exclude the photo from the "Puma"
-    # species bucket because of the (t.rank='species' OR NULL) guard.
-    # The curation eligibility EXISTS must exclude it too — otherwise
-    # the representative/highlight remains eligible for a photo that
-    # nothing else considers a Puma species record.
+    # Representative eligibility matches the widened Life List siblings:
+    # the higher-rank homonym is a valid representative for the "Puma"
+    # entry the user actually renders under on the Life List.
     reps = db.get_species_representative_lists(eligible_only=True)
-    assert reps.get("Puma") in (None, []), (
-        "genus-rank taxonomy row named 'Puma' must not satisfy species "
-        "'Puma' representative eligibility"
+    assert reps.get("Puma") == [pid], (
+        "higher-rank homonym 'Puma' must satisfy 'Puma' representative "
+        "eligibility, matching the widened life-list write path"
     )
-    assert db.get_species_representatives(eligible_only=True) == {}
+    assert db.get_species_representatives(eligible_only=True) == {"Puma": pid}
 
+    # Highlights remain species-only. The Highlights page surfaces
+    # species buckets, so a genus-rank keyword named 'Puma' must not
+    # keep the species 'Puma' highlight eligible.
     highlights = db.get_species_highlights(eligible_only=True)
     assert pid not in highlights.get("Puma", {}), (
         "genus-rank taxonomy row named 'Puma' must not satisfy species "
@@ -20017,8 +20021,7 @@ def test_curation_eligibility_rejects_higher_rank_taxonomy_homonym(tmp_path):
     assert pid not in single.get("Puma", {})
 
     # Sanity check: when the row is rebound to the species-rank taxon,
-    # eligibility flips back on. Confirms the guard, not something
-    # else, is what excludes the row.
+    # even the species-only highlight eligibility flips on.
     species_taxon = db.conn.execute(
         "SELECT id FROM taxa WHERE rank = 'species'"
     ).fetchone()["id"]

--- a/vireo/tests/test_life_list.py
+++ b/vireo/tests/test_life_list.py
@@ -674,8 +674,7 @@ def test_taxonomic_rank_and_class_attached(life_app):
     assert cardinal["taxonomic_class"] is None
 
 
-def test_higher_rank_taxonomy_identification_is_listed(life_app):
-    app, db, ids = life_app
+def _seed_higher_rank_accipiter(db, folder_id):
     aves = db.conn.execute(
         "INSERT INTO taxa (name, common_name, rank) VALUES (?, ?, ?)",
         ("Aves", "Birds", "class"),
@@ -690,7 +689,7 @@ def test_higher_rank_taxonomy_identification_is_listed(life_app):
         (accipiter, keyword_id),
     )
     photo_id = db.add_photo(
-        folder_id=ids["folder"],
+        folder_id=folder_id,
         filename="accipiter.jpg",
         extension=".jpg",
         file_size=1000,
@@ -698,20 +697,67 @@ def test_higher_rank_taxonomy_identification_is_listed(life_app):
         timestamp="2024-06-01T12:00:00",
     )
     db.tag_photo(photo_id, keyword_id)
+    db.conn.commit()
+    return {"aves": aves, "accipiter": accipiter, "photo": photo_id,
+            "keyword": keyword_id}
+
+
+def test_higher_rank_taxonomy_identification_is_listed(life_app):
+    app, db, ids = life_app
+    seed = _seed_higher_rank_accipiter(db, ids["folder"])
     # Tag the same photo with an existing location keyword so the entry
     # must surface its location chip / CSV value like species-rank rows do.
     location_id = db.add_keyword("Backyard", kw_type="location")
-    db.tag_photo(photo_id, location_id)
+    db.tag_photo(seed["photo"], location_id)
     db.conn.commit()
 
     entry = _entry(_get_life_list(app), "Accipiter")
     assert entry["taxon_rank"] == "genus"
     assert entry["taxonomic_class"] == {
-        "id": aves,
+        "id": seed["aves"],
         "name": "Aves",
         "common_name": "Birds",
     }
     assert entry["locations"] == ["Backyard"]
+
+
+def test_higher_rank_photo_can_be_life_list_representative(life_app):
+    """A photo tagged only with a linked higher-rank taxonomy identification
+    (genus/family/class) must expose the Life List representative row and
+    accept ``POST /api/photo-preferences`` for the entry it renders under.
+
+    Regression test for the eligibility guards in
+    :func:`get_photo_life_list_species` and
+    :func:`_photo_can_be_life_list_preference` that previously filtered to
+    ``t.rank = 'species' OR t.rank IS NULL`` — which hid the shared Set
+    Representative row on the higher-rank Life List entry and 400'd a
+    representative POST for the entry the user could actually see.
+    """
+    app, db, ids = life_app
+    seed = _seed_higher_rank_accipiter(db, ids["folder"])
+    client = app.test_client()
+
+    # The shared Set-Representative row (browse context menu / lightbox
+    # panel) reads the photo's life_list block, which comes from
+    # ``get_photo_life_list_species``. Without the broadened eligibility,
+    # this list would be empty and the affordance would not render.
+    detail = client.get(f"/api/photos/{seed['photo']}").get_json()
+    assert [entry["species"] for entry in detail["life_list"]] == ["Accipiter"]
+
+    # POST is gated by ``_photo_can_be_life_list_preference``. Without the
+    # broadened guard this returned 400 for the entry the user could see.
+    resp = client.post("/api/photo-preferences", json={
+        "purpose": "life_list",
+        "species": "Accipiter",
+        "photo_id": seed["photo"],
+    })
+    assert resp.status_code == 200
+
+    entry = _entry(_get_life_list(app), "Accipiter")
+    assert entry["best"]["id"] == seed["photo"]
+    assert entry["best"]["is_life_list_photo"] is True
+    assert entry["best"]["is_species_representative"] is True
+    assert entry["has_preferred_photo"] is True
 
 
 def test_locations_from_location_keywords(life_app):

--- a/vireo/tests/test_life_list.py
+++ b/vireo/tests/test_life_list.py
@@ -825,6 +825,224 @@ def test_higher_rank_taxonomy_link_survives_mark_species_pass(life_app):
     }
 
 
+def _seed_robin_with_ancestor_keywords(db, folder_id):
+    """Seed a photo tagged with a species (``American Robin``) plus every
+    ancestor keyword up to class rank — the shape produced by a Lightroom
+    catalog imported with ``includeParents`` (see ``vireo/catalog.py``)
+    and by the classifier auto-accept path that treats ancestor tags as
+    "broader labels for the same taxon" (see
+    ``_can_auto_accept_detection_prediction`` in ``vireo/classify_job.py``).
+    """
+    aves = db.conn.execute(
+        "INSERT INTO taxa (name, common_name, rank) VALUES (?, ?, ?)",
+        ("Aves", "Birds", "class"),
+    ).lastrowid
+    passeriformes = db.conn.execute(
+        "INSERT INTO taxa (name, rank, parent_id) VALUES (?, ?, ?)",
+        ("Passeriformes", "order", aves),
+    ).lastrowid
+    turdidae = db.conn.execute(
+        "INSERT INTO taxa (name, rank, parent_id) VALUES (?, ?, ?)",
+        ("Turdidae", "family", passeriformes),
+    ).lastrowid
+    turdus = db.conn.execute(
+        "INSERT INTO taxa (name, rank, parent_id) VALUES (?, ?, ?)",
+        ("Turdus", "genus", turdidae),
+    ).lastrowid
+    robin = db.conn.execute(
+        "INSERT INTO taxa (name, common_name, rank, parent_id) VALUES (?, ?, ?, ?)",
+        ("Turdus migratorius", "American Robin", "species", turdus),
+    ).lastrowid
+
+    def _linked(name, taxon_id):
+        kid = db.add_keyword(name, kw_type="taxonomy")
+        db.conn.execute(
+            "UPDATE keywords SET taxon_id = ? WHERE id = ?", (taxon_id, kid))
+        return kid
+
+    k_robin = _linked("American Robin", robin)
+    k_turdus = _linked("Turdus", turdus)
+    k_turdidae = _linked("Turdidae", turdidae)
+    k_aves = _linked("Aves", aves)
+    photo_id = db.add_photo(
+        folder_id=folder_id,
+        filename="robin.jpg",
+        extension=".jpg",
+        file_size=1000,
+        file_mtime=7.0,
+        timestamp="2024-07-01T12:00:00",
+    )
+    db.tag_photo(photo_id, k_robin)
+    db.tag_photo(photo_id, k_turdus)
+    db.tag_photo(photo_id, k_turdidae)
+    db.tag_photo(photo_id, k_aves)
+    db.conn.commit()
+    return {
+        "photo": photo_id,
+        "robin_kw": k_robin, "turdus_kw": k_turdus,
+        "turdidae_kw": k_turdidae, "aves_kw": k_aves,
+        "robin_taxon": robin, "turdus_taxon": turdus,
+        "turdidae_taxon": turdidae, "aves_taxon": aves,
+    }
+
+
+def test_life_list_suppresses_ancestor_keywords_from_lightroom_import(life_app):
+    """A species-tagged photo carrying Lightroom-imported ``includeParents``
+    ancestor keywords (``Turdus`` / ``Turdidae`` / ``Aves``) must contribute
+    only to the species bucket — the ancestor tags are broader labels for
+    the same taxon, not independent Life List entries.
+
+    Regression test for the removal of the ``t.rank = 'species'``
+    hierarchy guards: without ancestor suppression, every ancestor keyword
+    would inflate the Life List's species count and CSV exports with
+    duplicate class/family/genus buckets that the classifier already
+    treats as broader labels.
+    """
+    app, db, ids = life_app
+    seed = _seed_robin_with_ancestor_keywords(db, ids["folder"])
+
+    data = _get_life_list(app)
+    species_seen = [entry["species"] for entry in data["species"]]
+    # The three ancestor keywords on this photo must not appear as their
+    # own Life List buckets alongside "American Robin".
+    for ancestor in ("Turdus", "Turdidae", "Aves"):
+        assert ancestor not in species_seen, (
+            f"{ancestor} was inflated into its own bucket even though the "
+            f"same photo is species-identified as American Robin"
+        )
+    robin_entry = _entry(data, "American Robin")
+    # The species bucket itself must still resolve to a real photo.
+    assert robin_entry["best"]["id"] == seed["photo"]
+
+
+def test_life_list_locations_omit_ancestor_buckets(life_app):
+    """The locations map returned by ``get_life_list_locations`` must not
+    attribute a species-photo's location to its ancestor keywords — the
+    classifier's broader-label ancestors should not inherit every place
+    the species was seen. Codex noted this drove inflated ancestor
+    location chips and CSV values.
+    """
+    app, db, ids = life_app
+    seed = _seed_robin_with_ancestor_keywords(db, ids["folder"])
+    location_id = db.add_keyword("Backyard", kw_type="location")
+    db.tag_photo(seed["photo"], location_id)
+    db.conn.commit()
+
+    locations = db.get_life_list_locations()
+    assert "American Robin" in locations
+    assert locations["American Robin"] == ["Backyard"]
+    for ancestor in ("Turdus", "Turdidae", "Aves"):
+        assert ancestor not in locations, (
+            f"{ancestor} received the species' location even though "
+            f"the ancestor bucket itself is suppressed from Life List"
+        )
+
+
+def test_life_list_ancestor_only_photo_still_listed(life_app):
+    """Suppression must fire only when the same photo carries a descendant
+    identification — a genus-only photo (no species tag) must still surface
+    its higher-rank bucket. Without this guarantee the fix over-corrects
+    and hides genuine higher-rank-only observations.
+    """
+    app, db, ids = life_app
+    # Existing seed already has a genus-only Accipiter photo.
+    _seed_higher_rank_accipiter(db, ids["folder"])
+
+    entry = _entry(_get_life_list(app), "Accipiter")
+    assert entry["taxon_rank"] == "genus"
+
+
+def test_life_list_ancestor_representative_write_denied_when_descendant_exists(life_app):
+    """When a photo carries both a species-rank identification and a linked
+    ancestor keyword, ``POST /api/photo-preferences`` for the ancestor
+    entry must return 400. Otherwise a Set-Representative call for
+    ``Aves`` would succeed on a photo the Life List Aves bucket does not
+    even render, leaving orphaned curation the next eligible-only reader
+    silently drops.
+    """
+    app, db, ids = life_app
+    seed = _seed_robin_with_ancestor_keywords(db, ids["folder"])
+    client = app.test_client()
+
+    # Setting the species-level representative is fine.
+    resp_ok = client.post("/api/photo-preferences", json={
+        "purpose": "life_list",
+        "species": "American Robin",
+        "photo_id": seed["photo"],
+    })
+    assert resp_ok.status_code == 200
+
+    # Setting an ancestor-level representative on the same photo must be
+    # rejected because the ancestor bucket does not include this photo.
+    for ancestor in ("Aves", "Turdidae", "Turdus"):
+        resp = client.post("/api/photo-preferences", json={
+            "purpose": "life_list",
+            "species": ancestor,
+            "photo_id": seed["photo"],
+        })
+        assert resp.status_code == 400, (
+            f"ancestor {ancestor} preference should be denied for a "
+            f"photo whose Life List bucket is a descendant identification"
+        )
+
+
+def test_species_representative_lists_suppress_ancestor_with_descendant(life_app):
+    """``get_species_representative_lists(eligible_only=True)`` must drop
+    an ancestor keyword's representative when the photo also carries a
+    descendant identification. That reader powers ``is_current_photo`` on
+    ``GET /api/photos/<id>``, so a lingering ancestor eligibility would
+    make the lightbox re-offer "Set Representative" on a photo the
+    ancestor bucket does not render.
+    """
+    app, db, ids = life_app
+    seed = _seed_robin_with_ancestor_keywords(db, ids["folder"])
+    # Manually persist a curation row targeting the ancestor to prove the
+    # eligibility reader (not the write path) drops it. Without ancestor
+    # suppression on the EXISTS this photo would remain eligible for
+    # ``Aves`` even though the Life List query hides that bucket.
+    db.set_species_representative("Aves", seed["photo"])
+    db.conn.commit()
+
+    eligible = db.get_species_representative_lists(eligible_only=True)
+    assert "Aves" not in eligible, (
+        "Aves representative eligibility must be suppressed when the "
+        "photo also carries American Robin"
+    )
+
+
+def test_life_list_keeps_unrelated_higher_rank_identifications(life_app):
+    """A photo tagged with two unrelated higher-rank keywords (a class-level
+    ``Aves`` and a class-level ``Mammalia`` where neither is an ancestor
+    of the other) must keep both Life List entries. The suppression rule
+    only fires for genuine ancestor/descendant pairs on the same photo.
+    """
+    app, db, ids = life_app
+    aves = db.conn.execute(
+        "INSERT INTO taxa (name, common_name, rank) VALUES (?, ?, ?)",
+        ("Aves", "Birds", "class"),
+    ).lastrowid
+    mammalia = db.conn.execute(
+        "INSERT INTO taxa (name, common_name, rank) VALUES (?, ?, ?)",
+        ("Mammalia", "Mammals", "class"),
+    ).lastrowid
+    k_aves = db.add_keyword("Aves", kw_type="taxonomy")
+    db.conn.execute("UPDATE keywords SET taxon_id = ? WHERE id = ?", (aves, k_aves))
+    k_mam = db.add_keyword("Mammalia", kw_type="taxonomy")
+    db.conn.execute("UPDATE keywords SET taxon_id = ? WHERE id = ?", (mammalia, k_mam))
+    pid = db.add_photo(
+        folder_id=ids["folder"], filename="mixed.jpg", extension=".jpg",
+        file_size=1000, file_mtime=8.0, timestamp="2024-08-01T09:00:00",
+    )
+    db.tag_photo(pid, k_aves)
+    db.tag_photo(pid, k_mam)
+    db.conn.commit()
+
+    data = _get_life_list(app)
+    species_seen = {entry["species"] for entry in data["species"]}
+    assert "Aves" in species_seen
+    assert "Mammalia" in species_seen
+
+
 def test_locations_from_location_keywords(life_app):
     app, _, _ = life_app
     data = _get_life_list(app)

--- a/vireo/tests/test_life_list.py
+++ b/vireo/tests/test_life_list.py
@@ -759,6 +759,23 @@ def test_higher_rank_photo_can_be_life_list_representative(life_app):
     assert entry["best"]["is_species_representative"] is True
     assert entry["has_preferred_photo"] is True
 
+    # The just-saved representative must survive
+    # ``get_species_representative_lists(eligible_only=True)`` — which is
+    # what the lightbox / context menu re-reads via
+    # ``GET /api/photos/<id>`` to decide whether the button is current.
+    # Without the broadened eligibility EXISTS, the higher-rank row would
+    # be dropped and ``is_current_photo`` would come back false, so the
+    # UI would keep offering "Set Representative" for a save that
+    # already succeeded.
+    assert db.get_species_representative_lists(eligible_only=True) == {
+        "Accipiter": [seed["photo"]],
+    }
+    detail_after = client.get(f"/api/photos/{seed['photo']}").get_json()
+    accipiter_entry = next(
+        e for e in detail_after["life_list"] if e["species"] == "Accipiter"
+    )
+    assert accipiter_entry["is_current_photo"] is True
+
 
 def test_locations_from_location_keywords(life_app):
     app, _, _ = life_app

--- a/vireo/tests/test_life_list.py
+++ b/vireo/tests/test_life_list.py
@@ -674,6 +674,41 @@ def test_taxonomic_rank_and_class_attached(life_app):
     assert cardinal["taxonomic_class"] is None
 
 
+def test_higher_rank_taxonomy_identification_is_listed(life_app):
+    app, db, ids = life_app
+    aves = db.conn.execute(
+        "INSERT INTO taxa (name, common_name, rank) VALUES (?, ?, ?)",
+        ("Aves", "Birds", "class"),
+    ).lastrowid
+    accipiter = db.conn.execute(
+        "INSERT INTO taxa (name, rank, parent_id) VALUES (?, ?, ?)",
+        ("Accipiter", "genus", aves),
+    ).lastrowid
+    keyword_id = db.add_keyword("Accipiter", kw_type="taxonomy")
+    db.conn.execute(
+        "UPDATE keywords SET taxon_id = ? WHERE id = ?",
+        (accipiter, keyword_id),
+    )
+    photo_id = db.add_photo(
+        folder_id=ids["folder"],
+        filename="accipiter.jpg",
+        extension=".jpg",
+        file_size=1000,
+        file_mtime=6.0,
+        timestamp="2024-06-01T12:00:00",
+    )
+    db.tag_photo(photo_id, keyword_id)
+    db.conn.commit()
+
+    entry = _entry(_get_life_list(app), "Accipiter")
+    assert entry["taxon_rank"] == "genus"
+    assert entry["taxonomic_class"] == {
+        "id": aves,
+        "name": "Aves",
+        "common_name": "Birds",
+    }
+
+
 def test_locations_from_location_keywords(life_app):
     app, _, _ = life_app
     data = _get_life_list(app)

--- a/vireo/tests/test_life_list.py
+++ b/vireo/tests/test_life_list.py
@@ -698,6 +698,10 @@ def test_higher_rank_taxonomy_identification_is_listed(life_app):
         timestamp="2024-06-01T12:00:00",
     )
     db.tag_photo(photo_id, keyword_id)
+    # Tag the same photo with an existing location keyword so the entry
+    # must surface its location chip / CSV value like species-rank rows do.
+    location_id = db.add_keyword("Backyard", kw_type="location")
+    db.tag_photo(photo_id, location_id)
     db.conn.commit()
 
     entry = _entry(_get_life_list(app), "Accipiter")
@@ -707,6 +711,7 @@ def test_higher_rank_taxonomy_identification_is_listed(life_app):
         "name": "Aves",
         "common_name": "Birds",
     }
+    assert entry["locations"] == ["Backyard"]
 
 
 def test_locations_from_location_keywords(life_app):

--- a/vireo/tests/test_life_list.py
+++ b/vireo/tests/test_life_list.py
@@ -777,6 +777,54 @@ def test_higher_rank_photo_can_be_life_list_representative(life_app):
     assert accipiter_entry["is_current_photo"] is True
 
 
+def test_higher_rank_taxonomy_link_survives_mark_species_pass(life_app):
+    """A linked higher-rank taxonomy identification (genus/family/class)
+    must keep its ``taxon_id`` across the startup ``mark_species_keywords``
+    pass, so ``get_life_list_candidates`` continues to surface the entry's
+    ``taxon_rank`` / ``scientific_name`` / ``taxonomic_class`` metadata
+    used by the new Life List rank and class filters.
+
+    Regression test for the startup marking path: previously the pass
+    cleared ``taxon_id`` on any ``type='taxonomy'`` row whose current
+    binding pointed at a non-species-rank taxon when the taxonomy lookup
+    lacked a species-rank replacement — so an ``Accipiter`` genus entry
+    would render correctly on the first request but lose its rank/class
+    metadata on the next restart.
+    """
+    app, db, ids = life_app
+    seed = _seed_higher_rank_accipiter(db, ids["folder"])
+
+    class FakeTaxonomy:
+        # Only the Accipiter genus is known; no species-rank alternative
+        # exists (matches the concrete failure scenario in the review).
+        def lookup(self, name):
+            if name.lower() == "accipiter":
+                return {"taxon_id": seed["accipiter"]}
+            return None
+
+        def is_taxon(self, name):
+            return self.lookup(name) is not None
+
+    # The pass makes no changes because the row is already fully typed
+    # and its higher-rank binding is preserved.
+    assert db.mark_species_keywords(FakeTaxonomy()) == 0
+    row = db.conn.execute(
+        "SELECT taxon_id, type, is_species FROM keywords WHERE id = ?",
+        (seed["keyword"],),
+    ).fetchone()
+    assert row["taxon_id"] == seed["accipiter"]
+    assert row["type"] == "taxonomy"
+    assert row["is_species"] == 1
+
+    entry = _entry(_get_life_list(app), "Accipiter")
+    assert entry["taxon_rank"] == "genus"
+    assert entry["taxonomic_class"] == {
+        "id": seed["aves"],
+        "name": "Aves",
+        "common_name": "Birds",
+    }
+
+
 def test_locations_from_location_keywords(life_app):
     app, _, _ = life_app
     data = _get_life_list(app)


### PR DESCRIPTION
Life List candidate loading now retains linked genus, family, and other higher-rank taxonomy identifications so the existing identification-level and taxonomic-group filters can display them.

This fixes server-side filtering that previously discarded those entries before browser filters ran, and adds API regression coverage for genus and class metadata. The pipeline confirmation regression now waits for its rendered control before exercising duplicate-click locking, eliminating page-initialization timing failures. Validated with 81 affected unit and end-to-end tests plus 8 targeted taxonomy and curation tests.