### PR TITLE
Add Move action to Browse folder menu

### DIFF
--- a/tests/e2e/test_folder_tree_context_menu.py
+++ b/tests/e2e/test_folder_tree_context_menu.py
@@ -1,11 +1,12 @@
 """E2E tests for the folder-tree right-click context menu (Task 8).
 
-Menu items (first pass, per plan's "OPTION: skip for this first pass"):
+Menu items:
 - Filter by this folder
 - separator
 - Reveal in Finder/Folder
 - Copy Path
 - separator
+- Move…
 - Rescan this Folder
 
 "Expand All Children", "Collapse All Children", and "Hide from this Workspace"
@@ -30,11 +31,30 @@ def test_folder_tree_right_click_opens_menu(live_server, page):
         "Filter by this folder",
         "Reveal in",
         "Copy Path",
+        "Move…",
         "Rescan this Folder",
     ]:
         expect(
             menu.locator(".vireo-ctx-item", has_text=label)
         ).to_be_visible()
+
+
+def test_folder_tree_move_opens_move_page_with_source_selected(live_server, page):
+    """Move… opens Quick Move with the right-clicked folder as its source."""
+    live_server["db"].update_folder_counts()
+    url = live_server["url"]
+    page.goto(f"{url}/browse")
+
+    item = page.locator(".tree-item[data-folder-id]").first
+    item.wait_for(state="visible")
+    fid = item.get_attribute("data-folder-id")
+
+    item.click(button="right")
+    page.locator(".vireo-ctx-menu .vireo-ctx-item", has_text="Move…").click()
+
+    page.wait_for_url(f"**/move?folder_id={fid}")
+    expect(page.locator("#quickFolderSelect")).to_have_value(fid)
+    expect(page.locator("#quickFolderInfo")).not_to_be_empty()
 
 
 def test_folder_tree_filter_by_folder_fires_filter(live_server, page):

--- a/vireo/templates/browse.html
+++ b/vireo/templates/browse.html
@@ -8188,6 +8188,10 @@ async function copyFolderPath(fid) {
   }
 }
 
+function moveFolder(fid) {
+  window.location.href = '/move?folder_id=' + encodeURIComponent(fid);
+}
+
 async function rescanFolder(fid) {
   showToast('Starting folder rescan...', 'info');
   try {
@@ -8218,6 +8222,7 @@ document.addEventListener('contextmenu', function(e) {
     { label: window.VIREO_REVEAL_LABEL, onClick: function() { revealFolder(fid); } },
     { label: 'Copy Path', onClick: function() { copyFolderPath(fid); } },
     { separator: true },
+    { label: 'Move\u2026', onClick: function() { moveFolder(fid); } },
     { label: 'Rescan this Folder', onClick: function() { rescanFolder(fid); } },
   ]);
 });

--- a/vireo/templates/move.html
+++ b/vireo/templates/move.html
@@ -999,6 +999,13 @@ function populateFolderSelects() {
       sel.appendChild(opt);
     });
   });
+
+  var requestedFolderId = new URLSearchParams(window.location.search).get('folder_id');
+  if (requestedFolderId) {
+    var quickSelect = document.getElementById('quickFolderSelect');
+    quickSelect.value = requestedFolderId;
+    if (quickSelect.value === requestedFolderId) onQuickFolderChange();
+  }
 }
 
 /* ---------- Quick Move ---------- */


### PR DESCRIPTION
Adds a Move… action to the Browse folder context menu. The action opens Quick Move with the selected folder prepopulated through a folder ID query parameter, reducing repeated source selection. End-to-end coverage verifies the menu item, navigation, and selected source; the existing Move-page suite also passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a **“Move…”** option to the folder right-click context menu.
  - Selecting **“Move…”** opens the Move page with the chosen folder preselected as the source.
  - Move page links now load the selected folder’s details and update available actions automatically.

- **Tests**
  - Added end-to-end coverage verifying the new folder move workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->